### PR TITLE
AP-661 blank applications

### DIFF
--- a/app/controllers/concerns/backable.rb
+++ b/app/controllers/concerns/backable.rb
@@ -25,6 +25,12 @@ module Backable
     end
     helper_method :back_path
 
+    def replace_last_page_in_history(path)
+      return if page_history.empty?
+
+      page_history[-1] = path
+    end
+
     private
 
     def update_page_history

--- a/app/controllers/providers/applicant_details_controller.rb
+++ b/app/controllers/providers/applicant_details_controller.rb
@@ -1,5 +1,5 @@
 module Providers
-  class ApplicantsController < ProviderBaseController
+  class ApplicantDetailsController < ProviderBaseController
     def show
       authorize legal_aid_application
       @form = Applicants::BasicDetailsForm.new(model: applicant)

--- a/app/controllers/providers/applicant_details_controller.rb
+++ b/app/controllers/providers/applicant_details_controller.rb
@@ -19,10 +19,7 @@ module Providers
 
     def form_params
       merge_with_model(applicant) do
-        params.require(:applicant).permit(
-          :first_name, :last_name, :dob_day, :dob_month, :dob_year,
-          :national_insurance_number, :email
-        )
+        params.require(:applicant).permit(*Applicants::BasicDetailsForm::ATTRIBUTES)
       end
     end
   end

--- a/app/controllers/providers/applicants_controller.rb
+++ b/app/controllers/providers/applicants_controller.rb
@@ -1,0 +1,47 @@
+module Providers
+  class ApplicantsController < ProviderBaseController
+    legal_aid_application_not_required!
+
+    def new
+      @form = Applicants::BasicDetailsForm.new(model: applicant)
+    end
+
+    def create
+      @form = Applicants::BasicDetailsForm.new(form_params)
+
+      if save_continue_or_draft(@form)
+        legal_aid_application.update!(
+          applicant: applicant,
+          provider_step: edit_applicant_key_point.step
+        )
+        replace_last_page_in_history(edit_applicant_path)
+      else
+        render :new
+      end
+    end
+
+    private
+
+    def legal_aid_application
+      @legal_aid_application ||= LegalAidApplication.create!(provider: current_provider)
+    end
+
+    def applicant
+      @applicant ||= Applicant.new
+    end
+
+    def edit_applicant_path
+      edit_applicant_key_point.path(legal_aid_application)
+    end
+
+    def edit_applicant_key_point
+      @edit_applicant_key_point ||= Flow::KeyPoint.new(:providers, :edit_applicant)
+    end
+
+    def form_params
+      merge_with_model(applicant) do
+        params.require(:applicant).permit(*Applicants::BasicDetailsForm::ATTRIBUTES)
+      end
+    end
+  end
+end

--- a/app/controllers/providers/legal_aid_applications_controller.rb
+++ b/app/controllers/providers/legal_aid_applications_controller.rb
@@ -16,11 +16,9 @@ module Providers
 
     # POST /provider/applications
     def create
-      @legal_aid_application = LegalAidApplication.create(provider: current_provider)
       redirect_to Flow::KeyPoint.path_for(
         journey: :providers,
-        key_point: :journey_start,
-        legal_aid_application: @legal_aid_application
+        key_point: :journey_start
       )
     end
   end

--- a/app/forms/applicants/basic_details_form.rb
+++ b/app/forms/applicants/basic_details_form.rb
@@ -2,10 +2,12 @@ module Applicants
   class BasicDetailsForm
     include BaseForm
 
+    ATTRIBUTES = %i[first_name last_name national_insurance_number
+                    dob_year dob_month dob_day email].freeze
+
     form_for Applicant
 
-    attr_accessor :first_name, :last_name, :national_insurance_number,
-                  :dob_year, :dob_month, :dob_day, :email
+    attr_accessor(*ATTRIBUTES)
     attr_writer :date_of_birth
 
     before_validation :normalise_national_insurance_number

--- a/app/helpers/providers_helper.rb
+++ b/app/helpers/providers_helper.rb
@@ -17,7 +17,7 @@ module ProvidersHelper
   def journey_start_path(legal_aid_application)
     Flow::KeyPoint.path_for(
       journey: :providers,
-      key_point: :journey_start,
+      key_point: :edit_applicant,
       legal_aid_application: legal_aid_application
     )
   end

