### PR TITLE
AP-486 Specify english language for welsh addresses

### DIFF
--- a/app/services/address_lookup_service.rb
+++ b/app/services/address_lookup_service.rb
@@ -18,7 +18,8 @@ class AddressLookupService
   def query_params
     {
       key: ENV['ORDNANACE_SURVEY_API_KEY'],
-      postcode: postcode
+      postcode: postcode,
+      lr: 'EN'
     }
   end
 

--- a/features/cassettes/Civil_application_journeys/Completes_the_application_using_address_lookup.yml
+++ b/features/cassettes/Civil_application_journeys/Completes_the_application_using_address_lookup.yml
@@ -361,13 +361,373 @@ http_interactions:
     http_version: 
   recorded_at: Wed, 20 Mar 2019 16:51:29 GMT
 - request:
+    method: get
+    uri: https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?key=<ORDNANACE_SURVEY_API_KEY>&lr=EN&postcode=DA74NG
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Thu, 11 Apr 2019 10:50:24 GMT
+      Server:
+      - Apache-Coyote/1.1
+      Status:
+      - success
+      Tx-Id:
+      - 1554979824986:986
+      Content-Length:
+      - '11445'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "header" : {
+            "uri" : "https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?lr=EN&postcode=DA74NG",
+            "query" : "postcode=DA74NG",
+            "offset" : 0,
+            "totalresults" : 11,
+            "format" : "JSON",
+            "dataset" : "DPA",
+            "lr" : "EN",
+            "maxresults" : 100,
+            "epoch" : "65",
+            "output_srs" : "EPSG:27700"
+          },
+          "results" : [ {
+            "DPA" : {
+              "UPRN" : "100020211558",
+              "UDPRN" : "6248161",
+              "ADDRESS" : "1, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "1",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "2",
+              "X_COORDINATE" : 548894.0,
+              "Y_COORDINATE" : 176139.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD02",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095093",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211559",
+              "UDPRN" : "6248164",
+              "ADDRESS" : "2, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "2",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548861.0,
+              "Y_COORDINATE" : 176156.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095079",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211560",
+              "UDPRN" : "6248165",
+              "ADDRESS" : "3, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "3",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548888.0,
+              "Y_COORDINATE" : 176131.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD02",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb5000005153955102",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211561",
+              "UDPRN" : "6248166",
+              "ADDRESS" : "4, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "4",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548858.0,
+              "Y_COORDINATE" : 176150.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095080",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211562",
+              "UDPRN" : "6248167",
+              "ADDRESS" : "5, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "5",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548884.0,
+              "Y_COORDINATE" : 176118.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD02",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095091",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211563",
+              "UDPRN" : "6248168",
+              "ADDRESS" : "6, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "6",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548849.0,
+              "Y_COORDINATE" : 176141.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095082",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211564",
+              "UDPRN" : "6248169",
+              "ADDRESS" : "7, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "7",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548874.0,
+              "Y_COORDINATE" : 176106.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095089",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211565",
+              "UDPRN" : "6248170",
+              "ADDRESS" : "8, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "8",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548846.0,
+              "Y_COORDINATE" : 176133.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095083",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211566",
+              "UDPRN" : "6248171",
+              "ADDRESS" : "9, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "9",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548868.0,
+              "Y_COORDINATE" : 176104.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095088",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211567",
+              "UDPRN" : "6248162",
+              "ADDRESS" : "10, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "10",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548848.0,
+              "Y_COORDINATE" : 176115.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095085",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211568",
+              "UDPRN" : "6248163",
+              "ADDRESS" : "12, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "12",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "2",
+              "X_COORDINATE" : 548854.0,
+              "Y_COORDINATE" : 176110.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095086",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          } ]
+        }
+    http_version: 
+  recorded_at: Thu, 11 Apr 2019 10:50:25 GMT
+- request:
     method: post
     uri: https://benefitchecker.dev.legalservices.gov.uk/lsx/lsc-services/benefitChecker?wsdl
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:wsdl="https://lsc.gov.uk/benefitchecker/service/1.0/API_1.0_Check"
-        xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Body><wsdl:check><clientReference>76092f67-2adf-44b1-bb34-5acec9766a8a</clientReference><nino>CB987654A</nino><surname>USER</surname><dateOfBirth>19990403</dateOfBirth><dateOfAward>20190320</dateOfAward><lscServiceName><BC_LSC_SERVICE_NAME></lscServiceName><clientOrgId><BC_CLIENT_ORG_ID></clientOrgId><clientUserId><BC_CLIENT_USER_ID></clientUserId></wsdl:check></env:Body></env:Envelope>
+        xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Body><wsdl:check><clientReference>efa5a786-d582-477c-96be-b50af3eea299</clientReference><nino>CB987654A</nino><surname>USER</surname><dateOfBirth>19990403</dateOfBirth><dateOfAward>20190411</dateOfAward><lscServiceName><BC_LSC_SERVICE_NAME></lscServiceName><clientOrgId><BC_CLIENT_ORG_ID></clientOrgId><clientUserId><BC_CLIENT_USER_ID></clientUserId></wsdl:check></env:Body></env:Envelope>
     headers:
       Soapaction:
       - '"check"'
@@ -387,7 +747,7 @@ http_interactions:
       message: ''
     headers:
       Date:
-      - Wed, 20 Mar 2019 16:51:32 GMT
+      - Thu, 11 Apr 2019 10:50:27 GMT
       Content-Type:
       - text/xml;charset=utf-8
       Transfer-Encoding:
@@ -395,7 +755,7 @@ http_interactions:
       Connection:
       - keep-alive
       X-Amzn-Trace-Id:
-      - Root=1-5c926f94-1756f65663a0dd36ff50b2c6;
+      - Root=1-5caf1bf3-ac04c15c5a1fc941aef5b098;
       Vary:
       - Accept-Encoding
     body:
@@ -403,9 +763,9 @@ http_interactions:
       string: <?xml version="1.0" encoding="UTF-8"?><soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
         xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><soapenv:Body><benefitCheckerResponse
         xmlns="https://lsc.gov.uk/benefitchecker/service/1.0/API_1.0_Check"><ns1:originalClientRef
-        xmlns:ns1="http://lsc.gov.uk/benefitchecker/data/1.0">76092f67-2adf-44b1-bb34-5acec9766a8a</ns1:originalClientRef><ns2:benefitCheckerStatus
+        xmlns:ns1="http://lsc.gov.uk/benefitchecker/data/1.0">efa5a786-d582-477c-96be-b50af3eea299</ns1:originalClientRef><ns2:benefitCheckerStatus
         xmlns:ns2="http://lsc.gov.uk/benefitchecker/data/1.0">Undetermined</ns2:benefitCheckerStatus><ns3:confirmationRef
-        xmlns:ns3="http://lsc.gov.uk/benefitchecker/data/1.0">T1553100692229</ns3:confirmationRef></benefitCheckerResponse></soapenv:Body></soapenv:Envelope>
+        xmlns:ns3="http://lsc.gov.uk/benefitchecker/data/1.0">T1554979827886</ns3:confirmationRef></benefitCheckerResponse></soapenv:Body></soapenv:Envelope>
     http_version: 
-  recorded_at: Wed, 20 Mar 2019 16:51:32 GMT
+  recorded_at: Thu, 11 Apr 2019 10:50:27 GMT
 recorded_with: VCR 4.0.0

--- a/features/cassettes/Civil_application_journeys/Completes_the_application_using_manual_address.yml
+++ b/features/cassettes/Civil_application_journeys/Completes_the_application_using_manual_address.yml
@@ -52,13 +52,64 @@ http_interactions:
     http_version: 
   recorded_at: Wed, 20 Mar 2019 16:51:34 GMT
 - request:
+    method: get
+    uri: https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?key=<ORDNANACE_SURVEY_API_KEY>&lr=EN&postcode=SW1H9AJ
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Thu, 11 Apr 2019 10:50:50 GMT
+      Server:
+      - Apache-Coyote/1.1
+      Status:
+      - success
+      Tx-Id:
+      - 1554979850480:480
+      Content-Length:
+      - '337'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "header" : {
+            "uri" : "https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?lr=EN&postcode=SW1H9AJ",
+            "query" : "postcode=SW1H9AJ",
+            "offset" : 0,
+            "totalresults" : 0,
+            "format" : "JSON",
+            "dataset" : "DPA",
+            "lr" : "EN",
+            "maxresults" : 100,
+            "epoch" : "65",
+            "output_srs" : "EPSG:27700"
+          }
+        }
+    http_version: 
+  recorded_at: Thu, 11 Apr 2019 10:50:50 GMT
+- request:
     method: post
     uri: https://benefitchecker.dev.legalservices.gov.uk/lsx/lsc-services/benefitChecker?wsdl
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:wsdl="https://lsc.gov.uk/benefitchecker/service/1.0/API_1.0_Check"
-        xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Body><wsdl:check><clientReference>39cb9189-ff52-4c43-889c-b9fc729ed91f</clientReference><nino>CB987654A</nino><surname>USER</surname><dateOfBirth>19990403</dateOfBirth><dateOfAward>20190320</dateOfAward><lscServiceName><BC_LSC_SERVICE_NAME></lscServiceName><clientOrgId><BC_CLIENT_ORG_ID></clientOrgId><clientUserId><BC_CLIENT_USER_ID></clientUserId></wsdl:check></env:Body></env:Envelope>
+        xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Body><wsdl:check><clientReference>5e674336-b4a6-4294-ab7e-523aa81813c8</clientReference><nino>CB987654A</nino><surname>USER</surname><dateOfBirth>19990403</dateOfBirth><dateOfAward>20190411</dateOfAward><lscServiceName><BC_LSC_SERVICE_NAME></lscServiceName><clientOrgId><BC_CLIENT_ORG_ID></clientOrgId><clientUserId><BC_CLIENT_USER_ID></clientUserId></wsdl:check></env:Body></env:Envelope>
     headers:
       Soapaction:
       - '"check"'
@@ -78,7 +129,7 @@ http_interactions:
       message: ''
     headers:
       Date:
-      - Wed, 20 Mar 2019 16:51:37 GMT
+      - Thu, 11 Apr 2019 10:50:53 GMT
       Content-Type:
       - text/xml;charset=utf-8
       Transfer-Encoding:
@@ -86,7 +137,7 @@ http_interactions:
       Connection:
       - keep-alive
       X-Amzn-Trace-Id:
-      - Root=1-5c926f99-da2d53265542b174cb4ef564;
+      - Root=1-5caf1c0d-a04406298af88341ccf3f39d;
       Vary:
       - Accept-Encoding
     body:
@@ -94,9 +145,9 @@ http_interactions:
       string: <?xml version="1.0" encoding="UTF-8"?><soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
         xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><soapenv:Body><benefitCheckerResponse
         xmlns="https://lsc.gov.uk/benefitchecker/service/1.0/API_1.0_Check"><ns1:originalClientRef
-        xmlns:ns1="http://lsc.gov.uk/benefitchecker/data/1.0">39cb9189-ff52-4c43-889c-b9fc729ed91f</ns1:originalClientRef><ns2:benefitCheckerStatus
+        xmlns:ns1="http://lsc.gov.uk/benefitchecker/data/1.0">5e674336-b4a6-4294-ab7e-523aa81813c8</ns1:originalClientRef><ns2:benefitCheckerStatus
         xmlns:ns2="http://lsc.gov.uk/benefitchecker/data/1.0">Undetermined</ns2:benefitCheckerStatus><ns3:confirmationRef
-        xmlns:ns3="http://lsc.gov.uk/benefitchecker/data/1.0">T1553100697529</ns3:confirmationRef></benefitCheckerResponse></soapenv:Body></soapenv:Envelope>
+        xmlns:ns3="http://lsc.gov.uk/benefitchecker/data/1.0">T1554979853501</ns3:confirmationRef></benefitCheckerResponse></soapenv:Body></soapenv:Envelope>
     http_version: 
-  recorded_at: Wed, 20 Mar 2019 16:51:37 GMT
+  recorded_at: Thu, 11 Apr 2019 10:50:53 GMT
 recorded_with: VCR 4.0.0

--- a/features/cassettes/Civil_application_journeys/I_am_able_to_clear_proceeding_on_the_proceeding_page.yml
+++ b/features/cassettes/Civil_application_journeys/I_am_able_to_clear_proceeding_on_the_proceeding_page.yml
@@ -360,4 +360,364 @@ http_interactions:
         }
     http_version: 
   recorded_at: Tue, 29 Jan 2019 11:30:00 GMT
