### PR TITLE
AP-71 Allow applicant to select whether they have additional accounts

### DIFF
--- a/app/controllers/base_controller.rb
+++ b/app/controllers/base_controller.rb
@@ -1,3 +1,8 @@
 class BaseController < ApplicationController
   layout 'application'
+
+  def current_legal_aid_application
+    return unless session[:current_application_ref].present?
+    @current_legal_aid_application ||= LegalAidApplication.find(session[:current_application_ref])
+  end
 end

--- a/app/controllers/citizens/additional_accounts_controller.rb
+++ b/app/controllers/citizens/additional_accounts_controller.rb
@@ -1,0 +1,35 @@
+module Citizens
+  class AdditionalAccountsController < BaseController
+    def index; end
+
+    def create
+      case params[:additional_account]
+      when 'yes'
+        redirect_to new_citizens_additional_account_path
+      when 'no'
+        # TODO: - set redirect path when known
+        render plain: 'Landing page: Next step in Citizen journey'
+      else
+        flash[:error] = 'You must select either Yes or No'
+        render :index
+      end
+    end
+
+    def new; end
+
+    def update
+      case params[:additional_account]
+      when 'yes'
+        # TODO: - set redirect path when known
+        render plain: 'Landing page: Return to True Layer steps'
+      when 'no'
+        current_legal_aid_application&.update(has_offline_accounts: true)
+        # TODO: - set redirect path when known
+        render plain: 'Landing page: Next step in Citizen journey'
+      else
+        flash[:error] = 'You must select either Yes or No'
+        render :index
+      end
+    end
+  end
+end

--- a/app/views/citizens/additional_accounts/index.html.erb
+++ b/app/views/citizens/additional_accounts/index.html.erb
@@ -1,0 +1,43 @@
+<% content_for :navigation do %>
+  <%#= link_to 'Back', path-to-be-determined, class: 'govuk-back-link', id: 'back' %>
+<% end %>
+
+  <%= form_tag(citizens_additional_accounts_path) do %>
+
+    <div class="govuk-form-group">
+      <fieldset class="govuk-fieldset">
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+          <h1 class="govuk-fieldset__heading">
+            Do you have accounts with other banks?
+          </h1>
+        </legend>
+        <br />
+        <span class="govuk-hint">
+          Share details of any accounts you have with another bank or building society
+        </span>
+        <% if flash[:alert] %>
+          <%= flash[:alert] %>
+        <% end %>
+        <div class="govuk-radios">
+          <div class="govuk-radios__item">
+            <input class="govuk-radios__input" id="additional-account-1" name="additional_account" type="radio" value="yes" />
+            <label class="govuk-label govuk-radios__label" for="additional-account-1">
+              Yes
+            </label>
+          </div>
+          <div class="govuk-radios__item">
+            <input class="govuk-radios__input" id="additional-account-2" name="additional_account" type="radio" value="no" />
+            <label class="govuk-label govuk-radios__label" for="additional-account-2">
+              No
+            </label>
+          </div>
+        </div>
+      </fieldset>
+    </div>
+
+    <%= submit_tag 'Continue', class: 'govuk-button govuk-button' %>
+
+  <% end %>
+
+  </div>
+</div>

--- a/app/views/citizens/additional_accounts/new.html.erb
+++ b/app/views/citizens/additional_accounts/new.html.erb
@@ -1,0 +1,43 @@
+<% content_for :navigation do %>
+  <%#= link_to 'Back', path-to-be-determined, class: 'govuk-back-link', id: 'back' %>
+<% end %>
+
+  <%= form_tag(citizens_additional_account_path(id: :update), method: :patch) do %>
+
+    <div class="govuk-form-group">
+      <fieldset class="govuk-fieldset">
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+          <h1 class="govuk-fieldset__heading">
+            Do you have online access to your accounts with other banks?
+          </h1>
+        </legend>
+        <br />
+        <span class="govuk-hint">
+          If you do not, you will need to provide paper evidence for these accounts.
+        </span>
+        <% if flash[:alert] %>
+          <%= flash[:alert] %>
+        <% end %>
+        <div class="govuk-radios">
+          <div class="govuk-radios__item">
+            <input class="govuk-radios__input" id="additional-account-1" name="additional_account" type="radio" value="yes" />
+            <label class="govuk-label govuk-radios__label" for="additional-account-1">
+              Yes
+            </label>
+          </div>
+          <div class="govuk-radios__item">
+            <input class="govuk-radios__input" id="additional-account-2" name="additional_account" type="radio" value="no" />
+            <label class="govuk-label govuk-radios__label" for="additional-account-2">
+              No
+            </label>
+          </div>
+        </div>
+      </fieldset>
+    </div>
+
+    <%= submit_tag 'Continue', class: 'govuk-button govuk-button' %>
+
+  <% end %>
+
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,7 @@ Rails.application.routes.draw do
     resource :consent, only: [:show]
     resource :information, only: [:show]
     resources :accounts, only: [:index]
