### PR TITLE
Make forms more consistent, and simplify initializating with existing objects

### DIFF
--- a/app/controllers/citizens/own_homes_controller.rb
+++ b/app/controllers/citizens/own_homes_controller.rb
@@ -1,13 +1,11 @@
 module Citizens
   class OwnHomesController < BaseController
     def show
-      @legal_aid_application = LegalAidApplication.find(session[:current_application_ref])
-      @form = Citizens::OwnHomeForm.new(current_params)
+      @form = LegalAidApplications::OwnHomeForm.new(model: legal_aid_application)
     end
 
     def update
-      @legal_aid_application = LegalAidApplication.find(session[:current_application_ref])
-      @form = Citizens::OwnHomeForm.new(form_params)
+      @form = LegalAidApplications::OwnHomeForm.new(form_params)
 
       if @form.save
         if @form.own_home == 'no'
@@ -23,16 +21,16 @@ module Citizens
 
     private
 
-    def current_params
-      @legal_aid_application.attributes.symbolize_keys.slice(:own_home)
-    end
-
     def own_home_params
       params.fetch(:legal_aid_application, {}).permit(:own_home)
     end
 
     def form_params
-      own_home_params.merge(model: @legal_aid_application)
+      own_home_params.merge(model: legal_aid_application)
+    end
+
+    def legal_aid_application
+      @legal_aid_application ||= LegalAidApplication.find(session[:current_application_ref])
     end
   end
 end

--- a/app/controllers/citizens/percentage_homes_controller.rb
+++ b/app/controllers/citizens/percentage_homes_controller.rb
@@ -1,7 +1,7 @@
 module Citizens
   class PercentageHomesController < BaseController
     def show
-      @form = LegalAidApplications::PercentageHomeForm.new(current_params)
+      @form = LegalAidApplications::PercentageHomeForm.new(model: legal_aid_application)
     end
 
     def update
@@ -18,10 +18,6 @@ module Citizens
 
     def legal_aid_application
       @legal_aid_application ||= LegalAidApplication.find(session[:current_application_ref])
-    end
-
-    def current_params
-      legal_aid_application.attributes.symbolize_keys.slice(:percentage_home)
     end
 
     def percentage_home_params

--- a/app/controllers/citizens/property_values_controller.rb
+++ b/app/controllers/citizens/property_values_controller.rb
@@ -1,7 +1,7 @@
 module Citizens
   class PropertyValuesController < BaseController
     def show
-      @form = LegalAidApplications::PropertyValueForm.new
+      @form = LegalAidApplications::PropertyValueForm.new(model: legal_aid_application)
     end
 
     def update
@@ -21,7 +21,11 @@ module Citizens
     end
 
     def edit_params
-      property_value_params.merge(model: current_applicant.legal_aid_application)
+      property_value_params.merge(model: legal_aid_application)
+    end
+
+    def legal_aid_application
+      @legal_aid_application ||= LegalAidApplication.find(session[:current_application_ref])
     end
   end
 end

--- a/app/controllers/citizens/shared_ownerships_controller.rb
+++ b/app/controllers/citizens/shared_ownerships_controller.rb
@@ -1,7 +1,7 @@
 module Citizens
   class SharedOwnershipsController < BaseController
     def show
-      @form = LegalAidApplications::SharedOwnershipForm.new(current_params)
+      @form = LegalAidApplications::SharedOwnershipForm.new(model: legal_aid_application)
     end
 
     def update
@@ -22,10 +22,6 @@ module Citizens
 
     def legal_aid_application
       @legal_aid_application ||= LegalAidApplication.find(session[:current_application_ref])
-    end
-
-    def current_params
-      legal_aid_application.attributes.symbolize_keys.slice(:shared_ownership)
     end
 
     def shared_ownership_params

--- a/app/controllers/providers/address_lookups_controller.rb
+++ b/app/controllers/providers/address_lookups_controller.rb
@@ -4,11 +4,11 @@ module Providers
     include Steppable
 
     def show
-      @form = Applicants::AddressLookupForm.new
+      @form = Addresses::AddressLookupForm.new
     end
 
     def update
-      @form = Applicants::AddressLookupForm.new(form_params)
+      @form = Addresses::AddressLookupForm.new(form_params)
       @back_step_url = providers_legal_aid_application_address_lookup_path
 
       if @form.save
