### PR TITLE
Tech Debt - mainly standardise way of assigning model to params

### DIFF
--- a/app/controllers/base_controller.rb
+++ b/app/controllers/base_controller.rb
@@ -1,3 +1,10 @@
 class BaseController < ApplicationController
   include Flowable
+
+  def merge_with_model(model, options = {})
+    yield.tap do |hash|
+      hash.merge! options if options.present?
+      hash[:model] = model
+    end
+  end
 end

--- a/app/controllers/citizens/accounts_controller.rb
+++ b/app/controllers/citizens/accounts_controller.rb
@@ -15,8 +15,7 @@ module Citizens
     private
 
     def worker_errors
-      return [] unless worker
-      return [] unless worker['errors'].present?
+      return [] unless worker && worker['errors'].present?
 
       @worker_errors ||= JSON.parse(worker['errors'])
     end

--- a/app/controllers/citizens/check_answers_controller.rb
+++ b/app/controllers/citizens/check_answers_controller.rb
@@ -1,5 +1,6 @@
 module Citizens
   class CheckAnswersController < BaseController
+    include ApplicationFromSession
     before_action :authenticate_applicant!
 
     def index
@@ -14,12 +15,6 @@ module Citizens
     def reset
       legal_aid_application.reset!
       redirect_to back_path
-    end
-
-    private
-
-    def legal_aid_application
-      @legal_aid_application ||= LegalAidApplication.find(session[:current_application_ref])
     end
   end
 end

--- a/app/controllers/citizens/consents_controller.rb
+++ b/app/controllers/citizens/consents_controller.rb
@@ -9,7 +9,7 @@ module Citizens
 
       @form.save
 
-      if @form.open_banking_consent == 'true'
+      if @form.open_banking_consent?
         go_forward
       else
         render plain: 'Landing page: No Consent provided'
@@ -19,11 +19,9 @@ module Citizens
     private
 
     def edit_params
-      consent_params.merge(model: legal_aid_application)
-    end
-
-    def consent_params
-      params.require(:legal_aid_application).permit(:open_banking_consent, :open_banking_consent_choice_at)
+      merge_with_model(legal_aid_application) do
+        params.require(:legal_aid_application).permit(:open_banking_consent, :open_banking_consent_choice_at)
+      end
     end
   end
 end

--- a/app/controllers/citizens/legal_aid_applications_controller.rb
+++ b/app/controllers/citizens/legal_aid_applications_controller.rb
@@ -1,7 +1,8 @@
 module Citizens
   class LegalAidApplicationsController < BaseController
+    include ApplicationFromSession
     # User passes in the Secure Id at the start of the journey. If login succeeds, they
-    # are redirected to index and where the first page is displayed.
+    # are redirected to index where the first page is displayed.
     def show
       sign_out current_provider if provider_signed_in?
       secure_id = params[:id]
@@ -25,10 +26,6 @@ module Citizens
     def sign_applicant_in_via_devise(applicant)
       scope = Devise::Mapping.find_scope!(applicant)
       sign_in(scope, applicant, event: :authentication)
-    end
-
-    def legal_aid_application
-      @legal_aid_application ||= LegalAidApplication.find(session[:current_application_ref])
     end
   end
 end

--- a/app/controllers/citizens/other_assets_controller.rb
+++ b/app/controllers/citizens/other_assets_controller.rb
@@ -21,12 +21,11 @@ module Citizens
       @declaration ||= legal_aid_application.other_assets_declaration
     end
 
-    def other_asset_params
-      params[:other_assets_declaration].permit(*(Citizens::OtherAssetsForm::ALL_ATTRIBUTES + Citizens::OtherAssetsForm::CHECK_BOXES_ATTRIBUTES))
-    end
-
     def form_params
-      other_asset_params.merge(model: declaration)
+      merge_with_model(declaration) do
+        attrs = Citizens::OtherAssetsForm::ALL_ATTRIBUTES + Citizens::OtherAssetsForm::CHECK_BOXES_ATTRIBUTES
+        params[:other_assets_declaration].permit(*attrs)
+      end
     end
   end
 end

--- a/app/controllers/citizens/outstanding_mortgages_controller.rb
+++ b/app/controllers/citizens/outstanding_mortgages_controller.rb
@@ -19,8 +19,8 @@ module Citizens
     private
 
     def legal_aid_application_params
