### PR TITLE
AP-586 Handle 404 errors

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,7 @@ class ApplicationController < ActionController::Base
   layout 'application'
   include Backable
 
+  # See also catch all route at end of config/routes.rb
   rescue_from ActiveRecord::RecordNotFound, with: :page_not_found
 
   private

--- a/app/controllers/concerns/providers/application_dependable.rb
+++ b/app/controllers/concerns/providers/application_dependable.rb
@@ -30,8 +30,7 @@ module Providers
       end
 
       def process_invalid_application
-        flash[:error] = 'Invalid application'
-        redirect_to providers_legal_aid_applications_path
+        redirect_to error_path(:page_not_found)
       end
 
       def provider_step_params

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -145,4 +145,7 @@ Rails.application.routes.draw do
       resource :means_summary, only: %i[show update]
     end
   end
+
+  # Catch all route that traps paths not defined above. Must be last route.
+  match '*path', to: redirect('error/page_not_found'), via: :all
 end

--- a/spec/requests/errors_spec.rb
+++ b/spec/requests/errors_spec.rb
@@ -1,6 +1,26 @@
 require 'rails_helper'
 
 RSpec.describe ErrorsController, type: :request do
+  describe 'actions that result in error pages being shown' do
+    describe 'unknown page' do
+      before { get '/unknown/path' }
+
+      it 'redirect to page not found' do
+        expect(response).to redirect_to(error_path(:page_not_found))
+      end
+    end
+
+    describe 'object not found' do
+      before do
+        get feedback_path(SecureRandom.uuid)
+      end
+
+      it 'redirect to page not found' do
+        expect(response).to redirect_to(error_path(:page_not_found))
+      end
+    end
+  end
+
   describe 'GET /error/page_not_found' do
     subject { get error_path(:page_not_found) }
 

--- a/spec/requests/providers/about_the_financial_assessments_spec.rb
+++ b/spec/requests/providers/about_the_financial_assessments_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe 'about financial assessments requests', type: :request do
       context 'when the application does not exist' do
         let(:application_id) { SecureRandom.uuid }
 
-        it 'redirects to the applications page with an error' do
-          expect(response).to redirect_to(providers_legal_aid_applications_path)
+        it 'redirects to an error' do
+          expect(response).to redirect_to(error_path(:page_not_found))
         end
       end
 
@@ -54,12 +54,12 @@ RSpec.describe 'about financial assessments requests', type: :request do
       context 'when the application does not exist' do
         let(:application_id) { SecureRandom.uuid }
 
-        it 'redirects to the applications page without calling the email service' do
+        it 'redirects to and error page without calling the email service' do
           expect(CitizenEmailService).not_to receive(:new)
 
           subject
 
-          expect(response).to redirect_to(providers_legal_aid_applications_path)
+          expect(response).to redirect_to(error_path(:page_not_found))
         end
       end
 

--- a/spec/requests/providers/address_lookups_spec.rb
+++ b/spec/requests/providers/address_lookups_spec.rb
@@ -19,15 +19,6 @@ RSpec.describe 'address lookup requests', type: :request do
         subject
       end
 
-      context 'when the applicant does not exist' do
-        let(:invalid_legal_aid_application) { SecureRandom.uuid }
-        subject { get providers_legal_aid_application_address_lookup_path(invalid_legal_aid_application) }
-
-        it 'redirects the user to the applications page with an error message' do
-          expect(response).to redirect_to(providers_legal_aid_applications_path)
-        end
-      end
-
       it 'shows the postcode entry page' do
         expect(response).to be_successful
         expect(unescaped_response_body).to include(I18n.t('forms.address_lookup.heading'))
@@ -57,16 +48,6 @@ RSpec.describe 'address lookup requests', type: :request do
     context 'when the provider is authenticated' do
       before do
         login_as provider
-      end
-
-      context 'when the applicantion does not exist' do
-        let(:invalid_legal_aid_application) { SecureRandom.uuid }
-        subject { patch providers_legal_aid_application_address_lookup_path(invalid_legal_aid_application), params: params }
-
-        it 'redirects the user to the applications page with an error message' do
-          subject
-          expect(response).to redirect_to(providers_legal_aid_applications_path)
-        end
       end
 
       context 'with an invalid postcode' do

--- a/spec/requests/providers/address_selections_spec.rb
+++ b/spec/requests/providers/address_selections_spec.rb
@@ -108,17 +108,6 @@ RSpec.describe 'address selections requests', type: :request do
         login_as provider
       end
 
