### PR TITLE
AP-579 - Add service to obtain CCMS document ids

### DIFF
--- a/app/models/ccms/submission.rb
+++ b/app/models/ccms/submission.rb
@@ -8,6 +8,8 @@ module CCMS
 
     validates :legal_aid_application_id, presence: true
 
+    serialize :documents, Hash
+
     POLL_LIMIT = 10
 
     def process! # rubocop:disable Metrics/MethodLength
@@ -22,6 +24,8 @@ module CCMS
         AddCaseService.call(self)
       when 'case_submitted'
         CheckCaseStatusService.call(self)
+      when 'case_created'
+        ObtainDocumentIdService.call(self)
       else
         raise CcmsError, 'Unknown state'
       end

--- a/app/models/concerns/ccms_submission_state_machine.rb
+++ b/app/models/concerns/ccms_submission_state_machine.rb
@@ -11,6 +11,8 @@ module CCMSSubmissionStateMachine
       state :applicant_ref_obtained
       state :case_submitted
       state :case_created
+      state :document_ids_obtained
+      state :completed
       state :failed
 
       event :obtain_case_ref do
@@ -34,12 +36,21 @@ module CCMSSubmissionStateMachine
         transitions from: :case_submitted, to: :case_created
       end
 
+      event :obtain_document_ids do
+        transitions from: :case_created, to: :document_ids_obtained
+      end
+
+      event :complete do
+        transitions from: :case_created, to: :completed
+      end
+
       event :fail do
         transitions from: :initialised, to: :failed
         transitions from: :case_ref_obtained, to: :failed
         transitions from: :applicant_submitted, to: :failed
         transitions from: :applicant_ref_obtained, to: :failed
         transitions from: :case_submitted, to: :failed
+        transitions from: :case_created, to: :failed
       end
     end
   end

--- a/app/services/ccms/document_id_requestor.rb
+++ b/app/services/ccms/document_id_requestor.rb
@@ -21,7 +21,7 @@ module CCMS
     # temporarily ignore this until connectivity with ccms is working
     # :nocov:
     def call
-      soap_client.call(:process, xml: request_xml)
+      soap_client.call(:upload_document, xml: request_xml)
     end
     # :nocov:
 

--- a/app/services/ccms/document_upload_requestor.rb
+++ b/app/services/ccms/document_upload_requestor.rb
@@ -23,7 +23,7 @@ module CCMS
     # temporarily ignore this until connectivity with ccms is working
     # :nocov:
     def call
-      soap_client.call(:process, xml: request_xml)
+      soap_client.call(:upload_document, xml: request_xml)
     end
     # :nocov:
 

--- a/app/services/ccms/obtain_document_id_service.rb
+++ b/app/services/ccms/obtain_document_id_service.rb
@@ -1,0 +1,38 @@
+module CCMS
+  class ObtainDocumentIdService < BaseSubmissionService
+    def call
+      populate_documents
+      if submission.documents.empty?
+        create_history('case_created', submission.aasm_state) if submission.complete!
+      else
+        request_document_ids
+        create_history('case_created', submission.aasm_state) if submission.obtain_document_ids!
+      end
+    rescue CcmsError, StandardError => e # TODO: Replace `StandardError` with list of known expected errors
+      handle_failure(e)
+    end
+
+    private
+
+    def populate_documents
+      files = StatementOfCase.find_by(legal_aid_application_id: submission.legal_aid_application_id)&.original_files
+      files&.each { |document| submission.documents[document.id] = :new }
+    end
+
+    def request_document_ids
+      submission.documents.each do |key, _value|
+        tx_id = document_id_requestor.transaction_request_id
+        response = document_id_requestor.call
+        PdfFile.update(original_file_id: key, ccms_document_id: DocumentIdResponseParser.new(tx_id, response).document_id)
+        submission.documents[key] = :id_obtained
+      rescue CcmsError, StandardError => e # TODO: Replace `StandardError` with list of known expected errors
+        submission.documents[key] = :failed
+        raise CcmsError, e
+      end
+    end
+
+    def document_id_requestor
+      @document_id_requestor ||= DocumentIdRequestor.new(submission.case_ccms_reference)
+    end
+  end
+end

