### PR TITLE
AP-601 Dealing with Long Emails

### DIFF
--- a/app/assets/stylesheets/long-email-truncation.scss
+++ b/app/assets/stylesheets/long-email-truncation.scss
@@ -1,0 +1,34 @@
+/********
+All screens
+/********/
+
+#navigation>li {
+  max-width:100%;
+  overflow:hidden;
+  text-overflow: ellipsis;
+  &:focus-within {
+    color:#0b0c0c;
+  }
+}
+
+/********
+Approx 770px+
+/********/
+
+@media (min-width: 48.0625em) {
+  #navigation>li {
+    max-width:calc(50vw - 101px - 30px - 76px - 30px);
+    vertical-align:top;
+  }
+}
+
+/********
+1020px+
+(as per the govuk-width-container style)
+/********/
+
+@media (min-width: 1020px) {
+  #navigation>li {
+    max-width: 312px;
+  }
+}

--- a/app/views/shared/_provider_header_link.html.erb
+++ b/app/views/shared/_provider_header_link.html.erb
@@ -1,6 +1,6 @@
 <ul id="navigation" class="govuk-header__navigation" aria-label="Top Level Navigation">
   <li class="govuk-header__navigation-item">
-    <%= link_to(current_provider.username.truncate(20), providers_provider_path, class: 'govuk-header__link') %>
+    <%= link_to(current_provider.username, providers_provider_path, class: 'govuk-header__link') %>
   </li>
   <li class="govuk-header__navigation-item">
     <%= button = button_to(

--- a/config/initializers/mock_saml.rb
+++ b/config/initializers/mock_saml.rb
@@ -1,5 +1,6 @@
 Rails.configuration.x.application.mock_saml = OpenStruct.new(
   usernames: [
+    'really-really-long-email-address@example.com'.freeze,
     'test1@example.com'.freeze,
     'test2@example.com'.freeze
   ],


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-601)

New SCSS file with CSS to do the following:
- max-width that prevents email containing field from overlapping with the service title (non-mobile).
- overflow, vertical alignment added to stop other undesirable effects.
- removed Ruby truncation, so that full width is used in mobile displays.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
