### PR TITLE
AP572 & AP582 change other assets page for provider and applicant

### DIFF
--- a/app/assets/javascripts/checkbox_control.es6
+++ b/app/assets/javascripts/checkbox_control.es6
@@ -12,6 +12,8 @@ $(function() {
     const control = $(container.data('deselect-ctrl'))
     const checkboxMemory = []
     const checkboxes = container.find("input:checkbox")
+    const hiddenFieldMemory = []
+    const hideableFields = container.find('.govuk-checkboxes__conditional')
 
     if(!control.length) return
 
@@ -26,6 +28,7 @@ $(function() {
     */
     control.change( function() {
       const controlChecked = this.checked
+
       checkboxes.each(function(index) {
         const checkbox = $(this)
         if(controlChecked) {
@@ -33,6 +36,18 @@ $(function() {
           checkbox.prop("checked", false)
         } else {
           checkbox.prop("checked", checkboxMemory[index])
+        }
+      })
+
+      hideableFields.each(function (index) {
+        const hideableField = $(this)
+        if (controlChecked) {
+          if (!hideableField.hasClass('govuk-checkboxes__conditional--hidden')) {
+            hideableField.addClass('govuk-checkboxes__conditional--hidden')
+            hiddenFieldMemory[index] = true
+          }
+        } else if (hiddenFieldMemory[index]){
+            hideableField.removeClass('govuk-checkboxes__conditional--hidden')
         }
       })
     })

--- a/app/controllers/citizens/other_assets_controller.rb
+++ b/app/controllers/citizens/other_assets_controller.rb
@@ -8,11 +8,9 @@ module Citizens
 
     def update
       @form = Citizens::OtherAssetsForm.new(form_params)
-      if @form.save
-        go_forward
-      else
-        render :show
-      end
+      return go_forward if @form.save
+
+      render :show
     end
 
     private
@@ -22,7 +20,7 @@ module Citizens
     end
 
     def form_params
-      merge_with_model(declaration) do
+      merge_with_model(declaration, mode: :citizen) do
         attrs = Citizens::OtherAssetsForm::ALL_ATTRIBUTES + Citizens::OtherAssetsForm::CHECK_BOXES_ATTRIBUTES
         params[:other_assets_declaration].permit(*attrs)
       end

--- a/app/controllers/providers/other_assets_controller.rb
+++ b/app/controllers/providers/other_assets_controller.rb
@@ -18,7 +18,7 @@ module Providers
     end
 
     def form_params
-      merge_with_model(declaration) do
+      merge_with_model(declaration, mode: :provider) do
         attrs = Citizens::OtherAssetsForm::ALL_ATTRIBUTES + Citizens::OtherAssetsForm::CHECK_BOXES_ATTRIBUTES
         params[:other_assets_declaration].permit(*attrs)
       end

--- a/app/views/citizens/other_assets/show.html.erb
+++ b/app/views/citizens/other_assets/show.html.erb
@@ -1,9 +1,10 @@
-<%= page_template page_title: t('.h1-heading') do %>
-
+<%= page_template page_title: t('.h1-heading'), template: :basic, show_errors_for: @form do %>
   <%= render partial: '/shared/forms/other_assets/form',
              locals: {
                model: @form,
-               url: citizens_other_assets_path
+               url: citizens_other_assets_path,
+               sub_heading: t('.h2-heading'),
+               or_break: t('.or_break'),
+               none_selected: t('.none_selected')
              } %>
-
 <% end %>

--- a/app/views/providers/other_assets/show.html.erb
+++ b/app/views/providers/other_assets/show.html.erb
@@ -1,8 +1,11 @@
-<%= page_template page_title: t('.h1-heading') do %>
-  <%= render partial: '/shared/forms/other_assets/form',
-             locals: {
-               model: @form,
-               show_draft: true,
-               url: providers_legal_aid_application_other_assets_path(@legal_aid_application)
-             } %>
+<%= page_template page_title: t('.h1-heading'), template: :basic, show_errors_for: @form do %>
+    <%= render partial: '/shared/forms/other_assets/form',
+               locals: {
+                 model: @form,
+                 show_draft: true,
+                 sub_heading: t('.h2-heading'),
+                 or_break: t('.or_break'),
+                 none_selected: t('.none_selected'),
+                 url: providers_legal_aid_application_other_assets_path(@legal_aid_application)
+               } %>
 <% end %>

--- a/app/views/shared/forms/other_assets/_form.html.erb
+++ b/app/views/shared/forms/other_assets/_form.html.erb
@@ -1,15 +1,37 @@
+<%
+none_selected_id = '#other_assets_declaration_check_box_none_selected'
+%>
 <%= form_with(model: model, url: url, method: :patch, local: true) do |form| %>
 
-  <div class="govuk-form-group">
+  <%= govuk_form_group show_error_if: (@form.errors.present? && !@form.any_checkbox_checked?) do %>
+    <%= govuk_fieldset_header do %>
+      <h1 class="govuk-fieldset__heading govuk-!-padding-bottom-7"><%= page_title %></h1>
+      <h2 class="govuk-heading-m"><%= sub_heading %></h2>
+    <% end %>
     <fieldset class="govuk-fieldset" aria-describedby="citizenship-conditional-hint">
       <div class="govuk-checkboxes" data-module="checkboxes">
-        <%= render partial: '/shared/forms/other_assets/second_home_conditional_checkbox', locals: { model: model, form: form } %>
-        <%= render partial: '/shared/forms/revealing_checkbox/attribute',
-                   collection: Citizens::OtherAssetsForm::SINGLE_VALUE_ATTRIBUTES,
-                   locals: { model: model, form: form } %>
+        <div class="deselect-group" data-deselect-ctrl="<%= none_selected_id %>">
+          <%= render partial: '/shared/forms/revealing_checkbox/attribute',
+                     collection: Citizens::OtherAssetsForm::VALUABLE_ITEMS_VALUE_ATTRIBUTE,
+                     locals: { model: model, form: form } %>
+          <%= render partial: '/shared/forms/other_assets/second_home_conditional_checkbox', locals: { model: model, form: form } %>
+          <%= render partial: '/shared/forms/revealing_checkbox/attribute',
+                     collection: Citizens::OtherAssetsForm::SINGLE_VALUE_ATTRIBUTES,
+                     locals: { model: model, form: form } %>
+        </div>
       </div>
+
+      <p class="govuk-!-padding-top-4"><%= or_break %></p>
+
+      <div class="govuk-checkboxes">
+        <div class="govuk-checkboxes__item">
+          <%= form.check_box('check_box_none_selected', { class: 'govuk-checkboxes__input' }, 'true', false) %>
+          <%= form.label('check_box_none_selected', none_selected, class: 'govuk-label govuk-checkboxes__label') %>
+        </div>
+      </div>
+
     </fieldset>
-  </div>
+  <% end %>
 
   <%= next_action_buttons(
         show_draft: local_assigns.key?(:show_draft) ? show_draft : false,

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -162,11 +162,11 @@ en:
               blank: Enter explanation of why you think legal aid should be granted
         other_assets_declaration:
           attributes:
-            jewellery_value:
+            valuable_items_value:
               blank: Enter the estimated total value of valuable items
-              greater_than_or_equal_to: Estimated jewellery value must be 0 or more
+              greater_than_or_equal_to: Estimated valuable item value must be 0 or more
               not_a_number: Estimated valuable items value must be an amount of money, like 60,000
-              too_many_decimals: Estimated jewellery value must not include more than 2 decimal numbers
+              too_many_decimals: Estimated valuable items value must not include more than 2 decimal numbers
             land_value:
               blank: Enter the estimated land value
               greater_than_or_equal_to: Estimated land value must be 0 or more
@@ -197,16 +197,21 @@ en:
               greater_than_or_equal_to: Estimated second home value must be 0 or more
               not_a_number: Estimated value must be an amount of money, like 60,000
               too_many_decimals: Estimated second home value must not include more than 2 decimal numbers
-            timeshare_value:
-              blank: Enter the estimated timeshare value
+            timeshare_property_value:
+              blank: Enter the estimated timeshare property value
               greater_than_or_equal_to: Estimated timeshare value must be 0 or more
-              not_a_number: Estimated timeshare value must be an amount of money, like 60,000
+              not_a_number: Estimated timeshare property value must be an amount of money, like 60,000
               too_many_decimals: Estimated timeshare value must not include more than 2 decimal numbers
             trust_value:
               blank: Enter the estimated value of trust
               greater_than_or_equal_to: Estimated trust value must be 0 or more
               not_a_number: Estimated trust value must be an amount of money, like 60,000
               too_many_decimals: Estimated trust value must not include more than 2 decimal numbers
+            base:
+              citizen:
+                none_selected: Select if you have any of these types of assets              
+              provider:
+                none_selected: Select if your client has any of these types of assets
         respondent:
           attributes:
             understands_terms_of_court_order:

--- a/config/locales/en/citizens.yml
+++ b/config/locales/en/citizens.yml
@@ -67,7 +67,7 @@ en:
         submit_button: Agree and submit
     identify_types_of_incomes:
       show:
-        page_heading: What types of income do you receive?
+        page_heading: Which types of income do you receive?
     identify_types_of_outgoings:
       show:
         page_heading: What regular payments do you make?
@@ -105,7 +105,10 @@ en:
           situation and the details of your case.
     other_assets:
       show:
-        h1-heading: Do you have any of the following?
+        h1-heading: Which types of assets do you have?
+        h2-heading: Select all that apply
+        or_break: or
+        none_selected: None of these
     outstanding_mortgages:
       field_set_header: What is the outstanding mortgage on your home?
       hint: Check the statement from your mortgage provider or lender

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -196,7 +196,10 @@ en:
         heading: Does your client use online banking?
     other_assets:
       show:
-        h1-heading: Does your client have any of the following?
+        h1-heading: Which types of assets does your client have?
+        h2-heading: Select all that apply
+        or_break: or
+        none_selected: None of these
     outgoings_summary:
       add_other_outgoings:
         add_other_outgoings: Add another type of regular payment

--- a/config/locales/en/shared.yml
+++ b/config/locales/en/shared.yml
@@ -71,21 +71,23 @@ en:
         attribute:
           citizens:
             other_assets:
-              check_box_jewellery_value: Jewellery, art or antiques with a value over £500
+              check_box_valuable_items_value: Any valuable items worth more than £500
               check_box_land_value: Land
               check_box_money_assets_value: Money or assets from the estate of a person who has died
               check_box_money_owed_value: Money owed to you, including from a private mortgage
               check_box_second_home_mortgage: Second property or holiday home outstanding mortgage amount
               check_box_second_home_percentage: Second property or holiday home percentage owned
               check_box_second_home_value: Second property or holiday home estimated value
-              check_box_timeshare_value: Timeshare
+              check_box_timeshare_property_value: Timeshare property
               check_box_trust_value: Interest in a trust
-              jewellery_value: Enter estimated value, minus any sale costs
+              valuable_items_value: Enter estimated total value, minus any sale costs
               land_value: Enter estimated value
               money_assets_value: Enter estimated total value
               money_owed_value: Enter estimated amount owed
-              timeshare_value: Enter value, minus any loan and sale costs
+              timeshare_property_value: Enter value, minus any loan and sale costs
               trust_value: Enter estimated total value
+              hint:
+                check_box_valuable_items_value: For example, jewellery, art or antiques. Do not include wedding or engagement rings, furniture, clothing or tools used for work.
             savings_and_investments:
               cash: Enter total amount
               check_box_cash: Cash savings
@@ -107,21 +109,23 @@ en:
               plc_shares: Enter the total value of all you own
           providers:
             other_assets:
-              check_box_jewellery_value: Jewellery, art or antiques with a value over £500
+              check_box_valuable_items_value: Any valuable items worth more than £500
               check_box_land_value: Land
               check_box_money_assets_value: Money or assets from the estate of a person who has died
-              check_box_money_owed_value: Money owed to you, including from a private mortgage
+              check_box_money_owed_value: Money owed to them, including from a private mortgage
               check_box_second_home_mortgage: Second property or holiday home outstanding mortgage amount
               check_box_second_home_percentage: Second property or holiday home percentage owned
               check_box_second_home_value: Second property or holiday home estimated value
-              check_box_timeshare_value: Timeshare
+              check_box_timeshare_property_value: Timeshare property
               check_box_trust_value: Interest in a trust
-              jewellery_value: Enter estimated value, minus any sale costs
+              valuable_items_value: Enter estimated total value, minus any sale costs
               land_value: Enter estimated value
               money_assets_value: Enter estimated total value
               money_owed_value: Enter estimated amount owed
-              timeshare_value: Enter value, minus any loan and sale costs
+              timeshare_property_value: Enter value, minus any loan and sale costs
               trust_value: Enter estimated total value
+              hint:
+                check_box_valuable_items_value: For example, jewellery, art or antiques. Do not include wedding or engagement rings, furniture, clothing or tools used for work.
             savings_and_investments:
               cash: Enter total amount
               check_box_cash: Cash savings

--- a/db/migrate/20190523115648_rename_other_assets_declarations_columns.rb
+++ b/db/migrate/20190523115648_rename_other_assets_declarations_columns.rb
@@ -1,0 +1,6 @@
+class RenameOtherAssetsDeclarationsColumns < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :other_assets_declarations, :jewellery_value, :valuable_items_value
+    rename_column :other_assets_declarations, :timeshare_value, :timeshare_property_value
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -297,9 +297,9 @@ ActiveRecord::Schema.define(version: 2019_05_29_164413) do
     t.decimal "second_home_value", precision: 14, scale: 2
     t.decimal "second_home_mortgage", precision: 14, scale: 2
     t.decimal "second_home_percentage", precision: 14, scale: 2
-    t.decimal "timeshare_value", precision: 14, scale: 2
+    t.decimal "timeshare_property_value", precision: 14, scale: 2
     t.decimal "land_value", precision: 14, scale: 2
-    t.decimal "jewellery_value", precision: 14, scale: 2
+    t.decimal "valuable_items_value", precision: 14, scale: 2
     t.decimal "money_assets_value", precision: 14, scale: 2
     t.decimal "money_owed_value", precision: 14, scale: 2
     t.decimal "trust_value", precision: 14, scale: 2

--- a/features/citizens/citizens.feature
+++ b/features/citizens/citizens.feature
@@ -21,7 +21,7 @@ Feature: Citizen journey
     Then I should be on a page showing "Do you have accounts with other banks?"
     Then I choose "No"
     Then I click 'Save and continue'
-    Then I should be on a page showing "What types of income do you receive?"
+    Then I should be on a page showing "Which types of income do you receive?"
     And I select 'None of these'
     Then I click 'Save and continue'
     Then I should be on a page showing "What regular payments do you make?"
@@ -62,7 +62,7 @@ Feature: Citizen journey
     Then I select "Cash savings"
     Then I fill "Cash" with "100"
     Then I click 'Save and continue'
-    Then I should be on a page showing "Do you have any of the following?"
+    Then I should be on a page showing "Which types of assets do you have?"
     Then I select "Land"
     Then I fill "Land value" with "50000"
     Then I click 'Save and continue'
@@ -176,7 +176,7 @@ Feature: Citizen journey
     Given I have completed an application
     And I complete the citizen journey as far as check your answers
     And I click Check Your Answers Change link for 'Other assets'
-    Then I should be on a page showing 'Do you have any of the following?'
+    Then I should be on a page showing 'Which types of assets do you have?'
     Then I fill 'Land value' with '1234.56'
     Then I click 'Save and continue'
     Then I should be on a page showing 'Do any of the following restrictions apply to your property or other assets?'
@@ -190,14 +190,14 @@ Feature: Citizen journey
     Given I have completed an application
     And I complete the citizen journey as far as check your answers
     And I click Check Your Answers Change link for 'Other assets'
-    Then I should be on a page showing 'Do you have any of the following?'
-    Then I select 'Timeshare'
-    Then I fill 'Timeshare value' with '10000'
+    Then I should be on a page showing 'Which types of assets do you have?'
+    Then I select 'Timeshare property'
+    Then I fill 'Timeshare property value' with '10000'
     Then I click 'Save and continue'
     Then I should be on a page showing 'Do any of the following restrictions apply to your property or other assets?'
     Then I click 'Save and continue'
     Then I should be on a page showing 'Check your answers'
-    And the answer for 'Other assets' should be 'Timeshare'
+    And the answer for 'Other assets' should be 'Timeshare property'
     And the answer for 'Other assets' should be '£10,000.00'
 
   @javascript
@@ -205,7 +205,7 @@ Feature: Citizen journey
     Given I have completed an application
     And I complete the citizen journey as far as check your answers
     And I click Check Your Answers Change link for 'Other assets'
-    Then I should be on a page showing 'Do you have any of the following?'
+    Then I should be on a page showing 'Which types of assets do you have?'
     Then I click 'Save and continue'
     Then I should be on a page showing 'Do any of the following restrictions apply to your property or other assets?'
     Then I click 'Save and continue'

--- a/features/providers/check_your_answers.feature
+++ b/features/providers/check_your_answers.feature
@@ -105,7 +105,7 @@ Feature: Checking answers backwards and forwards
     Then I view the previously created application
     Then I am on the check your answers page for other assets
     And I click Check Your Answers Change link for 'other assets'
-    Then I should be on a page showing 'Does your client have any of the following?'
+    Then I should be on a page showing 'Which types of assets does your client have?'
     Then I select 'Land'
     Then I fill 'land_value' with '20,000'
     Then I click 'Save and continue'
@@ -121,7 +121,8 @@ Feature: Checking answers backwards and forwards
     Then I view the previously created application
     Then I am on the check your answers page for other assets
     And I click Check Your Answers Change link for 'other assets'
-    Then I should be on a page showing 'Does your client have any of the following?'
+    Then I should be on a page showing 'Which types of assets does your client have?'
+    Then I select 'None of these'
     Then I click 'Save and continue'
     Then I am on the check your answers page for other assets
     And the answer for 'Other assets' should be 'None declared'
@@ -170,7 +171,7 @@ Feature: Checking answers backwards and forwards
     Scenario: I want to view other assets via the capital check your answers page
       Given I complete the passported journey as far as capital check your answers
       And I click Check Your Answers Change link for 'Other assets'
-      Then I should be on a page showing 'Does your client have any of the following?'
+      Then I should be on a page showing 'Which types of assets does your client have?'
       Then I click 'Save and continue'
       Then I click 'Save and continue'
       Then I should be on a page showing 'Check your answers'

--- a/features/providers/civil_application_journey.feature
+++ b/features/providers/civil_application_journey.feature
@@ -392,7 +392,7 @@ Feature: Civil application journeys
     Then I select "Cash savings"
     Then I fill "Cash" with "10000"
     Then I click 'Save and continue'
-    Then I should be on a page showing "Does your client have any of the following?"
+    Then I should be on a page showing "Which types of assets does your client have?"
     Then I select "Land"
     Then I fill "Land value" with "50000"
     Then I click 'Save and continue'
@@ -404,7 +404,7 @@ Feature: Civil application journeys
     Then I click link "Back"
     Then I should be on a page showing "Do any of the following restrictions apply to your client's property or other assets?"
     Then I click link "Back"
-    Then I should be on a page showing "Does your client have any of the following?"
+    Then I should be on a page showing "Which types of assets does your client have?"
     Then I click link "Back"
     Then I should be on a page showing "Does your client have any savings and investments?"
     Then I click link "Back"

--- a/spec/factories/other_assets_declarations.rb
+++ b/spec/factories/other_assets_declarations.rb
@@ -12,9 +12,9 @@ FactoryBot.define do
       second_home_value { Faker::Number.decimal(6, 2) }
       second_home_mortgage { Faker::Number.decimal(6, 2) }
       second_home_percentage { Faker::Number.decimal(2, 2) }
-      timeshare_value { Faker::Number.decimal(6, 2) }
+      timeshare_property_value { Faker::Number.decimal(6, 2) }
       land_value { Faker::Number.decimal(6, 2) }
-      jewellery_value { Faker::Number.decimal(6, 2) }
+      valuable_items_value { Faker::Number.decimal(6, 2) }
       money_assets_value { Faker::Number.decimal(6, 2) }
       money_owed_value { Faker::Number.decimal(6, 2) }
       trust_value { Faker::Number.decimal(6, 2) }
@@ -24,9 +24,9 @@ FactoryBot.define do
       second_home_value { nil }
       second_home_mortgage { nil }
       second_home_percentage { nil }
-      timeshare_value { nil }
+      timeshare_property_value { nil }
       land_value { nil }
-      jewellery_value { nil }
+      valuable_items_value { nil }
       money_assets_value { nil }
       money_owed_value { nil }
       trust_value { nil }
@@ -36,9 +36,9 @@ FactoryBot.define do
       second_home_value { 0.0 }
       second_home_mortgage { 0.0 }
       second_home_percentage { 0.0 }
-      timeshare_value { 0.0 }
+      timeshare_property_value { 0.0 }
       land_value { 0.0 }
-      jewellery_value { 0.0 }
+      valuable_items_value { 0.0 }
       money_assets_value { 0.0 }
       money_owed_value { 0.0 }
       trust_value { 0.0 }
@@ -48,9 +48,9 @@ FactoryBot.define do
       second_home_value { Faker::Number.decimal(6, 2) }
       second_home_mortgage { Faker::Number.decimal(6, 2) }
       second_home_percentage { Faker::Number.decimal(6, 2) }
-      timeshare_value { Faker::Number.decimal(6, 2) }
+      timeshare_property_value { Faker::Number.decimal(6, 2) }
       land_value { nil }
-      jewellery_value { 0.0 }
+      valuable_items_value { 0.0 }
       money_assets_value { 0.0 }
       money_owed_value { nil }
       trust_value { 0.0 }

--- a/spec/forms/citizens/other_assets_form_spec.rb
+++ b/spec/forms/citizens/other_assets_form_spec.rb
@@ -17,7 +17,8 @@ RSpec.describe Citizens::OtherAssetsForm do
       { check_box_second_home: '',
         second_home_value: '',
         second_home_mortgage: '',
-        second_home_percentage: '' }
+        second_home_percentage: '',
+        check_box_none_selected: 'true' }
     end
 
     let(:alpha_second_home_params) do
@@ -94,18 +95,19 @@ RSpec.describe Citizens::OtherAssetsForm do
         second_home_value: '859,374.00',
         second_home_mortgage: '123,000.00',
         second_home_percentage: '66.66',
-        check_box_timeshare_value: 'true',
-        timeshare_value: '67762',
+        check_box_timeshare_property_value: 'true',
+        timeshare_property_value: '67762',
         check_box_land_value: 'true',
         land_value: '1,234.55',
-        check_box_jewellery_value: 'true',
-        jewellery_value: '566.0',
+        check_box_valuable_items_value: 'true',
+        valuable_items_value: '566.0',
         check_box_money_assets_value: 'true',
         money_assets_value: '3,500',
         check_box_money_owed_value: 'true',
         money_owed_value: '0.45',
         check_box_trust_value: 'true',
-        trust_value: '3,560,622.77' }
+        trust_value: '3,560,622.77',
+        check_box_none_selected: '' }
     end
 
     describe 'instantiation' do
@@ -125,7 +127,7 @@ RSpec.describe Citizens::OtherAssetsForm do
             end
 
             context 'no form fields present' do
-              let(:submitted_params) { {} }
+              let(:submitted_params) { { check_box_none_selected: 'true' } }
 
               it 'is valid' do
                 expect(form).to be_valid
@@ -138,9 +140,9 @@ RSpec.describe Citizens::OtherAssetsForm do
 
             it 'is not valid' do
               expect(form).not_to be_valid
-              expect(form.errors[:timeshare_value]).to eq [translation_for(:timeshare_value, 'not_a_number')]
+              expect(form.errors[:timeshare_property_value]).to eq [translation_for(:timeshare_property_value, 'not_a_number')]
               expect(form.errors[:land_value]).to eq [translation_for(:land_value, 'not_a_number')]
-              expect(form.errors[:jewellery_value]).to eq [translation_for(:jewellery_value, 'not_a_number')]
+              expect(form.errors[:valuable_items_value]).to eq [translation_for(:valuable_items_value, 'not_a_number')]
               expect(form.errors[:money_assets_value]).to eq [translation_for(:money_assets_value, 'not_a_number')]
               expect(form.errors[:money_owed_value]).to eq [translation_for(:money_owed_value, 'not_a_number')]
               expect(form.errors[:trust_value]).to eq [translation_for(:trust_value, 'not_a_number')]
@@ -160,9 +162,9 @@ RSpec.describe Citizens::OtherAssetsForm do
         expect(oad.second_home_value).to eq 859_374.0
         expect(oad.second_home_mortgage).to eq 123_000.0
         expect(oad.second_home_percentage).to eq 66.66
-        expect(oad.timeshare_value).to eq 67_762.0
+        expect(oad.timeshare_property_value).to eq 67_762.0
         expect(oad.land_value).to eq 1_234.55
-        expect(oad.jewellery_value).to eq 566.0
+        expect(oad.valuable_items_value).to eq 566.0
         expect(oad.money_assets_value).to eq 3_500.0
         expect(oad.money_owed_value).to eq 0.45
         expect(oad.trust_value).to eq 3_560_622.77

--- a/spec/requests/citizens/other_assets_spec.rb
+++ b/spec/requests/citizens/other_assets_spec.rb
@@ -30,22 +30,49 @@ RSpec.describe 'citizen other assets requests', type: :request do
           second_home_value: '875123',
           second_home_mortgage: '125,345.67',
           second_home_percentage: '64.440',
-          check_box_timeshare_value: 'true',
-          timeshare_value: '234,567.89',
+          check_box_timeshare_property_value: 'true',
+          timeshare_property_value: '234,567.89',
           check_box_land_value: 'true',
           land_value: '34,567.89',
-          check_box_jewellery_value: 'true',
-          jewellery_value: '456,789.01',
+          check_box_valuable_items_value: 'true',
+          valuable_items_value: '456,789.01',
           check_box_money_assets_value: 'true',
           money_assets_value: '89,012.34',
           check_box_money_owed_value: 'true',
           money_owed_value: '90,123.45',
           check_box_trust_value: 'true',
-          trust_value: '1,234.56'
+          trust_value: '1,234.56',
+          check_box_none_selected: ''
         },
         commit: 'Continue'
       }
     end
+
+    let(:empty_params) do
+      {
+        other_assets_declaration: {
+          check_box_second_home: '',
+          second_home_value: '',
+          second_home_mortgage: '',
+          second_home_percentage: '',
+          check_box_timeshare_property_value: '',
+          timeshare_property_value: '',
+          check_box_land_value: '',
+          land_value: '',
+          check_box_valuable_items_value: '',
+          valuable_items_value: '',
+          check_box_money_assets_value: '',
+          money_assets_value: '',
+          check_box_money_owed_value: '',
+          money_owed_value: '',
+          check_box_trust_value: '',
+          trust_value: '',
+          check_box_none_selected: check_box_none_selected
+        }
+      }
+    end
+
+    let(:check_box_none_selected) { '' }
 
     context 'valid params' do
       it 'updates the record' do
@@ -53,9 +80,9 @@ RSpec.describe 'citizen other assets requests', type: :request do
         expect(oad.second_home_value).to eq 875_123
         expect(oad.second_home_mortgage).to eq 125_345.67
         expect(oad.second_home_percentage).to eq 64.44
-        expect(oad.timeshare_value).to eq 234_567.89
+        expect(oad.timeshare_property_value).to eq 234_567.89
         expect(oad.land_value).to eq 34_567.89
-        expect(oad.jewellery_value).to eq 456_789.01
+        expect(oad.valuable_items_value).to eq 456_789.01
         expect(oad.money_assets_value).to eq 89_012.34
         expect(oad.money_owed_value).to eq 90_123.45
         expect(oad.trust_value).to eq 1_234.56
@@ -79,6 +106,14 @@ RSpec.describe 'citizen other assets requests', type: :request do
 
         it 'redirects to check answers page' do
           expect(response).to redirect_to(citizens_check_answers_path)
+        end
+
+        context 'and none of these checkbox is not selected' do
+          let(:check_box_none_selected) { '' }
+          before { patch citizens_other_assets_path, params: empty_params }
+          it 'the response includes the error message' do
+            expect(response.body).to include(I18n.t('activemodel.errors.models.other_assets_declaration.attributes.base.citizen.none_selected'))
+          end
         end
       end
     end

--- a/spec/requests/providers/other_assets_spec.rb
+++ b/spec/requests/providers/other_assets_spec.rb
@@ -38,18 +38,19 @@ RSpec.describe 'provider other assets requests', type: :request do
           second_home_value: '875123',
           second_home_mortgage: '125,345.67',
           second_home_percentage: '64.440',
-          check_box_timeshare_value: 'true',
-          timeshare_value: '234,567.89',
+          check_box_timeshare_property_value: 'true',
+          timeshare_property_value: '234,567.89',
           check_box_land_value: 'true',
           land_value: '34,567.89',
-          check_box_jewellery_value: 'true',
-          jewellery_value: '456,789.01',
+          check_box_valuable_items_value: 'true',
+          valuable_items_value: '456,789.01',
           check_box_money_assets_value: 'true',
           money_assets_value: '89,012.34',
           check_box_money_owed_value: 'true',
           money_owed_value: '90,123.45',
           check_box_trust_value: 'true',
-          trust_value: '1,234.56'
+          trust_value: '1,234.56',
+          check_box_none_selected: ''
         }
       }
     end
