### PR TITLE
AP-463 Setup spectre client

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,6 +76,7 @@ group :development, :test do
   # Available in dev env for generators
   gem 'factory_bot_rails'
   gem 'rspec-rails', '~> 3.8'
+  gem 'spectre_client', git: 'git@github.com:wearefriday/spectre_client.git'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,10 @@
+GIT
+  remote: git@github.com:wearefriday/spectre_client.git
+  revision: c55325a3a13b9a80c20985a73caae512e3778c3f
+  specs:
+    spectre_client (0.1.87)
+      rest-client (~> 2.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -152,6 +159,8 @@ GEM
       ruby-saml (~> 1.7)
     diff-lcs (1.3)
     docile (1.3.1)
+    domain_name (0.5.20180417)
+      unf (>= 0.0.5, < 1.0.0)
     dotenv (2.7.1)
     dotenv-rails (2.7.1)
       dotenv (= 2.7.1)
@@ -187,6 +196,8 @@ GEM
     hashie (3.6.0)
     highline (2.0.0)
     html_tokenizer (0.0.7)
+    http-cookie (1.0.3)
+      domain_name (~> 0.5)
     httpi (2.4.4)
       rack
       socksify
@@ -242,6 +253,7 @@ GEM
     multi_xml (0.6.0)
     multipart-post (2.0.0)
     mustermann (1.0.3)
+    netrc (0.11.0)
     nio4r (2.3.1)
     nokogiri (1.10.1)
       mini_portile2 (~> 2.4.0)
@@ -322,6 +334,10 @@ GEM
     responders (2.4.1)
       actionpack (>= 4.2.0, < 6.0)
       railties (>= 4.2.0, < 6.0)
+    rest-client (2.0.2)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     rspec-core (3.8.0)
       rspec-support (~> 3.8.0)
     rspec-expectations (3.8.2)
@@ -433,6 +449,9 @@ GEM
       thread_safe (~> 0.1)
     uglifier (4.1.20)
       execjs (>= 0.3.0, < 3)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.5)
     unicode-display_width (1.5.0)
     vcr (4.0.0)
     warden (1.2.8)
@@ -508,6 +527,7 @@ DEPENDENCIES
   simple_command (~> 0.0.9)
   simplecov
   simplecov-rcov
+  spectre_client!
   spring
   spring-watcher-listen (~> 2.0.0)
   sprockets (>= 3.0.0)

--- a/features/providers/civil_application_journey.feature
+++ b/features/providers/civil_application_journey.feature
@@ -12,8 +12,11 @@ Feature: Civil application journeys
   Scenario: No results returned is seen on screen when invalid proceeding search entered
     Given I am logged in as a provider
     Given I visit the application service
+    Then I take a snapshot of "Service start"
     And I click link "Start"
+    Then I take a snapshot of "Start page"
     And I click "Start now"
+    Then I take a snapshot of "Applicant page"
     Then I should be on the Applicant page
     Then I enter name 'Test', 'User'
     Then I enter the date of birth '03-04-1999'

--- a/features/providers/step_definitions/spectre.rb
+++ b/features/providers/step_definitions/spectre.rb
@@ -1,0 +1,20 @@
+def spectre_client
+  @spectre_client ||= begin
+    app_name = Rails.application.engine_name
+    current_branch = `git symbolic-ref --short HEAD`.chomp
+    spectre_url = 'http://localhost:3100'
+    SpectreClient::Client.new(app_name, current_branch, spectre_url)
+  end
+end
+
+Then("I take a snapshot of {string}") do |name|
+  page.save_screenshot('image.png')
+  file_path = Rails.root.join('tmp/capybara/image.png')
+  spectre_client.submit_test({
+    name: name,
+    size: '100',
+    browser: 'selenium',
+    screenshot: File.new(file_path, 'rb'),
+    source_url: 'http://localhost:3000/'
+  })
+end

--- a/features/support/vcr.rb
+++ b/features/support/vcr.rb
@@ -16,6 +16,10 @@ VCR.configure do |vcr_config|
     uri = URI(request.uri)
     uri.to_s =~ /__identify__/ || uri.to_s =~ /127.0.0.1.*(session|shutdown)/
   end
+  vcr_config.ignore_request do |request|
+    uri = URI(request.uri)
+    uri.to_s =~ /localhost:3100/
+  end
   vcr_config.filter_sensitive_data('<GOVUK_NOTIFY_API_KEY>') { ENV['GOVUK_NOTIFY_API_KEY'] }
   vcr_config.filter_sensitive_data('<ORDNANACE_SURVEY_API_KEY>') { ENV['ORDNANACE_SURVEY_API_KEY'] }
   vcr_config.filter_sensitive_data('<BC_LSC_SERVICE_NAME>') { ENV['BC_LSC_SERVICE_NAME'] }


### PR DESCRIPTION
[Jira AP-463](https://dsdmoj.atlassian.net/browse/AP-463)

I've created this PR so that people can see how relatively easy it is to set up cucumber to output screen shots and send them to a [Spectre](https://github.com/wearefriday/spectre) server.

However, I think there are a number of issues with running this on CI:

- The [Spectre app is no longer actively supported](https://github.com/wearefriday/spectre/issues/50) - the main development seems to have stopped three years ago. Things like the auto-creation of an instance on Heroku no longer seem to work. The Ruby version it uses is current fixed at 2.3.3.
- _(see comment below)_ How do you generate the base line set of images. You could perhaps create a rake task that rolled the changes back to master, ran the cucumber tests, then reapplied the changes and ran them again - but things like migrations and gem changes would make that difficult.
- _(see comment below)_  I can't see a way to delete old "projects" from the current web interface. Without that, the store could become very large with a lot of redundant images being stored. We could modify the app - but that means maintaining another app.

I wonder if other people have found issues with using it continually which is why it's no longer actively maintained.

I think it would be quite a handy tool to run locally. It would be easy to set the spectre url and enable/skip the screen shots via an environment variable, and you could manage the stored screen shots manually.

In my testing I ran Spectre locally at `localhost:3100`, and used the following command to just run the cucumber feature that took the snap shots:

```bash
cucumber features/providers/civil_application_journey.feature:11
```

Here are a few screen shots of the results. Note that in the live app, clicking on an image opens it up and allows you to zoom in to a reasonable degree.

**A summary of the runs I've triggered**
Note that the app seems to automatically store just the last 5 runs (in effect the results of last five times that the cucumber command was run in this branch)
![localhost_3100_projects_laa_apply_for_legal_aid_application_suites_ap-463-spectre-trial-setup (1)](https://user-images.githubusercontent.com/213040/55074600-9cec0a80-5088-11e9-8380-80142bc3e950.png)


**Details of a particular run showing a difference**
In this run I removed a `t` from a I18n call in the view
![localhost_3100_projects_laa_apply_for_legal_aid_application_suites_ap-463-spectre-trial-setup_runs_10](https://user-images.githubusercontent.com/213040/55074548-7d54e200-5088-11e9-9323-6875599467af.png)

