### PR TITLE
AP-408 Enter details of latest incident

### DIFF
--- a/app/controllers/concerns/providers/draftable.rb
+++ b/app/controllers/concerns/providers/draftable.rb
@@ -4,8 +4,10 @@ module Providers
   # So usually depends on `Flowable` and `ApplicationDependable` being included
   # into the host controller
   module Draftable
+    ENDPOINT = :providers_legal_aid_applications_path
+
     def draft_target_endpoint
-      providers_legal_aid_applications_path
+      __send__(ENDPOINT)
     end
 
     def save_continue_or_draft(form)

--- a/app/controllers/providers/applicants_controller.rb
+++ b/app/controllers/providers/applicants_controller.rb
@@ -1,12 +1,12 @@
 module Providers
   class ApplicantsController < ProviderBaseController
     def show
-      authorize @legal_aid_application
+      authorize legal_aid_application
       @form = Applicants::BasicDetailsForm.new(model: applicant)
     end
 
     def update
-      authorize @legal_aid_application
+      authorize legal_aid_application
       @form = Applicants::BasicDetailsForm.new(form_params)
       render :show unless save_continue_or_draft(@form)
     end

--- a/app/controllers/providers/details_latest_incidents_controller.rb
+++ b/app/controllers/providers/details_latest_incidents_controller.rb
@@ -1,5 +1,14 @@
 module Providers
-  class DetailsLatestIncidentsController < ApplicationController
-    def show; end
+  class DetailsLatestIncidentsController < ProviderBaseController
+    def show
+      authorize legal_aid_application
+      @form = Incidents::LatestIncidentForm.new(model: incident)
+    end
+
+    private
+
+    def incident
+      legal_aid_application.latest_incident || legal_aid_application.build_latest_incident
+    end
   end
 end

--- a/app/controllers/providers/details_latest_incidents_controller.rb
+++ b/app/controllers/providers/details_latest_incidents_controller.rb
@@ -1,0 +1,5 @@
+module Providers
+  class DetailsLatestIncidentsController < ApplicationController
+    def show; end
+  end
+end

--- a/app/controllers/providers/details_latest_incidents_controller.rb
+++ b/app/controllers/providers/details_latest_incidents_controller.rb
@@ -5,10 +5,24 @@ module Providers
       @form = Incidents::LatestIncidentForm.new(model: incident)
     end
 
+    def update
+      authorize legal_aid_application
+      @form = Incidents::LatestIncidentForm.new(form_params)
+      render :show unless save_continue_or_draft(@form)
+    end
+
     private
 
     def incident
       legal_aid_application.latest_incident || legal_aid_application.build_latest_incident
+    end
+
+    def form_params
+      merge_with_model(incident) do
+        params.require(:incident).permit(
+          :occurred_day, :occurred_month, :occurred_year, :details
+        )
+      end
     end
   end
 end

--- a/app/forms/applicants/basic_details_form.rb
+++ b/app/forms/applicants/basic_details_form.rb
@@ -35,16 +35,14 @@ module Applicants
       )
     end
 
-    # rubocop:disable Lint/HandleExceptions
     def date_of_birth
       return @date_of_birth if @date_of_birth.present?
       return incomplete_date if dobs.any?(&:blank?)
 
       @date_of_birth = attributes[:date_of_birth] = Date.new(*dobs.map(&:to_i))
-    rescue ArgumentError
+    rescue ArgumentError # rubocop:disable Lint/HandleExceptions
       # if date can't be parsed set as nil
     end
-    # rubocop:enable Lint/HandleExceptions
 
     def normalise_national_insurance_number
       return if national_insurance_number.blank?

--- a/app/forms/applicants/basic_details_form.rb
+++ b/app/forms/applicants/basic_details_form.rb
@@ -10,7 +10,10 @@ module Applicants
 
     before_validation :normalise_national_insurance_number
 
-    validates :email, :first_name, :last_name, :national_insurance_number, presence: true, unless: :draft?
+    # Note order of validation here determines order they appear on page
+    # So validations for each field need to be in order, and presence validations
+    # split so that they occur in the right order.
+    validates :first_name, :last_name, presence: true, unless: :draft?
 
     validates :date_of_birth, presence: true, unless: :draft_and_not_incomplete_date?
 
@@ -23,8 +26,10 @@ module Applicants
       allow_nil: true
     )
 
+    validates :national_insurance_number, presence: true, unless: :draft?
     validate :validate_national_insurance_number
 
+    validates :email, presence: true, unless: :draft?
     validates :email, format: { with: URI::MailTo::EMAIL_REGEXP }, allow_blank: true
 
     def initialize(*args)