@@ -61,21 +62,24 @@ RSpec.describe 'provider other assets requests', type: :request do
           second_home_value: '',
           second_home_mortgage: '',
           second_home_percentage: '',
-          check_box_timeshare_value: '',
-          timeshare_value: '',
+          check_box_timeshare_property_value: '',
+          timeshare_property_value: '',
           check_box_land_value: '',
           land_value: '',
-          check_box_jewellery_value: '',
-          jewellery_value: '',
+          check_box_valuable_items_value: '',
+          valuable_items_value: '',
           check_box_money_assets_value: '',
           money_assets_value: '',
           check_box_money_owed_value: '',
           money_owed_value: '',
           check_box_trust_value: '',
-          trust_value: ''
+          trust_value: '',
+          check_box_none_selected: check_box_none_selected
         }
       }
     end
+
+    let(:check_box_none_selected) { '' }
 
     context 'when the provider is authenticated' do
       before do
@@ -86,6 +90,7 @@ RSpec.describe 'provider other assets requests', type: :request do
         let(:submit_button) do
           { continue_button: 'Continue' }
         end
+
         before do
           patch providers_legal_aid_application_other_assets_path(oad.legal_aid_application), params: params.merge(submit_button)
         end
@@ -96,9 +101,9 @@ RSpec.describe 'provider other assets requests', type: :request do
             expect(oad.second_home_value).to eq 875_123
             expect(oad.second_home_mortgage).to eq 125_345.67
             expect(oad.second_home_percentage).to eq 64.44
