### PR TITLE
AP-613 - CCMS document upload requestors and parsers

### DIFF
--- a/app/services/ccms/document_id_requestor.rb
+++ b/app/services/ccms/document_id_requestor.rb
@@ -1,0 +1,48 @@
+module CCMS
+  class DocumentIdRequestor < BaseRequestor
+    wsdl_from 'DocumentServicesWsdl.xml'.freeze
+
+    uses_namespaces(
+      'xmlns:xsd' => 'http://www.w3.org/2001/XMLSchema',
+      'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance',
+      'xmlns:soap' => 'http://schemas.xmlsoap.org/soap/envelope/',
+      'xmlns:ns1' => 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd',
+      'xmlns:ns2' => 'http://legalservices.gov.uk/CCMS/CaseManagement/Case/1.0/CaseBIM',
+      'xmlns:ns3' => 'http://legalservices.gov.uk/Enterprise/Common/1.0/Header',
+      'xmlns:ns4' => 'http://legalservices.gov.uk/CCMS/CaseManagement/Case/1.0/CaseBIO'
+    )
+
+    attr_reader :case_ccms_reference
+
+    def initialize(case_ccms_reference)
+      @case_ccms_reference = case_ccms_reference
+    end
+
+    # temporarily ignore this until connectivity with ccms is working
+    # :nocov:
+    def call
+      soap_client.call(:process, xml: request_xml)
+    end
+    # :nocov:
+
+    private
+
+    def request_xml
+      soap_envelope(namespaces).to_xml
+    end
+
+    def soap_body(xml)
+      xml.__send__('ns2:DocumentUploadRQ') do
+        xml.__send__('ns3:HeaderRQ') { ns3_header_rq(xml) }
+        xml.__send__('ns2:NotificationID', -1)
+        xml.__send__('ns2:CaseReferenceNumber', case_ccms_reference)
+        xml.__send__('ns2:Document') { document(xml) }
+      end
+    end
+
+    def document(xml)
+      xml.__send__('ns4:DocumentType', 'ADMIN1')
+      xml.__send__('ns4:Channel', 'E')
+    end
+  end
+end

--- a/app/services/ccms/document_id_response_parser.rb
+++ b/app/services/ccms/document_id_response_parser.rb
@@ -1,0 +1,20 @@
+module CCMS
+  class DocumentIdResponseParser < BaseResponseParser
+    TRANSACTION_ID_PATH = '//Body//DocumentUploadRS//HeaderRS//TransactionID'.freeze
+    DOCUMENT_ID_PATH = '//Body//DocumentUploadRS//DocumentID'.freeze
+
+    def document_id
+      @document_id ||= parse(:extracted_document_id)
+    end
+
+    private
+
+    def extracted_transaction_request_id
+      text_from(TRANSACTION_ID_PATH)
+    end
+
+    def extracted_document_id
+      text_from(DOCUMENT_ID_PATH)
+    end
+  end
+end

--- a/app/services/ccms/document_upload_requestor.rb
+++ b/app/services/ccms/document_upload_requestor.rb
@@ -1,0 +1,53 @@
+module CCMS
+  class DocumentUploadRequestor < BaseRequestor
+    wsdl_from 'DocumentServicesWsdl.xml'.freeze
+
+    uses_namespaces(
+      'xmlns:xsd' => 'http://www.w3.org/2001/XMLSchema',
+      'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance',
+      'xmlns:soap' => 'http://schemas.xmlsoap.org/soap/envelope/',
+      'xmlns:ns1' => 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd',
+      'xmlns:ns2' => 'http://legalservices.gov.uk/CCMS/CaseManagement/Case/1.0/CaseBIM',
+      'xmlns:ns3' => 'http://legalservices.gov.uk/Enterprise/Common/1.0/Header',
+      'xmlns:ns4' => 'http://legalservices.gov.uk/CCMS/CaseManagement/Case/1.0/CaseBIO'
+    )
+
+    attr_reader :case_ccms_reference, :ccms_document_id, :document_encoded_base64
+
+    def initialize(case_ccms_reference, ccms_document_id, document_encoded_base64)
+      @case_ccms_reference = case_ccms_reference
+      @ccms_document_id = ccms_document_id
+      @document_encoded_base64 = document_encoded_base64
+    end
+
+    # temporarily ignore this until connectivity with ccms is working
+    # :nocov:
+    def call
+      soap_client.call(:process, xml: request_xml)
+    end
+    # :nocov:
+
+    private
+
+    def request_xml
+      soap_envelope(namespaces).to_xml
+    end
+
+    def soap_body(xml)
+      xml.__send__('ns2:DocumentUploadRQ') do
+        xml.__send__('ns3:HeaderRQ') { ns3_header_rq(xml) }
+        xml.__send__('ns2:NotificationID', -1)
+        xml.__send__('ns2:CaseReferenceNumber', case_ccms_reference)
+        xml.__send__('ns2:Document') { document(xml) }
+      end
+    end
+
+    def document(xml)
+      xml.__send__('ns4:CCMSDocumentID', ccms_document_id)
+      xml.__send__('ns4:DocumentType', 'ADMIN1')
+      xml.__send__('ns4:FileExtension', 'pdf')
+      xml.__send__('ns4:Channel', 'E')
+      xml.__send__('ns4:BinData', document_encoded_base64)
+    end
+  end
+end

