### PR TITLE
AP-213 Add Outstanding Mortgage page to Citizen journey

### DIFF
--- a/app/controllers/citizens/outstanding_mortgages_controller.rb
+++ b/app/controllers/citizens/outstanding_mortgages_controller.rb
@@ -1,0 +1,30 @@
+module Citizens
+  class OutstandingMortgagesController < ApplicationController
+    before_action :authenticate_applicant!
+
+    def show
+      @form = LegalAidApplications::OutstandingMortgageForm.new(model: legal_aid_application)
+    end
+
+    def update
+      @form = LegalAidApplications::OutstandingMortgageForm.new(legal_aid_application_params)
+      if @form.save
+        render plain: 'Landing page: 1d. Do you share ownership of your home?'
+      else
+        render :show
+      end
+    end
+
+    private
+
+    def legal_aid_application_params
+      params.require(:legal_aid_application).permit(:outstanding_mortgage_amount).tap do |hash|
+        hash[:model] = legal_aid_application
+      end
+    end
+
+    def legal_aid_application
+      @legal_aid_application ||= LegalAidApplication.find(session[:current_application_ref])
+    end
+  end
+end

--- a/app/forms/legal_aid_applications/outstanding_mortgage_form.rb
+++ b/app/forms/legal_aid_applications/outstanding_mortgage_form.rb
@@ -1,0 +1,32 @@
+module LegalAidApplications
+  class OutstandingMortgageForm
+    include BaseForm
+    form_for LegalAidApplication
+    attr_accessor :outstanding_mortgage_amount
+
+    before_validation :clean_up_input
+    validates(
+      :outstanding_mortgage_amount,
+      presence: true,
+      numericality: { greater_than: 0, allow_blank: true }
+    )
+
+    def initialize(*args)
+      super
+      @outstanding_mortgage_amount ||= model.outstanding_mortgage_amount
+    end
+
+    private
+
+    def clean_up_input
+      outstanding_mortgage_amount.delete!(',') if outstanding_mortgage_amount.is_a?(String) && valid_number_pattern =~ outstanding_mortgage_amount
+    end
+
+    # Starts with a digit
+    # Then perhaps any combination of digit, ',' or '_'
+    # Then perhaps dot followed by up to 2 digits
+    def valid_number_pattern
+      /\A\d[,_\d]*(\.\d{,2})?\z/
+    end
+  end
+end

--- a/app/helpers/gov_uk_form_helper.rb
+++ b/app/helpers/gov_uk_form_helper.rb
@@ -69,6 +69,15 @@ module GovUkFormHelper
     content_tag :span, text, merge_with_class(args, 'govuk-error-message')
   end
 
+  def govuk_error_class(error)
+    return '' unless error.present?
+    'govuk-input--error'
+  end
+
+  def govuk_currency_input_wrapper(&block)
+    render 'shared/forms/currency_input_wrapper', text_field: capture(&block)
+  end
+
   # Adds or appends `class_text` to `args[:class]`. So:
   #   args = { id: 'thing' }
   #   merge_with_class(args, 'bar') => { class: 'bar', id: 'thing' }

--- a/app/helpers/gov_uk_form_helper.rb
+++ b/app/helpers/gov_uk_form_helper.rb
@@ -69,15 +69,6 @@ module GovUkFormHelper
     content_tag :span, text, merge_with_class(args, 'govuk-error-message')
   end
 
-  def govuk_error_class(error)
-    return '' unless error.present?
-    'govuk-input--error'
-  end
-
-  def govuk_currency_input_wrapper(&block)
-    render 'shared/forms/currency_input_wrapper', text_field: capture(&block)
-  end
-
   # Adds or appends `class_text` to `args[:class]`. So:
   #   args = { id: 'thing' }
   #   merge_with_class(args, 'bar') => { class: 'bar', id: 'thing' }

--- a/app/lib/govuk_elements_form_builder/form_builder.rb
+++ b/app/lib/govuk_elements_form_builder/form_builder.rb
@@ -82,7 +82,7 @@ module GovukElementsFormBuilder
       message = hint_message(attribute)
       return unless message
 
-      content_tag(:span, message, class: 'govuk-hint')
+      content_tag(:span, message, class: 'govuk-hint', id: "#{attribute}_hint")
     end
 
     def error_tag(attribute)

