### PR TITLE
Small CCMS refactor to remove initialize overload

### DIFF
--- a/app/services/ccms/applicant_add_requestor.rb
+++ b/app/services/ccms/applicant_add_requestor.rb
@@ -1,18 +1,29 @@
 module CCMS
   class ApplicantAddRequestor < BaseRequestor
+    wsdl_from 'ClientProxyServiceWsdl.xml'.freeze
+
+    uses_namespaces(
+      'xmlns:xsd' => 'http://www.w3.org/2001/XMLSchema',
+      'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance',
+      'xmlns:ns2' => 'http://legalservices.gov.uk/CCMS/ClientManagement/Client/1.0/ClientBIM',
+      'xmlns:soap' => 'http://schemas.xmlsoap.org/soap/envelope/',
+      'xmlns:ns1' => 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd',
+      'xmlns:ns3' => 'http://legalservices.gov.uk/Enterprise/Common/1.0/Header',
+      'xmlns:ns4' => 'http://legalservices.gov.uk/Enterprise/Common/1.0/Common',
+      'xmlns:ns5' => 'http://legalservices.gov.uk/CCMS/ClientManagement/Client/1.0/ClientBIO'
+    )
+
     attr_reader :applicant
     delegate :address, to: :applicant
 
     def initialize(applicant)
       @applicant = applicant
-      @address = applicant.address
-      super()
     end
 
     # temporarily ignore this until connectivity with ccms is working
     # :nocov:
     def call
-      @soap_client.call(:create_client, xml: request_xml)
+      soap_client.call(:create_client, xml: request_xml)
     end
     # :nocov:
 
@@ -65,23 +76,6 @@ module CCMS
       xml.__send__('ns4:City', address.city)
       xml.__send__('ns4:Country', 'GBR')
       xml.__send__('ns4:PostalCode', address.pretty_postcode)
-    end
-
-    def namespaces
-      {
-        'xmlns:xsd' => 'http://www.w3.org/2001/XMLSchema',
-        'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance',
-        'xmlns:ns2' => 'http://legalservices.gov.uk/CCMS/ClientManagement/Client/1.0/ClientBIM',
-        'xmlns:soap' => 'http://schemas.xmlsoap.org/soap/envelope/',
-        'xmlns:ns1' => 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd',
-        'xmlns:ns3' => 'http://legalservices.gov.uk/Enterprise/Common/1.0/Header',
-        'xmlns:ns4' => 'http://legalservices.gov.uk/Enterprise/Common/1.0/Common',
-        'xmlns:ns5' => 'http://legalservices.gov.uk/CCMS/ClientManagement/Client/1.0/ClientBIO'
-      }.freeze
-    end
-
-    def wsdl_location
-      "#{File.dirname(__FILE__)}/wsdls/ClientProxyServiceWsdl.xml".freeze
     end
   end
 end

--- a/app/services/ccms/applicant_add_status_requestor.rb
+++ b/app/services/ccms/applicant_add_status_requestor.rb
@@ -1,16 +1,28 @@
 module CCMS
   class ApplicantAddStatusRequestor < BaseRequestor
+    wsdl_from 'ClientProxyServiceWsdl.xml'.freeze
+
+    uses_namespaces(
+      'xmlns:xsd' => 'http://www.w3.org/2001/XMLSchema',
+      'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance',
+      'xmlns:ns2' => 'http://legalservices.gov.uk/CCMS/ClientManagement/Client/1.0/ClientBIM',
+      'xmlns:soap' => 'http://schemas.xmlsoap.org/soap/envelope/',
+      'xmlns:ns1' => 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd',
+      'xmlns:ns3' => 'http://legalservices.gov.uk/Enterprise/Common/1.0/Header',
+      'xmlns:ns4' => 'http://legalservices.gov.uk/Enterprise/Common/1.0/Common',
+      'xmlns:ns5' => 'http://legalservices.gov.uk/CCMS/ClientManagement/Client/1.0/ClientBIO'
+    )
+
     attr_reader :applicant_add_transaction_id
 
     def initialize(applicant_add_transaction_id)
       @applicant_add_transaction_id = applicant_add_transaction_id
