### PR TITLE
Fix ruby metrics

### DIFF
--- a/app/services/metrics/send_metrics.rb
+++ b/app/services/metrics/send_metrics.rb
@@ -18,7 +18,7 @@ module Metrics
 
     def prometheus_client
       @prometheus_client ||= PrometheusExporter::Client.new(
-        host: Rails.configuration.x.service_host,
+        host: Rails.configuration.x.metrics_service_host,
         thread_sleep: PROMETHEUS_THREAD_SLEEP
       )
     end

--- a/config/application.rb
+++ b/config/application.rb
@@ -41,7 +41,7 @@ module LaaApplyForLegalAid
     config.x.admin_portal.allow_create_test_applications = ENV['ADMIN_ALLOW_CREATE_TEST_APPLICATIONS'] == 'true'
     config.x.admin_portal.password = ENV['ADMIN_PASSWORD']
 
-    config.x.service_host = ENV.fetch('SERVICE_HOST', 'localhost')
+    config.x.metrics_service_host = ENV.fetch('METRICS_SERVICE_HOST', 'localhost')
 
     require Rails.root.join 'app/lib/govuk_elements_form_builder/form_builder'
     ActionView::Base.default_form_builder = GovukElementsFormBuilder::FormBuilder

--- a/config/initializers/prometheus_metrics.rb
+++ b/config/initializers/prometheus_metrics.rb
@@ -3,7 +3,7 @@ if Rails.env.production? && Rails.configuration.x.kubernetes_deployment
   require 'prometheus_exporter/middleware'
 
   PrometheusExporter::Client.default = PrometheusExporter::Client.new(
-    host: Rails.configuration.x.service_host
+    host: Rails.configuration.x.metrics_service_host
   )
 
   PrometheusExporter::Instrumentation::Process.start(type: 'master')

--- a/helm_deploy/apply-for-legal-aid/templates/_envs.tpl
+++ b/helm_deploy/apply-for-legal-aid/templates/_envs.tpl
@@ -200,6 +200,6 @@ env:
         key: googleAnalyticsTrackingID
   - name: KUBERNETES_DEPLOYMENT
     value: "true"
-  - name: SERVICE_HOST
-    value: {{ .Release.Name }}
+  - name: METRICS_SERVICE_HOST
+    value: {{ template "apply-for-legal-aid.fullname" . }}-metrics
 {{- end }}

--- a/helm_deploy/apply-for-legal-aid/templates/deployment_metrics.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/deployment_metrics.yaml
@@ -11,13 +11,13 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: {{ template "apply-for-legal-aid.name" . }}
-      release: {{ .Release.Name }}
+      service: {{ template "apply-for-legal-aid.fullname" . }}-metrics
   template:
     metadata:
       labels:
         app: {{ template "apply-for-legal-aid.name" . }}
         release: {{ .Release.Name }}
+        service: {{ template "apply-for-legal-aid.fullname" . }}-metrics
     spec:
       containers:
         - name: metrics

--- a/helm_deploy/apply-for-legal-aid/templates/deployment_web.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/deployment_web.yaml
@@ -29,7 +29,7 @@ spec:
               protocol: TCP
           resources:
 {{ toYaml .Values.clamav.resources | indent 12 }}
-        - name: {{ .Chart.Name }}
+        - name: web
           image: '{{ .Values.image.repository }}:{{ .Values.image.tag }}'
           imagePullPolicy: IfNotPresent
 {{ include "apply-for-legal-aid.envs" . | nindent 10 }}

--- a/helm_deploy/apply-for-legal-aid/templates/service-metrics.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/service-metrics.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "apply-for-legal-aid.fullname" . }}-metrics
+  labels:
+    service: {{ template "apply-for-legal-aid.fullname" . }}-metrics
+    app: {{ template "apply-for-legal-aid.name" . }}
+    chart: {{ template "apply-for-legal-aid.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  ports:
+  - port: 9394
+    protocol: TCP
+    name: metrics
+  selector:
+    service: {{ template "apply-for-legal-aid.fullname" . }}-metrics

--- a/helm_deploy/apply-for-legal-aid/templates/service.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/service.yaml
@@ -14,9 +14,6 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
-    - port: 9394
-      targetPort: 9394
-      name: metrics
   selector:
     app: {{ template "apply-for-legal-aid.name" . }}
     release: {{ .Release.Name }}

--- a/spec/services/metrics/send_metrics_spec.rb
+++ b/spec/services/metrics/send_metrics_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Metrics::SendMetrics do
   describe '#call' do
-    let(:service_host) { Faker::Internet.domain_word }
+    let(:metrics_service_host) { Faker::Internet.domain_word }
     let(:prometheus_client) { spy(PrometheusExporter::Client) }
     let(:prometheus_thread_sleep) { rand(1..10).to_f / 1000 }
     subject { described_class.call }
@@ -10,13 +10,13 @@ RSpec.describe Metrics::SendMetrics do
     before do
       stub_const('Metrics::SendMetrics::PROMETHEUS_THREAD_SLEEP', prometheus_thread_sleep)
       allow(PrometheusExporter::Client).to receive(:new).and_return(prometheus_client)
-      allow(Rails.configuration.x).to receive(:service_host).and_return(service_host)
+      allow(Rails.configuration.x).to receive(:metrics_service_host).and_return(metrics_service_host)
     end
 
     it 'creates a prometheus client with the right settings' do
       expect(PrometheusExporter::Client)
         .to receive(:new)
-        .with(host: service_host, thread_sleep: prometheus_thread_sleep)
+        .with(host: metrics_service_host, thread_sleep: prometheus_thread_sleep)
         .and_return(prometheus_client)
       subject
     end


### PR DESCRIPTION
Ruby metrics were not reported since the metrics container was moved to its own pod.
A separate service needed to be created so the web and the worker pods can send metrics to it