### PR TITLE
AP-269 Draft button placement

### DIFF
--- a/app/views/shared/forms/_next_action_buttons.html.erb
+++ b/app/views/shared/forms/_next_action_buttons.html.erb
@@ -2,11 +2,7 @@
   show_draft = false unless local_assigns.key?(:show_draft)
 %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= form.submit t('generic.continue'), id: continue_id, name: 'continue_button', class: 'govuk-button form-button' %>
-    <% if show_draft %>
-      <%= form.submit t('generic.save_as_draft'), name: 'draft_button', id: 'draft_button', class: 'govuk-button form-button govuk-secondary-button' %>
-    <% end %>
-  </div>
-</div>
+<%= form.submit t('generic.continue'), id: continue_id, name: 'continue_button', class: 'govuk-button form-button' %>
+<% if show_draft %>
+  <%= form.submit t('generic.save_as_draft'), name: 'draft_button', id: 'draft_button', class: 'govuk-button form-button govuk-secondary-button' %>
+<% end %>


### PR DESCRIPTION
[AP-269](https://dsdmoj.atlassian.net/browse/AP-269)

## What

The issue was that the partial containing the button is already inside a `two-thirds` div. So the buttons ended up nested in two `two-thirds` divs. And it would break line unnecessarily.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unneccessary whitespace changes. These make diffs harder to read and conflicts more likely. 
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