-      params.require(:legal_aid_application).permit(:outstanding_mortgage_amount).tap do |hash|
-        hash[:model] = legal_aid_application
+      merge_with_model(legal_aid_application) do
+        params.require(:legal_aid_application).permit(:outstanding_mortgage_amount)
       end
     end
   end

--- a/app/controllers/citizens/own_homes_controller.rb
+++ b/app/controllers/citizens/own_homes_controller.rb
@@ -18,14 +18,12 @@ module Citizens
 
     private
 
-    def own_home_params
-      return {} unless params[:legal_aid_application]
-
-      params.require(:legal_aid_application).permit(:own_home)
-    end
-
     def form_params
-      own_home_params.merge(model: legal_aid_application)
+      merge_with_model(legal_aid_application) do
+        return {} unless params[:legal_aid_application]
+
+        params.require(:legal_aid_application).permit(:own_home)
+      end
     end
   end
 end

--- a/app/controllers/citizens/percentage_homes_controller.rb
+++ b/app/controllers/citizens/percentage_homes_controller.rb
@@ -6,7 +6,7 @@ module Citizens
     end
 
     def update
-      @form = LegalAidApplications::PercentageHomeForm.new(percentage_home_params.merge(model: legal_aid_application))
+      @form = LegalAidApplications::PercentageHomeForm.new(percentage_home_params)
 
       if @form.save
         go_forward
@@ -18,9 +18,11 @@ module Citizens
     private
 
     def percentage_home_params
-      return {} unless params[:legal_aid_application]
+      merge_with_model(legal_aid_application) do
+        return {} unless params[:legal_aid_application]
 
-      params.require(:legal_aid_application).permit(:percentage_home)
+        params.require(:legal_aid_application).permit(:percentage_home)
+      end
     end
   end
 end

--- a/app/controllers/citizens/property_values_controller.rb
+++ b/app/controllers/citizens/property_values_controller.rb
@@ -17,12 +17,10 @@ module Citizens
 
     private
 
-    def property_value_params
-      params.require(:legal_aid_application).permit(:property_value)
-    end
-
     def edit_params
-      property_value_params.merge(model: legal_aid_application)
+      merge_with_model(legal_aid_application) do
+        params.require(:legal_aid_application).permit(:property_value)
+      end
     end
   end
 end

--- a/app/controllers/citizens/savings_and_investments_controller.rb
+++ b/app/controllers/citizens/savings_and_investments_controller.rb
@@ -8,7 +8,7 @@ module Citizens
     end
 
     def update
-      @form = SavingsAmounts::SavingsAmountsForm.new(form_params.merge(model: savings_amount))
+      @form = SavingsAmounts::SavingsAmountsForm.new(form_params)
 
       if @form.save
         go_forward
@@ -36,7 +36,9 @@ module Citizens
     end
 
     def form_params
-      params.require(:savings_amount).permit(attributes + check_box_attributes)
+      merge_with_model(savings_amount) do
+        params.require(:savings_amount).permit(attributes + check_box_attributes)
+      end
     end
   end
 end

--- a/app/controllers/citizens/shared_ownerships_controller.rb
+++ b/app/controllers/citizens/shared_ownerships_controller.rb
@@ -7,7 +7,7 @@ module Citizens
     end
 
     def update
-      @form = LegalAidApplications::SharedOwnershipForm.new(shared_ownership_params.merge(model: legal_aid_application))
+      @form = LegalAidApplications::SharedOwnershipForm.new(shared_ownership_params)
 
       if @form.save
         go_forward
@@ -19,9 +19,11 @@ module Citizens
     private
 
     def shared_ownership_params
-      return {} unless params[:legal_aid_application]
+      merge_with_model(legal_aid_application) do
+        return {} unless params[:legal_aid_application]
 
-      params.require(:legal_aid_application).permit(:shared_ownership)
+        params.require(:legal_aid_application).permit(:shared_ownership)
+      end
     end
   end
 end

--- a/app/controllers/citizens/transactions_controller.rb
+++ b/app/controllers/citizens/transactions_controller.rb
@@ -1,6 +1,6 @@
 module Citizens
   class TransactionsController < BaseController
-    include Flowable
+    include ApplicationFromSession
     before_action :authenticate_applicant!
     helper_method :date_from, :date_to
 
@@ -55,10 +55,6 @@ module Citizens
         .bank_transactions
         .where(operation: transaction_type.operation)
         .order(happened_at: :desc, description: :desc)
