### PR TITLE
Ap 409 monitor sidekiq

### DIFF
--- a/app/lib/prometheus_collectors/collectors.rb
+++ b/app/lib/prometheus_collectors/collectors.rb
@@ -1,0 +1,3 @@
+module PrometheusCollectors
+  require_relative 'sidekiq_queue_collector'
+end

--- a/app/lib/prometheus_collectors/sidekiq_queue_collector.rb
+++ b/app/lib/prometheus_collectors/sidekiq_queue_collector.rb
@@ -1,0 +1,23 @@
+require 'prometheus_exporter/server'
+
+module PrometheusCollectors
+  class SidekiqQueueCollector < PrometheusExporter::Server::TypeCollector
+    COLLECTOR_TYPE = 'sidekiq_queue_size'.freeze
+
+    def initialize
+      @gauge = PrometheusExporter::Metric::Gauge.new(COLLECTOR_TYPE, 'Sidekiq queue size')
+    end
+
+    def type
+      COLLECTOR_TYPE
+    end
+
+    def collect(obj)
+      @gauge.observe(obj['size'], queue: obj['queue'])
+    end
+
+    def metrics
+      [@gauge]
+    end
+  end
+end

--- a/app/services/metrics/send_metrics.rb
+++ b/app/services/metrics/send_metrics.rb
@@ -1,0 +1,26 @@
+module Metrics
+  class SendMetrics
+    PROMETHEUS_THREAD_SLEEP = 0.1 # seconds
+
+    def self.call
+      new.call
+    end
+
+    def call
+      Metrics::SidekiqQueueSizes.call(prometheus_client)
+
+      # prometheus_exporter runs in a loop and we need to give it some time to send the metrics
+      # https://github.com/discourse/prometheus_exporter/blob/master/lib/prometheus_exporter/client.rb#L54
+      sleep PROMETHEUS_THREAD_SLEEP * 2
+    end
+
+    private
+
+    def prometheus_client
+      @prometheus_client ||= PrometheusExporter::Client.new(
+        host: Rails.configuration.x.service_host,
+        thread_sleep: PROMETHEUS_THREAD_SLEEP
+      )
+    end
+  end
+end

--- a/app/services/metrics/sidekiq_queue_sizes.rb
+++ b/app/services/metrics/sidekiq_queue_sizes.rb
@@ -1,0 +1,36 @@
+module Metrics
+  class SidekiqQueueSizes
+    def self.call(prometheus_client)
+      new(prometheus_client).call
+    end
+
+    def initialize(prometheus_client)
+      @prometheus_client = prometheus_client
+    end
+
+    def call
+      queues.each { |queue| send_metric(queue) }
+    end
+
+    private
+
+    attr_reader :prometheus_client
+
+    def send_metric(queue)
+      prometheus_client.send_json(
+        type: PrometheusCollectors::SidekiqQueueCollector::COLLECTOR_TYPE,
+        queue: queue,
+        size: queue_size(queue)
+      )
+    end
+
+    def queue_size(queue)
+      Sidekiq::Queue.new(queue).size
+    end
+
+    def queues
+      sidekiq_config = File.read(Rails.root.join('config', 'sidekiq.yml'))
+      YAML.safe_load(sidekiq_config, [Symbol])[:queues]
+    end
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -41,6 +41,8 @@ module LaaApplyForLegalAid
     config.x.admin_portal.allow_create_test_applications = ENV['ADMIN_ALLOW_CREATE_TEST_APPLICATIONS'] == 'true'
     config.x.admin_portal.password = ENV['ADMIN_PASSWORD']
 
+    config.x.service_host = ENV.fetch('SERVICE_HOST', 'localhost')
+
     require Rails.root.join 'app/lib/govuk_elements_form_builder/form_builder'
     ActionView::Base.default_form_builder = GovukElementsFormBuilder::FormBuilder
 

--- a/config/initializers/prometheus_metrics.rb
+++ b/config/initializers/prometheus_metrics.rb
@@ -2,6 +2,10 @@ if Rails.env.production? && Rails.configuration.x.kubernetes_deployment
   require 'prometheus_exporter/instrumentation'
   require 'prometheus_exporter/middleware'
 
