### PR TITLE
AP-592 add other type of payment for provider

### DIFF
--- a/app/controllers/providers/identify_types_of_outgoings_controller.rb
+++ b/app/controllers/providers/identify_types_of_outgoings_controller.rb
@@ -5,7 +5,7 @@ module Providers
     def show; end
 
     def update
-      return continue_or_draft if none_selected? || transactions_added
+      return continue_or_draft if none_selected? || transactions_added || draft_selected?
 
       legal_aid_application.errors.add :base, :none_selected
       render :show

--- a/app/controllers/providers/identify_types_of_outgoings_controller.rb
+++ b/app/controllers/providers/identify_types_of_outgoings_controller.rb
@@ -1,6 +1,42 @@
 module Providers
   class IdentifyTypesOfOutgoingsController < ProviderBaseController
-    def show
+    before_action :authorize_legal_aid_application
+
+    def show; end
+
+    def update
+      return continue_or_draft if none_selected? || transactions_added
+
+      legal_aid_application.errors.add :base, :none_selected
+      render :show
+    end
+
+    private
+
+    def legal_aid_application_params
+      params.require(:legal_aid_application).permit(transaction_type_ids: [])
+    end
+
+    def transaction_types
+      TransactionType.debits.where(id: legal_aid_application_params[:transaction_type_ids])
+    end
+
+    def none_selected?
+      params[:none_selected] == 'true' && remove_existing_transaction_types
+    end
+
+    def transactions_added
+      return if transaction_types.empty?
+
+      remove_existing_transaction_types
+      legal_aid_application.transaction_types << transaction_types
+    end
+
+    def remove_existing_transaction_types
+      legal_aid_application.legal_aid_application_transaction_types.debits.destroy_all
+    end
+
+    def authorize_legal_aid_application
       authorize @legal_aid_application
     end
   end