-      super()
     end
 
     # temporarily ignore this until connectivity with ccms is working
     # :nocov:
     def call
-      @soap_client.call(:get_client_txn_status, message: request_xml)
+      soap_client.call(:get_client_txn_status, message: request_xml)
     end
     # :nocov:
 
@@ -25,23 +37,6 @@ module CCMS
         xml.__send__('ns3:HeaderRQ') { ns3_header_rq(xml) }
         xml.__send__('ns2:TransactionID', applicant_add_transaction_id)
       end
-    end
-
-    def namespaces
-      {
-        'xmlns:xsd' => 'http://www.w3.org/2001/XMLSchema',
-        'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance',
-        'xmlns:ns2' => 'http://legalservices.gov.uk/CCMS/ClientManagement/Client/1.0/ClientBIM',
-        'xmlns:soap' => 'http://schemas.xmlsoap.org/soap/envelope/',
-        'xmlns:ns1' => 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd',
-        'xmlns:ns3' => 'http://legalservices.gov.uk/Enterprise/Common/1.0/Header',
-        'xmlns:ns4' => 'http://legalservices.gov.uk/Enterprise/Common/1.0/Common',
-        'xmlns:ns5' => 'http://legalservices.gov.uk/CCMS/ClientManagement/Client/1.0/ClientBIO'
-      }.freeze
-    end
-
-    def wsdl_location
-      "#{File.dirname(__FILE__)}/wsdls/ClientProxyServiceWsdl.xml".freeze
     end
   end
 end

--- a/app/services/ccms/applicant_search_requestor.rb
+++ b/app/services/ccms/applicant_search_requestor.rb
@@ -1,14 +1,26 @@
 module CCMS
   class ApplicantSearchRequestor < BaseRequestor
+    wsdl_from 'ClientProxyServiceWsdl.xml'.freeze
+
+    uses_namespaces(
+      'xmlns:xsd' => 'http://www.w3.org/2001/XMLSchema',
+      'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance',
+      'xmlns:ns2' => 'http://legalservices.gov.uk/CCMS/ClientManagement/Client/1.0/ClientBIM',
+      'xmlns:soap' => 'http://schemas.xmlsoap.org/soap/envelope/',
+      'xmlns:ns1' => 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd',
+      'xmlns:ns3' => 'http://legalservices.gov.uk/Enterprise/Common/1.0/Header',
+      'xmlns:ns4' => 'http://legalservices.gov.uk/Enterprise/Common/1.0/Common',
+      'xmlns:ns5' => 'http://legalservices.gov.uk/CCMS/ClientManagement/Client/1.0/ClientBIO'
+    )
+
     def initialize(applicant)
       @applicant = applicant
-      super()
     end
 
     # temporarily ignore this until connectivity with ccms is working
     # :nocov:
     def call
-      @soap_client.call(:get_client_details, xml: request_xml)
+      soap_client.call(:get_client_details, xml: request_xml)
     end
     # :nocov:
 
@@ -38,23 +50,6 @@ module CCMS
         xml.__send__('ns5:DateOfBirth', @applicant.date_of_birth.to_s(:ccms_date))
         xml.__send__('ns5:NINumber', @applicant.national_insurance_number)
       end
