### PR TITLE
AP 325 Fix validation

### DIFF
--- a/app/forms/base_form.rb
+++ b/app/forms/base_form.rb
@@ -67,7 +67,7 @@ module BaseForm
     def save
       return false unless valid?
 
-      model.attributes = assignable_attributes
+      model.attributes = clean_attributes(assignable_attributes)
       model.save(validate: false)
     end
 
@@ -96,6 +96,10 @@ module BaseForm
     end
 
     private
+
+    def clean_attributes(hash)
+      hash.transform_values { |v| v.is_a?(String) ? v.tr('£,', '') : v }
+    end
 
     def set_blanks_to_nil
       self.class.locally_assigned.each do |attr|

--- a/app/forms/base_form.rb
+++ b/app/forms/base_form.rb
@@ -76,6 +76,10 @@ module BaseForm
       []
     end
 
+    def attributes_to_clean
+      []
+    end
+
     def assignable_attributes
       exclude_attrs = exclude_from_model + [:model]
       attributes.except(*exclude_attrs.map(&:to_s))
@@ -98,7 +102,9 @@ module BaseForm
     private
 
     def clean_attributes(hash)
-      hash.transform_values { |v| v.is_a?(String) ? v.tr('£,', '') : v }
+      hash.each_with_object({}) do |(k, v), new_hash|
+        new_hash[k] = k.to_sym.in?(attributes_to_clean) ? v.to_s.tr('£,', '') : v
+      end
     end
 
     def set_blanks_to_nil

--- a/app/forms/citizens/other_assets_form.rb
+++ b/app/forms/citizens/other_assets_form.rb
@@ -25,12 +25,12 @@ module Citizens
 
     CHECK_BOXES_ATTRIBUTES = (SINGLE_VALUE_ATTRIBUTES.map { |attribute| "check_box_#{attribute}".to_sym } + [:check_box_second_home]).freeze
 
-    validates(*SECOND_HOME_ATTRIBUTES, numericality: { greater_than_or_equal_to: 0 }, allow_blank: true)
+    validates(:second_home_percentage, numericality: { greater_than_or_equal_to: 0 }, allow_blank: true)
     validates(*SECOND_HOME_ATTRIBUTES, presence: true, if: proc { |form| form.check_box_second_home.present? })
+    validates(*ALL_ATTRIBUTES - [:second_home_percentage], allow_blank: true, currency: { greater_than_or_equal_to: 0 })
 
     SINGLE_VALUE_ATTRIBUTES.each do |attribute|
       check_box_attribute = "check_box_#{attribute}".to_sym
-      validates attribute, numericality: { greater_than_or_equal_to: 0 }, allow_blank: true
       validates attribute, presence: true, if: proc { |form| form.__send__(check_box_attribute).present? }
     end
 
@@ -38,7 +38,7 @@ module Citizens
     attr_accessor(*CHECK_BOXES_ATTRIBUTES)
     attr_accessor :check_box_second_home
 
-    before_validation :normalize_amounts, :empty_unchecked_values
+    before_validation :empty_unchecked_values
 
     validate :all_second_home_values_present_if_any_are_present
 
@@ -77,13 +77,6 @@ module Citizens
       @second_home_value = nil
       @second_home_mortgage = nil
       @second_home_percentage = nil
-    end
-
-    def normalize_amounts
-      ALL_ATTRIBUTES
-        .map { |attribute| __send__(attribute) }
-        .compact
-        .each { |value| value.delete!(',') }
     end
 
     def all_second_home_values_present_if_any_are_present

--- a/app/forms/citizens/other_assets_form.rb
+++ b/app/forms/citizens/other_assets_form.rb
@@ -56,6 +56,10 @@ module Citizens
       CHECK_BOXES_ATTRIBUTES
     end
 
+    def attributes_to_clean
+      ALL_ATTRIBUTES - [:second_home_percentage]
+    end
+
     private
 
     def empty_unchecked_values

--- a/app/forms/legal_aid_applications/outstanding_mortgage_form.rb
+++ b/app/forms/legal_aid_applications/outstanding_mortgage_form.rb
@@ -4,24 +4,7 @@ module LegalAidApplications
     form_for LegalAidApplication
     attr_accessor :outstanding_mortgage_amount
 
-    before_validation :clean_up_input
-    validates(
-      :outstanding_mortgage_amount,
-      presence: { unless: :draft? },
-      numericality: { greater_than_or_equal_to: 0, allow_blank: true }
-    )
-
-    private
-
-    def clean_up_input
-      outstanding_mortgage_amount.delete!(',') if outstanding_mortgage_amount.is_a?(String) && valid_number_pattern =~ outstanding_mortgage_amount
-    end
-
-    # Starts with a digit
-    # Then perhaps any combination of digit, ',' or '_'
-    # Then perhaps dot followed by up to 2 digits
-    def valid_number_pattern
-      /\A\d[,_\d]*(\.\d{,2})?\z/
-    end
+    validates :outstanding_mortgage_amount, presence: { unless: :draft? }
+    validates :outstanding_mortgage_amount, allow_blank: true, currency: { greater_than_or_equal_to: 0.0 }
   end
 end

--- a/app/forms/legal_aid_applications/outstanding_mortgage_form.rb
+++ b/app/forms/legal_aid_applications/outstanding_mortgage_form.rb
@@ -6,5 +6,9 @@ module LegalAidApplications
 
     validates :outstanding_mortgage_amount, presence: { unless: :draft? }
     validates :outstanding_mortgage_amount, allow_blank: true, currency: { greater_than_or_equal_to: 0.0 }
+
+    def attributes_to_clean
+      [:outstanding_mortgage_amount]
+    end
   end
 end

--- a/app/forms/legal_aid_applications/property_value_form.rb
+++ b/app/forms/legal_aid_applications/property_value_form.rb
@@ -6,15 +6,8 @@ module LegalAidApplications
 
     attr_accessor :property_value, :mode
 
