### PR TITLE
Rename links on income summary page

### DIFF
--- a/app/views/citizens/income_summary/index.html.erb
+++ b/app/views/citizens/income_summary/index.html.erb
@@ -7,7 +7,7 @@
               'income_type_item',
               name: transaction_type.name,
               number: index + 1,
-              link_text: t('.select'),
+              link_text: t(".select_#{transaction_type.name}"),
               bank_transactions: @bank_transactions[transaction_type]
             ) %>
       <% end %>

--- a/config/locales/en/citizens.yml
+++ b/config/locales/en/citizens.yml
@@ -75,7 +75,13 @@ en:
       index:
         add_all_income: Add all your income from your bank statements.
         page_heading: Select your income
-        select: Select from your bank statement
+        select_benefits: Add benefits payments
+        select_friends_or_family: Add payments from friends or family
+        select_maintenance_in: Add maintenance payments
+        select_pension: Add pension payments
+        select_property_or_lodger: Add income from property or lodger
+        select_salary: Add salary or wage payments
+        select_student_loan: Add student loan or grant payments
     information:
       show:
         heading_1: Give one-time access to your bank accounts

--- a/features/citizens/citizens.feature
+++ b/features/citizens/citizens.feature
@@ -39,14 +39,14 @@ Feature: Citizen journey
 
     # select salary, show all the transactions, click Continue and abe taken back to the
     # same page
-    Then I click on the Select from your bank statement link for income type "Salary"
+    Then I click on the add payments link for income type "Salary"
     Then I should be on a page showing "Your salary or wage payments"
     Then I click "Continue"
     Then I should be on a page showing "Select your income"
 
     # select benefits, show all the transactions, click Continue and abe taken back to the
     # same page
-    Then I click on the Select from your bank statement link for income type "Benefits"
+    Then I click on the add payments link for income type "Benefits"
     Then I should be on a page showing "Your benefits"
     Then I click "Continue"
 

--- a/features/providers/step_definitions/civil_journey_steps.rb
+++ b/features/providers/step_definitions/civil_journey_steps.rb
@@ -178,10 +178,10 @@ Given('I click Check Your Answers Change link for {string}') do |field_name|
   end
 end
 
-Then('I click on the Select from your bank statement link for income type {string}') do |income_type|
+Then('I click on the add payments link for income type {string}') do |income_type|
   income_type.downcase!
   within "#income-type-#{income_type}" do
-    click_link('Select from your bank statement')
+    click_link(I18n.t(".citizens.income_summary.index.select_#{income_type}"))
   end
 end
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-421)

The wording of the link to the transactions page is currently identical
for each transaction type. This will give each link a unique wording
related to the transaction type.

- add link wordings to locales file
- amend view to use new wordings
- minor changes to feature tests to accommodate these changes

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.