### PR TITLE
AP-486 Specify english language for welsh addresses

### DIFF
--- a/app/services/address_lookup_service.rb
+++ b/app/services/address_lookup_service.rb
@@ -18,7 +18,8 @@ class AddressLookupService
   def query_params
     {
       key: ENV['ORDNANACE_SURVEY_API_KEY'],
-      postcode: postcode
+      postcode: postcode,
+      lr: 'EN'
     }
   end
 

--- a/features/cassettes/Civil_application_journeys/Completes_the_application_using_address_lookup.yml
+++ b/features/cassettes/Civil_application_journeys/Completes_the_application_using_address_lookup.yml
@@ -361,13 +361,373 @@ http_interactions:
     http_version: 
   recorded_at: Wed, 20 Mar 2019 16:51:29 GMT
 - request:
+    method: get
+    uri: https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?key=<ORDNANACE_SURVEY_API_KEY>&lr=EN&postcode=DA74NG
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Wed, 10 Apr 2019 17:18:18 GMT
+      Server:
+      - Apache-Coyote/1.1
+      Status:
+      - success
+      Tx-Id:
+      - '1554916699006:6'
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "header" : {
+            "uri" : "https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?lr=EN&postcode=DA74NG",
+            "query" : "postcode=DA74NG",
+            "offset" : 0,
+            "totalresults" : 11,
+            "format" : "JSON",
+            "dataset" : "DPA",
+            "lr" : "EN",
+            "maxresults" : 100,
+            "epoch" : "65",
+            "output_srs" : "EPSG:27700"
+          },
+          "results" : [ {
+            "DPA" : {
+              "UPRN" : "100020211558",
+              "UDPRN" : "6248161",
+              "ADDRESS" : "1, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "1",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "2",
+              "X_COORDINATE" : 548894.0,
+              "Y_COORDINATE" : 176139.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD02",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095093",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211559",
+              "UDPRN" : "6248164",
+              "ADDRESS" : "2, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "2",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548861.0,
+              "Y_COORDINATE" : 176156.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095079",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211560",
+              "UDPRN" : "6248165",
+              "ADDRESS" : "3, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "3",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548888.0,
+              "Y_COORDINATE" : 176131.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD02",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb5000005153955102",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211561",
+              "UDPRN" : "6248166",
+              "ADDRESS" : "4, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "4",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548858.0,
+              "Y_COORDINATE" : 176150.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095080",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211562",
+              "UDPRN" : "6248167",
+              "ADDRESS" : "5, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "5",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548884.0,
+              "Y_COORDINATE" : 176118.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD02",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095091",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211563",
+              "UDPRN" : "6248168",
+              "ADDRESS" : "6, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "6",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548849.0,
+              "Y_COORDINATE" : 176141.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095082",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211564",
+              "UDPRN" : "6248169",
+              "ADDRESS" : "7, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "7",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548874.0,
+              "Y_COORDINATE" : 176106.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095089",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211565",
+              "UDPRN" : "6248170",
+              "ADDRESS" : "8, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "8",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548846.0,
+              "Y_COORDINATE" : 176133.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095083",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211566",
+              "UDPRN" : "6248171",
+              "ADDRESS" : "9, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "9",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548868.0,
+              "Y_COORDINATE" : 176104.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095088",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211567",
+              "UDPRN" : "6248162",
+              "ADDRESS" : "10, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "10",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548848.0,
+              "Y_COORDINATE" : 176115.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095085",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211568",
+              "UDPRN" : "6248163",
+              "ADDRESS" : "12, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "12",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "2",
+              "X_COORDINATE" : 548854.0,
+              "Y_COORDINATE" : 176110.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095086",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          } ]
+        }
+    http_version: 
+  recorded_at: Wed, 10 Apr 2019 17:18:19 GMT
+- request:
     method: post
     uri: https://benefitchecker.dev.legalservices.gov.uk/lsx/lsc-services/benefitChecker?wsdl
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:wsdl="https://lsc.gov.uk/benefitchecker/service/1.0/API_1.0_Check"
-        xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Body><wsdl:check><clientReference>76092f67-2adf-44b1-bb34-5acec9766a8a</clientReference><nino>CB987654A</nino><surname>USER</surname><dateOfBirth>19990403</dateOfBirth><dateOfAward>20190320</dateOfAward><lscServiceName><BC_LSC_SERVICE_NAME></lscServiceName><clientOrgId><BC_CLIENT_ORG_ID></clientOrgId><clientUserId><BC_CLIENT_USER_ID></clientUserId></wsdl:check></env:Body></env:Envelope>
+        xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Body><wsdl:check><clientReference>f39c0307-3525-4389-b623-65334ffd3945</clientReference><nino>CB987654A</nino><surname>USER</surname><dateOfBirth>19990403</dateOfBirth><dateOfAward>20190410</dateOfAward><lscServiceName><BC_LSC_SERVICE_NAME></lscServiceName><clientOrgId><BC_CLIENT_ORG_ID></clientOrgId><clientUserId><BC_CLIENT_USER_ID></clientUserId></wsdl:check></env:Body></env:Envelope>
     headers:
       Soapaction:
       - '"check"'
@@ -387,7 +747,7 @@ http_interactions:
       message: ''
     headers:
       Date:
-      - Wed, 20 Mar 2019 16:51:32 GMT
+      - Wed, 10 Apr 2019 17:18:21 GMT
       Content-Type:
       - text/xml;charset=utf-8
       Transfer-Encoding:
@@ -395,7 +755,7 @@ http_interactions:
       Connection:
       - keep-alive
       X-Amzn-Trace-Id:
-      - Root=1-5c926f94-1756f65663a0dd36ff50b2c6;
+      - Root=1-5cae255d-56497c0cf58fbbbcb7e626ec;
       Vary:
       - Accept-Encoding
     body:
@@ -403,9 +763,9 @@ http_interactions:
       string: <?xml version="1.0" encoding="UTF-8"?><soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
         xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><soapenv:Body><benefitCheckerResponse
         xmlns="https://lsc.gov.uk/benefitchecker/service/1.0/API_1.0_Check"><ns1:originalClientRef
-        xmlns:ns1="http://lsc.gov.uk/benefitchecker/data/1.0">76092f67-2adf-44b1-bb34-5acec9766a8a</ns1:originalClientRef><ns2:benefitCheckerStatus
+        xmlns:ns1="http://lsc.gov.uk/benefitchecker/data/1.0">f39c0307-3525-4389-b623-65334ffd3945</ns1:originalClientRef><ns2:benefitCheckerStatus
         xmlns:ns2="http://lsc.gov.uk/benefitchecker/data/1.0">Undetermined</ns2:benefitCheckerStatus><ns3:confirmationRef
-        xmlns:ns3="http://lsc.gov.uk/benefitchecker/data/1.0">T1553100692229</ns3:confirmationRef></benefitCheckerResponse></soapenv:Body></soapenv:Envelope>
+        xmlns:ns3="http://lsc.gov.uk/benefitchecker/data/1.0">T1554916701808</ns3:confirmationRef></benefitCheckerResponse></soapenv:Body></soapenv:Envelope>
     http_version: 
-  recorded_at: Wed, 20 Mar 2019 16:51:32 GMT
+  recorded_at: Wed, 10 Apr 2019 17:18:21 GMT
 recorded_with: VCR 4.0.0

--- a/features/cassettes/Civil_application_journeys/Completes_the_application_using_manual_address.yml
+++ b/features/cassettes/Civil_application_journeys/Completes_the_application_using_manual_address.yml
@@ -52,13 +52,64 @@ http_interactions:
     http_version: 
   recorded_at: Wed, 20 Mar 2019 16:51:34 GMT
 - request:
+    method: get
+    uri: https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?key=<ORDNANACE_SURVEY_API_KEY>&lr=EN&postcode=SW1H9AJ
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Wed, 10 Apr 2019 17:18:24 GMT
+      Server:
+      - Apache-Coyote/1.1
+      Status:
+      - success
+      Tx-Id:
+      - 1554916704709:709
+      Content-Length:
+      - '337'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "header" : {
+            "uri" : "https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?lr=EN&postcode=SW1H9AJ",
+            "query" : "postcode=SW1H9AJ",
+            "offset" : 0,
+            "totalresults" : 0,
+            "format" : "JSON",
+            "dataset" : "DPA",
+            "lr" : "EN",
+            "maxresults" : 100,
+            "epoch" : "65",
+            "output_srs" : "EPSG:27700"
+          }
+        }
+    http_version: 
+  recorded_at: Wed, 10 Apr 2019 17:18:24 GMT
+- request:
     method: post
     uri: https://benefitchecker.dev.legalservices.gov.uk/lsx/lsc-services/benefitChecker?wsdl
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:wsdl="https://lsc.gov.uk/benefitchecker/service/1.0/API_1.0_Check"
-        xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Body><wsdl:check><clientReference>39cb9189-ff52-4c43-889c-b9fc729ed91f</clientReference><nino>CB987654A</nino><surname>USER</surname><dateOfBirth>19990403</dateOfBirth><dateOfAward>20190320</dateOfAward><lscServiceName><BC_LSC_SERVICE_NAME></lscServiceName><clientOrgId><BC_CLIENT_ORG_ID></clientOrgId><clientUserId><BC_CLIENT_USER_ID></clientUserId></wsdl:check></env:Body></env:Envelope>
+        xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Body><wsdl:check><clientReference>d3ce2878-1f2c-4e1d-b655-000a624a1dfb</clientReference><nino>CB987654A</nino><surname>USER</surname><dateOfBirth>19990403</dateOfBirth><dateOfAward>20190410</dateOfAward><lscServiceName><BC_LSC_SERVICE_NAME></lscServiceName><clientOrgId><BC_CLIENT_ORG_ID></clientOrgId><clientUserId><BC_CLIENT_USER_ID></clientUserId></wsdl:check></env:Body></env:Envelope>
     headers:
       Soapaction:
       - '"check"'
@@ -78,7 +129,7 @@ http_interactions:
       message: ''
     headers:
       Date:
-      - Wed, 20 Mar 2019 16:51:37 GMT
+      - Wed, 10 Apr 2019 17:18:27 GMT
       Content-Type:
       - text/xml;charset=utf-8
       Transfer-Encoding:
@@ -86,7 +137,7 @@ http_interactions:
       Connection:
       - keep-alive
       X-Amzn-Trace-Id:
-      - Root=1-5c926f99-da2d53265542b174cb4ef564;
+      - Root=1-5cae2563-09fd04382a3b6f64135b96f0;
       Vary:
       - Accept-Encoding
     body:
@@ -94,9 +145,9 @@ http_interactions:
       string: <?xml version="1.0" encoding="UTF-8"?><soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
         xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><soapenv:Body><benefitCheckerResponse
         xmlns="https://lsc.gov.uk/benefitchecker/service/1.0/API_1.0_Check"><ns1:originalClientRef
-        xmlns:ns1="http://lsc.gov.uk/benefitchecker/data/1.0">39cb9189-ff52-4c43-889c-b9fc729ed91f</ns1:originalClientRef><ns2:benefitCheckerStatus
+        xmlns:ns1="http://lsc.gov.uk/benefitchecker/data/1.0">d3ce2878-1f2c-4e1d-b655-000a624a1dfb</ns1:originalClientRef><ns2:benefitCheckerStatus
         xmlns:ns2="http://lsc.gov.uk/benefitchecker/data/1.0">Undetermined</ns2:benefitCheckerStatus><ns3:confirmationRef
-        xmlns:ns3="http://lsc.gov.uk/benefitchecker/data/1.0">T1553100697529</ns3:confirmationRef></benefitCheckerResponse></soapenv:Body></soapenv:Envelope>
+        xmlns:ns3="http://lsc.gov.uk/benefitchecker/data/1.0">T1554916707949</ns3:confirmationRef></benefitCheckerResponse></soapenv:Body></soapenv:Envelope>
     http_version: 
-  recorded_at: Wed, 20 Mar 2019 16:51:37 GMT
+  recorded_at: Wed, 10 Apr 2019 17:18:28 GMT
 recorded_with: VCR 4.0.0

--- a/features/cassettes/Civil_application_journeys/I_am_able_to_clear_proceeding_on_the_proceeding_page.yml
+++ b/features/cassettes/Civil_application_journeys/I_am_able_to_clear_proceeding_on_the_proceeding_page.yml
@@ -360,4 +360,364 @@ http_interactions:
         }
     http_version: 
   recorded_at: Tue, 29 Jan 2019 11:30:00 GMT
