### PR TITLE
Fix sporadically failing test

### DIFF
--- a/spec/factories/bank_transactions.rb
+++ b/spec/factories/bank_transactions.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
     true_layer_id { SecureRandom.hex }
     description { Faker::Lorem.sentence }
     merchant { Faker::Lorem.sentence }
-    happened_at { Faker::Date.backward(90) }
+    happened_at { Faker::Date.between(3.months.ago + 2.days, Time.now - 2.days) }
     currency { Faker::Currency.code }
     amount { Faker::Number.decimal(2) }
 


### PR DESCRIPTION
Some tests are failing whenever the `happened_at` happens to be just outside the filter used on the `legal_aid_application.bank_transactions ` method : 

```ruby
  def bank_transactions
    return applicant.bank_transactions if Setting.mock_true_layer_data?

    set_transaction_period unless transaction_period_start_at? && transaction_period_finish_at?
    applicant.bank_transactions.where(
      happened_at: transaction_period_start_at..transaction_period_finish_at
    )
  end

  def set_transaction_period
    update!(
      transaction_period_start_at: 3.months.ago.beginning_of_day,
      transaction_period_finish_at: Time.now.beginning_of_day
    )
  end
```