### PR TITLE
AP 304 feedback page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,9 @@ gem 'omniauth-oauth2' # Provide Oauth2 strategy framework
 # Authorization
 gem 'pundit'
 
+# Gathers data from user browser - OS and Browser name
+gem 'browser'
+
 # Used to mock saml request in UAT
 gem 'ruby-saml-idp'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,6 +75,7 @@ GEM
       smart_properties
     bootsnap (1.3.2)
       msgpack (~> 1.0)
+    browser (2.5.3)
     builder (3.2.3)
     byebug (10.0.2)
     capybara (3.13.2)
@@ -424,6 +425,7 @@ DEPENDENCIES
   active_model_serializers (~> 0.10.8)
   awesome_print (~> 1.8.0)
   bootsnap (>= 1.1.0)
+  browser
   byebug
   capybara (>= 2.15, < 4.0)
   chromedriver-helper

--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -1,11 +1,29 @@
 class FeedbackController < ApplicationController
   def new
-    @feedback = Feedback.new
+    feedback
   end
 
   def create
-    @feedback = Feedback.new
-    @feedback.errors.add(:improvment_suggestion, 'this is an error')
-    render :new
+    if feedback.update(feedback_params)
+      redirect_to feedback
+    else
+      render :new
+    end
+  end
+
+  def show
+    @feedback = Feedback.find(params[:id])
+  end
+
+  private
+
+  def feedback_params
+    params.require(:feedback).permit(
+      :done_all_needed, :satisfaction, :improvment_suggestion
+    )
+  end
+
+  def feedback
+    @feedback ||= Feedback.new
   end
 end

--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -28,7 +28,12 @@ class FeedbackController < ApplicationController
   end
 
   def feedback
-    @feedback ||= Feedback.new
+    @feedback ||= Feedback.new(
+      source: source,
+      os: browser.platform.name,
+      browser: browser.name,
+      browser_version: browser.full_version
+    )
   end
 
   def back_path
@@ -40,5 +45,13 @@ class FeedbackController < ApplicationController
     return if request.referer&.include?(feedback_index_path)
 
     session[:feedback_return_path] = request.referer
+  end
+
+  def source
+    path = session[:feedback_return_path]
+    return :Provider if %r{/providers/} =~ path
+    return :Citizen if %r{/citizens/} =~ path
+
+    :Unknown
   end
 end

--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -1,0 +1,11 @@
+class FeedbackController < ApplicationController
+  def new
+    @feedback = Feedback.new
+  end
+
+  def create
+    @feedback = Feedback.new
+    @feedback.errors.add(:improvment_suggestion, 'this is an error')
+    render :new
+  end
+end

--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -1,12 +1,16 @@
 class FeedbackController < ApplicationController
+  before_action :update_return_path
+
   def new
     feedback
   end
 
   def create
-    if feedback.update(feedback_params)
+    if feedback_params.values.any?(&:present?)
+      feedback.update(feedback_params)
       redirect_to feedback
     else
+      feedback
       render :new
     end
   end
@@ -19,11 +23,22 @@ class FeedbackController < ApplicationController
 
   def feedback_params
     params.require(:feedback).permit(
-      :done_all_needed, :satisfaction, :improvment_suggestion
+      :done_all_needed, :satisfaction, :improvement_suggestion
     )
   end
 
   def feedback
     @feedback ||= Feedback.new
+  end
+
+  def back_path
+    session.fetch(:feedback_return_path, :back)
+  end
+  helper_method :back_path
+
+  def update_return_path
+    return if request.referer&.include?(feedback_index_path)
+
+    session[:feedback_return_path] = request.referer
   end
 end

--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -6,13 +6,10 @@ class FeedbackController < ApplicationController
   end
 
   def create
-    if feedback_params.values.any?(&:present?)
-      feedback.update(feedback_params)
-      redirect_to feedback
-    else
-      feedback
-      render :new
-    end
+    feedback.update(feedback_params)
+    FeedbackMailer.notify(feedback).deliver_later if feedback_submitted?
+
+    redirect_to feedback
   end
 
   def show
@@ -53,5 +50,9 @@ class FeedbackController < ApplicationController
     return :Citizen if %r{/citizens/} =~ path
 
     :Unknown
+  end
+
+  def feedback_submitted?
+    feedback_params.values.any?(&:present?)
   end
 end

--- a/app/lib/govuk_elements_form_builder/form_builder.rb
+++ b/app/lib/govuk_elements_form_builder/form_builder.rb
@@ -91,6 +91,9 @@ module GovukElementsFormBuilder
     # You can pass a title with the :title parameter.
     # e.g., <%= form.govuk_collection_radio_buttons(:gender, ['f', 'm'], title: 'What is your gender?') %>
     #
+    # If you wish to specify the size of the heading pass a hash into title with text and size:
+    # <%= form.govuk_collection_radio_buttons(:gender, ['f', 'm'], title: { text: 'What is your gender?', size: :m } ) %>
+    #
     # Use the :inline parameter to have the radio buttons displayed horizontally rather than vertically
     # e.g., <%= form.govuk_collection_radio_buttons(:gender, ['f', 'm'], inline: true) %>
     #
@@ -121,7 +124,7 @@ module GovukElementsFormBuilder
     private
 
     def concat_tags(*tags)
