### PR TITLE
Refactor Check your answer 'redirect' mechanism

### DIFF
--- a/app/controllers/providers/check_provider_answers_controller.rb
+++ b/app/controllers/providers/check_provider_answers_controller.rb
@@ -8,17 +8,6 @@ module Providers
       @applicant = legal_aid_application.applicant
       @address = @applicant.addresses.first
       @back_step_url = back_step_path
-      legal_aid_application.check_your_answers! unless legal_aid_application.checking_answers?
-    end
-
-    def reset
-      legal_aid_application.reset!
-      redirect_to back_step_path
-    end
-
-    def continue
-      legal_aid_application.answers_checked!
-      redirect_to next_step_url
     end
 
     private

--- a/app/helpers/check_provider_answers_helper.rb
+++ b/app/helpers/check_provider_answers_helper.rb
@@ -11,9 +11,10 @@ module CheckProviderAnswersHelper
     )
   end
 
-  def change_address_link(applicant)
-    return providers_legal_aid_application_address_lookup_path(anchor: :postcode) if applicant.address&.lookup_used?
+  def change_address_link(applicant, options = {})
+    options[:anchor] = :postcode
+    return providers_legal_aid_application_address_lookup_path(options) if applicant.address&.lookup_used?
 
-    providers_legal_aid_application_address_path(anchor: :postcode)
+    providers_legal_aid_application_address_path(options)
   end
 end

--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -21,27 +21,10 @@ class LegalAidApplication < ApplicationRecord
 
   aasm column: :state do
     state :initiated, initial: true
-    state :checking_answers
-    state :answers_checked
     state :provider_submitted
-
-    event :check_your_answers do
-      transitions from: :initiated, to: :checking_answers
-      transitions from: :answers_checked, to: :checking_answers
-    end
-
-    event :answers_checked do
-      transitions from: :checking_answers, to: :answers_checked
-    end
 
     event :provider_submit do
       transitions from: :initiated, to: :provider_submitted
-      transitions from: :checking_answers, to: :provider_submitted
-      transitions from: :answers_checked, to: :provider_submitted
-    end
-
-    event :reset do
-      transitions from: :checking_answers, to: :initiated
     end
   end
 

--- a/app/views/providers/address_lookups/_form.html.erb
+++ b/app/views/providers/address_lookups/_form.html.erb
@@ -17,6 +17,8 @@
           local: true
         ) do |form| %>
 
+      <%= hidden_field_tag :redirect_path, params[:redirect_path] if params[:redirect_path] %>
+
       <div class="govuk-!-padding-bottom-6"></div>
 
       <div class="govuk-!-padding-bottom-2"></div>
@@ -25,7 +27,12 @@
 
       <%= form.submit 'Find address', id: 'find-address', class: 'govuk-button' %>
 
-      <p><%= link_to 'Enter address manually', providers_legal_aid_application_address_path, class: 'govuk-link' %></p>
+      <%
+        url_options = {}
+        url_options[:redirect_path] = params[:redirect_path] if params[:redirect_path]
+      %>
+
+      <p><%= link_to 'Enter address manually', providers_legal_aid_application_address_path(url_options), class: 'govuk-link' %></p>
     <% end %>
   </div>
 </div>

--- a/app/views/providers/address_selections/show.html.erb
+++ b/app/views/providers/address_selections/show.html.erb
@@ -10,6 +10,9 @@
           method: :patch,
           local: true
         ) do |f| %>
+
+      <%= hidden_field_tag :redirect_path, params[:redirect_path] if params[:redirect_path] %>
+
       <div class='govuk-form-group'>
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
           <h1 class="govuk-fieldset__heading">

--- a/app/views/providers/addresses/_form.html.erb
+++ b/app/views/providers/addresses/_form.html.erb
@@ -10,6 +10,8 @@
           local: true
         ) do |form| %>
 
+      <%= hidden_field_tag :redirect_path, params[:redirect_path] if params[:redirect_path] %>
+
     <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
       <h1 class="govuk-fieldset__heading">
         <% if form.object.lookup_error.present? %>

--- a/app/views/providers/applicants/show.html.erb
+++ b/app/views/providers/applicants/show.html.erb
@@ -23,6 +23,8 @@
             local: true
           ) do |form| %>
 
