### PR TITLE
CCMS: Use correct DocumentServicesWsdl.xml

### DIFF
--- a/app/services/ccms/wsdls/DocumentServicesWsdl.xml
+++ b/app/services/ccms/wsdls/DocumentServicesWsdl.xml
@@ -1,57 +1,113 @@
-<wsdl:definitions name="DocumentServices" targetNamespace="http://legalservices.gov.uk/CCMS/CaseManagement/Case/1.0/DocumentServices">
+<?xml version="1.0" encoding="UTF-8" ?>
+<wsdl:definitions
+  name="DocumentServices"
+  xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+  xmlns:tns="http://legalservices.gov.uk/CCMS/CaseManagement/Case/1.0/DocumentServices"
+  xmlns:ns1="http://legalservices.gov.uk/CCMS/CaseManagement/Case/1.0/CaseBIM"
+  xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"
+  xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+  xmlns:plnk="http://schemas.xmlsoap.org/ws/2003/05/partner-link/"
+  targetNamespace="http://legalservices.gov.uk/CCMS/CaseManagement/Case/1.0/DocumentServices"
+  >
   <wsdl:documentation>
     <abstractWSDL>https://sitsoa10.laadev.co.uk/soa-infra/services/default/DocumentServices!5.0/DocumentProxyService.wsdl</abstractWSDL>
   </wsdl:documentation>
+  <wsdl:types>
+    <schema xmlns="http://www.w3.org/2001/XMLSchema">
+      <import
+        namespace="http://legalservices.gov.uk/CCMS/CaseManagement/Case/1.0/CaseBIM"
+        schemaLocation="https://sitsoa10.laadev.co.uk/soa-infra/services/default/DocumentServices/apps/lsc/Schema/BusinessObjects/CCMS/CaseManagement/Case/1.0/CaseBIM.xsd"/>
+      <import
+        namespace="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"
+        schemaLocation="https://sitsoa10.laadev.co.uk/soa-infra/services/default/DocumentServices/apps/lsc/Schema/BusinessObjects/Enterprise/External/oasis/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"/>
+    </schema>
+  </wsdl:types>
+  <wsdl:message name="DownloadDocumentRequestMessage">
+    <wsdl:part name="payload" element="ns1:DocumentDownloadRQ"/>
+  </wsdl:message>
+  <wsdl:message name="DownloadDocumentResponseMessage">
+    <wsdl:part name="payload" element="ns1:DocumentDownloadRS"/>
+  </wsdl:message>
+  <wsdl:message name="UploadDocumentRequestMessage">
+    <wsdl:part name="payload" element="ns1:DocumentUploadRQ"/>
+  </wsdl:message>
+  <wsdl:message name="UploadDocumentResponseMessage">
+    <wsdl:part name="payload" element="ns1:DocumentUploadRS"/>
+  </wsdl:message>
+  <wsdl:message name="GetDocumentDetailsRequestMessage">
+    <wsdl:part name="GetDocumentDetailsABMRQ" element="ns1:GetDocumentDetailsABMRQ"/>
+  </wsdl:message>
+  <wsdl:message name="GetDocumentDetailsResponseMessage">
+    <wsdl:part name="GetDocumentDetailsABMRS" element="ns1:GetDocumentDetailsABMRS"/>
+  </wsdl:message>
+  <wsdl:message name="UsernameToken">
+    <wsdl:part name="Security" element="wsse:Security"/>
+  </wsdl:message>
+  <wsdl:portType name="DocumentServices">
+    <wsdl:operation name="DownloadDocument">
+      <wsdl:input message="tns:DownloadDocumentRequestMessage"/>
+      <wsdl:output message="tns:DownloadDocumentResponseMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="UploadDocument">
+      <wsdl:input message="tns:UploadDocumentRequestMessage"/>
+      <wsdl:output message="tns:UploadDocumentResponseMessage"/>
+    </wsdl:operation>
+    <wsdl:operation name="GetDocumentDetails">
+      <wsdl:input message="tns:GetDocumentDetailsRequestMessage"/>
+      <wsdl:output message="tns:GetDocumentDetailsResponseMessage"/>
+    </wsdl:operation>
+  </wsdl:portType>
   <plnk:partnerLinkType name="UploadDocument">