-            expect(oad.timeshare_value).to eq 234_567.89
+            expect(oad.timeshare_property_value).to eq 234_567.89
             expect(oad.land_value).to eq 34_567.89
-            expect(oad.jewellery_value).to eq 456_789.01
+            expect(oad.valuable_items_value).to eq 456_789.01
             expect(oad.money_assets_value).to eq 89_012.34
             expect(oad.money_owed_value).to eq 90_123.45
             expect(oad.trust_value).to eq 1_234.56
@@ -123,6 +128,7 @@ RSpec.describe 'provider other assets requests', type: :request do
           context 'has savings and investments' do
             let(:oad) { create :other_assets_declaration }
             let(:application) { oad.legal_aid_application }
+            let(:check_box_none_selected) { 'true' }
 
             before do
               application.create_savings_amount!
@@ -142,6 +148,7 @@ RSpec.describe 'provider other assets requests', type: :request do
           context 'has own home' do
             let(:application) { create :legal_aid_application, :with_own_home_mortgaged }
             let(:oad) { create :other_assets_declaration, legal_aid_application: application }
+            let(:check_box_none_selected) { 'true' }
 
             before do
               patch providers_legal_aid_application_other_assets_path(oad.legal_aid_application), params: empty_params.merge(submit_button)
@@ -159,6 +166,7 @@ RSpec.describe 'provider other assets requests', type: :request do
             let(:state) { :checking_passported_answers }
             let(:application) { create :legal_aid_application, :without_own_home, state: state }
             let(:oad) { create :other_assets_declaration, legal_aid_application: application }
