### PR TITLE
Improve text layout on check merits answers screen

### DIFF
--- a/app/views/providers/check_merits_answers/show.html.erb
+++ b/app/views/providers/check_merits_answers/show.html.erb
@@ -16,7 +16,7 @@
         ) %>
   </dl>
 
-  <div class='govuk-body'><%= @merits.application_purpose %></div>
+  <div class='govuk-body'><%= simple_format @merits.application_purpose %></div>
 
   <dl class="govuk-summary-list govuk-!-margin-bottom-9">
     <%= check_answer_link(
@@ -27,7 +27,7 @@
         ) %>
   </dl>
 
-  <div class='govuk-body'><%= @merits.details_of_proceedings_before_the_court %></div>
+  <div class='govuk-body'><%= simple_format @merits.details_of_proceedings_before_the_court %></div>
 
   <dl class="govuk-summary-list govuk-!-margin-bottom-9">
     <%= check_answer_link(
@@ -38,7 +38,7 @@
         ) %>
   </dl>
 
-  <div class='govuk-body'><%= @statement_of_case.statement %></div>
+  <div class='govuk-body'><%= simple_format @statement_of_case.statement %></div>
 
   <dl class="govuk-summary-list govuk-!-margin-bottom-9">
     <%= check_answer_link(
@@ -56,7 +56,7 @@
         ) %>
   </dl>
 
-  <div class='govuk-body'><%= @merits.success_prospect_details %></div>
+  <div class='govuk-body'><%= simple_format @merits.success_prospect_details %></div>
 
   <dl class="govuk-summary-list govuk-!-margin-bottom-9">
     <%= check_answer_link(


### PR DESCRIPTION
## What

[AP-361](https://dsdmoj.atlassian.net/browse/AP-361)

On a number of merits questions a provider can enter text explanations. It is possible that a user will enter multiple paragraphs of text, especially on the Statement of Case screen. At present when these responses are displayed on the check your answers screen line-breaks are ignored which means that multiple paragraphs are displayed as a single block of text, making it hard to read.

To improve this, use the `simple_format` method to display text on the check your answers screen as it was entered by the user.

Note: there are other existing issues with the look and feel of this screen which will be addressed by a separate story to be created by the designer.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unneccessary whitespace changes. These make diffs harder to read and conflicts more likely. 
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
