### PR TITLE
Update instructions for release deploy cleansing

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ may well be used to fire requests to other services.
 * System dependencies
     * postgres 10.5
     * npm
-    
+
 Install dependencies with homebrew:
 ```
 brew bundle
@@ -53,3 +53,15 @@ The deployment is triggered on all builds in [CircleCI](https://circleci.com/gh/
 **NOTE:** **git-crypt** is required to store secrets required for **uat**, **staging** and **production** environments. To be able to modify those secrets, **git-crypt** needs to be set up according to the following [guide](https://ministryofjustice.github.io/cloud-platform-user-docs/03-other-topics/001-git-crypt-setup/#git-crypt).
 
 For more deployment information refer to the specific [README](./helm_deploy/apply-for-legal-aid/README.md)
+
+### UAT Deployments
+
+**NOTE: Until an automated process is put in place to deal with this issue, once a branch has been merged into master or deleted, for which there's an associated release, the following commands should be executed to ensure those releases are deleted, as they're no longer necessary:**
+
+```
+# list the availables releases:
+helm list --tiller-namespace=laa-apply-for-legalaid-uat --namespace=laa-apply-for-legalaid-uat --debug --all
+
+# delete a specific release
+helm delete <name-of-the-release> --tiller-namespace=laa-apply-for-legalaid-uat --purge
+```


### PR DESCRIPTION
## What

To ensure UAT releases that are no longer necessary are deleted.

This is to avoid exceeding the quota limits associated with UAT.

In the future, the idea is to have this process automated so that people don't have to worry about it.

Describe what you did and why.