### PR TITLE
AP-449 Add applicant error pages for when link does not work

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,12 @@
 class ApplicationController < ActionController::Base
   layout 'application'
   include Backable
+
+  rescue_from ActiveRecord::RecordNotFound, with: :page_not_found
+
+  private
+
+  def page_not_found
+    redirect_to error_path(:page_not_found)
+  end
 end

--- a/app/controllers/citizens/legal_aid_applications_controller.rb
+++ b/app/controllers/citizens/legal_aid_applications_controller.rb
@@ -15,15 +15,11 @@ module Citizens
     private
 
     def expired
-      render plain: 'Expired Page - missed url expiry in 7 day window'
+      redirect_to error_path(:link_expired)
     end
 
     def completed
-      render plain: 'Expired Page - completed the application'
-    end
-
-    def application_not_found
-      render plain: 'Authentication failed'
+      redirect_to error_path(:assessment_already_completed)
     end
 
     def start_applicant_flow

--- a/app/controllers/citizens/legal_aid_applications_controller.rb
+++ b/app/controllers/citizens/legal_aid_applications_controller.rb
@@ -8,10 +8,6 @@ module Citizens
       return completed if application.completed_at.present?
 
       start_applicant_flow
-    rescue ActiveRecord::RecordNotFound
-      # TODO: Handle failure
-      # TODO: Modify Devise failures to handle failure to authenticate with project styled pages
-      application_not_found
     end
 
     def index; end

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,0 +1,3 @@
+class ErrorsController < ApplicationController
+  def show; end
+end

--- a/app/views/errors/show.html.erb
+++ b/app/views/errors/show.html.erb
@@ -1,0 +1,3 @@
+<%= page_template page_title: t(".#{params[:id]}.page_title"), back_link: :none do %>
+  <%= render "errors/show/#{params[:id]}" %>
+<% end %>

--- a/app/views/errors/show/_assessment_already_completed.html.erb
+++ b/app/views/errors/show/_assessment_already_completed.html.erb
@@ -1,0 +1,1 @@
+<p class="govuk-body"><%= t('.contact_provider') %></p>

--- a/app/views/errors/show/_link_expired.html.erb
+++ b/app/views/errors/show/_link_expired.html.erb
@@ -1,0 +1,3 @@
+<p class="govuk-body">
+  <%= link_to t('.new_link_request'), '#' %>
+</p>

--- a/app/views/errors/show/_page_not_found.html.erb
+++ b/app/views/errors/show/_page_not_found.html.erb
@@ -1,0 +1,2 @@
+<p govuk-body><%= t('.web_address_incorrect') %></p>
+<p govuk-body><%= t('.web_address_copied') %></p>

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -10,3 +10,14 @@ en:
       not_saved:
         one: '1 error prohibited this %{resource} from being saved:'
         other: "%{count} errors prohibited this %{resource} from being saved:"
+    show:
+      assessment_already_completed:
+        page_title: You've already completed your financial assessment
+        contact_provider: Speak with your solicitor to check your application status.
+      link_expired:
+        page_title: This link has expired
+        new_link_request: Request a new link
+      page_not_found:
+        page_title: Page not found
+        web_address_incorrect: If you typed the web address, check it is correct.
+        web_address_copied: If you pasted the web address, check you copied the entire address.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,7 @@ Rails.application.routes.draw do
   resources :status, only: [:index]
   resource :contact, only: [:show]
   resources :feedback, only: %i[new create show]
+  resources :errors, only: [:show], path: :error
 
   namespace :admin do
     root to: 'legal_aid_applications#index'

--- a/spec/requests/citizens/legal_aid_applications_spec.rb
+++ b/spec/requests/citizens/legal_aid_applications_spec.rb
@@ -38,10 +38,8 @@ RSpec.describe 'citizen home requests', type: :request do
     context 'when applicant has completed the means assessment' do
       let(:completed_at) { Faker::Time.backward }
 
