### PR TITLE
Refactor exisiting lists to use the same partial

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -34,4 +34,8 @@ module ApplicationHelper
     html = sanitize html, tags: %w[a], attributes: %w[href class rel data-method]
     content_tag :span, html, class: 'user-info'
   end
+
+  def list_from_translation_path(translation_path)
+    render 'shared/forms/list_items', translation_path: translation_path
+  end
 end

--- a/app/views/citizens/consents/show.html.erb
+++ b/app/views/citizens/consents/show.html.erb
@@ -6,7 +6,7 @@
         ) do %>
 
       <p class="govuk-body govuk-!-margin-top-3"><%= t('.body') %></p>
-      <%= render partial: 'shared/forms/detailed_list', locals: { translation_path: 'citizens.consents.show' } %>
+      <%= render 'shared/forms/detailed_list', translation_path: 'citizens.consents.show' %>
       <%= render partial: 'shared/forms/check_boxes', locals: { field_name: :open_banking_consent, label: t('.open_banking_consent.label.html'), form: form, checked: 'true', unchecked: 'false' } %>
     <% end %>
 

--- a/app/views/citizens/information/show.html.erb
+++ b/app/views/citizens/information/show.html.erb
@@ -4,7 +4,7 @@
   <h2 class="govuk-heading-m"><%= t('.list.title') %></h2>
 
   <p class="govuk-body">
-    <%= render partial: 'shared/forms/list_items', locals: { translation_path: 'citizens.information.show.list' } %>
+    <%= list_from_translation_path 'citizens.information.show.list' %>
   </p>
 
   <%= link_to t('generic.continue'), citizens_consent_path, class: 'govuk-button govuk-button', id: 'continue' %>

--- a/app/views/citizens/information/show.html.erb
+++ b/app/views/citizens/information/show.html.erb
@@ -4,11 +4,7 @@
   <h2 class="govuk-heading-m"><%= t('.list.title') %></h2>
 
   <p class="govuk-body">
-    <ul class="govuk-list govuk-list--bullet">
-      <li> <%= t('.list.item_1') %> </li>
-      <li> <%= t('.list.item_2') %> </li>
-      <li> <%= t('.list.item_3') %> </li>
-    </ul>
+    <%= render partial: 'shared/forms/list_items', locals: { translation_path: 'citizens.information.show.list' } %>
   </p>
 
   <%= link_to t('generic.continue'), citizens_consent_path, class: 'govuk-button govuk-button', id: 'continue' %>

--- a/app/views/citizens/legal_aid_applications/index.html.erb
+++ b/app/views/citizens/legal_aid_applications/index.html.erb
@@ -14,9 +14,7 @@
 
   <p class="govuk-body govuk-!-font-weight-bold"><%= t('.what_you_will_need') %></p>
 
-  <ul class="govuk-list govuk-list--bullet">
-    <li><%= t('.list.item_1') %></li>
-  </ul>
+    <%= render partial: 'shared/forms/list_items', locals: { translation_path: 'citizens.legal_aid_applications.index' } %>
 
   <%= link_to t('generic.start'), forward_path, class: 'govuk-button govuk-button--start', id: 'start' %>
 <% end %>

--- a/app/views/citizens/legal_aid_applications/index.html.erb
+++ b/app/views/citizens/legal_aid_applications/index.html.erb
@@ -14,7 +14,7 @@
 
   <p class="govuk-body govuk-!-font-weight-bold"><%= t('.what_you_will_need') %></p>
 
-    <%= render partial: 'shared/forms/list_items', locals: { translation_path: 'citizens.legal_aid_applications.index' } %>
+    <%= list_from_translation_path 'citizens.legal_aid_applications.index' %>
 
   <%= link_to t('generic.start'), forward_path, class: 'govuk-button govuk-button--start', id: 'start' %>
 <% end %>

--- a/app/views/providers/about_the_financial_assessments/show.html.erb
+++ b/app/views/providers/about_the_financial_assessments/show.html.erb
@@ -6,12 +6,7 @@
   <h2 class="govuk-heading-m"><%= t '.list.title' %></h2>
 
   <p class="govuk-body">
-    <ul class="govuk-list govuk-list--bullet">
-      <li><%= t '.list.item_1' %></li>
-      <li><%= t '.list.item_2' %></li>
-      <li><%= t '.list.item_3' %></li>
-      <li><%= t '.list.item_4' %></li>
-    </ul>
+    <%= render partial: 'shared/forms/list_items', locals: { translation_path: 'providers.about_the_financial_assessments.show.list' } %>
   </p>
 
   <h2 class="govuk-heading-m">