--- a/app/services/ccms/document_upload_response_parser.rb
+++ b/app/services/ccms/document_upload_response_parser.rb
@@ -1,0 +1,20 @@
+module CCMS
+  class DocumentUploadResponseParser < BaseResponseParser
+    TRANSACTION_ID_PATH = '//Body//DocumentUploadRS//HeaderRS//TransactionRequestID'.freeze
+    STATUS_PATH = '//Body//DocumentUploadRS//HeaderRS//Status'.freeze
+
+    def success?
+      parse(:extracted_status) == 'Success'
+    end
+
+    private
+
+    def extracted_transaction_request_id
+      text_from(TRANSACTION_ID_PATH)
+    end
+
+    def extracted_status
+      text_from(STATUS_PATH)
+    end
+  end
+end

--- a/app/services/ccms/wsdls/DocumentServicesWsdl.xml
+++ b/app/services/ccms/wsdls/DocumentServicesWsdl.xml
@@ -1,0 +1,57 @@
+<wsdl:definitions name="DocumentServices" targetNamespace="http://legalservices.gov.uk/CCMS/CaseManagement/Case/1.0/DocumentServices">
+  <wsdl:documentation>
+    <abstractWSDL>http://ds01za005:8650/soa-infra/services/default/DocumentServices!5.0/DocumentProxyService.wsdl</abstractWSDL>
+  </wsdl:documentation>
+  <plnk:partnerLinkType name="UploadDocument">
+    <plnk:role name="UploadDocumentProvider"><plnk:portType name="tns:UploadDocument"/></plnk:role>
+  </plnk:partnerLinkType>
+  <plnk:partnerLinkType name="DownloadDocument">
+    <plnk:role name="DownloadDocumentProvider"><plnk:portType name="tns:DownloadDocument"/></plnk:role>
+  </plnk:partnerLinkType>
+  <plnk:partnerLinkType name="GetDocumentDetails">
+    <plnk:role name="GetDocumentDetailsProvider"><plnk:portType name="tns:GetDocumentDetails"/></plnk:role>
+  </plnk:partnerLinkType>
+  <wsp:Policy wsu:Id="wss_username_token_service_policy">
+    <sp:SupportingTokens>
+      <wsp:Policy>
+        <sp:UsernameToken sp:IncludeToken="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/AlwaysToRecipient">
+          <wsp:Policy><sp:WssUsernameToken10/></wsp:Policy>
+        </sp:UsernameToken>
+      </wsp:Policy>
+    </sp:SupportingTokens>
+  </wsp:Policy>
+  <wsdl:types>
+    <schema><import namespace="http://legalservices.gov.uk/CCMS/CaseManagement/Case/1.0/CaseBIM" schemaLocation="http://ds01za005:8650/soa-infra/services/default/DocumentServices/apps/lsc/Schema/BusinessObjects/CCMS/CaseManagement/Case/1.0/CaseBIM.xsd"/><import
+      namespace="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"
+      schemaLocation="http://ds01za005:8650/soa-infra/services/default/DocumentServices/apps/lsc/Schema/BusinessObjects/Enterprise/External/oasis/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"/></schema>
+  </wsdl:types>
+  <wsdl:message name="DownloadDocumentRequestMessage"><wsdl:part name="payload" element="ns1:DocumentDownloadRQ"/></wsdl:message>
+  <wsdl:message name="DownloadDocumentResponseMessage"><wsdl:part name="payload" element="ns1:DocumentDownloadRS"/></wsdl:message>
+  <wsdl:message name="UploadDocumentRequestMessage"><wsdl:part name="payload" element="ns1:DocumentUploadRQ"/></wsdl:message>
+  <wsdl:message name="UploadDocumentResponseMessage"><wsdl:part name="payload" element="ns1:DocumentUploadRS"/></wsdl:message>
+  <wsdl:message name="GetDocumentDetailsRequestMessage"><wsdl:part name="GetDocumentDetailsABMRQ" element="ns1:GetDocumentDetailsABMRQ"/></wsdl:message>
+  <wsdl:message name="GetDocumentDetailsResponseMessage"><wsdl:part name="GetDocumentDetailsABMRS" element="ns1:GetDocumentDetailsABMRS"/></wsdl:message>
+  <wsdl:message name="UsernameToken"><wsdl:part name="Security" element="wsse:Security"/></wsdl:message>
+  <wsdl:portType name="DocumentServices">
+    <wsdl:operation name="DownloadDocument"><wsdl:input message="tns:DownloadDocumentRequestMessage"/><wsdl:output message="tns:DownloadDocumentResponseMessage"/></wsdl:operation>
+    <wsdl:operation name="UploadDocument"><wsdl:input message="tns:UploadDocumentRequestMessage"/><wsdl:output message="tns:UploadDocumentResponseMessage"/></wsdl:operation>
+    <wsdl:operation name="GetDocumentDetails"><wsdl:input message="tns:GetDocumentDetailsRequestMessage"/><wsdl:output message="tns:GetDocumentDetailsResponseMessage"/></wsdl:operation>
+  </wsdl:portType>
+  <wsdl:binding name="DocumentServicesSOAPBinding" type="tns:DocumentServices"><soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/><wsp:PolicyReference URI="#wss_username_token_service_policy" wsdl:required="false"/>
+    <wsdl:operation name="UploadDocument"><soap:operation style="document" soapAction="http://legalservices.gov.uk/CCMS/CaseManagement/Case/1.0/DocumentServices/UploadDocument"/>
+      <wsdl:input><soap:body use="literal" parts="payload"/><soap:header message="tns:UsernameToken" part="Security" use="literal"/></wsdl:input>
+      <wsdl:output><soap:body use="literal" parts="payload"/></wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="DownloadDocument"><soap:operation style="document" soapAction="http://legalservices.gov.uk/CCMS/CaseManagement/Case/1.0/DocumentServices/DownloadDocument"/>
+      <wsdl:input><soap:body use="literal" parts="payload"/><soap:header message="tns:UsernameToken" part="Security" use="literal"/></wsdl:input>
+      <wsdl:output><soap:body use="literal" parts="payload"/></wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="GetDocumentDetails"><soap:operation style="document" soapAction="http://legalservices.gov.uk/CCMS/CaseManagement/Case/1.0/DocumentServices/GetDocumentDetails"/>
+      <wsdl:input><soap:body use="literal" parts="GetDocumentDetailsABMRQ"/><soap:header message="tns:UsernameToken" part="Security" use="literal"/></wsdl:input>
+      <wsdl:output><soap:body use="literal" parts="GetDocumentDetailsABMRS"/></wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:service name="DocumentServices_ep">
+    <wsdl:port name="DocumentServices_pt" binding="tns:DocumentServicesSOAPBinding"><soap:address location="http://ds01za005:8650/soa-infra/services/default/DocumentServices/DocumentServices_ep"/></wsdl:port>
+  </wsdl:service>
+</wsdl:definitions>

