### PR TITLE
Fix small accessibility issue in proceeding types

### DIFF
--- a/app/views/providers/proceedings_types/_proceeding_type.html.erb
+++ b/app/views/providers/proceedings_types/_proceeding_type.html.erb
@@ -6,9 +6,13 @@
     </span>
   </div>
 
-  <%= form_for([:providers, @legal_aid_application], url: providers_legal_aid_application_proceedings_type_path) do |form| %>
+  <%= form_for(
+        [:providers, @legal_aid_application],
+        url: providers_legal_aid_application_proceedings_type_path,
+        html: { id: "add_legal_aid_application_proceeding_type_#{proceeding_type.code}" }
+      ) do |form| %>
   <div class="govuk-grid-column-one-third control-column">
-    <%= hidden_field_tag :proceeding_type, proceeding_type.code %>
+    <%= hidden_field_tag :proceeding_type, proceeding_type.code, id: "proceeding_type_#{proceeding_type.code}" %>
     <%= form.submit 'Select and continue', tabindex: '-1', class: 'govuk-button proceeding-link govuk-!-margin-top-4' %>
   </div>
   <% end %>


### PR DESCRIPTION
I found a small accessibility issue when playing with accessibility audit tools. The ids used in the proceeding type forms were not unique.