### PR TITLE
FIX - foreman in local - redirect to port 5000 after SAML auth

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: bundle exec puma -C config/puma.rb -p 3002
+web: bundle exec puma -C config/puma.rb
 worker: bundle exec sidekiq

--- a/docker/run
+++ b/docker/run
@@ -5,4 +5,4 @@ set -e
 ./bin/wait_for_pg
 ./bin/setup_db
 
-foreman start -f Procfile
+foreman start -f Procfile -p 3002


### PR DESCRIPTION
At the moment, when using `foreman`, when returning from the SAML authentication it redirects to port `5000` which is foreman default's port. And it fails because the app is on localhost:3002 (not 5000)

With this fix, you can choose which port you want to use : 
`foreman start -p 3000`
`foreman start -p 3002`
`foreman start` (port 5000)
And it will work