### PR TITLE
AP-390 Show percentage for second_home_percentage in check answer pages

### DIFF
--- a/app/helpers/capital_helper.rb
+++ b/app/helpers/capital_helper.rb
@@ -1,18 +1,36 @@
 module CapitalHelper
-  def capital_amounts_list(capital, locale_namespace:)
-    items = capital&.amount_attributes&.map do |attribute, amount|
-      next unless amount
-
-      label = t("#{locale_namespace}#{attribute}")
-      [label, amount]
-    end
+  def capital_amounts_list(capital, locale_namespace:, percentage_values: [])
+    items = capital_amount_items(capital, locale_namespace, percentage_values)
     items&.compact!
 
     return nil unless items.present?
 
     {
       items: items,
-      total_value: items.map(&:last).sum
+      total_value: items.map(&:amount).sum
     }
+  end
+
+  def capital_amount_items(capital, locale_namespace, percentage_values)
+    capital&.amount_attributes&.map do |attribute, amount|
+      next unless amount
+
+      type = percentage_values.include?(attribute.to_sym) ? :percentage : :currency
+
+      OpenStruct.new(
+        label: t("#{locale_namespace}#{attribute}"),
+        amount: amount,
+        type: type,
+        amount_text: capital_amount_text(amount, type)
+      )
+    end
+  end
+
+  def capital_amount_text(amount, type)
+    if type == :percentage
+      number_to_percentage(amount, precision: 2)
+    else
+      number_to_currency(amount, unit: t('currency.gbp'))
+    end
   end
 end

--- a/app/views/citizens/check_answers/index.html.erb
+++ b/app/views/citizens/check_answers/index.html.erb
@@ -10,7 +10,7 @@
     <%= t('.assets.heading') %>
   </h2>
 
-  <%= render partial: 'shared/check_answers_assets', locals: { user_type: :citizen } %>
+  <%= render 'shared/check_answers_assets', user_type: :citizen %>
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">

--- a/app/views/providers/check_passported_answers/show.html.erb
+++ b/app/views/providers/check_passported_answers/show.html.erb
@@ -7,7 +7,7 @@
     <%= @legal_aid_application.savings_amount? && @legal_aid_application.other_assets? ? t('.property') : t('.assets.heading') %>
   </h2>
 
-  <%= render partial: 'shared/check_answers_assets', locals: { user_type: :provider, application: @legal_aid_application } %>
+  <%= render 'shared/check_answers_assets', user_type: :provider, application: @legal_aid_application %>
 
   <h2 class="govuk-heading-m"><%= t('.merits_assessment_h2') %></h2>
 

--- a/app/views/shared/_check_answers_assets.html.erb
+++ b/app/views/shared/_check_answers_assets.html.erb
@@ -62,7 +62,11 @@
       name: :other_assets,
       url: check_answer_url_for(user_type, :other_assets, application),
       question: t('.assets.other_assets'),
-      answer_hash: capital_amounts_list(@legal_aid_application.other_assets_declaration, locale_namespace: "shared.forms.revealing_checkbox.attribute.#{user_type}s.other_assets.check_box_")
+      answer_hash: capital_amounts_list(
+        @legal_aid_application.other_assets_declaration,
+        locale_namespace: "shared.forms.revealing_checkbox.attribute.#{user_type}s.other_assets.check_box_",
+        percentage_values: [:second_home_percentage]
+      )
     ) if @legal_aid_application.other_assets? %>
 
 <%= check_answer_no_link_list(

--- a/app/views/shared/check_answers/_one_link_section.html.erb
+++ b/app/views/shared/check_answers/_one_link_section.html.erb
@@ -16,11 +16,11 @@
 <dl class="govuk-summary-list govuk-!-margin-bottom-9">
   <% if answer_hash.present? %>
 
-      <% answer_hash&.fetch(:items, [])&.each_with_index do |(label, amount), index| %>
+      <% answer_hash&.fetch(:items, [])&.each_with_index do |item, index| %>
         <%= check_answer_no_link(
               name: "#{name}_#{index}",
-              question: label,
-              answer: number_to_currency(amount, unit: t('currency.gbp'))
+              question: item.label,
+              answer: item.amount_text
             ) %>
       <% end %>
 

--- a/spec/requests/citizens/check_answers_spec.rb
+++ b/spec/requests/citizens/check_answers_spec.rb
@@ -51,8 +51,13 @@ RSpec.describe 'check your answers requests', type: :request do
     end
 
     it 'displays the correct assets details' do
-      legal_aid_application.other_assets_declaration.amount_attributes.each do |_, amount|
-        expect(response.body).to include(number_to_currency(amount, unit: '£')), 'asset amount should be in the page'
+      legal_aid_application.other_assets_declaration.amount_attributes.each do |attr, amount|
+        expected = if attr == 'second_home_percentage'
+                     number_to_percentage(amount, precision: 2)
+                   else
+                     number_to_currency(amount, unit: '£')
+                   end
+        expect(response.body).to include(expected), 'asset amount should be in the page'
       end
     end
 

--- a/spec/requests/providers/check_passported_answers_spec.rb
+++ b/spec/requests/providers/check_passported_answers_spec.rb
@@ -94,8 +94,13 @@ RSpec.describe 'check passported answers requests', type: :request do
       end
 
       it 'displays the correct assets details' do
-        application.other_assets_declaration.amount_attributes.each do |_, amount|
-          expect(response.body).to include(number_to_currency(amount, unit: '£')), 'asset amount should be in the page'
+        application.other_assets_declaration.amount_attributes.each do |attr, amount|
+          expected = if attr == 'second_home_percentage'
+                       number_to_percentage(amount, precision: 2)
+                     else
+                       number_to_currency(amount, unit: '£')
+                     end
+          expect(response.body).to include(expected), 'asset amount should be in the page'
         end
       end
 


### PR DESCRIPTION
[Jira AP-390](https://dsdmoj.atlassian.net/browse/AP-390)

Modifies the way the capital helpers work so that attributes can be flagged as percentage, and used that facility to fix the fact that second home percentage was being show as currency.