### PR TITLE
Add to govuk_text_field an option to insert a prefix inside the input

### DIFF
--- a/app/assets/stylesheets/govuk-prefix-input.scss
+++ b/app/assets/stylesheets/govuk-prefix-input.scss
@@ -1,0 +1,32 @@
+/*
+Used with:
+  <div class="govuk-prefix-input">
+    <div class="govuk-prefix-input__inner">
+      <span class="govuk-prefix-input__inner__unit">£</span>
+      <%= form.text_field :field_name, class: 'govuk-input govuk-prefix-input__inner__input' %>
+    </div>
+  </div>
+*/
+.govuk-prefix-input {
+  font-family: "nta", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  color: #0b0c0c;
+
+  &__inner {
+    position: relative;
+
+    &__unit {
+      line-height: 1.54;
+      font-size: 19px;
+      position: absolute;
+      bottom: 5px;
+      left: 10px;
+      font-weight: bold;
+    }
+
+    &__input.govuk-input {
+      padding-left: 26px;
+    }
+  }
+}

--- a/app/lib/govuk_elements_form_builder/form_builder.rb
+++ b/app/lib/govuk_elements_form_builder/form_builder.rb
@@ -26,7 +26,27 @@ module GovukElementsFormBuilder
       html.concat(hint_tag(attribute)) if !options[:hide_hint?] && hint_message(attribute)
       html.concat(error_tag(attribute)) if error?(attribute)
 
-      (html + text_field(attribute, options.except(:label, :label_options).merge(id: attribute))).html_safe
+      html.concat(field_tag(options, attribute))
+
+      html.html_safe
+    end
+
+    def field_tag(options, attribute)
+      input_prefix = options.delete(:input_prefix)
+      tag = text_field(attribute, options.except(:label, :label_options).merge(id: attribute))
+      return tag unless input_prefix
+
+      input_prefix_group(input_prefix) { tag }
+    end
+
+    def input_prefix_group(input_prefix)
+      content_tag :div, class: 'govuk-prefix-input' do
+        content_tag :div, class: 'govuk-prefix-input__inner' do
+          html = content_tag :span, input_prefix, class: 'govuk-prefix-input__inner__unit'
+          html.concat(yield)
+          html
+        end
+      end
     end
 
     # Given an attributes hash that could include any number of arbitrary keys, this method
@@ -42,6 +62,7 @@ module GovukElementsFormBuilder
     def field_classes!(options, attribute)
       default_classes = ['govuk-input']
       default_classes << 'govuk-input--error' if error?(options[:field_with_error] || attribute)
+      default_classes << 'govuk-prefix-input__inner__input' if options[:input_prefix]
 
       options ||= {}
       merge_attributes(options, default: { class: default_classes })

--- a/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
+++ b/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
@@ -37,6 +37,23 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
     expect(output).not_to include('<span class="govuk-hint">')
   end
 
+  context 'has an input_prefix option' do
+    let(:prefix) { '£' }
+
+    it 'includes a prefix ' do
+      output = builder.govuk_text_field(:email, input_prefix: prefix)
+
+      expected_output = [
+        '<div class="govuk-prefix-input">',
+        '<div class="govuk-prefix-input__inner">',
+        '<span class="govuk-prefix-input__inner__unit">',
+        prefix
+      ].join
+
+      expect(output).to include(expected_output)
+    end
+  end
+
   context 'when validation error on object' do
     before { resource.valid? }
 


### PR DESCRIPTION
To be used like this:

`govuk_text_field :home_value, input_prefix: '£'`
`govuk_text_field :home_percentage, input_prefix: '%'`

![image](https://user-images.githubusercontent.com/482806/49645656-adfb0800-fa14-11e8-8049-1fb2c4dfa99c.png)

![image](https://user-images.githubusercontent.com/482806/49645676-c23f0500-fa14-11e8-82f9-4c01c83a49ac.png)


## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unneccessary whitespace changes. These make diffs harder to read and conflicts more likely. 
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
