### PR TITLE
AP-232 Changed hardcoded h1s on various pages to use the html title helper.

### DIFF
--- a/app/views/citizens/accounts/index.html.erb
+++ b/app/views/citizens/accounts/index.html.erb
@@ -1,8 +1,7 @@
+<% content_for(:page_title) { t('.h1-heading') } %>
 <% content_for :navigation do %>
   <%= link_to t('generic.back'), citizens_consent_path, class: 'govuk-back-link', id: 'back' %>
 <% end %>
-
-<% content_for(:page_title) { t('.h1-heading') } %>
 
 <h1 class="govuk-heading-xl"><%= content_for(:page_title) %></h1>
 

--- a/app/views/citizens/accounts/index.html.erb
+++ b/app/views/citizens/accounts/index.html.erb
@@ -1,7 +1,11 @@
 <% content_for :navigation do %>
   <%= link_to t('generic.back'), citizens_consent_path, class: 'govuk-back-link', id: 'back' %>
 <% end %>
-<h1 class="govuk-heading-xl"><%= t '.heading_1' %></h1>
+
+<% content_for(:page_title) { t('.h1-heading') } %>
+
+<h1 class="govuk-heading-xl"><%= content_for(:page_title) %></h1>
+
 <p>
   <%= t '.intro_text' %>
 </p>

--- a/app/views/citizens/additional_accounts/index.html.erb
+++ b/app/views/citizens/additional_accounts/index.html.erb
@@ -1,8 +1,9 @@
+<% content_for(:page_title) { t('.field_set_header') } %>
 <% content_for :navigation do %>
   <%#= link_to 'Back', path-to-be-determined, class: 'govuk-back-link', id: 'back' %>
 <% end %>
 
-  <% content_for(:page_title) { t('.field_set_header') } %>
+  <%= govuk_fieldset_header content_for(:page_title), padding_below: 6 %>
 
   <%= form_tag(citizens_additional_accounts_path) do %>
 

--- a/app/views/citizens/additional_accounts/index.html.erb
+++ b/app/views/citizens/additional_accounts/index.html.erb
@@ -2,6 +2,8 @@
   <%#= link_to 'Back', path-to-be-determined, class: 'govuk-back-link', id: 'back' %>
 <% end %>
 
+  <% content_for(:page_title) { t('.field_set_header') } %>
+
   <%= form_tag(citizens_additional_accounts_path) do %>
 
     <%= govuk_form_group(
@@ -9,7 +11,6 @@
           hint_id: :additional_account_hint,
           input: :additional_account
         ) do %>
-      <%= govuk_fieldset_header t('.field_set_header'), padding_below: 6 %>
       <%= govuk_hint t('.hint'), id: :additional_account_hint %>
       <%= govuk_error_message @error %>
       <%= govuk_radio_inputs :additional_account, yes: t('generic.yes'), no: t('generic.no') %>

--- a/app/views/citizens/additional_accounts/new.html.erb
+++ b/app/views/citizens/additional_accounts/new.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:page_title) { t('.field_set_header') } %>
 <% content_for :navigation do %>
   <%#= link_to 'Back', path-to-be-determined, class: 'govuk-back-link', id: 'back' %>
 <% end %>
@@ -9,7 +10,7 @@
           hint_id: :has_offline_accounts_hint,
           input: :has_offline_accounts
         ) do %>
-      <%= govuk_fieldset_header t('.field_set_header'), padding_below: 6 %>
+      <%= govuk_fieldset_header content_for(:page_title), padding_below: 6 %>
       <%= govuk_hint t('.hint'), id: :has_offline_accounts_hint %>
       <%= govuk_error_message(@error) %>
       <%= govuk_radio_inputs :has_offline_accounts, yes: t('generic.yes'), no: t('generic.no') %>

--- a/app/views/citizens/consents/show.html.erb
+++ b/app/views/citizens/consents/show.html.erb
@@ -1,8 +1,7 @@
+<% content_for(:page_title) { t('.field_set_header') } %>
 <% content_for :navigation do %>
     <%= link_to t('generic.back'), citizens_information_path, class: 'govuk-back-link', id: 'back' %>
 <% end %>
-
-<% content_for(:page_title) { t('.field_set_header') } %>
 
 <%= form_with(model: @form, scope: :legal_aid_application, url: citizens_consent_path, local: true) do |form| %>
 

--- a/app/views/citizens/consents/show.html.erb
+++ b/app/views/citizens/consents/show.html.erb
@@ -2,12 +2,14 @@
     <%= link_to t('generic.back'), citizens_information_path, class: 'govuk-back-link', id: 'back' %>
 <% end %>
 
+<% content_for(:page_title) { t('.field_set_header') } %>
+
 <%= form_with(model: @form, scope: :legal_aid_application, url: citizens_consent_path, local: true) do |form| %>
 
   <%= govuk_form_group(
         input: :open_banking_consent
       ) do %>
