### PR TITLE
AP-282 Nightly deploy to Staging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -193,3 +193,13 @@ workflows:
         filters:
           branches:
             only: master
+  nightly:
+    triggers:
+    - schedule:
+        cron: "0 2 * * *"
+        filters:
+          branches:
+            only:
+            - master
+    jobs:
+    - deploy_staging


### PR DESCRIPTION
[AP-282](https://dsdmoj.atlassian.net/browse/AP-282)

## What

Triggers a deploy to staging every day at 2am UTC.
I just tried a schedule UAT deploy of this branch with a similar syntax and it worked. So hopefully this will work too.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unneccessary whitespace changes. These make diffs harder to read and conflicts more likely. 
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
