### PR TITLE
Add info about prometheus alerts

### DIFF
--- a/helm_deploy/prometheus-alerts.yaml
+++ b/helm_deploy/prometheus-alerts.yaml
@@ -1,0 +1,40 @@
+#
+# -- Prometheus Alerts --
+# Alerts are set manually for each namespace with this command:
+# kubectl apply -f helm_deploy/prometheus-alerts.yaml -n laa-apply-for-legalaid-production
+#
+# you can see current alerts of a namespace with the command:
+# kubectl describe prometheusrule -n laa-apply-for-legalaid-production
+#
+# CloudPlatform has set alerts to be forwarded to slack via the `severity` attribute.
+#
+#  severity                    | slack channel
+#  ---------------------------------------------------
+#  apply-for-legal-aid-prod    | #apply-alerts-prod
+#  apply-for-legal-aid-staging | #apply-alerts-staging
+#  apply-for-legal-aid-uat     | #apply-alerts-uat
+#
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  namespace: laa-apply-for-legalaid-production
+  labels:
+    role: alert-rules
+  name: prometheus-custom-rules-laa-apply-for-legal-aid
+spec:
+  groups:
+  - name: application-rules
+    rules:
+    - alert: Instance-Down
+      expr: absent(up{namespace="laa-apply-for-legalaid-production"}) == 1
+      for: 1m
+      labels:
+        severity: apply-for-legal-aid-prod
+    - alert: Quota-Exceeded
+      expr: 100 * kube_resourcequota{job="kube-state-metrics",type="used",namespace="laa-apply-for-legalaid-production"} / ignoring(instance, job, type) (kube_resourcequota{job="kube-state-metrics",type="hard",namespace="laa-apply-for-legalaid-production"} > 0) > 90
+      for: 1m
+      labels:
+        severity: apply-for-legal-aid-prod
+      annotations:
+        message: Namespace {{ $labels.namespace }} is using {{ printf "%0.0f" $value}}% of its {{ $labels.resource }} quota.
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubequotaexceeded


### PR DESCRIPTION
## What

[AP-74](https://dsdmoj.atlassian.net/browse/AP-74)

This PR is to add some explanation about Promotheus alerts.
But it doesn't change anything about our infrastructure because the alerts are to be set manually with  the `kubectl` command

## Checklist

Before you ask people to review this PR:

- [X] Tests and rubocop should be passing: `bundle exec rake`
- [X] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [X] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [X] The PR description should say what you changed and why, with a link to the JIRA story.
- [X] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [X] You should have checked that the commit messages say why the change was made.