-    end
-
-    def namespaces
-      {
-        'xmlns:xsd' => 'http://www.w3.org/2001/XMLSchema',
-        'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance',
-        'xmlns:ns2' => 'http://legalservices.gov.uk/CCMS/ClientManagement/Client/1.0/ClientBIM',
-        'xmlns:soap' => 'http://schemas.xmlsoap.org/soap/envelope/',
-        'xmlns:ns1' => 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd',
-        'xmlns:ns3' => 'http://legalservices.gov.uk/Enterprise/Common/1.0/Header',
-        'xmlns:ns4' => 'http://legalservices.gov.uk/Enterprise/Common/1.0/Common',
-        'xmlns:ns5' => 'http://legalservices.gov.uk/CCMS/ClientManagement/Client/1.0/ClientBIO'
-      }.freeze
-    end
-
-    def wsdl_location
-      "#{File.dirname(__FILE__)}/wsdls/ClientProxyServiceWsdl.xml".freeze
     end
   end
 end

--- a/app/services/ccms/base_requestor.rb
+++ b/app/services/ccms/base_requestor.rb
@@ -1,16 +1,15 @@
 module CCMS
   class BaseRequestor
-    def initialize
-      @soap_client = Savon.client(
-        env_namespace: :soap,
-        wsdl: wsdl_location,
-        namespaces: namespaces,
-        pretty_print_xml: true,
-        convert_request_keys_to: :none,
-        namespace_identifier: 'ns2',
-        log: true
-      )
-      @transaction_request_id = nil
+    class << self
+      attr_reader :wsdl, :namespaces
+
+      def wsdl_from(filename)
+        @wsdl = filename
+      end
+
+      def uses_namespaces(namespaces)
+        @namespaces = namespaces.freeze
+      end
     end
 
     def formatted_xml
@@ -26,6 +25,21 @@ module CCMS
     end
 
     private
+
+    # temporarily ignore this until connectivity with ccms is working
+    # :nocov:
+    def soap_client
+      @soap_client ||= Savon.client(
+        env_namespace: :soap,
+        wsdl: wsdl_location,
+        namespaces: namespaces,
+        pretty_print_xml: true,
+        convert_request_keys_to: :none,
+        namespace_identifier: 'ns2',
+        log: true
+      )
+    end
+    # :nocov:
 
     def soap_envelope(namespaces)
       Nokogiri::XML::Builder.new(encoding: 'UTF-8') do |xml|
@@ -50,6 +64,14 @@ module CCMS
       xml.__send__('ns3:Language', 'ENG')
       xml.__send__('ns3:UserLoginID', ENV['USER_LOGIN'])
       xml.__send__('ns3:UserRole', ENV['USER_ROLE'])
+    end
+
+    def wsdl_location
+      "#{File.dirname(__FILE__)}/wsdls/#{self.class.wsdl}".freeze
+    end
+
+    def namespaces
+      self.class.namespaces
     end
   end
 end

--- a/app/services/ccms/case_add_requestor.rb
+++ b/app/services/ccms/case_add_requestor.rb
@@ -2,8 +2,20 @@ module CCMS
   class CaseAddRequestor < BaseRequestor # rubocop:disable Metrics/ClassLength
     CONFIG_METHOD_REGEX = /^#(\S+)/.freeze
 
+    wsdl_from 'CaseServicesWsdl.xml'.freeze
+
+    uses_namespaces(
+      'xmlns:ns6' => 'http://legalservices.gov.uk/Enterprise/Common/1.0/Header',
+      'xmlns:ns5' => 'http://legalservices.gov.uk/CCMS/Finance/Payables/1.0/BillingBIO',
+      'xmlns:ns7' => 'uri',
+      'xmlns:ns0' => 'http://legalservices.gov.uk/Enterprise/Common/1.0/Common',
+      'xmlns:ns2' => 'http://legalservices.gov.uk/CCMS/CaseManagement/Case/1.0/CaseBIO',
+      'xmlns:ns1' => 'http://legalservices.gov.uk/CCMS/CaseManagement/Case/1.0/CaseBIM',
+      'xmlns:ns4' => 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd',
+      'xmlns:ns3' => 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd'
+    )
+
     def initialize(legal_aid_application)
