### PR TITLE
AP-398 Hide Menu button for Citizens

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -19,6 +19,12 @@ module ApplicationHelper
     t ".#{[*controller, lazy_t].join('.')}", *args
   end
 
+  def menu_button
+    button_tag(t('generic.menu'),
+               type: 'button', role: 'button', class: 'govuk-header__menu-button js-header-toggle',
+               aria: { controls: 'navigation', label: t('generic.toggle_navigation') })
+  end
+
   def back_link(text: t('generic.back'), path: back_path, method: nil)
     return unless path
 

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -18,7 +18,7 @@
     </div>
     <div class="govuk-header__content">
       <%= home_link %>
-      <button type="button" role="button" class="govuk-header__menu-button js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
+      <%= menu_button unless user_header_link.nil? %>
       <nav>
         <%= user_header_link %>
       </nav>

--- a/config/locales/en/generic.yml
+++ b/config/locales/en/generic.yml
@@ -14,6 +14,7 @@ en:
     home: Home
     information: Information
     'no': 'No'
+    menu: Menu
     none_declared: None declared
     remove: Remove
     save_and_continue: Save and continue
@@ -24,6 +25,7 @@ en:
     start_now: Start now
     submit: Submit
     total: Total
+    toggle_navigation: Show or hide Top Level Navigation
     undefined: Undefined
     upload_file: Attach a file
     view: View


### PR DESCRIPTION
[link to ticket](https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=233&projectKey=AP&modal=detail&selectedIssue=AP-398)

I created an application helper method for the menu button ( similar to the existing home_link)
This is because in that method, it returns nothing if there's nothing in the user_header_link
(which should only be visible for providers).

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
