### PR TITLE
AP-467 Add pagination to providers home page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,9 @@ gem 'omniauth-oauth2' # Provide Oauth2 strategy framework
 # Authorization
 gem 'pundit'
 
+# Pagination
+gem 'pagy'
+
 # Gathers data from user browser - OS and Browser name
 gem 'browser'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -262,6 +262,7 @@ GEM
       oauth2 (~> 1.1)
       omniauth (~> 1.9)
     orm_adapter (0.5.0)
+    pagy (2.1.5)
     parallel (1.17.0)
     parser (2.6.2.1)
       ast (~> 2.4.0)
@@ -487,6 +488,7 @@ DEPENDENCIES
   nokogiri
   omniauth
   omniauth-oauth2
+  pagy
   pg
   prometheus_exporter
   pry-byebug

--- a/app/assets/stylesheets/pagination.scss
+++ b/app/assets/stylesheets/pagination.scss
@@ -1,8 +1,13 @@
 .pagination-container {
   nav, .page-info {
     display: inline;
+    line-height: 2em;
   }
   .page-info {
     float: right;
+  }
+
+  .pagy-nav .page {
+    padding: 0 10px;
   }
 }

--- a/app/assets/stylesheets/pagination.scss
+++ b/app/assets/stylesheets/pagination.scss
@@ -1,0 +1,8 @@
+.pagination-container {
+  nav, .page-info {
+    display: inline;
+  }
+  .page-info {
+    float: right;
+  }
+}

--- a/app/controllers/providers/legal_aid_applications_controller.rb
+++ b/app/controllers/providers/legal_aid_applications_controller.rb
@@ -1,11 +1,17 @@
 module Providers
   class LegalAidApplicationsController < ProviderBaseController
+    include Pagy::Backend
     legal_aid_application_not_required!
+
+    DEFAULT_PAGE_SIZE = 20
 
     # GET /provider/applications
     def index
-      # TODO: Add pagination at some point
-      @applications = current_provider.legal_aid_applications.latest.limit(10)
+      @pagy, @legal_aid_applications = pagy(
+        current_provider.legal_aid_applications.latest,
+        items: params.fetch(:page_size, DEFAULT_PAGE_SIZE),
+        size: [1, 1, 1, 1] # control of how many elements shown in page info
+      )
     end
 
     # POST /provider/applications

--- a/app/helpers/pagination_helper.rb
+++ b/app/helpers/pagination_helper.rb
@@ -1,0 +1,3 @@
+module PaginationHelper
+  include Pagy::Frontend
+end

--- a/app/views/providers/legal_aid_applications/_legal_aid_applications.html.erb
+++ b/app/views/providers/legal_aid_applications/_legal_aid_applications.html.erb
@@ -12,7 +12,7 @@
         </tr>
       </thead>
 
-      <% @applications.each do |application| %>
+      <% legal_aid_applications.each do |application| %>
         <tbody class="govuk-table__body">
           <tr class="govuk-table__row">
             <td class="govuk-table__cell"><%= application.applicant_full_name || t('generic.undefined') %></td>
@@ -26,5 +26,11 @@
         </tbody>
       <% end %>
     </table>
+    <% if local_assigns[:pagy] %>
+      <div class="govuk-body pagination-container">
+        <%== pagy_nav(pagy) if pagy.pages > 1 %>
+        <span class="page-info"><%== pagy_info(pagy)&.chomp %></span>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/app/views/providers/legal_aid_applications/index.html.erb
+++ b/app/views/providers/legal_aid_applications/index.html.erb
@@ -16,4 +16,4 @@
 
 <% end %>
 
-<%= render('legal_aid_applications') if @applications.present? %>
+<%= render 'legal_aid_applications', legal_aid_applications: @legal_aid_applications, pagy: @pagy %>

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -1,0 +1,1 @@
+Pagy::I18n.load(locale: 'en', filepath: Rails.root.join('config/locales/en/pagy.yml'))

--- a/config/locales/en/model_enum_translations.yml
+++ b/config/locales/en/model_enum_translations.yml
@@ -19,3 +19,4 @@ en:
         means_completed: Means test completed
         merits_completed: Merits test completed
         provider_submitted: Submitted by provider
+        provider_checking_citizens_means_answers: Means test completed

--- a/config/locales/en/pagy.yml
+++ b/config/locales/en/pagy.yml
@@ -11,7 +11,7 @@ en:
         zero: "No results"
         one: "Showing 1 of 1"
         other: "Showing %{count} of %{count} results"
-      multiple_pages: "Showing %{from}-%{to} of %{count} results"
+      multiple_pages: "Showing %{from} - %{to} of %{count} results"
       item_name:
         zero: "items"
         one: "item"

