### PR TITLE
FormBuilder : Add govuk_collection_radio_buttons

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,7 @@ group :development, :test do
   gem 'faker', '>=1.9.1'
   gem 'i18n-tasks'
   gem 'json_expressions'
+  gem 'nokogiri'
   gem 'pry-byebug'
   gem 'rubocop', require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -419,6 +419,7 @@ DEPENDENCIES
   jwt
   listen (>= 3.0.5, < 3.2)
   loofah (>= 2.2.3)
+  nokogiri
   omniauth
   omniauth-oauth2
   pg

--- a/app/lib/govuk_elements_form_builder/form_builder.rb
+++ b/app/lib/govuk_elements_form_builder/form_builder.rb
@@ -1,106 +1,206 @@
 module GovukElementsFormBuilder
-  class FormBuilder < ActionView::Helpers::FormBuilder
+  # TODO: Refactor this class and remove the rubocop:disable
+  class FormBuilder < ActionView::Helpers::FormBuilder # rubocop:disable Metrics/ClassLength
     # Prevents surrounding of erroneous inputs with <div class="field_with_errors">
     # https://guides.rubyonrails.org/configuring.html#configuring-action-view
     ActionView::Base.field_error_proc = proc { |html_tag| html_tag.html_safe }
 
+    CUSTOM_OPTIONS = %i[label input_prefix field_with_error hide_hint? title inline].freeze
+
     delegate :content_tag, to: :@template
     delegate :errors, to: :@object
 
-    def govuk_text_field(attribute, *args)
-      content_tag :div, class: form_group_classes(attribute) do
-        options = args.extract_options!
+    # Usage:
+    # <%= form.govuk_text_field :name %>
+    #
+    # A hint will be displayed if it is defined in the locale file:
+    # 'helpers.hint.user.name'
+    #
+    # Use the :input_prefix to insert a character inside and at the beginning of the input field.
+    # e.g., <%= form.govuk_text_field :property_value, input_prefix: '$' %>
+    #
+    # Use :field_with_error to have the input be marked as erroneous when an other attribute has an error.
+    # e.g., <%= form.govuk_text_field :address_line_two, field_with_error: :address_line_one %>
+    #
+    # Use the hide_hint? option to not display the hint message.
+    # e.g., <%= form.govuk_text_field :name, hide_hint?: true %>
+    #
+    def govuk_text_field(attribute, options = {})
+      options[:class] = text_field_classes(attribute, options)
+      input_text_form_group(attribute, options) do
+        input_prefix = options[:input_prefix]
+        tag_options = options.except(*CUSTOM_OPTIONS)
+        tag_options[:id] = attribute
+        tag_options[:'aria-describedby'] = aria_describedby(attribute, options)
+        tag = text_field(attribute, tag_options)
 
-        label_classes!(options)
-        field_classes!(options, attribute)
+        input_prefix ? input_prefix_group(input_prefix) { tag } : tag
+      end
+    end
 
