### PR TITLE
AP-482 Fix markup issues in providers/applicant

### DIFF
--- a/app/helpers/page_template_helper.rb
+++ b/app/helpers/page_template_helper.rb
@@ -37,12 +37,13 @@ module PageTemplateHelper
   #     <p>Main content</p>
   #   <% end %>
   #
-  def page_template( # rubocop:disable Metrics/ParameterLists
+  def page_template( # rubocop:disable Metrics/ParameterLists Metrics/MethodLength
         page_title:,
         back_link: {},
         column_width: 'two-thirds',
         template: nil,
         show_errors_for: @form,
+        page_heading_options: {},
         &content
       )
     template = :default unless %i[form basic].include?(template)
@@ -55,7 +56,16 @@ module PageTemplateHelper
       back_link: back_link,
       column_width: column_width,
       content: content,
-      show_errors_for: show_errors_for
+      show_errors_for: show_errors_for,
+      page_heading_options: page_heading_options
     )
+  end
+
+  def page_heading(heading: :h1, size: :xl, margin_bottom: nil)
+    return unless content_for?(:page_title)
+
+    classes = ["govuk-heading-#{size}"]
+    classes << "govuk-!-margin-bottom-#{margin_bottom}" if margin_bottom
+    content_tag heading, content_for(:page_title), class: classes.join(' ')
   end
 end

--- a/app/views/admin/settings/show.html.erb
+++ b/app/views/admin/settings/show.html.erb
@@ -1,4 +1,4 @@
-<%= page_template page_title: t('.heading_1'), template: :form do %>
+<%= page_template page_title: t('.heading_1') do %>
   <%= form_with(
         model: @form,
         url: admin_settings_path,

--- a/app/views/providers/applicants/show.html.erb
+++ b/app/views/providers/applicants/show.html.erb
@@ -2,7 +2,7 @@
 <%= page_template(
       page_title: t('.page_title'),
       back_link: { text: t(back_label) },
-      template: :form
+      page_heading_options: { margin_bottom: 3 }
     ) do %>
 
   <%= form_with(
@@ -13,19 +13,27 @@
       ) do |form| %>
 
     <div class="govuk-!-padding-bottom-2"></div>
-    <span class="govuk-fieldset__legend govuk-fieldset__legend--m"><%= t('.full_name') %></span>
-    <%= form.govuk_text_field :first_name, class: 'govuk-input govuk-!-width-three-quarters', 'aria-label' => 'first name' %>
-    <%= form.govuk_text_field :last_name, class: 'govuk-input govuk-!-width-three-quarters', 'aria-label' => 'last name' %>
+    <fieldset class="govuk-fieldset">
+      <legend class="govuk-fieldset__legend govuk-fieldset__legend--m"><%= t('.full_name') %></legend>
+      <%= form.govuk_text_field :first_name, class: 'govuk-!-width-three-quarters', 'aria-label' => 'first name' %>
+      <%= form.govuk_text_field :last_name, class: 'govuk-!-width-three-quarters', 'aria-label' => 'last name' %>
+    </fieldset>
 
     <div class="govuk-!-padding-bottom-4"></div>
 
     <%= date_input_fields prefix: :dob, field_name: :date_of_birth, form: form %>
 
     <div class="govuk-!-padding-bottom-6"></div>
-    <%= form.govuk_label(:national_insurance_number, t('.nino_label')) %>
-    <%= form.govuk_text_field :national_insurance_number, label: nil, class: 'govuk-input govuk-input--width-10' %>
-    <%= form.govuk_label(:email, t('.email_label')) %>
-    <%= form.govuk_text_field :email, label: nil, class: 'govuk-input govuk-!-width-three-quarters' %>
+    <%= form.govuk_text_field(
+          :national_insurance_number,
+          label: { text: t('.nino_label'), size: :m },
+          class: 'govuk-input govuk-input--width-10'
+        ) %>
+    <%= form.govuk_text_field(
+          :email,
+          label: { text: t('.email_label'), size: :m },
+          class: 'govuk-input govuk-!-width-three-quarters'
+        ) %>
 
     <div class="govuk-!-padding-bottom-2"></div>
 

--- a/app/views/shared/page_templates/_default_page_template.html.erb
+++ b/app/views/shared/page_templates/_default_page_template.html.erb
@@ -8,9 +8,7 @@
         <%= content_for(:page_title) %>
       </h3>
     <% else %>
-      <% if content_for?(:page_title) %>
-        <h1 class="govuk-heading-xl"><%= content_for(:page_title) %></h1>
-      <% end %>
+      <%= page_heading page_heading_options %>
     <% end %>
     <%= content %>
   </div>


### PR DESCRIPTION
[Jira AP-482](https://dsdmoj.atlassian.net/browse/AP-482)

Corrects some errors in the mark up of the providers/applicant page.

- Modified the page template so that the margin below the heading can be set easily. Using the form page template results in a 15px margin below the heading, whereas the default page template heading has 30px below the head.
- Put the applicant name fields within a fieldset and put the legend within a legend tag rather than a span, and again within the new fieldset.
- Removed the duplication of the class "govuk-input" within the name input fields.
- Used the `govuk_text_field` `label` option to add a correctly format label *within the form group* which then allowed me to remove the labels that were rendering outside the form group.

When I started this I thought I would continue through and replace all the uses of the form page template, but the number of issues on this single page made this more complicated than I thought. So I have not completed this beyond modify the page template used by admin/settings.