--- a/config/locales/en/pagy.yml
+++ b/config/locales/en/pagy.yml
@@ -1,0 +1,22 @@
+---
+# Note: this page is loaded via the pagy initializer, so restart server to see changes
+en:
+  pagy:
+    nav:
+      prev: "&laquo;&nbsp;Previous"
+      next: "Next&nbsp;&raquo;"
+      gap: "&hellip;"
+    info:
+      single_page:
+        zero: "No results"
+        one: "Showing 1 of 1"
+        other: "Showing %{count} of %{count} results"
+      multiple_pages: "Showing %{from}-%{to} of %{count} results"
+      item_name:
+        zero: "items"
+        one: "item"
+        other: "items"
+    compact: "Page %{page_input} of %{pages}"
+    items:
+      one: "Show %{items_input} item per page"
+      other: "Show %{items_input} items per page"

--- a/spec/requests/providers/legal_aid_applications_spec.rb
+++ b/spec/requests/providers/legal_aid_applications_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe 'providers legal aid application requests', type: :request do
 
           it 'show page information' do
             subject
-            expect(response.body).to include('Showing 1-3 of 5')
+            expect(response.body).to include('Showing 1 - 3 of 5')
           end
 
           it 'shows pagination' do

--- a/spec/requests/providers/legal_aid_applications_spec.rb
+++ b/spec/requests/providers/legal_aid_applications_spec.rb
@@ -2,10 +2,11 @@ require 'rails_helper'
 
 RSpec.describe 'providers legal aid application requests', type: :request do
   describe 'GET /providers/applications' do
-    let!(:legal_aid_application) { create :legal_aid_application }
+    let(:legal_aid_application) { create :legal_aid_application }
     let(:provider) { legal_aid_application.provider }
     let(:other_provider) { create(:provider) }
-    subject { get providers_legal_aid_applications_path }
+    let(:params) { {} }
+    subject { get providers_legal_aid_applications_path(params) }
 
     context 'when the provider is not authenticated' do
       before { subject }
@@ -15,14 +16,15 @@ RSpec.describe 'providers legal aid application requests', type: :request do
     context 'when the provider is authenticated' do
       before do
         login_as provider
-        subject
       end
 
       it 'returns http success' do
+        subject
         expect(response).to have_http_status(:ok)
       end
 
       it "includes a link to the legal aid application's default start path" do
+        subject
         expect(response.body).to include(providers_legal_aid_application_proceedings_types_path(legal_aid_application))
       end
 
@@ -30,7 +32,36 @@ RSpec.describe 'providers legal aid application requests', type: :request do
         let!(:legal_aid_application) { create :legal_aid_application, provider_step: :applicants }
 
         it "includes a link to the legal aid application's current path" do
+          subject
           expect(response.body).to include(providers_legal_aid_application_applicant_path(legal_aid_application))
+        end
+      end
+
+      context 'with pagination' do
+        it 'shows current total information' do
+          subject
+          expect(response.body).to include('Showing 1 of 1')
+        end
+
+        it 'does not show navigation links' do
+          subject
+          expect(parsed_response_body.css('.pagination-container nav')).to be_empty
+        end
+
+        context 'and more applications than page size' do
+          # Creating 4 additional means there are now 5 applications
+          let!(:additional_applications) { create_list :legal_aid_application, 4, provider: provider }
+          let(:params) { { page_size: 3 } }
+
+          it 'show page information' do
+            subject
+            expect(response.body).to include('Showing 1-3 of 5')
+          end
+
+          it 'shows pagination' do
+            subject
+            expect(parsed_response_body.css('.pagination-container nav').text).to match(/Previous\s+1\s+2\s+Next/)
+          end
         end
       end
     end
@@ -41,8 +72,8 @@ RSpec.describe 'providers legal aid application requests', type: :request do
         subject
       end
 
-      it 'has no current applications' do
-        expect(response.body).not_to include('Current applications')
+      it 'displays no results' do
+        expect(response.body).to include('No results')
       end
     end
   end


### PR DESCRIPTION
[Jira AP-467](https://dsdmoj.atlassian.net/browse/AP-467)

Adds pagination to the providers page using the [Pagy gem](https://github.com/ddnexus/pagy).

I've got everything working as defined in the spec, except on page 4 the links look like:

![pagy-start-sequence](https://user-images.githubusercontent.com/213040/55622474-322d8400-5798-11e9-9af8-325c611f48df.png)

After that (page 5 onwards) they match the spec:

![pagy-mid-sequence](https://user-images.githubusercontent.com/213040/55622497-45d8ea80-5798-11e9-9858-b1e0c65f60a7.png)
