### PR TITLE
AP-292

### DIFF
--- a/app/assets/stylesheets/govuk_secondary_button.scss
+++ b/app/assets/stylesheets/govuk_secondary_button.scss
@@ -4,11 +4,21 @@
   box-shadow: 0 2px 0 #b5babe;
 }
 
-.govuk-button.govuk-secondary-button:hover, .govuk-button.govuk-secondary-button:focus  {
+.govuk-button.govuk-secondary-button:active, 
+.govuk-button.govuk-secondary-button:hover, 
+.govuk-button.govuk-secondary-button:focus  {
   background-color: #d0d3d6;
   color: #0b0c0c;
 }
 
+.govuk-button--disabled.govuk-secondary-button:hover,
+.govuk-button.govuk-secondary-button[disabled="disabled"]:hover,
+.govuk-button.govuk-secondary-button[disabled]:hover
+.govuk-button--disabled.govuk-secondary-button,
+.govuk-button.govuk-secondary-button[disabled="disabled"],
+.govuk-button.govuk-secondary-button[disabled] {
+  background: #dee0e2;
+}
 .form-button {
   margin-right: 15px;
 }

--- a/app/assets/stylesheets/govuk_secondary_button.scss
+++ b/app/assets/stylesheets/govuk_secondary_button.scss
@@ -12,11 +12,11 @@
 }
 
 .govuk-button--disabled.govuk-secondary-button:hover,
-.govuk-button.govuk-secondary-button[disabled="disabled"]:hover,
-.govuk-button.govuk-secondary-button[disabled]:hover
+.govuk-button[disabled="disabled"].govuk-secondary-button[disabled="disabled"]:hover,
+.govuk-button[disabled].govuk-secondary-button[disabled]:hover
 .govuk-button--disabled.govuk-secondary-button,
-.govuk-button.govuk-secondary-button[disabled="disabled"],
-.govuk-button.govuk-secondary-button[disabled] {
+.govuk-button[disabled="disabled"].govuk-secondary-button[disabled="disabled"],
+.govuk-button[disabled].govuk-secondary-button[disabled] {
   background: #dee0e2;
 }
 .form-button {


### PR DESCRIPTION
Added new styles to prevent undesirable cascading of styles
to disabled secondary buttons.

i.e.
- Stopped them turning green when disabled
- stopped the text turing white when active


## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-292)

Describe what you did and why.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake` (by will)
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unneccessary whitespace changes. These make diffs harder to read and conflicts more likely. 
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
