### PR TITLE
AP-576 - CCMS -Poll add_applicant requests

### DIFF
--- a/app/models/ccms/submission.rb
+++ b/app/models/ccms/submission.rb
@@ -8,7 +8,7 @@ module CCMS
 
     validates :legal_aid_application_id, presence: true
 
-    POLL_LIMIT = 10.freeze
+    POLL_LIMIT = 10
 
     def process!
       case aasm_state

--- a/app/models/ccms/submission.rb
+++ b/app/models/ccms/submission.rb
@@ -8,12 +8,16 @@ module CCMS
 
     validates :legal_aid_application_id, presence: true
 
+    POLL_LIMIT = 10.freeze
+
     def process!
       case aasm_state
       when 'initialised'
         ObtainCaseReferenceService.new(self).call
       when 'case_ref_obtained'
         ObtainApplicantReferenceService.new(self).call
+      when 'applicant_submitted'
+        CheckApplicantStatusService.new(self).call
       else
         raise CcmsError, 'Unknown state'
       end

--- a/app/services/ccms/add_applicant_service.rb
+++ b/app/services/ccms/add_applicant_service.rb
@@ -3,7 +3,7 @@ module CCMS
     def call
       response = applicant_add_requestor.call
       if applicant_add_response_parser(response).success?
-        submission.applicant_add_tx_id = applicant_add_requestor.transaction_request_id
+        submission.applicant_add_transaction_id = applicant_add_requestor.transaction_request_id
         create_history(submission.aasm_state, :applicant_submitted)
         submission.submit_applicant!
       else

--- a/app/services/ccms/add_applicant_service.rb
+++ b/app/services/ccms/add_applicant_service.rb
@@ -3,6 +3,7 @@ module CCMS
     def call
       response = applicant_add_requestor.call
       if applicant_add_response_parser(response).success?
+        submission.applicant_add_tx_id = applicant_add_requestor.transaction_request_id
         create_history(submission.aasm_state, :applicant_submitted)
         submission.submit_applicant!
       else

--- a/app/services/ccms/applicant_add_status_requestor.rb
+++ b/app/services/ccms/applicant_add_status_requestor.rb
@@ -1,5 +1,12 @@
 module CCMS
   class ApplicantAddStatusRequestor < BaseRequestor
+    attr_reader :applicant_add_transaction_id
+
+    def initialize(applicant_add_transaction_id)
+      @applicant_add_transaction_id = applicant_add_transaction_id
+      super()
+    end
+
     # temporarily ignore this until connectivity with ccms is working
     # :nocov:
     def call
@@ -16,7 +23,7 @@ module CCMS
     def soap_body(xml)
       xml.__send__('ns2:ClientAddUpdtStatusRQ') do
         xml.__send__('ns3:HeaderRQ') { ns3_header_rq(xml) }
-        xml.__send__('ns2:TransactionID', '20190101121530123456') # this needs to be the transaction id of the create client request
+        xml.__send__('ns2:TransactionID', applicant_add_transaction_id)
       end
     end
 

--- a/app/services/ccms/applicant_add_status_response_parser.rb
+++ b/app/services/ccms/applicant_add_status_response_parser.rb
@@ -2,11 +2,19 @@ module CCMS
   class ApplicantAddStatusResponseParser < BaseResponseParser
     TRANSACTION_ID_PATH = '//Body//ClientAddUpdtStatusRS//HeaderRS//TransactionID'.freeze
     STATUS_FREE_TEXT_PATH = '//Body//ClientAddUpdtStatusRS//HeaderRS//Status//StatusFreeText'.freeze
+    APPLICANT_CCMS_REFERENCE_PATH = '//Body//ClientInqRS//Client//ClientReferenceNumber'.freeze
+
+    attr_reader :status_free_text, :applicant_ccms_reference
 
     def parse
       raise CcmsError, 'Invalid transaction request id' if extracted_transaction_request_id != @transaction_request_id
 
-      extracted_status_free_text
+      @status_free_text = extracted_status_free_text
+      @applicant_ccms_reference = extracted_applicant_ccms_reference
+    end
+
+    def success?
+      extracted_status_free_text == 'Party Successfully Created.'
     end
 
     private
@@ -17,6 +25,10 @@ module CCMS
 
     def extracted_status_free_text
       @doc.xpath(STATUS_FREE_TEXT_PATH).text
+    end
+
+    def extracted_applicant_ccms_reference
+      @doc.xpath(APPLICANT_CCMS_REFERENCE_PATH).text
     end
   end
 end

