### PR TITLE
Resolve deprecation warning on cucumber tests by using the expect syntax

### DIFF
--- a/features/providers/step_definitions/civil_journey_steps.rb
+++ b/features/providers/step_definitions/civil_journey_steps.rb
@@ -9,7 +9,7 @@ When(/^the search for (.*) is not successful$/) do |proceeding_search|
 end
 
 Then('the result list on page returns a {string} message') do |string|
-  page.should have_content(string)
+  expect(page).to have_content(string)
 end
 
 And(/^I search for proceeding '(.*)'$/) do |proceeding_search|
@@ -22,15 +22,15 @@ When(/^I click clear search$/) do
 end
 
 Then(/^proceeding search field is empty$/) do
-  page.should have_field('proceeding-search-input', with: '')
+  expect(page).to have_field('proceeding-search-input', with: '')
 end
 
 Then(/^the results section is empty$/) do
-  page.should_not have_css('#proceeding-list > .proceeding-item')
+  expect(page).to_not have_css('#proceeding-list > .proceeding-item')
 end
 
 Then(/^proceeding suggestions has results$/) do
-  page.should have_css('#proceeding-list > .proceeding-item')
+  expect(page).to have_css('#proceeding-list > .proceeding-item')
 end
 
 And(/^I click "([^"]*)"$/) do |button_name|
@@ -46,7 +46,7 @@ Then(/^I select and continue$/) do
 end
 
 Then(/^I see the client details page$/) do
-  page.should have_content("Enter your client's details")
+  expect(page).to have_content("Enter your client's details")
 end
 
 Then(/^I enter name '(.*)', '(.*)'$/) do |first_name, last_name|
@@ -66,7 +66,7 @@ Then(/^I enter national insurance number '(.*)'$/) do |nino|
 end
 
 Then(/^I see a notice confirming an e-mail was sent to the citizen$/) do
-  page.should have_content('Application completed. An e-mail will be sent to the citizen.')
+  expect(page).to have_content('Application completed. An e-mail will be sent to the citizen.')
 end
 
 When(/^I click continue$/) do
@@ -90,7 +90,7 @@ Then(/^I enter postcode '(.*)'$/) do |postcode|
 end
 
 Then('I am on the postcode entry page') do
-  page.should have_content("Enter your client's home address")
+  expect(page).to have_content("Enter your client's home address")
 end
 
 Then(/^I enter a valid postcode '(.*)'$/) do |postcode|

--- a/features/step_definitions/citizens_steps.rb
+++ b/features/step_definitions/citizens_steps.rb
@@ -1,5 +1,5 @@
 Then('I see {string}') do |string|
-  page.should have_content(string)
+  expect(page).to have_content(string)
 end
 
 Then('I see the start link') do
@@ -31,7 +31,7 @@ Then('I see the start page') do
 end
 
 Then('I see the open banking information page') do
-  page.should have_content('Give one-time access to your bank accounts')
+  expect(page).to have_content('Give one-time access to your bank accounts')
 end
 
 When('I click the continue link') do


### PR DESCRIPTION
The `should` syntax in cucumber tests is generating a deprecation warning, changing to the `expect` syntax resolves this.

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unneccessary whitespace changes. These make diffs harder to read and conflicts more likely. 
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