-        form_group(options, attribute)
+    # Usage:
+    # <%= form.govuk_radio_button(:gender, 'm')
+    # <%= form.govuk_radio_button(:gender, 'm', label: 'Male')
+    #
+    # If label is not specified, it will be grabbed from the locale file at:
+    # 'helpers.label.user.gender.f'
+    #
+    def govuk_radio_button(attribute, value, *args)
+      options = args.extract_options!.symbolize_keys!
+
+      radio_classes = [options[:class]]
+      options[:class] = radio_classes.unshift('govuk-radios__input').compact.join(' ')
+      radio_html = radio_button(attribute, value, options.except(*CUSTOM_OPTIONS))
+
+      label_options = { value: value.to_s, class: 'govuk-label govuk-radios__label' }
+      label_html = label(attribute, options[:label], label_options)
+
+      content_tag(:div, class: 'govuk-radios__item') do
+        concat_tags(radio_html, label_html)
+      end
+    end
+
+    # Usage:
+    # Labels of each radio buttons can be either passed as parameters or defined in the locale file.
+    # For examples, for the gender of a user, if the radio button values are 'm' and 'f' the labels can be define at:
+    # 'helpers.label.user.gender.f'
+    #
+    # Option 1:
+    # <%= form.govuk_collection_radio_buttons(:gender, ['f', 'm']) %>
+    # Option 2:
+    # <%= form.govuk_collection_radio_buttons(:gender, [{ code: 'f' }, { code: 'm' }], :code) %>
+    # Option 3:
+    # <%= form.govuk_collection_radio_buttons(:gender, [{ code: 'f', label: 'Female' }, { code: 'm', label: 'Male' }], :code, :label) %>
+    #
+    # A hint will be displayed if it is defined in the locale file:
+    # 'helpers.hint.user.gender'
+    #
+    # You can pass a title with the :title parameter.
+    # e.g., <%= form.govuk_collection_radio_buttons(:gender, ['f', 'm'], title: 'What is your gender?') %>
+    #
+    # Use the :inline parameter to have the radio buttons displayed horizontally rather than vertically
+    # e.g., <%= form.govuk_collection_radio_buttons(:gender, ['f', 'm'], inline: true) %>
+    #
+    # TODO: Refactor this method and remove the rubocop:disable
+    def govuk_collection_radio_buttons(attribute, collection, *args) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+      options = args.extract_options!.symbolize_keys!
+      value_attr, label_attr = extract_value_and_label_attributes(args)
+
+      content_tag(:div, class: collection_radio_buttons_classes(attribute, options)) do
+        fieldset(attribute, options) do
+          classes = ['govuk-radios']
+          classes << 'govuk-radios--inline' if options[:inline]
+          concat_tags(
+            hint_and_error_tags(attribute, options),
+            content_tag(:div, class: classes.join(' ')) do
+              inputs = collection.map do |obj|
+                value = value_attr ? obj[value_attr] : obj
+                label = label_attr ? obj[label_attr] : nil
+                govuk_radio_button(attribute, value, options.merge(label: label))
+              end
+              concat_tags(inputs)
+            end
+          )
+        end
       end
     end
 
     private
 
-    def form_group(options, attribute)
-      html = label(attribute, options[:label_options].merge(for: attribute))
-
-      html.concat(hint_tag(attribute)) if !options[:hide_hint?] && hint_message(attribute)
-      html.concat(error_tag(attribute)) if error?(attribute)
-
-      html.concat(field_tag(options, attribute))
-
-      html.html_safe
+    def concat_tags(*tags)
+      tags.compact.join('').html_safe
     end
 
-    def field_tag(options, attribute)
-      input_prefix = options.delete(:input_prefix)
-      tag = text_field(attribute, options.except(:label, :label_options).merge(id: attribute))
-      return tag unless input_prefix
+    def extract_value_and_label_attributes(args)
+      value_attr = args[0].is_a?(Hash) ? nil : args[0]
+      label_attr = args[1].is_a?(Hash) ? nil : args[1]
+      [value_attr, label_attr]
+    end
 
-      input_prefix_group(input_prefix) { tag }
+    def collection_radio_buttons_classes(attribute, options)
+      classes = ['govuk-form-group']
+      classes << 'govuk-form-group--error' if error?(attribute, options)
+      classes.join(' ')
+    end
+
+    def text_field_classes(attribute, options)
+      classes = [options[:class]]
+      classes << 'govuk-input'
+      classes << 'govuk-input--error' if error?(attribute, options)
+      classes << 'govuk-prefix-input__inner__input' if options[:input_prefix]
+      classes.compact.join(' ')
     end
 
     def input_prefix_group(input_prefix)
       content_tag :div, class: 'govuk-prefix-input' do
         content_tag :div, class: 'govuk-prefix-input__inner' do
-          html = content_tag :span, input_prefix, class: 'govuk-prefix-input__inner__unit'
-          html.concat(yield)
-          html
+          prefix = content_tag :span, input_prefix, class: 'govuk-prefix-input__inner__unit'
+          concat_tags(prefix, yield)
         end
       end
     end
 
-    # Given an attributes hash that could include any number of arbitrary keys, this method
-    # ensure we merge one or more 'default' attributes into the hash, creating the keys if
-    # don't exist, or merging the defaults if the keys already exists.
-    # It supports strings or arrays as values.
-    #
-    def merge_attributes(attributes, default:)
-      hash = attributes || {}
-      hash.merge!(default) { |_key, oldval, newval| [newval] + [oldval] }
+    def input_text_form_group(attribute, options)
+      classes = ['govuk-form-group']
+      classes << 'govuk-form-group--error' if error?(attribute, options)
+      content_tag :div, class: classes.join(' ') do
+        label = label(attribute, class: 'govuk-label', for: attribute)
+        concat_tags(label, hint_and_error_tags(attribute, options), yield)
+      end
     end
 
