### PR TITLE
Address lookup and selection page styling amendments (AP-179)

### DIFF
--- a/app/views/providers/address_lookups/_form.html.erb
+++ b/app/views/providers/address_lookups/_form.html.erb
@@ -20,7 +20,8 @@
 
       <%= render partial: 'shared/forms/text_fields', locals: { field_name: :postcode,
                                                                 form: form,
-                                                                class: 'govuk-input--width-10' } %>
+                                                                class: 'govuk-input--width-10',
+                                                                hint?: true } %>
 
       <%= form.submit 'Find address', id: 'find-address', class: 'govuk-button' %>
 

--- a/app/views/providers/address_lookups/_form.html.erb
+++ b/app/views/providers/address_lookups/_form.html.erb
@@ -20,8 +20,7 @@
 
       <%= render partial: 'shared/forms/text_fields', locals: { field_name: :postcode,
                                                                 class: 'govuk-input--width-10',
-                                                                form: form,
-                                                                hint: :postcode_hint } %>
+                                                                form: form } %>
 
       <%= form.submit 'Find address', id: 'find-address', class: 'govuk-button' %>
 

--- a/app/views/providers/address_lookups/_form.html.erb
+++ b/app/views/providers/address_lookups/_form.html.erb
@@ -20,8 +20,7 @@
 
       <%= render partial: 'shared/forms/text_fields', locals: { field_name: :postcode,
                                                                 form: form,
-                                                                class: 'govuk-input--width-10',
-                                                                hint?: true } %>
+                                                                class: 'govuk-input--width-10' } %>
 
       <%= form.submit 'Find address', id: 'find-address', class: 'govuk-button' %>
 

--- a/app/views/providers/address_lookups/_form.html.erb
+++ b/app/views/providers/address_lookups/_form.html.erb
@@ -19,8 +19,8 @@
       <div class="govuk-!-padding-bottom-2"></div>
 
       <%= render partial: 'shared/forms/text_fields', locals: { field_name: :postcode,
-                                                                class: 'govuk-input--width-10',
-                                                                form: form } %>
+                                                                form: form,
+                                                                class: 'govuk-input--width-10' } %>
 
       <%= form.submit 'Find address', id: 'find-address', class: 'govuk-button' %>
 

--- a/app/views/providers/addresses/_form.html.erb
+++ b/app/views/providers/addresses/_form.html.erb
@@ -6,7 +6,6 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    
     <%= form_with(model: @form, scope: :address, url: providers_applicant_addresses_path(@applicant), local: true) do |form| %>
 
     <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
@@ -18,7 +17,6 @@
         <% end %>
       </h1>
     </legend>
-
 
       <% if form.object.lookup_postcode.present? %>
         <%= form.hidden_field :lookup_postcode %>

--- a/app/views/providers/addresses/_form.html.erb
+++ b/app/views/providers/addresses/_form.html.erb
@@ -48,7 +48,7 @@
 
       <%= render partial: 'shared/forms/text_fields', locals: { field_name: :city, class: 'govuk-!-width-two-thirds', form: form } %>
       <%= render partial: 'shared/forms/text_fields', locals: { field_name: :county, class: 'govuk-!-width-two-thirds', form: form } %>
-      <%= render partial: 'shared/forms/text_fields', locals: { field_name: :postcode, class: 'govuk-input--width-10', form: form } %>
+      <%= render partial: 'shared/forms/text_fields', locals: { field_name: :postcode, class: 'govuk-input--width-10', form: form, hide_hint?: true } %>
 
       <%= form.submit 'Continue', id: 'continue', class: 'govuk-button' %>
     <% end %>

--- a/app/views/providers/addresses/_form.html.erb
+++ b/app/views/providers/addresses/_form.html.erb
@@ -6,13 +6,20 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    
+    <%= form_with(model: @form, scope: :address, url: providers_applicant_addresses_path(@applicant), local: true) do |form| %>
+
     <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
       <h1 class="govuk-fieldset__heading">
-        <%= t('forms.address_lookup.heading') %>
+        <% if form.object.lookup_error.present? %>
+          <%= t('forms.address_lookup.heading') %>
+        <% else %>
+          <%= t('forms.address_manual.heading') %>
+        <% end %>
       </h1>
     </legend>
 
-    <%= form_with(model: @form, scope: :address, url: providers_applicant_addresses_path(@applicant), local: true) do |form| %>
+
       <% if form.object.lookup_postcode.present? %>
         <%= form.hidden_field :lookup_postcode %>
         <div class='govuk-form-group'>