-    before_validation :clean_up_input
-    # validates(
-    #   :property_value,
-    #   presence: true,
-    #   numericality: { greater_than: 0, allow_blank: true }
-    # )
-
-    # validates :property_value, presence: { message: 'citizen.blank' }, if: :citizen_mode?
-    validate :value_presence, :value_numericality
+    validate :value_presence
+    validates :property_value, allow_blank: true, currency: { greater_than_or_equal_to: 0.0 }
 
     def initialize(*args)
       super
@@ -29,31 +22,12 @@ module LegalAidApplications
       errors.add(:property_value, error_message_for(:blank)) if property_value.blank?
     end
 
-    def value_numericality
-      errors.add(:property_value, error_message_for(:not_a_number)) if value_not_a_number?
-    end
-
-    def value_not_a_number?
-      property_value.present? && valid_number_pattern !~ property_value.to_s
-    end
-
     def error_message_for(error_type)
       I18n.t("activemodel.errors.models.legal_aid_application.attributes.property_value.#{mode}.#{error_type}")
     end
 
     def exclude_from_model
       [:mode]
-    end
-
-    def clean_up_input
-      property_value.delete!(',') if property_value.is_a?(String) && valid_number_pattern =~ property_value
-    end
-
-    # Starts with a digit
-    # Then perhaps any combination of digit, ',' or '_'
-    # Then perhaps dot followed by up to 2 digits
-    def valid_number_pattern
-      /\A\d[,_\d]*(\.\d{,2})?\z/
     end
   end
 end

--- a/app/forms/legal_aid_applications/property_value_form.rb
+++ b/app/forms/legal_aid_applications/property_value_form.rb
@@ -14,6 +14,10 @@ module LegalAidApplications
       @mode = :citizen unless @mode == :provider
     end
 
+    def attributes_to_clean
+      [:property_value]
+    end
+
     private
 
     def value_presence

--- a/app/forms/merits_assessments/estimated_legal_cost_form.rb
+++ b/app/forms/merits_assessments/estimated_legal_cost_form.rb
@@ -6,7 +6,7 @@ module MeritsAssessments
 
     attr_accessor :estimated_legal_cost
 
-    validates :estimated_legal_cost, numericality: { greater_than_or_equal_to: 0 }, allow_blank: true
     validates :estimated_legal_cost, presence: true, unless: :draft?
+    validates :estimated_legal_cost, allow_blank: true, currency: { greater_than_or_equal_to: 0.0 }
   end
 end

--- a/app/forms/merits_assessments/estimated_legal_cost_form.rb
+++ b/app/forms/merits_assessments/estimated_legal_cost_form.rb
@@ -8,5 +8,9 @@ module MeritsAssessments
 
     validates :estimated_legal_cost, presence: true, unless: :draft?
     validates :estimated_legal_cost, allow_blank: true, currency: { greater_than_or_equal_to: 0.0 }
+
+    def attributes_to_clean
+      [:estimated_legal_cost]
+    end
   end
 end

--- a/app/forms/savings_amounts/savings_amounts_form.rb
+++ b/app/forms/savings_amounts/savings_amounts_form.rb
@@ -18,14 +18,15 @@ module SavingsAmounts
 
     ATTRIBUTES.each do |attribute|
       check_box_attribute = "check_box_#{attribute}".to_sym
-      validates attribute, numericality: { greater_than_or_equal_to: 0 }, allow_blank: true
       validates attribute, presence: true, if: proc { |form| form.send(check_box_attribute).present? }
     end
 
     attr_accessor(*ATTRIBUTES)
     attr_accessor(*CHECK_BOXES_ATTRIBUTES)
 
-    before_validation :empty_unchecked_values, :normalize_amounts
+    validates(*ATTRIBUTES, allow_blank: true, currency: { greater_than_or_equal_to: 0.0 })
+
+    before_validation :empty_unchecked_values
 
     def exclude_from_model
       CHECK_BOXES_ATTRIBUTES
@@ -41,13 +42,6 @@ module SavingsAmounts
           send("#{attribute}=", nil)
         end
       end
-    end
-
-    def normalize_amounts
-      ATTRIBUTES
-        .map { |attribute| send(attribute) }
-        .compact
-        .each { |value| value.delete!(',') }
     end
   end
 end

--- a/app/forms/statement_of_cases/statement_of_case_form.rb
+++ b/app/forms/statement_of_cases/statement_of_case_form.rb
@@ -29,8 +29,8 @@ module StatementOfCases
     validates :statement, presence: true, unless: :file_present_or_draft?
     validate :original_file_too_big
     validate :original_file_empty
-    validate :original_file_disallowed_content_type
     validate :original_file_malware_scan
+    validate :original_file_disallowed_content_type
 
     private
 

--- a/app/helpers/money_helper.rb
+++ b/app/helpers/money_helper.rb
@@ -2,4 +2,8 @@ module MoneyHelper
   def value_with_currency_unit(value, currency)
     number_to_currency(value, unit: I18n.t("currency.#{currency.downcase}", default: currency))
   end
+
+  def number_to_currency_or_original_string(value)
+    value.is_a?(String) ? value : number_to_currency(value, unit: '')
+  end
 end

--- a/app/lib/govuk_elements_form_builder/form_builder.rb
+++ b/app/lib/govuk_elements_form_builder/form_builder.rb
@@ -233,7 +233,7 @@ module GovukElementsFormBuilder
     def error_tag(attribute, options)
       return unless error?(attribute, options)
 
-      message = object.errors[attribute].join(', ')
+      message = object.errors[attribute].first
       return unless message.present?
 
       content_tag(:span, message, class: 'govuk-error-message', id: "#{attribute}-error")

