### PR TITLE
AP-367 Add destroy uploaded file action to statement of case

### DIFF
--- a/app/assets/stylesheets/providers/legal_aid_applications.scss
+++ b/app/assets/stylesheets/providers/legal_aid_applications.scss
@@ -1,3 +1,5 @@
+@import "govuk-frontend/settings/all";
+
 #clear-search-div {
   padding-left: 15px;
   padding-top: 5px;
@@ -18,4 +20,15 @@ div.no-results {
 
 .change-postcode-link {
   padding-left: .8em;
+}
+
+.button-as-link {
+  background: none !important;
+  color: $govuk-link-colour;
+  border: none;
+  padding: 0! important;
+  font: inherit;
+  text-decoration: underline;
+  cursor: pointer;
+  outline: none;
 }

--- a/app/controllers/providers/statement_of_cases_controller.rb
+++ b/app/controllers/providers/statement_of_cases_controller.rb
@@ -56,16 +56,20 @@ module Providers
     end
 
     def delete_original_file
-      file = statement_of_case.original_files.find_by(id: params[:original_file_id])
+      file = statement_of_case.original_files.find_by(id: original_file_id)
       if file
         file.purge
       else
-        Rails.logger.error "Unable to remove original file. Not found: #{params[:original_file_id]}"
+        Rails.logger.error "Unable to remove original file. Not found: #{original_file_id}"
       end
     end
 
     def delete_pdf_file
-      PdfFile.where(original_file_id: params[:original_file_id]).destroy_all
+      PdfFile.where(original_file_id: original_file_id).destroy_all
+    end
+
+    def original_file_id
+      params[:original_file_id]
     end
   end
 end

--- a/app/controllers/providers/statement_of_cases_controller.rb
+++ b/app/controllers/providers/statement_of_cases_controller.rb
@@ -23,6 +23,12 @@ module Providers
       end
     end
 
+    def destroy
+      file = statement_of_case.original_files.find_by(id: params[:original_file_id])
+      file.purge
+      redirect_to [:providers, legal_aid_application, :statement_of_case]
+    end
+
     private
 
     def convert_new_files_to_pdf

--- a/app/controllers/providers/statement_of_cases_controller.rb
+++ b/app/controllers/providers/statement_of_cases_controller.rb
@@ -24,12 +24,8 @@ module Providers
     end
 
     def destroy
-      file = statement_of_case.original_files.find_by(id: params[:original_file_id])
-      if file
-        file.purge
-      else
-        Rails.logger.error "Unable to remove original file. Not found: #{params[:original_file_id]}"
-      end
+      delete_original_file
+      delete_pdf_file
       redirect_to [:providers, legal_aid_application, :statement_of_case]
     end
 
@@ -57,6 +53,19 @@ module Providers
 
     def authorize_legal_aid_application
       authorize legal_aid_application
+    end
+
+    def delete_original_file
+      file = statement_of_case.original_files.find_by(id: params[:original_file_id])
+      if file
+        file.purge
+      else
+        Rails.logger.error "Unable to remove original file. Not found: #{params[:original_file_id]}"
+      end
+    end
+
+    def delete_pdf_file
+      PdfFile.where(original_file_id: params[:original_file_id]).destroy_all
     end
   end
 end

--- a/app/controllers/providers/statement_of_cases_controller.rb
+++ b/app/controllers/providers/statement_of_cases_controller.rb
@@ -25,7 +25,11 @@ module Providers
 
     def destroy
       file = statement_of_case.original_files.find_by(id: params[:original_file_id])
-      file.purge
+      if file
+        file.purge
+      else
+        Rails.logger.error "Unable to remove original file. Not found: #{params[:original_file_id]}"
+      end
       redirect_to [:providers, legal_aid_application, :statement_of_case]
     end
 

--- a/app/models/pdf_file.rb
+++ b/app/models/pdf_file.rb
@@ -2,8 +2,9 @@ class PdfFile < ApplicationRecord
   has_one_attached :file
 
   def self.convert_original_file(original_file_id)
-    return if exists?(original_file_id: original_file_id)
+    return if original_file_id.nil? || exists?(original_file_id: original_file_id)
 
-    PdfConverterWorker.perform_async(original_file_id)
+    pdf_file = create!(original_file_id: original_file_id)
+    PdfConverterWorker.perform_async(pdf_file.id)
   end
 end

--- a/app/services/pdf_converter.rb
+++ b/app/services/pdf_converter.rb
@@ -1,17 +1,22 @@
 class PdfConverter
-  def self.call(original_file_id)
-    new(original_file_id).call
+  def self.call(pdf_file_id)
+    new(pdf_file_id).call
   end
 
-  attr_reader :original_file_id
+  attr_reader :pdf_file_id
 
-  def initialize(original_file_id)
-    @original_file_id = original_file_id
+  def initialize(pdf_file_id)
+    @pdf_file_id = pdf_file_id
   end
 
   def call
+    return unless pdf_file # pdf_file may have been deleted on original file being deleted
+
+    file = converted_file
+    return unless PdfFile.exists?(pdf_file_id) # Check still there on completion of conversion
+
     pdf_file.file.attach(
-      io: File.open(converted_file.path),
+      io: File.open(file.path),
       filename: "#{original_attachment.filename.base}.pdf",
       content_type: 'application/pdf'
     )
@@ -20,8 +25,9 @@ class PdfConverter
   private
 
   def pdf_file
-    PdfFile.find_or_create_by!(original_file_id: original_file_id)
+    PdfFile.find_by(id: pdf_file_id)
   end
+  delegate :original_file_id, to: :pdf_file
 
   def converted_file
     return downloaded_file if original_attachment.content_type == 'application/pdf'

--- a/app/views/providers/statement_of_cases/_uploaded_files.html.erb
+++ b/app/views/providers/statement_of_cases/_uploaded_files.html.erb
@@ -15,13 +15,13 @@
       <td class="govuk-table__cell no-wrap"><%= number_to_human_size(file.blob.byte_size) %></td>
       <td class="govuk-table__cell"><span class="govuk-tag"><%= t('.uploaded') %></span></td>
       <td class="govuk-table__cell">
-        <%= form_tag(
+        <%= button_to(
+              t('.delete'),
               providers_legal_aid_application_statement_of_case_path(@legal_aid_application),
-              method: :delete
-            ) do %>
-          <%= hidden_field_tag :original_file_id, file.id %>
-          <%= submit_tag t('.delete'), class: 'button-as-link' %>
-        <% end %>
+              method: :delete,
+              class: 'button-as-link',
+              params: { original_file_id: file.id }
+            ) %>
       </td>
     </tr>
   <% end %>

--- a/app/views/providers/statement_of_cases/_uploaded_files.html.erb
+++ b/app/views/providers/statement_of_cases/_uploaded_files.html.erb
@@ -14,9 +14,16 @@
       <td class="govuk-table__cell"><%= file.filename %></td>
       <td class="govuk-table__cell no-wrap"><%= number_to_human_size(file.blob.byte_size) %></td>
       <td class="govuk-table__cell"><span class="govuk-tag"><%= t('.uploaded') %></span></td>
-      <td class="govuk-table__cell"><%= t('.delete') %></td>
+      <td class="govuk-table__cell">
+        <%= form_tag(
+              providers_legal_aid_application_statement_of_case_path(@legal_aid_application),
+              method: :delete
+            ) do %>
+          <%= hidden_field_tag :original_file_id, file.id %>
+          <%= submit_tag t('.delete'), class: 'button-as-link' %>
+        <% end %>
+      </td>
     </tr>
-
   <% end %>
   </tbody>
 </table>

--- a/app/views/providers/statement_of_cases/show.html.erb
+++ b/app/views/providers/statement_of_cases/show.html.erb
@@ -1,32 +1,33 @@
 <%= page_template page_title: t('.h1-heading'), template: :form do %>
 
-  <%= form_with(
-        model: @form,
-        url: providers_legal_aid_application_statement_of_case_path,
-        method: :patch,
-        local: true
-      ) do |form| %>
+  <%= govuk_form_group(
+        input: :proceedings_before_the_court,
+        show_error_if: @form.errors.any?
+      ) do %>
 
-    <%= govuk_form_group(
-          input: :proceedings_before_the_court,
-          show_error_if: @form.errors.any?
-        ) do %>
+    <label class="govuk-label" for="more-detail">
+      <p class="govuk-body-l"><%= t('.instructions') %></p>
+      <h2 class="govuk-heading-m"><%= t('.h2-heading') %></h2>
+      <ul class="govuk-list govuk-list--bullet">
+        <% (1..6).each do |bullet_number| %>
+          <li><%= t(".bullet-#{bullet_number}") %></li>
+        <% end %>
+      </ul>
+    </label>
 
-      <label class="govuk-label" for="more-detail">
-        <p class="govuk-body-l"><%= t('.instructions') %></p>
-        <h2 class="govuk-heading-m"><%= t('.h2-heading') %></h2>
-        <ul class="govuk-list govuk-list--bullet">
-          <% (1..6).each do |bullet_number| %>
-            <li><%= t(".bullet-#{bullet_number}") %></li>
-          <% end %>
-        </ul>
-      </label>
+    <div class="govuk-!-padding-bottom-2"></div>
 
-      <div class="govuk-!-padding-bottom-2"></div>
+    <% if @form.model.original_files && @form.model.original_files.any? %>
+      <%= render partial: 'uploaded_files', locals: { original_files: @form.model.original_files } %>
+    <% end %>
 
-      <% if @form.model.original_files && @form.model.original_files.any? %>
-        <%= render partial: 'uploaded_files', locals: { original_files: @form.model.original_files } %>
-      <% end %>
+    <%# Note this form needs to start after the list of original files to avoid nesting forms %>
+    <%= form_with(
+          model: @form,
+          url: providers_legal_aid_application_statement_of_case_path,
+          method: :patch,
+          local: true
+        ) do |form| %>
 
       <label class="govuk-heading-m" for="original_files"><%= t('generic.upload_file') %></label>
       <%= form.govuk_file_field :original_files, multiple: true, label: nil %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -73,7 +73,7 @@ Rails.application.routes.draw do
       resource :own_home, only: %i[show update]
       resource :check_benefit, only: %i[index update]
       resource :other_assets, only: %i[show update]
-      resource :statement_of_case, only: %i[show update]
+      resource :statement_of_case, only: %i[show update destroy]
       resources :check_benefits, only: [:index]
       resource :online_banking, only: %i[show update], path: 'does-client-use-online-banking'
       resource :merits_declaration, only: %i[show update]

--- a/spec/requests/providers/statement_of_case_spec.rb
+++ b/spec/requests/providers/statement_of_case_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'provider statement of case requests', type: :request do
   let(:provider) { legal_aid_application.provider }
   let(:soc) { nil }
 
-  describe 'GET providers/proceedings_before_the_court' do
+  describe 'GET /providers/applications/:legal_aid_application_id/statement_of_case' do
     subject { get providers_legal_aid_application_statement_of_case_path(legal_aid_application) }
 
     context 'when the provider is not authenticated' do
@@ -45,7 +45,7 @@ RSpec.describe 'provider statement of case requests', type: :request do
     end
   end
 
-  describe 'PATCH providers/proceedings_before_the_court' do
+  describe 'PATCH /providers/applications/:legal_aid_application_id/statement_of_case' do
     let(:entered_text) { Faker::Lorem.paragraph(3) }
     let(:original_file) { uploaded_file('spec/fixtures/files/documents/hello_world.pdf', 'application/pdf') }
     let(:statement_of_case) { legal_aid_application.statement_of_case }
@@ -263,6 +263,28 @@ RSpec.describe 'provider statement of case requests', type: :request do
         expect(response.body).to include 'There is a problem'
         expect(response.body).to include 'You must choose at least one file'
       end
+    end
+  end
+
+  describe 'DELETE /providers/applications/:legal_aid_application_id/statement_of_case' do
+    let(:statement_of_case) { create :statement_of_case, :with_attached_files }
+    let(:legal_aid_application) { statement_of_case.legal_aid_application }
+    let(:original_file) { statement_of_case.original_files.first }
+    let(:params) { { original_file_id: original_file.id } }
+
+    subject { delete providers_legal_aid_application_statement_of_case_path(legal_aid_application), params: params }
+
+    before do
+      login_as provider
+      subject
+    end
+
+    it 'redirects to show' do
+      expect(request).to redirect_to(providers_legal_aid_application_statement_of_case_path(legal_aid_application))
+    end
+
+    it 'deletes the file' do
+      expect(ActiveStorage::Attachment.exists?(original_file.id)).to be(false)
     end
   end
 end

--- a/spec/requests/providers/statement_of_case_spec.rb
+++ b/spec/requests/providers/statement_of_case_spec.rb
@@ -286,5 +286,17 @@ RSpec.describe 'provider statement of case requests', type: :request do
     it 'deletes the file' do
       expect(ActiveStorage::Attachment.exists?(original_file.id)).to be(false)
     end
+
+    context 'when file not found' do
+      let(:params) { { original_file_id: :unknown } }
+
+      it 'redirects to show' do
+        expect(request).to redirect_to(providers_legal_aid_application_statement_of_case_path(legal_aid_application))
+      end
+
+      it 'leaves the file in place' do
+        expect(ActiveStorage::Attachment.exists?(original_file.id)).to be(true)
+      end
+    end
   end
 end

--- a/spec/services/pdf_converter_spec.rb
+++ b/spec/services/pdf_converter_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe PdfConverter do
   let(:statement_of_case) { create :statement_of_case }
   let(:file) { OpenStruct.new(name: 'hello_world.pdf', content_type: 'application/pdf') }
   let(:original_file) { statement_of_case.original_files.first }
-  let(:pdf_file) { PdfFile.last }
+  let(:pdf_file) { PdfFile.create(original_file_id: original_file.id) }
 
   before do
     filepath = "#{Rails.root}/spec/fixtures/files/documents/#{file.name}"
@@ -12,12 +12,12 @@ RSpec.describe PdfConverter do
   end
 
   subject do
-    described_class.call(original_file.id)
+    described_class.call(pdf_file.id)
   end
 
   describe '#call' do
     it 'creates a PdfFile record with the same base name' do
-      expect { subject }.to change { PdfFile.count } .by(1)
+      expect { subject }.to change { ActiveStorage::Attachment.where(name: 'file').count } .by(1)
       expect(pdf_file.file.filename.base).to eq(original_file.filename.base)
       expect(pdf_file.file.content_type).to eq('application/pdf')
     end
@@ -34,7 +34,7 @@ RSpec.describe PdfConverter do
 
       it 'converts the file to pdf' do
         expect(Libreconv).to receive(:convert)
-        expect { subject }.to change { PdfFile.count } .by(1)
+        expect { subject }.to change { ActiveStorage::Attachment.where(name: 'file').count } .by(1)
         expect(pdf_file.file.filename.base).to eq(original_file.filename.base)
         expect(pdf_file.file.content_type).to eq('application/pdf')
       end


### PR DESCRIPTION
[Jira AP-367](https://dsdmoj.atlassian.net/browse/AP-367)

- Add an destroy action to the Statement of Case controller. 
- Adds a form to each file in the original files list - that on submission submits the current original file id to the destroy action
- Restyles the submit buttons to look like links
- Moves the start of the form on the show page - so that the destroy forms are not nested within the main page forms.