-    def field_classes!(options, attribute)
-      default_classes = ['govuk-input']
-      default_classes << 'govuk-input--error' if error?(options[:field_with_error] || attribute)
-      default_classes << 'govuk-prefix-input__inner__input' if options[:input_prefix]
-
-      options ||= {}
-      merge_attributes(options, default: { class: default_classes })
+    def fieldset(attribute, options)
+      content_tag(:fieldset, class: 'govuk-fieldset', 'aria-describedby': aria_describedby(attribute, options)) do
+        legend_tag = options[:title] ? fieldset_legend(options[:title]) : nil
+        concat_tags(legend_tag, yield)
+      end
     end
 
-    def label_classes!(options)
-      options ||= {}
-      options[:label_options] ||= {}
-      merge_attributes(options[:label_options], default: { class: 'govuk-label' })
+    def aria_describedby(attribute, options)
+      aria_describedby = []
+      aria_describedby << "#{attribute}-hint" if hint?(attribute, options)
+      aria_describedby << "#{attribute}-error" if error?(attribute, options)
+      aria_describedby.join(' ')
+    end
+
+    def fieldset_legend(title)
+      content_tag(:legend, class: 'govuk-fieldset__legend govuk-fieldset__legend--xl') do
+        content_tag(:h1, title, class: 'govuk-fieldset__heading')
+      end
+    end
+
+    def hint_and_error_tags(attribute, options)
+      concat_tags(hint_tag(attribute, options), error_tag(attribute, options))
+    end
+
+    def hint?(attribute, options)
+      !options[:hide_hint?] && hint_message(attribute)
     end
 
     def hint_message(attribute)
-      I18n.translate("helpers.hint.#{attribute}", default: nil)
+      I18n.translate("helpers.hint.#{@object_name}.#{attribute}", default: nil)
     end
 
-    def hint_tag(attribute)
-      message = hint_message(attribute)
-      return unless message
+    def hint_tag(attribute, options)
+      return unless hint?(attribute, options)
 
-      content_tag(:span, message, class: 'govuk-hint', id: "#{attribute}_hint")
+      content_tag(:span, hint_message(attribute), class: 'govuk-hint', id: "#{attribute}-hint")
     end
 
-    def error_tag(attribute)
-      return unless error?(attribute)
+    def error_tag(attribute, options)
+      return unless error?(attribute, options)
 
-      content_tag(:span, object.errors[attribute].join(', '), class: 'govuk-error-message')
+      message = object.errors[attribute].join(', ')
+      return unless message.present?
+
+      content_tag(:span, message, class: 'govuk-error-message', id: "#{attribute}-error")
     end
 
-    def error?(attribute)
+    def error?(attribute, options)
+      attr = options[:field_with_error] || attribute
       object.respond_to?(:errors) &&
-        errors.messages.key?(attribute) &&
-        errors.messages[attribute].present?
-    end
-
-    def form_group_classes(attribute)
-      classes = 'govuk-form-group'
-      classes += ' govuk-form-group--error' if error?(attribute)
-      classes
+        errors.messages.key?(attr) &&
+        errors.messages[attr].present?
     end
   end
 end

--- a/app/views/citizens/own_homes/show.html.erb
+++ b/app/views/citizens/own_homes/show.html.erb
@@ -4,35 +4,13 @@
 
 <% content_for(:page_title) { t('.h1-heading') } %>
 
-<h1 class="govuk-heading-xl"><%= content_for(:page_title) %></h1>
-
 <%= render partial: 'shared/forms/error_summary', locals: { model: @form } %>
 
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
     <%= form_with(model: @form, url: citizens_own_home_path, method: :patch, local: true) do |form| %>
 
