### PR TITLE
Add timeout to staging/prod helm deploys

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,7 +131,7 @@ jobs:
         command: |
 
           helm upgrade ${APPLICATION_DEPLOY_NAME} ./helm_deploy/apply-for-legal-aid/. \
-                        --install \
+                        --install --wait \
                         --tiller-namespace=${KUBE_ENV_STAGING_NAMESPACE} \
                         --namespace=${KUBE_ENV_STAGING_NAMESPACE} \
                         --values ./helm_deploy/apply-for-legal-aid/values-staging.yaml \
@@ -158,7 +158,7 @@ jobs:
         command: |
 
           helm upgrade ${APPLICATION_DEPLOY_NAME} ./helm_deploy/apply-for-legal-aid/. \
-                        --install \
+                        --install --wait \
                         --tiller-namespace=${KUBE_ENV_PRODUCTION_NAMESPACE} \
                         --namespace=${KUBE_ENV_PRODUCTION_NAMESPACE} \
                         --values ./helm_deploy/apply-for-legal-aid/values-production.yaml \


### PR DESCRIPTION
Recent circleci deployments to the staging environment have failed due
to an exceeded quota, however feedback from circleci indicates that the
build was successful. This meant that no one was aware of the failures.

To get more feedback in scenarios like this, add a --wait flag to the helm 
upgrade command so that if the deployment fails it will timeout and 
report a failure.

This replicates existing functionality for UAT deployments.

Separately, I have deleted old front-end/API releases from the staging 
namespace as they are no longer required, so the quota issue is no longer 
a problem.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely. 
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