+    resources :additional_accounts, only: %i[index create new update]
   end
 
   namespace :providers do

--- a/db/migrate/20181107093419_add_has_offline_accounts_to_legal_aid_applications.rb
+++ b/db/migrate/20181107093419_add_has_offline_accounts_to_legal_aid_applications.rb
@@ -1,0 +1,5 @@
+class AddHasOfflineAccountsToLegalAidApplications < ActiveRecord::Migration[5.2]
+  def change
+    add_column :legal_aid_applications, :has_offline_accounts, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_01_115246) do
+ActiveRecord::Schema.define(version: 2018_11_07_093419) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -72,6 +72,7 @@ ActiveRecord::Schema.define(version: 2018_11_01_115246) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.uuid "applicant_id"
+    t.boolean "has_offline_accounts"
     t.index ["applicant_id"], name: "index_legal_aid_applications_on_applicant_id"
   end
 

--- a/spec/requests/citizens/additional_accounts_spec.rb
+++ b/spec/requests/citizens/additional_accounts_spec.rb
@@ -1,0 +1,113 @@
+require 'rails_helper'
+
+RSpec.describe 'citizen additional accounts request test', type: :request do
+  describe 'GET /citizens/additional_accounts' do
+    before { get citizens_additional_accounts_path }
+
+    it 'returns http success' do
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe 'POST /citizens/additional_accounts' do
+    let(:params) { {} }
+    before { post citizens_additional_accounts_path, params: params }
+
+    it 'does not redirect if no choice submitted' do
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'should display an error' do
+      expect(response.body).to match('govuk-error-summary')
+    end
+
+    context 'with Yes submitted' do
+      let(:params) { { additional_account: 'yes' } }
+
+      it 'redirects to new action' do
+        expect(response).to redirect_to(new_citizens_additional_account_path)
+      end
+    end
+
+    context 'with No submitted' do
+      let(:params) { { additional_account: 'no' } }
+
+      xit 'redirects to the next step in Citizen jouney' do
+        # TODO: - set redirect path when known
+        expect(response).to redirect_to(:some_path)
+      end
+
+      it 'displays holding page' do
+        # TODO: Delete when redirect set
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to match('Landing page')
+      end
+    end
+  end
+
+  describe 'GET /citizens/additional_accounts/new' do
+    before { get new_citizens_additional_account_path }
+
+    it 'returns http success' do
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe 'PATCH/PUT /citizens/additional_accounts' do
+    let(:params) { {} }
+    let(:legal_aid_application) { create :legal_aid_application, :with_applicant }
+    before do
+      get citizens_legal_aid_application_path(legal_aid_application.id)
+      patch(
+        citizens_additional_account_path(id: :update),
+        params: params
+      )
+    end
+
+    it 'does not redirect if no choice submitted' do
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'should display an error' do
+      expect(response.body).to match('govuk-error-summary')
+    end
+
+    context 'with Yes submitted' do
+      let(:params) { { additional_account: 'yes' } }
+
+      xit 'redirects to back to the True Layer steps' do
+        # TODO: - set redirect path when known
+        expect(response).to redirect_to(:some_path)
+      end
+
+      it 'displays holding page' do
+        # TODO: Delete when redirect set
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to match('Landing page')
+      end
+
+      it 'does not record choice on legal_aid_application' do
+        expect(legal_aid_application.reload).not_to be_has_offline_accounts
+      end
+    end
+
+    context 'with No submitted' do
+      let(:params) { { additional_account: 'no' } }
+
+      xit 'redirects to the next step in Citizen jouney' do
+        # TODO: - set redirect path when known
+        expect(response).to redirect_to(:some_path)
+      end
+
+      it 'displays holding page' do
+        # TODO: Delete when redirect set
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to match('Landing page')
+      end
+
+      it 'records choice on legal_aid_application' do
+        expect(legal_aid_application.reload).to be_has_offline_accounts
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What

[JIRA AP-71](https://dsdmoj.atlassian.net/browse/AP-71)

The start of these steps is at `/citizens/additional_accounts`

Adds two screens to allow a user to:

- Confirm they have no more accounts and continue
- Start the True Layer add another account journey
- Confirm they have other accounts, that they will need to supply other evidence, and continue

At the moment the next step in the process and the "add another account" journey are not defined, so the endpoints instead display simple landing pages.