@@ -21,7 +21,11 @@ module Providers
     private
 
     def form_params
-      params.require(:address_lookup).permit(:postcode).merge(applicant_id: applicant.id)
+      params.require(:address_lookup).permit(:postcode).merge(model: address)
+    end
+
+    def address
+      applicant.address || applicant.build_address
     end
   end
 end

--- a/app/controllers/providers/addresses_controller.rb
+++ b/app/controllers/providers/addresses_controller.rb
@@ -4,11 +4,11 @@ module Providers
     include Providers::Steppable
 
     def show
-      @form = Applicants::AddressForm.new(current_address_params)
+      @form = Addresses::AddressForm.new(model: address)
     end
 
     def update
-      @form = Applicants::AddressForm.new(form_params)
+      @form = Addresses::AddressForm.new(form_params)
 
       if @form.save
         redirect_to next_step_url
@@ -23,18 +23,16 @@ module Providers
       %i[address_line_one address_line_two city county postcode lookup_postcode lookup_error]
     end
 
-    def current_address_params
-      return unless applicant.address
-
-      applicant.address.attributes.symbolize_keys.slice(*address_attributes)
-    end
-
     def address_params
       params.require(:address).permit(*address_attributes)
     end
 
     def form_params
-      address_params.merge(applicant_id: applicant.id)
+      address_params.merge(model: address)
+    end
+
+    def address
+      applicant.address || applicant.build_address
     end
   end
 end

--- a/app/controllers/providers/applicants_controller.rb
+++ b/app/controllers/providers/applicants_controller.rb
@@ -4,7 +4,7 @@ module Providers
     include Providers::Steppable
 
     def show
-      @form = Applicants::BasicDetailsForm.new(current_params)
+      @form = Applicants::BasicDetailsForm.new(model: applicant)
     end
 
     def update
@@ -18,22 +18,16 @@ module Providers
 
     private
 
+    def applicant
+      legal_aid_application.applicant || legal_aid_application.build_applicant
+    end
+
     def applicant_params
       params.require(:applicant).permit(:first_name, :last_name, :dob_day, :dob_month, :dob_year, :national_insurance_number, :email)
     end
 
     def form_params
-      applicant_params.merge(legal_aid_application_id: params[:legal_aid_application_id])
-    end
-
-    def applicant_attributes
-      %i[first_name last_name date_of_birth national_insurance_number email]
-    end
-
-    def current_params
-      return unless applicant
-
-      applicant.attributes.symbolize_keys.slice(*applicant_attributes).merge(applicant.dob)
+      applicant_params.merge(model: applicant)
     end
   end
 end

--- a/app/controllers/providers/online_bankings_controller.rb
+++ b/app/controllers/providers/online_bankings_controller.rb
@@ -4,7 +4,7 @@ module Providers
     include Steppable
 
     def show
-      @form = Applicants::UsesOnlineBankingForm.new(current_params)
+      @form = Applicants::UsesOnlineBankingForm.new(model: applicant)
     end
 
     def update
@@ -33,12 +33,6 @@ module Providers
 
     def form_params
       applicant_params.merge(model: applicant)
-    end
-
-    def current_params
-      return unless applicant
-
-      applicant.attributes.symbolize_keys.slice(:uses_online_banking)
     end
   end
 end

--- a/app/forms/addresses/address_form.rb
+++ b/app/forms/addresses/address_form.rb
@@ -1,10 +1,10 @@
-module Applicants
+module Addresses
   class AddressForm
     include BaseForm
 
     form_for Address
 
-    attr_accessor :applicant_id, :address_line_one, :address_line_two, :city, :county, :postcode, :lookup_postcode, :lookup_error
+    attr_accessor :address_line_one, :address_line_two, :city, :county, :postcode, :lookup_postcode, :lookup_error
 
     before_validation :normalise_postcode
 
@@ -25,14 +25,6 @@ module Applicants
     end
 
     private
-
-    def applicant
-      @applicant ||= Applicant.find(applicant_id)
-    end
-
-    def model
-      @model ||= applicant.address || applicant.addresses.build
-    end
 
     def normalise_postcode
       return unless postcode.present?

--- a/app/forms/addresses/address_lookup_form.rb
+++ b/app/forms/addresses/address_lookup_form.rb
@@ -1,4 +1,4 @@
-module Applicants
+module Addresses
   class AddressLookupForm
     include BaseForm
 