-      <div class="govuk-!-padding-bottom-8"></div>
-
-      <% error = form.object.errors[:own_home].first %>
-      <% group_error_class = error ? 'govuk-form-group--error' : '' %>
-      <% input_error_class = error ? 'govuk-input--error' : '' %>
-
-      <div class="govuk-form-group <%= group_error_class %>">
-        <div class="govuk-radios">
-          <%= content_tag(:span, error, class: 'govuk-error-message', id: 'own_home') if error %>
-          <div class="govuk-radios__item">
-            <%= form.radio_button 'own_home', 'mortgage', class: "govuk-radios__input #{input_error_class}" %>
-            <%= form.label 'own_home_mortgage', t('.own_home.mortgage'), class: 'govuk-label govuk-radios__label' %>
-          </div>
-          <div class='govuk-radios__item'>
-            <%= form.radio_button 'own_home', 'owned_outright', class: "govuk-radios__input #{input_error_class}" %>
-            <%= form.label 'own_home_owned_outright', t('.own_home.owned_outright'), class: 'govuk-label govuk-radios__label' %>
-          </div>
-          <div class='govuk-radios__item'>
-            <%= form.radio_button 'own_home', 'no', class: "govuk-radios__input #{input_error_class}" %>
-            <%= form.label 'own_home_no', t('.own_home.not'), class: 'govuk-label govuk-radios__label' %>
-          </div>
-        </div>
-      </div>
+      <%= form.govuk_collection_radio_buttons(:own_home, %w[mortgage owned_outright no], title: content_for(:page_title)) %>
 
       <div class="govuk-!-padding-bottom-6"></div>
 

--- a/app/views/citizens/property_values/show.html.erb
+++ b/app/views/citizens/property_values/show.html.erb
@@ -12,9 +12,9 @@
         ) do %>
 
       <%= govuk_fieldset_header t('.field_set_header'), padding_below: 6 %>
-      <%= form.govuk_text_field :property_value, input_prefix: t('currency.gbp'), class: 'govuk-input govuk-!-width-one-third' %>
+      <%= form.govuk_text_field :property_value, input_prefix: t('currency.gbp'), class: 'govuk-!-width-one-third' %>
     <% end %>
 
-      <%= govuk_submit_button t('generic.continue') %>
+    <%= govuk_submit_button t('generic.continue') %>
 
   <% end %>

--- a/app/views/citizens/savings_and_investments/_attribute.html.erb
+++ b/app/views/citizens/savings_and_investments/_attribute.html.erb
@@ -1,7 +1,7 @@
 <%
   check_box_attribute = "check_box_#{attribute}"
   conditional_div_id = "conditional_#{attribute}"
-  hint = I18n.translate("helpers.hint.#{check_box_attribute}", default: nil)
+  hint = I18n.translate("helpers.hint.#{model.model_name.i18n_key}.#{check_box_attribute}", default: nil)
   value = model.send(attribute)
   checked = value.present? || model.send(check_box_attribute).present? ? 'checked' : ''
 %>

--- a/app/views/providers/addresses/_form.html.erb
+++ b/app/views/providers/addresses/_form.html.erb
@@ -54,7 +54,7 @@
 
       <%= form.govuk_text_field :city, class: 'govuk-!-width-two-thirds' %>
       <%= form.govuk_text_field :county, class: 'govuk-!-width-two-thirds' %>
-      <%= form.govuk_text_field :postcode, hide_hint?: true, class: 'govuk-input--width-10' %>
+      <%= form.govuk_text_field :postcode, hint: nil, class: 'govuk-input--width-10' %>
 
       <%= form.submit 'Continue', id: 'continue', class: 'govuk-button' %>
     <% end %>

--- a/app/views/providers/online_bankings/show.html.erb
+++ b/app/views/providers/online_bankings/show.html.erb
@@ -4,13 +4,6 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-
-    <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
-      <h1 class="govuk-fieldset__heading">
-         <%= t '.heading' %>
-      </h1>
-    </legend>
-
     <%= form_with(
           model: @form,
           url: providers_legal_aid_application_online_banking_path(@legal_aid_application),
@@ -18,25 +11,7 @@
           local: true
         ) do |form| %>
 
