### PR TITLE
Delete individual applications using admin account

### DIFF
--- a/app/controllers/admin/legal_aid_applications_controller.rb
+++ b/app/controllers/admin/legal_aid_applications_controller.rb
@@ -16,14 +16,8 @@ module Admin
     def destroy
       raise 'Legal Aid Application Destroy action disabled' unless destroy_enabled?
 
-      applicant_id = LegalAidApplication.find(legal_aid_application_id).applicant_id
-
-      if applicant_id
-        Applicant.destroy(applicant_id)
-      else
-        LegalAidApplication.destroy(legal_aid_application_id)
-      end
-
+      legal_aid_application.applicant&.destroy
+      legal_aid_application.destroy
       redirect_to action: :index
     end
 
@@ -37,8 +31,8 @@ module Admin
 
     private
 
-    def legal_aid_application_id
-      params[:legal_aid_application_id]
+    def legal_aid_application
+      @legal_aid_application ||= LegalAidApplication.find(params[:id])
     end
   end
 end

--- a/app/controllers/admin/legal_aid_applications_controller.rb
+++ b/app/controllers/admin/legal_aid_applications_controller.rb
@@ -13,6 +13,20 @@ module Admin
       redirect_to action: :index
     end
 
+    def destroy
+      raise 'Legal Aid Application Destroy action disabled' unless destroy_enabled?
+
+      applicant_id = LegalAidApplication.find(legal_aid_application_id).applicant_id
+
+      if applicant_id
+        Applicant.destroy(applicant_id)
+      else
+        LegalAidApplication.destroy(legal_aid_application_id)
+      end
+
+      redirect_to action: :index
+    end
+
     protected
 
     # Note this action uses the mock_saml setting to determine if it should be enabled
@@ -20,5 +34,11 @@ module Admin
       Rails.configuration.x.admin_portal.allow_reset
     end
     helper_method :destroy_enabled?
+
+    private
+
+    def legal_aid_application_id
+      params[:legal_aid_application_id]
+    end
   end
 end

--- a/app/views/admin/legal_aid_applications/_legal_aid_applications.html.erb
+++ b/app/views/admin/legal_aid_applications/_legal_aid_applications.html.erb
@@ -21,7 +21,7 @@
             <td class="govuk-table__cell"><%= application.enum_t(:state) %></td>
             <td class="govuk-table__cell"><%= button_to(
                                                 t('.delete'),
-                                                admin_legal_aid_application_destroy_path(application.id),
+                                                admin_legal_aid_application_path(application.id),
                                                 method: :delete,
                                                 class: 'govuk-button destructive'
                                               ) if destroy_enabled? %></td>

--- a/app/views/admin/legal_aid_applications/_legal_aid_applications.html.erb
+++ b/app/views/admin/legal_aid_applications/_legal_aid_applications.html.erb
@@ -8,6 +8,7 @@
           <th class="govuk-table__header" scope="col"><%= t('.created_at') %></th>
           <th class="govuk-table__header" scope="col"><%= t('.application_ref') %></th>
           <th class="govuk-table__header" scope="col"><%= t('.status') %></th>
+          <th class="govuk-table__header" scope="col"></th>
         </tr>
       </thead>
 
@@ -18,6 +19,12 @@
             <td class="govuk-table__cell"><%= l(application.created_at, format: :date) %></td>
             <td class="govuk-table__cell"><%= application.application_ref %></td>
             <td class="govuk-table__cell"><%= application.enum_t(:state) %></td>
+            <td class="govuk-table__cell"><%= button_to(
+                                                t('.delete'),
+                                                admin_legal_aid_application_destroy_path(application.id),
+                                                method: :delete,
+                                                class: 'govuk-button destructive'
+                                              ) if destroy_enabled? %></td>
           </tr>
         </tbody>
       <% end %>

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -10,5 +10,6 @@ en:
         applicant_name: Client's name
         application_ref: Case reference
         created_at: Date started
+        delete: Delete
         latest_applications: Latest Legal Aid Applications
         status: Status

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,7 @@ Rails.application.routes.draw do
     root to: 'legal_aid_applications#index'
     resources :legal_aid_applications, only: [:index] do
       delete :destroy_all, on: :collection
+      delete :destroy
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,9 +22,8 @@ Rails.application.routes.draw do
 
   namespace :admin do
     root to: 'legal_aid_applications#index'