-      tags.compact.join('').html_safe
+      tags.compact.join.html_safe
     end
 
     def extract_value_and_label_attributes(args)
@@ -169,8 +172,7 @@ module GovukElementsFormBuilder
       classes = ['govuk-form-group']
       classes << 'govuk-form-group--error' if error?(attribute, options)
       content_tag :div, class: classes.join(' ') do
-        label = options.key?(:label) && options[:label].nil? ? '' : label(attribute, options[:label], class: 'govuk-label', for: attribute)
-        concat_tags(label, hint_and_error_tags(attribute, options), yield)
+        concat_tags(label_from_options(attribute, options), hint_and_error_tags(attribute, options), yield)
       end
     end
 
@@ -189,9 +191,23 @@ module GovukElementsFormBuilder
     end
 
     def fieldset_legend(title)
-      content_tag(:legend, class: 'govuk-fieldset__legend govuk-fieldset__legend--xl') do
-        content_tag(:h1, title, class: 'govuk-fieldset__heading')
+      title = text_hash(title)
+      size = title.fetch(:size, 'xl')
+      content_tag(:legend, class: "govuk-fieldset__legend govuk-fieldset__legend--#{size}") do
+        content_tag(:h1, title[:text], class: 'govuk-fieldset__heading')
       end
+    end
+
+    def label_from_options(attribute, options)
+      return '' if options.key?(:label) && options[:label].nil?
+      label_options = text_hash(options.fetch(:label, {}))
+      label_classes = ['govuk-label']
+      label_classes << "govuk-label--#{label_options[:size]}" if label_options[:size].present?
+      label(attribute, label_options[:text], class: label_classes.join(' '), for: attribute)
+    end
+
+    def text_hash(text)
+      text.is_a?(Hash) ? text : { text: text }
     end
 
     def hint_and_error_tags(attribute, options)

--- a/app/lib/govuk_elements_form_builder/form_builder.rb
+++ b/app/lib/govuk_elements_form_builder/form_builder.rb
@@ -176,6 +176,15 @@ module GovukElementsFormBuilder
       end
     end
 
+    def label_from_options(attribute, options)
+      return '' if options.key?(:label) && options[:label].nil?
+
+      label_options = text_hash(options.fetch(:label, {}))
+      label_classes = ['govuk-label']
+      label_classes << "govuk-label--#{label_options[:size]}" if label_options[:size].present?
+      label(attribute, label_options[:text], class: label_classes.join(' '), for: attribute)
+    end
+
     def fieldset(attribute, options)
       content_tag(:fieldset, class: 'govuk-fieldset', 'aria-describedby': aria_describedby(attribute, options)) do
         legend_tag = options[:title] ? fieldset_legend(options[:title]) : nil
@@ -196,14 +205,6 @@ module GovukElementsFormBuilder
       content_tag(:legend, class: "govuk-fieldset__legend govuk-fieldset__legend--#{size}") do
         content_tag(:h1, title[:text], class: 'govuk-fieldset__heading')
       end
-    end
-
-    def label_from_options(attribute, options)
-      return '' if options.key?(:label) && options[:label].nil?
-      label_options = text_hash(options.fetch(:label, {}))
-      label_classes = ['govuk-label']
-      label_classes << "govuk-label--#{label_options[:size]}" if label_options[:size].present?
-      label(attribute, label_options[:text], class: label_classes.join(' '), for: attribute)
     end
 
     def text_hash(text)

--- a/app/mailers/feedback_mailer.rb
+++ b/app/mailers/feedback_mailer.rb
@@ -11,8 +11,8 @@ class FeedbackMailer < GovukNotifyRails::Mailer
         feedback.source
       ].join(' - '),
       done_all_needed: feedback.done_all_needed.to_s,
-      satisfaction: feedback.satisfaction,
-      improvement_suggestion: feedback.improvement_suggestion
+      satisfaction: (feedback.satisfaction || ''),
+      improvement_suggestion: (feedback.improvement_suggestion || '')
     )
     mail to: TARGET_EMAIL
   end

--- a/app/mailers/feedback_mailer.rb
+++ b/app/mailers/feedback_mailer.rb
@@ -1,0 +1,30 @@
+class FeedbackMailer < GovukNotifyRails::Mailer
+  TARGET_EMAIL = 'apply-for-legal-aid@digital.justice.gov.uk'.freeze
+
+  def notify(feedback)
+    set_template_conf
+    set_personalisation(
+      created_at: feedback.created_at.to_s(:rfc822),
+      user_data: [
+        feedback.os,
+        "#{feedback.browser} #{feedback.browser_version}",
+        feedback.source
+      ].join(' - '),
+      done_all_needed: feedback.done_all_needed.to_s,
+      satisfaction: feedback.satisfaction,
+      improvement_suggestion: feedback.improvement_suggestion
+    )
+    mail to: TARGET_EMAIL
+  end
+
+  protected
+
+  def set_template_conf
+    template_id = template_ids.fetch(:feedback_notification)
+    set_template(template_id)
+  end
+
+  def template_ids
+    @template_ids ||= Rails.configuration.govuk_notify_templates
+  end
+end

--- a/app/models/concerns/translatable_model_attribute.rb
+++ b/app/models/concerns/translatable_model_attribute.rb
@@ -12,8 +12,37 @@
 # Enum translations should be stored in /config/locales/en/model_enum_translations.yml
 #
 module TranslatableModelAttribute
