### PR TITLE
Show nav links as menu on small screens

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -1,11 +1,25 @@
+@import "govuk-frontend/settings/all";
+@import "govuk-frontend/helpers/all";
+
 .govuk-header {
   .govuk-header__content .user-info {
-    float: right;
+    float: left;
     line-height: 30px;
     font-weight: bold;
 
     a {
       padding-left: 1em;
+    }
+  }
+
+  nav {
+    @include govuk-media-query($from: desktop) {
+      position: absolute;
+      top: 7px;
+      right: 0;
+      margin: 0;
+      padding: 0;
+      border: 0;
     }
   }
 }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -29,9 +29,10 @@ module ApplicationHelper
     html = ''
     # TODO: - set the link to point at Provider Profile page when that page exists
     #        and use the full name rather than user name when that is available
-    html << link_to(current_provider.username, providers_provider_path, class: 'user-link govuk-header__link')
-    html << link_to('Sign out', destroy_provider_session_path, method: :delete, class: 'log-out govuk-header__link')
-    html = sanitize html, tags: %w[a], attributes: %w[href class rel data-method]
+    html << content_tag(:li, link_to(current_provider.username.truncate(20), providers_provider_path, class: 'govuk-header__link'), class: 'govuk-header__navigation-item')
+    html << content_tag(:li, link_to('Sign out', destroy_provider_session_path, method: :delete, class: 'govuk-header__link'), class: 'govuk-header__navigation-item')
+    html = sanitize html, tags: %w[a li], attributes: %w[href class rel data-method]
+    html = content_tag :ul, html, id: 'navigation', class: 'govuk-header__navigation', 'aria-label': 'Top Level Navigation'
     content_tag :span, html, class: 'user-info'
   end
 

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,4 +1,4 @@
-<header class="govuk-header " role="banner" data-module="header">
+<header class="govuk-header" role="banner" data-module="header">
   <div class="govuk-header__container govuk-width-container">
 
     <div class="govuk-header__logo">
@@ -18,7 +18,10 @@
     </div>
     <div class="govuk-header__content">
       <%= home_link %>
-      <%= user_header_link %>
+      <button type="button" role="button" class="govuk-header__menu-button js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
+      <nav>
+        <%= user_header_link %>
+      </nav>
     </div>
   </div>
 </header>


### PR DESCRIPTION
## What

[AP-303](https://dsdmoj.atlassian.net/browse/AP-303)

Implement the GOVUK pattern which hides the username and logout links in the header when a small screen is used, allowing them to be revealed by clicking the Menu button: https://design-system.service.gov.uk/styles/page-template/custom/index.html

* Amend `application_helper.rb` to generate the correct html, by creating each link as a list element in a `<ul>` with the `govuk-header__navigation` class
* Truncate usernames at 20 characters at all screen sizes to prevent overlap with the service name
* Add the Menu button to the `_header.html.erb` partial
* Add extra styling to `layout.css` to position new elements correctly

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unneccessary whitespace changes. These make diffs harder to read and conflicts more likely. 
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
