### PR TITLE
Tech debt: Step into journeys to improve cucumber performance

### DIFF
--- a/app/controllers/providers/legal_aid_applications_controller.rb
+++ b/app/controllers/providers/legal_aid_applications_controller.rb
@@ -11,7 +11,6 @@ module Providers
     # POST /provider/applications
     def create
       @legal_aid_application = LegalAidApplication.create(provider: current_provider)
-      @legal_aid_application.create_other_assets_declaration!
       go_forward
     end
   end

--- a/app/controllers/providers/other_assets_controller.rb
+++ b/app/controllers/providers/other_assets_controller.rb
@@ -14,7 +14,7 @@ module Providers
     private
 
     def declaration
-      @declaration ||= legal_aid_application.other_assets_declaration
+      @declaration ||= legal_aid_application.other_assets_declaration || legal_aid_application.create_other_assets_declaration!
     end
 
     def form_params

--- a/app/views/shared/check_answers/_no_link_items.html.erb
+++ b/app/views/shared/check_answers/_no_link_items.html.erb
@@ -24,7 +24,7 @@
     <% end %>
   <% else %>
     <%= check_answer_link(
-          name: name,
+          name: "#{name}_no_link",
           url: url,
           question: question,
           answer: t('generic.none_declared')

--- a/features/citizens/citizens.feature
+++ b/features/citizens/citizens.feature
@@ -85,7 +85,8 @@ Feature: Citizen journey
 
   @javascript
   Scenario: I want to change property details via the check your answers page
-    Given I complete the citizen journey as far as check your answers
+    Given I have completed an application
+    And I complete the citizen journey as far as check your answers
     And I click Check Your Answers Change link for 'Own home'
     Then I should be on a page showing 'Do you own the home that you live in?'
     Then I click 'Continue'
@@ -103,13 +104,11 @@ Feature: Citizen journey
     Then I should be on a page showing 'Check your answers'
     And the answer for 'Own home' should be 'Yes, with a mortgage or loan'
     And the answer for 'Property value' should be '£500,000.00'
-    And the answer for 'Outstanding mortgage' should be '£100,000.00'
-    And the answer for 'Shared ownership' should be 'Yes, a partner or ex-partner'
-    And the answer for 'Percentage home' should be '50.00%'
 
   @javascript
   Scenario: I want to remove property details via the check your answers page
-    Given I complete the citizen journey as far as check your answers
+    Given I have completed an application
+    And I complete the citizen journey as far as check your answers
     And I click Check Your Answers Change link for 'Own home'
     Then I should be on a page showing 'Do you own the home that you live in?'
     Then I choose 'No'
@@ -119,7 +118,8 @@ Feature: Citizen journey
 
   @javascript
   Scenario: I want to return to the check your answers page without changing property details
-    Given I complete the citizen journey as far as check your answers
+    Given I have completed an application
+    And I complete the citizen journey as far as check your answers
     And I click Check Your Answers Change link for 'Own home'
     Then I should be on a page showing 'Do you own the home that you live in?'
     Then I click 'Continue'
@@ -134,15 +134,11 @@ Feature: Citizen journey
     Then I should be on a page showing 'Do any restrictions apply to your property, savings or assets?'
     Then I click 'Continue'
     Then I should be on a page showing 'Check your answers'
-    And the answer for 'Own home' should be 'Yes, with a mortgage or loan'
-    And the answer for 'Property value' should be '£200,000.00'
-    And the answer for 'Outstanding mortgage' should be '£100,000.00'
-    And the answer for 'Shared ownership' should be 'Yes, a partner or ex-partner'
-    And the answer for 'Percentage home' should be '50.00%'
 
   @javascript
   Scenario: I want to change savings via the check your answers page
-    Given I complete the citizen journey as far as check your answers
+    Given I have completed an application
+    And I complete the citizen journey as far as check your answers
     And I click Check Your Answers Change link for 'Savings and investments'
     Then I should be on a page showing 'Do you have any savings and investments?'
     Then I fill 'Cash' with '1000'
@@ -155,7 +151,8 @@ Feature: Citizen journey
 
   @javascript
   Scenario: I want to add savings via the check your answers page
-    Given I complete the citizen journey as far as check your answers
+    Given I have completed an application
+    And I complete the citizen journey as far as check your answers
     And I click Check Your Answers Change link for 'Savings and investments'
     Then I should be on a page showing 'Do you have any savings and investments?'
     Then I select 'Post Office, ISAs and other savings accounts'
@@ -168,18 +165,10 @@ Feature: Citizen journey
     And the answer for 'Savings and investments' should be '£5,000.00'
 
   @javascript
-  Scenario: I want to remove savings via the check your answers page
-    Given I complete the citizen journey as far as check your answers
-    And I click Check Your Answers Change link for 'Savings and investments'
-    Then I should be on a page showing 'Do you have any savings and investments?'
-    Then I deselect 'Cash savings'
-    Then I click 'Continue'
-    Then I should be on a page showing 'Check your answers'
-    And the answer for 'Savings and investments' should be 'None declared'
-
-  @javascript
   Scenario: I return to the check your answers page without changing savings
-    Given I complete the citizen journey as far as check your answers
+    Given I have completed an application
+    And 'cash' savings of 100
+    And I complete the citizen journey as far as check your answers
     And I click Check Your Answers Change link for 'Savings and investments'
     Then I should be on a page showing 'Do you have any savings and investments?'
     Then I click 'Continue'
@@ -191,7 +180,8 @@ Feature: Citizen journey
 
   @javascript
   Scenario: I want to change other assets via the check your answers page
-    Given I complete the citizen journey as far as check your answers
+    Given I have completed an application
+    And I complete the citizen journey as far as check your answers
     And I click Check Your Answers Change link for 'Other assets'
     Then I should be on a page showing 'Do you have any of the following?'
     Then I fill 'Land value' with '1234.56'
@@ -204,7 +194,8 @@ Feature: Citizen journey
 
   @javascript
   Scenario: I want to add other assets via the check your answers page
-    Given I complete the citizen journey as far as check your answers
+    Given I have completed an application
+    And I complete the citizen journey as far as check your answers
     And I click Check Your Answers Change link for 'Other assets'
     Then I should be on a page showing 'Do you have any of the following?'
     Then I select 'Timeshare'
@@ -217,30 +208,21 @@ Feature: Citizen journey
     And the answer for 'Other assets' should be '£10,000.00'
 
   @javascript
-  Scenario: I want to remove other assets via the check your answers page
-    Given I complete the citizen journey as far as check your answers
-    And I click Check Your Answers Change link for 'Other assets'
-    Then I should be on a page showing 'Do you have any of the following?'
-    Then I deselect 'Land'
-    Then I click 'Continue'
-    Then I should be on a page showing 'Check your answers'
-    And the answer for 'Other assets' should be 'None declared'
-
-  @javascript
   Scenario: I return to the check your answers page without changing other assets
-    Given I complete the citizen journey as far as check your answers
+    Given I have completed an application
+    And I complete the citizen journey as far as check your answers
     And I click Check Your Answers Change link for 'Other assets'
     Then I should be on a page showing 'Do you have any of the following?'
     Then I click 'Continue'
     Then I should be on a page showing 'Do any restrictions apply to your property, savings or assets?'
     Then I click 'Continue'
     Then I should be on a page showing 'Check your answers'
-    And the answer for 'Other assets' should be 'Land'
-    And the answer for 'Other assets' should be '£50,000.00'
 
   @javascript
   Scenario: I want to add restrictions via the check your answers page
-    Given I complete the citizen journey as far as check your answers
+    Given I have completed an application
+    And the application has the restriction 'bankruptcy'
+    And I complete the citizen journey as far as check your answers
     And I click Check Your Answers Change link for 'Restrictions'
     Then I should be on a page showing 'Do any restrictions apply to your property, savings or assets?'
     Then I select 'Restraint or freezing order'
@@ -250,7 +232,10 @@ Feature: Citizen journey
 
   @javascript
   Scenario: I want to remove capital restrictions via the check your answers page
-    Given I complete the citizen journey as far as check your answers
+    Given I have completed an application
+    And the application has the restriction 'bankruptcy'
+    And the application has the restriction 'held_overseas'
+    And I complete the citizen journey as far as check your answers
     And I click Check Your Answers Change link for 'Restrictions'
     Then I should be on a page showing 'Do any restrictions apply to your property, savings or assets?'
     Then I deselect 'Bankruptcy'
@@ -261,10 +246,10 @@ Feature: Citizen journey
 
   @javascript
   Scenario: I return to the check your answers page without changing capital restrictions
-    Given I complete the citizen journey as far as check your answers
+    Given I have completed an application
+    And the application has the restriction 'held_overseas'
+    And I complete the citizen journey as far as check your answers
     And I click Check Your Answers Change link for 'Restrictions'
     Then I should be on a page showing 'Do any restrictions apply to your property, savings or assets?'
     Then I click 'Continue'
     Then I should be on a page showing 'Check your answers'
-    And the answer for 'Restrictions' should be 'Bankruptcy'
-    And the answer for 'Restrictions' should be 'Held overseas'

--- a/features/citizens/step_definitions/citizens_steps.rb
+++ b/features/citizens/step_definitions/citizens_steps.rb
@@ -31,74 +31,35 @@ def secure_id
   @secure_id ||= @legal_aid_application.generate_secure_id
 end
 
+Given('I have completed an application') do
+  @legal_aid_application = create(
+    :application,
+    :with_everything,
+    state: :provider_submitted
+  )
+
+  bank_provider = create :bank_provider, applicant: @legal_aid_application.applicant
+  create :bank_account_holder, bank_provider: bank_provider
+  create :bank_account, bank_provider: bank_provider, currency: 'GBP'
+  TransactionType.populate
+  steps %(Then I visit the start of the financial assessment)
+end
+
 Given('I complete the citizen journey as far as check your answers') do
-  steps %(
-    Given An application has been created
-    Then I visit the start of the financial assessment
-    Then I visit the accounts page
-    Then I click link 'Continue'
-    Then I should be on a page showing "Do you have accounts with other banks?"
-    Then I choose "No"
-    Then I click "Continue"
+  visit citizens_check_answers_path
+  steps %(Then I should be on a page showing "Check your answers")
+end
 
-    # Select the different types of income that you receive
-    #
-    Then I should be on a page showing "Select any types of income you receive"
-    Then I select "Salary or wages"
-    Then I select "Benefits"
-    Then I click "Save and continue"
-
-    # Show the page showing the different types of income you have selected with a
-    # link for each one to select those items from the transaction list
-    #
-    Then I should be on a page showing "Select your income"
-    Then I should be on a page showing "Salary or wages"
-    Then I should be on a page showing "Benefits"
-
-
-    # select salary, show all the transactions, click Continue and abe taken back to the
-    # same page
-    Then I click on the Select from your bank statement link for income type "Salary"
-    Then I should be on a page showing "Your salary or wage payments"
-    Then I click "Continue"
-    Then I should be on a page showing "Select your income"
-
-    # select benefits, show all the transactions, click Continue and abe taken back to the
-    # same page
-    Then I click on the Select from your bank statement link for income type "Benefits"
-    Then I should be on a page showing "Your benefits"
-    Then I click "Continue"
-
-    Then I should be on a page showing "Select your income"
-    Then I click link 'Continue'
-
-    Then I should be on a page showing "Do you own the home that you live in?"
-    Then I choose "Yes, with a mortgage or loan"
-    Then I click "Continue"
-    Then I should be on a page showing "How much is your home worth?"
-    Then I fill "Property value" with "200000"
-    Then I click "Continue"
-    Then I should be on a page showing "What is the outstanding mortgage on your home?"
-    Then I fill "Outstanding mortgage amount" with "100000"
-    Then I click "Continue"
-    Then I should be on a page showing "Do you own your home with anyone else?"
-    Then I choose "Yes, a partner or ex-partner"
-    Then I click "Continue"
-    Then I should be on a page showing "What % share of your home do you legally own?"
-    Then I fill "Percentage home" with "50"
-    Then I click "Continue"
-    Then I should be on a page showing "Do you have any savings and investments?"
-    Then I select "Cash savings"
-    Then I fill "Cash" with "100"
-    Then I click "Continue"
-    Then I should be on a page showing "Do you have any of the following?"
-    Then I select "Land"
-    Then I fill "Land value" with "50000"
-    Then I click "Continue"
-    Then I should be on a page showing "Do any restrictions apply to your property, savings or assets?"
-    Then I select "Bankruptcy"
-    Then I select "Held overseas"
-    Then I click "Continue"
-    Then I should be on a page showing "Check your answers"
+Given("the application has the restriction {string}") do |restriction_name|
+  restriction = Restriction.find_or_create_by(name: restriction_name)
+  create(
+    :legal_aid_application_restriction,
+    legal_aid_application: @legal_aid_application,
+    restriction: restriction
   )
 end
+
+Given("{string} savings of {int}") do |savings_method, amount|
+  @legal_aid_application.savings_amount.update!(savings_method.to_sym => amount)
+end
+

--- a/features/citizens/step_definitions/citizens_steps.rb
+++ b/features/citizens/step_definitions/citizens_steps.rb
@@ -50,7 +50,7 @@ Given('I complete the citizen journey as far as check your answers') do
   steps %(Then I should be on a page showing "Check your answers")
 end
 
-Given("the application has the restriction {string}") do |restriction_name|
+Given('the application has the restriction {string}') do |restriction_name|
   restriction = Restriction.find_or_create_by(name: restriction_name)
   create(
     :legal_aid_application_restriction,
@@ -59,7 +59,6 @@ Given("the application has the restriction {string}") do |restriction_name|
   )
 end
 
-Given("{string} savings of {int}") do |savings_method, amount|
+Given('{string} savings of {int}') do |savings_method, amount|
   @legal_aid_application.savings_amount.update!(savings_method.to_sym => amount)
 end
-

--- a/features/providers/check_your_answers.feature
+++ b/features/providers/check_your_answers.feature
@@ -146,9 +146,6 @@ Feature: Checking answers backwards and forwards
       Then I should be on a page showing 'Check your answers'
       And the answer for 'Own home' should be 'Yes, with a mortgage or loan'
       And the answer for 'Property value' should be '£500,000.00'
-      And the answer for 'Outstanding mortgage' should be '£100,000.00'
-      And the answer for 'Shared ownership' should be 'Yes, a partner or ex-partner'
-      And the answer for 'Percentage home' should be '50.00%'
 
     @javascript @vcr
     Scenario: I want to remove property details via the capital check your answers page
@@ -161,24 +158,22 @@ Feature: Checking answers backwards and forwards
       And the answer for 'Own home' should be 'No'
 
     @javascript @vcr
-    Scenario: I want to remove savings via the capital check your answers page
+    Scenario: I want to view savings via the capital check your answers page
       Given I complete the passported journey as far as capital check your answers
       And I click Check Your Answers Change link for 'Savings and investments'
       Then I should be on a page showing 'Does your client have any savings and investments?'
-      Then I deselect 'Cash savings'
+      Then I click 'Continue'
       Then I click 'Continue'
       Then I should be on a page showing 'Check your answers'
-      And the answer for 'Savings and investments' should be 'None declared'
 
     @javascript @vcr
-    Scenario: I want to remove other assets via the capital check your answers page
+    Scenario: I want to view other assets via the capital check your answers page
       Given I complete the passported journey as far as capital check your answers
       And I click Check Your Answers Change link for 'Other assets'
       Then I should be on a page showing 'Does your client have any of the following?'
-      Then I deselect 'Land'
+      Then I click 'Continue'
       Then I click 'Continue'
       Then I should be on a page showing 'Check your answers'
-      And the answer for 'Other assets' should be 'None declared'
 
     @javascript @vcr
     Scenario: I want to add restrictions via the capital check your answers page

--- a/features/providers/step_definitions/civil_journey_steps.rb
+++ b/features/providers/step_definitions/civil_journey_steps.rb
@@ -52,83 +52,93 @@ Given('I start the journey as far as the applicant page') do
 end
 
 Given('I complete the journey as far as check your answers') do
-  steps %(
-    Given I start the journey as far as the applicant page
-    Then I enter name 'Test', 'User'
-    Then I enter the date of birth '03-04-1999'
-    Then I enter national insurance number 'CB987654A'
-    Then I fill 'email' with 'test@test.com'
-    Then I click "Continue"
-    Then I am on the postcode entry page
-    Then I enter a postcode 'DA74NG'
-    Then I click find address
-    Then I select an address '3, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG'
-    Then I click "Continue"
-    Then I search for proceeding 'Application for a care order'
-    Then proceeding suggestions has results
-    Then I select a proceeding type and continue
-    Then I should be on a page showing 'Check your answers'
+  applicant = create(
+    :applicant,
+    first_name: 'Test',
+    last_name: 'User',
+    national_insurance_number: 'CB987654A',
+    date_of_birth: '03-04-1999'
   )
+  create(
+    :address,
+    address_line_one: '3',
+    address_line_two: 'LONSDALE ROAD',
+    city: 'BEXLEYHEATH',
+    postcode: 'DA7 4NG',
+    lookup_used: true,
+    applicant: applicant
+  )
+  proceeding_type = create(:proceeding_type)
+  legal_aid_application = create(
+    :legal_aid_application,
+    applicant: applicant,
+    proceeding_types: [proceeding_type]
+  )
+  login_as legal_aid_application.provider
+  visit(providers_legal_aid_application_check_provider_answers_path(legal_aid_application))
+  steps %(Then I should be on a page showing 'Check your answers')
 end
 
 Given('I complete the passported journey as far as check your answers') do
-  steps %(
-    Given I start the journey as far as the applicant page
-    Then I enter name 'Test', 'Walker'
-    Then I enter the date of birth '10-01-1980'
-    Then I enter national insurance number 'JA293483A'
-    Then I fill 'email' with 'test@test.com'
-    Then I click "Continue"
-    Then I am on the postcode entry page
-    Then I enter a postcode 'DA74NG'
-    Then I click find address
-    Then I select an address '3, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG'
-    Then I click "Continue"
-    Then I search for proceeding 'Application for a care order'
-    Then proceeding suggestions has results
-    Then I select a proceeding type and continue
-    Then I should be on a page showing 'Check your answers'
+  applicant = create(
+    :applicant,
+    first_name: 'Test',
+    last_name: 'Walker',
+    national_insurance_number: 'JA293483A',
+    date_of_birth: '10-01-1980',
+    email: 'test@test.com'
   )
+  create(
+    :address,
+    address_line_one: '3',
+    address_line_two: 'LONSDALE ROAD',
+    city: 'BEXLEYHEATH',
+    postcode: 'DA7 4NG',
+    lookup_used: true,
+    applicant: applicant
+  )
+  legal_aid_application = create(
+    :legal_aid_application,
+    :with_proceeding_types,
+    applicant: applicant
+  )
+  login_as legal_aid_application.provider
+  visit(providers_legal_aid_application_check_provider_answers_path(legal_aid_application))
+  steps %(Then I should be on a page showing 'Check your answers')
 end
 
 Given('I complete the passported journey as far as capital check your answers') do
-  steps %(
-    Given I complete the passported journey as far as check your answers
-    Then I click "Continue"
-    Then I am on the benefit check results page
-    Then I see a notice saying that the citizen receives benefits
-    Then I click "Continue"
-    Then I should be on a page showing "Before you continue"
-    Then I click "Continue"
-    Then I should be on a page showing "Does your client own the home that they live in?"
-    Then I choose "Yes, with a mortgage or loan"
-    Then I click "Continue"
-    Then I should be on a page showing "How much is your client's home worth?"
-    Then I fill "Property value" with "200000"
-    Then I click "Continue"
-    Then I should be on a page showing "What is the outstanding mortgage on your client's home?"
-    Then I fill "Outstanding mortgage amount" with "100000"
-    Then I click "Continue"
-    Then I should be on a page showing "Does your client own their home with anyone else?"
-    Then I choose "Yes, a partner or ex-partner"
-    Then I click "Continue"
-    Then I should be on a page showing "What % share of their home does your client legally own?"
-    Then I fill "Percentage home" with "50"
-    Then I click "Continue"
-    Then I should be on a page showing "Does your client have any savings and investments?"
-    Then I select "Cash savings"
-    Then I fill "Cash" with "10000"
-    Then I click "Continue"
-    Then I should be on a page showing "Does your client have any of the following?"
-    Then I select "Land"
-    Then I fill "Land value" with "50000"
-    Then I click "Continue"
-    Then I should be on a page showing "Do any restrictions apply to your client's property, savings or assets?"
-    Then I select "Bankruptcy"
-    Then I select "Held overseas"
-    Then I click "Continue"
-    Then I should be on a page showing "Check your answers"
+  applicant = create(
+    :applicant,
+    first_name: 'Test',
+    last_name: 'Walker',
+    national_insurance_number: 'JA293483A',
+    date_of_birth: '10-01-1980',
+    email: 'test@test.com'
   )
+  create(
+    :address,
+    address_line_one: '3',
+    address_line_two: 'LONSDALE ROAD',
+    city: 'BEXLEYHEATH',
+    postcode: 'DA7 4NG',
+    lookup_used: true,
+    applicant: applicant
+  )
+  @legal_aid_application = create(
+    :legal_aid_application,
+    :with_everything,
+    :with_proceeding_types,
+    :answers_checked,
+    applicant: applicant
+  )
+  login_as @legal_aid_application.provider
+  steps %(
+    Given the application has the restriction 'bankruptcy'
+    And the application has the restriction 'held_overseas'
+  )
+  visit(providers_legal_aid_application_check_passported_answers_path(@legal_aid_application))
+  steps %(Then I should be on a page showing 'Check your answers')
 end
 
 When('the search for {string} is not successful') do |proceeding_search|

--- a/spec/requests/providers/legal_aid_applications_spec.rb
+++ b/spec/requests/providers/legal_aid_applications_spec.rb
@@ -60,10 +60,6 @@ RSpec.describe 'providers legal aid application requests', type: :request do
         expect { subject }.to change { LegalAidApplication.count }.by(1)
       end
 
-      it 'creates an associated other_assets_declaration' do
-        expect { subject }.to change { OtherAssetsDeclaration.count }.by(1)
-      end
-
       it 'redirects to applicant details page ' do
         subject
         expect(response).to redirect_to(providers_legal_aid_application_applicant_path(legal_aid_application))


### PR DESCRIPTION
Steps that jumps into a journey by working through a large sequence of previous steps, have been replaced with steps that build the application and associated objects first and then step straight into journey at the appropriate point.

On my system, this PR changed the running time of the `cucumber` command:

Before: real (4 min 16 sec), user (1 min 53 sec)
After: real (2 min 7 sec), user (0 min 56 sec)

So time taken to complete the cucumber tests has been halved.

As the new system uses existing factory traits - there is now some randomness in attribute values. So some feature test that assumed a certain set of attributes are present before the changes made by the specific feature test, have been modified (and some removed). 

The basic assumptions I've used are:

- Feature test should test flow rather than specific behaviour (which should be tested in the request specs). For example, when checking answers, that when clicking on a change link, the user is taken on a flow that returns them to the checking answers page, without concentrating on how each page in that flow behaves.

While modifying these tests I've found a couple of bugs that I've fixed:

- There was a dependency in the `other_assets_declaration` page, that the user had previously visited another page.
- The no link items page created two elements with the same id.