+  PrometheusExporter::Client.default = PrometheusExporter::Client.new(
+    host: Rails.configuration.x.service_host
+  )
+
   PrometheusExporter::Instrumentation::Process.start(type: 'master')
   Rails.application.middleware.unshift PrometheusExporter::Middleware
 end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,5 +1,7 @@
 require 'sidekiq'
 require 'sidekiq-status'
+require 'prometheus_exporter/client'
+require 'prometheus_exporter/instrumentation'
 
 redis_url = "rediss://:#{ENV['REDIS_PASSWORD']}@#{ENV['REDIS_HOST']}:6379" if ENV['REDIS_HOST'].present? && ENV['REDIS_PASSWORD'].present?
 namespace = ENV.fetch('HOST', 'laa-apply')
@@ -19,4 +21,24 @@ Sidekiq.configure_server do |config|
 
   # accepts :expiration (optional)
   Sidekiq::Status.configure_client_middleware config, expiration: 30.minutes
+
+  config.server_middleware do |chain|
+    chain.add PrometheusExporter::Instrumentation::Sidekiq
+  end
+
+  config.death_handlers << ->(job, _ex) do
+    PrometheusExporter::Client.default.send_json(
+      type: 'sidekiq',
+      name: job['class'],
+      dead: true
+    )
+  end
+
+  config.on :startup do
+    PrometheusExporter::Instrumentation::Process.start type: 'sidekiq'
+  end
+
+  at_exit do
+    PrometheusExporter::Client.default.stop(wait_timeout_seconds: 10)
+  end
 end

--- a/helm_deploy/apply-for-legal-aid/templates/_envs.tpl
+++ b/helm_deploy/apply-for-legal-aid/templates/_envs.tpl
@@ -200,4 +200,6 @@ env:
         key: googleAnalyticsTrackingID
   - name: KUBERNETES_DEPLOYMENT
     value: "true"
+  - name: SERVICE_HOST
+    value: {{ .Release.Name }}
 {{- end }}

--- a/helm_deploy/apply-for-legal-aid/templates/_helpers.tpl
+++ b/helm_deploy/apply-for-legal-aid/templates/_helpers.tpl
@@ -30,3 +30,18 @@ Create chart name and version as used by the chart label.
 {{- define "apply-for-legal-aid.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Defining cron schedule for the job sending metrics to Prometheus.
+In staging and production, the job runs every minute.
+In UAT, in order to not use too much resource, we run the job only once per hour.
+*/}}
+{{- define "apply-for-legal-aid.metrics-cronjob-schedule" -}}
+  {{- if contains "-uat" .Release.Namespace -}}
+    {{/* https://pauladamsmith.com/blog/2011/05/go_time.html */}}
+    {{- $currentMinute := now | date "4" -}}
+    {{- printf "%s * * * *" $currentMinute -}}
+  {{- else -}}
+    {{ "* * * * *" }}
+  {{- end -}}
+{{- end -}}

