### PR TITLE
AP-399 Fix address field width for mobile devices

### DIFF
--- a/app/views/providers/address_selections/show.html.erb
+++ b/app/views/providers/address_selections/show.html.erb
@@ -1,15 +1,15 @@
-<%= page_template(
-      page_title: t('forms.address_selection.heading'),
-      template: :form
-    ) do %>
+<%= form_with(
+      model: @form,
+      scope: :address_selection,
+      url: providers_legal_aid_application_address_selection_path(@legal_aid_application),
+      method: :patch,
+      local: true
+    ) do |f| %>
 
-  <%= form_with(
-        model: @form,
-        scope: :address_selection,
-        url: providers_legal_aid_application_address_selection_path(@legal_aid_application),
-        method: :patch,
-        local: true
-      ) do |f| %>
+  <%= page_template(
+        page_title: t('forms.address_selection.heading'),
+        template: :form
+      ) do %>
 
     <div class="govuk-!-padding-bottom-8"></div>
 

--- a/app/views/providers/address_selections/show.html.erb
+++ b/app/views/providers/address_selections/show.html.erb
@@ -39,7 +39,7 @@
         <%= content_tag(:span, @form.errors[:address].first, class: ['govuk-error-message']) %>
       <% end %>
       <% input_error_class = @form.errors[:address].any? ? 'govuk-select--error' : '' %>
-      <%= f.select(:lookup_id, @addresses.collect { |a| [a.full_address, a.lookup_id] }, { include_blank: "#{@addresses.size} addresses found" }, class: "govuk-select #{input_error_class}", id: :address) %>
+      <%= f.select(:lookup_id, @addresses.collect { |a| [a.full_address, a.lookup_id] }, { include_blank: "#{@addresses.size} addresses found" }, class: "govuk-select govuk-!-width-full #{input_error_class}", id: :address) %>
     </div>
 
     <p><%= link_to t('.link_text'), providers_legal_aid_application_address_path(@legal_aid_application), class: 'govuk-link' %></p>

--- a/app/views/shared/page_templates/_form_page_template.html.erb
+++ b/app/views/shared/page_templates/_form_page_template.html.erb
@@ -1,14 +1,10 @@
 <%= render(partial: 'shared/forms/error_summary', locals: { model: show_errors_for }) if show_errors_for %>
 <fieldset class="govuk-fieldset">
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
-        <h1 class="govuk-fieldset__heading">
-          <%= content_for(:page_title) %>
-        </h1>
-      </legend>
-    </div>
-  </div>
+  <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+    <h1 class="govuk-fieldset__heading">
+      <%= content_for(:page_title) %>
+    </h1>
+  </legend>
   <div class="govuk-!-padding-bottom-2"></div>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-<%= column_width %>">


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-399)

Fixed issue where the address selection field extended beyond the window on mobile devices.
Remove unnecessary divs to match govuk styling requirements

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
