### PR TITLE
Ap 365 multiple files upload

### DIFF
--- a/app/assets/stylesheets/no_wrap.scss
+++ b/app/assets/stylesheets/no_wrap.scss
@@ -1,0 +1,3 @@
+.no-wrap {
+  white-space: nowrap;
+}

--- a/app/controllers/providers/statement_of_cases_controller.rb
+++ b/app/controllers/providers/statement_of_cases_controller.rb
@@ -27,7 +27,7 @@ module Providers
 
     def statement_of_case_params
       merge_with_model(statement_of_case, provider_uploader: current_provider) do
-        params.require(:statement_of_case).permit(:statement, :original_file)
+        params.require(:statement_of_case).permit(:statement, original_files: [])
       end
     end
 

--- a/app/controllers/providers/statement_of_cases_controller.rb
+++ b/app/controllers/providers/statement_of_cases_controller.rb
@@ -8,11 +8,22 @@ module Providers
 
     def update
       @form = StatementOfCases::StatementOfCaseForm.new(statement_of_case_params)
+      if upload_button_pressed?
+        @form.upload_button_pressed = true
+        @form.save
+        render :show
+      end
+
+      return if performed?
 
       render :show unless save_continue_or_draft(@form)
     end
 
     private
+
+    def upload_button_pressed?
+      params[:upload_button].present?
+    end
 
     def statement_of_case_params
       merge_with_model(statement_of_case, provider_uploader: current_provider) do

--- a/app/forms/statement_of_cases/statement_of_case_form.rb
+++ b/app/forms/statement_of_cases/statement_of_case_form.rb
@@ -4,7 +4,7 @@ module StatementOfCases
 
     form_for StatementOfCase
 
-    attr_accessor :statement, :original_file, :provider_uploader
+    attr_accessor :statement, :original_files, :provider_uploader, :upload_button_pressed
 
     MAX_FILE_SIZE = 50.megabytes
 
@@ -26,69 +26,85 @@ module StatementOfCases
       MAX_FILE_SIZE
     end
 
+    def exclude_from_model
+      [:upload_button_pressed]
+    end
+
     validates :statement, presence: true, unless: :file_present_or_draft?
-    validate :original_file_too_big
-    validate :original_file_empty
-    validate :original_file_malware_scan
-    validate :original_file_disallowed_content_type
+    validate :original_files_valid
 
     private
 
+    def original_files_valid
+      if @upload_button_pressed == true
+        if original_files.nil? || original_files.none?
+          errors.add(:original_files, original_file_error_for(:no_file_chosen))
+          return
+        end
+      end
+      original_files&.each do |original_file|
+        original_file_too_big(original_file)
+        original_file_empty(original_file)
+        original_file_malware_scan(original_file)
+        original_file_disallowed_content_type(original_file)
+      end
+    end
+
     def file_present_or_draft?
-      file_present? || draft?
+      model.original_files.any? || original_files.any? || draft?
     end
 
-    def original_file_too_big
-      return unless file_present?
-      return if original_file_size <= StatementOfCaseForm.max_file_size
+    def original_file_too_big(original_file)
+      return unless file_present?(original_file)
+      return if original_file_size(original_file) <= StatementOfCaseForm.max_file_size
 
-      errors.add(:original_file, original_file_error_for(:file_too_big, size: StatementOfCaseForm.max_file_size / 1.megabyte))
+      errors.add(:original_files, original_file_error_for(:file_too_big, size: StatementOfCaseForm.max_file_size / 1.megabyte))
     end
 
-    def original_file_empty
-      return unless file_present?
+    def original_file_empty(original_file)
+      return unless file_present?(original_file)
       return if File.size(original_file.tempfile) > 1
 
       errors.add(:original_file, original_file_error_for(:file_empty))
     end
 
-    def original_file_disallowed_content_type
-      return unless file_present?
+    def original_file_disallowed_content_type(original_file)
+      return unless file_present?(original_file)
       return if original_file.content_type.in?(ALLOWED_CONTENT_TYPES)
 
       errors.add(:original_file, original_file_error_for(:content_type_invalid))
     end
 
-    def original_file_malware_scan
-      return unless file_present?
+    def original_file_malware_scan(original_file)
+      return unless file_present?(original_file)
 
-      return unless malware_scan_result.virus_found?
+      return unless malware_scan_result(original_file).virus_found?
 
-      errors.add(:original_file, original_file_error_for(:file_virus))
+      errors.add(:original_files, original_file_error_for(:file_virus))
     end
 
-    def file_present?
+    def file_present?(original_file)
       original_file.present?
     end
 
-    def malware_scan_result
+    def malware_scan_result(original_file)
       @malware_scan_result ||= MalwareScanner.call(
         file_path: original_file.tempfile.path,
         uploader: provider_uploader,
         file_details: {
-          size: original_file_size,
+          size: original_file_size(original_file),
           name: original_file.original_filename,
           content_type: original_file.content_type
         }
       )
     end
 
