### PR TITLE
AP-617 Create object to store and return thresholds

### DIFF
--- a/app/models/ccms/threshold.rb
+++ b/app/models/ccms/threshold.rb
@@ -1,0 +1,5 @@
+module CCMS
+  class Threshold < YamlStore
+    use_yml_file Rails.root.join('config/ccms/thresholds.yml'), section: :ccms
+  end
+end

--- a/app/models/yaml_store.rb
+++ b/app/models/yaml_store.rb
@@ -1,0 +1,36 @@
+class YamlStore
+  KeyNotRecognisedError = Class.new(StandardError)
+  ConfigurationError = Class.new(StandardError)
+
+  class << self
+    attr_reader :yaml_file_path, :yaml_args
+
+    def use_yml_file(path, *args)
+      @yaml_file_path = path
+      @yaml_args = args
+    end
+
+    def from_yaml_file(path, section: nil)
+      hash = YAML.load_file(path)
+      data = section ? hash[section.to_s] : hash
+      new(data)
+    end
+
+    def store
+      raise ConfigurationError, "use_yml_file not set in #{name}" unless yaml_file_path.present?
+
+      @store ||= from_yaml_file(yaml_file_path, *yaml_args)
+    end
+    delegate :threshold, to: :store
+  end
+
+  attr_reader :data
+
+  def initialize(hash)
+    @data = hash.deep_symbolize_keys
+  end
+
+  def threshold(key)
+    data[key] || raise(KeyNotRecognisedError, "key '#{key}' not set")
+  end
+end

--- a/config/ccms/thresholds.yml
+++ b/config/ccms/thresholds.yml
@@ -1,0 +1,11 @@
+---
+ccms:
+  gross_income_upper:
+    children:
+      one: 1
+      two: 3
+      many: 7
+  disposable_income_lower: 1000
+  disposable_income_upper: 10000
+  capital_lower: 10
+  capital_upper: 10000

--- a/spec/data/ccms/simple_thresholds.yml
+++ b/spec/data/ccms/simple_thresholds.yml
@@ -1,0 +1,11 @@
+---
+ccms:
+  gross_income_upper:
+    children:
+      one: 1
+      two: 3
+      many: 7
+  disposable_income_lower: 1000
+  disposable_income_upper: 10000
+  capital_lower: 10
+  capital_upper: 10000

--- a/spec/models/ccms/threshold_spec.rb
+++ b/spec/models/ccms/threshold_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+module CCMS
+  RSpec.describe Threshold do
+    let(:data) { YAML.load_file Rails.root.join('config/ccms/thresholds.yml') }
+
+    describe '.threshold' do
+      it 'returns data from yaml file' do
+        expect(described_class.threshold(:capital_upper)).to eq(data['ccms']['capital_upper'])
+      end
+    end
+  end
+end

--- a/spec/models/yaml_store_spec.rb
+++ b/spec/models/yaml_store_spec.rb
@@ -1,0 +1,64 @@
+require 'rails_helper'
+
+RSpec.describe YamlStore do
+  let(:file_path) { ccms_data_file_path 'simple_thresholds.yml' }
+  let(:data) { YAML.load_file file_path }
+
+  describe '#threshold' do
+    let(:threshold) { Faker::Number.number(4) }
+    let(:data) { { foo: threshold } }
+    let(:threshold_store) { described_class.new(data) }
+
+    it 'returns threshold' do
+      expect(threshold_store.threshold(:foo)).to eq(threshold)
+    end
+
+    it 'raises error if unknown' do
+      expect { threshold_store.threshold(:unkonwn) }.to raise_error(described_class::KeyNotRecognisedError)
+    end
+
+    context 'with string keyed data' do
+      let(:data) { { 'foo' => threshold } }
+
+      it 'returns threshold' do
+        expect(threshold_store.threshold(:foo)).to eq(threshold)
+      end
+    end
+  end
+
+  describe '.from_yaml_file' do
+    let(:threshold_store) { described_class.from_yaml_file(file_path) }
+
+    it 'returns data from file' do
+      expect(threshold_store.threshold(:ccms)).to eq(data['ccms'].deep_symbolize_keys)
+    end
+
+    context 'using sub-section' do
+      let(:threshold_store) { described_class.from_yaml_file(file_path, section: :ccms) }
+
+      it 'returns data from sub-section of file' do
+        expect(threshold_store.threshold(:capital_upper)).to eq(data['ccms']['capital_upper'])
+      end
+    end
+  end
+
+  describe '.threshold' do
+    let(:data) { YAML.load_file file_path }
+    let(:subclass) { Class.new(described_class) }
+    let(:configure_subclass) { subclass.use_yml_file(file_path) }
+
+    before { configure_subclass }
+
+    it 'returns data from file' do
+      expect(subclass.threshold(:ccms)).to eq(data['ccms'].deep_symbolize_keys)
+    end
+
+    context 'with subsection defined' do
+      let(:configure_subclass) { subclass.use_yml_file(file_path, section: :ccms) }
+
+      it 'returns data from sub-section of file' do
+        expect(subclass.threshold(:capital_upper)).to eq(data['ccms']['capital_upper'])
+      end
+    end
+  end
+end

--- a/spec/support/file_helpers.rb
+++ b/spec/support/file_helpers.rb
@@ -1,4 +1,7 @@
+def ccms_data_file_path(filename)
+  Rails.root.join 'spec/data/ccms', filename
+end
+
 def ccms_data_from_file(filename)
-  path = Rails.root.join 'spec/data/ccms', filename
-  File.read path
+  File.read ccms_data_file_path(filename)
 end


### PR DESCRIPTION
[Jira AP-617](https://dsdmoj.atlassian.net/browse/AP-617)

Creates a generic class that allows data to be retrieved from a YAML file. Then uses a sub-class of that class to retrieve thresholds set in `config/ccms/threasholds.yml`

With the current configuration you can do this:

```
2.5.3 :001 > CCMS::Threshold.threshold :gross_income_upper
 => {:children=>{:one=>1, :two=>3, :many=>7}} 
2.5.3 :002 > CCMS::Threshold.threshold :capital_upper
 => 10000 
```