--- a/app/services/currency_cleaner.rb
+++ b/app/services/currency_cleaner.rb
@@ -1,5 +1,5 @@
 class CurrencyCleaner
-  COMMA_STRIPPING_REGEX = /,(?=\d{3}\b)/.freeze
+  THOUSANDS_SEPARATOR_REGEX = /,(?=\d{3}\b)/.freeze
   LEADING_POUND_SIGN_REGEX = /^£/.freeze
   PURE_NUMERIC_REGEX = /^-?\d+\.?\d+?$/.freeze
 
@@ -17,6 +17,6 @@ class CurrencyCleaner
   private
 
   def remove_commas
-    @original_value.sub(LEADING_POUND_SIGN_REGEX, '').gsub(COMMA_STRIPPING_REGEX, '')
+    @original_value.sub(LEADING_POUND_SIGN_REGEX, '').gsub(THOUSANDS_SEPARATOR_REGEX, '')
   end
 end

--- a/app/services/currency_cleaner.rb
+++ b/app/services/currency_cleaner.rb
@@ -1,0 +1,22 @@
+class CurrencyCleaner
+  COMMA_STRIPPING_REGEX = /,(?=\d{3}\b)/.freeze
+  LEADING_POUND_SIGN_REGEX = /^£/.freeze
+  PURE_NUMERIC_REGEX = /^-?\d+\.?\d+?$/.freeze
+
+  def initialize(value)
+    @original_value = value
+  end
+
+  # will remove all commas if valid i.e. followed by 3 digits
+  # if invalid, the original String is returned
+  def clean
+    clean_value = remove_commas
+    PURE_NUMERIC_REGEX.match?(clean_value) ? clean_value : @original_value
+  end
+
+  private
+
+  def remove_commas
+    @original_value.sub(LEADING_POUND_SIGN_REGEX, '').gsub(COMMA_STRIPPING_REGEX, '')
+  end
+end

--- a/app/services/currency_cleaner.rb
+++ b/app/services/currency_cleaner.rb
@@ -9,7 +9,7 @@ class CurrencyCleaner
 
   # will remove all commas if valid i.e. followed by 3 digits
   # if invalid, the original String is returned
-  def clean
+  def call
     clean_value = remove_commas
     PURE_NUMERIC_REGEX.match?(clean_value) ? clean_value : @original_value
   end

--- a/app/validators/currency_validator.rb
+++ b/app/validators/currency_validator.rb
@@ -1,0 +1,15 @@
+class CurrencyValidator < ActiveModel::Validations::NumericalityValidator
+  ONLY_2_DECIMALS_PATTERN = /(\A-?[0-9]+\z)|(\A-?[0-9]*\.[0-9]{,2}\z)/.freeze
+
+  def validate_each(record, attr_name, value)
+    clean_value = clean_numeric_value(value)
+    super(record, attr_name, clean_value)
+    return if record.errors[attr_name].any?
+
+    record.errors.add(attr_name, :too_many_decimals) unless ONLY_2_DECIMALS_PATTERN.match?(clean_value)
+  end
+
+  def clean_numeric_value(value)
+    CurrencyCleaner.new(value).clean
+  end
+end

--- a/app/validators/currency_validator.rb
+++ b/app/validators/currency_validator.rb
@@ -10,6 +10,6 @@ class CurrencyValidator < ActiveModel::Validations::NumericalityValidator
   end
 
   def clean_numeric_value(value)
-    CurrencyCleaner.new(value).clean
+    CurrencyCleaner.new(value).call
   end
 end

--- a/app/views/citizens/property_values/_form.html.erb
+++ b/app/views/citizens/property_values/_form.html.erb
@@ -8,7 +8,7 @@
     <%= form.govuk_text_field :property_value,
                               label: controller_t('property_value'),
                               hint: controller_t('hint.property_value'),
-                              value: number_to_currency(model.property_value, unit: ''),
+                              value: number_to_currency_or_original_string(model.property_value),
                               input_prefix: t('currency.gbp'),
                               class: 'govuk-!-width-one-third' %>
   <% end %>

--- a/app/views/shared/forms/_error_summary.html.erb
+++ b/app/views/shared/forms/_error_summary.html.erb
@@ -6,9 +6,9 @@
     </h2>
     <div class="govuk-error-summary__body">
       <ul class="govuk-list govuk-error-summary__list">
-        <% model.errors.each do |attribute, message| %>
+        <% model.errors.keys.each do |attribute| %>
           <li>
-            <%= link_to message, "##{attribute_prefix}#{attribute}" %>
+            <%= link_to model.errors[attribute].first, "##{attribute_prefix}#{attribute}" %>
           </li>
         <% end %>
       </ul>

--- a/app/views/shared/forms/_estimated_legal_cost_form.html.erb
+++ b/app/views/shared/forms/_estimated_legal_cost_form.html.erb
@@ -10,7 +10,7 @@
     <%= form.govuk_text_field :estimated_legal_cost,
                               label: nil,
                               hint: t('helpers.hint.merits_assessment.estimated_legal_cost'),
-                              value: number_to_currency(model.estimated_legal_cost, unit: ''),
+                              value: number_to_currency_or_original_string(model.estimated_legal_cost),
                               input_prefix: t('currency.gbp'),
                               class: 'govuk-!-width-one-third' %>
   <% end %>

--- a/app/views/shared/forms/_outstanding_mortgage_form.html.erb
+++ b/app/views/shared/forms/_outstanding_mortgage_form.html.erb
@@ -7,7 +7,7 @@
     <%= govuk_fieldset_header controller_t('.field_set_header'), padding_below: 6 %>
     <%= form.govuk_text_field :outstanding_mortgage_amount,
                               hint: t("helpers.hint.legal_aid_application.outstanding_mortgage_amount.#{user_type}"),
