### PR TITLE
Refactor property value page to use helper method for showing currenc…

### DIFF
--- a/app/helpers/gov_uk_form_helper.rb
+++ b/app/helpers/gov_uk_form_helper.rb
@@ -42,10 +42,6 @@ module GovUkFormHelper
     'govuk-input--error'
   end
 
-  def govuk_currency_input_wrapper(&block)
-    render 'shared/forms/currency_input_wrapper', text_field: capture(&block)
-  end
-
   # `value_label_pairs should be a hash with the input values as keys, and the
   # matching labels as values. For example: `{ yes: 'I would', no: 'I would not' }`
   def govuk_radio_inputs(field_name, value_label_pairs)

--- a/app/helpers/gov_uk_form_helper.rb
+++ b/app/helpers/gov_uk_form_helper.rb
@@ -37,11 +37,6 @@ module GovUkFormHelper
     )
   end
 
-  def govuk_error_class(error)
-    return '' unless error.present?
-    'govuk-input--error'
-  end
-
   # `value_label_pairs should be a hash with the input values as keys, and the
   # matching labels as values. For example: `{ yes: 'I would', no: 'I would not' }`
   def govuk_radio_inputs(field_name, value_label_pairs)

--- a/app/views/citizens/property_values/show.html.erb
+++ b/app/views/citizens/property_values/show.html.erb
@@ -13,7 +13,7 @@
 
       <%= govuk_fieldset_header t('.field_set_header'), padding_below: 6 %>
         <% input_error_class = govuk_error_class(form.object.errors[:property_value]) %>
-      <%= form.govuk_text_field :property_value, input_prefix: '£', class: "govuk-input govuk-!-width-one-third #{input_error_class}" %>
+      <%= form.govuk_text_field :property_value, input_prefix: t('currency.gbp'), class: "govuk-input govuk-!-width-one-third #{input_error_class}" %>
     <% end %>
 
       <%= govuk_submit_button t('generic.continue') %>

--- a/app/views/citizens/property_values/show.html.erb
+++ b/app/views/citizens/property_values/show.html.erb
@@ -12,8 +12,7 @@
         ) do %>
 
       <%= govuk_fieldset_header t('.field_set_header'), padding_below: 6 %>
-        <% input_error_class = govuk_error_class(form.object.errors[:property_value]) %>
-      <%= form.govuk_text_field :property_value, input_prefix: t('currency.gbp'), class: "govuk-input govuk-!-width-one-third #{input_error_class}" %>
+      <%= form.govuk_text_field :property_value, input_prefix: t('currency.gbp'), class: 'govuk-input govuk-!-width-one-third' %>
     <% end %>
 
       <%= govuk_submit_button t('generic.continue') %>

--- a/app/views/citizens/property_values/show.html.erb
+++ b/app/views/citizens/property_values/show.html.erb
@@ -12,13 +12,8 @@
         ) do %>
 
       <%= govuk_fieldset_header t('.field_set_header'), padding_below: 6 %>
-      <%= form.label :property_value, t('.label'), class: 'govuk-label' %>
-      <%= govuk_hint t('.hint'), id: :property_value_hint %>
-      <%= govuk_error_message form.object.errors[:property_value].first %>
-      <%= govuk_currency_input_wrapper do %>
         <% input_error_class = govuk_error_class(form.object.errors[:property_value]) %>
-        <%= form.text_field :property_value, class: "govuk-input govuk-!-width-one-third govuk-currency-input__inner__input #{input_error_class}" %>
-      <% end %>
+      <%= form.govuk_text_field :property_value, input_prefix: '£', class: "govuk-input govuk-!-width-one-third #{input_error_class}" %>
     <% end %>
 
       <%= govuk_submit_button t('generic.continue') %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -14,6 +14,7 @@ en:
       check_box_isa: Accounts you do not access with online banking
       check_box_other_person_account: For example, a junior ISA for a child
       check_box_life_assurance_endowment_policy: Do not include policies that only pay out on death
+      property_value: You can use property websites to find the estimated value.
   shared:
     forms:
       date_input_fields:
@@ -55,6 +56,7 @@ en:
         peps_unit_trusts_capital_bonds_gov_stocks: Enter the total value of all you own
         check_box_life_assurance_endowment_policy: Life assurance and endowment policies not linked to a mortgage
         life_assurance_endowment_policy: Enter the total value of all you own
+        property_value: Enter the estimated value of your home
       applicants/address_form:
         <<: *address_attrs
       applicants/basic_details_form:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -41,6 +41,7 @@ en:
       legal_aid_application:
         percentage_home: Enter the estimated percentage share you own
         outstanding_mortgage_amount: Enter outstanding mortgage amount
+        property_value: Enter the estimated value of your home
       savings_amount:
         check_box_isa: Post Office, ISAs and other savings accounts
         isa: Enter the estimated total in all accounts
@@ -56,7 +57,6 @@ en:
         peps_unit_trusts_capital_bonds_gov_stocks: Enter the total value of all you own
         check_box_life_assurance_endowment_policy: Life assurance and endowment policies not linked to a mortgage
         life_assurance_endowment_policy: Enter the total value of all you own
-        property_value: Enter the estimated value of your home
       applicants/address_form:
         <<: *address_attrs
       applicants/basic_details_form:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -316,8 +316,6 @@ en:
     property_values:
       show:
         field_set_header: How much is your home worth?
-        label: Enter the estimated value of your home
-        hint: You can use property websites to find the estimated value.
     outstanding_mortgages:
       show:
         outstanding_mortgage_amount_heading: What is the outstanding mortgage on your home?

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -143,10 +143,10 @@ ActiveRecord::Schema.define(version: 2018_12_11_125447) do
     t.boolean "open_banking_consent"
     t.datetime "open_banking_consent_choice_at"
     t.string "own_home"
-    t.decimal "percentage_home"
     t.decimal "property_value", precision: 10, scale: 2
-    t.decimal "outstanding_mortgage_amount"
+    t.decimal "percentage_home"
     t.string "shared_ownership"
+    t.decimal "outstanding_mortgage_amount"
     t.index ["applicant_id"], name: "index_legal_aid_applications_on_applicant_id"
   end
 


### PR DESCRIPTION
Refactor the property value form to use the helper method for text fields that inserts a prefix. The existing version was not showing the currency unit in the correct font.

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unneccessary whitespace changes. These make diffs harder to read and conflicts more likely. 
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