--- a/app/services/ccms/check_applicant_status_service.rb
+++ b/app/services/ccms/check_applicant_status_service.rb
@@ -1,0 +1,33 @@
+module CCMS
+  class CheckApplicantStatusService < BaseSubmissionService
+    def call
+      tx_id = applicant_add_status_requestor.transaction_request_id
+      submission.poll_count += 1
+      response = applicant_add_status_requestor.call
+      parser = ApplicantAddStatusResponseParser.new(tx_id, response)
+      parser.parse
+      process_response(parser)
+    rescue CcmsError, StandardError => e # TODO: Replace `StandardError` with list of known expected errors
+      handle_failure(e)
+    end
+
+    private
+
+    def process_response(parser)
+      if parser.success?
+        submission.applicant_ccms_reference = parser.applicant_ccms_reference
+        create_history(submission.aasm_state, :applicant_ref_obtained)
+        submission.poll_count = 0
+        submission.obtain_applicant_ref!
+      elsif submission.poll_count >= Submission::POLL_LIMIT
+        handle_failure('Poll limit exceeded')
+      else
+        create_history(submission.aasm_state, submission.aasm_state)
+      end
+    end
+
+    def applicant_add_status_requestor
+      @applicant_add_status_requestor ||= ApplicantAddStatusRequestor.new(submission.applicant_add_transaction_id)
+    end
+  end
+end

--- a/db/migrate/20190514142921_add_applicant_add_tx_id_to_ccms_submissions.rb
+++ b/db/migrate/20190514142921_add_applicant_add_tx_id_to_ccms_submissions.rb
@@ -1,0 +1,5 @@
+class AddApplicantAddTxIdToCcmsSubmissions < ActiveRecord::Migration[5.2]
+  def change
+    add_column :ccms_submissions, :applicant_add_tx_id, :string
+  end
+end

--- a/db/migrate/20190514142921_add_applicant_add_tx_id_to_ccms_submissions.rb
+++ b/db/migrate/20190514142921_add_applicant_add_tx_id_to_ccms_submissions.rb
@@ -1,5 +1,5 @@
 class AddApplicantAddTxIdToCcmsSubmissions < ActiveRecord::Migration[5.2]
   def change
-    add_column :ccms_submissions, :applicant_add_tx_id, :string
+    add_column :ccms_submissions, :applicant_add_transaction_id, :string
   end
 end

--- a/db/migrate/20190514212618_add_poll_count_to_ccms_submissions.rb
+++ b/db/migrate/20190514212618_add_poll_count_to_ccms_submissions.rb
@@ -1,0 +1,5 @@
+class AddPollCountToCcmsSubmissions < ActiveRecord::Migration[5.2]
+  def change
+    add_column :ccms_submissions, :poll_count, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_01_123416) do
+ActiveRecord::Schema.define(version: 2019_05_14_142921) do
+
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -188,6 +189,7 @@ ActiveRecord::Schema.define(version: 2019_05_01_123416) do
     t.string "aasm_state"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "applicant_add_tx_id"
     t.index ["legal_aid_application_id"], name: "index_ccms_submissions_on_legal_aid_application_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_14_142921) do
-
+ActiveRecord::Schema.define(version: 2019_05_14_212618) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -189,7 +188,8 @@ ActiveRecord::Schema.define(version: 2019_05_14_142921) do
     t.string "aasm_state"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "applicant_add_tx_id"
+    t.string "applicant_add_transaction_id"
+    t.integer "poll_count", default: 0
     t.index ["legal_aid_application_id"], name: "index_ccms_submissions_on_legal_aid_application_id"
   end
 

--- a/spec/data/ccms/applicant_add_status_response.xml
+++ b/spec/data/ccms/applicant_add_status_response.xml
@@ -18,9 +18,10 @@
         </header:RequestDetails>
         <header:Status>
           <header:Status>Success</header:Status>
-          <header:StatusFreeText>User Authentication complete.</header:StatusFreeText>
+          <header:StatusFreeText>Party Successfully Created.</header:StatusFreeText>
         </header:Status>
       </header:HeaderRS>
+      <msg:ClientReferenceNumber>20910584</ns2:ClientReferenceNumber>
     </ClientAddUpdtStatusRS>
   </env:Body>
 </env:Envelope>

--- a/spec/factories/submissions.rb
+++ b/spec/factories/submissions.rb
@@ -5,5 +5,9 @@ FactoryBot.define do
     trait :case_ref_obtained do
       aasm_state { 'case_ref_obtained' }
     end
