### PR TITLE
AP-689 default unselect vehicle radio button

### DIFF
--- a/app/controllers/citizens/vehicles_controller.rb
+++ b/app/controllers/citizens/vehicles_controller.rb
@@ -3,39 +3,32 @@ module Citizens
     include ApplicationFromSession
 
     def show
-      vehicle
+      @form = LegalAidApplications::OwnVehicleForm.new(model: legal_aid_application)
     end
 
-    def create
-      case form_params[:persisted]
-      when 'true'
-        create_vehicle_and_continue
-      when 'false'
-        remove_vehicle_and_continue
+    def update
+      @form = LegalAidApplications::OwnVehicleForm.new(form_params)
+
+      if @form.save
+        legal_aid_application.own_vehicle ? vehicle.save! : vehicle.destroy!
+        go_forward
       else
-        vehicle.errors.add :exists_yes, I18n.t('citizens.vehicles.show.nothing_selected')
         render :show
       end
     end
 
     private
 
-    def create_vehicle_and_continue
-      vehicle.save! unless vehicle.persisted?
-      go_forward
-    end
+    def form_params
+      merge_with_model(legal_aid_application, mode: :citizen) do
+        next {} unless params[:legal_aid_application]
 
-    def remove_vehicle_and_continue
-      vehicle.destroy!
-      go_forward
+        params.require(:legal_aid_application).permit(:own_vehicle)
+      end
     end
 
     def vehicle
       @vehicle = legal_aid_application.vehicle || legal_aid_application.build_vehicle
-    end
-
-    def form_params
-      params.require(:vehicle).permit(:persisted)
     end
   end
 end

--- a/app/forms/legal_aid_applications/own_vehicle_form.rb
+++ b/app/forms/legal_aid_applications/own_vehicle_form.rb
@@ -1,0 +1,21 @@
+module LegalAidApplications
+  class OwnVehicleForm
+    include BaseForm
+
+    form_for LegalAidApplication
+
+    attr_accessor :own_vehicle, :mode
+
+    validate :own_vehicle_presence
+
+    def own_vehicle_presence
+      return if draft? || own_vehicle.present?
+
+      errors.add(:own_vehicle, I18n.t("activemodel.errors.models.legal_aid_application.attributes.own_vehicle.#{mode}.blank"))
+    end
+
+    def exclude_from_model
+      [:mode]
+    end
+  end
+end

--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -33,7 +33,6 @@ class LegalAidApplication < ApplicationRecord # rubocop:disable Metrics/ClassLen
   validates :provider, presence: true
 
   delegate :full_name, to: :applicant, prefix: true, allow_nil: true
-  delegate :persisted?, to: :vehicle, prefix: true, allow_nil: true
 
   scope :latest, -> { order(created_at: :desc) }
 