+            let(:check_box_none_selected) { 'true' }
 
             before do
               patch providers_legal_aid_application_other_assets_path(oad.legal_aid_application), params: empty_params.merge(submit_button)
@@ -183,16 +191,26 @@ RSpec.describe 'provider other assets requests', type: :request do
           context 'has nothing' do
             let(:oad) { create :other_assets_declaration }
             let(:application) { oad.legal_aid_application }
+            let(:check_box_none_selected) { 'true' }
 
             before do
               patch providers_legal_aid_application_other_assets_path(oad.legal_aid_application), params: empty_params.merge(submit_button)
             end
 
-            it 'redirects to check passported answers' do
-              expect(application.reload.other_assets?).to be false
-              expect(application.own_home?).to be false
-              expect(application.savings_amount?).to be false
-              expect(response).to redirect_to(providers_legal_aid_application_check_passported_answers_path(application))
+            context 'with none of these checkbox selected' do
+              it 'redirects to check passported answers' do
+                expect(application.reload.other_assets?).to be false
+                expect(application.own_home?).to be false
+                expect(application.savings_amount?).to be false
+                expect(response).to redirect_to(providers_legal_aid_application_check_passported_answers_path(application))
+              end
+            end
+            context 'and none of these checkbox is not selected' do
+              let(:check_box_none_selected) { '' }
+
+              it 'the response includes the error message' do
+                expect(response.body).to include(I18n.t('activemodel.errors.models.other_assets_declaration.attributes.base.provider.none_selected'))
+              end
             end
           end
         end
