### PR TITLE
Tidy up ccms services

### DIFF
--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -26,7 +26,11 @@ class Address < ApplicationRecord
   end
 
   def pretty_postcode
-    postcode.insert(-4, ' ')
+    pretty_postcode? ? postcode : postcode.insert(-4, ' ')
+  end
+
+  def pretty_postcode?
+    postcode[-4] == ' '
   end
 
   def first_lines

--- a/app/services/ccms/applicant_add_requestor.rb
+++ b/app/services/ccms/applicant_add_requestor.rb
@@ -20,12 +20,9 @@ module CCMS
       @applicant = applicant
     end
 
-    # temporarily ignore this until connectivity with ccms is working
-    # :nocov:
     def call
       soap_client.call(:create_client, xml: request_xml)
     end
-    # :nocov:
 
     private
 

--- a/app/services/ccms/applicant_add_status_requestor.rb
+++ b/app/services/ccms/applicant_add_status_requestor.rb
@@ -19,12 +19,9 @@ module CCMS
       @applicant_add_transaction_id = applicant_add_transaction_id
     end
 
-    # temporarily ignore this until connectivity with ccms is working
-    # :nocov:
     def call
-      soap_client.call(:get_client_txn_status, message: request_xml)
+      soap_client.call(:get_client_txn_status, xml: request_xml)
     end
-    # :nocov:
 
     private
 

--- a/app/services/ccms/applicant_search_requestor.rb
+++ b/app/services/ccms/applicant_search_requestor.rb
@@ -17,12 +17,9 @@ module CCMS
       @applicant = applicant
     end
 
-    # temporarily ignore this until connectivity with ccms is working
-    # :nocov:
     def call
       soap_client.call(:get_client_details, xml: request_xml)
     end
-    # :nocov:
 
     private
 

--- a/app/services/ccms/case_add_requestor.rb
+++ b/app/services/ccms/case_add_requestor.rb
@@ -22,25 +22,9 @@ module CCMS
       @attribute_value_generator = AttributeValueGenerator.new(@legal_aid_application)
     end
 
-    # temporarily ignore this until connectivity with ccms is working
-    # :nocov:
     def call
       soap_client.call(:add_case, xml: request_xml)
     end
-    # :nocov:
-
-    # def request
-    #   @request ||= build_request
-    # end
-
-    # def formatted_xml
-    #   result = ''
-    #   formatter = REXML::Formatters::Pretty.new
-    #   formatter.compact = true
-    #   formatter.width = 500
-    #   formatter.write(REXML::Document.new(request.to_xml), result)
-    #   result
-    # end
 
     private
 

--- a/app/services/ccms/case_add_status_requestor.rb
+++ b/app/services/ccms/case_add_status_requestor.rb
@@ -15,12 +15,9 @@ module CCMS
       @case_add_transaction_id = case_add_transaction_id
     end
 
-    # temporarily ignore this until connectivity with ccms is working
-    # :nocov:
     def call
-      soap_client.call(:get_case_txn_status, message: request_xml)
+      soap_client.call(:get_case_txn_status, xml: request_xml)
     end
-    # :nocov:
 
     private
 

--- a/app/services/ccms/document_id_requestor.rb
+++ b/app/services/ccms/document_id_requestor.rb
@@ -18,12 +18,9 @@ module CCMS
       @case_ccms_reference = case_ccms_reference
     end
 
-    # temporarily ignore this until connectivity with ccms is working
-    # :nocov:
     def call
       soap_client.call(:upload_document, xml: request_xml)
     end
-    # :nocov:
 
     private
 

--- a/app/services/ccms/document_upload_requestor.rb
+++ b/app/services/ccms/document_upload_requestor.rb
@@ -20,12 +20,9 @@ module CCMS
       @document_encoded_base64 = document_encoded_base64
     end
 
-    # temporarily ignore this until connectivity with ccms is working
-    # :nocov:
     def call
       soap_client.call(:upload_document, xml: request_xml)
     end
-    # :nocov:
 
     private
 

