### PR TITLE
Add font type for currency unit

### DIFF
--- a/app/assets/stylesheets/govuk-currency-input.scss
+++ b/app/assets/stylesheets/govuk-currency-input.scss
@@ -28,6 +28,7 @@ Used with:
 
 @media (min-width: 40.0625em) {
   .govuk-currency-input__inner__unit {
+    font-family: Arial, Helvetica, sans-serif;
     font-size: 19px;
     line-height: 1.3157894737;
     padding-top: 5px;


### PR DESCRIPTION
Incorrect font was being used for the currency unit in the property value page