-      <div class="govuk-!-padding-bottom-8"></div>
-
-      <% error = form.object.errors[:uses_online_banking].first %>
-      <% group_error_class = error ? 'govuk-form-group--error' : '' %>
-      <% input_error_class = error ? 'govuk-input--error' : '' %>
-
-      <div class="govuk-form-group <%= group_error_class %>">
-        <div class="govuk-radios">
-          <%= content_tag(:span, error, class: 'govuk-error-message') if error %>
-          <div class="govuk-radios__item">
-            <%= form.radio_button 'uses_online_banking', 'true', class: "govuk-radios__input #{input_error_class}" %>
-            <%= form.label 'uses_online_banking_true', t('generic.yes'), class: 'govuk-label govuk-radios__label' %>
-          </div>
-          <div class='govuk-radios__item'>
-            <%= form.radio_button 'uses_online_banking', 'false', class: "govuk-radios__input #{input_error_class}" %>
-            <%= form.label 'uses_online_banking_false', t('generic.no'), class: 'govuk-label govuk-radios__label' %>
-          </div>
-        </div>
-      </div>
+      <%= form.govuk_collection_radio_buttons(:uses_online_banking, [true, false], title: t('.heading')) %>
 
       <div class="govuk-!-padding-bottom-6"></div>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6,15 +6,29 @@ en:
         invalid: invalid
   helpers:
     hint:
-      national_insurance_number: For example, ‘QQ 12 34 56 C'
-      email: We'll use this to send your client a secure link
-      postcode: Postcode must be a valid UK postcode.
-      percentage_home: Your name must be on the property deeds, lease, freehold or mortgage.
-      outstanding_mortgage_amount: Check the statement from your mortgage provider or lender
-      check_box_isa: Accounts you do not access with online banking
-      check_box_other_person_account: For example, a junior ISA for a child
-      check_box_life_assurance_endowment_policy: Do not include policies that only pay out on death
-      property_value: You can use property websites to find the estimated value.
+      applicant:
+        national_insurance_number: For example, ‘QQ 12 34 56 C'
+        email: We'll use this to send your client a secure link
+      address_lookup:
+        postcode: Postcode must be a valid UK postcode.
+      legal_aid_application:
+        percentage_home: Your name must be on the property deeds, lease, freehold or mortgage.
+        outstanding_mortgage_amount: Check the statement from your mortgage provider or lender
+        property_value: You can use property websites to find the estimated value.
+      savings_amount:
+        check_box_isa: Accounts you do not access with online banking
+        check_box_other_person_account: For example, a junior ISA for a child
+        check_box_life_assurance_endowment_policy: Do not include policies that only pay out on death
+    label:
+      applicant:
+        uses_online_banking:
+          'true': 'Yes'
+          'false': 'No'
+      legal_aid_application:
+        own_home:
+          mortgage: Yes, with a mortage or loan
+          owned_outright: Yes, owned outright
+          not: "No"
   shared:
     forms:
       date_input_fields:
@@ -301,10 +315,6 @@ en:
     own_homes:
       show:
         h1-heading: Do you own the home that you live in?
-        own_home:
-          mortgage: Yes, with a mortage or loan
-          owned_outright: Yes, owned outright
-          not: "No"
     property_values:
       show:
         field_set_header: How much is your home worth?

--- a/spec/factories/applicants.rb
+++ b/spec/factories/applicants.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
     date_of_birth { Faker::Date.birthday }
     email { Faker::Internet.safe_email }
     national_insurance_number { Faker::Base.regexify(Applicant::NINO_REGEXP) }
+    uses_online_banking { [true, false].sample }
 
     trait :with_address do
       addresses { build_list :address, 1 }

--- a/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
+++ b/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
@@ -4,63 +4,235 @@ class TestHelper < ActionView::Base; end
 
 RSpec.describe GovukElementsFormBuilder::FormBuilder do
   let(:helper) { TestHelper.new }
-  let(:resource)  { Applicants::BasicDetailsForm.new }
-  let(:builder) { described_class.new :person, resource, helper, {} }
+  let(:resource) { 'applicant' }
+  let(:resource_form) { Applicants::BasicDetailsForm.new }
+  let(:builder) { described_class.new resource.to_sym, resource_form, helper, {} }
+  let(:parsed_html) { Nokogiri::HTML(subject) }
 
-  it 'surrounds the field in a div' do
-    output = builder.govuk_text_field(:email)
+  describe 'govuk_text_field' do
+    let(:attribute) { 'email' }
+    let(:params) { [:email] }
+    let(:email_label) { I18n.t("activemodel.attributes.#{resource}.#{attribute}") }
+    let(:email_hint) { I18n.t("helpers.hint.#{resource}.#{attribute}") }
+    let(:input) { parsed_html.at_css("input##{attribute}") }
 
