### PR TITLE
AP 217 Add restrictions that mean a Citizen cannot use capital assets

### DIFF
--- a/app/controllers/citizens/restrictions_controller.rb
+++ b/app/controllers/citizens/restrictions_controller.rb
@@ -1,0 +1,24 @@
+module Citizens
+  class RestrictionsController < ApplicationController
+    before_action :authenticate_applicant!
+
+    def index
+      legal_aid_application
+    end
+
+    def create
+      legal_aid_application.update!(legal_aid_application_params)
+      render plain: 'Holding page: Redirect to check you answers'
+    end
+
+    private
+
+    def legal_aid_application_params
+      params.require(:legal_aid_application).permit(restriction_ids: [])
+    end
+
+    def legal_aid_application
+      @legal_aid_application ||= LegalAidApplication.find(session[:current_application_ref])
+    end
+  end
+end

--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -10,6 +10,8 @@ class LegalAidApplication < ApplicationRecord
   has_many :proceeding_types, through: :application_proceeding_types
   has_one :benefit_check_result
   has_one :savings_amount
+  has_many :legal_aid_application_restrictions
+  has_many :restrictions, through: :legal_aid_application_restrictions
 
   before_create :create_app_ref
   before_save :set_open_banking_consent_choice_at

--- a/app/models/legal_aid_application_restriction.rb
+++ b/app/models/legal_aid_application_restriction.rb
@@ -1,0 +1,5 @@
+# Join object between LegalAidApplication and Restriction
+class LegalAidApplicationRestriction < ApplicationRecord
+  belongs_to :legal_aid_application
+  belongs_to :restriction
+end

--- a/app/models/restriction.rb
+++ b/app/models/restriction.rb
@@ -1,0 +1,25 @@
+class Restriction < ApplicationRecord
+  NAMES = %i[
+    reposession_or_deferred_interest
+    subject_matter_of_dispute
+    foreign_exchange_controls
+    restraint_or_freezing_order
+    bankruptcy
+    held_overseas
+  ].freeze
+
+  has_many :legal_aid_application_restrictions
+  has_many :legal_aid_applications, through: :legal_aid_application_restrictions
+
+  validates :name, presence: true, uniqueness: true
+
+  def self.populate
+    # using pluck rather than `find_or_create` in the iteration to reduce SQL calls
+    existing = pluck(:name).map(&:to_sym)
+    (NAMES - existing).each { |name| create!(name: name) }
+  end
+
+  def label_name
+    I18n.t("restrictions.names.#{name}")
+  end
+end

--- a/app/views/citizens/restrictions/index.html.erb
+++ b/app/views/citizens/restrictions/index.html.erb
@@ -1,0 +1,33 @@
+<% content_for :navigation do %>
+  <%# TODO: set correct back when Citizen journey set %>
+  <%= link_to t('generic.back'), '#', class: 'govuk-back-link', id: 'back' %>
+<% end %>
+
+<fieldset class="govuk-fieldset">
+  <div class="govuk-!-padding-bottom-2"></div>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl"><%= t('.h1-heading') %></h1>
+
+      <%= form_with(
+            model: @legal_aid_application,
+            url: citizens_restrictions_path,
+            method: :post,
+            local: true
+          ) do |form| %>
+        <%= govuk_form_group do %>
+          <div class="govuk-checkboxes">
+            <%= form.collection_check_boxes :restriction_ids, Restriction.all, :id, :label_name do |restriction_form| %>
+              <div class="govuk-checkboxes__item">
+                <%= restriction_form.check_box(class: 'govuk-checkboxes__input') %>
+                <%= restriction_form.label(class: 'govuk-label govuk-checkboxes__label') %>
+              </div>
+            <% end %>
+          </div>
+        <% end %>
+        <%= form.submit t('generic.continue'), class: 'govuk-button' %>
+      <% end %>
+    </div>
+  </div>
+</fieldset>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -189,21 +189,12 @@ en:
     client_detail:
       dob_hint: 'For example, 31 3 1980'
       national_insurance_number_hint: "For example, ‘QQ 12 34 56 C'"
-  generic:
-    'yes': 'Yes' # needs quotes as yes renders as true without them
-    'no': 'No'   # needs quotes as no renders as false without them
-    continue: Continue
-    back: Back
-    home: Home
-    submit: Submit
-    change: Change
-    errors:
-      yes_or_no: You must select either Yes or No
   layouts:
     application:
       header:
         gov_uk_link_title: Go to the GOV.UK homepage
         title: Apply for Legal Aid
+
   providers:
     check_benefits:
       index:
@@ -263,6 +254,7 @@ en:
         happen_next_heading: What happens next
         happen_next_text: "You will be sent the results of your client's financial assessment so you can confirm they are eligible for legal aid."
         back_button: "Back to your applications"
