### PR TITLE
AP-392 Merits-Assessment-Flow

### DIFF
--- a/app/services/flow/flows/provider_merits.rb
+++ b/app/services/flow/flows/provider_merits.rb
@@ -14,11 +14,11 @@ module Flow
         },
         respondents: {
           path: ->(application) { urls.providers_legal_aid_application_respondent_path(application) },
-          forward: :client_received_legal_helps,
+          forward: :statement_of_cases,
           check_answers: :check_merits_answers
         },
         client_received_legal_helps: {
-          path: ->(application) { urls.providers_legal_aid_application_client_received_legal_help_path(application) },
+          # path: ->(application) { urls.providers_legal_aid_application_client_received_legal_help_path(application) },
           forward: :proceedings_before_the_courts,
           check_answers: :check_merits_answers
         },

--- a/app/services/flow/flows/provider_merits.rb
+++ b/app/services/flow/flows/provider_merits.rb
@@ -18,7 +18,10 @@ module Flow
           check_answers: :check_merits_answers
         },
         client_received_legal_helps: {
-          # path: ->(application) { urls.providers_legal_aid_application_client_received_legal_help_path(application) },
+          # TODO: Should be removed when this page is being used.
+          # :nocov:
+          path: ->(application) { urls.providers_legal_aid_application_client_received_legal_help_path(application) },
+          # :nocov:
           forward: :proceedings_before_the_courts,
           check_answers: :check_merits_answers
         },

--- a/app/views/providers/check_merits_answers/show.html.erb
+++ b/app/views/providers/check_merits_answers/show.html.erb
@@ -53,26 +53,6 @@
     <%= t '.merits-heading' %>
   </h2>
 
-  <dl class="govuk-summary-list govuk-!-margin-bottom-9">
-    <%= check_answer_link(
-          name: :client_received_legal_help,
-          url: providers_legal_aid_application_client_received_legal_help_path,
-          question: t('.items.client_received_legal_help'),
-          answer: yes_no(@merits.client_received_legal_help)
-        ) %>
-  </dl>
-
-  <div class='govuk-body'><%= simple_format @merits.application_purpose %></div>
-
-  <dl class="govuk-summary-list govuk-!-margin-bottom-9">
-    <%= check_answer_link(
-          name: :proceedings_currently_before_court,
-          url: providers_legal_aid_application_proceedings_before_the_court_path,
-          question: t('.items.proceedings_currently_before_court'),
-          answer: yes_no(@merits.proceedings_before_the_court)
-        ) %>
-  </dl>
-
   <div class='govuk-body'><%= simple_format @merits.details_of_proceedings_before_the_court %></div>
 
   <dl class="govuk-summary-list govuk-!-margin-bottom-9">

--- a/features/providers/civil_application_journey.feature
+++ b/features/providers/civil_application_journey.feature
@@ -439,7 +439,6 @@ Feature: Civil application journeys
     Then I fill "Bail conditions set details" with "Foo bar"
     Then I click "Continue"
     And I should not see "Client received legal help"
-    And I should not see "Proceedings currently before court"
     Then I should be on a page showing "Statement of case"
     Then I fill "Statement" with "Statement of case"
     Then I upload a pdf file

--- a/features/providers/civil_application_journey.feature
+++ b/features/providers/civil_application_journey.feature
@@ -330,6 +330,40 @@ Feature: Civil application journeys
     Then I should be on the Applicant page
 
   @javascript @vcr
+  Scenario: Completes the merits application for applicant that does not receive benefits
+    Given I start the merits application
+    Then I should be on a page showing 'Enter details of the latest incident'
+    Then I enter the occurred on date of 2 days ago
+    Then I fill "Details" with "It happened"
+    Then I click "Continue"
+    Then I should be on a page showing "Respondent details"
+    Then I choose option "Respondent understands terms of court order True"
+    Then I choose option "Respondent warning letter sent True"
+    Then I choose option "Respondent police notified True"
+    Then I choose option "Respondent bail conditions set True"
+    Then I fill "Bail conditions set details" with "Foo bar"
+    Then I click "Continue"
+    And I should not see "Client received legal help"
+    And I should not see "Proceedings currently before court"
+    Then I should be on a page showing "Statement of case"
+    Then I fill "Statement" with "Statement of case"
+    Then I click "Continue"
+    Then I should be on a page showing "What are the estimated legal costs of doing the work?"
+    Then I fill "Estimated legal cost" with "1000"
+    Then I click "Continue"
+    Then I should be on a page showing "What are the prospects of success?"
+    Then I choose "Borderline"
+    Then I fill "Success prospect details" with "Prospects of success"
+    Then I click "Continue"
+    Then I should be on a page showing "Client declaration"
+    Then I click "Continue"
+    Then I should be on a page showing "Check your answers"
+    And the answer for 'Estimated legal costs' should be "£1,000.00"
+    Then I click "Accept and send application"
+    Then I should be on a page showing "End of provider-answered merits assessment questions for passported clients"
+
+
+  @javascript @vcr
   Scenario: Receives benefits and completes the application
     Given I complete the passported journey as far as check your answers
     Then I click "Continue"