@@ -238,9 +256,9 @@ RSpec.describe 'provider other assets requests', type: :request do
             expect(oad.second_home_value).to eq 875_123
             expect(oad.second_home_mortgage).to eq 125_345.67
             expect(oad.second_home_percentage).to eq 64.44
-            expect(oad.timeshare_value).to eq 234_567.89
+            expect(oad.timeshare_property_value).to eq 234_567.89
             expect(oad.land_value).to eq 34_567.89
-            expect(oad.jewellery_value).to eq 456_789.01
+            expect(oad.valuable_items_value).to eq 456_789.01
             expect(oad.money_assets_value).to eq 89_012.34
             expect(oad.money_owed_value).to eq 90_123.45
             expect(oad.trust_value).to eq 1_234.56
@@ -274,7 +292,7 @@ RSpec.describe 'provider other assets requests', type: :request do
             end
 
             it 'redirects to provider applications page' do
-              expect(application.reload.other_assets?).to be true
+              expect(application.reload.other_assets?).to be false
               expect(application.own_home?).to be false
               expect(application.savings_amount?).to be true
               expect(response).to redirect_to providers_legal_aid_applications_path
@@ -285,6 +303,7 @@ RSpec.describe 'provider other assets requests', type: :request do
             let(:application) { create :legal_aid_application, :with_own_home_mortgaged }
             let(:oad) { create :other_assets_declaration, legal_aid_application: application }
             let(:params) { empty_params }
