### PR TITLE
migration to add provider to legal aid application on staging

### DIFF
--- a/db/migrate/20190122115534_update_provider_id_to_application.rb
+++ b/db/migrate/20190122115534_update_provider_id_to_application.rb
@@ -1,0 +1,8 @@
+class UpdateProviderIdToApplication < ActiveRecord::Migration[5.2]
+  def up
+    provider_id = Provider.where(username: 'benreid').try(:provider_id)
+    return if provider_id.nil?
+
+    LegalAidApplication.where(provider_id: nil).update_all(provider_id: provider_id)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_01_10_104254) do
+ActiveRecord::Schema.define(version: 2019_01_22_115534) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"


### PR DESCRIPTION
## What
As we don't remove the application from staging on deploying, we have several application which can't be accessed because we don't have provider id.

I have added a migration to default these application to the test user which is working.

https://sentry.service.dsd.io/mojds/apply-for-legal-aid-staging/issues/34419/

Describe what you did and why.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unneccessary whitespace changes. These make diffs harder to read and conflicts more likely. 
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
