### PR TITLE
Rack gem had a vulnerability identified in version 2.0.5 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -208,7 +208,7 @@ GEM
       pry (~> 0.10)
     public_suffix (3.0.3)
     puma (3.12.0)
-    rack (2.0.5)
+    rack (2.0.6)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (5.2.0)


### PR DESCRIPTION
this has been fixed in 2.0.6 this update applies the latest version

As mentioned here:
https://groups.google.com/forum/#!topic/rubyonrails-security/U_x-YkfuVTg
https://groups.google.com/forum/#!topic/rubyonrails-security/GKsAFT924Ag

2 vulnerabilities were discovered in rack 2.0.5, the version we were using, and the patch is available in 2.0.6

Highlighted by Matthew Rudy in the development slack channel here:
https://mojdt.slack.com/archives/C3F8L6XQU/p1541498824032500 



## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unneccessary whitespace changes. These make diffs harder to read and conflicts more likely. 
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
