### PR TITLE
AP-339 Implement latest GOV-UK check answers styling and fix long emails

### DIFF
--- a/app/assets/stylesheets/check-your-answers.scss
+++ b/app/assets/stylesheets/check-your-answers.scss
@@ -47,3 +47,7 @@ $govuk-fonts-path: "/assets/";
     }
   }
 }
+
+.govuk-summary-list__key {
+  min-width: 5em;
+}

--- a/app/assets/stylesheets/check-your-answers.scss
+++ b/app/assets/stylesheets/check-your-answers.scss
@@ -49,5 +49,5 @@ $govuk-fonts-path: "/assets/";
 }
 
 .govuk-summary-list__key {
-  min-width: 5em;
+  min-width: 8em;
 }

--- a/app/helpers/check_answers_helper.rb
+++ b/app/helpers/check_answers_helper.rb
@@ -1,4 +1,8 @@
 module CheckAnswersHelper
+  # Creates one dictionary list item - so needs to be used within a `govuk-summary-list` `dl`:
+  #     <dl class="govuk-summary-list govuk-!-margin-bottom-9">
+  #       <%= check_answer_link ..... %>
+  #     </dl>
   def check_answer_link(url:, question:, answer:, name:)
     render(
       'shared/check_answers/item',
@@ -9,6 +13,7 @@ module CheckAnswersHelper
     )
   end
 
+  # Creates both the outer `dl` and the inner list items
   def check_answer_list(url:, question:, answers:, name:)
     render(
       'shared/check_answers/items',
@@ -19,6 +24,7 @@ module CheckAnswersHelper
     )
   end
 