--- a/app/services/flow/flows/citizen_vehicle.rb
+++ b/app/services/flow/flows/citizen_vehicle.rb
@@ -4,9 +4,9 @@ module Flow
       STEPS = {
         vehicles: {
           path: ->(_) { urls.citizens_vehicle_path },
-          forward: ->(application) { application.vehicle_persisted? ? :vehicles_estimated_values : :savings_and_investments },
+          forward: ->(application) { application.own_vehicle? ? :vehicles_estimated_values : :savings_and_investments },
           check_answers: :check_answers,
-          carry_on_sub_flow: ->(application) { application.vehicle_persisted? }
+          carry_on_sub_flow: ->(application) { application.own_vehicle? }
         },
         vehicles_estimated_values: {
           path: ->(_) { urls.citizens_vehicles_estimated_value_path },

--- a/app/services/flow/flows/provider_vehicle.rb
+++ b/app/services/flow/flows/provider_vehicle.rb
@@ -4,9 +4,9 @@ module Flow
       STEPS = {
         vehicles: {
           path: ->(application) { urls.providers_legal_aid_application_vehicle_path(application) },
-          forward: ->(application) { application.vehicle_persisted? ? :vehicles_estimated_values : :savings_and_investments },
+          forward: ->(application) { application.own_vehicle? ? :vehicles_estimated_values : :savings_and_investments },
           check_answers: ->(app) { app.provider_checking_citizens_means_answers? ? :means_summaries : :check_passported_answers },
-          carry_on_sub_flow: ->(application) { application.vehicle_persisted? }
+          carry_on_sub_flow: ->(application) { application.own_vehicle? }
         },
         vehicles_estimated_values: {
           path: ->(application) { urls.providers_legal_aid_application_vehicles_estimated_value_path(application) },

--- a/app/services/save_applicant_means_answers.rb
+++ b/app/services/save_applicant_means_answers.rb
@@ -22,6 +22,7 @@ class SaveApplicantMeansAnswers
         savings_amount
         other_assets_declaration
         restrictions
+        vehicle
       ]
     ).merge(bank_transactions: bank_transactions)
   end

--- a/app/views/citizens/vehicles/show.html.erb
+++ b/app/views/citizens/vehicles/show.html.erb
@@ -1,3 +1,3 @@
-<%= page_template page_title: t('.heading'), template: :basic, show_errors_for: @vehicle do %>
+<%= page_template page_title: t('.heading'), template: :basic do %>
   <%= render 'shared/forms/vehicles/own_vehicle', form_path: citizens_vehicle_path %>
 <% end %>

--- a/app/views/providers/vehicles/show.html.erb
+++ b/app/views/providers/vehicles/show.html.erb
@@ -1,4 +1,4 @@
-<%= page_template page_title: t('.heading'), template: :basic, show_errors_for: @vehicle do %>
+<%= page_template page_title: t('.heading'), template: :basic do %>
   <%= render(
         'shared/forms/vehicles/own_vehicle',
         form_path: providers_legal_aid_application_vehicle_path,

--- a/app/views/shared/_check_answers_vehicles.html.erb
+++ b/app/views/shared/_check_answers_vehicles.html.erb
@@ -7,7 +7,7 @@
         name: :vehicles,
         url: check_answer_url_for(user_type, :vehicles, application),
         question: t(".#{user_type}.own"),
-        answer: yes_no(application.vehicle_persisted?)
+        answer: yes_no(application.own_vehicle?)
       ) %>
 
   <%= check_answer_link(
@@ -15,26 +15,26 @@
         url: check_answer_url_for(user_type, :vehicles_estimated_values, application),
         question: t(".#{user_type}.estimated_value"),
         answer: number_to_currency(application.vehicle.estimated_value, unit: t('currency.gbp'))
-      ) if application.vehicle_persisted? %>
+      ) if application.own_vehicle? %>
 
   <%= check_answer_link(
         name: :vehicles_remaining_payments,
         url: check_answer_url_for(user_type, :vehicles_remaining_payments, application),
         question: t(".#{user_type}.payment_remaining"),
         answer: number_to_currency(application.vehicle.payment_remaining, unit: t('currency.gbp'))
-      ) if application.vehicle_persisted? %>
+      ) if application.own_vehicle? %>
 
   <%= check_answer_link(
         name: :vehicles_purchase_dates,
         url: check_answer_url_for(user_type, :vehicles_purchase_dates, application),
         question: t(".#{user_type}.purchased_on"),
         answer: application.vehicle.purchased_on
-      ) if application.vehicle_persisted? %>
+      ) if application.own_vehicle? %>
 
   <%= check_answer_link(
         name: :vehicles_regular_uses,
         url: check_answer_url_for(user_type, :vehicles_regular_uses, application),
         question: t(".#{user_type}.used_regularly"),
         answer: yes_no(application.vehicle.used_regularly)
-      ) if application.vehicle_persisted? %>
+      ) if application.own_vehicle? %>
 </dl>

--- a/app/views/shared/forms/vehicles/_own_vehicle.html.erb
+++ b/app/views/shared/forms/vehicles/_own_vehicle.html.erb
@@ -1,22 +1,13 @@
-<%= form_with(
-      model: @vehicle,
-      url: form_path,
-      method: :post,
-      local: true
-    ) do |form| %>
-  <%= govuk_form_group show_error_if: @vehicle.errors.present? do %>
-    <%= govuk_fieldset_header page_title %>
-    <%= govuk_hint t('.vehicle_types_included') %>
+<%= form_with(model: @form, url: form_path, method: :patch, local: true) do |form| %>
 
