### PR TITLE
AP-186 Identity Salary

### DIFF
--- a/app/controllers/citizens/transactions_controller.rb
+++ b/app/controllers/citizens/transactions_controller.rb
@@ -1,0 +1,63 @@
+module Citizens
+  class TransactionsController < BaseController
+    include Flowable
+    before_action :authenticate_applicant!
+
+    def show
+      transaction_type
+      bank_transactions
+    end
+
+    def update
+      reset_selection
+      set_selection
+
+      go_forward
+    end
+
+    def date_from
+      l(bank_transactions.last.happened_at.to_date, format: :long_date)
+    end
+    helper_method :date_from
+
+    def date_to
+      l(bank_transactions.first.happened_at.to_date, format: :long_date)
+    end
+    helper_method :date_to
+
+    private
+
+    def reset_selection
+      bank_transactions.where(transaction_type_id: transaction_type.id).update_all(transaction_type_id: nil)
+    end
+
+    def set_selection
+      BankTransaction
+        .where(id: transaction_ids_to_select)
+        .update_all(transaction_type_id: transaction_type.id)
+    end
+
+    def transaction_ids_to_select
+      bank_transactions.pluck(:id) & selected_transaction_ids
+    end
+
+    def selected_transaction_ids
+      params[:transaction_ids].select(&:present?)
+    end
+
+    def transaction_type
+      @transaction_type ||= TransactionType.find_by(name: params[:transaction_type]) || TransactionType.first
+    end
+
+    def bank_transactions
+      @bank_transactions ||=
+        BankTransaction
+        .of_applicant(legal_aid_application.applicant)
+        .where(operation: transaction_type.operation)
+    end
+
+    def legal_aid_application
+      @legal_aid_application ||= LegalAidApplication.find(session[:current_application_ref])
+    end
+  end
+end

--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -11,6 +11,8 @@ class Applicant < ApplicationRecord
   has_one :address, -> { order(created_at: :desc) }
   has_many :bank_providers
   has_many :bank_errors
+  has_many :bank_accounts, through: :bank_providers
+  has_many :bank_transactions, through: :bank_accounts
 
   def email_address
     email

--- a/app/models/bank_transaction.rb
+++ b/app/models/bank_transaction.rb
@@ -2,6 +2,12 @@ class BankTransaction < ApplicationRecord
   belongs_to :bank_account
   belongs_to :transaction_type, optional: true
 
