### PR TITLE
Remove 'Signed in successfully' message

### DIFF
--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -45,7 +45,7 @@ en:
       update_needs_confirmation: "You updated your account successfully, but we need to verify your new email address. Please check your email and follow the confirm link to confirm your new email address."
       updated: "Your account has been updated successfully."
     sessions:
-      signed_in: "Signed in successfully."
+      signed_in: ''
       signed_out: "Signed out successfully."
       already_signed_out: "Signed out successfully."
     unlocks:


### PR DESCRIPTION
## What

[AP-317](https://dsdmoj.atlassian.net/browse/AP-317)

When a user signs in via the portal, devise sets a flash message which is displayed to the user. They don't need to see this.

Remove it by removing the message wording from the config/locales/devise.en.yml file.

This will allow other flash messages set by devise to still work as expected (if we need them - if we decide later that we don't then they can be removed by a separate change).

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unneccessary whitespace changes. These make diffs harder to read and conflicts more likely. 
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
