### PR TITLE
AP556 Admin Confirm Delete

### DIFF
--- a/app/assets/javascripts/admin-delete.es6
+++ b/app/assets/javascripts/admin-delete.es6
@@ -2,55 +2,58 @@ $(document).ready(() => {
   $(".request-delete-button").click(function(event){
     event.preventDefault()
 
-    const method = $(this).attr("method")
-    const action = $(this).attr("action") 
+    const action = $(this).parent("form").attr("action") 
     let applicationID = $(this).attr("data-application-id") //ID code of element to delete
     let deleteDetails = $(this).attr("data-delete-message")
-
-    if (method == 'delete') prepareDeleteForm()
 
     //if the current error box is poised to delete the same field as is clicked,
     //we want to cancel the delete
     if (applicationID == $("#confirm-delete-button").attr("data-application-id")) {
-      $("#confirm-delete").attr('hidden',"true") //restore hidden status to box
-      $("#confirm-delete-button")
-        .attr('disabled',"true") //restore disabled status to button
-        .removeAttr("data-application-id") //remove the attribute ID from the button - this is used for comparison - the if statement we are currently in
-        .parent("form").attr("action","") //tells confirm button not to delete anything
-        
-      $(".request-delete-button").addClass("govuk-button--warning") //add the red button style to the button (it will currently be green)
-      $(this).val($(this).data("original-text")) //restore the original text to the button (it will currently say cancel delete)
+      cancelDeleteButton(this)   
     }
-    
     //if it isn't the same, then we are trying to delete something different from current
     //or the box is hidden
     //so we set up the record for deletion
     else {
+      prepareDeleteWarning(action, deleteDetails, applicationID)
+      showDeleteWarning()
+      resetAllButtons()
+      changeClickedButton(this)
+    }
+
+    function cancelDeleteButton(clickedButton) {
+      $("#confirm-delete").attr('hidden', "true") //restore hidden status to box
       $("#confirm-delete-button")
-        .removeAttr('disabled') //enable the delete button
+        .attr('disabled', "true") //restore disabled status to button
+        .removeAttr("data-application-id") //remove the attribute ID from the button - this is used for comparison - the if statement we are currently in
+        .parent("form").attr("action", "") //tells confirm button not to delete anything
+      $(".request-delete-button").addClass("govuk-button--warning") //add the red button style to the button (it will currently be green)
+      $(clickedButton).val($(clickedButton).data("original-text")) //restore the original text to the button (it will currently say cancel delete)
+    }
+
+    function prepareDeleteWarning(action, deleteDetails, applicationID) {
+      $("#confirm-delete-button")
+        .removeAttr('disabled')
         .attr("data-application-id", applicationID) //set the delete button to reference the specific case (this is for comparison, so another click on the same button will remove the box)
-        .parent("form")
-        .attr("action", action)
-        .attr("method", method) //tells confirm button what to delete
-      
-      $("#confirm-delete").removeAttr('hidden') //shows the box
-      $("#delete-case-details").text(deleteDetails)//changes delete details to relevant case (box title)
-            
+        .parent("form").attr("action", action) //tells confirm button what to delete
+      $("#delete-message").text(deleteDetails) //changes message of box
+    }
+
+    function showDeleteWarning() { $("#confirm-delete").removeAttr('hidden') }
+
+    function resetAllButtons() {
       $(".request-delete-button")
         .addClass("govuk-button--warning") //makes all buttons red (in case another button is in a green state)
-        .each(() => {
-          $(this).val($(this).data("original-text")) //makes all buttons revert to their original text (in case another button is in a cancel delete state)
-        })
-      $(this)
+        .each(function() {
+          $(this).val($(this).data("original-text")); //makes all buttons revert to their original text (in case another button is in a cancel delete state)
+        });
+    }
+
+    function changeClickedButton(clickedButton) {
+      $(clickedButton)
         .removeClass("govuk-button--warning") //makes this button green
         .val($("#confirm-delete").data("cancel-text")) //makes this button read "cancel delete"
     }
 
-    function prepareDeleteForm() {
-      const hiddenDeleteInput = document.createElement("INPUT")
-      hiddenDeleteInput.method = 'delete'
-      hiddenDeleteInput.value = 'delete'
-      hiddenDeleteInput.action = 
-    }
   })
 })

