### PR TITLE
AP-278 Modify blank isa error message so works for Citizen and Provider

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -246,7 +246,7 @@ en:
         savings_amount:
           attributes:
             isa:
-              blank: Enter the estimated total in your accounts
+              blank: Enter the estimated total in all accounts
               not_a_number: Total in accounts must be an amount of money, like 60,000
               greater_than_or_equal_to: Total in accounts must be 0 or more
             cash:


### PR DESCRIPTION
[JIra AP-278](https://dsdmoj.atlassian.net/browse/AP-278)

Very small update to copy to allow same blank isa error message to be used in both the Citizen and Provider journeys.