--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -74,6 +74,10 @@ class LegalAidApplication < ApplicationRecord
     applicant_updated_after_benefit_check_result_updated?
   end
 
+  def outstanding_mortgage?
+    outstanding_mortgage_amount?
+  end
+
   private
 
   def applicant_updated_after_benefit_check_result_updated?

--- a/app/views/citizens/outstanding_mortgages/show.html.erb
+++ b/app/views/citizens/outstanding_mortgages/show.html.erb
@@ -1,4 +1,4 @@
-<%= render 'shared/forms/error_summary', model: @form, attribute_prefix: :legal_aid_application_ %>
+<%= render 'shared/forms/error_summary', model: @form %>
 
 <fieldset class="govuk-fieldset">
   <div class="govuk-!-padding-bottom-2"></div>
@@ -15,19 +15,12 @@
 
         <%= govuk_form_group(
               show_error_if: form.object.errors[:outstanding_mortgage_amount].present?,
-              input: :legal_aid_application_outstanding_mortgage_amount,
+              input: :outstanding_mortgage_amount,
               hint_id: :outstanding_mortgage_amount_hint
             ) do %>
 
           <%= govuk_fieldset_header t('.outstanding_mortgage_amount_heading'), padding_below: 6 %>
-
-          <%= form.label :outstanding_mortgage_amount, t('.outstanding_mortgage_amount_label'), class: 'govuk-label' %>
-          <%= govuk_hint t('.outstanding_mortgage_amount_hint'), id: :outstanding_mortgage_amount_hint %>
-          <%= govuk_error_message form.object.errors[:outstanding_mortgage_amount].first %>
-          <%= govuk_currency_input_wrapper do %>
-            <% input_error_class = govuk_error_class(form.object.errors[:outstanding_mortgage_amount]) %>
-            <%= form.text_field :outstanding_mortgage_amount, class: "govuk-input govuk-currency-input__inner__input #{input_error_class}" %>
-          <% end %>
+          <%= form.govuk_text_field :outstanding_mortgage_amount, input_prefix: t('currency.gbp') %>
         <% end %>
 
         <div class="govuk-!-padding-bottom-2"></div>

--- a/app/views/citizens/outstanding_mortgages/show.html.erb
+++ b/app/views/citizens/outstanding_mortgages/show.html.erb
@@ -20,7 +20,7 @@
             ) do %>
 
           <%= govuk_fieldset_header t('.outstanding_mortgage_amount_heading'), padding_below: 6 %>
-          <%= form.govuk_text_field :outstanding_mortgage_amount, input_prefix: t('currency.gbp') %>
+          <%= form.govuk_text_field :outstanding_mortgage_amount, input_prefix: t('currency.gbp'), class: 'govuk-!-width-one-third' %>
         <% end %>
 
         <div class="govuk-!-padding-bottom-2"></div>

--- a/app/views/citizens/outstanding_mortgages/show.html.erb
+++ b/app/views/citizens/outstanding_mortgages/show.html.erb
@@ -1,0 +1,49 @@
+<%= render 'shared/forms/error_summary', model: @form, attribute_prefix: :legal_aid_application_ %>
+
+<fieldset class="govuk-fieldset">
+  <div class="govuk-!-padding-bottom-2"></div>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= form_with(
+            model: @form,
+            url: citizens_outstanding_mortgage_path,
+            method: :patch,
+            local: true
+          ) do |form| %>
+        <div class="govuk-!-padding-bottom-2"></div>
+
+        <%= govuk_form_group(
+              show_error_if: form.object.errors[:outstanding_mortgage_amount].present?,
+              input: :legal_aid_application_outstanding_mortgage_amount,
+              hint_id: :outstanding_mortgage_amount_hint
+            ) do %>
+
+          <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+            <h1 class="govuk-fieldset__heading">
+              <%= t('.outstanding_mortgage_amount_heading') %>
+            </h1>
+          </legend>
+
+          <div class="govuk-!-padding-bottom-6"></div>
+
+          <%= form.label :outstanding_mortgage_amount, t('.outstanding_mortgage_amount_label'), class: 'govuk-label' %>
+          <%= govuk_hint t('.outstanding_mortgage_amount_hint'), id: :outstanding_mortgage_amount_hint %>
+          <%= govuk_error_message form.object.errors[:outstanding_mortgage_amount].first %>
+          <%= govuk_currency_input_wrapper do %>
+            <% input_error_class = govuk_error_class(form.object.errors[:outstanding_mortgage_amount]) %>
+            <%= form.text_field :outstanding_mortgage_amount, class: "govuk-input govuk-currency-input__inner__input #{input_error_class}" %>
+          <% end %>
+        <% end %>
+
+        <div class="govuk-!-padding-bottom-2"></div>
+
+        <div class="govuk-grid-row">
+          <div class="govuk-grid-column-two-thirds">
+            <%= form.submit t('generic.continue'), id: 'continue', class: 'govuk-button govuk-button' %>
+          <% end %>
+         </div>
+       </div>
+    </div>
+  </div>
+</fieldset>