+  extend ActiveSupport::Concern
+
   def enum_t(attribute)
     model = model_name.i18n_key
     I18n.t(__send__(attribute), scope: [:model_enum_translations, model, attribute])
+  end
+
+  class_methods do
+    # This method generates a radio button for each option in an enum
+    # For example, if the form object is a `Feedback` instance which has the
+    # `satisfaction` enum attribute:
+    #     <%= Feedback.enum_radio_buttons(form, :satisfaction) %>
+    # To reverse the order:
+    #     <%= Feedback.enum_radio_buttons(form, :satisfaction, order: :reverse) %>
+    def enum_radio_buttons(form, attribute, order: :normal, args: nil)
+      collection = enum_ts(attribute).map do |option, translation|
+        { attribute.to_sym => option.to_s, label: translation }
+      end
+      collection.reverse! if order == :reverse
+      form.govuk_collection_radio_buttons(attribute, collection, attribute, :label, args)
+    end
+
+    def enum_ts(attribute)
+      enums = __send__(attribute.to_s.pluralize)
+      enum_ts_cache[attribute.to_sym] ||= enums.keys.each_with_object({}) do |value, hash|
+        hash[value.to_sym] = I18n.t(value, scope: [:model_enum_translations, model_name.i18n_key, attribute])
+      end
+    end
+
+    def enum_ts_cache
+      @enum_ts_cache ||= {}
+    end
   end
 end

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -1,0 +1,11 @@
+class Feedback < ApplicationRecord
+  include TranslatableModelAttribute
+
+  enum satisfaction: {
+    very_dissatisfied: 0,
+    dissatisfied: 1,
+    neither_dissatisfied_nor_satisfied: 2,
+    satisfied: 3,
+    very_satisfied: 4
+  }
+end

--- a/app/views/feedback/new.html.erb
+++ b/app/views/feedback/new.html.erb
@@ -23,13 +23,14 @@
             }
           ) %>
 
-      <%= form.govuk_text_field(
+      <%= form.govuk_text_area(
             :improvement_suggestion,
             label: {
               text: t('.improvement_suggestion'),
               size: :m
             },
-            class: 'govuk-!-width-one-half'
+            rows: 4,
+            class: 'govuk-!-width-full'
           ) %>
 
       <%= form.submit t('generic.send'), class: 'govuk-button' %>

--- a/app/views/feedback/new.html.erb
+++ b/app/views/feedback/new.html.erb
@@ -1,0 +1,14 @@
+<%= provider_basic_page page_title: 'Feedback', back_link: { path: :back } do %>
+    <div class="govuk-!-padding-bottom-2"></div>
+
+    <%= form_with(model: @feedback, url: feedback_index_path) do |form| %>
+
+      <div class="govuk-!-padding-bottom-2"></div>
+
+      <%= form.govuk_text_field :improvment_suggestion, class: 'govuk-!-width-one-half' %>
+
+      <%= render partial: 'shared/forms/next_action_buttons', locals: { continue_id: 'continue', show_draft: true, form: form } %>
+
+     </div>
+    <% end %>
+<% end %>

--- a/app/views/feedback/new.html.erb
+++ b/app/views/feedback/new.html.erb
@@ -1,4 +1,4 @@
-<%= provider_basic_page page_title: t('.title'), back_link: { path: :back } do %>
+<%= provider_basic_page page_title: t('.title'), back_link: { path: back_path } do %>
 
     <%= form_for(@feedback, url: feedback_index_path) do |form| %>
 
@@ -24,15 +24,15 @@
           ) %>
 
       <%= form.govuk_text_field(
-            :improvment_suggestion,
+            :improvement_suggestion,
             label: {
-              text: t('.improvment_suggestion'),
+              text: t('.improvement_suggestion'),
               size: :m
             },
             class: 'govuk-!-width-one-half'
           ) %>
 
-      <%= form.submit t('generic.continue'), class: "govuk-button" %>
+      <%= form.submit t('generic.send'), class: 'govuk-button' %>
 
     <% end %>
 <% end %>

--- a/app/views/feedback/new.html.erb
+++ b/app/views/feedback/new.html.erb
@@ -1,14 +1,38 @@
-<%= provider_basic_page page_title: 'Feedback', back_link: { path: :back } do %>
-    <div class="govuk-!-padding-bottom-2"></div>
+<%= provider_basic_page page_title: t('.title'), back_link: { path: :back } do %>
 
-    <%= form_with(model: @feedback, url: feedback_index_path) do |form| %>
+    <%= form_for(@feedback, url: feedback_index_path) do |form| %>
 
-      <div class="govuk-!-padding-bottom-2"></div>
+      <%= form.govuk_collection_radio_buttons(
+            :done_all_needed,
+            %w[yes no],
+            inline: true,
+            title: {
+              text: t('.done_all_needed'),
+              size: :m
+            }
+          ) %>
 
-      <%= form.govuk_text_field :improvment_suggestion, class: 'govuk-!-width-one-half' %>
+      <%= Feedback.enum_radio_buttons(
+            form, :satisfaction,
+            order: :reverse,
+            args: {
+              title: {
+                text: t('.satisfaction'),
+                size: :m
+              }
+            }
+          ) %>
 