--- a/spec/data/ccms/document_id_request.xml
+++ b/spec/data/ccms/document_id_request.xml
@@ -1,0 +1,27 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<soap:Envelope xmlns:xsd='http://www.w3.org/2001/XMLSchema' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xmlns:soap='http://schemas.xmlsoap.org/soap/envelope/' xmlns:ns1='http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd' xmlns:ns2='http://legalservices.gov.uk/CCMS/CaseManagement/Case/1.0/CaseBIM' xmlns:ns3='http://legalservices.gov.uk/Enterprise/Common/1.0/Header' xmlns:ns4='http://legalservices.gov.uk/CCMS/CaseManagement/Case/1.0/CaseBIO'>
+  <soap:Header>
+    <ns1:Security>
+      <ns1:UsernameToken>
+        <ns1:Username>my_soap_client_username</ns1:Username>
+        <ns1:Password Type='password_type'>xxxxx</ns1:Password>
+      </ns1:UsernameToken>
+    </ns1:Security>
+  </soap:Header>
+  <soap:Body>
+    <ns2:DocumentUploadRQ>
+      <ns3:HeaderRQ>
+        <ns3:TransactionRequestID>20190101121530123456</ns3:TransactionRequestID>
+        <ns3:Language>ENG</ns3:Language>
+        <ns3:UserLoginID>my_login</ns3:UserLoginID>
+        <ns3:UserRole>my_role</ns3:UserRole>
+      </ns3:HeaderRQ>
+      <ns2:NotificationID>-1</ns2:NotificationID>
+      <ns2:CaseReferenceNumber>1234567890</ns2:CaseReferenceNumber>
+      <ns2:Document>
+        <ns4:DocumentType>ADMIN1</ns4:DocumentType>
+        <ns4:Channel>E</ns4:Channel>
+      </ns2:Document>
+    </ns2:DocumentUploadRQ>
+  </soap:Body>
+</soap:Envelope>

