### PR TITLE
AP-329 provider capital cya property

### DIFF
--- a/app/forms/legal_aid_applications/own_home_form.rb
+++ b/app/forms/legal_aid_applications/own_home_form.rb
@@ -8,6 +8,8 @@ module LegalAidApplications
 
     validates :own_home, presence: { message: 'blank' }, unless: :draft?
 
+    after_validation { model.clear_property_details if own_home_no? }
+
     delegate :own_home_no?, :own_home_mortgage?, :own_home_owned_outright?, to: :model
   end
 end

--- a/app/forms/legal_aid_applications/shared_ownership_form.rb
+++ b/app/forms/legal_aid_applications/shared_ownership_form.rb
@@ -8,6 +8,8 @@ module LegalAidApplications
 
     validates :shared_ownership, presence: { message: 'blank' }, unless: :draft?
 
+    after_validation { model.percentage_home = nil unless shared_ownership? }
+
     delegate :shared_ownership?, to: :model
   end
 end

--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -102,6 +102,13 @@ class LegalAidApplication < ApplicationRecord
     other_assets_declaration.present? && other_assets_declaration.positive?
   end
 
+  def clear_property_details
+    self.percentage_home = nil
+    self.property_value = nil
+    self.shared_ownership = nil
+    self.outstanding_mortgage_amount = nil
+  end
+
   private
 
   def applicant_updated_after_benefit_check_result_updated?

--- a/spec/requests/providers/own_home_spec.rb
+++ b/spec/requests/providers/own_home_spec.rb
@@ -90,6 +90,23 @@ RSpec.describe 'provider own home requests', type: :request do
               expect(response).to redirect_to(providers_legal_aid_application_check_passported_answers_path(legal_aid_application))
             end
           end
+
+          context 'ownership is changed from yes to no' do
+            let(:legal_aid_application) { create :legal_aid_application, :with_everything, :checking_passported_answers }
+
+            it 'redirects to check answers page' do
+              subject
+              expect(response).to redirect_to(providers_legal_aid_application_check_passported_answers_path(legal_aid_application))
+            end
+
+            it 'deletes previous property values from the database' do
+              subject
+              expect(legal_aid_application.reload.property_value).to eq nil
+              expect(legal_aid_application.reload.outstanding_mortgage_amount).to eq nil
+              expect(legal_aid_application.reload.shared_ownership).to eq nil
+              expect(legal_aid_application.reload.percentage_home).to eq nil
+            end
+          end
         end
       end
 

--- a/spec/requests/providers/shared_ownerships_spec.rb
+++ b/spec/requests/providers/shared_ownerships_spec.rb
@@ -127,6 +127,20 @@ RSpec.describe 'providers shared ownership request test', type: :request do
               expect(response).to redirect_to providers_legal_aid_application_restrictions_path(legal_aid_application)
             end
           end
+
+          context 'shared ownership is changed from yes to no' do
+            let(:legal_aid_application) { create :legal_aid_application, :with_everything, :checking_passported_answers }
+
+            it 'redirects to check answers page' do
+              subject
+              expect(response).to redirect_to(providers_legal_aid_application_restrictions_path(legal_aid_application))
+            end
+
+            it 'deletes percentage owned from the database' do
+              subject
+              expect(legal_aid_application.reload.percentage_home).to eq nil
+            end
+          end
         end
 
         context 'with an invalid param' do


### PR DESCRIPTION
## What

[AP-329](https://dsdmoj.atlassian.net/browse/AP-329)

Most of the functional changes for this story have already been covered by previous stories (AP-312, AP-336).

The acceptance criteria for the story states that "Previously entered information from the property flow should not be saved if the user changes from a 'Yes' to a 'No'".

To do this I have added post-validation checks to the `own_home_form` and `shared_ownership_form` which will delete relevant data from the model if a 'No' is selected.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