--- a/app/views/providers/about_the_financial_assessments/show.html.erb
+++ b/app/views/providers/about_the_financial_assessments/show.html.erb
@@ -6,7 +6,7 @@
   <h2 class="govuk-heading-m"><%= t '.list.title' %></h2>
 
   <p class="govuk-body">
-    <%= render partial: 'shared/forms/list_items', locals: { translation_path: 'providers.about_the_financial_assessments.show.list' } %>
+    <%= list_from_translation_path 'providers.about_the_financial_assessments.show.list' %>
   </p>
 
   <h2 class="govuk-heading-m">

--- a/app/views/providers/merits_declarations/show.html.erb
+++ b/app/views/providers/merits_declarations/show.html.erb
@@ -16,7 +16,7 @@
 
         <%= simple_format t('.text_2') %>
 
-        <%= render partial: 'shared/forms/list_items', locals: { translation_path: 'providers.merits_declarations.show' } %>
+        <%= list_from_translation_path 'providers.merits_declarations.show' %>
 
         <%= simple_format t('.text_3') %>
 

--- a/app/views/providers/merits_declarations/show.html.erb
+++ b/app/views/providers/merits_declarations/show.html.erb
@@ -16,11 +16,7 @@
 
         <%= simple_format t('.text_2') %>
 
-        <ul class="govuk-list govuk-list--bullet">
-          <% t('.list').each_line do |item| %>
-            <li><%= item %></li>
-          <% end %>
-        </ul>
+        <%= render partial: 'shared/forms/list_items', locals: { translation_path: 'providers.merits_declarations.show' } %>
 
         <%= simple_format t('.text_3') %>
 

--- a/app/views/providers/start/index.html.erb
+++ b/app/views/providers/start/index.html.erb
@@ -2,21 +2,17 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl"><%= t('.apply_for_legal_aid_heading') %></h1>
     <p class="govuk-body"><%= t('.apply_civil_legal_para') %></p>
-    <ul class="govuk-list govuk-list--bullet">
-      <li><%= t('.apply_civil_legal_list.item_1') %></li>
-      <li><%= t('.apply_civil_legal_list.item_2') %></li>
-    </ul>
+
+    <%= render partial: 'shared/forms/list_items', locals: { translation_path: 'providers.start.index.apply_civil_legal_list' } %>
 
     <p class="govuk-body"><%= t('.use_ccms_para') %></p>
 
     <h2 class="govuk-heading-m"><%= t('.use_ccms_list.heading') %></h2>
 
     <p class="govuk-body"><%= t('.use_ccms_list.title') %></p>
-    <ul class="govuk-list govuk-list--bullet">
-      <li><%= t('.use_ccms_list.item_1') %></li>
-      <li><%= t('.use_ccms_list.item_2') %></li>
-      <li><%= t('.use_ccms_list.item_3') %></li>
-    </ul>
+
+    <%= render partial: 'shared/forms/list_items', locals: { translation_path: 'providers.start.index.use_ccms_list' } %>
+
     <p class="govuk-body"><%= t('.use_ccms_upload_document') %></p>
 
     <%= link_to t('generic.start'), providers_legal_aid_applications_path, class: 'govuk-button govuk-button--start', id: 'start' %>

--- a/app/views/providers/start/index.html.erb
+++ b/app/views/providers/start/index.html.erb
@@ -3,7 +3,7 @@
     <h1 class="govuk-heading-xl"><%= t('.apply_for_legal_aid_heading') %></h1>
     <p class="govuk-body"><%= t('.apply_civil_legal_para') %></p>
 
-    <%= render partial: 'shared/forms/list_items', locals: { translation_path: 'providers.start.index.apply_civil_legal_list' } %>
+    <%= list_from_translation_path 'providers.start.index.apply_civil_legal_list' %>
 
     <p class="govuk-body"><%= t('.use_ccms_para') %></p>
 
@@ -11,7 +11,7 @@
 
     <p class="govuk-body"><%= t('.use_ccms_list.title') %></p>
 
-    <%= render partial: 'shared/forms/list_items', locals: { translation_path: 'providers.start.index.use_ccms_list' } %>
+    <%= list_from_translation_path 'providers.start.index.use_ccms_list' %>
 
     <p class="govuk-body"><%= t('.use_ccms_upload_document') %></p>
 

--- a/app/views/shared/forms/_detailed_list.html.erb
+++ b/app/views/shared/forms/_detailed_list.html.erb
@@ -5,6 +5,6 @@
     </span>
   </summary>
   <div class="govuk-details__text">
-    <%= render partial: 'shared/forms/list_items', locals: { translation_path: translation_path } %>
+    <%= render 'shared/forms/list_items', translation_path: translation_path %>
   </div>
 </details>