-    def original_file_size
-      @original_file_size ||= File.size(original_file.tempfile)
+    def original_file_size(original_file)
+      File.size(original_file.tempfile)
     end
 
     def original_file_error_for(error_type, options = {})
-      I18n.t("activemodel.errors.models.statement_of_case.attributes.original_file.#{error_type}", options)
+      I18n.t("activemodel.errors.models.statement_of_case.attributes.original_files.#{error_type}", options)
     end
   end
 end

--- a/app/forms/statement_of_cases/statement_of_case_form.rb
+++ b/app/forms/statement_of_cases/statement_of_case_form.rb
@@ -51,7 +51,7 @@ module StatementOfCases
     end
 
     def file_present_or_draft?
-      model.original_files.any? || original_files.any? || draft?
+      model.original_files.any? || original_files&.any? || draft?
     end
 
     def original_file_too_big(original_file)

--- a/app/models/statement_of_case.rb
+++ b/app/models/statement_of_case.rb
@@ -1,5 +1,5 @@
 class StatementOfCase < ApplicationRecord
   belongs_to :legal_aid_application
   belongs_to :provider_uploader, class_name: 'Provider', optional: true
-  has_one_attached :original_file
+  has_many_attached :original_files
 end

--- a/app/views/providers/statement_of_cases/_uploaded_files.html.erb
+++ b/app/views/providers/statement_of_cases/_uploaded_files.html.erb
@@ -1,0 +1,23 @@
+<table class="govuk-table">
+<!--  <caption class="govuk-table__caption">Dates and amounts</caption>-->
+  <thead class="govuk-table__head">
+  <tr class="govuk-table__row">
+    <th class="govuk-table__header" scope="col">File name</th>
+    <th class="govuk-table__header" scope="col">Size</th>
+    <th class="govuk-table__header" scope="col">Status</th>
+    <th class="govuk-table__header" scope="col">Action</th>
+  </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+
+  <% original_files.order(:created_at).each do |file| %>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell"><%= file.filename %></td>
+      <td class="govuk-table__cell no-wrap"><%= number_to_human_size(file.blob.byte_size) %></td>
+      <td class="govuk-table__cell"><span class="govuk-tag">Uploaded</span></td>
+      <td class="govuk-table__cell">Delete</td>
+    </tr>
+
+  <% end %>
+  </tbody>
+</table>

--- a/app/views/providers/statement_of_cases/_uploaded_files.html.erb
+++ b/app/views/providers/statement_of_cases/_uploaded_files.html.erb
@@ -1,11 +1,10 @@
 <table class="govuk-table">
-<!--  <caption class="govuk-table__caption">Dates and amounts</caption>-->
   <thead class="govuk-table__head">
   <tr class="govuk-table__row">
-    <th class="govuk-table__header" scope="col">File name</th>
-    <th class="govuk-table__header" scope="col">Size</th>
-    <th class="govuk-table__header" scope="col">Status</th>
-    <th class="govuk-table__header" scope="col">Action</th>
+    <th class="govuk-table__header" scope="col"><%= t('.filename') %></th>
+    <th class="govuk-table__header" scope="col"><%= t('.size') %></th>
+    <th class="govuk-table__header" scope="col"><%= t('.status') %></th>
+    <th class="govuk-table__header" scope="col"><%= t('.action') %></th>
   </tr>
   </thead>
   <tbody class="govuk-table__body">
@@ -14,8 +13,8 @@
     <tr class="govuk-table__row">
       <td class="govuk-table__cell"><%= file.filename %></td>
       <td class="govuk-table__cell no-wrap"><%= number_to_human_size(file.blob.byte_size) %></td>
-      <td class="govuk-table__cell"><span class="govuk-tag">Uploaded</span></td>
-      <td class="govuk-table__cell">Delete</td>
+      <td class="govuk-table__cell"><span class="govuk-tag"><%= t('.uploaded') %></span></td>
+      <td class="govuk-table__cell"><%= t('.delete') %></td>
     </tr>
 
   <% end %>

