### PR TITLE
AP-290 Adjust page layout on citizen consent page 

### DIFF
--- a/app/helpers/gov_uk_form_helper.rb
+++ b/app/helpers/gov_uk_form_helper.rb
@@ -30,13 +30,6 @@ module GovUkFormHelper
     )
   end
 
-  def govuk_body(text)
-    render(
-      'shared/forms/body',
-      text: text
-    )
-  end
-
   # `value_label_pairs should be a hash with the input values as keys, and the
   # matching labels as values. For example: `{ yes: 'I would', no: 'I would not' }`
   def govuk_radio_inputs(field_name, value_label_pairs)

--- a/app/views/citizens/consents/show.html.erb
+++ b/app/views/citizens/consents/show.html.erb
@@ -10,7 +10,7 @@
             input: :open_banking_consent
           ) do %>
         <%= govuk_fieldset_header t('.field_set_header'), padding_below: 6 %>
-        <%= govuk_body t('.body') %>
+        <p><%= t('.body') %></p>
         <%= render partial: 'shared/forms/detailed_list', locals: { translation_path: 'citizens.consents.show' } %>
         <%= render partial: 'shared/forms/check_boxes', locals: { field_name: :open_banking_consent, label: t('.open_banking_consent.label.html'), form: form, checked: 'true', unchecked: 'false' } %>
       <% end %>

--- a/app/views/shared/forms/_body.html.erb
+++ b/app/views/shared/forms/_body.html.erb
@@ -1,7 +1,0 @@
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <p class="govuk-body">
-      <%= text %>
-    </p>
-  </div>
-</div>


### PR DESCRIPTION
## What
Adjust first paragraph which is in  a two-thirds div inside a two-thirds div.


[Link to story](https://dsdmoj.atlassian.net/browse/AP-90)

- put body text in simple p tags rather than govuk_body formbuilder method which adds the extra two thirds div
- remove the FormBuilder's govuk_body method as it isn't being used elsewhere
- remove the _body partial which is only used by the above method

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unneccessary whitespace changes. These make diffs harder to read and conflicts more likely. 
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
