### PR TITLE
Add delay to container's probes

### DIFF
--- a/helm_deploy/apply-for-legal-aid-uat/templates/deployment.yaml
+++ b/helm_deploy/apply-for-legal-aid-uat/templates/deployment.yaml
@@ -223,10 +223,12 @@ spec:
             httpGet:
               path: /status.json
               port: http
+            initialDelaySeconds: 60
           readinessProbe:
             httpGet:
               path: /status.json
               port: http
+            initialDelaySeconds: 60
           resources:
 {{ toYaml .Values.resources | indent 12 }}
     {{- with .Values.nodeSelector }}

--- a/helm_deploy/apply-for-legal-aid/templates/deployment.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/deployment.yaml
@@ -226,10 +226,12 @@ spec:
             httpGet:
               path: /status.json
               port: http
+            initialDelaySeconds: 60
           readinessProbe:
             httpGet:
               path: /status.json
               port: http
+            initialDelaySeconds: 60
           resources:
 {{ toYaml .Values.resources | indent 12 }}
     {{- with .Values.nodeSelector }}


### PR DESCRIPTION
## What

Our main container was stuck in a `CrashLoopBackOff`. Adding a delay to the probes seems to fix the problem

## Checklist

Before you ask people to review this PR:

- [X] Tests and rubocop should be passing: `bundle exec rake`
- [X] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [X] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [X] The PR description should say what you changed and why, with a link to the JIRA story.
- [X] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [X] You should have checked that the commit messages say why the change was made.