+        <%= hidden_field_tag :redirect_path, params[:redirect_path] if params[:redirect_path] %>
+
         <div class="govuk-!-padding-bottom-2"></div>
 
         <%= form.govuk_text_field :first_name, class: 'govuk-!-width-one-half' %>

--- a/app/views/providers/check_provider_answers/index.html.erb
+++ b/app/views/providers/check_provider_answers/index.html.erb
@@ -2,12 +2,13 @@
   content_for(:navigation) do
     link_to(
       t('generic.back'),
-      reset_providers_legal_aid_application_check_provider_answers_path,
+      @back_step_url,
       class: 'govuk-back-link',
-      id: 'back-top',
-      method: :post
+      id: 'back-top'
     )
   end
+
+  url_options = { redirect_path: request.fullpath }
 %>
 
 <div class="govuk-grid-row">
@@ -25,7 +26,7 @@
 
       <%= check_provider_answer_link(
             name: :proceeding_type,
-            url: providers_legal_aid_application_proceedings_type_path(anchor: 'proceeding-search-input'.freeze),
+            url: providers_legal_aid_application_proceedings_type_path(url_options.merge(anchor: 'proceeding-search-input'.freeze)),
             question: t('.section_1.proceeding'),
             answer: @proceeding.meaning
           ) %>
@@ -36,50 +37,50 @@
 
       <%= check_provider_answer_link(
             name: :first_name,
-            url: providers_legal_aid_application_applicant_path(anchor: :first_name),
+            url: providers_legal_aid_application_applicant_path(url_options.merge(anchor: :first_name)),
             question: t('.section_2.first_name'),
             answer: @applicant.first_name
           ) %>
 
       <%= check_provider_answer_link(
             name: :last_name,
-            url: providers_legal_aid_application_applicant_path(anchor: :last_name),
+            url: providers_legal_aid_application_applicant_path(url_options.merge(anchor: :last_name)),
             question: t('.section_2.last_name'),
             answer: @applicant.last_name
           ) %>
 
       <%= check_provider_answer_link(
             name: :date_of_birth,
-            url: providers_legal_aid_application_applicant_path(anchor: :dob_day),
+            url: providers_legal_aid_application_applicant_path(url_options.merge(anchor: :dob_day)),
             question: t('.section_2.dob'),
             answer: @applicant.date_of_birth
           ) %>
 
       <%= check_provider_answer_link(
             name: :national_insurance_number,
-            url: providers_legal_aid_application_applicant_path(anchor: :national_insurance_number),
+            url: providers_legal_aid_application_applicant_path(url_options.merge(anchor: :national_insurance_number)),
             question: t('.section_2.nino'),
             answer: @applicant.national_insurance_number
           ) %>
 
       <%= check_provider_answer_link(
             name: :email,
-            url: providers_legal_aid_application_applicant_path(anchor: :email),
+            url: providers_legal_aid_application_applicant_path(url_options.merge(anchor: :email)),
             question: t('.section_2.email'),
             answer: @applicant.email
           ) %>
 
       <%= check_provider_answer_link(
             name: :address,
-            url: change_address_link(@applicant),
+            url: change_address_link(@applicant, url_options),
             question: t('.section_2.address'),
             answer: address_with_line_breaks(@address)
           ) %>
     </dl>
   </div>
 </div>
-<%= button_to(
+<%= link_to(
       t('generic.continue'),
-      continue_providers_legal_aid_application_check_provider_answers_path,
+      next_step_url,
       class: 'govuk-button'
     ) %>

--- a/app/views/providers/proceedings_types/_proceeding_type.html.erb
+++ b/app/views/providers/proceedings_types/_proceeding_type.html.erb
@@ -12,6 +12,8 @@
         html: { id: "add_legal_aid_application_proceeding_type_#{proceeding_type.code}" }
       ) do |form| %>
   <div class="govuk-grid-column-one-third control-column">
+    <%= hidden_field_tag :redirect_path, params[:redirect_path] if params[:redirect_path] %>
+
     <%= hidden_field_tag :proceeding_type, proceeding_type.code, id: "proceeding_type_#{proceeding_type.code}" %>
     <%= form.submit 'Select and continue', tabindex: '-1', class: 'govuk-button proceeding-link govuk-!-margin-top-4' %>
   </div>

