### PR TITLE
AP-581 - Add service to upload documents to CCMS

### DIFF
--- a/app/models/ccms/submission.rb
+++ b/app/models/ccms/submission.rb
@@ -26,6 +26,8 @@ module CCMS
         CheckCaseStatusService.call(self)
       when 'case_created'
         ObtainDocumentIdService.call(self)
+      when 'document_ids_obtained'
+        UploadDocumentsService.call(self)
       else
         raise CcmsError, 'Unknown state'
       end

--- a/app/models/concerns/ccms_submission_state_machine.rb
+++ b/app/models/concerns/ccms_submission_state_machine.rb
@@ -42,6 +42,7 @@ module CCMSSubmissionStateMachine
 
       event :complete do
         transitions from: :case_created, to: :completed
+        transitions from: :document_ids_obtained, to: :completed
       end
 
       event :fail do
@@ -51,6 +52,7 @@ module CCMSSubmissionStateMachine
         transitions from: :applicant_ref_obtained, to: :failed
         transitions from: :case_submitted, to: :failed
         transitions from: :case_created, to: :failed
+        transitions from: :document_ids_obtained, to: :failed
       end
     end
   end

--- a/app/services/ccms/upload_documents_service.rb
+++ b/app/services/ccms/upload_documents_service.rb
@@ -1,0 +1,36 @@
+module CCMS
+  class UploadDocumentsService < BaseSubmissionService
+    def call
+      submission.documents.each do |key, _value|
+        upload_document(key)
+      end
+
+      failed_uploads = submission.documents.select { |_key, value| value == :failed }
+
+      if failed_uploads.empty?
+        create_history('document_ids_obtained', submission.aasm_state) if submission.complete!
+      else
+        handle_failure("#{failed_uploads.keys} failed to upload to CCMS")
+      end
+    rescue CcmsError, StandardError => e # TODO: Replace `StandardError` with list of known expected errors
+      handle_failure(e)
+    end
+
+    private
+
+    def upload_document(key)
+      pdf_file = PdfFile.find_by(original_file_id: key)
+      document_upload_requestor = DocumentUploadRequestor.new(submission.case_ccms_reference, pdf_file.ccms_document_id, pdf_file.file.download)
+      tx_id = document_upload_requestor.transaction_request_id
+      response = document_upload_requestor.call
+      submission.documents[key] = if DocumentUploadResponseParser.new(tx_id, response).success?
+                                    :uploaded
+                                  else
+                                    :failed
+                                  end
+    rescue CcmsError, StandardError => e # TODO: Replace `StandardError` with list of known expected errors
+      submission.documents[key] = :failed
+      raise CcmsError, e
+    end
+  end
+end

--- a/spec/factories/submissions.rb
+++ b/spec/factories/submissions.rb
@@ -21,5 +21,9 @@ FactoryBot.define do
     trait :case_created do
       aasm_state { 'case_created' }
     end
+
+    trait :document_ids_obtained do
+      aasm_state { 'document_ids_obtained' }
+    end
   end
 end

--- a/spec/models/ccms/submission_spec.rb
+++ b/spec/models/ccms/submission_spec.rb
@@ -83,9 +83,18 @@ module CCMS
         context 'case_created state' do
           let(:obtain_document_id_service_double) { ObtainDocumentIdService.new(submission) }
           let(:submission) { create :submission, :case_created }
-          it 'calls the orchestrate_document_upload_service service' do
+          it 'calls the obtain_document_id service' do
             expect(ObtainDocumentIdService).to receive(:new).with(submission).and_return(obtain_document_id_service_double)
             expect(obtain_document_id_service_double).to receive(:call)
+          end
+        end
+
+        context 'document_ids_obtained state' do
+          let(:upload_documents_service_double) { UploadDocumentsService.new(submission) }
+          let(:submission) { create :submission, :document_ids_obtained }
+          it 'calls the upload_documents service' do
+            expect(UploadDocumentsService).to receive(:new).with(submission).and_return(upload_documents_service_double)
+            expect(upload_documents_service_double).to receive(:call)
           end
         end
       end

--- a/spec/services/ccms/upload_documents_service_spec.rb
+++ b/spec/services/ccms/upload_documents_service_spec.rb
@@ -33,6 +33,11 @@ RSpec.describe CCMS::UploadDocumentsService do
       subject.call
     end
 
+    it 'encodes each document as base64' do
+      expect(Base64).to receive(:strict_encode64).exactly(submission.documents.count).times
+      subject.call
+    end
+
     it 'updates the status for each document to uploaded' do
       subject.call
       submission.documents.each do |_key, value|

