### PR TITLE
Remove validation for 2 digit year of birth

### DIFF
--- a/app/forms/applicants/basic_details_form.rb
+++ b/app/forms/applicants/basic_details_form.rb
@@ -17,7 +17,6 @@ module Applicants
       :date_of_birth,
       date: {
         not_in_the_future: true,
-        not_four_digit_year: true,
         earliest_allowed_date: { date: '1900-01-01' }
       }
     )

--- a/app/validators/date_validator.rb
+++ b/app/validators/date_validator.rb
@@ -6,7 +6,6 @@ class DateValidator < ActiveModel::EachValidator
     value = parse_date(value, options[:format]) if value.is_a?(String)
     return unless valid_date(record, attribute, value)
     validate_not_in_future(record, attribute, value)
-    validate_four_digit_year(record, attribute, value)
     validate_not_too_early(record, attribute, value)
   end
 
@@ -49,13 +48,5 @@ class DateValidator < ActiveModel::EachValidator
     date_options = options[:earliest_allowed_date]
     date = date_options.is_a?(Hash) && date_options[:date] ? date_options[:date] : DEFAULT_EARLIEST_DATE
     parse_date(date, options[:format])
-  end
-
-  def validate_four_digit_year(record, attribute, value)
-    required = options[:not_four_digit_year]
-    return unless required.present?
-    message = required[:message] if required.is_a?(Hash)
-    message ||= :year_is_not_four_digits
-    record.errors.add(attribute, message) if value < parse_date('1000-01-01', options[:format])
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -43,7 +43,6 @@ en:
               date_of_birth:
                 date_not_valid: 'Enter a valid date of birth'
                 date_is_in_the_future: 'Date of birth must be in the past'
-                year_is_not_four_digits: 'Enter a four-digit year of birth'
                 earliest_allowed_date: 'Date of birth cannot be before %{date}'
               national_insurance_number:
                 blank: 'Enter a National Insurance number'


### PR DESCRIPTION
It was previously necessary to have validation to prevent users
entering a two-digit year of birth. This was due to the way the provider
front-end application handled dates of birth as three separate values
which were passed to the api.

Following the move to a single application the way the date of birth is
handled has changed to use a date object and this validation is no
longer needed. Two-digit dates of birth are correctly interpreted by
rails without any validation.

The validation on two-digit years was added in AP-161. I've commented 
on the ticket to explain the reasons for removing the validation and this
has been approved by Neil. 

[AP-161](https://dsdmoj.atlassian.net/browse/AP-161)

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unneccessary whitespace changes. These make diffs harder to read and conflicts more likely. 
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