-    <%= govuk_fieldset_header t('.field_set_header'), padding_below: 6 %>
+    <%= govuk_fieldset_header content_for(:page_title), padding_below: 6 %>
     <%= govuk_body t('.body') %>
     <%= render partial: 'shared/forms/detailed_list', locals: { translation_path: 'citizens.consents.show' } %>
     <%= render partial: 'shared/forms/check_boxes', locals: { field_name: :open_banking_consent, label: t('.open_banking_consent.label.html'), form: form, checked: 'true', unchecked: 'false' } %>

--- a/app/views/citizens/information/show.html.erb
+++ b/app/views/citizens/information/show.html.erb
@@ -1,8 +1,7 @@
+<% content_for(:page_title) { t('.h1-heading') } %>
 <% content_for :navigation do %>
   <%= link_to t('generic.back'), citizens_legal_aid_application_path(id: session[:current_application_ref]), class: 'govuk-back-link', id: 'back' %>
 <% end %>
-
-<% content_for(:page_title) { t('.h1-heading') } %>
 
 <h1 class="govuk-heading-xl"><%= content_for(:page_title) %></h1>
 

--- a/app/views/citizens/information/show.html.erb
+++ b/app/views/citizens/information/show.html.erb
@@ -2,7 +2,9 @@
   <%= link_to t('generic.back'), citizens_legal_aid_application_path(id: session[:current_application_ref]), class: 'govuk-back-link', id: 'back' %>
 <% end %>
 
-<h1 class="govuk-heading-xl"><%= t('.heading_1') %></h1>
+<% content_for(:page_title) { t('.h1-heading') } %>
+
+<h1 class="govuk-heading-xl"><%= content_for(:page_title) %></h1>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/citizens/legal_aid_applications/show.html.erb
+++ b/app/views/citizens/legal_aid_applications/show.html.erb
@@ -1,10 +1,6 @@
-<<<<<<< HEAD
-<h1 class="govuk-heading-xl"><%= t('.heading_1') %></h1>
-=======
 <% content_for(:page_title) { t('.h1-heading') } %>
 
 <h1 class="govuk-heading-xl"><%= content_for(:page_title) %></h1>
->>>>>>> Changed hardcoded h1s on various pages to use the html title helper.
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/citizens/legal_aid_applications/show.html.erb
+++ b/app/views/citizens/legal_aid_applications/show.html.erb
@@ -1,4 +1,10 @@
+<<<<<<< HEAD
 <h1 class="govuk-heading-xl"><%= t('.heading_1') %></h1>
+=======
+<% content_for(:page_title) { t('.h1-heading') } %>
+
+<h1 class="govuk-heading-xl"><%= content_for(:page_title) %></h1>
+>>>>>>> Changed hardcoded h1s on various pages to use the html title helper.
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/citizens/outstanding_mortgages/show.html.erb
+++ b/app/views/citizens/outstanding_mortgages/show.html.erb
@@ -1,6 +1,5 @@
-<%= render 'shared/forms/error_summary', model: @form %>
-
 <% content_for(:page_title) { t('.field_set_header') } %>
+<%= render 'shared/forms/error_summary', model: @form %>
 
 <fieldset class="govuk-fieldset">
   <div class="govuk-!-padding-bottom-2"></div>

--- a/app/views/citizens/outstanding_mortgages/show.html.erb
+++ b/app/views/citizens/outstanding_mortgages/show.html.erb
@@ -1,5 +1,7 @@
 <%= render 'shared/forms/error_summary', model: @form %>
 
+<% content_for(:page_title) { t('.field_set_header') } %>
+
 <fieldset class="govuk-fieldset">
   <div class="govuk-!-padding-bottom-2"></div>
 
@@ -19,7 +21,7 @@
               hint_id: :outstanding_mortgage_amount_hint
             ) do %>
 
-          <%= govuk_fieldset_header t('.outstanding_mortgage_amount_heading'), padding_below: 6 %>
+          <%= govuk_fieldset_header content_for(:page_title), padding_below: 6 %>
           <%= form.govuk_text_field :outstanding_mortgage_amount, input_prefix: t('currency.gbp'), class: 'govuk-!-width-one-third' %>
         <% end %>
 

--- a/app/views/citizens/own_homes/show.html.erb
+++ b/app/views/citizens/own_homes/show.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:page_title) { t('.h1-heading') } %>
 <% content_for :navigation do %>
   <%= link_to t('generic.back'), citizens_consent_path(id: session[:current_application_ref]), class: 'govuk-back-link', id: 'back' %>
 <% end %>

--- a/app/views/citizens/percentage_homes/show.html.erb
+++ b/app/views/citizens/percentage_homes/show.html.erb
@@ -1,10 +1,9 @@
+<% content_for(:page_title) { t('.h1-heading') } %>
 <% content_for :navigation do %>
   <!-- TODO: navigate to "1d. shared ownership"  -->
 
   <%= link_to 'Back', citizens_additional_accounts_path, class: 'govuk-back-link', id: 'back' %>
 <% end %>
-
-<% content_for(:page_title) { t('.h1-heading') } %>
 
 <h1 class="govuk-heading-xl"><%= content_for(:page_title) %></h1>
 

