### PR TITLE
Improve malware scanner

### DIFF
--- a/app/services/malware_scanner.rb
+++ b/app/services/malware_scanner.rb
@@ -1,9 +1,11 @@
 class MalwareScanner
+  ClamdscanError = Class.new(StandardError)
+
   def self.call(file_path)
     new(file_path).call
   end
 
-  COMMAND = 'clamdscan --fdpass --no-summary'.freeze
+  COMMAND = %w[clamdscan --fdpass --no-summary].freeze
 
   attr_reader :file_path, :uploader, :file_details
 
@@ -17,16 +19,25 @@ class MalwareScanner
     MalwareScanResult.new(
       uploader: uploader,
       virus_found: virus_found?,
-      scan_result: scan_result,
+      scan_result: scan_result.stdout,
       file_details: file_details
     ).tap(&:save!)
   end
 
   def virus_found?
-    @virus_found ||= !scan_result.ends_with?('OK')
+    @virus_found ||= !scan_result.status.success?
   end
 
   def scan_result
-    @scan_result ||= `#{COMMAND} #{file_path}`.strip
+    @scan_result ||= begin
+      stdout, stderr, status = Open3.capture3(*(COMMAND + [file_path.to_s]))
+
+      raise ClamdscanError, stderr if stderr.present?
+
+      OpenStruct.new(
+        stdout: stdout.strip,
+        status: status
+      )
+    end
   end
 end

--- a/spec/services/malware_scanner_spec.rb
+++ b/spec/services/malware_scanner_spec.rb
@@ -51,14 +51,23 @@ RSpec.describe MalwareScanner do
       end
     end
 
-    context 'scan_result' do
-      let(:scan_result) { Faker::Lorem.sentence }
+    context 'command fails' do
+      let(:file_path) { Rails.root.join("spec/fixtures/files/#{SecureRandom.hex}") }
 
-      before { allow_any_instance_of(MalwareScanner).to receive(:`).and_return(scan_result) }
+      it 'raises an error' do
+        expect { subject }.to raise_error(described_class::ClamdscanError)
+      end
+    end
+
+    context 'scan_result' do
+      let(:stub_stdout) { Faker::Lorem.sentence }
+      let(:scan_result) { [stub_stdout, '', double('process_status', success?: true)] }
+
+      before { allow(Open3).to receive(:capture3).and_return(scan_result) }
 
       it 'returns and records the result of the scan' do
-        expect(subject.scan_result).to eq(scan_result.strip)
-        expect(malware_scan_result.scan_result).to eq(scan_result.strip)
+        expect(subject.scan_result).to eq(stub_stdout.strip)
+        expect(malware_scan_result.scan_result).to eq(stub_stdout.strip)
       end
     end
   end


### PR DESCRIPTION
## What

Improve the call to the malware scan `clamdscan`.
Before, if there was a problem with the command itself, it would no raise an error but fail silently and give a false positive result.
Now, it will raise an error.
And `Open3.capture3` seems to be a prefered way to run system commands with which you can get every outputs (stdout, stderr, and the exit code)

## Checklist

Before you ask people to review this PR:

- [X] Tests and rubocop should be passing: `bundle exec rake`
- [X] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [X] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [X] The PR description should say what you changed and why, with a link to the JIRA story.
- [X] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [X] You should have checked that the commit messages say why the change was made.