--- a/spec/services/ccms/upload_documents_service_spec.rb
+++ b/spec/services/ccms/upload_documents_service_spec.rb
@@ -1,0 +1,103 @@
+require 'rails_helper'
+
+RSpec.describe CCMS::UploadDocumentsService do
+  let(:legal_aid_application) { create :legal_aid_application, statement_of_case: statement_of_case }
+  let(:statement_of_case) { create :statement_of_case, :with_attached_files }
+  let(:document_id) { statement_of_case.original_files.first.id }
+  let(:submission) do
+    create :submission,
+           :document_ids_obtained,
+           legal_aid_application: legal_aid_application,
+           case_ccms_reference: Faker::Number.number(10),
+           documents: { document_id => :id_obtained }
+  end
+  let(:history) { CCMS::SubmissionHistory.find_by(submission_id: submission.id) }
+  let(:document_upload_requestor) { double CCMS::DocumentUploadRequestor.new(submission.case_ccms_reference, document_id, 'base64encodedpdf') }
+  let(:document_upload_response) { ccms_data_from_file 'document_upload_response.xml' }
+  let(:transaction_request_id_in_example_response) { '20190301030405123456' }
+  subject { described_class.new(submission) }
+
+  before do
+    PdfConverter.call(PdfFile.find_or_create_by(original_file_id: document_id).id)
+    allow(CCMS::DocumentUploadRequestor).to receive(:new).and_return(document_upload_requestor)
+    expect(document_upload_requestor).to receive(:transaction_request_id).and_return(transaction_request_id_in_example_response)
+  end
+
+  context 'operation successful' do
+    before do
+      expect(document_upload_requestor).to receive(:call).and_return(document_upload_response)
+    end
+
+    it 'creates a DocumentUploadRequestor object for each document to be uploaded' do
+      expect(CCMS::DocumentUploadRequestor).to receive(:new).exactly(submission.documents.count).times
+      subject.call
+    end
+
+    it 'updates the status for each document to uploaded' do
+      subject.call
+      submission.documents.each do |_key, value|
+        expect(value).to eq :uploaded
+      end
+    end
+
+    it 'changes the submission state to completed' do
+      expect { subject.call }.to change { submission.aasm_state }.to 'completed'
+    end
+
+    it 'writes a history record' do
+      expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
+      expect(history.from_state).to eq 'document_ids_obtained'
+      expect(history.to_state).to eq 'completed'
+      expect(history.success).to be true
+      expect(history.details).to be_nil
+    end
+  end
+
+  context 'operation unsuccessful' do
+    context 'operation fails due to an exception' do
+      before do
+        expect(document_upload_requestor).to receive(:call).and_raise(CCMS::CcmsError, 'failure uploading documents')
+      end
+
+      it 'changes the submission state to failed' do
+        expect { subject.call }.to change { submission.aasm_state }.to 'failed'
+      end
+
+      it 'changes the document state to failed' do
+        expect { subject.call }.to change { submission.documents[statement_of_case.original_files.first.id] }.to eq :failed
+      end
+
+      it 'writes a history record' do
+        expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
+        expect(history.from_state).to eq 'document_ids_obtained'
+        expect(history.to_state).to eq 'failed'
+        expect(history.success).to be false
+        expect(history.details).to match(/CcmsError/)
+        expect(history.details).to match(/failure uploading documents/)
+      end
+    end
+
+    context 'operation fails due to an error response from ccms' do
+      before do
+        allow_any_instance_of(CCMS::DocumentUploadResponseParser).to receive(:success?).and_return(false)
+        expect(document_upload_requestor).to receive(:call).and_return(document_upload_response)
+      end
+
+      it 'changes the submission state to failed' do
+        expect { subject.call }.to change { submission.aasm_state }.to 'failed'
+      end
+
+      it 'changes the document state to failed' do
+        expect { subject.call }.to change { submission.documents[statement_of_case.original_files.first.id] }.to eq :failed
+      end
+
+      it 'writes a history record' do
+        expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
+        expect(history.from_state).to eq 'document_ids_obtained'
+        expect(history.to_state).to eq 'failed'
+        expect(history.success).to be false
+        expect(history.details).to match('failed to upload to CCMS')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-581)

Create a new service to upload all documents for an application to CCMS (at this point only Statements of Case).

This does not handle retrying failed uploads, which will be addressed in another story.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