--- a/app/services/flow/flows/provider_start.rb
+++ b/app/services/flow/flows/provider_start.rb
@@ -2,8 +2,8 @@ module Flow
   module Flows
     class ProviderStart < FlowSteps
       STEPS = {
-        applicants: {
-          path: ->(application) { urls.providers_legal_aid_application_applicant_path(application) },
+        applicant_details: {
+          path: ->(application) { urls.providers_legal_aid_application_applicant_details_path(application) },
           forward: :address_lookups,
           check_answers: :check_provider_answers
         },

--- a/app/services/flow/flows/provider_start.rb
+++ b/app/services/flow/flows/provider_start.rb
@@ -2,6 +2,10 @@ module Flow
   module Flows
     class ProviderStart < FlowSteps
       STEPS = {
+        applicants: {
+          path: ->(_) { urls.new_providers_applicant_path },
+          forward: :address_lookups
+        },
         applicant_details: {
           path: ->(application) { urls.providers_legal_aid_application_applicant_details_path(application) },
           forward: :address_lookups,

--- a/app/services/flow/key_point.rb
+++ b/app/services/flow/key_point.rb
@@ -5,7 +5,7 @@ module Flow
     KEY_POINTS = {
       citizens: {},
       providers: {
-        journey_start: :applicants,
+        journey_start: :applicant_details,
         start_after_applicant_completes_means: :client_completed_means,
         start_income_update: :capital_introductions,
         start_vehicle_journey: :vehicles

--- a/app/services/flow/key_point.rb
+++ b/app/services/flow/key_point.rb
@@ -5,7 +5,8 @@ module Flow
     KEY_POINTS = {
       citizens: {},
       providers: {
-        journey_start: :applicant_details,
+        journey_start: :applicants,
+        edit_applicant: :applicant_details,
         start_after_applicant_completes_means: :client_completed_means,
         start_income_update: :capital_introductions,
         start_vehicle_journey: :vehicles
@@ -16,7 +17,7 @@ module Flow
       new(journey, key_point).step
     end
 
-    def self.path_for(journey:, key_point:, legal_aid_application:)
+    def self.path_for(journey:, key_point:, legal_aid_application: nil)
       new(journey, key_point).path(legal_aid_application)
     end
 

--- a/app/views/providers/applicant_details/show.html.erb
+++ b/app/views/providers/applicant_details/show.html.erb
@@ -1,43 +1,5 @@
-<% back_label = @legal_aid_application.checking_client_details_answers? ? 'generic.back' : 'generic.home' %>
-<%= page_template(
-      page_title: t('.page_title'),
-      back_link: { text: t(back_label) },
-      page_heading_options: { margin_bottom: 3 }
-    ) do %>
-
-  <%= form_with(
-        model: @form,
-        url: providers_legal_aid_application_applicant_details_path,
-        method: :patch,
-        local: true
-      ) do |form| %>
-
-    <div class="govuk-!-padding-bottom-2"></div>
-    <fieldset class="govuk-fieldset">
-      <legend class="govuk-fieldset__legend govuk-fieldset__legend--m"><%= t('.full_name') %></legend>
-      <%= form.govuk_text_field :first_name, class: 'govuk-!-width-three-quarters', 'aria-label' => 'first name' %>
-      <%= form.govuk_text_field :last_name, class: 'govuk-!-width-three-quarters', 'aria-label' => 'last name' %>
-    </fieldset>
-
-    <div class="govuk-!-padding-bottom-4"></div>
-
-    <%= date_input_fields prefix: :dob, field_name: :date_of_birth, form: form %>
-
-    <div class="govuk-!-padding-bottom-6"></div>
-    <%= form.govuk_text_field(
-          :national_insurance_number,
-          label: { text: t('.nino_label'), size: :m },
-          class: 'govuk-input govuk-input--width-10'
-        ) %>
-    <%= form.govuk_text_field(
-          :email,
-          label: { text: t('.email_label'), size: :m },
-          class: 'govuk-input govuk-!-width-three-quarters'
-        ) %>
-
-    <div class="govuk-!-padding-bottom-2"></div>
-
-    <%= next_action_buttons(show_draft: true, form: form) %>
-   </div>
-  <% end %>
-<% end %>
+<%= render(
+      'shared/forms/applicant_form',
+      form_url: providers_legal_aid_application_applicant_details_path,
+      form_method: :patch
+    ) %>

--- a/app/views/providers/applicant_details/show.html.erb
+++ b/app/views/providers/applicant_details/show.html.erb
@@ -7,7 +7,7 @@
 
   <%= form_with(
         model: @form,
-        url: providers_legal_aid_application_applicant_path,
+        url: providers_legal_aid_application_applicant_details_path,
         method: :patch,
         local: true
       ) do |form| %>

--- a/app/views/providers/applicants/new.html.erb
+++ b/app/views/providers/applicants/new.html.erb
@@ -1,0 +1,5 @@
+<%= render(
+      'shared/forms/applicant_form',
+      form_url: providers_applicants_path,
+      form_method: :post
+    ) %>

--- a/app/views/providers/check_provider_answers/index.html.erb
+++ b/app/views/providers/check_provider_answers/index.html.erb
@@ -21,7 +21,7 @@
 
     <%= check_answer_link(
           name: :first_name,
-          url: providers_legal_aid_application_applicant_path(anchor: :first_name),
+          url: providers_legal_aid_application_applicant_details_path(anchor: :first_name),
           question: t('.section_client.first_name'),
           answer: @applicant.first_name,
           read_only: @read_only
@@ -29,7 +29,7 @@
 
     <%= check_answer_link(
           name: :last_name,
-          url: providers_legal_aid_application_applicant_path(anchor: :last_name),
+          url: providers_legal_aid_application_applicant_details_path(anchor: :last_name),
           question: t('.section_client.last_name'),
           answer: @applicant.last_name,
           read_only: @read_only
@@ -37,7 +37,7 @@
 
     <%= check_answer_link(
           name: :date_of_birth,
-          url: providers_legal_aid_application_applicant_path(anchor: :dob_day),
+          url: providers_legal_aid_application_applicant_details_path(anchor: :dob_day),
           question: t('.section_client.dob'),
           answer: @applicant.date_of_birth,
           read_only: @read_only
@@ -45,7 +45,7 @@
 
     <%= check_answer_link(
           name: :national_insurance_number,
-          url: providers_legal_aid_application_applicant_path(anchor: :national_insurance_number),
+          url: providers_legal_aid_application_applicant_details_path(anchor: :national_insurance_number),
           question: t('.section_client.nino'),
           answer: @applicant.national_insurance_number,
           read_only: @read_only
@@ -53,7 +53,7 @@
 
     <%= check_answer_link(
           name: :email,
-          url: providers_legal_aid_application_applicant_path(anchor: :email),
+          url: providers_legal_aid_application_applicant_details_path(anchor: :email),
           question: t('.section_client.email'),
           answer: @applicant.email,
           read_only: @read_only

--- a/app/views/shared/forms/_applicant_form.html.erb
+++ b/app/views/shared/forms/_applicant_form.html.erb
@@ -1,0 +1,43 @@
+<% back_label = @legal_aid_application&.checking_client_details_answers? ? 'generic.back' : 'generic.home' %>
+<%= page_template(
+      page_title: t('.page_title'),
+      back_link: { text: t(back_label) },
+      page_heading_options: { margin_bottom: 3 }
+    ) do %>
+
+  <%= form_with(
+        model: @form,
+        url: form_url,
+        method: form_method,
+        local: true
+      ) do |form| %>
+
+    <div class="govuk-!-padding-bottom-2"></div>
+    <fieldset class="govuk-fieldset">
+      <legend class="govuk-fieldset__legend govuk-fieldset__legend--m"><%= t('.full_name') %></legend>
+      <%= form.govuk_text_field :first_name, class: 'govuk-!-width-three-quarters', 'aria-label' => 'first name' %>
+      <%= form.govuk_text_field :last_name, class: 'govuk-!-width-three-quarters', 'aria-label' => 'last name' %>
+    </fieldset>
+
+    <div class="govuk-!-padding-bottom-4"></div>
+
+    <%= date_input_fields prefix: :dob, field_name: :date_of_birth, form: form %>
+
+    <div class="govuk-!-padding-bottom-6"></div>
+    <%= form.govuk_text_field(
+          :national_insurance_number,
+          label: { text: t('.nino_label'), size: :m },
+          class: 'govuk-input govuk-input--width-10'
+        ) %>
+    <%= form.govuk_text_field(
+          :email,
+          label: { text: t('.email_label'), size: :m },
+          class: 'govuk-input govuk-!-width-three-quarters'
+        ) %>
+
+    <div class="govuk-!-padding-bottom-2"></div>
+
+    <%= next_action_buttons(show_draft: true, form: form) %>
+   </div>
+  <% end %>
+<% end %>

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -23,12 +23,6 @@ en:
       show:
         link_text: I can't find the address in the list
         select_address_label: Select an address
-    applicant_details:
-      show:
-        page_title: Enter your client's details
-        full_name: Full name
-        email_label: Email address
-        nino_label: National Insurance number
     application_confirmations:
       show:
         application_created: Application created

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -23,7 +23,7 @@ en:
       show:
         link_text: I can't find the address in the list
         select_address_label: Select an address
-    applicants:
+    applicant_details:
       show:
         page_title: Enter your client's details
         full_name: Full name

--- a/config/locales/en/shared.yml
+++ b/config/locales/en/shared.yml
@@ -34,6 +34,11 @@ en:
         purchased_on: When did your client buy the vehicle?
         used_regularly: Is the vehicle in regular use?
     forms:
+      applicant_form:
+        page_title: Enter your client's details
+        full_name: Full name
+        email_label: Email address
+        nino_label: National Insurance number
       date_input_fields:
         date_of_birth_hint: For example, 31 3 1980
         date_of_birth_label: Date of birth

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -87,7 +87,7 @@ Rails.application.routes.draw do
       resources :proceedings_types, only: %i[index create update]
       resource :property_value, only: %i[show update]
       resource :limitations, only: %i[show update]
-      resource :applicant, only: %i[show update]
+      resource :applicant_details, only: %i[show update]
       resource :address, only: %i[show update]
       resource :address_lookup, only: %i[show update]
       resource :address_selection, only: %i[show update]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -82,6 +82,7 @@ Rails.application.routes.draw do
   namespace :providers do
     root to: 'start#index' # TODO: In the live app this will point at an external url
     resource :provider, only: [:show], path: 'your_profile'
+    resources :applicants, only: %i[new create]
 
     resources :legal_aid_applications, path: 'applications', only: %i[index create] do
       resources :proceedings_types, only: %i[index create update]

--- a/spec/requests/providers/applicant_details_spec.rb
+++ b/spec/requests/providers/applicant_details_spec.rb
@@ -1,0 +1,150 @@
+require 'rails_helper'
+
+RSpec.describe Providers::ApplicantDetailsController, type: :request do
+  let(:application) { create(:legal_aid_application) }
+  let(:application_id) { application.id }
+  let(:provider) { application.provider }
+
+  describe 'GET /providers/applications/:legal_aid_application_id/applicant_details' do
+    subject { get "/providers/applications/#{application_id}/applicant_details" }
+
+    context 'when the provider is not authenticated' do
+      before { subject }
+      it_behaves_like 'a provider not authenticated'
+    end
+
+    context 'when the provider is authenticated' do
+      before do
+        login_as provider
+      end
+
+      it 'returns http success' do
+        subject
+        expect(response).to have_http_status(:ok)
+      end
+
+      context 'has already got applicant info' do
+        let(:applicant) { create(:applicant) }
+        let(:application) { create(:legal_aid_application, applicant: applicant) }
+
+        it 'display first_name' do
+          subject
+          expect(unescaped_response_body).to include(applicant.first_name)
+        end
+      end
+    end
+  end
+
+  describe 'PATCH /providers/applications/:legal_aid_application_id/applicant_details' do
+    let(:params) do
+      {
+        applicant: {
+          first_name: 'John',
+          last_name: 'Doe',
+          national_insurance_number: 'AA 12 34 56 C',
+          dob_year: '1981',
+          dob_month: '07',
+          dob_day: '11',
+          email: Faker::Internet.safe_email
+        }
+      }
+    end
+
+    context 'when the provider is authenticated' do
+      before do
+        login_as provider
+      end
+
+      subject do
+        patch providers_legal_aid_application_applicant_details_path(application), params: params
+      end
+
+      context 'Form submitted using Continue button' do
+        let(:submit_button) do
+          {
+            continue_button: 'Continue'
+          }
+        end
+
+        it 'redirects provider to next step of the submission' do
+          subject
+          expect(response).to redirect_to(providers_legal_aid_application_address_lookup_path(application))
+        end
+
+        it 'creates a new applicant associated with the application' do
+          expect { subject }.to change { Applicant.count }.by(1)
+
+          new_applicant = application.reload.applicant
+          expect(new_applicant).to be_instance_of(Applicant)
+        end
+
+        context 'when the application is in draft' do
+          let(:application) { create(:legal_aid_application, :draft) }
+
+          it 'redirects provider to next step of the submission' do
+            subject
+            expect(response).to redirect_to(providers_legal_aid_application_address_lookup_path(application))
+          end
+
+          it 'sets the application as no longer draft' do
+            expect { subject }.to change { application.reload.draft? }.from(true).to(false)
+          end
+        end
+
+        context 'when the legal aid application is in checking_client_details_answers state' do
+          let(:application) { create(:legal_aid_application, state: :checking_client_details_answers) }
+
+          it 'redirects to check_your_answers page' do
+            subject
+
+            expect(response).to redirect_to(providers_legal_aid_application_check_provider_answers_path)
+          end
+        end
+
+        context 'when the params are not valid' do
+          let(:params) do
+            {
+              applicant: {
+                first_name: '',
+                last_name: 'Doe',
+                national_insurance_number: 'AA 12 34 56 C',
+                dob_year: '1981',
+                dob_month: '07',
+                dob_day: '11',
+                email: Faker::Internet.safe_email
+              }
+            }
+          end
+
+          it 'renders the form page displaying the errors' do
+            subject
+
+            expect(unescaped_response_body).to include('There is a problem')
+            expect(unescaped_response_body).to include('Enter first name')
+          end
+
+          it 'does NOT create a new applicant' do
+            expect { subject }.not_to change { Applicant.count }
+          end
+        end
+      end
+
+      context 'Form submitted using Save as draft button' do
+        let(:submit_button) { { draft_button: 'Save as draft' } }
+
+        subject do
+          patch providers_legal_aid_application_applicant_details_path(application), params: params.merge(submit_button)
+        end
+
+        it "redirects provider to provider's applications page" do
+          subject
+          expect(response).to redirect_to(providers_legal_aid_applications_path)
+        end
+
+        it 'sets the application as draft' do
+          expect { subject }.to change { application.reload.draft? }.from(false).to(true)
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/providers/applicants_spec.rb
+++ b/spec/requests/providers/applicants_spec.rb
@@ -1,140 +1,106 @@
 require 'rails_helper'
 
-RSpec.describe 'providers applicant requests', type: :request do
-  let(:application) { create(:legal_aid_application) }
-  let(:application_id) { application.id }
-  let(:provider) { application.provider }
+RSpec.describe Providers::ApplicantsController, type: :request do
+  let(:provider) { create :provider }
+  let(:login) { login_as provider }
 
-  describe 'GET /providers/applications/:legal_aid_application_id/applicant' do
-    subject { get "/providers/applications/#{application_id}/applicant_details" }
+  before { login }
 
-    context 'when the provider is not authenticated' do
-      before { subject }
-      it_behaves_like 'a provider not authenticated'
-    end
+  describe 'GET /providers/applicants/new' do
+    subject { get new_providers_applicant_path }
 
-    context 'when the provider is authenticated' do
-      before do
-        login_as provider
-      end
-
-      it 'returns http success' do
-        subject
-        expect(response).to have_http_status(:ok)
-      end
-
-      context 'has already got applicant info' do
-        let(:applicant) { create(:applicant) }
-        let(:application) { create(:legal_aid_application, applicant: applicant) }
-
-        it 'display first_name' do
-          subject
-          expect(unescaped_response_body).to include(applicant.first_name)
-        end
-      end
+    it 'renders successfully' do
+      subject
+      expect(response).to have_http_status(:ok)
     end
   end
 
-  describe 'PATCH /providers/applications/:legal_aid_application_id/applicant' do
+  describe 'POST /providers/applicants' do
+    let(:submit_button) { {} }
+    let(:param_applicant) { FactoryBot.attributes_for :applicant }
     let(:params) do
       {
-        applicant: {
-          first_name: 'John',
-          last_name: 'Doe',
-          national_insurance_number: 'AA 12 34 56 C',
-          dob_year: '1981',
-          dob_month: '07',
-          dob_day: '11',
-          email: Faker::Internet.safe_email
-        }
+        applicant: param_applicant.merge(
+          dob_year: param_applicant[:date_of_birth].year.to_s,
+          dob_month: param_applicant[:date_of_birth].month.to_s,
+          dob_day: param_applicant[:date_of_birth].day.to_s
+        )
       }
     end
+    let(:legal_aid_application) { provider.legal_aid_applications.last }
+    let(:applicant) { legal_aid_application.applicant }
+    let(:next_url) { providers_legal_aid_application_address_lookup_path(legal_aid_application) }
 
-    context 'when the provider is authenticated' do
-      before do
-        login_as provider
+    subject { post providers_applicants_path, params: params.merge(submit_button) }
+
+    it 'creates an application' do
+      expect { subject }.to change { provider.legal_aid_applications.count }.by(1)
+    end
+
+    it 'creates an applicant' do
+      expect { subject }.to change { Applicant.count }.by(1)
+      expect(applicant).to be_present
+      expect(applicant.first_name).to eq(param_applicant[:first_name])
+      expect(applicant.last_name).to eq(param_applicant[:last_name])
+      expect(applicant.national_insurance_number).to eq(param_applicant[:national_insurance_number])
+      expect(applicant.email).to eq(param_applicant[:email])
+      expect(applicant.date_of_birth).to eq(param_applicant[:date_of_birth])
+    end
+
+    it 'redirects to next page' do
+      subject
+      expect(response).to redirect_to(next_url)
+    end
+
+    it "back link on the next page is to applicant's details page" do
+      get new_providers_applicant_path
+      subject
+      follow_redirect!
+      expect(response.body).to include(providers_legal_aid_application_applicant_details_path(legal_aid_application, back: true))
+    end
+
+    context 'with missing parameters' do
+      let(:params) { { applicant: { first_name: 'bob' } } }
+
+      it 'displays errors' do
+        subject
+        expect(response.body).to include('govuk-error-summary')
       end
 
-      subject do
-        patch providers_legal_aid_application_applicant_details_path(application), params: params
+      it 'does not create applicant' do
+        expect { subject }.not_to change { Applicant.count }
       end
 
-      context 'Form submitted using Continue button' do
-        let(:submit_button) do
-          {
-            continue_button: 'Continue'
-          }
-        end
+      it 'does not create application' do
+        expect { subject }.not_to change { LegalAidApplication.count }
+      end
+    end
 
-        it 'redirects provider to next step of the submission' do
-          subject
-          expect(response).to redirect_to(providers_legal_aid_application_address_lookup_path(application))
-        end
+    context 'Form submitted using Save as draft button' do
+      let(:submit_button) { { draft_button: 'Save as draft' } }
 
-        it 'creates a new applicant associated with the application' do
-          expect { subject }.to change { Applicant.count }.by(1)
-
-          new_applicant = application.reload.applicant
-          expect(new_applicant).to be_instance_of(Applicant)
-        end
-
-        context 'when the application is in draft' do
-          let(:application) { create(:legal_aid_application, :draft) }
-
-          it 'redirects provider to next step of the submission' do
-            subject
-            expect(response).to redirect_to(providers_legal_aid_application_address_lookup_path(application))
-          end
-
-          it 'sets the application as no longer draft' do
-            expect { subject }.to change { application.reload.draft? }.from(true).to(false)
-          end
-        end
-
-        context 'when the legal aid application is in checking_client_details_answers state' do
-          let(:application) { create(:legal_aid_application, state: :checking_client_details_answers) }
-
-          it 'redirects to check_your_answers page' do
-            subject
-
-            expect(response).to redirect_to(providers_legal_aid_application_check_provider_answers_path)
-          end
-        end
-
-        context 'when the params are not valid' do
-          let(:params) do
-            {
-              applicant: {
-                first_name: '',
-                last_name: 'Doe',
-                national_insurance_number: 'AA 12 34 56 C',
-                dob_year: '1981',
-                dob_month: '07',
-                dob_day: '11',
-                email: Faker::Internet.safe_email
-              }
-            }
-          end
-
-          it 'renders the form page displaying the errors' do
-            subject
-
-            expect(unescaped_response_body).to include('There is a problem')
-            expect(unescaped_response_body).to include('Enter first name')
-          end
-
-          it 'does NOT create a new applicant' do
-            expect { subject }.not_to change { Applicant.count }
-          end
-        end
+      it "redirects provider to provider's applications page" do
+        subject
+        expect(response).to redirect_to(providers_legal_aid_applications_path)
       end
 
-      context 'Form submitted using Save as draft button' do
-        let(:submit_button) { { draft_button: 'Save as draft' } }
+      it 'creates an application as draft' do
+        expect { subject }.to change { provider.legal_aid_applications.count }.by(1)
+        expect(legal_aid_application.draft?).to eq(true)
+      end
 
-        subject do
-          patch providers_legal_aid_application_applicant_details_path(application), params: params.merge(submit_button)
-        end
+      it 'creates an applicant' do
+        expect { subject }.to change { Applicant.count }.by(1)
+        expect(applicant).to be_present
+        expect(applicant.first_name).to eq(param_applicant[:first_name])
+        expect(applicant.last_name).to eq(param_applicant[:last_name])
+        expect(applicant.national_insurance_number).to eq(param_applicant[:national_insurance_number])
+        expect(applicant.email).to eq(param_applicant[:email])
+        expect(applicant.date_of_birth).to eq(param_applicant[:date_of_birth])
+      end
+
+      context 'with blank entries' do
+        let(:params) { { applicant: { first_name: 'bob' } } }
 
         it "redirects provider to provider's applications page" do
           subject
@@ -142,9 +108,22 @@ RSpec.describe 'providers applicant requests', type: :request do
         end
 
         it 'sets the application as draft' do
-          expect { subject }.to change { application.reload.draft? }.from(false).to(true)
+          subject
+          expect(legal_aid_application.draft?).to eq(true)
+        end
+
+        it 'leaves values blank' do
+          subject
+          expect(applicant.last_name).to be_blank
+          expect(applicant.national_insurance_number).to be_blank
         end
       end
+    end
+
+    context 'when the provider is not authenticated' do
+      let(:login) { nil }
+      before { subject }
+      it_behaves_like 'a provider not authenticated'
     end
   end
 end

--- a/spec/requests/providers/applicants_spec.rb
+++ b/spec/requests/providers/applicants_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'providers applicant requests', type: :request do
   let(:provider) { application.provider }
 
   describe 'GET /providers/applications/:legal_aid_application_id/applicant' do
-    subject { get "/providers/applications/#{application_id}/applicant" }
+    subject { get "/providers/applications/#{application_id}/applicant_details" }
 
     context 'when the provider is not authenticated' do
       before { subject }
@@ -56,7 +56,7 @@ RSpec.describe 'providers applicant requests', type: :request do
       end
 
       subject do
-        patch providers_legal_aid_application_applicant_path(application), params: params
+        patch providers_legal_aid_application_applicant_details_path(application), params: params
       end
 
       context 'Form submitted using Continue button' do
@@ -133,7 +133,7 @@ RSpec.describe 'providers applicant requests', type: :request do
         let(:submit_button) { { draft_button: 'Save as draft' } }
 
         subject do
-          patch providers_legal_aid_application_applicant_path(application), params: params.merge(submit_button)
+          patch providers_legal_aid_application_applicant_details_path(application), params: params.merge(submit_button)
         end
 
         it "redirects provider to provider's applications page" do

--- a/spec/requests/providers/concerns/draftable_spec.rb
+++ b/spec/requests/providers/concerns/draftable_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Providers::Draftable do
       login_as provider
     end
 
-    subject { patch providers_legal_aid_application_applicant_path(application), params: params.merge(submit_button) }
+    subject { patch providers_legal_aid_application_applicant_details_path(application), params: params.merge(submit_button) }
 
     context 'Form submitted using Continue button' do
       let(:submit_button) { { anything: 'That is not draft_button' } }

--- a/spec/requests/providers/email_addresses_spec.rb
+++ b/spec/requests/providers/email_addresses_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'update client email address before application confirmation', ty
 
       it 'displays the email label' do
         subject
-        expect(response.body).to include(I18n.translate('providers.applicants.show.email_label'))
+        expect(response.body).to include(I18n.translate('providers.applicant_details.show.email_label'))
         expect(unescaped_response_body).to include(I18n.translate('helpers.hint.applicant.email'))
       end
     end

--- a/spec/requests/providers/email_addresses_spec.rb
+++ b/spec/requests/providers/email_addresses_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'update client email address before application confirmation', ty
 
       it 'displays the email label' do
         subject
-        expect(response.body).to include(I18n.translate('providers.applicant_details.show.email_label'))
+        expect(response.body).to include(I18n.translate('shared.forms.applicant_form.email_label'))
         expect(unescaped_response_body).to include(I18n.translate('helpers.hint.applicant.email'))
       end
     end

--- a/spec/requests/providers/legal_aid_applications_spec.rb
+++ b/spec/requests/providers/legal_aid_applications_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe 'providers legal aid application requests', type: :request do
 
         it "includes a link to the legal aid application's current path" do
           subject
-          expect(response.body).to include(providers_legal_aid_application_applicant_path(legal_aid_application))
+          expect(response.body).to include(providers_legal_aid_application_applicant_details_path(legal_aid_application))
         end
       end
 
@@ -107,7 +107,7 @@ RSpec.describe 'providers legal aid application requests', type: :request do
 
       it 'redirects to applicant details page ' do
         subject
-        expect(response).to redirect_to(providers_legal_aid_application_applicant_path(legal_aid_application))
+        expect(response).to redirect_to(providers_legal_aid_application_applicant_details_path(legal_aid_application))
       end
     end
   end

--- a/spec/requests/providers/legal_aid_applications_spec.rb
+++ b/spec/requests/providers/legal_aid_applications_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'providers legal aid application requests', type: :request do
       end
 
       context 'when legal_aid_application current path set' do
-        let!(:legal_aid_application) { create :legal_aid_application, provider_step: :applicants }
+        let!(:legal_aid_application) { create :legal_aid_application, provider_step: :applicant_details }
 
         it "includes a link to the legal aid application's current path" do
           subject
@@ -44,7 +44,7 @@ RSpec.describe 'providers legal aid application requests', type: :request do
           subject
           start_path = Flow::KeyPoint.path_for(
             journey: :providers,
-            key_point: :journey_start,
+            key_point: :edit_applicant,
             legal_aid_application: legal_aid_application
           )
           expect(response.body).to include(start_path)
@@ -101,13 +101,13 @@ RSpec.describe 'providers legal aid application requests', type: :request do
         login_as create(:provider)
       end
 
-      it 'creates a new application record' do
-        expect { subject }.to change { LegalAidApplication.count }.by(1)
+      it 'does not create a new application record' do
+        expect { subject }.not_to change { LegalAidApplication.count }
       end
 
-      it 'redirects to applicant details page ' do
+      it 'redirects to new applicant page ' do
         subject
-        expect(response).to redirect_to(providers_legal_aid_application_applicant_details_path(legal_aid_application))
+        expect(response).to redirect_to(new_providers_applicant_path)
       end
     end
   end


### PR DESCRIPTION
## What

[AP-661](https://dsdmoj.atlassian.net/browse/AP-661)

- Rename path `/providers/applications/:id/applicant` to `/providers/applications/:id/applicant_details`
- Add new path `/providers/applicants`

This new controller is the new start of the provider flow. It creates the application and the applicant on submit. It then removes itself from the history and adds `/providers/applications/:id/applicant_details` instead.
That way, when navigating back to this step, the provider can edit the applicant's details rather than being presented with an empty page that would create an additional applicant and application when submitted


## Checklist

Before you ask people to review this PR:

- [X] Tests and rubocop should be passing: `bundle exec rake`
- [X] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [X] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [X] The PR description should say what you changed and why, with a link to the JIRA story.
- [X] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [X] You should have checked that the commit messages say why the change was made.