+- request:
+    method: get
+    uri: https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?key=<ORDNANACE_SURVEY_API_KEY>&lr=EN&postcode=DA74NG
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Wed, 10 Apr 2019 17:18:09 GMT
+      Server:
+      - Apache-Coyote/1.1
+      Status:
+      - success
+      Tx-Id:
+      - 1554916689301:301
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "header" : {
+            "uri" : "https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?lr=EN&postcode=DA74NG",
+            "query" : "postcode=DA74NG",
+            "offset" : 0,
+            "totalresults" : 11,
+            "format" : "JSON",
+            "dataset" : "DPA",
+            "lr" : "EN",
+            "maxresults" : 100,
+            "epoch" : "65",
+            "output_srs" : "EPSG:27700"
+          },
+          "results" : [ {
+            "DPA" : {
+              "UPRN" : "100020211558",
+              "UDPRN" : "6248161",
+              "ADDRESS" : "1, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "1",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "2",
+              "X_COORDINATE" : 548894.0,
+              "Y_COORDINATE" : 176139.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD02",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095093",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211559",
+              "UDPRN" : "6248164",
+              "ADDRESS" : "2, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "2",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548861.0,
+              "Y_COORDINATE" : 176156.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095079",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211560",
+              "UDPRN" : "6248165",
+              "ADDRESS" : "3, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "3",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548888.0,
+              "Y_COORDINATE" : 176131.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD02",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb5000005153955102",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211561",
+              "UDPRN" : "6248166",
+              "ADDRESS" : "4, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "4",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548858.0,
+              "Y_COORDINATE" : 176150.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095080",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211562",
+              "UDPRN" : "6248167",
+              "ADDRESS" : "5, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "5",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548884.0,
+              "Y_COORDINATE" : 176118.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD02",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095091",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211563",
+              "UDPRN" : "6248168",
+              "ADDRESS" : "6, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "6",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548849.0,
+              "Y_COORDINATE" : 176141.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095082",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211564",
+              "UDPRN" : "6248169",
+              "ADDRESS" : "7, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "7",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548874.0,
+              "Y_COORDINATE" : 176106.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095089",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211565",
+              "UDPRN" : "6248170",
+              "ADDRESS" : "8, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "8",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548846.0,
+              "Y_COORDINATE" : 176133.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095083",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211566",
+              "UDPRN" : "6248171",
+              "ADDRESS" : "9, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "9",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548868.0,
+              "Y_COORDINATE" : 176104.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095088",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211567",
+              "UDPRN" : "6248162",
+              "ADDRESS" : "10, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "10",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548848.0,
+              "Y_COORDINATE" : 176115.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095085",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211568",
+              "UDPRN" : "6248163",
+              "ADDRESS" : "12, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "12",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "2",
+              "X_COORDINATE" : 548854.0,
+              "Y_COORDINATE" : 176110.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095086",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          } ]
+        }
+    http_version: 
+  recorded_at: Wed, 10 Apr 2019 17:18:09 GMT
 recorded_with: VCR 4.0.0

--- a/features/cassettes/Civil_application_journeys/I_am_able_to_select_and_delete_proceeding_types.yml
+++ b/features/cassettes/Civil_application_journeys/I_am_able_to_select_and_delete_proceeding_types.yml
@@ -360,4 +360,364 @@ http_interactions:
         }
     http_version: 
   recorded_at: Wed, 30 Jan 2019 16:17:16 GMT
+- request:
+    method: get
+    uri: https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?key=<ORDNANACE_SURVEY_API_KEY>&lr=EN&postcode=DA74NG
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Wed, 10 Apr 2019 17:18:13 GMT
+      Server:
+      - Apache-Coyote/1.1
+      Status:
+      - success
+      Tx-Id:
+      - '1554916693001:1'
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "header" : {
+            "uri" : "https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?lr=EN&postcode=DA74NG",
+            "query" : "postcode=DA74NG",
+            "offset" : 0,
+            "totalresults" : 11,
+            "format" : "JSON",
+            "dataset" : "DPA",
+            "lr" : "EN",
+            "maxresults" : 100,
+            "epoch" : "65",
+            "output_srs" : "EPSG:27700"
+          },
+          "results" : [ {
+            "DPA" : {
+              "UPRN" : "100020211558",
+              "UDPRN" : "6248161",
+              "ADDRESS" : "1, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "1",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "2",
+              "X_COORDINATE" : 548894.0,
+              "Y_COORDINATE" : 176139.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD02",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095093",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211559",
+              "UDPRN" : "6248164",
+              "ADDRESS" : "2, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "2",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548861.0,
+              "Y_COORDINATE" : 176156.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095079",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211560",
+              "UDPRN" : "6248165",
+              "ADDRESS" : "3, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "3",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548888.0,
+              "Y_COORDINATE" : 176131.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD02",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb5000005153955102",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211561",
+              "UDPRN" : "6248166",
+              "ADDRESS" : "4, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "4",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548858.0,
+              "Y_COORDINATE" : 176150.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095080",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211562",
+              "UDPRN" : "6248167",
+              "ADDRESS" : "5, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "5",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548884.0,
+              "Y_COORDINATE" : 176118.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD02",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095091",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211563",
+              "UDPRN" : "6248168",
+              "ADDRESS" : "6, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "6",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548849.0,
+              "Y_COORDINATE" : 176141.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095082",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211564",
+              "UDPRN" : "6248169",
+              "ADDRESS" : "7, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "7",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548874.0,
+              "Y_COORDINATE" : 176106.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095089",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211565",
+              "UDPRN" : "6248170",
+              "ADDRESS" : "8, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "8",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548846.0,
+              "Y_COORDINATE" : 176133.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095083",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211566",
+              "UDPRN" : "6248171",
+              "ADDRESS" : "9, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "9",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548868.0,
+              "Y_COORDINATE" : 176104.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095088",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211567",
+              "UDPRN" : "6248162",
+              "ADDRESS" : "10, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "10",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548848.0,
+              "Y_COORDINATE" : 176115.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095085",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211568",
+              "UDPRN" : "6248163",
+              "ADDRESS" : "12, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "12",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "2",
+              "X_COORDINATE" : 548854.0,
+              "Y_COORDINATE" : 176110.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095086",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          } ]
+        }
+    http_version: 
+  recorded_at: Wed, 10 Apr 2019 17:18:13 GMT
 recorded_with: VCR 4.0.0

--- a/features/cassettes/Civil_application_journeys/I_can_see_that_the_applicant_does_not_receive_benefits.yml
+++ b/features/cassettes/Civil_application_journeys/I_can_see_that_the_applicant_does_not_receive_benefits.yml
@@ -361,13 +361,373 @@ http_interactions:
     http_version: 
   recorded_at: Wed, 20 Mar 2019 16:51:44 GMT
 - request:
+    method: get
+    uri: https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?key=<ORDNANACE_SURVEY_API_KEY>&lr=EN&postcode=DA74NG
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Wed, 10 Apr 2019 17:18:35 GMT
+      Server:
+      - Apache-Coyote/1.1
+      Status:
+      - success
+      Tx-Id:
+      - 1554916715920:920
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "header" : {
+            "uri" : "https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?lr=EN&postcode=DA74NG",
+            "query" : "postcode=DA74NG",
+            "offset" : 0,
+            "totalresults" : 11,
+            "format" : "JSON",
+            "dataset" : "DPA",
+            "lr" : "EN",
+            "maxresults" : 100,
+            "epoch" : "65",
+            "output_srs" : "EPSG:27700"
+          },
+          "results" : [ {
+            "DPA" : {
+              "UPRN" : "100020211558",
+              "UDPRN" : "6248161",
+              "ADDRESS" : "1, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "1",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "2",
+              "X_COORDINATE" : 548894.0,
+              "Y_COORDINATE" : 176139.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD02",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095093",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211559",
+              "UDPRN" : "6248164",
+              "ADDRESS" : "2, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "2",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548861.0,
+              "Y_COORDINATE" : 176156.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095079",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211560",
+              "UDPRN" : "6248165",
+              "ADDRESS" : "3, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "3",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548888.0,
+              "Y_COORDINATE" : 176131.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD02",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb5000005153955102",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211561",
+              "UDPRN" : "6248166",
+              "ADDRESS" : "4, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "4",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548858.0,
+              "Y_COORDINATE" : 176150.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095080",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211562",
+              "UDPRN" : "6248167",
+              "ADDRESS" : "5, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "5",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548884.0,
+              "Y_COORDINATE" : 176118.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD02",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095091",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211563",
+              "UDPRN" : "6248168",
+              "ADDRESS" : "6, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "6",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548849.0,
+              "Y_COORDINATE" : 176141.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095082",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211564",
+              "UDPRN" : "6248169",
+              "ADDRESS" : "7, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "7",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548874.0,
+              "Y_COORDINATE" : 176106.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095089",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211565",
+              "UDPRN" : "6248170",
+              "ADDRESS" : "8, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "8",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548846.0,
+              "Y_COORDINATE" : 176133.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095083",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211566",
+              "UDPRN" : "6248171",
+              "ADDRESS" : "9, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "9",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548868.0,
+              "Y_COORDINATE" : 176104.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095088",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211567",
+              "UDPRN" : "6248162",
+              "ADDRESS" : "10, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "10",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548848.0,
+              "Y_COORDINATE" : 176115.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095085",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211568",
+              "UDPRN" : "6248163",
+              "ADDRESS" : "12, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "12",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "2",
+              "X_COORDINATE" : 548854.0,
+              "Y_COORDINATE" : 176110.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095086",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          } ]
+        }
+    http_version: 
+  recorded_at: Wed, 10 Apr 2019 17:18:35 GMT
+- request:
     method: post
     uri: https://benefitchecker.dev.legalservices.gov.uk/lsx/lsc-services/benefitChecker?wsdl
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:wsdl="https://lsc.gov.uk/benefitchecker/service/1.0/API_1.0_Check"
-        xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Body><wsdl:check><clientReference>d1ccbc84-929d-4f8e-b209-fe7ddeb5634b</clientReference><nino>JA293483B</nino><surname>PAUL</surname><dateOfBirth>19611210</dateOfBirth><dateOfAward>20190320</dateOfAward><lscServiceName><BC_LSC_SERVICE_NAME></lscServiceName><clientOrgId><BC_CLIENT_ORG_ID></clientOrgId><clientUserId><BC_CLIENT_USER_ID></clientUserId></wsdl:check></env:Body></env:Envelope>
+        xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Body><wsdl:check><clientReference>98fe728e-d069-4e36-a149-2a7d8d48fb48</clientReference><nino>JA293483B</nino><surname>PAUL</surname><dateOfBirth>19611210</dateOfBirth><dateOfAward>20190410</dateOfAward><lscServiceName><BC_LSC_SERVICE_NAME></lscServiceName><clientOrgId><BC_CLIENT_ORG_ID></clientOrgId><clientUserId><BC_CLIENT_USER_ID></clientUserId></wsdl:check></env:Body></env:Envelope>
     headers:
       Soapaction:
       - '"check"'
@@ -387,7 +747,7 @@ http_interactions:
       message: ''
     headers:
       Date:
-      - Wed, 20 Mar 2019 16:51:47 GMT
+      - Wed, 10 Apr 2019 17:18:38 GMT
       Content-Type:
       - text/xml;charset=utf-8
       Transfer-Encoding:
@@ -395,7 +755,7 @@ http_interactions:
       Connection:
       - keep-alive
       X-Amzn-Trace-Id:
-      - Root=1-5c926fa3-047d04ca9c8947bfeac47f64;
+      - Root=1-5cae256e-28bcb23098baaef04a53f0dc;
       Vary:
       - Accept-Encoding
     body:
@@ -403,9 +763,9 @@ http_interactions:
       string: <?xml version="1.0" encoding="UTF-8"?><soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
         xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><soapenv:Body><benefitCheckerResponse
         xmlns="https://lsc.gov.uk/benefitchecker/service/1.0/API_1.0_Check"><ns1:originalClientRef
-        xmlns:ns1="http://lsc.gov.uk/benefitchecker/data/1.0">d1ccbc84-929d-4f8e-b209-fe7ddeb5634b</ns1:originalClientRef><ns2:benefitCheckerStatus
+        xmlns:ns1="http://lsc.gov.uk/benefitchecker/data/1.0">98fe728e-d069-4e36-a149-2a7d8d48fb48</ns1:originalClientRef><ns2:benefitCheckerStatus
         xmlns:ns2="http://lsc.gov.uk/benefitchecker/data/1.0">No</ns2:benefitCheckerStatus><ns3:confirmationRef
-        xmlns:ns3="http://lsc.gov.uk/benefitchecker/data/1.0">T1553100707328</ns3:confirmationRef></benefitCheckerResponse></soapenv:Body></soapenv:Envelope>
+        xmlns:ns3="http://lsc.gov.uk/benefitchecker/data/1.0">T1554916718768</ns3:confirmationRef></benefitCheckerResponse></soapenv:Body></soapenv:Envelope>
     http_version: 
-  recorded_at: Wed, 20 Mar 2019 16:51:47 GMT
+  recorded_at: Wed, 10 Apr 2019 17:18:38 GMT
 recorded_with: VCR 4.0.0

--- a/features/cassettes/Civil_application_journeys/I_can_see_that_the_applicant_receives_benefits.yml
+++ b/features/cassettes/Civil_application_journeys/I_can_see_that_the_applicant_receives_benefits.yml
@@ -361,13 +361,373 @@ http_interactions:
     http_version: 
   recorded_at: Wed, 20 Mar 2019 16:51:40 GMT
 - request:
+    method: get
+    uri: https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?key=<ORDNANACE_SURVEY_API_KEY>&lr=EN&postcode=DA74NG
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Wed, 10 Apr 2019 17:18:31 GMT
+      Server:
+      - Apache-Coyote/1.1
+      Status:
+      - success
+      Tx-Id:
+      - '1554916711005:5'
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "header" : {
+            "uri" : "https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?lr=EN&postcode=DA74NG",
+            "query" : "postcode=DA74NG",
+            "offset" : 0,
+            "totalresults" : 11,
+            "format" : "JSON",
+            "dataset" : "DPA",
+            "lr" : "EN",
+            "maxresults" : 100,
+            "epoch" : "65",
+            "output_srs" : "EPSG:27700"
+          },
+          "results" : [ {
+            "DPA" : {
+              "UPRN" : "100020211558",
+              "UDPRN" : "6248161",
+              "ADDRESS" : "1, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "1",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "2",
+              "X_COORDINATE" : 548894.0,
+              "Y_COORDINATE" : 176139.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD02",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095093",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211559",
+              "UDPRN" : "6248164",
+              "ADDRESS" : "2, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "2",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548861.0,
+              "Y_COORDINATE" : 176156.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095079",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211560",
+              "UDPRN" : "6248165",
+              "ADDRESS" : "3, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "3",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548888.0,
+              "Y_COORDINATE" : 176131.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD02",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb5000005153955102",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211561",
+              "UDPRN" : "6248166",
+              "ADDRESS" : "4, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "4",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548858.0,
+              "Y_COORDINATE" : 176150.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095080",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211562",
+              "UDPRN" : "6248167",
+              "ADDRESS" : "5, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "5",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548884.0,
+              "Y_COORDINATE" : 176118.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD02",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095091",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211563",
+              "UDPRN" : "6248168",
+              "ADDRESS" : "6, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "6",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548849.0,
+              "Y_COORDINATE" : 176141.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095082",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211564",
+              "UDPRN" : "6248169",
+              "ADDRESS" : "7, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "7",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548874.0,
+              "Y_COORDINATE" : 176106.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095089",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211565",
+              "UDPRN" : "6248170",
+              "ADDRESS" : "8, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "8",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548846.0,
+              "Y_COORDINATE" : 176133.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095083",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211566",
+              "UDPRN" : "6248171",
+              "ADDRESS" : "9, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "9",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548868.0,
+              "Y_COORDINATE" : 176104.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095088",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211567",
+              "UDPRN" : "6248162",
+              "ADDRESS" : "10, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "10",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548848.0,
+              "Y_COORDINATE" : 176115.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095085",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211568",
+              "UDPRN" : "6248163",
+              "ADDRESS" : "12, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "12",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "2",
+              "X_COORDINATE" : 548854.0,
+              "Y_COORDINATE" : 176110.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095086",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          } ]
+        }
+    http_version: 
+  recorded_at: Wed, 10 Apr 2019 17:18:31 GMT
+- request:
     method: post
     uri: https://benefitchecker.dev.legalservices.gov.uk/lsx/lsc-services/benefitChecker?wsdl
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:wsdl="https://lsc.gov.uk/benefitchecker/service/1.0/API_1.0_Check"
-        xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Body><wsdl:check><clientReference>aba9f257-f919-4e16-a1ca-d802b8c62fb6</clientReference><nino>JA293483A</nino><surname>WALKER</surname><dateOfBirth>19800110</dateOfBirth><dateOfAward>20190320</dateOfAward><lscServiceName><BC_LSC_SERVICE_NAME></lscServiceName><clientOrgId><BC_CLIENT_ORG_ID></clientOrgId><clientUserId><BC_CLIENT_USER_ID></clientUserId></wsdl:check></env:Body></env:Envelope>
+        xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Body><wsdl:check><clientReference>c2f6ce74-767b-4e5d-9f5d-14e710019a5a</clientReference><nino>JA293483A</nino><surname>WALKER</surname><dateOfBirth>19800110</dateOfBirth><dateOfAward>20190410</dateOfAward><lscServiceName><BC_LSC_SERVICE_NAME></lscServiceName><clientOrgId><BC_CLIENT_ORG_ID></clientOrgId><clientUserId><BC_CLIENT_USER_ID></clientUserId></wsdl:check></env:Body></env:Envelope>
     headers:
       Soapaction:
       - '"check"'
@@ -387,7 +747,7 @@ http_interactions:
       message: ''
     headers:
       Date:
-      - Wed, 20 Mar 2019 16:51:42 GMT
+      - Wed, 10 Apr 2019 17:18:33 GMT
       Content-Type:
       - text/xml;charset=utf-8
       Transfer-Encoding:
@@ -395,7 +755,7 @@ http_interactions:
       Connection:
       - keep-alive
       X-Amzn-Trace-Id:
-      - Root=1-5c926f9e-c14978bbab77bd431626c6b6;
+      - Root=1-5cae2569-ddd5561ced8bef5622e5e2db;
       Vary:
       - Accept-Encoding
     body:
@@ -403,9 +763,9 @@ http_interactions:
       string: <?xml version="1.0" encoding="UTF-8"?><soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
         xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><soapenv:Body><benefitCheckerResponse
         xmlns="https://lsc.gov.uk/benefitchecker/service/1.0/API_1.0_Check"><ns1:originalClientRef
-        xmlns:ns1="http://lsc.gov.uk/benefitchecker/data/1.0">aba9f257-f919-4e16-a1ca-d802b8c62fb6</ns1:originalClientRef><ns2:benefitCheckerStatus
+        xmlns:ns1="http://lsc.gov.uk/benefitchecker/data/1.0">c2f6ce74-767b-4e5d-9f5d-14e710019a5a</ns1:originalClientRef><ns2:benefitCheckerStatus
         xmlns:ns2="http://lsc.gov.uk/benefitchecker/data/1.0">Yes</ns2:benefitCheckerStatus><ns3:confirmationRef
-        xmlns:ns3="http://lsc.gov.uk/benefitchecker/data/1.0">T1553100702818</ns3:confirmationRef></benefitCheckerResponse></soapenv:Body></soapenv:Envelope>
+        xmlns:ns3="http://lsc.gov.uk/benefitchecker/data/1.0">T1554916713848</ns3:confirmationRef></benefitCheckerResponse></soapenv:Body></soapenv:Envelope>
     http_version: 
-  recorded_at: Wed, 20 Mar 2019 16:51:42 GMT
+  recorded_at: Wed, 10 Apr 2019 17:18:33 GMT
 recorded_with: VCR 4.0.0

--- a/features/cassettes/Civil_application_journeys/I_want_to_change_address_from_the_check_your_answers_page.yml
+++ b/features/cassettes/Civil_application_journeys/I_want_to_change_address_from_the_check_your_answers_page.yml
@@ -916,4 +916,364 @@ http_interactions:
         }
     http_version: 
   recorded_at: Wed, 28 Nov 2018 14:35:34 GMT
+- request:
+    method: get
+    uri: https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?key=<ORDNANACE_SURVEY_API_KEY>&lr=EN&postcode=DA74NG
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Wed, 10 Apr 2019 17:18:50 GMT
+      Server:
+      - Apache-Coyote/1.1
+      Status:
+      - success
+      Tx-Id:
+      - 1554916730410:410
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "header" : {
+            "uri" : "https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?lr=EN&postcode=DA74NG",
+            "query" : "postcode=DA74NG",
+            "offset" : 0,
+            "totalresults" : 11,
+            "format" : "JSON",
+            "dataset" : "DPA",
+            "lr" : "EN",
+            "maxresults" : 100,
+            "epoch" : "65",
+            "output_srs" : "EPSG:27700"
+          },
+          "results" : [ {
+            "DPA" : {
+              "UPRN" : "100020211558",
+              "UDPRN" : "6248161",
+              "ADDRESS" : "1, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "1",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "2",
+              "X_COORDINATE" : 548894.0,
+              "Y_COORDINATE" : 176139.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD02",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095093",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211559",
+              "UDPRN" : "6248164",
+              "ADDRESS" : "2, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "2",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548861.0,
+              "Y_COORDINATE" : 176156.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095079",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211560",
+              "UDPRN" : "6248165",
+              "ADDRESS" : "3, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "3",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548888.0,
+              "Y_COORDINATE" : 176131.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD02",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb5000005153955102",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211561",
+              "UDPRN" : "6248166",
+              "ADDRESS" : "4, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "4",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548858.0,
+              "Y_COORDINATE" : 176150.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095080",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211562",
+              "UDPRN" : "6248167",
+              "ADDRESS" : "5, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "5",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548884.0,
+              "Y_COORDINATE" : 176118.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD02",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095091",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211563",
+              "UDPRN" : "6248168",
+              "ADDRESS" : "6, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "6",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548849.0,
+              "Y_COORDINATE" : 176141.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095082",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211564",
+              "UDPRN" : "6248169",
+              "ADDRESS" : "7, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "7",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548874.0,
+              "Y_COORDINATE" : 176106.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095089",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211565",
+              "UDPRN" : "6248170",
+              "ADDRESS" : "8, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "8",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548846.0,
+              "Y_COORDINATE" : 176133.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095083",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211566",
+              "UDPRN" : "6248171",
+              "ADDRESS" : "9, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "9",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548868.0,
+              "Y_COORDINATE" : 176104.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095088",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211567",
+              "UDPRN" : "6248162",
+              "ADDRESS" : "10, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "10",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548848.0,
+              "Y_COORDINATE" : 176115.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095085",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211568",
+              "UDPRN" : "6248163",
+              "ADDRESS" : "12, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "12",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "2",
+              "X_COORDINATE" : 548854.0,
+              "Y_COORDINATE" : 176110.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095086",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          } ]
+        }
+    http_version: 
+  recorded_at: Wed, 10 Apr 2019 17:18:50 GMT
 recorded_with: VCR 4.0.0

--- a/features/cassettes/Civil_application_journeys/I_want_to_change_address_manually_from_the_check_your_answers_page.yml
+++ b/features/cassettes/Civil_application_journeys/I_want_to_change_address_manually_from_the_check_your_answers_page.yml
@@ -607,4 +607,55 @@ http_interactions:
         }
     http_version: 
   recorded_at: Wed, 28 Nov 2018 14:35:39 GMT
+- request:
+    method: get
+    uri: https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?key=<ORDNANACE_SURVEY_API_KEY>&lr=EN&postcode=SW1H9AJ
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Wed, 10 Apr 2019 17:18:52 GMT
+      Server:
+      - Apache-Coyote/1.1
+      Status:
+      - success
+      Tx-Id:
+      - 1554916732182:182
+      Content-Length:
+      - '337'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "header" : {
+            "uri" : "https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?lr=EN&postcode=SW1H9AJ",
+            "query" : "postcode=SW1H9AJ",
+            "offset" : 0,
+            "totalresults" : 0,
+            "format" : "JSON",
+            "dataset" : "DPA",
+            "lr" : "EN",
+            "maxresults" : 100,
+            "epoch" : "65",
+            "output_srs" : "EPSG:27700"
+          }
+        }
+    http_version: 
+  recorded_at: Wed, 10 Apr 2019 17:18:52 GMT
 recorded_with: VCR 4.0.0

--- a/features/cassettes/Civil_application_journeys/I_want_to_return_to_check_your_answers_from_address_select.yml
+++ b/features/cassettes/Civil_application_journeys/I_want_to_return_to_check_your_answers_from_address_select.yml
@@ -916,4 +916,364 @@ http_interactions:
         }
     http_version: 
   recorded_at: Wed, 28 Nov 2018 14:35:47 GMT
+- request:
+    method: get
+    uri: https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?key=<ORDNANACE_SURVEY_API_KEY>&lr=EN&postcode=DA74NG
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Wed, 10 Apr 2019 17:18:55 GMT
+      Server:
+      - Apache-Coyote/1.1
+      Status:
+      - success
+      Tx-Id:
+      - '1554916735043:43'
+      Content-Length:
+      - '11445'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "header" : {
+            "uri" : "https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?lr=EN&postcode=DA74NG",
+            "query" : "postcode=DA74NG",
+            "offset" : 0,
+            "totalresults" : 11,
+            "format" : "JSON",
+            "dataset" : "DPA",
+            "lr" : "EN",
+            "maxresults" : 100,
+            "epoch" : "65",
+            "output_srs" : "EPSG:27700"
+          },
+          "results" : [ {
+            "DPA" : {
+              "UPRN" : "100020211558",
+              "UDPRN" : "6248161",
+              "ADDRESS" : "1, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "1",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "2",
+              "X_COORDINATE" : 548894.0,
+              "Y_COORDINATE" : 176139.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD02",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095093",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211559",
+              "UDPRN" : "6248164",
+              "ADDRESS" : "2, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "2",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548861.0,
+              "Y_COORDINATE" : 176156.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095079",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211560",
+              "UDPRN" : "6248165",
+              "ADDRESS" : "3, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "3",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548888.0,
+              "Y_COORDINATE" : 176131.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD02",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb5000005153955102",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211561",
+              "UDPRN" : "6248166",
+              "ADDRESS" : "4, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "4",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548858.0,
+              "Y_COORDINATE" : 176150.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095080",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211562",
+              "UDPRN" : "6248167",
+              "ADDRESS" : "5, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "5",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548884.0,
+              "Y_COORDINATE" : 176118.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD02",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095091",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211563",
+              "UDPRN" : "6248168",
+              "ADDRESS" : "6, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "6",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548849.0,
+              "Y_COORDINATE" : 176141.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095082",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211564",
+              "UDPRN" : "6248169",
+              "ADDRESS" : "7, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "7",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548874.0,
+              "Y_COORDINATE" : 176106.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095089",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211565",
+              "UDPRN" : "6248170",
+              "ADDRESS" : "8, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "8",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548846.0,
+              "Y_COORDINATE" : 176133.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095083",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211566",
+              "UDPRN" : "6248171",
+              "ADDRESS" : "9, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "9",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548868.0,
+              "Y_COORDINATE" : 176104.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095088",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211567",
+              "UDPRN" : "6248162",
+              "ADDRESS" : "10, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "10",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548848.0,
+              "Y_COORDINATE" : 176115.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095085",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211568",
+              "UDPRN" : "6248163",
+              "ADDRESS" : "12, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "12",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "2",
+              "X_COORDINATE" : 548854.0,
+              "Y_COORDINATE" : 176110.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095086",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          } ]
+        }
+    http_version: 
+  recorded_at: Wed, 10 Apr 2019 17:18:55 GMT
 recorded_with: VCR 4.0.0

--- a/features/cassettes/Civil_application_journeys/No_results_returned_is_seen_on_screen_when_invalid_proceeding_search_entered.yml
+++ b/features/cassettes/Civil_application_journeys/No_results_returned_is_seen_on_screen_when_invalid_proceeding_search_entered.yml
@@ -360,4 +360,364 @@ http_interactions:
         }
     http_version: 
   recorded_at: Tue, 29 Jan 2019 11:35:53 GMT
+- request:
+    method: get
+    uri: https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?key=<ORDNANACE_SURVEY_API_KEY>&lr=EN&postcode=DA74NG
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Wed, 10 Apr 2019 17:18:06 GMT
+      Server:
+      - Apache-Coyote/1.1
+      Status:
+      - success
+      Tx-Id:
+      - 1554916686296:296
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "header" : {
+            "uri" : "https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?lr=EN&postcode=DA74NG",
+            "query" : "postcode=DA74NG",
+            "offset" : 0,
+            "totalresults" : 11,
+            "format" : "JSON",
+            "dataset" : "DPA",
+            "lr" : "EN",
+            "maxresults" : 100,
+            "epoch" : "65",
+            "output_srs" : "EPSG:27700"
+          },
+          "results" : [ {
+            "DPA" : {
+              "UPRN" : "100020211558",
+              "UDPRN" : "6248161",
+              "ADDRESS" : "1, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "1",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "2",
+              "X_COORDINATE" : 548894.0,
+              "Y_COORDINATE" : 176139.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD02",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095093",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211559",
+              "UDPRN" : "6248164",
+              "ADDRESS" : "2, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "2",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548861.0,
+              "Y_COORDINATE" : 176156.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095079",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211560",
+              "UDPRN" : "6248165",
+              "ADDRESS" : "3, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "3",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548888.0,
+              "Y_COORDINATE" : 176131.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD02",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb5000005153955102",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211561",
+              "UDPRN" : "6248166",
+              "ADDRESS" : "4, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "4",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548858.0,
+              "Y_COORDINATE" : 176150.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095080",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211562",
+              "UDPRN" : "6248167",
+              "ADDRESS" : "5, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "5",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548884.0,
+              "Y_COORDINATE" : 176118.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD02",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095091",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211563",
+              "UDPRN" : "6248168",
+              "ADDRESS" : "6, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "6",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548849.0,
+              "Y_COORDINATE" : 176141.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095082",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211564",
+              "UDPRN" : "6248169",
+              "ADDRESS" : "7, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "7",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548874.0,
+              "Y_COORDINATE" : 176106.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095089",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211565",
+              "UDPRN" : "6248170",
+              "ADDRESS" : "8, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "8",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548846.0,
+              "Y_COORDINATE" : 176133.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095083",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211566",
+              "UDPRN" : "6248171",
+              "ADDRESS" : "9, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "9",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548868.0,
+              "Y_COORDINATE" : 176104.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095088",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211567",
+              "UDPRN" : "6248162",
+              "ADDRESS" : "10, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "10",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548848.0,
+              "Y_COORDINATE" : 176115.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095085",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211568",
+              "UDPRN" : "6248163",
+              "ADDRESS" : "12, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "12",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "2",
+              "X_COORDINATE" : 548854.0,
+              "Y_COORDINATE" : 176110.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095086",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          } ]
+        }
+    http_version: 
+  recorded_at: Wed, 10 Apr 2019 17:18:06 GMT
 recorded_with: VCR 4.0.0

--- a/features/cassettes/Civil_application_journeys/Receives_benefits_and_completes_the_application.yml
+++ b/features/cassettes/Civil_application_journeys/Receives_benefits_and_completes_the_application.yml
@@ -7,7 +7,7 @@ http_interactions:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:wsdl="https://lsc.gov.uk/benefitchecker/service/1.0/API_1.0_Check"
-        xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Body><wsdl:check><clientReference>70b908ed-b306-49dd-80c8-86d3b2a96178</clientReference><nino>JA293483A</nino><surname>WALKER</surname><dateOfBirth>19800110</dateOfBirth><dateOfAward>20190320</dateOfAward><lscServiceName><BC_LSC_SERVICE_NAME></lscServiceName><clientOrgId><BC_CLIENT_ORG_ID></clientOrgId><clientUserId><BC_CLIENT_USER_ID></clientUserId></wsdl:check></env:Body></env:Envelope>
+        xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Body><wsdl:check><clientReference>0c17e9f8-94d0-4f53-ac9f-d4849b0537d6</clientReference><nino>JA293483A</nino><surname>WALKER</surname><dateOfBirth>19800110</dateOfBirth><dateOfAward>20190410</dateOfAward><lscServiceName><BC_LSC_SERVICE_NAME></lscServiceName><clientOrgId><BC_CLIENT_ORG_ID></clientOrgId><clientUserId><BC_CLIENT_USER_ID></clientUserId></wsdl:check></env:Body></env:Envelope>
     headers:
       Soapaction:
       - '"check"'
@@ -27,7 +27,7 @@ http_interactions:
       message: ''
     headers:
       Date:
-      - Wed, 20 Mar 2019 17:05:00 GMT
+      - Wed, 10 Apr 2019 17:19:02 GMT
       Content-Type:
       - text/xml;charset=utf-8
       Transfer-Encoding:
@@ -35,7 +35,7 @@ http_interactions:
       Connection:
       - keep-alive
       X-Amzn-Trace-Id:
-      - Root=1-5c9272bc-8bee2f0044498080de54f2ac;
+      - Root=1-5cae2586-327fd4e8eda01fb4bb44f7c4;
       Vary:
       - Accept-Encoding
     body:
@@ -43,9 +43,9 @@ http_interactions:
       string: <?xml version="1.0" encoding="UTF-8"?><soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
         xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><soapenv:Body><benefitCheckerResponse
         xmlns="https://lsc.gov.uk/benefitchecker/service/1.0/API_1.0_Check"><ns1:originalClientRef
-        xmlns:ns1="http://lsc.gov.uk/benefitchecker/data/1.0">70b908ed-b306-49dd-80c8-86d3b2a96178</ns1:originalClientRef><ns2:benefitCheckerStatus
+        xmlns:ns1="http://lsc.gov.uk/benefitchecker/data/1.0">0c17e9f8-94d0-4f53-ac9f-d4849b0537d6</ns1:originalClientRef><ns2:benefitCheckerStatus
         xmlns:ns2="http://lsc.gov.uk/benefitchecker/data/1.0">Yes</ns2:benefitCheckerStatus><ns3:confirmationRef
-        xmlns:ns3="http://lsc.gov.uk/benefitchecker/data/1.0">T1553101500262</ns3:confirmationRef></benefitCheckerResponse></soapenv:Body></soapenv:Envelope>
+        xmlns:ns3="http://lsc.gov.uk/benefitchecker/data/1.0">T1554916742072</ns3:confirmationRef></benefitCheckerResponse></soapenv:Body></soapenv:Envelope>
     http_version: 
-  recorded_at: Wed, 20 Mar 2019 17:05:00 GMT
+  recorded_at: Wed, 10 Apr 2019 17:19:02 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/BenefitCheckService/_check_benefits/when_some_credentials_are_missing/raises_a_detailed_error.yml
+++ b/spec/cassettes/BenefitCheckService/_check_benefits/when_some_credentials_are_missing/raises_a_detailed_error.yml
@@ -7,7 +7,7 @@ http_interactions:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:wsdl="https://lsc.gov.uk/benefitchecker/service/1.0/API_1.0_Check"
-        xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Body><wsdl:check><clientReference>927652ba-5892-454b-aa46-85a8e89981ba</clientReference><nino>JA293483A</nino><surname>WALKER</surname><dateOfBirth>19800110</dateOfBirth><dateOfAward>20190320</dateOfAward><lscServiceName><BC_LSC_SERVICE_NAME></lscServiceName><clientOrgId></clientOrgId><clientUserId><BC_CLIENT_USER_ID></clientUserId></wsdl:check></env:Body></env:Envelope>
+        xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Body><wsdl:check><clientReference>b3ecbfad-1018-408f-b3cf-807f67ad65a7</clientReference><nino>JA293483A</nino><surname>WALKER</surname><dateOfBirth>19800110</dateOfBirth><dateOfAward>20190410</dateOfAward><lscServiceName><BC_LSC_SERVICE_NAME></lscServiceName><clientOrgId></clientOrgId><clientUserId><BC_CLIENT_USER_ID></clientUserId></wsdl:check></env:Body></env:Envelope>
     headers:
       Soapaction:
       - '"check"'
@@ -27,7 +27,7 @@ http_interactions:
       message: ''
     headers:
       Date:
-      - Wed, 20 Mar 2019 16:45:48 GMT
+      - Wed, 10 Apr 2019 17:16:58 GMT
       Content-Type:
       - text/xml;charset=utf-8
       Transfer-Encoding:
@@ -35,7 +35,7 @@ http_interactions:
       Connection:
       - keep-alive
       X-Amzn-Trace-Id:
-      - Root=1-5c926e3c-ec2bfb405a3a4ad060dd87d0;
+      - Root=1-5cae250a-a60b41c032db2f909575d3e4;
       Vary:
       - Accept-Encoding
     body:
@@ -46,7 +46,7 @@ http_interactions:
         xmlns:ns2="http://lsc.gov.uk/benefitchecker/data/1.0">LSCBC205</ns2:MessageCode><ns3:MessageText
         xmlns:ns3="http://lsc.gov.uk/benefitchecker/data/1.0">Invalid request credentials.</ns3:MessageText></ns1:benefitCheckerFaultException><ns4:exceptionName
         xmlns:ns4="http://xml.apache.org/axis/">uk.gov.lsc.benefitchecker.data._1_0.BenefitCheckerFaultException</ns4:exceptionName><ns5:hostname
-        xmlns:ns5="http://xml.apache.org/axis/">76d3d47eb802</ns5:hostname></detail></soapenv:Fault></soapenv:Body></soapenv:Envelope>
+        xmlns:ns5="http://xml.apache.org/axis/">97d961dc7f48</ns5:hostname></detail></soapenv:Fault></soapenv:Body></soapenv:Envelope>
     http_version: 
-  recorded_at: Wed, 20 Mar 2019 16:45:48 GMT
+  recorded_at: Wed, 10 Apr 2019 17:16:58 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/BenefitCheckService/_check_benefits/when_the_API_raises_an_error/raises_a_detailed_error.yml
+++ b/spec/cassettes/BenefitCheckService/_check_benefits/when_the_API_raises_an_error/raises_a_detailed_error.yml
@@ -7,7 +7,7 @@ http_interactions:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:wsdl="https://lsc.gov.uk/benefitchecker/service/1.0/API_1.0_Check"
-        xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Body><wsdl:check><clientReference>f770edb0-ca39-4a17-b7e5-12ae34ea5410</clientReference><nino>JA293483A</nino><surname>SERVICEEXCEPTION</surname><dateOfBirth>19800110</dateOfBirth><dateOfAward>20190320</dateOfAward><lscServiceName><BC_LSC_SERVICE_NAME></lscServiceName><clientOrgId><BC_CLIENT_ORG_ID></clientOrgId><clientUserId><BC_CLIENT_USER_ID></clientUserId></wsdl:check></env:Body></env:Envelope>
+        xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Body><wsdl:check><clientReference>ee7efca3-949c-427e-98a2-1a6b225af896</clientReference><nino>JA293483A</nino><surname>SERVICEEXCEPTION</surname><dateOfBirth>19800110</dateOfBirth><dateOfAward>20190410</dateOfAward><lscServiceName><BC_LSC_SERVICE_NAME></lscServiceName><clientOrgId><BC_CLIENT_ORG_ID></clientOrgId><clientUserId><BC_CLIENT_USER_ID></clientUserId></wsdl:check></env:Body></env:Envelope>
     headers:
       Soapaction:
       - '"check"'
@@ -27,7 +27,7 @@ http_interactions:
       message: ''
     headers:
       Date:
-      - Wed, 20 Mar 2019 16:45:02 GMT
+      - Wed, 10 Apr 2019 17:16:58 GMT
       Content-Type:
       - text/xml;charset=utf-8
       Transfer-Encoding:
@@ -35,7 +35,7 @@ http_interactions:
       Connection:
       - keep-alive
       X-Amzn-Trace-Id:
-      - Root=1-5c926e0e-b7825105aa022d8848ef6f24;
+      - Root=1-5cae250a-53adeb4017d718885845cb14;
       Vary:
       - Accept-Encoding
     body:
@@ -46,7 +46,7 @@ http_interactions:
         xmlns:ns2="http://lsc.gov.uk/benefitchecker/data/1.0">LSCBC959</ns2:MessageCode><ns3:MessageText
         xmlns:ns3="http://lsc.gov.uk/benefitchecker/data/1.0">Service unavailable.</ns3:MessageText></ns1:benefitCheckerFaultException><ns4:exceptionName
         xmlns:ns4="http://xml.apache.org/axis/">uk.gov.lsc.benefitchecker.data._1_0.BenefitCheckerFaultException</ns4:exceptionName><ns5:hostname
-        xmlns:ns5="http://xml.apache.org/axis/">a7ae279cd176</ns5:hostname></detail></soapenv:Fault></soapenv:Body></soapenv:Envelope>
+        xmlns:ns5="http://xml.apache.org/axis/">d6acb6f1070e</ns5:hostname></detail></soapenv:Fault></soapenv:Body></soapenv:Envelope>
     http_version: 
-  recorded_at: Wed, 20 Mar 2019 16:45:02 GMT
+  recorded_at: Wed, 10 Apr 2019 17:16:58 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/BenefitCheckService/_check_benefits/when_the_call_is_successful/returns_the_right_parameters.yml
+++ b/spec/cassettes/BenefitCheckService/_check_benefits/when_the_call_is_successful/returns_the_right_parameters.yml
@@ -7,7 +7,7 @@ http_interactions:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:wsdl="https://lsc.gov.uk/benefitchecker/service/1.0/API_1.0_Check"
-        xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Body><wsdl:check><clientReference>880e256e-392e-4b7b-a674-e579e4240c21</clientReference><nino>JA293483A</nino><surname>WALKER</surname><dateOfBirth>19800110</dateOfBirth><dateOfAward>20190320</dateOfAward><lscServiceName><BC_LSC_SERVICE_NAME></lscServiceName><clientOrgId><BC_CLIENT_ORG_ID></clientOrgId><clientUserId><BC_CLIENT_USER_ID></clientUserId></wsdl:check></env:Body></env:Envelope>
+        xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Body><wsdl:check><clientReference>639a980e-446d-436d-b2df-dbbff3d67a63</clientReference><nino>JA293483A</nino><surname>WALKER</surname><dateOfBirth>19800110</dateOfBirth><dateOfAward>20190410</dateOfAward><lscServiceName><BC_LSC_SERVICE_NAME></lscServiceName><clientOrgId><BC_CLIENT_ORG_ID></clientOrgId><clientUserId><BC_CLIENT_USER_ID></clientUserId></wsdl:check></env:Body></env:Envelope>
     headers:
       Soapaction:
       - '"check"'
@@ -27,7 +27,7 @@ http_interactions:
       message: ''
     headers:
       Date:
-      - Wed, 20 Mar 2019 16:43:10 GMT
+      - Wed, 10 Apr 2019 17:16:57 GMT
       Content-Type:
       - text/xml;charset=utf-8
       Transfer-Encoding:
@@ -35,7 +35,7 @@ http_interactions:
       Connection:
       - keep-alive
       X-Amzn-Trace-Id:
-      - Root=1-5c926d9e-a0376ca8e9a8eaa00e51236a;
+      - Root=1-5cae2509-4467f5c2a4d688358aeae48b;
       Vary:
       - Accept-Encoding
     body:
@@ -43,9 +43,9 @@ http_interactions:
       string: <?xml version="1.0" encoding="UTF-8"?><soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
         xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><soapenv:Body><benefitCheckerResponse
         xmlns="https://lsc.gov.uk/benefitchecker/service/1.0/API_1.0_Check"><ns1:originalClientRef
-        xmlns:ns1="http://lsc.gov.uk/benefitchecker/data/1.0">880e256e-392e-4b7b-a674-e579e4240c21</ns1:originalClientRef><ns2:benefitCheckerStatus
+        xmlns:ns1="http://lsc.gov.uk/benefitchecker/data/1.0">639a980e-446d-436d-b2df-dbbff3d67a63</ns1:originalClientRef><ns2:benefitCheckerStatus
         xmlns:ns2="http://lsc.gov.uk/benefitchecker/data/1.0">Yes</ns2:benefitCheckerStatus><ns3:confirmationRef
-        xmlns:ns3="http://lsc.gov.uk/benefitchecker/data/1.0">T1553100190760</ns3:confirmationRef></benefitCheckerResponse></soapenv:Body></soapenv:Envelope>
+        xmlns:ns3="http://lsc.gov.uk/benefitchecker/data/1.0">T1554916617564</ns3:confirmationRef></benefitCheckerResponse></soapenv:Body></soapenv:Envelope>
     http_version: 
-  recorded_at: Wed, 20 Mar 2019 16:43:10 GMT
+  recorded_at: Wed, 10 Apr 2019 17:16:57 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/BenefitCheckService/_check_benefits/when_the_call_is_successful/sends_the_right_parameters.yml
+++ b/spec/cassettes/BenefitCheckService/_check_benefits/when_the_call_is_successful/sends_the_right_parameters.yml
@@ -7,7 +7,7 @@ http_interactions:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:wsdl="https://lsc.gov.uk/benefitchecker/service/1.0/API_1.0_Check"
-        xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Body><wsdl:check><clientReference>0496b5ac-5242-4970-a87d-6e0fa86b9e9f</clientReference><nino>JA293483A</nino><surname>WALKER</surname><dateOfBirth>19800110</dateOfBirth><dateOfAward>20190320</dateOfAward><lscServiceName><BC_LSC_SERVICE_NAME></lscServiceName><clientOrgId><BC_CLIENT_ORG_ID></clientOrgId><clientUserId><BC_CLIENT_USER_ID></clientUserId></wsdl:check></env:Body></env:Envelope>
+        xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Body><wsdl:check><clientReference>c1f37e33-f07f-4728-8352-e40c8953524e</clientReference><nino>JA293483A</nino><surname>WALKER</surname><dateOfBirth>19800110</dateOfBirth><dateOfAward>20190410</dateOfAward><lscServiceName><BC_LSC_SERVICE_NAME></lscServiceName><clientOrgId><BC_CLIENT_ORG_ID></clientOrgId><clientUserId><BC_CLIENT_USER_ID></clientUserId></wsdl:check></env:Body></env:Envelope>
     headers:
       Soapaction:
       - '"check"'
@@ -27,7 +27,7 @@ http_interactions:
       message: ''
     headers:
       Date:
-      - Wed, 20 Mar 2019 16:43:35 GMT
+      - Wed, 10 Apr 2019 17:16:57 GMT
       Content-Type:
       - text/xml;charset=utf-8
       Transfer-Encoding:
@@ -35,7 +35,7 @@ http_interactions:
       Connection:
       - keep-alive
       X-Amzn-Trace-Id:
-      - Root=1-5c926db7-f80ca1148498f0cca67aa282;
+      - Root=1-5cae2509-849724b8b822e000e1310314;
       Vary:
       - Accept-Encoding
     body:
@@ -43,9 +43,9 @@ http_interactions:
       string: <?xml version="1.0" encoding="UTF-8"?><soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
         xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><soapenv:Body><benefitCheckerResponse
         xmlns="https://lsc.gov.uk/benefitchecker/service/1.0/API_1.0_Check"><ns1:originalClientRef
-        xmlns:ns1="http://lsc.gov.uk/benefitchecker/data/1.0">0496b5ac-5242-4970-a87d-6e0fa86b9e9f</ns1:originalClientRef><ns2:benefitCheckerStatus
+        xmlns:ns1="http://lsc.gov.uk/benefitchecker/data/1.0">c1f37e33-f07f-4728-8352-e40c8953524e</ns1:originalClientRef><ns2:benefitCheckerStatus
         xmlns:ns2="http://lsc.gov.uk/benefitchecker/data/1.0">Yes</ns2:benefitCheckerStatus><ns3:confirmationRef
-        xmlns:ns3="http://lsc.gov.uk/benefitchecker/data/1.0">T1553100215622</ns3:confirmationRef></benefitCheckerResponse></soapenv:Body></soapenv:Envelope>
+        xmlns:ns3="http://lsc.gov.uk/benefitchecker/data/1.0">T1554916617941</ns3:confirmationRef></benefitCheckerResponse></soapenv:Body></soapenv:Envelope>
     http_version: 
-  recorded_at: Wed, 20 Mar 2019 16:43:35 GMT
+  recorded_at: Wed, 10 Apr 2019 17:16:57 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/BenefitCheckService/_check_benefits/when_the_call_is_successful/when_the_last_name_is_not_in_upper_case/normalizes_the_last_name.yml
+++ b/spec/cassettes/BenefitCheckService/_check_benefits/when_the_call_is_successful/when_the_last_name_is_not_in_upper_case/normalizes_the_last_name.yml
@@ -7,7 +7,7 @@ http_interactions:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:wsdl="https://lsc.gov.uk/benefitchecker/service/1.0/API_1.0_Check"
-        xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Body><wsdl:check><clientReference>76e82c49-e996-4a1c-8f6c-21dc3c7fbb56</clientReference><nino>JA293483A</nino><surname>WALKER</surname><dateOfBirth>19800110</dateOfBirth><dateOfAward>20190320</dateOfAward><lscServiceName><BC_LSC_SERVICE_NAME></lscServiceName><clientOrgId><BC_CLIENT_ORG_ID></clientOrgId><clientUserId><BC_CLIENT_USER_ID></clientUserId></wsdl:check></env:Body></env:Envelope>
+        xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Body><wsdl:check><clientReference>b05485e7-8b5b-4c09-94d5-f8a8620a81e2</clientReference><nino>JA293483A</nino><surname>WALKER</surname><dateOfBirth>19800110</dateOfBirth><dateOfAward>20190410</dateOfAward><lscServiceName><BC_LSC_SERVICE_NAME></lscServiceName><clientOrgId><BC_CLIENT_ORG_ID></clientOrgId><clientUserId><BC_CLIENT_USER_ID></clientUserId></wsdl:check></env:Body></env:Envelope>
     headers:
       Soapaction:
       - '"check"'
@@ -27,7 +27,7 @@ http_interactions:
       message: ''
     headers:
       Date:
-      - Wed, 20 Mar 2019 16:43:59 GMT
+      - Wed, 10 Apr 2019 17:16:58 GMT
       Content-Type:
       - text/xml;charset=utf-8
       Transfer-Encoding:
@@ -35,7 +35,7 @@ http_interactions:
       Connection:
       - keep-alive
       X-Amzn-Trace-Id:
-      - Root=1-5c926dcf-294bc86778073b23e685405a;
+      - Root=1-5cae250a-1fc2ef44e7903d7cd0689138;
       Vary:
       - Accept-Encoding
     body:
@@ -43,9 +43,9 @@ http_interactions:
       string: <?xml version="1.0" encoding="UTF-8"?><soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
         xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><soapenv:Body><benefitCheckerResponse
         xmlns="https://lsc.gov.uk/benefitchecker/service/1.0/API_1.0_Check"><ns1:originalClientRef
-        xmlns:ns1="http://lsc.gov.uk/benefitchecker/data/1.0">76e82c49-e996-4a1c-8f6c-21dc3c7fbb56</ns1:originalClientRef><ns2:benefitCheckerStatus
+        xmlns:ns1="http://lsc.gov.uk/benefitchecker/data/1.0">b05485e7-8b5b-4c09-94d5-f8a8620a81e2</ns1:originalClientRef><ns2:benefitCheckerStatus
         xmlns:ns2="http://lsc.gov.uk/benefitchecker/data/1.0">Yes</ns2:benefitCheckerStatus><ns3:confirmationRef
-        xmlns:ns3="http://lsc.gov.uk/benefitchecker/data/1.0">T1553100239293</ns3:confirmationRef></benefitCheckerResponse></soapenv:Body></soapenv:Envelope>
+        xmlns:ns3="http://lsc.gov.uk/benefitchecker/data/1.0">T1554916618076</ns3:confirmationRef></benefitCheckerResponse></soapenv:Body></soapenv:Envelope>
     http_version: 
-  recorded_at: Wed, 20 Mar 2019 16:43:59 GMT
+  recorded_at: Wed, 10 Apr 2019 17:16:58 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/BenefitCheckService/_check_benefits/when_the_call_is_successful/when_the_last_name_is_not_in_upper_case/sends_the_right_parameters.yml
+++ b/spec/cassettes/BenefitCheckService/_check_benefits/when_the_call_is_successful/when_the_last_name_is_not_in_upper_case/sends_the_right_parameters.yml
@@ -7,7 +7,7 @@ http_interactions:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:wsdl="https://lsc.gov.uk/benefitchecker/service/1.0/API_1.0_Check"
-        xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Body><wsdl:check><clientReference>74067303-2e51-43b3-9532-3acb91d6d122</clientReference><nino>JA293483A</nino><surname>WALKER</surname><dateOfBirth>19800110</dateOfBirth><dateOfAward>20190320</dateOfAward><lscServiceName><BC_LSC_SERVICE_NAME></lscServiceName><clientOrgId><BC_CLIENT_ORG_ID></clientOrgId><clientUserId><BC_CLIENT_USER_ID></clientUserId></wsdl:check></env:Body></env:Envelope>
+        xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Body><wsdl:check><clientReference>6d4bddfd-d298-495c-b42e-fcf6baf21211</clientReference><nino>JA293483A</nino><surname>WALKER</surname><dateOfBirth>19800110</dateOfBirth><dateOfAward>20190410</dateOfAward><lscServiceName><BC_LSC_SERVICE_NAME></lscServiceName><clientOrgId><BC_CLIENT_ORG_ID></clientOrgId><clientUserId><BC_CLIENT_USER_ID></clientUserId></wsdl:check></env:Body></env:Envelope>
     headers:
       Soapaction:
       - '"check"'
@@ -27,7 +27,7 @@ http_interactions:
       message: ''
     headers:
       Date:
-      - Wed, 20 Mar 2019 16:43:59 GMT
+      - Wed, 10 Apr 2019 17:16:58 GMT
       Content-Type:
       - text/xml;charset=utf-8
       Transfer-Encoding:
@@ -35,7 +35,7 @@ http_interactions:
       Connection:
       - keep-alive
       X-Amzn-Trace-Id:
-      - Root=1-5c926dcf-30c7e96aa73df332ea894450;
+      - Root=1-5cae250a-dd1a41883be1e728492cd1f4;
       Vary:
       - Accept-Encoding
     body:
@@ -43,9 +43,9 @@ http_interactions:
       string: <?xml version="1.0" encoding="UTF-8"?><soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
         xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><soapenv:Body><benefitCheckerResponse
         xmlns="https://lsc.gov.uk/benefitchecker/service/1.0/API_1.0_Check"><ns1:originalClientRef
-        xmlns:ns1="http://lsc.gov.uk/benefitchecker/data/1.0">74067303-2e51-43b3-9532-3acb91d6d122</ns1:originalClientRef><ns2:benefitCheckerStatus
+        xmlns:ns1="http://lsc.gov.uk/benefitchecker/data/1.0">6d4bddfd-d298-495c-b42e-fcf6baf21211</ns1:originalClientRef><ns2:benefitCheckerStatus
         xmlns:ns2="http://lsc.gov.uk/benefitchecker/data/1.0">Yes</ns2:benefitCheckerStatus><ns3:confirmationRef
-        xmlns:ns3="http://lsc.gov.uk/benefitchecker/data/1.0">T1553100239372</ns3:confirmationRef></benefitCheckerResponse></soapenv:Body></soapenv:Envelope>
+        xmlns:ns3="http://lsc.gov.uk/benefitchecker/data/1.0">T1554916618206</ns3:confirmationRef></benefitCheckerResponse></soapenv:Body></soapenv:Envelope>
     http_version: 
-  recorded_at: Wed, 20 Mar 2019 16:43:59 GMT
+  recorded_at: Wed, 10 Apr 2019 17:16:58 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/address_selections_requests/GET_/providers/applications/_legal_aid_application_id/address_selections/edit/when_the_provider_is_authenticated/a_postcode_have_been_entered_before/but_the_lookup_does_not_return_any_valid_results/renders_the_manual_address_selection_page.yml
+++ b/spec/cassettes/address_selections_requests/GET_/providers/applications/_legal_aid_application_id/address_selections/edit/when_the_provider_is_authenticated/a_postcode_have_been_entered_before/but_the_lookup_does_not_return_any_valid_results/renders_the_manual_address_selection_page.yml
@@ -51,4 +51,55 @@ http_interactions:
         }
     http_version: 
   recorded_at: Mon, 17 Dec 2018 11:33:35 GMT
+- request:
+    method: get
+    uri: https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?key=<ORDNANACE_SURVEY_API_KEY>&lr=EN&postcode=SW1H9AJ
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Wed, 10 Apr 2019 17:16:41 GMT
+      Server:
+      - Apache-Coyote/1.1
+      Status:
+      - success
+      Tx-Id:
+      - '1554916601054:54'
+      Content-Length:
+      - '337'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "header" : {
+            "uri" : "https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?lr=EN&postcode=SW1H9AJ",
+            "query" : "postcode=SW1H9AJ",
+            "offset" : 0,
+            "totalresults" : 0,
+            "format" : "JSON",
+            "dataset" : "DPA",
+            "lr" : "EN",
+            "maxresults" : 100,
+            "epoch" : "65",
+            "output_srs" : "EPSG:27700"
+          }
+        }
+    http_version: 
+  recorded_at: Wed, 10 Apr 2019 17:16:41 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/address_selections_requests/GET_/providers/applications/_legal_aid_application_id/address_selections/edit/when_the_provider_is_authenticated/a_postcode_have_been_entered_before/performs_an_address_lookup_with_the_provided_postcode.yml
+++ b/spec/cassettes/address_selections_requests/GET_/providers/applications/_legal_aid_application_id/address_selections/edit/when_the_provider_is_authenticated/a_postcode_have_been_entered_before/performs_an_address_lookup_with_the_provided_postcode.yml
@@ -360,4 +360,364 @@ http_interactions:
         }
     http_version: 
   recorded_at: Mon, 17 Dec 2018 11:33:34 GMT
+- request:
+    method: get
+    uri: https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?key=<ORDNANACE_SURVEY_API_KEY>&lr=EN&postcode=DA74NG
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Wed, 10 Apr 2019 17:16:40 GMT
+      Server:
+      - Apache-Coyote/1.1
+      Status:
+      - success
+      Tx-Id:
+      - 1554916600660:660
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "header" : {
+            "uri" : "https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?lr=EN&postcode=DA74NG",
+            "query" : "postcode=DA74NG",
+            "offset" : 0,
+            "totalresults" : 11,
+            "format" : "JSON",
+            "dataset" : "DPA",
+            "lr" : "EN",
+            "maxresults" : 100,
+            "epoch" : "65",
+            "output_srs" : "EPSG:27700"
+          },
+          "results" : [ {
+            "DPA" : {
+              "UPRN" : "100020211558",
+              "UDPRN" : "6248161",
+              "ADDRESS" : "1, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "1",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "2",
+              "X_COORDINATE" : 548894.0,
+              "Y_COORDINATE" : 176139.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD02",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095093",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211559",
+              "UDPRN" : "6248164",
+              "ADDRESS" : "2, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "2",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548861.0,
+              "Y_COORDINATE" : 176156.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095079",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211560",
+              "UDPRN" : "6248165",
+              "ADDRESS" : "3, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "3",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548888.0,
+              "Y_COORDINATE" : 176131.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD02",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb5000005153955102",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211561",
+              "UDPRN" : "6248166",
+              "ADDRESS" : "4, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "4",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548858.0,
+              "Y_COORDINATE" : 176150.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095080",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211562",
+              "UDPRN" : "6248167",
+              "ADDRESS" : "5, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "5",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548884.0,
+              "Y_COORDINATE" : 176118.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD02",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095091",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211563",
+              "UDPRN" : "6248168",
+              "ADDRESS" : "6, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "6",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548849.0,
+              "Y_COORDINATE" : 176141.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095082",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211564",
+              "UDPRN" : "6248169",
+              "ADDRESS" : "7, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "7",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548874.0,
+              "Y_COORDINATE" : 176106.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095089",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211565",
+              "UDPRN" : "6248170",
+              "ADDRESS" : "8, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "8",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548846.0,
+              "Y_COORDINATE" : 176133.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095083",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211566",
+              "UDPRN" : "6248171",
+              "ADDRESS" : "9, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "9",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548868.0,
+              "Y_COORDINATE" : 176104.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095088",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211567",
+              "UDPRN" : "6248162",
+              "ADDRESS" : "10, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "10",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548848.0,
+              "Y_COORDINATE" : 176115.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095085",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211568",
+              "UDPRN" : "6248163",
+              "ADDRESS" : "12, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "12",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "2",
+              "X_COORDINATE" : 548854.0,
+              "Y_COORDINATE" : 176110.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095086",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          } ]
+        }
+    http_version: 
+  recorded_at: Wed, 10 Apr 2019 17:16:40 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/address_selections_requests/GET_/providers/applications/_legal_aid_application_id/address_selections/edit/when_the_provider_is_authenticated/a_postcode_have_been_entered_before/renders_the_address_selection_page.yml
+++ b/spec/cassettes/address_selections_requests/GET_/providers/applications/_legal_aid_application_id/address_selections/edit/when_the_provider_is_authenticated/a_postcode_have_been_entered_before/renders_the_address_selection_page.yml
@@ -360,4 +360,364 @@ http_interactions:
         }
     http_version: 
   recorded_at: Mon, 17 Dec 2018 11:33:34 GMT
+- request:
+    method: get
+    uri: https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?key=<ORDNANACE_SURVEY_API_KEY>&lr=EN&postcode=DA74NG
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Wed, 10 Apr 2019 17:16:40 GMT
+      Server:
+      - Apache-Coyote/1.1
+      Status:
+      - success
+      Tx-Id:
+      - 1554916600860:860
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "header" : {
+            "uri" : "https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?lr=EN&postcode=DA74NG",
+            "query" : "postcode=DA74NG",
+            "offset" : 0,
+            "totalresults" : 11,
+            "format" : "JSON",
+            "dataset" : "DPA",
+            "lr" : "EN",
+            "maxresults" : 100,
+            "epoch" : "65",
+            "output_srs" : "EPSG:27700"
+          },
+          "results" : [ {
+            "DPA" : {
+              "UPRN" : "100020211558",
+              "UDPRN" : "6248161",
+              "ADDRESS" : "1, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "1",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "2",
+              "X_COORDINATE" : 548894.0,
+              "Y_COORDINATE" : 176139.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD02",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095093",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211559",
+              "UDPRN" : "6248164",
+              "ADDRESS" : "2, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "2",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548861.0,
+              "Y_COORDINATE" : 176156.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095079",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211560",
+              "UDPRN" : "6248165",
+              "ADDRESS" : "3, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "3",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548888.0,
+              "Y_COORDINATE" : 176131.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD02",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb5000005153955102",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211561",
+              "UDPRN" : "6248166",
+              "ADDRESS" : "4, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "4",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548858.0,
+              "Y_COORDINATE" : 176150.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095080",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211562",
+              "UDPRN" : "6248167",
+              "ADDRESS" : "5, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "5",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548884.0,
+              "Y_COORDINATE" : 176118.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD02",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095091",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211563",
+              "UDPRN" : "6248168",
+              "ADDRESS" : "6, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "6",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548849.0,
+              "Y_COORDINATE" : 176141.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095082",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211564",
+              "UDPRN" : "6248169",
+              "ADDRESS" : "7, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "7",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548874.0,
+              "Y_COORDINATE" : 176106.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095089",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211565",
+              "UDPRN" : "6248170",
+              "ADDRESS" : "8, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "8",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548846.0,
+              "Y_COORDINATE" : 176133.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095083",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211566",
+              "UDPRN" : "6248171",
+              "ADDRESS" : "9, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "9",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548868.0,
+              "Y_COORDINATE" : 176104.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095088",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211567",
+              "UDPRN" : "6248162",
+              "ADDRESS" : "10, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "10",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548848.0,
+              "Y_COORDINATE" : 176115.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095085",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211568",
+              "UDPRN" : "6248163",
+              "ADDRESS" : "12, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "12",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "2",
+              "X_COORDINATE" : 548854.0,
+              "Y_COORDINATE" : 176110.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095086",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          } ]
+        }
+    http_version: 
+  recorded_at: Wed, 10 Apr 2019 17:16:40 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/check_benefits_requests/GET_/providers/applications/_application_id/check_benefits/generates_a_new_check_benefit_result.yml
+++ b/spec/cassettes/check_benefits_requests/GET_/providers/applications/_application_id/check_benefits/generates_a_new_check_benefit_result.yml
@@ -7,7 +7,7 @@ http_interactions:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:wsdl="https://lsc.gov.uk/benefitchecker/service/1.0/API_1.0_Check"
-        xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Body><wsdl:check><clientReference>5498ee31-7455-489b-99d3-e465267ad93a</clientReference><nino>JA293483A</nino><surname>WALKER</surname><dateOfBirth>19800110</dateOfBirth><dateOfAward>20190325</dateOfAward><lscServiceName><BC_LSC_SERVICE_NAME></lscServiceName><clientOrgId><BC_CLIENT_ORG_ID></clientOrgId><clientUserId><BC_CLIENT_USER_ID></clientUserId></wsdl:check></env:Body></env:Envelope>
+        xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Body><wsdl:check><clientReference>9375e079-7293-4bbf-bc81-6b10549e5a0f</clientReference><nino>JA293483A</nino><surname>WALKER</surname><dateOfBirth>19800110</dateOfBirth><dateOfAward>20190410</dateOfAward><lscServiceName><BC_LSC_SERVICE_NAME></lscServiceName><clientOrgId><BC_CLIENT_ORG_ID></clientOrgId><clientUserId><BC_CLIENT_USER_ID></clientUserId></wsdl:check></env:Body></env:Envelope>
     headers:
       Soapaction:
       - '"check"'
@@ -27,7 +27,7 @@ http_interactions:
       message: ''
     headers:
       Date:
-      - Mon, 25 Mar 2019 16:14:46 GMT
+      - Wed, 10 Apr 2019 17:16:42 GMT
       Content-Type:
       - text/xml;charset=utf-8
       Transfer-Encoding:
@@ -35,7 +35,7 @@ http_interactions:
       Connection:
       - keep-alive
       X-Amzn-Trace-Id:
-      - Root=1-5c98fe76-58f0f111d6fa564dc91b430c;
+      - Root=1-5cae24fa-d3493d9012c22624dda363c0;
       Vary:
       - Accept-Encoding
     body:
@@ -43,9 +43,9 @@ http_interactions:
       string: <?xml version="1.0" encoding="UTF-8"?><soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
         xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><soapenv:Body><benefitCheckerResponse
         xmlns="https://lsc.gov.uk/benefitchecker/service/1.0/API_1.0_Check"><ns1:originalClientRef
-        xmlns:ns1="http://lsc.gov.uk/benefitchecker/data/1.0">5498ee31-7455-489b-99d3-e465267ad93a</ns1:originalClientRef><ns2:benefitCheckerStatus
+        xmlns:ns1="http://lsc.gov.uk/benefitchecker/data/1.0">9375e079-7293-4bbf-bc81-6b10549e5a0f</ns1:originalClientRef><ns2:benefitCheckerStatus
         xmlns:ns2="http://lsc.gov.uk/benefitchecker/data/1.0">Yes</ns2:benefitCheckerStatus><ns3:confirmationRef
-        xmlns:ns3="http://lsc.gov.uk/benefitchecker/data/1.0">T1553530486519</ns3:confirmationRef></benefitCheckerResponse></soapenv:Body></soapenv:Envelope>
+        xmlns:ns3="http://lsc.gov.uk/benefitchecker/data/1.0">T1554916602655</ns3:confirmationRef></benefitCheckerResponse></soapenv:Body></soapenv:Envelope>
     http_version: 
-  recorded_at: Mon, 25 Mar 2019 16:14:46 GMT
+  recorded_at: Wed, 10 Apr 2019 17:16:42 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/check_benefits_requests/GET_/providers/applications/_application_id/check_benefits/returns_http_success.yml
+++ b/spec/cassettes/check_benefits_requests/GET_/providers/applications/_application_id/check_benefits/returns_http_success.yml
@@ -7,7 +7,7 @@ http_interactions:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:wsdl="https://lsc.gov.uk/benefitchecker/service/1.0/API_1.0_Check"
-        xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Body><wsdl:check><clientReference>383b0fcd-a011-495e-ab67-c4fdc4bca62f</clientReference><nino>JA293483A</nino><surname>WALKER</surname><dateOfBirth>19800110</dateOfBirth><dateOfAward>20190325</dateOfAward><lscServiceName><BC_LSC_SERVICE_NAME></lscServiceName><clientOrgId><BC_CLIENT_ORG_ID></clientOrgId><clientUserId><BC_CLIENT_USER_ID></clientUserId></wsdl:check></env:Body></env:Envelope>
+        xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Body><wsdl:check><clientReference>5c6baafe-2d2d-43a7-b1f5-cf4f31afc8ce</clientReference><nino>JA293483A</nino><surname>WALKER</surname><dateOfBirth>19800110</dateOfBirth><dateOfAward>20190410</dateOfAward><lscServiceName><BC_LSC_SERVICE_NAME></lscServiceName><clientOrgId><BC_CLIENT_ORG_ID></clientOrgId><clientUserId><BC_CLIENT_USER_ID></clientUserId></wsdl:check></env:Body></env:Envelope>
     headers:
       Soapaction:
       - '"check"'
@@ -27,7 +27,7 @@ http_interactions:
       message: ''
     headers:
       Date:
-      - Mon, 25 Mar 2019 16:14:46 GMT
+      - Wed, 10 Apr 2019 17:16:42 GMT
       Content-Type:
       - text/xml;charset=utf-8
       Transfer-Encoding:
@@ -35,7 +35,7 @@ http_interactions:
       Connection:
       - keep-alive
       X-Amzn-Trace-Id:
-      - Root=1-5c98fe76-e384ecb9a421a9146df63259;
+      - Root=1-5cae24fa-b285c38009c322b854e504d8;
       Vary:
       - Accept-Encoding
     body:
@@ -43,9 +43,9 @@ http_interactions:
       string: <?xml version="1.0" encoding="UTF-8"?><soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
         xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><soapenv:Body><benefitCheckerResponse
         xmlns="https://lsc.gov.uk/benefitchecker/service/1.0/API_1.0_Check"><ns1:originalClientRef
-        xmlns:ns1="http://lsc.gov.uk/benefitchecker/data/1.0">383b0fcd-a011-495e-ab67-c4fdc4bca62f</ns1:originalClientRef><ns2:benefitCheckerStatus
+        xmlns:ns1="http://lsc.gov.uk/benefitchecker/data/1.0">5c6baafe-2d2d-43a7-b1f5-cf4f31afc8ce</ns1:originalClientRef><ns2:benefitCheckerStatus
         xmlns:ns2="http://lsc.gov.uk/benefitchecker/data/1.0">Yes</ns2:benefitCheckerStatus><ns3:confirmationRef
-        xmlns:ns3="http://lsc.gov.uk/benefitchecker/data/1.0">T1553530486208</ns3:confirmationRef></benefitCheckerResponse></soapenv:Body></soapenv:Envelope>
+        xmlns:ns3="http://lsc.gov.uk/benefitchecker/data/1.0">T1554916602462</ns3:confirmationRef></benefitCheckerResponse></soapenv:Body></soapenv:Envelope>
     http_version: 
-  recorded_at: Mon, 25 Mar 2019 16:14:46 GMT
+  recorded_at: Wed, 10 Apr 2019 17:16:42 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/check_benefits_requests/GET_/providers/applications/_application_id/check_benefits/when_the_check_benefit_result_already_exists/and_the_applicant_has_since_been_modified/updates_check_benefit_result.yml
+++ b/spec/cassettes/check_benefits_requests/GET_/providers/applications/_application_id/check_benefits/when_the_check_benefit_result_already_exists/and_the_applicant_has_since_been_modified/updates_check_benefit_result.yml
@@ -7,7 +7,7 @@ http_interactions:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:wsdl="https://lsc.gov.uk/benefitchecker/service/1.0/API_1.0_Check"
-        xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Body><wsdl:check><clientReference>06431b81-cca8-4a52-ad73-796b4217711f</clientReference><nino>JA293483A</nino><surname>WALKER</surname><dateOfBirth>19800110</dateOfBirth><dateOfAward>20190325</dateOfAward><lscServiceName><BC_LSC_SERVICE_NAME></lscServiceName><clientOrgId><BC_CLIENT_ORG_ID></clientOrgId><clientUserId><BC_CLIENT_USER_ID></clientUserId></wsdl:check></env:Body></env:Envelope>
+        xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Body><wsdl:check><clientReference>ca66c61f-6892-47aa-bc2f-d694fab28c6c</clientReference><nino>JA293483A</nino><surname>WALKER</surname><dateOfBirth>19800110</dateOfBirth><dateOfAward>20190410</dateOfAward><lscServiceName><BC_LSC_SERVICE_NAME></lscServiceName><clientOrgId><BC_CLIENT_ORG_ID></clientOrgId><clientUserId><BC_CLIENT_USER_ID></clientUserId></wsdl:check></env:Body></env:Envelope>
     headers:
       Soapaction:
       - '"check"'
@@ -27,7 +27,7 @@ http_interactions:
       message: ''
     headers:
       Date:
-      - Mon, 25 Mar 2019 16:14:46 GMT
+      - Wed, 10 Apr 2019 17:16:42 GMT
       Content-Type:
       - text/xml;charset=utf-8
       Transfer-Encoding:
@@ -35,7 +35,7 @@ http_interactions:
       Connection:
       - keep-alive
       X-Amzn-Trace-Id:
-      - Root=1-5c98fe76-154ca234ef5d0bd8e460993c;
+      - Root=1-5cae24fa-c2d22846e39e394d0424c72b;
       Vary:
       - Accept-Encoding
     body:
@@ -43,9 +43,9 @@ http_interactions:
       string: <?xml version="1.0" encoding="UTF-8"?><soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
         xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><soapenv:Body><benefitCheckerResponse
         xmlns="https://lsc.gov.uk/benefitchecker/service/1.0/API_1.0_Check"><ns1:originalClientRef
-        xmlns:ns1="http://lsc.gov.uk/benefitchecker/data/1.0">06431b81-cca8-4a52-ad73-796b4217711f</ns1:originalClientRef><ns2:benefitCheckerStatus
+        xmlns:ns1="http://lsc.gov.uk/benefitchecker/data/1.0">ca66c61f-6892-47aa-bc2f-d694fab28c6c</ns1:originalClientRef><ns2:benefitCheckerStatus
         xmlns:ns2="http://lsc.gov.uk/benefitchecker/data/1.0">Yes</ns2:benefitCheckerStatus><ns3:confirmationRef
-        xmlns:ns3="http://lsc.gov.uk/benefitchecker/data/1.0">T1553530486695</ns3:confirmationRef></benefitCheckerResponse></soapenv:Body></soapenv:Envelope>
+        xmlns:ns3="http://lsc.gov.uk/benefitchecker/data/1.0">T1554916602856</ns3:confirmationRef></benefitCheckerResponse></soapenv:Body></soapenv:Envelope>
     http_version: 
-  recorded_at: Mon, 25 Mar 2019 16:14:46 GMT
+  recorded_at: Wed, 10 Apr 2019 17:16:42 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/providers_legal_aid_application_proceedings_type_requests/index_GET_/providers/applications/_legal_aid_application_id/proceedings_types/when_the_provider_is_authenticated/back_link/the_applicant_s_address_used_s_address_lookup_service/should_redirect_to_the_address_lookup_page.yml
+++ b/spec/cassettes/providers_legal_aid_application_proceedings_type_requests/index_GET_/providers/applications/_legal_aid_application_id/proceedings_types/when_the_provider_is_authenticated/back_link/the_applicant_s_address_used_s_address_lookup_service/should_redirect_to_the_address_lookup_page.yml
@@ -39,4 +39,43 @@ http_interactions:
         }
     http_version: 
   recorded_at: Wed, 06 Feb 2019 14:37:04 GMT
+- request:
+    method: get
+    uri: https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?key=<ORDNANACE_SURVEY_API_KEY>&lr=EN&postcode=YO4B0LJ
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Wed, 10 Apr 2019 17:16:52 GMT
+      Server:
+      - Apache-Coyote/1.1
+      Content-Length:
+      - '189'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "error" : {
+            "statuscode" : 400,
+            "message" : "Requested postcode must contain a minimum of the sector plus 1 digit of the district e.g. SO1. Requested postcode was YO4B0LJ"
+          }
+        }
+    http_version: 
+  recorded_at: Wed, 10 Apr 2019 17:16:52 GMT
 recorded_with: VCR 4.0.0

--- a/spec/services/address_lookup_service_spec.rb
+++ b/spec/services/address_lookup_service_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe AddressLookupService do
   let(:query_params) do
     {
       key: ENV['ORDNANACE_SURVEY_API_KEY'],
-      postcode: postcode
+      postcode: postcode,
+      lr: 'EN'
     }
   end
   let(:api_request_uri) do


### PR DESCRIPTION
Currently a welsh postcode will return the address with Welsh language place names

[Link to story](https://dsdmoj.atlassian.net/browse/AP-486)

Added a language parameter to the request to specify 'EN' for english language spellings. 

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