+  # Creates both the outer `dl` and the inner list items
   def check_answer_currency_list(url:, question:, answer_hash:, name:)
     render(
       'shared/check_answers/currency_items',

--- a/app/helpers/check_answers_helper.rb
+++ b/app/helpers/check_answers_helper.rb
@@ -1,17 +1,31 @@
 module CheckAnswersHelper
-  def check_answer_link(url:, question:, answer:, name:, is_long: nil)
-    partial = case answer
-              when Hash
-                'currency_items'
-              when Array
-                'items'
-              else
-                'item'
-              end
-    is_long = '--long' if is_long
+  def check_answer_link(url:, question:, answer:, name:)
     render(
-      partial: "shared/check_answers/#{partial}",
-      locals: { url: url, question: question, answer: answer, name: name, is_long: is_long }
+      'shared/check_answers/item',
+      name: name,
+      url: url,
+      question: question,
+      answer: answer
+    )
+  end
+
+  def check_answer_list(url:, question:, answers:, name:)
+    render(
+      'shared/check_answers/items',
+      name: name,
+      url: url,
+      question: question,
+      answers: answers
+    )
+  end
+
+  def check_answer_currency_list(url:, question:, answer_hash:, name:)
+    render(
+      'shared/check_answers/currency_items',
+      name: name,
+      url: url,
+      question: question,
+      answer_hash: answer_hash
     )
   end
 end

--- a/app/views/citizens/check_answers/index.html.erb
+++ b/app/views/citizens/check_answers/index.html.erb
@@ -8,78 +8,78 @@
   <h2 class="govuk-heading-m">
     <%= t('.assets.heading') %>
   </h2>
-<% end %>
 
-<dl class="govuk-summary-list govuk-!-margin-bottom-9">
-  <%= check_answer_link(
-        name: :own_home,
-        url: citizens_own_home_path,
-        question: t('.assets.own_home'),
-        answer: @legal_aid_application.own_home.blank? ? '' : t("shared.forms.own_home_form.#{@legal_aid_application.own_home}")
-      ) %>
-
-  <%= check_answer_link(
-        name: :property_value,
-        url: citizens_property_value_path(anchor: 'property_value'.freeze),
-        question: t('.assets.property_value'),
-        answer: number_to_currency(@legal_aid_application.property_value, unit: t('currency.gbp'))
-      ) if @legal_aid_application.own_home? %>
-
-  <%= check_answer_link(
-        name: :outstanding_mortgage,
-        url: citizens_outstanding_mortgage_path(anchor: 'outstanding_mortgage_amount'.freeze),
-        question: t('.assets.outstanding_mortgage'),
-        answer: number_to_currency(@legal_aid_application.outstanding_mortgage_amount, unit: t('currency.gbp'))
-      ) if @legal_aid_application.own_home_mortgage? %>
-
-  <%= check_answer_link(
-        name: :shared_ownership,
-        url: citizens_shared_ownership_path,
-        question: t('.assets.shared_ownership'),
-        answer: @legal_aid_application.shared_ownership.blank? ? '' : t("shared.forms.shared_ownership_form.shared_ownership_item.#{@legal_aid_application.shared_ownership}")
-      ) if @legal_aid_application.own_home? %>
-
-  <%= check_answer_link(
-        name: :percentage_home,
-        url: citizens_percentage_home_path(anchor: 'percentage_home'.freeze),
-        question: t('.assets.percentage_home'),
-        answer: number_to_percentage(@legal_aid_application.percentage_home, precision: 2)
-      ) if @legal_aid_application.shared_ownership? %>
-</dl>
-
-<%= check_answer_currency_list(
-      name: :savings_and_investments,
-      url: citizens_savings_and_investment_path,
-      question: t('.assets.savings_and_investments'),
-      answer_hash: capital_amounts_list(@legal_aid_application.savings_amount, locale_namespace: 'shared.forms.revealing_checkbox.attribute.citizens.savings_and_investments.check_box_')
-    ) %>
-
-<%= check_answer_currency_list(
-      name: :other_assets,
-      url: citizens_other_assets_path,
-      question: t('.assets.other_assets'),
-      answer_hash: capital_amounts_list(@legal_aid_application.other_assets_declaration, locale_namespace: 'shared.forms.revealing_checkbox.attribute.citizens.other_assets.check_box_')
-    ) %>
-
-<%= check_answer_list(
-      name: :restrictions,
-      url: citizens_restrictions_path,
-      question: t('.assets.restrictions'),
-      answers: @legal_aid_application.restrictions.map { |restriction| t("restrictions.names.#{restriction.name}") }
-    ) if @legal_aid_application.own_capital? %>
-
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
-    <h2 class="govuk-heading-m"><%= t('.submit.heading') %></h2>
-
-    <p><%= t('.submit.text') %></p>
-
-    <%= button_to(
-          t('generic.submit'),
-          continue_citizens_check_answers_path,
-          class: 'govuk-button',
-          method: :patch
+  <dl class="govuk-summary-list govuk-!-margin-bottom-9">
+    <%= check_answer_link(
+          name: :own_home,
+          url: citizens_own_home_path,
+          question: t('.assets.own_home'),
+          answer: @legal_aid_application.own_home.blank? ? '' : t("shared.forms.own_home_form.#{@legal_aid_application.own_home}")
         ) %>
 
+    <%= check_answer_link(
+          name: :property_value,
+          url: citizens_property_value_path(anchor: 'property_value'.freeze),
+          question: t('.assets.property_value'),
+          answer: number_to_currency(@legal_aid_application.property_value, unit: t('currency.gbp'))
+        ) if @legal_aid_application.own_home? %>
+
+    <%= check_answer_link(
+          name: :outstanding_mortgage,
+          url: citizens_outstanding_mortgage_path(anchor: 'outstanding_mortgage_amount'.freeze),
+          question: t('.assets.outstanding_mortgage'),
+          answer: number_to_currency(@legal_aid_application.outstanding_mortgage_amount, unit: t('currency.gbp'))
+        ) if @legal_aid_application.own_home_mortgage? %>
+
+    <%= check_answer_link(
+          name: :shared_ownership,
+          url: citizens_shared_ownership_path,
+          question: t('.assets.shared_ownership'),
+          answer: @legal_aid_application.shared_ownership.blank? ? '' : t("shared.forms.shared_ownership_form.shared_ownership_item.#{@legal_aid_application.shared_ownership}")
+        ) if @legal_aid_application.own_home? %>
+
+    <%= check_answer_link(
+          name: :percentage_home,
+          url: citizens_percentage_home_path(anchor: 'percentage_home'.freeze),
+          question: t('.assets.percentage_home'),
+          answer: number_to_percentage(@legal_aid_application.percentage_home, precision: 2)
+        ) if @legal_aid_application.shared_ownership? %>
+  </dl>
+
+  <%= check_answer_currency_list(
+        name: :savings_and_investments,
+        url: citizens_savings_and_investment_path,
+        question: t('.assets.savings_and_investments'),
+        answer_hash: capital_amounts_list(@legal_aid_application.savings_amount, locale_namespace: 'shared.forms.revealing_checkbox.attribute.citizens.savings_and_investments.check_box_')
+      ) %>
+
+  <%= check_answer_currency_list(
+        name: :other_assets,
+        url: citizens_other_assets_path,
+        question: t('.assets.other_assets'),
+        answer_hash: capital_amounts_list(@legal_aid_application.other_assets_declaration, locale_namespace: 'shared.forms.revealing_checkbox.attribute.citizens.other_assets.check_box_')
+      ) %>
+
+  <%= check_answer_list(
+        name: :restrictions,
+        url: citizens_restrictions_path,
+        question: t('.assets.restrictions'),
+        answers: @legal_aid_application.restrictions.map { |restriction| t("restrictions.names.#{restriction.name}") }
+      ) if @legal_aid_application.own_capital? %>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <h2 class="govuk-heading-m"><%= t('.submit.heading') %></h2>
+
+      <p><%= t('.submit.text') %></p>
+
+      <%= button_to(
+            t('generic.submit'),
+            continue_citizens_check_answers_path,
+            class: 'govuk-button',
+            method: :patch
+          ) %>
+
+    </div>
   </div>
-</div>
+<% end %>

--- a/app/views/citizens/check_answers/index.html.erb
+++ b/app/views/citizens/check_answers/index.html.erb
@@ -10,60 +10,62 @@
   </h2>
 <% end %>
 
-<%= check_answer_link(
-      name: :own_home,
-      url: citizens_own_home_path,
-      question: t('.assets.own_home'),
-      answer: @legal_aid_application.own_home.blank? ? '' : t("shared.forms.own_home_form.#{@legal_aid_application.own_home}")
-    ) %>
+<dl class="govuk-summary-list govuk-!-margin-bottom-9">
+  <%= check_answer_link(
+        name: :own_home,
+        url: citizens_own_home_path,
+        question: t('.assets.own_home'),
+        answer: @legal_aid_application.own_home.blank? ? '' : t("shared.forms.own_home_form.#{@legal_aid_application.own_home}")
+      ) %>
 
-<%= check_answer_link(
-      name: :property_value,
-      url: citizens_property_value_path(anchor: 'property_value'.freeze),
-      question: t('.assets.property_value'),
-      answer: number_to_currency(@legal_aid_application.property_value, unit: t('currency.gbp'))
-    ) if @legal_aid_application.own_home? %>
+  <%= check_answer_link(
+        name: :property_value,
+        url: citizens_property_value_path(anchor: 'property_value'.freeze),
+        question: t('.assets.property_value'),
+        answer: number_to_currency(@legal_aid_application.property_value, unit: t('currency.gbp'))
+      ) if @legal_aid_application.own_home? %>
 
-<%= check_answer_link(
-      name: :outstanding_mortgage,
-      url: citizens_outstanding_mortgage_path(anchor: 'outstanding_mortgage_amount'.freeze),
-      question: t('.assets.outstanding_mortgage'),
-      answer: number_to_currency(@legal_aid_application.outstanding_mortgage_amount, unit: t('currency.gbp'))
-    ) if @legal_aid_application.own_home_mortgage? %>
+  <%= check_answer_link(
+        name: :outstanding_mortgage,
+        url: citizens_outstanding_mortgage_path(anchor: 'outstanding_mortgage_amount'.freeze),
+        question: t('.assets.outstanding_mortgage'),
+        answer: number_to_currency(@legal_aid_application.outstanding_mortgage_amount, unit: t('currency.gbp'))
+      ) if @legal_aid_application.own_home_mortgage? %>
 
-<%= check_answer_link(
-      name: :shared_ownership,
-      url: citizens_shared_ownership_path,
-      question: t('.assets.shared_ownership'),
-      answer: @legal_aid_application.shared_ownership.blank? ? '' : t("shared.forms.shared_ownership_form.shared_ownership_item.#{@legal_aid_application.shared_ownership}")
-    ) if @legal_aid_application.own_home? %>
+  <%= check_answer_link(
+        name: :shared_ownership,
+        url: citizens_shared_ownership_path,
+        question: t('.assets.shared_ownership'),
+        answer: @legal_aid_application.shared_ownership.blank? ? '' : t("shared.forms.shared_ownership_form.shared_ownership_item.#{@legal_aid_application.shared_ownership}")
+      ) if @legal_aid_application.own_home? %>
 
-<%= check_answer_link(
-      name: :percentage_home,
-      url: citizens_percentage_home_path(anchor: 'percentage_home'.freeze),
-      question: t('.assets.percentage_home'),
-      answer: number_to_percentage(@legal_aid_application.percentage_home, precision: 2)
-    ) if @legal_aid_application.shared_ownership? %>
+  <%= check_answer_link(
+        name: :percentage_home,
+        url: citizens_percentage_home_path(anchor: 'percentage_home'.freeze),
+        question: t('.assets.percentage_home'),
+        answer: number_to_percentage(@legal_aid_application.percentage_home, precision: 2)
+      ) if @legal_aid_application.shared_ownership? %>
+</dl>
 
-<%= check_answer_link(
+<%= check_answer_currency_list(
       name: :savings_and_investments,
       url: citizens_savings_and_investment_path,
       question: t('.assets.savings_and_investments'),
-      answer: capital_amounts_list(@legal_aid_application.savings_amount, locale_namespace: 'shared.forms.revealing_checkbox.attribute.citizens.savings_and_investments.check_box_')
+      answer_hash: capital_amounts_list(@legal_aid_application.savings_amount, locale_namespace: 'shared.forms.revealing_checkbox.attribute.citizens.savings_and_investments.check_box_')
     ) %>
 
-<%= check_answer_link(
+<%= check_answer_currency_list(
       name: :other_assets,
       url: citizens_other_assets_path,
       question: t('.assets.other_assets'),
-      answer: capital_amounts_list(@legal_aid_application.other_assets_declaration, locale_namespace: 'shared.forms.revealing_checkbox.attribute.citizens.other_assets.check_box_')
+      answer_hash: capital_amounts_list(@legal_aid_application.other_assets_declaration, locale_namespace: 'shared.forms.revealing_checkbox.attribute.citizens.other_assets.check_box_')
     ) %>
 
-<%= check_answer_link(
+<%= check_answer_list(
       name: :restrictions,
       url: citizens_restrictions_path,
       question: t('.assets.restrictions'),
-      answer: @legal_aid_application.restrictions.map { |restriction| t("restrictions.names.#{restriction.name}") }
+      answers: @legal_aid_application.restrictions.map { |restriction| t("restrictions.names.#{restriction.name}") }
     ) if @legal_aid_application.own_capital? %>
 
 <div class="govuk-grid-row">

--- a/app/views/citizens/own_homes/show.html.erb
+++ b/app/views/citizens/own_homes/show.html.erb
@@ -1,3 +1,3 @@
-<%= citizen_page page_title: t('.h1-heading') do %>
+<%= citizen_page page_title: t('.h1-heading'), template: :basic do %>
   <%= render 'shared/forms/own_home_form', form_path: citizens_own_home_path %>
 <% end %>

--- a/app/views/providers/check_merits_answers/show.html.erb
+++ b/app/views/providers/check_merits_answers/show.html.erb
@@ -3,80 +3,84 @@
       back_link: { path: reset_providers_legal_aid_application_check_merits_answers_path(@legal_aid_application), method: :patch }
     ) do %>
 
-    <h2 class="govuk-heading-m">
-      <%= t '.h2-heading' %>
-    </h2>
+  <h2 class="govuk-heading-m">
+    <%= t '.h2-heading' %>
+  </h2>
 
+  <dl class="govuk-summary-list govuk-!-margin-bottom-9">
     <%= check_answer_link(
           name: :client_received_legal_help,
           url: providers_legal_aid_application_client_received_legal_help_path,
           question: t('.items.client_received_legal_help'),
-          answer: @merits.client_received_legal_help ? 'Yes' : 'No',
-          is_long: true
+          answer: @merits.client_received_legal_help ? 'Yes' : 'No'
         ) %>
+  </dl>
 
-    <div class='govuk-body'><%= @merits.application_purpose %></div>
+  <div class='govuk-body'><%= @merits.application_purpose %></div>
 
+  <dl class="govuk-summary-list govuk-!-margin-bottom-9">
     <%= check_answer_link(
           name: :proceedings_currently_before_court,
           url: providers_legal_aid_application_proceedings_before_the_court_path,
           question: t('.items.proceedings_currently_before_court'),
-          answer: @merits.proceedings_before_the_court ? 'Yes' : 'No',
-          is_long: true
+          answer: @merits.proceedings_before_the_court ? 'Yes' : 'No'
         ) %>
+  </dl>
 
-    <div class='govuk-body'><%= @merits.details_of_proceedings_before_the_court %></div>
+  <div class='govuk-body'><%= @merits.details_of_proceedings_before_the_court %></div>
 
+  <dl class="govuk-summary-list govuk-!-margin-bottom-9">
     <%= check_answer_link(
           name: :statement_of_case,
           url: providers_legal_aid_application_statement_of_case_path,
           question: t('.items.statement_of_case'),
-          answer: nil,
-          is_long: true
+          answer: nil
         ) %>
+  </dl>
 
-    <div class='govuk-body'><%= @statement_of_case.statement %></div>
+  <div class='govuk-body'><%= @statement_of_case.statement %></div>
 
+  <dl class="govuk-summary-list govuk-!-margin-bottom-9">
     <%= check_answer_link(
           name: :estimated_legal_costs,
           url: providers_legal_aid_application_estimated_legal_costs_path,
           question: t('.items.estimated_legal_costs'),
-          answer: number_to_currency(@merits.estimated_legal_cost, unit: t('currency.gbp')),
-          is_long: true
+          answer: number_to_currency(@merits.estimated_legal_cost, unit: t('currency.gbp'))
         ) %>
 
     <%= check_answer_link(
           name: :prospects_of_success,
           url: providers_legal_aid_application_success_prospects_path,
           question: t('.items.prospects_of_success'),
-          answer: t("shared.forms.success_prospect.success_prospect_item.#{@merits.success_prospect}"),
-          is_long: true
+          answer: t("shared.forms.success_prospect.success_prospect_item.#{@merits.success_prospect}")
         ) %>
+  </dv>
 
-    <div class='govuk-body'><%= @merits.success_prospect_details %></div>
+  <div class='govuk-body'><%= @merits.success_prospect_details %></div>
 
+  <dl class="govuk-summary-list govuk-!-margin-bottom-9">
     <%= check_answer_link(
           name: :client_declaration,
           url: providers_legal_aid_application_merits_declaration_path,
           question: t('.items.client_declaration'),
-          answer: (t('.items.client_declaration_answer') if @merits.client_merits_declaration),
-          is_long: true
+          answer: (t('.items.client_declaration_answer') if @merits.client_merits_declaration)
         ) %>
+  </dl>
 
-    <div class="govuk-!-padding-bottom-6"></div>
+  <div class="govuk-!-padding-bottom-6"></div>
 
-    <h2 class="govuk-heading-m">
-      <%= t '.complete-application-heading' %>
-    </h2>
+  <h2 class="govuk-heading-m">
+    <%= t '.complete-application-heading' %>
+  </h2>
 
-    <p class="govuk-body">
-      <%= t '.complete-application-text' %>
-    </p>
+  <p class="govuk-body">
+    <%= t '.complete-application-text' %>
+  </p>
 
-    <%= button_to(
-          t('generic.accept_and_send'),
-          continue_providers_legal_aid_application_check_merits_answers_path(@legal_aid_application),
-          class: 'govuk-button',
-          method: :patch
-        ) %>
+  <%= button_to(
+        t('generic.accept_and_send'),
+        continue_providers_legal_aid_application_check_merits_answers_path(@legal_aid_application),
+        class: 'govuk-button',
+        method: :patch
+      ) %>
 <% end %>

--- a/app/views/providers/check_provider_answers/index.html.erb
+++ b/app/views/providers/check_provider_answers/index.html.erb
@@ -6,10 +6,9 @@
       }
     ) do %>
 
-  <dl class="app-check-your-answers app-check-your-answers--long">
-    <dt class="govuk-heading-m">
-      <%= t '.section_client.heading' %>
-    </dt>
+  <h2 class="govuk-heading-m"><%= t '.section_client.heading' %></h2>
+
+  <dl class="govuk-summary-list govuk-!-margin-bottom-9">
 
     <%= check_answer_link(
           name: :first_name,
@@ -54,15 +53,15 @@
         ) %>
   </dl>
 
-  <dt class="govuk-heading-m govuk-!-padding-top-9">
-    <%= t '.section_proceeding.heading' %>
-  </dt>
+  <h2 class="govuk-heading-m"><%= t '.section_proceeding.heading' %></h2>
+
+  <dl class="govuk-summary-list govuk-!-margin-bottom-9">
 
   <%= check_answer_link(
         name: :proceeding_type,
         url: providers_legal_aid_application_proceedings_types_path(anchor: 'proceeding-search-input'.freeze),
         question: t('.section_proceeding.proceeding'),
-        answer: @proceeding_types.map(&:meaning)
+        answer: @proceeding_types.first.meaning
       ) %>
 
   <div class="govuk-!-padding-bottom-9"></div>

--- a/app/views/providers/check_provider_answers/index.html.erb
+++ b/app/views/providers/check_provider_answers/index.html.erb
@@ -64,6 +64,7 @@
         answer: @proceeding_types.first.meaning
       ) %>
 
+  </dl>
   <div class="govuk-!-padding-bottom-9"></div>
 
   <%= render(

--- a/app/views/shared/_check_answers_assets.html.erb
+++ b/app/views/shared/_check_answers_assets.html.erb
@@ -1,6 +1,6 @@
 <% application = nil if local_assigns[:application].nil? %>
 
-<dl class="app-check-your-answers app-check-your-answers--long">
+<dl class="govuk-summary-list govuk-!-margin-bottom-9">
   <%= check_answer_link(
         name: :own_home,
         url: check_answer_url_for(user_type, :own_home, application),
@@ -35,25 +35,27 @@
         question: t('.assets.percentage_home'),
         answer: number_to_percentage(@legal_aid_application.percentage_home, precision: 2)
       ) if @legal_aid_application.shared_ownership? %>
+</dl>
 
-  <%= check_answer_link(
-        name: :savings_and_investments,
-        url: check_answer_url_for(user_type, :savings_and_investments, application),
-        question: t('.assets.savings_and_investments'),
-        answer: capital_amounts_list(@legal_aid_application.savings_amount, locale_namespace: 'shared.forms.revealing_checkbox.attribute.citizens.savings_and_investments.check_box_')
-      ) %>
+<%= check_answer_currency_list(
+      name: :savings_and_investments,
+      url: check_answer_url_for(user_type, :savings_and_investments, application),
+      question: t('.assets.savings_and_investments'),
+      answer_hash: capital_amounts_list(@legal_aid_application.savings_amount, locale_namespace: 'shared.forms.revealing_checkbox.attribute.citizens.savings_and_investments.check_box_')
+    ) %>
 
-  <%= check_answer_link(
-        name: :other_assets,
-        url: check_answer_url_for(user_type, :other_assets, application),
-        question: t('.assets.other_assets'),
-        answer: capital_amounts_list(@legal_aid_application.other_assets_declaration, locale_namespace: 'shared.forms.revealing_checkbox.attribute.citizens.other_assets.check_box_')
-      ) %>
+<%= check_answer_currency_list(
+      name: :other_assets,
+      url: check_answer_url_for(user_type, :other_assets, application),
+      question: t('.assets.other_assets'),
+      answer_hash: capital_amounts_list(@legal_aid_application.other_assets_declaration, locale_namespace: 'shared.forms.revealing_checkbox.attribute.citizens.other_assets.check_box_')
+    ) %>
 
-  <%= check_answer_link(
+<dl>
+  <%= check_answer_list(
         name: :restrictions,
         url: check_answer_url_for(user_type, :restrictions, application),
         question: t('.assets.restrictions'),
-        answer: @legal_aid_application.restrictions.map { |restriction| t("restrictions.names.#{restriction.name}") }
+        answers: @legal_aid_application.restrictions.map { |restriction| t("restrictions.names.#{restriction.name}") }
       ) if @legal_aid_application.own_capital? %>
 </dl>

--- a/app/views/shared/check_answers/_currency_items.html.erb
+++ b/app/views/shared/check_answers/_currency_items.html.erb
@@ -1,36 +1,11 @@
-<div class="app-check-your-answers<%= is_long %>" id="app-check-your-answers__<%= name %>">
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-three-quarters">
-      <%= question %>
-    </div>
-    <div class="govuk-grid-column-one-quarter align_right">
-      <%= link_to(url) do %>
-        <%= t('generic.change') %><span class="govuk-visually-hidden"><%= question %></span>
-      <% end %>
-    </div>
-  </div>
-
-  <% answer.fetch(:items, []).each do |label, amount| %>
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-one-quarter">&nbsp;</div>
-      <div class="govuk-grid-column-one-half"><%= label %></div>
-      <div class="govuk-grid-column-one-quarter">
-        <%= number_to_currency(amount, unit: t('currency.gbp')) %>
-      </div>
-    </div>
+<h2 class="govuk-heading-m" id="app-check-your-answers__<%= name %>"><%= question %></h2>
+<dl class="govuk-summary-list govuk-!-margin-bottom-9">
+  <% answer_hash&.fetch(:items, [])&.each_with_index do |(label, amount), index| %>
+    <%= check_answer_link(
+          name: "#{name}_#{index}",
+          url: url,
+          question: label,
+          answer: number_to_currency(amount, unit: t('currency.gbp'))
+        ) %>
   <% end %>
-
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-one-quarter">&nbsp;</div>
-    <div class="govuk-grid-column-one-half align_right">
-      <strong>
-        <%= t('generic.total') %>:
-      </strong>
-    </div>
-    <div class="govuk-grid-column-one-quarter">
-      <strong>
-        <%= number_to_currency(answer[:total_value], unit: t('currency.gbp')) %>
-      </strong>
-    </div>
-  </div>
-</div>
+</dl>

--- a/app/views/shared/check_answers/_item.html.erb
+++ b/app/views/shared/check_answers/_item.html.erb
@@ -1,15 +1,13 @@
-<div class="app-check-your-answers<%= is_long %>" id="app-check-your-answers__<%= name %>">
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-one-quarter">
-      <%= question %>
-    </div>
-    <div class="govuk-grid-column-one-half">
-      <%= answer.present? ? answer : '-' %>
-    </div>
-    <div class="govuk-grid-column-one-quarter align_right">
-      <%= link_to(url) do %>
-        <%= t('generic.change') %><span class="govuk-visually-hidden"><%= question %></span>
-      <% end %>
-    </div>
+<div class="govuk-summary-list__row" id="app-check-your-answers__<%= name %>">
+  <div class="govuk-summary-list__key">
+    <%= question %>
+  </div>
+  <div class="govuk-summary-list__value">
+    <%= answer.present? ? answer : '-' %>
+  </div>
+  <div class="govuk-summary-list__actions">
+    <%= link_to(url, class: 'govuk-link') do %>
+      <%= t('generic.change') %><span class="govuk-visually-hidden"><%= question %></span>
+    <% end %>
   </div>
 </div>

--- a/app/views/shared/check_answers/_items.html.erb
+++ b/app/views/shared/check_answers/_items.html.erb
@@ -1,7 +1,7 @@
 <h2 class="govuk-heading-m" id="app-check-your-answers__<%= name %>"><%= question %></h2>
 <dl class="govuk-summary-list govuk-!-margin-bottom-9">
-  <% answers.each do |answer| %>
-    <div class="govuk-summary-list__row">
+  <% answers.each_with_index do |answer, index| %>
+    <%= content_tag(:div, class: 'govuk-summary-list__row', id: "app-check-your-answers__#{name}_#{index}") do %>
       <div class="govuk-summary-list__key"></div>
       <div class="govuk-summary-list__value">
         <%= answer %>
@@ -11,6 +11,6 @@
           <%= t('generic.change') %><span class="govuk-visually-hidden"><%= question %></span>
         <% end %>
       </div>
-    </div>
+    <% end %>
   <% end %>
 </dl>

--- a/app/views/shared/check_answers/_items.html.erb
+++ b/app/views/shared/check_answers/_items.html.erb
@@ -1,19 +1,16 @@
-<div class="app-check-your-answers<%= is_long %>" id="app-check-your-answers__<%= name %>">
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-three-quarters">
-      <%= question %>
-    </div>
-    <div class="govuk-grid-column-one-quarter align_right">
-      <%= link_to(url) do %>
-        <%= t('generic.change') %><span class="govuk-visually-hidden"><%= question %></span>
-      <% end %>
-    </div>
-  </div>
-
-  <% answer.each do |line| %>
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-one-quarter">&nbsp;</div>
-      <div class="govuk-grid-column-three-quarters"><%= line %></div>
+<h2 class="govuk-heading-m" id="app-check-your-answers__<%= name %>"><%= question %></h2>
+<dl class="govuk-summary-list govuk-!-margin-bottom-9">
+  <% answers.each do |answer| %>
+    <div class="govuk-summary-list__row">
+      <div class="govuk-summary-list__key"></div>
+      <div class="govuk-summary-list__value">
+        <%= answer %>
+      </div>
+      <div class="govuk-summary-list__actions">
+        <%= link_to(url, class: 'govuk-link') do %>
+          <%= t('generic.change') %><span class="govuk-visually-hidden"><%= question %></span>
+        <% end %>
+      </div>
     </div>
   <% end %>
-</div>
+</dl>

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,9 +4,9 @@
   "lockfileVersion": 1,
   "dependencies": {
     "govuk-frontend": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-2.4.0.tgz",
-      "integrity": "sha512-WSecWLGM1qZ48UD0YGGWOfaBqrWtwf39cOUAuC8+SMNh7kkZ6Ou2Y7+d3Bt8OEPaFNFR2N2vZO2WRnT2gaCjMg=="
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-2.6.0.tgz",
+      "integrity": "sha512-JA1tk0MpkxJzoVjJ367JaoRIDHxUK9QqpG11aLlXlhEVcgCX3WBAxsVpx/dC7SwKBmM+F1C4yao0PLQzDFvmkg=="
     },
     "js-search": {
       "version": "1.4.2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "laa-apply-for-legal-aid",
   "private": true,
   "dependencies": {
-    "govuk-frontend": "^2.4.0",
+    "govuk-frontend": "^2.6.0",
     "js-search": "^1.4.2"
   }
 }

--- a/spec/requests/citizens/check_answers_spec.rb
+++ b/spec/requests/citizens/check_answers_spec.rb
@@ -2,7 +2,8 @@ require 'rails_helper'
 
 RSpec.describe 'check your answers requests', type: :request do
   include ActionView::Helpers::NumberHelper
-  let(:legal_aid_application) { create :legal_aid_application, :provider_submitted, :with_everything }
+  let!(:legal_aid_application) { create :legal_aid_application, :provider_submitted, :with_everything }
+  let!(:restriction) { create :restriction, legal_aid_applications: [legal_aid_application] }
   let(:secure_id) { legal_aid_application.generate_secure_id }
   before do
     get citizens_legal_aid_application_path(secure_id)
@@ -37,9 +38,9 @@ RSpec.describe 'check your answers requests', type: :request do
       expect(response.body).to have_change_link(:property_value, citizens_property_value_path(anchor: 'property_value'))
       expect(response.body).to have_change_link(:shared_ownership, citizens_shared_ownership_path)
       expect(response.body).to have_change_link(:percentage_home, citizens_percentage_home_path(anchor: 'percentage_home'))
-      expect(response.body).to have_change_link(:savings_and_investments, citizens_savings_and_investment_path)
-      expect(response.body).to have_change_link(:other_assets, citizens_other_assets_path)
-      expect(response.body).to have_change_link(:restrictions, citizens_restrictions_path)
+      expect(response.body).to include(citizens_savings_and_investment_path)
+      expect(response.body).to include(citizens_other_assets_path)
+      expect(response.body).to include(citizens_restrictions_path)
     end
 
     it 'displays the correct savings details' do

--- a/spec/requests/providers/check_passported_answers_spec.rb
+++ b/spec/requests/providers/check_passported_answers_spec.rb
@@ -4,11 +4,12 @@ RSpec.describe 'check passported answers requests', type: :request do
   include ActionView::Helpers::NumberHelper
 
   describe 'GET /providers/applications/:id/check_passported_answers' do
-    let(:application) do
+    let!(:application) do
       create :legal_aid_application,
              :with_everything,
              :answers_checked
     end
+    let!(:restriction) { create :restriction, legal_aid_applications: [application] }
 
     subject { get "/providers/applications/#{application.id}/check_passported_answers" }
 
@@ -48,9 +49,9 @@ RSpec.describe 'check passported answers requests', type: :request do
         expect(response.body).to have_change_link(:property_value, providers_legal_aid_application_property_value_path(application, anchor: 'property_value'))
         expect(response.body).to have_change_link(:shared_ownership, providers_legal_aid_application_shared_ownership_path(application))
         expect(response.body).to have_change_link(:percentage_home, providers_legal_aid_application_percentage_home_path(application, anchor: 'percentage_home'))
-        expect(response.body).to have_change_link(:savings_and_investments, providers_legal_aid_application_savings_and_investment_path(application))
-        expect(response.body).to have_change_link(:other_assets, providers_legal_aid_application_other_assets_path(application))
-        expect(response.body).to have_change_link(:restrictions, providers_legal_aid_application_restrictions_path(application))
+        expect(response.body).to include(providers_legal_aid_application_savings_and_investment_path(application))
+        expect(response.body).to include(providers_legal_aid_application_other_assets_path(application))
+        expect(response.body).to include(providers_legal_aid_application_restrictions_path(application))
       end
 
       it 'displays the correct savings details' do


### PR DESCRIPTION
[Jira AP-339](https://dsdmoj.atlassian.net/browse/AP-339)

Unfortunately this was a little like attacking a Hydra. Each action seemed to need multiple actions.

So in the end:
- Implemented [latest GOV-UK Check your answers styling](https://design-system.service.gov.uk/patterns/check-answers/). As there are many check your answers pages - they all needed to be updated.
- To get the new styling, `govuk-frontend` needed to be upgraded.
- Refactored `check_answer_link` to work with new styling - in the end split it into three. One to handle single entries, a second for lists of items, and another for groups of currency entries.
- This almost fixed the email issue, but with very long emails there was still an issue. Adding a `min-width` to `.govuk-summary-list__key` fixed that.