-    <div class="govuk-radios govuk-radios--conditional govuk-!-padding-bottom-6 govuk-!-padding-top-2"
-         data-module="radios">
-      <%= form.govuk_radio_button :persisted?, 'true', label: t('generic.yes') %>
-      <%= form.govuk_radio_button :persisted?, 'false', label: t('generic.no') %>
-    </div>
+  <%= form.govuk_collection_radio_buttons(
+        :own_vehicle,
+        [true, false],
+        title: content_for(:page_title)
+      ) %>
 
-    <%= next_action_buttons(
-          show_draft: local_assigns.key?(:show_draft) ? show_draft : false,
-          form: form
-        ) %>
-  <% end %>
+  <%= next_action_buttons(
+        show_draft: local_assigns.key?(:show_draft) ? show_draft : false,
+        form: form
+      ) %>
 <% end %>

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -123,6 +123,11 @@ en:
               too_many_decimals: Mortgage amount must not include more than 2 decimal numbers
             own_home:
               blank: Select yes if you own the home you live in
+            own_vehicle:
+              citizen:
+                blank: Select yes if you own a vehicle
+              provider:
+                blank: Select yes if your client owns a vehicle
             percentage_home:
               blank: Enter the percentage (%) share
               greater_than_or_equal_to: Share must be a percentage amount under 100, like 60
@@ -209,7 +214,7 @@ en:
               too_many_decimals: Estimated trust value must not include more than 2 decimal numbers
             base:
               citizen:
-                none_selected: Select if you have any of these types of assets              
+                none_selected: Select if you have any of these types of assets
               provider:
                 none_selected: Select if your client has any of these types of assets
         respondent:

--- a/config/locales/en/citizens.yml
+++ b/config/locales/en/citizens.yml
@@ -162,7 +162,6 @@ en:
     vehicles:
       show:
         heading: Do you own a vehicle?
-        nothing_selected: Select yes if you own a vehicle
       estimated_values:
         show:
           heading: What is the estimated value of the vehicle?

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -18,6 +18,7 @@ en:
           provider: ''
         percentage_home: Your name must be on the property deeds, lease, freehold or mortgage.
         property_value: You can use property websites to find the estimated value.
+        own_vehicle: This includes car, vans or motorcycles
       merits_assessment:
         estimated_legal_cost: Please include profit costs, disbursements, expert costs and counsel fees
     label:
@@ -37,6 +38,9 @@ en:
         second_home_mortgage: Enter outstanding mortgage amount
         second_home_percentage: Enter percentage share you legally own
         second_home_value: Enter estimated value
+      legal_aid_application:
+        own_vehicle:
+          <<: *true_false
       respondent:
         understands_terms_of_court_order_details: Tell us why you think the court would enforce a breach of an order
         warning_letter_sent_details: Tell us why a warning letter has not been sent

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -368,7 +368,6 @@ en:
     vehicles:
       show:
         heading: Does your client own a vehicle?
-        nothing_selected: Select yes if your client owns a vehicle
       estimated_values:
         show:
           heading: What is the estimated value of the vehicle?

--- a/config/locales/en/shared.yml
+++ b/config/locales/en/shared.yml
@@ -166,9 +166,6 @@ en:
         or_break: or
         none_selected: None of these
       vehicles:
-        own_vehicle:
-          vehicle_types_included: This includes car, vans or motorcycles.
-          nothing_selected: Select yes if your client owns a vehicle
         estimated_value:
           use_car_valuation_sites: You can use car valuation websites to find this out.
         remaining_payment:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,7 +48,7 @@ Rails.application.routes.draw do
     resource :own_home, only: %i[show update]
     resource :percentage_home, only: %i[show update]
     resource :outstanding_mortgage, only: %i[show update]
-    resource :vehicle, only: %i[show create]
+    resource :vehicle, only: %i[show update]
     namespace :vehicles do
       resource :estimated_value, only: %i[show update]
       resource :remaining_payment, only: %i[show update]