-      <%= render partial: 'shared/forms/next_action_buttons', locals: { continue_id: 'continue', show_draft: true, form: form } %>
+      <%= form.govuk_text_field(
+            :improvment_suggestion,
+            label: {
+              text: t('.improvment_suggestion'),
+              size: :m
+            },
+            class: 'govuk-!-width-one-half'
+          ) %>
 
-     </div>
+      <%= form.submit t('generic.continue'), class: "govuk-button" %>
+
     <% end %>
 <% end %>

--- a/app/views/feedback/new.html.erb
+++ b/app/views/feedback/new.html.erb
@@ -1,4 +1,4 @@
-<%= provider_basic_page page_title: t('.title'), back_link: { path: back_path } do %>
+<%= page_template page_title: t('.title'), back_link: back_link(path: back_path) do %>
 
     <%= form_for(@feedback, url: feedback_index_path) do |form| %>
 

--- a/app/views/feedback/show.html.erb
+++ b/app/views/feedback/show.html.erb
@@ -1,5 +1,5 @@
-<%= provider_basic_page(page_title: t('.title'), back_link: { path: :back }) do %>
+<%= provider_basic_page(page_title: t('.title'), back_link: { path: back_path }) do %>
   <p class="govuk-body">
-    <%= link_to t('.link'), :back, class: "govuk-link govuk-link--no-visited-state" %>
+    <%= link_to t('.link'), back_path, class: 'govuk-link govuk-link--no-visited-state' %>
   </p>
 <% end %>

--- a/app/views/feedback/show.html.erb
+++ b/app/views/feedback/show.html.erb
@@ -1,4 +1,4 @@
-<%= provider_basic_page(page_title: t('.title'), back_link: { path: back_path }) do %>
+<%= page_template page_title: t('.title'), back_link: back_link(path: back_path) do %>
   <p class="govuk-body">
     <%= link_to t('.link'), back_path, class: 'govuk-link govuk-link--no-visited-state' %>
   </p>

--- a/app/views/feedback/show.html.erb
+++ b/app/views/feedback/show.html.erb
@@ -1,0 +1,5 @@
+<%= provider_basic_page(page_title: t('.title'), back_link: { path: :back }) do %>
+  <p class="govuk-body">
+    <%= link_to t('.link'), :back, class: "govuk-link govuk-link--no-visited-state" %>
+  </p>
+<% end %>

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -10,10 +10,7 @@
           </li>
 
           <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="#">
-              <!-- TO DO add link -->
-              <%= t('layouts.application.footer.feedback') %>
-            </a>
+            <%= link_to t('layouts.application.footer.feedback'), new_feedback_path, class: 'govuk-footer__link' %>
           </li>
 
           <li class="govuk-footer__inline-list-item">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -48,7 +48,7 @@
           </strong>
           <span class="govuk-phase-banner__text">
             This is a new service – your
-            <a class="govuk-link" href="#">feedback</a>
+            <%= link_to 'feedback', new_feedback_path, class: 'govuk-link' %>
             will help us to improve it.
           </span>
         </p>

--- a/config/govuk_notify_templates.yml
+++ b/config/govuk_notify_templates.yml
@@ -10,6 +10,8 @@
 #
 development:
   citizen_start_application: '570e1b9d-6238-45fd-b75c-96f2f39db8e9'
+  feedback_notification: 'ac458f81-b7dd-4b2c-944c-3f17d2f2392c'
 
 production:
   citizen_start_application: '66865f0d-6410-40e2-b862-98724eb6e33a'
+  feedback_notification: '246379d9-14f5-470e-a8a4-31c4b61e64b2'

--- a/config/locales/en/citizens.yml
+++ b/config/locales/en/citizens.yml
@@ -42,7 +42,7 @@ en:
       show:
         body: We only use your bank transactions to support your legal aid application. We do not use the information for anything else.
         field_set_header: Do you agree to share your bank transactions with us?
-        list:
+        list: |
           We do not save your online banking username and password
           We do not have any ongoing access to your bank accounts
           We only use your details to assess your eligibility for legal aid

--- a/config/locales/en/default.yml
+++ b/config/locales/en/default.yml
@@ -31,7 +31,7 @@ en:
       title: Help us improve this service
       satisfaction: Overall, how satisfied were you with this service?
       done_all_needed: Were you able to do what you needed today?
-      improvment_suggestion: How could we improve this service?
+      improvement_suggestion: How could we improve this service?
     show:
       title: Thank you for your feedback
       link: Back to your application

--- a/config/locales/en/default.yml
+++ b/config/locales/en/default.yml
@@ -26,6 +26,15 @@ en:
     index:
       heading_1: Apply for Legal Aid
       welcome_home: Welcome Home
+  feedback:
+    new:
+      title: Help us improve this service
+      satisfaction: Overall, how satisfied were you with this service?
+      done_all_needed: Were you able to do what you needed today?
+      improvment_suggestion: How could we improve this service?
+    show:
+      title: Thank you for your feedback
+      link: Back to your application
   restrictions:
     names:
       bankruptcy: Bankruptcy

--- a/config/locales/en/default.yml
+++ b/config/locales/en/default.yml
@@ -22,19 +22,19 @@ en:
       not_saved:
         one: '1 error prohibited this %{resource} from being saved:'
         other: "%{count} errors prohibited this %{resource} from being saved:"
