### PR TITLE
ap521 Amend the error validation styling for address selection

### DIFF
--- a/app/views/providers/address_selections/show.html.erb
+++ b/app/views/providers/address_selections/show.html.erb
@@ -33,13 +33,13 @@
 
       <div class="govuk-!-padding-bottom-2"></div>
 
-      <% group_error_class = @form.errors[:address].any? ? 'govuk-form-group--error' : '' %>
+      <% group_error_class = @form.errors[:lookup_id].any? ? 'govuk-form-group--error' : '' %>
       <div class="govuk-form-group <%= group_error_class %>">
         <%= f.label :address, t('.select_address_label'), class: 'govuk-label' %>
-        <% if @form.errors[:address].any? %>
-          <%= content_tag(:span, @form.errors[:address].first, class: ['govuk-error-message']) %>
+        <% if @form.errors[:lookup_id].any? %>
+          <%= content_tag(:span, @form.errors[:lookup_id].first, class: ['govuk-error-message']) %>
         <% end %>
-        <% input_error_class = @form.errors[:address].any? ? 'govuk-select--error' : '' %>
+        <% input_error_class = @form.errors[:lookup_id].any? ? 'govuk-select--error' : '' %>
         <%= f.select(
               :lookup_id,
               @addresses.collect { |a| [a.full_address, a.lookup_id] },

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -55,7 +55,7 @@ en:
             city:
               blank: Enter a town or city
             lookup_id:
-              blank: Please select an address from the list
+              blank: Select an address from the list
             postcode:
               blank: Enter a postcode
               invalid: Enter a postcode in the right format

--- a/spec/forms/addresses/address_selection_form_spec.rb
+++ b/spec/forms/addresses/address_selection_form_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Addresses::AddressSelectionForm, type: :form do
 
       it 'contains a presence error on the lookup_id' do
         expect(form).not_to be_valid
-        expect(form.errors[:lookup_id]).to match_array(['Please select an address from the list'])
+        expect(form.errors[:lookup_id]).to match_array(['Select an address from the list'])
       end
     end
   end

--- a/spec/requests/providers/address_selections_spec.rb
+++ b/spec/requests/providers/address_selections_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe 'address selections requests', type: :request do
           subject
 
           expect(response).to be_successful
-          expect(unescaped_response_body).to match('Please select an address from the list')
+          expect(unescaped_response_body).to match('Select an address from the list')
           expect(unescaped_response_body).to match('Select an address')
           expect(unescaped_response_body).to match('[1-9]{1}[0-9]? addresses found')
         end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-521)

Address drop down was not showing the error styling on the input field. This change applies the GDS error styling requirements to the address selection drop down menu.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
