### PR TITLE
Fix typo in state machine

### DIFF
--- a/app/models/concerns/legal_aid_application_state_machine.rb
+++ b/app/models/concerns/legal_aid_application_state_machine.rb
@@ -52,7 +52,7 @@ module LegalAidApplicationStateMachine
         transitions from: :checking_citizen_answers, to: :means_completed,
                     after: -> do
                       CleanupCapitalAttributes.call(self)
-                      update!(provider_step: :details_latest_incident)
+                      update!(provider_step: :details_latest_incidents)
                     end
         transitions from: :checking_passported_answers, to: :means_completed
       end

--- a/spec/requests/citizens/check_answers_spec.rb
+++ b/spec/requests/citizens/check_answers_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe 'check your answers requests', type: :request do
 
     it 'should change the provider step to client_received_legal_helps' do
       subject
-      expect(legal_aid_application.reload.provider_step).to eq('details_latest_incident')
+      expect(legal_aid_application.reload.provider_step).to eq('details_latest_incidents')
     end
 
     it 'syncs the application' do


### PR DESCRIPTION
I added the letter 's' to details_latest_incident in the state machine. This resolves the issue where the provider can't go to the next step (start of the merits)

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
