### PR TITLE
Improve error reporting of BenefitChecker API

### DIFF
--- a/app/services/benefit_check_service.rb
+++ b/app/services/benefit_check_service.rb
@@ -1,5 +1,6 @@
 class BenefitCheckService
   BENEFIT_CHECKER_NAMESPACE = 'https://lsc.gov.uk/benefitchecker/service/1.0/API_1.0_Check'.freeze
+  ApiError = Class.new(StandardError)
 
   def initialize(application)
     @application = application
@@ -8,6 +9,10 @@ class BenefitCheckService
 
   def call
     soap_client.call(:check, message: benefit_checker_params).body.dig(:benefit_checker_response)
+  rescue Savon::SOAPFault => error
+    raise ApiError, "HTTP #{error.http.code}, #{error.to_hash}"
+  rescue Net::ReadTimeout => error
+    raise ApiError, error
   end
 
   private

--- a/spec/cassettes/BenefitCheckService/_check_benefits/when_some_credentials_are_missing/raises_a_detailed_error.yml
+++ b/spec/cassettes/BenefitCheckService/_check_benefits/when_some_credentials_are_missing/raises_a_detailed_error.yml
@@ -2,154 +2,6 @@
 http_interactions:
 - request:
     method: get
-    uri: http://www.example.com
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: ''
-    headers:
-      Date:
-      - Tue, 06 Nov 2018 16:55:29 GMT
-      Content-Type:
-      - text/xml;charset=utf-8
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      X-Amzn-Trace-Id:
-      - Root=1-5be1c781-95b81ee01a7942586e878bdc;
-      Vary:
-      - Accept-Encoding
-    body:
-      encoding: ASCII-8BIT
-      string: |
-        <?xml version="1.0" encoding="UTF-8"?>
-        <wsdl:definitions targetNamespace="https://lsc.gov.uk/benefitchecker/service/1.0" xmlns:apachesoap="http://xml.apache.org/xml-soap" xmlns:impl="https://lsc.gov.uk/benefitchecker/service/1.0" xmlns:intf="https://lsc.gov.uk/benefitchecker/service/1.0" xmlns:tns1="http://lsc.gov.uk/benefitchecker/data/1.0" xmlns:tns2="https://lsc.gov.uk/benefitchecker/service/1.0/API_1.0_Check" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:wsdlsoap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-        <!--WSDL created by Apache Axis version: 1.4
-        Built on Apr 22, 2006 (06:55:48 PDT)-->
-         <wsdl:types>
-          <schema elementFormDefault="qualified" targetNamespace="http://lsc.gov.uk/benefitchecker/data/1.0" xmlns="http://www.w3.org/2001/XMLSchema">
-           <complexType name="benefitCheckerRequest">
-            <sequence>
-             <element name="clientOrgId" type="xsd:string"/>
-             <element name="clientUserId" type="xsd:string"/>
-             <element name="clientReference" type="xsd:string"/>
-             <element name="lscServiceName" type="xsd:string"/>
-             <element name="nino" type="xsd:string"/>
-             <element name="surname" type="xsd:string"/>
-             <element name="dateOfBirth" type="xsd:string"/>
-             <element name="dateOfAward" nillable="true" type="xsd:string"/>
-            </sequence>
-           </complexType>
-           <complexType name="benefitCheckerResponse">
-            <sequence>
-             <element name="originalClientRef" type="xsd:string"/>
-             <element name="benefitCheckerStatus" type="xsd:string"/>
-             <element name="confirmationRef" type="xsd:string"/>
-            </sequence>
-           </complexType>
-           <complexType name="benefitCheckerFaultException">
-            <sequence>
-             <element name="MessageCode" nillable="true" type="xsd:string"/>
-             <element name="MessageText" nillable="true" type="xsd:string"/>
-            </sequence>
-           </complexType>
-          </schema>
-          <schema elementFormDefault="qualified" targetNamespace="https://lsc.gov.uk/benefitchecker/service/1.0/API_1.0_Check" xmlns="http://www.w3.org/2001/XMLSchema">
-           <import namespace="http://lsc.gov.uk/benefitchecker/data/1.0"/>
-           <element name="benefitCheckerRequest" type="tns1:benefitCheckerRequest"/>
-           <element name="benefitCheckerResponse" type="tns1:benefitCheckerResponse"/>
-           <element name="benefitCheckerFaultException" type="tns1:benefitCheckerFaultException"/>
-          </schema>
-         </wsdl:types>
-
-           <wsdl:message name="BenefitCheckerFaultException">
-
-              <wsdl:part element="tns2:benefitCheckerFaultException" name="benefitCheckerFaultException"/>
-
-           </wsdl:message>
-
-           <wsdl:message name="checkRequest">
-
-              <wsdl:part element="tns2:benefitCheckerRequest" name="benefitCheckerRequest"/>
-
-           </wsdl:message>
-
-           <wsdl:message name="checkResponse">
-
-              <wsdl:part element="tns2:benefitCheckerResponse" name="benefitCheckerResponse"/>
-
-           </wsdl:message>
-
-           <wsdl:portType name="benefitChecker">
-
-              <wsdl:operation name="check" parameterOrder="benefitCheckerRequest">
-
-                 <wsdl:input message="impl:checkRequest" name="checkRequest"/>
-
-                 <wsdl:output message="impl:checkResponse" name="checkResponse"/>
-
-                 <wsdl:fault message="impl:BenefitCheckerFaultException" name="BenefitCheckerFaultException"/>
-
-              </wsdl:operation>
-
-           </wsdl:portType>
-
-           <wsdl:binding name="benefitCheckerSoapBinding" type="impl:benefitChecker">
-
-              <wsdlsoap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
-
-              <wsdl:operation name="check">
-
-                 <wsdlsoap:operation soapAction=""/>
-
-                 <wsdl:input name="checkRequest">
-
-                    <wsdlsoap:body use="literal"/>
-
-                 </wsdl:input>
-
-                 <wsdl:output name="checkResponse">
-
-                    <wsdlsoap:body use="literal"/>
-
-                 </wsdl:output>
-
-                 <wsdl:fault name="BenefitCheckerFaultException">
-
-                    <wsdlsoap:fault name="BenefitCheckerFaultException" use="literal"/>
-
-                 </wsdl:fault>
-
-              </wsdl:operation>
-
-           </wsdl:binding>
-
-           <wsdl:service name="benefitCheckerWS">
-
-              <wsdl:port binding="impl:benefitCheckerSoapBinding" name="benefitChecker">
-
-                 <wsdlsoap:address location="https://benefitchecker.dev.legalservices.gov.uk/lsx/lsc-services/benefitChecker"/>
-
-              </wsdl:port>
-
-           </wsdl:service>
-
-        </wsdl:definitions>
-    http_version: 
-  recorded_at: Tue, 06 Nov 2018 16:55:29 GMT
-- request:
-    method: get
     uri: https://benefitchecker.dev.legalservices.gov.uk/lsx/lsc-services/benefitChecker?wsdl
     body:
       encoding: US-ASCII