-      it 'redirects to expired page (completed_at is not null)' do
-        # TO DO when correct path is known
-        # expect(response).to redirect_to(path_to_be_determined)
-        expect(response.body).to include('Expired Page - completed the application')
+      it 'redirects to error page (assessment already completed)' do
+        expect(response).to redirect_to(error_path(:assessment_already_completed))
       end
     end
 
@@ -53,10 +51,8 @@ RSpec.describe 'citizen home requests', type: :request do
         )
       end
 
-      it 'redirects to expired page (7 days)' do
-        # TO DO when correct path is known
-        # expect(response).to redirect_to(path_to_be_determined)
-        expect(response.body).to include('Expired Page - missed url expiry in 7 day window')
+      it 'redirects to error page (link expired)' do
+        expect(response).to redirect_to(error_path(:link_expired))
       end
     end
   end

--- a/spec/requests/citizens/legal_aid_applications_spec.rb
+++ b/spec/requests/citizens/legal_aid_applications_spec.rb
@@ -30,12 +30,8 @@ RSpec.describe 'citizen home requests', type: :request do
     context 'when no matching legal aid application exists' do
       let(:secure_id) { SecureRandom.uuid }
 
-      it 'returns http success' do
-        expect(response).to have_http_status(:ok)
-      end
-
-      it 'show a landing page' do
-        expect(response.body).to match('Authentication failed')
+      it 'redirects to page not found error' do
+        expect(response).to redirect_to(error_path(:page_not_found))
       end
     end
 

--- a/spec/requests/citizens/restrictions_spec.rb
+++ b/spec/requests/citizens/restrictions_spec.rb
@@ -58,8 +58,9 @@ RSpec.describe 'citizen restrictions request', type: :request do
 
       # As I can not think of a "normal" behaviour that can cause an error.
       # Error handling falls back to standard error handling.
-      it 'raises error' do
-        expect { subject }.to raise_error(ActiveRecord::RecordNotFound)
+      it 'displays error' do
+        subject
+        expect(response).to redirect_to(error_path(:page_not_found))
       end
     end
   end

--- a/spec/requests/errors_spec.rb
+++ b/spec/requests/errors_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.describe ErrorsController, type: :request do
+  describe 'GET /error/page_not_found' do
+    subject { get error_path(:page_not_found) }
+
+    before { subject }
+
+    it 'renders successfully' do
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'displays the correct header' do
+      expect(response.body).to include('Page not found')
+    end
+  end
+
+  describe 'GET /error/assessment_already_completed' do
+    subject { get error_path(:assessment_already_completed) }
+
+    before { subject }
+
+    it 'renders successfully' do
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'displays the correct header' do
+      expect(response.body).to match(/already completed[\w\s]+financial assessment/)
+    end
+  end
+
+  describe 'GET /error/link_expired' do
+    subject { get error_path(:link_expired) }
+
+    before { subject }
+
+    it 'renders successfully' do
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'displays the correct header' do
+      expect(response.body).to match('link has expired')
+    end
+  end
+end

--- a/spec/requests/providers/restrictions_spec.rb
+++ b/spec/requests/providers/restrictions_spec.rb
@@ -79,8 +79,9 @@ RSpec.describe 'citizen restrictions request', type: :request do
 
           # As I can not think of a "normal" behaviour that can cause an error.
           # Error handling falls back to standard error handling.
-          it 'raises error' do
-            expect { subject }.to raise_error(ActiveRecord::RecordNotFound)
+          it 'displays error' do
+            subject
+            expect(response).to redirect_to(error_path(:page_not_found))
           end
         end
 


### PR DESCRIPTION
[Jira AP-449](https://dsdmoj.atlassian.net/browse/AP-449)

Adds an **errors** controller and uses it to display errors for "page not found", "assessment already completed" and "link expired".

Then uses error pages as endpoints for errors at start of Citizen journey.