### PR TITLE
Ap 386 remove transactions without reload

### DIFF
--- a/app/assets/javascripts/bank_transactions.es6
+++ b/app/assets/javascripts/bank_transactions.es6
@@ -1,0 +1,13 @@
+$(document).ready(function(){
+    document.body.addEventListener('ajax:success', function(event) {
+      var row = $(event.srcElement).parents("tr");
+      row.css("height",row.height()); //we fix the row height to stop it collapsing straight away
+      row.children("td").css("display","none"); //we remove the row innards to allow the row to collapse to zero height
+      row.slideUp(); //invoke collapse
+    })
+
+    document.body.addEventListener('ajax:error', function(event){
+      console.log("Remove failed for unknown reason.  Page reloading.") //placeholder for any error message
+      location.reload(); //reloads page - because if it has failed, the row might've been removed behind the scenes
+    });
+});

--- a/app/assets/javascripts/bank_transactions.es6
+++ b/app/assets/javascripts/bank_transactions.es6
@@ -5,6 +5,12 @@ $(document).ready(function(){
       row.css("height",row.height()); //we fix the row height to stop it collapsing straight away
       row.children("td").css("display","none"); //we remove the row innards to allow the row to collapse to zero height
       row.slideUp(); //invoke collapse
+
+      if (!row.siblings("tr").filter(function() {return $(this).css('display') !== 'none';}).length) { //there are no remaining siblings - all rows have been removed
+        row.parents("table").css("height",row.parents("table").height());
+        row.parents("table").children().css("display","none");
+        row.parents("table").slideUp();
+      }
     })
 
     document.body.addEventListener('ajax:error', function(event){

--- a/app/assets/javascripts/bank_transactions.es6
+++ b/app/assets/javascripts/bank_transactions.es6
@@ -1,5 +1,6 @@
 $(document).ready(function(){
     document.body.addEventListener('ajax:success', function(event) {
+      if (!event.srcElement.classList.contains('remote-remove-transaction')) return
       var row = $(event.srcElement).parents("tr");
       row.css("height",row.height()); //we fix the row height to stop it collapsing straight away
       row.children("td").css("display","none"); //we remove the row innards to allow the row to collapse to zero height
@@ -7,6 +8,7 @@ $(document).ready(function(){
     })
 
     document.body.addEventListener('ajax:error', function(event){
+      if (!event.srcElement.classList.contains('remote-remove-transaction')) return
       console.log("Remove failed for unknown reason.  Page reloading.") //placeholder for any error message
       location.reload(); //reloads page - because if it has failed, the row might've been removed behind the scenes
     });

--- a/app/controllers/citizens/bank_transactions_controller.rb
+++ b/app/controllers/citizens/bank_transactions_controller.rb
@@ -9,7 +9,7 @@ module Citizens
         format.html do
           redirect_back fallback_location: citizens_identify_types_of_income_path
         end
-        format.json { head :ok }
+        format.js { head :ok }
       end
     end
 

--- a/app/controllers/citizens/bank_transactions_controller.rb
+++ b/app/controllers/citizens/bank_transactions_controller.rb
@@ -3,7 +3,7 @@ module Citizens
     include ApplicationFromSession
     before_action :authenticate_applicant!
 
-    def remove_transation_type
+    def remove_transaction_type
       bank_transaction.update! transaction_type: nil
       respond_to do |format|
         format.html do

--- a/app/views/citizens/income_summary/_income_type_item.html.erb
+++ b/app/views/citizens/income_summary/_income_type_item.html.erb
@@ -37,7 +37,8 @@
                       t('.remove_link'),
                       remove_transation_type_citizens_bank_transaction_path(bank_transaction),
                       method: :patch,
-                      class: 'button-as-link'
+                      class: 'button-as-link',
+                      remote: true
                     ) %>
               </td>
             </tr>

--- a/app/views/citizens/income_summary/_income_type_item.html.erb
+++ b/app/views/citizens/income_summary/_income_type_item.html.erb
@@ -38,6 +38,7 @@
                       remove_transaction_type_citizens_bank_transaction_path(bank_transaction),
                       method: :patch,
                       class: 'button-as-link',
+                      form_class: 'remote-remove-transaction',
                       remote: true
                     ) %>
               </td>

--- a/app/views/citizens/income_summary/_income_type_item.html.erb
+++ b/app/views/citizens/income_summary/_income_type_item.html.erb
@@ -35,7 +35,7 @@
               <td class="govuk-table__cell">
                 <%= button_to(
                       t('.remove_link'),
-                      remove_transation_type_citizens_bank_transaction_path(bank_transaction),
+                      remove_transaction_type_citizens_bank_transaction_path(bank_transaction),
                       method: :patch,
                       class: 'button-as-link',
                       remote: true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -65,7 +65,7 @@ Rails.application.routes.draw do
       patch '/:transaction_type', to: 'outgoing_transactions#update'
     end
     resources :bank_transactions, only: [] do
-      patch 'remove_transation_type', on: :member
+      patch 'remove_transaction_type', on: :member
     end
   end
 

--- a/spec/requests/citizens/bank_transactions_spec.rb
+++ b/spec/requests/citizens/bank_transactions_spec.rb
@@ -10,11 +10,13 @@ RSpec.describe Citizens::BankTransactionsController, type: :request do
     let!(:transaction_type) { create :transaction_type }
     let(:bank_transaction) { create :bank_transaction, transaction_type: transaction_type }
     let(:headers) { {} }
+    let(:xhr) { false }
 
     subject do
       patch(
         remove_transaction_type_citizens_bank_transaction_path(bank_transaction),
-        headers: headers
+        headers: headers,
+        xhr: xhr
       )
     end
 
@@ -32,17 +34,17 @@ RSpec.describe Citizens::BankTransactionsController, type: :request do
       expect(response).to redirect_to(citizens_identify_types_of_income_path)
     end
 
-    context 'with JSON request' do
-      let(:headers) { { 'ACCEPT' => 'application/json' } }
+    context 'with ajax request' do
+      let(:xhr) { true }
 
       it 'removes the assocation with the transaction type' do
         subject
         expect(bank_transaction.reload.transaction_type).to be_nil
       end
 
-      it 'returns a json response' do
+      it 'returns a js response' do
         subject
-        expect(response.content_type).to eq('application/json')
+        expect(response.content_type).to eq('text/javascript')
       end
 
       it 'does not redirect on success' do

--- a/spec/requests/citizens/bank_transactions_spec.rb
+++ b/spec/requests/citizens/bank_transactions_spec.rb
@@ -6,14 +6,14 @@ RSpec.describe Citizens::BankTransactionsController, type: :request do
 
   before { get citizens_legal_aid_application_path(secure_id) }
 
-  describe 'PATCH /citizens/bank_transactions/:id/remove_transation_type' do
+  describe 'PATCH /citizens/bank_transactions/:id/remove_transaction_type' do
     let!(:transaction_type) { create :transaction_type }
     let(:bank_transaction) { create :bank_transaction, transaction_type: transaction_type }
     let(:headers) { {} }
 
     subject do
       patch(
-        remove_transation_type_citizens_bank_transaction_path(bank_transaction),
+        remove_transaction_type_citizens_bank_transaction_path(bank_transaction),
         headers: headers
       )
     end

--- a/spec/requests/citizens/income_summary_spec.rb
+++ b/spec/requests/citizens/income_summary_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Citizens::IncomeSummaryController do
       end
     end
 
-    context 'with assigned (by type) transations' do
+    context 'with assigned (by type) transactions' do
       let(:applicant) { create :applicant }
       let(:bank_provider) { create :bank_provider, applicant: applicant }
       let(:bank_account) { create :bank_account, bank_provider: bank_provider }


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-386)

Use javascript to allow a user to remove bank transactions that they have identified as income without refreshing the screen.

- Adds 'remote: true' to the partial that generates the 'Remove' link to so that an ajax request is send when clicked.
- Adds a javascript file to handle the ajax response and remove the appropriate row of the table.
- Corrects a typo in 'remove_transaction_type'.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
