### PR TITLE
Retrieve Organisation from postcode API results

### DIFF
--- a/app/forms/applicants/address_selection_form.rb
+++ b/app/forms/applicants/address_selection_form.rb
@@ -4,7 +4,7 @@ module Applicants
 
     form_for Address
 
-    attr_accessor :applicant_id, :address, :postcode, :address_line_one, :address_line_two, :city
+    attr_accessor :applicant_id, :address, :postcode, :address_line_one, :address_line_two, :city, :organisation
 
     before_validation :deserialize_address
 
@@ -23,6 +23,7 @@ module Applicants
     def deserialize_address
       return unless address.present?
       hash = JSON.parse(address)
+      attributes[:organisation] = hash['organisation']
       attributes[:address_line_one] = hash['address_line_one']
       attributes[:address_line_two] = hash['address_line_two']
       attributes[:city] = hash['city']

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -18,15 +18,16 @@ class Address < ApplicationRecord
 
   def self.from_json(json)
     attrs = JSON.parse(json)
-    new(attrs.slice('address_line_one', 'address_line_two', 'city', 'postcode'))
+    new(attrs.slice('organisation', 'address_line_one', 'address_line_two', 'city', 'postcode'))
   end
 
   def full_address
-    [address_line_one, address_line_two, city, postcode].compact.join(', ')
+    [organisation, address_line_one, address_line_two, city, postcode].compact.reject(&:blank?).join(', ')
   end
 
   def to_json
     {
+      organisation: organisation,
       address_line_one: address_line_one,
       address_line_two: address_line_two,
       city: city,

--- a/app/serializers/address_serializer.rb
+++ b/app/serializers/address_serializer.rb
@@ -1,3 +1,3 @@
 class AddressSerializer < ActiveModel::Serializer
-  attributes :address_line_one, :address_line_two, :city, :county, :postcode, :applicant_id
+  attributes :organisation, :address_line_one, :address_line_two, :city, :county, :postcode, :applicant_id
 end

--- a/app/services/map_address_lookup_results.rb
+++ b/app/services/map_address_lookup_results.rb
@@ -16,13 +16,12 @@ class MapAddressLookupResults
       mem << result[part]
     end
 
-    attributes = {
+    Address.new(
+      organisation: result['ORGANISATION_NAME'],
       address_line_one: line_one_parts.compact.join(', '),
       address_line_two: line_two_parts.compact.join(', '),
       city: result['POST_TOWN'],
       postcode: result['POSTCODE']
-    }
-
-    Address.new(attributes)
+    )
   end
 end

--- a/db/migrate/20181113153145_add_organisation_to_address.rb
+++ b/db/migrate/20181113153145_add_organisation_to_address.rb
@@ -1,0 +1,5 @@
+class AddOrganisationToAddress < ActiveRecord::Migration[5.2]
+  def change
+    add_column :addresses, :organisation, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_09_095753) do
+ActiveRecord::Schema.define(version: 2018_11_13_153145) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -25,6 +25,7 @@ ActiveRecord::Schema.define(version: 2018_11_09_095753) do
     t.uuid "applicant_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "organisation"
     t.index ["applicant_id"], name: "index_addresses_on_applicant_id"
   end
 

--- a/spec/requests/applicants/create_address_spec.rb
+++ b/spec/requests/applicants/create_address_spec.rb
@@ -59,6 +59,7 @@ RSpec.describe 'POST /v1/applicants/:applicant_id/addresses', type: :request do
     post_request.call
 
     expected_json = {
+      organisation: nil,
       address_line_one: '123',
       address_line_two: 'High Street',
       city: 'London',


### PR DESCRIPTION
## What

[AP-181](https://dsdmoj.atlassian.net/browse/AP-181)

There are certain cases where the Ordnance Survey postcode API returns
results which do not have any values which we include in line_one or
line_two of the address. SW1A 1AA is an example of this. This means
that when the address is displayed for selection it is meaningless to
the user.

To address this, we will retrieve the ORGANISATION_NAME from the result 
and include it in the address. It will be persisted to the database. No change 
will be made to allow a user to manually enter an Organisation as part of an
address.

The story also refers to scenarios where no results are being returned by 
the API, even though it is a valid postcode (eg. SW1H 9AJ). I've opened a 
ticket with Ordnance Survey about this and will update Jira with the results 
of their investigation.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unneccessary whitespace changes. These make diffs harder to read and conflicts more likely. 
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
