### PR TITLE
Fix UAT branching name

### DIFF
--- a/bin/uat_deploy
+++ b/bin/uat_deploy
@@ -22,7 +22,7 @@ clean_old_releases() {
 
 deploy() {
   IMG_REPO="$ECR_ENDPOINT/$GITHUB_TEAM_NAME_SLUG/$REPO_NAME"
-  RELEASE_BRANCH=$(echo $CIRCLE_BRANCH | rev | cut -c1-30 | rev | tr -s ' _/[]()')
+  RELEASE_BRANCH=$(echo $CIRCLE_BRANCH | rev | cut -c1-30 | rev | tr -s ' _/[]()' '-' | sed "s/^-//")
   RELEASE_NAME="$APPLICATION_DEPLOY_NAME-$RELEASE_BRANCH"
   RELEASE_HOST="$RELEASE_BRANCH-$UAT_HOST"
 


### PR DESCRIPTION
## What 🐛 

During the move of the UAT deploy logic to this script, introduced in https://github.com/ministryofjustice/laa-apply-for-legal-aid/pull/67 I've incidentally introduced a bug whereas the `tr` command was no longer doing a replacement of the characters that we don't want as part of the name.

Also, this ensures, for the purposes of having a valid URL, that the branch name does not start with a `-`, which is being used to form the final UAT host URL.