--- a/app/services/ccms/reference_data_requestor.rb
+++ b/app/services/ccms/reference_data_requestor.rb
@@ -13,12 +13,9 @@ module CCMS
       'xmlns:ns5' => 'http://legalservices.gov.uk/CCMS/Common/ReferenceData/1.0/ReferenceDataBIO'
     )
 
-    # temporarily ignore this until connectivity with ccms is working
-    # :nocov:
     def call
       soap_client.call(:process, xml: request_xml)
     end
-    # :nocov:
 
     private
 

--- a/spec/services/ccms/applicant_add_requestor_spec.rb
+++ b/spec/services/ccms/applicant_add_requestor_spec.rb
@@ -42,7 +42,22 @@ module CCMS
 
     describe 'wsdl_location' do
       it 'points to correct location' do
-        expect(requestor.send(:wsdl_location)).to match('app/services/ccms/wsdls/ClientProxyServiceWsdl.xml')
+        expect(requestor.__send__(:wsdl_location)).to match('app/services/ccms/wsdls/ClientProxyServiceWsdl.xml')
+      end
+    end
+
+    describe '#call' do
+      let(:soap_client_double) { Savon.client(env_namespace: :soap, wsdl: requestor.__send__(:wsdl_location)) }
+      let(:expected_soap_operation) { :create_client }
+      let(:expected_xml) { requestor.__send__(:request_xml) }
+
+      before do
+        expect(requestor).to receive(:soap_client).and_return(soap_client_double)
+      end
+
+      it 'calls the savon soap client' do
+        expect(soap_client_double).to receive(:call).with(expected_soap_operation, xml: expected_xml)
+        requestor.call
       end
     end
   end

--- a/spec/services/ccms/applicant_add_status_requestor_spec.rb
+++ b/spec/services/ccms/applicant_add_status_requestor_spec.rb
@@ -4,11 +4,11 @@ module CCMS
   RSpec.describe ApplicantAddStatusRequestor do
     let(:expected_xml) { ccms_data_from_file 'applicant_add_status_request.xml' }
     let(:expected_tx_id) { '20190101121530123456' }
+    let(:requestor) { described_class.new(expected_tx_id) }
 
     describe 'XML request' do
       it 'generates the expected XML' do
         with_modified_env(modified_environment_vars) do
-          requestor = described_class.new(expected_tx_id)
           allow(requestor).to receive(:transaction_request_id).and_return(expected_tx_id)
           expect(requestor.formatted_xml).to eq expected_xml.chomp
         end
@@ -18,9 +18,23 @@ module CCMS
     describe '#transaction_request_id' do
       it 'returns the id based on current time' do
         Timecop.freeze(2019, 1, 1, 12, 15, 30.123456) do
-          requestor = described_class.new(expected_tx_id)
           expect(requestor.transaction_request_id).to start_with expected_tx_id
         end
+      end
+    end
+
+    describe '#call' do
+      let(:soap_client_double) { Savon.client(env_namespace: :soap, wsdl: requestor.__send__(:wsdl_location)) }
+      let(:expected_soap_operation) { :get_client_txn_status }
+      let(:expected_xml) { requestor.__send__(:request_xml) }
+
+      before do
+        expect(requestor).to receive(:soap_client).and_return(soap_client_double)
+      end
+
+      it 'calls the savon soap client' do
+        expect(soap_client_double).to receive(:call).with(expected_soap_operation, xml: expected_xml)
+        requestor.call
       end
     end
   end

--- a/spec/services/ccms/applicant_search_requestor_spec.rb
+++ b/spec/services/ccms/applicant_search_requestor_spec.rb
@@ -11,11 +11,11 @@ module CCMS
              date_of_birth: Date.new(1969, 1, 1),
              national_insurance_number: 'YS327299B')
     end
+    let(:requestor) { described_class.new(applicant) }
 
     describe 'XML request' do
       it 'generates the expected XML' do
         with_modified_env(modified_environment_vars) do
-          requestor = described_class.new(applicant)
           allow(requestor).to receive(:transaction_request_id).and_return(expected_tx_id)
           expect(requestor.formatted_xml).to eq expected_xml.chomp
         end
@@ -25,14 +25,24 @@ module CCMS
     describe '#transaction_request_id' do
       it 'returns the id based on current time' do
         Timecop.freeze(2019, 1, 1, 12, 15, 30.123456) do