-    expect(output).to start_with('<div class="govuk-form-group">')
-    expect(output).to end_with('</div>')
-  end
+    subject { builder.govuk_text_field(*params) }
 
-  it 'includes a label' do
-    output = builder.govuk_text_field(:email)
+    it 'generates a text field' do
+      expect(input.classes).to include('govuk-input')
+      expect(input[:type]).to eq('text')
+      expect(input[:name]).to eq("#{resource}[#{attribute}]")
+    end
 
-    expect(output).to include('<label class="govuk-label" for="email">Email address</label>')
-  end
+    it 'surrounds the field in a div' do
+      div = input.parent
 
-  it 'adds custom class to input when passed class: "custom-class"' do
-    output = builder.govuk_text_field(:email, class: 'custom-class')
-    expect(output).to include('<input class="govuk-input custom-class"')
-  end
+      expect(div.name).to eq('div')
+      expect(div.classes).to include('govuk-form-group')
+    end
 
-  it 'includes a hint message' do
-    output = builder.govuk_text_field(:email)
+    it 'includes a label' do
+      label = input.parent.at_css('label')
 
-    expect(output).to include('class="govuk-hint"')
-    expect(output).to include('id="email_hint"')
-  end
+      expect(label.classes).to include('govuk-label')
+      expect(label[:for]).to eq('email')
+      expect(label.content).to eq(email_label)
+    end
 
-  it 'does not include a hint message if hide_hint? is true' do
-    output = builder.govuk_text_field(:email, hide_hint?: true)
+    it 'includes a hint message' do
+      hint_span = input.parent.at_css("span##{attribute}-hint")
 
-    expect(output).not_to include('class="govuk-hint"')
-  end
+      expect(hint_span.classes).to include('govuk-hint')
+      expect(hint_span.content).to include(email_hint)
+      expect(input['aria-describedby']).to eq("#{attribute}-hint")
+    end
 
-  context 'has an input_prefix option' do
-    let(:prefix) { '£' }
+    context 'hide_hint?: true' do
+      let(:params) { [:email, hide_hint?: true] }
 
-    it 'includes a prefix ' do
-      output = builder.govuk_text_field(:email, input_prefix: prefix)
+      it 'does not include a hint message' do
+        expect(subject).not_to include('govuk-hint')
+        expect(input['aria-describedby']).to eq('')
+      end
+    end
 
-      expected_output = [
-        '<div class="govuk-prefix-input">',
-        '<div class="govuk-prefix-input__inner">',
-        '<span class="govuk-prefix-input__inner__unit">',
-        prefix
-      ].join
+    context 'adding a custom class to the input' do
+      let(:custom_class) { 'govuk-!-width-one-third' }
+      let(:params) { [:email, class: custom_class] }
 
-      expect(output).to include(expected_output)
+      it 'adds custom class to the input' do
+        expect(input.classes).to include(custom_class)
+      end
+    end
+
+    context 'has an input_prefix option' do
+      let(:prefix) { '£' }
+      let(:params) { [:email, input_prefix: prefix] }
+
+      it 'includes a prefix ' do
+        expect(input.previous_element.content).to eq(prefix)
+        expect(input.previous_element.name).to eq('span')
+        expect(input.previous_element.classes).to contain_exactly('govuk-prefix-input__inner__unit')
+        expect(input.parent.name).to eq('div')
+        expect(input.parent.classes).to contain_exactly('govuk-prefix-input__inner')
+        expect(input.parent.parent.name).to eq('div')
+        expect(input.parent.parent.classes).to contain_exactly('govuk-prefix-input')
+      end
+    end
+
+    context 'when validation error on object' do
+      let(:email_error) { I18n.t("activemodel.errors.models.#{resource}.attributes.#{attribute}.blank") }
+
+      before { resource_form.valid? }
+
+      it 'includes an error message' do
+        error_span = input.previous_element
+        expect(error_span.content).to eq(email_error)
+        expect(error_span.name).to eq('span')
+        expect(error_span.classes).to include('govuk-error-message')
+        expect(input.classes).to include('govuk-input--error')
+        expect(input['aria-describedby'].split(' ')).to include('email-error')
+        expect(input.parent.classes).to include('govuk-form-group--error')
+      end
     end
   end
 