--- a/app/views/citizens/outstanding_mortgages/show.html.erb
+++ b/app/views/citizens/outstanding_mortgages/show.html.erb
@@ -19,13 +19,7 @@
               hint_id: :outstanding_mortgage_amount_hint
             ) do %>
 
-          <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
-            <h1 class="govuk-fieldset__heading">
-              <%= t('.outstanding_mortgage_amount_heading') %>
-            </h1>
-          </legend>
-
-          <div class="govuk-!-padding-bottom-6"></div>
+          <%= govuk_fieldset_header t('.outstanding_mortgage_amount_heading'), padding_below: 6 %>
 
           <%= form.label :outstanding_mortgage_amount, t('.outstanding_mortgage_amount_label'), class: 'govuk-label' %>
           <%= govuk_hint t('.outstanding_mortgage_amount_hint'), id: :outstanding_mortgage_amount_hint %>
@@ -41,9 +35,9 @@
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-two-thirds">
             <%= form.submit t('generic.continue'), id: 'continue', class: 'govuk-button govuk-button' %>
-          <% end %>
          </div>
        </div>
+      <% end %>
     </div>
   </div>
 </fieldset>

--- a/app/views/shared/forms/_form_group.html.erb
+++ b/app/views/shared/forms/_form_group.html.erb
@@ -1,5 +1,5 @@
 <div class="govuk-form-group  <%= error_class %>">
-  <fieldset class="govuk-fieldset" <%= aria_describedby.html_safe %>>
+  <fieldset class="govuk-fieldset" <%= aria_describedby&.html_safe %>>
     <%= content %>
   </fieldset>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -10,6 +10,7 @@ en:
       email: We'll use this to send your client a secure link
       postcode: Postcode must be a valid UK postcode.
       percentage_home: Your name must be on the property deeds, lease, freehold or mortgage.
+      outstanding_mortgage_amount: Check the statement from your mortgage provider or lender.        
   shared:
     forms:
       date_input_fields:
@@ -35,6 +36,7 @@ en:
         email: 'Email address'
       legal_aid_application:
         percentage_home: Enter the estimated percentage share you own
+        outstanding_mortgage_amount: Enter outstanding mortgage amount
       applicants/address_form:
         <<: *address_attrs
       applicants/basic_details_form:
@@ -258,8 +260,6 @@ en:
     outstanding_mortgages:
       show:
         outstanding_mortgage_amount_heading: What is the outstanding mortgage on your home?
-        outstanding_mortgage_amount_hint: Check the statement from your mortgage provider or lender.
-        outstanding_mortgage_amount_label: Enter outstanding mortgage amount
   currency:
     gbp: £
     eur: €

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -10,7 +10,7 @@ en:
       email: We'll use this to send your client a secure link
       postcode: Postcode must be a valid UK postcode.
       percentage_home: Your name must be on the property deeds, lease, freehold or mortgage.
-      outstanding_mortgage_amount: Check the statement from your mortgage provider or lender.        
+      outstanding_mortgage_amount: Check the statement from your mortgage provider or lender        
   shared:
     forms:
       date_input_fields:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -100,6 +100,10 @@ en:
               blank: Enter an estimated value for your home
               not_a_number: &property_value_nan Estimated value must be an amount of money, like 80,000
               greater_than: *property_value_nan