-                              value: number_to_currency(model.outstanding_mortgage_amount, unit: ''),
+                              value: number_to_currency_or_original_string(model.outstanding_mortgage_amount),
                               input_prefix: t('currency.gbp'),
                               class: 'govuk-!-width-one-third' %>
   <% end %>

--- a/app/views/shared/forms/_percentage_home_form.html.erb
+++ b/app/views/shared/forms/_percentage_home_form.html.erb
@@ -7,7 +7,7 @@
               <%= form.govuk_text_field :percentage_home,
                                         label: controller_t('percentage_home'),
                                         hint: controller_t('hint.percentage_home'),
-                                        value: number_to_currency(model.percentage_home, unit: ''),
+                                        value: model.percentage_home,
                                         class: 'govuk-input--width-5 input-percentage',
                                         suffix: '%' %>
 

--- a/app/views/shared/forms/other_assets/_second_home_conditional_checkbox.html.erb
+++ b/app/views/shared/forms/other_assets/_second_home_conditional_checkbox.html.erb
@@ -14,15 +14,15 @@
 <div class="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden" id="<%= conditional_div_id %>">
   <%= form.govuk_text_field :second_home_value,
                             input_prefix: t('currency.gbp'),
-                            value: number_to_currency(model.second_home_value, unit: ''),
+                            value: number_to_currency_or_original_string(model.second_home_value),
                             class: 'govuk-!-width-one-third' %>
 
   <%= form.govuk_text_field :second_home_mortgage,
                             input_prefix: t('currency.gbp'),
-                            value: number_to_currency(model.second_home_mortgage, unit: ''),
+                            value: number_to_currency_or_original_string(model.second_home_mortgage),
                             class: 'govuk-!-width-one-third' %>
       <%= form.govuk_text_field :second_home_percentage,
-                                value: number_to_currency(model.second_home_percentage, unit: ''),
+                                value: model.second_home_percentage,
                                 class: 'govuk-input--width-5 input-percentage',
                                 suffix: '%' %>
 </div>

--- a/app/views/shared/forms/revealing_checkbox/_attribute.html.erb
+++ b/app/views/shared/forms/revealing_checkbox/_attribute.html.erb
@@ -12,5 +12,5 @@
   <%= govuk_hint(hint, class: 'govuk-checkboxes__hint') if hint.present? %>
 </div>
 <div class="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden" id="<%= conditional_div_id %>">
-  <%= form.govuk_text_field attribute, label: controller_t(attribute), input_prefix: t('currency.gbp'), value: number_to_currency(value, unit: ''), class: 'govuk-!-width-one-third' %>
+  <%= form.govuk_text_field attribute, label: controller_t(attribute), input_prefix: t('currency.gbp'), value: number_to_currency_or_original_string(value), class: 'govuk-!-width-one-third' %>
 </div>

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -95,8 +95,9 @@ en:
           attributes:
             outstanding_mortgage_amount:
               blank: Enter the outstanding mortgage amount
-              greater_than_or_equal_to: Mortgage amount must be zero or an amount of money, like 60,000
               not_a_number: Mortgage amount must be an amount of money, like 60,000
+              too_many_decimals: Mortgage amount must not include more than 2 decimal numbers
+              greater_than_or_equal_to: Mortgage amount must be 0 or more
             own_home:
               blank: Select yes if you own the home you live in
             percentage_home:
@@ -108,8 +109,10 @@ en:
               citizen:
                 blank: Enter an estimated value for your home
                 not_a_number: The estimated value of your home must be an amount of money, like 60,000
-              greater_than: Estimated value must be an amount of money, like 80,000
-              not_a_number: Estimated value must be an amount of money, like 80,000
+              greater_than: Estimated value must be 0 or more
+              not_a_number: Estimated value must be an amount of money, like 60,000
+              too_many_decimals: Estimated value must not include more than 2 decimal numbers
+              greater_than_or_equal_to: Estimated value must be 0 or more
               provider:
                 blank: Enter an estimated value for your client's home
                 not_a_number: The estimated value of your client's home must be an amount of money, like 60,000
@@ -126,6 +129,8 @@ en:
             estimated_legal_cost:
               blank: Enter the estimated legal costs of doing the work
               not_a_number: Estimated cost must be an amount of money, like 25,000
+              too_many_decimals: Estimated cost must not include more than 2 decimal numbers
+              greater_than_or_equal_to: Estimated cost must be 0 or more
             proceedings_before_the_court:
               blank: Select Yes if the proceedings for which funding is being sought are currently before the court
             success_prospect:
@@ -137,66 +142,95 @@ en:
             classic_car_value:
               blank: Enter the estimated classic car value
               not_a_number: Estimated classic car value must be an amount of money, like 60,000
+              too_many_decimals: Estimated classic car value must not include more than 2 decimal numbers
+              greater_than_or_equal_to: Estimated classic car value must be 0 or more
             jewellery_value:
               blank: Enter the estimated total value of valuable items
               not_a_number: Estimated valuable items value must be an amount of money, like 60,000
+              too_many_decimals: Estimated jewellery value must not include more than 2 decimal numbers
+              greater_than_or_equal_to: Estimated jewellery value must be 0 or more
             land_value:
               blank: Enter the estimated land value
               not_a_number: Estimated land value must be an amount of money, like 60,000
+              too_many_decimals: Estimated land value must not include more than 2 decimal numbers
+              greater_than_or_equal_to: Estimated land value must be 0 or more
             money_assets_value:
               blank: Enter the estimated value of estate
               not_a_number: Estimated estate value must be an amount of money, like 60,000
+              too_many_decimals: Estimated money assets value must not include more than 2 decimal numbers
+              greater_than_or_equal_to: Estimated money assets value must be 0 or more
             money_owed_value:
               blank: Enter the estimated value of money owed
               not_a_number: Estimated money owed must be an amount of money, like 60,000
