### PR TITLE
AP531 Bail conditions content on /respondent page

### DIFF
--- a/app/assets/javascripts/respondent_detail.es6
+++ b/app/assets/javascripts/respondent_detail.es6
@@ -1,0 +1,31 @@
+$(document).ready(() => {
+  if ($("#bail_conditions_set").length) {
+    const bailConditionOptions = "input[type = radio][name = 'respondent[bail_conditions_set]']";
+    $(bailConditionOptions).on("change", setBailConditionsLabel);
+    setBailConditionsLabel();
+    if($('#bail_conditions_set_details-error').length) updateError();
+  };
+
+  function setBailConditionsLabel() {
+    const bailConditionsLabel = "label[for='bail_conditions_set_details']";
+    $(bailConditionsLabel).text($('#bail_conditions_set_details').attr(`data-bail-conditions-${selectedBailOption()}`));
+  }
+
+  function selectedBailOption(){
+    let optionChecked = "input[type = radio][name = 'respondent[bail_conditions_set]']:checked";
+    let optionValue = $(optionChecked).val() == 'false' ? 'no' : 'yes'
+    return optionValue
+  }
+
+  function updateError(){
+    if ($('#bail_conditions_set_details-error').length && selectedBailOption() == 'no'){
+      $('#bail_conditions_set_details-error').text($('#bail_conditions_set_details').attr(`data-bail-conditions-no`));
+      updateErrorSummary();
+    }
+  }
+
+  function updateErrorSummary(){
+    const errorSummaryListText = $(document.body.querySelectorAll('*[href="#bail_conditions_set_details"]')[0]);
+    errorSummaryListText.text($('#bail_conditions_set_details').attr(`data-bail-conditions-no`));
+  }
+});

--- a/app/assets/javascripts/respondent_detail.es6
+++ b/app/assets/javascripts/respondent_detail.es6
@@ -25,15 +25,21 @@ $(document).ready(() => {
       $("label[for='bail_conditions_set_details']").text(selectedBailConditionsLabel())
     }
 
+    function selectedBailConditionsError() {
+      if (selectedBailCondition().val() == 'false') {
+        return $('#bail_conditions_set_details').data('bail-conditions-blank-error-no')
+      }
+      else {
+        return $('#bail_conditions_set_details').data('bail-conditions-blank-error-yes')
+      }
+    }
+
     function updateError() {
       if (!$('#bail_conditions_set_details-error').length) return
 
-      let label = selectedBailConditionsLabel()
-      if (selectedBailCondition().val() != 'false') {
-        label = $('#bail_conditions_set_details').data('bail-conditions-blank-error')
-      }
-      $('#bail_conditions_set_details-error').text(label)
-      $('[href="#bail_conditions_set_details"]').text(label)
+      const error = selectedBailConditionsError()
+      $('#bail_conditions_set_details-error').text(error)
+      $('[href="#bail_conditions_set_details"]').text(error)
     }
   }
 })

