### PR TITLE
AP-259 Fix Page layouts

### DIFF
--- a/app/views/citizens/accounts/index.html.erb
+++ b/app/views/citizens/accounts/index.html.erb
@@ -14,44 +14,48 @@
       <h2 class="govuk-heading-m"><%= t '.your_accounts' %></h2>
     </div>
   </div>
+</div>
 
-  <% @applicant_banks.each do |applicant_bank| %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <% @applicant_banks.each do |applicant_bank| %>
 
-    <table class="govuk-table">
-      <tbody class="govuk-table__body">
-        <tr class="govuk-table__row">
-          <th class="govuk-table__header" scope="row"><%= t '.account_holder_name_heading' %></th>
-          <td class="govuk-table__cell"><%= applicant_bank.main_account_holder_name %></td>
-        </tr>
-        <tr class="govuk-table__row">
-          <th class="govuk-table__header" scope="row"><%= t '.account_holder_address_heading' %></th>
-          <td class="govuk-table__cell"><%= applicant_bank.main_account_holder_address %></td>
-        </tr>
-      </tbody>
-    </table>
-
-    <table class="govuk-table">
-       <thead class="govuk-table__head">
-        <tr class="govuk-table__row">
-          <th class="govuk-table__header" scope="col"><%= t '.type_heading' %></th>
-          <th class="govuk-table__header" scope="col"><%= t '.account_number_heading' %></th>
-          <th class="govuk-table__header" scope="col"><%= t '.sort_code_heading' %></th>
-          <th class="govuk-table__header govuk-table__header--numeric" scope="col"><%= t '.balance_heading' %></th>
-        </tr>
-      </thead>
-      <tbody class="govuk-table__body">
-        <% applicant_bank.bank_accounts.each do |bank_account| %>
+      <table class="govuk-table">
+        <tbody class="govuk-table__body">
           <tr class="govuk-table__row">
-            <td class="govuk-table__cell"><%= "#{applicant_bank.name} #{bank_account.name}" %></td>
-            <td class="govuk-table__cell"><%= bank_account.account_number %></td>
-            <td class="govuk-table__cell"><%= bank_account.sort_code %></td>
-            <td class="govuk-table__cell govuk-table__cell--numeric"><%= value_with_currency_unit(bank_account.balance, bank_account.currency) %></td>
+            <th class="govuk-table__header" scope="row"><%= t '.account_holder_name_heading' %></th>
+            <td class="govuk-table__cell"><%= applicant_bank.main_account_holder_name %></td>
           </tr>
-        <% end %>
-      </tbody>
+          <tr class="govuk-table__row">
+            <th class="govuk-table__header" scope="row"><%= t '.account_holder_address_heading' %></th>
+            <td class="govuk-table__cell"><%= applicant_bank.main_account_holder_address %></td>
+          </tr>
+        </tbody>
+      </table>
 
-    </table>
-  <% end %>
+      <table class="govuk-table">
+         <thead class="govuk-table__head">
+          <tr class="govuk-table__row">
+            <th class="govuk-table__header" scope="col"><%= t '.type_heading' %></th>
+            <th class="govuk-table__header" scope="col"><%= t '.account_number_heading' %></th>
+            <th class="govuk-table__header" scope="col"><%= t '.sort_code_heading' %></th>
+            <th class="govuk-table__header govuk-table__header--numeric" scope="col"><%= t '.balance_heading' %></th>
+          </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+          <% applicant_bank.bank_accounts.each do |bank_account| %>
+            <tr class="govuk-table__row">
+              <td class="govuk-table__cell"><%= "#{applicant_bank.name} #{bank_account.name}" %></td>
+              <td class="govuk-table__cell"><%= bank_account.account_number %></td>
+              <td class="govuk-table__cell"><%= bank_account.sort_code %></td>
+              <td class="govuk-table__cell govuk-table__cell--numeric"><%= value_with_currency_unit(bank_account.balance, bank_account.currency) %></td>
+            </tr>
+          <% end %>
+        </tbody>
+
+      </table>
+    <% end %>
+  </div>
   <div class="govuk-!-padding-top-3">
     <%= link_to t('generic.continue'), citizens_additional_accounts_path, class: 'govuk-button', id: 'continue' %>
   </div>

--- a/app/views/citizens/accounts/index.html.erb
+++ b/app/views/citizens/accounts/index.html.erb
@@ -55,8 +55,9 @@
 
       </table>
     <% end %>