@@ -167,7 +19,7 @@ http_interactions:
       message: ''
     headers:
       Date:
-      - Thu, 08 Nov 2018 10:54:31 GMT
+      - Mon, 07 Jan 2019 14:54:09 GMT
       Content-Type:
       - text/xml;charset=utf-8
       Transfer-Encoding:
@@ -175,7 +27,7 @@ http_interactions:
       Connection:
       - keep-alive
       X-Amzn-Trace-Id:
-      - Root=1-5be415e7-10ebacd4c2acbb73035fd2e3;
+      - Root=1-5c336811-45adf8f0957491d0ae8eb250;
       Vary:
       - Accept-Encoding
     body:
@@ -295,7 +147,7 @@ http_interactions:
 
         </wsdl:definitions>
     http_version: 
-  recorded_at: Thu, 08 Nov 2018 10:54:31 GMT
+  recorded_at: Mon, 07 Jan 2019 14:54:10 GMT
 - request:
     method: post
     uri: https://benefitchecker.dev.legalservices.gov.uk/lsx/lsc-services/benefitChecker
@@ -303,14 +155,14 @@ http_interactions:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><soapenv:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tns2="https://lsc.gov.uk/benefitchecker/service/1.0"
-        xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ins0="https://lsc.gov.uk/benefitchecker/service/1.0/API_1.0_Check"><soapenv:Body><ins0:benefitCheckerRequest><ins0:clientReference>9ae33ab2-7604-4ef5-a2d7-d7a85d05e61e</ins0:clientReference><ins0:nino>JA293483A</ins0:nino><ins0:surname>SERVICEEXCEPTION</ins0:surname><ins0:dateOfBirth>19800110</ins0:dateOfBirth><ins0:dateOfAward>20181108</ins0:dateOfAward><ins0:lscServiceName><BC_LSC_SERVICE_NAME></ins0:lscServiceName><ins0:clientOrgId><BC_CLIENT_ORG_ID></ins0:clientOrgId><ins0:clientUserId><BC_CLIENT_USER_ID></ins0:clientUserId></ins0:benefitCheckerRequest></soapenv:Body></soapenv:Envelope>
+        xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ins0="https://lsc.gov.uk/benefitchecker/service/1.0/API_1.0_Check"><soapenv:Body><ins0:benefitCheckerRequest><ins0:clientReference>f0128b37-0f3b-456e-a2cb-1bc94b3c108a</ins0:clientReference><ins0:nino>JA293483A</ins0:nino><ins0:surname>WALKER</ins0:surname><ins0:dateOfBirth>19800110</ins0:dateOfBirth><ins0:dateOfAward>20190107</ins0:dateOfAward><ins0:lscServiceName><BC_LSC_SERVICE_NAME></ins0:lscServiceName><ins0:clientOrgId></ins0:clientOrgId><ins0:clientUserId><BC_CLIENT_USER_ID></ins0:clientUserId></ins0:benefitCheckerRequest></soapenv:Body></soapenv:Envelope>
     headers:
       Soapaction:
       - '"check"'
       Content-Type:
       - text/xml;charset=UTF-8
       Content-Length:
-      - '852'
+      - '829'
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -323,7 +175,7 @@ http_interactions:
       message: ''
     headers:
       Date:
-      - Thu, 08 Nov 2018 10:54:31 GMT
+      - Mon, 07 Jan 2019 14:54:10 GMT
       Content-Type:
       - text/xml;charset=utf-8
       Transfer-Encoding:
@@ -331,7 +183,7 @@ http_interactions:
       Connection:
       - keep-alive
       X-Amzn-Trace-Id:
-      - Root=1-5be415e7-f6088b604433db0863a8e440;
+      - Root=1-5c336812-6d410ba8acc84fe1eebb7ff8;
       Vary:
       - Accept-Encoding
     body:
@@ -339,10 +191,10 @@ http_interactions:
       string: <?xml version="1.0" encoding="UTF-8"?><soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
         xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><soapenv:Body><soapenv:Fault><faultcode>soapenv:Server.generalException</faultcode><faultstring></faultstring><detail><ns1:benefitCheckerFaultException
         xmlns:ns1="https://lsc.gov.uk/benefitchecker/service/1.0/API_1.0_Check"><ns2:MessageCode
-        xmlns:ns2="http://lsc.gov.uk/benefitchecker/data/1.0">LSCBC959</ns2:MessageCode><ns3:MessageText
-        xmlns:ns3="http://lsc.gov.uk/benefitchecker/data/1.0">Service unavailable.</ns3:MessageText></ns1:benefitCheckerFaultException><ns4:exceptionName
+        xmlns:ns2="http://lsc.gov.uk/benefitchecker/data/1.0">LSCBC205</ns2:MessageCode><ns3:MessageText
+        xmlns:ns3="http://lsc.gov.uk/benefitchecker/data/1.0">Invalid request credentials.</ns3:MessageText></ns1:benefitCheckerFaultException><ns4:exceptionName
         xmlns:ns4="http://xml.apache.org/axis/">uk.gov.lsc.benefitchecker.data._1_0.BenefitCheckerFaultException</ns4:exceptionName><ns5:hostname
-        xmlns:ns5="http://xml.apache.org/axis/">f2126f5225c6</ns5:hostname></detail></soapenv:Fault></soapenv:Body></soapenv:Envelope>
+        xmlns:ns5="http://xml.apache.org/axis/">f39b11ca7d30</ns5:hostname></detail></soapenv:Fault></soapenv:Body></soapenv:Envelope>
     http_version: 
-  recorded_at: Thu, 08 Nov 2018 10:54:31 GMT
+  recorded_at: Mon, 07 Jan 2019 14:54:10 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/BenefitCheckService/_check_benefits/when_the_API_raises_an_error/raises_a_detailed_error.yml
+++ b/spec/cassettes/BenefitCheckService/_check_benefits/when_the_API_raises_an_error/raises_a_detailed_error.yml
@@ -2,154 +2,6 @@
 http_interactions:
 - request:
     method: get
