### PR TITLE
AP-554 Change copy on details_latest_incident page

### DIFF
--- a/app/views/providers/details_latest_incidents/show.html.erb
+++ b/app/views/providers/details_latest_incidents/show.html.erb
@@ -9,7 +9,7 @@
 
     <%= date_input_fields prefix: :occurred, field_name: :occurred_on, width: :full, form: form %>
 
-    <%= form.govuk_text_area :details, rows: 10 %>
+    <%= form.govuk_text_area :details, rows: 10, label: { text: t('.details_label'), size: :m } %>
 
     <%= next_action_buttons(show_draft: true, form: form) %>
 

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -37,7 +37,6 @@ en:
         occurred_day: Day
         occurred_month: Month
         occurred_year: Year
-        details: Details of the incident
       legal_aid_application:
         outstanding_mortgage_amount: Enter outstanding mortgage amount
         property_value: Enter the estimated value of your home
@@ -106,9 +105,9 @@ en:
               date_is_in_the_future: Date your client told you about the latest incident must be in the past
               blank: Enter the date your client told you about the latest domestic abuse incident
             occurred_on:
-              date_not_valid: Enter a date in the right format
-              date_is_in_the_future: Date your client contacted you must be in the past
-              blank: Enter the date your client contacted you about the incident
+              date_not_valid: Enter a valid date
+              date_is_in_the_future: Date the incident occurred must be in the past
+              blank: Enter the date the incident occurred
             details:
               blank: Enter details of the incident
         legal_aid_application:

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -127,7 +127,8 @@ en:
         h1-heading: When did your client tell you about the latest domestic abuse incident?
     details_latest_incidents:
       show:
-        h1-heading: Enter details of the latest incident
+        h1-heading: Details of the latest domestic abuse incident
+        details_label: What happened during the incident?
     estimated_legal_costs:
       show:
         h1-heading: What are the estimated legal costs of doing the work?

--- a/config/locales/en/shared.yml
+++ b/config/locales/en/shared.yml
@@ -23,7 +23,7 @@ en:
         date_of_birth_hint: For example, 31 3 1980
         date_of_birth_label: Date of birth
         occurred_on_hint: For example 31 3 2019
-        occurred_on_label: Date your client contacted you about the incident
+        occurred_on_label: When did the incident occur?
         told_on_hint: For example 31 3 2019
       outstanding_mortgage_form:
         citizens:

--- a/features/providers/civil_application_journey.feature
+++ b/features/providers/civil_application_journey.feature
@@ -345,7 +345,7 @@ Feature: Civil application journeys
     Then I should be on a page showing 'When did your client tell you about the latest domestic abuse incident?'
     Then I enter the told on date of 2 days ago
     Then I click 'Save and continue'
-    Then I should be on a page showing 'Enter details of the latest incident'
+    Then I should be on a page showing 'Details of the latest domestic abuse incident'
     Then I enter the occurred on date of 2 days ago
     Then I fill "Details" with "It happened"
     Then I click 'Save and continue'
@@ -443,7 +443,7 @@ Feature: Civil application journeys
     Then I should be on a page showing 'When did your client tell you about the latest domestic abuse incident?'
     Then I enter the told on date of 2 days ago
     Then I click 'Save and continue'
-    Then I should be on a page showing "Enter details of the latest incident"
+    Then I should be on a page showing "Details of the latest domestic abuse incident"
     Then I enter the occurred on date of 2 days ago
     Then I fill "Details" with "It happened"
     Then I click 'Save and continue'


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-554)

I just had to change the copy because even though the copy was about "date your client contacted you the incident", the model attribute was already called `occurred_on`

## Checklist

Before you ask people to review this PR:

- [X] Tests and rubocop should be passing: `bundle exec rake`
- [X] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [X] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [X] The PR description should say what you changed and why, with a link to the JIRA story.
- [X] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [X] You should have checked that the commit messages say why the change was made.