--- a/app/views/providers/proceedings_types/show.html.erb
+++ b/app/views/providers/proceedings_types/show.html.erb
@@ -6,7 +6,7 @@
 </noscript>
 <%
   content_for(:navigation) do
-    back_label = @legal_aid_application.checking_answers? ? 'generic.back' : 'generic.home'
+    back_label = params[:redirect_path].present? ? 'generic.back' : 'generic.home'
     provider_back_link t(back_label)
   end
 %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,10 +43,7 @@ Rails.application.routes.draw do
         get :passported, on: :collection
       end
       resource :online_banking, only: %i[show update], path: 'does-client-use-online-banking'
-      resources :check_provider_answers, only: [:index] do
-        post :reset, on: :collection
-        post :continue, on: :collection
-      end
+      resources :check_provider_answers, only: [:index]
       resource :about_the_financial_assessment, only: [:show] do
         post :submit, on: :collection
       end

--- a/features/providers/civil_application_journey.feature
+++ b/features/providers/civil_application_journey.feature
@@ -56,7 +56,7 @@ Feature: Civil application journeys
     Then I select an address '3, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG'
     Then I click "Continue"
     Then I should be on the Check Your Answers page
-    Then I click "Continue"
+    Then I click link "Continue"
     Then I am on the benefit check results page
     When I click "Continue"
     Then I am on the client use online banking page
@@ -82,7 +82,7 @@ Feature: Civil application journeys
     Then I enter postcode 'SW1H 9AJ'
     Then I click "Continue"
     Then I should be on the Check Your Answers page
-    Then I click "Continue"
+    Then I click link "Continue"
     Then I am on the benefit check results page
     When I click "Continue"
     Then I am on the client use online banking page
@@ -106,7 +106,7 @@ Feature: Civil application journeys
     Then I select an address '3, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG'
     Then I click "Continue"
     Then I should be on the Check Your Answers page
-    Then I click "Continue"
+    Then I click link "Continue"
     Then I am on the benefit check results page
     Then I see a notice saying that the citizen receives benefits
 
@@ -124,7 +124,7 @@ Feature: Civil application journeys
     Then I select an address '3, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG'
     Then I click "Continue"
     Then I should be on the Check Your Answers page
-    Then I click "Continue"
+    Then I click link "Continue"
     Then I am on the benefit check results page
     Then I see a notice saying that the citizen does not receive benefits
 

--- a/spec/models/legal_aid_application_spec.rb
+++ b/spec/models/legal_aid_application_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe LegalAidApplication, type: :model do
 
       context 'but later, state changes' do
         before do
-          legal_aid_application.check_your_answers!
+          legal_aid_application.provider_submit!
         end
 
         it 'returns false' do

--- a/spec/requests/providers/applicants_spec.rb
+++ b/spec/requests/providers/applicants_spec.rb
@@ -35,19 +35,18 @@ RSpec.describe 'providers applicant requests', type: :request do
   end
 
   describe 'PATCH /providers/applications/:legal_aid_application_id/applicant' do
-    let(:params) do
+    let(:applicant_params) do
       {
-        applicant: {
-          first_name: 'John',
-          last_name: 'Doe',
-          national_insurance_number: 'AA 12 34 56 C',
-          dob_year: '1981',
-          dob_month: '07',
-          dob_day: '11',
-          email: Faker::Internet.safe_email
-        }
+        first_name: 'John',
+        last_name: 'Doe',
+        national_insurance_number: 'AA 12 34 56 C',
+        dob_year: '1981',
+        dob_month: '07',
+        dob_day: '11',
+        email: Faker::Internet.safe_email
       }
     end
+    let(:params) { { applicant: applicant_params } }
     let(:patch_request) { patch "/providers/applications/#{application_id}/applicant", params: params }
 
     it 'redirects provider to next step of the submission' do
@@ -64,7 +63,12 @@ RSpec.describe 'providers applicant requests', type: :request do
     end
 
     context 'when the legal aid application is in checking_answers state' do
