### PR TITLE
Update govuk-frontend to the most recent version (2.4.0)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,9 +4,9 @@
   "lockfileVersion": 1,
   "dependencies": {
     "govuk-frontend": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-1.1.1.tgz",
-      "integrity": "sha512-Ut4BWcW4LZrHMe5E+0+Py6yScoguDnZ17GohA2okbTw/nzhp4st2p1AK9N9dvqaLYS1yw0pcfgRP5jzyCZ14QQ=="
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-2.4.0.tgz",
+      "integrity": "sha512-WSecWLGM1qZ48UD0YGGWOfaBqrWtwf39cOUAuC8+SMNh7kkZ6Ou2Y7+d3Bt8OEPaFNFR2N2vZO2WRnT2gaCjMg=="
     },
     "js-search": {
       "version": "1.4.2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "laa-apply-for-legal-aid",
   "private": true,
   "dependencies": {
-    "govuk-frontend": "^1.1.1",
+    "govuk-frontend": "2.4.0",
     "js-search": "^1.4.2"
   }
 }


### PR DESCRIPTION
govuk-frontend is currently on version 1.3.0, the most recent version is 2.4.0 which was released 11 days ago. This change brings the version up to date without anything breaking.

[Link to story](https://dsdmoj.atlassian.net/browse/AP-219)

## Checklist
- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unneccessary whitespace changes. These make diffs harder to read and conflicts more likely. 
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