@@ -109,7 +109,7 @@ Rails.application.routes.draw do
       resource :email_address, only: %i[show update]
       resource :application_confirmation, only: :show
       resource :percentage_home, only: %i[show update]
-      resource :vehicle, only: %i[show create]
+      resource :vehicle, only: %i[show update]
       namespace :vehicles do
         resource :estimated_value, only: %i[show update]
         resource :remaining_payment, only: %i[show update]

--- a/db/migrate/20190611134522_add_own_vehicle_to_legal_aid_application.rb
+++ b/db/migrate/20190611134522_add_own_vehicle_to_legal_aid_application.rb
@@ -1,0 +1,5 @@
+class AddOwnVehicleToLegalAidApplication < ActiveRecord::Migration[5.2]
+  def change
+    add_column :legal_aid_applications, :own_vehicle, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_29_164413) do
+ActiveRecord::Schema.define(version: 2019_06_11_134522) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -261,6 +261,7 @@ ActiveRecord::Schema.define(version: 2019_05_29_164413) do
     t.datetime "declaration_accepted_at"
     t.datetime "completed_at"
     t.json "provider_step_params"
+    t.boolean "own_vehicle"
     t.index ["applicant_id"], name: "index_legal_aid_applications_on_applicant_id"
     t.index ["application_ref"], name: "index_legal_aid_applications_on_application_ref", unique: true
     t.index ["provider_id"], name: "index_legal_aid_applications_on_provider_id"

--- a/features/providers/civil_application_journey.feature
+++ b/features/providers/civil_application_journey.feature
@@ -402,7 +402,7 @@ Feature: Civil application journeys
     Then I fill "Percentage home" with "50"
     Then I click 'Save and continue'
     Then I should be on a page showing "Does your client own a vehicle?"
-    Then I choose option "Vehicle persisted false"
+    Then I choose "No"
     Then I click 'Save and continue'
     Then I should be on a page showing "Does your client have any savings and investments?"
     Then I select "Cash savings"
@@ -517,7 +517,7 @@ Feature: Civil application journeys
   Scenario: Complete the vehicle part of the journey
     Given I start the journey as far as the start of the vehicle section
     Then I should be on a page showing "Does your client own a vehicle?"
-    Then I choose option "Vehicle persisted true"
+    Then I choose "Yes"
     And I click "Save and continue"
     Then I should be on a page showing "What is the estimated value of the vehicle?"
     Then I fill "Estimated value" with "4000"

--- a/spec/factories/legal_aid_applications.rb
+++ b/spec/factories/legal_aid_applications.rb
@@ -119,6 +119,7 @@ FactoryBot.define do
     end
 
     trait :with_vehicle do
+      own_vehicle { true }
       vehicle
     end
 

--- a/spec/requests/citizens/check_answers_spec.rb
+++ b/spec/requests/citizens/check_answers_spec.rb
@@ -3,7 +3,14 @@ require 'rails_helper'
 RSpec.describe 'check your answers requests', type: :request do
   include ActionView::Helpers::NumberHelper
   let(:vehicle) { create :vehicle, :populated }
-  let!(:legal_aid_application) { create :legal_aid_application, :provider_submitted, :with_everything, vehicle: vehicle }
+  let(:own_vehicle) { true }
+  let!(:legal_aid_application) do
+    create :legal_aid_application,
+           :provider_submitted,
+           :with_everything,
+           vehicle: vehicle,
+           own_vehicle: own_vehicle
+  end
   let!(:restriction) { create :restriction, legal_aid_applications: [legal_aid_application] }
   let(:secure_id) { legal_aid_application.generate_secure_id }
   before do
@@ -135,6 +142,8 @@ RSpec.describe 'check your answers requests', type: :request do
 
     context 'applicant does not have vehicle' do
       let(:vehicle) { nil }
+      let(:own_vehicle) { false }
+
       it 'displays first vehicle question' do
         expect(response.body).to include(I18n.t('shared.check_answers_vehicles.citizens.own'))
       end

