### PR TITLE
AP-227 Capital restrictions page for providers

### DIFF
--- a/app/controllers/concerns/providers/steppable.rb
+++ b/app/controllers/concerns/providers/steppable.rb
@@ -46,6 +46,10 @@ module Providers
       own_homes: {
         # forward: determined by controller action logic
         back: :providers_legal_aid_application_check_benefits_path
+      },
+      restrictions: {
+        # forward:  figure this out later,
+        back: :providers_legal_aid_applications_path
       }
     }.freeze
 

--- a/app/controllers/providers/restrictions_controller.rb
+++ b/app/controllers/providers/restrictions_controller.rb
@@ -1,0 +1,21 @@
+module Providers
+  class RestrictionsController < ApplicationController
+    include Steppable
+    include Providers::ApplicationDependable
+
+    def index
+      legal_aid_application
+    end
+
+    def create
+      legal_aid_application.update!(legal_aid_application_params)
+      render plain: 'Holding page: Redirect to check you answers'
+    end
+
+    private
+
+    def legal_aid_application_params
+      params.require(:legal_aid_application).permit(restriction_ids: [])
+    end
+  end
+end

--- a/app/views/citizens/restrictions/_form.html.erb
+++ b/app/views/citizens/restrictions/_form.html.erb
@@ -1,0 +1,13 @@
+<%= form_with(model: model, url: url, method: :post, local: true) do |form| %>
+  <%= govuk_form_group do %>
+    <div class="govuk-checkboxes">
+      <%= form.collection_check_boxes :restriction_ids, Restriction.all, :id, :label_name do |restriction_form| %>
+        <div class="govuk-checkboxes__item">
+          <%= restriction_form.check_box(class: 'govuk-checkboxes__input') %>
+          <%= restriction_form.label(class: 'govuk-label govuk-checkboxes__label') %>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
+  <%= form.submit t('generic.continue'), class: 'govuk-button' %>
+<% end %>

--- a/app/views/citizens/restrictions/index.html.erb
+++ b/app/views/citizens/restrictions/index.html.erb
@@ -10,24 +10,8 @@
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl"><%= t('.h1-heading') %></h1>
 
-      <%= form_with(
-            model: @legal_aid_application,
-            url: citizens_restrictions_path,
-            method: :post,
-            local: true
-          ) do |form| %>
-        <%= govuk_form_group do %>
-          <div class="govuk-checkboxes">
-            <%= form.collection_check_boxes :restriction_ids, Restriction.all, :id, :label_name do |restriction_form| %>
-              <div class="govuk-checkboxes__item">
-                <%= restriction_form.check_box(class: 'govuk-checkboxes__input') %>
-                <%= restriction_form.label(class: 'govuk-label govuk-checkboxes__label') %>
-              </div>
-            <% end %>
-          </div>
-        <% end %>
-        <%= form.submit t('generic.continue'), class: 'govuk-button' %>
-      <% end %>
+        <%= render partial: 'form', locals: { model: @legal_aid_application, url: citizens_restrictions_path } %>
+
     </div>
   </div>
 </fieldset>

--- a/app/views/providers/restrictions/index.html.erb
+++ b/app/views/providers/restrictions/index.html.erb
@@ -1,0 +1,22 @@
+<% content_for(:page_title) { t('.h1-heading') } %>
+
+<% content_for :navigation do %>
+  <%= provider_back_link t('generic.back') %>
+<% end %>
+
+<fieldset class="govuk-fieldset">
+  <div class="govuk-!-padding-bottom-2"></div>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl"><%= t('.h1-heading') %></h1>
+
+      <%= render partial: '/citizens/restrictions/form',
+                 locals: {
+                   model: @legal_aid_application,
+                   url: providers_legal_aid_application_restrictions_path(@legal_aid_application)
+                 } %>
+
+    </div>
+  </div>
+</fieldset>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -374,6 +374,9 @@ en:
     own_homes:
       show:
         h1-heading: Does your client own the home that they live in?
+    restrictions:
+      index:
+        h1-heading: Do any restrictions apply to your client's property, savings or assets?
 
   citizens:
     accounts:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,6 +47,7 @@ Rails.application.routes.draw do
         post :reset, on: :collection
         post :continue, on: :collection
       end
+      resources :restrictions, only: %i[index create] # as multiple restrictions
       resource :about_the_financial_assessment, only: [:show] do
         post :submit, on: :collection
       end

--- a/spec/requests/providers/restrictions_spec.rb
+++ b/spec/requests/providers/restrictions_spec.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+
+RSpec.describe 'citizen restrictions request', type: :request do
+  let(:legal_aid_application) { create :legal_aid_application, :with_applicant }
+  let!(:restrictions) { create_list :restriction, 3 }
+
+  describe 'GET /providers/applications/:id/restrictions' do
+    before { get providers_legal_aid_application_restrictions_path(legal_aid_application) }
+
+    it 'returns http success' do
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'displays the restriction name labels' do
+      restrictions.map(&:label_name).each do |label|
+        expect(unescaped_response_body).to include(label)
+      end
+    end
+  end
+
+  describe 'POST /citizens/restrictions' do
+    let(:restriction_ids) { restrictions.pluck(:id) }
+    let(:params) do
+      {
+        legal_aid_application_id: legal_aid_application.id,
+        legal_aid_application: {
+          restriction_ids: restriction_ids
+        }
+      }
+    end
+    subject { post providers_legal_aid_application_restrictions_path(legal_aid_application), params: params }
+
+    it 'creates a mapping for each restriction' do
+      expect { subject }.to change { LegalAidApplicationRestriction.count }.by(restrictions.count)
+    end
+
+    context 'after success' do
+      before do
+        subject
+        legal_aid_application.reload
+      end
+
+      it 'updates the legal_aid_application.restrictions' do
+        expect(legal_aid_application.restrictions).to match_array(restrictions)
+      end
+
+      xit 'redirects to check your answers' do
+        # TODO: - set redirect path when known
+        expect(response).to redirect_to(:some_path)
+      end
+
+      it 'displays a holding page' do
+        # TODO: - replace with 'redirects to check your answers'
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include('Holding page')
+      end
+    end
+
+    context 'on error' do
+      let(:restriction_ids) { %i[foo bar] }
+
+      # As I can not think of a "normal" behaviour that can cause an error.
+      # Error handling falls back to standard error handling.
+      it 'raises error' do
+        expect { subject }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This change adds the controller and views for the Restrictions page on the provider journey

[Link to story](https://dsdmoj.atlassian.net/browse/AP-227)

There is already a restrictions page on the citizens journey.  However, for passported users,
this is filled out by the provider.  This PR creates a separate controller for the provider journey,
but the view uses the form partial from the citizen journey.

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unneccessary whitespace changes. These make diffs harder to read and conflicts more likely. 
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