+- request:
+    method: get
+    uri: https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?key=<ORDNANACE_SURVEY_API_KEY>&lr=EN&postcode=DA74NG
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Thu, 11 Apr 2019 10:47:34 GMT
+      Server:
+      - Apache-Coyote/1.1
+      Status:
+      - success
+      Tx-Id:
+      - 1554979654547:547
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "header" : {
+            "uri" : "https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?lr=EN&postcode=DA74NG",
+            "query" : "postcode=DA74NG",
+            "offset" : 0,
+            "totalresults" : 11,
+            "format" : "JSON",
+            "dataset" : "DPA",
+            "lr" : "EN",
+            "maxresults" : 100,
+            "epoch" : "65",
+            "output_srs" : "EPSG:27700"
+          },
+          "results" : [ {
+            "DPA" : {
+              "UPRN" : "100020211558",
+              "UDPRN" : "6248161",
+              "ADDRESS" : "1, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "1",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "2",
+              "X_COORDINATE" : 548894.0,
+              "Y_COORDINATE" : 176139.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD02",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095093",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211559",
+              "UDPRN" : "6248164",
+              "ADDRESS" : "2, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "2",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548861.0,
+              "Y_COORDINATE" : 176156.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095079",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211560",
+              "UDPRN" : "6248165",
+              "ADDRESS" : "3, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "3",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548888.0,
+              "Y_COORDINATE" : 176131.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD02",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb5000005153955102",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211561",
+              "UDPRN" : "6248166",
+              "ADDRESS" : "4, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "4",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548858.0,
+              "Y_COORDINATE" : 176150.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095080",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211562",
+              "UDPRN" : "6248167",
+              "ADDRESS" : "5, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "5",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548884.0,
+              "Y_COORDINATE" : 176118.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD02",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095091",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211563",
+              "UDPRN" : "6248168",
+              "ADDRESS" : "6, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "6",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548849.0,
+              "Y_COORDINATE" : 176141.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095082",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211564",
+              "UDPRN" : "6248169",
+              "ADDRESS" : "7, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "7",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548874.0,
+              "Y_COORDINATE" : 176106.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095089",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211565",
+              "UDPRN" : "6248170",
+              "ADDRESS" : "8, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "8",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548846.0,
+              "Y_COORDINATE" : 176133.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095083",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211566",
+              "UDPRN" : "6248171",
+              "ADDRESS" : "9, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "9",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548868.0,
+              "Y_COORDINATE" : 176104.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095088",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211567",
+              "UDPRN" : "6248162",
+              "ADDRESS" : "10, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "10",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548848.0,
+              "Y_COORDINATE" : 176115.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095085",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211568",
+              "UDPRN" : "6248163",
+              "ADDRESS" : "12, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "12",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "2",
+              "X_COORDINATE" : 548854.0,
+              "Y_COORDINATE" : 176110.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095086",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          } ]
+        }
+    http_version: 
+  recorded_at: Thu, 11 Apr 2019 10:47:34 GMT
 recorded_with: VCR 4.0.0

--- a/features/cassettes/Civil_application_journeys/I_am_able_to_select_and_delete_proceeding_types.yml
+++ b/features/cassettes/Civil_application_journeys/I_am_able_to_select_and_delete_proceeding_types.yml
@@ -360,4 +360,364 @@ http_interactions:
         }
     http_version: 
   recorded_at: Wed, 30 Jan 2019 16:17:16 GMT
+- request:
+    method: get
+    uri: https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?key=<ORDNANACE_SURVEY_API_KEY>&lr=EN&postcode=DA74NG
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Thu, 11 Apr 2019 10:47:47 GMT
+      Server:
+      - Apache-Coyote/1.1
+      Status:
+      - success
+      Tx-Id:
+      - 1554979667905:905
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "header" : {
+            "uri" : "https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?lr=EN&postcode=DA74NG",
+            "query" : "postcode=DA74NG",
+            "offset" : 0,
+            "totalresults" : 11,
+            "format" : "JSON",
+            "dataset" : "DPA",
+            "lr" : "EN",
+            "maxresults" : 100,
+            "epoch" : "65",
+            "output_srs" : "EPSG:27700"
+          },
+          "results" : [ {
+            "DPA" : {
+              "UPRN" : "100020211558",
+              "UDPRN" : "6248161",
+              "ADDRESS" : "1, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "1",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "2",
+              "X_COORDINATE" : 548894.0,
+              "Y_COORDINATE" : 176139.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD02",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095093",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211559",
+              "UDPRN" : "6248164",
+              "ADDRESS" : "2, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "2",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548861.0,
+              "Y_COORDINATE" : 176156.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095079",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211560",
+              "UDPRN" : "6248165",
+              "ADDRESS" : "3, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "3",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548888.0,
+              "Y_COORDINATE" : 176131.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD02",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb5000005153955102",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211561",
+              "UDPRN" : "6248166",
+              "ADDRESS" : "4, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "4",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548858.0,
+              "Y_COORDINATE" : 176150.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095080",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211562",
+              "UDPRN" : "6248167",
+              "ADDRESS" : "5, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "5",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548884.0,
+              "Y_COORDINATE" : 176118.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD02",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095091",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211563",
+              "UDPRN" : "6248168",
+              "ADDRESS" : "6, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "6",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548849.0,
+              "Y_COORDINATE" : 176141.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095082",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211564",
+              "UDPRN" : "6248169",
+              "ADDRESS" : "7, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "7",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548874.0,
+              "Y_COORDINATE" : 176106.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095089",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211565",
+              "UDPRN" : "6248170",
+              "ADDRESS" : "8, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "8",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548846.0,
+              "Y_COORDINATE" : 176133.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095083",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211566",
+              "UDPRN" : "6248171",
+              "ADDRESS" : "9, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "9",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548868.0,
+              "Y_COORDINATE" : 176104.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095088",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211567",
+              "UDPRN" : "6248162",
+              "ADDRESS" : "10, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "10",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548848.0,
+              "Y_COORDINATE" : 176115.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095085",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211568",
+              "UDPRN" : "6248163",
+              "ADDRESS" : "12, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "12",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "2",
+              "X_COORDINATE" : 548854.0,
+              "Y_COORDINATE" : 176110.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095086",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          } ]
+        }
+    http_version: 
+  recorded_at: Thu, 11 Apr 2019 10:47:47 GMT
 recorded_with: VCR 4.0.0

--- a/features/cassettes/Civil_application_journeys/I_can_see_that_the_applicant_does_not_receive_benefits.yml
+++ b/features/cassettes/Civil_application_journeys/I_can_see_that_the_applicant_does_not_receive_benefits.yml
@@ -361,13 +361,373 @@ http_interactions:
     http_version: 
   recorded_at: Wed, 20 Mar 2019 16:51:44 GMT
 - request:
+    method: get
+    uri: https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?key=<ORDNANACE_SURVEY_API_KEY>&lr=EN&postcode=DA74NG
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Thu, 11 Apr 2019 10:51:22 GMT
+      Server:
+      - Apache-Coyote/1.1
+      Status:
+      - success
+      Tx-Id:
+      - 1554979882597:597
+      Content-Length:
+      - '11445'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "header" : {
+            "uri" : "https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?lr=EN&postcode=DA74NG",
+            "query" : "postcode=DA74NG",
+            "offset" : 0,
+            "totalresults" : 11,
+            "format" : "JSON",
+            "dataset" : "DPA",
+            "lr" : "EN",
+            "maxresults" : 100,
+            "epoch" : "65",
+            "output_srs" : "EPSG:27700"
+          },
+          "results" : [ {
+            "DPA" : {
+              "UPRN" : "100020211558",
+              "UDPRN" : "6248161",
+              "ADDRESS" : "1, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "1",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "2",
+              "X_COORDINATE" : 548894.0,
+              "Y_COORDINATE" : 176139.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD02",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095093",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211559",
+              "UDPRN" : "6248164",
+              "ADDRESS" : "2, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "2",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548861.0,
+              "Y_COORDINATE" : 176156.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095079",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211560",
+              "UDPRN" : "6248165",
+              "ADDRESS" : "3, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "3",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548888.0,
+              "Y_COORDINATE" : 176131.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD02",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb5000005153955102",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211561",
+              "UDPRN" : "6248166",
+              "ADDRESS" : "4, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "4",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548858.0,
+              "Y_COORDINATE" : 176150.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095080",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211562",
+              "UDPRN" : "6248167",
+              "ADDRESS" : "5, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "5",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548884.0,
+              "Y_COORDINATE" : 176118.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD02",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095091",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211563",
+              "UDPRN" : "6248168",
+              "ADDRESS" : "6, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "6",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548849.0,
+              "Y_COORDINATE" : 176141.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095082",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211564",
+              "UDPRN" : "6248169",
+              "ADDRESS" : "7, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "7",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548874.0,
+              "Y_COORDINATE" : 176106.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095089",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211565",
+              "UDPRN" : "6248170",
+              "ADDRESS" : "8, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "8",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548846.0,
+              "Y_COORDINATE" : 176133.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095083",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211566",
+              "UDPRN" : "6248171",
+              "ADDRESS" : "9, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "9",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548868.0,
+              "Y_COORDINATE" : 176104.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095088",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211567",
+              "UDPRN" : "6248162",
+              "ADDRESS" : "10, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "10",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548848.0,
+              "Y_COORDINATE" : 176115.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095085",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211568",
+              "UDPRN" : "6248163",
+              "ADDRESS" : "12, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "12",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "2",
+              "X_COORDINATE" : 548854.0,
+              "Y_COORDINATE" : 176110.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095086",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          } ]
+        }
+    http_version: 
+  recorded_at: Thu, 11 Apr 2019 10:51:22 GMT
+- request:
     method: post
     uri: https://benefitchecker.dev.legalservices.gov.uk/lsx/lsc-services/benefitChecker?wsdl
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:wsdl="https://lsc.gov.uk/benefitchecker/service/1.0/API_1.0_Check"
-        xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Body><wsdl:check><clientReference>d1ccbc84-929d-4f8e-b209-fe7ddeb5634b</clientReference><nino>JA293483B</nino><surname>PAUL</surname><dateOfBirth>19611210</dateOfBirth><dateOfAward>20190320</dateOfAward><lscServiceName><BC_LSC_SERVICE_NAME></lscServiceName><clientOrgId><BC_CLIENT_ORG_ID></clientOrgId><clientUserId><BC_CLIENT_USER_ID></clientUserId></wsdl:check></env:Body></env:Envelope>
+        xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Body><wsdl:check><clientReference>ecc70842-986d-476d-81d9-a6f5fa8e772f</clientReference><nino>JA293483B</nino><surname>PAUL</surname><dateOfBirth>19611210</dateOfBirth><dateOfAward>20190411</dateOfAward><lscServiceName><BC_LSC_SERVICE_NAME></lscServiceName><clientOrgId><BC_CLIENT_ORG_ID></clientOrgId><clientUserId><BC_CLIENT_USER_ID></clientUserId></wsdl:check></env:Body></env:Envelope>
     headers:
       Soapaction:
       - '"check"'
@@ -387,7 +747,7 @@ http_interactions:
       message: ''
     headers:
       Date:
-      - Wed, 20 Mar 2019 16:51:47 GMT
+      - Thu, 11 Apr 2019 10:51:25 GMT
       Content-Type:
       - text/xml;charset=utf-8
       Transfer-Encoding:
@@ -395,7 +755,7 @@ http_interactions:
       Connection:
       - keep-alive
       X-Amzn-Trace-Id:
-      - Root=1-5c926fa3-047d04ca9c8947bfeac47f64;
+      - Root=1-5caf1c2d-30ad8a6da2018e538cb94377;
       Vary:
       - Accept-Encoding
     body:
@@ -403,9 +763,9 @@ http_interactions:
       string: <?xml version="1.0" encoding="UTF-8"?><soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
         xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><soapenv:Body><benefitCheckerResponse
         xmlns="https://lsc.gov.uk/benefitchecker/service/1.0/API_1.0_Check"><ns1:originalClientRef
-        xmlns:ns1="http://lsc.gov.uk/benefitchecker/data/1.0">d1ccbc84-929d-4f8e-b209-fe7ddeb5634b</ns1:originalClientRef><ns2:benefitCheckerStatus
+        xmlns:ns1="http://lsc.gov.uk/benefitchecker/data/1.0">ecc70842-986d-476d-81d9-a6f5fa8e772f</ns1:originalClientRef><ns2:benefitCheckerStatus
         xmlns:ns2="http://lsc.gov.uk/benefitchecker/data/1.0">No</ns2:benefitCheckerStatus><ns3:confirmationRef
-        xmlns:ns3="http://lsc.gov.uk/benefitchecker/data/1.0">T1553100707328</ns3:confirmationRef></benefitCheckerResponse></soapenv:Body></soapenv:Envelope>
+        xmlns:ns3="http://lsc.gov.uk/benefitchecker/data/1.0">T1554979885423</ns3:confirmationRef></benefitCheckerResponse></soapenv:Body></soapenv:Envelope>
     http_version: 
-  recorded_at: Wed, 20 Mar 2019 16:51:47 GMT
+  recorded_at: Thu, 11 Apr 2019 10:51:25 GMT
 recorded_with: VCR 4.0.0

--- a/features/cassettes/Civil_application_journeys/I_can_see_that_the_applicant_receives_benefits.yml
+++ b/features/cassettes/Civil_application_journeys/I_can_see_that_the_applicant_receives_benefits.yml
@@ -361,13 +361,373 @@ http_interactions:
     http_version: 
   recorded_at: Wed, 20 Mar 2019 16:51:40 GMT
 - request:
+    method: get
+    uri: https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?key=<ORDNANACE_SURVEY_API_KEY>&lr=EN&postcode=DA74NG
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Thu, 11 Apr 2019 10:51:08 GMT
+      Server:
+      - Apache-Coyote/1.1
+      Status:
+      - success
+      Tx-Id:
+      - 1554979868984:984
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "header" : {
+            "uri" : "https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?lr=EN&postcode=DA74NG",
+            "query" : "postcode=DA74NG",
+            "offset" : 0,
+            "totalresults" : 11,
+            "format" : "JSON",
+            "dataset" : "DPA",
+            "lr" : "EN",
+            "maxresults" : 100,
+            "epoch" : "65",
+            "output_srs" : "EPSG:27700"
+          },
+          "results" : [ {
+            "DPA" : {
+              "UPRN" : "100020211558",
+              "UDPRN" : "6248161",
+              "ADDRESS" : "1, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "1",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "2",
+              "X_COORDINATE" : 548894.0,
+              "Y_COORDINATE" : 176139.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD02",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095093",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211559",
+              "UDPRN" : "6248164",
+              "ADDRESS" : "2, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "2",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548861.0,
+              "Y_COORDINATE" : 176156.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095079",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211560",
+              "UDPRN" : "6248165",
+              "ADDRESS" : "3, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "3",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548888.0,
+              "Y_COORDINATE" : 176131.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD02",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb5000005153955102",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211561",
+              "UDPRN" : "6248166",
+              "ADDRESS" : "4, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "4",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548858.0,
+              "Y_COORDINATE" : 176150.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095080",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211562",
+              "UDPRN" : "6248167",
+              "ADDRESS" : "5, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "5",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548884.0,
+              "Y_COORDINATE" : 176118.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD02",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095091",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211563",
+              "UDPRN" : "6248168",
+              "ADDRESS" : "6, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "6",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548849.0,
+              "Y_COORDINATE" : 176141.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095082",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211564",
+              "UDPRN" : "6248169",
+              "ADDRESS" : "7, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "7",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548874.0,
+              "Y_COORDINATE" : 176106.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095089",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211565",
+              "UDPRN" : "6248170",
+              "ADDRESS" : "8, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "8",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548846.0,
+              "Y_COORDINATE" : 176133.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095083",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211566",
+              "UDPRN" : "6248171",
+              "ADDRESS" : "9, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "9",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548868.0,
+              "Y_COORDINATE" : 176104.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095088",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211567",
+              "UDPRN" : "6248162",
+              "ADDRESS" : "10, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "10",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548848.0,
+              "Y_COORDINATE" : 176115.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095085",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211568",
+              "UDPRN" : "6248163",
+              "ADDRESS" : "12, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "12",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "2",
+              "X_COORDINATE" : 548854.0,
+              "Y_COORDINATE" : 176110.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095086",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          } ]
+        }
+    http_version: 
+  recorded_at: Thu, 11 Apr 2019 10:51:09 GMT
+- request:
     method: post
     uri: https://benefitchecker.dev.legalservices.gov.uk/lsx/lsc-services/benefitChecker?wsdl
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:wsdl="https://lsc.gov.uk/benefitchecker/service/1.0/API_1.0_Check"
-        xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Body><wsdl:check><clientReference>aba9f257-f919-4e16-a1ca-d802b8c62fb6</clientReference><nino>JA293483A</nino><surname>WALKER</surname><dateOfBirth>19800110</dateOfBirth><dateOfAward>20190320</dateOfAward><lscServiceName><BC_LSC_SERVICE_NAME></lscServiceName><clientOrgId><BC_CLIENT_ORG_ID></clientOrgId><clientUserId><BC_CLIENT_USER_ID></clientUserId></wsdl:check></env:Body></env:Envelope>
+        xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Body><wsdl:check><clientReference>48ddf2ba-93ad-44bd-a209-61b340166b56</clientReference><nino>JA293483A</nino><surname>WALKER</surname><dateOfBirth>19800110</dateOfBirth><dateOfAward>20190411</dateOfAward><lscServiceName><BC_LSC_SERVICE_NAME></lscServiceName><clientOrgId><BC_CLIENT_ORG_ID></clientOrgId><clientUserId><BC_CLIENT_USER_ID></clientUserId></wsdl:check></env:Body></env:Envelope>
     headers:
       Soapaction:
       - '"check"'
@@ -387,7 +747,7 @@ http_interactions:
       message: ''
     headers:
       Date:
-      - Wed, 20 Mar 2019 16:51:42 GMT
+      - Thu, 11 Apr 2019 10:51:11 GMT
       Content-Type:
       - text/xml;charset=utf-8
       Transfer-Encoding:
@@ -395,7 +755,7 @@ http_interactions:
       Connection:
       - keep-alive
       X-Amzn-Trace-Id:
-      - Root=1-5c926f9e-c14978bbab77bd431626c6b6;
+      - Root=1-5caf1c1f-998592307f967120c7ec99da;
       Vary:
       - Accept-Encoding
     body:
@@ -403,9 +763,9 @@ http_interactions:
       string: <?xml version="1.0" encoding="UTF-8"?><soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
         xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><soapenv:Body><benefitCheckerResponse
         xmlns="https://lsc.gov.uk/benefitchecker/service/1.0/API_1.0_Check"><ns1:originalClientRef
-        xmlns:ns1="http://lsc.gov.uk/benefitchecker/data/1.0">aba9f257-f919-4e16-a1ca-d802b8c62fb6</ns1:originalClientRef><ns2:benefitCheckerStatus
+        xmlns:ns1="http://lsc.gov.uk/benefitchecker/data/1.0">48ddf2ba-93ad-44bd-a209-61b340166b56</ns1:originalClientRef><ns2:benefitCheckerStatus
         xmlns:ns2="http://lsc.gov.uk/benefitchecker/data/1.0">Yes</ns2:benefitCheckerStatus><ns3:confirmationRef
-        xmlns:ns3="http://lsc.gov.uk/benefitchecker/data/1.0">T1553100702818</ns3:confirmationRef></benefitCheckerResponse></soapenv:Body></soapenv:Envelope>
+        xmlns:ns3="http://lsc.gov.uk/benefitchecker/data/1.0">T1554979871802</ns3:confirmationRef></benefitCheckerResponse></soapenv:Body></soapenv:Envelope>
     http_version: 
-  recorded_at: Wed, 20 Mar 2019 16:51:42 GMT
+  recorded_at: Thu, 11 Apr 2019 10:51:11 GMT
 recorded_with: VCR 4.0.0

--- a/features/cassettes/Civil_application_journeys/I_want_to_change_address_from_the_check_your_answers_page.yml
+++ b/features/cassettes/Civil_application_journeys/I_want_to_change_address_from_the_check_your_answers_page.yml
@@ -916,4 +916,364 @@ http_interactions:
         }
     http_version: 
   recorded_at: Wed, 28 Nov 2018 14:35:34 GMT
+- request:
+    method: get
+    uri: https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?key=<ORDNANACE_SURVEY_API_KEY>&lr=EN&postcode=DA74NG
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Thu, 11 Apr 2019 10:51:56 GMT
+      Server:
+      - Apache-Coyote/1.1
+      Status:
+      - success
+      Tx-Id:
+      - 1554979916491:491
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "header" : {
+            "uri" : "https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?lr=EN&postcode=DA74NG",
+            "query" : "postcode=DA74NG",
+            "offset" : 0,
+            "totalresults" : 11,
+            "format" : "JSON",
+            "dataset" : "DPA",
+            "lr" : "EN",
+            "maxresults" : 100,
+            "epoch" : "65",
+            "output_srs" : "EPSG:27700"
+          },
+          "results" : [ {
+            "DPA" : {
+              "UPRN" : "100020211558",
+              "UDPRN" : "6248161",
+              "ADDRESS" : "1, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "1",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "2",
+              "X_COORDINATE" : 548894.0,
+              "Y_COORDINATE" : 176139.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD02",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095093",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211559",
+              "UDPRN" : "6248164",
+              "ADDRESS" : "2, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "2",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548861.0,
+              "Y_COORDINATE" : 176156.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095079",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211560",
+              "UDPRN" : "6248165",
+              "ADDRESS" : "3, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "3",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548888.0,
+              "Y_COORDINATE" : 176131.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD02",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb5000005153955102",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211561",
+              "UDPRN" : "6248166",
+              "ADDRESS" : "4, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "4",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548858.0,
+              "Y_COORDINATE" : 176150.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095080",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211562",
+              "UDPRN" : "6248167",
+              "ADDRESS" : "5, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "5",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548884.0,
+              "Y_COORDINATE" : 176118.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD02",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095091",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211563",
+              "UDPRN" : "6248168",
+              "ADDRESS" : "6, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "6",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548849.0,
+              "Y_COORDINATE" : 176141.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095082",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211564",
+              "UDPRN" : "6248169",
+              "ADDRESS" : "7, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "7",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548874.0,
+              "Y_COORDINATE" : 176106.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095089",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211565",
+              "UDPRN" : "6248170",
+              "ADDRESS" : "8, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "8",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548846.0,
+              "Y_COORDINATE" : 176133.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095083",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211566",
+              "UDPRN" : "6248171",
+              "ADDRESS" : "9, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "9",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548868.0,
+              "Y_COORDINATE" : 176104.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095088",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211567",
+              "UDPRN" : "6248162",
+              "ADDRESS" : "10, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "10",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548848.0,
+              "Y_COORDINATE" : 176115.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095085",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211568",
+              "UDPRN" : "6248163",
+              "ADDRESS" : "12, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "12",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "2",
+              "X_COORDINATE" : 548854.0,
+              "Y_COORDINATE" : 176110.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095086",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          } ]
+        }
+    http_version: 
+  recorded_at: Thu, 11 Apr 2019 10:51:56 GMT
 recorded_with: VCR 4.0.0

--- a/features/cassettes/Civil_application_journeys/I_want_to_change_address_manually_from_the_check_your_answers_page.yml
+++ b/features/cassettes/Civil_application_journeys/I_want_to_change_address_manually_from_the_check_your_answers_page.yml
@@ -607,4 +607,55 @@ http_interactions:
         }
     http_version: 
   recorded_at: Wed, 28 Nov 2018 14:35:39 GMT
+- request:
+    method: get
+    uri: https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?key=<ORDNANACE_SURVEY_API_KEY>&lr=EN&postcode=SW1H9AJ
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Thu, 11 Apr 2019 10:52:07 GMT
+      Server:
+      - Apache-Coyote/1.1
+      Status:
+      - success
+      Tx-Id:
+      - 1554979927381:381
+      Content-Length:
+      - '337'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "header" : {
+            "uri" : "https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?lr=EN&postcode=SW1H9AJ",
+            "query" : "postcode=SW1H9AJ",
+            "offset" : 0,
+            "totalresults" : 0,
+            "format" : "JSON",
+            "dataset" : "DPA",
+            "lr" : "EN",
+            "maxresults" : 100,
+            "epoch" : "65",
+            "output_srs" : "EPSG:27700"
+          }
+        }
+    http_version: 
+  recorded_at: Thu, 11 Apr 2019 10:52:07 GMT
 recorded_with: VCR 4.0.0

--- a/features/cassettes/Civil_application_journeys/I_want_to_return_to_check_your_answers_from_address_select.yml
+++ b/features/cassettes/Civil_application_journeys/I_want_to_return_to_check_your_answers_from_address_select.yml
@@ -916,4 +916,364 @@ http_interactions:
         }
     http_version: 
   recorded_at: Wed, 28 Nov 2018 14:35:47 GMT
+- request:
+    method: get
+    uri: https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?key=<ORDNANACE_SURVEY_API_KEY>&lr=EN&postcode=DA74NG
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Thu, 11 Apr 2019 10:52:25 GMT
+      Server:
+      - Apache-Coyote/1.1
+      Status:
+      - success
+      Tx-Id:
+      - 1554979945353:353
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "header" : {
+            "uri" : "https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?lr=EN&postcode=DA74NG",
+            "query" : "postcode=DA74NG",
+            "offset" : 0,
+            "totalresults" : 11,
+            "format" : "JSON",
+            "dataset" : "DPA",
+            "lr" : "EN",
+            "maxresults" : 100,
+            "epoch" : "65",
+            "output_srs" : "EPSG:27700"
+          },
+          "results" : [ {
+            "DPA" : {
+              "UPRN" : "100020211558",
+              "UDPRN" : "6248161",
+              "ADDRESS" : "1, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "1",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "2",
+              "X_COORDINATE" : 548894.0,
+              "Y_COORDINATE" : 176139.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD02",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095093",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211559",
+              "UDPRN" : "6248164",
+              "ADDRESS" : "2, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "2",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548861.0,
+              "Y_COORDINATE" : 176156.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095079",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211560",
+              "UDPRN" : "6248165",
+              "ADDRESS" : "3, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "3",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548888.0,
+              "Y_COORDINATE" : 176131.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD02",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb5000005153955102",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211561",
+              "UDPRN" : "6248166",
+              "ADDRESS" : "4, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "4",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548858.0,
+              "Y_COORDINATE" : 176150.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095080",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211562",
+              "UDPRN" : "6248167",
+              "ADDRESS" : "5, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "5",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548884.0,
+              "Y_COORDINATE" : 176118.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD02",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095091",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211563",
+              "UDPRN" : "6248168",
+              "ADDRESS" : "6, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "6",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548849.0,
+              "Y_COORDINATE" : 176141.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095082",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211564",
+              "UDPRN" : "6248169",
+              "ADDRESS" : "7, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "7",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548874.0,
+              "Y_COORDINATE" : 176106.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095089",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211565",
+              "UDPRN" : "6248170",
+              "ADDRESS" : "8, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "8",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548846.0,
+              "Y_COORDINATE" : 176133.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095083",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211566",
+              "UDPRN" : "6248171",
+              "ADDRESS" : "9, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "9",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548868.0,
+              "Y_COORDINATE" : 176104.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095088",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211567",
+              "UDPRN" : "6248162",
+              "ADDRESS" : "10, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "10",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548848.0,
+              "Y_COORDINATE" : 176115.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095085",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211568",
+              "UDPRN" : "6248163",
+              "ADDRESS" : "12, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "12",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "2",
+              "X_COORDINATE" : 548854.0,
+              "Y_COORDINATE" : 176110.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095086",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          } ]
+        }
+    http_version: 
+  recorded_at: Thu, 11 Apr 2019 10:52:25 GMT
 recorded_with: VCR 4.0.0

--- a/features/cassettes/Civil_application_journeys/No_results_returned_is_seen_on_screen_when_invalid_proceeding_search_entered.yml
+++ b/features/cassettes/Civil_application_journeys/No_results_returned_is_seen_on_screen_when_invalid_proceeding_search_entered.yml
@@ -360,4 +360,364 @@ http_interactions:
         }
     http_version: 
   recorded_at: Tue, 29 Jan 2019 11:35:53 GMT
+- request:
+    method: get
+    uri: https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?key=<ORDNANACE_SURVEY_API_KEY>&lr=EN&postcode=DA74NG
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Thu, 11 Apr 2019 10:47:07 GMT
+      Server:
+      - Apache-Coyote/1.1
+      Status:
+      - success
+      Tx-Id:
+      - '1554979627003:3'
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "header" : {
+            "uri" : "https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?lr=EN&postcode=DA74NG",
+            "query" : "postcode=DA74NG",
+            "offset" : 0,
+            "totalresults" : 11,
+            "format" : "JSON",
+            "dataset" : "DPA",
+            "lr" : "EN",
+            "maxresults" : 100,
+            "epoch" : "65",
+            "output_srs" : "EPSG:27700"
+          },
+          "results" : [ {
+            "DPA" : {
+              "UPRN" : "100020211558",
+              "UDPRN" : "6248161",
+              "ADDRESS" : "1, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "1",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "2",
+              "X_COORDINATE" : 548894.0,
+              "Y_COORDINATE" : 176139.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD02",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095093",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211559",
+              "UDPRN" : "6248164",
+              "ADDRESS" : "2, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "2",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548861.0,
+              "Y_COORDINATE" : 176156.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095079",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211560",
+              "UDPRN" : "6248165",
+              "ADDRESS" : "3, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "3",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548888.0,
+              "Y_COORDINATE" : 176131.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD02",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb5000005153955102",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211561",
+              "UDPRN" : "6248166",
+              "ADDRESS" : "4, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "4",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548858.0,
+              "Y_COORDINATE" : 176150.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095080",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211562",
+              "UDPRN" : "6248167",
+              "ADDRESS" : "5, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "5",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548884.0,
+              "Y_COORDINATE" : 176118.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD02",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095091",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211563",
+              "UDPRN" : "6248168",
+              "ADDRESS" : "6, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "6",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548849.0,
+              "Y_COORDINATE" : 176141.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095082",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211564",
+              "UDPRN" : "6248169",
+              "ADDRESS" : "7, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "7",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548874.0,
+              "Y_COORDINATE" : 176106.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095089",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211565",
+              "UDPRN" : "6248170",
+              "ADDRESS" : "8, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "8",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548846.0,
+              "Y_COORDINATE" : 176133.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095083",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211566",
+              "UDPRN" : "6248171",
+              "ADDRESS" : "9, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "9",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548868.0,
+              "Y_COORDINATE" : 176104.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095088",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211567",
+              "UDPRN" : "6248162",
+              "ADDRESS" : "10, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "10",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548848.0,
+              "Y_COORDINATE" : 176115.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095085",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211568",
+              "UDPRN" : "6248163",
+              "ADDRESS" : "12, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "12",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "2",
+              "X_COORDINATE" : 548854.0,
+              "Y_COORDINATE" : 176110.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095086",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          } ]
+        }
+    http_version: 
+  recorded_at: Thu, 11 Apr 2019 10:47:07 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/address_selections_requests/GET_/providers/applications/_legal_aid_application_id/address_selections/edit/when_the_provider_is_authenticated/a_postcode_have_been_entered_before/but_the_lookup_does_not_return_any_valid_results/renders_the_manual_address_selection_page.yml
+++ b/spec/cassettes/address_selections_requests/GET_/providers/applications/_legal_aid_application_id/address_selections/edit/when_the_provider_is_authenticated/a_postcode_have_been_entered_before/but_the_lookup_does_not_return_any_valid_results/renders_the_manual_address_selection_page.yml
@@ -51,4 +51,55 @@ http_interactions:
         }
     http_version: 
   recorded_at: Mon, 17 Dec 2018 11:33:35 GMT
+- request:
+    method: get
+    uri: https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?key=<ORDNANACE_SURVEY_API_KEY>&lr=EN&postcode=SW1H9AJ
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Thu, 11 Apr 2019 10:35:42 GMT
+      Server:
+      - Apache-Coyote/1.1
+      Status:
+      - success
+      Tx-Id:
+      - 1554978942685:685
+      Content-Length:
+      - '337'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "header" : {
+            "uri" : "https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?lr=EN&postcode=SW1H9AJ",
+            "query" : "postcode=SW1H9AJ",
+            "offset" : 0,
+            "totalresults" : 0,
+            "format" : "JSON",
+            "dataset" : "DPA",
+            "lr" : "EN",
+            "maxresults" : 100,
+            "epoch" : "65",
+            "output_srs" : "EPSG:27700"
+          }
+        }
+    http_version: 
+  recorded_at: Thu, 11 Apr 2019 10:35:42 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/address_selections_requests/GET_/providers/applications/_legal_aid_application_id/address_selections/edit/when_the_provider_is_authenticated/a_postcode_have_been_entered_before/performs_an_address_lookup_with_the_provided_postcode.yml
+++ b/spec/cassettes/address_selections_requests/GET_/providers/applications/_legal_aid_application_id/address_selections/edit/when_the_provider_is_authenticated/a_postcode_have_been_entered_before/performs_an_address_lookup_with_the_provided_postcode.yml
@@ -360,4 +360,364 @@ http_interactions:
         }
     http_version: 
   recorded_at: Mon, 17 Dec 2018 11:33:34 GMT
+- request:
+    method: get
+    uri: https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?key=<ORDNANACE_SURVEY_API_KEY>&lr=EN&postcode=DA74NG
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Thu, 11 Apr 2019 10:35:25 GMT
+      Server:
+      - Apache-Coyote/1.1
+      Status:
+      - success
+      Tx-Id:
+      - 1554978925583:583
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "header" : {
+            "uri" : "https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?lr=EN&postcode=DA74NG",
+            "query" : "postcode=DA74NG",
+            "offset" : 0,
+            "totalresults" : 11,
+            "format" : "JSON",
+            "dataset" : "DPA",
+            "lr" : "EN",
+            "maxresults" : 100,
+            "epoch" : "65",
+            "output_srs" : "EPSG:27700"
+          },
+          "results" : [ {
+            "DPA" : {
+              "UPRN" : "100020211558",
+              "UDPRN" : "6248161",
+              "ADDRESS" : "1, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "1",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "2",
+              "X_COORDINATE" : 548894.0,
+              "Y_COORDINATE" : 176139.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD02",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095093",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211559",
+              "UDPRN" : "6248164",
+              "ADDRESS" : "2, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "2",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548861.0,
+              "Y_COORDINATE" : 176156.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095079",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211560",
+              "UDPRN" : "6248165",
+              "ADDRESS" : "3, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "3",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548888.0,
+              "Y_COORDINATE" : 176131.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD02",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb5000005153955102",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211561",
+              "UDPRN" : "6248166",
+              "ADDRESS" : "4, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "4",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548858.0,
+              "Y_COORDINATE" : 176150.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095080",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211562",
+              "UDPRN" : "6248167",
+              "ADDRESS" : "5, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "5",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548884.0,
+              "Y_COORDINATE" : 176118.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD02",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095091",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211563",
+              "UDPRN" : "6248168",
+              "ADDRESS" : "6, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "6",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548849.0,
+              "Y_COORDINATE" : 176141.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095082",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211564",
+              "UDPRN" : "6248169",
+              "ADDRESS" : "7, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "7",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548874.0,
+              "Y_COORDINATE" : 176106.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095089",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211565",
+              "UDPRN" : "6248170",
+              "ADDRESS" : "8, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "8",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548846.0,
+              "Y_COORDINATE" : 176133.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095083",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211566",
+              "UDPRN" : "6248171",
+              "ADDRESS" : "9, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "9",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548868.0,
+              "Y_COORDINATE" : 176104.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095088",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211567",
+              "UDPRN" : "6248162",
+              "ADDRESS" : "10, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "10",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548848.0,
+              "Y_COORDINATE" : 176115.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095085",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211568",
+              "UDPRN" : "6248163",
+              "ADDRESS" : "12, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "12",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "2",
+              "X_COORDINATE" : 548854.0,
+              "Y_COORDINATE" : 176110.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095086",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          } ]
+        }
+    http_version: 
+  recorded_at: Thu, 11 Apr 2019 10:35:25 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/address_selections_requests/GET_/providers/applications/_legal_aid_application_id/address_selections/edit/when_the_provider_is_authenticated/a_postcode_have_been_entered_before/renders_the_address_selection_page.yml
+++ b/spec/cassettes/address_selections_requests/GET_/providers/applications/_legal_aid_application_id/address_selections/edit/when_the_provider_is_authenticated/a_postcode_have_been_entered_before/renders_the_address_selection_page.yml
@@ -360,4 +360,364 @@ http_interactions:
         }
     http_version: 
   recorded_at: Mon, 17 Dec 2018 11:33:34 GMT
+- request:
+    method: get
+    uri: https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?key=<ORDNANACE_SURVEY_API_KEY>&lr=EN&postcode=DA74NG
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Thu, 11 Apr 2019 10:35:34 GMT
+      Server:
+      - Apache-Coyote/1.1
+      Status:
+      - success
+      Tx-Id:
+      - 1554978934156:156
+      Content-Length:
+      - '11445'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "header" : {
+            "uri" : "https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?lr=EN&postcode=DA74NG",
+            "query" : "postcode=DA74NG",
+            "offset" : 0,
+            "totalresults" : 11,
+            "format" : "JSON",
+            "dataset" : "DPA",
+            "lr" : "EN",
+            "maxresults" : 100,
+            "epoch" : "65",
+            "output_srs" : "EPSG:27700"
+          },
+          "results" : [ {
+            "DPA" : {
+              "UPRN" : "100020211558",
+              "UDPRN" : "6248161",
+              "ADDRESS" : "1, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "1",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "2",
+              "X_COORDINATE" : 548894.0,
+              "Y_COORDINATE" : 176139.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD02",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095093",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211559",
+              "UDPRN" : "6248164",
+              "ADDRESS" : "2, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "2",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548861.0,
+              "Y_COORDINATE" : 176156.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095079",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211560",
+              "UDPRN" : "6248165",
+              "ADDRESS" : "3, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "3",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548888.0,
+              "Y_COORDINATE" : 176131.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD02",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb5000005153955102",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211561",
+              "UDPRN" : "6248166",
+              "ADDRESS" : "4, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "4",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548858.0,
+              "Y_COORDINATE" : 176150.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095080",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211562",
+              "UDPRN" : "6248167",
+              "ADDRESS" : "5, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "5",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548884.0,
+              "Y_COORDINATE" : 176118.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD02",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095091",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211563",
+              "UDPRN" : "6248168",
+              "ADDRESS" : "6, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "6",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548849.0,
+              "Y_COORDINATE" : 176141.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095082",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211564",
+              "UDPRN" : "6248169",
+              "ADDRESS" : "7, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "7",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548874.0,
+              "Y_COORDINATE" : 176106.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095089",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211565",
+              "UDPRN" : "6248170",
+              "ADDRESS" : "8, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "8",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548846.0,
+              "Y_COORDINATE" : 176133.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095083",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211566",
+              "UDPRN" : "6248171",
+              "ADDRESS" : "9, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "9",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548868.0,
+              "Y_COORDINATE" : 176104.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095088",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211567",
+              "UDPRN" : "6248162",
+              "ADDRESS" : "10, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "10",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548848.0,
+              "Y_COORDINATE" : 176115.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095085",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211568",
+              "UDPRN" : "6248163",
+              "ADDRESS" : "12, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "12",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "2",
+              "X_COORDINATE" : 548854.0,
+              "Y_COORDINATE" : 176110.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095086",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          } ]
+        }
+    http_version: 
+  recorded_at: Thu, 11 Apr 2019 10:35:34 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/providers_legal_aid_application_proceedings_type_requests/index_GET_/providers/applications/_legal_aid_application_id/proceedings_types/when_the_provider_is_authenticated/back_link/the_applicant_s_address_used_s_address_lookup_service/should_redirect_to_the_address_lookup_page.yml
+++ b/spec/cassettes/providers_legal_aid_application_proceedings_type_requests/index_GET_/providers/applications/_legal_aid_application_id/proceedings_types/when_the_provider_is_authenticated/back_link/the_applicant_s_address_used_s_address_lookup_service/should_redirect_to_the_address_lookup_page.yml
@@ -39,4 +39,43 @@ http_interactions:
         }
     http_version: 
   recorded_at: Wed, 06 Feb 2019 14:37:04 GMT
+- request:
+    method: get
+    uri: https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?key=<ORDNANACE_SURVEY_API_KEY>&lr=EN&postcode=YO4B0LJ
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Thu, 11 Apr 2019 10:39:11 GMT
+      Server:
+      - Apache-Coyote/1.1
+      Content-Length:
+      - '189'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "error" : {
+            "statuscode" : 400,
+            "message" : "Requested postcode must contain a minimum of the sector plus 1 digit of the district e.g. SO1. Requested postcode was YO4B0LJ"
+          }
+        }
+    http_version: 
+  recorded_at: Thu, 11 Apr 2019 10:39:11 GMT
 recorded_with: VCR 4.0.0

--- a/spec/services/address_lookup_service_spec.rb
+++ b/spec/services/address_lookup_service_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe AddressLookupService do
   let(:query_params) do
     {
       key: ENV['ORDNANACE_SURVEY_API_KEY'],
-      postcode: postcode
+      postcode: postcode,
+      lr: 'EN'
     }
   end
   let(:api_request_uri) do


### PR DESCRIPTION
Currently a welsh postcode will return the address with Welsh language place names

[Link to story](https://dsdmoj.atlassian.net/browse/AP-486)

Added a language parameter to the request to specify 'EN' for english language spellings.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.