+            let(:check_box_none_selected) { 'true' }
 
             it 'redirects to provider applications page' do
               expect(application.reload.other_assets?).to be false
@@ -298,6 +317,7 @@ RSpec.describe 'provider other assets requests', type: :request do
             let(:oad) { create :other_assets_declaration }
             let(:application) { oad.legal_aid_application }
             let(:params) { empty_params }
+            let(:check_box_none_selected) { 'true' }
 
             it 'redirects to provider applications page' do
               expect(application.reload.other_assets?).to be false


### PR DESCRIPTION
AP572 & AP582 change other assets page for provider and applicant

[Link to provider other assets story](https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=233&projectKey=AP&modal=detail&selectedIssue=AP-572)

[Link to applicant other assets story](https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=233&projectKey=AP&modal=detail&selectedIssue=AP-582)

- Changed the order of the options and the content as written in the user stories. 
- Added a 'Select all that apply header'
- Updated jewellery_value to valuable_items_value within the app and database (via migration file) as this now takes a total value of valuable items.
-------------------------
- Updated Timeshare name to Timeshare property within the database (via a migration file) and app.
- Added Javascript for the none_selected checkbox feature.
- Updated forms to handle validation of no checkbox selected
- Added error for when no checkboxes are selected at all and an error bar is shown across the side of the page to include the title.
-------------------------
- Included this into the user story > Changed 'What types of income do you receive?' on the /citizens/identify_types_of_income to 'Which types of income do you receive?'

- Updated error messages
- Updated tests.
-------------------------
## Checklist

Before you ask people to review this PR:

- [X] Tests and rubocop should be passing: `bundle exec rake`
- [X] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [X] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [X] The PR description should say what you changed and why, with a link to the JIRA story.
- [X] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [X] You should have checked that the commit messages say why the change was made.
