### PR TITLE
AP-413 Add styling to wrap text on provider profile

### DIFF
--- a/app/assets/stylesheets/helpers.scss
+++ b/app/assets/stylesheets/helpers.scss
@@ -6,3 +6,8 @@
 .hidden {
   display: none;
 }
+
+.wrap-text {
+  word-break: break-all;
+  word-break: break-word;
+}

--- a/app/views/providers/providers/show.html.erb
+++ b/app/views/providers/providers/show.html.erb
@@ -14,7 +14,7 @@
       </tr>
       <tr class="govuk-table__row">
         <th class="govuk-table__header" scope="row"><%= t('.role') %></th>
-        <td class="govuk-table__cell"><%= @provider.roles %></td>
+        <td class="govuk-table__cell wrap-text"><%= @provider.roles&.gsub(/,(?=\S)/, ', ') %></td>
       </tr>
       <tr class="govuk-table__row">
         <th class="govuk-table__header" scope="row"><%= t('.account_number') %></th>

--- a/spec/requests/providers/providers_spec.rb
+++ b/spec/requests/providers/providers_spec.rb
@@ -20,4 +20,11 @@ RSpec.describe Providers::ProvidersController, type: :request do
   it 'displays provider data' do
     expect(response.body).to include(provider.username)
   end
+
+  context 'with unspaced roles' do
+    let(:provider) { create :provider, roles: 'CWA,PUI' }
+    it 'displays roles with spaces' do
+      expect(response.body).to include('CWA, PUI')
+    end
+  end
 end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-413)

The 'role' field on the provider profile page can contain a long list of roles which does not currently wrap.

This commit adds a css class to force the text to wrap. It also changes the way the comma-separated list of roles is displayed by adding a space after each comma, which will prevent the list wrapping mid-word.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
