### PR TITLE
FIX: failed deployment because of NetworkPolicy name

### DIFF
--- a/helm_deploy/apply-for-legal-aid/templates/network-policy.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/network-policy.yaml
@@ -1,7 +1,7 @@
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:
-  name: {{ .Release.Name }}
+  name: {{ .Release.Name }}-netpol
   namespace: {{ .Release.Namespace }}
 spec:
   podSelector:

--- a/helm_deploy/apply-for-legal-aid/templates/service-monitor.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/service-monitor.yaml
@@ -1,7 +1,7 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ .Release.Name }}
+  name: {{ .Release.Name }}-monitor
   namespace: {{ .Release.Namespace }}
 spec:
   selector:


### PR DESCRIPTION
The nightly staging deploy job failed with: 
`Error: UPGRADE FAILED: no NetworkPolicy with the name "apply-for-legal-aid" found`

I ran the command on my computer and reproduced the error.
I think there is a conflict of names between resources.
I tried using `{{ template "apply-for-legal-aid.fullname" . }}` like for the other resources (Deployment, Ingress, Secret, Service) but got the same error.
`{{ .Release.Name }}-netpol` works and it makes sense in my opinion (`netpol` is the shortname for `NetworkPolicy`. See `kubectl api-resources`).
I'm also changing the name of the service monitor resource to follow the same pattern.

I ran several times the staging deploy command from my computer and it now works.