+              too_many_decimals: Estimated money owed value must not include more than 2 decimal numbers
+              greater_than_or_equal_to: Estimated money owed value must be 0 or more
             second_home_mortgage:
               blank: Enter outstanding mortgage amount
               not_a_number: Outstanding mortgage amount must be an amount of money, like 60,000
+              too_many_decimals: Estimated second home mortgage must not include more than 2 decimal numbers
+              greater_than_or_equal_to: Estimated second home mortgage must be 0 or more
             second_home_percentage:
               blank: Enter property percentage share
               not_a_number: Ownership share must be percentage, like 33.33
+              too_many_decimals: Estimated second home percentage must not include more than 2 decimal numbers
+              greater_than_or_equal_to: Estimated second home percentage value must be 0 or more
             second_home_value:
               blank: Enter the estimated property value
               not_a_number: Estimated value must be an amount of money, like 60,000
+              too_many_decimals: Estimated second home value must not include more than 2 decimal numbers
+              greater_than_or_equal_to: Estimated second home value must be 0 or more
             timeshare_value:
               blank: Enter the estimated timeshare value
               not_a_number: Estimated timeshare value must be an amount of money, like 60,000
+              too_many_decimals: Estimated timeshare value must not include more than 2 decimal numbers
+              greater_than_or_equal_to: Estimated timeshare value must be 0 or more
             trust_value:
               blank: Enter the estimated value of trust
               not_a_number: Estimated trust value must be an amount of money, like 60,000
+              too_many_decimals: Estimated trust value must not include more than 2 decimal numbers
+              greater_than_or_equal_to: Estimated trust value must be 0 or more
             vehicle_value:
               blank: Enter the estimated vehicle value
               not_a_number: Estimated vehicle value must be an amount of money, like 60,000
+              too_many_decimals: Estimated vehicle value must not include more than 2 decimal numbers
+              greater_than_or_equal_to: Estimated vehicle value must be 0 or more
         savings_amount:
           attributes:
             cash:
               blank: Enter the total amount of cash savings
               greater_than_or_equal_to: Total cash savings must be 0 or more
               not_a_number: Total cash savings must be an amount of money, like 60,000
+              too_many_decimals: Estimated cash value must not include more than 2 decimal numbers
             isa:
               blank: Enter the estimated total in all accounts
               greater_than_or_equal_to: Total in accounts must be 0 or more
               not_a_number: Total in accounts must be an amount of money, like 60,000
+              too_many_decimals: Estimated isa value must not include more than 2 decimal numbers
             life_assurance_endowment_policy:
               blank: Enter the total value of life assurance policies
               greater_than_or_equal_to: Total of life assurance policies must be 0 or more
               not_a_number: Total of life assurance policies must be an amount of money, like 60,000
+              too_many_decimals: Estimated life assurance policies value must not include more than 2 decimal numbers
             national_savings:
               blank: Enter the total value of certificates and bonds
               greater_than_or_equal_to: Total of certificates and bonds must be 0 or more
               not_a_number: Total of certificates and bonds must be an amount of money, like 60,000
+              too_many_decimals: Estimated trust value must not include more than 2 decimal numbers
             other_person_account:
               blank: Enter the estimated total in other people’s accounts
               greater_than_or_equal_to: Total in other people’s accounts must be 0 or more
               not_a_number: Total in other people’s accounts must be an amount of money, like 60,000
+              too_many_decimals: Estimated other people’s accounts value must not include more than 2 decimal numbers
             peps_unit_trusts_capital_bonds_gov_stocks:
               blank: Enter the total value of other investments
               greater_than_or_equal_to: Total of other investments must be 0 or more
               not_a_number: Total of other investments must be an amount of money, like 60,000
+              too_many_decimals: Estimated other investments value must not include more than 2 decimal numbers
             plc_shares:
               blank: Enter the total value of shares
               greater_than_or_equal_to: Total of shares must be 0 or more
               not_a_number: Total of shares must be an amount of money, like 60,000
+              too_many_decimals: Estimated shares value must not include more than 2 decimal numbers
         statement_of_case:
           attributes:
             statement:

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -184,8 +184,8 @@ ActiveRecord::Schema.define(version: 2019_02_14_171720) do
     t.boolean "open_banking_consent"
     t.datetime "open_banking_consent_choice_at"
     t.string "own_home"
-    t.decimal "percentage_home"
     t.decimal "property_value", precision: 10, scale: 2
+    t.decimal "percentage_home"
     t.string "shared_ownership"
     t.decimal "outstanding_mortgage_amount"
     t.string "provider_step"
@@ -214,8 +214,8 @@ ActiveRecord::Schema.define(version: 2019_02_14_171720) do
     t.text "application_purpose"
     t.boolean "proceedings_before_the_court"
     t.text "details_of_proceedings_before_the_court"
-    t.decimal "estimated_legal_cost", precision: 10, scale: 2
     t.boolean "client_merits_declaration"
+    t.decimal "estimated_legal_cost", precision: 10, scale: 2
     t.string "success_prospect"
     t.text "success_prospect_details"
     t.index ["legal_aid_application_id"], name: "index_merits_assessments_on_legal_aid_application_id"
@@ -223,17 +223,17 @@ ActiveRecord::Schema.define(version: 2019_02_14_171720) do
 
   create_table "other_assets_declarations", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "legal_aid_application_id", null: false
