### PR TITLE
Add a back to applications link to the access denied page

### DIFF
--- a/app/views/shared/access_denied.html.erb
+++ b/app/views/shared/access_denied.html.erb
@@ -5,6 +5,8 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl"><%= t('.heading_1') %></h1>
     <p class="govuk-body"><%= t('.permission_text') %></p>
-    <p class="govuk-body"><a href="/providers/applications"><%= t('.back_to_apps_link') %></a></p>
+    <p class="govuk-body">
+      <%= link_to t('.back_to_apps_link'), providers_legal_aid_applications_path %>
+    </p>
   </div>
 </div>

--- a/app/views/shared/access_denied.html.erb
+++ b/app/views/shared/access_denied.html.erb
@@ -5,5 +5,6 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl"><%= t('.heading_1') %></h1>
     <p class="govuk-body"><%= t('.permission_text') %></p>
+    <p class="govuk-body"><a href="/providers/applications"><%= t('.back_to_apps_link') %></a></p>
   </div>
 </div>

--- a/config/locales/en/shared.yml
+++ b/config/locales/en/shared.yml
@@ -4,6 +4,7 @@ en:
     access_denied:
       heading_1: You cannot view this page
       permission_text: You can only view or edit this application if you created it
+      back_to_apps_link: Back to your applications
     check_answers_assets:
       assets:
         other_assets: Other assets


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-351)

Add a return to applications link to the access denied page so a provider can exit the page and return to where they can search for the application they need.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
