### PR TITLE
AP 587 Retry failed email notifications

### DIFF
--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -7,7 +7,8 @@ class FeedbackController < ApplicationController
 
   def create
     feedback.update(feedback_params)
-    FeedbackMailer.notify(feedback).deliver_later if feedback_submitted?
+    # Must use bang version `deliver_later!` or failures won't be retried by sidekiq
+    FeedbackMailer.notify(feedback).deliver_later! if feedback_submitted?
 
     redirect_to feedback
   end

--- a/app/controllers/providers/legal_aid_applications_controller.rb
+++ b/app/controllers/providers/legal_aid_applications_controller.rb
@@ -17,7 +17,11 @@ module Providers
     # POST /provider/applications
     def create
       @legal_aid_application = LegalAidApplication.create(provider: current_provider)
-      go_forward
+      redirect_to Flow::KeyPoint.path_for(
+        journey: :providers,
+        key_point: :journey_start,
+        legal_aid_application: @legal_aid_application
+      )
     end
   end
 end

--- a/app/helpers/providers_helper.rb
+++ b/app/helpers/providers_helper.rb
@@ -7,5 +7,18 @@ module ProvidersHelper
       current_step: name.to_sym,
       params: legal_aid_application.provider_step_params&.symbolize_keys
     ).current_path
+  rescue Flow::FlowError => e
+    Raven.capture_exception(e)
+    Rails.logger.error e.message
+
+    journey_start_path(legal_aid_application)
+  end
+
+  def journey_start_path(legal_aid_application)
+    Flow::KeyPoint.path_for(
+      journey: :providers,
+      key_point: :journey_start,
+      legal_aid_application: legal_aid_application
+    )
   end
 end

--- a/app/mailers/feedback_mailer.rb
+++ b/app/mailers/feedback_mailer.rb
@@ -1,4 +1,5 @@
 class FeedbackMailer < GovukNotifyRails::Mailer
+  require_relative 'concerns/notify_template_methods'
   include NotifyTemplateMethods
 
   def notify(feedback)

--- a/app/mailers/notify_mailer.rb
+++ b/app/mailers/notify_mailer.rb
@@ -1,5 +1,4 @@
 class NotifyMailer < GovukNotifyRails::Mailer
-
   # Require relative statement required as concern not found when loaded from sidekiq on retry
   require_relative 'concerns/notify_template_methods'
   include NotifyTemplateMethods

--- a/app/mailers/notify_mailer.rb
+++ b/app/mailers/notify_mailer.rb
@@ -1,4 +1,7 @@
 class NotifyMailer < GovukNotifyRails::Mailer
+
+  # Require relative statement required as concern not found when loaded from sidekiq on retry
+  require_relative 'concerns/notify_template_methods'
   include NotifyTemplateMethods
 
   def citizen_start_email(app_id, email, application_url, client_name)

--- a/app/mailers/resend_link_request_mailer.rb
+++ b/app/mailers/resend_link_request_mailer.rb
@@ -1,4 +1,5 @@
 class ResendLinkRequestMailer < GovukNotifyRails::Mailer
+  require_relative 'concerns/notify_template_methods'
   include NotifyTemplateMethods
 
   def notify(legal_aid_application)

--- a/app/services/citizen_email_service.rb
+++ b/app/services/citizen_email_service.rb
@@ -6,7 +6,8 @@ class CitizenEmailService
   end
 
   def send_email
-    NotifyMailer.citizen_start_email(*mailer_args).deliver_later
+    # Must use bang version `deliver_later!` or failures won't be retried by sidekiq
+    NotifyMailer.citizen_start_email(*mailer_args).deliver_later!
   end
 
   private

--- a/app/services/flow/base_flow_service.rb
+++ b/app/services/flow/base_flow_service.rb
@@ -75,7 +75,7 @@ module Flow
 
     def path_for(step, option)
       path_action = steps.dig(step, option)
-      raise ":#{option} of step :#{step} is not defined" unless path_action
+      raise FlowError, ":#{option} of step :#{step} is not defined" unless path_action
 
       return path_action unless path_action.is_a?(Proc)
 

