### PR TITLE
Run clean_up_ecr nightly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,6 +156,17 @@ jobs:
                         --set ingress.hosts="{${PRODUCTION_HOST}}" \
                         --set replicaCount="2"
 
+  clean_up_ecr:
+    <<: *build_container_config
+    steps:
+    - checkout
+    - setup_remote_docker
+    - *setup_test_env
+    - run:
+        name: Delete old images from ecr repo
+        command: |
+          ./bin/clean_up_ecr
+
 workflows:
   version: 2
   build_and_deploy:
@@ -203,4 +214,5 @@ workflows:
             only:
             - master
     jobs:
+    - clean_up_ecr
     - deploy_staging

--- a/bin/clean_up_ecr
+++ b/bin/clean_up_ecr
@@ -1,0 +1,10 @@
+#!/bin/sh
+echo "Logging into ECR"
+
+aws configure set default.region eu-west-1
+
+docker_login=$(aws ecr get-login)
+
+eval $docker_login
+
+./bin/delete_ecr_images

--- a/bin/delete_ecr_images
+++ b/bin/delete_ecr_images
@@ -1,7 +1,11 @@
+#!/usr/bin/env ruby
 require 'json'
+require 'date'
 
 repo = 'laa-apply-for-legal-aid/applyforlegalaid-service'
 delete_if_older_than = 30 # days
+
+puts 'Identifying images to delete'
 
 json_output = `aws ecr describe-images --repository-name #{repo} --output json`
 images = JSON.parse(json_output)['imageDetails']
@@ -13,13 +17,15 @@ images.each do |i|
   images_to_delete << i if age_in_days > delete_if_older_than
 end
 
-puts "There are #{images_to_delete.size} images that will be deleted. Is that okay?"
-input = STDIN.gets.strip
-exit 5 unless input =~ /^y/i
+if images_to_delete.empty?
+  puts 'Nothing to delete'
+else
+  puts 'Deleting images'
 
-images_to_delete.each_slice(100) do |batch|
-  image_ids = batch.map { |i| "imageDigest=#{i['imageDigest']}" }.join(' ')
-  puts `aws ecr batch-delete-image --repository-name #{repo} --image-ids #{image_ids}`
+  images_to_delete.each_slice(100) do |batch|
+    image_ids = batch.map { |i| "imageDigest=#{i['imageDigest']}" }.join(' ')
+    puts `aws ecr batch-delete-image --repository-name #{repo} --image-ids #{image_ids}`
+  end
+
+  puts 'Done!'
 end
-
-puts 'Done!'


### PR DESCRIPTION
## What

clean_up_ecr is a script that deletes old images in order to resolve/avoid the limit of 1000 images in the ECR repo. Rather than run this manually it would be useful if this was automated. This change creates a job to run it and add it to the nightly job in .circleci/config.yml.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unneccessary whitespace changes. These make diffs harder to read and conflicts more likely. 
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
