### PR TITLE
Fix bug with UAT names that end in dash

### DIFF
--- a/bin/uat_deploy
+++ b/bin/uat_deploy
@@ -22,7 +22,7 @@ clean_old_releases() {
 
 deploy() {
   IMG_REPO="$ECR_ENDPOINT/$GITHUB_TEAM_NAME_SLUG/$REPO_NAME"
-  RELEASE_BRANCH=$(echo $CIRCLE_BRANCH | sed 's:^\w*\/::' | tr -s ' _/[]()' '-' | cut -c1-30)
+  RELEASE_BRANCH=$(echo $CIRCLE_BRANCH | sed 's:^\w*\/::' | tr -s ' _/[]()' '-' | cut -c1-30 | sed 's/-$//')
   RELEASE_NAME="$APPLICATION_DEPLOY_NAME-$RELEASE_BRANCH"
   RELEASE_HOST="$RELEASE_BRANCH-$UAT_HOST"
 
@@ -42,4 +42,3 @@ deploy() {
 
 clean_old_releases
 deploy
-


### PR DESCRIPTION
After the change to the naming convention for UAT instances, it's now
possible to have a name that ends with a '-'. This causes a failure
in CircleCI.

![image](https://user-images.githubusercontent.com/28729201/51707229-96a1c980-2018-11e9-9fe8-bd27a84ad990.png)

To fix this, amend the bash command that calculates the name so that it
strips any trailing dashes.

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unneccessary whitespace changes. These make diffs harder to read and conflicts more likely. 
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
