### PR TITLE
Ap 426 remove council tax

### DIFF
--- a/app/models/transaction_type.rb
+++ b/app/models/transaction_type.rb
@@ -14,15 +14,15 @@ class TransactionType < ApplicationRecord
     ],
     debit: %i[
       rent_or_mortgage
-      council_tax
       child_care
       maintenance_out
       legal_aid
     ]
   }.freeze
 
-  scope :debits, -> { where(operation: :debit) }
-  scope :credits, -> { where(operation: :credit) }
+  scope :active, -> { where(archived_at: nil) }
+  scope :debits, -> { active.where(operation: :debit) }
+  scope :credits, -> { active.where(operation: :credit) }
 
   def self.populate
     populate_records
@@ -36,6 +36,8 @@ class TransactionType < ApplicationRecord
         transaction_type.update! sort_order: start_number
       end
     end
+
+    TransactionType.active.where.not(name: TransactionType::NAMES.values.flatten).update(archived_at: Time.now)
   end
 
   def label_name

--- a/app/views/citizens/identify_types_of_outgoings/show.html.erb
+++ b/app/views/citizens/identify_types_of_outgoings/show.html.erb
@@ -9,7 +9,8 @@
 
     <%= transaction_type_check_boxes(
           form: form,
-          transaction_types: TransactionType.debits
+          transaction_types: TransactionType.debits,
+          hints: { maintenance_out: t('transaction_types.hints.maintenance_out') }
         ) %>
 
     <%= next_action_buttons(form: form, continue_button_text: t('generic.save_and_continue')) %>

--- a/config/locales/en/transaction_types.yml
+++ b/config/locales/en/transaction_types.yml
@@ -4,7 +4,6 @@ en:
     names:
       benefits: Benefits
       child_care: Childcare costs to a nursery or registered provider
-      council_tax: Council Tax
       friends_or_family: Financial help from friends or family
       legal_aid: Existing legal aid contributions
       maintenance_in: Maintenance payments
@@ -17,7 +16,6 @@ en:
     page_titles:
       benefits: Your benefits
       child_care: Childcare costs to a nursery or registered provider
-      council_tax: Council Tax
       friends_or_family: Financial help from friends or family
       legal_aid: Existing legal aid contributions
       maintenance_in: Maintenance payments (for children or from an ex-partner)

--- a/config/locales/en/transaction_types.yml
+++ b/config/locales/en/transaction_types.yml
@@ -5,12 +5,12 @@ en:
       benefits: Benefits
       child_care: Childcare costs to a nursery or registered provider
       friends_or_family: Financial help from friends or family
-      legal_aid: Existing legal aid contributions
+      legal_aid: Payments towards legal aid in a criminal case
       maintenance_in: Maintenance payments
       maintenance_out: Maintenance payments
       pension: Pensions
       property_or_lodger: Income from a property or lodger
-      rent_or_mortgage: Rent or mortgage
+      rent_or_mortgage: Rent or mortgage payments
       salary: Salary or wages
       student_loan: Student loan or grant
     hints:

--- a/config/locales/en/transaction_types.yml
+++ b/config/locales/en/transaction_types.yml
@@ -7,12 +7,14 @@ en:
       friends_or_family: Financial help from friends or family
       legal_aid: Existing legal aid contributions
       maintenance_in: Maintenance payments
-      maintenance_out: Maintenance payments (for children or to an ex-partner)
+      maintenance_out: Maintenance payments
       pension: Pensions
       property_or_lodger: Income from a property or lodger
       rent_or_mortgage: Rent or mortgage
       salary: Salary or wages
       student_loan: Student loan or grant
+    hints:
+      maintenance_out: For example, for children or to an ex-partner
     page_titles:
       benefits: Your benefits
       child_care: Childcare costs to a nursery or registered provider

