### PR TITLE
AP-468 HostingEnvironment class to determine where we are running

### DIFF
--- a/config/initializers/hosting_environment.rb
+++ b/config/initializers/hosting_environment.rb
@@ -1,0 +1,1 @@
+require "#{Rails.root}/lib/hosting_environment.rb"

--- a/lib/hosting_environment.rb
+++ b/lib/hosting_environment.rb
@@ -1,0 +1,55 @@
+class HostingEnvironment
+  UAT_HOST_REGEX = /applyforlegalaid-uat/.freeze
+  STAGING_HOST_NAME = 'applyforlegalaid-staging.apps.cloud-platform-live-0.k8s.integration.dsd.io'.freeze
+  LIVE_HOST_NAME = 'applyforlegalaid.apps.cloud-platform-live-0.k8s.integration.dsd.io'.freeze
+
+  def self.env
+    if Rails.env.development?
+      :development
+    elsif Rails.env.test?
+      :test
+    elsif uat_host?
+      :uat
+    elsif staging_host?
+      :staging
+    elsif live_host?
+      :live
+    else
+      raise 'Unknown Host Environment'
+    end
+  end
+
+  def self.test?
+    Rails.env.test?
+  end
+
+  def self.development?
+    Rails.env.development?
+  end
+
+  def self.uat?
+    uat_host?
+  end
+
+  def self.staging?
+    staging_host?
+  end
+
+  def self.live?
+    live_host?
+  end
+
+  def self.uat_host?
+    UAT_HOST_REGEX.match?(ENV['HOST'])
+  end
+
+  def self.staging_host?
+    STAGING_HOST_NAME == ENV['HOST']
+  end
+
+  def self.live_host?
+    LIVE_HOST_NAME == ENV['HOST']
+  end
+
+  private_class_method :uat_host?, :staging_host?, :live_host?
+end

