### PR TITLE
AP 247 provider capital introduction

### DIFF
--- a/app/controllers/providers/capital_introductions_controller.rb
+++ b/app/controllers/providers/capital_introductions_controller.rb
@@ -1,0 +1,17 @@
+module Providers
+  class CapitalIntroductionsController < ProviderBaseController
+    before_action :authorize_legal_aid_application
+
+    def show; end
+
+    def update
+      continue_or_draft
+    end
+
+    private
+
+    def authorize_legal_aid_application
+      authorize @legal_aid_application
+    end
+  end
+end

--- a/app/services/flow/flows/provider_start.rb
+++ b/app/services/flow/flows/provider_start.rb
@@ -36,7 +36,11 @@ module Flow
         },
         check_benefits: {
           path: ->(application) { urls.providers_legal_aid_application_check_benefits_path(application) },
-          forward: ->(application) { application.benefit_check_result.positive? ? :own_homes : :online_bankings }
+          forward: ->(application) { application.benefit_check_result.positive? ? :capital_introductions : :online_bankings }
+        },
+        capital_introductions: {
+          path: ->(application) { urls.providers_legal_aid_application_capital_introduction_path(application) },
+          forward: :own_homes
         },
         online_bankings: {
           path: ->(application) { urls.providers_legal_aid_application_online_banking_path(application) },

--- a/app/views/providers/capital_introductions/show.html.erb
+++ b/app/views/providers/capital_introductions/show.html.erb
@@ -1,11 +1,11 @@
 <%= page_template page_title: t('.h1-heading') do %>
-  <%= simple_format t('.text_1') %>
+  <%= simple_format t('.does_your_client') %>
 
-  <%= list_from_translation_path 'providers.capital_introductions.show' %>
+  <%= list_from_translation_path 'providers.capital_introductions.show.about_the_client' %>
 
-  <%= simple_format t('.text_2') %>
+  <%= simple_format t('.client_to_provide') %>
 
-  <%= list_from_translation_path 'providers.capital_introductions.show.list_2' %>
+  <%= list_from_translation_path 'providers.capital_introductions.show.items_to_be_provided' %>
 
   <div class="govuk-!-padding-bottom-4"></div>
 

--- a/app/views/providers/capital_introductions/show.html.erb
+++ b/app/views/providers/capital_introductions/show.html.erb
@@ -1,0 +1,18 @@
+<%= page_template page_title: t('.h1-heading') do %>
+  <%= simple_format t('.text_1') %>
+
+  <%= list_from_translation_path 'providers.capital_introductions.show' %>
+
+  <%= simple_format t('.text_2') %>
+
+  <%= list_from_translation_path 'providers.capital_introductions.show.list_2' %>
+
+  <div class="govuk-!-padding-bottom-4"></div>
+
+  <%= next_action_buttons_with_form(
+        url: providers_legal_aid_application_capital_introduction_path,
+        method: :patch,
+        show_draft: true
+      ) %>
+
+<% end %>

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -216,16 +216,17 @@ en:
         h1-heading: What are the prospects of success?
     capital_introductions:
       show:
-        list: |
-          owns a home or has a mortgage (and their values)
-          has any savings, investments or other capital (and their values)
-          has any other ways to contribute towards legal costs
-        list_2:
+        about_the_client:
+          list: |
+            owns a home or has a mortgage (and their values)
+            has any savings, investments or other capital (and their values)
+            has any other ways to contribute towards legal costs
+        items_to_be_provided:
           list: |
             a statement of case
             information about any attempts to settle
             cost estimates
             the prospects of success
         h1-heading: Before you continue
-        text_1: "You'll need to tell us if your client:"
-        text_2: "You'll also need to provide:"
+        does_your_client: "You'll need to tell us if your client:"
+        client_to_provide: "You'll also need to provide:"

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -214,3 +214,18 @@ en:
     success_prospects:
       show:
         h1-heading: What are the prospects of success?
+    capital_introductions:
+      show:
+        list: |
+          owns a home or has a mortgage (and their values)
+          has any savings, investments or other capital (and their values)
+          has any other ways to contribute towards legal costs
+        list_2:
+          list: |
+            a statement of case
+            information about any attempts to settle
+            cost estimates
+            the prospects of success
+        h1-heading: Before you continue
+        text_1: "You'll need to tell us if your client:"
+        text_2: "You'll also need to provide:"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -63,6 +63,7 @@ Rails.application.routes.draw do
       resources :check_benefits, only: [:index]
       resource :online_banking, only: %i[show update], path: 'does-client-use-online-banking'
       resource :merits_declaration, only: %i[show update]
+      resource :capital_introduction, only: %i[show update]
       resources :check_provider_answers, only: [:index] do
         post :reset, on: :collection
         patch :continue, on: :collection

--- a/features/providers/civil_application_journey.feature
+++ b/features/providers/civil_application_journey.feature
@@ -324,6 +324,8 @@ Feature: Civil application journeys
     Then I am on the benefit check results page
     Then I see a notice saying that the citizen receives benefits
     Then I click "Continue"
+    Then I should be on a page showing "Before you continue"
+    Then I click "Continue"
     Then I should be on a page showing "Does your client own the home that they live in?"
     Then I choose "Yes, with a mortgage or loan"
     Then I click "Continue"

--- a/spec/requests/providers/capital_introductions_spec.rb
+++ b/spec/requests/providers/capital_introductions_spec.rb
@@ -22,6 +22,17 @@ RSpec.describe Providers::CapitalIntroductionsController, type: :request do
         expect(response).to have_http_status(:ok)
         expect(response.body).to include('Before you continue')
       end
+    end
+  end
+
+  describe 'PATCH /providers/applications/:id/capital_introduction' do
+    subject { patch providers_legal_aid_application_capital_introduction_path(legal_aid_application) }
+
+    context 'when the provider is authenticated' do
+      before do
+        login_as provider
+        subject
+      end
 
       context 'when the Continue button is pressed' do
         subject { patch providers_legal_aid_application_capital_introduction_path(legal_aid_application) }

--- a/spec/requests/providers/capital_introductions_spec.rb
+++ b/spec/requests/providers/capital_introductions_spec.rb
@@ -28,21 +28,12 @@ RSpec.describe Providers::CapitalIntroductionsController, type: :request do
   describe 'PATCH /providers/applications/:id/capital_introduction' do
     subject { patch providers_legal_aid_application_capital_introduction_path(legal_aid_application) }
 
-    context 'when the provider is authenticated' do
-      before do
-        login_as provider
-        subject
-      end
+    before do
+      login_as provider
+    end
 
-      context 'when the Continue button is pressed' do
-        subject { patch providers_legal_aid_application_capital_introduction_path(legal_aid_application) }
-        let(:submit_button) { { continue_button: 'Continue' } }
-
-        it 'redirects to next page' do
-          subject
-          expect(response).to redirect_to(providers_legal_aid_application_own_home_path(legal_aid_application))
-        end
-      end
+    it 'redirects to next page' do
+      expect(subject).to redirect_to(providers_legal_aid_application_own_home_path(legal_aid_application))
     end
   end
 end

--- a/spec/requests/providers/capital_introductions_spec.rb
+++ b/spec/requests/providers/capital_introductions_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+RSpec.describe Providers::CapitalIntroductionsController, type: :request do
+  let(:legal_aid_application) { create :legal_aid_application }
+  let(:provider) { legal_aid_application.provider }
+
+  describe 'GET /providers/applications/:id/capital_introduction' do
+    subject { get providers_legal_aid_application_capital_introduction_path(legal_aid_application) }
+
+    context 'when the provider is not authenticated' do
+      before { subject }
+      it_behaves_like 'a provider not authenticated'
+    end
+
+    context 'when the provider is authenticated' do
+      before do
+        login_as provider
+        subject
+      end
+
+      it 'returns http success' do
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include('Before you continue')
+      end
+
+      context 'when the Continue button is pressed' do
+        subject { patch providers_legal_aid_application_capital_introduction_path(legal_aid_application) }
+        let(:submit_button) { { continue_button: 'Continue' } }
+
+        it 'redirects to next page' do
+          subject
+          expect(response).to redirect_to(providers_legal_aid_application_own_home_path(legal_aid_application))
+        end
+      end
+    end
+  end
+
+  describe 'PATCH /providers/applications/:application_id/capital_introduction' do
+    subject { patch providers_legal_aid_application_check_benefit_path(legal_aid_application.id), params: params }
+
+    context 'when the provider is authenticated' do
+      before do
+        login_as provider
+        subject
+      end
+
+      context 'Form submitted using Save as draft button' do
+        let(:params) { { draft_button: 'Save as draft' } }
+
+        it "redirects provider to provider's applications page" do
+          subject
+          expect(response).to redirect_to(providers_legal_aid_applications_path)
+        end
+
+        it 'sets the application as draft' do
+          expect(legal_aid_application.reload).to be_draft
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/providers/capital_introductions_spec.rb
+++ b/spec/requests/providers/capital_introductions_spec.rb
@@ -34,28 +34,4 @@ RSpec.describe Providers::CapitalIntroductionsController, type: :request do
       end
     end
   end
-
-  describe 'PATCH /providers/applications/:application_id/capital_introduction' do
-    subject { patch providers_legal_aid_application_check_benefit_path(legal_aid_application.id), params: params }
-
-    context 'when the provider is authenticated' do
-      before do
-        login_as provider
-        subject
-      end
-
-      context 'Form submitted using Save as draft button' do
-        let(:params) { { draft_button: 'Save as draft' } }
-
-        it "redirects provider to provider's applications page" do
-          subject
-          expect(response).to redirect_to(providers_legal_aid_applications_path)
-        end
-
-        it 'sets the application as draft' do
-          expect(legal_aid_application.reload).to be_draft
-        end
-      end
-    end
-  end
 end

--- a/spec/requests/providers/check_benefits_spec.rb
+++ b/spec/requests/providers/check_benefits_spec.rb
@@ -96,8 +96,8 @@ RSpec.describe 'check benefits requests', type: :request do
         context 'when the check_benefit_results is positive' do
           let(:application) { create :legal_aid_application, :with_positive_benefit_check_result }
 
-          it 'displays the own home page' do
-            expect(response).to redirect_to providers_legal_aid_application_own_home_path(application)
+          it 'displays the capital introduction page' do
+            expect(response).to redirect_to providers_legal_aid_application_capital_introduction_path(application)
           end
         end
 


### PR DESCRIPTION
add the capital introduction page to the start of the capital flow questions.

[Link to story](https://dsdmoj.atlassian.net/browse/AP-247)

updated the provider flow to direct the provider to this page if the client is passported, otherwise they dont see this page. 

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