--- a/app/services/flow/flows/provider_capital.rb
+++ b/app/services/flow/flows/provider_capital.rb
@@ -11,7 +11,8 @@ module Flow
           forward: :income_summary
         },
         identify_types_of_outgoings: {
-          path: ->(application) { urls.providers_legal_aid_application_identify_types_of_outgoing_path(application) }
+          path: ->(application) { urls.providers_legal_aid_application_identify_types_of_outgoing_path(application) },
+          forward: :outgoings_summary
         },
         own_homes: {
           path: ->(application) { urls.providers_legal_aid_application_own_home_path(application) },

--- a/app/views/citizens/identify_types_of_outgoings/show.html.erb
+++ b/app/views/citizens/identify_types_of_outgoings/show.html.erb
@@ -1,34 +1,6 @@
 <%= page_template page_title: t('.page_heading'), template: :basic, show_errors_for: @legal_aid_application do %>
-  <%= form_with(
-        model: @legal_aid_application,
-        url: citizens_identify_types_of_outgoing_path,
-        method: :patch,
-        local: true
-      ) do |form| %>
-
-    <%= govuk_form_group show_error_if: @legal_aid_application.errors.present? do %>
-      <%= govuk_fieldset_header do %>
-        <h1 class="govuk-fieldset__heading govuk-!-padding-bottom-7"><%= page_title %></h1>
-        <h2 class="govuk-heading-m"><%= t('.sub_heading') %></h2>
-      <% end %>
-
-      <div class="deselect-group" data-deselect-ctrl="#none_selected">
-        <%= transaction_type_check_boxes(
-              form: form,
-              transaction_types: TransactionType.debits
-            ) %>
-      </div>
-
-      <p class="govuk-!-padding-top-4"><%= t('.or_break') %></p>
-
-      <div class="govuk-checkboxes">
-        <div class="govuk-checkboxes__item">
-          <%= check_box_tag :none_selected, 'true', false, class: 'govuk-checkboxes__input' %>
-          <%= label_tag :none_selected, t('.none_selected'), class: 'govuk-label govuk-checkboxes__label' %>
-        </div>
-      </div>
-
-    <% end %>
-    <%= next_action_buttons(form: form) %>
-  <% end %>
+  <%= render(
+        'shared/forms/identify_types_of_outgoings_form',
+        form_path: citizens_identify_types_of_outgoing_path
+      ) %>
 <% end %>

--- a/app/views/providers/identify_types_of_outgoings/show.html.erb
+++ b/app/views/providers/identify_types_of_outgoings/show.html.erb
@@ -1,3 +1,7 @@
-<%= page_template page_title: '' do %>
-  <p class="govuk-body">[PLACEHOLDER] identify types of outgoings</p>
+<%= page_template page_title: t('.page_heading'), template: :basic, show_errors_for: @legal_aid_application do %>
+  <%= render(
+        'shared/forms/identify_types_of_outgoings_form',
+        form_path: providers_legal_aid_application_identify_types_of_outgoing_path(@legal_aid_application),
+        show_draft: true
+      ) %>
 <% end %>

--- a/app/views/providers/outgoings_summary/_add_other_outgoings.erb
+++ b/app/views/providers/outgoings_summary/_add_other_outgoings.erb
@@ -3,6 +3,6 @@
     <span class="app-task-list__section-number">
       <%= image_tag('plus_icon.svg') %>
     </span>
-    <%= link_to t('.add_other_outgoings'), '#todo', class: 'govuk-body' %>
+    <%= link_to t('.add_other_outgoings'), providers_legal_aid_application_identify_types_of_outgoing_path(@legal_aid_application), class: 'govuk-body' %>
   </h2>
 </li>

--- a/app/views/shared/forms/_identify_types_of_outgoings_form.html.erb
+++ b/app/views/shared/forms/_identify_types_of_outgoings_form.html.erb
@@ -1,0 +1,36 @@
+<%= form_with(
+      model: @legal_aid_application,
+      url: form_path,
+      method: :patch,
+      local: true
+    ) do |form| %>
+
+  <%= govuk_form_group show_error_if: @legal_aid_application.errors.present? do %>
+    <%= govuk_fieldset_header do %>
+      <h1 class="govuk-fieldset__heading govuk-!-padding-bottom-7"><%= page_title %></h1>
+      <h2 class="govuk-heading-m"><%= t('.sub_heading') %></h2>
+    <% end %>
+
+    <div class="deselect-group" data-deselect-ctrl="#none_selected">
+      <%= transaction_type_check_boxes(
+            form: form,
+            transaction_types: TransactionType.debits
+          ) %>
+    </div>
+
+    <p class="govuk-!-padding-top-4"><%= t('.or_break') %></p>
+
+    <div class="govuk-checkboxes">
+      <div class="govuk-checkboxes__item">
+        <%= check_box_tag :none_selected, 'true', false, class: 'govuk-checkboxes__input' %>
+        <%= label_tag :none_selected, t('.none_selected'), class: 'govuk-label govuk-checkboxes__label' %>
+      </div>
+    </div>
+
+  <% end %>
+
+  <%= next_action_buttons(
+        show_draft: local_assigns.key?(:show_draft) ? show_draft : false,
+        form: form
+      ) %>
+<% end %>

--- a/config/locales/en/citizens.yml
+++ b/config/locales/en/citizens.yml
@@ -71,9 +71,6 @@ en:
     identify_types_of_outgoings:
       show:
         page_heading: What regular payments do you make?
-        sub_heading: Select all that apply
-        or_break: or
-        none_selected: None of these
     information:
       show:
         heading: Give one-time access to your bank accounts

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -139,6 +139,9 @@ en:
     identify_types_of_incomes:
       show:
         page_heading: Which types of income does your client receive?
+    identify_types_of_outgoings:
+      show:
+        page_heading: Which regular payments does your client make?
     income_summary:
       add_other_income:
         add_other_income: Add another type of income

--- a/config/locales/en/shared.yml
+++ b/config/locales/en/shared.yml
@@ -33,6 +33,10 @@ en:
         occurred_on_label: When did the incident occur?
         told_on_hint: For example 31 3 2019
         purchased_on_hint: For example, 31 3 1980.
+      identify_types_of_outgoings_form:
+        sub_heading: Select all that apply
+        or_break: or
+        none_selected: None of these
       outstanding_mortgage_form:
         citizens:
           outstanding_mortgages:

--- a/features/providers/complete_and_check_means_answers.feature
+++ b/features/providers/complete_and_check_means_answers.feature
@@ -1,0 +1,52 @@
+Feature: Completing and checking means answers backwards and forwards
+
+  @javascript
+  Scenario: I select some outgoing transaction types and then remove them
+    Given The means questions have been answered by the applicant
+    Then I should be on a page showing 'Your client has completed their financial assessment'
+    Then I click 'Continue'
+    Then I should be on a page showing "Your client's income"
+    Then I click 'Save and continue'
+    Then I should be on a page showing "Your client's regular payments"
+    Then I click link 'Add another type of regular payment'
+    Then I should be on a page showing 'Which regular payments does your client make?'
+    Then I select 'Rent or mortgage payments'
+    Then I select 'Payments towards legal aid in a criminal case'
+    Then I click 'Save and continue'
+    Then I should be on a page showing "Your client's regular payments"
+    Then I should be on a page showing "Rent or mortgage payments"
+    Then I should be on a page showing "Payments towards legal aid in a criminal case"
+    Then I click link 'Add another type of regular payment'
+    Then I select 'None of these'
+    Then I click 'Save and continue'
+    Then I should be on a page showing "Your client's regular payments"
+    Then I should be on a page not showing "Rent or mortgage payments"
+    Then I should be on a page not showing "Payments towards legal aid in a criminal case"
+    Then I click 'Save and continue'
+    Then I should be on a page showing "Check your answers"
+
+  @javascript
+  Scenario: I navigate to the Check your answers page and then add some outgoing transaction types
+    Given The means questions have been answered by the applicant
+    Then I should be on a page showing 'Your client has completed their financial assessment'
+    Then I click 'Continue'
+    Then I should be on a page showing "Your client's income"
+    Then I click 'Save and continue'
+    Then I should be on a page showing "Your client's regular payments"
+    Then I click 'Save and continue'
+    Then I should be on a page showing "Check your answers"
+    Then I click link 'View/change declared outgoings'
+    Then I should be on a page showing "Your client's regular payments"
+    Then I click link 'Add another type of regular payment'
+    Then I should be on a page showing 'Which regular payments does your client make?'
+    Then I select 'Rent or mortgage payments'
+    Then I select 'Payments towards legal aid in a criminal case'
+    Then I click 'Save and continue'
+    Then I should be on a page showing "Your client's regular payments"
+    Then I should be on a page showing "Rent or mortgage payments"
+    Then I should be on a page showing "Payments towards legal aid in a criminal case"
+    Then I click 'Save and continue'
+    Then I should be on a page showing "Check your answers"
+
+
+

--- a/features/providers/step_definitions/civil_journey_steps.rb
+++ b/features/providers/step_definitions/civil_journey_steps.rb
@@ -205,6 +205,21 @@ Given('I complete the application and view the check your answers page') do
   visit(providers_legal_aid_application_check_provider_answers_path(legal_aid_application))
 end
 
+Given('The means questions have been answered by the applicant') do
+  @legal_aid_application = create(
+    :application,
+    :with_applicant,
+    :with_proceeding_types,
+    :means_completed
+  )
+  login_as @legal_aid_application.provider
+  visit Flow::KeyPoint.path_for(
+    journey: :providers,
+    key_point: :start_after_applicant_completes_means,
+    legal_aid_application: @legal_aid_application
+  )
+end
+
 When('the search for {string} is not successful') do |proceeding_search|
   fill_in('proceeding-search-input', with: proceeding_search)
 end

--- a/features/support/steps_helper.rb
+++ b/features/support/steps_helper.rb
@@ -2,6 +2,10 @@ Then('I should be on a page showing {string}') do |title|
   expect(page).to have_content(title)
 end
 
+Then('I should be on a page not showing {string}') do |title|
+  expect(page).not_to have_content(title)
+end
+
 Then('I choose {string}') do |option|
   choose(option, allow_label_click: true)
 end

--- a/spec/requests/providers/identify_types_of_outgoings_spec.rb
+++ b/spec/requests/providers/identify_types_of_outgoings_spec.rb
@@ -1,0 +1,139 @@
+require 'rails_helper'
+
+RSpec.describe Providers::IdentifyTypesOfOutgoingsController do
+  let(:legal_aid_application) { create :legal_aid_application, :with_applicant }
+  let(:provider) { legal_aid_application.provider }
+  let(:login) { login_as provider }
+  let!(:outgoing_types) { create_list :transaction_type, 3, :debit_with_standard_name }
+  before { login }
+
+  describe 'GET /providers/identify_types_of_outgoing' do
+    before { get providers_legal_aid_application_identify_types_of_outgoing_path(legal_aid_application) }
+
+    it 'returns http success' do
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'displays the outgoing type labels' do
+      outgoing_types.map(&:label_name).each do |label|
+        expect(unescaped_response_body).to include(label)
+      end
+      expect(unescaped_response_body).not_to include('translation missing')
+    end
+
+    context 'when the provider is not authenticated' do
+      let(:login) { nil }
+      it_behaves_like 'a provider not authenticated'
+    end
+  end
+
+  describe 'PATCH /providers/identify_types_of_outgoing' do
+    let(:transaction_type_ids) { [] }
+    let(:submit_button) { {} }
+    let(:params) do
+      {
+        legal_aid_application: {
+          transaction_type_ids: transaction_type_ids
+        }
+      }
+    end
+
+    subject do
+      patch(
+        providers_legal_aid_application_identify_types_of_outgoing_path(legal_aid_application),
+        params: params.merge(submit_button)
+      )
+    end
+
+    it 'does not add transaction types to the application' do
+      expect { subject }.not_to change { LegalAidApplicationTransactionType.count }
+    end
+
+    it 'should display an error' do
+      subject
+      expect(response.body).to match('govuk-error-summary')
+    end
+
+    it 'returns http success' do
+      subject
+      expect(response).to have_http_status(:ok)
+    end
+
+    context 'when transaction types selected' do
+      let(:transaction_type_ids) { outgoing_types.map(&:id) }
+
+      it 'adds transaction types to the application' do
+        expect { subject }.to change { LegalAidApplicationTransactionType.count }.by(outgoing_types.length)
+        expect(legal_aid_application.reload.transaction_types).to match_array(outgoing_types)
+      end
+
+      it 'should redirect to the next step' do
+        expect(subject).to redirect_to(flow_forward_path)
+      end
+
+      context 'Form submitted with Save as draft button' do
+        let(:submit_button) { { draft_button: 'Save as draft' } }
+
+        it 'redirects to the list of applications' do
+          subject
+          expect(response).to redirect_to providers_legal_aid_applications_path
+        end
+      end
+    end
+
+    context 'when application has transaction types of other kind' do
+      let(:other_transaction_type) { create :transaction_type, :credit }
+      let(:legal_aid_application) { create :legal_aid_application, :with_applicant, transaction_types: [other_transaction_type] }
+
+      it 'does not remove existing transation of other type' do
+        expect { subject }.not_to change { legal_aid_application.transaction_types.count }
+      end
+
+      it 'does not delete transaction types' do
+        expect { subject }.not_to change { TransactionType.count }
+      end
+    end
+
+    context 'when "none selected" has been selected' do
+      let(:params) { { none_selected: 'true' } }
+
+      it 'does not add transaction types to the application' do
+        expect { subject }.not_to change { LegalAidApplicationTransactionType.count }
+      end
+
+      it 'redirects to the next step' do
+        expect(subject).to redirect_to(flow_forward_path)
+      end
+
+      context 'and application has transactions' do
+        let(:legal_aid_application) do
+          create :legal_aid_application, :with_applicant, transaction_types: outgoing_types
+        end
+
+        it 'removes transaction types from the application' do
+          expect { subject }.to change { LegalAidApplicationTransactionType.count }
+            .by(-outgoing_types.length)
+        end
+
+        it 'redirects to the next step' do
+          expect(subject).to redirect_to(flow_forward_path)
+        end
+      end
+    end
+
+    context 'the wrong transaction type is passed in' do
+      let!(:income_types) { create_list :transaction_type, 3, :credit_with_standard_name }
+      let(:transaction_type_ids) { income_types.map(&:id) }
+
+      it 'does not add the transaction types' do
+        expect { subject }.not_to change { legal_aid_application.transaction_types.count }
+      end
+    end
+
+    context 'when the provider is not authenticated' do
+      before { subject }
+      let(:login) { nil }
+      it_behaves_like 'a provider not authenticated'
+    end
+  end
+end

--- a/spec/requests/providers/identify_types_of_outgoings_spec.rb
+++ b/spec/requests/providers/identify_types_of_outgoings_spec.rb
@@ -72,6 +72,7 @@ RSpec.describe Providers::IdentifyTypesOfOutgoingsController do
       end
 
       context 'Form submitted with Save as draft button' do
+        let(:transaction_type_ids) { [] }
         let(:submit_button) { { draft_button: 'Save as draft' } }
 
         it 'redirects to the list of applications' do


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-592)

Implement the **Identify types of outgoings** page on the provider flow.
Move the view to a partial in order to reuse the html from the applicant flow

## Checklist

Before you ask people to review this PR:

- [X] Tests and rubocop should be passing: `bundle exec rake`
- [X] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [X] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [X] The PR description should say what you changed and why, with a link to the JIRA story.
- [X] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [X] You should have checked that the commit messages say why the change was made.
