### PR TITLE
Remove Warning from about_the_financial_assessments

### DIFF
--- a/app/views/providers/about_the_financial_assessments/show.html.erb
+++ b/app/views/providers/about_the_financial_assessments/show.html.erb
@@ -11,10 +11,7 @@
 
     <p class="govuk-body"><%= t '.para_3' %></p>
 
-    <div class="govuk-warning-text">
-      <span class="govuk-warning-text__icon govuk-circle" aria-hidden="true">i</span>
-      <strong class="govuk-warning-text__text"><%= t '.list.title' %></strong>
-    </div>
+    <h2 class="govuk-heading-m"><%= t '.list.title' %></h2>
 
     <p class="govuk-body">
       <ul class="govuk-list govuk-list--bullet">


### PR DESCRIPTION
[AP-210](https://dsdmoj.atlassian.net/browse/AP-210)

The original design included a warning symbol (a circle with an
exclamation mark in it). During review by the designer/product manager
it was decided that this was unnecessary and can be replaced with a
govuk-heading-m tag.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unneccessary whitespace changes. These make diffs harder to read and conflicts more likely. 
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
