### PR TITLE
Remove back link from post-feedback page

### DIFF
--- a/app/views/feedback/show.html.erb
+++ b/app/views/feedback/show.html.erb
@@ -1,4 +1,4 @@
-<%= page_template page_title: t('.title'), back_link: back_link(path: back_path) do %>
+<%= page_template page_title: t('.title') do %>
   <p class="govuk-body">
     <%= link_to t('.link'), back_path, class: 'govuk-link govuk-link--no-visited-state' %>
   </p>


### PR DESCRIPTION
## What

[AP-349](https://dsdmoj.atlassian.net/browse/AP-349)

Remove `back_link parameter` from call to `page_template` helper in `feedback/show.html.erb`.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unneccessary whitespace changes. These make diffs harder to read and conflicts more likely. 
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
