### PR TITLE
AP218 Fix proceeding search item not clickable

### DIFF
--- a/app/assets/javascripts/proceeding_types.es6
+++ b/app/assets/javascripts/proceeding_types.es6
@@ -1,6 +1,5 @@
 var submitForm = proceedingItem => {
-  $('#proceeding_code').val($(proceedingItem).attr('id'));
-  $('#new_legal_aid_application').submit();
+  $(proceedingItem).find('form').submit();
 }
 
 $.getJSON("/v1/proceeding_types", function (proceedings_data) {


### PR DESCRIPTION
[JIRA AP218](https://dsdmoj.atlassian.net/browse/AP-218)

The JavaScript code that handled submitting the form on clicking the div containing the proceeding type, had not been updated to match recent changes. That is, originally there was only one form and each button modified that form submission. Now there is a form for each proceeding type. Clicking the div now submits the form within that div.

Also note that this fixes the issue for keyboard submission too.