### PR TITLE
Reduce number of UAT instances to 1

### DIFF
--- a/bin/uat_deploy
+++ b/bin/uat_deploy
@@ -37,7 +37,7 @@ deploy() {
                 --set image.repository="$IMG_REPO" \
                 --set image.tag="${CIRCLE_SHA1}" \
                 --set ingress.hosts="{$RELEASE_HOST}" \
-                --set replicaCount="2"
+                --set replicaCount="1"
 }
 
 clean_old_releases


### PR DESCRIPTION
**Reduce number of UAT instances to 1**

UAT deploys are failing because of a lack of resources in the UAT
cloud platform environment.

To try and remediate this, reduce the number of instances created from
two to one. This should hopefully reduce resource consumption, while the
resilience offered by a replica instance is not really needed in a
short-lived UAT environment.

_Before_

Each environment has three pods, two applications and one postgres database:

<img width="392" alt="screen shot 2018-12-12 at 14 52 26" src="https://user-images.githubusercontent.com/28729201/49878262-0b30f800-fe1f-11e8-8bc3-4a6552a4a129.png">

_After_

Each environment has two pods, one applications and one postgres database:

<img width="387" alt="screen shot 2018-12-12 at 14 52 50" src="https://user-images.githubusercontent.com/28729201/49878239-fc4a4580-fe1e-11e8-9e0d-c595414c9b7b.png">

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unneccessary whitespace changes. These make diffs harder to read and conflicts more likely. 
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