-          requestor = described_class.new(applicant)
           expect(requestor.transaction_request_id).to start_with expected_tx_id
         end
       end
     end
 
-    def expected_xml
-      ccms_data_from_file 'applicant_search_request.xml'
+    describe '#call' do
+      let(:soap_client_double) { Savon.client(env_namespace: :soap, wsdl: requestor.__send__(:wsdl_location)) }
+      let(:expected_soap_operation) { :get_client_details }
+      let(:expected_xml) { requestor.__send__(:request_xml) }
+
+      before do
+        expect(requestor).to receive(:soap_client).and_return(soap_client_double)
+      end
+
+      it 'calls the savon soap client' do
+        expect(soap_client_double).to receive(:call).with(expected_soap_operation, xml: expected_xml)
+        requestor.call
+      end
     end
   end
 end

--- a/spec/services/ccms/case_add_status_requestor_spec.rb
+++ b/spec/services/ccms/case_add_status_requestor_spec.rb
@@ -4,11 +4,11 @@ module CCMS
   RSpec.describe CaseAddStatusRequestor do
     let(:expected_xml) { ccms_data_from_file 'case_add_status_request.xml' }
     let(:expected_tx_id) { '20190101121530123456' }
+    let(:requestor) { described_class.new(expected_tx_id) }
 
     describe 'XML request' do
       it 'generates the expected XML' do
         with_modified_env(modified_environment_vars) do
-          requestor = described_class.new(expected_tx_id)
           allow(requestor).to receive(:transaction_request_id).and_return(expected_tx_id)
           expect(requestor.formatted_xml).to eq expected_xml.chomp
         end
@@ -18,9 +18,23 @@ module CCMS
     describe '#transaction_request_id' do
       it 'returns the id based on current time' do
         Timecop.freeze(2019, 1, 1, 12, 15, 30.123456) do
-          requestor = described_class.new(expected_tx_id)
           expect(requestor.transaction_request_id).to start_with expected_tx_id
         end
+      end
+    end
+
+    describe '#call' do
+      let(:soap_client_double) { Savon.client(env_namespace: :soap, wsdl: requestor.__send__(:wsdl_location)) }
+      let(:expected_soap_operation) { :get_case_txn_status }
+      let(:expected_xml) { requestor.__send__(:request_xml) }
+
+      before do
+        expect(requestor).to receive(:soap_client).and_return(soap_client_double)
+      end
+
+      it 'calls the savon soap client' do
+        expect(soap_client_double).to receive(:call).with(expected_soap_operation, xml: expected_xml)
+        requestor.call
       end
     end
   end

--- a/spec/services/ccms/document_id_requestor_spec.rb
+++ b/spec/services/ccms/document_id_requestor_spec.rb
@@ -5,11 +5,11 @@ module CCMS
     let(:expected_xml) { ccms_data_from_file 'document_id_request.xml' }
     let(:expected_tx_id) { '20190101121530123456' }
     let(:case_ccms_reference) { '1234567890' }
+    let(:requestor) { described_class.new(case_ccms_reference) }
 
     describe 'XML request' do
       it 'generates the expected XML' do
         with_modified_env(modified_environment_vars) do
-          requestor = described_class.new(case_ccms_reference)
           allow(requestor).to receive(:transaction_request_id).and_return(expected_tx_id)
           expect(requestor.formatted_xml).to eq expected_xml.chomp
         end
@@ -19,9 +19,23 @@ module CCMS
     describe '#transaction_request_id' do
       it 'returns the id based on current time' do
         Timecop.freeze(2019, 1, 1, 12, 15, 30.123456) do
-          requestor = described_class.new(case_ccms_reference)
           expect(requestor.transaction_request_id).to start_with expected_tx_id
         end
+      end
+    end
+
+    describe '#call' do
+      let(:soap_client_double) { Savon.client(env_namespace: :soap, wsdl: requestor.__send__(:wsdl_location)) }
+      let(:expected_soap_operation) { :upload_document }
+      let(:expected_xml) { requestor.__send__(:request_xml) }
+
+      before do
+        expect(requestor).to receive(:soap_client).and_return(soap_client_double)
+      end
+
+      it 'calls the savon soap client' do
+        expect(soap_client_double).to receive(:call).with(expected_soap_operation, xml: expected_xml)
+        requestor.call
       end
     end
   end

