### PR TITLE
AP-275 check passported answers

### DIFF
--- a/app/controllers/concerns/providers/save_as_draftable.rb
+++ b/app/controllers/concerns/providers/save_as_draftable.rb
@@ -3,7 +3,9 @@ module Providers
     extend ActiveSupport::Concern
 
     def continue_or_save_draft(continue_url: next_step_url, save_url: providers_legal_aid_applications_path)
-      if params.key?(:continue_button)
+      if legal_aid_application.checking_passported_answers?
+        redirect_to providers_legal_aid_application_check_passported_answers_path(legal_aid_application)
+      elsif params.key?(:continue_button)
         redirect_to continue_url
       elsif params.key?(:draft_button)
         redirect_to save_url

--- a/app/controllers/concerns/providers/steps.rb
+++ b/app/controllers/concerns/providers/steps.rb
@@ -39,7 +39,7 @@ module Providers
     check_passported_answers: {
       path: :providers_legal_aid_application_check_passported_answers_path
       # forward TBD
-      # back TBD
+      # back: determined by controller action
     },
     check_benefits: {
       path: :providers_legal_aid_application_check_benefits_path,

--- a/app/controllers/concerns/providers/steps.rb
+++ b/app/controllers/concerns/providers/steps.rb
@@ -36,6 +36,11 @@ module Providers
       forward: :check_benefits
       # Back determined by controller action logic
     },
