### PR TITLE
Bugfix/postcode not found

### DIFF
--- a/app/controllers/providers/address_lookups_controller.rb
+++ b/app/controllers/providers/address_lookups_controller.rb
@@ -30,8 +30,6 @@ module Providers
         @form = Applicants::AddressSelectionForm.new(postcode: @form.postcode)
         render template: 'providers/address_selections/new'
       else
-        # @lookup_error = outcome.errors[:lookup].first
-        # @lookup_postcode = @form.postcode
         @form = Applicants::AddressForm.new(lookup_postcode: @form.postcode, lookup_error: outcome.errors[:lookup].first)
         render template: 'providers/addresses/new'
       end

--- a/app/controllers/providers/address_lookups_controller.rb
+++ b/app/controllers/providers/address_lookups_controller.rb
@@ -30,9 +30,9 @@ module Providers
         @form = Applicants::AddressSelectionForm.new(postcode: @form.postcode)
         render template: 'providers/address_selections/new'
       else
-        @lookup_error = outcome.errors[:lookup].first
+        # @lookup_error = outcome.errors[:lookup].first
         # @lookup_postcode = @form.postcode
-        @form = Applicants::AddressForm.new(lookup_postcode: @form.postcode)
+        @form = Applicants::AddressForm.new(lookup_postcode: @form.postcode, lookup_error: outcome.errors[:lookup].first)
         render template: 'providers/addresses/new'
       end
     end

--- a/app/controllers/providers/address_lookups_controller.rb
+++ b/app/controllers/providers/address_lookups_controller.rb
@@ -31,8 +31,8 @@ module Providers
         render template: 'providers/address_selections/new'
       else
         @lookup_error = outcome.errors[:lookup].first
-        @lookup_postcode = @form.postcode
-        @form = Applicants::AddressForm.new
+        # @lookup_postcode = @form.postcode
+        @form = Applicants::AddressForm.new(lookup_postcode: @form.postcode)
         render template: 'providers/addresses/new'
       end
     end

--- a/app/controllers/providers/addresses_controller.rb
+++ b/app/controllers/providers/addresses_controller.rb
@@ -16,6 +16,7 @@ module Providers
         redirect_to action_for_next_step(options: { application: applicant.legal_aid_application })
       else
         @lookup_postcode = params[:address][:lookup_postcode]
+        @lookup_error = params[:address][:lookup_error]
         render :new
       end
     end
@@ -23,7 +24,7 @@ module Providers
     private
 
     def address_params
-      params.require(:address).permit(:address_line_one, :address_line_two, :city, :county, :postcode, :lookup_postcode)
+      params.require(:address).permit(:address_line_one, :address_line_two, :city, :county, :postcode, :lookup_postcode, :lookup_error)
     end
 
     def form_params

--- a/app/controllers/providers/addresses_controller.rb
+++ b/app/controllers/providers/addresses_controller.rb
@@ -15,8 +15,6 @@ module Providers
       if @form.save
         redirect_to action_for_next_step(options: { application: applicant.legal_aid_application })
       else
-        @lookup_postcode = params[:address][:lookup_postcode]
-        @lookup_error = params[:address][:lookup_error]
         render :new
       end
     end

--- a/app/controllers/providers/addresses_controller.rb
+++ b/app/controllers/providers/addresses_controller.rb
@@ -15,6 +15,7 @@ module Providers
       if @form.save
         redirect_to action_for_next_step(options: { application: applicant.legal_aid_application })
       else
+        @lookup_postcode = params[:address][:lookup_postcode]
         render :new
       end
     end
@@ -22,7 +23,7 @@ module Providers
     private
 
     def address_params
-      params.require(:address).permit(:address_line_one, :address_line_two, :city, :county, :postcode)
+      params.require(:address).permit(:address_line_one, :address_line_two, :city, :county, :postcode, :lookup_postcode)
     end
 
     def form_params