--- a/spec/requests/citizens/vehicles_spec.rb
+++ b/spec/requests/citizens/vehicles_spec.rb
@@ -17,12 +17,12 @@ RSpec.describe Citizens::VehiclesController, type: :request do
     end
   end
 
-  describe 'POST /citizens/vehicle' do
-    let(:option) { 'foo' }
+  describe 'PATCH /citizens/vehicle' do
+    let(:own_vehicle) { nil }
     let(:params) do
-      { vehicle: { persisted: option } }
+      { legal_aid_application: { own_vehicle: own_vehicle } }
     end
-    subject { post citizens_vehicle_path, params: params }
+    subject { patch citizens_vehicle_path, params: params }
 
     it 'renders successfully' do
       subject
@@ -35,12 +35,16 @@ RSpec.describe Citizens::VehiclesController, type: :request do
     end
 
     context 'with option "true"' do
-      let(:option) { 'true' }
+      let(:own_vehicle) { 'true' }
       let(:next_url) { citizens_vehicles_estimated_value_path }
 
       it 'creates a vehicle' do
         expect { subject }.to change { Vehicle.count }.by(1)
         expect(legal_aid_application.reload.vehicle).to be_present
+      end
+
+      it 'sets own_vehicle to true' do
+        expect { subject }.to change { legal_aid_application.reload.own_vehicle }.to(true)
       end
 
       it 'redirects to estimated value' do
@@ -72,11 +76,15 @@ RSpec.describe Citizens::VehiclesController, type: :request do
     end
 
     context 'with option "false"' do
-      let(:option) { 'false' }
+      let(:own_vehicle) { 'false' }
       let(:next_url) { citizens_savings_and_investment_path }
 
       it 'does not create a vehicle' do
         expect { subject }.not_to change { Vehicle.count }
+      end
+
+      it 'sets own_vehicle to false' do
+        expect { subject }.to change { legal_aid_application.reload.own_vehicle }.to(false)
       end
 
       it 'redirects to savings and investment' do

--- a/spec/requests/providers/check_passported_answers_spec.rb
+++ b/spec/requests/providers/check_passported_answers_spec.rb
@@ -5,11 +5,13 @@ RSpec.describe 'check passported answers requests', type: :request do
 
   describe 'GET /providers/applications/:id/check_passported_answers' do
     let(:vehicle) { create :vehicle, :populated }
+    let(:own_vehicle) { true }
     let!(:application) do
       create :legal_aid_application,
              :with_everything,
              :client_details_answers_checked,
-             vehicle: vehicle
+             vehicle: vehicle,
+             own_vehicle: own_vehicle
     end
     let!(:restriction) { create :restriction, legal_aid_applications: [application] }
 
@@ -153,6 +155,7 @@ RSpec.describe 'check passported answers requests', type: :request do
 
       context 'applicant does not have vehicle' do
         let(:vehicle) { nil }
+        let(:own_vehicle) { false }
         it 'displays first vehicle question' do
           expect(response.body).to include(I18n.t('shared.check_answers_vehicles.providers.own'))
         end

--- a/spec/requests/providers/means_summaries_spec.rb
+++ b/spec/requests/providers/means_summaries_spec.rb
@@ -8,8 +8,15 @@ RSpec.describe Providers::MeansSummariesController, type: :request do
   let(:bank_provider) { create :bank_provider, applicant: applicant }
   let(:bank_account) { create :bank_account, bank_provider: bank_provider }
   let(:vehicle) { create :vehicle, :populated }
+  let(:own_vehicle) { true }
   let(:legal_aid_application) do
-    create :legal_aid_application, vehicle: vehicle, applicant: applicant, provider: provider, transaction_types: [transaction_type], state: :means_completed
+    create :legal_aid_application,
+           vehicle: vehicle,
+           own_vehicle: own_vehicle,
+           applicant: applicant,
+           provider: provider,
+           transaction_types: [transaction_type],
+           state: :means_completed
   end
   let(:login) { login_as provider }
 
@@ -52,6 +59,7 @@ RSpec.describe Providers::MeansSummariesController, type: :request do
 
     context 'applicant does not have vehicle' do
       let(:vehicle) { nil }
