### PR TITLE
Force version of chromedriver used

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,6 +15,9 @@
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 require 'simplecov'
 require 'webmock/rspec'
+require 'chromedriver-helper'
+
+Chromedriver.set_version '2.46'
 
 SimpleCov.minimum_coverage 100
 unless ENV['NOCOVERAGE']


### PR DESCRIPTION
## What

Builds are currently failing on CircleCI as the version of
chromedriver we are using (74.0.3729.6) is not compatible with the
version of chrome that runs on CircleCI (72.0.3626.121-1).

This change will force chromedriver to version 2.46, which does support
v72 of chrome.

This probably isn't a long term solution but as there is already an existing
story to remove chromedriver [(AP-523)](https://dsdmoj.atlassian.net/browse/AP-523) this should work as an interim 
solution to allow builds to pass.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