@@ -404,14 +438,8 @@ Feature: Civil application journeys
     Then I choose option "Respondent bail conditions set True"
     Then I fill "Bail conditions set details" with "Foo bar"
     Then I click "Continue"
-    Then I should be on a page showing "Has your client received legal help for the matter?"
-    Then I choose "No"
-    Then I fill "Application purpose" with "because I can't afford it"
-    Then I click "Continue"
-    Then I should be on a page showing "Are the proceedings, for which funding is being sought, currently, before the court?"
-    Then I choose "Yes"
-    Then I fill "Details of proceedings before the court" with "The case is already in the court"
-    Then I click "Continue"
+    And I should not see "Client received legal help"
+    And I should not see "Proceedings currently before court"
     Then I should be on a page showing "Statement of case"
     Then I fill "Statement" with "Statement of case"
     Then I upload a pdf file
@@ -434,11 +462,6 @@ Feature: Civil application journeys
     Then I click "Continue"
     Then I should be on a page showing "Check your answers"
     And the answer for 'Statement of case' should be 'This is some test data for the statement of case'
-    Then I click Check Your Answers Change link for 'Client received legal help'
-    Then I choose "Yes"
-    Then I click "Continue"
-    Then I should be on a page showing "Check your answers"
-    And the answer for 'Client received legal help' should be 'Yes'
     Then I click Check Your Answers Change link for 'Estimated legal costs'
     Then I should be on a page showing "What are the estimated legal costs of doing the work?"
     Then I fill "Estimated legal cost" with "2345"

--- a/features/providers/step_definitions/civil_journey_steps.rb
+++ b/features/providers/step_definitions/civil_journey_steps.rb
@@ -51,6 +51,17 @@ Given('I start the journey as far as the applicant page') do
   )
 end
 
