### PR TITLE
Ap 562 Remove Estimated Legal Costs From Merits Flow

### DIFF
--- a/app/services/flow/flows/provider_merits.rb
+++ b/app/services/flow/flows/provider_merits.rb
@@ -37,10 +37,11 @@ module Flow
         },
         statement_of_cases: {
           path: ->(application) { urls.providers_legal_aid_application_statement_of_case_path(application) },
-          forward: :estimated_legal_costs,
+          forward: :success_prospects,
           check_answers: :check_merits_answers
         },
         estimated_legal_costs: {
+          # TODO: Page not being used. Remove this comment when this page is being used.
           path: ->(application) { urls.providers_legal_aid_application_estimated_legal_costs_path(application) },
           forward: :success_prospects,
           check_answers: :check_merits_answers

--- a/app/views/providers/check_merits_answers/show.html.erb
+++ b/app/views/providers/check_merits_answers/show.html.erb
@@ -67,12 +67,6 @@
   <div class='govuk-body'><%= simple_format @statement_of_case.statement %></div>
 
   <dl class="govuk-summary-list govuk-!-margin-bottom-9">
-    <%= check_answer_link(
-          name: :estimated_legal_costs,
-          url: providers_legal_aid_application_estimated_legal_costs_path,
-          question: t('.items.estimated_legal_costs'),
-          answer: number_to_currency(@merits.estimated_legal_cost, unit: t('currency.gbp'))
-        ) %>
 
     <%= check_answer_link(
           name: :prospects_of_success,

--- a/app/views/providers/shared_ownerships/show.html.erb
+++ b/app/views/providers/shared_ownerships/show.html.erb
@@ -1,4 +1,4 @@
-<%= page_template page_title: t('.heading_1') do %>
+<%= page_template page_title: t('.heading_1'), template: :basic do %>
   <%= render(
         'shared/forms/shared_ownership_form',
         form_path: providers_legal_aid_application_shared_ownership_path(@legal_aid_application),

--- a/features/providers/civil_application_journey.feature
+++ b/features/providers/civil_application_journey.feature
@@ -361,15 +361,11 @@ Feature: Civil application journeys
     Then I should be on a page showing "Statement of case"
     Then I fill "Statement" with "Statement of case"
     Then I click 'Save and continue'
-    Then I should be on a page showing "What are the estimated legal costs of doing the work?"
-    Then I fill "Estimated legal cost" with "1000"
-    Then I click 'Save and continue'
     Then I should be on a page showing "What are the prospects of success?"
     Then I choose "Borderline"
     Then I fill "Success prospect details" with "Prospects of success"
     Then I click 'Save and continue'
     Then I should be on a page showing "Check your answers"
-    And the answer for 'Estimated legal costs' should be "£1,000.00"
     Then I click "Save and continue"
     Then I should be on a page showing "Declaration"
     Then I click 'Submit and continue'
@@ -462,9 +458,6 @@ Feature: Civil application journeys
     Then I should be on a page showing "hello_world.pdf"
     Then I should be on a page showing "UPLOADED"
     Then I click 'Save and continue'
-    Then I should be on a page showing "What are the estimated legal costs of doing the work?"
-    Then I fill "Estimated legal cost" with "1000"
-    Then I click 'Save and continue'
     Then I should be on a page showing "What are the prospects of success?"
     Then I choose "Borderline"
     Then I fill "Success prospect details" with "Prospects of success"
@@ -475,12 +468,6 @@ Feature: Civil application journeys
     Then I click 'Save and continue'
     Then I should be on a page showing "Check your answers"
     And the answer for 'Statement of case' should be 'This is some test data for the statement of case'
-    Then I click Check Your Answers Change link for 'Estimated legal costs'
-    Then I should be on a page showing "What are the estimated legal costs of doing the work?"
-    Then I fill "Estimated legal cost" with "2345"
-    And I click 'Save and continue'
-    Then I should be on a page showing "Check your answers"
-    And the answer for 'Estimated legal costs' should be "£2,345.00"
     Then I click "Save and continue"
     Then I should be on a page showing "Declaration"
     Then I click 'Submit and continue'

--- a/spec/requests/providers/check_merits_answers_spec.rb
+++ b/spec/requests/providers/check_merits_answers_spec.rb
@@ -37,7 +37,6 @@ RSpec.describe 'check merits answers requests', type: :request do
         expect(response.body).to include(I18n.translate('providers.check_merits_answers.show.items.police_notified'))
         expect(response.body).to include(I18n.translate('providers.check_merits_answers.show.items.bail_conditions_set'))
         expect(response.body).to include(I18n.translate('providers.check_merits_answers.show.items.statement_of_case'))
-        expect(response.body).to include(I18n.translate('providers.check_merits_answers.show.items.estimated_legal_costs'))
         expect(response.body).to include(I18n.translate('providers.check_merits_answers.show.items.prospects_of_success'))
         expect(response.body).to include(I18n.translate('providers.check_merits_answers.show.items.client_declaration'))
       end
@@ -48,7 +47,6 @@ RSpec.describe 'check merits answers requests', type: :request do
         expect(response.body).to have_change_link(:police_notified, providers_legal_aid_application_respondent_path(application, anchor: :police_notified))
         expect(response.body).to have_change_link(:bail_conditions_set, providers_legal_aid_application_respondent_path(application, anchor: :bail_conditions_set))
         expect(response.body).to have_change_link(:statement_of_case, providers_legal_aid_application_statement_of_case_path(application))
-        expect(response.body).to have_change_link(:estimated_legal_costs, providers_legal_aid_application_estimated_legal_costs_path(application))
         expect(response.body).to have_change_link(:prospects_of_success, providers_legal_aid_application_success_prospects_path(application))
         expect(response.body).to have_change_link(:client_declaration, providers_legal_aid_application_merits_declaration_path(application))
       end
@@ -71,10 +69,6 @@ RSpec.describe 'check merits answers requests', type: :request do
 
       it 'displays the statement of case' do
         expect(response.body).to include(application.statement_of_case.statement)
-      end
-
-      it 'displays the estimated legal costs' do
-        expect(response.body).to include(number_to_currency(application.merits_assessment.estimated_legal_cost, unit: '£'))
       end
 
       context 'prospects of success has supplementary text' do

--- a/spec/requests/providers/statement_of_case_spec.rb
+++ b/spec/requests/providers/statement_of_case_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe 'provider statement of case requests', type: :request do
 
     it 'redirects to the next page' do
       subject
-      expect(response).to redirect_to providers_legal_aid_application_estimated_legal_costs_path(legal_aid_application)
+      expect(response).to redirect_to providers_legal_aid_application_success_prospects_path(legal_aid_application)
     end
 
     context '2 files are uploaded' do


### PR DESCRIPTION
Remove Estimated Legal Costs From Merits Flow and the check answers page

[Link to story](https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=233&projectKey=AP&modal=detail&selectedIssue=AP-562)

1. Remove Estimated Legal Costs From Merits Flow and the check answers page
2. Amend tests

- Fix bug for shared_ownership page where there is a duplicate title on a passported application.

## Checklist

Before you ask people to review this PR:

- [X] Tests and rubocop should be passing: `bundle exec rake`
- [X] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [X] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [X] The PR description should say what you changed and why, with a link to the JIRA story.
- [X] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [X] You should have checked that the commit messages say why the change was made.