+  scope :of_applicant, ->(applicant) do
+    joins(bank_account: { bank_provider: :applicant })
+      .where(bank_accounts: { bank_providers: { applicant: applicant } })
+      .order(happened_at: :desc, id: :desc)
+  end
+
   enum operation: {
     credit: 'credit'.freeze,
     debit: 'debit'.freeze

--- a/app/models/bank_transaction.rb
+++ b/app/models/bank_transaction.rb
@@ -2,12 +2,6 @@ class BankTransaction < ApplicationRecord
   belongs_to :bank_account
   belongs_to :transaction_type, optional: true
 
-  scope :of_applicant, ->(applicant) do
-    joins(bank_account: { bank_provider: :applicant })
-      .where(bank_accounts: { bank_providers: { applicant: applicant } })
-      .order(happened_at: :desc, id: :desc)
-  end
-
   enum operation: {
     credit: 'credit'.freeze,
     debit: 'debit'.freeze

--- a/app/models/transaction_type.rb
+++ b/app/models/transaction_type.rb
@@ -8,7 +8,7 @@ class TransactionType < ApplicationRecord
       property_or_lodger
       student_loan
       pension
-      fiends_or_family
+      friends_or_family
     ],
     debit: %i[
       rent_or_mortgage

--- a/app/services/flow/flows/citizen_income.rb
+++ b/app/services/flow/flows/citizen_income.rb
@@ -5,6 +5,12 @@ module Flow
         identify_types_of_incomes: {
           path: ->(_) { urls.citizens_identify_types_of_income_path },
           forward: :own_homes
+        },
+        transactions: {
+          forward: :placeholder_summary_transaction
+        },
+        placeholder_summary_transaction: {
+          path: '[PLACEHOLDER] Summary of income or payments'
         }
       }.freeze
     end

--- a/app/views/citizens/transactions/show.html.erb
+++ b/app/views/citizens/transactions/show.html.erb
@@ -9,19 +9,19 @@
     <%= form.hidden_field :transaction_type, value: @transaction_type.name %>
 
     <table class="govuk-table">
-      <caption class="govuk-table__caption"><%= t('date.date_period', from: date_from, to: date_to) if @bank_transactions.any? %></caption>
+      <%= content_tag(:caption, t('date.date_period', from: date_from, to: date_to), class: 'govuk-table__caption') if @bank_transactions.any? %>
       <thead class="govuk-table__head">
         <tr class="govuk-table__row">
           <th class="govuk-table__header" scope="col"><%= t '.col_select_all' %></th>
           <th class="govuk-table__header" scope="col"><%= t '.col_date' %></th>
           <th class="govuk-table__header" scope="col"><%= t '.col_description' %></th>
-          <th class="govuk-table__header" scope="col"><%= t '.col_amount' %></th>
+          <th class="govuk-table__header govuk-table__header--numeric" scope="col"><%= t '.col_amount' %></th>
         </tr>
       </thead>
       <tbody class="govuk-table__body">
         <%= form.collection_check_boxes :transaction_ids, @bank_transactions, :id, :description do |builder| %>
           <tr class="govuk-table__row">
-            <th class="govuk-table__cell" scope="row">
+            <th class="govuk-table__cell">
               <div class="govuk-checkboxes__item">
                 <% checked = builder.object.transaction_type_id == @transaction_type.id %>
                 <%= builder.check_box(class: 'govuk-checkboxes__input', checked: checked) %>
@@ -30,13 +30,13 @@
             </th>
             <td class="govuk-table__cell"><%= l(builder.object.happened_at.to_date, format: :short_date) %></td>
             <td class="govuk-table__cell"><%= builder.object.description %></td>
-            <td class="govuk-table__cell"><%= value_with_currency_unit(builder.object.amount, builder.object.currency) %></td>
+            <td class="govuk-table__cell govuk-table__cell--numeric"><%= value_with_currency_unit(builder.object.amount, builder.object.currency) %></td>
           </tr>
         <% end %>
       </tbody>
     </table>
 
-    <%= next_action_buttons(show_draft: false, form: form) %>
+    <%= next_action_buttons(form: form) %>
 
   <% end %>
 

--- a/app/views/citizens/transactions/show.html.erb
+++ b/app/views/citizens/transactions/show.html.erb
@@ -1,0 +1,43 @@
+<%= page_template page_title: t("transaction_types.page_titles.#{@transaction_type.name}"), template: :default do %>
+
+  <h2 class="govuk-heading-m"><%= t '.sub_heading' %></h2>
+
+  <div class="govuk-!-padding-bottom-4"></div>
+
+  <%= form_with(url: citizens_transactions_path, method: :patch, local: true) do |form| %>
+
+    <%= form.hidden_field :transaction_type, value: @transaction_type.name %>
+
+    <table class="govuk-table">
+      <caption class="govuk-table__caption"><%= t('date.date_period', from: date_from, to: date_to) if @bank_transactions.any? %></caption>
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th class="govuk-table__header" scope="col"><%= t '.col_select_all' %></th>
+          <th class="govuk-table__header" scope="col"><%= t '.col_date' %></th>
+          <th class="govuk-table__header" scope="col"><%= t '.col_description' %></th>
+          <th class="govuk-table__header" scope="col"><%= t '.col_amount' %></th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+        <%= form.collection_check_boxes :transaction_ids, @bank_transactions, :id, :description do |builder| %>
+          <tr class="govuk-table__row">
+            <th class="govuk-table__cell" scope="row">
+              <div class="govuk-checkboxes__item">
+                <% checked = builder.object.transaction_type_id == @transaction_type.id %>
+                <%= builder.check_box(class: 'govuk-checkboxes__input', checked: checked) %>
+                <label class="govuk-label govuk-checkboxes__label"></label>
+              </div>
+            </th>
+            <td class="govuk-table__cell"><%= l(builder.object.happened_at.to_date, format: :short_date) %></td>
+            <td class="govuk-table__cell"><%= builder.object.description %></td>
+            <td class="govuk-table__cell"><%= value_with_currency_unit(builder.object.amount, builder.object.currency) %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+
+    <%= next_action_buttons(show_draft: false, form: form) %>
+
+  <% end %>
+
+<% end %>

--- a/config/locales/en/citizens.yml
+++ b/config/locales/en/citizens.yml
@@ -121,3 +121,10 @@ en:
     shared_ownerships:
       show:
         heading_1: Do you own your home with anyone else?
+    transactions:
+      show:
+        sub_heading: Select all that apply
+        col_select_all: Select all
+        col_date: Date
+        col_description: Description
+        col_amount: Amount

--- a/config/locales/en/default.yml
+++ b/config/locales/en/default.yml
@@ -12,6 +12,9 @@ en:
   date:
     formats:
       default: "%a, %d %b %Y"
+      short_date: "%d %b %Y"
+      long_date: "%d %B %Y"
+    date_period: "%{from} to %{to}"
   errors:
     messages:
       already_confirmed: was already confirmed, please try signing in

--- a/config/locales/en/models.yml
+++ b/config/locales/en/models.yml
@@ -16,4 +16,17 @@ en:
       property_or_lodger: Income from a property or lodger
       student_loan: Student loan or grant
       pension: Pensions
-      fiends_or_family: Financial help from friends or family
+      friends_or_family: Financial help from friends or family
+    page_titles:
+      salary: Your salary or wage payments
+      benefits: Benefits
+      maintenance_in: Maintenance payments (for children or from an ex-partner)
+      property_or_lodger: Income from a property or lodger
+      student_loan: Student loan or grant
+      pension: Pensions (State, work or private)
+      friends_or_family: Financial help from friends or family
+      rent_or_mortgage: Rent or mortgage
+      council_tax: Council Tax
+      child_care: Childcare costs to a nursery or registered provider
+      maintenance_out: Maintenance payments (for children or to an ex-partner)
+      legal_aid: Existing legal aid contributions

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,6 +43,7 @@ Rails.application.routes.draw do
       patch :continue, on: :collection
     end
     resource :identify_types_of_income, only: %i[show update]
+    resource :transactions, only: %i[show update]
   end
 
   namespace :providers do

--- a/spec/factories/bank_transactions.rb
+++ b/spec/factories/bank_transactions.rb
@@ -2,5 +2,17 @@ FactoryBot.define do
   factory :bank_transaction do
     bank_account
     true_layer_id { SecureRandom.hex }
+    description { Faker::Lorem.sentence }
+    merchant { Faker::Lorem.sentence }
+    happened_at { Faker::Date.backward(90) }
+    currency { Faker::Currency.code }
+    amount { Faker::Number.decimal(2) }
+
+    trait :debit do
+      operation { :debit }
+    end
+    trait :credit do
+      operation { :credit }
+    end
   end
 end

--- a/spec/factories/transaction_types.rb
+++ b/spec/factories/transaction_types.rb
@@ -12,7 +12,7 @@ end
 
 FactoryBot.define do
   factory :transaction_type do
-    name { Faker::Commerce.unique.product_name.underscore }
+    name { TransactionType::NAMES.values.flatten.sample }
     operation { TransactionType::NAMES.keys.sample }
 
     trait :credit_with_standard_name do

--- a/spec/requests/citizens/transactions_spec.rb
+++ b/spec/requests/citizens/transactions_spec.rb
@@ -1,0 +1,104 @@
+require 'rails_helper'
+
+RSpec.describe Citizens::TransactionsController, type: :request do
+  include ActionView::Helpers::NumberHelper
+  let(:legal_aid_application) { create :legal_aid_application, :with_applicant }
+  let(:applicant) { legal_aid_application.applicant }
+  let(:secure_id) { legal_aid_application.generate_secure_id }
+  let(:transaction_type) { create :transaction_type }
+  let(:bank_provider) { create :bank_provider, applicant: applicant }
+  let(:bank_account) { create :bank_account, bank_provider: bank_provider }
+  let(:parsed_html) { Nokogiri::HTML(response.body) }
+
+  before do
+    get citizens_legal_aid_application_path(secure_id)
+  end
+
+  describe 'GET #citizens/transactions' do
+    subject { get citizens_transactions_path(transaction_type: transaction_type.name) }
+
+    it 'returns http success' do
+      subject
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'renders the transactions page' do
+      subject
+      expect(unescaped_response_body).to include(I18n.t("transaction_types.page_titles.#{transaction_type.name}"))
+    end
+
+    context 'When there are transactions' do
+      let(:not_matching_operation) { (TransactionType::NAMES.keys.map(&:to_s) - [transaction_type.operation.to_s]).first }
+      let!(:bank_transaction_matching) { create :bank_transaction, bank_account: bank_account, operation: transaction_type.operation }
+      let!(:bank_transaction_selected) { create :bank_transaction, bank_account: bank_account, operation: transaction_type.operation, transaction_type: transaction_type }
+      let!(:bank_transaction_not_matching) { create :bank_transaction, bank_account: bank_account, operation: not_matching_operation }
+      let!(:bank_transaction_other_applicant) { create :bank_transaction, operation: transaction_type.operation }
+
+      it 'shows the transactions matching the operation on the transaction type' do
+        subject
+        expect(unescaped_response_body).to include(bank_transaction_matching.description)
+        expect(unescaped_response_body).to include(bank_transaction_selected.description)
+      end
+
+      it 'shows the transaction date' do
+        subject
+        expect(unescaped_response_body).to include(bank_transaction_matching.happened_at.to_date.strftime(I18n.t('date.formats.short_date')))
+      end
+
+      it 'shows the transaction amount' do
+        subject
+        transaction = bank_transaction_matching
+        expected_amount = number_to_currency(transaction.amount, unit: I18n.t("currency.#{transaction.currency.downcase}", default: transaction.currency))
+        expect(unescaped_response_body).to include(expected_amount)
+      end
+
+      it 'shows selected transactions' do
+        subject
+        checkbox = parsed_html.at_css("[value='#{bank_transaction_selected.id}']")
+        expect(checkbox[:checked]).to eq('checked')
+      end
+
+      it 'does not show transactions that do not match the operation on the transaction type' do
+        subject
+        expect(unescaped_response_body).not_to include(bank_transaction_not_matching.description)
+      end
+
+      it 'does not show other applicants transactions' do
+        subject
+        expect(unescaped_response_body).not_to include(bank_transaction_other_applicant.description)
+      end
+    end
+
+    describe 'PATCH #citizens/transactions' do
+      let!(:bank_transaction_A) { create :bank_transaction, bank_account: bank_account, operation: transaction_type.operation, transaction_type: transaction_type }
+      let!(:bank_transaction_B) { create :bank_transaction, bank_account: bank_account, operation: transaction_type.operation }
+      let!(:bank_transaction_other_applicant) { create :bank_transaction, operation: transaction_type.operation }
+      let(:selected_transactions) { [bank_transaction_B, bank_transaction_other_applicant] }
+      let(:params) do
+        {
+          transaction_type: transaction_type.name,
+          transaction_ids: selected_transactions.pluck(:id)
+        }
+      end
+
+      subject { patch citizens_transactions_path(params) }
+
+      it 'unselect the previously selected' do
+        expect { subject }.to change { bank_transaction_A.reload.transaction_type }.to(nil)
+      end
+
+      it 'saves the selected transactions' do
+        expect { subject }.to change { bank_transaction_B.reload.transaction_type }.from(nil).to(transaction_type)
+      end
+
+      it 'does not change other applicants transactions' do
+        expect { subject }.not_to change { bank_transaction_other_applicant.reload.transaction_type }
+      end
+
+      it 'redirects to the next page' do
+        subject
+        expect(response.body).to include('Summary of income or payments')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What

[AP-186](https://dsdmoj.atlassian.net/browse/AP-186)

Paired with @AbdirizakObsiye2018 

Page to assign transactions to a transaction type.
Works with any transaction type.
`transaction_type` is a parameter of the page.
For example: `/citizens/transactions?transaction_type=salary`

If the transaction type is a `credit` type, only `credit` transactions are listed. And vice versa.

Transaction types are:
```
    credit: 
      salary
      benefits
      maintenance_in
      property_or_lodger
      student_loan
      pension
      fiends_or_family
    debit: 
      rent_or_mortgage
      council_tax
      child_care
      maintenance_out
      legal_aid
```

## Checklist

Before you ask people to review this PR:

- [X] Tests and rubocop should be passing: `bundle exec rake`
- [X] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [X] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [X] The PR description should say what you changed and why, with a link to the JIRA story.
- [X] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [X] You should have checked that the commit messages say why the change was made.
