### PR TITLE
AP-296 Check Your Answer is Read Only for submitted applicant

### DIFF
--- a/app/controllers/providers/application_confirmations_controller.rb
+++ b/app/controllers/providers/application_confirmations_controller.rb
@@ -1,6 +1,10 @@
 module Providers
   class ApplicationConfirmationsController < ProviderBaseController
-    def show
+    def show; end
+
+    private
+
+    def set_legal_aid_application
       legal_aid_application.update!(provider_step: :check_provider_answers)
     end
   end

--- a/app/controllers/providers/application_confirmations_controller.rb
+++ b/app/controllers/providers/application_confirmations_controller.rb
@@ -1,5 +1,7 @@
 module Providers
   class ApplicationConfirmationsController < ProviderBaseController
-    def show; end
+    def show
+      legal_aid_application.update!(provider_step: :check_provider_answers)
+    end
   end
 end

--- a/app/controllers/providers/check_provider_answers_controller.rb
+++ b/app/controllers/providers/check_provider_answers_controller.rb
@@ -3,8 +3,9 @@ module Providers
     def index
       @proceeding_types = legal_aid_application.proceeding_types
       @applicant = legal_aid_application.applicant
+      @read_only = legal_aid_application.read_only?
       @address = @applicant.addresses.first
-      legal_aid_application.check_your_answers! unless legal_aid_application.checking_answers?
+      legal_aid_application.check_your_answers! unless legal_aid_application.checking_answers? || legal_aid_application.provider_submitted?
     end
 
     def reset

--- a/app/helpers/check_answers_helper.rb
+++ b/app/helpers/check_answers_helper.rb
@@ -3,13 +3,14 @@ module CheckAnswersHelper
   #     <dl class="govuk-summary-list govuk-!-margin-bottom-9">
   #       <%= check_answer_link ..... %>
   #     </dl>
-  def check_answer_link(url:, question:, answer:, name:)
+  def check_answer_link(url:, question:, answer:, name:, read_only: false)
     render(
       'shared/check_answers/item',
       name: name,
       url: url,
       question: question,
-      answer: answer
+      answer: answer,
+      read_only: read_only
     )
   end
 

--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -120,6 +120,12 @@ class LegalAidApplication < ApplicationRecord # rubocop:disable Metrics/ClassLen
     other_assets_declaration.present? && other_assets_declaration.positive?
   end
 
+  # Refactored into its own method because there may be multiple conditions in the future
+  # which make it read only.
+  def read_only?
+    provider_submitted?
+  end
+
   private
 
   def applicant_updated_after_benefit_check_result_updated?

--- a/app/views/providers/check_provider_answers/index.html.erb
+++ b/app/views/providers/check_provider_answers/index.html.erb
@@ -1,11 +1,11 @@
 <%= page_template(
-      page_title: t('.title'),
+      page_title: @read_only ? '' : t('.title'),
       back_link: {
-        path: reset_providers_legal_aid_application_check_provider_answers_path,
-        method: :post
+        path: @read_only ? providers_legal_aid_applications_path : reset_providers_legal_aid_application_check_provider_answers_path,
+        text: @read_only ? t('generic.home') : t('generic.back'),
+        method: @read_only ? :get : :post
       }
     ) do %>
-
   <h2 class="govuk-heading-m"><%= t '.section_client.heading' %></h2>
 
   <dl class="govuk-summary-list govuk-!-margin-bottom-9">
@@ -14,42 +14,48 @@
           name: :first_name,
           url: providers_legal_aid_application_applicant_path(anchor: :first_name),
           question: t('.section_client.first_name'),
-          answer: @applicant.first_name
+          answer: @applicant.first_name,
+          read_only: @read_only
         ) %>
 
     <%= check_answer_link(
           name: :last_name,
           url: providers_legal_aid_application_applicant_path(anchor: :last_name),
           question: t('.section_client.last_name'),
-          answer: @applicant.last_name
+          answer: @applicant.last_name,
+          read_only: @read_only
         ) %>
 
     <%= check_answer_link(
           name: :date_of_birth,
           url: providers_legal_aid_application_applicant_path(anchor: :dob_day),
           question: t('.section_client.dob'),
-          answer: @applicant.date_of_birth
+          answer: @applicant.date_of_birth,
+          read_only: @read_only
         ) %>
 
     <%= check_answer_link(
           name: :national_insurance_number,
           url: providers_legal_aid_application_applicant_path(anchor: :national_insurance_number),
           question: t('.section_client.nino'),
-          answer: @applicant.national_insurance_number
+          answer: @applicant.national_insurance_number,
+          read_only: @read_only
         ) %>
 
     <%= check_answer_link(
           name: :email,
           url: providers_legal_aid_application_applicant_path(anchor: :email),
           question: t('.section_client.email'),
-          answer: @applicant.email
+          answer: @applicant.email,
+          read_only: @read_only
         ) %>
 
     <%= check_answer_link(
           name: :address,
           url: change_address_link(@applicant),
           question: t('.section_client.address'),
-          answer: address_with_line_breaks(@address)
+          answer: address_with_line_breaks(@address),
+          read_only: @read_only
         ) %>
   </dl>
 