--- a/app/forms/incidents/latest_incident_form.rb
+++ b/app/forms/incidents/latest_incident_form.rb
@@ -1,0 +1,66 @@
+module Incidents
+  class LatestIncidentForm
+    include BaseForm
+
+    form_for Incident
+
+    attr_accessor :occurred_year, :occurred_month, :occurred_day, :details
+    attr_writer :occurred_on
+
+    validates :details, presence: true, unless: :draft?
+    validates :occurred_on, presence: true, unless: :draft_and_not_incomplete_date?
+    validates :occurred_on, date: { not_in_the_future: true }, allow_nil: true
+
+    def initialize(*args)
+      super
+      set_instance_variables_for_attributes_if_not_set_but_in_model(
+        attrs: occurred_on_fields,
+        model_attributes: occurred_on_from_model
+      )
+    end
+
+    def occurred_on
+      return @occurred_on if @occurred_on.present?
+      return incomplete_date if occurred_on_methods.any?(&:blank?)
+
+      @occurred_on = attributes[:occurred_on] = Date.new(*occurred_on_methods.map(&:to_i))
+    rescue ArgumentError # rubocop:disable Lint/HandleExceptions
+      # if date can't be parsed set as nil
+    end
+
+    def exclude_from_model
+      occurred_on_fields
+    end
+
+    def occurred_on_fields
+      %i[occurred_year occurred_month occurred_day]
+    end
+
+    def occurred_on_methods
+      @occurred_on_methods ||= occurred_on_fields.map { |f| __send__(f) }
+    end
+
+    def occurred_on_from_model
+      return unless model.occurred_on?
+
+      {
+        occurred_year: model.occurred_on.year,
+        occurred_month: model.occurred_on.month,
+        occurred_day: model.occurred_on.day
+      }
+    end
+
+    def incomplete_date
+      @incomplete_date = true unless occurred_on_methods.all?(&:blank?)
+      nil
+    end
+
+    def incomplete_date?
+      @incomplete_date
+    end
+
+    def draft_and_not_incomplete_date?
+      draft? && !incomplete_date?
+    end
+  end
+end

--- a/app/forms/incidents/latest_incident_form.rb
+++ b/app/forms/incidents/latest_incident_form.rb
@@ -7,9 +7,9 @@ module Incidents
     attr_accessor :occurred_year, :occurred_month, :occurred_day, :details
     attr_writer :occurred_on
 
-    validates :details, presence: true, unless: :draft?
     validates :occurred_on, presence: true, unless: :draft_and_not_incomplete_date?
     validates :occurred_on, date: { not_in_the_future: true }, allow_nil: true
+    validates :details, presence: true, unless: :draft?
 
     def initialize(*args)
       super
@@ -24,8 +24,8 @@ module Incidents
       return incomplete_date if occurred_on_methods.any?(&:blank?)
 
       @occurred_on = attributes[:occurred_on] = Date.new(*occurred_on_methods.map(&:to_i))
-    rescue ArgumentError # rubocop:disable Lint/HandleExceptions
-      # if date can't be parsed set as nil
+    rescue ArgumentError
+      :invalid
     end
 
     private
@@ -53,8 +53,10 @@ module Incidents
     end
 
     def incomplete_date
-      @incomplete_date = true unless occurred_on_methods.all?(&:blank?)
-      nil
+      return nil if occurred_on_methods.all?(&:blank?)
+
+      @incomplete_date = true
+      :invalid
     end
 
     def incomplete_date?

--- a/app/forms/incidents/latest_incident_form.rb
+++ b/app/forms/incidents/latest_incident_form.rb
@@ -28,6 +28,8 @@ module Incidents
       # if date can't be parsed set as nil
     end
 
+    private
+
     def exclude_from_model
       occurred_on_fields
     end

--- a/app/helpers/gov_uk_form_helper.rb
+++ b/app/helpers/gov_uk_form_helper.rb
@@ -54,6 +54,18 @@ module GovUkFormHelper
     content_tag :span, text, merge_with_class(args, 'govuk-error-message')
   end
 
+  def date_input_fields(prefix:, field_name:, form:, width: 'two-thirds')
+    group_error_class = form.object.errors[field_name].any? ? 'govuk-form-group--error' : ''
+    render(
+      'shared/forms/date_input_fields',
+      prefix: prefix,
+      field_name: field_name,
+      form: form,
+      width: width,
+      group_error_class: group_error_class
+    )
+  end
+
   # Adds or appends `class_text` to `args[:class]`. So:
   #   args = { id: 'thing' }
   #   merge_with_class(args, 'bar') => { class: 'bar', id: 'thing' }

--- a/app/models/concerns/legal_aid_application_state_machine.rb
+++ b/app/models/concerns/legal_aid_application_state_machine.rb
@@ -52,7 +52,7 @@ module LegalAidApplicationStateMachine
         transitions from: :checking_citizen_answers, to: :means_completed,
                     after: -> do
                       CleanupCapitalAttributes.call(self)
-                      update!(provider_step: :client_received_legal_helps)
+                      update!(provider_step: :details_latest_incident)
                     end
         transitions from: :checking_passported_answers, to: :means_completed
       end

--- a/app/models/incident.rb
+++ b/app/models/incident.rb
@@ -1,0 +1,3 @@
+class Incident < ApplicationRecord
+  belongs_to :legal_aid_application
+end

--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -17,6 +17,7 @@ class LegalAidApplication < ApplicationRecord
   has_one :merits_assessment, dependent: :destroy
   has_one :statement_of_case, dependent: :destroy
   has_one :respondent, dependent: :destroy
