### PR TITLE
AP-257 Add providers profile page

### DIFF
--- a/app/controllers/providers/providers_controller.rb
+++ b/app/controllers/providers/providers_controller.rb
@@ -1,0 +1,7 @@
+module Providers
+  class ProvidersController < BaseController
+    def show
+      @provider = current_provider
+    end
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -29,7 +29,7 @@ module ApplicationHelper
     html = ''
     # TODO: - set the link to point at Provider Profile page when that page exists
     #        and use the full name rather than user name when that is available
-    html << link_to(current_provider.username, '#', class: 'user-link govuk-header__link')
+    html << link_to(current_provider.username, providers_provider_path, class: 'user-link govuk-header__link')
     html << link_to('Sign out', destroy_provider_session_path, method: :delete, class: 'log-out govuk-header__link')
     html = sanitize html, tags: %w[a], attributes: %w[href class rel data-method]
     content_tag :span, html, class: 'user-info'

--- a/app/helpers/providers_helper.rb
+++ b/app/helpers/providers_helper.rb
@@ -1,5 +1,15 @@
 module ProvidersHelper
-  def provider_back_link(text = t('generic.back'))
-    link_to text, back_step_url, class: 'govuk-back-link', id: 'back-top'
+  def provider_back_link(text: t('generic.back'), path: back_step_url)
+    link_to text, path, class: 'govuk-back-link', id: 'back-top'
+  end
+
+  def provider_basic_page(page_title:, back_link: nil, column_width: 'two-thirds', &content)
+    render(
+      'shared/providers/basic_page_template',
+      page_title: page_title,
+      back_link: back_link,
+      column_width: column_width,
+      content: capture(&content)
+    )
   end
 end

--- a/app/views/providers/outstanding_mortgages/show.html.erb
+++ b/app/views/providers/outstanding_mortgages/show.html.erb
@@ -1,7 +1,7 @@
 <% content_for(:page_title) { t('.h1-heading') } %>
 
 <% content_for :navigation do %>
-    <%= provider_back_link t('generic.back') %>
+    <%= provider_back_link %>
 <% end %>
 
 <%= render partial: 'shared/forms/error_summary', locals: { model: @form, attribute_prefix: :legal_aid_application_ } %>

--- a/app/views/providers/own_homes/show.html.erb
+++ b/app/views/providers/own_homes/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :navigation do %>
-  <%= provider_back_link t('generic.back') %>
+  <%= provider_back_link %>
 <% end %>
 
 <% content_for(:page_title) { t('.h1-heading') } %>

--- a/app/views/providers/proceedings_types/show.html.erb
+++ b/app/views/providers/proceedings_types/show.html.erb
@@ -7,12 +7,14 @@
 <%
   content_for(:navigation) do
     back_label = @legal_aid_application.checking_answers? ? 'generic.back' : 'generic.home'
-    provider_back_link t(back_label)
+    provider_back_link text: t(back_label)
   end
 %>
+<% content_for(:page_title) { t('.heading_1') } %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl"><%= t '.heading_1' %></h1>
+    <h1 class="govuk-heading-xl"><%= content_for(:page_title) %></h1>
   </div>
 </div>
 

--- a/app/views/providers/property_values/show.html.erb
+++ b/app/views/providers/property_values/show.html.erb
@@ -1,7 +1,7 @@
 <% content_for(:page_title) { t('.h1-heading') } %>
 
 <% content_for :navigation do %>
-  <%= provider_back_link t('generic.back') %>
+  <%= provider_back_link %>
 <% end %>
 
 <%= render partial: 'shared/forms/error_summary', locals: { model: @form } %>

