### PR TITLE
AP 532 Applicant needs new link notification

### DIFF
--- a/app/controllers/citizens/legal_aid_applications_controller.rb
+++ b/app/controllers/citizens/legal_aid_applications_controller.rb
@@ -17,7 +17,7 @@ module Citizens
     private
 
     def expired
-      redirect_to error_path(:link_expired)
+      redirect_to citizens_resend_link_request_path(params[:id])
     end
 
     def completed

--- a/app/controllers/citizens/resend_link_requests_controller.rb
+++ b/app/controllers/citizens/resend_link_requests_controller.rb
@@ -1,0 +1,17 @@
+module Citizens
+  class ResendLinkRequestsController < ApplicationController
+    def show; end
+
+    def update
+      ResendLinkRequestMailer.notify(
+        secure_application_finder.legal_aid_application
+      ).deliver_later
+    end
+
+    private
+
+    def secure_application_finder
+      @secure_application_finder ||= SecureApplicationFinder.new(params[:id])
+    end
+  end
+end

--- a/app/mailers/concerns/notify_template_methods.rb
+++ b/app/mailers/concerns/notify_template_methods.rb
@@ -1,0 +1,10 @@
+module NotifyTemplateMethods
+  def template_name(template_name)
+    template_id = template_ids.fetch(template_name)
+    set_template(template_id)
+  end
+
+  def template_ids
+    @template_ids ||= Rails.configuration.govuk_notify_templates
+  end
+end

--- a/app/mailers/concerns/notify_template_methods.rb
+++ b/app/mailers/concerns/notify_template_methods.rb
@@ -7,4 +7,8 @@ module NotifyTemplateMethods
   def template_ids
     @template_ids ||= Rails.configuration.govuk_notify_templates
   end
+
+  def support_email_address
+    Rails.configuration.x.support_email_address
+  end
 end

--- a/app/mailers/feedback_mailer.rb
+++ b/app/mailers/feedback_mailer.rb
@@ -1,6 +1,4 @@
 class FeedbackMailer < GovukNotifyRails::Mailer
-  TARGET_EMAIL = 'apply-for-legal-aid@digital.justice.gov.uk'.freeze
-
   include NotifyTemplateMethods
 
   def notify(feedback)
@@ -16,6 +14,6 @@ class FeedbackMailer < GovukNotifyRails::Mailer
       satisfaction: (feedback.satisfaction || ''),
       improvement_suggestion: (feedback.improvement_suggestion || '')
     )
-    mail to: TARGET_EMAIL
+    mail to: support_email_address
   end
 end

--- a/app/mailers/feedback_mailer.rb
+++ b/app/mailers/feedback_mailer.rb
@@ -1,8 +1,10 @@
 class FeedbackMailer < GovukNotifyRails::Mailer
   TARGET_EMAIL = 'apply-for-legal-aid@digital.justice.gov.uk'.freeze
 
+  include NotifyTemplateMethods
+
   def notify(feedback)
-    set_template_conf
+    template_name :feedback_notification
     set_personalisation(
       created_at: feedback.created_at.to_s(:rfc822),
       user_data: [
@@ -15,16 +17,5 @@ class FeedbackMailer < GovukNotifyRails::Mailer
       improvement_suggestion: (feedback.improvement_suggestion || '')
     )
     mail to: TARGET_EMAIL
-  end
-
-  protected
-
-  def set_template_conf
-    template_id = template_ids.fetch(:feedback_notification)
-    set_template(template_id)
-  end
-
-  def template_ids
-    @template_ids ||= Rails.configuration.govuk_notify_templates
   end
 end

--- a/app/mailers/notify_mailer.rb
+++ b/app/mailers/notify_mailer.rb
@@ -1,18 +1,9 @@
 class NotifyMailer < GovukNotifyRails::Mailer
+  include NotifyTemplateMethods
+
   def citizen_start_email(app_id, email, application_url, client_name)
-    set_template_conf
+    template_name :citizen_start_application
     set_personalisation(application_url: application_url, client_name: client_name, ref_number: app_id)
     mail(to: email)
-  end
-
-  protected
-
-  def set_template_conf
-    template_id = template_ids.fetch(:citizen_start_application)
-    set_template(template_id)
-  end
-
-  def template_ids
-    @template_ids ||= Rails.configuration.govuk_notify_templates
   end
 end

--- a/app/mailers/resend_link_request_mailer.rb
+++ b/app/mailers/resend_link_request_mailer.rb
@@ -1,0 +1,14 @@
+class ResendLinkRequestMailer < GovukNotifyRails::Mailer
+  include NotifyTemplateMethods
+
+  def notify(legal_aid_application)
+    template_name :new_link_request
+    set_personalisation(
+      applicant_name: legal_aid_application.applicant_full_name,
+      provider: legal_aid_application.provider_id,
+      application_ref: legal_aid_application.application_ref,
+      requested_at: Time.current.to_s(:datetime)
+    )
+    mail to: support_email_address
+  end
+end

--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -53,15 +53,6 @@ class LegalAidApplication < ApplicationRecord # rubocop:disable Metrics/ClassLen
     )
   end
 