-  </div>
-  <div class="govuk-!-padding-top-3">
-    <%= link_to t('generic.continue'), citizens_additional_accounts_path, class: 'govuk-button', id: 'continue' %>
+
+    <div class="govuk-!-padding-top-3">
+      <%= link_to t('generic.continue'), citizens_additional_accounts_path, class: 'govuk-button', id: 'continue' %>
+    </div>
   </div>
 </div>

--- a/app/views/citizens/accounts/index.html.erb
+++ b/app/views/citizens/accounts/index.html.erb
@@ -1,54 +1,58 @@
 <% content_for :navigation do %>
   <%= link_to t('generic.back'), citizens_consent_path, class: 'govuk-back-link', id: 'back' %>
 <% end %>
-<h1 class="govuk-heading-xl"><%= t '.heading_1' %></h1>
-<p>
-  <%= t '.intro_text' %>
-</p>
-<p>
-  <%= t '.balance_text' %>
-</p>
-<div class="govuk-!-padding-bottom-5">
-  <h2 class="govuk-heading-m"><%= t '.your_accounts' %></h2>
-</div>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl"><%= t '.heading_1' %></h1>
+    <p>
+      <%= t '.intro_text' %>
+    </p>
+    <p>
+      <%= t '.balance_text' %>
+    </p>
+    <div class="govuk-!-padding-bottom-5">
+      <h2 class="govuk-heading-m"><%= t '.your_accounts' %></h2>
+    </div>
+  </div>
 
-<% @applicant_banks.each do |applicant_bank| %>
+  <% @applicant_banks.each do |applicant_bank| %>
 
-  <table class="govuk-table">
-    <tbody class="govuk-table__body">
-      <tr class="govuk-table__row">
-        <th class="govuk-table__header" scope="row"><%= t '.account_holder_name_heading' %></th>
-        <td class="govuk-table__cell"><%= applicant_bank.main_account_holder_name %></td>
-      </tr>
-      <tr class="govuk-table__row">
-        <th class="govuk-table__header" scope="row"><%= t '.account_holder_address_heading' %></th>
-        <td class="govuk-table__cell"><%= applicant_bank.main_account_holder_address %></td>
-      </tr>
-    </tbody>
-  </table>
-
-  <table class="govuk-table">
-     <thead class="govuk-table__head">
-      <tr class="govuk-table__row">
-        <th class="govuk-table__header" scope="col"><%= t '.type_heading' %></th>
-        <th class="govuk-table__header" scope="col"><%= t '.account_number_heading' %></th>
-        <th class="govuk-table__header" scope="col"><%= t '.sort_code_heading' %></th>
-        <th class="govuk-table__header govuk-table__header--numeric" scope="col"><%= t '.balance_heading' %></th>
-      </tr>
-    </thead>
-    <tbody class="govuk-table__body">
-      <% applicant_bank.bank_accounts.each do |bank_account| %>
+    <table class="govuk-table">
+      <tbody class="govuk-table__body">
         <tr class="govuk-table__row">
-          <td class="govuk-table__cell"><%= "#{applicant_bank.name} #{bank_account.name}" %></td>
-          <td class="govuk-table__cell"><%= bank_account.account_number %></td>
-          <td class="govuk-table__cell"><%= bank_account.sort_code %></td>
-          <td class="govuk-table__cell govuk-table__cell--numeric"><%= value_with_currency_unit(bank_account.balance, bank_account.currency) %></td>
+          <th class="govuk-table__header" scope="row"><%= t '.account_holder_name_heading' %></th>
+          <td class="govuk-table__cell"><%= applicant_bank.main_account_holder_name %></td>
         </tr>
-      <% end %>
-    </tbody>
+        <tr class="govuk-table__row">
+          <th class="govuk-table__header" scope="row"><%= t '.account_holder_address_heading' %></th>
+          <td class="govuk-table__cell"><%= applicant_bank.main_account_holder_address %></td>
+        </tr>
+      </tbody>
+    </table>
 