-    end
-
-    def legal_aid_application
-      @legal_aid_application ||= LegalAidApplication.find(session[:current_application_ref])
     end
   end
 end

--- a/app/controllers/providers/address_lookups_controller.rb
+++ b/app/controllers/providers/address_lookups_controller.rb
@@ -14,7 +14,9 @@ module Providers
     private
 
     def form_params
-      params.require(:address_lookup).permit(:postcode).merge(model: address)
+      merge_with_model(address) do
+        params.require(:address_lookup).permit(:postcode)
+      end
     end
 
     def address

--- a/app/controllers/providers/address_selections_controller.rb
+++ b/app/controllers/providers/address_selections_controller.rb
@@ -16,7 +16,7 @@ module Providers
     def update
       authorize @legal_aid_application
       @addresses = build_addresses_from_form_data
-      @form = Addresses::AddressSelectionForm.new(permitted_params.merge(addresses: @addresses, model: address))
+      @form = Addresses::AddressSelectionForm.new(permitted_params)
 
       render :show unless save_continue_or_draft(@form)
     end
@@ -32,7 +32,9 @@ module Providers
     end
 
     def permitted_params
-      params.require(:address_selection).permit(:lookup_id, :postcode)
+      merge_with_model(address, addresses: @addresses) do
+        params.require(:address_selection).permit(:lookup_id, :postcode)
+      end
     end
 
     def address_list_params

--- a/app/controllers/providers/addresses_controller.rb
+++ b/app/controllers/providers/addresses_controller.rb
@@ -15,12 +15,10 @@ module Providers
       %i[address_line_one address_line_two city county postcode lookup_postcode lookup_error]
     end
 
-    def address_params
-      params.require(:address).permit(*address_attributes)
-    end
-
     def form_params
-      address_params.merge(model: address)
+      merge_with_model(address) do
+        params.require(:address).permit(*address_attributes)
+      end
     end
 
     def address

--- a/app/controllers/providers/applicants_controller.rb
+++ b/app/controllers/providers/applicants_controller.rb
@@ -17,12 +17,13 @@ module Providers
       legal_aid_application.applicant || legal_aid_application.build_applicant
     end
 
-    def applicant_params
-      params.require(:applicant).permit(:first_name, :last_name, :dob_day, :dob_month, :dob_year, :national_insurance_number, :email)
-    end
-
     def form_params
-      applicant_params.merge(model: applicant)
+      merge_with_model(applicant) do
+        params.require(:applicant).permit(
+          :first_name, :last_name, :dob_day, :dob_month, :dob_year,
+          :national_insurance_number, :email
+        )
+      end
     end
   end
 end

--- a/app/controllers/providers/client_received_legal_helps_controller.rb
+++ b/app/controllers/providers/client_received_legal_helps_controller.rb
@@ -7,7 +7,7 @@ module Providers
     end
 
     def update
-      @form = MeritsAssessments::ClientReceivedLegalHelpForm.new(client_received_legal_help_params.merge(model: merits_assessment))
+      @form = MeritsAssessments::ClientReceivedLegalHelpForm.new(client_received_legal_help_params)
 
       render :show unless save_continue_or_draft(@form)
     end
@@ -19,7 +19,9 @@ module Providers
     end
 
     def client_received_legal_help_params
-      params.require(:merits_assessment).permit(:client_received_legal_help, :application_purpose)
+      merge_with_model(merits_assessment) do
+        params.require(:merits_assessment).permit(:client_received_legal_help, :application_purpose)
+      end
     end
 
     def authorize_legal_aid_application

--- a/app/controllers/providers/estimated_legal_costs_controller.rb
+++ b/app/controllers/providers/estimated_legal_costs_controller.rb
@@ -7,7 +7,7 @@ module Providers
     end
 
     def update
-      @form = MeritsAssessments::EstimatedLegalCostForm.new(form_params.merge(model: merits_assessment))
+      @form = MeritsAssessments::EstimatedLegalCostForm.new(form_params)
 
       render :show unless save_continue_or_draft(@form)
     end
@@ -15,7 +15,9 @@ module Providers
     private
 
     def form_params
-      params.require(:merits_assessment).permit(:estimated_legal_cost)
+      merge_with_model(merits_assessment) do
+        params.require(:merits_assessment).permit(:estimated_legal_cost)
+      end
     end
 
     def merits_assessment