--- a/helm_deploy/apply-for-legal-aid/templates/deployment_metrics.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/deployment_metrics.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: {{ template "apply-for-legal-aid.fullname" . }}-metrics
+  labels:
+    app: {{ template "apply-for-legal-aid.name" . }}
+    chart: {{ template "apply-for-legal-aid.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.worker.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "apply-for-legal-aid.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "apply-for-legal-aid.name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: metrics
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: IfNotPresent
+          command: ['sh', '-c', 'bundle exec prometheus_exporter -a app/lib/prometheus_collectors/collectors.rb']
+          ports:
+          - containerPort: 9394
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: 9394
+            initialDelaySeconds: 10
+            periodSeconds: 60
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: 9394
+            initialDelaySeconds: 10
+            periodSeconds: 60
+          resources:
+            limits:
+              cpu: 100m
+              memory: 128Mi
+            requests:
+              cpu: 100m
+              memory: 128Mi

--- a/helm_deploy/apply-for-legal-aid/templates/deployment_web.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/deployment_web.yaml
@@ -29,31 +29,6 @@ spec:
               protocol: TCP
           resources:
 {{ toYaml .Values.clamav.resources | indent 12 }}
-        - name: metrics
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-          imagePullPolicy: IfNotPresent
-          command: ['sh', '-c', 'bundle exec prometheus_exporter']
-          ports:
-          - containerPort: 9394
-          livenessProbe:
-            httpGet:
-              path: /metrics
-              port: 9394
-            initialDelaySeconds: 10
-            periodSeconds: 60
-          readinessProbe:
-            httpGet:
-              path: /metrics
-              port: 9394
-            initialDelaySeconds: 10
-            periodSeconds: 60
-          resources:
-            limits:
-              cpu: 100m
-              memory: 128Mi
-            requests:
-              cpu: 100m
-              memory: 128Mi
         - name: {{ .Chart.Name }}
           image: '{{ .Values.image.repository }}:{{ .Values.image.tag }}'
           imagePullPolicy: IfNotPresent

--- a/helm_deploy/apply-for-legal-aid/templates/metrics-cronjob.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/metrics-cronjob.yaml
@@ -1,0 +1,37 @@
+{{- $schedule := include "apply-for-legal-aid.metrics-cronjob-schedule" . -}}
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: {{ .Release.Name }}-cronjob
+  labels:
+    app: {{ template "apply-for-legal-aid.name" . }}
+    chart: {{ template "apply-for-legal-aid.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  schedule: '{{ $schedule }}'
+  selector:
+    matchLabels:
+      app: {{ template "apply-for-legal-aid.name" . }}
+      release: {{ .Release.Name }}
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 0
+  failedJobsHistoryLimit: 0
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: {{ .Chart.Name }}
+            image: '{{ .Values.image.repository }}:{{ .Values.image.tag }}'
+            imagePullPolicy: IfNotPresent
+            command: ['bin/rails', 'send_metrics_to_prometheus']
+{{ include "apply-for-legal-aid.envs" . | nindent 12 }}
+            resources:
+              limits:
+                cpu: 200m
+                memory: 256Mi
+              requests:
+                cpu: 100m
+                memory: 128Mi
+          restartPolicy: Never

--- a/helm_deploy/prometheus-alerts.yaml
+++ b/helm_deploy/prometheus-alerts.yaml
@@ -53,3 +53,11 @@ spec:
         severity: apply-for-legal-aid-prod
       annotations:
         message: An HTTP 5xx error has occurred
+    - alert: SidekiqQueueSize-Threshold-Reached
+      expr: sum(sidekiq_queue_size{namespace="laa-apply-for-legalaid-production"}) > 10 or absent(sidekiq_queue_size{namespace="laa-apply-for-legalaid-production"})
+      for: 1m
+      labels:
+        severity: apply-for-legal-aid-prod
+      annotations:
+        message: Sidekiq queue size is more than 10 or is not reported
+

--- a/lib/tasks/send_metrics_to_prometheus.rake
+++ b/lib/tasks/send_metrics_to_prometheus.rake
@@ -1,0 +1,4 @@
+desc 'Send metrics to prometheus'
+task send_metrics_to_prometheus: :environment do
+  Metrics::SendMetrics.call
+end

--- a/spec/lib/prometheus_collectors/sidekiq_queue_collector_spec.rb
+++ b/spec/lib/prometheus_collectors/sidekiq_queue_collector_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+require 'prometheus_exporter/server'
+
+RSpec.describe PrometheusCollectors::SidekiqQueueCollector do
+  let(:queue) { 'mailers' }
+  let(:gauge) { spy(PrometheusExporter::Metric::Gauge) }
+  let(:queue_size) { rand(1..100) }
+  subject { described_class.new }
+
+  before do
+    allow(PrometheusExporter::Metric::Gauge)
+      .to receive(:new)
+      .and_return(gauge)
+  end
+
+  it 'has the right type' do
+    expect(subject.type).to eq(PrometheusCollectors::SidekiqQueueCollector::COLLECTOR_TYPE)
+  end
+
+  it 'has one gauge' do
+    expect(subject.metrics.size).to eq(1)
+    expect(subject.metrics.first).to be(gauge)
+  end
+
+  it 'sends the queue size to the prometheus gauge' do
+    expect(gauge).to receive(:observe).with(queue_size, queue: queue)
+    subject.collect('queue' => queue, 'size' => queue_size)
+  end
+end

--- a/spec/services/metrics/send_metrics_spec.rb
+++ b/spec/services/metrics/send_metrics_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+RSpec.describe Metrics::SendMetrics do
+  describe '#call' do
+    let(:service_host) { Faker::Internet.domain_word }
+    let(:prometheus_client) { spy(PrometheusExporter::Client) }
+    let(:prometheus_thread_sleep) { rand(1..10).to_f / 1000 }
+    subject { described_class.call }
+
+    before do
+      stub_const('Metrics::SendMetrics::PROMETHEUS_THREAD_SLEEP', prometheus_thread_sleep)
+      allow(PrometheusExporter::Client).to receive(:new).and_return(prometheus_client)
+      allow(Rails.configuration.x).to receive(:service_host).and_return(service_host)
+    end
+
+    it 'creates a prometheus client with the right settings' do
+      expect(PrometheusExporter::Client)
+        .to receive(:new)
+        .with(host: service_host, thread_sleep: prometheus_thread_sleep)
+        .and_return(prometheus_client)
+      subject
+    end
+
+    it 'sleeps during twice the time of a prometheus loop' do
+      allow_any_instance_of(Object).to receive(:sleep).with(prometheus_thread_sleep * 2)
+      subject
+    end
+
+    it 'sends to prometheus the size of sidekiq queues' do
+      expect(Metrics::SidekiqQueueSizes).to receive(:call).with(prometheus_client).and_call_original
+      expect(prometheus_client).to receive(:send_json).with(
+        hash_including(
+          type: PrometheusCollectors::SidekiqQueueCollector::COLLECTOR_TYPE,
+          queue: 'mailers'
+        )
+      )
+      subject
+    end
+  end
+end

--- a/spec/services/metrics/sidekiq_queue_sizes_spec.rb
+++ b/spec/services/metrics/sidekiq_queue_sizes_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe Metrics::SidekiqQueueSizes do
+  describe '#call' do
+    let(:queues) { %w[default mailers sidekiq_alive] }
+    let(:prometheus_client) { spy(PrometheusExporter::Client) }
+    let(:collector_type) { PrometheusCollectors::SidekiqQueueCollector::COLLECTOR_TYPE }
+    subject { described_class.call(prometheus_client) }
+
+    it 'sends to prometheus the size of each queue' do
+      queues.each do |queue|
+        expect(prometheus_client).to receive(:send_json).with(
+          type: collector_type, queue: queue, size: Sidekiq::Queue.new(queue).size
+        )
+      end
+      subject
+    end
+
+    context 'with known sizes' do
+      let(:expected_sizes) { queues.each_with_object({}) { |q, hash| hash[q] = rand(0..100) } }
+
+      before do
+        queues.each do |queue|
+          allow(Sidekiq::Queue)
+            .to receive(:new)
+            .with(queue)
+            .and_return(double('Queue', size: expected_sizes[queue]))
+        end
+      end
+
+      it 'sends to prometheus the size of each queue' do
+        queues.each do |queue|
+          expect(prometheus_client).to receive(:send_json).with(
+            type: collector_type, queue: queue, size: expected_sizes[queue]
+          )
+        end
+        subject
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What

[AP-409](https://dsdmoj.atlassian.net/browse/AP-409)

 - creating `SidekiqQueueCollector`. It is started on the `metrics` container, collect metrics from the job and send them to prometheus.
 - creating `SidekiqQueueSizes`. It collects sidekiq queue sizes and send them to the collector above
 - creating a kubernetes cron-job. It will run `SidekiqQueueSizes` every minute. (Or every hour in UAT). I tried running it every minute in UAT and it runs OK but it will be too much when we have several UAT envs with a job for each
 - moving the `metrics` container to its own pod so it can be used by all pods and it's best practice to have only one container per pod as much as possible
 - creating a prometheus alert. It triggers if total size of all queues is more than 10 or if that metric is absent

In Prometheus, the query is `ruby_sidekiq_queue_size`.
The name of the queue is within the label of the metrics. 
https://prometheus.apps.cloud-platform-live-0.k8s.integration.dsd.io/graph?g0.range_input=1h&g0.expr=ruby_sidekiq_queue_size&g0.tab=1


## Checklist

Before you ask people to review this PR:

- [X] Tests and rubocop should be passing: `bundle exec rake`
- [X] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [X] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [X] The PR description should say what you changed and why, with a link to the JIRA story.
- [X] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [X] You should have checked that the commit messages say why the change was made.