--- a/app/forms/applicants/address_form.rb
+++ b/app/forms/applicants/address_form.rb
@@ -4,7 +4,7 @@ module Applicants
 
     form_for Address
 
-    attr_accessor :applicant_id, :address_line_one, :address_line_two, :city, :county, :postcode, :lookup_postcode
+    attr_accessor :applicant_id, :address_line_one, :address_line_two, :city, :county, :postcode, :lookup_postcode, :lookup_error
 
     before_validation :normalise_postcode
 

--- a/app/forms/applicants/address_form.rb
+++ b/app/forms/applicants/address_form.rb
@@ -15,6 +15,10 @@ module Applicants
 
     validate :validate_building_and_street
 
+    def exclude_from_model
+      %i[lookup_postcode lookup_error]
+    end
+
     private
 
     def applicant

--- a/app/forms/applicants/address_form.rb
+++ b/app/forms/applicants/address_form.rb
@@ -4,7 +4,7 @@ module Applicants
 
     form_for Address
 
-    attr_accessor :applicant_id, :address_line_one, :address_line_two, :city, :county, :postcode
+    attr_accessor :applicant_id, :address_line_one, :address_line_two, :city, :county, :postcode, :lookup_postcode
 
     before_validation :normalise_postcode
 

--- a/app/forms/base_form.rb
+++ b/app/forms/base_form.rb
@@ -42,7 +42,7 @@ module BaseForm
 
     # List of form attributes not to be passed to model
     def exclude_from_model
-      %i[lookup_postcode lookup_error]
+      []
     end
 
     def assignable_attributes

--- a/app/forms/base_form.rb
+++ b/app/forms/base_form.rb
@@ -42,7 +42,7 @@ module BaseForm
 
     # List of form attributes not to be passed to model
     def exclude_from_model
-      []
+      %i[lookup_postcode lookup_error]
     end
 
     def assignable_attributes

--- a/app/views/providers/addresses/_form.html.erb
+++ b/app/views/providers/addresses/_form.html.erb
@@ -11,12 +11,13 @@
     </h1>
 
     <%= form_with(model: @form, scope: :address, url: providers_applicant_addresses_path(@applicant), local: true) do |form| %>
-      <% if @lookup_postcode %>
+      <% if form.object.lookup_postcode.present? %>
+        <%= form.hidden_field :lookup_postcode %>
         <div class='govuk-form-group'>
           <%= label_tag 'postcode', class: 'govuk-label' do %>
             Postcode
             <p class='govuk-body govuk-!-font-weight-bold'>
-              <%= @lookup_postcode %>
+              <%= form.object.lookup_postcode %>
               <%= link_to 'Change', new_providers_applicant_address_lookups_path(@applicant), class: 'govuk-body change-link change-postcode-link' %>
             </p>
           <% end %>

--- a/app/views/providers/addresses/_form.html.erb
+++ b/app/views/providers/addresses/_form.html.erb
@@ -24,10 +24,11 @@
         </div>
       <% end %>
 
-      <% if @lookup_error %>
-        <div class='govuk-inset-text'>
-          <%= t("forms.address.errors.#{@lookup_error}") %>
-        </div>
+      <% if form.object.lookup_error.present? %>
+        <%= form.hidden_field :lookup_error %>
+          <div class='govuk-inset-text'>
+            <%= t("forms.address.errors.#{form.object.lookup_error}") %>
+          </div>
       <% end %>
 
       <div class="govuk-!-padding-bottom-2"></div>


### PR DESCRIPTION
The design requires the form to show the lookup postcode and inset text to the user after they submit an address manually, if the form contains errors. Currently the validation of the form will remove the postcode and inset text from the users view.

[Link to story](https://dsdmoj.atlassian.net/browse/AP-170)

Add lookup_postcode and lookup_error to parameters so they can be rendered with the new page
after a validation error.
Exclude the new lookup_* parameters from being passed to the model

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely. 
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