--- a/app/controllers/providers/online_bankings_controller.rb
+++ b/app/controllers/providers/online_bankings_controller.rb
@@ -13,12 +13,10 @@ module Providers
 
     private
 
-    def applicant_params
-      params.permit(applicant: :uses_online_banking)[:applicant] || {}
-    end
-
     def form_params
-      applicant_params.merge(model: applicant)
+      merge_with_model(applicant) do
+        params.permit(applicant: :uses_online_banking)[:applicant] || {}
+      end
     end
   end
 end

--- a/app/controllers/providers/other_assets_controller.rb
+++ b/app/controllers/providers/other_assets_controller.rb
@@ -17,12 +17,11 @@ module Providers
       @declaration ||= legal_aid_application.other_assets_declaration
     end
 
-    def other_asset_params
-      params[:other_assets_declaration].permit(*(Citizens::OtherAssetsForm::ALL_ATTRIBUTES + Citizens::OtherAssetsForm::CHECK_BOXES_ATTRIBUTES))
-    end
-
     def form_params
-      other_asset_params.merge(model: declaration)
+      merge_with_model(declaration) do
+        attrs = Citizens::OtherAssetsForm::ALL_ATTRIBUTES + Citizens::OtherAssetsForm::CHECK_BOXES_ATTRIBUTES
+        params[:other_assets_declaration].permit(*attrs)
+      end
     end
   end
 end

--- a/app/controllers/providers/outstanding_mortgages_controller.rb
+++ b/app/controllers/providers/outstanding_mortgages_controller.rb
@@ -15,8 +15,8 @@ module Providers
     private
 
     def legal_aid_application_params
-      params.require(:legal_aid_application).permit(:outstanding_mortgage_amount).tap do |hash|
-        hash[:model] = legal_aid_application
+      merge_with_model(legal_aid_application) do
+        params.require(:legal_aid_application).permit(:outstanding_mortgage_amount)
       end
     end
   end

--- a/app/controllers/providers/own_homes_controller.rb
+++ b/app/controllers/providers/own_homes_controller.rb
@@ -13,14 +13,12 @@ module Providers
 
     private
 
-    def own_home_params
-      return {} unless params[:legal_aid_application]
-
-      params.require(:legal_aid_application).permit(:own_home)
-    end
-
     def form_params
-      own_home_params.merge(model: legal_aid_application)
+      merge_with_model(legal_aid_application) do
+        return {} unless params[:legal_aid_application]
+
+        params.require(:legal_aid_application).permit(:own_home)
+      end
     end
   end
 end

--- a/app/controllers/providers/percentage_homes_controller.rb
+++ b/app/controllers/providers/percentage_homes_controller.rb
@@ -7,7 +7,7 @@ module Providers
 
     def update
       authorize @legal_aid_application
-      @form = LegalAidApplications::PercentageHomeForm.new(percentage_home_params.merge(model: legal_aid_application))
+      @form = LegalAidApplications::PercentageHomeForm.new(percentage_home_params)
 
       render :show unless save_continue_or_draft(@form)
     end
@@ -15,9 +15,11 @@ module Providers
     private
 
     def percentage_home_params
-      return {} unless params[:legal_aid_application]
+      merge_with_model(legal_aid_application) do
+        return {} unless params[:legal_aid_application]
 
-      params.require(:legal_aid_application).permit(:percentage_home)
+        params.require(:legal_aid_application).permit(:percentage_home)
+      end
     end
   end
 end

--- a/app/controllers/providers/proceedings_before_the_courts_controller.rb
+++ b/app/controllers/providers/proceedings_before_the_courts_controller.rb
@@ -7,7 +7,7 @@ module Providers
     end
 
     def update
-      @form = MeritsAssessments::ProceedingsBeforeTheCourtForm.new(proceedings_before_the_court_params.merge(model: merits_assessment))
+      @form = MeritsAssessments::ProceedingsBeforeTheCourtForm.new(proceedings_before_the_court_params)
 
       render :show unless save_continue_or_draft(@form)
     end
@@ -15,7 +15,9 @@ module Providers
     private
 
     def proceedings_before_the_court_params
-      params.require(:merits_assessment).permit(:proceedings_before_the_court, :details_of_proceedings_before_the_court)
+      merge_with_model(merits_assessment) do
+        params.require(:merits_assessment).permit(:proceedings_before_the_court, :details_of_proceedings_before_the_court)
+      end
     end
 
     def merits_assessment

