### PR TITLE
Run sudo apt-get update during nightly deploys

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,6 +58,11 @@ references:
           docker push "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${REPO_NAME}:latest"
         fi
 
+  update_packages: &update_packages
+    run:
+      name: Update packages
+      command: sudo apt-get update
+
 jobs:
   build_and_test:
     <<: *build_container_config
@@ -65,7 +70,7 @@ jobs:
     - checkout
     - setup_remote_docker:
         docker_layer_caching: true
-    - run: sudo apt-get update
+    - *update_packages
     - *setup_test_env
     - *install_clamav
     - *install_libreoffice
@@ -172,6 +177,7 @@ jobs:
     steps:
     - checkout
     - setup_remote_docker
+    - *update_packages
     - *setup_test_env
     - run:
         name: Delete old images from ecr repo


### PR DESCRIPTION
## What

Nightly deployments to staging are failing as CircleCI cannot find the correct versions of packages to install. This is the same issue that was partially fixed here https://github.com/ministryofjustice/laa-apply-for-legal-aid/pull/485. The change made there doesn't affect the `clean_up_ecr` job, so this change pulls the `sudo apt-get update` command into a separate process which is now run run by both jobs.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
