### PR TITLE
AP-397 Fix back link on Provider page

### DIFF
--- a/app/views/providers/providers/show.html.erb
+++ b/app/views/providers/providers/show.html.erb
@@ -1,6 +1,5 @@
 <%= page_template(
       page_title: t('.page_title'),
-      back_link: { path: :back },
       column_width: 'full'
     ) do %>
   <table class="govuk-table">


### PR DESCRIPTION
[Jira AP-397](https://dsdmoj.atlassian.net/browse/AP397)

Back link behaved differently to other back links in app - and this caused a loop to develop if you clicked back repeatedly.

Fixed by removing page's special behaviour.