### PR TITLE
Fix duplication of heading

### DIFF
--- a/app/views/providers/own_homes/show.html.erb
+++ b/app/views/providers/own_homes/show.html.erb
@@ -1,4 +1,4 @@
-<%= provider_page page_title: t('.h1-heading') do %>
+<%= provider_page page_title: t('.h1-heading'), template: :basic do %>
   <%= render(
         'shared/forms/own_home_form',
         form_path: providers_legal_aid_application_own_home_path(@legal_aid_application),

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -166,11 +166,11 @@ ActiveRecord::Schema.define(version: 2019_01_29_120515) do
     t.uuid "legal_aid_application_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.boolean "client_merits_declaration"
     t.boolean "client_received_legal_help"
     t.text "application_purpose"
     t.boolean "proceedings_before_the_court"
     t.text "details_of_proceedings_before_the_court"
+    t.boolean "client_merits_declaration"
     t.decimal "estimated_legal_cost", precision: 10, scale: 2
     t.index ["legal_aid_application_id"], name: "index_merits_assessments_on_legal_aid_application_id"
   end


### PR DESCRIPTION
## What

This fixes a bug on the Provider Own Home page where the H1 heading was duplicated

Used the basic_template rather than the default template.


## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unneccessary whitespace changes. These make diffs harder to read and conflicts more likely. 
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
