### PR TITLE
AP-461 - HTML structure for tickboxes

### DIFF
--- a/app/views/shared/forms/_savings_and_investments_form.html.erb
+++ b/app/views/shared/forms/_savings_and_investments_form.html.erb
@@ -17,7 +17,7 @@
           ) %>
     </div>
   <% end %>
-    
+
   <%= next_action_buttons(
         show_draft: local_assigns.key?(:show_draft) ? show_draft : false,
         form: form

--- a/app/views/shared/forms/_savings_and_investments_form.html.erb
+++ b/app/views/shared/forms/_savings_and_investments_form.html.erb
@@ -5,17 +5,19 @@
               method: :patch,
               local: true) do |form| %>
 
-  <div class="govuk-checkboxes" data-module="checkboxes">
-    <%= render(
-          partial: 'shared/forms/revealing_checkbox/attribute',
-          collection: attributes,
-          locals: {
-            model: @form,
-            form: form
-          }
-        ) %>
-  </div>
-
+  <%= govuk_form_group do %>
+    <div class="govuk-checkboxes" data-module="checkboxes">
+      <%= render(
+            partial: 'shared/forms/revealing_checkbox/attribute',
+            collection: attributes,
+            locals: {
+              model: @form,
+              form: form
+            }
+          ) %>
+    </div>
+  <% end %>
+    
   <%= next_action_buttons(
         show_draft: local_assigns.key?(:show_draft) ? show_draft : false,
         form: form


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-XXX)

HTML structure for tickboxes.
The tickboxes in page _**savings_and_investment**_ were not wrapped in a form group.  

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