@@ -12,14 +12,6 @@ module Applicants
     validates :postcode, format: { with: POSTCODE_REGEXP, if: proc { |a| a.postcode.present? } }
 
     private
-
-    def applicant
-      @applicant ||= Applicant.find(applicant_id)
-    end
-
-    def model
-      @model ||= applicant.address || applicant.addresses.build
-    end
 
     def normalise_postcode
       return unless postcode.present?

--- a/app/forms/addresses/address_selection_form.rb
+++ b/app/forms/addresses/address_selection_form.rb
@@ -1,10 +1,10 @@
-module Applicants
+module Addresses
   class AddressSelectionForm
     include BaseForm
 
     form_for Address
 
-    attr_accessor :applicant_id, :addresses, :postcode, :address_line_one, :address_line_two, :city, :organisation, :lookup_id
+    attr_accessor :addresses, :postcode, :address_line_one, :address_line_two, :city, :organisation, :lookup_id
 
     before_validation :deserialize_address
 
@@ -16,14 +16,6 @@ module Applicants
     end
 
     private
-
-    def applicant
-      @applicant ||= Applicant.find(applicant_id)
-    end
-
-    def model
-      @model ||= applicant.address || applicant.addresses.build
-    end
 
     def deserialize_address
       return unless lookup_id.present?

--- a/app/forms/base_form.rb
+++ b/app/forms/base_form.rb
@@ -3,6 +3,7 @@
 #   Add the following to the form:
 #
 #       include BaseForm
+#       form_for <ModelClass>
 #
 
 module BaseForm
@@ -21,7 +22,7 @@ module BaseForm
     end
 
     def model_class
-      @model_class || raise('Model class must be defined. Use: `form_for ClassName`')
+      @model_class || raise('Model class must be defined. Use: `form_for Class`')
     end
 
     def model_name
@@ -32,7 +33,7 @@ module BaseForm
     def attr_accessor(*symbols)
       locally_assigned << symbols
       locally_assigned.flatten!
-      super *symbols
+      super(*symbols)
     end
 
     def locally_assigned
@@ -41,10 +42,22 @@ module BaseForm
   end
 
   module InstanceMethods
-
+    # Allows a form to be initiated with an existing model instance, and for the values in the
+    # model to be passed to the form.
+    #
+    #   some_model = SomeModel.find(params[:id])
+    #   some_model.foo = :bar
+    #   form = SomeForm.new(model: some_model)
+    #   form.foo == :bar
+    #
+    # Assuming SomeForm definition includes `attr_accessor :foo`
+    #
     def initialize(*args)
       super
-      self.class.locally_assigned.map(&:to_s).each{ |m| instance_variable_set(:"@#{m}", model.attributes[m]) unless attributes[m]}
+      set_instance_variables_for_attributes_if_not_set_but_in_model(
+        attrs: self.class.locally_assigned,
+        model_attributes: model&.attributes
+      )
     end
 
     def model
@@ -81,5 +94,16 @@ module BaseForm
       super
     end
     # rubocop:enable Naming/UncommunicativeMethodParamName
+
+    def set_instance_variables_for_attributes_if_not_set_but_in_model(attrs:, model_attributes:)
+      return unless model_attributes.present?
+
+      model_attributes.stringify_keys!
+
+      attrs.map(&:to_s).each do |method|
+        model_value = model_attributes[method]
+        instance_variable_set(:"@#{method}", model_value) if model_value && attributes[method].nil?
+      end
+    end
   end
 end

--- a/app/forms/base_form.rb
+++ b/app/forms/base_form.rb
@@ -27,9 +27,26 @@ module BaseForm
     def model_name
       ActiveModel::Name.new(self, nil, model_class.to_s)
     end
+
+    # Overrides `attr_accessor` to track which attributes have been assigned within the form
+    def attr_accessor(*symbols)
+      locally_assigned << symbols
+      locally_assigned.flatten!
+      super *symbols
+    end
+
+    def locally_assigned
+      @locally_assigned ||= []
+    end
   end
 
   module InstanceMethods
+
+    def initialize(*args)
+      super
+      self.class.locally_assigned.map(&:to_s).each{ |m| instance_variable_set(:"@#{m}", model.attributes[m]) unless attributes[m]}
+    end
+
     def model
       @model ||= self.class.model_class.new
     end