--- a/db/migrate/20190313174812_add_archived_at_to_transaction_types.rb
+++ b/db/migrate/20190313174812_add_archived_at_to_transaction_types.rb
@@ -1,0 +1,10 @@
+class AddArchivedAtToTransactionTypes < ActiveRecord::Migration[5.2]
+  def up
+    add_column(:transaction_types, :archived_at, :datetime)
+    TransactionType.populate
+  end
+
+  def down
+    remove_column(:transaction_types, :archived_at, :datetime)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_07_104610) do
+ActiveRecord::Schema.define(version: 2019_03_13_174812) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -366,6 +366,7 @@ ActiveRecord::Schema.define(version: 2019_03_07_104610) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "sort_order"
+    t.datetime "archived_at"
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"

--- a/spec/models/transaction_type_spec.rb
+++ b/spec/models/transaction_type_spec.rb
@@ -36,5 +36,20 @@ RSpec.describe TransactionType, type: :model do
         }.to change { described_class.count }.by(total)
       end
     end
+
+    context 'when a transaction type has been removed from the model' do
+      let!(:old_transaction_type) { create :transaction_type, name: :council_tax }
+      it 'sets the archived_at date in the database' do
+        subject
+        expect(described_class.find_by(name: 'council_tax').archived_at).to_not eq nil
+      end
+
+      it 'does not set the archived_at date in the database for active transaction types' do
+        subject
+        names.values.flatten.each do |transaction_name|
+          expect(described_class.find_by(name: transaction_name).archived_at).to eq nil
+        end
+      end
+    end
   end
 end

--- a/spec/requests/citizens/outgoings_summary_spec.rb
+++ b/spec/requests/citizens/outgoings_summary_spec.rb
@@ -4,13 +4,12 @@ RSpec.describe Citizens::OutgoingsSummaryController do
   let(:legal_aid_application) { create :legal_aid_application, :with_applicant }
   let(:secure_id) { legal_aid_application.generate_secure_id }
   let!(:rent_or_mortgage) { create :transaction_type, name: 'rent_or_mortgage', operation: 'debit' }
-  let!(:council_tax) { create :transaction_type, name: 'council_tax', operation: 'debit' }
   let!(:child_care) { create :transaction_type, name: 'child_care', operation: 'debit' }
   let!(:maintenance_out) { create :transaction_type, name: 'maintenance_out', operation: 'debit' }
   let!(:legal_aid) { create :transaction_type, name: 'legal_aid', operation: 'debit' }
 
   before do
-    legal_aid_application.transaction_types = [rent_or_mortgage, council_tax]
+    legal_aid_application.transaction_types = [rent_or_mortgage, child_care]
     get citizens_legal_aid_application_path(secure_id)
   end
 
@@ -22,14 +21,14 @@ RSpec.describe Citizens::OutgoingsSummaryController do
     end
 
     it 'displays a section for all transaction types linked to this application' do
-      [rent_or_mortgage, council_tax].pluck(:name).each do |name|
+      [rent_or_mortgage, child_care].pluck(:name).each do |name|
         legend = I18n.t("transaction_types.names.#{name}")
         expect(parsed_response_body.css("ol li h2#outgoing-type-#{name}").text).to match(/#{legend}/)
       end
     end
 
     it 'does not display a section for transaction types not linked to this application' do
-      [child_care, maintenance_out, legal_aid].pluck(:name) do |name|
+      [maintenance_out, legal_aid].pluck(:name) do |name|
         expect(parsed_response_body.css("ol li h2#outgoing-type-#{name}").size).to eq 0
       end
     end
@@ -42,7 +41,6 @@ RSpec.describe Citizens::OutgoingsSummaryController do
 
     context 'all transaction types selected' do
       before do
-        legal_aid_application.transaction_types << child_care
         legal_aid_application.transaction_types << maintenance_out
         legal_aid_application.transaction_types << legal_aid
       end


### PR DESCRIPTION
## What

[AP-426](https://dsdmoj.atlassian.net/browse/AP-426)

Changes to the 'identify types of outgoing' and 'outgoings summary' screens:

- The main change is the removal of council tax as a category (I've added an `archived_at` column to the `transaction_types` table in the database to facilitate this)

- There are also a couple of minor wording changes and the addition of a hint

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