@@ -61,15 +67,16 @@
         name: :proceeding_type,
         url: providers_legal_aid_application_proceedings_types_path(anchor: 'proceeding-search-input'.freeze),
         question: t('.section_proceeding.proceeding'),
-        answer: @proceeding_types.first.meaning
+        answer: @proceeding_types.first.meaning,
+        read_only: @read_only
       ) %>
 
   </dl>
-  <div class="govuk-!-padding-bottom-9"></div>
 
   <%= next_action_buttons_with_form(
-        url: continue_providers_legal_aid_application_check_provider_answers_path,
-        method: :patch,
-        show_draft: true
+        url: @read_only ? providers_legal_aid_applications_path : continue_providers_legal_aid_application_check_provider_answers_path,
+        method: @read_only ? :get : :patch,
+        show_draft: @read_only ? false : true,
+        continue_button_text: @read_only ? t('generic.back_to_your_applications') : t('generic.continue')
       ) %>
 <% end %>

--- a/app/views/providers/check_provider_answers/index.html.erb
+++ b/app/views/providers/check_provider_answers/index.html.erb
@@ -1,10 +1,19 @@
+<%
+  read_only_back_link = {
+    path: providers_legal_aid_applications_path,
+    text: t('generic.home'),
+    method: :get
+  }
+  back_link = {
+    path: reset_providers_legal_aid_application_check_provider_answers_path,
+    text: t('generic.back'),
+    method: :post
+  }
+%>
+
 <%= page_template(
       page_title: @read_only ? '' : t('.title'),
-      back_link: {
-        path: @read_only ? providers_legal_aid_applications_path : reset_providers_legal_aid_application_check_provider_answers_path,
-        text: @read_only ? t('generic.home') : t('generic.back'),
-        method: @read_only ? :get : :post
-      }
+      back_link: @read_only ? read_only_back_link : back_link
     ) do %>
   <h2 class="govuk-heading-m"><%= t '.section_client.heading' %></h2>
 
@@ -73,10 +82,21 @@
 
   </dl>
 
-  <%= next_action_buttons_with_form(
-        url: @read_only ? providers_legal_aid_applications_path : continue_providers_legal_aid_application_check_provider_answers_path,
-        method: @read_only ? :get : :patch,
-        show_draft: @read_only ? false : true,
-        continue_button_text: @read_only ? t('generic.back_to_your_applications') : t('generic.continue')
-      ) %>
+<%
+  next_button_options = {
+    url: continue_providers_legal_aid_application_check_provider_answers_path,
+    method: :patch,
+    show_draft: true,
+    continue_button_text: t('generic.continue')
+  }
+  read_only_next_button_options = {
+    url: providers_legal_aid_applications_path,
+    method: :get,
+    show_draft: false,
+    continue_button_text: t('generic.back_to_your_applications')
+  }
+%>
+<%= next_action_buttons_with_form(
+      @read_only ? read_only_next_button_options : next_button_options
+    ) %>
 <% end %>

--- a/app/views/shared/check_answers/_item.html.erb
+++ b/app/views/shared/check_answers/_item.html.erb
@@ -9,7 +9,7 @@
   </div>
   <% unless read_only %>
     <div class="govuk-summary-list__actions">
-      <%= link_to(url, class: 'govuk-link') do %>
+      <%= link_to(url, class: 'govuk-link change-link') do %>
         <%= t('generic.change') %><span class="govuk-visually-hidden"><%= question %></span>
       <% end %>
     </div>

--- a/app/views/shared/check_answers/_item.html.erb
+++ b/app/views/shared/check_answers/_item.html.erb
@@ -1,3 +1,5 @@
+<% read_only = local_assigns[:read_only] ? read_only : false %>
+
 <div class="govuk-summary-list__row normal-word-break" id="app-check-your-answers__<%= name %>">
   <div class="govuk-summary-list__key govuk-!-width-one-half">
     <%= question %>
@@ -5,9 +7,11 @@
   <div class="govuk-summary-list__value">
     <%= answer.present? ? answer : '-' %>
   </div>
