### PR TITLE
AP-337 Back link behaviour

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,9 @@ gem 'sidekiq-status'
 gem 'sprockets', '>= 3.0.0'
 gem 'sprockets-es6'
 
+# URL and path parsing
+gem 'addressable'
+
 group :development, :test do
   gem 'awesome_print', '~> 1.8.0'
   gem 'byebug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -425,6 +425,7 @@ PLATFORMS
 DEPENDENCIES
   aasm (~> 5.0.1)
   active_model_serializers (~> 0.10.9)
+  addressable
   awesome_print (~> 1.8.0)
   bootsnap (>= 1.1.0)
   browser

--- a/app/controllers/base_controller.rb
+++ b/app/controllers/base_controller.rb
@@ -1,0 +1,3 @@
+class BaseController < ApplicationController
+  include Backable
+end

--- a/app/controllers/citizens/accounts_controller.rb
+++ b/app/controllers/citizens/accounts_controller.rb
@@ -1,5 +1,5 @@
 module Citizens
-  class AccountsController < ApplicationController
+  class AccountsController < BaseController
     before_action :authenticate_applicant!
     include Flowable
 

--- a/app/controllers/citizens/additional_accounts_controller.rb
+++ b/app/controllers/citizens/additional_accounts_controller.rb
@@ -1,5 +1,5 @@
 module Citizens
-  class AdditionalAccountsController < ApplicationController
+  class AdditionalAccountsController < BaseController
     include Flowable
 
     def index; end

--- a/app/controllers/citizens/check_answers_controller.rb
+++ b/app/controllers/citizens/check_answers_controller.rb
@@ -1,5 +1,5 @@
 module Citizens
-  class CheckAnswersController < ApplicationController
+  class CheckAnswersController < BaseController
     include Flowable
     before_action :authenticate_applicant!
 

--- a/app/controllers/citizens/consents_controller.rb
+++ b/app/controllers/citizens/consents_controller.rb
@@ -1,5 +1,5 @@
 module Citizens
-  class ConsentsController < ApplicationController
+  class ConsentsController < BaseController
     include Flowable
 
     def show; end

--- a/app/controllers/citizens/information_controller.rb
+++ b/app/controllers/citizens/information_controller.rb
@@ -1,5 +1,5 @@
 module Citizens
-  class InformationController < ApplicationController
+  class InformationController < BaseController
     include Flowable
 
     def show

--- a/app/controllers/citizens/legal_aid_applications_controller.rb
+++ b/app/controllers/citizens/legal_aid_applications_controller.rb
@@ -1,5 +1,5 @@
 module Citizens
-  class LegalAidApplicationsController < ApplicationController
+  class LegalAidApplicationsController < BaseController
     include Flowable
 
     # User passes in the Secure Id at the start of the journey. If login succeeds, they

--- a/app/controllers/citizens/other_assets_controller.rb
+++ b/app/controllers/citizens/other_assets_controller.rb
@@ -1,5 +1,5 @@
 module Citizens
-  class OtherAssetsController < ApplicationController
+  class OtherAssetsController < BaseController
     include Flowable
 
     def show

--- a/app/controllers/citizens/outstanding_mortgages_controller.rb
+++ b/app/controllers/citizens/outstanding_mortgages_controller.rb
@@ -1,5 +1,5 @@
 module Citizens
-  class OutstandingMortgagesController < ApplicationController
+  class OutstandingMortgagesController < BaseController
     include Flowable
     before_action :authenticate_applicant!
 

--- a/app/controllers/citizens/own_homes_controller.rb
+++ b/app/controllers/citizens/own_homes_controller.rb
@@ -1,5 +1,5 @@
 module Citizens
-  class OwnHomesController < ApplicationController
+  class OwnHomesController < BaseController
     include Flowable
 
     def show

--- a/app/controllers/citizens/percentage_homes_controller.rb
+++ b/app/controllers/citizens/percentage_homes_controller.rb
@@ -1,5 +1,5 @@
 module Citizens
-  class PercentageHomesController < ApplicationController
+  class PercentageHomesController < BaseController
     include Flowable
 
     def show

--- a/app/controllers/citizens/property_values_controller.rb
+++ b/app/controllers/citizens/property_values_controller.rb
@@ -1,5 +1,5 @@
 module Citizens
-  class PropertyValuesController < ApplicationController
+  class PropertyValuesController < BaseController
     include Flowable
 
     def show

--- a/app/controllers/citizens/restrictions_controller.rb
+++ b/app/controllers/citizens/restrictions_controller.rb
@@ -1,5 +1,5 @@
 module Citizens
-  class RestrictionsController < ApplicationController
+  class RestrictionsController < BaseController
     include Flowable
     before_action :authenticate_applicant!
 

--- a/app/controllers/citizens/savings_and_investments_controller.rb
+++ b/app/controllers/citizens/savings_and_investments_controller.rb
@@ -1,5 +1,5 @@
 module Citizens
-  class SavingsAndInvestmentsController < ApplicationController
+  class SavingsAndInvestmentsController < BaseController
     include Flowable
 
     helper_method :bank_accounts, :attributes

--- a/app/controllers/citizens/shared_ownerships_controller.rb
+++ b/app/controllers/citizens/shared_ownerships_controller.rb
@@ -1,5 +1,5 @@
 module Citizens
-  class SharedOwnershipsController < ApplicationController
+  class SharedOwnershipsController < BaseController
     include Flowable
 
     def show

--- a/app/controllers/concerns/backable.rb
+++ b/app/controllers/concerns/backable.rb
@@ -1,0 +1,63 @@
+module Backable
+  extend ActiveSupport::Concern
+  HISTORY_SIZE = 20
+
+  included do
+    before_action :update_page_history
+
+    # Adding ?back=true to the path of the previous page to indicate that we are moving backward in the page history
+    def back_path
+      return unless page_history.size > 1
+
+      path = Addressable::URI.parse(page_history[-2])
+      path.query_values = (path.query_values || {}).merge(back: true)
+      path.to_s
+    end
+    helper_method :back_path
+
+    private
+
+    def update_page_history
+      return unless request.request_method_symbol == :get
+
+      if navigated_back?
+        cleanup_path
+      elsif flash[:back] == true
+        page_history.pop
+        flash[:back] = nil
+      elsif !same_page?
+        add_page_to_history
+      end
+
+      remove_old_history
+    end
+
+    def add_page_to_history
+      page_history << request.fullpath
+    end
+
+    def navigated_back?
+      params.key?(:back)
+    end
+
+    # removing "?back=true" param from the path
+    def cleanup_path
+      path = Addressable::URI.parse(request.fullpath)
+      path.query_values = (path.query_values || {}).except('back')
+      path.query_values = nil if path.query_values.empty?
+      redirect_to path.to_s, flash: { back: true }
+    end
+
+    def same_page?
+      page_history.last == request.fullpath
+    end
+
+    def remove_old_history
+      page_history.shift while page_history.size > HISTORY_SIZE
+    end
+
+    def page_history
+      session[:page_history] ||= []
+    end
+  end
+end

--- a/app/controllers/concerns/flowable.rb
+++ b/app/controllers/concerns/flowable.rb
@@ -2,8 +2,8 @@ module Flowable
   extend ActiveSupport::Concern
 
   included do
-    delegate :back_path, :forward_path, to: :flow_service
-    helper_method :back_path, :forward_path
+    delegate :forward_path, to: :flow_service
+    helper_method :forward_path
 
     def go_forward
       if path?(forward_path)

--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -1,3 +1,3 @@
-class ContactsController < ApplicationController
+class ContactsController < BaseController
   def show; end
 end

--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -1,4 +1,4 @@
-class FeedbackController < ApplicationController
+class FeedbackController < BaseController
   before_action :update_return_path
 
   def new

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,3 +1,3 @@
-class HomeController < ApplicationController
+class HomeController < BaseController
   def index; end
 end

--- a/app/controllers/providers/about_the_financial_assessments_controller.rb
+++ b/app/controllers/providers/about_the_financial_assessments_controller.rb
@@ -1,17 +1,19 @@
 module Providers
-  class AboutTheFinancialAssessmentsController < BaseController
+  class AboutTheFinancialAssessmentsController < ProviderBaseController
     include ApplicationDependable
     include Flowable
     include Draftable
 
     def show; end
 
-    def submit
+    def update
       return continue_or_draft if draft_selected?
-      return if legal_aid_application.provider_submitted?
 
-      legal_aid_application.provider_submit!
-      CitizenEmailService.new(legal_aid_application).send_email
+      unless legal_aid_application.provider_submitted?
+        legal_aid_application.provider_submit!
+        CitizenEmailService.new(legal_aid_application).send_email
+      end
+      go_forward
     end
   end
 end

--- a/app/controllers/providers/address_lookups_controller.rb
+++ b/app/controllers/providers/address_lookups_controller.rb
@@ -1,5 +1,5 @@
 module Providers
-  class AddressLookupsController < BaseController
+  class AddressLookupsController < ProviderBaseController
     include ApplicationDependable
     include Flowable
 

--- a/app/controllers/providers/address_selections_controller.rb
+++ b/app/controllers/providers/address_selections_controller.rb
@@ -1,5 +1,5 @@
 module Providers
-  class AddressSelectionsController < BaseController
+  class AddressSelectionsController < ProviderBaseController
     include ApplicationDependable
     include Flowable
     include Draftable

--- a/app/controllers/providers/addresses_controller.rb
+++ b/app/controllers/providers/addresses_controller.rb
@@ -1,5 +1,5 @@
 module Providers
-  class AddressesController < BaseController
+  class AddressesController < ProviderBaseController
     include ApplicationDependable
     include Flowable
 

--- a/app/controllers/providers/applicants_controller.rb
+++ b/app/controllers/providers/applicants_controller.rb
@@ -1,5 +1,5 @@
 module Providers
-  class ApplicantsController < BaseController
+  class ApplicantsController < ProviderBaseController
     include ApplicationDependable
     include Flowable
     include Draftable