-      super()
       @legal_aid_application = legal_aid_application
       @transaction_time_stamp = Time.now.to_s(:ccms_date_time)
       @ccms_attribute_keys = YAML.load_file(File.join(Rails.root, 'config', 'ccms', 'ccms_keys.yml'))
@@ -13,7 +25,7 @@ module CCMS
     # temporarily ignore this until connectivity with ccms is working
     # :nocov:
     def call
-      @soap_client.call(:add_case, xml: request_xml)
+      soap_client.call(:add_case, xml: request_xml)
     end
     # :nocov:
 
@@ -475,23 +487,6 @@ module CCMS
 
     def wage_slips
       @wage_slips ||= @legal_aid_application.wage_slips
-    end
-
-    def namespaces
-      {
-        'xmlns:ns6' => 'http://legalservices.gov.uk/Enterprise/Common/1.0/Header',
-        'xmlns:ns5' => 'http://legalservices.gov.uk/CCMS/Finance/Payables/1.0/BillingBIO',
-        'xmlns:ns7' => 'uri',
-        'xmlns:ns0' => 'http://legalservices.gov.uk/Enterprise/Common/1.0/Common',
-        'xmlns:ns2' => 'http://legalservices.gov.uk/CCMS/CaseManagement/Case/1.0/CaseBIO',
-        'xmlns:ns1' => 'http://legalservices.gov.uk/CCMS/CaseManagement/Case/1.0/CaseBIM',
-        'xmlns:ns4' => 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd',
-        'xmlns:ns3' => 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd'
-      }.freeze
-    end
-
-    def wsdl_location
-      "#{File.dirname(__FILE__)}/wsdls/CaseServicesWsdl.xml".freeze
     end
   end
 end

--- a/app/services/ccms/case_add_status_requestor.rb
+++ b/app/services/ccms/case_add_status_requestor.rb
@@ -1,9 +1,18 @@
 module CCMS
   class CaseAddStatusRequestor < BaseRequestor
+    wsdl_from 'ClientServiceWsdl.xml'.freeze
+
+    uses_namespaces(
+      'xmlns:soap' => 'http://schemas.xmlsoap.org/soap/envelope/',
+      'xmlns:ns1' => 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd',
+      'xmlns:ns2' => 'http://legalservices.gov.uk/CCMS/CaseManagement/Case/1.0/CaseBIM',
+      'xmlns:ns3' => 'http://legalservices.gov.uk/Enterprise/Common/1.0/Header'
+    )
+
     # temporarily ignore this until connectivity with ccms is working
     # :nocov:
     def call
-      @soap_client.call(:get_case_txn_status, message: request_xml)
+      soap_client.call(:get_case_txn_status, message: request_xml)
     end
     # :nocov:
 
@@ -18,19 +27,6 @@ module CCMS
         xml.__send__('ns3:HeaderRQ') { ns3_header_rq(xml) }
         xml.__send__('ns2:TransactionID', '20190101121530123456') # this needs to be the transaction id of the create case request
       end
-    end
-
-    def namespaces
-      {
-        'xmlns:soap' => 'http://schemas.xmlsoap.org/soap/envelope/',
-        'xmlns:ns1' => 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd',
-        'xmlns:ns2' => 'http://legalservices.gov.uk/CCMS/CaseManagement/Case/1.0/CaseBIM',
-        'xmlns:ns3' => 'http://legalservices.gov.uk/Enterprise/Common/1.0/Header'
-      }.freeze
-    end
-
-    def wsdl_location
-      "#{File.dirname(__FILE__)}/wsdls/ClientServiceWsdl.xml".freeze
     end
   end
 end

--- a/app/services/ccms/reference_data_requestor.rb
+++ b/app/services/ccms/reference_data_requestor.rb
@@ -1,9 +1,22 @@
 module CCMS
   class ReferenceDataRequestor < BaseRequestor
