### PR TITLE
Add merits start page

### DIFF
--- a/app/controllers/providers/start_merits_assessments_controller.rb
+++ b/app/controllers/providers/start_merits_assessments_controller.rb
@@ -1,0 +1,17 @@
+module Providers
+  class StartMeritsAssessmentsController < ProviderBaseController
+    before_action :authorize_legal_aid_application
+
+    def show; end
+
+    def update
+      continue_or_draft
+    end
+
+    private
+
+    def authorize_legal_aid_application
+      authorize @legal_aid_application
+    end
+  end
+end

--- a/app/models/concerns/legal_aid_application_state_machine.rb
+++ b/app/models/concerns/legal_aid_application_state_machine.rb
@@ -52,7 +52,7 @@ module LegalAidApplicationStateMachine
         transitions from: :checking_citizen_answers, to: :means_completed,
                     after: -> do
                       CleanupCapitalAttributes.call(self)
-                      update!(provider_step: :details_latest_incidents)
+                      update!(provider_step: :start_merits_assessment)
                     end
         transitions from: :checking_passported_answers, to: :means_completed
       end

--- a/app/services/flow/flows/provider_capital.rb
+++ b/app/services/flow/flows/provider_capital.rb
@@ -48,7 +48,7 @@ module Flow
         },
         check_passported_answers: {
           path: ->(application) { urls.providers_legal_aid_application_check_passported_answers_path(application) },
-          forward: :details_latest_incidents
+          forward: :start_merits_assessments
         }
       }.freeze
     end

--- a/app/services/flow/flows/provider_merits.rb
+++ b/app/services/flow/flows/provider_merits.rb
@@ -2,6 +2,11 @@ module Flow
   module Flows
     class ProviderMerits < FlowSteps
       STEPS = {
+        start_merits_assessments: {
+          path: ->(application) { urls.providers_legal_aid_application_start_merits_assessment_path(application) },
+          forward: :details_latest_incidents,
+          check_answers: :check_merits_answers
+        },
         details_latest_incidents: {
           path: ->(application) { urls.providers_legal_aid_application_details_latest_incident_path(application) },
           forward: :respondents,

--- a/app/views/providers/start_merits_assessments/show.html.erb
+++ b/app/views/providers/start_merits_assessments/show.html.erb
@@ -1,0 +1,13 @@
+<%= page_template page_title: t('.h1-heading') do %>
+  <%= simple_format t('.do_merits_of_case_qualify') %>
+
+  <%= list_from_translation_path 'providers.start_merits_assessments.show.do_merits_of_case_qualify_list' %>
+
+  <div class="govuk-!-padding-bottom-4"></div>
+
+  <%= next_action_buttons_with_form(
+        url: providers_legal_aid_application_start_merits_assessment_path,
+        method: :patch,
+        show_draft: true
+      ) %>
+<% end %>

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -228,6 +228,20 @@ en:
           title: 'You can only use this service if your client:'
         use_ccms_para: Use CCMS for Section 8 orders, cases involving the Special Children's Act, and all other types of civil and criminal legal aid.
         use_ccms_upload_document: You cannot upload documents using this service. Use CCMS if you want to submit evidence to support your case.
+    start_merits_assessments:
+      show:
+        h1-heading: Provide details of the case
+        do_merits_of_case_qualify: |
+          We need to know if the merits of the case qualify for legal aid.
+
+          You'll need to enter:
+        do_merits_of_case_qualify_list:
+          list: |
+            details about the most recent incident
+            information about the respondent
+            a statement of case
+            the estimated costs of doing the work
+            the chances of a successful outcome
     statement_of_cases:
       show:
         bullet-1: What has happend so far.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -107,6 +107,7 @@ Rails.application.routes.draw do
         patch :continue
         patch :reset
       end
+      resource :start_merits_assessment, only: %i[show update]
     end
   end
 end

--- a/features/providers/civil_application_journey.feature
+++ b/features/providers/civil_application_journey.feature
@@ -379,6 +379,8 @@ Feature: Civil application journeys
     Then I click "Continue"
     Then I click "Continue"
     Then I click "Submit"
+    Then I should be on a page showing "Provide details of the case"
+    Then I click "Continue"
     Then I should be on a page showing "Enter details of the latest incident"
     Then I enter the occurred on date of 2 days ago
     Then I fill "Details" with "It happened"

--- a/spec/requests/citizens/check_answers_spec.rb
+++ b/spec/requests/citizens/check_answers_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe 'check your answers requests', type: :request do
 
     it 'should change the provider step to client_received_legal_helps' do
       subject
-      expect(legal_aid_application.reload.provider_step).to eq('details_latest_incidents')
+      expect(legal_aid_application.reload.provider_step).to eq('start_merits_assessment')
     end
 
     it 'syncs the application' do

--- a/spec/requests/providers/start_merits_assessments_spec.rb
+++ b/spec/requests/providers/start_merits_assessments_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+RSpec.describe Providers::StartMeritsAssessmentsController, type: :request do
+  let(:legal_aid_application) { create :legal_aid_application }
+  let(:provider) { legal_aid_application.provider }
+
+  describe 'GET /providers/applications/:id/start_merits_assessment' do
+    subject { get providers_legal_aid_application_start_merits_assessment_path(legal_aid_application) }
+
+    context 'when the provider is not authenticated' do
+      before { subject }
+      it_behaves_like 'a provider not authenticated'
+    end
+
+    context 'when the provider is authenticated' do
+      before do
+        login_as provider
+        subject
+      end
+
+      it 'returns http success' do
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include('Provide details of the case')
+      end
+    end
+  end
+
+  describe 'PATCH /providers/applications/:id/start_merits_assessment' do
+    subject { patch providers_legal_aid_application_start_merits_assessment_path(legal_aid_application), params: params.merge(submit_button) }
+    let(:params) { {} }
+
+    context 'when the provider is authenticated' do
+      before do
+        login_as provider
+        subject
+      end
+
+      context 'Continue button pressed' do
+        let(:submit_button) { { continue_button: 'Continue' } }
+        it 'redirects to next page' do
+          expect(subject).to redirect_to(providers_legal_aid_application_details_latest_incident_path)
+        end
+      end
+
+      context 'Save as draft button pressed' do
+        let(:submit_button) { { draft_button: 'Save as draft' } }
+
+        it "redirects provider to provider's applications page" do
+          subject
+          expect(response).to redirect_to(providers_legal_aid_applications_path)
+        end
+
+        it 'sets the application as draft' do
+          expect(legal_aid_application.reload).to be_draft
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-434)

Create screen at start of merits flow to inform provider of the
information they will need to enter.

- add controller and route
- add view
- amend flows
- add text to locale file
- create spec
- amend feature test

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