--- a/app/services/flow/flow_error.rb
+++ b/app/services/flow/flow_error.rb
@@ -1,0 +1,3 @@
+module Flow
+  FlowError = Class.new(StandardError)
+end

--- a/app/services/flow/flows/provider_start.rb
+++ b/app/services/flow/flows/provider_start.rb
@@ -2,9 +2,6 @@ module Flow
   module Flows
     class ProviderStart < FlowSteps
       STEPS = {
-        legal_aid_applications: {
-          forward: :applicants
-        },
         applicants: {
           path: ->(application) { urls.providers_legal_aid_application_applicant_path(application) },
           forward: :address_lookups,

--- a/app/services/flow/key_point.rb
+++ b/app/services/flow/key_point.rb
@@ -6,7 +6,8 @@ module Flow
       citizens: {},
       providers: {
         start_after_applicant_completes_means: :client_completed_means,
-        start_income_update: :capital_introductions
+        start_income_update: :capital_introductions,
+        journey_start: :applicants
       }
     }.freeze
 

--- a/spec/requests/feedbacks_spec.rb
+++ b/spec/requests/feedbacks_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'FeedbacksController', type: :request do
     end
 
     it 'sends an email' do
-      mailer = double(deliver_later: true)
+      mailer = double(deliver_later!: true)
       expect(FeedbackMailer).to receive(:notify).and_return(mailer)
       subject
     end

--- a/spec/requests/providers/legal_aid_applications_spec.rb
+++ b/spec/requests/providers/legal_aid_applications_spec.rb
@@ -37,6 +37,20 @@ RSpec.describe 'providers legal aid application requests', type: :request do
         end
       end
 
+      context 'when legal_aid_application current path is unknown' do
+        let!(:legal_aid_application) { create :legal_aid_application, provider_step: :unknown }
+
+        it 'links to start of journey' do
+          subject
+          start_path = Flow::KeyPoint.path_for(
+            journey: :providers,
+            key_point: :journey_start,
+            legal_aid_application: legal_aid_application
+          )
+          expect(response.body).to include(start_path)
+        end
+      end
+
       context 'with pagination' do
         it 'shows current total information' do
           subject

--- a/spec/services/citizen_email_service_spec.rb
+++ b/spec/services/citizen_email_service_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe CitizenEmailService do
       expect(NotifyMailer).to receive(:citizen_start_email)
         .with(application.application_ref, 'test@example.com', citizen_url, 'John Doe')
         .and_return(message_delivery)
-      expect(message_delivery).to receive(:deliver_later)
+      expect(message_delivery).to receive(:deliver_later!)
       expect(application).to receive(:generate_secure_id).and_return(secure_id)
 
       subject.send_email


### PR DESCRIPTION
[JIRA AP-587](https://dsdmoj.atlassian.net/browse/AP-587)

This PR addresses 2 issues.

### Failed emails not being retried by Sidekiq
There were two things preventing Sidekiq handling failed email sends:

1. When mail send was being retried, Sidekiq was not finding the module `NotifyTemplateMethods` that was mixed into the mailers. Adding a `require_relative` pointing at the module file fixed that.
2. The mailer method `deliver_later` was not raising errors on connection failure. Changing this to the bang version fixed that: `deliver_later!`

With these changes in place when I disconnected my computer from the network and triggered a client journey start email, it was held in Sidekiq and retried until the connection was re-enabled.

![email_retry_enabled](https://user-images.githubusercontent.com/213040/57614044-3e171d80-7570-11e9-9694-bcfb402b515c.png)

### Unknown step causing providers list of applications page to crash
While working on this bug I found another bug that I've also fixed here. If the code base changed so that a step that an application was associated with was removed, adding a link to the applications "current" location caused an error. I've made the following changes to fix that:

1. Changed the step path not found error raised by the flow process to use a specific error rather than a standard error.
2. Caught that error in the link creation helper and replaced it with a link to the start of the provider journey for that application.
3. Refactored the start of the provider journey so that it was defined by a `Flow::KeyPoint`.