--- a/app/views/citizens/property_values/show.html.erb
+++ b/app/views/citizens/property_values/show.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:page_title) { t('.field_set_header') } %>
 <% content_for :navigation do %>
     <%= link_to t('generic.back'), new_citizens_additional_account_path, class: 'govuk-back-link', id: 'back' %>
 <% end %>
@@ -13,19 +14,6 @@
           input: :property_value
         ) do %>
 
-<<<<<<< HEAD
-      <%= govuk_fieldset_header t('.field_set_header'), padding_below: 6 %>
-      <%= form.govuk_text_field :property_value, input_prefix: t('currency.gbp'), class: 'govuk-!-width-one-third' %>
-=======
-      <%= govuk_fieldset_header content_for(:page_title), padding_below: 6 %>
-      <%= form.label :property_value, t('.label'), class: 'govuk-label' %>
-      <%= govuk_hint t('.hint'), id: :property_value_hint %>
-      <%= govuk_error_message form.object.errors[:property_value].first %>
-      <%= govuk_currency_input_wrapper do %>
-        <% input_error_class = govuk_error_class(form.object.errors[:property_value]) %>
-        <%= form.text_field :property_value, class: "govuk-input govuk-!-width-one-third govuk-currency-input__inner__input #{input_error_class}" %>
-      <% end %>
->>>>>>> Refactored the h1s on views to be at the top of the page for consistancy
     <% end %>
 
     <%= govuk_submit_button t('generic.continue') %>

--- a/app/views/citizens/property_values/show.html.erb
+++ b/app/views/citizens/property_values/show.html.erb
@@ -2,6 +2,8 @@
     <%= link_to t('generic.back'), new_citizens_additional_account_path, class: 'govuk-back-link', id: 'back' %>
 <% end %>
 
+<% content_for(:page_title) { t('.field_set_header') } %>
+
 <%= render partial: 'shared/forms/error_summary', locals: { model: @form, attribute_prefix: :legal_aid_application_ } %>
 
   <%= form_with(model: @form, scope: :legal_aid_application, url: citizens_property_value_path, method: :patch, local: true) do |form| %>
@@ -11,8 +13,19 @@
           input: :property_value
         ) do %>
 
+<<<<<<< HEAD
       <%= govuk_fieldset_header t('.field_set_header'), padding_below: 6 %>
       <%= form.govuk_text_field :property_value, input_prefix: t('currency.gbp'), class: 'govuk-!-width-one-third' %>
+=======
+      <%= govuk_fieldset_header content_for(:page_title), padding_below: 6 %>
+      <%= form.label :property_value, t('.label'), class: 'govuk-label' %>
+      <%= govuk_hint t('.hint'), id: :property_value_hint %>
+      <%= govuk_error_message form.object.errors[:property_value].first %>
+      <%= govuk_currency_input_wrapper do %>
+        <% input_error_class = govuk_error_class(form.object.errors[:property_value]) %>
+        <%= form.text_field :property_value, class: "govuk-input govuk-!-width-one-third govuk-currency-input__inner__input #{input_error_class}" %>
+      <% end %>
+>>>>>>> Refactored the h1s on views to be at the top of the page for consistancy
     <% end %>
 
     <%= govuk_submit_button t('generic.continue') %>

--- a/app/views/citizens/savings_and_investments/show.html.erb
+++ b/app/views/citizens/savings_and_investments/show.html.erb
@@ -1,8 +1,7 @@
+<% content_for(:page_title) { t('.h1-heading') } %>
 <% content_for :navigation do %>
    <%= link_to t('generic.back'), back_link, class: 'govuk-back-link', id: 'back' %>
 <% end %>
-
-<% content_for(:page_title) { t('.h1-heading') } %>
 
 <%= render partial: 'shared/forms/error_summary', locals: { model: @form } %>
 

--- a/app/views/citizens/shared_ownerships/show.html.erb
+++ b/app/views/citizens/shared_ownerships/show.html.erb
@@ -1,8 +1,7 @@
+<% content_for(:page_title) { t('.h1-heading') } %>
 <% content_for :navigation do %>
   <%= link_to t('generic.back'), '#', class: 'govuk-back-link', id: 'back' %>
 <% end %>
-
-<% content_for(:page_title) { t('.h1-heading') } %>
 
 <h1 class="govuk-heading-xl"><%= content_for(:page_title) %></h1>
 

--- a/app/views/citizens/shared_ownerships/show.html.erb
+++ b/app/views/citizens/shared_ownerships/show.html.erb
@@ -2,7 +2,9 @@
   <%= link_to t('generic.back'), '#', class: 'govuk-back-link', id: 'back' %>
 <% end %>
 
-<h1 class="govuk-heading-xl"><%= t('.heading_1') %></h1>
+<% content_for(:page_title) { t('.h1-heading') } %>
+
+<h1 class="govuk-heading-xl"><%= content_for(:page_title) %></h1>
 
 <%= render partial: 'shared/forms/error_summary', locals: { model: @form } %>
 