-    t.decimal "second_home_value", precision: 14, scale: 2
-    t.decimal "second_home_mortgage", precision: 14, scale: 2
-    t.decimal "second_home_percentage", precision: 14, scale: 2
-    t.decimal "timeshare_value", precision: 14, scale: 2
-    t.decimal "land_value", precision: 14, scale: 2
-    t.decimal "jewellery_value", precision: 14, scale: 2
-    t.decimal "vehicle_value", precision: 14, scale: 2
-    t.decimal "classic_car_value", precision: 14, scale: 2
-    t.decimal "money_assets_value", precision: 14, scale: 2
-    t.decimal "money_owed_value", precision: 14, scale: 2
-    t.decimal "trust_value", precision: 14, scale: 2
+    t.decimal "second_home_value"
+    t.decimal "second_home_mortgage"
+    t.decimal "second_home_percentage"
+    t.decimal "timeshare_value"
+    t.decimal "land_value"
+    t.decimal "jewellery_value"
+    t.decimal "vehicle_value"
+    t.decimal "classic_car_value"
+    t.decimal "money_assets_value"
+    t.decimal "money_owed_value"
+    t.decimal "trust_value"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["legal_aid_application_id"], name: "index_other_assets_declarations_on_legal_aid_application_id", unique: true
@@ -322,5 +322,8 @@ ActiveRecord::Schema.define(version: 2019_02_14_171720) do
   add_foreign_key "merits_assessments", "legal_aid_applications"
   add_foreign_key "savings_amounts", "legal_aid_applications"
   add_foreign_key "statement_of_cases", "legal_aid_applications"
+<<<<<<< HEAD
   add_foreign_key "statement_of_cases", "providers", column: "provider_uploader_id"
+=======
+>>>>>>> ap-325 rebase on master
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -321,12 +321,6 @@ ActiveRecord::Schema.define(version: 2019_02_14_171720) do
   add_foreign_key "legal_aid_applications", "providers"
   add_foreign_key "merits_assessments", "legal_aid_applications"
   add_foreign_key "savings_amounts", "legal_aid_applications"
-<<<<<<< HEAD
   add_foreign_key "statement_of_cases", "legal_aid_applications"
-<<<<<<< HEAD
   add_foreign_key "statement_of_cases", "providers", column: "provider_uploader_id"
-=======
->>>>>>> ap-325 rebase on master
-=======
->>>>>>> AP-325 reverse schema changes
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -184,8 +184,8 @@ ActiveRecord::Schema.define(version: 2019_02_14_171720) do
     t.boolean "open_banking_consent"
     t.datetime "open_banking_consent_choice_at"
     t.string "own_home"
-    t.decimal "property_value", precision: 10, scale: 2
     t.decimal "percentage_home"
+    t.decimal "property_value", precision: 10, scale: 2
     t.string "shared_ownership"
     t.decimal "outstanding_mortgage_amount"
     t.string "provider_step"
@@ -214,8 +214,8 @@ ActiveRecord::Schema.define(version: 2019_02_14_171720) do
     t.text "application_purpose"
     t.boolean "proceedings_before_the_court"
     t.text "details_of_proceedings_before_the_court"
-    t.boolean "client_merits_declaration"
     t.decimal "estimated_legal_cost", precision: 10, scale: 2
+    t.boolean "client_merits_declaration"
     t.string "success_prospect"
     t.text "success_prospect_details"
     t.index ["legal_aid_application_id"], name: "index_merits_assessments_on_legal_aid_application_id"
@@ -223,17 +223,17 @@ ActiveRecord::Schema.define(version: 2019_02_14_171720) do
 
   create_table "other_assets_declarations", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "legal_aid_application_id", null: false
-    t.decimal "second_home_value"
-    t.decimal "second_home_mortgage"
-    t.decimal "second_home_percentage"
-    t.decimal "timeshare_value"
-    t.decimal "land_value"
-    t.decimal "jewellery_value"
-    t.decimal "vehicle_value"
-    t.decimal "classic_car_value"
-    t.decimal "money_assets_value"
-    t.decimal "money_owed_value"
-    t.decimal "trust_value"
+    t.decimal "second_home_value", precision: 14, scale: 2
+    t.decimal "second_home_mortgage", precision: 14, scale: 2
+    t.decimal "second_home_percentage", precision: 14, scale: 2
+    t.decimal "timeshare_value", precision: 14, scale: 2
+    t.decimal "land_value", precision: 14, scale: 2
+    t.decimal "jewellery_value", precision: 14, scale: 2
+    t.decimal "vehicle_value", precision: 14, scale: 2
+    t.decimal "classic_car_value", precision: 14, scale: 2
+    t.decimal "money_assets_value", precision: 14, scale: 2
+    t.decimal "money_owed_value", precision: 14, scale: 2
+    t.decimal "trust_value", precision: 14, scale: 2
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["legal_aid_application_id"], name: "index_other_assets_declarations_on_legal_aid_application_id", unique: true
@@ -321,9 +321,12 @@ ActiveRecord::Schema.define(version: 2019_02_14_171720) do
   add_foreign_key "legal_aid_applications", "providers"
   add_foreign_key "merits_assessments", "legal_aid_applications"
   add_foreign_key "savings_amounts", "legal_aid_applications"
+<<<<<<< HEAD
   add_foreign_key "statement_of_cases", "legal_aid_applications"
 <<<<<<< HEAD
   add_foreign_key "statement_of_cases", "providers", column: "provider_uploader_id"
 =======
 >>>>>>> ap-325 rebase on master
+=======
+>>>>>>> AP-325 reverse schema changes
 end

--- a/spec/forms/citizens/other_assets_form_spec.rb
+++ b/spec/forms/citizens/other_assets_form_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Citizens::OtherAssetsForm do
       { check_box_second_home: 'yes',
         second_home_value: 'aabb',
         second_home_mortgage: '123000.00',
-        second_home_percentage: '100' }
+        second_home_percentage: '100xxx' }
     end
 
     let(:partial_second_home_params) do
@@ -80,6 +80,7 @@ RSpec.describe Citizens::OtherAssetsForm do
             it 'is not valid' do
               expect(form).not_to be_valid
               expect(form.errors[:second_home_value]).to eq [translation_for(:second_home_value, :not_a_number)]
+              expect(form.errors[:second_home_percentage]).to eq [translation_for(:second_home_percentage, :not_a_number)]
             end
           end
         end