+Given('I start the merits application') do
+  @legal_aid_application = create(
+    :application,
+    :with_applicant,
+    :with_proceeding_types,
+    :means_completed
+  )
+  login_as @legal_aid_application.provider
+  visit(providers_legal_aid_application_details_latest_incident_path(@legal_aid_application))
+end
+
 Given('I complete the journey as far as check your answers') do
   applicant = create(
     :applicant,
@@ -208,6 +219,10 @@ Given('I click Check Your Answers Change link for {string}') do |field_name|
   within "#app-check-your-answers__#{field_name}" do
     click_link('Change')
   end
+end
+
+And(/^I should not see "(.*?)"$/) do |arg1|
+  page.should have_no_content(arg1)
 end
 
 Then('I click on the add payments link for income type {string}') do |income_type|

--- a/features/providers/step_definitions/civil_journey_steps.rb
+++ b/features/providers/step_definitions/civil_journey_steps.rb
@@ -221,10 +221,6 @@ Given('I click Check Your Answers Change link for {string}') do |field_name|
   end
 end
 
-And(/^I should not see "(.*?)"$/) do |arg1|
-  page.should have_no_content(arg1)
-end
-
 Then('I click on the add payments link for income type {string}') do |income_type|
   income_type.downcase!
   within "#income-type-#{income_type}" do

--- a/spec/requests/citizens/check_answers_spec.rb
+++ b/spec/requests/citizens/check_answers_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe 'check your answers requests', type: :request do
       expect(legal_aid_application.reload.means_completed?).to be_truthy
     end
 
-    it 'should change the provider step to client_received_legal_helps' do
+    it 'should change the provider step to start_merits_assessment' do
       subject
       expect(legal_aid_application.reload.provider_step).to eq('means_summaries')
     end

--- a/spec/requests/providers/check_merits_answers_spec.rb
+++ b/spec/requests/providers/check_merits_answers_spec.rb
@@ -36,8 +36,6 @@ RSpec.describe 'check merits answers requests', type: :request do
         expect(response.body).to include(I18n.translate('providers.check_merits_answers.show.items.warning_letter_sent'))
         expect(response.body).to include(I18n.translate('providers.check_merits_answers.show.items.police_notified'))
         expect(response.body).to include(I18n.translate('providers.check_merits_answers.show.items.bail_conditions_set'))
-        expect(response.body).to include(I18n.translate('providers.check_merits_answers.show.items.client_received_legal_help'))
-        expect(response.body).to include(I18n.translate('providers.check_merits_answers.show.items.proceedings_currently_before_court'))
         expect(response.body).to include(I18n.translate('providers.check_merits_answers.show.items.statement_of_case'))
         expect(response.body).to include(I18n.translate('providers.check_merits_answers.show.items.estimated_legal_costs'))
         expect(response.body).to include(I18n.translate('providers.check_merits_answers.show.items.prospects_of_success'))
@@ -49,8 +47,6 @@ RSpec.describe 'check merits answers requests', type: :request do
         expect(response.body).to have_change_link(:warning_letter_sent, providers_legal_aid_application_respondent_path(application, anchor: :warning_letter_sent))
         expect(response.body).to have_change_link(:police_notified, providers_legal_aid_application_respondent_path(application, anchor: :police_notified))
         expect(response.body).to have_change_link(:bail_conditions_set, providers_legal_aid_application_respondent_path(application, anchor: :bail_conditions_set))
-        expect(response.body).to have_change_link(:client_received_legal_help, providers_legal_aid_application_client_received_legal_help_path(application))
-        expect(response.body).to have_change_link(:proceedings_currently_before_court, providers_legal_aid_application_proceedings_before_the_court_path(application))
         expect(response.body).to have_change_link(:statement_of_case, providers_legal_aid_application_statement_of_case_path(application))
         expect(response.body).to have_change_link(:estimated_legal_costs, providers_legal_aid_application_estimated_legal_costs_path(application))
         expect(response.body).to have_change_link(:prospects_of_success, providers_legal_aid_application_success_prospects_path(application))
@@ -71,20 +67,6 @@ RSpec.describe 'check merits answers requests', type: :request do
 
       it 'displays the details of whether the bail conditions have been set' do
         expect(response.body).to include(application.respondent.bail_conditions_set_details)
-      end
-
-      context 'client has not received legal help' do
-        it 'displays whether the client has received legal help, with supplementary text' do
-          expect(response.body).to include('No')
-          expect(response.body).to include(application.merits_assessment.application_purpose)
-        end
-      end
-
-      context 'proceedings are before the court' do
-        it 'displays whether proceedings are currently before the court, with supplementary text' do
-          expect(response.body).to include 'Yes'
-          expect(response.body).to include(application.merits_assessment.details_of_proceedings_before_the_court)
-        end
       end
 
       it 'displays the statement of case' do

--- a/spec/requests/providers/respondents_spec.rb
+++ b/spec/requests/providers/respondents_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe Providers::RespondentsController, type: :request do
 
     it 'redirects to the next page' do
       subject
-      expect(response).to redirect_to(providers_legal_aid_application_statement_of_case_path)
+      expect(response).to redirect_to(flow_forward_path)
     end
 
     context 'when not authenticated' do

--- a/spec/requests/providers/respondents_spec.rb
+++ b/spec/requests/providers/respondents_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe Providers::RespondentsController, type: :request do
 
     it 'redirects to the next page' do
       subject
-      expect(response).to redirect_to(providers_legal_aid_application_client_received_legal_help_path)
+      expect(response).to redirect_to(providers_legal_aid_application_statement_of_case_path)
     end
 
     context 'when not authenticated' do


### PR DESCRIPTION
 Merits-Assessment-Flow is correct to current requirements

[Link to story](https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=233&projectKey=AP&modal=detail&selectedIssue=AP-392)

- Skip over two pages in the provider merits flow for passported and non-passported applications. This is because these pages are not needed now but could be used in the future for certain proceeding types. The pages are  proceedings_before_the_courts  and client_received_legal_helps.

- Remove the mentions of client has not received legal help and proceedings before the courts in the check merits answers page.

- Created tests for Merits-Assessment-Flow to check that the flow is correct and updated tests to not include proceedings_before_the_courts  and client_received_legal_helps pages.

## Checklist

Before you ask people to review this PR:

- [X] Tests and rubocop should be passing: `bundle exec rake`
- [X] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [X] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [X] The PR description should say what you changed and why, with a link to the JIRA story.
- [X] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [X] You should have checked that the commit messages say why the change was made.