--- a/app/views/providers/about_the_financial_assessments/show.html.erb
+++ b/app/views/providers/about_the_financial_assessments/show.html.erb
@@ -1,9 +1,9 @@
 <% content_for(:navigation) { provider_back_link } %>
 
+<% content_for(:page_title) { t('.h1-heading') } %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-
-    <% content_for(:page_title) { t('.h1-heading') } %>
 
     <h1 class="govuk-heading-xl"><%= content_for(:page_title) %></h1>
 

--- a/app/views/providers/about_the_financial_assessments/show.html.erb
+++ b/app/views/providers/about_the_financial_assessments/show.html.erb
@@ -3,7 +3,9 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-    <h1 class="govuk-heading-xl"><%= t '.title' %></h1>
+    <% content_for(:page_title) { t('.h1-heading') } %>
+
+    <h1 class="govuk-heading-xl"><%= content_for(:page_title) %></h1>
 
     <p class="govuk-body"><%= t '.sign_in_para' %></p>
 

--- a/app/views/providers/about_the_financial_assessments/show.html.erb
+++ b/app/views/providers/about_the_financial_assessments/show.html.erb
@@ -1,6 +1,5 @@
-<% content_for(:navigation) { provider_back_link } %>
-
 <% content_for(:page_title) { t('.h1-heading') } %>
+<% content_for(:navigation) { provider_back_link } %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/providers/address_lookups/_form.html.erb
+++ b/app/views/providers/address_lookups/_form.html.erb
@@ -1,6 +1,5 @@
-<%= render partial: 'shared/forms/error_summary', locals: { model: @form } %>
-
 <% content_for(:page_title) { t('forms.address_lookup.h1-heading') } %>
+<%= render partial: 'shared/forms/error_summary', locals: { model: @form } %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/providers/address_lookups/_form.html.erb
+++ b/app/views/providers/address_lookups/_form.html.erb
@@ -1,9 +1,9 @@
 <%= render partial: 'shared/forms/error_summary', locals: { model: @form } %>
 
+<% content_for(:page_title) { t('forms.address_lookup.h1-heading') } %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-
-    <% content_for(:page_title) { t('forms.address_lookup.h1-heading') } %>
 
     <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
       <h1 class="govuk-fieldset__heading"><%= content_for(:page_title) %></h1>

--- a/app/views/providers/address_lookups/_form.html.erb
+++ b/app/views/providers/address_lookups/_form.html.erb
@@ -3,10 +3,10 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
+    <% content_for(:page_title) { t('forms.address_lookup.h1-heading') } %>
+
     <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
-      <h1 class="govuk-fieldset__heading">
-        <%= t('forms.address_lookup.heading') %>
-      </h1>
+      <h1 class="govuk-fieldset__heading"><%= content_for(:page_title) %></h1>
     </legend>
 
     <%= form_with(

--- a/app/views/providers/address_selections/show.html.erb
+++ b/app/views/providers/address_selections/show.html.erb
@@ -12,9 +12,8 @@
         ) do |f| %>
       <div class='govuk-form-group'>
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
-          <h1 class="govuk-fieldset__heading">
-            <%= t('forms.address_selection.heading') %>
-          </h1>
+          <% content_for(:page_title) { t('forms.address_selection.h1-heading') } %>
+          <h1 class="govuk-heading-xl"><%= content_for(:page_title) %></h1>
         </legend>
         <div class="govuk-!-padding-bottom-8"></div>
 

--- a/app/views/providers/address_selections/show.html.erb
+++ b/app/views/providers/address_selections/show.html.erb
@@ -1,4 +1,5 @@
-  <% content_for(:navigation) { provider_back_link } %>
+<% content_for(:page_title) { t('forms.address_selection.h1-heading') } %>
+<% content_for(:navigation) { provider_back_link } %>
 <%= render partial: 'shared/forms/error_summary', locals: { model: @form } %>
 
 <div class="govuk-grid-row">
@@ -12,7 +13,6 @@
         ) do |f| %>
       <div class='govuk-form-group'>
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
-          <% content_for(:page_title) { t('forms.address_selection.h1-heading') } %>
           <h1 class="govuk-heading-xl"><%= content_for(:page_title) %></h1>
         </legend>
         <div class="govuk-!-padding-bottom-8"></div>

--- a/app/views/providers/addresses/_form.html.erb
+++ b/app/views/providers/addresses/_form.html.erb
@@ -13,9 +13,9 @@
     <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
       <h1 class="govuk-fieldset__heading">
         <% if form.object.lookup_error.present? %>
-          <%= t('forms.address_lookup.heading') %>
+          <%= t('forms.address_lookup.h1-heading') %>
         <% else %>
-          <%= t('forms.address_manual.heading') %>
+          <%= t('forms.address_manual.h1-heading') %>
         <% end %>
       </h1>
     </legend>

--- a/app/views/providers/addresses/_form.html.erb
+++ b/app/views/providers/addresses/_form.html.erb
@@ -10,14 +10,14 @@
           local: true
         ) do |form| %>
 
-    <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
-      <h1 class="govuk-fieldset__heading">
         <% if form.object.lookup_error.present? %>