--- a/spec/data/ccms/document_id_response.xml
+++ b/spec/data/ccms/document_id_response.xml
@@ -1,0 +1,15 @@
+<env:Envelope xmlns:env='http://schemas.xmlsoap.org/soap/envelope/' xmlns:wsa='http://www.w3.org/2005/08/addressing'>
+  <env:Body>
+    <DocumentUploadRS xmlns='http://legalservices.gov.uk/CCMS/CaseManagement/Case/1.0/CaseBIM'>
+      <HeaderRS xmlns='http://legalservices.gov.uk/Enterprise/Common/1.0/Header'>
+        <TransactionID>20190301030405123456</TransactionID>
+        <RequestDetails/>
+        <Status>
+          <Status>Success</Status>
+          <StatusFreeText/>
+        </Status>
+      </HeaderRS>
+      <DocumentID>4420073</DocumentID>
+    </DocumentUploadRS>
+  </env:Body>
+</env:Envelope>

--- a/spec/data/ccms/document_upload_request.xml
+++ b/spec/data/ccms/document_upload_request.xml
@@ -1,0 +1,30 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<soap:Envelope xmlns:xsd='http://www.w3.org/2001/XMLSchema' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xmlns:soap='http://schemas.xmlsoap.org/soap/envelope/' xmlns:ns1='http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd' xmlns:ns2='http://legalservices.gov.uk/CCMS/CaseManagement/Case/1.0/CaseBIM' xmlns:ns3='http://legalservices.gov.uk/Enterprise/Common/1.0/Header' xmlns:ns4='http://legalservices.gov.uk/CCMS/CaseManagement/Case/1.0/CaseBIO'>
+  <soap:Header>
+    <ns1:Security>
+      <ns1:UsernameToken>
+        <ns1:Username>my_soap_client_username</ns1:Username>
+        <ns1:Password Type='password_type'>xxxxx</ns1:Password>
+      </ns1:UsernameToken>
+    </ns1:Security>
+  </soap:Header>
+  <soap:Body>
+    <ns2:DocumentUploadRQ>
+      <ns3:HeaderRQ>
+        <ns3:TransactionRequestID>20190101121530123456</ns3:TransactionRequestID>
+        <ns3:Language>ENG</ns3:Language>
+        <ns3:UserLoginID>my_login</ns3:UserLoginID>
+        <ns3:UserRole>my_role</ns3:UserRole>
+      </ns3:HeaderRQ>
+      <ns2:NotificationID>-1</ns2:NotificationID>
+      <ns2:CaseReferenceNumber>1234567890</ns2:CaseReferenceNumber>
+      <ns2:Document>
+        <ns4:CCMSDocumentID>4420073</ns4:CCMSDocumentID>
+        <ns4:DocumentType>ADMIN1</ns4:DocumentType>
+        <ns4:FileExtension>pdf</ns4:FileExtension>
+        <ns4:Channel>E</ns4:Channel>
+        <ns4:BinData>JVBERi0xLjUNCiW1tbW1DQoxIDAgb2JqDQo8PC9UeXBlL0NhdGFsb2cvUGFnZXMgMiA</ns4:BinData>
+      </ns2:Document>
+    </ns2:DocumentUploadRQ>
+  </soap:Body>
+</soap:Envelope>

--- a/spec/data/ccms/document_upload_response.xml
+++ b/spec/data/ccms/document_upload_response.xml
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<env:Envelope xmlns:env='http://schemas.xmlsoap.org/soap/envelope/' xmlns:wsa='http://www.w3.org/2005/08/addressing'>
+  <env:Body>
+    <ns6:DocumentUploadRS xmlns:ns6='http://legalservices.gov.uk/CCMS/CaseManagement/Case/1.0/CaseBIM'>
+      <ns1:HeaderRS xmlns:ns1='http://legalservices.gov.uk/Enterprise/Common/1.0/Header'>
+        <ns1:TransactionRequestID>20190301030405123456</ns1:TransactionRequestID>
+        <ns1:RequestDetails/>
+        <ns1:ResultCount/>
+        <ns1:Status>Success</ns1:Status>
+      </ns1:HeaderRS>
+    </ns6:DocumentUploadRS>
+  </env:Body>
+</env:Envelope>