+
   citizens:
     accounts:
       index:
@@ -327,6 +319,29 @@ en:
           housing_assocation_or_landlord: Yes, a housing association or landlord
           friend_family_member_or_other_individual: Yes, a friend, family member or other individual
           no_sole_owner: No, I am the sole owner
+    restrictions:
+      index:
+        h1-heading: Do any restrictions apply to your property, savings or assets?
+
+  restrictions:
+    names:
+      reposession_or_deferred_interest: Reposession or deferred interest in a property
+      subject_matter_of_dispute: Subject matter of dispute in other legal proceedings
+      foreign_exchange_controls: Foreign exchange controls
+      restraint_or_freezing_order: Restraint or freezing order
+      bankruptcy: Bankruptcy
+      held_overseas: Held overseas
+
+  generic:
+    'yes': 'Yes' # needs quotes as yes renders as true without them
+    'no': 'No'   # needs quotes as no renders as false without them
+    continue: Continue
+    back: Back
+    home: Home
+    submit: Submit
+    change: Change
+    errors:
+      yes_or_no: You must select either Yes or No
   currency:
     gbp: £
     eur: €

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,7 @@ Rails.application.routes.draw do
     resource :outstanding_mortgage, only: %i[show update]
     resource :savings_and_investment, only: %i[show update]
     resource :shared_ownership, only: %i[show update]
+    resources :restrictions, only: %i[index create] # as multiple restrictions
   end
 
   namespace :providers do

--- a/db/migrate/20181207162049_create_restrictions.rb
+++ b/db/migrate/20181207162049_create_restrictions.rb
@@ -1,0 +1,9 @@
+class CreateRestrictions < ActiveRecord::Migration[5.2]
+  def change
+    create_table :restrictions, id: :uuid do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20181207162311_create_legal_aid_application_restrictions.rb
+++ b/db/migrate/20181207162311_create_legal_aid_application_restrictions.rb
@@ -1,0 +1,14 @@
+class CreateLegalAidApplicationRestrictions < ActiveRecord::Migration[5.2]
+  def change
+    create_table :legal_aid_application_restrictions, id: :uuid do |t|
+      t.references(
+        :legal_aid_application,
+        foreign_key: true,
+        type: :uuid,
+        index: { name: 'laa_id_laa_restriction_id' }
+      )
+      t.references :restriction, foreign_key: true, type: :uuid
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -133,6 +133,15 @@ ActiveRecord::Schema.define(version: 2018_12_11_125447) do
     t.index ["legal_aid_application_id"], name: "index_benefit_check_results_on_legal_aid_application_id"
   end
 
+  create_table "legal_aid_application_restrictions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "legal_aid_application_id"
+    t.uuid "restriction_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["legal_aid_application_id"], name: "laa_id_laa_restriction_id"
+    t.index ["restriction_id"], name: "index_legal_aid_application_restrictions_on_restriction_id"
+  end
+
   create_table "legal_aid_applications", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "application_ref"
     t.datetime "created_at", null: false
@@ -164,6 +173,12 @@ ActiveRecord::Schema.define(version: 2018_12_11_125447) do
     t.index ["code"], name: "index_proceeding_types_on_code"
   end
 
+  create_table "restrictions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "savings_amounts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "legal_aid_application_id", null: false
     t.decimal "isa"
@@ -193,6 +208,8 @@ ActiveRecord::Schema.define(version: 2018_12_11_125447) do
   add_foreign_key "bank_providers", "applicants"
   add_foreign_key "bank_transactions", "bank_accounts"
   add_foreign_key "benefit_check_results", "legal_aid_applications"
+  add_foreign_key "legal_aid_application_restrictions", "legal_aid_applications"
+  add_foreign_key "legal_aid_application_restrictions", "restrictions"
   add_foreign_key "legal_aid_applications", "applicants"
   add_foreign_key "savings_amounts", "legal_aid_applications"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,6 +6,8 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 Dir[File.join(Rails.root, 'db', 'seeds', '*.rb')].sort.each do |seed|
-  puts "Seeding '#{seed}'..."
+  message = "Seeding '#{seed}'..."
+  Rails.logger.info message
+  puts message
   load seed
 end

--- a/db/seeds/restriction.rb
+++ b/db/seeds/restriction.rb
@@ -1,0 +1,2 @@
+Rails.logger.info 'Populating restrictions'
+Restriction.populate

--- a/spec/factories/legal_aid_application_restrictions.rb
+++ b/spec/factories/legal_aid_application_restrictions.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :legal_aid_application_restriction do
+    legal_aid_application
+    restriction
+  end
+end

