### PR TITLE
Refactor Flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ sudo freshclam
 sudo /etc/init.d/clamav-daemon start
 ```
 
+You may also need to run:
+```
+sudo apt install clamdscan
+```
+
 ### Run the application server
 
 ```

--- a/app/services/flow/base_flow_service.rb
+++ b/app/services/flow/base_flow_service.rb
@@ -40,7 +40,9 @@ module Flow
     private
 
     def checking_answers?
-      legal_aid_application.checking_answers? || legal_aid_application.checking_citizen_answers? || legal_aid_application.checking_passported_answers? ||
+      legal_aid_application.checking_answers? ||
+        legal_aid_application.checking_citizen_answers? ||
+        legal_aid_application.checking_passported_answers? ||
         legal_aid_application.checking_merits_answers?
     end
 
@@ -54,12 +56,7 @@ module Flow
     end
 
     def path(step)
-      path = steps.dig(step, :path)
-      raise ":path of step :#{step} is not defined" unless path
-
-      return path unless path.is_a?(Proc)
-
-      path.call(legal_aid_application, urls)
+      path_for(step, :path)
     end
 
     def forward_step
@@ -77,20 +74,20 @@ module Flow
     end
 
     def step(direction)
-      step = steps.dig(current_step, direction)
-      raise "#{direction.to_s.humanize} step of #{current_step} is not defined" unless step
+      path_for(current_step, direction)
+    end
 
-      return step unless step.is_a?(Proc)
+    def path_for(step, option)
+      path_action = steps.dig(step, option)
+      raise ":#{option} of step :#{step} is not defined" unless path_action
 
-      step.call(legal_aid_application)
+      return path_action unless path_action.is_a?(Proc)
+
+      path_action.call(legal_aid_application)
     end
 
     def steps
       self.class.steps
-    end
-
-    def urls
-      @urls ||= Rails.application.routes.url_helpers
     end
   end
 end

--- a/app/services/flow/flow_steps.rb
+++ b/app/services/flow/flow_steps.rb
@@ -1,0 +1,7 @@
+module Flow
+  class FlowSteps
+    def self.urls
+      Rails.application.routes.url_helpers
+    end
+  end
+end

--- a/app/services/flow/flows/citizen_capital.rb
+++ b/app/services/flow/flows/citizen_capital.rb
@@ -1,53 +1,53 @@
 module Flow
   module Flows