--- a/spec/services/ccms/document_id_requestor_spec.rb
+++ b/spec/services/ccms/document_id_requestor_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+module CCMS
+  RSpec.describe DocumentIdRequestor do
+    let(:expected_xml) { ccms_data_from_file 'document_id_request.xml' }
+    let(:expected_tx_id) { '20190101121530123456' }
+    let(:case_ccms_reference) { '1234567890' }
+
+    describe 'XML request' do
+      it 'generates the expected XML' do
+        with_modified_env(modified_environment_vars) do
+          requestor = described_class.new(case_ccms_reference)
+          allow(requestor).to receive(:transaction_request_id).and_return(expected_tx_id)
+          expect(requestor.formatted_xml).to eq expected_xml.chomp
+        end
+      end
+    end
+
+    describe '#transaction_request_id' do
+      it 'returns the id based on current time' do
+        Timecop.freeze(2019, 1, 1, 12, 15, 30.123456) do
+          requestor = described_class.new(case_ccms_reference)
+          expect(requestor.transaction_request_id).to start_with expected_tx_id
+        end
+      end
+    end
+  end
+end

--- a/spec/services/ccms/document_id_response_parser_spec.rb
+++ b/spec/services/ccms/document_id_response_parser_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+module CCMS
+  RSpec.describe DocumentIdResponseParser do
+    describe '#document_id' do
+      let(:response_xml) { ccms_data_from_file 'document_id_response.xml' }
+      let(:expected_tx_id) { '20190301030405123456' }
+      let(:expected_document_id) { '4420073' }
+
+      it 'extracts the document id' do
+        parser = described_class.new(expected_tx_id, response_xml)
+        expect(parser.document_id).to eq expected_document_id
+      end
+
+      it 'raises if the transaction_request_ids dont match' do
+        expect {
+          parser = described_class.new(Faker::Number.number(20), response_xml)
+          parser.document_id
+        }.to raise_error CcmsError, 'Invalid transaction request id'
+      end
+    end
+  end
+end

--- a/spec/services/ccms/document_upload_requestor_spec.rb
+++ b/spec/services/ccms/document_upload_requestor_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+module CCMS
+  RSpec.describe DocumentUploadRequestor do
+    let(:expected_xml) { ccms_data_from_file 'document_upload_request.xml' }
+    let(:expected_tx_id) { '20190101121530123456' }
+    let(:case_ccms_reference) { '1234567890' }
+    let(:document_id) { '4420073' }
+    let(:document_encoded_base64) { 'JVBERi0xLjUNCiW1tbW1DQoxIDAgb2JqDQo8PC9UeXBlL0NhdGFsb2cvUGFnZXMgMiA' }
+
+    describe 'XML request' do
+      it 'generates the expected XML' do
+        with_modified_env(modified_environment_vars) do
+          requestor = described_class.new(case_ccms_reference, document_id, document_encoded_base64)
+          allow(requestor).to receive(:transaction_request_id).and_return(expected_tx_id)
+          expect(requestor.formatted_xml).to eq expected_xml.chomp
+        end
+      end
+    end
+
+    describe '#transaction_request_id' do
+      it 'returns the id based on current time' do
+        Timecop.freeze(2019, 1, 1, 12, 15, 30.123456) do
+          requestor = described_class.new(case_ccms_reference, document_id, document_encoded_base64)
+          expect(requestor.transaction_request_id).to start_with expected_tx_id
+        end
+      end
+    end
+  end
+end

--- a/spec/services/ccms/document_upload_response_parser_spec.rb
+++ b/spec/services/ccms/document_upload_response_parser_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+module CCMS
+  RSpec.describe DocumentUploadResponseParser do
+    describe '#success?' do
+      let(:response_xml) { ccms_data_from_file 'document_upload_response.xml' }
+      let(:expected_tx_id) { '20190301030405123456' }
+      let(:expected_document_id) { '4420073' }
+
+      it 'extracts the status' do
+        parser = described_class.new(expected_tx_id, response_xml)
+        expect(parser.success?).to eq true
+      end
+
+      it 'raises if the transaction_request_ids dont match' do
+        expect {
+          parser = described_class.new(Faker::Number.number(20), response_xml)
+          parser.success?
+        }.to raise_error CcmsError, 'Invalid transaction request id'
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-613)

To upload documents for an application (eg statements of case) into CCMS, two calls to CCMS webservices are required:

1. to 'register' the document and receive a document_id
2. to upload a base64 encoded version of the file

This PR creates _requester and _response_parser classes to handle these two calls, based on the pattern used for other API calls to CCMS.

It also adds test data and the WSDL which is the basis of the request.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and cxnflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