--- a/spec/lib/hosting_environment_spec.rb
+++ b/spec/lib/hosting_environment_spec.rb
@@ -1,0 +1,293 @@
+require 'rails_helper'
+
+RSpec.describe HostingEnvironment do
+  context 'testing environment' do
+    describe '.env' do
+      it 'returns :test' do
+        expect(HostingEnvironment.env).to eq :test
+      end
+    end
+
+    describe '.test?' do
+      it 'is true' do
+        expect(HostingEnvironment.test?).to be true
+      end
+    end
+
+    describe '.development?' do
+      it 'is false' do
+        expect(HostingEnvironment.development?).to be false
+      end
+    end
+
+    describe '.uat?' do
+      it 'is false' do
+        expect(HostingEnvironment.uat?).to be false
+      end
+    end
+
+    describe '.staging?' do
+      it 'is false' do
+        expect(HostingEnvironment.staging?).to be false
+      end
+    end
+
+    describe '.live?' do
+      it 'is false' do
+        expect(HostingEnvironment.live?).to be false
+      end
+    end
+  end
+
+  context 'development environment' do
+    before do
+      allow(Rails.env).to receive(:development?).and_return(true)
+      allow(Rails.env).to receive(:test?).and_return(false)
+    end
+    describe '.env' do
+      it 'returns :development' do
+        expect(HostingEnvironment.env).to eq :development
+      end
+    end
+
+    describe '.test?' do
+      it 'is false' do
+        expect(HostingEnvironment.test?).to be false
+      end
+    end
+
+    describe '.development?' do
+      it 'is true' do
+        expect(HostingEnvironment.development?).to be true
+      end
+    end
+
+    describe '.uat?' do
+      it 'is false' do
+        expect(HostingEnvironment.uat?).to be false
+      end
+    end
+
+    describe '.staging?' do
+      it 'is false' do
+        expect(HostingEnvironment.staging?).to be false
+      end
+    end
+
+    describe '.live?' do
+      it 'is false' do
+        expect(HostingEnvironment.live?).to be false
+      end
+    end
+  end
+
+  context 'uat environment' do
+    before do
+      allow(Rails.env).to receive(:test?).and_return(false)
+    end
+
+    describe '.env' do
+      it 'returns :uat' do
+        with_modified_env uat_env do
+          expect(HostingEnvironment.env).to eq :uat
+        end
+      end
+    end
+
+    describe '.test?' do
+      it 'is false' do
+        with_modified_env uat_env do
+          expect(HostingEnvironment.test?).to be false
+        end
+      end
+    end
+
+    describe '.development?' do
+      it 'is false' do
+        with_modified_env uat_env do
+          expect(HostingEnvironment.development?).to be false
+        end
+      end
+    end
+
+    describe '.uat?' do
+      it 'is true' do
+        with_modified_env uat_env do
+          expect(HostingEnvironment.uat?).to be true
+        end
+      end
+    end
+
+    describe '.staging?' do
+      it 'is false' do
+        with_modified_env uat_env do
+          expect(HostingEnvironment.staging?).to be false
+        end
+      end
+    end
+
+    describe '.live?' do
+      it 'is false' do
+        with_modified_env uat_env do
+          expect(HostingEnvironment.live?).to be false
+        end
+      end
+    end
+  end
+
+  context 'staging' do
+    before do
+      allow(Rails.env).to receive(:test?).and_return(false)
+    end
+
+    describe '.env' do
+      it 'returns :staging' do
+        with_modified_env staging_env do
+          expect(HostingEnvironment.env).to eq :staging
+        end
+      end
+    end
+
+    describe '.test?' do
+      it 'is false' do
+        with_modified_env staging_env do
+          expect(HostingEnvironment.test?).to be false
+        end
+      end
+    end
+
+    describe '.development?' do
+      it 'is false' do
+        with_modified_env staging_env do
+          expect(HostingEnvironment.development?).to be false
+        end
+      end
+    end
+
+    describe '.uat?' do
+      it 'is false' do
+        with_modified_env staging_env do
+          expect(HostingEnvironment.uat?).to be false
+        end
+      end
+    end
+
+    describe '.staging?' do
+      it 'is true' do
+        with_modified_env staging_env do
+          expect(HostingEnvironment.staging?).to be true
+        end
+      end
+    end
+
+    describe '.live?' do
+      it 'is false' do
+        with_modified_env staging_env do
+          expect(HostingEnvironment.live?).to be false
+        end
+      end
+    end
+  end
+
+  context 'live' do
+    before do
+      allow(Rails.env).to receive(:test?).and_return(false)
+    end
+
+    describe '.env' do
+      it 'returns :live' do
+        with_modified_env live_env do
+          expect(HostingEnvironment.env).to eq :live
+        end
+      end
+    end
+
+    describe '.test?' do
+      it 'is false' do
+        with_modified_env live_env do
+          expect(HostingEnvironment.test?).to be false
+        end
+      end
+    end
+
+    describe '.development?' do
+      it 'is false' do
+        with_modified_env live_env do
+          expect(HostingEnvironment.development?).to be false
+        end
+      end
+    end
+
+    describe '.uat?' do
+      it 'is false' do
+        with_modified_env live_env do
+          expect(HostingEnvironment.uat?).to be false
+        end
+      end
+    end
+
+    describe '.staging?' do
+      it 'is false' do
+        with_modified_env live_env do
+          expect(HostingEnvironment.staging?).to be false
+        end
+      end
+    end
+
+    describe '.live?' do
+      it 'is true' do
+        with_modified_env live_env do
+          expect(HostingEnvironment.live?).to be true
+        end
+      end
+    end
+  end
+
+  context 'unknown host name' do
+    before do
+      allow(Rails.env).to receive(:test?).and_return(false)
+    end
+
+    it 'raises an exception' do
+      with_modified_env unknown_env do
+        expect {
+          HostingEnvironment.env
+        }.to raise_error RuntimeError, 'Unknown Host Environment'
+      end
+    end
+
+    it 'returns false for all other methods' do
+      with_modified_env unknown_env do
+        expect(HostingEnvironment.test?).to be false
+        expect(HostingEnvironment.development?).to be false
+        expect(HostingEnvironment.staging?).to be false
+        expect(HostingEnvironment.live?).to be false
+        expect(HostingEnvironment.uat?).to be false
+      end
+    end
+  end
+
+  def uat_env
+    {
+      HOST: 'ap-296-submitted-applicant-rea-applyforlegalaid-uat.apps.cloud-platform-live-0.k8s.integration.dsd.io'
+    }
+  end
+
+  def staging_env
+    {
+      HOST: 'applyforlegalaid-staging.apps.cloud-platform-live-0.k8s.integration.dsd.io'
+    }
+  end
+
+  def live_env
+    {
+      HOST: 'applyforlegalaid.apps.cloud-platform-live-0.k8s.integration.dsd.io'
+    }
+  end
+
+  def unknown_env
+    {
+      HOST: 'unknown-env.apps.cloud-platform-live-0.k8s.integration.dsd.io'
+    }
+  end
+end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-468)

Created a HostingEnvironment class to determine which environment we're running in.

Within this class, there is the .env class method to return the environment name in symbol format.
Also, created methods: test?, development?, uat?, staging? and live? that return true if it's in said environment.
A runtime error is set off if the environment url is unknown.

Lastly, created tests.

## Checklist

Before you ask people to review this PR:

- [X] Tests and rubocop should be passing: `bundle exec rake`
- [X] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [X] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [X] The PR description should say what you changed and why, with a link to the JIRA story.
- [X] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [X] You should have checked that the commit messages say why the change was made.