@@ -90,7 +91,7 @@ RSpec.describe Citizens::OtherAssetsForm do
   describe 'other params' do
     let(:params) do
       { check_box_second_home: 'true',
-        second_home_value: '85,9374.00',
+        second_home_value: '859,374.00',
         second_home_mortgage: '123,000.00',
         second_home_percentage: '66.66',
         check_box_timeshare_value: 'true',

--- a/spec/forms/outstanding_mortgage_form_spec.rb
+++ b/spec/forms/outstanding_mortgage_form_spec.rb
@@ -75,9 +75,9 @@ RSpec.describe LegalAidApplications::OutstandingMortgageForm, type: :form do
       end
 
       context 'with negative numbers' do
-        let(:amount) { "'#{Faker::Number.negative}'" }
+        let(:amount) { Faker::Number.negative.to_s }
         it 'generates an error' do
-          expect(subject.errors[:outstanding_mortgage_amount]).to contain_exactly('Mortgage amount must be an amount of money, like 60,000')
+          expect(subject.errors[:outstanding_mortgage_amount]).to contain_exactly('Mortgage amount must be 0 or more')
         end
       end
 

--- a/spec/forms/outstanding_mortgage_form_spec.rb
+++ b/spec/forms/outstanding_mortgage_form_spec.rb
@@ -75,14 +75,14 @@ RSpec.describe LegalAidApplications::OutstandingMortgageForm, type: :form do
       end
 
       context 'with negative numbers' do
-        let(:amount) { Faker::Number.negative }
+        let(:amount) { "'#{Faker::Number.negative}'" }
         it 'generates an error' do
-          expect(subject.errors[:outstanding_mortgage_amount]).to contain_exactly('Mortgage amount must be zero or an amount of money, like 60,000')
+          expect(subject.errors[:outstanding_mortgage_amount]).to contain_exactly('Mortgage amount must be an amount of money, like 60,000')
         end
       end
 
       context 'with zero' do
-        let(:amount) { 0 }
+        let(:amount) { '0' }
         it 'does not generates an error' do
           expect(subject.errors[:outstanding_mortgage_amount]).to be_empty
         end

--- a/spec/helpers/money_helper_spec.rb
+++ b/spec/helpers/money_helper_spec.rb
@@ -25,4 +25,32 @@ RSpec.describe MoneyHelper, type: :helper do
       it { is_expected.to eq("#{currency}#{balance}") }
     end
   end
+
+  describe '#number_to_currency_or_original_string' do
+    let(:result) { number_to_currency_or_original_string(value) }
+
+    context 'is a number' do
+      let(:value) { BigDecimal(12_345.5, 12) }
+
+      it 'formats the currency' do
+        expect(result).to eq '12,345.50'
+      end
+    end
+
+    context 'invalid numeric string' do
+      let(:value) { '12345.5678' }
+
+      it 'returns original value' do
+        expect(result).to eq '12345.5678'
+      end
+    end
+
+    context 'invalid alphanumeric string' do
+      let(:value) { '123xc45.5678' }
+
+      it 'returns original value' do
+        expect(result).to eq '123xc45.5678'
+      end
+    end
+  end
 end

--- a/spec/requests/providers/estimated_legal_costs_spec.rb
+++ b/spec/requests/providers/estimated_legal_costs_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe Providers::EstimatedLegalCostsController, type: :request do
   let(:legal_aid_application) { create :legal_aid_application, :with_applicant }
   let(:provider) { legal_aid_application.provider }
+  let!(:estimated_legal_cost_as_text) { '250,000.00' }
 
   describe 'GET /providers/applications/:id/estimated_legal_costs' do
     subject { get providers_legal_aid_application_estimated_legal_costs_path(legal_aid_application) }
@@ -28,7 +29,7 @@ RSpec.describe Providers::EstimatedLegalCostsController, type: :request do
     let(:params) do
       {
         merits_assessment: {
-          estimated_legal_cost: estimated_legal_cost
+          estimated_legal_cost: estimated_legal_cost_as_text
         }
       }
     end
@@ -47,7 +48,7 @@ RSpec.describe Providers::EstimatedLegalCostsController, type: :request do
           }
         end
 
-        let!(:estimated_legal_cost) { 250_00 }
+        let!(:estimated_legal_cost) { 250_000 }
 
         it 'does NOT create an new application record' do
           expect { subject }.not_to change { LegalAidApplication.count }
@@ -92,7 +93,7 @@ RSpec.describe Providers::EstimatedLegalCostsController, type: :request do
           }
         end
 
-        let!(:estimated_legal_cost) { 250_00 }
+        let!(:estimated_legal_cost) { 250_000 }
 
         it 'updates the estimated_legal_cost amount' do
           expect(legal_aid_application.merits_assessment).to eq nil

--- a/spec/services/currency_cleaner_spec.rb
+++ b/spec/services/currency_cleaner_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe CurrencyCleaner do
         %w[-1,000 -1000]
       ]
       valid_strings.each do |valid_pair|
-        expect(CurrencyCleaner.new(valid_pair.first).clean).to eq valid_pair.last
+        expect(CurrencyCleaner.new(valid_pair.first).call).to eq valid_pair.last
       end
     end
   end
@@ -34,7 +34,7 @@ RSpec.describe CurrencyCleaner do
       ]
 
       invalid_strings.each do |invalid_string|
-        expect(CurrencyCleaner.new(invalid_string).clean).to eq invalid_string
+        expect(CurrencyCleaner.new(invalid_string).call).to eq invalid_string
       end
     end
   end

