### PR TITLE
AP-345 Unable to log in with SAML on UAT when Javascript is turned off

### DIFF
--- a/app/views/saml_idp/idp/saml_post.html.erb
+++ b/app/views/saml_idp/idp/saml_post.html.erb
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset='utf-8' />
+    <meta http-equiv='X-UA-Compatible' content='IE=edge,chrome=1' />
+  </head>
+  <body onload="document.forms[0].submit();">
+    <%= form_tag("http://#{Rails.configuration.x.application.host}/providers/saml/auth") do %>
+      <%= hidden_field_tag('SAMLResponse', @saml_response) %>
+      <%= hidden_field_tag('RelayState', params[:RelayState]) %>
+      <%= submit_tag 'Submit' %>
+    <% end %>
+  </body>
+</html>


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-345)

Describe what you did and why.

We use `ruby-saml-idp` gem to mock saml.  In [app/views/saml_idp/idp/saml_post.html.erb](https://github.com/saml-idp/saml_idp/blob/master/app/views/saml_idp/idp/saml_post.html.erb) which post the saml details on load of page using javascript.   This would break when javascript is turned off.  

I have created a new version of app/views/saml_idp/idp/saml_post.html.erb in our app, which overrides the gem version and display a submit button if javascript is disabled.



## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unneccessary whitespace changes. These make diffs harder to read and conflicts more likely. 
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