--- a/app/assets/javascripts/admin-delete.es6
+++ b/app/assets/javascripts/admin-delete.es6
@@ -4,7 +4,9 @@ $(document).ready(() => {
 
     const action = $(this).parent("form").attr("action"); 
     let applicationID = $(this).attr("data-application-id"); //ID code of element to delete
-    let deleteDetails = $(this).attr("data-delete-message");
+    let deleteTitle = $(this).attr("data-delete-message");
+    let deleteName = $(this).attr("data-delete-name");
+    let deleteRef = $(this).attr("data-delete-ref");
 
     //if the current error box is poised to delete the same field as is clicked,
     //we want to cancel the delete
@@ -15,7 +17,7 @@ $(document).ready(() => {
     //or the box is hidden
     //so we set up the record for deletion
     else {
-      prepareDeleteWarning(action, deleteDetails, applicationID);
+      prepareDeleteWarning(action, deleteTitle, deleteName, deleteRef, applicationID);
       showDeleteWarning();
       resetAllButtons();
       changeClickedButton(this);
@@ -31,15 +33,27 @@ $(document).ready(() => {
       $(clickedButton).val($(clickedButton).data("original-text")); //restore the original text to the button (it will currently say cancel delete)
     }
 
-    function prepareDeleteWarning(action, deleteDetails, applicationID) {
+    function prepareDeleteWarning(action, deleteTitle, deleteName, deleteRef, applicationID) {
+      $("#delete-case-name").text(""); //removes any hangover content
+      $("#delete-case-ref").text(""); //removes any hangover content
       $("#confirm-delete-button")
-        .removeAttr('disabled')
+        .removeAttr('disabled') //enable button
         .attr("data-application-id", applicationID) //set the delete button to reference the specific case (this is for comparison, so another click on the same button will remove the box)
         .parent("form").attr("action", action); //tells confirm button what to delete
-      $("#delete-message").text(deleteDetails); //changes message of box
+      console.log(applicationID);
+      $("#delete-message").text(deleteTitle); //changes title of box
+      $("#delete-case-name").text(deleteName); //changes message of box
+      $("#delete-case-ref").text(deleteRef); //changes message of box
+      if ($("#delete-case-name").text().length) {
+        $("#delete-case-details").removeAttr("hidden");
+      } else {
+        $("#delete-case-details").attr("hidden","hidden");
+      }
     }
 
-    function showDeleteWarning() { $("#confirm-delete").removeAttr('hidden'); }
+    function showDeleteWarning() { 
+      $("#confirm-delete").removeAttr('hidden'); 
+    }
 
     function resetAllButtons() {
       $(".request-delete-button")

--- a/app/assets/javascripts/admin-delete.es6
+++ b/app/assets/javascripts/admin-delete.es6
@@ -1,0 +1,46 @@
+$(document).ready(function() {
+  $(".request-delete-button").click(function(){
+    const actionRoot = "/admin/legal_aid_applications/"; 
+    let applicationID = $(this).attr("data-application-id"); //ID code of element to delete
+    let fullName = $(this).parent().siblings(".case-full-name").text(); //Full Name of case to delete
+    let caseNumber = $(this).parent().siblings(".case-reference-number").text(); //Case Reference Number of case to delete
+    let deleteDetails = " " + caseNumber + " (" +fullName+")";
+    if (!fullName) deleteDetails = ""; //if there is no full name (i.e. a delete all), no details to display
+    
+    //if the current error box is poised to delete the same field as is clicked,
+    //we want to cancel the delete
+    if (applicationID == $("#confirm-delete-button").attr("data-application-id")) {
+      $("#confirm-delete").attr('hidden',"true"); //restore hidden status to box
+      $("#confirm-delete-button")
+        .attr('disabled',"true") //restore disabled status to button
+        .removeAttr("data-application-id") //remove the attribute ID from the button - this is used for comparison - the if statement we are currently in
+        .parent("form").attr("action",""); //tells confirm button not to delete anything
+        
+      $(".request-delete-button").addClass("govuk-button--warning"); //add the red button style to the button (it will currently be green)
+      $(this).val($(this).data("original-text")); //restore the original text to the button (it will currently say cancel delete)
+    }
+    
+    //if it isn't the same, then we are trying to delete something different from current
+    //or the box is hidden
+    //so we set up the record for deletion
+    else {
+      $("#confirm-delete-button")
+        .removeAttr('disabled') //enable the delete button
+        .attr("data-application-id",applicationID) //set the delete button to reference the specific case (this is for comparison, so another click on the same button will remove the box)
+        .parent("form").attr("action",actionRoot + applicationID); //tells confirm button what to delete
+      
+      $("#confirm-delete").removeAttr('hidden'); //shows the box
+      $("#delete-case-details").text(deleteDetails);//changes delete details to relevant case (box title)
+      $("#delete-message").text($(this).attr("data-delete-message")); //changes message of box
+            
+      $(".request-delete-button")
+        .addClass("govuk-button--warning") //makes all buttons red (in case another button is in a green state)
+        .each(function(){
+          $(this).val($(this).data("original-text")); //makes all buttons revert to their original text (in case another button is in a cancel delete state)
+        });
+      $(this)
+        .removeClass("govuk-button--warning") //makes this button green
+        .val($("#confirm-delete").data("cancel-text")); //makes this button read "cancel delete"
+    }
+  });
+});

--- a/app/assets/javascripts/admin-delete.es6
+++ b/app/assets/javascripts/admin-delete.es6
@@ -1,12 +1,10 @@
 $(document).ready(() => {
   $(".request-delete-button").click(function(event){
-    event.preventDefault();
-
     const action = $(this).parent("form").attr("action"); 
-    let applicationID = $(this).data("application-id"); //ID code of element to delete
-    let deleteTitle = $(this).data("delete-message");
-    let deleteName = $(this).data("delete-name");
-    let deleteRef = $(this).data("delete-ref");
+    const applicationID = $(this).data("application-id"); //ID code of element to delete
+    const deleteTitle = $(this).data("delete-message");
+    const deleteName = $(this).data("delete-name");
+    const deleteRef = $(this).data("delete-ref");
 
     //if the current error box is poised to delete the same field as is clicked,
     //we want to cancel the delete
@@ -63,5 +61,6 @@ $(document).ready(() => {
         .val($("#confirm-delete").data("cancel-text")); //makes this button read "cancel delete"
     }
 
+    return false;
   })
 })

--- a/app/assets/javascripts/admin-delete.es6
+++ b/app/assets/javascripts/admin-delete.es6
@@ -1,45 +1,45 @@
 $(document).ready(() => {
   $(".request-delete-button").click(function(event){
-    event.preventDefault()
+    event.preventDefault();
 
-    const action = $(this).parent("form").attr("action") 
-    let applicationID = $(this).attr("data-application-id") //ID code of element to delete
-    let deleteDetails = $(this).attr("data-delete-message")
+    const action = $(this).parent("form").attr("action"); 
+    let applicationID = $(this).attr("data-application-id"); //ID code of element to delete
+    let deleteDetails = $(this).attr("data-delete-message");
 
     //if the current error box is poised to delete the same field as is clicked,
     //we want to cancel the delete
     if (applicationID == $("#confirm-delete-button").attr("data-application-id")) {
-      cancelDeleteButton(this)   
+      cancelDeleteButton(this);  
     }
     //if it isn't the same, then we are trying to delete something different from current
     //or the box is hidden
     //so we set up the record for deletion
     else {
-      prepareDeleteWarning(action, deleteDetails, applicationID)
-      showDeleteWarning()
-      resetAllButtons()
-      changeClickedButton(this)
+      prepareDeleteWarning(action, deleteDetails, applicationID);
+      showDeleteWarning();
+      resetAllButtons();
+      changeClickedButton(this);
     }
 
     function cancelDeleteButton(clickedButton) {
-      $("#confirm-delete").attr('hidden', "true") //restore hidden status to box
+      $("#confirm-delete").attr('hidden', "true"); //restore hidden status to box
       $("#confirm-delete-button")
         .attr('disabled', "true") //restore disabled status to button
         .removeAttr("data-application-id") //remove the attribute ID from the button - this is used for comparison - the if statement we are currently in
-        .parent("form").attr("action", "") //tells confirm button not to delete anything
-      $(".request-delete-button").addClass("govuk-button--warning") //add the red button style to the button (it will currently be green)
-      $(clickedButton).val($(clickedButton).data("original-text")) //restore the original text to the button (it will currently say cancel delete)
+        .parent("form").attr("action", ""); //tells confirm button not to delete anything
+      $(".request-delete-button").addClass("govuk-button--warning"); //add the red button style to the button (it will currently be green)
+      $(clickedButton).val($(clickedButton).data("original-text")); //restore the original text to the button (it will currently say cancel delete)
     }
 
     function prepareDeleteWarning(action, deleteDetails, applicationID) {
       $("#confirm-delete-button")
         .removeAttr('disabled')
         .attr("data-application-id", applicationID) //set the delete button to reference the specific case (this is for comparison, so another click on the same button will remove the box)
-        .parent("form").attr("action", action) //tells confirm button what to delete
-      $("#delete-message").text(deleteDetails) //changes message of box
+        .parent("form").attr("action", action); //tells confirm button what to delete
+      $("#delete-message").text(deleteDetails); //changes message of box
     }
 
-    function showDeleteWarning() { $("#confirm-delete").removeAttr('hidden') }
+    function showDeleteWarning() { $("#confirm-delete").removeAttr('hidden'); }
 
     function resetAllButtons() {
       $(".request-delete-button")
@@ -52,7 +52,7 @@ $(document).ready(() => {
     function changeClickedButton(clickedButton) {
       $(clickedButton)
         .removeClass("govuk-button--warning") //makes this button green
-        .val($("#confirm-delete").data("cancel-text")) //makes this button read "cancel delete"
+        .val($("#confirm-delete").data("cancel-text")); //makes this button read "cancel delete"
     }
 
   })

--- a/app/assets/javascripts/admin-delete.es6
+++ b/app/assets/javascripts/admin-delete.es6
@@ -1,23 +1,25 @@
-$(document).ready(function() {
-  $(".request-delete-button").click(function(){
-    const actionRoot = "/admin/legal_aid_applications/"; 
-    let applicationID = $(this).attr("data-application-id"); //ID code of element to delete
-    let fullName = $(this).parent().siblings(".case-full-name").text(); //Full Name of case to delete
-    let caseNumber = $(this).parent().siblings(".case-reference-number").text(); //Case Reference Number of case to delete
-    let deleteDetails = " " + caseNumber + " (" +fullName+")";
-    if (!fullName) deleteDetails = ""; //if there is no full name (i.e. a delete all), no details to display
-    
+$(document).ready(() => {
+  $(".request-delete-button").click(function(event){
+    event.preventDefault()
+
+    const method = $(this).attr("method")
+    const action = $(this).attr("action") 
+    let applicationID = $(this).attr("data-application-id") //ID code of element to delete
+    let deleteDetails = $(this).attr("data-delete-message")
+
+    if (method == 'delete') prepareDeleteForm()
+
     //if the current error box is poised to delete the same field as is clicked,
     //we want to cancel the delete
     if (applicationID == $("#confirm-delete-button").attr("data-application-id")) {
-      $("#confirm-delete").attr('hidden',"true"); //restore hidden status to box
+      $("#confirm-delete").attr('hidden',"true") //restore hidden status to box
       $("#confirm-delete-button")
         .attr('disabled',"true") //restore disabled status to button
         .removeAttr("data-application-id") //remove the attribute ID from the button - this is used for comparison - the if statement we are currently in
-        .parent("form").attr("action",""); //tells confirm button not to delete anything
+        .parent("form").attr("action","") //tells confirm button not to delete anything
         
-      $(".request-delete-button").addClass("govuk-button--warning"); //add the red button style to the button (it will currently be green)
-      $(this).val($(this).data("original-text")); //restore the original text to the button (it will currently say cancel delete)
+      $(".request-delete-button").addClass("govuk-button--warning") //add the red button style to the button (it will currently be green)
+      $(this).val($(this).data("original-text")) //restore the original text to the button (it will currently say cancel delete)
     }
     
     //if it isn't the same, then we are trying to delete something different from current
@@ -26,21 +28,29 @@ $(document).ready(function() {
     else {
       $("#confirm-delete-button")
         .removeAttr('disabled') //enable the delete button
-        .attr("data-application-id",applicationID) //set the delete button to reference the specific case (this is for comparison, so another click on the same button will remove the box)
-        .parent("form").attr("action",actionRoot + applicationID); //tells confirm button what to delete
+        .attr("data-application-id", applicationID) //set the delete button to reference the specific case (this is for comparison, so another click on the same button will remove the box)
+        .parent("form")
+        .attr("action", action)
+        .attr("method", method) //tells confirm button what to delete
       
-      $("#confirm-delete").removeAttr('hidden'); //shows the box
-      $("#delete-case-details").text(deleteDetails);//changes delete details to relevant case (box title)
-      $("#delete-message").text($(this).attr("data-delete-message")); //changes message of box
+      $("#confirm-delete").removeAttr('hidden') //shows the box
+      $("#delete-case-details").text(deleteDetails)//changes delete details to relevant case (box title)
             
       $(".request-delete-button")
         .addClass("govuk-button--warning") //makes all buttons red (in case another button is in a green state)
-        .each(function(){
-          $(this).val($(this).data("original-text")); //makes all buttons revert to their original text (in case another button is in a cancel delete state)
-        });
+        .each(() => {
+          $(this).val($(this).data("original-text")) //makes all buttons revert to their original text (in case another button is in a cancel delete state)
+        })
       $(this)
         .removeClass("govuk-button--warning") //makes this button green
-        .val($("#confirm-delete").data("cancel-text")); //makes this button read "cancel delete"
+        .val($("#confirm-delete").data("cancel-text")) //makes this button read "cancel delete"
     }
-  });
-});
+
+    function prepareDeleteForm() {
+      const hiddenDeleteInput = document.createElement("INPUT")
+      hiddenDeleteInput.method = 'delete'
+      hiddenDeleteInput.value = 'delete'
+      hiddenDeleteInput.action = 
+    }
+  })
+})

--- a/app/assets/javascripts/admin-delete.es6
+++ b/app/assets/javascripts/admin-delete.es6
@@ -3,14 +3,14 @@ $(document).ready(() => {
     event.preventDefault();
 
     const action = $(this).parent("form").attr("action"); 
-    let applicationID = $(this).attr("data-application-id"); //ID code of element to delete
-    let deleteTitle = $(this).attr("data-delete-message");
-    let deleteName = $(this).attr("data-delete-name");
-    let deleteRef = $(this).attr("data-delete-ref");
+    let applicationID = $(this).data("application-id"); //ID code of element to delete
+    let deleteTitle = $(this).data("delete-message");
+    let deleteName = $(this).data("delete-name");
+    let deleteRef = $(this).data("delete-ref");
 
     //if the current error box is poised to delete the same field as is clicked,
     //we want to cancel the delete
-    if (applicationID == $("#confirm-delete-button").attr("data-application-id")) {
+    if (applicationID == $("#confirm-delete-button").data("application-id")) {
       cancelDeleteButton(this);  
     }
     //if it isn't the same, then we are trying to delete something different from current
@@ -27,7 +27,7 @@ $(document).ready(() => {
       $("#confirm-delete").attr('hidden', "true"); //restore hidden status to box
       $("#confirm-delete-button")
         .attr('disabled', "true") //restore disabled status to button
-        .removeAttr("data-application-id") //remove the attribute ID from the button - this is used for comparison - the if statement we are currently in
+        .removeData("application-id") //remove the attribute ID from the button - this is used for comparison - the if statement we are currently in
         .parent("form").attr("action", ""); //tells confirm button not to delete anything
       $(".request-delete-button").addClass("govuk-button--warning"); //add the red button style to the button (it will currently be green)
       $(clickedButton).val($(clickedButton).data("original-text")); //restore the original text to the button (it will currently say cancel delete)
@@ -38,17 +38,11 @@ $(document).ready(() => {
       $("#delete-case-ref").text(""); //removes any hangover content
       $("#confirm-delete-button")
         .removeAttr('disabled') //enable button
-        .attr("data-application-id", applicationID) //set the delete button to reference the specific case (this is for comparison, so another click on the same button will remove the box)
+        .data("application-id", applicationID) //set the delete button to reference the specific case (this is for comparison, so another click on the same button will remove the box)
         .parent("form").attr("action", action); //tells confirm button what to delete
-      console.log(applicationID);
-      $("#delete-message").text(deleteTitle); //changes title of box
-      $("#delete-case-name").text(deleteName); //changes message of box
-      $("#delete-case-ref").text(deleteRef); //changes message of box
-      if ($("#delete-case-name").text().length) {
-        $("#delete-case-details").removeAttr("hidden");
-      } else {
-        $("#delete-case-details").attr("hidden","hidden");
-      }
+      $("#delete-message").text(deleteTitle); //changes title of error box
+      $("#delete-case-name").text(deleteName); //changes name in error box
+      $("#delete-case-ref").text(deleteRef); //changes reference in error box
     }
 
     function showDeleteWarning() { 

--- a/app/views/admin/legal_aid_applications/_legal_aid_applications.html.erb
+++ b/app/views/admin/legal_aid_applications/_legal_aid_applications.html.erb
@@ -18,13 +18,14 @@
             <td class="govuk-table__cell"><%= l(application.created_at, format: :date) %></td>
             <td class="govuk-table__cell case-reference-number"><%= application.application_ref %></td>
             <td class="govuk-table__cell"><%= application.enum_t(:state) %></td>
-            <td class="govuk-table__cell"><%= submit_tag(
+            <td class="govuk-table__cell"><%= button_to(
                                                 t('.delete'),
-                                                type: 'button',
+                                                admin_legal_aid_application_path(application.id),
+                                                method: :delete,
                                                 class: 'govuk-button govuk-button--warning request-delete-button',
                                                 "data-application-id": application.id,
                                                 "data-original-text": t('.delete'),
-                                                "data-delete-message": t('.warning.delete')
+                                                "data-delete-message": "#{t('.warning.delete')} #{application.application_ref} (#{application.applicant_full_name || t('generic.undefined')})"
                                               ) if destroy_enabled? %>
                                              </td>
           </tr>

--- a/app/views/admin/legal_aid_applications/_legal_aid_applications.html.erb
+++ b/app/views/admin/legal_aid_applications/_legal_aid_applications.html.erb
@@ -25,8 +25,8 @@
                                                 class: 'govuk-button govuk-button--warning request-delete-button',
                                                 "data-application-id": application.id,
                                                 "data-original-text": t('.delete'),
-                                                "data-delete-name": application.applicant_full_name || t('generic.undefined'),
-                                                "data-delete-ref": application.application_ref,
+                                                "data-delete-name": "#{t('.applicant_name')}: #{application.applicant_full_name || t('generic.undefined')}",
+                                                "data-delete-ref": "#{t('.application_ref')}: #{application.application_ref}",
                                                 "data-delete-message": t('.warning.delete')
                                               ) if destroy_enabled? %>
                                              </td>

--- a/app/views/admin/legal_aid_applications/_legal_aid_applications.html.erb
+++ b/app/views/admin/legal_aid_applications/_legal_aid_applications.html.erb
@@ -25,7 +25,9 @@
                                                 class: 'govuk-button govuk-button--warning request-delete-button',
                                                 "data-application-id": application.id,
                                                 "data-original-text": t('.delete'),
-                                                "data-delete-message": "#{t('.warning.delete')} #{application.application_ref} (#{application.applicant_full_name || t('generic.undefined')})"
+                                                "data-delete-name": application.applicant_full_name || t('generic.undefined'),
+                                                "data-delete-ref": application.application_ref,
+                                                "data-delete-message": t('.warning.delete')
                                               ) if destroy_enabled? %>
                                              </td>
           </tr>

--- a/app/views/admin/legal_aid_applications/_legal_aid_applications.html.erb
+++ b/app/views/admin/legal_aid_applications/_legal_aid_applications.html.erb
@@ -14,16 +14,19 @@
       <tbody class="govuk-table__body">
         <% @applications.each do |application| %>
           <tr class="govuk-table__row">
-            <td class="govuk-table__cell"><%= application.applicant_full_name || t('generic.undefined') %></td>
+            <td class="govuk-table__cell case-full-name"><%= application.applicant_full_name || t('generic.undefined') %></td>
             <td class="govuk-table__cell"><%= l(application.created_at, format: :date) %></td>
-            <td class="govuk-table__cell"><%= application.application_ref %></td>
+            <td class="govuk-table__cell case-reference-number"><%= application.application_ref %></td>
             <td class="govuk-table__cell"><%= application.enum_t(:state) %></td>
-            <td class="govuk-table__cell"><%= button_to(
+            <td class="govuk-table__cell"><%= submit_tag(
                                                 t('.delete'),
-                                                admin_legal_aid_application_path(application.id),
-                                                method: :delete,
-                                                class: 'govuk-button destructive'
-                                              ) if destroy_enabled? %></td>
+                                                type: 'button',
+                                                class: 'govuk-button govuk-button--warning request-delete-button',
+                                                "data-application-id": application.id,
+                                                "data-original-text": t('.delete'),
+                                                "data-delete-message": t('.warning.delete')
+                                              ) if destroy_enabled? %>
+                                             </td>
           </tr>
         <% end %>
       </tbody>

--- a/app/views/admin/legal_aid_applications/index.html.erb
+++ b/app/views/admin/legal_aid_applications/index.html.erb
@@ -6,9 +6,12 @@
 
   <div id="confirm-delete" class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="error-summary" data-cancel-text="<%= t('.cancel_delete') %>" hidden>
     <h2 class="govuk-error-summary__title" id="error-summary-title">
-      <span id="delete-message"></span>
-      <span id="delete-case-details"></span>
+      <span id="delete-message"><% t('.warning.delete') %></span>
     </h2>
+    <div class="govuk-inset-text" id="delete-case-details" hidden>
+      <p id="delete-case-name" class="govuk-body-m"></p>
+      <p id="delete-case-ref" class="govuk-body-m"></p>
+    </div>
     <div class="govuk-error-summary__body">
       <%= t('.warning.delete_consequence') %>
     </div>

--- a/app/views/admin/legal_aid_applications/index.html.erb
+++ b/app/views/admin/legal_aid_applications/index.html.erb
@@ -30,14 +30,15 @@
           class: 'govuk-button'
         ) if create_test_applications_enabled? %>
 
-    <%= submit_tag(
+    <%= button_to(
           t('.delete_all'),
-          type: 'button',
+          destroy_all_admin_legal_aid_applications_path,
+          method: :delete,
           class: 'govuk-button govuk-button--warning request-delete-button',
           "data-original-text": t('.delete_all'),
           "data-application-id": 'destroy_all',
           "data-delete-message": t('.warning.delete_all')
-        ) if @applications.present? %>
+        ) if @applications.present? && destroy_enabled? %>
 <% end %>
 
 <% if @applications.present? %>

--- a/app/views/admin/legal_aid_applications/index.html.erb
+++ b/app/views/admin/legal_aid_applications/index.html.erb
@@ -4,8 +4,25 @@
       back_link: :none
     ) do %>
 
-  <p><%= link_to t('.edit_settings'), admin_settings_path, class: 'govuk-link' %></p>
+  <div id="confirm-delete" class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="error-summary" data-cancel-text="<%= t('.cancel_delete') %>" hidden>
+    <h2 class="govuk-error-summary__title" id="error-summary-title">
+      <span id="delete-message"></span>
+      <span id="delete-case-details"></span>
+    </h2>
+    <div class="govuk-error-summary__body">
+      <%= t('.warning.delete_consequence') %>
+    </div>
+    <%= button_to(
+          t('.confirm_delete'),
+          nil,
+          method: :delete,
+          class: 'govuk-button govuk-button--warning govuk-!-margin-bottom-1 govuk-!-margin-top-4',
+          id: 'confirm-delete-button',
+          disabled: 'true'
+        ) if destroy_enabled? %>
+  </div>
 
+  <p><%= link_to t('.edit_settings'), admin_settings_path, class: 'govuk-link' %></p>
     <%= button_to(
           t('generic.create_test_applications'),
           create_test_applications_admin_legal_aid_applications_path,
@@ -13,12 +30,14 @@
           class: 'govuk-button'
         ) if create_test_applications_enabled? %>
 
-  <%= button_to(
-        t('.delete_all'),
-        destroy_all_admin_legal_aid_applications_path,
-        method: :delete,
-        class: 'govuk-button destructive'
-      ) if @applications.present? && destroy_enabled? %>
+    <%= submit_tag(
+          t('.delete_all'),
+          type: 'button',
+          class: 'govuk-button govuk-button--warning request-delete-button',
+          "data-original-text": t('.delete_all'),
+          "data-application-id": 'destroy_all',
+          "data-delete-message": t('.warning.delete_all')
+        ) if @applications.present? %>
 <% end %>
 
 <% if @applications.present? %>

--- a/app/views/admin/legal_aid_applications/index.html.erb
+++ b/app/views/admin/legal_aid_applications/index.html.erb
@@ -6,13 +6,13 @@
 
   <div id="confirm-delete" class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="error-summary" data-cancel-text="<%= t('.cancel_delete') %>" hidden>
     <h2 class="govuk-error-summary__title" id="error-summary-title">
-      <span id="delete-message"><% t('.warning.delete') %></span>
+      <span id="delete-message"></span>
     </h2>
-    <div class="govuk-inset-text" id="delete-case-details" hidden>
-      <p id="delete-case-name" class="govuk-body-m"></p>
-      <p id="delete-case-ref" class="govuk-body-m"></p>
+    <div class="govuk-body-m" id="delete-case-details">
+      <p id="delete-case-name"></p>
+      <p id="delete-case-ref"></p>
     </div>
-    <div class="govuk-error-summary__body">
+    <div class="govuk-error-summary__body govuk-inset-text">
       <%= t('.warning.delete_consequence') %>
     </div>
     <%= button_to(

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -9,6 +9,8 @@ en:
         no_applications: No applications present
         edit_settings: Edit Settings
         confirm_delete: Yes, delete
+        applicant_name: Client's name
+        application_ref: Case reference
         warning: 
           delete_all: Are you sure you want to delete all applications?
           delete_consequence: This action can't be undone

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -4,10 +4,17 @@ en:
     legal_aid_applications:
       index:
         delete_all: Delete all applications
+        cancel_delete: Cancel delete
         heading_1: 'Admin: Legal Aid Applications'
         no_applications: No applications present
         edit_settings: Edit Settings
+        confirm_delete: Yes, delete
+        warning: 
+          delete_all: Are you sure you want to delete all applications
+          delete_consequence: This action can't be undone
       legal_aid_applications:
+        warning: 
+          delete: Are you sure you want to delete case
         applicant_name: Client's name
         application_ref: Case reference
         created_at: Date started
@@ -21,4 +28,3 @@ en:
           mock_true_layer_data: Mock TrueLayer Data
         hints:
           mock_true_layer_data: Select Yes and TrueLayer data will be replaced by mock data
-

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -10,11 +10,11 @@ en:
         edit_settings: Edit Settings
         confirm_delete: Yes, delete
         warning: 
-          delete_all: Are you sure you want to delete all applications
+          delete_all: Are you sure you want to delete all applications?
           delete_consequence: This action can't be undone
       legal_aid_applications:
         warning: 
-          delete: Are you sure you want to delete case
+          delete: Are you sure you want to delete this case?
         applicant_name: Client's name
         application_ref: Case reference
         created_at: Date started


### PR DESCRIPTION
Add Admin Confirmation button upon deleting an application or all applications

[Link to story](https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=233&projectKey=AP&modal=detail&selectedIssue=AP-556)

Have a confirmation button on the admin page upon clicking either:
-  the delete button on a legal aid application record
- the delete all applications button

Include the confirmation button into an alert/error summary message, which appears when 'Delete all applications' or 'Delete' buttons are pressed.

Have JavaScript toggle the view of the error summary/confirmation alert message when a button is pressed. Also, have JavaScript to adapt the 'Yes, delete' confirmation button's action route to the data record delete was clicked on or to all applications if 'Delete all applications' was clicked.

## Checklist

Before you ask people to review this PR:

- [X] Tests and rubocop should be passing: `bundle exec rake`
- [X] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [X] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [X] The PR description should say what you changed and why, with a link to the JIRA story.
- [X] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [X] You should have checked that the commit messages say why the change was made.