+      let(:own_vehicle) { false }
       it 'displays first vehicle question' do
         expect(response.body).to include(I18n.t('shared.check_answers_vehicles.providers.own'))
       end

--- a/spec/requests/providers/vehicles_spec.rb
+++ b/spec/requests/providers/vehicles_spec.rb
@@ -21,13 +21,13 @@ RSpec.describe Providers::VehiclesController, type: :request do
     end
   end
 
-  describe 'POST /providers/applications/:legal_aid_application_id/vehicle' do
-    let(:option) { 'foo' }
+  describe 'PATCH /providers/applications/:legal_aid_application_id/vehicle' do
+    let(:own_vehicle) { nil }
     let(:params) do
-      { vehicle: { persisted: option } }
+      { legal_aid_application: { own_vehicle: own_vehicle } }
     end
     subject do
-      post(
+      patch(
         providers_legal_aid_application_vehicle_path(legal_aid_application),
         params: params
       )
@@ -50,7 +50,7 @@ RSpec.describe Providers::VehiclesController, type: :request do
     end
 
     context 'with option "true"' do
-      let(:option) { 'true' }
+      let(:own_vehicle) { 'true' }
       let(:target_url) do
         providers_legal_aid_application_vehicles_estimated_value_path(legal_aid_application)
       end
@@ -58,6 +58,10 @@ RSpec.describe Providers::VehiclesController, type: :request do
       it 'creates a vehicle' do
         expect { subject }.to change { Vehicle.count }.by(1)
         expect(legal_aid_application.reload.vehicle).to be_present
+      end
+
+      it 'sets own_vehicle to true' do
+        expect { subject }.to change { legal_aid_application.reload.own_vehicle }.to(true)
       end
 
       it 'redirects to estimated value' do
@@ -89,13 +93,17 @@ RSpec.describe Providers::VehiclesController, type: :request do
     end
 
     context 'with option "false"' do
-      let(:option) { 'false' }
+      let(:own_vehicle) { 'false' }
       let(:target_url) do
         providers_legal_aid_application_savings_and_investment_path(legal_aid_application)
       end
 
       it 'does not create a vehicle' do
         expect { subject }.not_to change { Vehicle.count }
+      end
+
+      it 'sets own_vehicle to false' do
+        expect { subject }.to change { legal_aid_application.reload.own_vehicle }.to(false)
       end
 
       it 'redirects to savings and investment' do

--- a/spec/services/save_applicant_means_answers_spec.rb
+++ b/spec/services/save_applicant_means_answers_spec.rb
@@ -1,7 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe SaveApplicantMeansAnswers do
-  let(:application) { create :legal_aid_application, :with_everything }
+  let(:vehicle) { create :vehicle, :populated }
+  let(:application) { create :legal_aid_application, :with_everything, :with_vehicle, vehicle: vehicle }
   let(:savings_amount) { application.savings_amount }
   let(:other_assets_declaration) { application.other_assets_declaration }
   let(:bank_provider) { create :bank_provider, applicant: application.applicant }
@@ -67,6 +68,11 @@ RSpec.describe SaveApplicantMeansAnswers do
       restrictions = application.applicant_means_answers['restrictions'].pluck('name')
       expected_restrictions = application.restrictions.pluck(:name)
       expect(restrictions).to match_array(expected_restrictions)
+    end
+
+    it 'copies the vehicle of the application' do
+      subject
+      expect(application.applicant_means_answers['vehicle']).to eq(JSON.parse(application.vehicle.to_json))
     end
 
     it 'copies the bank transactions' do


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-689)

- On the "Do you own a vehicle?" page, prevent "No" from being selected by adding a new attribute and a form
- Save the applicant's vehicle answers at the end of the applicant flow

## Checklist

Before you ask people to review this PR:

- [X] Tests and rubocop should be passing: `bundle exec rake`
- [X] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [X] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [X] The PR description should say what you changed and why, with a link to the JIRA story.
- [X] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [X] You should have checked that the commit messages say why the change was made.