--- a/app/views/providers/providers/show.html.erb
+++ b/app/views/providers/providers/show.html.erb
@@ -1,0 +1,26 @@
+<%= provider_basic_page(
+      page_title: t('.page_title'),
+      back_link: { path: :back },
+      column_width: 'full'
+    ) do %>
+  <table class="govuk-table">
+    <tbody class="govuk-table__body">
+      <tr class="govuk-table__row">
+        <th class="govuk-table__header" scope="row"><%= t('.name') %></th>
+        <td class="govuk-table__cell"><%= @provider.username %></td>
+      </tr>
+      <tr class="govuk-table__row">
+        <th class="govuk-table__header" scope="row"><%= t('.email') %></th>
+        <td class="govuk-table__cell"></td>
+      </tr>
+      <tr class="govuk-table__row">
+        <th class="govuk-table__header" scope="row"><%= t('.role') %></th>
+        <td class="govuk-table__cell"><%= @provider.roles %></td>
+      </tr>
+      <tr class="govuk-table__row">
+        <th class="govuk-table__header" scope="row"><%= t('.account_number') %></th>
+        <td class="govuk-table__cell"></td>
+      </tr>
+    </tbody>
+  </table>
+<% end %>

--- a/app/views/providers/restrictions/index.html.erb
+++ b/app/views/providers/restrictions/index.html.erb
@@ -1,7 +1,7 @@
 <% content_for(:page_title) { t('.h1-heading') } %>
 
 <% content_for :navigation do %>
-  <%= provider_back_link t('generic.back') %>
+  <%= provider_back_link %>
 <% end %>
 
 <fieldset class="govuk-fieldset">

--- a/app/views/providers/savings_and_investments/show.html.erb
+++ b/app/views/providers/savings_and_investments/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :navigation do %>
-  <%= provider_back_link t('generic.back') %>
+  <%= provider_back_link text: t('generic.back') %>
 <% end %>
 
 <% content_for(:page_title) { t('.h1-heading') } %>

--- a/app/views/shared/providers/_basic_page_template.html.erb
+++ b/app/views/shared/providers/_basic_page_template.html.erb
@@ -1,0 +1,13 @@
+<% content_for :navigation do %>
+  <%= provider_back_link back_link %>
+<% end %>
+
+<% content_for(:page_title) { page_title } %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-<%= column_width %>">
+    <h1 class="govuk-heading-xl"><%= content_for(:page_title) %></h1>
+
+    <%= content %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -379,6 +379,13 @@ en:
           title: Related content
           item_1: Legal aid
           item_2: More
+    providers:
+      show:
+        page_title: Your profile
+        name: Name
+        email: Email address
+        role: Role
+        account_number: Account number
     address_selections:
       show:
         select_address_label: Select an address

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,6 +41,7 @@ Rails.application.routes.draw do
 
   namespace :providers do
     root to: 'start#index' # TODO: In the live app this will point at an external url
+    resource :provider, only: [:show], path: 'your_profile'
 
     resources :legal_aid_applications, path: 'applications', only: %i[index create] do
       resource :proceedings_type, only: %i[show update]

--- a/spec/requests/providers/providers_spec.rb
+++ b/spec/requests/providers/providers_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe Providers::ProvidersController, type: :request do
+  let(:provider) { create :provider }
+  subject { get providers_provider_path }
+
+  before do
+    login_as provider
+    subject
+  end
+
+  it 'renders' do
+    expect(response).to have_http_status(:ok)
+  end
+
+  it 'displays the header' do
+    expect(response.body).to include(I18n.t('providers.providers.show.page_title'))
+  end
+
+  it 'displays provider data' do
+    expect(response.body).to include(provider.username)
+  end
+end


### PR DESCRIPTION
[Jira AP-257](https://dsdmoj.atlassian.net/browse/AP-257)

Adds a provider user profile page.

The username link at the top of the page now leads you to the new page (once you are logged in as a Provider):
![profile_link](https://user-images.githubusercontent.com/213040/50976531-1e031f00-14e8-11e9-9215-f936fe501fa5.png)

Currently the new page doesn't show a lot as there is not a lot of Provider data coming back from the log on system. 

Note - that the route path attribute give the path `/providers/your_profile` and the "back" link does a JavaScript back - so takes you back to your previous page.

![provider_profile](https://user-images.githubusercontent.com/213040/50976557-33784900-14e8-11e9-8b5b-e9d12a4a9c05.png)
 
Note that I've also added a new template that makes it easier to create pages using the standard format. The template is inserted via the helper method `provider_basic_page`. If people like this approach, I don't think it will be difficult to extend it to work with forms.