### PR TITLE
AP-660 Bug fix on vehicles/remaining_payment page

### DIFF
--- a/app/views/shared/forms/vehicles/_remaining_payment.html.erb
+++ b/app/views/shared/forms/vehicles/_remaining_payment.html.erb
@@ -32,7 +32,7 @@
             :payments_remain,
             false,
             label: t('generic.no'),
-            checked: @form.model.payment_remaining&.zero?
+            checked: @form.model.payment_remaining&.zero? && !@form.payments_remain?
           ) %>
 
   <% end %>

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -283,10 +283,12 @@ en:
               blank: Enter the estimated value of the vehicle
               not_a_number: Estimated value must be an amount of money, like 5,000
               greater_than_or_equal_to: Estimated value must be 0 or more
+              too_many_decimals: Estimated value must not include more than 2 decimal numbers
             payment_remaining:
               blank: Enter the amount left to pay
               not_a_number: The amount left to pay must be an amount of money, like 5,000
               greater_than_or_equal_to: The amount left to page must be 0 or more
+              too_many_decimals: Amount must not include more than 2 decimal numbers
             payments_remain:
               blank: Select yes if there are any payments left on the vehicle
             purchased_on:


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-660)

- Adding missing locales
- Fix this bug: On `remaining_payment` if “Yes” is selected and any error is shown (like for a non-numeric value) the selected answer changes to “No” 

## Checklist

Before you ask people to review this PR:

- [X] Tests and rubocop should be passing: `bundle exec rake`
- [X] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [X] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [X] The PR description should say what you changed and why, with a link to the JIRA story.
- [X] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [X] You should have checked that the commit messages say why the change was made.