+    check_passported_answers: {
+      path: :providers_legal_aid_application_check_passported_answers_path
+      # forward TBD
+      # back TBD
+    },
     check_benefits: {
       path: :providers_legal_aid_application_check_benefits_path,
       # forward: :providers_legal_aid_application_check_provider_answers_path,
@@ -52,7 +57,7 @@ module Providers
     },
     restrictions: {
       path: :providers_legal_aid_application_restrictions_path,
-      forward: :check_provider_answers,
+      forward: :check_passported_answers,
       back: :other_assets
     },
     percentage_homes: {

--- a/app/controllers/providers/check_passported_answers_controller.rb
+++ b/app/controllers/providers/check_passported_answers_controller.rb
@@ -12,6 +12,11 @@ module Providers
       legal_aid_application.check_passported_answers! unless legal_aid_application.checking_passported_answers?
     end
 
+    def continue
+      legal_aid_application.complete_means! unless legal_aid_application.means_completed?
+      render plain: 'End of provider-answered mean test questions for passported clients'
+    end
+
     def reset
       legal_aid_application.reset!
       redirect_to back_step_path

--- a/app/controllers/providers/check_passported_answers_controller.rb
+++ b/app/controllers/providers/check_passported_answers_controller.rb
@@ -12,10 +12,23 @@ module Providers
       legal_aid_application.check_passported_answers! unless legal_aid_application.checking_passported_answers?
     end
 
+    def reset
+      legal_aid_application.reset!
+      redirect_to back_step_path
+    end
+
     private
 
     def back_step_path
-      '/home'
+      legal_aid_application.own_capital? ? restrictions_path : other_assets_path
+    end
+
+    def restrictions_path
+      providers_legal_aid_application_restrictions_path(legal_aid_application)
+    end
+
+    def other_assets_path
+      providers_legal_aid_application_other_assets_path(legal_aid_application)
     end
   end
 end

--- a/app/controllers/providers/check_passported_answers_controller.rb
+++ b/app/controllers/providers/check_passported_answers_controller.rb
@@ -1,3 +1,5 @@
+# Check passported answers controller - at end of capital questions
+# for passported clients on Provider journey
 module Providers
   class CheckPassportedAnswersController < BaseController
     include ApplicationDependable

--- a/app/controllers/providers/check_passported_answers_controller.rb
+++ b/app/controllers/providers/check_passported_answers_controller.rb
@@ -1,5 +1,3 @@
-# Check passported answers controller - at end of capital questions
-# for passported clients on Provider journey
 module Providers
   class CheckPassportedAnswersController < BaseController
     include ApplicationDependable

--- a/app/controllers/providers/check_passported_answers_controller.rb
+++ b/app/controllers/providers/check_passported_answers_controller.rb
@@ -1,0 +1,21 @@
+module Providers
+  class CheckPassportedAnswersController < BaseController
+    include ApplicationDependable
+    include SaveAsDraftable
+    include Steppable
+
+    def show
+      @proceeding = legal_aid_application.proceeding_types.first
+      @applicant = legal_aid_application.applicant
+      @address = @applicant.addresses.first
+      @back_step_url = back_step_path
+      legal_aid_application.check_passported_answers! unless legal_aid_application.checking_passported_answers?
+    end
+
+    private
+
+    def back_step_path
+      '/home'
+    end
+  end
+end

--- a/app/controllers/providers/other_assets_controller.rb
+++ b/app/controllers/providers/other_assets_controller.rb
@@ -25,7 +25,7 @@ module Providers
       if legal_aid_application.own_capital?
         providers_legal_aid_application_restrictions_path(legal_aid_application)
       else
-        providers_legal_aid_application_check_provider_answers_path(legal_aid_application)
+        providers_legal_aid_application_check_passported_answers_path(legal_aid_application)
       end
     end
 

--- a/app/helpers/check_answer_url_helper.rb
+++ b/app/helpers/check_answer_url_helper.rb
@@ -1,0 +1,58 @@
+module CheckAnswerUrlHelper
+  def check_answer_url_for(user_type, field_name, application = nil)
+    case user_type
+    when :provider
+      check_answer_provider_url_for(field_name, application)
+    when :citizen
+      check_answer_citizen_url_for(field_name)
+    else
+      raise ArgumentError, 'Wrong user type passed to #check_answer_url_for'
+    end
+  end
+
+  def check_answer_provider_url_for(field_name, application) # rubocop:disable Metrics/MethodLength
+    case field_name
+    when :own_home
+      providers_legal_aid_application_own_home_path(application)
+    when :property_value
+      providers_legal_aid_application_property_value_path(application, anchor: :property_value)
+    when :outstanding_mortgage
+      providers_legal_aid_application_outstanding_mortgage_path(application, anchor: :outstanding_mortgage_amount)
+    when :shared_ownership
+      providers_legal_aid_application_shared_ownership_path
+    when :percentage_home
+      providers_legal_aid_application_percentage_home_path(anchor: 'percentage_home')
+    when :savings_and_investments
+      providers_legal_aid_application_savings_and_investment_path
+    when :other_assets
+      providers_legal_aid_application_other_assets_path
+    when :restrictions
+      providers_legal_aid_application_restrictions_path
+    else
+      raise ArgumentError, "Invalid field name for #check_answer_url_for: #{field_name}"
+    end
+  end
+
+  def check_answer_citizen_url_for(field_name) # rubocop:disable Metrics/MethodLength
+    case field_name
+    when :own_home
+      citizens_own_home_path
+    when :property_value
+      citizens_property_value_path(anchor: :property_value)
+    when :outstanding_mortgage
+      citizens_outstanding_mortgage_path(anchor: :outstanding_mortgage_amount)
+    when :shared_ownership
+      citizens_shared_ownership_path
+    when :percentage_home
+      citizens_percentage_home_path(anchor: 'percentage_home')
+    when :savings_and_investments
+      citizens_savings_and_investment_path
+    when :other_assets
+      citizens_other_assets_path
+    when :restrictions
+      citizens_restrictions_path
+    else
+      raise ArgumentError, "Invalid field name for #check_answer_url_for: #{field_name}"
+    end
+  end
+end

--- a/app/helpers/check_answer_url_helper.rb
+++ b/app/helpers/check_answer_url_helper.rb
@@ -1,48 +1,34 @@
 module CheckAnswerUrlHelper
   URL_HELPERS = Rails.application.routes.url_helpers
 
-  CITIZEN_URLS = {
-    own_home: -> { URL_HELPERS.citizens_own_home_path },
-    property_value: -> { URL_HELPERS.citizens_property_value_path(anchor: :property_value) },
-    outstanding_mortgage: -> { URL_HELPERS.citizens_outstanding_mortgage_path(anchor: :outstanding_mortgage_amount) },
-    shared_ownership: -> { URL_HELPERS.citizens_shared_ownership_path },
-    percentage_home: -> { URL_HELPERS.citizens_percentage_home_path(anchor: 'percentage_home') },
-    savings_and_investments: -> { URL_HELPERS.citizens_savings_and_investment_path },
-    other_assets: -> { URL_HELPERS.citizens_other_assets_path },
-    restrictions: -> { URL_HELPERS.citizens_restrictions_path }
-  }.freeze
-
-  PROVIDER_URLS = {
-    own_home: ->(application) { URL_HELPERS.providers_legal_aid_application_own_home_path(application) },
-    property_value: ->(application) { URL_HELPERS.providers_legal_aid_application_property_value_path(application, anchor: :property_value) },
-    outstanding_mortgage: ->(application) { URL_HELPERS.providers_legal_aid_application_outstanding_mortgage_path(application, anchor: :outstanding_mortgage_amount) },
-    shared_ownership: ->(application) { URL_HELPERS.providers_legal_aid_application_shared_ownership_path(application) },
-    percentage_home: ->(application) { URL_HELPERS.providers_legal_aid_application_percentage_home_path(application, anchor: 'percentage_home') },
-    savings_and_investments: ->(application) { URL_HELPERS.providers_legal_aid_application_savings_and_investment_path(application) },
-    other_assets: ->(application) { URL_HELPERS.providers_legal_aid_application_other_assets_path(application) },
-    restrictions: ->(application) { URL_HELPERS.providers_legal_aid_application_restrictions_path(application) }
+  URLS = {
+    citizen: {
+      own_home: -> { URL_HELPERS.citizens_own_home_path },
+      property_value: -> { URL_HELPERS.citizens_property_value_path(anchor: :property_value) },
+      outstanding_mortgage: -> { URL_HELPERS.citizens_outstanding_mortgage_path(anchor: :outstanding_mortgage_amount) },
+      shared_ownership: -> { URL_HELPERS.citizens_shared_ownership_path },
+      percentage_home: -> { URL_HELPERS.citizens_percentage_home_path(anchor: 'percentage_home') },
+      savings_and_investments: -> { URL_HELPERS.citizens_savings_and_investment_path },
+      other_assets: -> { URL_HELPERS.citizens_other_assets_path },
+      restrictions: -> { URL_HELPERS.citizens_restrictions_path }
+    },
+    provider: {
+      own_home: ->(application) { URL_HELPERS.providers_legal_aid_application_own_home_path(application) },
+      property_value: ->(application) { URL_HELPERS.providers_legal_aid_application_property_value_path(application, anchor: :property_value) },
+      outstanding_mortgage: ->(application) { URL_HELPERS.providers_legal_aid_application_outstanding_mortgage_path(application, anchor: :outstanding_mortgage_amount) },
+      shared_ownership: ->(application) { URL_HELPERS.providers_legal_aid_application_shared_ownership_path(application) },
+      percentage_home: ->(application) { URL_HELPERS.providers_legal_aid_application_percentage_home_path(application, anchor: 'percentage_home') },
+      savings_and_investments: ->(application) { URL_HELPERS.providers_legal_aid_application_savings_and_investment_path(application) },
+      other_assets: ->(application) { URL_HELPERS.providers_legal_aid_application_other_assets_path(application) },
+      restrictions: ->(application) { URL_HELPERS.providers_legal_aid_application_restrictions_path(application) }
+    }
   }.freeze
 
   def check_answer_url_for(user_type, field_name, application = nil)
-    case user_type
-    when :provider
-      check_answer_provider_url_for(field_name, application)
-    when :citizen
-      check_answer_citizen_url_for(field_name)
-    else
-      raise ArgumentError, 'Wrong user type passed to #check_answer_url_for'
-    end
-  end
+    raise ArgumentError, 'Wrong user type passed to #check_answer_url_for' if URLS[user_type].nil?
+    raise ArgumentError, "Invalid field name for #check_answer_url_for: #{field_name}" if URLS[user_type][field_name].nil?
 
-  def check_answer_provider_url_for(field_name, application)
-    raise ArgumentError, "Invalid field name for #check_answer_url_for: #{field_name}" unless PROVIDER_URLS.key?(field_name)
-
-    PROVIDER_URLS[field_name].call(application)
-  end
-
-  def check_answer_citizen_url_for(field_name)
-    raise ArgumentError, "Invalid field name for #check_answer_url_for: #{field_name}" unless CITIZEN_URLS.key?(field_name)
-
-    CITIZEN_URLS[field_name].call
+    proc = URLS[user_type][field_name]
+    application.nil? ? proc.yield : proc.yield(application)
   end
 end

--- a/app/helpers/check_answer_url_helper.rb
+++ b/app/helpers/check_answer_url_helper.rb
@@ -1,4 +1,28 @@
 module CheckAnswerUrlHelper
+  URL_HELPERS = Rails.application.routes.url_helpers
+
+  CITIZEN_URLS = {
+    own_home: -> { URL_HELPERS.citizens_own_home_path },
+    property_value: -> { URL_HELPERS.citizens_property_value_path(anchor: :property_value) },
+    outstanding_mortgage: -> { URL_HELPERS.citizens_outstanding_mortgage_path(anchor: :outstanding_mortgage_amount) },
+    shared_ownership: -> { URL_HELPERS.citizens_shared_ownership_path },
+    percentage_home: -> { URL_HELPERS.citizens_percentage_home_path(anchor: 'percentage_home') },
+    savings_and_investments: -> { URL_HELPERS.citizens_savings_and_investment_path },
+    other_assets: -> { URL_HELPERS.citizens_other_assets_path },
+    restrictions: -> { URL_HELPERS.citizens_restrictions_path }
+  }.freeze
+
+  PROVIDER_URLS = {
+    own_home: ->(application) { URL_HELPERS.providers_legal_aid_application_own_home_path(application) },
+    property_value: ->(application) { URL_HELPERS.providers_legal_aid_application_property_value_path(application, anchor: :property_value) },
+    outstanding_mortgage: ->(application) { URL_HELPERS.providers_legal_aid_application_outstanding_mortgage_path(application, anchor: :outstanding_mortgage_amount) },
+    shared_ownership: ->(application) { URL_HELPERS.providers_legal_aid_application_shared_ownership_path(application) },
+    percentage_home: ->(application) { URL_HELPERS.providers_legal_aid_application_percentage_home_path(application, anchor: 'percentage_home') },
+    savings_and_investments: ->(application) { URL_HELPERS.providers_legal_aid_application_savings_and_investment_path(application) },
+    other_assets: ->(application) { URL_HELPERS.providers_legal_aid_application_other_assets_path(application) },
+    restrictions: ->(application) { URL_HELPERS.providers_legal_aid_application_restrictions_path(application) }
+  }.freeze
+
   def check_answer_url_for(user_type, field_name, application = nil)
     case user_type
     when :provider
@@ -10,49 +34,15 @@ module CheckAnswerUrlHelper
     end
   end
 
-  def check_answer_provider_url_for(field_name, application) # rubocop:disable Metrics/MethodLength
-    case field_name
-    when :own_home
-      providers_legal_aid_application_own_home_path(application)
-    when :property_value
-      providers_legal_aid_application_property_value_path(application, anchor: :property_value)
-    when :outstanding_mortgage
-      providers_legal_aid_application_outstanding_mortgage_path(application, anchor: :outstanding_mortgage_amount)
-    when :shared_ownership
-      providers_legal_aid_application_shared_ownership_path
-    when :percentage_home
-      providers_legal_aid_application_percentage_home_path(anchor: 'percentage_home')
-    when :savings_and_investments
-      providers_legal_aid_application_savings_and_investment_path
-    when :other_assets
-      providers_legal_aid_application_other_assets_path
-    when :restrictions
-      providers_legal_aid_application_restrictions_path
-    else
-      raise ArgumentError, "Invalid field name for #check_answer_url_for: #{field_name}"
-    end
+  def check_answer_provider_url_for(field_name, application)
+    raise ArgumentError, "Invalid field name for #check_answer_url_for: #{field_name}" unless PROVIDER_URLS.key?(field_name)
+
+    PROVIDER_URLS[field_name].call(application)
   end
 
-  def check_answer_citizen_url_for(field_name) # rubocop:disable Metrics/MethodLength
-    case field_name
-    when :own_home
-      citizens_own_home_path
-    when :property_value
-      citizens_property_value_path(anchor: :property_value)
-    when :outstanding_mortgage
-      citizens_outstanding_mortgage_path(anchor: :outstanding_mortgage_amount)
-    when :shared_ownership
-      citizens_shared_ownership_path
-    when :percentage_home
-      citizens_percentage_home_path(anchor: 'percentage_home')
-    when :savings_and_investments
-      citizens_savings_and_investment_path
-    when :other_assets
-      citizens_other_assets_path
-    when :restrictions
-      citizens_restrictions_path
-    else
-      raise ArgumentError, "Invalid field name for #check_answer_url_for: #{field_name}"
-    end
+  def check_answer_citizen_url_for(field_name)
+    raise ArgumentError, "Invalid field name for #check_answer_url_for: #{field_name}" unless CITIZEN_URLS.key?(field_name)
+
+    CITIZEN_URLS[field_name].call
   end
 end

--- a/app/helpers/providers_helper.rb
+++ b/app/helpers/providers_helper.rb
@@ -1,6 +1,6 @@
 module ProvidersHelper
-  def provider_back_link(text: t('generic.back'), path: back_step_url)
-    link_to text, path, class: 'govuk-back-link', id: 'back-top'
+  def provider_back_link(text: t('generic.back'), path: back_step_url, method: :get)
+    link_to text, path, method: method, class: 'govuk-back-link', id: 'back-top'
   end
 
   def provider_basic_page(page_title:, back_link: nil, column_width: 'two-thirds', &content)

--- a/app/models/concerns/legal_aid_application_state_machine.rb
+++ b/app/models/concerns/legal_aid_application_state_machine.rb
@@ -10,6 +10,7 @@ module LegalAidApplicationStateMachine
       state :answers_checked
       state :provider_submitted
       state :checking_citizen_answers
+      state :checking_passported_answers
       state :means_completed
 
       event :check_your_answers do
@@ -19,6 +20,10 @@ module LegalAidApplicationStateMachine
 
       event :answers_checked do
         transitions from: :checking_answers, to: :answers_checked
+      end
+
+      event :check_passported_answers do
+        transitions from: :answers_checked, to: :checking_passported_answers
       end
 
       event :provider_submit do

--- a/app/models/concerns/legal_aid_application_state_machine.rb
+++ b/app/models/concerns/legal_aid_application_state_machine.rb
@@ -45,6 +45,7 @@ module LegalAidApplicationStateMachine
 
       event :complete_means do
         transitions from: :checking_citizen_answers, to: :means_completed
+        transitions from: :checking_passported_answers, to: :means_completed
       end
     end
   end

--- a/app/models/concerns/legal_aid_application_state_machine.rb
+++ b/app/models/concerns/legal_aid_application_state_machine.rb
@@ -35,6 +35,7 @@ module LegalAidApplicationStateMachine
       event :reset do
         transitions from: :checking_answers, to: :initiated
         transitions from: :checking_citizen_answers, to: :provider_submitted
+        transitions from: :checking_passported_answers, to: :answers_checked
       end
 
       event :check_citizen_answers do

--- a/app/views/providers/check_passported_answers/show.html.erb
+++ b/app/views/providers/check_passported_answers/show.html.erb
@@ -18,7 +18,7 @@
 
     <%= button_to(
           t('generic.submit'),
-          continue_citizens_check_answers_path,
+          continue_providers_legal_aid_application_check_passported_answers_path(@legal_aid_application),
           class: 'govuk-button',
           method: :patch
         ) %>

--- a/app/views/providers/check_passported_answers/show.html.erb
+++ b/app/views/providers/check_passported_answers/show.html.erb
@@ -1,27 +1,15 @@
-<%
-  content_for(:navigation) do
-    back_link(path: reset_providers_legal_aid_application_check_passported_answers_path(@legal_aid_application), method: :patch)
-  end
-%>
+<%= provider_basic_page(page_title: t('.h1-heading'), back_link: {path: reset_providers_legal_aid_application_check_passported_answers_path(@legal_aid_application) }
+  ) do %>
+      <h2 class="govuk-heading-m">
+        <%= t('.assets.heading') %>
+      </h2>
 
-<% content_for(:page_title) { t('.h1-heading') } %>
+      <%= render partial: 'shared/check_answers_assets', locals: { user_type: :provider, application: @legal_aid_application } %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl"><%= content_for(:page_title) %></h1>
-
-    <h2 class="govuk-heading-m">
-      <%= t('.assets.heading') %>
-    </h2>
-
-    <%= render partial: 'shared/check_answers_assets', locals: { user_type: :provider, application: @legal_aid_application } %>
-
-    <%= button_to(
-          t('generic.submit'),
-          continue_providers_legal_aid_application_check_passported_answers_path(@legal_aid_application),
-          class: 'govuk-button',
-          method: :patch
-        ) %>
-
-  </div>
-</div>
+      <%= button_to(
+            t('generic.submit'),
+            continue_providers_legal_aid_application_check_passported_answers_path(@legal_aid_application),
+            class: 'govuk-button',
+            method: :patch
+          ) %>
+<% end %>

--- a/app/views/providers/check_passported_answers/show.html.erb
+++ b/app/views/providers/check_passported_answers/show.html.erb
@@ -1,5 +1,7 @@
-<%= provider_basic_page(page_title: t('.h1-heading'), back_link: {path: reset_providers_legal_aid_application_check_passported_answers_path(@legal_aid_application) }
-  ) do %>
+<%= provider_basic_page(
+      page_title: t('.h1-heading'),
+      back_link: { path: reset_providers_legal_aid_application_check_passported_answers_path(@legal_aid_application) }
+    ) do %>
       <h2 class="govuk-heading-m">
         <%= t('.assets.heading') %>
       </h2>

--- a/app/views/providers/check_passported_answers/show.html.erb
+++ b/app/views/providers/check_passported_answers/show.html.erb
@@ -1,6 +1,6 @@
 <%= provider_basic_page(
       page_title: t('.h1-heading'),
-      back_link: { path: reset_providers_legal_aid_application_check_passported_answers_path(@legal_aid_application) }
+      back_link: { path: reset_providers_legal_aid_application_check_passported_answers_path(@legal_aid_application), method: :patch }
     ) do %>
       <h2 class="govuk-heading-m">
         <%= t('.assets.heading') %>

--- a/app/views/providers/check_passported_answers/show.html.erb
+++ b/app/views/providers/check_passported_answers/show.html.erb
@@ -1,4 +1,9 @@
-<% content_for(:navigation) { back_link(path: reset_citizens_check_answers_path, method: :patch) } %>
+<%
+  content_for(:navigation) do
+    back_link(path: reset_providers_legal_aid_application_check_passported_answers_path(@legal_aid_application), method: :patch)
+  end
+%>
+
 <% content_for(:page_title) { t('.h1-heading') } %>
 
 <div class="govuk-grid-row">

--- a/app/views/providers/check_passported_answers/show.html.erb
+++ b/app/views/providers/check_passported_answers/show.html.erb
@@ -1,0 +1,22 @@
+<% content_for(:navigation) { back_link(path: reset_citizens_check_answers_path, method: :patch) } %>
+<% content_for(:page_title) { t('.h1-heading') } %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl"><%= content_for(:page_title) %></h1>
+
+    <h2 class="govuk-heading-m">
+      <%= t('.assets.heading') %>
+    </h2>
+
+    <%= render partial: 'shared/check_answers_assets', locals: { user_type: :provider, application: @legal_aid_application } %>
+
+    <%= button_to(
+          t('generic.submit'),
+          continue_citizens_check_answers_path,
+          class: 'govuk-button',
+          method: :patch
+        ) %>
+
+  </div>
+</div>

--- a/app/views/shared/_check_answers_assets.html.erb
+++ b/app/views/shared/_check_answers_assets.html.erb
@@ -1,0 +1,59 @@
+<% application = nil if local_assigns[:application].nil? %>
+
+<dl class="app-check-your-answers app-check-your-answers--long">
+  <%= check_answer_link(
+        name: :own_home,
+        url: check_answer_url_for(user_type, :own_home, application),
+        question: t('.assets.own_home'),
+        answer: @legal_aid_application.own_home.blank? ? '' : t("shared.forms.own_home_form.#{@legal_aid_application.own_home}")
+      ) %>
+
+  <%= check_answer_link(
+        name: :property_value,
+        url: check_answer_url_for(user_type, :property_value, application),
+        question: t('.assets.property_value'),
+        answer: number_to_currency(@legal_aid_application.property_value, unit: t('currency.gbp'))
+      ) if @legal_aid_application.own_home? %>
+
+  <%= check_answer_link(
+        name: :outstanding_mortgage,
+        url: check_answer_url_for(user_type, :outstanding_mortgage, application),
+        question: t('.assets.outstanding_mortgage'),
+        answer: number_to_currency(@legal_aid_application.outstanding_mortgage_amount, unit: t('currency.gbp'))
+      ) if @legal_aid_application.own_home_mortgage? %>
+
+  <%= check_answer_link(
+        name: :shared_ownership,
+        url: check_answer_url_for(user_type, :shared_ownership, application),
+        question: t('.assets.shared_ownership'),
+        answer: @legal_aid_application.shared_ownership.blank? ? '' : t("shared.forms.shared_ownership_form.shared_ownership_item.#{@legal_aid_application.shared_ownership}")
+      ) if @legal_aid_application.own_home? %>
+
+  <%= check_answer_link(
+        name: :percentage_home,
+        url: check_answer_url_for(user_type, :percentage_home, application),
+        question: t('.assets.percentage_home'),
+        answer: number_to_percentage(@legal_aid_application.percentage_home, precision: 2)
+      ) if @legal_aid_application.shared_ownership? %>
+
+  <%= check_answer_link(
+        name: :savings_and_investments,
+        url: check_answer_url_for(user_type, :savings_and_investments, application),
+        question: t('.assets.savings_and_investments'),
+        answer: capital_amounts_list(@legal_aid_application.savings_amount, locale_namespace: 'shared.forms.revealing_checkbox.attribute.citizens.savings_and_investments.check_box_')
+      ) %>
+
+  <%= check_answer_link(
+        name: :other_assets,
+        url: check_answer_url_for(user_type, :other_assets, application),
+        question: t('.assets.other_assets'),
+        answer: capital_amounts_list(@legal_aid_application.other_assets_declaration, locale_namespace: 'shared.forms.revealing_checkbox.attribute.citizens.other_assets.check_box_')
+      ) %>
+
+  <%= check_answer_link(
+        name: :restrictions,
+        url: check_answer_url_for(user_type, :restrictions, application),
+        question: t('.assets.restrictions'),
+        answer: @legal_aid_application.restrictions.map { |restriction| t("restrictions.names.#{restriction.name}") }
+      ) if @legal_aid_application.own_capital? %>
+</dl>

--- a/bin/uat_deploy
+++ b/bin/uat_deploy
@@ -42,3 +42,4 @@ deploy() {
 
 clean_old_releases
 deploy
+

--- a/bin/uat_deploy
+++ b/bin/uat_deploy
@@ -37,6 +37,7 @@ deploy() {
                 --set image.repository="$IMG_REPO" \
                 --set image.tag="${CIRCLE_SHA1}" \
                 --set ingress.hosts="{$RELEASE_HOST}" \
+                --debug \
                 --set replicaCount="1"
 }
 

--- a/bin/uat_deploy
+++ b/bin/uat_deploy
@@ -37,7 +37,6 @@ deploy() {
                 --set image.repository="$IMG_REPO" \
                 --set image.tag="${CIRCLE_SHA1}" \
                 --set ingress.hosts="{$RELEASE_HOST}" \
-                --debug \
                 --set replicaCount="1"
 }
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -148,6 +148,19 @@ en:
               percentage_home: Enter the estimated property share
     page-title:
       suffix: Apply for legal aid
+    check_answers_assets:
+      assets:
+        own_home: Own the home you live in
+        property_value: Property value
+        outstanding_mortgage: Outstanding mortgage amount
+        shared_ownership: Owned with anyone else
+        percentage_home: Percentage owned
+        savings_and_investments: Savings and investments
+        other_assets: Other assets
+        restrictions: Do any restrictions apply?
+      submit:
+        heading: Submit your details
+        text: By submitting this application you are confirming that, to the best of your knowledge, the details you are providing are correct.
   activemodel:
     attributes:
       address: &address_attrs
@@ -407,6 +420,11 @@ en:
           title: 'must complete a financial assessment'
           body: 'Your client does not receive benefits that qualify for legal aid.'
           next: 'Your client will have to complete a financial means assessment. They can complete the financial assessment online from home or another location.'
+    check_passported_answers:
+      show:
+        h1-heading: Check your answers for passported client
+        assets:
+          heading: Property, savings and other assets
     legal_aid_applications:
         index:
           heading_1: Your legal aid applications

--- a/config/locales/model_enum_translations.en.yml
+++ b/config/locales/model_enum_translations.en.yml
@@ -8,3 +8,4 @@ en:
         provider_submitted: Submitted by provider
         checking_citizen_answers: Applicant checking answers
         means_completed: Means test completed
+        checking_passported_answers: Provider checking means test answers

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -70,7 +70,9 @@ Rails.application.routes.draw do
       resource :percentage_home, only: %i[show update]
       resource :savings_and_investment, only: %i[show update]
       resource :shared_ownership, only: %i[show update]
-      resource :check_passported_answers, only: [:show]
+      resource :check_passported_answers, only: [:show] do
+        patch :reset
+      end
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -57,9 +57,7 @@ Rails.application.routes.draw do
       resource :own_home, only: %i[show update]
       resource :check_benefit, only: %i[index update]
       resource :other_assets, only: %i[show update]
-      resources :check_benefits, only: [:index] do
-        get :passported, on: :collection
-      end
+      resources :check_benefits, only: [:index]
       resource :online_banking, only: %i[show update], path: 'does-client-use-online-banking'
       resources :check_provider_answers, only: [:index] do
         post :reset, on: :collection
@@ -72,6 +70,7 @@ Rails.application.routes.draw do
       resource :percentage_home, only: %i[show update]
       resource :savings_and_investment, only: %i[show update]
       resource :shared_ownership, only: %i[show update]
+      resource :check_passported_answers, only: [:show]
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -71,6 +71,7 @@ Rails.application.routes.draw do
       resource :savings_and_investment, only: %i[show update]
       resource :shared_ownership, only: %i[show update]
       resource :check_passported_answers, only: [:show] do
+        patch :continue
         patch :reset
       end
     end

--- a/spec/factories/legal_aid_applications.rb
+++ b/spec/factories/legal_aid_applications.rb
@@ -18,6 +18,14 @@ FactoryBot.define do
       state { 'provider_submitted' }
     end
 
+    trait :answers_checked do
+      state { 'answers_checked' }
+    end
+
+    trait :checking_passported_answers do
+      state { 'checking_passported_answers' }
+    end
+
     trait :with_proceeding_types do
       transient do
         proceeding_types_count { 1 }

--- a/spec/helpers/check_answer_url_helper_spec.rb
+++ b/spec/helpers/check_answer_url_helper_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+RSpec.describe CheckAnswerUrlHelper, type: :helper do
+  let(:application) { build :legal_aid_application, id: 'bf07c530-718a-4537-b9e1-c04ad956cc71' }
+
+  describe '#check_answer_url_for' do
+    context 'provider' do
+      it 'returns the correct path' do
+        url = check_answer_url_for(:provider, :outstanding_mortgage, application)
+        expect(url).to eq '/providers/applications/bf07c530-718a-4537-b9e1-c04ad956cc71/outstanding_mortgage#outstanding_mortgage_amount'
+      end
+    end
+
+    context 'citizen' do
+      it 'returns the correct path' do
+        url = check_answer_url_for(:citizen, :property_value)
+        expect(url).to eq '/citizens/property_value#property_value'
+      end
+    end
+
+    context 'error raising' do
+      context 'invalid user type' do
+        it 'raises' do
+          expect {
+            check_answer_url_for(:employee, :own_home)
+          }.to raise_error ArgumentError, 'Wrong user type passed to #check_answer_url_for'
+        end
+      end
+
+      context 'provider' do
+        context 'invalid field name' do
+          it 'raises' do
+            expect {
+              check_answer_url_for(:provider, :holiday_let, application)
+            }.to raise_error ArgumentError, 'Invalid field name for #check_answer_url_for: holiday_let'
+          end
+        end
+      end
+
+      context 'citizen' do
+        context 'invalid field name' do
+          it 'raises' do
+            expect {
+              check_answer_url_for(:citizen, :granny_flat)
+            }.to raise_error ArgumentError, 'Invalid field name for #check_answer_url_for: granny_flat'
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/helpers/check_answer_url_helper_spec.rb
+++ b/spec/helpers/check_answer_url_helper_spec.rb
@@ -5,16 +5,86 @@ RSpec.describe CheckAnswerUrlHelper, type: :helper do
 
   describe '#check_answer_url_for' do
     context 'provider' do
-      it 'returns the correct path' do
+      it 'returns the correct path for own_home' do
+        url = check_answer_url_for(:provider, :own_home, application)
+        expect(url).to eq '/providers/applications/bf07c530-718a-4537-b9e1-c04ad956cc71/own_home'
+      end
+
+      it 'returns the correct path for property_value' do
+        url = check_answer_url_for(:provider, :property_value, application)
+        expect(url).to eq '/providers/applications/bf07c530-718a-4537-b9e1-c04ad956cc71/property_value#property_value'
+      end
+
+      it 'returns the correct path for outstanding mortgage' do
         url = check_answer_url_for(:provider, :outstanding_mortgage, application)
         expect(url).to eq '/providers/applications/bf07c530-718a-4537-b9e1-c04ad956cc71/outstanding_mortgage#outstanding_mortgage_amount'
+      end
+
+      it 'returns the correct path for shared_ownership' do
+        url = check_answer_url_for(:provider, :shared_ownership, application)
+        expect(url).to eq '/providers/applications/bf07c530-718a-4537-b9e1-c04ad956cc71/shared_ownership'
+      end
+
+      it 'returns the correct path for percentage_home' do
+        url = check_answer_url_for(:provider, :percentage_home, application)
+        expect(url).to eq '/providers/applications/bf07c530-718a-4537-b9e1-c04ad956cc71/percentage_home#percentage_home'
+      end
+
+      it 'returns the correct path for savings_and_investments' do
+        url = check_answer_url_for(:provider, :savings_and_investments, application)
+        expect(url).to eq '/providers/applications/bf07c530-718a-4537-b9e1-c04ad956cc71/savings_and_investment'
+      end
+
+      it 'returns the correct path for other_assets' do
+        url = check_answer_url_for(:provider, :other_assets, application)
+        expect(url).to eq '/providers/applications/bf07c530-718a-4537-b9e1-c04ad956cc71/other_assets'
+      end
+
+      it 'returns the correct path for restrictions' do
+        url = check_answer_url_for(:provider, :restrictions, application)
+        expect(url).to eq '/providers/applications/bf07c530-718a-4537-b9e1-c04ad956cc71/restrictions'
       end
     end
 
     context 'citizen' do
-      it 'returns the correct path' do
+      it 'returns the correct path for own_home' do
+        url = check_answer_url_for(:citizen, :own_home)
+        expect(url).to eq '/citizens/own_home'
+      end
+
+      it 'returns the correct path for property_value' do
         url = check_answer_url_for(:citizen, :property_value)
         expect(url).to eq '/citizens/property_value#property_value'
+      end
+
+      it 'returns the correct path for outstanding_mortgage' do
+        url = check_answer_url_for(:citizen, :outstanding_mortgage)
+        expect(url).to eq '/citizens/outstanding_mortgage#outstanding_mortgage_amount'
+      end
+
+      it 'returns the correct path for shared_ownership' do
+        url = check_answer_url_for(:citizen, :shared_ownership)
+        expect(url).to eq '/citizens/shared_ownership'
+      end
+
+      it 'returns the correct path for percentage_home' do
+        url = check_answer_url_for(:citizen, :percentage_home)
+        expect(url).to eq '/citizens/percentage_home#percentage_home'
+      end
+
+      it 'returns the correct path for savings_and_investments' do
+        url = check_answer_url_for(:citizen, :savings_and_investments)
+        expect(url).to eq '/citizens/savings_and_investment'
+      end
+
+      it 'returns the correct path for other_assets' do
+        url = check_answer_url_for(:citizen, :other_assets)
+        expect(url).to eq '/citizens/other_assets'
+      end
+
+      it 'returns the correct path for restrictions' do
+        url = check_answer_url_for(:citizen, :restrictions)
+        expect(url).to eq '/citizens/restrictions'
       end
     end
 

--- a/spec/requests/citizens/check_answers_spec.rb
+++ b/spec/requests/citizens/check_answers_spec.rb
@@ -32,6 +32,16 @@ RSpec.describe 'check your answers requests', type: :request do
       expect(response.body).to include('restrictions')
     end
 
+    it 'displays the correct URLs for changing values' do
+      expect(response.body).to have_change_link(:own_home, citizens_own_home_path)
+      expect(response.body).to have_change_link(:property_value, citizens_property_value_path(anchor: 'property_value'))
+      expect(response.body).to have_change_link(:shared_ownership, citizens_shared_ownership_path)
+      expect(response.body).to have_change_link(:percentage_home, citizens_percentage_home_path(anchor: 'percentage_home'))
+      expect(response.body).to have_change_link(:savings_and_investments, citizens_savings_and_investment_path)
+      expect(response.body).to have_change_link(:other_assets, citizens_other_assets_path)
+      expect(response.body).to have_change_link(:restrictions, citizens_restrictions_path)
+    end
+
     it 'displays the correct savings details' do
       legal_aid_application.savings_amount.amount_attributes.each do |_, amount|
         expect(response.body).to include(number_to_currency(amount, unit: '£')), 'saving amount should be in the page'

--- a/spec/requests/providers/check_passported_answers_spec.rb
+++ b/spec/requests/providers/check_passported_answers_spec.rb
@@ -1,0 +1,109 @@
+require 'rails_helper'
+
+RSpec.describe 'check passported answers requests', type: :request do
+  include ActionView::Helpers::NumberHelper
+
+  let(:application) do
+    create :legal_aid_application,
+           :with_everything,
+           :answers_checked
+  end
+
+  describe 'GET /providers/applications/:id/check_passported_answers' do
+    subject { get "/providers/applications/#{application.id}/check_passported_answers" }
+
+    context 'unauthenticated' do
+      before { subject }
+      it_behaves_like 'a provider not authenticated'
+    end
+
+    context 'logged in as an authenticated provider' do
+      before do
+        login_as create(:provider)
+        subject
+      end
+
+      it 'returns http success' do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'displays the correct details' do
+        expect(response.body).to include(I18n.translate("shared.forms.own_home_form.#{application.own_home}"))
+        expect(response.body).to include(number_to_currency(application.property_value, unit: '£'))
+        expect(response.body).to include(number_to_currency(application.outstanding_mortgage_amount, unit: '£'))
+        expect(response.body).to include(I18n.translate("shared.forms.shared_ownership_form.shared_ownership_item.#{application.shared_ownership}"))
+        expect(response.body).to include(number_to_percentage(application.percentage_home, precision: 2))
+        expect(response.body).to include('Own the home')
+        expect(response.body).to include('Property value')
+        expect(response.body).to include('Outstanding mortgage')
+        expect(response.body).to include('Owned with anyone else')
+        expect(response.body).to include('Percentage')
+        expect(response.body).to include('Savings')
+        expect(response.body).to include('assets')
+        expect(response.body).to include('restrictions')
+      end
+
+      it 'displays the correct URLs for changing values' do
+        expect(response.body).to have_change_link(:own_home, providers_legal_aid_application_own_home_path(application))
+        expect(response.body).to have_change_link(:property_value, providers_legal_aid_application_property_value_path(application, anchor: 'property_value'))
+        expect(response.body).to have_change_link(:shared_ownership, providers_legal_aid_application_shared_ownership_path(application))
+        expect(response.body).to have_change_link(:percentage_home, providers_legal_aid_application_percentage_home_path(application, anchor: 'percentage_home'))
+        expect(response.body).to have_change_link(:savings_and_investments, providers_legal_aid_application_savings_and_investment_path(application))
+        expect(response.body).to have_change_link(:other_assets, providers_legal_aid_application_other_assets_path(application))
+        expect(response.body).to have_change_link(:restrictions, providers_legal_aid_application_restrictions_path(application))
+      end
+
+      it 'displays the correct savings details' do
+        application.savings_amount.amount_attributes.each do |_, amount|
+          expect(response.body).to include(number_to_currency(amount, unit: '£')), 'saving amount should be in the page'
+        end
+      end
+
+      it 'displays the correct assets details' do
+        application.other_assets_declaration.amount_attributes.each do |_, amount|
+          expect(response.body).to include(number_to_currency(amount, unit: '£')), 'asset amount should be in the page'
+        end
+      end
+
+      it 'should change the state to "checking_passported_answers"' do
+        expect(application.reload.checking_passported_answers?).to be_truthy
+      end
+
+      context 'applicant does not own home' do
+        let(:application) { create :legal_aid_application, :with_everything, :without_own_home, :answers_checked }
+        it 'does not display property value' do
+          expect(response.body).not_to include(number_to_currency(application.property_value, unit: '£'))
+          expect(response.body).not_to include('Property value')
+        end
+
+        it 'does not display shared ownership question' do
+          expect(response.body).not_to include(I18n.translate("shared.forms.shared_ownership_form.shared_ownership_item.#{application.shared_ownership}"))
+          expect(response.body).not_to include('Owned with anyone else')
+        end
+      end
+
+      context 'applicant owns home without mortgage' do
+        let(:application) { create :legal_aid_application, :with_everything, :with_own_home_owned_outright, :answers_checked }
+        it 'does not display property value' do
+          expect(response.body).not_to include(number_to_currency(application.outstanding_mortgage_amount, unit: '£'))
+          expect(response.body).not_to include('Outstanding mortgage')
+        end
+      end
+
+      context 'applicant is sole owner of home' do
+        let(:application) { create :legal_aid_application, :with_everything, :with_home_sole_owner, :answers_checked }
+        it 'does not display percentage owned' do
+          expect(response.body).not_to include(number_to_percentage(application.percentage_home, precision: 2))
+          expect(response.body).not_to include('Percentage')
+        end
+      end
+
+      context 'applicant does not have any capital' do
+        let(:application) { create :legal_aid_application, :provider_submitted, :with_applicant, :without_own_home, :answers_checked }
+        it 'does not display capital restrictions' do
+          expect(response.body).not_to include('restrictions')
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/providers/other_assets_spec.rb
+++ b/spec/requests/providers/other_assets_spec.rb
@@ -179,11 +179,11 @@ RSpec.describe 'provider other assets requests', type: :request do
               patch providers_legal_aid_application_other_assets_path(oad.legal_aid_application), params: empty_params.merge(submit_button)
             end
 
-            it 'redirects to check provider answers' do
+            it 'redirects to check passported answers' do
               expect(application.reload.other_assets?).to be false
               expect(application.own_home?).to be false
               expect(application.savings_amount?).to be false
-              expect(response).to redirect_to(providers_legal_aid_application_check_provider_answers_path(application))
+              expect(response).to redirect_to(providers_legal_aid_application_check_passported_answers_path(application))
             end
           end
         end

--- a/spec/requests/providers/restrictions_spec.rb
+++ b/spec/requests/providers/restrictions_spec.rb
@@ -75,8 +75,8 @@ RSpec.describe 'citizen restrictions request', type: :request do
             expect(legal_aid_application.restrictions).to match_array(restrictions)
           end
 
-          it 'redirects to check your answers' do
-            expect(response).to redirect_to(providers_legal_aid_application_check_provider_answers_path(legal_aid_application))
+          it 'redirects to check passported answers' do
+            expect(response).to redirect_to(providers_legal_aid_application_check_passported_answers_path(legal_aid_application))
           end
         end
 

--- a/spec/requests/providers/savings_and_investments_spec.rb
+++ b/spec/requests/providers/savings_and_investments_spec.rb
@@ -79,40 +79,51 @@ RSpec.describe 'providers savings and investments', type: :request do
           }
         end
 
-        it 'updates the isa amount' do
-          expect { subject }.to change { savings_amount.reload.isa.to_s }.to(isa)
-        end
-
-        it 'does not displays an error' do
-          subject
-          expect(response.body).not_to match('govuk-error-message')
-          expect(response.body).not_to match('govuk-form-group--error')
-        end
-
-        xit 'redirects to the next step in Citizen jouney' do
-          # TODO: - set redirect path when known
-          subject
-          expect(response).to redirect_to(:some_path)
-        end
-
-        it 'displays holding page' do
-          subject
-          expect(response).to redirect_to providers_legal_aid_application_other_assets_path(application)
-        end
-
-        context 'with invalid input' do
-          let(:isa) { 'fifty' }
-
-          it 'renders successfully' do
-            subject
-            expect(response).to have_http_status(:ok)
+        context 'not in checking passported answers state' do
+          it 'updates the isa amount' do
+            expect { subject }.to change { savings_amount.reload.isa.to_s }.to(isa)
           end
 
-          it 'displays an error' do
+          it 'does not displays an error' do
             subject
-            expect(response.body).to match(I18n.t('activemodel.errors.models.savings_amount.attributes.isa.not_a_number'))
-            expect(response.body).to match('govuk-error-message')
-            expect(response.body).to match('govuk-form-group--error')
+            expect(response.body).not_to match('govuk-error-message')
+            expect(response.body).not_to match('govuk-form-group--error')
+          end
+
+          it 'redirects to the next step in Citizen jouney' do
+            subject
+            expect(response).to redirect_to(providers_legal_aid_application_other_assets_path(application))
+          end
+
+          context 'with invalid input' do
+            let(:isa) { 'fifty' }
+
+            it 'renders successfully' do
+              subject
+              expect(response).to have_http_status(:ok)
+            end
+
+            it 'displays an error' do
+              subject
+              expect(response.body).to match(I18n.t('activemodel.errors.models.savings_amount.attributes.isa.not_a_number'))
+              expect(response.body).to match('govuk-error-message')
+              expect(response.body).to match('govuk-form-group--error')
+            end
+          end
+        end
+
+        context 'when in checking passported answers state' do
+          let(:application) { create :legal_aid_application, :with_applicant, :with_savings_amount, :checking_passported_answers }
+
+          let(:submit_button) do
+            {
+              continue_button: 'Continue'
+            }
+          end
+
+          it 'redirects to the check passported answers page' do
+            subject
+            expect(response).to redirect_to(providers_legal_aid_application_check_passported_answers_path(application))
           end
         end
       end
@@ -134,10 +145,9 @@ RSpec.describe 'providers savings and investments', type: :request do
           expect(response.body).not_to match('govuk-form-group--error')
         end
 
-        xit 'redirects to the next step in Citizen jouney' do
-          # TODO: - set redirect path when known
+        it 'redirects to the next step in Citizen jouney' do
           subject
-          expect(response).to redirect_to(:some_path)
+          expect(response).to redirect_to(providers_legal_aid_applications_path)
         end
 
         it 'displays holding page' do

--- a/spec/support/change_link_matcher.rb
+++ b/spec/support/change_link_matcher.rb
@@ -14,7 +14,7 @@ RSpec::Matchers.define :have_change_link do |field_name, expected_link|
 
   def extract_link(html, field_name)
     document = Nokogiri::HTML.parse(html)
-    links = document.css("div#app-check-your-answers__#{field_name} .app-check-your-answers__change a")
+    links = document.css("div#app-check-your-answers__#{field_name} a")
     links.first&.attr('href')
   end
 end

--- a/spec/support/change_link_matcher.rb
+++ b/spec/support/change_link_matcher.rb
@@ -1,0 +1,20 @@
+RSpec::Matchers.define :have_change_link do |field_name, expected_link|
+  match do |actual|
+    link = extract_link(actual, field_name)
+    link == expected_link
+  end
+  failure_message do |actual|
+    link = extract_link(actual, field_name)
+    if link.nil?
+      "Expected to find change link for #{field_name}, but none found"
+    else
+      "Expected change link for #{field_name} to be #{expected_link}, was #{link}"
+    end
+  end
+
+  def extract_link(html, field_name)
+    document = Nokogiri::HTML.parse(html)
+    link = document.css("div#app-check-your-answers__#{field_name}")
+    link.css('.app-check-your-answers__change a').first&.attr('href')
+  end
+end

--- a/spec/support/change_link_matcher.rb
+++ b/spec/support/change_link_matcher.rb
@@ -14,7 +14,7 @@ RSpec::Matchers.define :have_change_link do |field_name, expected_link|
 
   def extract_link(html, field_name)
     document = Nokogiri::HTML.parse(html)
-    link = document.css("div#app-check-your-answers__#{field_name}")
-    link.css('.app-check-your-answers__change a').first&.attr('href')
+    links = document.css("div#app-check-your-answers__#{field_name} .app-check-your-answers__change a")
+    links.first&.attr('href')
   end
 end


### PR DESCRIPTION
For passported clients (i.e. clients with a qualifying DWP benefit), the
provider fills out the capital questions rather than the client.

At the end of this process, the provider gets a chance to review the
answers he's supplied and change those that need changing.

[Link to story](https://dsdmoj.atlassian.net/browse/AP-275)

The main body of the citizens' check your answer page has been put into
a partial, and the providers/check_passported answers page uses that as well.
Because the Change links vary betwen the provider and passported journey, the
partial now calls a new helper method `#check_answer_url_for`

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unneccessary whitespace changes. These make diffs harder to read and conflicts more likely. 
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