-          <%= t('forms.address_lookup.h1-heading') %>
+          <% content_for(:page_title) { t('forms.address_lookup.h1-heading') } %>
         <% else %>
-          <%= t('forms.address_manual.h1-heading') %>
+          <% content_for(:page_title) { t('forms.address_manual.h1-heading') } %>
         <% end %>
-      </h1>
+
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+      <h1 class="govuk-heading-xl"><%= content_for(:page_title) %></h1>
     </legend>
 
       <% if form.object.lookup_postcode.present? %>

--- a/app/views/providers/applicants/show.html.erb
+++ b/app/views/providers/applicants/show.html.erb
@@ -5,9 +5,8 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
-        <h1 class="govuk-fieldset__heading">
-          Enter your client's details
-        </h1>
+        <% content_for(:page_title) { t('.h1-heading') } %>
+        <h1 class="govuk-fieldset__heading"><%= content_for(:page_title) %></h1>
       </legend>
     </div>
   </div>

--- a/app/views/providers/applicants/show.html.erb
+++ b/app/views/providers/applicants/show.html.erb
@@ -1,11 +1,11 @@
 <% content_for(:navigation) { provider_back_link } %>
+<% content_for(:page_title) { t('.h1-heading') } %>
 <%= render partial: 'shared/forms/error_summary', locals: { model: @form } %>
 
 <fieldset class="govuk-fieldset">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
-        <% content_for(:page_title) { t('.h1-heading') } %>
         <h1 class="govuk-fieldset__heading"><%= content_for(:page_title) %></h1>
       </legend>
     </div>

--- a/app/views/providers/applicants/show.html.erb
+++ b/app/views/providers/applicants/show.html.erb
@@ -1,5 +1,5 @@
-<% content_for(:navigation) { provider_back_link } %>
 <% content_for(:page_title) { t('.h1-heading') } %>
+<% content_for(:navigation) { provider_back_link } %>
 <%= render partial: 'shared/forms/error_summary', locals: { model: @form } %>
 
 <fieldset class="govuk-fieldset">

--- a/app/views/providers/check_provider_answers/index.html.erb
+++ b/app/views/providers/check_provider_answers/index.html.erb
@@ -10,10 +10,10 @@
   end
 %>
 
+<% content_for(:page_title) { t('.h1-heading') } %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-
-    <% content_for(:page_title) { t('.h1-heading') } %>
 
     <h1 class="govuk-heading-xl"><%= content_for(:page_title) %></h1>
 

--- a/app/views/providers/check_provider_answers/index.html.erb
+++ b/app/views/providers/check_provider_answers/index.html.erb
@@ -13,9 +13,9 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-    <h1 class="govuk-heading-xl">
-      <%= t '.title' %>
-    </h1>
+    <% content_for(:page_title) { t('.h1-heading') } %>
+
+    <h1 class="govuk-heading-xl"><%= content_for(:page_title) %></h1>
 
     <dl class="app-check-your-answers app-check-your-answers--long">
 

--- a/app/views/providers/check_provider_answers/index.html.erb
+++ b/app/views/providers/check_provider_answers/index.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:page_title) { t('.h1-heading') } %>
 <%
   content_for(:navigation) do
     link_to(
@@ -9,8 +10,6 @@
     )
   end
 %>
-
-<% content_for(:page_title) { t('.h1-heading') } %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/providers/legal_aid_applications/index.html.erb
+++ b/app/views/providers/legal_aid_applications/index.html.erb
@@ -1,8 +1,7 @@
+  <% content_for(:page_title) { t('.h1-heading') } %>
   <% content_for :navigation do %>
     <!-- no nav needed here -->
   <% end %>
-
-  <% content_for(:page_title) { t('.h1-heading') } %>
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/app/views/providers/legal_aid_applications/index.html.erb
+++ b/app/views/providers/legal_aid_applications/index.html.erb
@@ -1,11 +1,12 @@
   <% content_for :navigation do %>
     <!-- no nav needed here -->
   <% end %>
+
+  <% content_for(:page_title) { t('.h1-heading') } %>
+
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <div class="govuk-!-padding-top-4"></div>
-      <% content_for(:page_title) { t('.h1-heading') } %>
-
       <h1 class="govuk-heading-xl"><%= content_for(:page_title) %></h1>
       <h3 class="govuk-heading-m"><%= t('.make_new_application') %></h3>
       <p>

--- a/app/views/providers/legal_aid_applications/index.html.erb
+++ b/app/views/providers/legal_aid_applications/index.html.erb
@@ -4,7 +4,9 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <div class="govuk-!-padding-top-4"></div>
-      <h1 class="govuk-heading-xl"><%= t('.heading_1') %></h1>
+      <% content_for(:page_title) { t('.h1-heading') } %>
+
+      <h1 class="govuk-heading-xl"><%= content_for(:page_title) %></h1>
       <h3 class="govuk-heading-m"><%= t('.make_new_application') %></h3>
       <p>
         <%= t('.basic_details_para') %>