--- a/app/controllers/providers/application_confirmations_controller.rb
+++ b/app/controllers/providers/application_confirmations_controller.rb
@@ -1,0 +1,8 @@
+module Providers
+  class ApplicationConfirmationsController < ProviderBaseController
+    include ApplicationDependable
+    include Flowable
+
+    def show; end
+  end
+end

--- a/app/controllers/providers/check_benefits_controller.rb
+++ b/app/controllers/providers/check_benefits_controller.rb
@@ -1,5 +1,5 @@
 module Providers
-  class CheckBenefitsController < BaseController
+  class CheckBenefitsController < ProviderBaseController
     include ApplicationDependable
     include Flowable
     include Draftable

--- a/app/controllers/providers/check_merits_answers_controller.rb
+++ b/app/controllers/providers/check_merits_answers_controller.rb
@@ -1,5 +1,5 @@
 module Providers
-  class CheckMeritsAnswersController < BaseController
+  class CheckMeritsAnswersController < ProviderBaseController
     include ApplicationDependable
     include Flowable
 

--- a/app/controllers/providers/check_passported_answers_controller.rb
+++ b/app/controllers/providers/check_passported_answers_controller.rb
@@ -1,5 +1,5 @@
 module Providers
-  class CheckPassportedAnswersController < BaseController
+  class CheckPassportedAnswersController < ProviderBaseController
     include ApplicationDependable
     include Flowable
 

--- a/app/controllers/providers/check_provider_answers_controller.rb
+++ b/app/controllers/providers/check_provider_answers_controller.rb
@@ -1,5 +1,5 @@
 module Providers
-  class CheckProviderAnswersController < BaseController
+  class CheckProviderAnswersController < ProviderBaseController
     include ApplicationDependable
     include Flowable
     include Draftable

--- a/app/controllers/providers/client_received_legal_helps_controller.rb
+++ b/app/controllers/providers/client_received_legal_helps_controller.rb
@@ -1,5 +1,5 @@
 module Providers
-  class ClientReceivedLegalHelpsController < BaseController
+  class ClientReceivedLegalHelpsController < ProviderBaseController
     include ApplicationDependable
     include Flowable
     include Draftable

--- a/app/controllers/providers/estimated_legal_costs_controller.rb
+++ b/app/controllers/providers/estimated_legal_costs_controller.rb
@@ -1,5 +1,5 @@
 module Providers
-  class EstimatedLegalCostsController < BaseController
+  class EstimatedLegalCostsController < ProviderBaseController
     include ApplicationDependable
     include Flowable
     include Draftable

--- a/app/controllers/providers/legal_aid_applications_controller.rb
+++ b/app/controllers/providers/legal_aid_applications_controller.rb
@@ -1,5 +1,5 @@
 module Providers
-  class LegalAidApplicationsController < BaseController
+  class LegalAidApplicationsController < ProviderBaseController
     attr_reader :legal_aid_application
     include Flowable
 

--- a/app/controllers/providers/merits_declarations_controller.rb
+++ b/app/controllers/providers/merits_declarations_controller.rb
@@ -1,5 +1,5 @@
 module Providers
-  class MeritsDeclarationsController < BaseController
+  class MeritsDeclarationsController < ProviderBaseController
     include ApplicationDependable
     include Flowable
 

--- a/app/controllers/providers/online_bankings_controller.rb
+++ b/app/controllers/providers/online_bankings_controller.rb
@@ -1,5 +1,5 @@
 module Providers
-  class OnlineBankingsController < BaseController
+  class OnlineBankingsController < ProviderBaseController
     include ApplicationDependable
     include Flowable
 

--- a/app/controllers/providers/other_assets_controller.rb
+++ b/app/controllers/providers/other_assets_controller.rb
@@ -1,5 +1,5 @@
 module Providers
-  class OtherAssetsController < BaseController
+  class OtherAssetsController < ProviderBaseController
     include ApplicationDependable
     include Flowable
     include Draftable

--- a/app/controllers/providers/outstanding_mortgages_controller.rb
+++ b/app/controllers/providers/outstanding_mortgages_controller.rb
@@ -1,5 +1,5 @@
 module Providers
-  class OutstandingMortgagesController < BaseController
+  class OutstandingMortgagesController < ProviderBaseController
     include ApplicationDependable
     include Flowable
     include Draftable

--- a/app/controllers/providers/own_homes_controller.rb
+++ b/app/controllers/providers/own_homes_controller.rb
@@ -1,5 +1,5 @@
 module Providers
-  class OwnHomesController < BaseController
+  class OwnHomesController < ProviderBaseController
     include ApplicationDependable
     include Flowable
     include Draftable

--- a/app/controllers/providers/percentage_homes_controller.rb
+++ b/app/controllers/providers/percentage_homes_controller.rb
@@ -1,5 +1,5 @@
 module Providers
-  class PercentageHomesController < BaseController
+  class PercentageHomesController < ProviderBaseController
     include ApplicationDependable
     include Flowable
     include Draftable

--- a/app/controllers/providers/proceedings_before_the_courts_controller.rb
+++ b/app/controllers/providers/proceedings_before_the_courts_controller.rb
@@ -1,5 +1,5 @@
 module Providers
-  class ProceedingsBeforeTheCourtsController < BaseController
+  class ProceedingsBeforeTheCourtsController < ProviderBaseController
     include ApplicationDependable
     include Flowable
     include Draftable

--- a/app/controllers/providers/proceedings_types_controller.rb
+++ b/app/controllers/providers/proceedings_types_controller.rb
@@ -1,5 +1,5 @@
 module Providers
-  class ProceedingsTypesController < BaseController
+  class ProceedingsTypesController < ProviderBaseController
     include ApplicationDependable
     include Flowable
     include Draftable

--- a/app/controllers/providers/property_values_controller.rb
+++ b/app/controllers/providers/property_values_controller.rb
@@ -1,5 +1,5 @@
 module Providers
-  class PropertyValuesController < BaseController
+  class PropertyValuesController < ProviderBaseController
     include ApplicationDependable
     include Flowable
     include Draftable

--- a/app/controllers/providers/provider_base_controller.rb
+++ b/app/controllers/providers/provider_base_controller.rb
@@ -1,5 +1,5 @@
 module Providers
-  class BaseController < ApplicationController
+  class ProviderBaseController < BaseController
     before_action :authenticate_provider!
     before_action :set_cache_buster
     include Pundit

--- a/app/controllers/providers/providers_controller.rb
+++ b/app/controllers/providers/providers_controller.rb
@@ -1,5 +1,5 @@
 module Providers
-  class ProvidersController < BaseController
+  class ProvidersController < ProviderBaseController
     def show
       @provider = current_provider
     end

--- a/app/controllers/providers/restrictions_controller.rb
+++ b/app/controllers/providers/restrictions_controller.rb
@@ -1,5 +1,5 @@
 module Providers
-  class RestrictionsController < BaseController
+  class RestrictionsController < ProviderBaseController
     include ApplicationDependable
     include Flowable
     include Draftable

--- a/app/controllers/providers/savings_and_investments_controller.rb
+++ b/app/controllers/providers/savings_and_investments_controller.rb
@@ -1,5 +1,5 @@
 module Providers
-  class SavingsAndInvestmentsController < BaseController
+  class SavingsAndInvestmentsController < ProviderBaseController
     include ApplicationDependable
     include Flowable
     include Draftable

--- a/app/controllers/providers/shared_ownerships_controller.rb
+++ b/app/controllers/providers/shared_ownerships_controller.rb
@@ -1,5 +1,5 @@
 module Providers
-  class SharedOwnershipsController < BaseController
+  class SharedOwnershipsController < ProviderBaseController
     include ApplicationDependable
     include Flowable
     include Draftable

--- a/app/controllers/providers/start_controller.rb
+++ b/app/controllers/providers/start_controller.rb
@@ -2,7 +2,7 @@
 #       In the finished app, this page will be externally hosted
 #       When this is removed the route `providers_root` will need to point at the external url
 module Providers
-  class StartController < ApplicationController
+  class StartController < BaseController
     def index; end
   end
 end

--- a/app/controllers/providers/statement_of_cases_controller.rb
+++ b/app/controllers/providers/statement_of_cases_controller.rb
@@ -1,5 +1,5 @@
 module Providers
-  class StatementOfCasesController < BaseController
+  class StatementOfCasesController < ProviderBaseController
     include ApplicationDependable
     include Flowable
     include Draftable

--- a/app/controllers/providers/success_prospects_controller.rb
+++ b/app/controllers/providers/success_prospects_controller.rb
@@ -1,5 +1,5 @@
 module Providers
-  class SuccessProspectsController < BaseController
+  class SuccessProspectsController < ProviderBaseController
     include ApplicationDependable
     include Flowable
     include Draftable

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -20,6 +20,8 @@ module ApplicationHelper
   end
 
   def back_link(text: t('generic.back'), path: back_path, method: nil)
+    return unless path
+
     link_to text, path, class: 'govuk-back-link', id: 'back', method: method
   end
 

--- a/app/helpers/page_template_helper.rb
+++ b/app/helpers/page_template_helper.rb
@@ -1,9 +1,6 @@
 module PageTemplateHelper
   # A wrapper for the main elements needed in a page.
   #
-  # Note that there are journey specific methods that call `page_template`
-  # with modifications tailored to that journey: `provider_page` and `citizen_page`
-  #
   # `page_template` will wrap the main content, and add the main elements needed
   # at the start of each page (HTML title, navigation links, and heading):
   #
@@ -49,7 +46,7 @@ module PageTemplateHelper
         &content
       )
     template = :default unless %i[form basic].include?(template)
-    content_for(:navigation) { back_link unless back_link == :none }
+    content_for(:navigation) { back_link(back_link) unless back_link == :none }
     content_for(:page_title) { page_title }
     content = capture(&content) if content
     render(
@@ -60,17 +57,5 @@ module PageTemplateHelper
       content: content,
       show_errors_for: show_errors_for
     )
