### PR TITLE
fix duplicated NetworkPolicy & ServiceMonitor in UAT

### DIFF
--- a/helm_deploy/apply-for-legal-aid-uat/templates/network-policy.yaml
+++ b/helm_deploy/apply-for-legal-aid-uat/templates/network-policy.yaml
@@ -1,7 +1,7 @@
-kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
 metadata:
-  name: allow-prometheus-scraping
+  name: {{ .Release.Name }}
   namespace: {{ .Release.Namespace }}
 spec:
   podSelector:

--- a/helm_deploy/apply-for-legal-aid-uat/templates/service-monitor.yaml
+++ b/helm_deploy/apply-for-legal-aid-uat/templates/service-monitor.yaml
@@ -1,7 +1,7 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ .Chart.Name }}
+  name: {{ .Release.Name }}
   namespace: {{ .Release.Namespace }}
 spec:
   selector:


### PR DESCRIPTION
## What

When deploying to UAT, we get the error:
`Error: release apply-for-legal-aid-fix-typo failed: networkpolicies.networking.k8s.io "allow-prometheus-scraping" already exists`.
This is because it is trying to create the same resource simultaneously.
Giving it a dynamic name fixes the problem.

I'm also changing the name of the `ServiceMonitor` because it has the same problem.

## Checklist

Before you ask people to review this PR:

- [X] Tests and rubocop should be passing: `bundle exec rake`
- [X] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [X] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [X] The PR description should say what you changed and why, with a link to the JIRA story.
- [X] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [X] You should have checked that the commit messages say why the change was made.
