### PR TITLE
AP-375 Show selected transaction on summary of income types page

### DIFF
--- a/app/controllers/citizens/bank_transactions_controller.rb
+++ b/app/controllers/citizens/bank_transactions_controller.rb
@@ -1,0 +1,17 @@
+module Citizens
+  class BankTransactionsController < ApplicationController
+    include ApplicationFromSession
+    before_action :authenticate_applicant!
+
+    def remove_transation_type
+      bank_transaction.update transaction_type: nil
+      redirect_back fallback_location: citizens_identify_types_of_income_path
+    end
+
+    private
+
+    def bank_transaction
+      @bank_transaction ||= BankTransaction.find(params[:id])
+    end
+  end
+end

--- a/app/controllers/citizens/bank_transactions_controller.rb
+++ b/app/controllers/citizens/bank_transactions_controller.rb
@@ -4,7 +4,7 @@ module Citizens
     before_action :authenticate_applicant!
 
     def remove_transation_type
-      bank_transaction.update transaction_type: nil
+      bank_transaction.update! transaction_type: nil
       redirect_back fallback_location: citizens_identify_types_of_income_path
     end
 

--- a/app/controllers/citizens/bank_transactions_controller.rb
+++ b/app/controllers/citizens/bank_transactions_controller.rb
@@ -5,7 +5,12 @@ module Citizens
 
     def remove_transation_type
       bank_transaction.update! transaction_type: nil
-      redirect_back fallback_location: citizens_identify_types_of_income_path
+      respond_to do |format|
+        format.html do
+          redirect_back fallback_location: citizens_identify_types_of_income_path
+        end
+        format.json { head :ok }
+      end
     end
 
     private

--- a/app/controllers/citizens/income_summary_controller.rb
+++ b/app/controllers/citizens/income_summary_controller.rb
@@ -5,6 +5,7 @@ module Citizens
 
     def index
       legal_aid_application
+      @bank_transactions = legal_aid_application.bank_transactions.by_type
     end
   end
 end

--- a/app/controllers/citizens/income_summary_controller.rb
+++ b/app/controllers/citizens/income_summary_controller.rb
@@ -5,7 +5,9 @@ module Citizens
 
     def index
       legal_aid_application
-      @bank_transactions = legal_aid_application.bank_transactions.by_type
+      @bank_transactions = legal_aid_application.bank_transactions
+                                                .order(happened_at: :desc)
+                                                .by_type
     end
   end
 end

--- a/app/controllers/citizens/transactions_controller.rb
+++ b/app/controllers/citizens/transactions_controller.rb
@@ -31,7 +31,7 @@ module Citizens
     end
 
     def set_selection
-      BankTransaction
+      bank_transactions
         .where(id: transaction_ids_to_select)
         .update_all(transaction_type_id: transaction_type.id)
     end

--- a/app/controllers/citizens/transactions_controller.rb
+++ b/app/controllers/citizens/transactions_controller.rb
@@ -32,12 +32,8 @@ module Citizens
 
     def set_selection
       bank_transactions
-        .where(id: transaction_ids_to_select)
+        .where(id: selected_transaction_ids)
         .update_all(transaction_type_id: transaction_type.id)
-    end
-
-    def transaction_ids_to_select
-      bank_transactions.pluck(:id) & selected_transaction_ids
     end
 
     def selected_transaction_ids

--- a/app/models/bank_transaction.rb
+++ b/app/models/bank_transaction.rb
@@ -2,6 +2,12 @@ class BankTransaction < ApplicationRecord
   belongs_to :bank_account
   belongs_to :transaction_type, optional: true
 
+  scope :by_type, -> do
+    includes(:transaction_type)
+      .where.not(transaction_type_id: nil)
+      .group_by(&:transaction_type)
+  end
+
   enum operation: {
     credit: 'credit'.freeze,
     debit: 'debit'.freeze

--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -22,6 +22,7 @@ class LegalAidApplication < ApplicationRecord
   has_many :restrictions, through: :legal_aid_application_restrictions
   has_many :legal_aid_application_transaction_types, dependent: :destroy
   has_many :transaction_types, through: :legal_aid_application_transaction_types
+  has_many :bank_transactions, through: :applicant
 
   before_create :create_app_ref
   before_save :set_open_banking_consent_choice_at

--- a/app/views/admin/legal_aid_applications/_legal_aid_applications.html.erb
+++ b/app/views/admin/legal_aid_applications/_legal_aid_applications.html.erb
@@ -11,9 +11,8 @@
           <th class="govuk-table__header" scope="col"></th>
         </tr>
       </thead>
-
-      <% @applications.each do |application| %>
-        <tbody class="govuk-table__body">
+      <tbody class="govuk-table__body">
+        <% @applications.each do |application| %>
           <tr class="govuk-table__row">
             <td class="govuk-table__cell"><%= application.applicant_full_name || t('generic.undefined') %></td>
             <td class="govuk-table__cell"><%= l(application.created_at, format: :date) %></td>
@@ -26,8 +25,8 @@
                                                 class: 'govuk-button destructive'
                                               ) if destroy_enabled? %></td>
           </tr>