-      let(:application) { create(:legal_aid_application, state: :checking_answers) }
+      let(:params) do
+        {
+          applicant: applicant_params,
+          redirect_path: providers_legal_aid_application_check_provider_answers_path(application_id)
+        }
+      end
 
       it 'redirects to check_your_answers page' do
         patch_request

--- a/spec/requests/providers/check_provider_answers_spec.rb
+++ b/spec/requests/providers/check_provider_answers_spec.rb
@@ -5,38 +5,38 @@ RSpec.describe 'check your answers requests', type: :request do
   let(:application_id) { application.id }
 
   describe 'GET /providers/applications/:legal_aid_application_id/check_provider_answers' do
-    let(:get_request) { get "/providers/applications/#{application_id}/check_provider_answers" }
+    subject { get "/providers/applications/#{application_id}/check_provider_answers" }
 
     context 'when the application does not exist' do
       let(:application_id) { SecureRandom.uuid }
 
       it 'redirects to the applications page with an error' do
-        get_request
+        subject
 
         expect(response).to redirect_to(providers_legal_aid_applications_path)
       end
     end
 
     it 'returns success' do
-      get_request
+      subject
 
       expect(response).to be_successful
     end
 
     it 'displays the correct page' do
-      get_request
+      subject
 
       expect(unescaped_response_body).to include('Check your answers')
     end
 
     it 'displays the correct proceeding' do
-      get_request
+      subject
 
       expect(unescaped_response_body).to include(application.proceeding_types[0].meaning)
     end
 
     it 'displays the correct client details' do
-      get_request
+      subject
 
       applicant = application.applicant
       address = applicant.addresses[0]
@@ -50,60 +50,26 @@ RSpec.describe 'check your answers requests', type: :request do
       expect(unescaped_response_body).to include(address.city)
       expect(unescaped_response_body).to include(address.postcode)
     end
-  end
 
-  describe 'POST /providers/applications/:legal_aid_application_id/check_provider_answers/reset' do
-    subject { post "/providers/applications/#{application_id}/check_provider_answers/reset" }
-
-    before do
-      application.check_your_answers!
-    end
-
-    it 'should redirect back' do
+    it 'should have a link to next step' do
       subject
-      expect(response).to redirect_to(providers_legal_aid_application_address_path(application))
+      expect(unescaped_response_body).to include(providers_legal_aid_application_check_benefits_path(application))
     end
 
     context "the applicant's address used s address lookup service" do
       let(:application) { create(:legal_aid_application, :with_proceeding_types, :with_applicant_and_address_lookup) }
-      let(:application_id) { application.id }
-      let(:address_lookup_used) { true }
 
-      it 'should redirect to the address lookup page' do
+      it 'should have a link to the address lookup page' do
         subject
-        expect(response).to redirect_to(providers_legal_aid_application_address_selection_path(application))
+        expect(unescaped_response_body).to include(providers_legal_aid_application_address_selection_path(application))
       end
     end
 
     context "the applicant's address used manual entry" do
-      let(:address_lookup_used) { false }
-
-      it 'should redirect to manual address pagelookup page' do
+      it 'should have a link to manual address pagelookup page' do
         subject
-        expect(response).to redirect_to(providers_legal_aid_application_address_path(application))
+        expect(unescaped_response_body).to include(providers_legal_aid_application_address_path(application))
       end
-    end
-
-    it 'should change the stage back to "initialized' do
-      subject
-      expect(application.reload.initiated?).to be_truthy
-    end
-  end
-
-  describe 'POST /providers/applications/:legal_aid_application_id/check_provider_answers/continue' do
-    subject { post "/providers/applications/#{application_id}/check_provider_answers/continue" }
-
-    before do
-      application.check_your_answers!
-      subject
-    end
-
-    it 'should redirect to next step' do
-      expect(response).to redirect_to(providers_legal_aid_application_check_benefits_path(application))
-    end
-
-    it 'should change the stage to "answers_checked"' do
-      expect(application.reload.answers_checked?).to be_truthy
     end
   end
 end


### PR DESCRIPTION
I had a go at changing the way the "Check your answer" flow works.
By passing a `redirect_path` parameter around rather than using the state of the `legal_aid_application`.
Personally, I think it makes things simpler and we don't have to worry about the state.
Let me know what you think.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unneccessary whitespace changes. These make diffs harder to read and conflicts more likely. 
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