-  context 'when validation error on object' do
-    before { resource.valid? }
+  describe 'govuk_radio_button' do
+    let(:attribute) { 'uses_online_banking' }
+    let(:resource_form) { Applicants::UsesOnlineBankingForm.new }
+    let(:params) { [:uses_online_banking, true] }
+    let(:label_copy) { CGI.escapeHTML I18n.t("helpers.label.#{resource}.#{attribute}.true") }
+    let(:input) { parsed_html.at_css("input##{resource}_#{attribute}_true") }
 
-    it 'includes an error message' do
-      output = builder.govuk_text_field(:email)
-      expect(output).to include('<span class="govuk-error-message">Enter email address</span>')
+    subject { builder.govuk_radio_button(*params) }
+
+    it 'generates a radio button' do
+      expect(input.classes).to include('govuk-radios__input')
+      expect(input[:type]).to eq('radio')
+      expect(input[:value]).to eq('true')
+      expect(input[:name]).to eq("#{resource}[#{attribute}]")
+    end
+
+    it 'surrounds the field in a div' do
+      div = input.parent
+
+      expect(div.name).to eq('div')
+      expect(div.classes).to include('govuk-radios__item')
+    end
+
+    it 'includes a label' do
+      label = input.parent.at_css('label')
+
+      expect(label.classes).to include('govuk-label')
+      expect(label.classes).to include('govuk-radios__label')
+      expect(label[:for]).to eq("#{resource}_#{attribute}_true")
+      expect(label.content).to eq(label_copy)
+    end
+
+    context 'adding a custom class to the input' do
+      let(:custom_class) { 'govuk-!-width-one-third' }
+      let(:params) { [:uses_online_banking, true, class: custom_class] }
+
+      it 'adds custom class to the input' do
+        expect(input.classes).to include(custom_class)
+      end
+    end
+
+    context 'label is passed as a parameter' do
+      let(:custom_label) { 'Yes I use online banking' }
+      let(:params) { [:uses_online_banking, true, label: custom_label] }
+
+      it 'display the custom label instead of the one in locale file' do
+        label = input.parent.at_css('label')
+        expect(label.content).to eq(custom_label)
+      end
+    end
+  end
+
+  describe 'govuk_collection_radio_buttons' do
+    let(:attribute) { 'uses_online_banking' }
+    let(:resource_form) { Applicants::UsesOnlineBankingForm.new }
+    let(:options) { [true, false] }
+    let(:params) { [:uses_online_banking, options] }
+    let(:inputs) { options.map { |option| parsed_html.at_css("input##{resource}_#{attribute}_#{option}") } }
+    let(:input) { inputs.first }
+    let(:div_radios) { parsed_html.at_css('div.govuk-radios') }
+    let(:div_form_group) { parsed_html.at_css('div.govuk-form-group') }
+    let(:fieldset) { parsed_html.at_css('fieldset') }
+    let(:legend) { parsed_html.at_css('legend') }
+    let(:h1) { parsed_html.at_css('h1') }
+
+    subject { builder.govuk_collection_radio_buttons(*params) }
+
+    it 'generates radio buttons' do
+      expect(inputs.size).to eq(options.size)
+      expect(inputs.pluck(:class).uniq).to include('govuk-radios__input')
+      expect(inputs.pluck(:type).uniq).to include('radio')
+      expect(inputs.pluck(:value)).to eq(options.map(&:to_s))
+      expect(inputs.pluck(:name).uniq).to include("#{resource}[#{attribute}]")
+    end
+
+    it 'surrounds the radio buttons in a div' do
+      expect(div_radios.children.size).to eq(options.size)
+      expect(div_radios.search('[type=radio]').count).to eq(options.size)
+      expect(div_radios.children.pluck(:class).uniq).to include('govuk-radios__item')
+    end
+
+    it 'surrounds everything in a from group div' do
+      first_div = parsed_html.search('div').first
+      expect(first_div.classes).to include('govuk-form-group')
+    end
+
+    it 'includes a fieldset tag' do
+      expect(div_form_group.child.name).to eq('fieldset')
+      expect(fieldset.classes).to include('govuk-fieldset')
+    end
+
+    context 'when there is a hint message defined' do
+      let(:hint_message) { 'Choose an option' }
+      let(:span_hint) { parsed_html.at_css('span.govuk-hint') }
+
+      before do
+        allow(I18n)
+          .to receive(:translate)
+          .with("helpers.hint.#{resource}.#{attribute}", default: nil)
+          .and_return(hint_message)
+      end
+
+      it 'includes a hint message' do
+        expect(fieldset['aria-describedby'].split(' ')).to include("#{attribute}-hint")
+        expect(span_hint[:id]).to eq("#{attribute}-hint")
+        expect(span_hint.content).to eq(hint_message)
+        expect(span_hint.parent).to eq(fieldset)
+      end
+    end
+
+    context 'when validation error on object' do
+      let(:error_message) { I18n.t("activemodel.errors.models.#{resource}.attributes.#{attribute}.blank") }
+      let(:span_error) { parsed_html.at_css('span.govuk-error-message') }
+
+      before { resource_form.valid? }
+
+      it 'includes an error message' do
+        expect(fieldset['aria-describedby'].split(' ')).to include("#{attribute}-error")
+        expect(span_error[:id]).to eq("#{attribute}-error")
+        expect(span_error.content).to eq(error_message)
+        expect(span_error.parent).to eq(fieldset)
+      end
+    end
+
+    context 'title is passed as a parameter' do
+      let(:title) { 'Pick an option' }
+      let(:params) { [:uses_online_banking, options, title: title] }
+
+      it 'display the title in a <legend> and <h1> tag' do
+        expect(fieldset.child.name).to eq('legend')
+        expect(fieldset.child.child.name).to eq('h1')
+        expect(legend.classes).to include('govuk-fieldset__legend')
+        expect(legend.classes).to include('govuk-fieldset__legend--xl')
+        expect(h1.classes).to include('govuk-fieldset__heading')
+        expect(h1.content).to eq(title)
+      end
     end
   end
 end