--- a/app/assets/javascripts/respondent_detail.es6
+++ b/app/assets/javascripts/respondent_detail.es6
@@ -1,31 +1,39 @@
 $(document).ready(() => {
   if ($("#bail_conditions_set").length) {
-    const bailConditionOptions = "input[type = radio][name = 'respondent[bail_conditions_set]']";
-    $(bailConditionOptions).on("change", setBailConditionsLabel);
-    setBailConditionsLabel();
-    if($('#bail_conditions_set_details-error').length) updateError();
-  };
+    $("input[type=radio][name='respondent[bail_conditions_set]']").on("change", () => {
+      setBailConditionsLabel()
+      updateError()
+    })
+    setBailConditionsLabel()
+    updateError()
 
-  function setBailConditionsLabel() {
-    const bailConditionsLabel = "label[for='bail_conditions_set_details']";
-    $(bailConditionsLabel).text($('#bail_conditions_set_details').attr(`data-bail-conditions-${selectedBailOption()}`));
-  }
+    function selectedBailConditionsLabel() {
+      const optionChecked = selectedBailCondition()
+      if (optionChecked.val() == 'false') {
+        return $('#bail_conditions_set_details').data('bail-conditions-no')
+      }
+      else {
+        return $('#bail_conditions_set_details').data('bail-conditions-yes')
+      }
+    }
 
-  function selectedBailOption(){
-    let optionChecked = "input[type = radio][name = 'respondent[bail_conditions_set]']:checked";
-    let optionValue = $(optionChecked).val() == 'false' ? 'no' : 'yes'
-    return optionValue
-  }
+    function selectedBailCondition(){
+      return $("input[type=radio][name='respondent[bail_conditions_set]']:checked")
+    }
 
-  function updateError(){
-    if ($('#bail_conditions_set_details-error').length && selectedBailOption() == 'no'){
-      $('#bail_conditions_set_details-error').text($('#bail_conditions_set_details').attr(`data-bail-conditions-no`));
-      updateErrorSummary();
+    function setBailConditionsLabel() {
+      $("label[for='bail_conditions_set_details']").text(selectedBailConditionsLabel())
+    }
+
+    function updateError() {
+      if (!$('#bail_conditions_set_details-error').length) return
+
+      let label = selectedBailConditionsLabel()
+      if (selectedBailCondition().val() != 'false') {
+        label = $('#bail_conditions_set_details').data('bail-conditions-blank-error')
+      }
+      $('#bail_conditions_set_details-error').text(label)
+      $('[href="#bail_conditions_set_details"]').text(label)
     }
   }
-
-  function updateErrorSummary(){
-    const errorSummaryListText = $(document.body.querySelectorAll('*[href="#bail_conditions_set_details"]')[0]);
-    errorSummaryListText.text($('#bail_conditions_set_details').attr(`data-bail-conditions-no`));
-  }
-});
+})

--- a/app/views/providers/respondents/_respondent_detail.html.erb
+++ b/app/views/providers/respondents/_respondent_detail.html.erb
@@ -19,9 +19,10 @@
               question.attribute_details,
               id: question.attribute_details,
               rows: 5,
-              label: bail_conditions_titles['yes'],
-              'data-bail-conditions-yes' => bail_conditions_titles['yes'],
-              'data-bail-conditions-no' => bail_conditions_titles['no']
+              label: bail_conditions_titles[:yes],
+              'data-bail-conditions-yes' => bail_conditions_titles[:yes],
+              'data-bail-conditions-no' => bail_conditions_titles[:no],
+              'data-bail-conditions-blank-error' => bail_conditions_titles[:blank_error]
             ) %>
       <% else %>
         <%= form.govuk_text_area question.attribute_details, id: question.attribute_details, rows: 5 %>

--- a/app/views/providers/respondents/_respondent_detail.html.erb
+++ b/app/views/providers/respondents/_respondent_detail.html.erb
@@ -22,7 +22,8 @@
               label: bail_conditions_titles[:yes],
               'data-bail-conditions-yes' => bail_conditions_titles[:yes],
               'data-bail-conditions-no' => bail_conditions_titles[:no],
-              'data-bail-conditions-blank-error' => bail_conditions_titles[:blank_error]
+              'data-bail-conditions-blank-error-yes' => bail_conditions_titles[:blank_error],
+              'data-bail-conditions-blank-error-no' => bail_conditions_titles[:no]
             ) %>
       <% else %>
         <%= form.govuk_text_area question.attribute_details, id: question.attribute_details, rows: 5 %>

--- a/app/views/providers/respondents/_respondent_detail.html.erb
+++ b/app/views/providers/respondents/_respondent_detail.html.erb
@@ -14,7 +14,18 @@
 
     <% always_showing = question.show_details_when.nil? %>
     <%= content_tag(:div, id: conditional_id, class: always_showing ? nil : 'govuk-radios__conditional--hidden') do %>