+
+    trait :applicant_submitted do
+      aasm_state { 'applicant_submitted' }
+    end
   end
 end

--- a/spec/models/ccms/submission_spec.rb
+++ b/spec/models/ccms/submission_spec.rb
@@ -2,19 +2,19 @@ require 'rails_helper'
 
 module CCMS
   RSpec.describe Submission do
-    let(:sub) { create :submission }
+    let(:submission) { create :submission }
 
     context 'Validations' do
       it 'errors if no legal aid application id is present' do
-        sub.legal_aid_application = nil
-        expect(sub).not_to be_valid
-        expect(sub.errors[:legal_aid_application_id]).to eq ["can't be blank"]
+        submission.legal_aid_application = nil
+        expect(submission).not_to be_valid
+        expect(submission.errors[:legal_aid_application_id]).to eq ["can't be blank"]
       end
     end
 
     describe 'initial state' do
       it 'puts new records into the initial state' do
-        expect(sub.aasm_state).to eq 'initialised'
+        expect(submission.aasm_state).to eq 'initialised'
       end
     end
 
@@ -23,19 +23,19 @@ module CCMS
 
       context 'invalid state' do
         it 'raises if state is invalid' do
-          sub.aasm_state = 'xxxxx'
+          submission.aasm_state = 'xxxxx'
           expect {
-            sub.process!
+            submission.process!
           }.to raise_error CcmsError, 'Unknown state'
         end
       end
 
       context 'initialised state' do
-        let(:obtain_case_reference_service_double) { ObtainCaseReferenceService.new(sub) }
+        let(:obtain_case_reference_service_double) { ObtainCaseReferenceService.new(submission) }
         it 'calls the obtain_case_reference service' do
-          expect(ObtainCaseReferenceService).to receive(:new).with(sub).and_return(obtain_case_reference_service_double)
+          expect(ObtainCaseReferenceService).to receive(:new).with(submission).and_return(obtain_case_reference_service_double)
           expect(obtain_case_reference_service_double).to receive(:call)
-          sub.process!
+          submission.process!
         end
       end
 
@@ -50,12 +50,12 @@ module CCMS
       end
 
       context 'applicant_submitted state' do
-        let(:sub) { create :submission, :applicant_submitted }
-        let(:check_applicant_status_service_double) { CheckApplicantStatusService.new(sub) }
+        let(:submission) { create :submission, :applicant_submitted }
+        let(:check_applicant_status_service_double) { CheckApplicantStatusService.new(submission) }
         it 'calls the obtain_applicant_reference service' do
-          expect(CheckApplicantStatusService).to receive(:new).with(sub).and_return(check_applicant_status_service_double)
+          expect(CheckApplicantStatusService).to receive(:new).with(submission).and_return(check_applicant_status_service_double)
           expect(check_applicant_status_service_double).to receive(:call)
-          sub.process!
+          submission.process!
         end
       end
     end

--- a/spec/models/ccms/submission_spec.rb
+++ b/spec/models/ccms/submission_spec.rb
@@ -48,6 +48,16 @@ module CCMS
           submission.process!
         end
       end
+
+      context 'applicant_submitted state' do
+        let(:sub) { create :submission, :applicant_submitted }
+        let(:check_applicant_status_service_double) { CheckApplicantStatusService.new(sub) }
+        it 'calls the obtain_applicant_reference service' do
+          expect(CheckApplicantStatusService).to receive(:new).with(sub).and_return(check_applicant_status_service_double)
+          expect(check_applicant_status_service_double).to receive(:call)
+          sub.process!
+        end
+      end
     end
   end
 end

--- a/spec/services/ccms/add_applicant_service_spec.rb
+++ b/spec/services/ccms/add_applicant_service_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe CCMS::AddApplicantService do
 
       it 'records the transaction id of the request' do
         subject.call
-        expect(submission.applicant_add_tx_id).to eq transaction_request_id_in_example_response
+        expect(submission.applicant_add_transaction_id).to eq transaction_request_id_in_example_response
       end
 
       it 'writes a history record' do

--- a/spec/services/ccms/add_applicant_service_spec.rb
+++ b/spec/services/ccms/add_applicant_service_spec.rb
@@ -18,12 +18,17 @@ RSpec.describe CCMS::AddApplicantService do
 
       before do
         expect(applicant_add_requestor).to receive(:call).and_return(applicant_add_response)
