### PR TITLE
AP-216 Implementation of Other Assets page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,7 @@ gem 'sprockets', '>= 3.0.0'
 gem 'sprockets-es6'
 
 group :development, :test do
+  gem 'awesome_print', '~> 1.8.0'
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
   gem 'dotenv-rails'
   gem 'erb_lint', require: false
@@ -50,7 +51,6 @@ group :development, :test do
 end
 
 group :development do
-  gem 'awesome_print', '~> 1.8.0'
   gem 'listen', '>= 3.0.5', '< 3.2'
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'

--- a/app/assets/stylesheets/govuk-currency-input.scss
+++ b/app/assets/stylesheets/govuk-currency-input.scss
@@ -1,12 +1,12 @@
-/*
-Used with:
-  <div class="govuk-currency-input">
-    <div class="govuk-currency-input__inner">
-      <span class="govuk-currency-input__inner__unit">£</span>
-      <%= form.text_field :field_name, class: 'govuk-input govuk-currency-input__inner__input' %>
+  /*
+  Used with:
+    <div class="govuk-currency-input">
+      <div class="govuk-currency-input__inner">
+        <span class="govuk-currency-input__inner__unit">£</span>
+        <%= form.text_field :field_name, class: 'govuk-input govuk-currency-input__inner__input' %>
+      </div>
     </div>
-  </div>
-*/
+  */
 .govuk-currency-input {
   &__inner {
     position: relative;

--- a/app/assets/stylesheets/govuk_percent-input.scss
+++ b/app/assets/stylesheets/govuk_percent-input.scss
@@ -1,0 +1,5 @@
+.input-percentage + .input-suffix {
+  font-family: "nta", Arial, sans-serif;
+  line-height: 1.54;
+  font-size: 19px;
+}

--- a/app/controllers/citizens/other_assets_controller.rb
+++ b/app/controllers/citizens/other_assets_controller.rb
@@ -1,0 +1,43 @@
+module Citizens
+  class OtherAssetsController < BaseController
+    def show
+      declaration
+      @form = Citizens::OtherAssetsForm.new(current_params)
+    end
+
+    def update
+      @form = Citizens::OtherAssetsForm.new(form_params.merge(model: declaration))
+      if @form.save
+        render plain: 'Navigate to next question after any other assets'
+      else
+        render :show
+      end
+    end
+
+    private
+
+    def legal_aid_application
+      @legal_aid_application ||= LegalAidApplication.find(session[:current_application_ref])
+    end
+
+    def declaration
+      @declaration ||= legal_aid_application.other_assets_declaration
+    end
+
+    def attributes
+      @attributes ||= Citizens::OtherAssetsForm::ALL_ATTRIBUTES
+    end
+
+    def current_params
+      @declaration.attributes.symbolize_keys.slice(*attributes)
+    end
+
+    def other_asset_params
+      params[:other_assets_declaration].permit(*(Citizens::OtherAssetsForm::ALL_ATTRIBUTES + Citizens::OtherAssetsForm::CHECK_BOXES_ATTRIBUTES))
+    end
+
+    def form_params
+      other_asset_params.merge(model: @declaration)
+    end
+  end
+end

--- a/app/controllers/citizens/other_assets_controller.rb
+++ b/app/controllers/citizens/other_assets_controller.rb
@@ -1,12 +1,11 @@
 module Citizens
   class OtherAssetsController < BaseController
     def show
-      declaration
-      @form = Citizens::OtherAssetsForm.new(current_params)
+      @form = Citizens::OtherAssetsForm.new(model: declaration)
     end
 
     def update
-      @form = Citizens::OtherAssetsForm.new(form_params.merge(model: declaration))
+      @form = Citizens::OtherAssetsForm.new(form_params)
       if @form.save
         render plain: 'Navigate to next question after any other assets'
       else
@@ -24,20 +23,12 @@ module Citizens
       @declaration ||= legal_aid_application.other_assets_declaration
     end
 
-    def attributes
-      @attributes ||= Citizens::OtherAssetsForm::ALL_ATTRIBUTES
-    end
-
-    def current_params
-      @declaration.attributes.symbolize_keys.slice(*attributes)
-    end
-
     def other_asset_params
       params[:other_assets_declaration].permit(*(Citizens::OtherAssetsForm::ALL_ATTRIBUTES + Citizens::OtherAssetsForm::CHECK_BOXES_ATTRIBUTES))
     end
 
     def form_params
-      other_asset_params.merge(model: @declaration)
+      other_asset_params.merge(model: declaration)
     end
   end
 end

--- a/app/controllers/providers/legal_aid_applications_controller.rb
+++ b/app/controllers/providers/legal_aid_applications_controller.rb
@@ -9,6 +9,7 @@ module Providers
     # POST /provider/applications
     def create
       @legal_aid_application = LegalAidApplication.create
+      @legal_aid_application.create_other_assets_declaration!
       redirect_to next_step_url
     end
   end

--- a/app/forms/citizens/other_assets_form.rb
+++ b/app/forms/citizens/other_assets_form.rb
@@ -1,0 +1,104 @@
+module Citizens
+  class OtherAssetsForm
+    include BaseForm
+
+    form_for OtherAssetsDeclaration
+
+    SINGLE_VALUE_ATTRIBUTES = %i[
+      timeshare_value
+      land_value
+      jewellery_value
+      vehicle_value
+      classic_car_value
+      money_assets_value
+      money_owed_value
+      trust_value
+    ].freeze
+
+    SECOND_HOME_ATTRIBUTES = %i[
+      second_home_value
+      second_home_mortgage
+      second_home_percentage
+    ].freeze
+
+    ALL_ATTRIBUTES = (SECOND_HOME_ATTRIBUTES + SINGLE_VALUE_ATTRIBUTES).freeze
+
+    CHECK_BOXES_ATTRIBUTES = (SINGLE_VALUE_ATTRIBUTES.map { |attribute| "check_box_#{attribute}".to_sym } + [:check_box_second_home]).freeze
+
+    SINGLE_VALUE_ATTRIBUTES.each do |attribute|
+      check_box_attribute = "check_box_#{attribute}".to_sym
+      validates attribute, numericality: { greater_than_or_equal_to: 0 }, allow_blank: true
+      validates attribute, presence: true, if: proc { |form| form.send(check_box_attribute).present? }
+    end
+
+    validates :second_home_value, :second_home_mortgage, :second_home_percentage, numericality: { greater_than_or_equal_to: 0 }, allow_blank: true
+
+    attr_accessor(*ALL_ATTRIBUTES)
+    attr_accessor(*CHECK_BOXES_ATTRIBUTES)
+    attr_accessor :check_box_second_home
+
+    before_validation :normalize_amounts, :empty_unchecked_values
+
+    validate :all_second_home_values_present_if_any_are_present
+
+    def second_home_checkbox_status
+      any_second_home_value_present? ? 'checked' : nil
+    end
+
+    def any_second_home_value_present?
+      present_and_not_zero?(@second_home_value) ||
+        present_and_not_zero?(@second_home_mortgage) ||
+        present_and_not_zero?(@second_home_percentage)
+    end
+
+    def exclude_from_model
+      CHECK_BOXES_ATTRIBUTES
+    end
+
+    private
+
+    def empty_unchecked_values
+      SINGLE_VALUE_ATTRIBUTES.each do |attribute|
+        check_box_attribute = "check_box_#{attribute}".to_sym
+        if send(check_box_attribute).blank?
+          attributes[attribute] = nil
+          send("#{attribute}=", nil)
+        end
+      end
+
+      nullify_second_home_attrs if @check_box_second_home.blank?
+    end
+
+    def nullify_second_home_attrs
+      attributes[:second_home_value] = nil
+      attributes[:second_home_mortgage] = nil
+      attributes[:second_home_percentage] = nil
+      @second_home_value = nil
+      @second_home_mortgage = nil
+      @second_home_percentage = nil
+    end
+
+    def normalize_amounts
+      ALL_ATTRIBUTES
+        .map { |attribute| send(attribute) }
+        .compact
+        .each { |value| value.delete!(',') }
+    end
+
+    def all_second_home_values_present_if_any_are_present
+      return unless any_second_home_value_present?
+
+      %i[second_home_value second_home_mortgage second_home_percentage].each do |attr|
+        errors.add(attr, :blank) if __send__(attr).blank?
+      end
+    end
+
+    def present_and_not_zero?(attr)
+      attr.present? && !zero_string?(attr)
+    end
+
+    def zero_string?(attr)
+      /\A0+\z/.match? attr.to_s.tr(' ,.', '')
+    end
+  end
+end

--- a/app/forms/citizens/other_assets_form.rb
+++ b/app/forms/citizens/other_assets_form.rb
@@ -28,10 +28,10 @@ module Citizens
     SINGLE_VALUE_ATTRIBUTES.each do |attribute|
       check_box_attribute = "check_box_#{attribute}".to_sym
       validates attribute, numericality: { greater_than_or_equal_to: 0 }, allow_blank: true
-      validates attribute, presence: true, if: proc { |form| form.send(check_box_attribute).present? }
+      validates attribute, presence: true, if: proc { |form| form.__send__(check_box_attribute).present? }
     end
 
-    validates :second_home_value, :second_home_mortgage, :second_home_percentage, numericality: { greater_than_or_equal_to: 0 }, allow_blank: true
+    validates(*SECOND_HOME_ATTRIBUTES, numericality: { greater_than_or_equal_to: 0 }, allow_blank: true)
 
     attr_accessor(*ALL_ATTRIBUTES)
     attr_accessor(*CHECK_BOXES_ATTRIBUTES)
@@ -60,9 +60,9 @@ module Citizens
     def empty_unchecked_values
       SINGLE_VALUE_ATTRIBUTES.each do |attribute|
         check_box_attribute = "check_box_#{attribute}".to_sym
-        if send(check_box_attribute).blank?
+        if __send__(check_box_attribute).blank?
           attributes[attribute] = nil
-          send("#{attribute}=", nil)
+          instance_variable_set(:"@#{attribute}", nil)
         end
       end
 
@@ -80,7 +80,7 @@ module Citizens
 
     def normalize_amounts
       ALL_ATTRIBUTES
-        .map { |attribute| send(attribute) }
+        .map { |attribute| __send__(attribute) }
         .compact
         .each { |value| value.delete!(',') }
     end
@@ -88,7 +88,7 @@ module Citizens
     def all_second_home_values_present_if_any_are_present
       return unless any_second_home_value_present?
 
-      %i[second_home_value second_home_mortgage second_home_percentage].each do |attr|
+      SECOND_HOME_ATTRIBUTES.each do |attr|
         errors.add(attr, :blank) if __send__(attr).blank?
       end
     end

--- a/app/forms/citizens/other_assets_form.rb
+++ b/app/forms/citizens/other_assets_form.rb
@@ -25,13 +25,14 @@ module Citizens
 
     CHECK_BOXES_ATTRIBUTES = (SINGLE_VALUE_ATTRIBUTES.map { |attribute| "check_box_#{attribute}".to_sym } + [:check_box_second_home]).freeze
 
+    validates(*SECOND_HOME_ATTRIBUTES, numericality: { greater_than_or_equal_to: 0 }, allow_blank: true)
+    validates(*SECOND_HOME_ATTRIBUTES, presence: true, if: proc { |form| form.check_box_second_home.present? })
+
     SINGLE_VALUE_ATTRIBUTES.each do |attribute|
       check_box_attribute = "check_box_#{attribute}".to_sym
       validates attribute, numericality: { greater_than_or_equal_to: 0 }, allow_blank: true
       validates attribute, presence: true, if: proc { |form| form.__send__(check_box_attribute).present? }
     end
-
-    validates(*SECOND_HOME_ATTRIBUTES, numericality: { greater_than_or_equal_to: 0 }, allow_blank: true)
 
     attr_accessor(*ALL_ATTRIBUTES)
     attr_accessor(*CHECK_BOXES_ATTRIBUTES)

--- a/app/helpers/money_helper.rb
+++ b/app/helpers/money_helper.rb
@@ -1,5 +1,6 @@
 module MoneyHelper
-  def value_with_currency_unit(value, currency)
+  def value_with_currency_unit(value, currency = nil)
+    currency = 'gbp' if currency.nil?
     number_to_currency(value, unit: I18n.t("currency.#{currency.downcase}", default: currency))
   end
 end

--- a/app/lib/govuk_elements_form_builder/form_builder.rb
+++ b/app/lib/govuk_elements_form_builder/form_builder.rb
@@ -31,6 +31,7 @@ module GovukElementsFormBuilder
     #
     def govuk_text_field(attribute, options = {})
       options[:class] = text_field_classes(attribute, options)
+      suffix = options.delete(:suffix)
       input_text_form_group(attribute, options) do
         input_prefix = options[:input_prefix]
         tag_options = options.except(*CUSTOM_OPTIONS)
@@ -38,7 +39,8 @@ module GovukElementsFormBuilder
         tag_options[:'aria-describedby'] = aria_describedby(attribute, options)
         tag = text_field(attribute, tag_options)
 
-        input_prefix ? input_prefix_group(input_prefix) { tag } : tag
+        tag = input_prefix ? input_prefix_group(input_prefix) { tag } : tag
+        tag = suffix ? suffix_span_tag(suffix) { tag } : tag
       end
     end
 
@@ -119,7 +121,6 @@ module GovukElementsFormBuilder
       value_attr = args[0].is_a?(Hash) ? nil : args[0]
       label_attr = args[1].is_a?(Hash) ? nil : args[1]
       [value_attr, label_attr]
-
     end
 
     def collection_radio_buttons_classes(attribute, options)
@@ -143,6 +144,13 @@ module GovukElementsFormBuilder
           concat_tags(prefix, yield)
         end
       end
+    end
+
+    def suffix_span_tag(suffix)
+      span_tag = content_tag :span, class: 'input-suffix' do
+        " #{suffix}"
+      end
+      yield + span_tag
     end
 
     def input_text_form_group(attribute, options)

--- a/app/lib/govuk_elements_form_builder/form_builder.rb
+++ b/app/lib/govuk_elements_form_builder/form_builder.rb
@@ -119,6 +119,7 @@ module GovukElementsFormBuilder
       value_attr = args[0].is_a?(Hash) ? nil : args[0]
       label_attr = args[1].is_a?(Hash) ? nil : args[1]
       [value_attr, label_attr]
+
     end
 
     def collection_radio_buttons_classes(attribute, options)

--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -9,6 +9,7 @@ class LegalAidApplication < ApplicationRecord
   has_many :application_proceeding_types
   has_many :proceeding_types, through: :application_proceeding_types
   has_one :benefit_check_result
+  has_one :other_assets_declaration
   has_one :savings_amount
   has_many :legal_aid_application_restrictions
   has_many :restrictions, through: :legal_aid_application_restrictions

--- a/app/models/other_assets_declaration.rb
+++ b/app/models/other_assets_declaration.rb
@@ -1,0 +1,3 @@
+class OtherAssetsDeclaration < ApplicationRecord
+  belongs_to :legal_aid_application
+end

--- a/app/views/citizens/other_assets/_second_home_conditional_checkbox.html.erb
+++ b/app/views/citizens/other_assets/_second_home_conditional_checkbox.html.erb
@@ -1,0 +1,24 @@
+
+<%
+  check_box_attribute = 'check_box_second_home'
+  conditional_div_id = 'conditional_second_home'
+  hint = I18n.translate("helpers.hint.#{check_box_attribute}", default: nil)
+  value1 = model.second_home_value
+  value2 = model.second_home_mortgage
+  value3 = model.second_home_percentage
+  checked = value1.present? || model.send(check_box_attribute).present? ? 'checked' : ''
+%>
+
+<div class="govuk-checkboxes__item">
+  <%= form.check_box check_box_attribute, { class: 'govuk-checkboxes__input', 'data-aria-controls' => conditional_div_id, checked: checked }, 'true', '' %>
+  <%= form.label check_box_attribute, class: 'govuk-label govuk-checkboxes__label' %>
+  <%= govuk_hint(hint, class: 'govuk-checkboxes__hint') if hint %>
+</div>
+
+<div class="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden" id="<%= conditional_div_id %>">
+  <%= form.govuk_text_field :second_home_value, input_prefix: t('currency.gbp'), value: number_to_currency(value1, unit: ''), class: 'govuk-!-width-one-third' %>
+
+  <%= form.govuk_text_field :second_home_mortgage, input_prefix: t('currency.gbp'), value: number_to_currency(value2, unit: ''), class: 'govuk-!-width-one-third' %>
+
+  <%= form.govuk_text_field :second_home_percentage, input_suffix: '%', value: number_to_currency(value3, unit: ''), class: 'govuk-!-width-one-third' %>
+</div>

--- a/app/views/citizens/other_assets/_second_home_conditional_checkbox.html.erb
+++ b/app/views/citizens/other_assets/_second_home_conditional_checkbox.html.erb
@@ -2,10 +2,7 @@
   check_box_attribute = 'check_box_second_home'
   conditional_div_id = 'conditional_second_home'
   hint = I18n.translate("helpers.hint.#{check_box_attribute}", default: nil)
-  value1 = model.second_home_value
-  value2 = model.second_home_mortgage
-  value3 = model.second_home_percentage
-  checked = value1.present? || model.send(check_box_attribute).present? ? 'checked' : ''
+  checked = model.second_home_value.present? || model.send(check_box_attribute).present? ? 'checked' : ''
 %>
 
 <div class="govuk-checkboxes__item">
@@ -15,10 +12,17 @@
 </div>
 
 <div class="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden" id="<%= conditional_div_id %>">
-  <%= form.govuk_text_field :second_home_value, input_prefix: t('currency.gbp'), value: number_to_currency(value1, unit: ''), class: 'govuk-!-width-one-third' %>
+  <%= form.govuk_text_field :second_home_value,
+                            input_prefix: t('currency.gbp'),
+                            value: number_to_currency(model.second_home_value, unit: ''),
+                            class: 'govuk-!-width-one-third' %>
 
-  <%= form.govuk_text_field :second_home_mortgage, input_prefix: t('currency.gbp'), value: number_to_currency(value2, unit: ''), class: 'govuk-!-width-one-third' %>
-  <div class="govuk-!-width-one-third">
-      <%= form.govuk_text_field :second_home_percentage, value: number_to_currency(value3, unit: ''), class: 'govuk-input govuk-input--width-5 input-percentage', suffix: '%' %>
-  </div>
+  <%= form.govuk_text_field :second_home_mortgage,
+                            input_prefix: t('currency.gbp'),
+                            value: number_to_currency(model.second_home_mortgage, unit: ''),
+                            class: 'govuk-!-width-one-third' %>
+      <%= form.govuk_text_field :second_home_percentage,
+                                value: number_to_currency(model.second_home_percentage, unit: ''),
+                                class: 'govuk-input govuk-input--width-5 input-percentage',
+                                suffix: '%' %>
 </div>

--- a/app/views/citizens/other_assets/_second_home_conditional_checkbox.html.erb
+++ b/app/views/citizens/other_assets/_second_home_conditional_checkbox.html.erb
@@ -1,4 +1,3 @@
-
 <%
   check_box_attribute = 'check_box_second_home'
   conditional_div_id = 'conditional_second_home'
@@ -20,6 +19,6 @@
 
   <%= form.govuk_text_field :second_home_mortgage, input_prefix: t('currency.gbp'), value: number_to_currency(value2, unit: ''), class: 'govuk-!-width-one-third' %>
   <div class="govuk-!-width-one-third">
-      <%= form.govuk_text_field :second_home_percentage, value: number_to_currency(value3, unit: ''), class: 'govuk-input govuk-input--width-5 input-percentage', suffix: ' %' %>
+      <%= form.govuk_text_field :second_home_percentage, value: number_to_currency(value3, unit: ''), class: 'govuk-input govuk-input--width-5 input-percentage', suffix: '%' %>
   </div>
 </div>

--- a/app/views/citizens/other_assets/_second_home_conditional_checkbox.html.erb
+++ b/app/views/citizens/other_assets/_second_home_conditional_checkbox.html.erb
@@ -19,6 +19,7 @@
   <%= form.govuk_text_field :second_home_value, input_prefix: t('currency.gbp'), value: number_to_currency(value1, unit: ''), class: 'govuk-!-width-one-third' %>
 
   <%= form.govuk_text_field :second_home_mortgage, input_prefix: t('currency.gbp'), value: number_to_currency(value2, unit: ''), class: 'govuk-!-width-one-third' %>
-
-  <%= form.govuk_text_field :second_home_percentage, input_suffix: '%', value: number_to_currency(value3, unit: ''), class: 'govuk-!-width-one-third' %>
+  <div class="govuk-!-width-one-third">
+      <%= form.govuk_text_field :second_home_percentage, value: number_to_currency(value3, unit: ''), class: 'govuk-input govuk-input--width-5 input-percentage', suffix: ' %' %>
+  </div>
 </div>

--- a/app/views/citizens/other_assets/show.html.erb
+++ b/app/views/citizens/other_assets/show.html.erb
@@ -1,0 +1,30 @@
+<% content_for :navigation do %>
+  <%= link_to 'Back', citizens_additional_accounts_path, class: 'govuk-back-link', id: 'back' %>
+<% end %>
+
+<% content_for(:page_title) { t('.h1-heading') } %>
+
+<%= render partial: 'shared/forms/error_summary', locals: { model: @form } %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl"><%= content_for(:page_title) %></h1>
+  </div>
+</div>
+
+<%= form_with(model: @form, url: citizens_other_assets_path, method: :patch, local: true) do |form| %>
+  <div class="govuk-!-padding-bottom-8"></div>
+
+  <div class="govuk-form-group">
+    <fieldset class="govuk-fieldset" aria-describedby="citizenship-conditional-hint">
+      <div class="govuk-checkboxes" data-module="checkboxes">
+        <%= render partial: 'second_home_conditional_checkbox', locals: { model: @form, form: form } %>
+        <%= render partial: 'shared/revealing_checkbox/attribute',
+                   collection: Citizens::OtherAssetsForm::SINGLE_VALUE_ATTRIBUTES,
+                   locals: { model: @form, form: form } %>
+      </div>
+    </fieldset>
+  </div>
+<div class="govuk-!-padding-bottom-6"></div>
+  <%= form.submit t('generic.continue'), id: 'continue', class: 'govuk-button' %>
+<% end %>

--- a/app/views/citizens/other_assets/show.html.erb
+++ b/app/views/citizens/other_assets/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :navigation do %>
-  <%= link_to 'Back', citizens_additional_accounts_path, class: 'govuk-back-link', id: 'back' %>
+  <%= link_to t('generic.back'), citizens_additional_accounts_path, class: 'govuk-back-link', id: 'back' %>
 <% end %>
 
 <% content_for(:page_title) { t('.h1-heading') } %>

--- a/app/views/citizens/savings_and_investments/show.html.erb
+++ b/app/views/citizens/savings_and_investments/show.html.erb
@@ -19,7 +19,7 @@
                   local: true) do |form| %>
 
       <div class="govuk-checkboxes" data-module="checkboxes">
-        <%= render partial: 'attribute', collection: @attributes, locals: { model: @form, form: form } %>
+        <%= render partial: 'shared/revealing_checkbox/attribute', collection: @attributes, locals: { model: @form, form: form } %>
       </div>
 
       <%= form.submit t('generic.continue'), id: 'continue', class: 'govuk-button' %>

--- a/app/views/shared/forms/_conditional_checkbox_with_numeric_input.html.erb
+++ b/app/views/shared/forms/_conditional_checkbox_with_numeric_input.html.erb
@@ -1,0 +1,25 @@
+<div class="govuk-checkboxes__item">
+  <input class="govuk-checkboxes__input"
+         id="<%= attr.to_s %>"
+         name="<%= "#{attr}_checkbox" %>"
+         type="checkbox"
+         value="yes"
+         <%= @form.checkbox_status("#{attr}_value") %>
+         data-aria-controls="<%= "conditional-#{attr}" %>" />
+  <label class="govuk-label govuk-checkboxes__label" for="<%= "#{attr}_checkbox" %>">
+    <%= label %>
+  </label>
+</div>
+
+<div class="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden" id="<%= "conditional-#{attr}" %>">
+  <div class="govuk-form-group">
+    <label class="govuk-label" for="<%= "#{attr}_value" %>">
+      <%= hint %>
+    </label>
+    <input class="govuk-input govuk-!-width-one-third"
+           id="<%= "#{attr}_value" %>"
+           name="<%= "#{attr}_value" %>"
+           value="<%= value_with_currency_unit(@form.__send__("#{attr}_value")) %>"
+           pattern="\A[0-9][0-9,]+(.[0-9]{0,2})?\z" />
+  </div>
+</div>

--- a/app/views/shared/revealing_checkbox/_attribute.html.erb
+++ b/app/views/shared/revealing_checkbox/_attribute.html.erb
@@ -1,0 +1,16 @@
+<%
+  check_box_attribute = "check_box_#{attribute}"
+  conditional_div_id = "conditional_#{attribute}"
+  hint = I18n.translate("helpers.hint.#{check_box_attribute}", default: nil)
+  value = model.send(attribute)
+  checked = value.present? || model.send(check_box_attribute).present? ? 'checked' : ''
+%>
+
+<div class="govuk-checkboxes__item">
+  <%= form.check_box check_box_attribute, { class: 'govuk-checkboxes__input', 'data-aria-controls' => conditional_div_id, checked: checked }, 'true', '' %>
+  <%= form.label check_box_attribute, class: 'govuk-label govuk-checkboxes__label' %>
+  <%= govuk_hint(hint, class: 'govuk-checkboxes__hint') if hint %>
+</div>
+<div class="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden" id="<%= conditional_div_id %>">
+  <%= form.govuk_text_field attribute, input_prefix: t('currency.gbp'), value: number_to_currency(value, unit: ''), class: 'govuk-!-width-one-third' %>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -71,6 +71,27 @@ en:
         peps_unit_trusts_capital_bonds_gov_stocks: Enter the total value of all you own
         check_box_life_assurance_endowment_policy: Life assurance and endowment policies not linked to a mortgage
         life_assurance_endowment_policy: Enter the total value of all you own
+      other_assets_declaration:
+        check_box_second_home: Second property or holiday home
+        second_home_value: Enter estimated value
+        second_home_mortgage: Enter outstanding mortgage amount
+        second_home_percentage: Enter percentage share you legally own
+        check_box_timeshare_value: Timeshare
+        timeshare_value: Enter value, minus any loan and sale costs
+        check_box_land_value: Land
+        land_value: Enter estimated value
+        check_box_jewellery_value: Jewellery, art or antiques with a value over 500
+        jewellery_value: Enter estimated value, minus any sale costs
+        check_box_vehicle_value: Car, van or motorcycle less than 3 years old
+        vehicle_value: Enter estimated value, minus any outstanding payments
+        check_box_classic_car_value: Classic car purchased as an investment
+        classic_car_value: Enter the estimated value
+        check_box_money_assets_value: Money or assets from the estate of a person who has died
+        money_assets_value: Enter estimated total value
+        check_box_money_owed_value: Money owed to you, including from a private mortgage
+        money_owed_value: Enter estimated amount owed
+        check_box_trust_value: Interest in a trust
+        trust_value: Enter estimated total value
       applicants/address_form:
         <<: *address_attrs
       applicants/basic_details_form:
@@ -172,6 +193,34 @@ en:
               blank: *enter_total_value
               not_a_number: *total_must_be_money
               greater_than_or_equal_to: *total_must_be_positive
+
+        other_assets_declaration:
+          attributes:
+            second_home_value:
+              not_a_number: Second home or property value is not a number
+              blank: Second home or property value must be entered if checkbox is ticked
+            second_home_mortgage:
+              not_a_number: Second home or property mortgage is not a number'
+              blank: Second home or property mortgage must be entered if checkbox is ticked
+            second_home_percentage:
+              not_a_number: Second home or property percentage ownership is not a number'
+              blank: Second home or property percentage ownership must be entered if checkbox is ticked
+            timeshare_value:
+              not_a_number: Timeshare value is not a number
+            land_value:
+              not_a_number: Land value is not a number
+            jewellery_value:
+              not_a_number: Jewellery value is not a number
+            vehicle_value:
+              not_a_number: Vehicle value is not a number
+            classic_car_value:
+              not_a_number: Clasic car value is not a number
+            money_assets_value:
+              not_a_number: Money assets value is not a number
+            money_owed_value:
+              not_a_number: Money owed value is not a number
+            trust_value:
+              not_a_number: Trust value is not a number
 
   activerecord:
     errors:
@@ -365,6 +414,9 @@ en:
     property_values:
       show:
         field_set_header: How much is your home worth?
+    other_assets:
+      show:
+        h1-heading: Do you have any of the following?
     outstanding_mortgages:
       show:
         outstanding_mortgage_amount_heading: What is the outstanding mortgage on your home?
@@ -426,6 +478,26 @@ en:
     errors:
       yes_or_no: You must select either Yes or No
       problem_text: There is a problem
+    other_assets:
+      show:
+        amount_owed: Enter estimated amount owed
+        classic_car: Clasic car purchased as an investment
+        estimated_value: Enter estimated value
+        estimated_total_value: Enter estimated total value
+        h1-heading: Do you have any of the following?
+        jewellery: Jewellery, art or antiques with a value over £500
+        land: Land
+        money_assets: Money or assets from the estate of a person who has died
+        money_owed: Money owed to you, including from a private mortgage
+        mortgage: Enter outstanding mortgage amount
+        percentage: Enter percentage share you legally own
+        second_home: Second property or holiday home
+        timeshare: Timeshare
+        trust: Interest in a trust
+        value_after_loan: Enter value, minus any loan and sale costs
+        value_after_sale: Enter estimated value, minus any sale costs
+        value_after_payments: Enter estimated value, minus any outstanding payments
+        vehicle: Car, van or motorcycle less than 3 years old
   currency:
     gbp: £
     eur: €

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -197,37 +197,37 @@ en:
         other_assets_declaration:
           attributes:
             second_home_value:
-              not_a_number: Property value is not a number
+              not_a_number: Estimated value must be an amount of money, like 60,000
               blank: Enter the estimated property value
             second_home_mortgage:
-              not_a_number: Property mortgage is not a number
+              not_a_number: Outstanding mortgage amount must be an amount of money, like 60,000
               blank: Enter outstanding mortgage amount
             second_home_percentage:
-              not_a_number: Property percentage ownership is not a number
+              not_a_number: Ownership share must be percentage, like 33.33
               blank: Enter property percentage share
             timeshare_value:
-              not_a_number: Timeshare value is not a number
+              not_a_number: Estimated timeshare value must be an amount of money, like 60,000
               blank: Enter the estimated timeshare value
             land_value:
-              not_a_number: Land value is not a number
+              not_a_number: Estimated land value must be an amount of money, like 60,000
               blank: Enter the estimated land value
             jewellery_value:
-              not_a_number: Jewellery value is not a number
+              not_a_number: Estimated valuable items value must be an amount of money, like 60,000
               blank: Enter the estimated total value of valuable items
             vehicle_value:
-              not_a_number: Vehicle value is not a number
+              not_a_number: Estimated vehicle value must be an amount of money, like 60,000
               blank: Enter the estimated vehicle value
             classic_car_value:
-              not_a_number: Clasic car value is not a number
+              not_a_number: Estimated classic car value must be an amount of money, like 60,000
               blank: Enter the estimated classic car value
             money_assets_value:
-              not_a_number: Money assets value is not a number
+              not_a_number: Estimated estate value must be an amount of money, like 60,000
               blank: Enter the estimated value of estate
             money_owed_value:
-              not_a_number: Money owed value is not a number
+              not_a_number: Estimated money owed must be an amount of money, like 60,000
               blank: Enter the estimated value of money owed
             trust_value:
-              not_a_number: Trust value is not a number
+              not_a_number: Estimated trust value must be an amount of money, like 60,000
               blank: Enter the estimated value of trust
 
   activerecord:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -197,30 +197,38 @@ en:
         other_assets_declaration:
           attributes:
             second_home_value:
-              not_a_number: Second home or property value is not a number
-              blank: Second home or property value must be entered if checkbox is ticked
+              not_a_number: Property value is not a number
+              blank: Enter the estimated property value
             second_home_mortgage:
-              not_a_number: Second home or property mortgage is not a number'
-              blank: Second home or property mortgage must be entered if checkbox is ticked
+              not_a_number: Property mortgage is not a number
+              blank: Enter outstanding mortgage amount
             second_home_percentage:
-              not_a_number: Second home or property percentage ownership is not a number'
-              blank: Second home or property percentage ownership must be entered if checkbox is ticked
+              not_a_number: Property percentage ownership is not a number
+              blank: Enter property percentage share
             timeshare_value:
               not_a_number: Timeshare value is not a number
+              blank: Enter the estimated timeshare value
             land_value:
               not_a_number: Land value is not a number
+              blank: Enter the estimated land value
             jewellery_value:
               not_a_number: Jewellery value is not a number
+              blank: Enter the estimated total value of valuable items
             vehicle_value:
               not_a_number: Vehicle value is not a number
+              blank: Enter the estimated vehicle value
             classic_car_value:
               not_a_number: Clasic car value is not a number
+              blank: Enter the estimated classic car value
             money_assets_value:
               not_a_number: Money assets value is not a number
+              blank: Enter the estimated value of estate
             money_owed_value:
               not_a_number: Money owed value is not a number
+              blank: Enter the estimated value of money owed
             trust_value:
               not_a_number: Trust value is not a number
+              blank: Enter the estimated value of trust
 
   activerecord:
     errors:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,6 +28,7 @@ Rails.application.routes.draw do
     resource :savings_and_investment, only: %i[show update]
     resource :shared_ownership, only: %i[show update]
     resources :restrictions, only: %i[index create] # as multiple restrictions
+    resource :other_assets, only: %i[show update]
   end
 
   namespace :providers do

--- a/db/migrate/20181206142708_create_other_asset_declaration.rb
+++ b/db/migrate/20181206142708_create_other_asset_declaration.rb
@@ -1,0 +1,22 @@
+class CreateOtherAssetDeclaration < ActiveRecord::Migration[5.2]
+  def change
+    create_table :other_assets_declarations, id: :uuid do |t|
+      t.uuid :legal_aid_application_id, null: false
+      t.decimal :second_home_value
+      t.decimal :second_home_mortgage
+      t.decimal :second_home_percentage
+      t.decimal :timeshare_value
+      t.decimal :land_value
+      t.decimal :jewellery_value
+      t.decimal :vehicle_value
+      t.decimal :classic_car_value
+      t.decimal :money_assets_value
+      t.decimal :money_owed_value
+      t.decimal :trust_value
+
+      t.timestamps
+    end
+
+    add_index :other_assets_declarations, :legal_aid_application_id, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -161,17 +161,17 @@ ActiveRecord::Schema.define(version: 2018_12_19_135328) do
 
   create_table "other_assets_declarations", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "legal_aid_application_id", null: false
-    t.decimal "second_home_value"
-    t.decimal "second_home_mortgage"
-    t.decimal "second_home_percentage"
-    t.decimal "timeshare_value"
-    t.decimal "land_value"
-    t.decimal "jewellery_value"
-    t.decimal "vehicle_value"
-    t.decimal "classic_car_value"
-    t.decimal "money_assets_value"
-    t.decimal "money_owed_value"
-    t.decimal "trust_value"
+    t.decimal "second_home_value", precision: 14, scale: 2
+    t.decimal "second_home_mortgage", precision: 14, scale: 2
+    t.decimal "second_home_percentage", precision: 14, scale: 2
+    t.decimal "timeshare_value", precision: 14, scale: 2
+    t.decimal "land_value", precision: 14, scale: 2
+    t.decimal "jewellery_value", precision: 14, scale: 2
+    t.decimal "vehicle_value", precision: 14, scale: 2
+    t.decimal "classic_car_value", precision: 14, scale: 2
+    t.decimal "money_assets_value", precision: 14, scale: 2
+    t.decimal "money_owed_value", precision: 14, scale: 2
+    t.decimal "trust_value", precision: 14, scale: 2
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["legal_aid_application_id"], name: "index_other_assets_declarations_on_legal_aid_application_id", unique: true

--- a/spec/factories/legal_aid_applications.rb
+++ b/spec/factories/legal_aid_applications.rb
@@ -1,11 +1,5 @@
 FactoryBot.define do
   factory :legal_aid_application, aliases: [:application] do
-    # rubocop:disable Style/SymbolProc
-    after(:create) do |application|
-      application.create_other_assets_declaration!
-    end
-    # rubocop:enable Style/SymbolProc
-
     trait :with_applicant do
       applicant
     end

--- a/spec/factories/legal_aid_applications.rb
+++ b/spec/factories/legal_aid_applications.rb
@@ -1,5 +1,11 @@
 FactoryBot.define do
   factory :legal_aid_application, aliases: [:application] do
+    # rubocop:disable Style/SymbolProc
+    after(:create) do |application|
+      application.create_other_assets_declaration!
+    end
+    # rubocop:enable Style/SymbolProc
+
     trait :with_applicant do
       applicant
     end

--- a/spec/factories/other_assets_declarations.rb
+++ b/spec/factories/other_assets_declarations.rb
@@ -1,12 +1,11 @@
 FactoryBot.define do
   factory :other_assets_declaration do
-    # initialize_with { create(:legal_aid_application).other_assets_declaration }
     legal_aid_application
 
     trait :with_second_home do
-      second_home_value { 850_000.00 }
-      second_home_mortgage { 122_316.00 }
-      second_home_percentage { 100 }
+      second_home_value { Faker::Number.decimal(6, 2) }
+      second_home_mortgage { Faker::Number.decimal(6, 2) }
+      second_home_percentage { Faker::Number.decimal(2, 2) }
     end
 
     trait :with_all_values do

--- a/spec/factories/other_assets_declarations.rb
+++ b/spec/factories/other_assets_declarations.rb
@@ -1,0 +1,25 @@
+FactoryBot.define do
+  factory :other_assets_declaration do
+    initialize_with { create(:legal_aid_application).other_assets_declaration }
+
+    trait :with_second_home do
+      second_home_value { 850_000.00 }
+      second_home_mortgage { 122_316.00 }
+      second_home_percentage { 100 }
+    end
+
+    trait :with_all_values do
+      second_home_value { Faker::Number.decimal(6, 2) }
+      second_home_mortgage { Faker::Number.decimal(6, 2) }
+      second_home_percentage { Faker::Number.decimal(2, 2) }
+      timeshare_value { Faker::Number.decimal(6, 2) }
+      land_value { Faker::Number.decimal(6, 2) }
+      jewellery_value { Faker::Number.decimal(6, 2) }
+      vehicle_value { Faker::Number.decimal(6, 2) }
+      classic_car_value { Faker::Number.decimal(6, 2) }
+      money_assets_value { Faker::Number.decimal(6, 2) }
+      money_owed_value { Faker::Number.decimal(6, 2) }
+      trust_value { Faker::Number.decimal(6, 2) }
+    end
+  end
+end

--- a/spec/factories/other_assets_declarations.rb
+++ b/spec/factories/other_assets_declarations.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :other_assets_declaration do
-    initialize_with { create(:legal_aid_application).other_assets_declaration }
+    # initialize_with { create(:legal_aid_application).other_assets_declaration }
+    legal_aid_application
 
     trait :with_second_home do
       second_home_value { 850_000.00 }

--- a/spec/forms/citizens/other_assets_form_spec.rb
+++ b/spec/forms/citizens/other_assets_form_spec.rb
@@ -1,0 +1,191 @@
+require 'rails_helper'
+
+RSpec.describe Citizens::OtherAssetsForm do
+  let(:empty_oad) { create :other_assets_declaration }
+  let(:oad_with_second_home) { create :other_assets_declaration, :with_second_home }
+  let(:oad_with_all_values) { create :other_assets_declaration, :with_all_values }
+
+  context 'second home params' do
+    let(:valid_second_home_params) do
+      { check_box_second_home: 'yes',
+        second_home_value: '859374.00',
+        second_home_mortgage: '123000.00',
+        second_home_percentage: '66.66' }
+    end
+
+    let(:empty_second_home_params) do
+      { check_box_second_home: 'yes',
+        second_home_value: '',
+        second_home_mortgage: '',
+        second_home_percentage: '' }
+    end
+
+    let(:alpha_second_home_params) do
+      { check_box_second_home: 'yes',
+        second_home_value: 'aabb',
+        second_home_mortgage: '123000.00',
+        second_home_percentage: '100' }
+    end
+
+    let(:partial_second_home_params) do
+      { check_box_second_home: 'yes',
+        second_home_mortgage: '123000.00',
+        second_home_percentage: '100' }
+    end
+
+    describe 'instantiation' do
+      context 'from an existing record' do
+        let(:form) { described_class.new(current_params(empty_oad)) }
+
+        context 'with values all nil' do
+          it 'returns an unchecked status for second home checkbox' do
+            expect(form.second_home_checkbox_status).to be_nil
+          end
+        end
+
+        context 'with second home values' do
+          let(:form) { described_class.new(current_params(oad_with_second_home)) }
+
+          it 'returns checked status for second home checkbox' do
+            expect(form.second_home_checkbox_status).to eq 'checked'
+          end
+        end
+      end
+
+      context 'from an existing record and form params' do
+        let(:form) { described_class.new(form_params(empty_oad)) }
+
+        context 'valid form params' do
+          context 'all fields present' do
+            let(:submitted_params) { valid_second_home_params }
+
+            it 'is valid' do
+              expect(form).to be_valid
+            end
+          end
+
+          context 'no fields present' do
+            let(:submitted_params) { empty_second_home_params }
+
+            it 'is valid' do
+              expect(form).to be_valid
+            end
+          end
+        end
+
+        context 'invalid form params' do
+          context 'non-numeric characters' do
+            let(:submitted_params) { alpha_second_home_params }
+
+            it 'is not valid' do
+              expect(form).not_to be_valid
+              expect(form.errors[:second_home_value]).to eq [translation_for(:second_home_value, :not_a_number)]
+            end
+          end
+        end
+      end
+    end
+  end
+
+  describe 'other params' do
+    let(:params) do
+      { check_box_second_home: 'true',
+        second_home_value: '85,9374.00',
+        second_home_mortgage: '123,000.00',
+        second_home_percentage: '66.66',
+        check_box_timeshare_value: 'true',
+        timeshare_value: '67762',
+        check_box_land_value: 'true',
+        land_value: '1,234.55',
+        check_box_jewellery_value: 'true',
+        jewellery_value: '566.0',
+        check_box_vehicle_value: 'true',
+        vehicle_value: '7,338.0',
+        check_box_classic_car_value: 'true',
+        classic_car_value: '5,000',
+        check_box_money_assets_value: 'true',
+        money_assets_value: '3,500',
+        check_box_money_owed_value: 'true',
+        money_owed_value: '0.45',
+        check_box_trust_value: 'true',
+        trust_value: '3,560,622.77' }
+    end
+
+    describe 'instantiation' do
+      context 'from an existing record' do
+        let(:form) { described_class.new(current_params(oad_with_all_values)) }
+
+        context 'from an existing record and form params' do
+          let(:form) { described_class.new(form_params(empty_oad)) }
+          context 'valid form params' do
+            context 'all fields present' do
+              let(:submitted_params) { params }
+
+              it 'is valid' do
+                form.valid?
+                expect(form).to be_valid
+              end
+            end
+
+            context 'no form fields present' do
+              let(:submitted_params) { {} }
+
+              it 'is valid' do
+                expect(form).to be_valid
+              end
+            end
+          end
+
+          context 'invalid params - each value suffixed with an x' do
+            let(:submitted_params) { params.each { |_key, val| val.sub!(/$/, 'x') } }
+
+            it 'is not valid' do
+              expect(form).not_to be_valid
+              expect(form.errors[:timeshare_value]).to eq [translation_for(:timeshare_value, 'not_a_number')]
+              expect(form.errors[:land_value]).to eq [translation_for(:land_value, 'not_a_number')]
+              expect(form.errors[:jewellery_value]).to eq [translation_for(:jewellery_value, 'not_a_number')]
+              expect(form.errors[:vehicle_value]).to eq [translation_for(:vehicle_value, 'not_a_number')]
+              expect(form.errors[:classic_car_value]).to eq [translation_for(:classic_car_value, 'not_a_number')]
+              expect(form.errors[:money_assets_value]).to eq [translation_for(:money_assets_value, 'not_a_number')]
+              expect(form.errors[:money_owed_value]).to eq [translation_for(:money_owed_value, 'not_a_number')]
+              expect(form.errors[:trust_value]).to eq [translation_for(:trust_value, 'not_a_number')]
+            end
+          end
+        end
+      end
+    end
+
+    describe '#save' do
+      let(:submitted_params) { params }
+      let(:form) { described_class.new(form_params(empty_oad)) }
+
+      it 'saves all the normalized values to the record' do
+        expect(form.save).to be true
+        oad = empty_oad.reload
+        expect(oad.second_home_value).to eq 859_374.0
+        expect(oad.second_home_mortgage).to eq 123_000.0
+        expect(oad.second_home_percentage).to eq 66.66
+        expect(oad.timeshare_value).to eq 67_762.0
+        expect(oad.land_value).to eq 1_234.55
+        expect(oad.jewellery_value).to eq 566.0
+        expect(oad.vehicle_value).to eq 7_338.0
+        expect(oad.classic_car_value).to eq 5_000.0
+        expect(oad.money_assets_value).to eq 3_500.0
+        expect(oad.money_owed_value).to eq 0.45
+        expect(oad.trust_value).to eq 3_560_622.77
+      end
+    end
+  end
+
+  def current_params(oad)
+    oad.attributes.symbolize_keys.except(:id, :created_at, :updated_at, :legal_aid_application_id)
+  end
+
+  def form_params(oad)
+    submitted_params.merge(model: oad)
+  end
+
+  def translation_for(attr, error)
+    I18n.t("activemodel.errors.models.other_assets_declaration.attributes.#{attr}.#{error}")
+  end
+end

--- a/spec/forms/citizens/other_assets_form_spec.rb
+++ b/spec/forms/citizens/other_assets_form_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Citizens::OtherAssetsForm do
     end
 
     let(:empty_second_home_params) do
-      { check_box_second_home: 'yes',
+      { check_box_second_home: '',
         second_home_value: '',
         second_home_mortgage: '',
         second_home_percentage: '' }

--- a/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
+++ b/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
@@ -69,6 +69,14 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
       end
     end
 
+    context 'suffix' do
+      let(:params) { [:email, suffix: 'litres'] }
+
+      it 'shows the suffix' do
+        expect(subject).to include %(<span class="input-suffix"> litres</span></div>)
+      end
+    end
+
     context 'adding a custom class to the input' do
       let(:custom_class) { 'govuk-!-width-one-third' }
       let(:params) { [:email, class: custom_class] }

--- a/spec/models/legal_aid_application_spec.rb
+++ b/spec/models/legal_aid_application_spec.rb
@@ -3,20 +3,6 @@ require 'rails_helper'
 RSpec.describe LegalAidApplication, type: :model do
   let(:legal_aid_application) { create :legal_aid_application }
 
-  describe 'after_create_hook' do
-    it 'creates an OtherAssetsDeclaration' do
-      expect { create(:legal_aid_application) }.to change { OtherAssetsDeclaration.count }.by(1)
-    end
-
-    it 'sets all the attributes to nil' do
-      oad = legal_aid_application.other_assets_declaration
-      attribute_names = oad.attributes.symbolize_keys.except(:id, :created_at, :updated_at, :legal_aid_application_id).keys
-      attribute_names.each do |attr|
-        expect(oad.__send__(attr)).to be_nil, "Expected #{attr} to be nil, was #{oad.__send__(attr)}"
-      end
-    end
-  end
-
   describe 'validations' do
     let(:attributes) { { proceeding_type_codes: %w[invalid_code1 invalid_code2] } }
     let(:legal_aid_application) { described_class.new(attributes) }

--- a/spec/models/legal_aid_application_spec.rb
+++ b/spec/models/legal_aid_application_spec.rb
@@ -3,6 +3,20 @@ require 'rails_helper'
 RSpec.describe LegalAidApplication, type: :model do
   let(:legal_aid_application) { create :legal_aid_application }
 
+  describe 'after_create_hook' do
+    it 'creates an OtherAssetsDeclaration' do
+      expect { create(:legal_aid_application) }.to change { OtherAssetsDeclaration.count }.by(1)
+    end
+
+    it 'sets all the attributes to nil' do
+      oad = legal_aid_application.other_assets_declaration
+      attribute_names = oad.attributes.symbolize_keys.except(:id, :created_at, :updated_at, :legal_aid_application_id).keys
+      attribute_names.each do |attr|
+        expect(oad.__send__(attr)).to be_nil, "Expected #{attr} to be nil, was #{oad.__send__(attr)}"
+      end
+    end
+  end
+
   describe 'validations' do
     let(:attributes) { { proceeding_type_codes: %w[invalid_code1 invalid_code2] } }
     let(:legal_aid_application) { described_class.new(attributes) }

--- a/spec/models/other_assets_declaraion_spec.rb
+++ b/spec/models/other_assets_declaraion_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe OtherAssetsDeclaration do
+  describe 'unique index on legal_aid_application_id' do
+    it 'throws an exception if you attempt to create a second record for an application' do
+      application = create :legal_aid_application
+      expect {
+        OtherAssetsDeclaration.create!(legal_aid_application_id: application.id)
+      }.to raise_error ActiveRecord::RecordNotUnique
+    end
+  end
+end

--- a/spec/models/other_assets_declaraion_spec.rb
+++ b/spec/models/other_assets_declaraion_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe OtherAssetsDeclaration do
   describe 'unique index on legal_aid_application_id' do
     it 'throws an exception if you attempt to create a second record for an application' do
       application = create :legal_aid_application
+      application.create_other_assets_declaration!
       expect {
         OtherAssetsDeclaration.create!(legal_aid_application_id: application.id)
       }.to raise_error ActiveRecord::RecordNotUnique

--- a/spec/requests/citizens/legal_aid_applications_spec.rb
+++ b/spec/requests/citizens/legal_aid_applications_spec.rb
@@ -20,8 +20,8 @@ RSpec.describe 'citizen home requests', type: :request do
       end
 
       it 'returns the correct application' do
-        expect(unescaped_response_body).to include(applicant_first_name.html_safe)
-        expect(unescaped_response_body).to include(applicant_last_name.html_safe)
+        expect(response.body).to include(CGI.escapeHTML(applicant_first_name.html_safe))
+        expect(response.body).to include(CGI.escapeHTML(applicant_last_name.html_safe))
       end
     end
 

--- a/spec/requests/citizens/other_assets_spec.rb
+++ b/spec/requests/citizens/other_assets_spec.rb
@@ -1,0 +1,123 @@
+require 'rails_helper'
+
+RSpec.describe 'citizen other assets requests', type: :request do
+  let(:application) { create :application, :with_applicant }
+  let(:oad) { application.other_assets_declaration }
+  let(:application_id) { application.id }
+  let(:secure_id) { application.generate_secure_id }
+
+  before { get citizens_legal_aid_application_path(secure_id) }
+
+  describe 'GET citizens/own_home' do
+    it 'returns http success' do
+      get citizens_other_assets_path
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'displays the show page' do
+      get citizens_other_assets_path
+      expect(response.body).to include I18n.t('citizens.other_assets.show.h1-heading')
+    end
+  end
+
+  describe 'PATCH citizens/own_home' do
+    before { patch citizens_other_assets_path, params: params }
+
+    let(:params) do
+      {
+        other_assets_declaration: {
+          check_box_second_home: 'true',
+          second_home_value: '875123',
+          second_home_mortgage: '125,345.67',
+          second_home_percentage: '64.440',
+          check_box_timeshare_value: 'true',
+          timeshare_value: '234,567.89',
+          check_box_land_value: 'true',
+          land_value: '34,567.89',
+          check_box_jewellery_value: 'true',
+          jewellery_value: '456,789.01',
+          check_box_vehicle_value: 'true',
+          vehicle_value: '56,789.01',
+          check_box_classic_car_value: 'true',
+          classic_car_value: '67,890.12',
+          check_box_money_assets_value: 'true',
+          money_assets_value: '89,012.34',
+          check_box_money_owed_value: 'true',
+          money_owed_value: '90,123.45',
+          check_box_trust_value: 'true',
+          trust_value: '1,234.56'
+        },
+        commit: 'Continue'
+      }
+    end
+
+    context 'valid params' do
+      it 'returns http_success' do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'updates the record' do
+        oad.reload
+        expect(oad.second_home_value).to eq 875_123
+        expect(oad.second_home_mortgage).to eq 125_345.67
+        expect(oad.second_home_percentage).to eq 64.44
+        expect(oad.timeshare_value).to eq 234_567.89
+        expect(oad.land_value).to eq 34_567.89
+        expect(oad.jewellery_value).to eq 456_789.01
+        expect(oad.vehicle_value).to eq 56_789.01
+        expect(oad.classic_car_value).to eq 67_890.12
+        expect(oad.money_assets_value).to eq 89_012.34
+        expect(oad.money_owed_value).to eq 90_123.45
+        expect(oad.trust_value).to eq 1_234.56
+      end
+
+      # TODO: setup redirect when known
+      xit 'redirects to the next page in the flow' do
+        expect(response).to redirect_to(:next_page_in_the_flow)
+      end
+
+      # TODO: remove when redirect set up
+      it 'displays holding text' do
+        expect(response.body).to eq 'Navigate to next question after any other assets'
+      end
+    end
+
+    context 'invalid params - nothing specified' do
+      let(:params) do
+        {
+          other_assets_declaration: {
+            check_box_second_home: 'true',
+            second_home_value: 'aaa'
+          },
+          commit: 'Continue'
+        }
+      end
+
+      it 'returns http_success' do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'does not update the record' do
+        expect(oad.second_home_value).to be_nil
+        expect(oad.second_home_mortgage).to be_nil
+        expect(oad.second_home_percentage).to be_nil
+        expect(oad.timeshare_value).to be_nil
+        expect(oad.land_value).to be_nil
+        expect(oad.jewellery_value).to be_nil
+        expect(oad.vehicle_value).to be_nil
+        expect(oad.classic_car_value).to be_nil
+        expect(oad.money_assets_value).to be_nil
+        expect(oad.money_owed_value).to be_nil
+        expect(oad.trust_value).to be_nil
+      end
+
+      it 'the response includes the error message' do
+        expect(response.body).to include(I18n.t('activemodel.errors.models.other_assets_declaration.attributes.second_home_value.not_a_number'))
+      end
+
+      it 'renders the show page' do
+        expect(response.body).to include I18n.t('citizens.other_assets.show.h1-heading')
+      end
+    end
+  end
+end

--- a/spec/requests/citizens/other_assets_spec.rb
+++ b/spec/requests/citizens/other_assets_spec.rb
@@ -2,9 +2,9 @@ require 'rails_helper'
 
 RSpec.describe 'citizen other assets requests', type: :request do
   let(:application) { create :application, :with_applicant }
-  let(:oad) { application.other_assets_declaration }
+  let(:oad) { application.create_other_assets_declaration! }
   let(:application_id) { application.id }
-  let(:secure_id) { application.generate_secure_id }
+  let(:secure_id) { oad.legal_aid_application.generate_secure_id }
 
   before { get citizens_legal_aid_application_path(secure_id) }
 

--- a/spec/requests/providers/legal_aid_applications_spec.rb
+++ b/spec/requests/providers/legal_aid_applications_spec.rb
@@ -17,6 +17,10 @@ RSpec.describe 'providers legal aid application requests', type: :request do
       expect { subject }.to change { LegalAidApplication.count }.by(1)
     end
 
+    it 'creates an associated other_assets_declaration' do
+      expect { subject }.to change { OtherAssetsDeclaration.count }.by(1)
+    end
+
     it 'redirects to proceedings types' do
       subject
       expect(response).to redirect_to(


### PR DESCRIPTION
## Implementation of Other Assets Page
[Link to story](https://dsdmoj.atlassian.net/browse/AP-216)

This page comprises 9 checkboxes which expand to expose 1 to 3 edit boxes
when checked.  The data is stored in an OtherAssetsDeclaration model which
is linked to the legal aid application on a one-to-one bases (legal aid application
has one other_assets_declaration) - this is to help prevent the legal aid declaration
model ending up with 50 columns.

Although working, the markup for the revealing checkboxes may need to be tweaked 
in order to make appearance and behaviour the same as on the other page with 
revealing checkboxes, probably by implementing this element in the FormBuilder 
and using the FormBuilder on both pages.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unneccessary whitespace changes. These make diffs harder to read and conflicts more likely. 
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