--- a/app/forms/legal_aid_applications/outstanding_mortgage_form.rb
+++ b/app/forms/legal_aid_applications/outstanding_mortgage_form.rb
@@ -11,11 +11,6 @@ module LegalAidApplications
       numericality: { greater_than: 0, allow_blank: true }
     )
 
-    def initialize(*args)
-      super
-      @outstanding_mortgage_amount ||= model.outstanding_mortgage_amount
-    end
-
     private
 
     def clean_up_input

--- a/app/forms/legal_aid_applications/own_home_form.rb
+++ b/app/forms/legal_aid_applications/own_home_form.rb
@@ -1,4 +1,4 @@
-module Citizens
+module LegalAidApplications
   class OwnHomeForm
     include BaseForm
 

--- a/spec/forms/addresses/address_form_spec.rb
+++ b/spec/forms/addresses/address_form_spec.rb
@@ -1,12 +1,13 @@
 require 'rails_helper'
 
-RSpec.describe Applicants::AddressForm, type: :form do
+RSpec.describe Addresses::AddressForm, type: :form do
   let(:address_line_one) { 'Ministry of Justice' }
   let(:address_line_two) { '102 Petty France' }
   let(:city) { 'London' }
   let(:county) { '' }
   let(:postcode) { 'SW1H 9AJ' }
   let(:applicant) { create(:applicant) }
+  let(:address) { applicant.build_address }
   let(:applicant_id) { applicant.id }
   let(:address_params) do
     {
@@ -18,7 +19,7 @@ RSpec.describe Applicants::AddressForm, type: :form do
     }
   end
 
-  subject(:form) { described_class.new(address_params.merge(applicant_id: applicant_id)) }
+  subject(:form) { described_class.new(address_params.merge(model: address)) }
 
   describe 'validations' do
     it 'is valid with all the required attributes' do

--- a/spec/forms/addresses/address_lookup_form_spec.rb
+++ b/spec/forms/addresses/address_lookup_form_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Applicants::AddressLookupForm, type: :form do
+RSpec.describe Addresses::AddressLookupForm, type: :form do
   subject(:form) { described_class.new(params) }
 
   describe 'validations' do

--- a/spec/forms/addresses/address_selection_form_spec.rb
+++ b/spec/forms/addresses/address_selection_form_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
-RSpec.describe Applicants::AddressSelectionForm, type: :form do
+RSpec.describe Addresses::AddressSelectionForm, type: :form do
   let(:postcode) { 'DA7 4NG' }
   let(:lookup_id) { '123456' }
-  let(:applicant_id) { SecureRandom.uuid }
+  let(:applicant) { create :applicant }
   let(:form_params) do
     {
       lookup_id: lookup_id,
@@ -11,7 +11,7 @@ RSpec.describe Applicants::AddressSelectionForm, type: :form do
       addresses: [Address.new(lookup_id: lookup_id)]
     }
   end
-  subject(:form) { described_class.new(form_params.merge(applicant_id: applicant_id)) }
+  subject(:form) { described_class.new(form_params.merge(model: applicant)) }
 
   describe 'validations' do
     it 'is valid with all the required attributes' do

--- a/spec/forms/applicants/basic_details_form_spec.rb
+++ b/spec/forms/applicants/basic_details_form_spec.rb
@@ -13,12 +13,15 @@ RSpec.describe Applicants::BasicDetailsForm, type: :form do
 
   let(:attr_list) do
     %i[
-      first_name last_name national_insurance_number
-      date_of_birth email
+      first_name
+      last_name
+      national_insurance_number
+      date_of_birth
+      email
     ]
   end
 
-  let(:params) { attributes.slice(*attr_list).merge(legal_aid_application_id: legal_aid_application_id) }
+  let(:params) { attributes.slice(*attr_list).merge(model: legal_aid_application.build_applicant) }
 
   subject { described_class.new(params) }
 
@@ -113,8 +116,8 @@ RSpec.describe Applicants::BasicDetailsForm, type: :form do
           dob_year: attributes[:date_of_birth].year.to_s,
           dob_month: attributes[:date_of_birth].month.to_s,
           dob_day: attributes[:date_of_birth].day.to_s,
-          legal_aid_application_id: legal_aid_application.id,
-          email: Faker::Internet.safe_email
+          email: Faker::Internet.safe_email,
+          model: applicant
         }
       end
 