-        expect(applicant_add_requestor).to receive(:transaction_request_id).and_return(transaction_request_id_in_example_response)
+        allow(applicant_add_requestor).to receive(:transaction_request_id).and_return(transaction_request_id_in_example_response)
       end
 
       it 'sets state to applicant_submitted' do
         subject.call
         expect(submission.aasm_state).to eq 'applicant_submitted'
+      end
+
+      it 'records the transaction id of the request' do
+        subject.call
+        expect(submission.applicant_add_tx_id).to eq transaction_request_id_in_example_response
       end
 
       it 'writes a history record' do

--- a/spec/services/ccms/applicant_add_status_requestor_spec.rb
+++ b/spec/services/ccms/applicant_add_status_requestor_spec.rb
@@ -8,7 +8,7 @@ module CCMS
     describe 'XML request' do
       it 'generates the expected XML' do
         with_modified_env(modified_environment_vars) do
-          requestor = described_class.new
+          requestor = described_class.new(expected_tx_id)
           allow(requestor).to receive(:transaction_request_id).and_return(expected_tx_id)
           expect(requestor.formatted_xml).to eq expected_xml.chomp
         end
@@ -18,7 +18,7 @@ module CCMS
     describe '#transaction_request_id' do
       it 'returns the id based on current time' do
         Timecop.freeze(2019, 1, 1, 12, 15, 30.123456) do
-          requestor = described_class.new
+          requestor = described_class.new(expected_tx_id)
           expect(requestor.transaction_request_id).to start_with expected_tx_id
         end
       end

--- a/spec/services/ccms/applicant_add_status_response_parser_spec.rb
+++ b/spec/services/ccms/applicant_add_status_response_parser_spec.rb
@@ -2,13 +2,14 @@ require 'rails_helper'
 
 module CCMS
   RSpec.describe ApplicantAddStatusResponseParser do
-    describe '#parse' do
-      let(:response_xml) { ccms_data_from_file 'applicant_add_status_response.xml' }
-      let(:expected_tx_id) { '20190301030405123456' }
+    let(:response_xml) { ccms_data_from_file 'applicant_add_status_response.xml' }
+    let(:expected_tx_id) { '20190301030405123456' }
 
+    describe '#parse' do
       it 'extracts the status free text' do
         parser = described_class.new(expected_tx_id, response_xml)
-        expect(parser.parse).to eq 'User Authentication complete.'
+        parser.parse
+        expect(parser.status_free_text).to eq 'Party Successfully Created.'
       end
 
       it 'raises if the transaction_request_ids dont match' do
@@ -16,6 +17,14 @@ module CCMS
           parser = described_class.new(Faker::Number.number(20), response_xml)
           parser.parse
         }.to raise_error CcmsError, 'Invalid transaction request id'
+      end
+    end
+
+    describe '#success' do
+      it 'returns true if extracted_status_free_text = "Party Successfully Created."' do
+        parser = described_class.new(expected_tx_id, response_xml)
+        parser.parse
+        expect(parser.success?).to be true
       end
     end
   end

