### PR TITLE
AP-317 supressing flash notices in SAML session controller

### DIFF
--- a/app/controllers/saml_sessions_controller.rb
+++ b/app/controllers/saml_sessions_controller.rb
@@ -8,4 +8,14 @@ class SamlSessionsController < Devise::SamlSessionsController
     sign_out current_provider
     redirect_to providers_root_url
   end
+
+  private
+
+  # :nocov:
+  def set_flash_message(key, kind, options = {})
+    return Rails.logger.info("Devise flash message suppressed: #{kind}") if key.to_sym == :notice
+
+    super
+  end
+  # :nocov:
 end


### PR DESCRIPTION
[Jira AP-317](https://dsdmoj.atlassian.net/browse/AP-317)

Overridden the devise method that generates the flash messages, so that it just logs notice flash messages.