### PR TITLE
New Style and HTML for narrow tables

### DIFF
--- a/app/assets/stylesheets/narrow-table-display.scss
+++ b/app/assets/stylesheets/narrow-table-display.scss
@@ -1,0 +1,34 @@
+.table-combine_narrow_2and3 th:nth-of-type(2) .table-hidden_column3_title {
+  display: none;
+}
+
+.govuk-checkboxes__label.table-checkbox_label {
+  /*removing padding for labels in tables*/
+  padding: 0;
+}
+
+@media (max-width: 435px) {
+  .table-combine_narrow_2and3 td:nth-of-type(3),
+  .table-combine_narrow_2and3 td:nth-of-type(2) {
+    display: block;
+    border-bottom: 0px;
+  }
+
+  .table-combine_narrow_2and3 tr {
+    border-bottom: 1px solid #bfc1c3;
+  }
+
+  .table-combine_narrow_2and3 th:nth-of-type(3) {
+    display: none;
+  }
+
+  .table-combine_narrow_2and3 th:nth-of-type(2) .table-hidden_column3_title {
+    display: inline;
+    white-space:normal;
+  }
+}
+@media (min-width: 375px) {
+  .select-clear-all {
+    white-space: nowrap;
+  }
+}

--- a/app/assets/stylesheets/narrow-table-display.scss
+++ b/app/assets/stylesheets/narrow-table-display.scss
@@ -1,34 +1,33 @@
-.table-combine_narrow_2and3 th:nth-of-type(2) .table-hidden_column3_title {
-  display: none;
+th.table-combine_right_if_narrow .table-hidden_right_title {
+    display:none;
 }
 
 .govuk-checkboxes__label.table-checkbox_label {
   /*removing padding for labels in tables*/
   padding: 0;
 }
-
-@media (max-width: 435px) {
-  .table-combine_narrow_2and3 td:nth-of-type(3),
-  .table-combine_narrow_2and3 td:nth-of-type(2) {
-    display: block;
-    border-bottom: 0px;
-  }
-
-  .table-combine_narrow_2and3 tr {
-    border-bottom: 1px solid #bfc1c3;
-  }
-
-  .table-combine_narrow_2and3 th:nth-of-type(3) {
-    display: none;
-  }
-
-  .table-combine_narrow_2and3 th:nth-of-type(2) .table-hidden_column3_title {
-    display: inline;
-    white-space:normal;
-  }
-}
-@media (min-width: 375px) {
+@media (min-width: 350px) {
   .select-clear-all {
     white-space: nowrap;
   }
 }
+@media (max-width: 435px) {
+  td.table-combine_right_if_narrow,
+  td.table-combine_right_if_narrow + td {
+    display: block;
+    border-bottom: 0px;
+  }
+  th.table-combine_right_if_narrow{
+    .table-hidden_right_title {
+      display: inline;
+      white-space:normal;
+    }
+    + th {
+      display: none;
+    }
+  }
+  .table-merge_columns tr {
+    border-bottom: 1px solid #bfc1c3;
+  }
+}
+

--- a/app/assets/stylesheets/width-style-correction.scss
+++ b/app/assets/stylesheets/width-style-correction.scss
@@ -1,0 +1,5 @@
+@media (max-width: 48.0525em) {
+  .govuk-grid-column-one-third, .govuk-grid-column-two-thirds, .govuk-grid-column-one-quarter {
+    width: 100%!important;
+  }
+}

--- a/app/assets/stylesheets/width-style-correction.scss
+++ b/app/assets/stylesheets/width-style-correction.scss
@@ -1,5 +1,0 @@
-@media (max-width: 48.0525em) {
-  .govuk-grid-column-one-third, .govuk-grid-column-two-thirds, .govuk-grid-column-one-quarter {
-    width: 100%!important;
-  }
-}

--- a/app/views/providers/transactions/show.html.erb
+++ b/app/views/providers/transactions/show.html.erb
@@ -6,7 +6,7 @@
 
     <%= form.hidden_field :transaction_type, value: @transaction_type.name %>
 
-    <table class="govuk-table sortable">
+    <table class="govuk-table sortable table-combine_narrow_2and3">
       <%= content_tag(:caption, t('date.date_period', from: date_from, to: date_to), class: 'govuk-table__caption') if @bank_transactions.any? %>
       <thead class="govuk-table__head">
         <tr class="govuk-table__row">
@@ -17,7 +17,7 @@
               data-copy-select="<%= t '.col_select_all' %>"
               data-copy-clear="<%= t '.col_clear_all' %>"></a>
           </th>
-          <th class="govuk-table__header sort header-sort-asc" scope="col"><%= t('.col_date') %></th>
+          <th class="govuk-table__header sort header-sort-asc" scope="col"><%= t('.col_date') %><span class="table-hidden_column3_title"> &amp; <%= t('.col_description') %></span></th>
           <th class="govuk-table__header sort" scope="col"><%= t('.col_description') %></th>
           <th class="govuk-table__header govuk-table__header--numeric sort" scope="col"><%= t('.col_amount') %></th>
         </tr>
@@ -25,15 +25,15 @@
       <tbody class="govuk-table__body">
         <%= form.collection_check_boxes :transaction_ids, @bank_transactions, :id, :description do |builder| %>
           <tr class="govuk-table__row">
-            <th class="govuk-table__cell">
+            <td class="govuk-table__cell">
               <% if builder.object.transaction_type_id == nil || builder.object.transaction_type_id == @transaction_type.id %>
                 <div class="govuk-checkboxes__item">
                   <% checked = builder.object.transaction_type_id == @transaction_type.id %>
                   <%= builder.check_box(class: 'govuk-checkboxes__input', checked: checked) %>
-                  <label class="govuk-label govuk-checkboxes__label"></label>
+                  <label class="govuk-label govuk-checkboxes__label table-checkbox_label"></label>
                 </div>
               <% end %>
-            </th>
+            </td>
             <td class="govuk-table__cell" data-sort-value="<%= "#{builder.object.happened_at.to_i}#{builder.object.description}" %>">
               <%= l(builder.object.happened_at.to_date, format: :short_date) %>
             </td>

--- a/app/views/providers/transactions/show.html.erb
+++ b/app/views/providers/transactions/show.html.erb
@@ -6,7 +6,7 @@
 
     <%= form.hidden_field :transaction_type, value: @transaction_type.name %>
 
-    <table class="govuk-table sortable table-combine_narrow_2and3">
+    <table class="govuk-table sortable table-merge_columns">
       <%= content_tag(:caption, t('date.date_period', from: date_from, to: date_to), class: 'govuk-table__caption') if @bank_transactions.any? %>
       <thead class="govuk-table__head">
         <tr class="govuk-table__row">
@@ -17,7 +17,7 @@
               data-copy-select="<%= t '.col_select_all' %>"
               data-copy-clear="<%= t '.col_clear_all' %>"></a>
           </th>
-          <th class="govuk-table__header sort header-sort-asc" scope="col"><%= t('.col_date') %><span class="table-hidden_column3_title"> &amp; <%= t('.col_description') %></span></th>
+          <th class="govuk-table__header sort header-sort-asc table-combine_right_if_narrow" scope="col"><%= t('.col_date') %><span class="table-hidden_right_title"> &amp; <%= t('.col_description') %></span></th>
           <th class="govuk-table__header sort" scope="col"><%= t('.col_description') %></th>
           <th class="govuk-table__header govuk-table__header--numeric sort" scope="col"><%= t('.col_amount') %></th>
         </tr>
@@ -34,7 +34,7 @@
                 </div>
               <% end %>
             </td>
-            <td class="govuk-table__cell" data-sort-value="<%= "#{builder.object.happened_at.to_i}#{builder.object.description}" %>">
+            <td class="govuk-table__cell table-combine_right_if_narrow" data-sort-value="<%= "#{builder.object.happened_at.to_i}#{builder.object.description}" %>">
               <%= l(builder.object.happened_at.to_date, format: :short_date) %>
             </td>
             <td class="govuk-table__cell">


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-455)

Added new HTML with the column 3 title and new classes. 
Added new CSS for narrow displays.
Added new CSS to remove padding that affects narrow displays.
Added new CSS to control white-space wrapping for "select all".

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
