### PR TITLE
AP-523 Replace deprecated chrome drive gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -94,7 +94,6 @@ end
 
 group :test do
   gem 'capybara', '>= 2.15', '< 4.0'
-  gem 'chromedriver-helper'
   gem 'climate_control' # Allows environment variables to be modified within specs
   gem 'cucumber-rails', require: false
   gem 'database_cleaner'
@@ -105,6 +104,7 @@ group :test do
   gem 'simplecov-rcov'
   gem 'timecop'
   gem 'vcr'
+  gem 'webdrivers', '~> 3.0'
   gem 'webmock'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,8 +54,6 @@ GEM
     akami (1.3.1)
       gyoku (>= 0.4.0)
       nokogiri
-    archive-zip (0.12.0)
-      io-like (~> 0.3.0)
     arel (9.0.0)
     ast (2.4.0)
     awesome_print (1.8.0)
@@ -106,9 +104,6 @@ GEM
       activesupport
     childprocess (1.0.1)
       rake (< 13.0)
-    chromedriver-helper (2.1.1)
-      archive-zip (~> 0.10)
-      nokogiri (~> 1.8)
     chronic_duration (0.10.6)
       numerizer (~> 0.1.1)
     climate_control (0.2.0)
@@ -202,7 +197,6 @@ GEM
       rails-i18n
       rainbow (>= 2.2.2, < 4.0)
       terminal-table (>= 1.5.1)
-    io-like (0.3.0)
     jaro_winkler (1.5.2)
     jmespath (1.4.0)
     jquery-rails (4.3.3)
@@ -445,6 +439,10 @@ GEM
       nokogiri (>= 1.4.2)
     webdack-uuid_migration (1.2.0)
       activerecord (>= 4.0)
+    webdrivers (3.8.0)
+      nokogiri (~> 1.6)
+      rubyzip (~> 1.0)
+      selenium-webdriver (~> 3.0)
     webmock (3.5.1)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -468,7 +466,6 @@ DEPENDENCIES
   browser
   byebug
   capybara (>= 2.15, < 4.0)
-  chromedriver-helper
   climate_control
   cucumber-rails
   database_cleaner
@@ -523,6 +520,7 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   vcr
   webdack-uuid_migration (~> 1.2.0)
+  webdrivers (~> 3.0)
   webmock
 
 RUBY VERSION

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -10,12 +10,21 @@ require 'capybara/cucumber'
 require 'selenium/webdriver'
 require 'webmock/cucumber'
 require 'factory_bot'
+require 'webdrivers'
 
 allowed_sites = [
-  ->(uri) { uri.to_s =~ /__identify__/ || uri.to_s =~ /127.0.0.1.*(session|shutdown)/ }
+  ->(uri) do
+    [
+      /__identify__/,
+      /127.0.0.1.*(session|shutdown)/,
+      /chromedriver.storage.googleapis.com/
+    ].any? { |pattern| uri.to_s =~ pattern }
+  end
 ]
 
 WebMock.disable_net_connect!(allow: allowed_sites)
+
+Webdrivers::Chromedriver.update
 
 Capybara.register_driver :headless_chrome do |app|
   browser_options = Selenium::WebDriver::Chrome::Options.new(args: %w[start-maximized headless disable-gpu no-sandbox])

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,9 +15,6 @@
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 require 'simplecov'
 require 'webmock/rspec'
-require 'chromedriver-helper'
-
-Chromedriver.set_version '2.46'
 
 SimpleCov.minimum_coverage 100
 unless ENV['NOCOVERAGE']


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-523)

Replace deprecated gem `chromedriver-helper` with `webdrivers`

## Checklist

Before you ask people to review this PR:

- [X] Tests and rubocop should be passing: `bundle exec rake`
- [X] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [X] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [X] The PR description should say what you changed and why, with a link to the JIRA story.
- [X] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [X] You should have checked that the commit messages say why the change was made.