+  has_one :latest_incident, -> { order(occurred_on: :desc) }, class_name: :Incident, dependent: :destroy
   has_many :legal_aid_application_restrictions, dependent: :destroy
   has_many :restrictions, through: :legal_aid_application_restrictions
   has_many :legal_aid_application_transaction_types, dependent: :destroy

--- a/app/services/flow/flows/provider_capital.rb
+++ b/app/services/flow/flows/provider_capital.rb
@@ -48,7 +48,7 @@ module Flow
         },
         check_passported_answers: {
           path: ->(application) { urls.providers_legal_aid_application_check_passported_answers_path(application) },
-          forward: :details_latest_incident
+          forward: :details_latest_incidents
         }
       }.freeze
     end

--- a/app/services/flow/flows/provider_capital.rb
+++ b/app/services/flow/flows/provider_capital.rb
@@ -48,7 +48,7 @@ module Flow
         },
         check_passported_answers: {
           path: ->(application) { urls.providers_legal_aid_application_check_passported_answers_path(application) },
-          forward: :respondents
+          forward: :details_latest_incident
         }
       }.freeze
     end

--- a/app/services/flow/flows/provider_merits.rb
+++ b/app/services/flow/flows/provider_merits.rb
@@ -2,9 +2,14 @@ module Flow
   module Flows
     class ProviderMerits < FlowSteps
       STEPS = {
+        details_latest_incident: {
+          path: ->(application) { urls.providers_legal_aid_application_details_latest_incident_path(application) },
+          forward: :respondents,
+          check_answers: :check_merits_answers
+        },
         respondents: {
           path: ->(application) { urls.providers_legal_aid_application_respondent_path(application) },
-          forward: :client_received_legal_helps, # TODO: Change this when new start to merits complete
+          forward: :client_received_legal_helps,
           check_answers: :check_merits_answers
         },
         client_received_legal_helps: {

--- a/app/services/flow/flows/provider_merits.rb
+++ b/app/services/flow/flows/provider_merits.rb
@@ -2,7 +2,7 @@ module Flow
   module Flows
     class ProviderMerits < FlowSteps
       STEPS = {
-        details_latest_incident: {
+        details_latest_incidents: {
           path: ->(application) { urls.providers_legal_aid_application_details_latest_incident_path(application) },
           forward: :respondents,
           check_answers: :check_merits_answers

--- a/app/views/providers/applicants/show.html.erb
+++ b/app/views/providers/applicants/show.html.erb
@@ -19,7 +19,7 @@
 
     <div class="govuk-!-padding-bottom-4"></div>
 
-    <%= render partial: 'shared/forms/date_input_fields', locals: { prefix: :dob, field_name: :date_of_birth, form: form } %>
+    <%= date_input_fields prefix: :dob, field_name: :date_of_birth, form: form %>
 
     <div class="govuk-!-padding-bottom-6"></div>
 

--- a/app/views/providers/details_latest_incidents/show.html.erb
+++ b/app/views/providers/details_latest_incidents/show.html.erb
@@ -1,3 +1,18 @@
 <%= page_template page_title: t('.h1-heading'), template: :form do %>
 
+  <%= form_with(
+        model: @form,
+        url: providers_legal_aid_application_details_latest_incident_path,
+        method: :patch,
+        local: true
+      ) do |form| %>
+
+    <%= date_input_fields prefix: :occurred, field_name: :occurred_on, width: :full, form: form %>
+
+    <%= form.govuk_text_area :details, rows: 10 %>
+
+    <%= next_action_buttons(show_draft: true, form: form) %>
+
+  <% end %>
+
 <% end %>

--- a/app/views/providers/details_latest_incidents/show.html.erb
+++ b/app/views/providers/details_latest_incidents/show.html.erb
@@ -1,0 +1,3 @@
+<%= page_template page_title: t('.h1-heading'), template: :form do %>
+
+<% end %>

--- a/app/views/shared/forms/_date_input_fields.html.erb
+++ b/app/views/shared/forms/_date_input_fields.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-<%= width %>">
     <div class="govuk-form-group">
-      <div class="govuk-date-input__item <%= group_error_class %>" id="<%= field_name %>">
+      <div class="govuk-date-input__item <%= group_error_class %>">
 
         <%= content_tag(:label, t(".#{field_name}_label"), default: '', id: "#{field_name}-label".dasherize, class: ['govuk-label']) %>
         <% hint = t(".#{field_name}_hint", default: '') %>
@@ -15,7 +15,7 @@
 
         <fieldset class="govuk-fieldset">
           <div class="govuk-date-input">
-            <%= render 'shared/forms/date_part_input_fields', parent_field: field_name, field_name: :"#{prefix}_day", form: form %>
+            <%= render 'shared/forms/date_part_input_fields', parent_field: field_name, field_name: :"#{prefix}_day", form: form, use_parent_as_id: true %>
             <%= render 'shared/forms/date_part_input_fields', parent_field: field_name, field_name: :"#{prefix}_month", form: form %>
             <%= render 'shared/forms/date_part_input_fields', parent_field: field_name, field_name: :"#{prefix}_year", form: form %>
           </div>

--- a/app/views/shared/forms/_date_input_fields.html.erb
+++ b/app/views/shared/forms/_date_input_fields.html.erb
@@ -1,11 +1,5 @@
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <% group_error_class = '' %>
-
-    <% if form.object.errors[field_name].any? %>
-      <% group_error_class = 'govuk-form-group--error' %>
-    <% end %>
-
+  <div class="govuk-grid-column-<%= width %>">
     <div class="govuk-form-group">
       <div class="govuk-date-input__item <%= group_error_class %>" id="<%= field_name %>">
 
@@ -21,9 +15,9 @@
 
         <fieldset class="govuk-fieldset">
           <div class="govuk-date-input">
-            <%= render partial: 'shared/forms/date_part_input_fields', locals: { parent_field: field_name, field_name: :"#{prefix}_day", form: form } %>
-            <%= render partial: 'shared/forms/date_part_input_fields', locals: { parent_field: field_name, field_name: :"#{prefix}_month", form: form } %>
-            <%= render partial: 'shared/forms/date_part_input_fields', locals: { parent_field: field_name, field_name: :"#{prefix}_year", form: form } %>
+            <%= render 'shared/forms/date_part_input_fields', parent_field: field_name, field_name: :"#{prefix}_day", form: form %>
+            <%= render 'shared/forms/date_part_input_fields', parent_field: field_name, field_name: :"#{prefix}_month", form: form %>
+            <%= render 'shared/forms/date_part_input_fields', parent_field: field_name, field_name: :"#{prefix}_year", form: form %>
           </div>
         </fieldset>
       </div>

--- a/app/views/shared/forms/_date_part_input_fields.html.erb
+++ b/app/views/shared/forms/_date_part_input_fields.html.erb
@@ -1,9 +1,13 @@
-<% field_error_class = form.object.errors[field_name].present? || form.object.errors[parent_field].present? ? 'govuk-input--error' : '' %>
-<% width = /_year\z/.match?(field_name.to_s) ? '4' : '2' %>
+<%
+  field_error_class = form.object.errors[field_name].present? || form.object.errors[parent_field].present? ? 'govuk-input--error' : ''
+  width = /_year\z/.match?(field_name.to_s) ? '4' : '2'
+  use_parent_as_id = false unless local_assigns[:use_parent_as_id]
+  input_id = use_parent_as_id ? parent_field : field_name
+%>
 
 <div class="govuk-date-input__item">
   <div class="govuk-form-group">
     <%= form.label field_name, class: ['govuk-date-input__label govuk-label'] %>
-    <%= form.text_field field_name, id: field_name, class: ["govuk-input govuk-date-input__input govuk-input--width-#{width} #{field_error_class}"] %>
+    <%= form.text_field field_name, id: input_id, class: ["govuk-input govuk-date-input__input govuk-input--width-#{width} #{field_error_class}"] %>
   </div>
 </div>

--- a/app/views/shared/page_templates/_form_page_template.html.erb
+++ b/app/views/shared/page_templates/_form_page_template.html.erb
@@ -11,7 +11,7 @@
   </div>
   <div class="govuk-!-padding-bottom-2"></div>
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-grid-column-<%= column_width %>">
       <%= content %>
     </div>
   </div>

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -91,6 +91,14 @@ en:
           attributes:
             code:
               blank: A proceeding must be selected
+        incident:
+          attributes:
+            occurred_on:
+              date_not_valid: Enter a valid date for date your client contacted you
+              date_is_in_the_future: Date your client contacted you should be in the past
+              blank: Enter details of the latest incident
+            details:
+              blank: Enter details of the latest incident
         legal_aid_application:
           attributes:
             outstanding_mortgage_amount:

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -30,6 +30,11 @@ en:
         first_name: First name
         last_name: Last name
         national_insurance_number: National Insurance number
+      incident:
+        occurred_day: Day
+        occurred_month: Month
+        occurred_year: Year
+        details: Details of the incident
       legal_aid_application:
         outstanding_mortgage_amount: Enter outstanding mortgage amount
         property_value: Enter the estimated value of your home

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -99,11 +99,11 @@ en:
         incident:
           attributes:
             occurred_on:
-              date_not_valid: Enter a valid date for date your client contacted you
-              date_is_in_the_future: Date your client contacted you should be in the past
-              blank: Enter details of the latest incident
+              date_not_valid: Enter a date in the right format
+              date_is_in_the_future: Date your client contacted you must be in the past
+              blank: Enter the date your client contacted you about the incident
             details:
-              blank: Enter details of the latest incident
+              blank: Enter details of the incident
         legal_aid_application:
           attributes:
             outstanding_mortgage_amount:

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -106,6 +106,9 @@ en:
     client_received_legal_helps:
       show:
         h1-heading: Has your client received legal help for the matter?
+    details_latest_incidents:
+      show:
+        h1-heading: Enter details of the latest incident
     estimated_legal_costs:
       show:
         h1-heading: What are the estimated legal costs of doing the work?

--- a/config/locales/en/shared.yml
+++ b/config/locales/en/shared.yml
@@ -22,7 +22,7 @@ en:
       date_input_fields:
         date_of_birth_hint: For example, 31 3 1980
         date_of_birth_label: Date of birth
-        occurred_on_hint: For example, 31 3 1980
+        occurred_on_hint: For example 31 3 2019
         occurred_on_label: Date your client contacted you about the incident
       outstanding_mortgage_form:
         citizens:

--- a/config/locales/en/shared.yml
+++ b/config/locales/en/shared.yml
@@ -22,6 +22,8 @@ en:
       date_input_fields:
         date_of_birth_hint: For example, 31 3 1980
         date_of_birth_label: Date of birth
+        occurred_on_hint: For example, 31 3 1980
+        occurred_on_label: Date your client contacted you about the incident
       outstanding_mortgage_form:
         citizens:
           outstanding_mortgages:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -95,6 +95,7 @@ Rails.application.routes.draw do
         patch :reset
       end
       resource :respondent, only: %i[show update]
+      resource :details_latest_incident, only: %i[show update]
       resource :client_received_legal_help, only: %i[show update]
       resource :proceedings_before_the_court, only: %i[show update]
       resource :estimated_legal_costs, only: %i[show update]

--- a/db/migrate/20190305152510_create_incidents.rb
+++ b/db/migrate/20190305152510_create_incidents.rb
@@ -1,0 +1,11 @@
+class CreateIncidents < ActiveRecord::Migration[5.2]
+  def change
+    create_table :incidents, id: :uuid do |t|
+      t.date :occurred_on
+      t.text :details
+      t.references :legal_aid_application, index: true, type: :uuid
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -182,6 +182,15 @@ ActiveRecord::Schema.define(version: 2019_03_07_104610) do
     t.string "source"
   end
 
+  create_table "incidents", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.date "occurred_on"
+    t.text "details"
+    t.uuid "legal_aid_application_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["legal_aid_application_id"], name: "index_incidents_on_legal_aid_application_id"
+  end
+
   create_table "legal_aid_application_restrictions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "legal_aid_application_id"
     t.uuid "restriction_id"

--- a/features/providers/civil_application_journey.feature
+++ b/features/providers/civil_application_journey.feature
@@ -379,6 +379,10 @@ Feature: Civil application journeys
     Then I click "Continue"
     Then I click "Continue"
     Then I click "Submit"
+    Then I should be on a page showing "Enter details of the latest incident"
+    Then I enter the occurred on date of 2 days ago
+    Then I fill "Details" with "It happened"
+    Then I click "Continue"
     Then I should be on a page showing "Respondent details"
     Then I choose option "Respondent understands terms of court order True"
     Then I choose option "Respondent warning letter sent True"

--- a/features/providers/step_definitions/civil_journey_steps.rb
+++ b/features/providers/step_definitions/civil_journey_steps.rb
@@ -232,6 +232,13 @@ Then(/^I enter the date of birth '(\d+-\d+-\d+)'$/) do |dob|
   fill_in('dob_year', with: dob_year)
 end
 
+Then('I enter the occurred on date of {int} days ago') do |number|
+  date = number.days.ago
+  fill_in('occurred_day', with: date.day)
+  fill_in('occurred_month', with: date.month)
+  fill_in('occurred_year', with: date.year)
+end
+
 Then(/^I see a notice confirming an e-mail was sent to the citizen$/) do
   expect(page).to have_content('Application completed. An e-mail will be sent to the citizen.')
 end

--- a/features/providers/step_definitions/civil_journey_steps.rb
+++ b/features/providers/step_definitions/civil_journey_steps.rb
@@ -227,14 +227,14 @@ end
 
 Then(/^I enter the date of birth '(\d+-\d+-\d+)'$/) do |dob|
   dob_day, dob_month, dob_year = dob.split('-')
-  fill_in('dob_day', with: dob_day)
+  fill_in('date_of_birth', with: dob_day)
   fill_in('dob_month', with: dob_month)
   fill_in('dob_year', with: dob_year)
 end
 
 Then('I enter the occurred on date of {int} days ago') do |number|
   date = number.days.ago
-  fill_in('occurred_day', with: date.day)
+  fill_in('occurred_on', with: date.day)
   fill_in('occurred_month', with: date.month)
   fill_in('occurred_year', with: date.year)
 end

--- a/spec/factories/incidents.rb
+++ b/spec/factories/incidents.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :incident do
+    occurred_on { Faker::Date.backward(90) }
+    details { Faker::Lorem.paragraph }
+    legal_aid_application
+  end
+end

--- a/spec/forms/incidents/latest_incident_form_spec.rb
+++ b/spec/forms/incidents/latest_incident_form_spec.rb
@@ -1,0 +1,184 @@
+require 'rails_helper'
+
+RSpec.describe Incidents::LatestIncidentForm, type: :form do
+  let(:incident) { create :incident }
+  let(:occurred_on) { rand(20).days.ago.to_date }
+  let(:details) { Faker::Lorem.paragraph }
+  let(:i18n_scope) { 'activemodel.errors.models.incident.attributes' }
+  let(:error_locale) { :foo }
+  let(:message) { I18n.t(error_locale, scope: i18n_scope) }
+
+  let(:params) { { occurred_on: occurred_on, details: details } }
+
+  subject { described_class.new(params.merge(model: incident)) }
+
+  describe '#save' do
+    before do
+      subject.save
+      incident.reload
+    end
+
+    it 'updates the incident' do
+      expect(incident.details).to eq(details)
+      expect(incident.occurred_on).to eq(occurred_on)
+    end
+
+    context 'when occurred on is invalid' do
+      let(:occurred_on) { '55-55-1955' }
+      let(:error_locale) { 'occurred_on.date_not_valid' }
+
+      it 'is invalid' do
+        expect(subject).to be_invalid
+      end
+
+      it 'generates an error' do
+        expect(subject.errors[:occurred_on].join).to match(message)
+      end
+    end
+
+    context 'when occurred on is in future' do
+      let(:occurred_on) { 1.days.from_now.to_date }
+      let(:error_locale) { 'occurred_on.date_is_in_the_future' }
+
+      it 'is invalid' do
+        expect(subject).to be_invalid
+      end
+
+      it 'generates an error' do
+        expect(subject.errors[:occurred_on].join).to match(message)
+      end
+    end
+
+    context 'with date entered in parts' do
+      let(:params) do
+        {
+          details: details,
+          occurred_year: occurred_on.year.to_s,
+          occurred_month: occurred_on.month.to_s,
+          occurred_day: occurred_on.day.to_s
+        }
+      end
+
+      it 'updates the incident' do
+        expect(incident.details).to eq(details)
+        expect(incident.occurred_on).to eq(occurred_on)
+      end
+    end
+
+    context 'without date' do
+      let(:occurred_on) { '' }
+      let(:incident) { create :incident, occurred_on: nil }
+      let(:error_locale) { 'occurred_on.blank' }
+
+      it 'is invalid' do
+        expect(subject).to be_invalid
+      end
+
+      it 'generates an error' do
+        expect(subject.errors[:occurred_on].join).to match(message)
+      end
+    end
+
+    context 'without detail' do
+      let(:details) { '' }
+      let(:incident) { create :incident, details: nil }
+      let(:error_locale) { 'details.blank' }
+
+      it 'is invalid' do
+        expect(subject).to be_invalid
+      end
+
+      it 'generates an error' do
+        expect(subject.errors[:details].join).to match(message)
+      end
+    end
+  end
+
+  describe '#save_as_draft' do
+    before do
+      subject.save_as_draft
+      incident.reload
+    end
+
+    it 'updates the incident' do
+      expect(incident.details).to eq(details)
+      expect(incident.occurred_on).to eq(occurred_on)
+    end
+
+    context 'when occurred on is invalid' do
+      let(:occurred_on) { '55-55-1955' }
+      let(:error_locale) { 'occurred_on.date_not_valid' }
+
+      it 'is invalid' do
+        expect(subject).to be_invalid
+      end
+
+      it 'generates an error' do
+        expect(subject.errors[:occurred_on].join).to match(message)
+      end
+    end
+
+    context 'when occurred on is in future' do
+      let(:occurred_on) { 1.days.from_now.to_date }
+      let(:error_locale) { 'occurred_on.date_is_in_the_future' }
+
+      it 'is invalid' do
+        expect(subject).to be_invalid
+      end
+
+      it 'generates an error' do
+        expect(subject.errors[:occurred_on].join).to match(message)
+      end
+    end
+
+    context 'with date entered in parts' do
+      let(:params) do
+        {
+          details: details,
+          occurred_year: occurred_on.year.to_s,
+          occurred_month: occurred_on.month.to_s,
+          occurred_day: occurred_on.day.to_s
+        }
+      end
+
+      it 'updates the incident' do
+        expect(incident.details).to eq(details)
+        expect(incident.occurred_on).to eq(occurred_on)
+      end
+    end
+
+    context 'without date' do
+      let(:occurred_on) { '' }
+      let(:incident) { create :incident, occurred_on: nil }
+
+      it 'is valid' do
+        expect(subject).to be_valid
+      end
+
+      it 'save details' do
+        expect(incident.details).to eq(details)
+      end
+    end
+
+    context 'without detail' do
+      let(:params) do
+        {
+          details: '',
+          occurred_year: occurred_on.year.to_s,
+          occurred_month: occurred_on.month.to_s,
+          occurred_day: occurred_on.day.to_s
+        }
+      end
+      let(:incident) { create :incident, details: nil }
+
+      it 'is valid' do
+        expect(subject).to be_valid
+      end
+
+      it 'updates occurred on' do
+        # Note, fails if date passed in as `occurred_on` rather than in day, month, year format.
+        expect(incident.occurred_on).to eq(occurred_on)
+      end
+    end
+  end
+end

--- a/spec/forms/incidents/latest_incident_form_spec.rb
+++ b/spec/forms/incidents/latest_incident_form_spec.rb
@@ -24,7 +24,14 @@ RSpec.describe Incidents::LatestIncidentForm, type: :form do
     end
 
     context 'when occurred on is invalid' do
-      let(:occurred_on) { '55-55-1955' }
+      let(:params) do
+        {
+          details: details,
+          occurred_year: occurred_on.year.to_s,
+          occurred_month: '55',
+          occurred_day: occurred_on.day.to_s
+        }
+      end
       let(:error_locale) { 'occurred_on.date_not_valid' }
 
       it 'is invalid' do
@@ -69,6 +76,26 @@ RSpec.describe Incidents::LatestIncidentForm, type: :form do
       let(:occurred_on) { '' }
       let(:incident) { create :incident, occurred_on: nil }
       let(:error_locale) { 'occurred_on.blank' }
+
+      it 'is invalid' do
+        expect(subject).to be_invalid
+      end
+
+      it 'generates an error' do
+        expect(subject.errors[:occurred_on].join).to match(message)
+      end
+    end
+
+    context 'with an invalid partial date' do
+      let(:error_locale) { 'occurred_on.date_not_valid' }
+      let(:params) do
+        {
+          details: details,
+          occurred_year: occurred_on.year.to_s,
+          occurred_month: '',
+          occurred_day: occurred_on.day.to_s
+        }
+      end
 
       it 'is invalid' do
         expect(subject).to be_invalid

--- a/spec/models/incident_spec.rb
+++ b/spec/models/incident_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Incident, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/incident_spec.rb
+++ b/spec/models/incident_spec.rb
@@ -1,5 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe Incident, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
-end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -62,6 +62,7 @@ RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
   config.include RequestHelpers, type: :request
   config.include TrueLayerHelpers
+  config.include FlowHelpers, type: :request
 
   config.before(:suite) do
     Faker::Config.locale = 'en-GB'

--- a/spec/requests/citizens/additional_accounts_spec.rb
+++ b/spec/requests/citizens/additional_accounts_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'citizen additional accounts request test', type: :request do
   let(:application) { create :application, :with_applicant }
   let(:application_id) { application.id }
   let(:secure_id) { application.generate_secure_id }
-  let(:next_flow_step) { citizens_identify_types_of_income_path }
+  let(:next_flow_step) { flow_forward_path }
 
   before { get citizens_legal_aid_application_path(secure_id) }
 

--- a/spec/requests/citizens/check_answers_spec.rb
+++ b/spec/requests/citizens/check_answers_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe 'check your answers requests', type: :request do
 
     it 'should change the provider step to client_received_legal_helps' do
       subject
-      expect(legal_aid_application.reload.provider_step).to eq('client_received_legal_helps')
+      expect(legal_aid_application.reload.provider_step).to eq('details_latest_incident')
     end
 
     it 'syncs the application' do

--- a/spec/requests/citizens/identify_types_of_incomes_spec.rb
+++ b/spec/requests/citizens/identify_types_of_incomes_spec.rb
@@ -25,13 +25,6 @@ RSpec.describe 'IndentifyTypesOfIncomesController' do
   end
 
   describe 'PATCH /citizens/identify_types_of_income' do
-    let(:flow) do
-      Flow::BaseFlowService.flow_service_for(
-        :citizens,
-        legal_aid_application: legal_aid_application,
-        current_step: :identify_types_of_incomes
-      )
-    end
     let(:transaction_type_ids) { [] }
     let(:params) do
       {
@@ -47,7 +40,7 @@ RSpec.describe 'IndentifyTypesOfIncomesController' do
     end
 
     it 'redirects to the next step' do
-      expect(subject).to redirect_to(flow.forward_path)
+      expect(subject).to redirect_to(flow_forward_path)
     end
 
     context 'when transaction types selected' do
@@ -59,7 +52,7 @@ RSpec.describe 'IndentifyTypesOfIncomesController' do
       end
 
       it 'should redirect to the next step' do
-        expect(subject).to redirect_to(flow.forward_path)
+        expect(subject).to redirect_to(flow_forward_path)
       end
     end
   end

--- a/spec/requests/citizens/identify_types_of_outgoings_spec.rb
+++ b/spec/requests/citizens/identify_types_of_outgoings_spec.rb
@@ -25,13 +25,6 @@ RSpec.describe 'IndentifyTypesOfOutgoingsController' do
   end
 
   describe 'PATCH /citizens/identify_types_of_outgoing' do
-    let(:flow) do
-      Flow::BaseFlowService.flow_service_for(
-        :citizens,
-        legal_aid_application: legal_aid_application,
-        current_step: :identify_types_of_outgoings
-      )
-    end
     let(:transaction_type_ids) { [] }
     let(:params) do
       {
@@ -48,7 +41,7 @@ RSpec.describe 'IndentifyTypesOfOutgoingsController' do
     end
 
     it 'redirects to the next step' do
-      expect(subject).to redirect_to(flow.forward_path)
+      expect(subject).to redirect_to(flow_forward_path)
     end
 
     context 'when transaction types selected' do
@@ -60,7 +53,7 @@ RSpec.describe 'IndentifyTypesOfOutgoingsController' do
       end
 
       it 'should redirect to the next step' do
-        expect(subject).to redirect_to(flow.forward_path)
+        expect(subject).to redirect_to(flow_forward_path)
       end
     end
   end

--- a/spec/requests/providers/applicants_spec.rb
+++ b/spec/requests/providers/applicants_spec.rb
@@ -33,14 +33,12 @@ RSpec.describe 'providers applicant requests', type: :request do
         end
       end
 
-      context 'has already got applicant infro' do
+      context 'has already got applicant info' do
         let(:applicant) { create(:applicant) }
-        let(:laa) { create(:legal_aid_application, applicant: applicant) }
-        let(:get_request) { get "/providers/applications/#{laa.id}/applicant" }
-        let(:provider) { laa.provider }
+        let(:application) { create(:legal_aid_application, applicant: applicant) }
 
         it 'display first_name' do
-          get_request
+          subject
           expect(unescaped_response_body).to include(applicant.first_name)
         end
       end

--- a/spec/requests/providers/check_passported_answers_spec.rb
+++ b/spec/requests/providers/check_passported_answers_spec.rb
@@ -160,7 +160,7 @@ RSpec.describe 'check passported answers requests', type: :request do
       end
 
       it 'redirects to Has your client received legal help for the matter?' do
-        expect(response).to redirect_to providers_legal_aid_application_respondent_path(application)
+        expect(response).to redirect_to flow_forward_path
       end
 
       it 'transitions to means_completed state' do

--- a/spec/requests/providers/details_latest_incidents_spec.rb
+++ b/spec/requests/providers/details_latest_incidents_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe Providers::DetailsLatestIncidentsController, type: :request do
+  let(:legal_aid_application) { create :legal_aid_application }
+  let(:login_provider) { login_as legal_aid_application.provider }
+
+  describe 'GET /providers/applications/:legal_aid_application_id/details_latest_incident' do
+    subject do
+      get providers_legal_aid_application_details_latest_incident_path(legal_aid_application)
+    end
+
+    before do
+      login_provider
+      subject
+    end
+
+    it 'renders successfully' do
+      expect(response).to have_http_status(:ok)
+    end
+
+    context 'when not authenticated' do
+      let(:login_provider) { nil }
+      it_behaves_like 'a provider not authenticated'
+    end
+
+    context 'with an existing incident' do
+      let(:incident) { create :incident }
+      let(:legal_aid_application) { create :legal_aid_application, latest_incident: incident }
+
+      it 'renders successfully' do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'displays incident data' do
+        expect(response.body).to include(incident.details)
+      end
+    end
+  end
+end

--- a/spec/requests/providers/statement_of_case_spec.rb
+++ b/spec/requests/providers/statement_of_case_spec.rb
@@ -238,18 +238,18 @@ RSpec.describe 'provider statement of case requests', type: :request do
         expect(statement_of_case.original_files.first).to be_present
       end
 
-      it 'redirects to provider applications home page' do
+      it 'redirects to provider draft endpoint' do
         subject
-        expect(response).to redirect_to providers_legal_aid_applications_path
+        expect(response).to redirect_to provider_draft_endpoint
       end
 
       context 'nothing specified' do
         let(:entered_text) { '' }
         let(:original_file) { nil }
 
-        it 'redirects to provider applications home page' do
+        it 'redirects to provider draft endpoint' do
           subject
-          expect(response).to redirect_to providers_legal_aid_applications_path
+          expect(response).to redirect_to provider_draft_endpoint
         end
       end
     end

--- a/spec/support/flow_helpers.rb
+++ b/spec/support/flow_helpers.rb
@@ -15,4 +15,8 @@ module FlowHelpers
     )
     flow.forward_path
   end
+
+  def provider_draft_endpoint
+    __send__(Providers::Draftable::ENDPOINT)
+  end
 end

--- a/spec/support/flow_helpers.rb
+++ b/spec/support/flow_helpers.rb
@@ -1,0 +1,18 @@
+module FlowHelpers
+  # Takes the last request path and uses it to determine the next step from flows
+  # Makes some assumptions so may not work with every request
+  def flow_forward_path
+    path = request.path
+    parts = path.split('/').select(&:present?)
+    journey = parts.first.to_sym
+    step_index = journey == :citizens ? 1 : 3
+    current_step = parts[step_index].pluralize.to_sym
+    legal_aid_application = journey == :citizens ? LegalAidApplication.new : LegalAidApplication.find(parts[2])
+    flow = Flow::BaseFlowService.flow_service_for(
+      journey,
+      legal_aid_application: legal_aid_application,
+      current_step: current_step
+    )
+    flow.forward_path
+  end
+end


### PR DESCRIPTION
[JIRA AP-408](https://dsdmoj.atlassian.net/browse/AP-408)

The main thing this does is add a new page where the provider can enter the date and details of an incident. The most complicated part of the task was getting the form to work - specifically getting the date assembly working (mostly reworking the way date of birth is handled in the applicants form).

I also added a couple of rspec helper methods ( so we don't need to keep updating existing specs when the flow changes). 
- **`provider_draft_endpoint`** returns the url a provider should be sent to on Saving as Draft. I've updated `Providers::Draftable` so that this endpoint is defined in one place - this method using that definition.
- **`flow_forward_path`** looks at the last `request.path` and uses that to determine what the next forward url should be via flows. 

I've updates a couple of other specs to make sure that the way I'd coded these helpers was generic.