-  def self.find_by_secure_id!(secure_id)
-    secure_data = SecureData.for(secure_id)
-    if secure_data[:expired_at] && secure_data[:expired_at] < Time.current
-      SimpleResult.new(error: :expired)
-    else
-      SimpleResult.new(value: find_by!(secure_data[:legal_aid_application]))
-    end
-  end
-
   def generate_secure_id
     SecureData.create_and_store!(
       legal_aid_application: { id: id },

--- a/app/services/secure_application_finder.rb
+++ b/app/services/secure_application_finder.rb
@@ -1,0 +1,29 @@
+class SecureApplicationFinder
+  attr_reader :secure_id
+
+  def initialize(secure_id)
+    @secure_id = secure_id
+  end
+
+  def error
+    @error ||= check_for_errors
+  end
+
+  def legal_aid_application
+    LegalAidApplication.find_by! secure_data[:legal_aid_application]
+  end
+
+  private
+
+  def secure_data
+    @secure_data ||= SecureData.for(secure_id)
+  end
+
+  def check_for_errors
+    return :expired if expired?
+  end
+
+  def expired?
+    secure_data[:expired_at] && secure_data[:expired_at] < Time.current
+  end
+end

--- a/app/views/citizens/resend_link_requests/show.html.erb
+++ b/app/views/citizens/resend_link_requests/show.html.erb
@@ -1,0 +1,9 @@
+<%= page_template page_title: t('.page_title'), back_link: :none do %>
+  <p class="govuk-body">
+    <%= link_to(
+          t('.new_link_request'),
+          citizens_resend_link_request_path(params[:id]),
+          method: :patch
+        ) %>
+  </p>
+<% end %>

--- a/app/views/citizens/resend_link_requests/update.html.erb
+++ b/app/views/citizens/resend_link_requests/update.html.erb
@@ -1,0 +1,5 @@
+<%= page_template page_title: t('.page_title'), back_link: :none do %>
+  <p class="govuk-body">
+    <%= t('.contact_provider') %>
+  </p>
+<% end %>

--- a/app/views/errors/show/_link_expired.html.erb
+++ b/app/views/errors/show/_link_expired.html.erb
@@ -1,3 +1,0 @@
-<p class="govuk-body">
-  <%= link_to t('.new_link_request'), '#' %>
-</p>

--- a/config/application.rb
+++ b/config/application.rb
@@ -32,7 +32,8 @@ module LaaApplyForLegalAid
     config.x.kubernetes_deployment = ENV['KUBERNETES_DEPLOYMENT'] == 'true'
 
     config.govuk_notify_templates = config_for(
-      :govuk_notify_templates, env: ENV.fetch('GOVUK_NOTIFY_ENV', 'development')
+      :govuk_notify_templates,
+      env: ENV.fetch('GOVUK_NOTIFY_ENV', 'development')
     ).symbolize_keys
 
     config.x.admin_portal.allow_reset = ENV['ADMIN_ALLOW_RESET'] == 'true'

--- a/config/application.rb
+++ b/config/application.rb
@@ -35,6 +35,7 @@ module LaaApplyForLegalAid
       :govuk_notify_templates,
       env: ENV.fetch('GOVUK_NOTIFY_ENV', 'development')
     ).symbolize_keys
+    config.x.support_email_address = 'apply-for-legal-aid@digital.justice.gov.uk'.freeze
 
     config.x.admin_portal.allow_reset = ENV['ADMIN_ALLOW_RESET'] == 'true'
     config.x.admin_portal.allow_create_test_applications = ENV['ADMIN_ALLOW_CREATE_TEST_APPLICATIONS'] == 'true'

--- a/config/govuk_notify_templates.yml
+++ b/config/govuk_notify_templates.yml
@@ -9,9 +9,11 @@
 # we default to 'integration' group.
 #
 development:
-  citizen_start_application: '570e1b9d-6238-45fd-b75c-96f2f39db8e9'
-  feedback_notification: 'ac458f81-b7dd-4b2c-944c-3f17d2f2392c'
+  citizen_start_application: 570e1b9d-6238-45fd-b75c-96f2f39db8e9
+  feedback_notification: ac458f81-b7dd-4b2c-944c-3f17d2f2392c
+  new_link_request: a577582b-3e60-44a4-885c-d4b12bf23958
 
 production:
-  citizen_start_application: '66865f0d-6410-40e2-b862-98724eb6e33a'
-  feedback_notification: '246379d9-14f5-470e-a8a4-31c4b61e64b2'
+  citizen_start_application: 66865f0d-6410-40e2-b862-98724eb6e33a
+  feedback_notification: 246379d9-14f5-470e-a8a4-31c4b61e64b2
+  new_link_request: 3cc3be57-e072-4095-9caa-c0cd52193405

--- a/config/initializers/date_formats.rb
+++ b/config/initializers/date_formats.rb
@@ -1,2 +1,3 @@
 # Note - if using `l(date)` in an erb, format is defined in locale at en.date.formats
 Date::DATE_FORMATS[:default] = '%e %B %Y'
+Time::DATE_FORMATS[:datetime] = '%H:%M %d-%b-%Y'

--- a/config/initializers/gov_uk_notify.rb
+++ b/config/initializers/gov_uk_notify.rb
@@ -1,2 +1,5 @@
-ActionMailer::Base.add_delivery_method :govuk_notify, GovukNotifyRails::Delivery,
-                                       api_key: ENV['GOVUK_NOTIFY_API_KEY']
+ActionMailer::Base.add_delivery_method(
+  :govuk_notify,
+  GovukNotifyRails::Delivery,
+  api_key: ENV['GOVUK_NOTIFY_API_KEY']
+)

--- a/config/locales/en/citizens.yml
+++ b/config/locales/en/citizens.yml
@@ -133,6 +133,13 @@ en:
             property_value: Enter the estimated value of your home
       show:
         h1-heading: How much is your home worth?
+    resend_link_requests:
+      show:
+        page_title: This link has expired
+        new_link_request: Request a new link
+      update:
+        page_title: Your request for a new link has been sent
+        contact_provider: Speak with your solicitor to check your application status.
     restrictions:
       index:
         h1-heading: Do any of the following restrictions apply to your property or other assets?

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -14,9 +14,6 @@ en:
       assessment_already_completed:
         page_title: You've already completed your financial assessment
         contact_provider: Speak with your solicitor to check your application status.
-      link_expired:
-        page_title: This link has expired
-        new_link_request: Request a new link
       page_not_found:
         page_title: Page not found
         web_address_incorrect: If you typed the web address, check it is correct.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,6 +37,7 @@ Rails.application.routes.draw do
 
   namespace :citizens do
     resources :legal_aid_applications, only: %i[show index]
+    resources :resend_link_requests, only: %i[show update], path: 'resend_link'
     resource :consent, only: %i[show create]
     resource :property_value, only: %i[show update]
     resource :information, only: [:show]

--- a/spec/mailers/resend_link_request_mailer_spec.rb
+++ b/spec/mailers/resend_link_request_mailer_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
-RSpec.describe FeedbackMailer, type: :mailer do
+RSpec.describe ResendLinkRequestMailer, type: :mailer do
   describe 'notify' do
-    let(:feedback) { create :feedback }
-    let(:mail) { described_class.notify(feedback) }
+    let(:legal_aid_application) { create :legal_aid_application, :with_applicant }
+    let(:mail) { described_class.notify(legal_aid_application) }
 
     it 'sends to correct address' do
       expect(mail.to).to eq([Rails.configuration.x.support_email_address])

--- a/spec/models/legal_aid_application_spec.rb
+++ b/spec/models/legal_aid_application_spec.rb
@@ -144,15 +144,6 @@ RSpec.describe LegalAidApplication, type: :model do
     end
   end
 
-  describe '.find_by_secure_id!' do
-    let(:legal_aid_application) { create :legal_aid_application }
-    let(:secure_id) { legal_aid_application.generate_secure_id }
-
-    it 'should return matching legal aid legal_aid_application' do
-      expect(described_class.find_by_secure_id!(secure_id).value).to eq(legal_aid_application)
-    end
-  end
-
   describe 'state machine' do
     subject(:legal_aid_application) { create(:legal_aid_application) }
 