--- a/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
+++ b/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
@@ -47,12 +47,25 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
       expect(input['aria-describedby']).to eq("#{attribute}-hint")
     end
 
-    context 'hide_hint?: true' do
-      let(:params) { [:email, hide_hint?: true] }
+    context 'hint: nil' do
+      let(:params) { [:email, hint: nil] }
 
       it 'does not include a hint message' do
         expect(subject).not_to include('govuk-hint')
         expect(input['aria-describedby']).to eq('')
+      end
+    end
+
+    context 'pass a label parameter' do
+      let(:custom_label) { "Your client's email" }
+      let(:params) { [:email, label: custom_label] }
+
+      it 'shows the custom label' do
+        label = input.parent.at_css('label')
+
+        expect(label.classes).to include('govuk-label')
+        expect(label[:for]).to eq('email')
+        expect(label.content).to eq(custom_label)
       end
     end
 

--- a/spec/requests/providers/online_bankings_spec.rb
+++ b/spec/requests/providers/online_bankings_spec.rb
@@ -1,11 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe 'does client use online banking requests', type: :request do
-  let(:applicant) { create :applicant }
+  let(:applicant) { create :applicant, uses_online_banking: nil }
   let(:application) { create :legal_aid_application, applicant: applicant }
   let(:application_id) { application.id }
 
-  describe 'GET /providers/applications/:legal_aid_application_id/applicant' do
+  describe 'GET /providers/applications/:legal_aid_application_id/does-client-use-online-banking' do
     subject { get "/providers/applications/#{application_id}/does-client-use-online-banking" }
 
     it 'returns http success' do
@@ -28,7 +28,7 @@ RSpec.describe 'does client use online banking requests', type: :request do
     end
   end
 
-  describe 'PATCH /providers/applications/:legal_aid_application_id/applicant' do
+  describe 'PATCH /providers/applications/:legal_aid_application_id/does-client-use-online-banking' do
     let(:params) do
       {
         applicant: { uses_online_banking: uses_online_banking }


### PR DESCRIPTION
. Add `govuk_radio_button` and `govuk_collection_radio_buttons` to the form builder
. Refactor form_builder and its tests to make it a bit less complicated and add `aria-describedby` attributes.
. Modify a couple of pages to use `govuk_collection_radio_buttons`.

FYI, this FormBuilder generates HTML described on https://design-system.service.gov.uk/components/radios/

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unneccessary whitespace changes. These make diffs harder to read and conflicts more likely. 
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