--- a/app/controllers/providers/property_values_controller.rb
+++ b/app/controllers/providers/property_values_controller.rb
@@ -12,12 +12,10 @@ module Providers
 
     private
 
-    def property_value_params
-      params.require(:legal_aid_application).permit(:property_value)
-    end
-
     def edit_params
-      property_value_params.merge(model: legal_aid_application, mode: :provider)
+      merge_with_model(legal_aid_application, mode: :provider) do
+        params.require(:legal_aid_application).permit(:property_value)
+      end
     end
   end
 end

--- a/app/controllers/providers/savings_and_investments_controller.rb
+++ b/app/controllers/providers/savings_and_investments_controller.rb
@@ -7,7 +7,7 @@ module Providers
     end
 
     def update
-      @form = SavingsAmounts::SavingsAmountsForm.new(form_params.merge(model: savings_amount))
+      @form = SavingsAmounts::SavingsAmountsForm.new(form_params)
 
       render :show unless save_continue_or_draft(@form)
     end
@@ -27,7 +27,9 @@ module Providers
     end
 
     def form_params
-      params.require(:savings_amount).permit(attributes + check_box_attributes)
+      merge_with_model(savings_amount) do
+        params.require(:savings_amount).permit(attributes + check_box_attributes)
+      end
     end
   end
 end

--- a/app/controllers/providers/shared_ownerships_controller.rb
+++ b/app/controllers/providers/shared_ownerships_controller.rb
@@ -5,7 +5,7 @@ module Providers
     end
 
     def update
-      @form = LegalAidApplications::SharedOwnershipForm.new(shared_ownership_params.merge(model: legal_aid_application))
+      @form = LegalAidApplications::SharedOwnershipForm.new(shared_ownership_params)
 
       render :show unless save_continue_or_draft(@form)
     end
@@ -13,9 +13,11 @@ module Providers
     private
 
     def shared_ownership_params
-      return {} unless params[:legal_aid_application]
+      merge_with_model(legal_aid_application) do
+        return {} unless params[:legal_aid_application]
 
-      params.require(:legal_aid_application).permit(:shared_ownership)
+        params.require(:legal_aid_application).permit(:shared_ownership)
+      end
     end
   end
 end

--- a/app/controllers/providers/statement_of_cases_controller.rb
+++ b/app/controllers/providers/statement_of_cases_controller.rb
@@ -15,10 +15,9 @@ module Providers
     private
 
     def statement_of_case_params
-      params
-        .require(:statement_of_case)
-        .permit(:statement, :original_file)
-        .merge(model: statement_of_case, provider_uploader: current_provider)
+      merge_with_model(statement_of_case, provider_uploader: current_provider) do
+        params.require(:statement_of_case).permit(:statement, :original_file)
+      end
     end
 
     def statement_of_case

--- a/app/controllers/providers/success_prospects_controller.rb
+++ b/app/controllers/providers/success_prospects_controller.rb
@@ -7,7 +7,7 @@ module Providers
     end
 
     def update
-      @form = MeritsAssessments::SuccessProspectForm.new(form_params.merge(model: merits_assessment))
+      @form = MeritsAssessments::SuccessProspectForm.new(form_params)
 
       render :show unless save_continue_or_draft(@form)
     end
@@ -23,7 +23,9 @@ module Providers
     end
 
     def form_params
-      params.require(:merits_assessment).permit(:success_prospect, :success_prospect_details)
+      merge_with_model(merits_assessment) do
+        params.require(:merits_assessment).permit(:success_prospect, :success_prospect_details)
+      end
     end
   end
 end

--- a/app/forms/applicants/open_banking_consent_form.rb
+++ b/app/forms/applicants/open_banking_consent_form.rb
@@ -5,5 +5,9 @@ module Applicants
     form_for LegalAidApplication
 
     attr_accessor :open_banking_consent
+
+    def open_banking_consent?
+      open_banking_consent == 'true'
+    end
   end
 end


### PR DESCRIPTION
**Tech debt**

On a review of the code, there were many ways in which `:model` was merged into params. This PR adds a method that is used to do the merge in a consistent manner.

Other tasks:

- User `include ApplicationFromSession` instead of individual method to get `legal_aid_application` in Citizen journey
- Small tidy up of the `citizens/accounts_controller.rb` logic