### PR TITLE
Ap 295 display selected legal proceeding

### DIFF
--- a/app/assets/stylesheets/providers/proceeding_types.scss
+++ b/app/assets/stylesheets/providers/proceeding_types.scss
@@ -1,6 +1,9 @@
+@import "govuk-frontend/settings/all";
+@import "govuk-frontend/helpers/all";
+
 .proceeding-item {
   display: none;
-  
+
   .control-column {
     text-align: right;
   }
@@ -17,4 +20,12 @@
   margin-right: 1px;
   background-color: #fff2d3;
   padding: 2px 0px 0px;
+}
+
+.selected-proceeding-types {
+  .control-column {
+    @include govuk-media-query($from: desktop) {
+      text-align: right;
+    }
+  }
 }

--- a/app/controllers/concerns/providers/steps.rb
+++ b/app/controllers/concerns/providers/steps.rb
@@ -28,7 +28,7 @@ module Providers
       back: :address_lookups
     },
     proceedings_types: {
-      path: :providers_legal_aid_application_proceedings_type_path,
+      path: :providers_legal_aid_application_proceedings_types_path,
       forward: :check_provider_answers,
       back: :addresses
       # Back determined by controller action logic

--- a/app/controllers/providers/check_provider_answers_controller.rb
+++ b/app/controllers/providers/check_provider_answers_controller.rb
@@ -5,7 +5,7 @@ module Providers
     include Steppable
 
     def index
-      @proceeding = legal_aid_application.proceeding_types.first
+      @proceeding_types = legal_aid_application.proceeding_types
       @applicant = legal_aid_application.applicant
       @address = @applicant.addresses.first
       legal_aid_application.check_your_answers! unless legal_aid_application.checking_answers?

--- a/app/controllers/providers/proceedings_types_controller.rb
+++ b/app/controllers/providers/proceedings_types_controller.rb
@@ -3,7 +3,6 @@ module Providers
     include ApplicationDependable
     include Steppable
 
-
     # GET /provider/applications/:legal_aid_application_id/proceedings_types
     def index
       authorize legal_aid_application
@@ -13,10 +12,11 @@ module Providers
 
     # POST /provider/applications/:legal_aid_application_id/proceedings_types
     def create
+      authorize legal_aid_application
       if legal_aid_application.proceeding_types.present?
         redirect_to next_step_url
       else
-        legal_aid_application.errors.add(base: 'Select one')
+        legal_aid_application.errors.add(:'proceeding-search-input', t('.search_and_select'))
         proceeding_types
         render :index
       end
@@ -31,11 +31,10 @@ module Providers
 
     # PATCH /provider/applications/:legal_aid_application_id/proceedings_types/:id
     def destroy
+      authorize legal_aid_application
       legal_aid_application.proceeding_types.delete(proceeding_type)
       redirect_to providers_legal_aid_application_proceedings_types_path(legal_aid_application)
     end
-
-
 
     private
 

--- a/app/controllers/providers/proceedings_types_controller.rb
+++ b/app/controllers/providers/proceedings_types_controller.rb
@@ -2,6 +2,7 @@ module Providers
   class ProceedingsTypesController < BaseController
     include ApplicationDependable
     include Steppable
+    include SaveAsDraftable
 
     # GET /provider/applications/:legal_aid_application_id/proceedings_types
     def index
@@ -14,7 +15,7 @@ module Providers
     def create
       authorize legal_aid_application
       if legal_aid_application.proceeding_types.present?
-        redirect_to next_step_url
+        continue_or_save_draft
       else
         legal_aid_application.errors.add(:'proceeding-search-input', t('.search_and_select'))
         proceeding_types

--- a/app/controllers/providers/proceedings_types_controller.rb
+++ b/app/controllers/providers/proceedings_types_controller.rb
@@ -25,6 +25,7 @@ module Providers
     # PATCH /provider/applications/:legal_aid_application_id/proceedings_types/:id
     def update
       authorize legal_aid_application
+      legal_aid_application.proceeding_types.clear # Remove this when multiple proceeding types required!
       legal_aid_application.proceeding_types << proceeding_type unless legal_aid_application.proceeding_types.include?(proceeding_type)
       redirect_to providers_legal_aid_application_proceedings_types_path(legal_aid_application)
     end

--- a/app/controllers/providers/proceedings_types_controller.rb
+++ b/app/controllers/providers/proceedings_types_controller.rb
@@ -3,32 +3,44 @@ module Providers
     include ApplicationDependable
     include Steppable
 
-    # GET /provider/applications/:legal_aid_application_id/proceedings_type
-    def show
-      authorize @legal_aid_application
+
+    # GET /provider/applications/:legal_aid_application_id/proceedings_types
+    def index
+      authorize legal_aid_application
       @back_step_url = back_step_path unless legal_aid_application.checking_answers?
       proceeding_types
     end
 
-    # POST /provider/applications/:legal_aid_application_id/proceedings_type
-    def update
-      authorize @legal_aid_application
-      if legal_aid_application.update(app_params)
+    # POST /provider/applications/:legal_aid_application_id/proceedings_types
+    def create
+      if legal_aid_application.proceeding_types.present?
         redirect_to next_step_url
       else
+        legal_aid_application.errors.add(base: 'Select one')
         proceeding_types
-        render :show
+        render :index
       end
     end
 
-    private
-
-    def app_params
-      { proceeding_type_codes: [permitted_params[:proceeding_type]] }
+    # PATCH /provider/applications/:legal_aid_application_id/proceedings_types/:id
+    def update
+      authorize legal_aid_application
+      legal_aid_application.proceeding_types << proceeding_type unless legal_aid_application.proceeding_types.include?(proceeding_type)
+      redirect_to providers_legal_aid_application_proceedings_types_path(legal_aid_application)
     end
 
-    def permitted_params
-      params.permit(:proceeding_type)
+    # PATCH /provider/applications/:legal_aid_application_id/proceedings_types/:id
+    def destroy
+      legal_aid_application.proceeding_types.delete(proceeding_type)
+      redirect_to providers_legal_aid_application_proceedings_types_path(legal_aid_application)
+    end
+
+
+
+    private
+
+    def proceeding_type
+      @proceeding_type = ProceedingType.find(params[:id])
     end
 
     def proceeding_types

--- a/app/policies/legal_aid_application_policy.rb
+++ b/app/policies/legal_aid_application_policy.rb
@@ -1,4 +1,8 @@
 class LegalAidApplicationPolicy < ApplicationPolicy
+  def index?
+    my_record?
+  end
+
   def show?
     my_record?
   end

--- a/app/policies/legal_aid_application_policy.rb
+++ b/app/policies/legal_aid_application_policy.rb
@@ -11,6 +11,14 @@ class LegalAidApplicationPolicy < ApplicationPolicy
     my_record?
   end
 
+  def destroy?
+    my_record?
+  end
+
+  def create?
+    my_record?
+  end
+
   private
 
   def my_record?

--- a/app/views/providers/check_provider_answers/index.html.erb
+++ b/app/views/providers/check_provider_answers/index.html.erb
@@ -60,9 +60,9 @@
 
   <%= check_answer_link(
         name: :proceeding_type,
-        url: providers_legal_aid_application_proceedings_type_path(anchor: 'proceeding-search-input'.freeze),
+        url: providers_legal_aid_application_proceedings_types_path(anchor: 'proceeding-search-input'.freeze),
         question: t('.section_proceeding.proceeding'),
-        answer: @proceeding.meaning
+        answer: @proceeding_types.map(&:meaning)
       ) %>
 
   <div class="govuk-!-padding-bottom-9"></div>

--- a/app/views/providers/proceedings_types/_proceeding_type.html.erb
+++ b/app/views/providers/proceedings_types/_proceeding_type.html.erb
@@ -1,4 +1,4 @@
-<div class="govuk-grid-row">
+<div class="govuk-grid-row selected-proceeding-type">
   <div class="govuk-grid-column-two-thirds text-column">
     <h3 class="govuk-body govuk-!-margin-bottom-1 govuk-!-margin-top-4"><%= proceeding_type.meaning %></h3>
     <span class="govuk-caption-m">
@@ -6,18 +6,20 @@
     </span>
   </div>
   <div class="govuk-grid-column-one-third control-column">
-    <%= link_to(
-          t('generic.remove'),
-          providers_legal_aid_application_proceedings_type_path(
-            legal_aid_application_id: @legal_aid_application,
-            id: proceeding_type
-          ),
-          method: :delete,
-        ) %>
+    <p class="govuk-body govuk-!-margin-bottom-1 govuk-!-margin-top-4">
+      <%= link_to(
+            t('generic.remove'),
+            providers_legal_aid_application_proceedings_type_path(
+              legal_aid_application_id: @legal_aid_application,
+              id: proceeding_type
+            ),
+            method: :delete
+          ) %>
+    </p>
   </div>
 </div>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full text-column">
-    <hr class="govuk-section-break govuk-section-break--visible govuk-!-padding-top-1 govuk-!-padding-bottom-1">
+    <hr class="govuk-section-break govuk-section-break--visible govuk-!-padding-top-1 govuk-!-padding-bottom-1" />
   </div>
 </div>

--- a/app/views/providers/proceedings_types/_proceeding_type_form.html.erb
+++ b/app/views/providers/proceedings_types/_proceeding_type_form.html.erb
@@ -1,23 +1,23 @@
-<div class="govuk-grid-row">
+<li id="<%= proceeding_type.code %>" class="govuk-grid-row proceeding-item govuk-!-margin-bottom-0" tabindex="0">
   <div class="govuk-grid-column-two-thirds text-column">
     <h3 class="govuk-body govuk-!-margin-bottom-1 govuk-!-margin-top-4"><%= proceeding_type.meaning %></h3>
     <span class="govuk-caption-m">
       <%= proceeding_type.ccms_category_law %> &gt; <%= proceeding_type.ccms_matter %>
     </span>
   </div>
+
   <div class="govuk-grid-column-one-third control-column">
-    <%= link_to(
-          t('generic.remove'),
+    <%= button_to(
+          t('generic.select'),
           providers_legal_aid_application_proceedings_type_path(
             legal_aid_application_id: @legal_aid_application,
             id: proceeding_type
           ),
-          method: :delete,
+          method: :patch,
+          tabindex: '-1',
+          class: 'govuk-button proceeding-link govuk-!-margin-top-4'
         ) %>
   </div>
-</div>
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-full text-column">
-    <hr class="govuk-section-break govuk-section-break--visible govuk-!-padding-top-1 govuk-!-padding-bottom-1">
-  </div>
-</div>
+
+  <hr class="govuk-section-break govuk-section-break--visible govuk-!-width-full govuk-!-margin-bottom-0" style="width: 100%;" />
+</li>

--- a/app/views/providers/proceedings_types/index.html.erb
+++ b/app/views/providers/proceedings_types/index.html.erb
@@ -5,23 +5,33 @@
   </style>
 </noscript>
 
-<%= provider_page(page_title: t('.heading_1')) %>
+<%= provider_page(
+      page_title: t('.heading_1'),
+      show_errors_for: @legal_aid_application
+    ) %>
 
-<% if @legal_aid_application %>
+<% if @legal_aid_application.proceeding_types.present? %>
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h2 class="govuk-heading-m">
         <%= t('.you_have_selected', count: pluralize(@legal_aid_application.proceeding_types.size, t('.proceeding'))) %>
       </h2>
+      <div class="selected-proceeding-types">
+        <%= render partial: 'proceeding_type', collection: @legal_aid_application.proceeding_types %>
+      </div>
     </div>
   </div>
 
-  <%= render partial: 'proceeding_type', collection: @legal_aid_application.proceeding_types %>
-
+  <div class="govuk-!-padding-bottom-7"></div>
 <% end %>
 
-<div id="search-field" class="govuk-form-group govuk-!-margin-top-0 govuk-!-margin-bottom-0">
+<%
+  error_message = @legal_aid_application.errors[:'proceeding-search-input']&.to_sentence
+  form_group_error_class = error_message.present? ? 'govuk-form-group--error' : ''
+  input_error = error_message.present? ? 'govuk-input--error' : ''
+%>
+<div id="search-field" class="govuk-form-group govuk-!-margin-top-0 govuk-!-margin-bottom-0 <%= form_group_error_class %>">
   <label class="govuk-heading-m govuk-!-margin-bottom-0" for="proceeding-search-input">
     <h2 class="govuk-heading-m govuk-!-margin-bottom-0"><%= t '.heading_2' %></h2>
       <span class="govuk-hint govuk-!-margin-top-0">
@@ -31,7 +41,8 @@
 
   <div class="govuk-grid-row search-field govuk-!-margin-top-0">
     <div class="govuk-grid-column-two-thirds govuk-!-margin-top-0">
-      <input class="govuk-input" id="proceeding-search-input" name="proceeding-search-input" type="text" />
+      <%= govuk_error_message(@legal_aid_application.errors[:'proceeding-search-input']&.to_sentence) %>
+      <input class="govuk-input <%= input_error %>" id="proceeding-search-input" name="proceeding-search-input" type="text" />
     </div>
 
     <div class="govuk-grid-column-one-third govuk-!-margin-top-2 clear-search">
@@ -48,5 +59,16 @@
     <div class="govuk-grid-column-two-thirds">
       <span class="govuk-body"><%= t '.no_results' %></span>
     </div>
+  </div>
+</div>
+
+<div class="govuk-grid-row govuk-!-margin-top-5">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render(
+          'shared/forms/next_action_buttons_form',
+          url: providers_legal_aid_application_proceedings_types_path,
+          method: :post,
+          show_draft: true
+        ) %>
   </div>
 </div>

--- a/app/views/providers/proceedings_types/index.html.erb
+++ b/app/views/providers/proceedings_types/index.html.erb
@@ -7,6 +7,20 @@
 
 <%= provider_page(page_title: t('.heading_1')) %>
 
+<% if @legal_aid_application %>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h2 class="govuk-heading-m">
+        <%= t('.you_have_selected', count: pluralize(@legal_aid_application.proceeding_types.size, t('.proceeding'))) %>
+      </h2>
+    </div>
+  </div>
+
+  <%= render partial: 'proceeding_type', collection: @legal_aid_application.proceeding_types %>
+
+<% end %>
+
 <div id="search-field" class="govuk-form-group govuk-!-margin-top-0 govuk-!-margin-bottom-0">
   <label class="govuk-heading-m govuk-!-margin-bottom-0" for="proceeding-search-input">
     <h2 class="govuk-heading-m govuk-!-margin-bottom-0"><%= t '.heading_2' %></h2>
@@ -28,7 +42,7 @@
 
 <div class="govuk-grid-row govuk-!-margin-top-0">
   <ul id="proceeding-list" class="govuk-grid-column-full govuk-list govuk-!-margin-bottom-0">
-    <%= render partial: 'proceeding_type', collection: @proceeding_types %>
+    <%= render partial: 'proceeding_type_form', collection: @proceeding_types, as: :proceeding_type %>
   </ul>
   <div class="govuk-grid-row no-proceeding-items" style="display: none;">
     <div class="govuk-grid-column-two-thirds">

--- a/config/locales/en/generic.yml
+++ b/config/locales/en/generic.yml
@@ -13,7 +13,9 @@ en:
     home: Home
     information: Information
     'no': 'No'
+    remove: Remove
     save_as_draft: Save as draft
+    select: Select
     send: Send
     start: Start
     start_now: Start now

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -126,12 +126,16 @@ en:
       show:
         h1-heading: Are the proceedings, for which funding is being sought, currently, before the court?
     proceedings_types:
-      show:
+      create:
+        search_and_select: Search and select a proceeding
+      index:
         clear_search: Clear search
         heading_1: What does your client want legal aid for?
         heading_2: Search for legal proceedings
         no_results: No results found.
+        proceeding: proceeding
         search_help_example: For example by category of law, matter type or legal proceeding.
+        you_have_selected: You have selected %{count}
     property_values:
       hint:
         property_value: You can use property websites to find the estimated value.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -49,7 +49,7 @@ Rails.application.routes.draw do
     resource :provider, only: [:show], path: 'your_profile'
 
     resources :legal_aid_applications, path: 'applications', only: %i[index create] do
-      resource :proceedings_type, only: %i[show update]
+      resources :proceedings_types, only: %i[index create update destroy]
       resource :property_value, only: %i[show update]
       resource :applicant, only: %i[show update]
       resource :address, only: %i[show update]

--- a/features/cassettes/Civil_application_journeys/I_am_able_to_select_and_delete_proceeding_types.yml
+++ b/features/cassettes/Civil_application_journeys/I_am_able_to_select_and_delete_proceeding_types.yml
@@ -1,0 +1,363 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?key=<ORDNANACE_SURVEY_API_KEY>&postcode=DA74NG
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Wed, 30 Jan 2019 16:17:16 GMT
+      Server:
+      - Apache-Coyote/1.1
+      Status:
+      - success
+      Tx-Id:
+      - 1548865036545:545
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "header" : {
+            "uri" : "https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?postcode=DA74NG",
+            "query" : "postcode=DA74NG",
+            "offset" : 0,
+            "totalresults" : 11,
+            "format" : "JSON",
+            "dataset" : "DPA",
+            "lr" : "EN,CY",
+            "maxresults" : 100,
+            "epoch" : "64",
+            "output_srs" : "EPSG:27700"
+          },
+          "results" : [ {
+            "DPA" : {
+              "UPRN" : "100020211558",
+              "UDPRN" : "6248161",
+              "ADDRESS" : "1, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "1",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "2",
+              "X_COORDINATE" : 548894.0,
+              "Y_COORDINATE" : 176139.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD02",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095093",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211559",
+              "UDPRN" : "6248164",
+              "ADDRESS" : "2, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "2",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548861.0,
+              "Y_COORDINATE" : 176156.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095079",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211560",
+              "UDPRN" : "6248165",
+              "ADDRESS" : "3, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "3",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548888.0,
+              "Y_COORDINATE" : 176131.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD02",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb5000005153955102",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211561",
+              "UDPRN" : "6248166",
+              "ADDRESS" : "4, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "4",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548858.0,
+              "Y_COORDINATE" : 176150.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095080",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211562",
+              "UDPRN" : "6248167",
+              "ADDRESS" : "5, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "5",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548884.0,
+              "Y_COORDINATE" : 176118.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD02",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095091",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211563",
+              "UDPRN" : "6248168",
+              "ADDRESS" : "6, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "6",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548849.0,
+              "Y_COORDINATE" : 176141.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095082",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211564",
+              "UDPRN" : "6248169",
+              "ADDRESS" : "7, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "7",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548874.0,
+              "Y_COORDINATE" : 176106.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095089",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211565",
+              "UDPRN" : "6248170",
+              "ADDRESS" : "8, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "8",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548846.0,
+              "Y_COORDINATE" : 176133.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095083",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211566",
+              "UDPRN" : "6248171",
+              "ADDRESS" : "9, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "9",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548868.0,
+              "Y_COORDINATE" : 176104.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095088",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211567",
+              "UDPRN" : "6248162",
+              "ADDRESS" : "10, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "10",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548848.0,
+              "Y_COORDINATE" : 176115.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095085",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211568",
+              "UDPRN" : "6248163",
+              "ADDRESS" : "12, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "12",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "2",
+              "X_COORDINATE" : 548854.0,
+              "Y_COORDINATE" : 176110.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095086",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          } ]
+        }
+    http_version: 
+  recorded_at: Wed, 30 Jan 2019 16:17:16 GMT
+recorded_with: VCR 4.0.0

--- a/features/cassettes/Civil_application_journeys/I_am_able_to_select_multiple_proceeding_types.yml
+++ b/features/cassettes/Civil_application_journeys/I_am_able_to_select_multiple_proceeding_types.yml
@@ -1,0 +1,363 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?key=<ORDNANACE_SURVEY_API_KEY>&postcode=DA74NG
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Wed, 30 Jan 2019 16:16:06 GMT
+      Server:
+      - Apache-Coyote/1.1
+      Status:
+      - success
+      Tx-Id:
+      - 1548864966398:398
+      Content-Length:
+      - '11442'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "header" : {
+            "uri" : "https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?postcode=DA74NG",
+            "query" : "postcode=DA74NG",
+            "offset" : 0,
+            "totalresults" : 11,
+            "format" : "JSON",
+            "dataset" : "DPA",
+            "lr" : "EN,CY",
+            "maxresults" : 100,
+            "epoch" : "64",
+            "output_srs" : "EPSG:27700"
+          },
+          "results" : [ {
+            "DPA" : {
+              "UPRN" : "100020211558",
+              "UDPRN" : "6248161",
+              "ADDRESS" : "1, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "1",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "2",
+              "X_COORDINATE" : 548894.0,
+              "Y_COORDINATE" : 176139.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD02",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095093",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211559",
+              "UDPRN" : "6248164",
+              "ADDRESS" : "2, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "2",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548861.0,
+              "Y_COORDINATE" : 176156.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095079",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211560",
+              "UDPRN" : "6248165",
+              "ADDRESS" : "3, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "3",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548888.0,
+              "Y_COORDINATE" : 176131.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD02",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb5000005153955102",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211561",
+              "UDPRN" : "6248166",
+              "ADDRESS" : "4, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "4",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548858.0,
+              "Y_COORDINATE" : 176150.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095080",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211562",
+              "UDPRN" : "6248167",
+              "ADDRESS" : "5, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "5",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548884.0,
+              "Y_COORDINATE" : 176118.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD02",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095091",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211563",
+              "UDPRN" : "6248168",
+              "ADDRESS" : "6, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "6",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548849.0,
+              "Y_COORDINATE" : 176141.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095082",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211564",
+              "UDPRN" : "6248169",
+              "ADDRESS" : "7, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "7",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548874.0,
+              "Y_COORDINATE" : 176106.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095089",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211565",
+              "UDPRN" : "6248170",
+              "ADDRESS" : "8, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "8",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548846.0,
+              "Y_COORDINATE" : 176133.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095083",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211566",
+              "UDPRN" : "6248171",
+              "ADDRESS" : "9, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "9",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548868.0,
+              "Y_COORDINATE" : 176104.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095088",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211567",
+              "UDPRN" : "6248162",
+              "ADDRESS" : "10, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "10",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548848.0,
+              "Y_COORDINATE" : 176115.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095085",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211568",
+              "UDPRN" : "6248163",
+              "ADDRESS" : "12, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "12",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "2",
+              "X_COORDINATE" : 548854.0,
+              "Y_COORDINATE" : 176110.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095086",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          } ]
+        }
+    http_version: 
+  recorded_at: Wed, 30 Jan 2019 16:16:06 GMT
+recorded_with: VCR 4.0.0

--- a/features/providers/civil_application_journey.feature
+++ b/features/providers/civil_application_journey.feature
@@ -51,6 +51,55 @@ Feature: Civil application journeys
     Then the results section is empty
     Then proceeding search field is empty
 
+  @javascript @vcr
+  Scenario: I am able to select multiple proceeding types
+    Given I start the journey as far as the applicant page
+    Then I enter name 'Test', 'User'
+    Then I enter the date of birth '03-04-1999'
+    Then I enter national insurance number 'CB987654A'
+    Then I fill 'email' with 'test@test.com'
+    Then I click "Continue"
+    Then I am on the postcode entry page
+    Then I enter a postcode 'DA74NG'
+    Then I click find address
+    Then I select an address '3, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG'
+    Then I click "Continue"
+    Then I expect to see 0 proceeding types selected
+    And I search for proceeding 'app'
+    Then proceeding suggestions has results
+    When I select proceeding type 3
+    Then I expect to see 1 proceeding types selected
+    And I search for proceeding 'child'
+    When I select proceeding type 1
+    Then I expect to see 2 proceeding types selected
+    When I click 'Continue'
+    Then I should be on a page showing 'Check your answers'
+
+  @javascript @vcr
+  Scenario: I am able to select and delete proceeding types
+    Given I start the journey as far as the applicant page
+    Then I enter name 'Test', 'User'
+    Then I enter the date of birth '03-04-1999'
+    Then I enter national insurance number 'CB987654A'
+    Then I fill 'email' with 'test@test.com'
+    Then I click "Continue"
+    Then I am on the postcode entry page
+    Then I enter a postcode 'DA74NG'
+    Then I click find address
+    Then I select an address '3, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG'
+    Then I click "Continue"
+    And I search for proceeding 'app'
+    Then proceeding suggestions has results
+    When I select proceeding type 2
+    Then I expect to see 1 proceeding types selected
+    When I click the first 'Remove' in selected proceeding types
+    Then I expect to see 0 proceeding types selected
+    And I search for proceeding 'child'
+    When I select proceeding type 4
+    Then I expect to see 1 proceeding types selected
+    When I click 'Continue'
+    Then I should be on a page showing 'Check your answers'
+
   @javascript
   Scenario: I complete each step up to the applicant page
     # testing shared steps: Given I start the journey as far as the applicant page
@@ -75,7 +124,7 @@ Feature: Civil application journeys
     Then I click "Continue"
     Then I search for proceeding 'Application for a care order'
     Then proceeding suggestions has results
-    Then I select and continue
+    Then I select a proceeding type and continue
     Then I should be on a page showing 'Check your answers'
     Then I click "Continue"
     Then I am on the benefit check results page
@@ -104,7 +153,7 @@ Feature: Civil application journeys
     Then I click "Continue"
     Then I search for proceeding 'Application for a care order'
     Then proceeding suggestions has results
-    Then I select and continue
+    Then I select a proceeding type and continue
     Then I should be on a page showing 'Check your answers'
     Then I click "Continue"
     Then I am on the benefit check results page
@@ -131,7 +180,7 @@ Feature: Civil application journeys
     Then I click "Continue"
     Then I search for proceeding 'Application for a care order'
     Then proceeding suggestions has results
-    Then I select and continue
+    Then I select a proceeding type and continue
     Then I should be on a page showing 'Check your answers'
     Then I click "Continue"
     Then I am on the benefit check results page
@@ -152,7 +201,7 @@ Feature: Civil application journeys
     Then I click "Continue"
     Then I search for proceeding 'Application for a care order'
     Then proceeding suggestions has results
-    Then I select and continue
+    Then I select a proceeding type and continue
     Then I should be on a page showing 'Check your answers'
     Then I click "Continue"
     Then I am on the benefit check results page
@@ -180,7 +229,7 @@ Feature: Civil application journeys
     And I click Check Your Answers Change link for 'Proceeding Type'
     And I search for proceeding 'Application for a care order'
     Then proceeding suggestions has results
-    Then I select and continue
+    Then I select a proceeding type and continue
     Then I should be on a page showing 'Check your answers'
 
   @javascript @vcr

--- a/features/providers/civil_application_journey.feature
+++ b/features/providers/civil_application_journey.feature
@@ -53,6 +53,7 @@ Feature: Civil application journeys
 
   @javascript @vcr
   Scenario: I am able to select multiple proceeding types
+    Given I skip the rest of this scenario until multiple proceeding types are supported
     Given I start the journey as far as the applicant page
     Then I enter name 'Test', 'User'
     Then I enter the date of birth '03-04-1999'

--- a/features/providers/step_definitions/civil_journey_steps.rb
+++ b/features/providers/step_definitions/civil_journey_steps.rb
@@ -53,7 +53,7 @@ Given('I complete the journey as far as check your answers') do
     Then I click "Continue"
     Then I search for proceeding 'Application for a care order'
     Then proceeding suggestions has results
-    Then I select and continue
+    Then I select a proceeding type and continue
     Then I should be on a page showing 'Check your answers'
   )
 end
@@ -73,7 +73,7 @@ Given('I complete the passported journey as far as check your answers') do
     Then I click "Continue"
     Then I search for proceeding 'Application for a care order'
     Then proceeding suggestions has results
-    Then I select and continue
+    Then I select a proceeding type and continue
     Then I should be on a page showing 'Check your answers'
   )
 end
@@ -123,8 +123,24 @@ Then('the answer for {string} should be {string}') do |field_name, answer|
   end
 end
 
-Then(/^I select and continue$/) do
-  find('#proceeding-list').first(:button, 'Select and continue').click
+Then('I select a proceeding type and continue') do
+  find('#proceeding-list').first(:button, 'Select').click
+  click_button('Continue')
+end
+
+Then('I select proceeding type {int}') do |index|
+  find('#proceeding-list').all(:button, 'Select')[index - 1].click
+end
+
+Then('I expect to see {int} proceeding types selected') do |number|
+  expect(page).to have_selector(
+    '.selected-proceeding-types .selected-proceeding-type',
+    count: number
+  )
+end
+
+Then('I click the first {string} in selected proceeding types') do |link|
+  find('.selected-proceeding-types').first(:link, link).click
 end
 
 Then(/^I see the client details page$/) do

--- a/features/providers/step_definitions/skippy.rb
+++ b/features/providers/step_definitions/skippy.rb
@@ -1,0 +1,5 @@
+# Allows scenarios to be skipped
+# See: https://relishapp.com/cucumber/cucumber/docs/defining-steps/skip-scenario
+Given(/skip.*this scenario/) do
+  skip_this_scenario
+end

--- a/spec/requests/providers/address_selections_spec.rb
+++ b/spec/requests/providers/address_selections_spec.rb
@@ -142,7 +142,7 @@ RSpec.describe 'address selections requests', type: :request do
       it 'redirects to next submission step' do
         subject
 
-        expect(response).to redirect_to(providers_legal_aid_application_proceedings_type_path)
+        expect(response).to redirect_to(providers_legal_aid_application_proceedings_types_path)
       end
 
       it 'records that the lookup service was used' do

--- a/spec/requests/providers/addresses_spec.rb
+++ b/spec/requests/providers/addresses_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe 'address requests', type: :request do
       context 'with a valid address' do
         it 'redirects successfully to the next step' do
           subject
-          expect(response).to redirect_to(providers_legal_aid_application_proceedings_type_path)
+          expect(response).to redirect_to(providers_legal_aid_application_proceedings_types_path)
         end
 
         it 'creates an address record' do

--- a/spec/requests/providers/application_dependable_spec.rb
+++ b/spec/requests/providers/application_dependable_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'Providers::ApplicationDependable' do
   let(:provider) { legal_aid_application.provider }
 
   describe 'GET an action' do
-    subject { get providers_legal_aid_application_proceedings_type_path(legal_aid_application) }
+    subject { get providers_legal_aid_application_proceedings_types_path(legal_aid_application) }
 
     context 'when the provider is not authenticated' do
       before { subject }
@@ -27,9 +27,8 @@ RSpec.describe 'Providers::ApplicationDependable' do
       end
 
       context 'with an invalid legal_aid_application' do
-        subject { get providers_legal_aid_application_proceedings_type_path(invlaid_legal_aid_application) }
-
-        let(:invlaid_legal_aid_application) { build :legal_aid_application, id: SecureRandom.uuid }
+        let(:invalid_legal_aid_application) { build :legal_aid_application, id: SecureRandom.uuid }
+        subject { get providers_legal_aid_application_proceedings_types_path(invalid_legal_aid_application) }
         it "redirects to provider's start page" do
           expect(response).to redirect_to(providers_legal_aid_applications_path)
         end

--- a/spec/requests/providers/base_controller_spec.rb
+++ b/spec/requests/providers/base_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe 'Providers::BaseController' do
   let(:legal_aid_application) { create :legal_aid_application }
   let(:provider) { create(:provider) }
-  subject { get providers_legal_aid_application_proceedings_type_path(legal_aid_application) }
+  subject { get providers_legal_aid_application_proceedings_types_path(legal_aid_application) }
 
   context '#provider_not_authorized' do
     before do

--- a/spec/requests/providers/check_provider_answers_spec.rb
+++ b/spec/requests/providers/check_provider_answers_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe 'check your answers requests', type: :request do
       end
 
       it 'should redirect back' do
-        expect(response).to redirect_to(providers_legal_aid_application_proceedings_type_path(application))
+        expect(response).to redirect_to(providers_legal_aid_application_proceedings_types_path(application))
       end
 
       it 'should change the stage back to "initialized' do

--- a/spec/requests/providers/legal_aid_applications_spec.rb
+++ b/spec/requests/providers/legal_aid_applications_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'providers legal aid application requests', type: :request do
       end
 
       it "includes a link to the legal aid application's default start path" do
-        expect(response.body).to include(providers_legal_aid_application_proceedings_type_path(legal_aid_application))
+        expect(response.body).to include(providers_legal_aid_application_proceedings_types_path(legal_aid_application))
       end
 
       context 'when legal_aid_application current path set' do

--- a/spec/requests/providers/proceedings_types_spec.rb
+++ b/spec/requests/providers/proceedings_types_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe 'providers legal aid application proceedings type requests', type
   let(:legal_aid_application) { create :legal_aid_application, :with_applicant }
   let(:provider) { legal_aid_application.provider }
 
-  describe 'GET /providers/applications/:legal_aid_application_id/proceedings_type' do
-    subject { get providers_legal_aid_application_proceedings_type_path(legal_aid_application) }
+  describe 'index: GET /providers/applications/:legal_aid_application_id/proceedings_types' do
+    subject { get providers_legal_aid_application_proceedings_types_path(legal_aid_application) }
 
     context 'when the provider is not authenticated' do
       before { subject }
@@ -20,6 +20,16 @@ RSpec.describe 'providers legal aid application proceedings type requests', type
 
       it 'returns http success' do
         expect(response).to have_http_status(:ok)
+      end
+
+      it 'does not displays the proceeding types' do
+        expect(unescaped_response_body).not_to include('class="selected-proceeding-types"')
+      end
+
+      it 'displays no errors' do
+        subject
+        expect(response.body).not_to include('govuk-input--error')
+        expect(response.body).not_to include('govuk-form-group--error')
       end
 
       describe 'back link' do
@@ -38,45 +48,102 @@ RSpec.describe 'providers legal aid application proceedings type requests', type
         end
       end
     end
-  end
 
-  describe 'PATCH /providers/applications/:legal_aid_application_id/proceedings_type' do
-    let(:code) { 'PR0001' }
-    let!(:proceeding_type) { create(:proceeding_type, code: code) }
-    let(:params) { { proceeding_type: code } }
-    subject do
-      patch(
-        providers_legal_aid_application_proceedings_type_path(legal_aid_application),
-        params: params
-      )
-    end
-
-    context 'when the provider is authenticated' do
+    context 'when application has proceeding types' do
+      let!(:proceeding_type) { create :proceeding_type, legal_aid_applications: [legal_aid_application] }
       before do
         login_as provider
         subject
       end
 
-      it 'redirects successfully to the next submission step' do
+      it 'returns http success' do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'displays the proceeding types' do
+        expect(unescaped_response_body).to include('class="selected-proceeding-types"')
+      end
+    end
+  end
+
+  describe 'create: POST /providers/applications/:legal_aid_application_id/proceedings_types' do
+    subject { post providers_legal_aid_application_proceedings_types_path(legal_aid_application) }
+
+    before do
+      login_as provider
+    end
+
+    it 'renders index' do
+      subject
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'displays errors' do
+      subject
+      expect(response.body).to include('govuk-input--error')
+      expect(response.body).to include('govuk-form-group--error')
+    end
+
+    context 'with proceeding types' do
+      let!(:proceeding_type) { create :proceeding_type, legal_aid_applications: [legal_aid_application] }
+
+      it 'redirects to next step' do
         subject
         expect(response).to redirect_to(providers_legal_aid_application_check_provider_answers_path(legal_aid_application))
       end
+    end
+  end
 
-      it 'associates proceeding type with legal aid application' do
-        expect(legal_aid_application.reload.proceeding_types).to include(proceeding_type)
-      end
+  describe 'update: PATCH /providers/applications/:legal_aid_application_id/proceedings_type/:id' do
+    let(:code) { 'PR0001' }
+    let!(:proceeding_type) { create(:proceeding_type) }
+    let(:params) do
+      {
+        legal_aid_application_id: legal_aid_application,
+        id: proceeding_type
+      }
+    end
+    subject do
+      patch providers_legal_aid_application_proceedings_type_path(params)
+    end
 
-      context 'when the params are not valid' do
-        let(:params) { { proceeding_type: 'random-code' } }
+    before do
+      login_as provider
+      subject
+    end
 
-        it 're-renders the proceeding type selection page' do
-          expect(unescaped_response_body).to include('What does your client want legal aid for?')
-        end
+    it 'displays the change via index' do
+      expect(response).to redirect_to(providers_legal_aid_application_proceedings_types_path(legal_aid_application))
+    end
 
-        it 'renders show' do
-          expect(response).to have_http_status(:ok)
-        end
-      end
+    it 'associates proceeding type with legal aid application' do
+      expect(legal_aid_application.reload.proceeding_types).to include(proceeding_type)
+    end
+  end
+
+  describe 'destroy: DELETE /providers/applications/:legal_aid_application_id/proceedings_type/:id' do
+    let!(:proceeding_type) { create(:proceeding_type, legal_aid_applications: [legal_aid_application]) }
+    let(:params) do
+      {
+        legal_aid_application_id: legal_aid_application,
+        id: proceeding_type
+      }
+    end
+    subject do
+      delete providers_legal_aid_application_proceedings_type_path(params)
+    end
+
+    before do
+      login_as provider
+      subject
+    end
+
+    it 'displays the change via index' do
+      expect(response).to redirect_to(providers_legal_aid_application_proceedings_types_path(legal_aid_application))
+    end
+
+    it 'associates proceeding type with legal aid application' do
+      expect(legal_aid_application.reload.proceeding_types).not_to include(proceeding_type)
     end
   end
 end

--- a/spec/requests/providers/proceedings_types_spec.rb
+++ b/spec/requests/providers/proceedings_types_spec.rb
@@ -67,7 +67,12 @@ RSpec.describe 'providers legal aid application proceedings type requests', type
   end
 
   describe 'create: POST /providers/applications/:legal_aid_application_id/proceedings_types' do
-    subject { post providers_legal_aid_application_proceedings_types_path(legal_aid_application) }
+    subject do
+      post(
+        providers_legal_aid_application_proceedings_types_path(legal_aid_application),
+        params: { continue_button: 'Continue' }
+      )
+    end
 
     before do
       login_as provider


### PR DESCRIPTION
[AP-295](https://dsdmoj.atlassian.net/browse/AP-295)

This PR changes the behaviour of `proceeding_types` page. Now:

- When a Provider selects a Proceeding Type from the search results it appears in the list of selected Proceeding Types.
- They can then either: select another Proceeding Type, remove a selected one, or click on Continue to move to the next page
- If they click Continue without having first selected a Proceeding Type, they see an error and are prompted to select one.