--- a/spec/requests/citizens/legal_aid_applications_spec.rb
+++ b/spec/requests/citizens/legal_aid_applications_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe 'citizen home requests', type: :request do
       end
 
       it 'redirects to error page (link expired)' do
-        expect(response).to redirect_to(error_path(:link_expired))
+        expect(response).to redirect_to(citizens_resend_link_request_path(secure_id))
       end
     end
   end

--- a/spec/requests/citizens/resend_link_requests_spec.rb
+++ b/spec/requests/citizens/resend_link_requests_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe Citizens::ResendLinkRequestsController, type: :request do
+  let(:legal_aid_application) { create :legal_aid_application, :with_applicant }
+  let(:secure_data_id) { legal_aid_application.generate_secure_id }
+
+  describe 'GET /citizens/resend_link/:id' do
+    subject { get citizens_resend_link_request_path(secure_data_id) }
+
+    it 'renders page' do
+      subject
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe 'PATCH /citizens/resend_link/:id' do
+    subject { patch citizens_resend_link_request_path(secure_data_id) }
+
+    it 'renders page' do
+      subject
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'sends an email' do
+      mailer = double(deliver_later: true)
+      expect(ResendLinkRequestMailer).to receive(:notify).and_return(mailer)
+      subject
+    end
+  end
+end

--- a/spec/requests/errors_spec.rb
+++ b/spec/requests/errors_spec.rb
@@ -28,18 +28,4 @@ RSpec.describe ErrorsController, type: :request do
       expect(response.body).to match(/already completed[\w\s]+financial assessment/)
     end
   end
-
-  describe 'GET /error/link_expired' do
-    subject { get error_path(:link_expired) }
-
-    before { subject }
-
-    it 'renders successfully' do
-      expect(response).to have_http_status(:ok)
-    end
-
-    it 'displays the correct header' do
-      expect(response.body).to match('link has expired')
-    end
-  end
 end

--- a/spec/services/secure_application_finder_spec.rb
+++ b/spec/services/secure_application_finder_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe SecureApplicationFinder, type: :service do
       expect(subject.legal_aid_application).to eq(legal_aid_application)
     end
 
-    it 'has no errors' do
+    it 'has :expired error' do
       expect(subject.error).to eq(:expired)
     end
   end

--- a/spec/services/secure_application_finder_spec.rb
+++ b/spec/services/secure_application_finder_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe SecureApplicationFinder, type: :service do
+  let(:legal_aid_application) { create :legal_aid_application }
+  let(:expired_at) { 1.hour.from_now }
+  let(:secure_data_id) do
+    SecureData.create_and_store!(
+      legal_aid_application: { id: legal_aid_application.id },
+      expired_at: expired_at
+    )
+  end
+  subject { described_class.new(secure_data_id) }
+
+  it 'finds the application' do
+    expect(subject.legal_aid_application).to eq(legal_aid_application)
+  end
+
+  it 'has no errors' do
+    expect(subject.error).to be_nil
+  end
+
+  context 'when expired' do
+    let(:expired_at) { 1.hour.ago }
+
+    it 'does not find the application' do
+      expect(subject.legal_aid_application).to eq(legal_aid_application)
+    end
+
+    it 'has no errors' do
+      expect(subject.error).to eq(:expired)
+    end
+  end
+end


### PR DESCRIPTION
[JIRA AP-532](https://dsdmoj.atlassian.net/browse/AP-532)

This PR changes the response to someone trying to start the Citizen journey with an expired link. They are now sent to a page where they are prompted to send a request for a new link.

## The changes:

- A refactor of the existing mailer so that I could reuse code in the a new mailer.
- Change the citizens/legal_aid_applications_controller response to an expired request to redirect to a new end point.
- Removed the error/link_expired endpoint as it is now redundant
- Moved the `LegalAidApplication.find_by_secure_id!` functionality to a service so that I could reuse the functionality a little more easily.
- Created `Citizens::ResendLinkRequestsController` with `show` and `update` actions to handle the new request link functionality. 
- Created `ResendLinkRequestMailer` to use a [new Notify template](https://www.notifications.service.gov.uk/services/163de143-2d34-4454-b1fc-2f41624f2771/templates/a577582b-3e60-44a4-885c-d4b12bf23958).
- Moved `support_email_address` definition to `config/application` so that it's set in the same place as other global settings and can be easily updated later to be over-ridden with an environment variable if needed. It needed to be in a common location now that it is used across multiple mailers.