-  <div class="govuk-summary-list__actions">
-    <%= link_to(url, class: 'govuk-link') do %>
-      <%= t('generic.change') %><span class="govuk-visually-hidden"><%= question %></span>
-    <% end %>
-  </div>
+  <% unless read_only %>
+    <div class="govuk-summary-list__actions">
+      <%= link_to(url, class: 'govuk-link') do %>
+        <%= t('generic.change') %><span class="govuk-visually-hidden"><%= question %></span>
+      <% end %>
+    </div>
+  <% end %>
 </div>

--- a/app/views/shared/page_templates/_default_page_template.html.erb
+++ b/app/views/shared/page_templates/_default_page_template.html.erb
@@ -8,7 +8,9 @@
         <%= content_for(:page_title) %>
       </h3>
     <% else %>
-      <h1 class="govuk-heading-xl"><%= content_for(:page_title) %></h1>
+      <% if content_for(:page_title) %>
+        <h1 class="govuk-heading-xl"><%= content_for(:page_title) %></h1>
+      <% end %>
     <% end %>
     <%= content %>
   </div>

--- a/app/views/shared/page_templates/_default_page_template.html.erb
+++ b/app/views/shared/page_templates/_default_page_template.html.erb
@@ -8,7 +8,7 @@
         <%= content_for(:page_title) %>
       </h3>
     <% else %>
-      <% if content_for(:page_title) %>
+      <% if content_for?(:page_title) %>
         <h1 class="govuk-heading-xl"><%= content_for(:page_title) %></h1>
       <% end %>
     <% end %>

--- a/config/locales/en/generic.yml
+++ b/config/locales/en/generic.yml
@@ -8,6 +8,7 @@ en:
     back: Back
     change: Change
     continue: Continue
+    back_to_your_applications: Back to your applications
     errors:
       problem_text: There is a problem
       yes_or_no: You must select either Yes or No

--- a/features/providers/check_your_answers.feature
+++ b/features/providers/check_your_answers.feature
@@ -205,3 +205,12 @@ Feature: Checking answers backwards and forwards
       Then I should be on a page showing 'Check your answers'
       And the answer for 'Restrictions' should be 'Bankruptcy'
       And the answer for 'Restrictions' should be 'Held overseas'
+
+    @javascript @vcr
+    Scenario: I submit the application and view the check_your_answers page
+      Given I complete the application and view the check your answers page
+      Then I am on the read only version of the check your answers page
+      Then I click 'Back to your applications'
+      Then I should be on a page showing 'Your legal aid applications'
+      Then I click view on an application
+      Then I am on the read only version of the check your answers page

--- a/features/providers/step_definitions/civil_journey_steps.rb
+++ b/features/providers/step_definitions/civil_journey_steps.rb
@@ -141,6 +141,34 @@ Given('I complete the passported journey as far as capital check your answers') 
   steps %(Then I should be on a page showing 'Check your answers')
 end
 
+Given('I complete the application and view the check your answers page') do
+  applicant = create(
+    :applicant,
+    first_name: 'Test',
+    last_name: 'User',
+    national_insurance_number: 'CB987654A',
+    date_of_birth: '03-04-1999'
+  )
+  create(
+    :address,
+    address_line_one: '3',
+    address_line_two: 'LONSDALE ROAD',
+    city: 'BEXLEYHEATH',
+    postcode: 'DA7 4NG',
+    lookup_used: true,
+    applicant: applicant
+  )
+  proceeding_type = create(:proceeding_type)
+  legal_aid_application = create(
+    :legal_aid_application,
+    applicant: applicant,
+    proceeding_types: [proceeding_type],
+    state: :provider_submitted
+  )
+  login_as legal_aid_application.provider
+  visit(providers_legal_aid_application_check_provider_answers_path(legal_aid_application))
+end
+
 When('the search for {string} is not successful') do |proceeding_search|
   fill_in('proceeding-search-input', with: proceeding_search)
 end
@@ -152,6 +180,10 @@ end
 And('I search for proceeding {string}') do |proceeding_search|
   fill_in('proceeding-search-input', with: proceeding_search)
   wait_for_ajax
+end
+
+And(/^I should not see "(.*?)"$/) do |arg1|
+  page.should have_no_content(arg1)
 end
 
 When(/^I click clear search$/) do
@@ -303,6 +335,20 @@ end
 Then('I am on the check your answers page for other assets') do
   expect(page).to have_content('Check your answers')
   expect(page).to have_content('Other assets')