-      <%= form.govuk_text_area question.attribute_details, id: question.attribute_details, rows: 5 %>
+      <% if question.attribute == :bail_conditions_set %>
+        <%= form.govuk_text_area(
+              question.attribute_details,
+              id: question.attribute_details,
+              rows: 5,
+              label: bail_conditions_titles['yes'],
+              'data-bail-conditions-yes' => bail_conditions_titles['yes'],
+              'data-bail-conditions-no' => bail_conditions_titles['no']
+            ) %>
+      <% else %>
+        <%= form.govuk_text_area question.attribute_details, id: question.attribute_details, rows: 5 %>
+      <% end %>
     <% end %>
   </div>
 </div>

--- a/app/views/providers/respondents/show.html.erb
+++ b/app/views/providers/respondents/show.html.erb
@@ -28,8 +28,9 @@
       end
 
       bail_conditions_titles = {
-        'yes' => t('.bail_conditions_set_yes'),
-        'no' => t('.bail_conditions_set_no')
+        yes: t('.bail_conditions_set_yes'),
+        no: t('.bail_conditions_set_no'),
+        blank_error: t('.bail_conditions_set_blank')
       }
     %>
     <%= render partial: 'respondent_detail', collection: questions, as: :question, locals: { form: form, bail_conditions_titles: bail_conditions_titles } %>

--- a/app/views/providers/respondents/show.html.erb
+++ b/app/views/providers/respondents/show.html.erb
@@ -26,9 +26,13 @@
       questions.each do |question|
         question.show_details_when = nil if question.attribute == :bail_conditions_set
       end
-    %>
 
-    <%= render partial: 'respondent_detail', collection: questions, as: :question, locals: { form: form } %>
+      bail_conditions_titles = {
+        'yes' => t('.bail_conditions_set_yes'),
+        'no' => t('.bail_conditions_set_no')
+      }
+    %>
+    <%= render partial: 'respondent_detail', collection: questions, as: :question, locals: { form: form, bail_conditions_titles: bail_conditions_titles } %>
 
     <%= next_action_buttons(show_draft: true, form: form) %>
   <% end %>

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -245,6 +245,7 @@ en:
         bail_conditions_set: Have bail conditions been set?
         bail_conditions_set_no: Tell us why bail conditions have not been set
         bail_conditions_set_yes: Give details of the bail conditions, including the date they're likely to end
+        bail_conditions_set_blank: Give details of the bail conditions
     restrictions:
       index:
         h1-heading: Do any of the following restrictions apply to your client's property or other assets?

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -243,6 +243,8 @@ en:
         warning_letter_sent: Has a warning letter been sent to the respondent?
         police_notified: Have the police been notified?
         bail_conditions_set: Have bail conditions been set?
+        bail_conditions_set_no: Tell us why bail conditions have not been set
+        bail_conditions_set_yes: Give details of the bail conditions, including the date they're likely to end
     restrictions:
       index:
         h1-heading: Do any of the following restrictions apply to your client's property or other assets?


### PR DESCRIPTION
Bail conditions content on /respondent page 

For the question 'Have bail conditions been set?' on the respondent page, the label for its text area should change depending on whether the user selects yes or no as an answer to this question.

[Link to story](https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=233&projectKey=AP&modal=detail&selectedIssue=AP-531)

1. Added custom data attributes to store the two labels for Bail conditions. 
2. Using JavaScript in the front-end to change the label depending on the option selected for bail_conditions_set ('yes', 'no').
3. Update the error text and the error summary list depending on the label.

## Checklist

Before you ask people to review this PR:

- [X] Tests and rubocop should be passing: `bundle exec rake`
- [X] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [X] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [X] The PR description should say what you changed and why, with a link to the JIRA story.
- [X] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [X] You should have checked that the commit messages say why the change was made.
