### PR TITLE
Add styling to the proceedings search page to match design spec

### DIFF
--- a/app/assets/javascripts/templates/proceeding_result_template.js
+++ b/app/assets/javascripts/templates/proceeding_result_template.js
@@ -3,9 +3,9 @@ var templates = (function(){
 
     return `<div class="govuk-grid-row proceeding-item" style="display: block;">
               <div class="govuk-grid-column-two-thirds">
-                <a class="govuk-caption-m">
+                <div class="govuk-caption-m">
                   ` + categoryOfLaw + ' > ' + matterType + `
-                </a>
+                </div>
                 <span class="govuk-body">` + proceedingMeaning + `</span>
               </div>
 
@@ -14,6 +14,7 @@ var templates = (function(){
                         name="proceeding_type"
                         value="` + proceedingCode + `"
                         id="proceedingType` + proceedingCode + `" />
+                <div class="govuk-!-padding-bottom-2"></div>
                 <input  type="button"
                         value="Select and continue"
                         class="govuk-button proceeding-link"

--- a/app/assets/stylesheets/providers/legal_aid_applications.scss
+++ b/app/assets/stylesheets/providers/legal_aid_applications.scss
@@ -1,5 +1,5 @@
 #clear-search-div {
-  padding-left: 0;
+  padding-left: 15px;
   padding-top: 5px;
 }
 

--- a/app/views/providers/legal_aid_applications/new.html.erb
+++ b/app/views/providers/legal_aid_applications/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :navigation do %>
-  <%= link_to 'Home', providers_root_path, class: 'govuk-back-link' %>
+  <%= link_to 'Home', providers_legal_aid_applications_path, class: 'govuk-back-link' %>
 <% end %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -14,14 +14,21 @@
   </div>
 </div>
 
+<div class="govuk-!-padding-bottom-2"></div>
+
 <div class="govuk-grid-row search-field">
   <div class="govuk-grid-column-two-thirds">
     <input class="govuk-input" id="proceeding-search" name="proceeding-search-input" type="input" aria-describedby="offence-hint" />
   </div>
+
+  <div class="govuk-!-padding-bottom-1"></div>
+
   <div id="clear-search-div" class="govuk-grid-column-one-third">
       <a id="clearSearch" href="#" class="govuk-link govuk-!-font-size-19">Clear search</a>
   </div>
 </div>
+
+<div class="govuk-!-padding-bottom-4"></div>
 
 <div class="govuk-grid-row">
   <%= form_with(model: [:providers, @legal_aid_application], local: true, html: { id: 'proceeding-form' }) do |form| %>


### PR DESCRIPTION
The current version has some styling differences to the prototype these changes bring it into line with the prototype

[Link to story](https://dsdmoj.atlassian.net/browse/AP-180)
Add padding to some elements for spacing
Replace link tag on text that was not a link
Change page the Home button redirects to
## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely. 
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