+  feedback:
+    new:
+      done_all_needed: Were you able to do what you needed today?
+      improvement_suggestion: How could we improve this service?
+      satisfaction: Overall, how satisfied were you with this service?
+      title: Help us improve this service
+    show:
+      link: Back to your application
+      title: Thank you for your feedback
   home:
     index:
       heading_1: Apply for Legal Aid
       welcome_home: Welcome Home
-  feedback:
-    new:
-      title: Help us improve this service
-      satisfaction: Overall, how satisfied were you with this service?
-      done_all_needed: Were you able to do what you needed today?
-      improvement_suggestion: How could we improve this service?
-    show:
-      title: Thank you for your feedback
-      link: Back to your application
   restrictions:
     names:
       bankruptcy: Bankruptcy

--- a/config/locales/en/generic.yml
+++ b/config/locales/en/generic.yml
@@ -14,6 +14,7 @@ en:
     information: Information
     'no': 'No'
     save_as_draft: Save as draft
+    send: Send
     start: Start
     start_now: Start now
     submit: Submit

--- a/config/locales/en/mailers.yml
+++ b/config/locales/en/mailers.yml
@@ -1,4 +1,0 @@
-en:
-  feedback_mailer:
-    notify:
-      subject: 'Apply For Legal Aid: Feedback %{increment}'

--- a/config/locales/en/mailers.yml
+++ b/config/locales/en/mailers.yml
@@ -1,0 +1,4 @@
+en:
+  feedback_mailer:
+    notify:
+      subject: 'Apply For Legal Aid: Feedback %{increment}'

--- a/config/locales/en/model_enum_translations.yml
+++ b/config/locales/en/model_enum_translations.yml
@@ -10,3 +10,11 @@ en:
         initiated: In progress
         means_completed: Means test completed
         provider_submitted: Submitted by provider
+    feedback:
+      satisfaction:
+        very_dissatisfied: Very dissatisfied
+        dissatisfied: Dissatisfied
+        neither_dissatisfied_nor_satisfied: Neither satisfied nor dissatisfied
+        satisfied: Satisfied
+        very_satisfied: Very satisfied
+

--- a/config/locales/en/model_enum_translations.yml
+++ b/config/locales/en/model_enum_translations.yml
@@ -1,6 +1,13 @@
 ---
 en:
   model_enum_translations:
+    feedback:
+      satisfaction:
+        dissatisfied: Dissatisfied
+        neither_dissatisfied_nor_satisfied: Neither satisfied nor dissatisfied
+        satisfied: Satisfied
+        very_dissatisfied: Very dissatisfied
+        very_satisfied: Very satisfied
     legal_aid_application:
       state:
         answers_checked: Answers checked
@@ -10,11 +17,3 @@ en:
         initiated: In progress
         means_completed: Means test completed
         provider_submitted: Submitted by provider
-    feedback:
-      satisfaction:
-        very_dissatisfied: Very dissatisfied
-        dissatisfied: Dissatisfied
-        neither_dissatisfied_nor_satisfied: Neither satisfied nor dissatisfied
-        satisfied: Satisfied
-        very_satisfied: Very satisfied
-

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -4,13 +4,13 @@ en:
     about_the_financial_assessments:
       show:
         list:
-          title: How we use your client's details
           list: |
             We download 3 months of bank transactions
             We only use information for the legal aid application
             We automatically end the bank connection after 1 hour
             We do not save online banking details
             How we use your client's details
+          title: How we use your client's details
         section_1:
           heading: Give your client access to the financial assessment
           text: When you click 'Submit' we will send your client a secure link to the online financial assessment.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,7 +17,7 @@ Rails.application.routes.draw do
 
   resources :status, only: [:index]
   resource :contact, only: [:show]
-  resources :feedback, only: %i[new create], path_names: { new: '' }
+  resources :feedback, only: %i[new create show]
 
   namespace 'v1' do
     resources :proceeding_types, only: [:index]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
 
   resources :status, only: [:index]
   resource :contact, only: [:show]
+  resources :feedback, only: %i[new create], path_names: { new: '' }
 
   namespace 'v1' do
     resources :proceeding_types, only: [:index]

--- a/db/migrate/20190124140446_create_feedbacks.rb
+++ b/db/migrate/20190124140446_create_feedbacks.rb
@@ -3,7 +3,7 @@ class CreateFeedbacks < ActiveRecord::Migration[5.2]
     create_table :feedbacks, id: :uuid do |t|
       t.boolean :done_all_needed
       t.integer :satisfaction
-      t.text :improvment_suggestion
+      t.text :improvement_suggestion
       t.timestamps
     end
   end

--- a/db/migrate/20190124140446_create_feedbacks.rb
+++ b/db/migrate/20190124140446_create_feedbacks.rb
@@ -1,0 +1,10 @@
+class CreateFeedbacks < ActiveRecord::Migration[5.2]
+  def change
+    create_table :feedbacks, id: :uuid do |t|
+      t.boolean :done_all_needed
+      t.integer :satisfaction
+      t.text :improvment_suggestion
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190128091816_add_os_browser_and_source_to_feedbacks.rb
+++ b/db/migrate/20190128091816_add_os_browser_and_source_to_feedbacks.rb
@@ -1,0 +1,8 @@
+class AddOsBrowserAndSourceToFeedbacks < ActiveRecord::Migration[5.2]
+  def change
+    add_column :feedbacks, :os, :string
+    add_column :feedbacks, :browser, :string
+    add_column :feedbacks, :browser_version, :string
+    add_column :feedbacks, :source, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -133,6 +133,18 @@ ActiveRecord::Schema.define(version: 2019_01_29_120515) do
     t.index ["legal_aid_application_id"], name: "index_benefit_check_results_on_legal_aid_application_id"
   end
 
