### PR TITLE
Change order flow for citizens account questions

### DIFF
--- a/app/controllers/citizens/additional_accounts_controller.rb
+++ b/app/controllers/citizens/additional_accounts_controller.rb
@@ -7,8 +7,7 @@ module Citizens
       when 'yes'
         redirect_to new_citizens_additional_account_path
       when 'no'
-        # TODO: - set redirect path when known
-        render plain: 'Landing page: Next step in Citizen journey'
+        redirect_to citizens_own_home_path
       else
         @error = I18n.t('generic.errors.yes_or_no')
         render :index
@@ -20,8 +19,7 @@ module Citizens
     def update
       case params[:has_offline_accounts]
       when 'yes'
-        # TODO: - set redirect path when known
-        render plain: 'Landing page: Return to True Layer steps'
+        redirect_to applicant_true_layer_omniauth_authorize_path
       when 'no'
         legal_aid_application.update(has_offline_accounts: true)
         redirect_to citizens_own_home_path

--- a/app/views/citizens/accounts/index.html.erb
+++ b/app/views/citizens/accounts/index.html.erb
@@ -51,5 +51,5 @@
 <% end %>
 
 <div class="govuk-!-padding-top-3">
-  <%= link_to 'Continue', new_citizens_additional_account_path, class: 'govuk-button', id: 'continue' %>
+  <%= link_to 'Continue', citizens_additional_accounts_path, class: 'govuk-button', id: 'continue' %>
 </div>

--- a/spec/requests/citizens/additional_accounts_spec.rb
+++ b/spec/requests/citizens/additional_accounts_spec.rb
@@ -32,15 +32,9 @@ RSpec.describe 'citizen additional accounts request test', type: :request do
     context 'with No submitted' do
       let(:params) { { additional_account: 'no' } }
 
-      xit 'redirects to the next step in Citizen jouney' do
+      it 'redirects to the next step in Citizen jouney' do
         # TODO: - set redirect path when known
-        expect(response).to redirect_to(:some_path)
-      end
-
-      it 'displays holding page' do
-        # TODO: Delete when redirect set
-        expect(response).to have_http_status(:ok)
-        expect(response.body).to match('Landing page')
+        expect(response).to redirect_to(citizens_own_home_path)
       end
     end
   end
@@ -75,15 +69,9 @@ RSpec.describe 'citizen additional accounts request test', type: :request do
     context 'with Yes submitted' do
       let(:params) { { has_offline_accounts: 'yes' } }
 
-      xit 'redirects to back to the True Layer steps' do
+      it 'redirects to back to the True Layer steps' do
         # TODO: - set redirect path when known
-        expect(response).to redirect_to(:some_path)
-      end
-
-      it 'displays holding page' do
-        # TODO: Delete when redirect set
-        expect(response).to have_http_status(:ok)
-        expect(response.body).to match('Landing page')
+        expect(response).to redirect_to(applicant_true_layer_omniauth_authorize_path)
       end
 
       it 'does not record choice on legal_aid_application' do


### PR DESCRIPTION
The current flow goes from the account summary page to asking if you have online access to other banks, skipping out the intermediate step of asking i they have other accounts.

Users are now asked if they have other bank accounts before they are asked if they have online access to those accounts.

[Link to story](https://dsdmoj.atlassian.net/browse/AP-240)

Changed the behaviour of the controllers to implement this loop. I looked at recreating the steppable module from providers, but it seemed like an overly complicated way to achieve this result. Also this forms more of a loop and exit as opposed to a linear step.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely. 
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
