### PR TITLE
FIX : Wrong Sidekiq instance picking up job

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,7 @@ gem 'ruby-saml-idp'
 gem 'jwt'
 
 # background processing
+gem 'redis-namespace'
 gem 'sidekiq'
 gem 'sidekiq-status'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -293,6 +293,8 @@ GEM
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
     redis (4.1.0)
+    redis-namespace (1.6.0)
+      redis (>= 3.0.4)
     regexp_parser (1.3.0)
     responders (2.4.0)
       actionpack (>= 4.2.0, < 5.3)
@@ -453,6 +455,7 @@ DEPENDENCIES
   puma (~> 3.11)
   pundit
   rails (~> 5.2.2)
+  redis-namespace
   rspec-rails (~> 3.8)
   rubocop
   ruby-saml-idp

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -2,16 +2,17 @@ require 'sidekiq'
 require 'sidekiq-status'
 
 redis_url = "rediss://:#{ENV['REDIS_PASSWORD']}@#{ENV['REDIS_HOST']}:6379" if ENV['REDIS_HOST'].present? && ENV['REDIS_PASSWORD'].present?
+namespace = ENV.fetch('HOST', 'laa-apply')
 
 Sidekiq.configure_client do |config|
-  config.redis = { url: redis_url } if redis_url
+  config.redis = { url: redis_url, namespace: namespace } if redis_url
 
   # accepts :expiration (optional)
   Sidekiq::Status.configure_client_middleware config, expiration: 30.minutes
 end
 
 Sidekiq.configure_server do |config|
-  config.redis = { url: redis_url } if redis_url
+  config.redis = { url: redis_url, namespace: namespace } if redis_url
 
   # accepts :expiration (optional)
   Sidekiq::Status.configure_server_middleware config, expiration: 30.minutes


### PR DESCRIPTION
I noticed that the pulling of data from TrueLayer was not working in UAT because all UAT envs share the same redis instance and therefore, any UAT sidekiq instance could pick up a job started from any other UAT envs.
I'm adding the host (i.e.: `fix-sidekiq-applyforlegalaid-uat.apps.cloud-platform-live-0.k8s.integration.dsd.io`) as a namespace


## Checklist

Before you ask people to review this PR:

- [X] Tests and rubocop should be passing: `bundle exec rake`
- [X] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [X] There should be no unneccessary whitespace changes. These make diffs harder to read and conflicts more likely. 
- [X] The PR description should say what you changed and why, with a link to the JIRA story.
- [X] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [X] You should have checked that the commit messages say why the change was made.
