### PR TITLE
Disable malware check until it works consistently

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,14 +30,6 @@ references:
         sudo pip3 install awscli
         $(aws ecr get-login --region eu-west-1 --no-include-email)
 
-  install_clamav: &install_clamav
-    run:
-      name: Install Clamav
-      command: |
-        sudo apt-get install clamav clamav-daemon -y
-        sudo freshclam
-        sudo /etc/init.d/clamav-daemon start
-
   build_docker_image: &build_docker_image
     run:
       name: Build laa-apply-for-legal-aid  docker image
@@ -63,7 +55,6 @@ jobs:
     - setup_remote_docker:
         docker_layer_caching: true
     - *setup_test_env
-    - *install_clamav
     - restore_cache:
         keys:
           - laa-apply-for-legal-aid-v2-{{ checksum "Gemfile.lock" }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,6 @@ RUN touch /etc/inittab
 
 RUN apt-get update && apt-get install -y
 RUN apt-get install postgresql postgresql-contrib -y
-RUN apt-get install clamav clamav-daemon -y
-RUN freshclam
-RUN /etc/init.d/clamav-daemon start
 RUN gem install foreman
 
 EXPOSE $PORT

--- a/app/forms/statement_of_cases/statement_of_case_form.rb
+++ b/app/forms/statement_of_cases/statement_of_case_form.rb
@@ -59,6 +59,8 @@ module StatementOfCases
       errors.add(:original_file, original_file_error_for(:content_type_invalid))
     end
 
+    # TODO: re-enable when clamdscan's bug is fixed
+    # :nocov:
     def original_file_malware_scan
       return unless file_present?
 
@@ -66,6 +68,7 @@ module StatementOfCases
 
       errors.add(:original_file, original_file_error_for(:file_virus))
     end
+    # :nocov:
 
     def file_present?
       original_file.present?

--- a/app/services/malware_scanner.rb
+++ b/app/services/malware_scanner.rb
@@ -25,19 +25,23 @@ class MalwareScanner
   end
 
   def virus_found?
-    @virus_found ||= !scan_result.status.success?
+    false
+    # TODO: re-enable when clamdscan's bug is fixed
+    # @virus_found ||= !scan_result.status.success?
   end
 
   def scan_result
-    @scan_result ||= begin
-      stdout, stderr, status = Open3.capture3(*(COMMAND + [file_path.to_s]))
+    OpenStruct.new(stdout: '')
+    # TODO: re-enable when clamdscan's bug is fixed
+    # @scan_result ||= begin
+    #   stdout, stderr, status = Open3.capture3(*(COMMAND + [file_path.to_s]))
 
-      raise ClamdscanError, stderr if stderr.present?
+    #   raise ClamdscanError, stderr if stderr.present?
 
-      OpenStruct.new(
-        stdout: stdout.strip,
-        status: status
-      )
-    end
+    #   OpenStruct.new(
+    #     stdout: stdout.strip,
+    #     status: status
+    #   )
+    # end
   end
 end

--- a/spec/requests/providers/statement_of_case_spec.rb
+++ b/spec/requests/providers/statement_of_case_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe 'provider proceedings before the court requests', type: :request 
         context 'file contains a malware' do
           let(:original_file) { uploaded_file('spec/fixtures/files/malware.doc') }
 
-          it 'does not save the object and raise an error' do
+          xit 'does not save the object and raise an error' do
             subject
             expect(response.body).to include(I18n.t('activemodel.errors.models.statement_of_case.attributes.original_file.file_virus'))
             expect(legal_aid_application.statement_of_case).to be_nil

--- a/spec/services/malware_scanner_spec.rb
+++ b/spec/services/malware_scanner_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe MalwareScanner do
     context 'virus is found' do
       let(:file_path) { Rails.root.join('spec/fixtures/files/malware.doc') }
 
-      it 'sets virus_found to true' do
+      xit 'sets virus_found to true' do
         expect(subject.virus_found?).to eq(true)
       end
     end
@@ -54,7 +54,7 @@ RSpec.describe MalwareScanner do
     context 'command fails' do
       let(:file_path) { Rails.root.join("spec/fixtures/files/#{SecureRandom.hex}") }
 
-      it 'raises an error' do
+      xit 'raises an error' do
         expect { subject }.to raise_error(described_class::ClamdscanError)
       end
     end
@@ -65,7 +65,7 @@ RSpec.describe MalwareScanner do
 
       before { allow(Open3).to receive(:capture3).and_return(scan_result) }
 
-      it 'returns and records the result of the scan' do
+      xit 'returns and records the result of the scan' do
         expect(subject.scan_result).to eq(stub_stdout.strip)
         expect(malware_scan_result.scan_result).to eq(stub_stdout.strip)
       end


### PR DESCRIPTION
## What

[AP-396](https://dsdmoj.atlassian.net/browse/AP-396)

Disable malware-check for now.
At the moment, `clamdscan` stops when the k8s container is restarted

TODO: re-enable it when `clamdscan` works consistently

## Checklist

Before you ask people to review this PR:

- [X] Tests and rubocop should be passing: `bundle exec rake`
- [X] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [X] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [X] The PR description should say what you changed and why, with a link to the JIRA story.
- [X] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [X] You should have checked that the commit messages say why the change was made.