+  create_table "feedbacks", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.boolean "done_all_needed"
+    t.integer "satisfaction"
+    t.text "improvement_suggestion"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "os"
+    t.string "browser"
+    t.string "browser_version"
+    t.string "source"
+  end
+
   create_table "legal_aid_application_restrictions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "legal_aid_application_id"
     t.uuid "restriction_id"

--- a/features/cassettes/Civil_application_journeys/Enter_feedback_within_provider_journey.yml
+++ b/features/cassettes/Civil_application_journeys/Enter_feedback_within_provider_journey.yml
@@ -1,0 +1,58 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.notifications.service.gov.uk/v2/notifications/email
+    body:
+      encoding: UTF-8
+      string: '{"email_address":"apply-for-legal-aid@digital.justice.gov.uk","template_id":"ac458f81-b7dd-4b2c-944c-3f17d2f2392c","personalisation":{"created_at":"Tue,
+        29 Jan 2019 12:00:11 +0000","user_data":"Generic Linux - Chrome 71.0.3578.98
+        - Provider","done_all_needed":"","satisfaction":"","improvement_suggestion":"Foo
+        bar"}}'
+    headers:
+      User-Agent:
+      - NOTIFY-API-RUBY-CLIENT/2.9.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiIxNjNkZTE0My0yZDM0LTQ0NTQtYjFmYy0yZjQxNjI0ZjI3NzEiLCJpYXQiOjE1NDg3NjMyMTF9.SyT1pvChSi56tQYpjha8YHHxK2u73mRnnzpGPpuHTV4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type,Authorization
+      Access-Control-Allow-Methods:
+      - GET,PUT,POST,DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 29 Jan 2019 12:00:11 GMT
+      Server:
+      - nginx
+      X-B3-Spanid:
+      - bc169b482cba7dfd
+      X-B3-Traceid:
+      - bc169b482cba7dfd
+      X-Vcap-Request-Id:
+      - 117fa853-5b23-4f81-7e32-557a151f91ba
+      Content-Length:
+      - '131'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"errors":[{"error":"BadRequestError","message":"Can\u2019t send to
+        this recipient using a team-only API key"}],"status_code":400}
+
+'
+    http_version: 
+  recorded_at: Tue, 29 Jan 2019 12:00:11 GMT
+recorded_with: VCR 4.0.0

--- a/features/cassettes/Civil_application_journeys/Enter_feedback_within_provider_journey_then_click_Back.yml
+++ b/features/cassettes/Civil_application_journeys/Enter_feedback_within_provider_journey_then_click_Back.yml
@@ -1,0 +1,58 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.notifications.service.gov.uk/v2/notifications/email
+    body:
+      encoding: UTF-8
+      string: '{"email_address":"apply-for-legal-aid@digital.justice.gov.uk","template_id":"ac458f81-b7dd-4b2c-944c-3f17d2f2392c","personalisation":{"created_at":"Mon,
+        28 Jan 2019 14:02:56 +0000","user_data":"Generic Linux - Chrome 71.0.3578.98
+        - Provider","done_all_needed":"","satisfaction":"","improvement_suggestion":"Foo
+        bar"}}'
+    headers:
+      User-Agent:
+      - NOTIFY-API-RUBY-CLIENT/2.9.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiIxNjNkZTE0My0yZDM0LTQ0NTQtYjFmYy0yZjQxNjI0ZjI3NzEiLCJpYXQiOjE1NDg2ODQxNzZ9.q2GyamGNlMqGjn68gBEpUE9eexJ3PPKzJuhYnxs_T_U
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type,Authorization
+      Access-Control-Allow-Methods:
+      - GET,PUT,POST,DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 28 Jan 2019 14:02:56 GMT
+      Server:
+      - nginx
+      X-B3-Spanid:
+      - 9c65072a74a2fee4
+      X-B3-Traceid:
+      - 9c65072a74a2fee4
+      X-Vcap-Request-Id:
+      - 3a01a41c-f5ed-4ccf-5971-8d82ac7ac862
+      Content-Length:
+      - '131'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"errors":[{"error":"BadRequestError","message":"Can\u2019t send to
+        this recipient using a team-only API key"}],"status_code":400}
+
+'
+    http_version: 
+  recorded_at: Mon, 28 Jan 2019 14:02:56 GMT
+recorded_with: VCR 4.0.0

--- a/features/providers/civil_application_journey.feature
+++ b/features/providers/civil_application_journey.feature
@@ -332,3 +332,32 @@ Feature: Civil application journeys
     Then I should be on a page showing "How much is your client's home worth?"
     Then I click link "Back"
     Then I should be on a page showing "Does your client own the home that they live in?"
+
+  @javascript @vcr
+  Scenario: View feedback form within provider journey
+    Given I start the journey as far as the applicant page
+    Then I click link "feedback"
+    Then I click link "Back"
+    Then I should be on the Applicant page
+
+  @javascript @vcr
+  Scenario: Enter feedback within provider journey
+    Given I start the journey as far as the applicant page
+    Then I click link "feedback"
+    Then I should be on a page showing "Help us improve this service"
+    Then I fill "improvement suggestion" with "Foo bar"
+    Then I click "Send"
+    Then I should be on a page showing "Thank you for your feedback"
+    Then I click link "Back to your application"
+    Then I should be on the Applicant page
+
+  @javascript @vcr
+  Scenario: Enter feedback within provider journey then click Back
+    Given I start the journey as far as the applicant page
+    Then I click link "feedback"
+    Then I should be on a page showing "Help us improve this service"
+    Then I fill "improvement suggestion" with "Foo bar"
+    Then I click "Send"
+    Then I should be on a page showing "Thank you for your feedback"
+    Then I click link "Back"
+    Then I should be on the Applicant page

--- a/spec/factories/feedbacks.rb
+++ b/spec/factories/feedbacks.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :feedback do
-    done_all_needed { false }
-    satisfaction { 1 }
-    improvment_suggestion { 'MyText' }
+    done_all_needed { Faker::Boolean.boolean }
+    satisfaction { Feedback.satisfactions.keys.sample }
+    improvement_suggestion { Faker::Lorem.paragraph }
   end
 end

--- a/spec/factories/feedbacks.rb
+++ b/spec/factories/feedbacks.rb
@@ -3,5 +3,9 @@ FactoryBot.define do
     done_all_needed { Faker::Boolean.boolean }
     satisfaction { Feedback.satisfactions.keys.sample }
     improvement_suggestion { Faker::Lorem.paragraph }
+    os { %w[Linux Windows Mac].sample }
+    browser { %w[IE Chrome Safari Firefox Opera].sample }
+    browser_version { Faker::App.semantic_version }
+    source { %w[Providers Citizens Unknown].sample }
   end
 end

--- a/spec/factories/feedbacks.rb
+++ b/spec/factories/feedbacks.rb
@@ -2,6 +2,6 @@ FactoryBot.define do
   factory :feedback do
     done_all_needed { false }
     satisfaction { 1 }
-    improvment_suggestion { "MyText" }
+    improvment_suggestion { 'MyText' }
   end
 end

--- a/spec/factories/feedbacks.rb
+++ b/spec/factories/feedbacks.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :feedback do
+    done_all_needed { false }
+    satisfaction { 1 }
+    improvment_suggestion { "MyText" }
+  end
+end

--- a/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
+++ b/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
@@ -133,6 +133,7 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
     let(:email_label) { I18n.t("activemodel.attributes.#{resource}.#{attribute}") }
     let(:email_hint) { I18n.t("helpers.hint.#{resource}.#{attribute}") }
     let(:tag) { parsed_html.at_css("textarea##{attribute}") }
+    let(:label) { tag.parent.at_css('label') }
 
     subject { builder.govuk_text_area(*params) }
 
@@ -149,8 +150,6 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
     end
 
     it 'includes a label' do
-      label = tag.parent.at_css('label')
-
       expect(label.classes).to include('govuk-label')
       expect(label[:for]).to eq('email')
       expect(label.content).to eq(email_label)
@@ -178,11 +177,24 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
       let(:params) { [:email, label: custom_label] }
 
       it 'shows the custom label' do
-        label = tag.parent.at_css('label')
-
         expect(label.classes).to include('govuk-label')
         expect(label[:for]).to eq('email')
         expect(label.content).to eq(custom_label)
+      end
+    end
+
+    context 'pass a label parameter with text and size' do
+      let(:custom_label) { "Your client's email" }
+      let(:params) { [:email, label: { text: custom_label, size: :m }] }
+
+      it 'shows the custom label' do
+        expect(label.classes).to include('govuk-label')
+        expect(label[:for]).to eq('email')
+        expect(label.content).to eq(custom_label)
+      end
+
+      it 'includes a size class' do
+        expect(label.classes).to include('govuk-label--m')
       end
     end
 
@@ -345,6 +357,20 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
         expect(fieldset.child.child.name).to eq('h1')
         expect(legend.classes).to include('govuk-fieldset__legend')
         expect(legend.classes).to include('govuk-fieldset__legend--xl')
+        expect(h1.classes).to include('govuk-fieldset__heading')
+        expect(h1.content).to eq(title)
+      end
+    end
+
+    context 'title is passed as text and size' do
+      let(:title) { 'Pick an option' }
+      let(:params) { [:uses_online_banking, options, title: { text: title, size: :m }] }
+
+      it 'display the title in a <legend> and <h1> tag' do
+        expect(fieldset.child.name).to eq('legend')
+        expect(fieldset.child.child.name).to eq('h1')
+        expect(legend.classes).to include('govuk-fieldset__legend')
+        expect(legend.classes).to include('govuk-fieldset__legend--m')
         expect(h1.classes).to include('govuk-fieldset__heading')
         expect(h1.content).to eq(title)
       end

--- a/spec/mailers/feedback_mailer_spec.rb
+++ b/spec/mailers/feedback_mailer_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe FeedbackMailer, type: :mailer do
+  describe 'notify' do
+    let(:feedback) { create :feedback }
+    let(:mail) { FeedbackMailer.notify(feedback) }
+
+    it 'sends to correct address' do
+      expect(mail.to).to eq([described_class::TARGET_EMAIL])
+    end
+
+    it 'is a govuk_notify delivery' do
+      expect(mail.delivery_method).to be_a(GovukNotifyRails::Delivery)
+    end
+  end
+end

--- a/spec/models/concerns/translatable_model_attribute_spec.rb
+++ b/spec/models/concerns/translatable_model_attribute_spec.rb
@@ -18,4 +18,21 @@ RSpec.describe TranslatableModelAttribute do
       end
     end
   end
+
+  describe '.enum_ts' do
+    let(:klass) { Feedback }
+    let(:satisfactions) { klass.satisfactions }
+    let(:instance) { klass.new }
+    subject { klass.enum_ts(:satisfaction) }
+
+    it 'returns a hash with an entry for each state' do
+      expect(subject.keys).to match_array satisfactions.keys.map(&:to_sym)
+    end
+
+    it 'has values that match the translations' do
+      key = subject.keys.sample
+      instance.satisfaction = key
+      expect(subject[key]).to eq(instance.enum_t(:satisfaction))
+    end
+  end
 end

--- a/spec/models/feedback_spec.rb
+++ b/spec/models/feedback_spec.rb
@@ -1,5 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe Feedback, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
-end

--- a/spec/models/feedback_spec.rb
+++ b/spec/models/feedback_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Feedback, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/feedbacks_spec.rb
+++ b/spec/requests/feedbacks_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+RSpec.describe 'FeedbacksController', type: :request do
+  describe 'POST /feedback' do
+    let(:params) { attributes_for(:feedback) }
+    let(:feedback) { Feedback.order(created_at: :asc).last }
+    subject { post feedback_index_path, params: { feedback: params } }
+
+    it 'create a feedback' do
+      expect { subject }.to change { Feedback.count }.by(1)
+    end
+
+    it 'applies params to new feedback' do
+      subject
+      expect(feedback.done_all_needed).to eq(params[:done_all_needed])
+      expect(feedback.satisfaction).to eq(params[:satisfaction])
+      expect(feedback.improvement_suggestion).to eq(params[:improvement_suggestion])
+    end
+
+    it 'redirects to show action' do
+      subject
+      expect(response).to redirect_to(feedback_path(feedback))
+    end
+
+    context 'with empty params' do
+      let(:params) { { improvement_suggestion: '' } }
+
+      it 'does not create a feedback' do
+        expect { subject }.not_to change { Feedback.count }
+      end
+
+      it 'renders a page' do
+        subject
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+
+  describe 'GET /feedback/new' do
+    before { get new_feedback_path }
+
+    it 'renders the page' do
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe 'GET /feedback/:id' do
+    let(:feedback) { create :feedback }
+
+    before { get feedback_path(feedback) }
+
+    it 'renders the page' do
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'displays a message' do
+      expect(unescaped_response_body).to match(I18n.t('feedback.show.title'))
+    end
+  end
+end

--- a/spec/requests/feedbacks_spec.rb
+++ b/spec/requests/feedbacks_spec.rb
@@ -17,6 +17,13 @@ RSpec.describe 'FeedbacksController', type: :request do
       expect(feedback.improvement_suggestion).to eq(params[:improvement_suggestion])
     end
 
+    it 'gathers browser data' do
+      subject
+      expect(feedback.browser).not_to be_empty
+      expect(feedback.os).not_to be_empty
+      expect(feedback.source).to eq('Unknown')
+    end
+
     it 'redirects to show action' do
       subject
       expect(response).to redirect_to(feedback_path(feedback))

--- a/spec/requests/feedbacks_spec.rb
+++ b/spec/requests/feedbacks_spec.rb
@@ -24,6 +24,12 @@ RSpec.describe 'FeedbacksController', type: :request do
       expect(feedback.source).to eq('Unknown')
     end
 
+    it 'sends an email' do
+      mailer = double(deliver_later: true)
+      expect(FeedbackMailer).to receive(:notify).and_return(mailer)
+      subject
+    end
+
     it 'redirects to show action' do
       subject
       expect(response).to redirect_to(feedback_path(feedback))
@@ -32,13 +38,18 @@ RSpec.describe 'FeedbacksController', type: :request do
     context 'with empty params' do
       let(:params) { { improvement_suggestion: '' } }
 
-      it 'does not create a feedback' do
-        expect { subject }.not_to change { Feedback.count }
+      it 'creates a feedback to record browser data' do
+        expect { subject }.to change { Feedback.count }.by(1)
       end
 
-      it 'renders a page' do
+      it 'does not send an email' do
+        expect(FeedbackMailer).not_to receive(:notify)
         subject
-        expect(response).to have_http_status(:ok)
+      end
+
+      it 'renders to show action a page' do
+        subject
+        expect(response).to redirect_to(feedback_path(feedback))
       end
     end
   end


### PR DESCRIPTION
[Jira AP-304](https://dsdmoj.atlassian.net/browse/AP-304)

- Adds a `Feedback` object to store user feedback submission and information about their Browser, OS, and whether they came from the Providers or Citizens journey. 
- Adds a Feedbacks controller with `new` `create` and `show` actions
- Stores url that user left to access feedback so they can get back there easily
- Sends an email to `apply-for-legal-aid@digital.justice.gov.uk` with feedback data
- Updated the form builder so that title text sizes can be modified.
- Added a method to make it easier to build a set of radio buttons for an object's enum property
- Updated header and footer "feedback" links to point at `feedbacks#new`