+            outstanding_mortgage_amount:
+              blank: Enter the outstanding mortgage amount
+              not_a_number: &outstanding_mortgage_amount_nan 'Mortgage amount must be an amount of money, like 60,000'
+              greater_than: *outstanding_mortgage_amount_nan
   activerecord:
     errors:
       models:
@@ -251,6 +255,11 @@ en:
         field_set_header: How much is your home worth?
         label: Enter the estimated value of your home
         hint: You can use property websites to find the estimated value.
+    outstanding_mortgages:
+      show:
+        outstanding_mortgage_amount_heading: What is the outstanding mortgage on your home?
+        outstanding_mortgage_amount_hint: Check the statement from your mortgage provider or lender.
+        outstanding_mortgage_amount_label: Enter outstanding mortgage amount
   currency:
     gbp: £
     eur: €

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,7 @@ Rails.application.routes.draw do
     resources :additional_accounts, only: %i[index create new update]
     resource :own_home, only: %i[show update]
     resource :percentage_home, only: %i[show update]
+    resource :outstanding_mortgage, only: %i[show update]
   end
 
   namespace :providers do

--- a/db/migrate/20181206100314_add_outstanding_mortgage_amount_to_legal_aid_applications.rb
+++ b/db/migrate/20181206100314_add_outstanding_mortgage_amount_to_legal_aid_applications.rb
@@ -1,0 +1,5 @@
+class AddOutstandingMortgageAmountToLegalAidApplications < ActiveRecord::Migration[5.2]
+  def change
+    add_column :legal_aid_applications, :outstanding_mortgage_amount, :decimal
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_12_06_132736) do
+ActiveRecord::Schema.define(version: 2018_12_06_100314) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -144,6 +144,7 @@ ActiveRecord::Schema.define(version: 2018_12_06_132736) do
     t.string "own_home"
     t.decimal "percentage_home"
     t.decimal "property_value", precision: 10, scale: 2
+    t.decimal "outstanding_mortgage_amount"
     t.index ["applicant_id"], name: "index_legal_aid_applications_on_applicant_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_12_06_100314) do
+ActiveRecord::Schema.define(version: 2018_12_06_132736) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"

--- a/spec/forms/outstanding_mortgage_form_spec.rb
+++ b/spec/forms/outstanding_mortgage_form_spec.rb
@@ -1,0 +1,99 @@
+require 'rails_helper'
+
+RSpec.describe LegalAidApplications::OutstandingMortgageForm, type: :form do
+  let(:legal_aid_application) do
+    create :legal_aid_application, outstanding_mortgage_amount: nil
+  end
+  let(:amount) { Faker::Number.decimal(4) }
+  let(:params) do
+    {
+      model: legal_aid_application,
+      outstanding_mortgage_amount: amount
+    }
+  end
+  subject { described_class.new(params) }
+
+  describe '#outstanding_mortgage_amount' do
+    let(:existing_amount) { Faker::Number.decimal(4) }
+    let(:legal_aid_application) do
+      create :legal_aid_application, outstanding_mortgage_amount: existing_amount
+    end
+    it 'matches the value in params' do
+      expect(subject.outstanding_mortgage_amount).to eq(amount)
+    end
+    context 'when no amount passed in' do
+      let(:params) do
+        { model: legal_aid_application }
+      end
+      it 'matches the existing amount' do
+        expect(subject.outstanding_mortgage_amount).to eq(existing_amount.to_d)
+      end
+    end
+  end
+
+  describe '#save' do
+    it 'does not create a new legal_aid_application' do
+      expect { subject.save }.not_to change { LegalAidApplication }
+    end
+
+    context 'is called' do
+      before do
+        subject.save
+        legal_aid_application.reload
+      end
+
+      it 'updates ammount' do
+        expect(legal_aid_application.outstanding_mortgage_amount).to eq(amount.to_d)
+      end
+
+      it 'flags outstanding_mortgage' do
+        expect(legal_aid_application.outstanding_mortgage?).to be_truthy
+      end
+
+      context 'with an empty input' do
+        let(:amount) { '' }
+        it 'generates an error' do
+          expect(subject.errors[:outstanding_mortgage_amount]).to contain_exactly('Enter the outstanding mortgage amount')
+        end
+
+        it 'does not update model' do
+          expect(legal_aid_application.outstanding_mortgage_amount).to be_nil
+          expect(legal_aid_application.outstanding_mortgage?).to be_falsey
+        end
+      end
+
+      context 'with something not a number' do
+        let(:amount) { 'not a number' }
+        it 'generates an error' do
+          expect(subject.errors[:outstanding_mortgage_amount]).to contain_exactly('Mortgage amount must be an amount of money, like 60,000')
+        end
+
+        it 'does not update model' do
+          expect(legal_aid_application.outstanding_mortgage_amount).to be_nil
+          expect(legal_aid_application.outstanding_mortgage?).to be_falsey
+        end
+      end
+
+      context 'with negative numbers' do
+        let(:amount) { Faker::Number.negative }
+        it 'generates an error' do
+          expect(subject.errors[:outstanding_mortgage_amount]).to contain_exactly('Mortgage amount must be an amount of money, like 60,000')
+        end
+      end
+
+      context 'with zero' do
+        let(:amount) { 0 }
+        it 'generates an error' do
+          expect(subject.errors[:outstanding_mortgage_amount]).to contain_exactly('Mortgage amount must be an amount of money, like 60,000')
+        end
+      end
+
+      context 'with comma delimiter' do
+        let(:amount) { '12,345' }
+        it 'converts it to a number' do
+          expect(legal_aid_application.outstanding_mortgage_amount).to eq(12_345)
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
+++ b/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
@@ -28,13 +28,14 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
   it 'includes a hint message' do
     output = builder.govuk_text_field(:email)
 