--- a/app/views/providers/addresses/_form.html.erb
+++ b/app/views/providers/addresses/_form.html.erb
@@ -6,9 +6,11 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">
-      Enter your client's address manually
-    </h1>
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+      <h1 class="govuk-fieldset__heading">
+        <%= t('forms.address_lookup.heading') %>
+      </h1>
+    </legend>
 
     <%= form_with(model: @form, scope: :address, url: providers_applicant_addresses_path(@applicant), local: true) do |form| %>
       <% if form.object.lookup_postcode.present? %>

--- a/app/views/providers/applicants/new.html.erb
+++ b/app/views/providers/applicants/new.html.erb
@@ -30,7 +30,7 @@
 
         <div class="govuk-!-padding-bottom-6"></div>
 
-        <%= render partial: 'shared/forms/text_fields', locals: { field_name: :national_insurance_number, form: form, class: 'govuk-!-width-one-half', hint?: true } %>
+        <%= render partial: 'shared/forms/text_fields', locals: { field_name: :national_insurance_number, form: form, class: 'govuk-!-width-one-half' } %>
 
         <div class="govuk-!-padding-bottom-2"></div>
 

--- a/app/views/providers/applicants/new.html.erb
+++ b/app/views/providers/applicants/new.html.erb
@@ -30,7 +30,7 @@
 
         <div class="govuk-!-padding-bottom-6"></div>
 
-        <%= render partial: 'shared/forms/text_fields', locals: { field_name: :national_insurance_number, form: form, class: 'govuk-!-width-one-half' } %>
+        <%= render partial: 'shared/forms/text_fields', locals: { field_name: :national_insurance_number, form: form, class: 'govuk-!-width-one-half', hint?: true } %>
 
         <div class="govuk-!-padding-bottom-2"></div>
 

--- a/app/views/shared/forms/_text_fields.html.erb
+++ b/app/views/shared/forms/_text_fields.html.erb
@@ -6,8 +6,10 @@
 <div class="govuk-form-group <%= group_error_class %>">
   <%= form.label field_name, class: ['govuk-label'] %>
   <% hint = t(".#{field_name}_hint", default: '') %>
-    <% if hint.present? %>
-      <%= content_tag(:span, hint, id: "#{field_name}-hint".dasherize, class: ['govuk-hint']) %>
+    <% if local_assigns[:hint?] == true %>
+      <% if hint.present? %>
+        <%= content_tag(:span, hint, id: "#{field_name}-hint".dasherize, class: ['govuk-hint']) %>
+      <% end %>
     <% end %>
   <% if form.object.errors[field_with_error].any? %>
     <%= content_tag(:span, form.object.errors[field_name].first, class: ['govuk-error-message']) %>

--- a/app/views/shared/forms/_text_fields.html.erb
+++ b/app/views/shared/forms/_text_fields.html.erb
@@ -6,7 +6,7 @@
 <div class="govuk-form-group <%= group_error_class %>">
   <%= form.label field_name, class: ['govuk-label'] %>
   <% hint = t(".#{field_name}_hint", default: '') %>
-  <% if local_assigns[:hint?] && hint.present? %>
+  <% if !local_assigns[:hide_hint?] && hint.present? %>
     <%= content_tag(:span, hint, id: "#{field_name}-hint".dasherize, class: ['govuk-hint']) %>
   <% end %>
   <% if form.object.errors[field_with_error].any? %>

--- a/app/views/shared/forms/_text_fields.html.erb
+++ b/app/views/shared/forms/_text_fields.html.erb
@@ -6,11 +6,9 @@
 <div class="govuk-form-group <%= group_error_class %>">
   <%= form.label field_name, class: ['govuk-label'] %>
   <% hint = t(".#{field_name}_hint", default: '') %>
-    <% if local_assigns[:hint?] == true %>
-      <% if hint.present? %>
-        <%= content_tag(:span, hint, id: "#{field_name}-hint".dasherize, class: ['govuk-hint']) %>
-      <% end %>
-    <% end %>
+  <% if local_assigns[:hint?] && hint.present? %>
+    <%= content_tag(:span, hint, id: "#{field_name}-hint".dasherize, class: ['govuk-hint']) %>
+  <% end %>
   <% if form.object.errors[field_with_error].any? %>
     <%= content_tag(:span, form.object.errors[field_name].first, class: ['govuk-error-message']) %>
   <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -8,6 +8,7 @@ en:
     forms:
       text_fields:
         national_insurance_number_hint: "For example, ‘QQ 12 34 56 C'"
+        postcode_hint: 'Postcode must be a valid UK postcode.'
       date_input_fields:
         date_of_birth_label: 'Date of birth'
         date_of_birth_hint: 'For example, 31 3 1980'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -102,8 +102,6 @@ en:
       postcode_hint: 'Postcode must be a valid UK postcode.'
     address_manual:
       heading: "Enter your client's address manually"