--- a/spec/services/ccms/document_upload_requestor_spec.rb
+++ b/spec/services/ccms/document_upload_requestor_spec.rb
@@ -7,11 +7,11 @@ module CCMS
     let(:case_ccms_reference) { '1234567890' }
     let(:document_id) { '4420073' }
     let(:document_encoded_base64) { 'JVBERi0xLjUNCiW1tbW1DQoxIDAgb2JqDQo8PC9UeXBlL0NhdGFsb2cvUGFnZXMgMiA' }
+    let(:requestor) { described_class.new(case_ccms_reference, document_id, document_encoded_base64) }
 
     describe 'XML request' do
       it 'generates the expected XML' do
         with_modified_env(modified_environment_vars) do
-          requestor = described_class.new(case_ccms_reference, document_id, document_encoded_base64)
           allow(requestor).to receive(:transaction_request_id).and_return(expected_tx_id)
           expect(requestor.formatted_xml).to eq expected_xml.chomp
         end
@@ -21,9 +21,23 @@ module CCMS
     describe '#transaction_request_id' do
       it 'returns the id based on current time' do
         Timecop.freeze(2019, 1, 1, 12, 15, 30.123456) do
-          requestor = described_class.new(case_ccms_reference, document_id, document_encoded_base64)
           expect(requestor.transaction_request_id).to start_with expected_tx_id
         end
+      end
+    end
+
+    describe '#call' do
+      let(:soap_client_double) { Savon.client(env_namespace: :soap, wsdl: requestor.__send__(:wsdl_location)) }
+      let(:expected_soap_operation) { :upload_document }
+      let(:expected_xml) { requestor.__send__(:request_xml) }
+
+      before do
+        expect(requestor).to receive(:soap_client).and_return(soap_client_double)
+      end
+
+      it 'calls the savon soap client' do
+        expect(soap_client_double).to receive(:call).with(expected_soap_operation, xml: expected_xml)
+        requestor.call
       end
     end
   end

--- a/spec/services/ccms/reference_data_requestor_spec.rb
+++ b/spec/services/ccms/reference_data_requestor_spec.rb
@@ -4,11 +4,11 @@ module CCMS
   RSpec.describe ReferenceDataRequestor do
     let(:expected_xml) { ccms_data_from_file 'reference_data_request.xml' }
     let(:expected_tx_id) { '20190101121530123456' }
+    let(:requestor) { described_class.new }
 
     describe 'XML request' do
       it 'generates the expected XML' do
         with_modified_env(modified_environment_vars) do
-          requestor = described_class.new
           allow(requestor).to receive(:transaction_request_id).and_return(expected_tx_id)
           expect(requestor.formatted_xml).to eq expected_xml.chomp
         end
@@ -18,9 +18,24 @@ module CCMS
     describe '#transaction_request_id' do
       it 'returns the id based on current time' do
         Timecop.freeze(2019, 1, 1, 12, 15, 30.123456) do
-          requestor = described_class.new
           expect(requestor.transaction_request_id).to start_with expected_tx_id
         end
+      end
+    end
+
+    describe '#call' do
+      let(:soap_client_double) { Savon.client(env_namespace: :soap, wsdl: requestor.__send__(:wsdl_location)) }
+      let(:expected_soap_operation) { :process }
+      let(:expected_xml) { requestor.__send__(:request_xml) }
+
+      before do
+        Timecop.freeze
+        expect(requestor).to receive(:soap_client).and_return(soap_client_double)
+      end
+
+      it 'calls the savon soap client' do
+        expect(soap_client_double).to receive(:call).with(expected_soap_operation, xml: expected_xml)
+        requestor.call
       end
     end
   end


### PR DESCRIPTION
## What

Tidy up CCMS services: 

  - remove unused methods
  - remove nocov from `call` methods
  - add tests for `call` methods, mocking soap calls
  - minor naming corrections 

Also improve functionality of `pretty_postcode` method to prevent multiple spaces being added.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