-  end
-
-  def provider_page(args, &content)
-    back_link = args.fetch(:back_link, {})
-    args[:back_link] = provider_back_link(back_link) unless back_link == :none
-    page_template(args, &content)
-  end
-
-  def citizen_page(args, &content)
-    back_link_args = args.fetch(:back_link, {})
-    args[:back_link] = back_link(back_link_args) unless back_link_args == :none
-    page_template(args, &content)
   end
 end

--- a/app/helpers/providers_helper.rb
+++ b/app/helpers/providers_helper.rb
@@ -1,8 +1,4 @@
 module ProvidersHelper
-  def provider_back_link(text: t('generic.back'), path: back_path, method: :get)
-    link_to text, path, class: 'govuk-back-link', id: 'back-top', method: method
-  end
-
   def url_for_application(legal_aid_application)
     name = legal_aid_application.provider_step.presence || :proceedings_types
 

--- a/app/services/flow/base_flow_service.rb
+++ b/app/services/flow/base_flow_service.rb
@@ -23,12 +23,6 @@ module Flow
       @current_step = current_step
     end
 
-    def back_path
-      return path(check_answers_step) if checking_answers? && check_answers_step
-
-      path(back_step)
-    end
-
     def forward_path
       if checking_answers? && check_answers_step
         return path(forward_step) if carry_on_sub_flow?
@@ -66,10 +60,6 @@ module Flow
       return path unless path.is_a?(Proc)
 
       path.call(legal_aid_application, urls)
-    end
-
-    def back_step
-      @back_step ||= step(:back)
     end
 
     def forward_step

--- a/app/services/flow/flows/citizen_capital.rb
+++ b/app/services/flow/flows/citizen_capital.rb
@@ -4,70 +4,55 @@ module Flow
       STEPS = {
         own_homes: {
           path: ->(_, urls) { urls.citizens_own_home_path },
-          back: :additional_accounts,
           forward: ->(application) { application.own_home_no? ? :savings_and_investments : :property_values },
           carry_on_sub_flow: ->(application) { !application.own_home_no? },
           check_answers: :check_answers
         },
         property_values: {
           path: ->(_, urls) { urls.citizens_property_value_path },
-          back: :own_homes,
           forward: ->(application) { application.own_home_mortgage? ? :outstanding_mortgages : :shared_ownerships },
           carry_on_sub_flow: true,
           check_answers: :check_answers
         },
         outstanding_mortgages: {
           path: ->(_, urls) { urls.citizens_outstanding_mortgage_path },
-          back: :property_values,
           forward: :shared_ownerships,
           carry_on_sub_flow: true,
           check_answers: :check_answers
         },
         shared_ownerships: {
           path: ->(_, urls) { urls.citizens_shared_ownership_path },
-          back: ->(application) { application.own_home_mortgage? ? :outstanding_mortgages : :property_values },
           forward: ->(application) { application.shared_ownership? ? :percentage_homes : :savings_and_investments },
           carry_on_sub_flow: ->(application) { application.shared_ownership? },
           check_answers: :check_answers
         },
         percentage_homes: {
           path: ->(_, urls) { urls.citizens_percentage_home_path },
-          back: :shared_ownerships,
           forward: :savings_and_investments,
           check_answers: :check_answers
         },
         savings_and_investments: {
           path: ->(_, urls) { urls.citizens_savings_and_investment_path },
-          back: ->(application) do
-            return :own_homes if application.own_home_no?
-            return :percentage_homes if application.shared_ownership?
-
-            :shared_ownerships
-          end,
           forward: :other_assets,
           check_answers: :check_answers
         },
         other_assets: {
           path: ->(_, urls) { urls.citizens_other_assets_path },
           forward: ->(application) { application.own_capital? ? :restrictions : :check_answers },
-          back: :savings_and_investments,
           check_answers: :check_answers
         },
         restrictions: {
           path: ->(_, urls) { urls.citizens_restrictions_path },
           forward: :check_answers,
-          back: :other_assets,
           check_answers: :check_answers
         },
         check_answers: {
           path: ->(_, urls) { urls.citizens_check_answers_path },
-          forward: :application_submitted,
-          back: ->(application) { application.own_capital? ? :restrictions : :other_assets }
+          forward: :application_submitted
         },
         application_submitted: {
           path: 'citizens_application_submitted_path',
-          forward: nil,
-          back: :check_answers
+          forward: nil
         }
       }.freeze
     end

--- a/app/services/flow/flows/citizen_start.rb
+++ b/app/services/flow/flows/citizen_start.rb
@@ -3,30 +3,24 @@ module Flow
     module CitizenStart
       STEPS = {
         legal_aid_applications: {
-          path: ->(_, urls) { urls.citizens_legal_aid_applications_path },
           forward: :information
         },
         information: {
-          back: :legal_aid_applications,
           path: ->(_, urls) { urls.citizens_information_path },
           forward: :consents
         },
         consents: {
           path: ->(_, urls) { urls.citizens_consent_path },
-          back: :information,
           forward: :true_layer
         },
         true_layer: {
           path: ->(_, urls) { urls.applicant_true_layer_omniauth_authorize_path }
         },
         accounts: {
-          path: ->(_, urls) { urls.citizens_accounts_path },
-          back: :consents,
           forward: :additional_accounts
         },
         additional_accounts: {
           path: ->(_, urls) { urls.citizens_additional_accounts_path },
-          back: :accounts,
           forward: :own_homes
         }
       }.freeze

--- a/app/services/flow/flows/provider_capital.rb
+++ b/app/services/flow/flows/provider_capital.rb
@@ -4,65 +4,51 @@ module Flow
       STEPS = {
         own_homes: {
           path: ->(application, urls) { urls.providers_legal_aid_application_own_home_path(application) },
-          back: :check_benefits,
           forward: ->(application) { application.own_home_no? ? :savings_and_investments : :property_values },
           carry_on_sub_flow: ->(application) { !application.own_home_no? },
           check_answers: :check_passported_answers
         },
         property_values: {
           path: ->(application, urls) { urls.providers_legal_aid_application_property_value_path(application) },
-          back: :own_homes,
           forward: ->(application) { application.own_home_mortgage? ? :outstanding_mortgages : :shared_ownerships },
           carry_on_sub_flow: true,
           check_answers: :check_passported_answers
         },
         outstanding_mortgages: {
           path: ->(application, urls) { urls.providers_legal_aid_application_outstanding_mortgage_path(application) },
-          back: :property_values,
           forward: :shared_ownerships,
           carry_on_sub_flow: true,
           check_answers: :check_passported_answers
         },
         shared_ownerships: {
           path: ->(application, urls) { urls.providers_legal_aid_application_shared_ownership_path(application) },
-          back: ->(application) { application.own_home_mortgage? ? :outstanding_mortgages : :property_values },
           forward: ->(application) { application.shared_ownership? ? :percentage_homes : :savings_and_investments },
           carry_on_sub_flow: ->(application) { application.shared_ownership? },
           check_answers: :check_passported_answers
         },
         percentage_homes: {
           path: ->(application, urls) { urls.providers_legal_aid_application_percentage_home_path(application) },
-          back: :shared_ownerships,
           forward: :savings_and_investments,
           check_answers: :check_passported_answers
         },
         savings_and_investments: {
           path: ->(application, urls) { urls.providers_legal_aid_application_savings_and_investment_path(application) },
-          back: ->(application) do
-            return :own_homes if application.own_home_no?
-            return :percentage_homes if application.shared_ownership?
-
-            :shared_ownerships
-          end,
           forward: :other_assets,
           check_answers: :check_passported_answers
         },
         other_assets: {
           path: ->(application, urls) { urls.providers_legal_aid_application_other_assets_path(application) },
           forward: ->(application) { application.own_capital? ? :restrictions : :check_passported_answers },
-          back: :savings_and_investments,
           check_answers: :check_passported_answers
         },
         restrictions: {
           path: ->(application, urls) { urls.providers_legal_aid_application_restrictions_path(application) },
           forward: :check_passported_answers,
-          back: :other_assets,
           check_answers: :check_passported_answers
         },
         check_passported_answers: {
           path: ->(application, urls) { urls.providers_legal_aid_application_check_passported_answers_path(application) },
-          forward: :client_received_legal_helps,
-          back: ->(application) { application.own_capital? ? :restrictions : :other_assets }
+          forward: :client_received_legal_helps
         }
       }.freeze
     end

