### PR TITLE
AP-489 Add path for :address and add unit tests to make sure all paths are always present

### DIFF
--- a/app/services/flow/flows/provider_start.rb
+++ b/app/services/flow/flows/provider_start.rb
@@ -22,6 +22,7 @@ module Flow
           check_answers: :check_provider_answers
         },
         addresses: {
+          path: ->(application) { urls.providers_legal_aid_application_address_path(application) },
           forward: :proceedings_types,
           check_answers: :check_provider_answers
         },

--- a/spec/helpers/providers_helper_spec.rb
+++ b/spec/helpers/providers_helper_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe ProvidersHelper, type: :helper do
+  let(:legal_aid_application) { create :legal_aid_application }
+  let(:provider_routes) do
+    Rails.application.routes.routes.select do |route|
+      route.defaults[:controller].to_s.split('/')[0] == 'providers' &&
+        route.parts.include?(:legal_aid_application_id)
+    end
+  end
+  let(:provider_controller_names) do
+    provider_routes.map { |route|
+      route.defaults[:controller].to_s.split('/')[1]
+    }.uniq
+  end
+
+  describe '#url_for_application' do
+    it 'should not crash' do
+      provider_controller_names.each do |controller_name|
+        legal_aid_application.provider_step = controller_name
+        url_for_application(legal_aid_application)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What

[AP-489](https://dsdmoj.atlassian.net/browse/AP-489)

Fixing this error: https://sentry.service.dsd.io/mojds/apply-for-legal-aid-staging/issues/35319/

This bug happens when you leave the application at the manual address input stage.
Then, when accessing the list of applications, it crashes because the path for the `:addresses` step is not defined

- Adding the path for the `:addresses` step
- Adding a unit test to make sure the paths of all steps are always present

## Checklist

Before you ask people to review this PR:

- [X] Tests and rubocop should be passing: `bundle exec rake`
- [X] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [X] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [X] The PR description should say what you changed and why, with a link to the JIRA story.
- [X] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [X] You should have checked that the commit messages say why the change was made.