@@ -137,8 +140,8 @@ RSpec.describe Applicants::BasicDetailsForm, type: :form do
           dob_year: '10',
           dob_month: '21',
           dob_day: '44',
-          legal_aid_application_id: legal_aid_application.id,
-          email: Faker::Internet.safe_email
+          email: Faker::Internet.safe_email,
+          model: applicant
         }
       end
 
@@ -157,6 +160,30 @@ RSpec.describe Applicants::BasicDetailsForm, type: :form do
     it 'returns a new applicant' do
       expect(subject.model).to be_a(Applicant)
       expect(subject.model).not_to be_persisted
+    end
+
+    context 'with an existing applicant passed in' do
+      let(:applicant) { create :applicant }
+      let(:params) { attributes.slice(*attr_list).merge(model: applicant) }
+      it 'returns the applicant' do
+        expect(subject.model).to eq(applicant)
+      end
+    end
+
+    context 'with no attributes but populated model' do
+      let(:applicant) { create :applicant }
+      let(:params) { { model: applicant } }
+
+      it 'populates attributes from model' do
+        expect(subject.first_name).to eq(applicant.first_name)
+        expect(subject.last_name).to eq(applicant.last_name)
+      end
+
+      it 'populates dob fields from model' do
+        expect(subject.dob_year).to eq(applicant.date_of_birth.year)
+        expect(subject.dob_month).to eq(applicant.date_of_birth.month)
+        expect(subject.dob_day).to eq(applicant.date_of_birth.day)
+      end
     end
   end
 

--- a/spec/forms/legal_aid_applications/own_home_form_spec.rb
+++ b/spec/forms/legal_aid_applications/own_home_form_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Citizens::OwnHomeForm, type: :form do
+RSpec.describe LegalAidApplications::OwnHomeForm, type: :form do
   let(:application) { create :legal_aid_application, :with_applicant_and_address }
   let(:attributes) { legal_aid_application.attributes }
   let(:params) { { own_home: 'mortgage' } }

--- a/spec/requests/citizens/property_value_spec.rb
+++ b/spec/requests/citizens/property_value_spec.rb
@@ -1,6 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe Citizens::PropertyValuesController, type: :request do
+  let(:legal_aid_application) { create :legal_aid_application, :with_applicant }
+  let(:secure_id) { legal_aid_application.generate_secure_id }
+  before { get citizens_legal_aid_application_path(secure_id) }
+
   describe 'citizen property value test' do
     describe 'GET /citizens/property_value' do
       before { get citizens_property_value_path }
@@ -13,11 +17,7 @@ RSpec.describe Citizens::PropertyValuesController, type: :request do
   end
 
   describe 'PATCH /citizens/property_value', type: :request do
-    let(:legal_aid_application) { create :legal_aid_application, :with_applicant }
-    before do
-      sign_in legal_aid_application.applicant
-      patch citizens_property_value_path, params: params
-    end
+    before { patch citizens_property_value_path, params: params }
 
     context 'when a property value is entered' do
       let(:params) { { legal_aid_application: { property_value: 123_456.78 } } }


### PR DESCRIPTION
This PR: 
## Moves the responsibility of gathering existing attributes, from the controller to the form
That is, this controller code:
```ruby
def show
  @form = SomeForm.new(current_params)
end

def current_params
  model.attributes.symbolize_keys.slice(:an_attribute, :another_attribute)
end
```
Is replaced with:
```ruby
def show
  @form = SomeForm.new(model: model)
end
```
This means the complicated bit (deciding where to get the data (existing or passed in attribute)) is defined once (in `BaseForm`), and not in every controller.

## Moves responsibility for selecting the model from the form, to the controller

Each form now just accepts the object it applies to, and it relies on the controller to choose/gather the object and pass it to the form. So parameters passed to the form to allow it to select an object have been removed. That is, instead of passing in the id of the `LegalAidApplication` to the form for it to gather that, and then from that get the target object (e.g. `Applicant`), the controller gathers the target object and passes that directly to the form.

That simplified a lot of the form logic and remove a lot of the differences between forms.

## Made namespaces more consistent

The namespace reflects the object the form is applied to. So a form that modifies an `Applicant` is in the `Applicants` name space. This was the case for some, but not all forms.