--- a/app/views/providers/statement_of_cases/show.html.erb
+++ b/app/views/providers/statement_of_cases/show.html.erb
@@ -32,7 +32,7 @@
       <%= form.govuk_file_field :original_files, multiple: true, label: nil %>
 
       <%= form.submit(
-            'Upload',
+            t('.upload'),
             id: 'upload',
             name: 'upload_button',
             class: 'govuk-button form-button'

--- a/app/views/providers/statement_of_cases/show.html.erb
+++ b/app/views/providers/statement_of_cases/show.html.erb
@@ -24,7 +24,19 @@
 
       <div class="govuk-!-padding-bottom-2"></div>
 
-      <%= form.govuk_file_field :original_file, label: t('generic.upload_file') %>
+      <% if @form.model.original_files && @form.model.original_files.any? %>
+        <%= render partial: 'uploaded_files', locals: { original_files: @form.model.original_files } %>
+      <% end %>
+
+      <label class="govuk-heading-m" for="original_files"><%= t('generic.upload_file') %></label>
+      <%= form.govuk_file_field :original_files, multiple: true, label: nil %>
+
+      <%= form.submit(
+            'Upload',
+            id: 'upload',
+            name: 'upload_button',
+            class: 'govuk-button form-button'
+          ) %>
 
       <div class="govuk-!-padding-bottom-2"></div>
 

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -235,8 +235,9 @@ en:
           attributes:
             statement:
               blank: Enter the statement of case
-            original_file:
+            original_files:
               content_type_invalid: The selected file must be a DOC, DOCX, RTF, ODT, JPG, BMP, PNG, TIF or PDF
               file_too_big: "The selected file must be smaller than %{size}MB"
               file_empty: The selected file is empty
               file_virus: The selected file contains a virus
+              no_file_chosen: You must choose at least one file

--- a/config/locales/en/generic.yml
+++ b/config/locales/en/generic.yml
@@ -27,4 +27,4 @@ en:
     undefined: Undefined
     view: View
     'yes': 'Yes'
-    upload_file: Upload a file
+    upload_file: Attach a file

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -188,6 +188,14 @@ en:
         bullet-6: |
           Details of the most recent incident, if a warning letter has been sent,
           the police have been notified or there are any criminal charges.
+        upload: Upload
+      uploaded_files:
+        action: Action
+        delete: Delete
+        filename: Filename
+        size: Size
+        status: Status
+        uploaded: Uploaded
     shared_ownerships:
       show:
         heading_1: Does your client own their home with anyone else?

--- a/features/support/steps_helper.rb
+++ b/features/support/steps_helper.rb
@@ -27,5 +27,5 @@ Then('I fill {string} with {string}') do |field, value|
 end
 
 Then('I upload a pdf file') do
-  attach_file('Upload a file', Rails.root.join('spec/fixtures/files/lorem_ipsum.pdf'))
+  attach_file('Attach a file', Rails.root.join('spec/fixtures/files/lorem_ipsum.pdf'))
 end

--- a/spec/factories/statement_of_cases.rb
+++ b/spec/factories/statement_of_cases.rb
@@ -3,5 +3,16 @@ FactoryBot.define do
     legal_aid_application
 
     statement { Faker::Lorem.paragraph }
+
+    trait :with_empty_text do
+      statement { nil }
+    end
+
+    trait :with_attached_files do
+      after :create do |soc|
+        filepath = "#{Rails.root}/spec/fixtures/files/lorem_ipsum.pdf"
+        soc.original_files.attach(io: File.open(filepath), filename: 'lorem_ipsum.pdf', content_type: 'application/pdf')
+      end
+    end
   end
 end

--- a/spec/requests/providers/statement_of_case_spec.rb
+++ b/spec/requests/providers/statement_of_case_spec.rb
@@ -65,6 +65,8 @@ RSpec.describe 'provider proceedings before the court requests', type: :request 
       let(:upload_button) { {} }
 
       it 'updates the record' do
+        puts ">>>>>>>>>>  #{__FILE__}:#{__LINE__} <<<<<<<<<<"
+        ap params
         subject
         expect(legal_aid_application.statement_of_case.reload.statement).to eq(entered_text)
         expect(legal_aid_application.statement_of_case.original_files.first).to be_present

--- a/spec/requests/providers/statement_of_case_spec.rb
+++ b/spec/requests/providers/statement_of_case_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'provider proceedings before the court requests', type: :request do
+RSpec.describe 'provider proceedings before the§ court requests', type: :request do
   let(:legal_aid_application) { create :legal_aid_application }
   let(:provider) { legal_aid_application.provider }
   let(:soc) { nil }
@@ -45,7 +45,7 @@ RSpec.describe 'provider proceedings before the court requests', type: :request 
   end
 
   describe 'PATCH providers/proceedings_before_the_court' do
-    subject { patch providers_legal_aid_application_statement_of_case_path(legal_aid_application), params: params.merge(submit_button) }
+    subject { patch providers_legal_aid_application_statement_of_case_path(legal_aid_application), params: params.merge(submit_button).merge(upload_button) }
     let(:entered_text) { Faker::Lorem.paragraph(3) }
     let(:original_file) { uploaded_file('spec/fixtures/files/lorem_ipsum.pdf', 'application/pdf') }
 
@@ -53,7 +53,7 @@ RSpec.describe 'provider proceedings before the court requests', type: :request 
       {
         statement_of_case: {
           statement: entered_text,
-          original_file: original_file
+          original_files: [original_file]
         }
       }
     end
@@ -62,11 +62,12 @@ RSpec.describe 'provider proceedings before the court requests', type: :request 
       before { login_as provider }
 
       let(:submit_button) { {} }
+      let(:upload_button) { {} }
 
       it 'updates the record' do
         subject
         expect(legal_aid_application.statement_of_case.reload.statement).to eq(entered_text)
-        expect(legal_aid_application.statement_of_case.original_file.attachment).to be_present
+        expect(legal_aid_application.statement_of_case.original_files.first).to be_present
       end
 
       it 'redirects to the next page' do
@@ -80,7 +81,7 @@ RSpec.describe 'provider proceedings before the court requests', type: :request 
         it 'updates the statement text' do
           subject
           expect(legal_aid_application.statement_of_case.reload.statement).to eq(entered_text)
-          expect(legal_aid_application.statement_of_case.original_file.attachment).not_to be_present
+          expect(legal_aid_application.statement_of_case.original_files.first).not_to be_present
         end
       end
 
@@ -90,7 +91,7 @@ RSpec.describe 'provider proceedings before the court requests', type: :request 
         it 'updates the file' do
           subject
           expect(legal_aid_application.statement_of_case.reload.statement).to eq('')
-          expect(legal_aid_application.statement_of_case.original_file.attachment).to be_present
+          expect(legal_aid_application.statement_of_case.original_files.first).to be_present
         end
       end
 
@@ -99,7 +100,7 @@ RSpec.describe 'provider proceedings before the court requests', type: :request 
 
         it 'does not save the object and raise an error' do
           subject
-          expect(response.body).to include(I18n.t('activemodel.errors.models.statement_of_case.attributes.original_file.content_type_invalid'))
+          expect(response.body).to include(I18n.t('activemodel.errors.models.statement_of_case.attributes.original_files.content_type_invalid'))
           expect(legal_aid_application.statement_of_case).to be_nil
         end
       end
@@ -109,7 +110,7 @@ RSpec.describe 'provider proceedings before the court requests', type: :request 
 
         it 'does not save the object and raise an error' do
           subject
-          expect(response.body).to include(I18n.t('activemodel.errors.models.statement_of_case.attributes.original_file.file_too_big', size: 0))
+          expect(response.body).to include(I18n.t('activemodel.errors.models.statement_of_case.attributes.original_files.file_too_big', size: 0))
           expect(legal_aid_application.statement_of_case).to be_nil
         end
       end
@@ -119,7 +120,7 @@ RSpec.describe 'provider proceedings before the court requests', type: :request 
 
         it 'does not save the object and raise an error' do
           subject
-          expect(response.body).to include(I18n.t('activemodel.errors.models.statement_of_case.attributes.original_file.file_empty'))
+          expect(response.body).to include(I18n.t('activemodel.errors.models.statement_of_case.attributes.original_files.file_empty'))
           expect(legal_aid_application.statement_of_case).to be_nil
         end
       end
@@ -143,7 +144,7 @@ RSpec.describe 'provider proceedings before the court requests', type: :request 
 
           it 'does not save the object and raise an error' do
             subject
-            expect(response.body).to include(I18n.t('activemodel.errors.models.statement_of_case.attributes.original_file.file_virus'))
+            expect(response.body).to include(I18n.t('activemodel.errors.models.statement_of_case.attributes.original_files.file_virus'))
             expect(legal_aid_application.statement_of_case).to be_nil
           end
         end
@@ -155,7 +156,7 @@ RSpec.describe 'provider proceedings before the court requests', type: :request 
         it 'updates the record' do
           subject
           expect(legal_aid_application.statement_of_case.reload.statement).to eq(entered_text)
-          expect(legal_aid_application.statement_of_case.original_file.attachment).to be_present
+          expect(legal_aid_application.statement_of_case.original_files.first).to be_present
         end
 
         it 'redirects to provider applications home page' do
@@ -171,6 +172,18 @@ RSpec.describe 'provider proceedings before the court requests', type: :request 
             subject
             expect(response).to redirect_to providers_legal_aid_applications_path
           end
+        end
+      end
+
+      context 'Uplaod button pressed' do
+        let(:upload_button) { { upload_button: 'Upload' } }
+        let(:submit_button) { {} }
+        let(:original_file) { nil }
+
+        it 'errors if no file is specified' do
+          subject
+          expect(response.body).to include 'There is a problem'
+          expect(response.body).to include 'You must choose at least one file'
         end
       end
     end


### PR DESCRIPTION
## Enable upload of multiple files

[Link to story](https://dsdmoj.atlassian.net/browse/AP-365)

- Added a partial to display details of files already uploaded
- Added an Upload button to allow upload of files without progressing to the next page
- Changed validation to iterate through all files uploaded in one go and perform validation
- Added validation to ensure a file was specified if the upload button was pressed.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
