### PR TITLE
Add styling for app-check-your-answers--long

### DIFF
--- a/app/assets/stylesheets/check-your-answers.scss
+++ b/app/assets/stylesheets/check-your-answers.scss
@@ -14,9 +14,35 @@ $govuk-fonts-path: "/assets/";
     font-weight: bold;
   }
 
+  .align_right {
+    @include govuk-media-query($from: desktop) {
+      text-align: right;
+    }
+  }
+}
+
+.app-check-your-answers--long {
+  @include govuk-font(19);
+  @include govuk-responsive-margin(3, "bottom");
+  border-top: 1px solid $govuk-border-colour;
+  @include govuk-responsive-padding(3, "top");
+
+  .govuk-grid-row div:first-child {
+    font-weight: bold;
+    width: 50%;
+  }
+
+  .govuk-grid-row div:nth-child(2) {
+    width: 25%;
+  }
+
+  .govuk-grid-row div:last-child {
+    width: 25%;
+  }
 
   .align_right {
     @include govuk-media-query($from: desktop) {
+      width: 100%;
       text-align: right;
     }
   }

--- a/app/helpers/check_answers_helper.rb
+++ b/app/helpers/check_answers_helper.rb
@@ -1,5 +1,5 @@
 module CheckAnswersHelper
-  def check_answer_link(url:, question:, answer:, name:)
+  def check_answer_link(url:, question:, answer:, name:, is_long: nil)
     partial = case answer
               when Hash
                 'currency_items'
@@ -8,9 +8,10 @@ module CheckAnswersHelper
               else
                 'item'
               end
+    is_long = '--long' if is_long
     render(
       partial: "shared/check_answers/#{partial}",
-      locals: { url: url, question: question, answer: answer, name: name }
+      locals: { url: url, question: question, answer: answer, name: name, is_long: is_long }
     )
   end
 end

--- a/app/views/shared/check_answers/_currency_items.html.erb
+++ b/app/views/shared/check_answers/_currency_items.html.erb
@@ -1,4 +1,4 @@
-<div class="app-check-your-answers" id="app-check-your-answers__<%= name %>">
+<div class="app-check-your-answers<%= is_long %>" id="app-check-your-answers__<%= name %>">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-three-quarters">
       <%= question %>

--- a/app/views/shared/check_answers/_item.html.erb
+++ b/app/views/shared/check_answers/_item.html.erb
@@ -1,4 +1,4 @@
-<div class="app-check-your-answers" id="app-check-your-answers__<%= name %>">
+<div class="app-check-your-answers<%= is_long %>" id="app-check-your-answers__<%= name %>">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-one-quarter">
       <%= question %>

--- a/app/views/shared/check_answers/_items.html.erb
+++ b/app/views/shared/check_answers/_items.html.erb
@@ -1,4 +1,4 @@
-<div class="app-check-your-answers" id="app-check-your-answers__<%= name %>">
+<div class="app-check-your-answers<%= is_long %>" id="app-check-your-answers__<%= name %>">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-three-quarters">
       <%= question %>


### PR DESCRIPTION
## What

The GOVUK design system has additional styling for Check Your Answers pages, the `.app-check-your-answers--long` class which increases the width of question fields to prevent long questions being split over multiple lines.

This was removed from our version of the pattern by a previous commit but is now required for AP-266, the merits check your answers page.

This change adds back in the styling for the class, and amends the check_answers_helper and shared partials to allow an extra parameter (`is_long`) to be passed so that the `--long` version of the class can be used from the existing helper, eg

```
    <%= check_answer_link(
          name: 'foo',
          url: '#',
          question: 'a very long question that would split over multiple lines',
          answer: 'yes',
          is_long: true
        ) %>
```
would result in

![image](https://user-images.githubusercontent.com/28729201/51982789-d8a29380-248e-11e9-825b-887d436a39b5.png)
 instead of 

![image](https://user-images.githubusercontent.com/28729201/51982811-ec4dfa00-248e-11e9-8994-f214ae29fee3.png)

which is what would be displayed without the `is_long: true` parameter.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unneccessary whitespace changes. These make diffs harder to read and conflicts more likely. 
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