+    wsdl_from 'GetReferenceDataWsdl.xml'.freeze
+
+    uses_namespaces(
+      'xmlns:xsd' => 'http://www.w3.org/2001/XMLSchema',
+      'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance',
+      'xmlns:ns2' => 'http://legalservices.gov.uk/CCMS/Common/ReferenceData/1.0/ReferenceDataBIM',
+      'xmlns:soap' => 'http://schemas.xmlsoap.org/soap/envelope/',
+      'xmlns:ns1' => 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd',
+      'xmlns:ns3' => 'http://legalservices.gov.uk/Enterprise/Common/1.0/Header',
+      'xmlns:ns4' => 'http://legalservices.gov.uk/Enterprise/Common/1.0/Common',
+      'xmlns:ns5' => 'http://legalservices.gov.uk/CCMS/Common/ReferenceData/1.0/ReferenceDataBIO'
+    )
+
     # temporarily ignore this until connectivity with ccms is working
     # :nocov:
     def call
-      @soap_client.call(:process, xml: request_xml)
+      soap_client.call(:process, xml: request_xml)
     end
     # :nocov:
 
@@ -25,23 +38,6 @@ module CCMS
       xml.__send__('ns5:SearchKey') do
         xml.__send__('ns5:Key', 'CaseReferenceNumber')
       end
-    end
-
-    def namespaces
-      {
-        'xmlns:xsd' => 'http://www.w3.org/2001/XMLSchema',
-        'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance',
-        'xmlns:ns2' => 'http://legalservices.gov.uk/CCMS/Common/ReferenceData/1.0/ReferenceDataBIM',
-        'xmlns:soap' => 'http://schemas.xmlsoap.org/soap/envelope/',
-        'xmlns:ns1' => 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd',
-        'xmlns:ns3' => 'http://legalservices.gov.uk/Enterprise/Common/1.0/Header',
-        'xmlns:ns4' => 'http://legalservices.gov.uk/Enterprise/Common/1.0/Common',
-        'xmlns:ns5' => 'http://legalservices.gov.uk/CCMS/Common/ReferenceData/1.0/ReferenceDataBIO'
-      }.freeze
-    end
-
-    def wsdl_location
-      "#{File.dirname(__FILE__)}/wsdls/GetReferenceDataWsdl.xml".freeze
     end
   end
 end

--- a/spec/services/ccms/applicant_add_requestor_spec.rb
+++ b/spec/services/ccms/applicant_add_requestor_spec.rb
@@ -21,10 +21,11 @@ module CCMS
              date_of_birth: Date.new(1969, 1, 1))
     end
 
+    let(:requestor) { described_class.new(applicant) }
+
     describe 'XML request' do
       it 'generates the expected XML' do
         with_modified_env(modified_environment_vars) do
-          requestor = described_class.new(applicant)
           allow(requestor).to receive(:transaction_request_id).and_return(expected_tx_id)
           expect(requestor.formatted_xml).to eq expected_xml.chomp
         end
@@ -34,9 +35,14 @@ module CCMS
     describe '#transaction_request_id' do
       it 'returns the id based on current time' do
         Timecop.freeze(2019, 1, 1, 12, 15, 30.123456) do
-          requestor = described_class.new(applicant)
           expect(requestor.transaction_request_id).to start_with expected_tx_id
         end
+      end
+    end
+
+    describe 'wsdl_location' do
+      it 'points to correct location' do
+        expect(requestor.send(:wsdl_location)).to match('app/services/ccms/wsdls/ClientProxyServiceWsdl.xml')
       end
     end
   end


### PR DESCRIPTION
A refactor to address:
- Remove the loading of `soap_client` from the initialization method. This was leading to `super()` having to be called unnecessarily in child classes of `BaseRequestor`.
- Set WSDL file and namespace definition at the class level, so that is done once on app load instead of every time an instance is created. I've also simplified the WSDL config so that all that needs to be defined in each child class is the file name, and `BaseRequestor` can be left to identify the storage location.