### PR TITLE
Add Identify Types of Outgoing page

### DIFF
--- a/app/controllers/citizens/identify_types_of_outgoings_controller.rb
+++ b/app/controllers/citizens/identify_types_of_outgoings_controller.rb
@@ -1,0 +1,21 @@
+module Citizens
+  class IdentifyTypesOfOutgoingsController < BaseController
+    include ApplicationFromSession
+    before_action :authenticate_applicant!
+
+    def show
+      legal_aid_application
+    end
+
+    def update
+      legal_aid_application.update!(legal_aid_application_params)
+      go_forward
+    end
+
+    private
+
+    def legal_aid_application_params
+      params.require(:legal_aid_application).permit(transaction_type_ids: [])
+    end
+  end
+end

--- a/app/services/flow/flows/citizen_income.rb
+++ b/app/services/flow/flows/citizen_income.rb
@@ -6,6 +6,10 @@ module Flow
           path: ->(_) { urls.citizens_identify_types_of_income_path },
           forward: :own_homes
         },
+        identify_types_of_outgoings: {
+          # path: ->(_) { urls.citizens_identify_types_of_outgoing_path }, # TODO: implement when navigation from preceding page is required
+          forward: :own_homes # TODO: replace with correct page when known
+        },
         transactions: {
           forward: :placeholder_summary_transaction
         },

--- a/app/views/citizens/identify_types_of_outgoings/show.html.erb
+++ b/app/views/citizens/identify_types_of_outgoings/show.html.erb
@@ -1,0 +1,17 @@
+<%= page_template page_title: t('.page_heading'), template: :form do %>
+  <%= form_with(model: @legal_aid_application, url: citizens_identify_types_of_outgoing_path, method: :patch, local: true) do |form| %>
+
+    <div class="govuk-!-padding-bottom-4"></div>
+
+    <%= govuk_hint t('.hint') %>
+
+    <div class="govuk-!-padding-bottom-4"></div>
+
+    <%= transaction_type_check_boxes(
+          form: form,
+          transaction_types: TransactionType.debits
+        ) %>
+
+    <%= next_action_buttons(form: form, continue_button_text: t('generic.save_and_continue')) %>
+  <% end %>
+<% end %>

--- a/config/locales/en/citizens.yml
+++ b/config/locales/en/citizens.yml
@@ -59,6 +59,10 @@ en:
         maintenance_in_examples: For example, for children or from an ex-partner
         page_heading: Select any types of income you receive
         pension_examples: Include State, work or private pensions
+    identify_types_of_outgoings:
+      show:
+        page_heading: Select any regular payments you make
+        hint: Do not select any if you make no regular payments.
     information:
       show:
         heading_1: Give one-time access to your bank accounts

--- a/config/locales/en/models.yml
+++ b/config/locales/en/models.yml
@@ -11,12 +11,14 @@ en:
   transaction_types:
     names:
       benefits: Benefits
-      fiends_or_family: Financial help from friends or family
+      child_care: Childcare costs to a nursery or registered provider
+      council_tax: Council Tax
+      friends_or_family: Financial help from friends or family
+      legal_aid: Existing legal aid contributions
       maintenance_in: Maintenance payments
+      maintenance_out: Maintenance payments (for children or to an ex-partner)
       pension: Pensions
-      property_or_lodger: Income from a property or lodger
-      salary: Salary or wages
-      student_loan: Student loan or grant
+      rent_or_mortgage: Rent or mortgage
     page_titles:
       benefits: Your benefits
       child_care: Your childcare costs to a nursery or registered provider

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,6 +51,7 @@ Rails.application.routes.draw do
       patch :continue, on: :collection
     end
     resource :identify_types_of_income, only: %i[show update]
+    resource :identify_types_of_outgoing, only: %i[show update]
     resource :transactions, only: [] do
       get '/:transaction_type', to: 'transactions#show', as: ''
       patch '/:transaction_type', to: 'transactions#update'

--- a/spec/requests/citizens/identify_types_of_outgoings_spec.rb
+++ b/spec/requests/citizens/identify_types_of_outgoings_spec.rb
@@ -1,0 +1,66 @@
+require 'rails_helper'
+
+RSpec.describe 'IndentifyTypesOfOutgoingsController' do
+  let(:legal_aid_application) { create :legal_aid_application, :with_applicant }
+  let(:secure_id) { legal_aid_application.generate_secure_id }
+  before do
+    get citizens_legal_aid_application_path(secure_id)
+  end
+
+  let!(:outgoing_types) { create_list :transaction_type, 3, :debit_with_standard_name }
+
+  describe 'GET /citizens/identify_types_of_outgoing' do
+    before { get citizens_identify_types_of_outgoing_path }
+
+    it 'returns http success' do
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'displays the outgoing type labels' do
+      outgoing_types.map(&:label_name).each do |label|
+        expect(unescaped_response_body).to include(label)
+      end
+    end
+  end
+
+  describe 'PATCH /citizens/identify_types_of_outgoing' do
+    let(:flow) do
+      Flow::BaseFlowService.flow_service_for(
+        :citizens,
+        legal_aid_application: legal_aid_application,
+        current_step: :identify_types_of_outgoings
+      )
+    end
+    let(:transaction_type_ids) { [] }
+    let(:params) do
+      {
+        legal_aid_application: {
+          transaction_type_ids: transaction_type_ids
+        }
+      }
+    end
+
+    subject { patch citizens_identify_types_of_outgoing_path, params: params }
+
+    it 'does not add transaction types to the application' do
+      expect { subject }.not_to change { LegalAidApplicationTransactionType.count }
+    end
+
+    it 'redirects to the next step' do
+      expect(subject).to redirect_to(flow.forward_path)
+    end
+
+    context 'when transaction types selected' do
+      let(:transaction_type_ids) { outgoing_types.map(&:id) }
+
+      it 'adds transaction types to the application' do
+        expect { subject }.to change { LegalAidApplicationTransactionType.count }.by(outgoing_types.length)
+        expect(legal_aid_application.reload.transaction_types).to match_array(outgoing_types)
+      end
+
+      it 'should redirect to the next step' do
+        expect(subject).to redirect_to(flow.forward_path)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What

[AP-377](https://dsdmoj.atlassian.net/browse/AP-377)

This commit adds the necessary code for the page to allow a citizen to
identify their regular outgoings.

The previous and next pages do not yet exist so navigation is not fully
implemented here. For this reason no feature tests have been written.
These will need to be addressed when more of the flow is in place.

- add route
- add controller
- add (minimal) navigation
- add view
- add translations
- add tests

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