-    address_manual:
-      heading: "Enter your client's address manually"
     address_selection:
       heading: "Enter your client's home address"
     client_detail:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -100,6 +100,8 @@ en:
     address_lookup:
       heading: "Enter your client's home address"
       postcode_hint: 'Postcode must be a valid UK postcode.'
+    address_manual:
+      heading: "Enter your client's address manually"
     address_selection:
       heading: "Enter your client's home address"
     client_detail:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -102,6 +102,8 @@ en:
       postcode_hint: 'Postcode must be a valid UK postcode.'
     address_manual:
       heading: "Enter your client's address manually"
+    address_manual:
+      heading: "Enter your client's address manually"
     address_selection:
       heading: "Enter your client's home address"
     client_detail:

--- a/spec/requests/providers/address_lookups_spec.rb
+++ b/spec/requests/providers/address_lookups_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe 'address lookup requests', type: :request do
 
       context 'but the lookup does not return any valid results' do
         let(:postcode) { 'SW1H 9AJ' } # NOTE: test account does not return any results for this postcode
-        let(:form_heading) { "Enter your client's address manually" }
+        let(:form_heading) { "Enter your client's home address" }
         let(:error_message) { "Sorry - we couldn't find any addresses for that postcode, please enter the address manually" }
 
         it 'renders the manual address selection page' do

--- a/spec/requests/providers/addresses_request_spec.rb
+++ b/spec/requests/providers/addresses_request_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe 'address requests', type: :request do
       get_request
 
       expect(response).to be_successful
-      expect(response.body).to include(CGI.escapeHTML("Enter your client's address manually"))
+      expect(unescaped_response_body).to include("Enter your client's address manually")
     end
   end
 
@@ -71,7 +71,7 @@ RSpec.describe 'address requests', type: :request do
 
       it 'renders the form again if validation fails' do
         post_request
-        expect(response.body).to include(CGI.escapeHTML("Enter your client's address manually"))
+        expect(unescaped_response_body).to include("Enter your client's address manually")
         expect(response.body).to include('Enter a postcode')
       end
     end

--- a/spec/requests/providers/addresses_request_spec.rb
+++ b/spec/requests/providers/addresses_request_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe 'address requests', type: :request do
       get_request
 
       expect(response).to be_successful
-      expect(response.body).to include(CGI.escapeHTML("Enter your client's home address"))
+      expect(response.body).to include(CGI.escapeHTML("Enter your client's address manually"))
     end
   end
 
@@ -71,7 +71,7 @@ RSpec.describe 'address requests', type: :request do
 
       it 'renders the form again if validation fails' do
         post_request
-        expect(response.body).to include(CGI.escapeHTML("Enter your client's home address"))
+        expect(response.body).to include(CGI.escapeHTML("Enter your client's address manually"))
         expect(response.body).to include('Enter a postcode')
       end
     end

--- a/spec/requests/providers/addresses_request_spec.rb
+++ b/spec/requests/providers/addresses_request_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe 'address requests', type: :request do
       get_request
 
       expect(response).to be_successful
-      expect(response.body).to include('Enter your client&#39;s home address')
+      expect(response.body).to include(CGI.escapeHTML("Enter your client's home address"))
     end
   end
 
@@ -71,7 +71,7 @@ RSpec.describe 'address requests', type: :request do
 
       it 'renders the form again if validation fails' do
         post_request
-        expect(response.body).to include('Enter your client&#39;s home address')
+        expect(response.body).to include(CGI.escapeHTML("Enter your client's home address"))
         expect(response.body).to include('Enter a postcode')
       end
     end

--- a/spec/requests/providers/addresses_request_spec.rb
+++ b/spec/requests/providers/addresses_request_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe 'address requests', type: :request do
       get_request
 
       expect(response).to be_successful
-      expect(response.body).to include("Enter your client's address manually")
+      expect(response.body).to include('Enter your client&#39;s home address')
     end
   end
 
@@ -71,7 +71,7 @@ RSpec.describe 'address requests', type: :request do
 
       it 'renders the form again if validation fails' do
         post_request
-        expect(response.body).to include("Enter your client's address manually")
+        expect(response.body).to include('Enter your client&#39;s home address')
         expect(response.body).to include('Enter a postcode')
       end
     end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-179)

- Added a new local variable to the Text Field partial that determines if a hint is displayed
This means on one page we can display the postcode field with a hint and on another without the hint
- Correcting the postcode text field partial call seemed to have fixed the error anchor link
- Added some logic that determines which title the manual address page should display depending on whether the user chose to input the address manual or was redirected after a lookup fail

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unneccessary whitespace changes. These make diffs harder to read and conflicts more likely. 
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
