### PR TITLE
Install rubocop-performance gem

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,5 @@
+require: rubocop-performance
+
 inherit_from: .rubocop_todo.yml
 
 AllCops:

--- a/Gemfile
+++ b/Gemfile
@@ -79,6 +79,7 @@ group :development, :test do
   gem 'nokogiri'
   gem 'pry-byebug'
   gem 'rubocop', require: false
+  gem 'rubocop-performance'
 
   # Available in dev env for generators
   gem 'rspec-rails', '~> 3.8'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -347,6 +347,8 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.6)
+    rubocop-performance (1.2.0)
+      rubocop (>= 0.68.0)
     ruby-progressbar (1.10.0)
     ruby-saml (1.9.0)
       nokogiri (>= 1.5.10)
@@ -499,6 +501,7 @@ DEPENDENCIES
   regexp-examples
   rspec-rails (~> 3.8)
   rubocop
+  rubocop-performance
   ruby-saml-idp
   sass-rails (~> 5.0)
   savon (~> 2.12.0)


### PR DESCRIPTION
## What

Performance Cops have been removed from RuboCop 0.68, which we upgraded to earlier. As a result of this a number of warnings are now thrown when `rubocop` and `erblint` run.

eg.

![image](https://user-images.githubusercontent.com/28729201/57387495-5ec92700-71ae-11e9-8924-bbb6f666c5b4.png)

Following the recommendations here

![image](https://user-images.githubusercontent.com/28729201/57387382-20cc0300-71ae-11e9-8d44-5ffe879f0053.png)

this PR installs `rubocop-performance` to maintain the level of `rubocop` coverage we had before.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