-        </tbody>
-      <% end %>
+        <% end %>
+      </tbody>
     </table>
   </div>
 </div>

--- a/app/views/citizens/income_summary/_income_type_item.html.erb
+++ b/app/views/citizens/income_summary/_income_type_item.html.erb
@@ -1,5 +1,5 @@
-<li>
-  <h2 class="app-task-list__section" id="<%= "income-type-#{name}" %>">
+<li id="<%= "income-type-#{name}" %>">
+  <h2 class="app-task-list__section">
     <span class="app-task-list__section-number"><%= number %>. </span>
     <%= t("transaction_types.names.#{name}") %>
     <% if I18n.exists? "transaction_types.hints.#{name}" %>
@@ -8,9 +8,43 @@
       </span>
     <% end %>
   </h2>
-  <ul class="app-task-list__items">
-    <li class="app-task-list__item" id="<%= "list-item-#{name}" %>">
-      <%= link_to link_text, citizens_transactions_path(transaction_type: name), class: 'govuk-body' %>
-    </li>
-  </ul>
+  <div class="app-task-list__items">
+    <% if bank_transactions.present? %>
+      <table class="govuk-table">
+        <thead class="govuk-table__head">
+          <tr class="govuk-table__row">
+            <th class="govuk-table__header" scope="col"><%= t('.col_date') %></th>
+            <th class="govuk-table__header" scope="col"><%= t('.col_description') %></th>
+            <th class="govuk-table__header" scope="col"><%= t('.col_amount') %></th>
+            <th class="govuk-table__header" scope="col"></th>
+          </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+          <% bank_transactions.each do |bank_transaction| %>
+            <tr class="govuk-table__row">
+              <td class="govuk-table__cell">
+                <%= l(bank_transaction.happened_at, format: :date) %>
+              </td>
+              <td class="govuk-table__cell">
+                <%= bank_transaction.description %>
+              </td>
+              <td class="govuk-table__cell">
+                <%= value_with_currency_unit(bank_transaction.amount, bank_transaction.currency) %>
+              </td>
+              <td class="govuk-table__cell">
+                <%= button_to(
+                      t('.remove_link'),
+                      remove_transation_type_citizens_bank_transaction_path(bank_transaction),
+                      method: :patch,
+                      class: 'button-as-link'
+                    ) %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    <% end %>
+
+    <%= link_to link_text, citizens_transactions_path(transaction_type: name), class: 'govuk-body transaction-type-link' %>
+  </div>
 </li>

--- a/app/views/citizens/income_summary/index.html.erb
+++ b/app/views/citizens/income_summary/index.html.erb
@@ -2,21 +2,19 @@
 
   <p class="govuk-body"><%= t('.add_all_income') %></p>
     <ol class="app-task-list">
-
       <% @legal_aid_application.transaction_types.credits.each_with_index do |transaction_type, index| %>
-
-        <%= render partial: 'income_type_item',
-                   locals: {
-                     name: transaction_type.name,
-                     number: index + 1,
-                     link_text: t('.select')
-                   } %>
+        <%= render(
+              'income_type_item',
+              name: transaction_type.name,
+              number: index + 1,
+              link_text: t('.select'),
+              bank_transactions: @bank_transactions[transaction_type]
+            ) %>
       <% end %>
 
       <% if @legal_aid_application.transaction_types.credits.count < TransactionType.credits.count %>
         <%= render partial: 'add_other_income' %>
       <% end %>
-
     </ol>
 
   <%= link_to t('generic.continue'), forward_path, class: 'govuk-button govuk-button', id: 'continue' %>

--- a/config/locales/en/citizens.yml
+++ b/config/locales/en/citizens.yml
@@ -67,6 +67,11 @@ en:
     income_summary:
       add_other_income:
         add_other_income: Add another type of income
+      income_type_item:
+        col_amount: Amount
+        col_date: Date
+        col_description: Description
+        remove_link: Remove
       index:
         add_all_income: Add all your income from your bank statements.
         page_heading: Select your income

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -58,6 +58,9 @@ Rails.application.routes.draw do
       get '/:transaction_type', to: 'transactions#show', as: ''
       patch '/:transaction_type', to: 'transactions#update'
     end
+    resources :bank_transactions, only: [] do
+      patch 'remove_transation_type', on: :member
+    end
   end
 
   namespace :providers do

--- a/features/providers/step_definitions/civil_journey_steps.rb
+++ b/features/providers/step_definitions/civil_journey_steps.rb
@@ -180,7 +180,7 @@ end
 
 Then('I click on the Select from your bank statement link for income type {string}') do |income_type|
   income_type.downcase!
-  within "#list-item-#{income_type}" do
+  within "#income-type-#{income_type}" do
     click_link('Select from your bank statement')
   end
 end