-    module CitizenCapital
+    class CitizenCapital < FlowSteps
       STEPS = {
         own_homes: {
-          path: ->(_, urls) { urls.citizens_own_home_path },
+          path: ->(_) { urls.citizens_own_home_path },
           forward: ->(application) { application.own_home_no? ? :savings_and_investments : :property_values },
           carry_on_sub_flow: ->(application) { !application.own_home_no? },
           check_answers: :check_answers
         },
         property_values: {
-          path: ->(_, urls) { urls.citizens_property_value_path },
+          path: ->(_) { urls.citizens_property_value_path },
           forward: ->(application) { application.own_home_mortgage? ? :outstanding_mortgages : :shared_ownerships },
           carry_on_sub_flow: true,
           check_answers: :check_answers
         },
         outstanding_mortgages: {
-          path: ->(_, urls) { urls.citizens_outstanding_mortgage_path },
+          path: ->(_) { urls.citizens_outstanding_mortgage_path },
           forward: :shared_ownerships,
           carry_on_sub_flow: true,
           check_answers: :check_answers
         },
         shared_ownerships: {
-          path: ->(_, urls) { urls.citizens_shared_ownership_path },
+          path: ->(_) { urls.citizens_shared_ownership_path },
           forward: ->(application) { application.shared_ownership? ? :percentage_homes : :savings_and_investments },
           carry_on_sub_flow: ->(application) { application.shared_ownership? },
           check_answers: :check_answers
         },
         percentage_homes: {
-          path: ->(_, urls) { urls.citizens_percentage_home_path },
+          path: ->(_) { urls.citizens_percentage_home_path },
           forward: :savings_and_investments,
           check_answers: :check_answers
         },
         savings_and_investments: {
-          path: ->(_, urls) { urls.citizens_savings_and_investment_path },
+          path: ->(_) { urls.citizens_savings_and_investment_path },
           forward: :other_assets,
           check_answers: :check_answers
         },
         other_assets: {
-          path: ->(_, urls) { urls.citizens_other_assets_path },
+          path: ->(_) { urls.citizens_other_assets_path },
           forward: ->(application) { application.own_capital? ? :restrictions : :check_answers },
           check_answers: :check_answers
         },
         restrictions: {
-          path: ->(_, urls) { urls.citizens_restrictions_path },
+          path: ->(_) { urls.citizens_restrictions_path },
           forward: :check_answers,
           check_answers: :check_answers
         },
         check_answers: {
-          path: ->(_, urls) { urls.citizens_check_answers_path },
+          path: ->(_) { urls.citizens_check_answers_path },
           forward: :application_submitted
         },
         application_submitted: {

--- a/app/services/flow/flows/citizen_start.rb
+++ b/app/services/flow/flows/citizen_start.rb
@@ -1,26 +1,26 @@
 module Flow
   module Flows
-    module CitizenStart
+    class CitizenStart < FlowSteps
       STEPS = {
         legal_aid_applications: {
           forward: :information
         },
         information: {
-          path: ->(_, urls) { urls.citizens_information_path },
+          path: ->(_) { urls.citizens_information_path },
           forward: :consents
         },
         consents: {
-          path: ->(_, urls) { urls.citizens_consent_path },
+          path: ->(_) { urls.citizens_consent_path },
           forward: :true_layer
         },
         true_layer: {
-          path: ->(_, urls) { urls.applicant_true_layer_omniauth_authorize_path }
+          path: ->(_) { urls.applicant_true_layer_omniauth_authorize_path }
         },
         accounts: {
           forward: :additional_accounts
         },
         additional_accounts: {
-          path: ->(_, urls) { urls.citizens_additional_accounts_path },
+          path: ->(_) { urls.citizens_additional_accounts_path },
           forward: :own_homes
         }
       }.freeze

--- a/app/services/flow/flows/provider_capital.rb
+++ b/app/services/flow/flows/provider_capital.rb
@@ -1,53 +1,53 @@
 module Flow
   module Flows
-    module ProviderCapital
+    class ProviderCapital < FlowSteps
       STEPS = {
         own_homes: {
-          path: ->(application, urls) { urls.providers_legal_aid_application_own_home_path(application) },
+          path: ->(application) { urls.providers_legal_aid_application_own_home_path(application) },
           forward: ->(application) { application.own_home_no? ? :savings_and_investments : :property_values },
           carry_on_sub_flow: ->(application) { !application.own_home_no? },
           check_answers: :check_passported_answers
         },
         property_values: {
-          path: ->(application, urls) { urls.providers_legal_aid_application_property_value_path(application) },
+          path: ->(application) { urls.providers_legal_aid_application_property_value_path(application) },
           forward: ->(application) { application.own_home_mortgage? ? :outstanding_mortgages : :shared_ownerships },
           carry_on_sub_flow: true,
           check_answers: :check_passported_answers
         },
         outstanding_mortgages: {
-          path: ->(application, urls) { urls.providers_legal_aid_application_outstanding_mortgage_path(application) },
+          path: ->(application) { urls.providers_legal_aid_application_outstanding_mortgage_path(application) },
           forward: :shared_ownerships,
           carry_on_sub_flow: true,
           check_answers: :check_passported_answers
         },
         shared_ownerships: {
-          path: ->(application, urls) { urls.providers_legal_aid_application_shared_ownership_path(application) },
+          path: ->(application) { urls.providers_legal_aid_application_shared_ownership_path(application) },
           forward: ->(application) { application.shared_ownership? ? :percentage_homes : :savings_and_investments },
           carry_on_sub_flow: ->(application) { application.shared_ownership? },
           check_answers: :check_passported_answers
         },
         percentage_homes: {
-          path: ->(application, urls) { urls.providers_legal_aid_application_percentage_home_path(application) },
+          path: ->(application) { urls.providers_legal_aid_application_percentage_home_path(application) },
           forward: :savings_and_investments,
           check_answers: :check_passported_answers
         },
         savings_and_investments: {
-          path: ->(application, urls) { urls.providers_legal_aid_application_savings_and_investment_path(application) },
+          path: ->(application) { urls.providers_legal_aid_application_savings_and_investment_path(application) },
           forward: :other_assets,
           check_answers: :check_passported_answers
         },
         other_assets: {
-          path: ->(application, urls) { urls.providers_legal_aid_application_other_assets_path(application) },
+          path: ->(application) { urls.providers_legal_aid_application_other_assets_path(application) },
           forward: ->(application) { application.own_capital? ? :restrictions : :check_passported_answers },
           check_answers: :check_passported_answers
         },
         restrictions: {
-          path: ->(application, urls) { urls.providers_legal_aid_application_restrictions_path(application) },
+          path: ->(application) { urls.providers_legal_aid_application_restrictions_path(application) },
           forward: :check_passported_answers,
           check_answers: :check_passported_answers
         },
         check_passported_answers: {
-          path: ->(application, urls) { urls.providers_legal_aid_application_check_passported_answers_path(application) },
+          path: ->(application) { urls.providers_legal_aid_application_check_passported_answers_path(application) },
           forward: :client_received_legal_helps
         }
       }.freeze

--- a/app/services/flow/flows/provider_merits.rb
+++ b/app/services/flow/flows/provider_merits.rb
@@ -1,39 +1,39 @@
 module Flow
   module Flows
-    module ProviderMerits
+    class ProviderMerits < FlowSteps
       STEPS = {
         client_received_legal_helps: {
-          path: ->(application, urls) { urls.providers_legal_aid_application_client_received_legal_help_path(application) },
+          path: ->(application) { urls.providers_legal_aid_application_client_received_legal_help_path(application) },
           forward: :proceedings_before_the_courts,
           check_answers: :check_merits_answers
         },
         proceedings_before_the_courts: {
-          path: ->(application, urls) { urls.providers_legal_aid_application_proceedings_before_the_court_path(application) },
+          path: ->(application) { urls.providers_legal_aid_application_proceedings_before_the_court_path(application) },
           forward: :statement_of_cases,
           check_answers: :check_merits_answers
         },
         statement_of_cases: {
-          path: ->(application, urls) { urls.providers_legal_aid_application_statement_of_case_path(application) },
+          path: ->(application) { urls.providers_legal_aid_application_statement_of_case_path(application) },
           forward: :estimated_legal_costs,
           check_answers: :check_merits_answers
         },
         estimated_legal_costs: {
-          path: ->(application, urls) { urls.providers_legal_aid_application_estimated_legal_costs_path(application) },
+          path: ->(application) { urls.providers_legal_aid_application_estimated_legal_costs_path(application) },
           forward: :success_prospects,
           check_answers: :check_merits_answers
         },
         success_prospects: {
-          path: ->(application, urls) { urls.providers_legal_aid_application_success_prospects_path(application) },
+          path: ->(application) { urls.providers_legal_aid_application_success_prospects_path(application) },
           forward: :merits_declarations,
           check_answers: :check_merits_answers
         },
         merits_declarations: {
-          path: ->(application, urls) { urls.providers_legal_aid_application_merits_declaration_path(application) },
+          path: ->(application) { urls.providers_legal_aid_application_merits_declaration_path(application) },
           forward: :check_merits_answers,
           check_answers: :check_merits_answers
         },
         check_merits_answers: {
-          path: ->(application, urls) { urls.providers_legal_aid_application_check_merits_answers_path(application) },
+          path: ->(application) { urls.providers_legal_aid_application_check_merits_answers_path(application) },
           forward: :placeholder_end_merits,
           check_answers: :check_merits_answers
         },

--- a/app/services/flow/flows/provider_start.rb
+++ b/app/services/flow/flows/provider_start.rb
@@ -1,23 +1,23 @@
 module Flow
   module Flows
-    module ProviderStart
+    class ProviderStart < FlowSteps
       STEPS = {
         legal_aid_applications: {
           forward: :applicants
         },
         applicants: {
-          path: ->(application, urls) { urls.providers_legal_aid_application_applicant_path(application) },
+          path: ->(application) { urls.providers_legal_aid_application_applicant_path(application) },
           forward: :address_lookups,
           check_answers: :check_provider_answers
         },
         address_lookups: {
-          path: ->(application, urls) { urls.providers_legal_aid_application_address_lookup_path(application) },
+          path: ->(application) { urls.providers_legal_aid_application_address_lookup_path(application) },
           forward: :address_selections,
           check_answers: :check_provider_answers,
           carry_on_sub_flow: true
         },
         address_selections: {
-          path: ->(application, urls) { urls.providers_legal_aid_application_address_selection_path(application) },
+          path: ->(application) { urls.providers_legal_aid_application_address_selection_path(application) },
           forward: :proceedings_types,
           check_answers: :check_provider_answers
         },
@@ -26,28 +26,28 @@ module Flow
           check_answers: :check_provider_answers
         },
         proceedings_types: {
-          path: ->(application, urls) { urls.providers_legal_aid_application_proceedings_types_path(application) },
+          path: ->(application) { urls.providers_legal_aid_application_proceedings_types_path(application) },
           forward: :check_provider_answers,
           check_answers: :check_provider_answers
         },
         check_provider_answers: {
-          path: ->(application, urls) { urls.providers_legal_aid_application_check_provider_answers_path(application) },
+          path: ->(application) { urls.providers_legal_aid_application_check_provider_answers_path(application) },
           forward: :check_benefits
         },
         check_benefits: {
-          path: ->(application, urls) { urls.providers_legal_aid_application_check_benefits_path(application) },
+          path: ->(application) { urls.providers_legal_aid_application_check_benefits_path(application) },
           forward: ->(application) { application.benefit_check_result.positive? ? :own_homes : :online_bankings }
         },
         online_bankings: {
-          path: ->(application, urls) { urls.providers_legal_aid_application_online_banking_path(application) },
+          path: ->(application) { urls.providers_legal_aid_application_online_banking_path(application) },
           forward: ->(application) { application.applicant.uses_online_banking? ? :about_the_financial_assessments : :place_holder_ccms }
         },
         about_the_financial_assessments: {
-          path: ->(application, urls) { urls.providers_legal_aid_application_about_the_financial_assessment_path(application) },
+          path: ->(application) { urls.providers_legal_aid_application_about_the_financial_assessment_path(application) },
           forward: :application_confirmations
         },
         application_confirmations: {
-          path: ->(application, urls) { urls.providers_legal_aid_application_application_confirmation_path(application) }
+          path: ->(application) { urls.providers_legal_aid_application_application_confirmation_path(application) }
         },
         place_holder_ccms: {
           path: '[PLACEHOLDER] Page directing provider to use CCMS'

--- a/spec/services/flow_service_spec.rb
+++ b/spec/services/flow_service_spec.rb
@@ -77,4 +77,53 @@ RSpec.describe Flow::BaseFlowService do
       end
     end
   end
+
+  context 'with basic data' do
+    let(:url_helpers) { Rails.application.routes.url_helpers }
+    let(:current_step) { :foo }
+    let(:path) { :path }
+    let(:forward) { :forward }
+    let(:carry_on_sub_flow) { true }
+    let(:check_answers) { :check_answers }
+    let(:forward_url) { :forward_url }
+    let(:steps) do
+      {
+        current_step => {
+          path: path,
+          forward: forward,
+          carry_on_sub_flow: carry_on_sub_flow,
+          check_answers: check_answers
+        },
+        forward => {
+          path: forward_url
+        }
+      }
+    end
+
+    describe '#current_path' do
+      it 'returns path' do
+        expect(subject.current_path).to eq(path)
+      end
+
+      context 'when path not defined' do
+        let(:path) { nil }
+        it 'raises an error' do
+          expect { subject.current_path }.to raise_error(/not defined/)
+        end
+      end
+
+      context 'when path is a proc' do
+        let(:path) { ->(passed_in) { passed_in } }
+        it 'passes in the legal aid application' do
+          expect(subject.current_path).to eq(legal_aid_application)
+        end
+      end
+    end
+
+    describe '#forward_path' do
+      it 'returns forward url' do
+        expect(subject.forward_path).to eq(forward_url)
+      end
+    end
+  end
 end


### PR DESCRIPTION
A small refactor. I've done three main things:

1. Remove some duplication of code (the `step` and `path` methods were very similar)
2. Moved `urls` into the context of the `STEPS` defining objects - so they no longer need to be passed into each `proc` call.
3. Added some specs that pass in a plain hash rather than an existing `STEPS` to make it easier to test at a very low level.