-    <plnk:role name="UploadDocumentProvider"><plnk:portType name="tns:UploadDocument"/></plnk:role>
+    <plnk:role name="UploadDocumentProvider">
+      <plnk:portType name="tns:UploadDocument"/>
+    </plnk:role>
   </plnk:partnerLinkType>
   <plnk:partnerLinkType name="DownloadDocument">
-    <plnk:role name="DownloadDocumentProvider"><plnk:portType name="tns:DownloadDocument"/></plnk:role>
+    <plnk:role name="DownloadDocumentProvider">
+      <plnk:portType name="tns:DownloadDocument"/>
+    </plnk:role>
   </plnk:partnerLinkType>
   <plnk:partnerLinkType name="GetDocumentDetails">
-    <plnk:role name="GetDocumentDetailsProvider"><plnk:portType name="tns:GetDocumentDetails"/></plnk:role>
+    <plnk:role name="GetDocumentDetailsProvider">
+      <plnk:portType name="tns:GetDocumentDetails"/>
+    </plnk:role>
   </plnk:partnerLinkType>
-  <wsp:Policy wsu:Id="wss_username_token_service_policy">
-    <sp:SupportingTokens>
-      <wsp:Policy>
-        <sp:UsernameToken sp:IncludeToken="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/AlwaysToRecipient">
-          <wsp:Policy><sp:WssUsernameToken10/></wsp:Policy>
-        </sp:UsernameToken>
-      </wsp:Policy>
-    </sp:SupportingTokens>
-  </wsp:Policy>
-  <wsdl:types>
-    <schema><import namespace="http://legalservices.gov.uk/CCMS/CaseManagement/Case/1.0/CaseBIM" schemaLocation="https://sitsoa10.laadev.co.uk/soa-infra/services/default/DocumentServices/apps/lsc/Schema/BusinessObjects/CCMS/CaseManagement/Case/1.0/CaseBIM.xsd"/><import
-      namespace="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"
-      schemaLocation="https://sitsoa10.laadev.co.uk/soa-infra/services/default/DocumentServices/apps/lsc/Schema/BusinessObjects/Enterprise/External/oasis/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"/></schema>
-  </wsdl:types>
-  <wsdl:message name="DownloadDocumentRequestMessage"><wsdl:part name="payload" element="ns1:DocumentDownloadRQ"/></wsdl:message>
-  <wsdl:message name="DownloadDocumentResponseMessage"><wsdl:part name="payload" element="ns1:DocumentDownloadRS"/></wsdl:message>
-  <wsdl:message name="UploadDocumentRequestMessage"><wsdl:part name="payload" element="ns1:DocumentUploadRQ"/></wsdl:message>
-  <wsdl:message name="UploadDocumentResponseMessage"><wsdl:part name="payload" element="ns1:DocumentUploadRS"/></wsdl:message>
-  <wsdl:message name="GetDocumentDetailsRequestMessage"><wsdl:part name="GetDocumentDetailsABMRQ" element="ns1:GetDocumentDetailsABMRQ"/></wsdl:message>
-  <wsdl:message name="GetDocumentDetailsResponseMessage"><wsdl:part name="GetDocumentDetailsABMRS" element="ns1:GetDocumentDetailsABMRS"/></wsdl:message>
-  <wsdl:message name="UsernameToken"><wsdl:part name="Security" element="wsse:Security"/></wsdl:message>
-  <wsdl:portType name="DocumentServices">
-    <wsdl:operation name="DownloadDocument"><wsdl:input message="tns:DownloadDocumentRequestMessage"/><wsdl:output message="tns:DownloadDocumentResponseMessage"/></wsdl:operation>
-    <wsdl:operation name="UploadDocument"><wsdl:input message="tns:UploadDocumentRequestMessage"/><wsdl:output message="tns:UploadDocumentResponseMessage"/></wsdl:operation>
-    <wsdl:operation name="GetDocumentDetails"><wsdl:input message="tns:GetDocumentDetailsRequestMessage"/><wsdl:output message="tns:GetDocumentDetailsResponseMessage"/></wsdl:operation>
-  </wsdl:portType>
-  <wsdl:binding name="DocumentServicesSOAPBinding" type="tns:DocumentServices"><soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/><wsp:PolicyReference URI="#wss_username_token_service_policy" wsdl:required="false"/>
-    <wsdl:operation name="UploadDocument"><soap:operation style="document" soapAction="http://legalservices.gov.uk/CCMS/CaseManagement/Case/1.0/DocumentServices/UploadDocument"/>
-      <wsdl:input><soap:body use="literal" parts="payload"/><soap:header message="tns:UsernameToken" part="Security" use="literal"/></wsdl:input>
-      <wsdl:output><soap:body use="literal" parts="payload"/></wsdl:output>
+  <wsdl:binding name="DocumentServicesSOAPBinding" type="tns:DocumentServices">
+    <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="UploadDocument">
+      <soap:operation style="document" soapAction="http://legalservices.gov.uk/CCMS/CaseManagement/Case/1.0/DocumentServices/UploadDocument"/>
+      <wsdl:input>
+        <soap:body use="literal" parts="payload"/>
+        <soap:header message="tns:UsernameToken" use="literal" part="Security"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" parts="payload"/>
+      </wsdl:output>
     </wsdl:operation>