-    expect(output).to include('<span class="govuk-hint">')
+    expect(output).to include('class="govuk-hint"')
+    expect(output).to include('id="email_hint"')
   end
 
   it 'does not include a hint message if hide_hint? is true' do
     output = builder.govuk_text_field(:email, hide_hint?: true)
 
-    expect(output).not_to include('<span class="govuk-hint">')
+    expect(output).not_to include('class="govuk-hint"')
   end
 
   context 'has an input_prefix option' do

--- a/spec/requests/citizens/outstanding_mortgage_spec.rb
+++ b/spec/requests/citizens/outstanding_mortgage_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+RSpec.describe 'citizen outstanding mortgage request', type: :request do
+  let(:legal_aid_application) { create :legal_aid_application, :with_applicant }
+  let(:secure_id) { legal_aid_application.generate_secure_id }
+
+  before do
+    get citizens_legal_aid_application_path(secure_id)
+    subject
+  end
+
+  describe 'GET /citizens/outstanding_mortgage' do
+    subject { get citizens_outstanding_mortgage_path }
+    it 'renders successfully' do
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe 'PATCH /citizens/outstanding_mortgage' do
+    let(:amount) { Faker::Number.decimal(4) }
+    let(:params) do
+      { legal_aid_application: { outstanding_mortgage_amount: amount } }
+    end
+    subject { patch citizens_outstanding_mortgage_path, params: params }
+
+    xit 'redirects to the next step in Citizen jouney' do
+      # TODO: - set redirect path when known
+      expect(response).to redirect_to(:some_path)
+    end
+
+    it 'displays holding page' do
+      # TODO: Delete when redirect set
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to match('Landing page')
+    end
+
+    it 'updates the legal_aid_application' do
+      expect(legal_aid_application.reload.outstanding_mortgage_amount).to eq(amount.to_d)
+    end
+
+    it 'does not displays an error' do
+      expect(response.body).not_to match('govuk-error-message')
+      expect(response.body).not_to match('govuk-form-group--error')
+    end
+
+    context 'with invalid input' do
+      let(:amount) { 'invalid' }
+
+      it 'renders successfully' do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'displays an error' do
+        expect(response.body).to match('govuk-error-message')
+        expect(response.body).to match('govuk-form-group--error')
+      end
+    end
+  end
+end


### PR DESCRIPTION
[AP-213](https://dsdmoj.atlassian.net/browse/AP-213)

Added a new citizens controller with show and update views.

Some extra complexity was added to get the £ sign within the input field.

GET renders:

![show_outstanding_mortgate](https://user-images.githubusercontent.com/213040/49593336-38872d00-f96b-11e8-8de2-1841e02b9362.png)

PATCH with invalid input renders: 

![show_outstanding_mortgage_error](https://user-images.githubusercontent.com/213040/49593350-463cb280-f96b-11e8-892e-ccb4f006152d.png)