--- a/spec/services/currency_cleaner_spec.rb
+++ b/spec/services/currency_cleaner_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe CurrencyCleaner do
+  context 'valid strings' do
+    it 'returns the string stripped of commas and pound signs' do
+      valid_strings = [
+        %w[£1,123,456.78 1123456.78],
+        %w[£1,123,456 1123456],
+        %w[£1,123.45 1123.45],
+        %w[£123456.78 123456.78],
+        %w[£1,123 1123],
+        %w[£100.12 100.12],
+        %w[£100.1 100.1],
+        %w[£100 100],
+        %w[100 100],
+        %w[-100 -100],
+        %w[-1,000 -1000]
+      ]
+      valid_strings.each do |valid_pair|
+        expect(CurrencyCleaner.new(valid_pair.first).clean).to eq valid_pair.last
+      end
+    end
+  end
+
+  context 'invalid strings' do
+    it 'returns the original string' do
+      invalid_strings = %w[
+        £1,1234,456.78
+        £1,123,5656.78
+        £1,123,565.78.66
+        £1,12£3,565.78
+        $1,123,565.78
+        £1234,5
+      ]
+
+      invalid_strings.each do |invalid_string|
+        expect(CurrencyCleaner.new(invalid_string).clean).to eq invalid_string
+      end
+    end
+  end
+end

--- a/spec/validators/currency_validator_spec.rb
+++ b/spec/validators/currency_validator_spec.rb
@@ -1,0 +1,72 @@
+require 'rails_helper'
+
+RSpec.describe CurrencyValidator do
+  class DummyClass
+    include ActiveModel::Model
+    include ActiveModel::Validations
+
+    attr_accessor :val1, :val2, :val3
+
+    validates :val1, :val2, :val3, currency: { greater_than_or_equal_to: 0 }, allow_blank: true
+  end
+  describe 'numericality validation' do
+    let(:dummy) { DummyClass.new }
+
+    it 'raises not numeric errors on each invalid field' do
+      dummy.val1 = 'abc'
+      dummy.val2 = 'qwe'
+      expect(dummy).to be_invalid
+      expect(dummy.errors[:val1]).to eq ['is not a number']
+      expect(dummy.errors[:val2]).to eq ['is not a number']
+      expect(dummy.errors[:val3]).to be_empty
+    end
+
+    it 'errors if given negative number' do
+      dummy.val1 = '-1234'
+      dummy.val2 = '1234'
+      expect(dummy).to be_invalid
+      expect(dummy.errors[:val1]).to eq ['must be greater than or equal to 0']
+      expect(dummy.errors[:val2]).to be_empty
+      expect(dummy.errors[:val3]).to be_empty
+    end
+
+    it 'validates ok with £ and commas' do
+      dummy.val1 = '-1,234'
+      dummy.val2 = '£1,234.88'
+      expect(dummy).to be_invalid
+      expect(dummy.errors[:val1]).to eq ['must be greater than or equal to 0']
+      expect(dummy.errors[:val2]).to be_empty
+      expect(dummy.errors[:val3]).to be_empty
+    end
+
+    it 'does not clean the number if invalid' do
+      dummy.val1 = '-1,234'
+      dummy.val2 = '-£1,234.88'
+      expect(dummy).to be_invalid
+      expect(dummy.val1).to eq '-1,234'
+      expect(dummy.val2).to eq '-£1,234.88'
+    end
+
+    it 'fails if there are too many decimals' do
+      dummy.val1 = '1,234.123'
+      dummy.val2 = '£1,234.8888'
+      expect(dummy).to be_invalid
+      expect(dummy.errors.details[:val1].first[:error]).to eq :too_many_decimals
+      expect(dummy.errors.details[:val2].first[:error]).to eq :too_many_decimals
+      expect(dummy.errors[:val3]).to be_empty
+      expect(dummy.val1).to eq '1,234.123'
+      expect(dummy.val2).to eq '£1,234.8888'
+    end
+
+    it 'fails if comma is followed by less than 3 digits' do
+      dummy.val1 = '1,23.00'
+      dummy.val2 = '-£1,23'
+      expect(dummy).to be_invalid
+      expect(dummy.errors.details[:val1].first[:error]).to eq :not_a_number
+      expect(dummy.errors.details[:val2].first[:error]).to eq :not_a_number
+      expect(dummy.errors[:val3]).to be_empty
+      expect(dummy.val1).to eq '1,23.00'
+      expect(dummy.val2).to eq '-£1,23'
+    end
+  end
+end

--- a/spec/validators/currency_validator_spec.rb
+++ b/spec/validators/currency_validator_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe CurrencyValidator do
     end
 
     it 'errors if given negative number' do
-      dummy.val1 = Faker::Number.between(-9999,-1).to_s
+      dummy.val1 = Faker::Number.between(-9999, -1).to_s
       dummy.val2 = Faker::Number.number.to_s
       expect(dummy).to be_invalid
       expect(dummy.errors[:val1]).to eq ['must be greater than or equal to 0']

--- a/spec/validators/currency_validator_spec.rb
+++ b/spec/validators/currency_validator_spec.rb
@@ -22,8 +22,8 @@ RSpec.describe CurrencyValidator do
     end
 
     it 'errors if given negative number' do
-      dummy.val1 = '-1234'
-      dummy.val2 = '1234'
+      dummy.val1 = Faker::Number.between(-9999,-1).to_s
+      dummy.val2 = Faker::Number.number.to_s
       expect(dummy).to be_invalid
       expect(dummy.errors[:val1]).to eq ['must be greater than or equal to 0']
       expect(dummy.errors[:val2]).to be_empty


### PR DESCRIPTION
## AP-325 Fix and standardise currency validations

[Link to story](https://dsdmoj.atlassian.net/browse/AP-325)

Previously, currency validations were inconsistent and allowed too many decimals.
Have created a new currency validator, which is used on all forms.
In addition, CurrencyCleaner will remove currency signs and commas if the string is a valid value.
If there are errors, the original String that was input by the user is redisplayed back on the form.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unneccessary whitespace changes. These make diffs harder to read and conflicts more likely. 
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