-  </table>
-<% end %>
-<div class="govuk-!-padding-top-3">
-  <%= link_to t('generic.continue'), citizens_additional_accounts_path, class: 'govuk-button', id: 'continue' %>
+    <table class="govuk-table">
+       <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th class="govuk-table__header" scope="col"><%= t '.type_heading' %></th>
+          <th class="govuk-table__header" scope="col"><%= t '.account_number_heading' %></th>
+          <th class="govuk-table__header" scope="col"><%= t '.sort_code_heading' %></th>
+          <th class="govuk-table__header govuk-table__header--numeric" scope="col"><%= t '.balance_heading' %></th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+        <% applicant_bank.bank_accounts.each do |bank_account| %>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell"><%= "#{applicant_bank.name} #{bank_account.name}" %></td>
+            <td class="govuk-table__cell"><%= bank_account.account_number %></td>
+            <td class="govuk-table__cell"><%= bank_account.sort_code %></td>
+            <td class="govuk-table__cell govuk-table__cell--numeric"><%= value_with_currency_unit(bank_account.balance, bank_account.currency) %></td>
+          </tr>
+        <% end %>
+      </tbody>
+
+    </table>
+  <% end %>
+  <div class="govuk-!-padding-top-3">
+    <%= link_to t('generic.continue'), citizens_additional_accounts_path, class: 'govuk-button', id: 'continue' %>
+  </div>
 </div>

--- a/app/views/citizens/additional_accounts/index.html.erb
+++ b/app/views/citizens/additional_accounts/index.html.erb
@@ -2,20 +2,23 @@
   <%#= link_to 'Back', path-to-be-determined, class: 'govuk-back-link', id: 'back' %>
 <% end %>
 
-  <%= form_tag(citizens_additional_accounts_path) do %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_tag(citizens_additional_accounts_path) do %>
 
-    <%= govuk_form_group(
-          show_error_if: @error,
-          hint_id: :additional_account_hint,
-          input: :additional_account
-        ) do %>
-      <%= govuk_fieldset_header t('.field_set_header'), padding_below: 6 %>
-      <%= govuk_hint t('.hint'), id: :additional_account_hint %>
-      <%= govuk_error_message @error %>
-      <%= govuk_radio_inputs :additional_account, yes: t('generic.yes'), no: t('generic.no') %>
+      <%= govuk_form_group(
+            show_error_if: @error,
+            hint_id: :additional_account_hint,
+            input: :additional_account
+          ) do %>
+        <%= govuk_fieldset_header t('.field_set_header'), padding_below: 6 %>
+        <%= govuk_hint t('.hint'), id: :additional_account_hint %>
+        <%= govuk_error_message @error %>
+        <%= govuk_radio_inputs :additional_account, yes: t('generic.yes'), no: t('generic.no') %>
+      <% end %>
+
+      <%= govuk_submit_button t('generic.continue') %>
+
     <% end %>
-
-    <%= govuk_submit_button t('generic.continue') %>
-
-  <% end %>
+  </div>
 </div>

--- a/app/views/citizens/additional_accounts/new.html.erb
+++ b/app/views/citizens/additional_accounts/new.html.erb
@@ -2,20 +2,23 @@
   <%#= link_to 'Back', path-to-be-determined, class: 'govuk-back-link', id: 'back' %>
 <% end %>
 
-  <%= form_tag(citizens_additional_account_path(id: :update), method: :patch) do %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_tag(citizens_additional_account_path(id: :update), method: :patch) do %>
 
-    <%= govuk_form_group(
-          show_error_if: @error,
-          hint_id: :has_offline_accounts_hint,
-          input: :has_offline_accounts
-        ) do %>
-      <%= govuk_fieldset_header t('.field_set_header'), padding_below: 6 %>
-      <%= govuk_hint t('.hint'), id: :has_offline_accounts_hint %>
-      <%= govuk_error_message(@error) %>
-      <%= govuk_radio_inputs :has_offline_accounts, yes: t('generic.yes'), no: t('generic.no') %>
+      <%= govuk_form_group(
+            show_error_if: @error,
+            hint_id: :has_offline_accounts_hint,
+            input: :has_offline_accounts
+          ) do %>
+        <%= govuk_fieldset_header t('.field_set_header'), padding_below: 6 %>
+        <%= govuk_hint t('.hint'), id: :has_offline_accounts_hint %>
+        <%= govuk_error_message(@error) %>
+        <%= govuk_radio_inputs :has_offline_accounts, yes: t('generic.yes'), no: t('generic.no') %>
+      <% end %>
+
+      <%= govuk_submit_button t('generic.continue') %>
+
     <% end %>
-
-    <%= govuk_submit_button t('generic.continue') %>
-
-  <% end %>
+  </div>
 </div>

--- a/app/views/citizens/consents/show.html.erb
+++ b/app/views/citizens/consents/show.html.erb
@@ -2,17 +2,21 @@
     <%= link_to t('generic.back'), citizens_information_path, class: 'govuk-back-link', id: 'back' %>
 <% end %>
 
-<%= form_with(model: @form, scope: :legal_aid_application, url: citizens_consent_path, local: true) do |form| %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with(model: @form, scope: :legal_aid_application, url: citizens_consent_path, local: true) do |form| %>
 