--- a/db/migrate/20190529090545_add_documents_to_ccms_submissions.rb
+++ b/db/migrate/20190529090545_add_documents_to_ccms_submissions.rb
@@ -1,0 +1,5 @@
+class AddDocumentsToCcmsSubmissions < ActiveRecord::Migration[5.2]
+  def change
+    add_column :ccms_submissions, :documents, :text, default: '{}'
+  end
+end

--- a/db/migrate/20190529164413_add_ccms_document_id_to_pdf_files.rb
+++ b/db/migrate/20190529164413_add_ccms_document_id_to_pdf_files.rb
@@ -1,0 +1,5 @@
+class AddCcmsDocumentIdToPdfFiles < ActiveRecord::Migration[5.2]
+  def change
+    add_column :pdf_files, :ccms_document_id, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_24_143312) do
+ActiveRecord::Schema.define(version: 2019_05_29_164413) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -193,6 +193,7 @@ ActiveRecord::Schema.define(version: 2019_05_24_143312) do
     t.integer "applicant_poll_count", default: 0
     t.string "case_add_transaction_id"
     t.integer "case_poll_count", default: 0
+    t.text "documents"
     t.index ["legal_aid_application_id"], name: "index_ccms_submissions_on_legal_aid_application_id"
   end
 
@@ -309,6 +310,7 @@ ActiveRecord::Schema.define(version: 2019_05_24_143312) do
 
   create_table "pdf_files", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "original_file_id", null: false
+    t.text "ccms_document_id"
     t.index ["original_file_id"], name: "index_pdf_files_on_original_file_id", unique: true
   end
 

--- a/spec/factories/submissions.rb
+++ b/spec/factories/submissions.rb
@@ -17,5 +17,9 @@ FactoryBot.define do
     trait :case_submitted do
       aasm_state { 'case_submitted' }
     end
+
+    trait :case_created do
+      aasm_state { 'case_created' }
+    end
   end
 end

--- a/spec/models/ccms/submission_spec.rb
+++ b/spec/models/ccms/submission_spec.rb
@@ -2,7 +2,8 @@ require 'rails_helper'
 
 module CCMS
   RSpec.describe Submission do
-    let(:submission) { create :submission }
+    let(:legal_aid_application) { create :legal_aid_application, :with_applicant }
+    let(:submission) { create :submission, legal_aid_application: legal_aid_application }
 
     context 'Validations' do
       it 'errors if no legal aid application id is present' do
@@ -76,6 +77,15 @@ module CCMS
           it 'calls the check_case_status service' do
             expect(CheckCaseStatusService).to receive(:new).with(submission).and_return(check_case_status_service_double)
             expect(check_case_status_service_double).to receive(:call)
+          end
+        end
+
+        context 'case_created state' do
+          let(:obtain_document_id_service_double) { ObtainDocumentIdService.new(submission) }
+          let(:submission) { create :submission, :case_created }
+          it 'calls the orchestrate_document_upload_service service' do
+            expect(ObtainDocumentIdService).to receive(:new).with(submission).and_return(obtain_document_id_service_double)
+            expect(obtain_document_id_service_double).to receive(:call)
           end
         end
       end

