### PR TITLE
Run sudo apt-get update as part of build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,6 +65,7 @@ jobs:
     - checkout
     - setup_remote_docker:
         docker_layer_caching: true
+    - run: sudo apt-get update
     - *setup_test_env
     - *install_clamav
     - *install_libreoffice
@@ -72,7 +73,6 @@ jobs:
         keys:
           - laa-apply-for-legal-aid-v2-{{ checksum "Gemfile.lock" }}
           - laa-apply-for-legal-aid-v2
-
     - run:
         name: Bundle Install
         command: bundle check --path vendor/bundle || bundle install --path vendor/bundle


### PR DESCRIPTION
## What

For the last couple of days CircleCI builds have been failing with this error when installing packages:

![image](https://user-images.githubusercontent.com/28729201/57359190-00c91f00-716f-11e9-8a2c-51a8e3c5f689.png)

To fix it, I've added an extra step to the build process to run `sudo apt-get update` before running any installs.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