-    uri: http://www.example.com
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: ''
-    headers:
-      Date:
-      - Tue, 06 Nov 2018 16:55:30 GMT
-      Content-Type:
-      - text/xml;charset=utf-8
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      X-Amzn-Trace-Id:
-      - Root=1-5be1c782-75946cf1c96c938b364a0b8e;
-      Vary:
-      - Accept-Encoding
-    body:
-      encoding: ASCII-8BIT
-      string: |
-        <?xml version="1.0" encoding="UTF-8"?>
-        <wsdl:definitions targetNamespace="https://lsc.gov.uk/benefitchecker/service/1.0" xmlns:apachesoap="http://xml.apache.org/xml-soap" xmlns:impl="https://lsc.gov.uk/benefitchecker/service/1.0" xmlns:intf="https://lsc.gov.uk/benefitchecker/service/1.0" xmlns:tns1="http://lsc.gov.uk/benefitchecker/data/1.0" xmlns:tns2="https://lsc.gov.uk/benefitchecker/service/1.0/API_1.0_Check" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:wsdlsoap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-        <!--WSDL created by Apache Axis version: 1.4
-        Built on Apr 22, 2006 (06:55:48 PDT)-->
-         <wsdl:types>
-          <schema elementFormDefault="qualified" targetNamespace="http://lsc.gov.uk/benefitchecker/data/1.0" xmlns="http://www.w3.org/2001/XMLSchema">
-           <complexType name="benefitCheckerRequest">
-            <sequence>
-             <element name="clientOrgId" type="xsd:string"/>
-             <element name="clientUserId" type="xsd:string"/>
-             <element name="clientReference" type="xsd:string"/>
-             <element name="lscServiceName" type="xsd:string"/>
-             <element name="nino" type="xsd:string"/>
-             <element name="surname" type="xsd:string"/>
-             <element name="dateOfBirth" type="xsd:string"/>
-             <element name="dateOfAward" nillable="true" type="xsd:string"/>
-            </sequence>
-           </complexType>
-           <complexType name="benefitCheckerResponse">
-            <sequence>
-             <element name="originalClientRef" type="xsd:string"/>
-             <element name="benefitCheckerStatus" type="xsd:string"/>
-             <element name="confirmationRef" type="xsd:string"/>
-            </sequence>
-           </complexType>
-           <complexType name="benefitCheckerFaultException">
-            <sequence>
-             <element name="MessageCode" nillable="true" type="xsd:string"/>
-             <element name="MessageText" nillable="true" type="xsd:string"/>
-            </sequence>
-           </complexType>
-          </schema>
-          <schema elementFormDefault="qualified" targetNamespace="https://lsc.gov.uk/benefitchecker/service/1.0/API_1.0_Check" xmlns="http://www.w3.org/2001/XMLSchema">
-           <import namespace="http://lsc.gov.uk/benefitchecker/data/1.0"/>
-           <element name="benefitCheckerRequest" type="tns1:benefitCheckerRequest"/>
-           <element name="benefitCheckerResponse" type="tns1:benefitCheckerResponse"/>
-           <element name="benefitCheckerFaultException" type="tns1:benefitCheckerFaultException"/>
-          </schema>
-         </wsdl:types>
-
-           <wsdl:message name="BenefitCheckerFaultException">
-
-              <wsdl:part element="tns2:benefitCheckerFaultException" name="benefitCheckerFaultException"/>
-
-           </wsdl:message>
-
-           <wsdl:message name="checkRequest">
-
-              <wsdl:part element="tns2:benefitCheckerRequest" name="benefitCheckerRequest"/>
-
-           </wsdl:message>
-
-           <wsdl:message name="checkResponse">
-
-              <wsdl:part element="tns2:benefitCheckerResponse" name="benefitCheckerResponse"/>
-
-           </wsdl:message>
-
-           <wsdl:portType name="benefitChecker">
-
-              <wsdl:operation name="check" parameterOrder="benefitCheckerRequest">
-
-                 <wsdl:input message="impl:checkRequest" name="checkRequest"/>
-
-                 <wsdl:output message="impl:checkResponse" name="checkResponse"/>
-
-                 <wsdl:fault message="impl:BenefitCheckerFaultException" name="BenefitCheckerFaultException"/>
-
-              </wsdl:operation>
-
-           </wsdl:portType>
-
-           <wsdl:binding name="benefitCheckerSoapBinding" type="impl:benefitChecker">
-
-              <wsdlsoap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
-
-              <wsdl:operation name="check">
-
-                 <wsdlsoap:operation soapAction=""/>
-
-                 <wsdl:input name="checkRequest">
-
-                    <wsdlsoap:body use="literal"/>
-
-                 </wsdl:input>
-
-                 <wsdl:output name="checkResponse">
-
-                    <wsdlsoap:body use="literal"/>
-
-                 </wsdl:output>
-
-                 <wsdl:fault name="BenefitCheckerFaultException">
-
-                    <wsdlsoap:fault name="BenefitCheckerFaultException" use="literal"/>
-
-                 </wsdl:fault>
-
-              </wsdl:operation>
-
-           </wsdl:binding>
-
-           <wsdl:service name="benefitCheckerWS">
-
-              <wsdl:port binding="impl:benefitCheckerSoapBinding" name="benefitChecker">
-
-                 <wsdlsoap:address location="https://benefitchecker.dev.legalservices.gov.uk/lsx/lsc-services/benefitChecker"/>
-
-              </wsdl:port>
-
-           </wsdl:service>
-
-        </wsdl:definitions>
-    http_version: 
-  recorded_at: Tue, 06 Nov 2018 16:55:30 GMT
-- request:
-    method: get
     uri: https://benefitchecker.dev.legalservices.gov.uk/lsx/lsc-services/benefitChecker?wsdl
     body:
       encoding: US-ASCII