-  <%= govuk_form_group(
-        input: :open_banking_consent
-      ) do %>
-    <%= govuk_fieldset_header t('.field_set_header'), padding_below: 6 %>
-    <%= govuk_body t('.body') %>
-    <%= render partial: 'shared/forms/detailed_list', locals: { translation_path: 'citizens.consents.show' } %>
-    <%= render partial: 'shared/forms/check_boxes', locals: { field_name: :open_banking_consent, label: t('.open_banking_consent.label.html'), form: form, checked: 'true', unchecked: 'false' } %>
+      <%= govuk_form_group(
+            input: :open_banking_consent
+          ) do %>
+        <%= govuk_fieldset_header t('.field_set_header'), padding_below: 6 %>
+        <%= govuk_body t('.body') %>
+        <%= render partial: 'shared/forms/detailed_list', locals: { translation_path: 'citizens.consents.show' } %>
+        <%= render partial: 'shared/forms/check_boxes', locals: { field_name: :open_banking_consent, label: t('.open_banking_consent.label.html'), form: form, checked: 'true', unchecked: 'false' } %>
+      <% end %>
+
+      <%= govuk_submit_button t('generic.continue') %>
+
     <% end %>
-
-    <%= govuk_submit_button t('generic.continue') %>
-
-<% end %>
+  </div>
+</div>

--- a/app/views/citizens/information/show.html.erb
+++ b/app/views/citizens/information/show.html.erb
@@ -2,11 +2,9 @@
   <%= link_to t('generic.back'), citizens_legal_aid_application_path(id: session[:current_application_ref]), class: 'govuk-back-link', id: 'back' %>
 <% end %>
 
-<h1 class="govuk-heading-xl"><%= t('.heading_1') %></h1>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-
+    <h1 class="govuk-heading-xl"><%= t('.heading_1') %></h1>
     <p class="govuk-body"><%= t('.para_1') %></p>
     <p class="govuk-body"><%= t('.para_2') %></p>
     <br />

--- a/app/views/citizens/legal_aid_applications/show.html.erb
+++ b/app/views/citizens/legal_aid_applications/show.html.erb
@@ -1,8 +1,6 @@
-<h1 class="govuk-heading-xl"><%= t('.heading_1') %></h1>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-
+    <h1 class="govuk-heading-xl"><%= t('.heading_1') %></h1>
     <p class="govuk-body">
       <%= t('.name') %>
       <b><%= current_applicant.first_name %></b>

--- a/app/views/providers/check_benefits/index.html.erb
+++ b/app/views/providers/check_benefits/index.html.erb
@@ -30,20 +30,20 @@
     <p class="govuk-body">
       <%= t "#{result_namespace}.next" %>
     </p>
+
+    <%= form_with(
+          model: @form,
+          url: providers_legal_aid_application_check_benefit_path,
+          method: :patch,
+          local: true
+        ) do |form| %>
+
+      <%= render partial: 'shared/forms/next_action_buttons',
+                 locals: {
+                   continue_id: 'continue',
+                   show_draft: true,
+                   form: form
+                 } %>
+    <% end %>
   </div>
-
-  <%= form_with(
-        model: @form,
-        url: providers_legal_aid_application_check_benefit_path,
-        method: :patch,
-        local: true
-      ) do |form| %>
-
-    <%= render partial: 'shared/forms/next_action_buttons',
-               locals: {
-                 continue_id: 'continue',
-                 show_draft: true,
-                 form: form
-               } %>
-  <% end %>
 </div>

--- a/app/views/shared/forms/other_assets/_form.html.erb
+++ b/app/views/shared/forms/other_assets/_form.html.erb
@@ -1,5 +1,4 @@
 <%= form_with(model: model, url: url, method: :patch, local: true) do |form| %>
-  <div class="govuk-!-padding-bottom-8"></div>
 
   <div class="govuk-form-group">
     <fieldset class="govuk-fieldset" aria-describedby="citizenship-conditional-hint">
@@ -11,7 +10,6 @@
       </div>
     </fieldset>
   </div>
-  <div class="govuk-!-padding-bottom-6"></div>
 
   <%= render partial: 'shared/forms/next_action_buttons',
              locals: {


### PR DESCRIPTION
Fix page layouts to ensure all except tables inside two-thirds div

[Link to story](https://dsdmoj.atlassian.net/browse/AP-259)

Put all of page content except tables inside a two-thirds width div, inside a row div.  Tables are full page width


## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unneccessary whitespace changes. These make diffs harder to read and conflicts more likely. 
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