--- a/app/views/providers/online_bankings/show.html.erb
+++ b/app/views/providers/online_bankings/show.html.erb
@@ -1,19 +1,15 @@
-<% content_for(:navigation) { provider_back_link } %>
-
 <% content_for(:page_title) { t('.h1-heading') } %>
+<% content_for(:navigation) { provider_back_link } %>
 
 <%= render partial: 'shared/forms/error_summary', locals: { model: @form } %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-<<<<<<< HEAD
-=======
 
     <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
       <h1 class="govuk-fieldset__heading"><%= content_for(:page_title) %></h1>
     </legend>
 
->>>>>>> Changed hardcoded h1s on various pages to use the html title helper.
     <%= form_with(
           model: @form,
           url: providers_legal_aid_application_online_banking_path(@legal_aid_application),
@@ -21,7 +17,7 @@
           local: true
         ) do |form| %>
 
-      <%= form.govuk_collection_radio_buttons(:uses_online_banking, [true, false], title: t('.heading')) %>
+      <%= form.govuk_collection_radio_buttons(:uses_online_banking, [true, false], title: t('.h1-heading')) %>
 
       <div class="govuk-!-padding-bottom-6"></div>
 

--- a/app/views/providers/online_bankings/show.html.erb
+++ b/app/views/providers/online_bankings/show.html.erb
@@ -1,13 +1,13 @@
 <% content_for(:navigation) { provider_back_link } %>
 
+<% content_for(:page_title) { t('.h1-heading') } %>
+
 <%= render partial: 'shared/forms/error_summary', locals: { model: @form } %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 <<<<<<< HEAD
 =======
-
-    <% content_for(:page_title) { t('.h1-heading') } %>
 
     <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
       <h1 class="govuk-fieldset__heading"><%= content_for(:page_title) %></h1>