@@ -167,7 +19,7 @@ http_interactions:
       message: ''
     headers:
       Date:
-      - Thu, 08 Nov 2018 10:54:31 GMT
+      - Mon, 07 Jan 2019 14:54:09 GMT
       Content-Type:
       - text/xml;charset=utf-8
       Transfer-Encoding:
@@ -175,7 +27,7 @@ http_interactions:
       Connection:
       - keep-alive
       X-Amzn-Trace-Id:
-      - Root=1-5be415e7-f8a2df50ea4ef5b1acf4928e;
+      - Root=1-5c336811-5ed2ef173700f6e70b5db539;
       Vary:
       - Accept-Encoding
     body:
@@ -295,7 +147,7 @@ http_interactions:
 
         </wsdl:definitions>
     http_version: 
-  recorded_at: Thu, 08 Nov 2018 10:54:31 GMT
+  recorded_at: Mon, 07 Jan 2019 14:54:09 GMT
 - request:
     method: post
     uri: https://benefitchecker.dev.legalservices.gov.uk/lsx/lsc-services/benefitChecker
@@ -303,14 +155,14 @@ http_interactions:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><soapenv:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tns2="https://lsc.gov.uk/benefitchecker/service/1.0"
-        xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ins0="https://lsc.gov.uk/benefitchecker/service/1.0/API_1.0_Check"><soapenv:Body><ins0:benefitCheckerRequest><ins0:clientReference>e985843a-2cd5-49b0-b4a2-731bafb5ea69</ins0:clientReference><ins0:nino>JA293483A</ins0:nino><ins0:surname>WALKER</ins0:surname><ins0:dateOfBirth>19800110</ins0:dateOfBirth><ins0:dateOfAward>20181108</ins0:dateOfAward><ins0:lscServiceName><BC_LSC_SERVICE_NAME></ins0:lscServiceName><ins0:clientOrgId></ins0:clientOrgId><ins0:clientUserId><BC_CLIENT_USER_ID></ins0:clientUserId></ins0:benefitCheckerRequest></soapenv:Body></soapenv:Envelope>
+        xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ins0="https://lsc.gov.uk/benefitchecker/service/1.0/API_1.0_Check"><soapenv:Body><ins0:benefitCheckerRequest><ins0:clientReference>eadca07b-db2c-4b0f-8288-90a4eaa85c22</ins0:clientReference><ins0:nino>JA293483A</ins0:nino><ins0:surname>SERVICEEXCEPTION</ins0:surname><ins0:dateOfBirth>19800110</ins0:dateOfBirth><ins0:dateOfAward>20190107</ins0:dateOfAward><ins0:lscServiceName><BC_LSC_SERVICE_NAME></ins0:lscServiceName><ins0:clientOrgId><BC_CLIENT_ORG_ID></ins0:clientOrgId><ins0:clientUserId><BC_CLIENT_USER_ID></ins0:clientUserId></ins0:benefitCheckerRequest></soapenv:Body></soapenv:Envelope>
     headers:
       Soapaction:
       - '"check"'
       Content-Type:
       - text/xml;charset=UTF-8
       Content-Length:
-      - '829'
+      - '852'
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -323,7 +175,7 @@ http_interactions:
       message: ''
     headers:
       Date:
-      - Thu, 08 Nov 2018 10:54:31 GMT
+      - Mon, 07 Jan 2019 14:54:09 GMT
       Content-Type:
       - text/xml;charset=utf-8
       Transfer-Encoding:
@@ -331,7 +183,7 @@ http_interactions:
       Connection:
       - keep-alive
       X-Amzn-Trace-Id:
-      - Root=1-5be415e7-694dcc947c4925cfa680f54d;
+      - Root=1-5c336811-c431f34035459580a2dd2e60;
       Vary:
       - Accept-Encoding
     body:
@@ -339,10 +191,10 @@ http_interactions:
       string: <?xml version="1.0" encoding="UTF-8"?><soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
         xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><soapenv:Body><soapenv:Fault><faultcode>soapenv:Server.generalException</faultcode><faultstring></faultstring><detail><ns1:benefitCheckerFaultException
         xmlns:ns1="https://lsc.gov.uk/benefitchecker/service/1.0/API_1.0_Check"><ns2:MessageCode
-        xmlns:ns2="http://lsc.gov.uk/benefitchecker/data/1.0">LSCBC205</ns2:MessageCode><ns3:MessageText
-        xmlns:ns3="http://lsc.gov.uk/benefitchecker/data/1.0">Invalid request credentials.</ns3:MessageText></ns1:benefitCheckerFaultException><ns4:exceptionName
+        xmlns:ns2="http://lsc.gov.uk/benefitchecker/data/1.0">LSCBC959</ns2:MessageCode><ns3:MessageText
+        xmlns:ns3="http://lsc.gov.uk/benefitchecker/data/1.0">Service unavailable.</ns3:MessageText></ns1:benefitCheckerFaultException><ns4:exceptionName
         xmlns:ns4="http://xml.apache.org/axis/">uk.gov.lsc.benefitchecker.data._1_0.BenefitCheckerFaultException</ns4:exceptionName><ns5:hostname
-        xmlns:ns5="http://xml.apache.org/axis/">3693506f57f5</ns5:hostname></detail></soapenv:Fault></soapenv:Body></soapenv:Envelope>
+        xmlns:ns5="http://xml.apache.org/axis/">1f5e6eb6e68f</ns5:hostname></detail></soapenv:Fault></soapenv:Body></soapenv:Envelope>
     http_version: 
-  recorded_at: Thu, 08 Nov 2018 10:54:31 GMT
+  recorded_at: Mon, 07 Jan 2019 14:54:09 GMT
 recorded_with: VCR 4.0.0

--- a/spec/services/benefit_check_service_spec.rb
+++ b/spec/services/benefit_check_service_spec.rb
@@ -59,8 +59,20 @@ RSpec.describe BenefitCheckService do
     context 'when the API raises an error' do
       let(:last_name) { 'SERVICEEXCEPTION' }
 
+      it 'raises a detailed error' do
+        expect { subject.call }.to raise_error(described_class::ApiError, /Service unavailable/)
+      end
+    end
+
+    context 'when the API times out' do
+      before do
+        savon_client = double(:savon_client)
+        allow(savon_client).to receive(:call).and_raise(Net::ReadTimeout)
+        allow(subject).to receive(:soap_client).and_return(savon_client)
+      end
+
       it 'raises an error' do
-        expect { subject.call }.to raise_error(Savon::SOAPFault)
+        expect { subject.call }.to raise_error(described_class::ApiError)
       end
     end
 
@@ -69,8 +81,8 @@ RSpec.describe BenefitCheckService do
         allow(Rails.configuration.x.benefit_check).to receive(:client_org_id).and_return('')
       end
 
-      it 'raises an error' do
-        expect { subject.call }.to raise_error(Savon::SOAPFault)
+      it 'raises a detailed error' do
+        expect { subject.call }.to raise_error(described_class::ApiError, /Invalid request credentials/)
       end
     end
   end


### PR DESCRIPTION
Improve error reporting of BenefitChecker API by including more information about the error.
Recently, the API raised an error because the `surname` passed in parameter was only one character.
However, the error we saw in Sentry was simply **"Savon::SOAPFault: (soapenv:Server.generalException)"**.
With this PR, the error includes the real error message **"Error in request parameter 'Surname'"**

## Checklist

Before you ask people to review this PR:

- [X] Tests and rubocop should be passing: `bundle exec rake`
- [X] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [X] There should be no unneccessary whitespace changes. These make diffs harder to read and conflicts more likely. 
- [X] The PR description should say what you changed and why, with a link to the JIRA story.
- [X] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [X] You should have checked that the commit messages say why the change was made.
