### PR TITLE
Change way UAT instances are named so that easier to identify

### DIFF
--- a/bin/uat_deploy
+++ b/bin/uat_deploy
@@ -22,7 +22,7 @@ clean_old_releases() {
 
 deploy() {
   IMG_REPO="$ECR_ENDPOINT/$GITHUB_TEAM_NAME_SLUG/$REPO_NAME"
-  RELEASE_BRANCH=$(echo $CIRCLE_BRANCH | rev | cut -c1-30 | rev | tr -s ' _/[]()' '-' | sed "s/^-//")
+  RELEASE_BRANCH=$(echo $CIRCLE_BRANCH | sed 's:^\w*\/::' | tr -s ' _/[]()' '-' | cut -c1-30)
   RELEASE_NAME="$APPLICATION_DEPLOY_NAME-$RELEASE_BRANCH"
   RELEASE_HOST="$RELEASE_BRANCH-$UAT_HOST"
 


### PR DESCRIPTION
A small change to code that constructs the UAT instance name. The new system:

- Removes leading labels such as `feature/` or `release/`
- Truncates the end of the name rather than the beginning. As most devs put the ticket label at the start of the branch name, this is preserved in the UAT instance name.

If you look at the deployment output of this PR you can see the result of this change:
```
==> v1/Service
apply-for-legal-aid-ap-xxx-modify-name-of-uat-inst-postgresql    1m
apply-for-legal-aid-ap-xxx-modify-name-of-uat-inst-apply-for-le  1m

==> v1beta1/Deployment
apply-for-legal-aid-ap-xxx-modify-name-of-uat-inst-postgresql  1m


NOTES:
1. Get the application URL by running these commands:
  http://ap-xxx-modify-name-of-uat-inst-applyforlegalaid-uat.apps.cloud-platform-live-0.k8s.integration.dsd.io/
```
Compare that with the branch name at the top of this page.