### PR TITLE
Fix number of replicas for the metrics container

### DIFF
--- a/helm_deploy/apply-for-legal-aid/templates/deployment_metrics.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/deployment_metrics.yaml
@@ -8,7 +8,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  replicas: {{ .Values.worker.replicaCount }}
+  replicas: 1
   selector:
     matchLabels:
       app: {{ template "apply-for-legal-aid.name" . }}


### PR DESCRIPTION
When creating this PR https://github.com/ministryofjustice/laa-apply-for-legal-aid/pull/437
I moved the `metrics` container to its own pod and accidentally used the wrong value for the number of replicas.
`{{ .Values.worker.replicaCount }}` is **2** in staging and production but I think **1** is enough. 