-    <wsdl:operation name="DownloadDocument"><soap:operation style="document" soapAction="http://legalservices.gov.uk/CCMS/CaseManagement/Case/1.0/DocumentServices/DownloadDocument"/>
-      <wsdl:input><soap:body use="literal" parts="payload"/><soap:header message="tns:UsernameToken" part="Security" use="literal"/></wsdl:input>
-      <wsdl:output><soap:body use="literal" parts="payload"/></wsdl:output>
+    <wsdl:operation name="DownloadDocument">
+      <soap:operation style="document" soapAction="http://legalservices.gov.uk/CCMS/CaseManagement/Case/1.0/DocumentServices/DownloadDocument"/>
+      <wsdl:input>
+        <soap:body use="literal" parts="payload"/>
+        <soap:header message="tns:UsernameToken" use="literal" part="Security"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" parts="payload"/>
+      </wsdl:output>
     </wsdl:operation>
-    <wsdl:operation name="GetDocumentDetails"><soap:operation style="document" soapAction="http://legalservices.gov.uk/CCMS/CaseManagement/Case/1.0/DocumentServices/GetDocumentDetails"/>
-      <wsdl:input><soap:body use="literal" parts="GetDocumentDetailsABMRQ"/><soap:header message="tns:UsernameToken" part="Security" use="literal"/></wsdl:input>
-      <wsdl:output><soap:body use="literal" parts="GetDocumentDetailsABMRS"/></wsdl:output>
+    <wsdl:operation name="GetDocumentDetails">
+      <soap:operation style="document" soapAction="http://legalservices.gov.uk/CCMS/CaseManagement/Case/1.0/DocumentServices/GetDocumentDetails"/>
+      <wsdl:input>
+        <soap:body use="literal" parts="GetDocumentDetailsABMRQ"/>
+        <soap:header message="tns:UsernameToken" use="literal" part="Security"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" parts="GetDocumentDetailsABMRS"/>
+      </wsdl:output>
     </wsdl:operation>
   </wsdl:binding>
   <wsdl:service name="DocumentServices_ep">
-    <wsdl:port name="DocumentServices_pt" binding="tns:DocumentServicesSOAPBinding"><soap:address location="https://sitsoa10.laadev.co.uk/soa-infra/services/default/DocumentServices/DocumentServices_ep"/></wsdl:port>
-  </wsdl:service>
+    <wsdl:port name="DocumentServices_pt" binding="tns:DocumentServicesSOAPBinding">
+      <soap:address location="https://sitsoa10.laadev.co.uk/soa-infra/services/default/DocumentServices/DocumentServices_ep"/>
+    </wsdl:port>
+  <wsdl:service>
 </wsdl:definitions>


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-718)

The WSDL for the api call to upload a document to CCMS is incorrect. Replace it with the correct version of DocumentServicesWsdl.xml.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