+end
+
+Then('I am on the read only version of the check your answers page') do
+  expect(page).to have_content('Home')
+  expect(page).not_to have_content('change')
+  expect(page).not_to have_content('Continue')
+  expect(page).not_to have_content('Back')
+  expect(page).not_to have_content('Check your answers')
+end
+
+Then('I click view on an application') do
+  steps %(
+    And I click link "View"
+  )
 end
 
 # rubocop:disable Lint/Debugger

--- a/features/providers/step_definitions/civil_journey_steps.rb
+++ b/features/providers/step_definitions/civil_journey_steps.rb
@@ -339,10 +339,7 @@ end
 
 Then('I am on the read only version of the check your answers page') do
   expect(page).to have_content('Home')
-  expect(page).not_to have_content('change')
-  expect(page).not_to have_content('Continue')
-  expect(page).not_to have_content('Back')
-  expect(page).not_to have_content('Check your answers')
+  expect(page).not_to have_css('.change-link')
 end
 
 Then('I click view on an application') do

--- a/spec/models/legal_aid_application_spec.rb
+++ b/spec/models/legal_aid_application_spec.rb
@@ -241,6 +241,22 @@ RSpec.describe LegalAidApplication, type: :model do
     end
   end
 
+  describe '#read_only?' do
+    context 'provider application not submitted' do
+      let(:legal_aid_application) { create :legal_aid_application }
+      it 'returns false' do
+        expect(legal_aid_application.read_only?).to be false
+      end
+    end
+
+    context 'provider submitted' do
+      let(:legal_aid_application) { create :legal_aid_application, :provider_submitted }
+      it 'returns true' do
+        expect(legal_aid_application.read_only?).to eq(true)
+      end
+    end
+  end
+
   describe 'attributes are synced on answers_checked' do
     let(:legal_aid_application) { create :legal_aid_application, :with_everything, :without_own_home, state: :checking_answers }
     it 'passes application to keep in sync service' do

--- a/spec/requests/providers/check_provider_answers_spec.rb
+++ b/spec/requests/providers/check_provider_answers_spec.rb
@@ -57,6 +57,39 @@ RSpec.describe 'check your answers requests', type: :request do
         expect(unescaped_response_body).to include(address.city)
         expect(unescaped_response_body).to include(address.postcode)
       end
+
+      context 'when the application is in provider submitted state' do
+        before do
+          application.provider_submit!
+          get providers_legal_aid_application_check_provider_answers_path(application)
+        end
+
+        describe 'back link' do
+          it 'points to the applications page' do
+            expect(response.body).to have_back_link(providers_legal_aid_applications_path)
+          end
+        end
+
+        describe 'Back to your applications button' do
+          it 'has a back to your applications button' do
+            expect(button_value(html_body: response.body, attr: '#continue')).to eq('Back to your applications')
+          end
+        end
+
+        it 'displays the correct client details' do
+          applicant = application.applicant
+          address = applicant.addresses[0]
+
+          expect(unescaped_response_body).to include(applicant.first_name)
+          expect(unescaped_response_body).to include(applicant.last_name)
+          expect(unescaped_response_body).to include(applicant.date_of_birth.to_s)
+          expect(unescaped_response_body).to include(applicant.national_insurance_number)
+          expect(unescaped_response_body).to include(applicant.email_address)
+          expect(unescaped_response_body).to include(address.address_line_one)
+          expect(unescaped_response_body).to include(address.city)
+          expect(unescaped_response_body).to include(address.postcode)
+        end
+      end
     end
   end
 

--- a/spec/support/common_methods.rb
+++ b/spec/support/common_methods.rb
@@ -1,3 +1,7 @@
 def parsed_response_body(html = response.body)
   Nokogiri::HTML(html)
 end
+
+def button_value(html_body:, attr:)
+  parsed_response_body(html_body).css(attr)[0].attr('value')
+end


### PR DESCRIPTION
Ap 296 Check Your Answers page is Read Only for applications that are provider_submitted.

[Link to story](https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=233&projectKey=AP&modal=detail&selectedIssue=AP-296)

I created read_only variable in the controller which is true when the state is provider_submitted. This means that the check your answers page for provider can be read only on the condition that the application is submitted.

Also, When a provider clicks link 'View' on an application that has state provider_submitted, they'll be directed to the read only version of the check your answers page. 

Created a helper method for getting the html value of a button.

Updated the provider_step when the provider submits an application and is on the application_confirmation page, so when they view the application from the providers/applicants page, they'll end up on the check your answers and not the application_confirmation page. 

## Checklist

Before you ask people to review this PR:

- [X] Tests and rubocop should be passing: `bundle exec rake`
- [X] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [X] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [X] The PR description should say what you changed and why, with a link to the JIRA story.
- [X] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [X] You should have checked that the commit messages say why the change was made.