--- a/spec/factories/restrictions.rb
+++ b/spec/factories/restrictions.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :restriction do
+    name { Faker::Commerce.product_name.underscore }
+
+    trait :with_standard_name do
+      sequence(:name) { |n| Restriction::NAMES[n.to_i - 1] }
+    end
+  end
+end

--- a/spec/models/restriction_spec.rb
+++ b/spec/models/restriction_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe Restriction, type: :model do
+  describe '.populate' do
+    subject { described_class.populate }
+    let(:names) { described_class::NAMES }
+
+    it 'create instances from names' do
+      expect { subject }.to change { described_class.count }.by(names.length)
+    end
+
+    it 'creates instances with names from NAMES' do
+      subject
+      expect(described_class.pluck(:name).map(&:to_sym)).to match_array(names)
+    end
+
+    context 'when a restriction exists' do
+      let!(:restriction) { create :restriction, :with_standard_name }
+      it 'creates one less restriction' do
+        expect { subject }.to change { described_class.count }.by(names.length - 1)
+      end
+    end
+
+    context 'when run twice' do
+      it 'creates the same total number of instancees' do
+        expect {
+          subject
+          subject
+        }.to change { described_class.count }.by(names.length)
+      end
+    end
+  end
+end

--- a/spec/requests/citizens/accounts_spec.rb
+++ b/spec/requests/citizens/accounts_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'citizen accounts request test', type: :request do
+RSpec.describe 'citizen accounts request', type: :request do
   describe 'GET /citizens/account' do
     let!(:applicant) { create :applicant }
     let(:addresses) do

--- a/spec/requests/citizens/restrictions_spec.rb
+++ b/spec/requests/citizens/restrictions_spec.rb
@@ -1,0 +1,72 @@
+require 'rails_helper'
+
+RSpec.describe 'citizen restrictions request', type: :request do
+  let(:legal_aid_application) { create :legal_aid_application, :with_applicant }
+  let(:secure_id) { legal_aid_application.generate_secure_id }
+  let!(:restrictions) { create_list :restriction, 3 }
+  before do
+    get citizens_legal_aid_application_path(secure_id)
+  end
+
+  describe 'GET /citizens/restrictions' do
+    before { get citizens_restrictions_path }
+
+    it 'returns http success' do
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'displays the restriction name labels' do
+      restrictions.map(&:label_name).each do |label|
+        expect(unescaped_response_body).to include(label)
+      end
+    end
+  end
+
+  describe 'POST /citizens/restrictions' do
+    let(:restriction_ids) { restrictions.pluck(:id) }
+    let(:params) do
+      {
+        legal_aid_application: {
+          restriction_ids: restriction_ids
+        }
+      }
+    end
+    subject { post citizens_restrictions_path, params: params }
+
+    it 'creates a mapping for each restriction' do
+      expect { subject }.to change { LegalAidApplicationRestriction.count }.by(restrictions.count)
+    end
+
+    context 'after success' do
+      before do
+        subject
+        legal_aid_application.reload
+      end
+
+      it 'updates the legal_aid_application.restrictions' do
+        expect(legal_aid_application.restrictions).to match_array(restrictions)
+      end
+
+      xit 'redirects to check your answers' do
+        # TODO: - set redirect path when known
+        expect(response).to redirect_to(:some_path)
+      end
+
+      it 'displays a holding page' do
+        # TODO: - replace with 'redirects to check your answers'
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include('Holding page')
+      end
+    end
+
+    context 'on error' do
+      let(:restriction_ids) { %i[foo bar] }
+
+      # As I can not think of a "normal" behaviour that can cause an error.
+      # Error handling falls back to standard error handling.
+      it 'raises error' do
+        expect { subject }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
+end


### PR DESCRIPTION
[Jira AP-217](https://dsdmoj.atlassian.net/browse/AP-217)

This PR adds a `Restriction` model, and a `has_many :restrictions, through: :legal_aid_application_restrictions` on `LegalAidApplication`. The new page then allows a Citizen to choose to associate all, any or none of those restrictions with their current application.

`Restriction` has a number of predefined instances (named) to describe each restriction condition, and there is a class method to generate these. This has been added to seeding, so `rake db:seed` adds the standard `restrictions`. The generation task can be run multiple times without generating duplicates.

I cannot think of a normal invalid condition (the Citizen selects from pre-existings objects via checkboxes generated by the app). So there is no validation - and therefore no form object is needed. Also no standard error handling - instead errors such as `ActiveRecord::RecordNotFound` (when an unrecognised id is submitted) bubble to the surface rather than being trapped.

![citizens_restrictions](https://user-images.githubusercontent.com/213040/49794975-c2027a80-fd30-11e8-8863-e540075bd46b.png)
