### PR TITLE
AP-471 Applicant Means Test Result

### DIFF
--- a/app/assets/stylesheets/govuk-mods.scss
+++ b/app/assets/stylesheets/govuk-mods.scss
@@ -3,3 +3,23 @@
   background-color: #b10e1e;
   box-shadow: 0 2px 0 #0b0c0c;
 }
+
+dl.govuk-list.inline-list {
+  dt:before {
+    content: "";
+    display: block;
+  }
+  dt, dd {
+    display: inline;
+  }
+  dd {
+    margin-inline-start: 0.1em;
+  }
+}
+
+.govuk-panel {
+  dl.govuk-list {
+    color: white;
+    font-size: inherit;
+  }
+}

--- a/app/controllers/citizens/means_test_results_controller.rb
+++ b/app/controllers/citizens/means_test_results_controller.rb
@@ -1,0 +1,8 @@
+module Citizens
+  class MeansTestResultsController < BaseController
+    include ApplicationFromSession
+    def show
+      @applicant = legal_aid_application.applicant
+    end
+  end
+end

--- a/app/views/citizens/means_test_results/show.html.erb
+++ b/app/views/citizens/means_test_results/show.html.erb
@@ -1,0 +1,25 @@
+<% content_for(:panel) do %>
+  <div class="govuk-panel govuk-panel--confirmation">
+    <h2 class="govuk-panel__title govuk-!-padding-top-4">
+      <%= t('.completed_financial_assessment') %>
+    </h2>
+    <div class="govuk-panel__body">
+      <dl class="govuk-list inline-list">
+        <dt><%= t('.name') %>:</dt>
+        <dd>
+          <strong><%= @applicant.full_name %></strong>
+        </dd>
+
+        <dt><%= t('.reference_number') %>:</dt>
+        <dd>
+          <strong><%= @legal_aid_application.application_ref %></strong>
+        </dd>
+      </dl>
+    </div>
+  </div>
+<% end %>
+
+<%= page_template page_title: t('.page-heading'), back_link: :none do %>
+  <p class="govuk-body"><%= t('.solicitors-actions') %></p>
+  <p class="govuk-body"><%= t('.what-happens-next') %></p>
+<% end %>

--- a/app/views/providers/application_confirmations/show.html.erb
+++ b/app/views/providers/application_confirmations/show.html.erb
@@ -13,15 +13,15 @@
 
 <%= page_template page_title: t('.secure_link_heading') do %>
 
-    <p class="govuk-body"><%= t '.secure_link_text' %></p>
-    <h3 class="govuk-heading-m"><%= t '.happen_next_heading' %></h3>
-    <p class="govuk-body">
-     <%= t '.happen_next_text' %>
-    </p>
-    <%= link_to(
-          t('.back_button'),
-          providers_legal_aid_applications_path,
-          class: 'govuk-button govuk-button',
-          id: 'continue'
-        ) %>
+  <p class="govuk-body"><%= t '.secure_link_text' %></p>
+  <h3 class="govuk-heading-m"><%= t '.happen_next_heading' %></h3>
+  <p class="govuk-body">
+   <%= t '.happen_next_text' %>
+  </p>
+  <%= link_to(
+        t('.back_button'),
+        providers_legal_aid_applications_path,
+        class: 'govuk-button govuk-button',
+        id: 'continue'
+      ) %>
 <% end %>

--- a/config/locales/en/citizens.yml
+++ b/config/locales/en/citizens.yml
@@ -111,6 +111,16 @@ en:
 '
         name: 'Name:'
         what_you_will_need: What you will need
+    means_test_results:
+      show:
+        page-heading: What happens next
+        completed_financial_assessment: You've completed your financial assessment
+        name: Name
+        reference_number: Reference number
+        solicitors-actions: Your solicitor will use your answers to help them complete your application.
+        what-happens-next: >
+          We'll confirm if you're eligible for legal aid once we've checked your financial
+          situation and the details of your case.
     other_assets:
       show:
         h1-heading: Do you have any of the following?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -68,6 +68,7 @@ Rails.application.routes.draw do
     resources :bank_transactions, only: [] do
       patch 'remove_transaction_type', on: :member
     end
+    resource :means_test_result, only: [:show]
   end
 
   namespace :providers do

--- a/spec/requests/citizens/means_test_results_spec.rb
+++ b/spec/requests/citizens/means_test_results_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe Citizens::MeansTestResultsController, type: :request do
+  let(:legal_aid_application) { create :legal_aid_application, :with_applicant }
+
+  before { get citizens_legal_aid_application_path(legal_aid_application.generate_secure_id) }
+
+  describe 'GET /citizens/means_test_result' do
+    subject { get citizens_means_test_result_path }
+
+    it 'renders successfully' do
+      subject
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end


### PR DESCRIPTION
[Jira AP-471](https://dsdmoj.atlassian.net/browse/AP-471)

Adds a new page to the Citizen journey - Means Test Result.

Prototype page is here: https://apply-for-legal-aid-prototype.herokuapp.com/apply_for_legal_aid_prototype/citizen_means_calculation

Currently this page stands alone as the page that leads to it is not yet in master. See https://github.com/ministryofjustice/laa-apply-for-legal-aid/pull/420