--- a/app/views/shared/forms/_detailed_list.html.erb
+++ b/app/views/shared/forms/_detailed_list.html.erb
@@ -5,10 +5,6 @@
     </span>
   </summary>
   <div class="govuk-details__text">
-    <ul class="govuk-list govuk-list--bullet">
-      <li><%= t "#{translation_path}.list_1" %></li>
-      <li><%= t "#{translation_path}.list_2" %></li>
-      <li><%= t "#{translation_path}.list_3" %></li>
-    </ul>
+    <%= render partial: 'shared/forms/list_items', locals: { translation_path: translation_path } %>
   </div>
 </details>

--- a/app/views/shared/forms/_list_items.html.erb
+++ b/app/views/shared/forms/_list_items.html.erb
@@ -1,0 +1,7 @@
+<div class="govuk-list">
+  <ul class="govuk-list govuk-list--bullet">
+    <% t("#{translation_path}.list").each_line do |item| %>
+      <li><%= item %></li>
+    <% end %>
+  </ul>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -431,14 +431,16 @@ en:
         use_ccms_para: Use CCMS for Section 8 orders, cases involving the Special Children's Act, and all other types of civil and criminal legal aid.
         use_ccms_upload_document: You cannot upload documents using this service. Use CCMS if you want to submit evidence to support your case.
         apply_civil_legal_list:
-          item_1: public family law
-          item_2: domestic violence or abuse
+          list: |
+            public family law
+            domestic violence or abuse
         use_ccms_list:
           heading: Who can use this service?
           title:  "You can only use this service if your client:"
-          item_1: has a National Insurance number
-          item_2: uses online banking
-          item_3: is single, does not have an income, or their partner is the opponent in the case
+          list: |
+            has a National Insurance number
+            uses online banking
+            is single, does not have an income, or their partner is the opponent in the case
         related_content_list:
           title: Related content
           item_1: Legal aid
@@ -559,10 +561,11 @@ en:
         share_bank_accounts_para: Your client will need to share all bank accounts, including any in joint names or with no money.
         list:
           title: How we use your client's details
-          item_1: We download 3 months of bank transactions
-          item_2: We only use information for the legal aid application
-          item_3: We automatically end the bank connection after 1 hour
-          item_4: We do not save online banking details
+          list: |
+            We download 3 months of bank transactions
+            We only use information for the legal aid application
+            We automatically end the bank connection after 1 hour
+            We do not save online banking details
         section_1:
           heading: Give your client access to the financial assessment
           text: When you click 'Submit' we will send your client a secure link to the online financial assessment.
@@ -625,9 +628,10 @@ en:
         field_set_header: Do you agree to share your bank transactions with us?
         body: We only use your bank transactions to support your legal aid application. We do not use the information for anything else.
         list_heading: Find out how we use and store your personal data
-        list_1: We do not save your online banking username and password
-        list_2: We do not have any ongoing access to your bank accounts
-        list_3: We only use your details to assess your eligibility for legal aid
+        list: |
+          We do not save your online banking username and password
+          We do not have any ongoing access to your bank accounts
+          We only use your details to assess your eligibility for legal aid
     percentage_homes:
       show:
         h1-heading: What % share of your home do you legally own?
@@ -680,9 +684,10 @@ en:
         para_2: You will need to share all of your bank accounts, including any in joint names or with no money.
         list:
           title: How we connect to your online banking
-          item_1: Sign in and authorise access to your accounts
-          item_2: We download 3 months of transactions
-          item_3: Your online banking details are not saved
+          list: |
+            Sign in and authorise access to your accounts
+            We download 3 months of transactions
+            Your online banking details are not saved
     legal_aid_applications:
         index:
           heading_1: Complete your legal aid financial assessment
@@ -691,8 +696,8 @@ en:
           financial_situation_para: Find out if you can get legal aid because of your financial situation.
           legal_cost_para: You might not have to pay legal costs if you are on certain benefits, a low income or have little or no savings.
           what_you_will_need: What you will need
-          list:
-            item_1: your online banking log in
+          list: |
+            your online banking log in
     check_answers:
       index:
         h1-heading: Check your answers


### PR DESCRIPTION
The existing detailed_list partial was not suitable for all list types, this creates a new list_item partial that is more flexible allowing new list items to be easily added or removed without needing to amend the code in the view.

Describe what you did and why.

The list_item partial checks the locales (en.yml) file for the relevant items. Instead of using:

```
item_1: First list item
item_2: Second list item
item_3: Another list item for good measure
```
You can now use:

```
list: |
  First list item
  Second list item
  Another list item for good measure
```
Items in the list can be added or removed without needing to change anything in the view. 

The detailed_list partial has also been amended to use this partial.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely. 
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
