### PR TITLE
AP-458 - Add padding between page titles and radio buttons

### DIFF
--- a/app/helpers/gov_uk_form_helper.rb
+++ b/app/helpers/gov_uk_form_helper.rb
@@ -30,16 +30,6 @@ module GovUkFormHelper
     )
   end
 
-  # `value_label_pairs should be a hash with the input values as keys, and the
-  # matching labels as values. For example: `{ yes: 'I would', no: 'I would not' }`
-  def govuk_radio_inputs(field_name, value_label_pairs)
-    render(
-      'shared/forms/radio_inputs',
-      field_name: field_name,
-      value_label_pairs: value_label_pairs
-    )
-  end
-
   def govuk_hint(text, args = {})
     content_tag :span, text, merge_with_class(args, 'govuk-hint')
   end

--- a/app/lib/govuk_elements_form_builder/form_builder.rb
+++ b/app/lib/govuk_elements_form_builder/form_builder.rb
@@ -105,7 +105,7 @@ module GovukElementsFormBuilder
       content_tag(:div, class: collection_radio_buttons_classes(attribute, options)) do
         fieldset(attribute, options) do
           classes = ['govuk-radios']
-          classes << 'govuk-radios--inline' if options[:inline]
+          classes << (options[:inline] ? 'govuk-radios--inline' : 'govuk-!-padding-top-2')
           concat_tags(
             hint_and_error_tags(attribute, options),
             content_tag(:div, class: classes.join(' ')) do

--- a/app/views/citizens/additional_accounts/index.html.erb
+++ b/app/views/citizens/additional_accounts/index.html.erb
@@ -1,15 +1,24 @@
-<%= page_template page_title: t('.field_set_header'), template: :form do %>
-  <%= form_with(url: citizens_additional_accounts_path, local: true) do |form| %>
+<%= page_template page_title: t('.field_set_header'), template: :basic do %>
+  <%= form_with(model: @form, url: citizens_additional_accounts_path, method: :post, local: true) do |form| %>
 
     <%= govuk_form_group(
           show_error_if: @error,
-          hint_id: :additional_account_hint,
           input: :additional_account
         ) do %>
-      <div class="govuk-!-padding-bottom-4"></div>
-      <%= govuk_hint t('.hint'), id: :additional_account_hint %>
+
       <%= govuk_error_message @error %>
-      <%= govuk_radio_inputs :additional_account, yes: t('generic.yes'), no: t('generic.no') %>
+
+      <%
+        options = [
+          { value: :yes, label: t('generic.yes') },
+          { value: :no,  label: t('generic.no') }
+        ]
+      %>
+
+      <%= govuk_fieldset_header(content_for(:page_title)) %>
+
+      <%= form.govuk_collection_radio_buttons :additional_account, options, :value, :label, error: @error %>
+
     <% end %>
 
     <%= next_action_buttons(form: form) %>

--- a/app/views/citizens/additional_accounts/new.html.erb
+++ b/app/views/citizens/additional_accounts/new.html.erb
@@ -1,15 +1,24 @@
-<%= page_template page_title: t('.field_set_header'), template: :form do %>
-  <%= form_with(url: citizens_additional_account_path(id: :update), method: :patch, local: true) do |form| %>
+<%= page_template page_title: t('.field_set_header'), template: :basic do %>
+  <%= form_with(model: @form, url: citizens_additional_account_path(id: :update), method: :patch, local: true) do |form| %>
 
     <%= govuk_form_group(
           show_error_if: @error,
-          hint_id: :has_offline_accounts_hint,
           input: :has_offline_accounts
         ) do %>
 
-      <%= govuk_hint t('.hint'), id: :has_offline_accounts_hint %>
-      <%= govuk_error_message(@error) %>
-      <%= govuk_radio_inputs :has_offline_accounts, yes: t('generic.yes'), no: t('generic.no') %>
+      <%= govuk_error_message @error %>
+
+      <%
+        options = [
+          { value: :yes, label: t('generic.yes') },
+          { value: :no,  label: t('generic.no') }
+        ]
+      %>
+
+      <%= govuk_fieldset_header(content_for(:page_title)) %>
+
+      <%= form.govuk_collection_radio_buttons :has_offline_accounts, options, :value, :label %>
+
     <% end %>
 
     <%= next_action_buttons(form: form) %>

--- a/app/views/citizens/shared_ownerships/show.html.erb
+++ b/app/views/citizens/shared_ownerships/show.html.erb
@@ -1,3 +1,3 @@
-<%= page_template page_title: t('.heading_1') do %>
+<%= page_template page_title: t('.heading_1'), template: :basic do %>
   <%= render 'shared/forms/shared_ownership_form', form_path: citizens_shared_ownership_path %>
 <% end %>

--- a/app/views/providers/client_received_legal_helps/show.html.erb
+++ b/app/views/providers/client_received_legal_helps/show.html.erb
@@ -15,7 +15,7 @@
 
       <%= govuk_error_message(form.object.errors[:client_received_legal_help].first) %>
 
-      <div class="govuk-radios govuk-radios--conditional" data-module="radios">
+      <div class="govuk-radios govuk-radios--conditional govuk-!-padding-top-2" data-module="radios">
         <%= form.govuk_radio_button(:client_received_legal_help, true) %>
         <%= form.govuk_radio_button(:client_received_legal_help, false,
                                     'data-aria-controls' => 'conditional-false',

--- a/app/views/providers/proceedings_before_the_courts/show.html.erb
+++ b/app/views/providers/proceedings_before_the_courts/show.html.erb
@@ -16,7 +16,7 @@
 
       <%= govuk_error_message(form.object.errors[:proceedings_before_the_court].first) %>
 
-      <div class="govuk-radios govuk-radios--conditional" data-module="radios">
+      <div class="govuk-radios govuk-radios--conditional govuk-!-padding-top-2" data-module="radios">
         <%= form.govuk_radio_button(:proceedings_before_the_court, true, 'data-aria-controls' => 'conditional-true') %>
         <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-true">
           <%= form.govuk_text_area :details_of_proceedings_before_the_court, rows: 5 %>

--- a/app/views/shared/forms/_shared_ownership_form.html.erb
+++ b/app/views/shared/forms/_shared_ownership_form.html.erb
@@ -7,8 +7,9 @@
   <% group_error_class = error ? 'govuk-form-group--error' : '' %>
   <% input_error_class = error ? 'govuk-input--error' : '' %>
   <%= content_tag(:span, error, class: 'govuk-error-message', id: 'shared_ownership') if error %>
+  <%= govuk_fieldset_header(content_for(:page_title)) %>
   <div class="govuk-form-group <%= group_error_class %>">
-    <div class="govuk-radios">
+    <div class="govuk-radios govuk-!-padding-top-2">
       <%= render partial: 'shared/forms/shared_ownership_form/shared_ownership_item',
                  collection: LegalAidApplication::SHARED_OWNERSHIP_REASONS, as: :reason,
                  locals: { form: form,
@@ -17,8 +18,6 @@
 
     </div>
   </div>
-
-  <div class="govuk-!-padding-bottom-6"></div>
 
   <%= next_action_buttons(
         show_draft: local_assigns.key?(:show_draft) ? show_draft : false,

--- a/app/views/shared/forms/_success_prospect_form.html.erb
+++ b/app/views/shared/forms/_success_prospect_form.html.erb
@@ -12,7 +12,7 @@
     <%= govuk_fieldset_header(content_for(:page_title)) %>
     <%= govuk_error_message(form.object.errors[:client_received_legal_help].first) %>
 
-    <div class="govuk-radios govuk-radios--conditional" data-module="radios">
+    <div class="govuk-radios govuk-radios--conditional govuk-!-padding-top-2" data-module="radios">
       <%= form.govuk_radio_button(:success_prospect, MeritsAssessment.prospect_likely_to_succeed, label: t('.likely')) %>
 
       <%= render partial: 'shared/forms/success_prospect/success_prospect_item',

--- a/config/locales/en/citizens.yml
+++ b/config/locales/en/citizens.yml
@@ -19,7 +19,6 @@ en:
     additional_accounts:
       index:
         field_set_header: Do you have accounts with other banks?
-        hint: Share details of any accounts you have with another bank or building society
       new:
         field_set_header: Do you have online access to your accounts with other banks?
         hint: If you do not, you will need to provide paper evidence for these accounts.

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -5,11 +5,13 @@ true_false: &true_false
 en:
   helpers:
     hint:
+      additional_account: Share details of any accounts you have with another bank or building society
       address_lookup:
         postcode: Postcode must be a valid UK postcode.
       applicant:
         email: We'll send your client a link to our service if they need to answer questions about their finances
         national_insurance_number: For example, 'QQ 12 34 56 C'
+      has_offline_accounts: If you do not, you will need to provide paper evidence for these accounts.
       legal_aid_application:
         outstanding_mortgage_amount:
           citizen: Check the statement from your mortgage provider or lender


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-458)

In order to improve the layout of pages that contain vertically-aligned radio buttons, amend form_builder so that padding is added above the radio buttons. The padding is not added if the radio buttons are inline.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