-      context 'when the applicant does not exist' do
-        let(:invalid_legal_aid_application) { SecureRandom.uuid }
-        subject { patch providers_legal_aid_application_address_selection_path(invalid_legal_aid_application), params: params }
-
-        it 'redirects the user to the applications page with an error message' do
-          subject
-
-          expect(response).to redirect_to(providers_legal_aid_applications_path)
-        end
-      end
-
       context 'when no address was selected from the list' do
         let(:lookup_id) { '' }
 

--- a/spec/requests/providers/addresses_spec.rb
+++ b/spec/requests/providers/addresses_spec.rb
@@ -33,9 +33,9 @@ RSpec.describe 'address requests', type: :request do
       context 'when the applicant does not exist' do
         let(:legal_aid_application) { SecureRandom.uuid }
 
-        it 'redirects the user to the applications page with an error message' do
+        it 'redirects the user to an error page' do
           subject
-          expect(response).to redirect_to(providers_legal_aid_applications_path)
+          expect(response).to redirect_to(error_path(:page_not_found))
         end
       end
 
@@ -82,14 +82,9 @@ RSpec.describe 'address requests', type: :request do
       context 'when the legal aid application does not exist' do
         let(:legal_aid_application) { SecureRandom.uuid }
 
-        it 'redirects the user to the applications page with an error message' do
+        it 'redirects the user to an error message' do
           subject
-          expect(response).to redirect_to(providers_legal_aid_applications_path)
-        end
-
-        it 'displays an error if the applicant does not exist' do
-          subject
-          expect(flash[:error]).to eq('Invalid application')
+          expect(response).to redirect_to(error_path(:page_not_found))
         end
 
         it 'does NOT create an address record' do

--- a/spec/requests/providers/applicants_spec.rb
+++ b/spec/requests/providers/applicants_spec.rb
@@ -23,16 +23,6 @@ RSpec.describe 'providers applicant requests', type: :request do
         expect(response).to have_http_status(:ok)
       end
 
-      context 'when the application does not exist' do
-        let(:application_id) { SecureRandom.uuid }
-
-        it 'redirects the user to the applications page with an error message' do
-          subject
-
-          expect(response).to redirect_to(providers_legal_aid_applications_path)
-        end
-      end
-
       context 'has already got applicant info' do
         let(:applicant) { create(:applicant) }
         let(:application) { create(:legal_aid_application, applicant: applicant) }

--- a/spec/requests/providers/application_dependable_spec.rb
+++ b/spec/requests/providers/application_dependable_spec.rb
@@ -25,14 +25,6 @@ RSpec.describe 'Providers::ApplicationDependable' do
       it 'records the current controller name' do
         expect(legal_aid_application.reload.provider_step).to eq('proceedings_types')
       end
-
-      context 'with an invalid legal_aid_application' do
-        let(:invalid_legal_aid_application) { build :legal_aid_application, id: SecureRandom.uuid }
-        subject { get providers_legal_aid_application_proceedings_types_path(invalid_legal_aid_application) }
-        it "redirects to provider's start page" do
-          expect(response).to redirect_to(providers_legal_aid_applications_path)
-        end
-      end
     end
   end
 end

--- a/spec/requests/providers/check_provider_answers_spec.rb
+++ b/spec/requests/providers/check_provider_answers_spec.rb
@@ -18,14 +18,6 @@ RSpec.describe 'check your answers requests', type: :request do
         subject
       end
 
-      context 'when the application does not exist' do
-        let(:application_id) { SecureRandom.uuid }
-
-        it 'redirects to the applications page with an error' do
-          expect(response).to redirect_to(providers_legal_aid_applications_path)
-        end
-      end
-
       it 'returns success' do
         expect(response).to be_successful
       end

--- a/spec/requests/providers/online_bankings_spec.rb
+++ b/spec/requests/providers/online_bankings_spec.rb
@@ -27,14 +27,6 @@ RSpec.describe 'does client use online banking requests', type: :request do
       it 'displays the correct page' do
         expect(unescaped_response_body).to include('Does your client use online banking?')
       end
-
-      context 'when the application does not exist' do
-        let(:application_id) { SecureRandom.uuid }
-
-        it 'redirects the user to the applications page with an error message' do
-          expect(response).to redirect_to(providers_legal_aid_applications_path)
-        end
-      end
     end
   end
 


### PR DESCRIPTION
[AP-586](https://dsdmoj.atlassian.net/browse/AP-586)

This was a little more complicated than I thought. You can't just catch `ActionController::RoutingError` in the controller, because the error occurs before the controller is loaded - a controller instance is created once routing determines which class of controller to use. Instead I had to add a catch all route at the end of the routes (as described [here](https://stackoverflow.com/questions/18359088/custom-error-handling-with-rails-4-0#20508445)).

Also many request specs test for application id not matching. This I think is over-kill as it is basically repeatedly testing the same functionality. So I've removed many of these tests; leaving ones where something else was tested too.