### PR TITLE
Add clean_up_ecr script

### DIFF
--- a/bin/clean_up_ecr.rb
+++ b/bin/clean_up_ecr.rb
@@ -1,0 +1,25 @@
+require 'json'
+
+repo = 'laa-apply-for-legal-aid/applyforlegalaid-service'
+delete_if_older_than = 30 # days
+
+json_output = `aws ecr describe-images --repository-name #{repo} --output json`
+images = JSON.parse(json_output)['imageDetails']
+
+images_to_delete = []
+images.each do |i|
+  date_pushed = DateTime.strptime(i['imagePushedAt'].to_s, '%s')
+  age_in_days = (DateTime.now - date_pushed).to_i
+  images_to_delete << i if age_in_days > delete_if_older_than
+end
+
+puts "There are #{images_to_delete.size} images that will be deleted. Is that okay?"
+input = STDIN.gets.strip
+exit 5 unless input =~ /^y/i
+
+images_to_delete.each_slice(100) do |batch|
+  image_ids = batch.map { |i| "imageDigest=#{i['imageDigest']}" }.join(' ')
+  puts `aws ecr batch-delete-image --repository-name #{repo} --image-ids #{image_ids}`
+end
+
+puts 'Done!'


### PR DESCRIPTION
## What

AWS ECR repositories have a limit of 1000 images. When this limit is reached no further builds are possible.

This script will delete all but the last 30 days of images, allowing builds to resume.

To run it, first follow the instructions in https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/1377992881/ECR+Repository+Maintenance to connect to the ECR instance.

(The code for this was stolen shamelessly from https://gist.github.com/dmerrick/503655db7ff90b70c2d15fc9dd83b45e)

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unneccessary whitespace changes. These make diffs harder to read and conflicts more likely. 
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