--- a/spec/services/ccms/obtain_document_id_service_spec.rb
+++ b/spec/services/ccms/obtain_document_id_service_spec.rb
@@ -1,0 +1,129 @@
+require 'rails_helper'
+
+RSpec.describe CCMS::ObtainDocumentIdService do
+  let(:legal_aid_application) { create :legal_aid_application, statement_of_case: statement_of_case }
+  let(:submission) { create :submission, :case_created, legal_aid_application: legal_aid_application, case_ccms_reference: Faker::Number.number(10) }
+  let(:statement_of_case) { create :statement_of_case }
+  let(:history) { CCMS::SubmissionHistory.find_by(submission_id: submission.id) }
+  let(:document_id_requestor) { double CCMS::DocumentIdRequestor.new(submission.case_ccms_reference) }
+  subject { described_class.new(submission) }
+
+  context 'operation successful' do
+    context 'the application has no documents' do
+      it 'creates an empty documents hash' do
+        subject.call
+        expect(submission.documents&.size).to eq 0
+      end
+
+      it 'changes the submission state to completed' do
+        expect { subject.call }.to change { submission.aasm_state }.to 'completed'
+      end
+
+      it 'writes a history record' do
+        expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
+        expect(history.from_state).to eq 'case_created'
+        expect(history.to_state).to eq 'completed'
+        expect(history.success).to be true
+        expect(history.details).to be_nil
+      end
+    end
+
+    context 'the application has documents to upload' do
+      let(:statement_of_case) { create :statement_of_case, :with_attached_files }
+      let(:document_id_response) { ccms_data_from_file 'document_id_response.xml' }
+      let(:transaction_request_id_in_example_response) { '20190301030405123456' }
+      let(:ccms_document_id_in_example_response) { '4420073' }
+
+      before do
+        allow(subject).to receive(:document_id_requestor).and_return(document_id_requestor)
+        expect(document_id_requestor).to receive(:transaction_request_id).and_return(transaction_request_id_in_example_response)
+        expect(document_id_requestor).to receive(:call).and_return(document_id_response)
+      end
+
+      it 'populates the documents hash with all documents for the application' do
+        subject.call
+        expect(submission.documents&.size).to eq statement_of_case.original_files.count
+      end
+
+      context 'when requesting document_ids' do
+        it 'updates the ccms_document_id for each document' do
+          subject.call
+          submission.documents.each do |key, _value|
+            expect(PdfFile.find_by(original_file_id: key).ccms_document_id).to eq ccms_document_id_in_example_response
+          end
+        end
+
+        it 'updates the status for each document to id_obtained' do
+          subject.call
+          submission.documents.each do |_key, value|
+            expect(value).to eq :id_obtained
+          end
+        end
+
+        it 'changes the submission state to document_ids_obtained' do
+          expect { subject.call }.to change { submission.aasm_state }.to 'document_ids_obtained'
+        end
+      end
+    end
+  end
+
+  context 'operation unsuccessful' do
+    context 'when populating documents' do
+      before do
+        expect(subject).to receive(:populate_documents).and_raise(CCMS::CcmsError, 'failure populating document hash')
+      end
+
+      it 'changes the submission state to failed' do
+        expect { subject.call }.to change { submission.aasm_state }.to 'failed'
+      end
+
+      it 'writes a history record' do
+        expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
+        expect(history.from_state).to eq 'case_created'
+        expect(history.to_state).to eq 'failed'
+        expect(history.success).to be false
+        expect(history.details).to match(/CcmsError/)
+        expect(history.details).to match(/failure populating document hash/)
+      end
+    end
+
+    context 'when requesting document_ids' do
+      let(:statement_of_case) { create :statement_of_case, :with_attached_files }
+
+      before do
+        allow(subject).to receive(:document_id_requestor).and_return(document_id_requestor)
+        expect(document_id_requestor).to receive(:transaction_request_id).and_return(Faker::Number.number(8))
+        expect(document_id_requestor).to receive(:call).and_raise(CCMS::CcmsError, 'failure requesting document ids')
+      end
+
+      it 'changes the submission state to failed' do
+        expect { subject.call }.to change { submission.aasm_state }.to 'failed'
+      end
+
+      it 'changes the document state to failed' do
+        expect { subject.call }.to change { submission.documents[statement_of_case.original_files.first.id] }.to eq :failed
+      end
+
+      it 'writes a history record' do
+        expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
+        expect(history.from_state).to eq 'case_created'
+        expect(history.to_state).to eq 'failed'
+        expect(history.success).to be false
+        expect(history.details).to match(/CcmsError/)
+        expect(history.details).to match(/failure requesting document ids/)
+      end
+    end
+  end
+
+  # private method tested here because it is mocked out above
+  #
+  describe '#document_id_requestor' do
+    let(:service) { CCMS::ObtainDocumentIdService.new(submission) }
+    let(:requestor1) { service.__send__(:document_id_requestor) }
+    let(:requestor2) { service.__send__(:document_id_requestor) }
+    it 'only instantiates one copy of the DocumentIdRequestor' do
+      expect(requestor1).to be_instance_of(CCMS::DocumentIdRequestor)
+      expect(requestor1).to eq requestor2
+    end
+  end
+end


### PR DESCRIPTION

## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-579)

Create a new service to register all documents that need to be uploaded
to CCMS for an application and receive a document id in return.

If no documents exist for the application, the status is changed to
completed as at that point all relevant data has been sent to CCMS.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