-    resources :legal_aid_applications, only: [:index] do
+    resources :legal_aid_applications, only: %i[index destroy] do
       delete :destroy_all, on: :collection
-      delete :destroy
     end
   end
 

--- a/spec/requests/admin/legal_aid_applications_spec.rb
+++ b/spec/requests/admin/legal_aid_applications_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe Admin::LegalAidApplicationsController, type: :request do
   end
 
   describe 'DELETE /admin/legal_aid_applications/:legal_aid_application_id/destroy' do
-    let(:application) { legal_aid_applications.first.id }
+    let(:application) { legal_aid_applications.first }
     subject { delete admin_legal_aid_application_destroy_path(application) }
 
     context 'when enabled' do
@@ -90,8 +90,9 @@ RSpec.describe Admin::LegalAidApplicationsController, type: :request do
         allow(Rails.configuration.x.admin_portal).to receive(:allow_reset).and_return(true)
       end
 
-      it 'deletes the legal_aid_applications' do
+      it 'deletes the legal_aid_application' do
         expect { subject }.to change { LegalAidApplication.count }.by(-1)
+        expect(LegalAidApplication.all).not_to include(application)
       end
 
       it 'deletes the applicant too' do

--- a/spec/requests/admin/legal_aid_applications_spec.rb
+++ b/spec/requests/admin/legal_aid_applications_spec.rb
@@ -80,4 +80,63 @@ RSpec.describe Admin::LegalAidApplicationsController, type: :request do
       end
     end
   end
+
+  describe 'DELETE /admin/legal_aid_applications/:legal_aid_application_id/destroy' do
+    let(:application) { legal_aid_applications.first.id }
+    subject { delete admin_legal_aid_application_destroy_path(application) }
+
+    context 'when enabled' do
+      before do
+        allow(Rails.configuration.x.admin_portal).to receive(:allow_reset).and_return(true)
+      end
+
+      it 'deletes the legal_aid_applications' do
+        expect { subject }.to change { LegalAidApplication.count }.by(-1)
+      end
+
+      it 'deletes the applicant too' do
+        expect { subject }.to change { Applicant.count }.by(-1)
+      end
+
+      it 'redirects back to admin root' do
+        subject
+        expect(response).to redirect_to(admin_root_path)
+      end
+
+      context 'when not authenticated' do
+        before { sign_out admin_user }
+
+        it 'redirects to log in' do
+          subject
+          expect(response).to redirect_to(new_admin_user_session_path)
+        end
+      end
+
+      context 'with a lot of associations' do
+        let!(:application) { create :legal_aid_application, :with_everything }
+
+        it 'gets deleted too' do
+          expect { subject }.to change { LegalAidApplication.count }.by(-1)
+        end
+      end
+
+      context 'application has no applicant' do
+        let!(:application) { create :legal_aid_application }
+
+        it 'gets deleted too' do
+          expect { subject }.to change { LegalAidApplication.count }.by(-1)
+          expect { subject }.not_to change { Applicant.count }
+        end
+      end
+    end
+
+    context 'when disabled' do
+      before do
+        allow(Rails.configuration.x.admin_portal).to receive(:allow_reset).and_return(false)
+      end
+      it 'raises an error' do
+        expect { subject }.to raise_error('Legal Aid Application Destroy action disabled')
+      end
+    end
+  end
 end

--- a/spec/requests/admin/legal_aid_applications_spec.rb
+++ b/spec/requests/admin/legal_aid_applications_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe Admin::LegalAidApplicationsController, type: :request do
 
   describe 'DELETE /admin/legal_aid_applications/:legal_aid_application_id/destroy' do
     let(:application) { legal_aid_applications.first }
-    subject { delete admin_legal_aid_application_destroy_path(application) }
+    subject { delete admin_legal_aid_application_path(application) }
 
     context 'when enabled' do
       before do


### PR DESCRIPTION
## What

[AP-371](https://dsdmoj.atlassian.net/browse/AP-371)

Enhance existing admin functionality to allow a user to delete an single record.

- amend view to add a delete button at the end of each row
- add a translation for the button name
- add controller functionality to delete a single application
- add a route
- add tests

It is possible to have a `legal_aid_application` without an `applicant` (if a user starts an application but aborts before saving the client's details). The controller checks if an `applicant` is present and if so destroys it. This cascades so that all related data is deleted. If an `applicant` is not present then the `legal_aid_application` is instead destroyed, also cascading to delete related data.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