--- a/spec/requests/citizens/bank_transactions_spec.rb
+++ b/spec/requests/citizens/bank_transactions_spec.rb
@@ -9,8 +9,14 @@ RSpec.describe Citizens::BankTransactionsController, type: :request do
   describe 'PATCH /citizens/bank_transactions/:id/remove_transation_type' do
     let!(:transaction_type) { create :transaction_type }
     let(:bank_transaction) { create :bank_transaction, transaction_type: transaction_type }
+    let(:headers) { {} }
 
-    subject { patch remove_transation_type_citizens_bank_transaction_path(bank_transaction) }
+    subject do
+      patch(
+        remove_transation_type_citizens_bank_transaction_path(bank_transaction),
+        headers: headers
+      )
+    end
 
     it 'does not delete the transaction type' do
       expect { subject }.not_to change { TransactionType.count }
@@ -24,6 +30,25 @@ RSpec.describe Citizens::BankTransactionsController, type: :request do
     it 'redirects on completion' do
       subject
       expect(response).to redirect_to(citizens_identify_types_of_income_path)
+    end
+
+    context 'with JSON request' do
+      let(:headers) { { 'ACCEPT' => 'application/json' } }
+
+      it 'removes the assocation with the transaction type' do
+        subject
+        expect(bank_transaction.reload.transaction_type).to be_nil
+      end
+
+      it 'returns a json response' do
+        subject
+        expect(response.content_type).to eq('application/json')
+      end
+
+      it 'does not redirect on success' do
+        subject
+        expect(response).to have_http_status(:ok)
+      end
     end
   end
 end

--- a/spec/requests/citizens/bank_transactions_spec.rb
+++ b/spec/requests/citizens/bank_transactions_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe Citizens::BankTransactionsController, type: :request do
+  let(:legal_aid_application) { create :legal_aid_application, :with_applicant }
+  let(:secure_id) { legal_aid_application.generate_secure_id }
+
+  before { get citizens_legal_aid_application_path(secure_id) }
+
+  describe 'PATCH /citizens/bank_transactions/:id/remove_transation_type' do
+    let!(:transaction_type) { create :transaction_type }
+    let(:bank_transaction) { create :bank_transaction, transaction_type: transaction_type }
+
+    subject { patch remove_transation_type_citizens_bank_transaction_path(bank_transaction) }
+
+    it 'does not delete the transaction type' do
+      expect { subject }.not_to change { TransactionType.count }
+    end
+
+    it 'removes the assocation with the transaction type' do
+      subject
+      expect(bank_transaction.reload.transaction_type).to be_nil
+    end
+
+    it 'redirects on completion' do
+      subject
+      expect(response).to redirect_to(citizens_identify_types_of_income_path)
+    end
+  end
+end

--- a/spec/requests/citizens/check_answers_spec.rb
+++ b/spec/requests/citizens/check_answers_spec.rb
@@ -68,7 +68,6 @@ RSpec.describe 'check your answers requests', type: :request do
     context 'applicant does not own home' do
       let(:legal_aid_application) { create :legal_aid_application, :with_everything, :without_own_home }
       it 'does not display property value' do
-        expect(response.body).not_to include(number_to_currency(legal_aid_application.property_value, unit: '£'))
         expect(response.body).not_to include('Property value')
       end
 
@@ -81,7 +80,6 @@ RSpec.describe 'check your answers requests', type: :request do
     context 'applicant owns home without mortgage' do
       let(:legal_aid_application) { create :legal_aid_application, :with_everything, :with_own_home_owned_outright }
       it 'does not display property value' do
-        expect(response.body).not_to include(number_to_currency(legal_aid_application.outstanding_mortgage_amount, unit: '£'))
         expect(response.body).not_to include('Outstanding mortgage')
       end
     end
@@ -89,7 +87,6 @@ RSpec.describe 'check your answers requests', type: :request do
     context 'applicant is sole owner of home' do
       let(:legal_aid_application) { create :legal_aid_application, :with_everything, :with_home_sole_owner }
       it 'does not display percentage owned' do
-        expect(response.body).not_to include(number_to_percentage(legal_aid_application.percentage_home, precision: 2))
         expect(response.body).not_to include('Percentage')
       end
     end


### PR DESCRIPTION
[Jira AP-375](https://dsdmoj.atlassian.net/browse/AP-375)

- Updates model associations so that can easily get from an application to the bank transactions associated with it.
- Adds a scope to get a hash with transaction types as keys, and the array of bank transactions of that type as the values
- Adds a table of selected bank transactions to each transaction type section of `citizens/income_summary`
- Adds an action that disassociates a bank transaction from a transaction type and uses that as an endpoint for "remove" "links" (that are in fact buttons, but look like links) 

![income_summary_with_bank_transactions](https://user-images.githubusercontent.com/213040/54128263-9b251480-4403-11e9-8c9b-6278516d761b.png)
