### PR TITLE
AP-457 Fix issue with wrong transaction types being deleted by update

### DIFF
--- a/app/controllers/citizens/identify_types_of_incomes_controller.rb
+++ b/app/controllers/citizens/identify_types_of_incomes_controller.rb
@@ -8,7 +8,8 @@ module Citizens
     end
 
     def update
-      legal_aid_application.update!(legal_aid_application_params)
+      legal_aid_application.transaction_types.credits.destroy_all
+      legal_aid_application.transaction_types << transaction_types
       go_forward
     end
 
@@ -16,6 +17,10 @@ module Citizens
 
     def legal_aid_application_params
       params.require(:legal_aid_application).permit(transaction_type_ids: [])
+    end
+
+    def transaction_types
+      TransactionType.credits.where(id: legal_aid_application_params[:transaction_type_ids])
     end
   end
 end

--- a/app/controllers/citizens/identify_types_of_incomes_controller.rb
+++ b/app/controllers/citizens/identify_types_of_incomes_controller.rb
@@ -8,7 +8,7 @@ module Citizens
     end
 
     def update
-      legal_aid_application.transaction_types.credits.destroy_all
+      legal_aid_application.legal_aid_application_transaction_types.credits.destroy_all
       legal_aid_application.transaction_types << transaction_types
       go_forward
     end

--- a/app/controllers/citizens/identify_types_of_outgoings_controller.rb
+++ b/app/controllers/citizens/identify_types_of_outgoings_controller.rb
@@ -8,7 +8,8 @@ module Citizens
     end
 
     def update
-      legal_aid_application.update!(legal_aid_application_params)
+      legal_aid_application.transaction_types.debits.destroy_all
+      legal_aid_application.transaction_types << transaction_types
       go_forward
     end
 
@@ -16,6 +17,10 @@ module Citizens
 
     def legal_aid_application_params
       params.require(:legal_aid_application).permit(transaction_type_ids: [])
+    end
+
+    def transaction_types
+      TransactionType.debits.where(id: legal_aid_application_params[:transaction_type_ids])
     end
   end
 end

--- a/app/controllers/citizens/identify_types_of_outgoings_controller.rb
+++ b/app/controllers/citizens/identify_types_of_outgoings_controller.rb
@@ -8,7 +8,7 @@ module Citizens
     end
 
     def update
-      legal_aid_application.transaction_types.debits.destroy_all
+      legal_aid_application.legal_aid_application_transaction_types.debits.destroy_all
       legal_aid_application.transaction_types << transaction_types
       go_forward
     end

--- a/app/models/legal_aid_application_transaction_type.rb
+++ b/app/models/legal_aid_application_transaction_type.rb
@@ -1,4 +1,7 @@
 class LegalAidApplicationTransactionType < ApplicationRecord
   belongs_to :legal_aid_application
   belongs_to :transaction_type
+
+  scope :credits, -> { includes(:transaction_type).where(transaction_types: { operation: :credit }) }
+  scope :debits, -> { includes(:transaction_type).where(transaction_types: { operation: :debit }) }
 end

--- a/spec/requests/citizens/identify_types_of_incomes_spec.rb
+++ b/spec/requests/citizens/identify_types_of_incomes_spec.rb
@@ -55,5 +55,27 @@ RSpec.describe 'IndentifyTypesOfIncomesController' do
         expect(subject).to redirect_to(flow_forward_path)
       end
     end
+
+    context 'when application has transaction types of other kind' do
+      let(:other_transaction_type) { create :transaction_type, :debit }
+      let(:legal_aid_application) { create :legal_aid_application, :with_applicant, transaction_types: [other_transaction_type] }
+
+      it 'does not remove existing transation of other type' do
+        expect { subject }.not_to change { legal_aid_application.transaction_types.count }
+      end
+
+      it 'does not delete transaction types' do
+        expect { subject }.not_to change { TransactionType.count }
+      end
+    end
+
+    context 'the wrong transaction type is passed in' do
+      let!(:income_types) { create_list :transaction_type, 3, :debit_with_standard_name }
+      let(:transaction_type_ids) { income_types.map(&:id) }
+
+      it 'does not add the transaction types' do
+        expect { subject }.not_to change { legal_aid_application.transaction_types.count }
+      end
+    end
   end
 end

--- a/spec/requests/citizens/identify_types_of_outgoings_spec.rb
+++ b/spec/requests/citizens/identify_types_of_outgoings_spec.rb
@@ -56,5 +56,27 @@ RSpec.describe 'IndentifyTypesOfOutgoingsController' do
         expect(subject).to redirect_to(flow_forward_path)
       end
     end
+
+    context 'when application has transaction types of other kind' do
+      let(:other_transaction_type) { create :transaction_type, :credit }
+      let(:legal_aid_application) { create :legal_aid_application, :with_applicant, transaction_types: [other_transaction_type] }
+
+      it 'does not remove existing transation of other type' do
+        expect { subject }.not_to change { legal_aid_application.transaction_types.count }
+      end
+
+      it 'does not delete transaction types' do
+        expect { subject }.not_to change { TransactionType.count }
+      end
+    end
+
+    context 'the wrong transaction type is passed in' do
+      let!(:income_types) { create_list :transaction_type, 3, :credit_with_standard_name }
+      let(:transaction_type_ids) { income_types.map(&:id) }
+
+      it 'does not add the transaction types' do
+        expect { subject }.not_to change { legal_aid_application.transaction_types.count }
+      end
+    end
   end
 end


### PR DESCRIPTION
[Jira AP-457](https://dsdmoj.atlassian.net/browse/AP-457)

The cause of the bug:

If you do this
```ruby
selected_ids = [1,2,3]
legal_aid_application.update!(transaction_type_ids: selected_ids)
```
That removes all existing association between the legal aid application and transaction types, as well as apply the new associations. So each update to associate one type (debit or credit) of transaction type was wiping the associations with the other transaction type.

The solution is a little more verbose, but ensures that only the correct transaction types are modified.