--- a/spec/services/ccms/check_applicant_status_service_spec.rb
+++ b/spec/services/ccms/check_applicant_status_service_spec.rb
@@ -1,0 +1,137 @@
+require 'rails_helper'
+
+RSpec.describe CCMS::CheckApplicantStatusService do
+  let(:submission) { create :submission, :applicant_submitted }
+  let(:applicant_add_status_requestor) { double CCMS::ApplicantAddStatusRequestor }
+  let(:history) { CCMS::SubmissionHistory.find_by(submission_id: submission.id) }
+  let(:applicant_add_status_response) { ccms_data_from_file 'applicant_add_status_response.xml' }
+  subject { described_class.new(submission) }
+
+  before do
+    allow(subject).to receive(:applicant_add_status_requestor).and_return(applicant_add_status_requestor)
+  end
+
+  context 'applicant_submitted state' do
+    context 'operation successful' do
+      let(:transaction_request_id_in_example_response) { '20190301030405123456' }
+
+      context 'applicant not yet created' do
+        before do
+          expect(applicant_add_status_requestor).to receive(:call).and_return(applicant_add_status_response)
+          expect(applicant_add_status_requestor).to receive(:transaction_request_id).and_return(transaction_request_id_in_example_response)
+          allow_any_instance_of(CCMS::ApplicantAddStatusResponseParser).to receive(:success?).and_return(false)
+        end
+
+        context 'poll count remains below limit' do
+          it 'increments the poll count' do
+            expect { subject.call }.to change { submission.poll_count }.by 1
+          end
+
+          it 'does not change the state' do
+            expect { subject.call }.not_to change { submission.aasm_state }
+          end
+
+          it 'writes a history record' do
+            expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
+            expect(history.from_state).to eq 'applicant_submitted'
+            expect(history.to_state).to eq 'applicant_submitted'
+            expect(history.success).to be true
+            expect(history.details).to be_nil
+          end
+        end
+
+        context 'poll count reaches limit' do
+          before do
+            submission.poll_count = CCMS::Submission::POLL_LIMIT - 1
+          end
+
+          it 'increments the poll count' do
+            expect { subject.call }.to change { submission.poll_count }.by 1
+          end
+
+          it 'changes the state to failed' do
+            expect { subject.call }.to change { submission.aasm_state }.to 'failed'
+          end
+
+          it 'writes a history record' do
+            expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
+            expect(history.from_state).to eq 'applicant_submitted'
+            expect(history.to_state).to eq 'failed'
+            expect(history.success).to be false
+            expect(history.details).to eq 'Poll limit exceeded'
+          end
+        end
+      end
+
+      context 'applicant is created' do
+        let(:expected_applicant_ccms_reference) { Faker::Number.number(10) }
+
+        before do
+          expect(applicant_add_status_requestor).to receive(:call).and_return(applicant_add_status_response)
+          expect(applicant_add_status_requestor).to receive(:transaction_request_id).and_return(transaction_request_id_in_example_response)
+          allow_any_instance_of(CCMS::ApplicantAddStatusResponseParser).to receive(:success?).and_return(true)
+          allow_any_instance_of(CCMS::ApplicantAddStatusResponseParser).to receive(:applicant_ccms_reference).and_return(expected_applicant_ccms_reference)
+        end
+
+        it 'changes the state to applicant_ref_obtained' do
+          expect { subject.call }.to change { submission.aasm_state }.to 'applicant_ref_obtained'
+        end
+
+        it 'updates the applicant_ccms_reference' do
+          expect { subject.call }.to change { submission.applicant_ccms_reference }.to expected_applicant_ccms_reference
+        end
+
+        it 'writes a history record' do
+          expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
+          expect(history.from_state).to eq 'applicant_submitted'
+          expect(history.to_state).to eq 'applicant_ref_obtained'
+          expect(history.success).to be true
+          expect(history.details).to be_nil
+        end
+
+        it 'resets the poll count to 0' do
+          subject.call
+          expect(submission.poll_count).to eq 0
+        end
+      end
+    end
+
+    context 'operation unsuccessful' do
+      let(:transaction_request_id_in_example_response) { '20190301030405123456' }
+
+      before do
+        expect(applicant_add_status_requestor).to receive(:call).and_raise(RuntimeError, 'oops')
+        expect(applicant_add_status_requestor).to receive(:transaction_request_id).and_return(transaction_request_id_in_example_response)
+      end
+
+      it 'increments the poll count' do
+        expect { subject.call }.to change { submission.poll_count }.by 1
+      end
+
+      it 'changes the state to failed' do
+        expect { subject.call }.to change { submission.aasm_state }.to 'failed'
+      end
+
+      it 'records the error in the submission history' do
+        expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
+        expect(history.from_state).to eq 'applicant_submitted'
+        expect(history.to_state).to eq 'failed'
+        expect(history.success).to be false
+        expect(history.details).to match(/RuntimeError/)
+        expect(history.details).to match(/oops/)
+      end
+    end
+  end
+
+  # private method tested here because it is mocked out above
+  #
+  describe '#applicant_add_status_requestor' do
+    let(:service_double) { CCMS::CheckApplicantStatusService.new(submission) }
+    let(:requestor1) { service_double.__send__(:applicant_add_status_requestor) }
+    let(:requestor2) { service_double.__send__(:applicant_add_status_requestor) }
+    it 'only instantiates one copy of the ApplicantAddStatusRequestor' do
+      expect(requestor1).to be_instance_of(CCMS::ApplicantAddStatusRequestor)
+      expect(requestor1.object_id).to eq requestor2.object_id
+    end
+  end
+end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-576)

This change adds functionality to the CCMS orchestration process to poll the status of the creation of an applicant in CCMS. It:

- amends the add_applicant_service so that the transaction_id sent in the add request is recorded against the submission, so that it can be included in the poll request
- adds a poll count to the submission record which is incremented for each poll. An error is thrown when a limit (10) is reached
- adds a new check_applicant_status_service to handle the call to CCMS and process the response
- fixes minor issues with existing tests/test data

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
