### PR TITLE
Reducing size of release name in UAT

### DIFF
--- a/bin/uat_deploy
+++ b/bin/uat_deploy
@@ -23,7 +23,7 @@ clean_old_releases() {
 deploy() {
   IMG_REPO="$ECR_ENDPOINT/$GITHUB_TEAM_NAME_SLUG/$REPO_NAME"
   RELEASE_BRANCH=$(echo $CIRCLE_BRANCH | sed 's:^\w*\/::' | tr -s ' _/[]()' '-' | cut -c1-30 | sed 's/-$//')
-  RELEASE_NAME="$APPLICATION_DEPLOY_NAME-$RELEASE_BRANCH"
+  RELEASE_NAME="apply-$RELEASE_BRANCH"
   RELEASE_HOST="$RELEASE_BRANCH-$UAT_HOST"
 
   echo "Deploying CIRCLE_SHA1: $CIRCLE_SHA1 under release name: '$RELEASE_NAME'..."


### PR DESCRIPTION
In UAT, the name of the release can be too long depending on the length of the name of the branch.
i.e. : https://circleci.com/gh/ministryofjustice/laa-apply-for-legal-aid/5190

We can easily fix that by replacing `apply-for-legal-aid` at the beginning with `apply`.
But it stays `apply-for-legal-aid` in staging and production