### PR TITLE
Fix flashing rspec test

### DIFF
--- a/spec/requests/citizens/legal_aid_applications_spec.rb
+++ b/spec/requests/citizens/legal_aid_applications_spec.rb
@@ -20,8 +20,8 @@ RSpec.describe 'citizen home requests', type: :request do
       end
 
       it 'returns the correct application' do
-        expect(response.body).to include(applicant_first_name.html_safe)
-        expect(response.body).to include(applicant_last_name.html_safe)
+        expect(unescaped_response_body).to include(applicant_first_name.html_safe)
+        expect(unescaped_response_body).to include(applicant_last_name.html_safe)
       end
     end
 


### PR DESCRIPTION
**Fix flashing rspec test**

/spec/requests/citizens/legal_aid_applications_spec.rb fails if Faker
generates a first_name or last_name that contains a non-alpha
character - usually an apostrophe.

Prevent this occurring by using unescaped_response_body instead of
response.body for the comparison.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unneccessary whitespace changes. These make diffs harder to read and conflicts more likely. 
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