--- a/app/services/flow/flows/provider_merits.rb
+++ b/app/services/flow/flows/provider_merits.rb
@@ -5,43 +5,36 @@ module Flow
         client_received_legal_helps: {
           path: ->(application, urls) { urls.providers_legal_aid_application_client_received_legal_help_path(application) },
           forward: :proceedings_before_the_courts,
-          back: :check_passported_answers,
           check_answers: :check_merits_answers
         },
         proceedings_before_the_courts: {
           path: ->(application, urls) { urls.providers_legal_aid_application_proceedings_before_the_court_path(application) },
           forward: :statement_of_cases,
-          back: :client_received_legal_helps,
           check_answers: :check_merits_answers
         },
         statement_of_cases: {
           path: ->(application, urls) { urls.providers_legal_aid_application_statement_of_case_path(application) },
           forward: :estimated_legal_costs,
-          back: :proceedings_before_the_courts,
           check_answers: :check_merits_answers
         },
         estimated_legal_costs: {
           path: ->(application, urls) { urls.providers_legal_aid_application_estimated_legal_costs_path(application) },
           forward: :success_prospects,
-          back: :statement_of_cases,
           check_answers: :check_merits_answers
         },
         success_prospects: {
           path: ->(application, urls) { urls.providers_legal_aid_application_success_prospects_path(application) },
           forward: :merits_declarations,
-          back: :estimated_legal_costs,
           check_answers: :check_merits_answers
         },
         merits_declarations: {
           path: ->(application, urls) { urls.providers_legal_aid_application_merits_declaration_path(application) },
           forward: :check_merits_answers,
-          back: :success_prospects,
           check_answers: :check_merits_answers
         },
         check_merits_answers: {
           path: ->(application, urls) { urls.providers_legal_aid_application_check_merits_answers_path(application) },
           forward: :placeholder_end_merits,
-          back: :merits_declarations,
           check_answers: :check_merits_answers
         },
         placeholder_end_merits: {

--- a/app/services/flow/flows/provider_start.rb
+++ b/app/services/flow/flows/provider_start.rb
@@ -3,58 +3,51 @@ module Flow
     module ProviderStart
       STEPS = {
         legal_aid_applications: {
-          path: ->(_, urls) { urls.providers_legal_aid_applications_path },
           forward: :applicants
         },
         applicants: {
           path: ->(application, urls) { urls.providers_legal_aid_application_applicant_path(application) },
-          back: :legal_aid_applications,
           forward: :address_lookups,
           check_answers: :check_provider_answers
         },
         address_lookups: {
           path: ->(application, urls) { urls.providers_legal_aid_application_address_lookup_path(application) },
-          back: :applicants,
           forward: :address_selections,
           check_answers: :check_provider_answers,
           carry_on_sub_flow: true
         },
         address_selections: {
           path: ->(application, urls) { urls.providers_legal_aid_application_address_selection_path(application) },
-          back: :address_lookups,
           forward: :proceedings_types,
           check_answers: :check_provider_answers
         },
         addresses: {
-          path: ->(application, urls) { urls.providers_legal_aid_application_address_path(application) },
-          back: :address_lookups,
           forward: :proceedings_types,
           check_answers: :check_provider_answers
         },
         proceedings_types: {
           path: ->(application, urls) { urls.providers_legal_aid_application_proceedings_types_path(application) },
-          back: ->(application) { application.applicant.address&.lookup_used? ? :address_selections : :addresses },
           forward: :check_provider_answers,
           check_answers: :check_provider_answers
         },
         check_provider_answers: {
           path: ->(application, urls) { urls.providers_legal_aid_application_check_provider_answers_path(application) },
-          back: :proceedings_types,
           forward: :check_benefits
         },
         check_benefits: {
           path: ->(application, urls) { urls.providers_legal_aid_application_check_benefits_path(application) },
-          back: :check_provider_answers,
           forward: ->(application) { application.benefit_check_result.positive? ? :own_homes : :online_bankings }
         },
         online_bankings: {
           path: ->(application, urls) { urls.providers_legal_aid_application_online_banking_path(application) },
-          back: :check_benefits,
           forward: ->(application) { application.applicant.uses_online_banking? ? :about_the_financial_assessments : :place_holder_ccms }
         },
         about_the_financial_assessments: {
           path: ->(application, urls) { urls.providers_legal_aid_application_about_the_financial_assessment_path(application) },
-          back: :online_bankings
+          forward: :application_confirmations
+        },
+        application_confirmations: {
+          path: ->(application, urls) { urls.providers_legal_aid_application_application_confirmation_path(application) }
         },
         place_holder_ccms: {
           path: '[PLACEHOLDER] Page directing provider to use CCMS'

--- a/app/views/citizens/accounts/_accounts.html.erb
+++ b/app/views/citizens/accounts/_accounts.html.erb
@@ -5,7 +5,7 @@
   </div>
 <% end %>
 
-<%= citizen_page page_title: t('.heading_1') do %>
+<%= page_template page_title: t('.heading_1') do %>
   <p>
     <%= t '.intro_text' %>
   </p>

--- a/app/views/citizens/additional_accounts/index.html.erb
+++ b/app/views/citizens/additional_accounts/index.html.erb
@@ -1,4 +1,4 @@
-<%= citizen_page page_title: t('.field_set_header'), template: :form do %>
+<%= page_template page_title: t('.field_set_header'), template: :form do %>
   <%= form_tag(citizens_additional_accounts_path) do %>
 
     <%= govuk_form_group(

--- a/app/views/citizens/additional_accounts/new.html.erb
+++ b/app/views/citizens/additional_accounts/new.html.erb
@@ -1,11 +1,4 @@
-<%= citizen_page(
-      page_title: t('.field_set_header'),
-      back_link: {
-        path: citizens_additional_accounts_path
-      },
-      template: :form
-    ) do %>
-
+<%= page_template page_title: t('.field_set_header'), template: :form do %>
   <%= form_tag(citizens_additional_account_path(id: :update), method: :patch) do %>
 
     <%= govuk_form_group(

--- a/app/views/citizens/check_answers/index.html.erb
+++ b/app/views/citizens/check_answers/index.html.erb
@@ -1,4 +1,4 @@
-<%= citizen_page(
+<%= page_template(
       page_title: t('.h1-heading'),
       back_link: {
         path: reset_citizens_check_answers_path,

--- a/app/views/citizens/consents/show.html.erb
+++ b/app/views/citizens/consents/show.html.erb
@@ -1,4 +1,4 @@
-<%= citizen_page page_title: t('.field_set_header'), template: :form do %>
+<%= page_template page_title: t('.field_set_header'), template: :form do %>
 
   <%= form_with(model: @form, scope: :legal_aid_application, url: citizens_consent_path, local: true) do |form| %>
     <%= govuk_form_group(

--- a/app/views/citizens/information/show.html.erb
+++ b/app/views/citizens/information/show.html.erb
@@ -1,4 +1,4 @@
-<%= citizen_page page_title: t('.heading_1') do %>
+<%= page_template page_title: t('.heading_1') do %>
   <p class="govuk-body"><%= t('.para_1') %></p>
   <p class="govuk-body govuk-!-padding-bottom-2"><%= t('.para_2') %></p>
   <h2 class="govuk-heading-m"><%= t('.list.title') %></h2>

--- a/app/views/citizens/legal_aid_applications/index.html.erb
+++ b/app/views/citizens/legal_aid_applications/index.html.erb
@@ -1,4 +1,4 @@
-<%= citizen_page page_title: t('.heading_1'), back_link: :none do %>
+<%= page_template page_title: t('.heading_1'), back_link: :none do %>
   <p class="govuk-body">
     <%= t('.name') %>
     <b><%= current_applicant.first_name %></b>

--- a/app/views/citizens/other_assets/show.html.erb
+++ b/app/views/citizens/other_assets/show.html.erb
@@ -1,4 +1,4 @@
-<%= citizen_page page_title: t('.h1-heading') do %>
+<%= page_template page_title: t('.h1-heading') do %>
 
   <%= render partial: '/shared/forms/other_assets/form',
              locals: {

--- a/app/views/citizens/outstanding_mortgages/show.html.erb
+++ b/app/views/citizens/outstanding_mortgages/show.html.erb
@@ -1,4 +1,4 @@
-<%= citizen_page page_title: t('.h1-heading'), template: :basic do %>
+<%= page_template page_title: t('.h1-heading'), template: :basic do %>
 
     <%= render(
           partial: '/shared/forms/outstanding_mortgage_form',

--- a/app/views/citizens/own_homes/show.html.erb
+++ b/app/views/citizens/own_homes/show.html.erb
@@ -1,3 +1,3 @@
-<%= citizen_page page_title: t('.h1-heading'), template: :basic do %>
+<%= page_template page_title: t('.h1-heading'), template: :basic do %>
   <%= render 'shared/forms/own_home_form', form_path: citizens_own_home_path %>
 <% end %>

--- a/app/views/citizens/percentage_homes/show.html.erb
+++ b/app/views/citizens/percentage_homes/show.html.erb
@@ -1,4 +1,4 @@
-<%= citizen_page page_title: t('.h1-heading') do %>
+<%= page_template page_title: t('.h1-heading') do %>
   <%= render partial: 'shared/forms/percentage_home_form',
              locals: {
                model: @form,

--- a/app/views/citizens/property_values/show.html.erb
+++ b/app/views/citizens/property_values/show.html.erb
@@ -1,3 +1,3 @@
-<%= citizen_page page_title: t('.h1-heading') do %>
+<%= page_template page_title: t('.h1-heading') do %>
   <%= render partial: 'form', locals: { model: @form, url: citizens_property_value_path } %>
 <% end %>

--- a/app/views/citizens/restrictions/index.html.erb
+++ b/app/views/citizens/restrictions/index.html.erb
@@ -1,4 +1,4 @@
-<%= citizen_page page_title: t('.h1-heading'), template: :form do %>
+<%= page_template page_title: t('.h1-heading'), template: :form do %>
   <%= render partial: 'form',
              locals: {
                model: @legal_aid_application,

--- a/app/views/citizens/savings_and_investments/show.html.erb
+++ b/app/views/citizens/savings_and_investments/show.html.erb
@@ -1,4 +1,4 @@
-<%= citizen_page page_title: t('.h1-heading') do %>
+<%= page_template page_title: t('.h1-heading') do %>
   <%= render(
         'shared/forms/savings_and_investments_form',
         bank_accounts: bank_accounts,

--- a/app/views/citizens/shared_ownerships/show.html.erb
+++ b/app/views/citizens/shared_ownerships/show.html.erb
@@ -1,3 +1,3 @@
-<%= citizen_page page_title: t('.heading_1') do %>
+<%= page_template page_title: t('.heading_1') do %>
   <%= render 'shared/forms/shared_ownership_form', form_path: citizens_shared_ownership_path %>
 <% end %>

--- a/app/views/contacts/show.html.erb
+++ b/app/views/contacts/show.html.erb
@@ -1,4 +1,4 @@
-<%= page_template page_title: t('.h1-heading'), back_link: back_link(path: :back) do %>
+<%= page_template page_title: t('.h1-heading') do %>
   <p class="govuk-body"><%= t('.page_header') %></p>
 
   <p class="govuk-body">

--- a/app/views/feedback/new.html.erb
+++ b/app/views/feedback/new.html.erb
@@ -1,4 +1,4 @@
-<%= page_template page_title: t('.title'), back_link: back_link(path: back_path) do %>
+<%= page_template page_title: t('.title') do %>
 
     <%= form_for(@feedback, url: feedback_index_path) do |form| %>
 

--- a/app/views/providers/about_the_financial_assessments/show.html.erb
+++ b/app/views/providers/about_the_financial_assessments/show.html.erb
@@ -1,4 +1,4 @@
-<%= provider_page(page_title: t('.title')) do %></h1>
+<%= page_template(page_title: t('.title')) do %></h1>
   <p class="govuk-body"><%= t '.sign_in_para' %></p>
 
   <p class="govuk-body"><%= t '.share_bank_accounts_para' %></p>
@@ -19,7 +19,8 @@
 
   <div class="govuk-grid-row">
     <%= next_action_buttons_with_form(
-          url: submit_providers_legal_aid_application_about_the_financial_assessment_path,
+          url: providers_legal_aid_application_about_the_financial_assessment_path,
+          method: :patch,
           show_draft: true
         ) %>
   </div>

--- a/app/views/providers/address_lookups/_form.html.erb
+++ b/app/views/providers/address_lookups/_form.html.erb
@@ -1,4 +1,4 @@
-<%= provider_page(
+<%= page_template(
       page_title: t('forms.address_lookup.heading'),
       template: :form
     ) do %>

--- a/app/views/providers/address_selections/show.html.erb
+++ b/app/views/providers/address_selections/show.html.erb
@@ -1,4 +1,4 @@
-<%= provider_page(
+<%= page_template(
       page_title: t('forms.address_selection.heading'),
       template: :form
     ) do %>

--- a/app/views/providers/addresses/_form.html.erb
+++ b/app/views/providers/addresses/_form.html.erb
@@ -1,5 +1,5 @@
 <% heading_type = @form.lookup_error.present? ? :lookup : :manual %>
-<%= provider_page(
+<%= page_template(
       page_title: t("forms.address_#{heading_type}.heading"),
       template: :form
     ) do %>

--- a/app/views/providers/applicants/show.html.erb
+++ b/app/views/providers/applicants/show.html.erb
@@ -1,5 +1,5 @@
 <% back_label = @legal_aid_application.checking_answers? ? 'generic.back' : 'generic.home' %>
-<%= provider_page(
+<%= page_template(
       page_title: t('.page_title'),
       back_link: { text: t(back_label) },
       template: :form

--- a/app/views/providers/application_confirmations/show.html.erb
+++ b/app/views/providers/application_confirmations/show.html.erb
@@ -11,7 +11,7 @@
   </div>
 <% end %>
 
-<%= provider_page page_title: t('.secure_link_heading') do %>
+<%= page_template page_title: t('.secure_link_heading') do %>
 
     <p class="govuk-body"><%= t '.secure_link_text' %></p>
     <h3 class="govuk-heading-m"><%= t '.happen_next_heading' %></h3>

--- a/app/views/providers/check_benefits/index.html.erb
+++ b/app/views/providers/check_benefits/index.html.erb
@@ -8,7 +8,7 @@
   </div>
 <% end %>
 
-<%= provider_page page_title: t('.heading_1') do %>
+<%= page_template page_title: t('.heading_1') do %>
 
   <p class="govuk-body">
     <%= t "#{result_namespace}.body" %>

--- a/app/views/providers/check_merits_answers/show.html.erb
+++ b/app/views/providers/check_merits_answers/show.html.erb
@@ -1,4 +1,4 @@
-<%= provider_page(
+<%= page_template(
       page_title: t('.h1-heading'),
       back_link: { path: reset_providers_legal_aid_application_check_merits_answers_path(@legal_aid_application), method: :patch }
     ) do %>

--- a/app/views/providers/check_passported_answers/show.html.erb
+++ b/app/views/providers/check_passported_answers/show.html.erb
@@ -1,4 +1,4 @@
-<%= provider_page(
+<%= page_template(
       page_title: t('.h1-heading'),
       back_link: { path: reset_providers_legal_aid_application_check_passported_answers_path(@legal_aid_application), method: :patch }
     ) do %>

--- a/app/views/providers/check_provider_answers/index.html.erb
+++ b/app/views/providers/check_provider_answers/index.html.erb
@@ -1,4 +1,4 @@
-<%= provider_page(
+<%= page_template(
       page_title: t('.title'),
       back_link: {
         path: reset_providers_legal_aid_application_check_provider_answers_path,

--- a/app/views/providers/client_received_legal_helps/show.html.erb
+++ b/app/views/providers/client_received_legal_helps/show.html.erb
@@ -1,4 +1,4 @@
-<%= provider_page page_title: t('.h1-heading'), template: :basic do %>
+<%= page_template page_title: t('.h1-heading'), template: :basic do %>
   <%= form_with(
         model: @form,
         url: providers_legal_aid_application_client_received_legal_help_path,

--- a/app/views/providers/estimated_legal_costs/show.html.erb
+++ b/app/views/providers/estimated_legal_costs/show.html.erb
@@ -1,4 +1,4 @@
-<%= provider_page page_title: t('.h1-heading'), template: :basic do %>
+<%= page_template page_title: t('.h1-heading'), template: :basic do %>
   <%= render(
         partial: 'shared/forms/estimated_legal_cost_form',
         locals: {

--- a/app/views/providers/legal_aid_applications/index.html.erb
+++ b/app/views/providers/legal_aid_applications/index.html.erb
@@ -1,4 +1,4 @@
-<%= provider_page(
+<%= page_template(
       page_title: t('.heading_1'),
       back_link: :none
     ) do %>

--- a/app/views/providers/merits_declarations/show.html.erb
+++ b/app/views/providers/merits_declarations/show.html.erb
@@ -1,25 +1,15 @@
-<% content_for :navigation do %>
-    <%= provider_back_link text: t('generic.back') %>
-  <% end %>
+<%= page_template page_title: t('.h1-heading') do %>
+  <%= simple_format t('.text_1') %>
 
-  <% content_for(:page_title) { t('.h1-heading') } %>
+  <ul class="govuk-list govuk-list--bullet">
+      <li><%= simple_format t('.leaflet_link') %></li>
+  </ul>
 
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-xl"><%= t('.heading_1') %></h1>
+  <%= simple_format t('.text_2') %>
 
-        <%= simple_format t('.text_1') %>
+  <%= list_from_translation_path 'providers.merits_declarations.show' %>
 
-        <ul class="govuk-list govuk-list--bullet">
-            <li><%= simple_format t('.leaflet_link') %></li>
-        </ul>
+  <%= simple_format t('.text_3') %>
 
-        <%= simple_format t('.text_2') %>
-
-        <%= list_from_translation_path 'providers.merits_declarations.show' %>
-
-        <%= simple_format t('.text_3') %>
-
-        <%= button_to t('generic.continue'), providers_legal_aid_application_merits_declaration_path, method: :patch, class: 'govuk-button' %>
-    </div>
-  </div>
+  <%= button_to t('generic.continue'), providers_legal_aid_application_merits_declaration_path, method: :patch, class: 'govuk-button' %>
+<% end %>

--- a/app/views/providers/online_bankings/show.html.erb
+++ b/app/views/providers/online_bankings/show.html.erb
@@ -1,4 +1,4 @@
-<%= provider_page(
+<%= page_template(
       page_title: t('.heading'),
       template: :basic
     ) do %>

--- a/app/views/providers/other_assets/show.html.erb
+++ b/app/views/providers/other_assets/show.html.erb
@@ -1,4 +1,4 @@
-<%= provider_page page_title: t('.h1-heading') do %>
+<%= page_template page_title: t('.h1-heading') do %>
   <%= render partial: '/shared/forms/other_assets/form',
              locals: {
                model: @form,

--- a/app/views/providers/outstanding_mortgages/show.html.erb
+++ b/app/views/providers/outstanding_mortgages/show.html.erb
@@ -1,4 +1,4 @@
-<%= provider_page(page_title: t('.h1-heading'), template: :basic) do %>
+<%= page_template(page_title: t('.h1-heading'), template: :basic) do %>
   <%= render(
         partial: '/shared/forms/outstanding_mortgage_form',
         locals: {

--- a/app/views/providers/own_homes/show.html.erb
+++ b/app/views/providers/own_homes/show.html.erb
@@ -1,4 +1,4 @@
-<%= provider_page page_title: t('.h1-heading'), template: :basic do %>
+<%= page_template page_title: t('.h1-heading'), template: :basic do %>
   <%= render(
         'shared/forms/own_home_form',
         form_path: providers_legal_aid_application_own_home_path(@legal_aid_application),

--- a/app/views/providers/percentage_homes/show.html.erb
+++ b/app/views/providers/percentage_homes/show.html.erb
@@ -1,4 +1,4 @@
-<%= provider_page page_title: t('.h1-heading') do %>
+<%= page_template page_title: t('.h1-heading') do %>
   <%= render partial: 'shared/forms/percentage_home_form',
              locals: {
                model: @form,

--- a/app/views/providers/proceedings_before_the_courts/show.html.erb
+++ b/app/views/providers/proceedings_before_the_courts/show.html.erb
@@ -1,4 +1,4 @@
-<%= provider_page page_title: t('.h1-heading'), template: :basic do %>
+<%= page_template page_title: t('.h1-heading'), template: :basic do %>
 
 <%= form_with(
       model: @form,

--- a/app/views/providers/proceedings_types/index.html.erb
+++ b/app/views/providers/proceedings_types/index.html.erb
@@ -5,7 +5,7 @@
   </style>
 </noscript>
 
-<%= provider_page(
+<%= page_template(
       page_title: t('.heading_1'),
       show_errors_for: @legal_aid_application
     ) %>

--- a/app/views/providers/property_values/show.html.erb
+++ b/app/views/providers/property_values/show.html.erb
@@ -1,4 +1,4 @@
-<%= provider_page page_title: t('.h1-heading') do %>
+<%= page_template page_title: t('.h1-heading') do %>
   <%= render(
         partial: '/citizens/property_values/form',
         locals: {

--- a/app/views/providers/providers/show.html.erb
+++ b/app/views/providers/providers/show.html.erb
@@ -1,4 +1,4 @@
-<%= provider_page(
+<%= page_template(
       page_title: t('.page_title'),
       back_link: { path: :back },
       column_width: 'full'

--- a/app/views/providers/restrictions/index.html.erb
+++ b/app/views/providers/restrictions/index.html.erb
@@ -1,4 +1,4 @@
-<%= provider_page page_title: t('.h1-heading'), template: :form do %>
+<%= page_template page_title: t('.h1-heading'), template: :form do %>
   <div class="govuk-!-padding-top-4"></div>
   <%= render partial: '/citizens/restrictions/form',
              locals: {

--- a/app/views/providers/savings_and_investments/show.html.erb
+++ b/app/views/providers/savings_and_investments/show.html.erb
@@ -1,4 +1,4 @@
-<%= provider_page page_title: t('.h1-heading') do %>
+<%= page_template page_title: t('.h1-heading') do %>
 <%= render(
       'shared/forms/savings_and_investments_form',
       bank_accounts: [],

--- a/app/views/providers/shared_ownerships/show.html.erb
+++ b/app/views/providers/shared_ownerships/show.html.erb
@@ -1,4 +1,4 @@
-<%= provider_page page_title: t('.heading_1') do %>
+<%= page_template page_title: t('.heading_1') do %>
   <%= render(
         'shared/forms/shared_ownership_form',
         form_path: providers_legal_aid_application_shared_ownership_path(@legal_aid_application),

--- a/app/views/providers/statement_of_cases/show.html.erb
+++ b/app/views/providers/statement_of_cases/show.html.erb
@@ -1,4 +1,4 @@
-<%= provider_page page_title: t('.h1-heading'), template: :basic do %>
+<%= page_template page_title: t('.h1-heading'), template: :basic do %>
 
   <%= form_with(
         model: @statement_of_case,

--- a/app/views/providers/success_prospects/show.html.erb
+++ b/app/views/providers/success_prospects/show.html.erb
@@ -1,4 +1,4 @@
-<%= provider_page page_title: t('.h1-heading'), template: :basic do %>
+<%= page_template page_title: t('.h1-heading'), template: :basic do %>
   <%= render(
         'shared/forms/success_prospect_form',
         form_path: providers_legal_aid_application_success_prospects_path(@legal_aid_application),

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -18,7 +18,8 @@ en:
         share_bank_accounts_para: Your client will need to share all bank accounts, including any in joint names or with no money.
         sign_in_para: Your client will be asked to sign in to online banking and give temporary access to their bank accounts.
         title: About the online financial assessment
-      submit:
+    application_confirmations:
+      show:
         application_created: Application created
         back_button: Back to your applications
         happen_next_heading: What happens next

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -68,9 +68,8 @@ Rails.application.routes.draw do
         patch :continue, on: :collection
       end
       resources :restrictions, only: %i[index create] # as multiple restrictions
-      resource :about_the_financial_assessment, only: [:show] do
-        post :submit, on: :collection
-      end
+      resource :about_the_financial_assessment, only: %i[show update]
+      resource :application_confirmation, only: :show
       resource :percentage_home, only: %i[show update]
       resource :savings_and_investment, only: %i[show update]
       resource :shared_ownership, only: %i[show update]

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -11,7 +11,7 @@ Before you ask people to review this PR:
 
 - [ ] Tests and rubocop should be passing: `bundle exec rake`
 - [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
-- [ ] There should be no unneccessary whitespace changes. These make diffs harder to read and conflicts more likely. 
+- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
 - [ ] The PR description should say what you changed and why, with a link to the JIRA story.
 - [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
 - [ ] You should have checked that the commit messages say why the change was made.

--- a/features/providers/civil_application_journey.feature
+++ b/features/providers/civil_application_journey.feature
@@ -298,6 +298,7 @@ Feature: Civil application journeys
     Then I enter a postcode 'DA74NG'
     Then I click find address
     Then I click link "Back"
+    Then I click link "Back"
     Then I should be on a page showing 'Check your answers'
 
   Scenario: I navigate to Contact page from application service and back
@@ -351,6 +352,30 @@ Feature: Civil application journeys
     Then I select "Held overseas"
     Then I click "Continue"
     Then I should be on a page showing "Check your answers"
+    Then I click link "Back"
+    Then I should be on a page showing "Do any restrictions apply to your client's property, savings or assets?"
+    Then I click link "Back"
+    Then I should be on a page showing "Does your client have any of the following?"
+    Then I click link "Back"
+    Then I should be on a page showing "Does your client have any savings and investments?"
+    Then I click link "Back"
+    Then I should be on a page showing "What % share of their home does your client legally own?"
+    Then I click link "Back"
+    Then I should be on a page showing "Does your client own their home with anyone else?"
+    Then I click link "Back"
+    Then I should be on a page showing "What is the outstanding mortgage on your client's home?"
+    Then I click link "Back"
+    Then I should be on a page showing "How much is your client's home worth?"
+    Then I click link "Back"
+    Then I should be on a page showing "Does your client own the home that they live in?"
+    Then I click "Continue"
+    Then I click "Continue"
+    Then I click "Continue"
+    Then I click "Continue"
+    Then I click "Continue"
+    Then I click "Continue"
+    Then I click "Continue"
+    Then I click "Continue"
     Then I click "Submit"
     Then I should be on a page showing "Has your client received legal help for the matter?"
     Then I choose "No"
@@ -391,27 +416,6 @@ Feature: Civil application journeys
     And the answer for 'Estimated legal costs' should be "£2,345.00"
     Then I click "Accept and send application"
     Then I should be on a page showing "End of provider-answered merits assessment questions for passported clients"
-
-  @javascript
-  Scenario: Navigate back capital flow
-    Given I previously created a passported application and left on the "Restrictions" page
-    Then I visit the applications page
-    Then I view the previously created application
-    Then I should be on a page showing "Do any restrictions apply to your client's property, savings or assets?"
-    Then I click link "Back"
-    Then I should be on a page showing "Does your client have any of the following?"
-    Then I click link "Back"
-    Then I should be on a page showing "Does your client have any savings and investments?"
-    Then I click link "Back"
-    Then I should be on a page showing "What % share of their home does your client legally own?"
-    Then I click link "Back"
-    Then I should be on a page showing "Does your client own their home with anyone else?"
-    Then I click link "Back"
-    Then I should be on a page showing "What is the outstanding mortgage on your client's home?"
-    Then I click link "Back"
-    Then I should be on a page showing "How much is your client's home worth?"
-    Then I click link "Back"
-    Then I should be on a page showing "Does your client own the home that they live in?"
 
   @javascript @vcr
   Scenario: View feedback form within provider journey

--- a/spec/cassettes/providers_legal_aid_application_proceedings_type_requests/index_GET_/providers/applications/_legal_aid_application_id/proceedings_types/when_the_provider_is_authenticated/back_link/the_applicant_s_address_used_s_address_lookup_service/should_redirect_to_the_address_lookup_page.yml
+++ b/spec/cassettes/providers_legal_aid_application_proceedings_type_requests/index_GET_/providers/applications/_legal_aid_application_id/proceedings_types/when_the_provider_is_authenticated/back_link/the_applicant_s_address_used_s_address_lookup_service/should_redirect_to_the_address_lookup_page.yml
@@ -1,0 +1,42 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?key=<ORDNANACE_SURVEY_API_KEY>&postcode=YO4B0LJ
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Wed, 06 Feb 2019 14:37:04 GMT
+      Server:
+      - Apache-Coyote/1.1
+      Content-Length:
+      - '189'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "error" : {
+            "statuscode" : 400,
+            "message" : "Requested postcode must contain a minimum of the sector plus 1 digit of the district e.g. SO1. Requested postcode was YO4B0LJ"
+          }
+        }
+    http_version: 
+  recorded_at: Wed, 06 Feb 2019 14:37:04 GMT
+recorded_with: VCR 4.0.0

--- a/spec/requests/backable_spec.rb
+++ b/spec/requests/backable_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+RSpec.describe 'Backable', type: :request do
+  let(:application) { create :legal_aid_application, :with_applicant }
+
+  before { login_as application.provider }
+
+  let(:page_1) { providers_legal_aid_application_address_lookup_path(application) }
+  let(:page_2) { providers_legal_aid_application_address_path(application) }
+  let(:page_3) { providers_legal_aid_application_proceedings_types_path(application) }
+
+  let(:address_params) do
+    {
+      address:
+      {
+        address_line_one: '123',
+        address_line_two: 'High Street',
+        city: 'London',
+        county: 'Greater London',
+        postcode: 'SW1H 9AJ'
+      }
+    }
+  end
+
+  describe 'back_path' do
+    before do
+      get page_1
+      get page_2
+      patch page_2, params: address_params
+      get page_3
+    end
+
+    it 'has a back link to the previous page' do
+      expect(response.body).to have_back_link(page_2 + '?back=true')
+    end
+
+    context 'we reload the current page several times' do
+      before do
+        get page_3
+        get page_3
+      end
+
+      it 'has a back link to the previous page' do
+        expect(response.body).to have_back_link(page_2 + '?back=true')
+      end
+    end
+
+    context 'we go back once' do
+      it 'redirects to same page without the param' do
+        get page_2 + '?back=true'
+        expect(response).to redirect_to(page_2)
+      end
+
+      it 'has a link to the previous page' do
+        get page_2 + '?back=true'
+        get page_2
+        expect(response.body).to have_back_link(page_1 + '?back=true')
+      end
+    end
+  end
+end

--- a/spec/requests/citizens/check_answers_spec.rb
+++ b/spec/requests/citizens/check_answers_spec.rb
@@ -129,11 +129,13 @@ RSpec.describe 'check your answers requests', type: :request do
 
     before do
       legal_aid_application.check_citizen_answers!
+      get citizens_restrictions_path
+      get citizens_check_answers_path
       subject
     end
 
     it 'should redirect back' do
-      expect(response).to redirect_to(citizens_restrictions_path)
+      expect(response).to redirect_to(citizens_restrictions_path(back: true))
     end
 
     it 'should change the state back to "provider_submitted"' do

--- a/spec/requests/providers/about_the_financial_assessments_spec.rb
+++ b/spec/requests/providers/about_the_financial_assessments_spec.rb
@@ -36,10 +36,10 @@ RSpec.describe 'about financial assessments requests', type: :request do
     end
   end
 
-  describe 'POST /providers/applications/:legal_aid_application_id/about_the_financial_assessment/submit' do
-    let(:params) { {} }
-    subject { post "/providers/applications/#{application_id}/about_the_financial_assessment/submit", params: params }
+  describe 'PATCH /providers/applications/:legal_aid_application_id/about_the_financial_assessment/submit' do
     let(:mocked_email_service) { instance_double(CitizenEmailService) }
+    let(:params) { {} }
+    subject { patch "/providers/applications/#{application_id}/about_the_financial_assessment", params: params }
 
     context 'when the provider is not authenticated' do
       before { subject }
@@ -98,7 +98,7 @@ RSpec.describe 'about financial assessments requests', type: :request do
 
         it 'display confirmation page after calling the email service' do
           subject
-          expect(response.body).to include(application.application_ref)
+          expect(response).to redirect_to providers_legal_aid_application_application_confirmation_path(application_id)
         end
       end
 

--- a/spec/requests/providers/address_selections_spec.rb
+++ b/spec/requests/providers/address_selections_spec.rb
@@ -53,10 +53,13 @@ RSpec.describe 'address selections requests', type: :request do
       end
 
       context 'no postcode have been entered yet' do
+        before do
+          get providers_legal_aid_application_address_lookup_path(legal_aid_application)
+        end
+
         it 'redirects to the postcode entering page' do
           subject
-
-          expect(response).to redirect_to(providers_legal_aid_application_address_lookup_path)
+          expect(response).to redirect_to(providers_legal_aid_application_address_lookup_path(back: true))
         end
       end
     end

--- a/spec/requests/providers/application_confirmations_spec.rb
+++ b/spec/requests/providers/application_confirmations_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe 'about financial assessments requests', type: :request do
+  let(:application) { create :legal_aid_application }
+
+  describe 'GET /providers/applications/:legal_aid_application_id/about_the_financial_assessment' do
+    subject { get providers_legal_aid_application_application_confirmation_path(application) }
+    before do
+      login_as application.provider
+      subject
+    end
+
+    it 'returns success' do
+      expect(response).to be_successful
+    end
+
+    it 'displays application_ref' do
+      expect(response.body).to include(application.application_ref)
+    end
+  end
+end

--- a/spec/requests/providers/check_merits_answers_spec.rb
+++ b/spec/requests/providers/check_merits_answers_spec.rb
@@ -138,6 +138,8 @@ RSpec.describe 'check merits answers requests', type: :request do
     context 'logged in as an authenticated provider' do
       before do
         login_as create(:provider)
+        get providers_legal_aid_application_merits_declaration_path(application)
+        get providers_legal_aid_application_check_merits_answers_path(application)
         subject
       end
 
@@ -147,7 +149,7 @@ RSpec.describe 'check merits answers requests', type: :request do
 
       describe 'redirection' do
         it 'redirects to client declaration page' do
-          expect(response).to redirect_to providers_legal_aid_application_merits_declaration_path(application)
+          expect(response).to redirect_to providers_legal_aid_application_merits_declaration_path(application, back: true)
         end
       end
     end

--- a/spec/requests/providers/check_passported_answers_spec.rb
+++ b/spec/requests/providers/check_passported_answers_spec.rb
@@ -152,8 +152,12 @@ RSpec.describe 'check passported answers requests', type: :request do
     end
 
     context 'logged in as an authenticated provider' do
+      let(:application) { create :legal_aid_application, :with_everything, :answers_checked }
+
       before do
         login_as create(:provider)
+        get providers_legal_aid_application_other_assets_path(application)
+        get providers_legal_aid_application_check_passported_answers_path(application)
         subject
       end
 
@@ -161,21 +165,8 @@ RSpec.describe 'check passported answers requests', type: :request do
         expect(application.reload.answers_checked?).to be true
       end
 
-      describe 'redirection' do
-        context 'no capital' do
-          let(:application) { create :legal_aid_application, :checking_passported_answers }
-          it 'redirects to other assets page' do
-            expect(application.own_capital?).to be false
-            expect(response).to redirect_to providers_legal_aid_application_other_assets_path(application)
-          end
-        end
-
-        context 'some capital' do
-          it 'redirects to restrictions page' do
-            expect(application.own_capital?).to be true
-            expect(response).to redirect_to providers_legal_aid_application_restrictions_path(application)
-          end
-        end
+      it 'redirects to the previous page' do
+        expect(response).to redirect_to providers_legal_aid_application_other_assets_path(application, back: true)
       end
     end
   end

--- a/spec/requests/providers/check_provider_answers_spec.rb
+++ b/spec/requests/providers/check_provider_answers_spec.rb
@@ -67,11 +67,13 @@ RSpec.describe 'check your answers requests', type: :request do
       before do
         login_as create(:provider)
         application.check_your_answers!
+        get providers_legal_aid_application_proceedings_types_path(application)
+        get providers_legal_aid_application_check_provider_answers_path(application)
         subject
       end
 
       it 'should redirect back' do
-        expect(response).to redirect_to(providers_legal_aid_application_proceedings_types_path(application))
+        expect(response).to redirect_to(providers_legal_aid_application_proceedings_types_path(application, back: true))
       end
 
       it 'should change the stage back to "initialized' do

--- a/spec/requests/providers/client_received_legal_helps_spec.rb
+++ b/spec/requests/providers/client_received_legal_helps_spec.rb
@@ -21,12 +21,6 @@ RSpec.describe 'client received legal help', type: :request do
       it 'returns http success' do
         expect(response).to have_http_status(:ok)
       end
-
-      describe 'back link' do
-        it 'points to check_passported_answers page' do
-          expect(response.body).to have_back_link(providers_legal_aid_application_check_passported_answers_path(legal_aid_application))
-        end
-      end
     end
   end
 

--- a/spec/requests/providers/estimated_legal_costs_spec.rb
+++ b/spec/requests/providers/estimated_legal_costs_spec.rb
@@ -21,12 +21,6 @@ RSpec.describe Providers::EstimatedLegalCostsController, type: :request do
       it 'returns http success' do
         expect(response).to have_http_status(:ok)
       end
-
-      describe 'back link' do
-        it 'points to statement of case' do
-          expect(response.body).to have_back_link(providers_legal_aid_application_statement_of_case_path(legal_aid_application))
-        end
-      end
     end
   end
 

--- a/spec/requests/providers/merits_declarations_spec.rb
+++ b/spec/requests/providers/merits_declarations_spec.rb
@@ -22,12 +22,6 @@ RSpec.describe Providers::MeritsDeclarationsController, type: :request do
         expect(response).to have_http_status(:ok)
         expect(response.body).to include('Client declaration')
       end
-
-      describe 'back link' do
-        it 'points to prospects of success' do
-          expect(response.body).to have_back_link(providers_legal_aid_application_success_prospects_path(legal_aid_application))
-        end
-      end
     end
   end
 

--- a/spec/requests/providers/other_assets_spec.rb
+++ b/spec/requests/providers/other_assets_spec.rb
@@ -27,12 +27,6 @@ RSpec.describe 'provider other assets requests', type: :request do
       it 'displays the show page' do
         expect(response.body).to include I18n.t('providers.other_assets.show.h1-heading')
       end
-
-      describe 'back link' do
-        it 'points to savings and investments page' do
-          expect(response.body).to have_back_link(providers_legal_aid_application_savings_and_investment_path(application))
-        end
-      end
     end
   end
 

--- a/spec/requests/providers/outstanding_mortgage_spec.rb
+++ b/spec/requests/providers/outstanding_mortgage_spec.rb
@@ -28,12 +28,6 @@ RSpec.describe Providers::OutstandingMortgagesController, type: :request do
         expect(response).to have_http_status(:ok)
         expect(unescaped_response_body).to include("What is the outstanding mortgage on your client's home?")
       end
-
-      describe 'back link' do
-        it 'points to the property value page' do
-          expect(response.body).to have_back_link(providers_legal_aid_application_property_value_path(legal_aid_application))
-        end
-      end
     end
   end
 

--- a/spec/requests/providers/own_home_spec.rb
+++ b/spec/requests/providers/own_home_spec.rb
@@ -21,12 +21,6 @@ RSpec.describe 'provider own home requests', type: :request do
       it 'returns http success' do
         expect(response).to have_http_status(:ok)
       end
-
-      describe 'back link' do
-        it 'points to the check benefits page' do
-          expect(response.body).to have_back_link(providers_legal_aid_application_check_benefits_path(legal_aid_application))
-        end
-      end
     end
   end
 

--- a/spec/requests/providers/percentage_home_spec.rb
+++ b/spec/requests/providers/percentage_home_spec.rb
@@ -20,12 +20,6 @@ RSpec.describe 'provider percentage share of home test', type: :request do
       it 'returns http success' do
         expect(response).to have_http_status(:ok)
       end
-
-      describe 'back link' do
-        it 'points to the shared ownership page' do
-          expect(response.body).to have_back_link(providers_legal_aid_application_shared_ownership_path(application))
-        end
-      end
     end
   end
 

--- a/spec/requests/providers/proceedings_before_the_court_spec.rb
+++ b/spec/requests/providers/proceedings_before_the_court_spec.rb
@@ -21,12 +21,6 @@ RSpec.describe 'provider proceedings before the court requests', type: :request 
       it 'returns http success' do
         expect(response).to have_http_status(:ok)
       end
-
-      describe 'back link' do
-        it 'points to the client has received legal help page' do
-          expect(response.body).to have_back_link(providers_legal_aid_application_client_received_legal_help_path(legal_aid_application))
-        end
-      end
     end
   end
 

--- a/spec/requests/providers/proceedings_types_spec.rb
+++ b/spec/requests/providers/proceedings_types_spec.rb
@@ -15,14 +15,15 @@ RSpec.describe 'providers legal aid application proceedings type requests', type
     context 'when the provider is authenticated' do
       before do
         login_as provider
-        subject
       end
 
       it 'returns http success' do
+        subject
         expect(response).to have_http_status(:ok)
       end
 
       it 'does not displays the proceeding types' do
+        subject
         expect(unescaped_response_body).not_to include('class="selected-proceeding-types"')
       end
 
@@ -33,17 +34,28 @@ RSpec.describe 'providers legal aid application proceedings type requests', type
       end
 
       describe 'back link' do
-        context "the applicant's address used s address lookup service" do
+        context "the applicant's address used s address lookup service", :vcr do
           let(:legal_aid_application) { create :legal_aid_application, :with_applicant_and_address_lookup }
 
+          before do
+            legal_aid_application.applicant.address.update!(postcode: 'YO4B0LJ')
+            get providers_legal_aid_application_address_selection_path(legal_aid_application)
+          end
+
           it 'should redirect to the address lookup page' do
-            expect(response.body).to have_back_link(providers_legal_aid_application_address_selection_path(legal_aid_application))
+            subject
+            expect(response.body).to have_back_link(providers_legal_aid_application_address_selection_path(legal_aid_application, back: true))
           end
         end
 
         context "the applicant's address used manual entry" do
+          before do
+            get providers_legal_aid_application_address_path(legal_aid_application)
+          end
+
           it 'should redirect to manual address pagelookup page' do
-            expect(response.body).to have_back_link(providers_legal_aid_application_address_path(legal_aid_application))
+            subject
+            expect(response.body).to have_back_link(providers_legal_aid_application_address_path(legal_aid_application, back: true))
           end
         end
       end

--- a/spec/requests/providers/property_value_spec.rb
+++ b/spec/requests/providers/property_value_spec.rb
@@ -22,12 +22,6 @@ RSpec.describe Providers::PropertyValuesController, type: :request do
         expect(response).to have_http_status(:ok)
         expect(unescaped_response_body).to include("How much is your client's home worth?")
       end
-
-      describe 'back link' do
-        it 'points to the own home page' do
-          expect(response.body).to have_back_link(providers_legal_aid_application_own_home_path(legal_aid_application))
-        end
-      end
     end
   end
 

--- a/spec/requests/providers/restrictions_spec.rb
+++ b/spec/requests/providers/restrictions_spec.rb
@@ -27,12 +27,6 @@ RSpec.describe 'citizen restrictions request', type: :request do
           expect(unescaped_response_body).to include(label)
         end
       end
-
-      describe 'back liink' do
-        it 'points to other assets page' do
-          expect(response.body).to have_back_link(providers_legal_aid_application_other_assets_path(legal_aid_application))
-        end
-      end
     end
   end
 

--- a/spec/requests/providers/savings_and_investments_spec.rb
+++ b/spec/requests/providers/savings_and_investments_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe 'providers savings and investments', type: :request do
     context 'when the provider is authenticated' do
       before do
         login_as create(:provider)
-        subject
       end
 
       it 'returns http success' do
@@ -30,23 +29,29 @@ RSpec.describe 'providers savings and investments', type: :request do
 
       describe 'back link' do
         context 'applicant does not own home' do
-          let(:application) { create :legal_aid_application, :without_own_home }
+          before { get providers_legal_aid_application_own_home_path(application) }
+
           it 'points to the own  home page' do
-            expect(response.body).to have_back_link(providers_legal_aid_application_own_home_path(application))
+            subject
+            expect(response.body).to have_back_link(providers_legal_aid_application_own_home_path(application, back: true))
           end
         end
 
         context 'applicant owns home with shared ownership' do
-          let(:application) { create :legal_aid_application, :with_own_home_mortgaged, :with_home_shared_with_partner }
+          before { get providers_legal_aid_application_percentage_home_path(application) }
+
           it 'points to percentage owned page' do
-            expect(response.body).to have_back_link(providers_legal_aid_application_percentage_home_path(application))
+            subject
+            expect(response.body).to have_back_link(providers_legal_aid_application_percentage_home_path(application, back: true))
           end
         end
 
         context 'applicant owns home sole ownership' do
-          let(:application) { create :legal_aid_application, :with_own_home_mortgaged, :with_home_sole_owner }
+          before { get providers_legal_aid_application_shared_ownership_path(application) }
+
           it 'points to the shared ownership page' do
-            expect(response.body).to have_back_link(providers_legal_aid_application_shared_ownership_path(application))
+            subject
+            expect(response.body).to have_back_link(providers_legal_aid_application_shared_ownership_path(application, back: true))
           end
         end
       end

--- a/spec/requests/providers/shared_ownerships_spec.rb
+++ b/spec/requests/providers/shared_ownerships_spec.rb
@@ -14,14 +14,15 @@ RSpec.describe 'providers shared ownership request test', type: :request do
     context 'when the provider is authenticated' do
       before do
         login_as create(:provider)
-        subject
       end
 
       it 'returns http success' do
+        subject
         expect(response).to have_http_status(:ok)
       end
 
       it 'renders the shared ownership page' do
+        subject
         expect(response).to be_successful
         expect(unescaped_response_body).to match('Does your client own their home with anyone else?')
         expect(unescaped_response_body).to match(LegalAidApplication::SHARED_OWNERSHIP_YES_REASONS.first)
@@ -29,15 +30,20 @@ RSpec.describe 'providers shared ownership request test', type: :request do
 
       describe 'back link' do
         context 'applicant owns with mortgage' do
+          before { get providers_legal_aid_application_outstanding_mortgage_path(legal_aid_application) }
+
           it 'points to oustanding mortgage page' do
-            expect(response.body).to have_back_link(providers_legal_aid_application_outstanding_mortgage_path(legal_aid_application))
+            subject
+            expect(response.body).to have_back_link(providers_legal_aid_application_outstanding_mortgage_path(legal_aid_application, back: true))
           end
         end
 
         context 'applicant owns home outright' do
-          let(:legal_aid_application) { create :legal_aid_application, :with_own_home_owned_outright }
+          before { get providers_legal_aid_application_property_value_path(legal_aid_application) }
+
           it 'points to the property value page' do
-            expect(response.body).to have_back_link(providers_legal_aid_application_property_value_path(legal_aid_application))
+            subject
+            expect(response.body).to have_back_link(providers_legal_aid_application_property_value_path(legal_aid_application, back: true))
           end
         end
       end

--- a/spec/requests/providers/statement_of_case_spec.rb
+++ b/spec/requests/providers/statement_of_case_spec.rb
@@ -42,13 +42,6 @@ RSpec.describe 'provider proceedings before the court requests', type: :request 
           expect(response.body).to have_text_area_with_id_and_content('statement', soc.statement)
         end
       end
-
-      describe 'back link' do
-        it 'points to the client has received legal help page' do
-          subject
-          expect(response.body).to have_back_link(providers_legal_aid_application_proceedings_before_the_court_path(legal_aid_application))
-        end
-      end
     end
   end
 

--- a/spec/requests/providers/success_prospects_spec.rb
+++ b/spec/requests/providers/success_prospects_spec.rb
@@ -21,12 +21,6 @@ RSpec.describe Providers::SuccessProspectsController, type: :request do
       it 'returns http success' do
         expect(response).to have_http_status(:ok)
       end
-
-      describe 'back link' do
-        it 'points to estimated legal costs' do
-          expect(response.body).to have_back_link(providers_legal_aid_application_estimated_legal_costs_path(legal_aid_application))
-        end
-      end
     end
   end
 

--- a/spec/services/flow_service_spec.rb
+++ b/spec/services/flow_service_spec.rb
@@ -16,56 +16,6 @@ RSpec.describe Flow::BaseFlowService do
 
   before { flow_service_class.use_steps steps }
 
-  describe '#back_path' do
-    let(:current_step) { :property_values }
-
-    it 'returns back url' do
-      expect(subject.back_path).to eq('/citizens/own_home')
-    end
-
-    context 'with logic' do
-      let(:current_step) { :shared_ownerships }
-
-      it 'returns back url' do
-        expect(subject.back_path).to eq('/citizens/property_value')
-      end
-    end
-
-    context 'step is not defined' do
-      let(:current_step) { :foo_bar }
-
-      it 'raises an error' do
-        expect { subject.back_path }.to raise_error(/not defined/)
-      end
-    end
-
-    context 'back step is not defined' do
-      let(:steps) { { foo: :bar } }
-
-      it 'raises an error' do
-        expect { subject.back_path }.to raise_error(/not defined/)
-      end
-    end
-
-    context 'checking answer' do
-      let(:legal_aid_application) { create :legal_aid_application, :checking_answers }
-
-      context 'and check_answers page is defined' do
-        it 'returns check_answers url' do
-          expect(subject.back_path).to eq('/citizens/check_answers')
-        end
-      end
-
-      context 'and check_answers page is not defined' do
-        let(:current_step) { :consents }
-
-        it 'returns back url' do
-          expect(subject.back_path).to eq('/citizens/information')
-        end
-      end
-    end
-  end
-
   describe '#forward_path' do
     let(:current_step) { :percentage_homes }
     let(:expected_error) { "Forward step of #{current_step} is not defined" }


### PR DESCRIPTION
## What

[AP-337](https://dsdmoj.atlassian.net/browse/AP-337)

Simplify the back button behaviour. It now simply brings the user to the previous page.
We keep a page history in session.
Each time a page is accessed via GET, we add it to the history.
The tricky part is to know if a page is accessed via the backlink or not.
To do that, each backlink also adds `?back=true` to the URL
Once we know the page is accessed via the backlink, we remove `?back=true` by using a redirect to the same page

I modified the "About The Financial Assessment" page to extract it into two pages because otherwise, the second part was a POST request and therefore was not added to the history.


## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely. 
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
