### PR TITLE
Move validation order to match the order required by the design spec

### DIFF
--- a/app/forms/applicants/address_form.rb
+++ b/app/forms/applicants/address_form.rb
@@ -8,12 +8,12 @@ module Applicants
 
     before_validation :normalise_postcode
 
+    validate :validate_building_and_street
+
     validates :city, :postcode,
               presence: true
 
     validates :postcode, format: { with: POSTCODE_REGEXP, if: proc { |a| a.postcode.present? } }
-
-    validate :validate_building_and_street
 
     def exclude_from_model
       %i[lookup_postcode lookup_error]

--- a/app/forms/applicants/basic_details_form.rb
+++ b/app/forms/applicants/basic_details_form.rb
@@ -12,7 +12,8 @@ module Applicants
 
     before_validation :normalise_national_insurance_number
 
-    validates :first_name, :last_name, :national_insurance_number, presence: true
+    validates :first_name, :last_name, presence: true
+
     validates(
       :date_of_birth,
       date: {
@@ -20,6 +21,9 @@ module Applicants
         earliest_allowed_date: { date: '1900-01-01' }
       }
     )
+
+    validates :national_insurance_number, presence: true
+
     validates :national_insurance_number, format: { with: NINO_REGEXP, message: :not_valid }, allow_blank: true
 
     # rubocop:disable Lint/DuplicateMethods


### PR DESCRIPTION
The error summary was showing messages in an order different to the one in the design spec. 

[Link to story](https://dsdmoj.atlassian.net/browse/AP-171)

Moved the validation rules in the models so they are run and reported in the order required in the specification

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unneccessary whitespace changes. These make diffs harder to read and conflicts more likely. 
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
