### PR TITLE
Script to make SSHing into AWS containers easy

### DIFF
--- a/bin/kubessh.rb
+++ b/bin/kubessh.rb
@@ -1,0 +1,22 @@
+#!/usr/bin/env ruby
+
+if ARGV.empty?
+  puts "Specify one of the following pod names to SSH into. "
+  pipe = IO.popen("kubectl get pods")
+  results = pipe.readlines
+  pipe.close
+
+  pods = results.select{ |line| line !~ /-postgres/ }
+  pods.each do | line |
+    puts line
+  end
+  exit
+end
+
+command = "kubectl exec -c apply-for-legal-aid-uat --stdin --tty --namespace laa-apply-for-legalaid-uat #{ARGV[0]} -- /bin/bash"
+puts "Executing command: #{command}"
+puts " "
+system command
+
+
+


### PR DESCRIPTION
## Script to enable SSH to AWS containers running in the UAT namespace


Describe what you did and why.

## Checklist

A small script `bin/kubessh.rb` that will:
- list available pods if no parameter given
- ssh into that container if a pod name is given.

TODO:
- upgrade it so that it optionally takes a namespace parameter




Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
