### PR TITLE
Reverted autofocus changes and added correct autofocus on element on …

### DIFF
--- a/app/views/providers/address_selections/new.html.erb
+++ b/app/views/providers/address_selections/new.html.erb
@@ -36,7 +36,7 @@
             <%= content_tag(:span, @form.errors[:address].first, class: ['govuk-error-message']) %>
           <% end %>
           <% input_error_class = @form.errors[:address].any? ? 'govuk-select--error' : '' %>
-          <%= f.select(:address, @addresses.collect { |a| [a.full_address, a.to_json] }, { include_blank: "#{@addresses.size} addresses found" }, class: "govuk-select govuk-!-width-two-thirds #{input_error_class}", autofocus: true) %>
+          <%= f.select(:address, @addresses.collect { |a| [a.full_address, a.to_json] }, { include_blank: "#{@addresses.size} addresses found" }, class: "govuk-select govuk-!-width-two-thirds #{input_error_class}", id: :address) %>
         </div>
       </div>
 


### PR DESCRIPTION
## What

https://dsdmoj.atlassian.net/browse/AP-184

Reverted autofocus changes and added correct autofocus on element when error summary link is clicked

Added ID to select element as it was not being automatically generated correctly

## Checklist

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unneccessary whitespace changes. These make diffs harder to read and conflicts more likely. 
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.