--- a/app/views/providers/online_bankings/show.html.erb
+++ b/app/views/providers/online_bankings/show.html.erb
@@ -4,6 +4,16 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+<<<<<<< HEAD
+=======
+
+    <% content_for(:page_title) { t('.h1-heading') } %>
+
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+      <h1 class="govuk-fieldset__heading"><%= content_for(:page_title) %></h1>
+    </legend>
+
+>>>>>>> Changed hardcoded h1s on various pages to use the html title helper.
     <%= form_with(
           model: @form,
           url: providers_legal_aid_application_online_banking_path(@legal_aid_application),

--- a/app/views/providers/proceedings_types/show.html.erb
+++ b/app/views/providers/proceedings_types/show.html.erb
@@ -12,7 +12,9 @@
 %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl"><%= t '.heading_1' %></h1>
+    <% content_for(:page_title) { t('.h1-heading') } %>
+
+    <h1 class="govuk-heading-xl"><%= content_for(:page_title) %></h1>
   </div>
 </div>
 

--- a/app/views/providers/proceedings_types/show.html.erb
+++ b/app/views/providers/proceedings_types/show.html.erb
@@ -4,14 +4,13 @@
     #search-field { display: none; }
   </style>
 </noscript>
+<% content_for(:page_title) { t('.h1-heading') } %>
 <%
   content_for(:navigation) do
     back_label = @legal_aid_application.checking_answers? ? 'generic.back' : 'generic.home'
     provider_back_link t(back_label)
   end
 %>
-
-<% content_for(:page_title) { t('.h1-heading') } %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/providers/proceedings_types/show.html.erb
+++ b/app/views/providers/proceedings_types/show.html.erb
@@ -10,10 +10,11 @@
     provider_back_link t(back_label)
   end
 %>
+
+<% content_for(:page_title) { t('.h1-heading') } %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <% content_for(:page_title) { t('.h1-heading') } %>
-
     <h1 class="govuk-heading-xl"><%= content_for(:page_title) %></h1>
   </div>
 </div>

--- a/app/views/providers/start/index.html.erb
+++ b/app/views/providers/start/index.html.erb
@@ -1,14 +1,20 @@
   <% content_for :navigation do %>
     <!-- no nav needed here -->
   <% end %>
+
+  <% content_for(:page_title) { t('.h1-heading') } %>
+
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+<<<<<<< HEAD
 <<<<<<< HEAD
       <h1 class="govuk-heading-xl"><%= t('.apply_for_legal_aid_heading') %></h1>
       <p class="govuk-body"><%= t('.apply_civil_legal_para') %></p>
 =======
       <% content_for(:page_title) { t('.h1-heading') } %>
 
+=======
+>>>>>>> Refactored the h1s on views to be at the top of the page for consistancy
       <h1 class="govuk-heading-xl"><%= content_for(:page_title) %></h1>
       <p class="govuk-body">Use this service to apply for civil legal aid for cases involving:</p>
 >>>>>>> Changed hardcoded h1s on various pages to use the html title helper.

--- a/app/views/providers/start/index.html.erb
+++ b/app/views/providers/start/index.html.erb
@@ -3,8 +3,15 @@
   <% end %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+<<<<<<< HEAD
       <h1 class="govuk-heading-xl"><%= t('.apply_for_legal_aid_heading') %></h1>
       <p class="govuk-body"><%= t('.apply_civil_legal_para') %></p>
+=======
+      <% content_for(:page_title) { t('.h1-heading') } %>
+
+      <h1 class="govuk-heading-xl"><%= content_for(:page_title) %></h1>
+      <p class="govuk-body">Use this service to apply for civil legal aid for cases involving:</p>
+>>>>>>> Changed hardcoded h1s on various pages to use the html title helper.
       <ul class="govuk-list govuk-list--bullet">
         <li><%= t('.apply_civil_legal_list.item_1') %></li>
         <li><%= t('.apply_civil_legal_list.item_2') %></li>

--- a/app/views/providers/start/index.html.erb
+++ b/app/views/providers/start/index.html.erb
@@ -1,23 +1,14 @@
+  <% content_for(:page_title) { t('.apply_for_legal_aid_heading') } %>
   <% content_for :navigation do %>
     <!-- no nav needed here -->
   <% end %>
 
-  <% content_for(:page_title) { t('.h1-heading') } %>
-
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-<<<<<<< HEAD
-<<<<<<< HEAD
-      <h1 class="govuk-heading-xl"><%= t('.apply_for_legal_aid_heading') %></h1>
-      <p class="govuk-body"><%= t('.apply_civil_legal_para') %></p>
-=======
-      <% content_for(:page_title) { t('.h1-heading') } %>
 
-=======
->>>>>>> Refactored the h1s on views to be at the top of the page for consistancy
       <h1 class="govuk-heading-xl"><%= content_for(:page_title) %></h1>
-      <p class="govuk-body">Use this service to apply for civil legal aid for cases involving:</p>
->>>>>>> Changed hardcoded h1s on various pages to use the html title helper.
+      <p class="govuk-body"><%= t('.apply_civil_legal_para') %></p>
+
       <ul class="govuk-list govuk-list--bullet">
         <li><%= t('.apply_civil_legal_list.item_1') %></li>
         <li><%= t('.apply_civil_legal_list.item_2') %></li>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -296,6 +296,7 @@ en:
         happen_next_heading: What happens next
         happen_next_text: "You will be sent the results of your client's financial assessment so you can confirm they are eligible for legal aid."
         back_button: "Back to your applications"
+<<<<<<< HEAD
     start:
       index:
         apply_for_legal_aid_heading: Apply for Legal Aid
@@ -316,6 +317,8 @@ en:
           item_1: Legal aid
           item_2: More
 
+=======
+>>>>>>> Added missing title refactor and moved content to locales
     legal_aid_applications:
       index:
          h1-heading: Your legal aid applications

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -106,18 +106,18 @@ en:
               code:
                 blank: 'A proceeding must be selected'
         address: &address_errors
-         attributes:
-           lookup_id:
+          attributes:
+            lookup_id:
               blank: 'Please select an address from the list'
-           address_line_one:
-             blank: 'Enter a building and street'
-           city:
-             blank: 'Enter a town or city'
-           postcode:
-             blank: 'Enter a postcode'
-             invalid: 'Enter a postcode in the right format'
+            address_line_one:
+              blank: 'Enter a building and street'
+            city:
+              blank: 'Enter a town or city'
+            postcode:
+              blank: 'Enter a postcode'
+              invalid: 'Enter a postcode in the right format'
         applicants/address_form:
-         <<: *address_errors
+          <<: *address_errors
         applicants/address_lookup_form:
           attributes:
             postcode:
@@ -296,7 +296,6 @@ en:
         happen_next_heading: What happens next
         happen_next_text: "You will be sent the results of your client's financial assessment so you can confirm they are eligible for legal aid."
         back_button: "Back to your applications"
-<<<<<<< HEAD
     start:
       index:
         apply_for_legal_aid_heading: Apply for Legal Aid
@@ -316,15 +315,14 @@ en:
           title: Related content
           item_1: Legal aid
           item_2: More
-
-=======
->>>>>>> Added missing title refactor and moved content to locales
     legal_aid_applications:
       index:
          h1-heading: Your legal aid applications
-    start:
-      index:
-        h1-heading: Apply for Legal Aid
+         make_new_application: Make a new application
+         basic_details_para: Tell us the basic case details and see if your client’s benefits or income qualifies for legal aid.
+    applicants:
+      show:
+        h1-heading: Enter your client's details
   citizens:
     accounts:
       index:
@@ -356,12 +354,6 @@ en:
         list_1: We do not save your online banking username and password
         list_2: We do not have any ongoing access to your bank accounts
         list_3: We only use your details to assess your eligibility for legal aid
-    information:
-      show:
-        h1-heading: Give one-time access to your bank accounts
-    legal_aid_applications:
-      show:
-        h1-heading: Complete your legal aid financial assessment
     percentage_homes:
       show:
         h1-heading: What % share of your home do you legally own?
@@ -396,7 +388,7 @@ en:
         h1-heading: Do any restrictions apply to your property, savings or assets?
     information:
       show:
-        heading_1: Give one-time access to your bank accounts
+        h1-heading: Give one-time access to your bank accounts
         para_1: You will be redirected to a secure service to sign in to your online banking.
         para_2: You will need to share all of your bank accounts, including any in joint names or with no money.
         list:
@@ -406,7 +398,7 @@ en:
           item_3: Your online banking details are not saved
     legal_aid_applications:
         show:
-          heading_1: Complete your legal aid financial assessment
+          h1-heading: Complete your legal aid financial assessment
           name: 'Name:'
           case_reference: 'Case reference:'
           financial_situation_para: Find out if you can get legal aid because of your financial situation.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -194,16 +194,16 @@ en:
         no_results: &postcode_no_results "Sorry - we couldn't find any addresses for that postcode, please enter the address manually."
         unsuccessful: *postcode_no_results
     address_lookup:
-      heading: "Enter your client's home address"
+      h1-heading: "Enter your client's home address"
       postcode_hint: 'Postcode must be a valid UK postcode.'
       submit_button: Find address
       address_manual_link: Enter address manually
       label_1: postcode
       postcode: Postcode
     address_manual:
-      heading: "Enter your client's address manually"
+      h1-heading: "Enter your client's address manually"
     address_selection:
-      heading: "Enter your client's home address"
+      h1-heading: "Enter your client's home address"
     client_detail:
       dob_hint: 'For example, 31 3 1980'
       national_insurance_number_hint: "For example, ‘QQ 12 34 56 C'"
@@ -251,10 +251,10 @@ en:
           basic_details_para: Tell us the basic case details and see if your client’s benefits or income qualifies for legal aid.
     online_bankings:
       show:
-        heading: Does your client use online banking?
+        h1-heading: Does your client use online banking?
     check_provider_answers:
       index:
-        title: Check your answers
+        h1-heading: Check your answers
         section_1:
           heading: Scope of legal aid
           proceeding: Proceeding
@@ -268,14 +268,14 @@ en:
           email: Email address
     proceedings_types:
       show:
-        heading_1: "What does your client want legal aid for?"
+        h1-heading: "What does your client want legal aid for?"
         heading_2: "Search for legal proceedings"
         search_help_example: "For example by category of law, matter type or legal proceeding."
         no_results: "No results found."
         clear_search: "Clear search"
     about_the_financial_assessments:
       show:
-        title: About the online financial assessment
+        h1-heading: About the online financial assessment
         secure_link_para: Send an email to your client with a secure link to the online assessment.
         sign_in_para: Your client will be asked to sign in to online banking and give temporary access to their bank accounts.
         share_bank_accounts_para: Your client will need to share all bank accounts, including any in joint names or with no money.
@@ -316,13 +316,19 @@ en:
           item_1: Legal aid
           item_2: More
 
+    legal_aid_applications:
+      index:
+         h1-heading: Your legal aid applications
+    start:
+      index:
+        h1-heading: Apply for Legal Aid
   citizens:
     accounts:
       index:
         account_holder_name_heading: Account holder name
         account_holder_address_heading: Account holder address
         type_heading: Type
-        heading_1: You have successfully shared your account information
+        h1-heading: You have successfully shared your account information
         account_number_heading: Account Number
         sort_code_heading: Sort Code
         balance_heading: Balance
@@ -347,6 +353,12 @@ en:
         list_1: We do not save your online banking username and password
         list_2: We do not have any ongoing access to your bank accounts
         list_3: We only use your details to assess your eligibility for legal aid
+    information:
+      show:
+        h1-heading: Give one-time access to your bank accounts
+    legal_aid_applications:
+      show:
+        h1-heading: Complete your legal aid financial assessment
     percentage_homes:
       show:
         h1-heading: What % share of your home do you legally own?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -382,10 +382,10 @@ en:
         field_set_header: How much is your home worth?
     outstanding_mortgages:
       show:
-        outstanding_mortgage_amount_heading: What is the outstanding mortgage on your home?
+        field_set_header: What is the outstanding mortgage on your home?
     shared_ownerships:
       show:
-        heading_1: Do you own your home with anyone else?
+        h1-heading: Do you own your home with anyone else?
       shared_ownership_item:
           partner_or_ex_partner:  Yes, a partner or ex-partner
           housing_assocation_or_landlord: Yes, a housing association or landlord

--- a/spec/requests/providers/address_lookups_spec.rb
+++ b/spec/requests/providers/address_lookups_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'address lookup requests', type: :request do
     it 'shows the postcode entry page' do
       subject
       expect(response).to be_successful
-      expect(unescaped_response_body).to include(I18n.t('forms.address_lookup.heading'))
+      expect(unescaped_response_body).to include(I18n.t('forms.address_lookup.h1-heading'))
     end
   end
 


### PR DESCRIPTION
## What

https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=233&projectKey=AP&modal=detail&selectedIssue=AP-232

We had lots of pages with hardcoded HTML and translation paths in the page. I went through and switched them to use the html title helper which will display them in a consistent format for accessibility reasons

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unneccessary whitespace changes. These make diffs harder to read and conflicts more likely. 
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
