### PR TITLE
AP-662 has Provider used Delegated Functions?

### DIFF
--- a/app/controllers/providers/substantive_applications_controller.rb
+++ b/app/controllers/providers/substantive_applications_controller.rb
@@ -1,0 +1,7 @@
+module Providers
+  class SubstantiveApplicationsController < ProviderBaseController
+    def show
+      render plain: 'Landing page: Substantive Application functionality to be built'
+    end
+  end
+end

--- a/app/controllers/providers/used_delegated_functions_controller.rb
+++ b/app/controllers/providers/used_delegated_functions_controller.rb
@@ -1,9 +1,27 @@
 module Providers
   class UsedDelegatedFunctionsController < ProviderBaseController
     def show
+      authorize legal_aid_application
       @form = LegalAidApplications::UsedDelegatedFunctionsForm.new(model: legal_aid_application)
     end
 
-    def update; end
+    def update
+      authorize legal_aid_application
+      @form = LegalAidApplications::UsedDelegatedFunctionsForm.new(form_params)
+      render :show unless save_continue_or_draft(@form)
+    end
+
+    private
+
+    def form_params
+      merge_with_model(legal_aid_application) do
+        params.require(:legal_aid_application).permit(
+          :used_delegated_functions_year,
+          :used_delegated_functions_month,
+          :used_delegated_functions_day,
+          :used_delegated_functions
+        )
+      end
+    end
   end
 end

--- a/app/controllers/providers/used_delegated_functions_controller.rb
+++ b/app/controllers/providers/used_delegated_functions_controller.rb
@@ -1,0 +1,9 @@
+module Providers
+  class UsedDelegatedFunctionsController < ProviderBaseController
+    def show
+      @form = LegalAidApplications::UsedDelegatedFunctionsForm.new(model: legal_aid_application)
+    end
+
+    def update; end
+  end
+end

--- a/app/forms/base_form.rb
+++ b/app/forms/base_form.rb
@@ -1,3 +1,5 @@
+require_relative 'concerns/date_field_builder'
+
 # Add common methods to forms.
 # Usage:
 #   Add the following to the form:

--- a/app/forms/concerns/date_field_builder.rb
+++ b/app/forms/concerns/date_field_builder.rb
@@ -1,0 +1,61 @@
+class DateFieldBuilder
+  DATE_PARTS = %i[year month day].freeze
+
+  attr_reader :form, :model, :method, :prefix
+
+  # :method is the target method on the model
+  # :prefix is used to construct date part fields
+  def initialize(form:, model:, method:, prefix:)
+    @form = form
+    @model = model
+    @method = method
+    @prefix = prefix
+  end
+
+  def blank?
+    from_form.all?(&:blank?)
+  end
+
+  def complete?
+    @complete ||= from_form.all?(&:present?)
+  end
+
+  def partially_complete?
+    !blank? && !complete?
+  end
+
+  # Date part fields
+  def fields
+    DATE_PARTS.map { |part| field_for(part) }
+  end
+
+  # An array of the data stored in the form's date part fields
+  def from_form
+    @from_form ||= fields.map { |field| form.__send__(field) }
+  end
+
+  # A hash that can populate the form's date part fields from data in the model
+  def model_attributes
+    return unless model_date.present?
+
+    DATE_PARTS.each_with_object({}) { |part, hash| hash[field_for(part)] = model_date.__send__(part) }
+  end
+
+  def model_date
+    @model_date ||= model.__send__(method)
+  end
+
+  def form_date_invalid?
+    !Date.valid_date?(*from_form.map(&:to_i))
+  end
+
+  def form_date
+    @form_date ||= Date.new(*from_form.map(&:to_i))
+  end
+
+  private
+
+  def field_for(part)
+    [prefix, part].join.to_sym
+  end
+end

--- a/app/forms/incidents/latest_incident_form.rb
+++ b/app/forms/incidents/latest_incident_form.rb
@@ -1,70 +1,48 @@
 module Incidents
   class LatestIncidentForm
     include BaseForm
-
     form_for Incident
 
     attr_accessor :occurred_year, :occurred_month, :occurred_day, :details
     attr_writer :occurred_on
 
-    validates :occurred_on, presence: true, unless: :draft_and_not_incomplete_date?
+    validates :occurred_on, presence: true, unless: :draft_and_not_partially_complete_date?
     validates :occurred_on, date: { not_in_the_future: true }, allow_nil: true
     validates :details, presence: true, unless: :draft?
 
     def initialize(*args)
       super
       set_instance_variables_for_attributes_if_not_set_but_in_model(
-        attrs: occurred_on_fields,
-        model_attributes: occurred_on_from_model
+        attrs: date_fields.fields,
+        model_attributes: date_fields.model_attributes
       )
     end
 
     def occurred_on
       return @occurred_on if @occurred_on.present?
-      return incomplete_date if occurred_on_methods.any?(&:blank?)
+      return if date_fields.blank?
+      return :invalid if date_fields.partially_complete? || date_fields.form_date_invalid?
 
-      @occurred_on = attributes[:occurred_on] = Date.new(*occurred_on_methods.map(&:to_i))
-    rescue ArgumentError
-      :invalid
+      @occurred_on = attributes[:occurred_on] = date_fields.form_date
     end
 
     private
 
     def exclude_from_model
-      occurred_on_fields
+      date_fields.fields
     end
 
-    def occurred_on_fields
-      %i[occurred_year occurred_month occurred_day]
+    def draft_and_not_partially_complete_date?
+      draft? && !date_fields.partially_complete?
     end
 
-    def occurred_on_methods
-      @occurred_on_methods ||= occurred_on_fields.map { |f| __send__(f) }
-    end
-
-    def occurred_on_from_model
-      return unless model.occurred_on?
-
-      {
-        occurred_year: model.occurred_on.year,
-        occurred_month: model.occurred_on.month,
-        occurred_day: model.occurred_on.day
-      }
-    end
-
-    def incomplete_date
-      return nil if occurred_on_methods.all?(&:blank?)
-
-      @incomplete_date = true
-      :invalid
-    end
-
-    def incomplete_date?
-      @incomplete_date
-    end
-
-    def draft_and_not_incomplete_date?
-      draft? && !incomplete_date?
+    def date_fields
+      @date_fields ||= DateFieldBuilder.new(
+        form: self,
+        model: model,
+        method: :occurred_on,
+        prefix: :occurred_
+      )
     end
   end
 end

--- a/app/forms/legal_aid_applications/used_delegated_functions_form.rb
+++ b/app/forms/legal_aid_applications/used_delegated_functions_form.rb
@@ -1,0 +1,50 @@
+module LegalAidApplications
+  class UsedDelegatedFunctionsForm
+    include BaseForm
+    form_for LegalAidApplication
+
+    attr_accessor :used_delegated_functions_year, :used_delegated_functions_month,
+                  :used_delegated_functions_day
+    attr_writer :used_delegated_functions_on
+
+    validates :used_delegated_functions_on, presence: true, unless: :draft_and_not_partially_complete_date?
+    validates :used_delegated_functions_on, date: { not_in_the_future: true }, allow_nil: true
+
+    def initialize(*args)
+      super
+      set_instance_variables_for_attributes_if_not_set_but_in_model(
+        attrs: date_fields.fields,
+        model_attributes: date_fields.model_attributes
+      )
+    end
+
+    # Note that this method is first called by `validates`.
+    # Without that validation, the functionality in this method will not be called before save
+    def used_delegated_functions_on
+      return @used_delegated_functions_on if @used_delegated_functions_on.present?
+      return if date_fields.blank?
+      return :invalid if date_fields.partially_complete? || date_fields.form_date_invalid?
+
+      @used_delegated_functions_on = attributes[:used_delegated_functions_on] = date_fields.form_date
+    end
+
+    private
+
+    def exclude_from_model
+      date_fields.fields
+    end
+
+    def draft_and_not_partially_complete_date?
+      draft? && !date_fields.partially_complete?
+    end
+
+    def date_fields
+      @date_fields ||= DateFieldBuilder.new(
+        form: self,
+        model: model,
+        method: :used_delegated_functions_on,
+        prefix: :used_delegated_functions_
+      )
+    end
+  end
+end

--- a/app/forms/legal_aid_applications/used_delegated_functions_form.rb
+++ b/app/forms/legal_aid_applications/used_delegated_functions_form.rb
@@ -7,6 +7,7 @@ module LegalAidApplications
                   :used_delegated_functions_day, :used_delegated_functions
     attr_writer :used_delegated_functions_on
 
+    validates :used_delegated_functions, presence: { unless: :draft? }
     validates :used_delegated_functions_on, presence: { unless: :date_not_required? }
     validates :used_delegated_functions_on, date: { not_in_the_future: true }, allow_nil: true
 

--- a/app/services/flow/flows/provider_start.rb
+++ b/app/services/flow/flows/provider_start.rb
@@ -37,7 +37,14 @@ module Flow
         },
         check_benefits: {
           path: ->(application) { urls.providers_legal_aid_application_check_benefits_path(application) },
-          forward: ->(application) { application.benefit_check_result.positive? ? :capital_introductions : :online_bankings }
+          forward: ->(application) { application.benefit_check_result.positive? ? :capital_introductions : :used_delegated_functions }
+        },
+        used_delegated_functions: {
+          path: ->(application) { urls.providers_legal_aid_application_used_delegated_functions_path(application) },
+          forward: ->(application) { application.used_delegated_functions? ? :substantive_applications : :online_bankings }
+        },
+        substantive_applications: {
+          path: ->(application) { urls.providers_legal_aid_application_substantive_application_path(application) }
         },
         online_bankings: {
           path: ->(application) { urls.providers_legal_aid_application_online_banking_path(application) },

--- a/app/views/providers/used_delegated_functions/show.html.erb
+++ b/app/views/providers/used_delegated_functions/show.html.erb
@@ -19,13 +19,19 @@
             ) %>
 
         <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-true">
-          <%= date_input_fields(
-                prefix: :used_delegated_functions,
-                field_name: :used_delegated_functions_on,
-                width: :full,
-                set_error_class_here: false,
-                form: form
-              ) %>
+          <fieldset class="govuk-fieldset">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+              <%= t('.used_delegated_functions_on') %>
+            </legend>
+            <%= govuk_hint t('.used_delegated_functions_on_hint') %>
+            <%= date_input_fields(
+                  prefix: :used_delegated_functions,
+                  field_name: :used_delegated_functions_on,
+                  width: :full,
+                  set_error_class_here: false,
+                  form: form
+                ) %>
+          </fieldset>
         </div>
 
         <%= form.govuk_radio_button(

--- a/app/views/providers/used_delegated_functions/show.html.erb
+++ b/app/views/providers/used_delegated_functions/show.html.erb
@@ -1,4 +1,4 @@
-<%= page_template page_title: t('.heading') do %>
+<%= page_template page_title: t('.heading'), template: :basic do %>
 
   <%= form_with(
         model: @form,
@@ -7,10 +7,38 @@
         local: true
       ) do |form| %>
 
-    <%= date_input_fields prefix: :used_delegated_functions, field_name: :used_delegated_functions_on, width: :full, form: form %>
+    <%= govuk_form_group show_error_if: @form.errors.present? do %>
+      <%= govuk_fieldset_header page_title %>
+
+      <div class="govuk-radios govuk-radios--conditional" data-module="radios">
+        <%= form.govuk_radio_button(
+              :used_delegated_functions,
+              true,
+              label: t('generic.yes'),
+              'data-aria-controls' => 'conditional-true'
+            ) %>
+
+        <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-true">
+          <%= date_input_fields(
+                prefix: :used_delegated_functions,
+                field_name: :used_delegated_functions_on,
+                width: :full,
+                set_error_class_here: false,
+                form: form
+              ) %>
+        </div>
+
+        <%= form.govuk_radio_button(
+              :used_delegated_functions,
+              false,
+              label: t('generic.no')
+            ) %>
+      </div>
+
+    <% end %>
+
+    <div class="govuk-!-padding-bottom-4"></div>
 
     <%= next_action_buttons(show_draft: true, form: form) %>
-
   <% end %>
-
 <% end %>

--- a/app/views/providers/used_delegated_functions/show.html.erb
+++ b/app/views/providers/used_delegated_functions/show.html.erb
@@ -1,0 +1,16 @@
+<%= page_template page_title: t('.heading') do %>
+
+  <%= form_with(
+        model: @form,
+        url: providers_legal_aid_application_used_delegated_functions_path,
+        method: :patch,
+        local: true
+      ) do |form| %>
+
+    <%= date_input_fields prefix: :used_delegated_functions, field_name: :used_delegated_functions_on, width: :full, form: form %>
+
+    <%= next_action_buttons(show_draft: true, form: form) %>
+
+  <% end %>
+
+<% end %>

--- a/app/views/shared/forms/vehicles/_remaining_payment.html.erb
+++ b/app/views/shared/forms/vehicles/_remaining_payment.html.erb
@@ -4,6 +4,7 @@
       method: :patch,
       local: true
     ) do |form| %>
+
   <%= govuk_form_group show_error_if: @form.errors.present? do %>
     <%= govuk_fieldset_header page_title %>
 
@@ -34,6 +35,7 @@
             label: t('generic.no'),
             checked: @form.model.payment_remaining&.zero? && !@form.payments_remain?
           ) %>
+    </div>
 
   <% end %>
   <div class="govuk-!-padding-bottom-4"></div>

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -40,6 +40,9 @@ en:
       legal_aid_application:
         outstanding_mortgage_amount: Enter outstanding mortgage amount
         property_value: Enter the estimated value of your home
+        used_delegated_functions_day: Day
+        used_delegated_functions_month: Month
+        used_delegated_functions_year: Year
       vehicle:
         purchased_on_day: Day
         purchased_on_month: Month

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -146,6 +146,10 @@ en:
               too_many_decimals: Estimated value must not include more than 2 decimal numbers
             shared_ownership:
               blank: Select yes if you own your home with someone else
+            used_delegated_functions_on:
+              date_not_valid: Enter a valid date
+              date_is_in_the_future: The date you used delegated functions must be in the past
+              blank: Enter the date you used delegated functions
         merits_assessment:
           attributes:
             application_purpose:

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -149,6 +149,8 @@ en:
               too_many_decimals: Estimated value must not include more than 2 decimal numbers
             shared_ownership:
               blank: Select yes if you own your home with someone else
+            used_delegated_functions:
+              blank: Please select Yes or No
             used_delegated_functions_on:
               date_not_valid: Enter a valid date
               date_is_in_the_future: The date you used delegated functions must be in the past

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -365,6 +365,9 @@ en:
         sort_z_a_html: " from <em>Zed</em> to <em>A</em>"
         sort_small_large_html: " from <em>smallest</em> to <em>largest</em>"
         sort_large_small_html: "from <em>largest</em> to <em>smallest</em>"
+    used_delegated_functions:
+      show:
+        heading: Have you used delegated functions?
     vehicles:
       show:
         heading: Does your client own a vehicle?

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -64,7 +64,7 @@ en:
       index:
         what_happens_next: What happens next
         because_not_receiving_benefits: This is because they do not receive benefits that qualify for legal aid.
-        you_need_to: 'You''ll need to:'
+        you_need_to: "You'll need to:"
         negative_result:
           title: "%{name} must complete a financial assessment"
           must_answer_financial_questions: Your client will need to answer questions about their financial situation.
@@ -368,6 +368,8 @@ en:
     used_delegated_functions:
       show:
         heading: Have you used delegated functions?
+        used_delegated_functions_on: Date you used delegated functions
+        used_delegated_functions_on_hint: For example, 18 4 2019
     vehicles:
       show:
         heading: Does your client own a vehicle?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -151,6 +151,7 @@ Rails.application.routes.draw do
         patch 'remove_transaction_type', on: :member
       end
       resource :means_summary, only: %i[show update]
+      resource :used_delegated_functions, only: %i[show update]
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -152,6 +152,7 @@ Rails.application.routes.draw do
       end
       resource :means_summary, only: %i[show update]
       resource :used_delegated_functions, only: %i[show update]
+      resource :substantive_application, only: %i[show update]
     end
   end
 

--- a/db/migrate/20190611120953_add_used_delegated_functions_on_to_legal_aid_applications.rb
+++ b/db/migrate/20190611120953_add_used_delegated_functions_on_to_legal_aid_applications.rb
@@ -1,0 +1,5 @@
+class AddUsedDelegatedFunctionsOnToLegalAidApplications < ActiveRecord::Migration[5.2]
+  def change
+    add_column :legal_aid_applications, :used_delegated_functions_on, :date
+  end
+end

--- a/db/migrate/20190611120953_add_used_delegated_functions_on_to_legal_aid_applications.rb
+++ b/db/migrate/20190611120953_add_used_delegated_functions_on_to_legal_aid_applications.rb
@@ -1,5 +1,6 @@
 class AddUsedDelegatedFunctionsOnToLegalAidApplications < ActiveRecord::Migration[5.2]
   def change
     add_column :legal_aid_applications, :used_delegated_functions_on, :date
+    add_column :legal_aid_applications, :used_delegated_functions, :boolean
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -263,6 +263,7 @@ ActiveRecord::Schema.define(version: 2019_06_11_134522) do
     t.json "provider_step_params"
     t.boolean "own_vehicle"
     t.date "used_delegated_functions_on"
+    t.boolean "used_delegated_functions"
     t.index ["applicant_id"], name: "index_legal_aid_applications_on_applicant_id"
     t.index ["application_ref"], name: "index_legal_aid_applications_on_application_ref", unique: true
     t.index ["provider_id"], name: "index_legal_aid_applications_on_provider_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -262,6 +262,7 @@ ActiveRecord::Schema.define(version: 2019_06_11_134522) do
     t.datetime "completed_at"
     t.json "provider_step_params"
     t.boolean "own_vehicle"
+    t.date "used_delegated_functions_on"
     t.index ["applicant_id"], name: "index_legal_aid_applications_on_applicant_id"
     t.index ["application_ref"], name: "index_legal_aid_applications_on_application_ref", unique: true
     t.index ["provider_id"], name: "index_legal_aid_applications_on_provider_id"

--- a/features/providers/civil_application_journey.feature
+++ b/features/providers/civil_application_journey.feature
@@ -108,7 +108,10 @@ Feature: Civil application journeys
     Then I should be on a page showing 'Check your answers'
     Then I click 'Save and continue'
     Then I should be on a page showing 'must complete a financial assessment'
-    When I click 'Continue'
+    Then I click 'Continue'
+    Then I should be on a page showing 'Have you used delegated functions?'
+    Then I choose 'No'
+    Then I click 'Save and continue'
     Then I am on the client use online banking page
     Then I choose "Yes"
     Then I click 'Save and continue'
@@ -139,7 +142,10 @@ Feature: Civil application journeys
     Then I should be on a page showing 'Check your answers'
     Then I click 'Save and continue'
     Then I should be on a page showing 'must complete a financial assessment'
-    When I click 'Continue'
+    Then I click 'Continue'
+    Then I should be on a page showing 'Have you used delegated functions?'
+    Then I choose 'No'
+    Then I click 'Save and continue'
     Then I am on the client use online banking page
     Then I choose "Yes"
     Then I click 'Save and continue'

--- a/features/providers/civil_application_journey.feature
+++ b/features/providers/civil_application_journey.feature
@@ -279,6 +279,9 @@ Feature: Civil application journeys
     Then I click 'Save and continue'
     Then I should be on a page showing 'must complete a financial assessment'
     Then I click 'Continue'
+    Then I should be on a page showing 'Have you used delegated functions?'
+    Then I choose 'No'
+    Then I click 'Save and continue'
     Then I should be on a page showing 'Does your client use online banking?'
     Then I choose "Yes"
     Then I click 'Save and continue'

--- a/spec/forms/concerns/date_field_builder_spec.rb
+++ b/spec/forms/concerns/date_field_builder_spec.rb
@@ -1,0 +1,121 @@
+require 'rails_helper'
+
+RSpec.describe DateFieldBuilder do
+  let(:form_date) { Date.today }
+  let(:model_date) { 2.days.ago }
+  let(:model) { OpenStruct.new(happened_on: model_date) }
+  let(:form) do
+    OpenStruct.new(
+      happened_day: form_date.day,
+      happened_month: form_date.month,
+      happened_year: form_date.year
+    )
+  end
+
+  subject do
+    described_class.new(
+      form: form,
+      model: model,
+      method: :happened_on,
+      prefix: :happened_
+    )
+  end
+
+  describe '#fields' do
+    it 'returns three prefixed names for day, month, and year' do
+      expect(subject.fields).to eq(%i[happened_year happened_month happened_day])
+    end
+  end
+
+  describe '#from_form' do
+    it 'returns array of data stored in form prefixed part fields' do
+      expect(subject.from_form).to eq([form_date.year, form_date.month, form_date.day])
+    end
+  end
+
+  describe '#model_attributes' do
+    it 'returns hash of data for form build from model date' do
+      expected = {
+        happened_day: model_date.day,
+        happened_month: model_date.month,
+        happened_year: model_date.year
+      }
+      expect(subject.model_attributes).to eq(expected)
+    end
+  end
+
+  describe '#model_date' do
+    it 'returns date from model' do
+      expect(subject.model_date).to eq(model_date)
+    end
+  end
+
+  describe '#form_date' do
+    it 'returns date built from form part fields' do
+      expect(subject.form_date).to eq(form_date)
+    end
+  end
+
+  describe '#form_date_invalid?' do
+    it 'returns false with valid date data' do
+      expect(subject.form_date_invalid?).to be false
+    end
+
+    context 'with invalid data' do
+      let(:form) do
+        OpenStruct.new(
+          happened_day: form_date.day,
+          happened_month: 15,
+          happened_year: form_date.year
+        )
+      end
+
+      it 'returns false' do
+        expect(subject.form_date_invalid?).to be true
+      end
+    end
+  end
+
+  describe '#blank?' do
+    it 'returns false if fully populated' do
+      expect(subject.blank?).to be false
+    end
+
+    context 'when all form part fields are empty' do
+      let(:form) { OpenStruct.new }
+
+      it 'returns true' do
+        expect(subject.blank?).to be true
+      end
+    end
+  end
+
+  describe '#partially_complete?' do
+    it 'returns false if fully populated' do
+      expect(subject.partially_complete?).to be false
+    end
+
+    context 'when one part field is empty' do
+      let(:form) do
+        OpenStruct.new(
+          happened_day: form_date.day,
+          happened_year: form_date.year
+        )
+      end
+
+      it 'returns true' do
+        expect(subject.partially_complete?).to be true
+      end
+    end
+
+    context 'when all part fields empty' do
+      let(:form) do
+        OpenStruct.new
+      end
+
+      it 'returns false' do
+        expect(subject.partially_complete?).to be false
+      end
+    end
+  end
+end

--- a/spec/forms/incidents/latest_incident_form_spec.rb
+++ b/spec/forms/incidents/latest_incident_form_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Incidents::LatestIncidentForm, type: :form do
   let(:occurred_on) { rand(20).days.ago.to_date }
   let(:details) { Faker::Lorem.paragraph }
   let(:i18n_scope) { 'activemodel.errors.models.incident.attributes' }
-  let(:error_locale) { :foo }
+  let(:error_locale) { :defined_in_spec }
   let(:message) { I18n.t(error_locale, scope: i18n_scope) }
 
   let(:params) { { occurred_on: occurred_on, details: details } }

--- a/spec/forms/legal_aid_applications/used_delegated_functions_form_spec.rb
+++ b/spec/forms/legal_aid_applications/used_delegated_functions_form_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe LegalAidApplications::UsedDelegatedFunctionsForm, type: :form do
   let(:legal_aid_application) { create :legal_aid_application }
+  let(:used_delegated_functions) { true }
   let(:used_delegated_functions_on) { rand(20).days.ago.to_date }
   let(:day) { used_delegated_functions_on.day }
   let(:month) { used_delegated_functions_on.month }
@@ -14,7 +15,8 @@ RSpec.describe LegalAidApplications::UsedDelegatedFunctionsForm, type: :form do
     {
       used_delegated_functions_day: day.to_s,
       used_delegated_functions_month: month.to_s,
-      used_delegated_functions_year: year.to_s
+      used_delegated_functions_year: year.to_s,
+      used_delegated_functions: used_delegated_functions.to_s
     }
   end
 
@@ -28,6 +30,32 @@ RSpec.describe LegalAidApplications::UsedDelegatedFunctionsForm, type: :form do
 
     it 'updates the application' do
       expect(legal_aid_application.used_delegated_functions_on).to eq(used_delegated_functions_on)
+      expect(legal_aid_application.used_delegated_functions).to be used_delegated_functions
+    end
+
+    context 'when not using delegated functions selected' do
+      let(:used_delegated_functions) { false }
+
+      it 'updates the application' do
+        expect(legal_aid_application.used_delegated_functions).to be used_delegated_functions
+      end
+
+      it 'does not update the date' do
+        expect(legal_aid_application.used_delegated_functions_on).to be_nil
+      end
+    end
+
+    context 'when not using delegated functions selected and date exists on model' do
+      let(:used_delegated_functions) { false }
+      let(:legal_aid_application) { create :legal_aid_application, used_delegated_functions_on: 1.day.ago }
+
+      it 'updates the application' do
+        expect(legal_aid_application.used_delegated_functions).to be used_delegated_functions
+      end
+
+      it 'deletes the date' do
+        expect(legal_aid_application.used_delegated_functions_on).to be_nil
+      end
     end
 
     context 'when date is invalid' do
@@ -58,8 +86,8 @@ RSpec.describe LegalAidApplications::UsedDelegatedFunctionsForm, type: :form do
       end
     end
 
-    context 'without date' do
-      let(:params) { {} }
+    context 'with delegated function selected but without date' do
+      let(:params) { { used_delegated_functions: 'true' } }
       let(:legal_aid_application) { create :legal_aid_application, used_delegated_functions_on: nil }
       let(:error_locale) { 'used_delegated_functions_on.blank' }
 
@@ -79,7 +107,8 @@ RSpec.describe LegalAidApplications::UsedDelegatedFunctionsForm, type: :form do
         {
           used_delegated_functions_year: year.to_s,
           used_delegated_functions_month: '',
-          used_delegated_functions_day: day.to_s
+          used_delegated_functions_day: day.to_s,
+          used_delegated_functions: used_delegated_functions.to_s
         }
       end
 

--- a/spec/forms/legal_aid_applications/used_delegated_functions_form_spec.rb
+++ b/spec/forms/legal_aid_applications/used_delegated_functions_form_spec.rb
@@ -58,6 +58,20 @@ RSpec.describe LegalAidApplications::UsedDelegatedFunctionsForm, type: :form do
       end
     end
 
+    context 'when nothing selected' do
+      let(:params) { {} }
+      let(:error_locale) { 'used_delegated_functions.blank' }
+
+      it 'is invalid' do
+        expect(subject).to be_invalid
+      end
+
+      it 'generates the expected error message' do
+        expect(message).not_to match(/^translation missing:/)
+        expect(subject.errors[:used_delegated_functions].join).to match(message)
+      end
+    end
+
     context 'when date is invalid' do
       let(:month) { 15 }
       let(:error_locale) { 'used_delegated_functions_on.date_not_valid' }

--- a/spec/forms/legal_aid_applications/used_delegated_functions_form_spec.rb
+++ b/spec/forms/legal_aid_applications/used_delegated_functions_form_spec.rb
@@ -1,0 +1,144 @@
+require 'rails_helper'
+
+RSpec.describe LegalAidApplications::UsedDelegatedFunctionsForm, type: :form do
+  let(:legal_aid_application) { create :legal_aid_application }
+  let(:used_delegated_functions_on) { rand(20).days.ago.to_date }
+  let(:day) { used_delegated_functions_on.day }
+  let(:month) { used_delegated_functions_on.month }
+  let(:year) { used_delegated_functions_on.year }
+  let(:i18n_scope) { 'activemodel.errors.models.legal_aid_application.attributes' }
+  let(:error_locale) { :defined_in_spec }
+  let(:message) { I18n.t(error_locale, scope: i18n_scope) }
+
+  let(:params) do
+    {
+      used_delegated_functions_day: day.to_s,
+      used_delegated_functions_month: month.to_s,
+      used_delegated_functions_year: year.to_s
+    }
+  end
+
+  subject { described_class.new(params.merge(model: legal_aid_application)) }
+
+  describe '#save' do
+    before do
+      subject.save
+      legal_aid_application.reload
+    end
+
+    it 'updates the application' do
+      expect(legal_aid_application.used_delegated_functions_on).to eq(used_delegated_functions_on)
+    end
+
+    context 'when date is invalid' do
+      let(:month) { 15 }
+      let(:error_locale) { 'used_delegated_functions_on.date_not_valid' }
+
+      it 'is invalid' do
+        expect(subject).to be_invalid
+      end
+
+      it 'generates the expected error message' do
+        expect(message).not_to match(/^translation missing:/)
+        expect(subject.errors[:used_delegated_functions_on].join).to match(message)
+      end
+    end
+
+    context 'when occurred on is in future' do
+      let(:used_delegated_functions_on) { 1.days.from_now.to_date }
+      let(:error_locale) { 'used_delegated_functions_on.date_is_in_the_future' }
+
+      it 'is invalid' do
+        expect(subject).to be_invalid
+      end
+
+      it 'generates the expected error message' do
+        expect(message).not_to match(/^translation missing:/)
+        expect(subject.errors[:used_delegated_functions_on].join).to match(message)
+      end
+    end
+
+    context 'without date' do
+      let(:params) { {} }
+      let(:legal_aid_application) { create :legal_aid_application, used_delegated_functions_on: nil }
+      let(:error_locale) { 'used_delegated_functions_on.blank' }
+
+      it 'is invalid' do
+        expect(subject).to be_invalid
+      end
+
+      it 'generates the expected error message' do
+        expect(message).not_to match(/^translation missing:/)
+        expect(subject.errors[:used_delegated_functions_on].join).to match(message)
+      end
+    end
+
+    context 'with a partial date' do
+      let(:error_locale) { 'used_delegated_functions_on.date_not_valid' }
+      let(:params) do
+        {
+          used_delegated_functions_year: year.to_s,
+          used_delegated_functions_month: '',
+          used_delegated_functions_day: day.to_s
+        }
+      end
+
+      it 'is invalid' do
+        expect(subject).to be_invalid
+      end
+
+      it 'generates the expected error message' do
+        expect(message).not_to match(/^translation missing:/)
+        expect(subject.errors[:used_delegated_functions_on].join).to match(message)
+      end
+    end
+
+    describe '#save_as_draft' do
+      before do
+        subject.save_as_draft
+        legal_aid_application.reload
+      end
+
+      it 'updates the legal_aid_application' do
+        expect(legal_aid_application.used_delegated_functions_on).to eq(used_delegated_functions_on)
+      end
+
+      context 'when occurred on is invalid' do
+        let(:month) { 15 }
+        let(:error_locale) { 'used_delegated_functions_on.date_not_valid' }
+
+        it 'is invalid' do
+          expect(subject).to be_invalid
+        end
+
+        it 'generates the expected error message' do
+          expect(message).not_to match(/^translation missing:/)
+          expect(subject.errors[:used_delegated_functions_on].join).to match(message)
+        end
+      end
+
+      context 'when occurred on is in future' do
+        let(:used_delegated_functions_on) { 1.days.from_now.to_date }
+        let(:error_locale) { 'used_delegated_functions_on.date_is_in_the_future' }
+
+        it 'is invalid' do
+          expect(subject).to be_invalid
+        end
+
+        it 'generates the expected error message' do
+          expect(message).not_to match(/^translation missing:/)
+          expect(subject.errors[:used_delegated_functions_on].join).to match(message)
+        end
+      end
+
+      context 'without date' do
+        let(:params) { {} }
+        let(:legal_aid_application) { create :legal_aid_application, used_delegated_functions_on: nil }
+
+        it 'is valid' do
+          expect(subject).to be_valid
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/providers/check_benefits_spec.rb
+++ b/spec/requests/providers/check_benefits_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe 'check benefits requests', type: :request do
           let(:application) { create :legal_aid_application, :with_negative_benefit_check_result }
 
           it 'displays the online banking page' do
-            expect(response).to redirect_to providers_legal_aid_application_online_banking_path(application)
+            expect(response).to redirect_to providers_legal_aid_application_used_delegated_functions_path(application)
           end
         end
 
@@ -102,7 +102,7 @@ RSpec.describe 'check benefits requests', type: :request do
           let(:application) { create :legal_aid_application, :with_undetermined_benefit_check_result }
 
           it 'displays the online banking page' do
-            expect(response).to redirect_to providers_legal_aid_application_online_banking_path(application)
+            expect(response).to redirect_to providers_legal_aid_application_used_delegated_functions_path(application)
           end
         end
       end

--- a/spec/requests/providers/used_delegated_functions_spec.rb
+++ b/spec/requests/providers/used_delegated_functions_spec.rb
@@ -1,0 +1,70 @@
+require 'rails_helper'
+RSpec.describe Providers::UsedDelegatedFunctionsController, type: :request do
+  let(:legal_aid_application) { create :legal_aid_application }
+  let(:login_provider) { login_as legal_aid_application.provider }
+
+  before do
+    login_provider
+    subject
+  end
+
+  describe 'GET /providers/applications/:legal_aid_application_id/used_delegated_functions' do
+    subject do
+      get providers_legal_aid_application_used_delegated_functions_path(legal_aid_application)
+    end
+
+    it 'renders successfully' do
+      expect(response).to have_http_status(:ok)
+    end
+
+    context 'when not authenticated' do
+      let(:login_provider) { nil }
+      it_behaves_like 'a provider not authenticated'
+    end
+  end
+
+  describe 'PATCH /providers/applications/:legal_aid_application_id/used_delegated_functions' do
+    let(:used_delegated_functions_on) { rand(20).days.ago.to_date }
+    let(:day) { used_delegated_functions_on.day }
+    let(:month) { used_delegated_functions_on.month }
+    let(:year) { used_delegated_functions_on.year }
+    let(:params) do
+      {
+        legal_aid_application: {
+          used_delegated_functions_day: day.to_s,
+          used_delegated_functions_month: month.to_s,
+          used_delegated_functions_year: year.to_s
+        }
+      }
+    end
+    let(:button_clicked) { {} }
+
+    subject do
+      patch(
+        providers_legal_aid_application_used_delegated_functions_path(legal_aid_application),
+        params: params.merge(button_clicked)
+      )
+    end
+
+    it 'update the application' do
+      expect(legal_aid_application.reload.used_delegated_functions_on).to eq(used_delegated_functions_on)
+    end
+
+    it 'redirects to the next page' do
+      expect(response).to redirect_to(flow_forward_path)
+    end
+
+    context 'when not authenticated' do
+      let(:login_provider) { nil }
+      it_behaves_like 'a provider not authenticated'
+    end
+
+    context 'when incomplete' do
+      let(:month) { '' }
+
+      it 'renders show' do
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+end

--- a/spec/requests/providers/used_delegated_functions_spec.rb
+++ b/spec/requests/providers/used_delegated_functions_spec.rb
@@ -28,12 +28,14 @@ RSpec.describe Providers::UsedDelegatedFunctionsController, type: :request do
     let(:day) { used_delegated_functions_on.day }
     let(:month) { used_delegated_functions_on.month }
     let(:year) { used_delegated_functions_on.year }
+    let(:used_delegated_functions) { true }
     let(:params) do
       {
         legal_aid_application: {
           used_delegated_functions_day: day.to_s,
           used_delegated_functions_month: month.to_s,
-          used_delegated_functions_year: year.to_s
+          used_delegated_functions_year: year.to_s,
+          used_delegated_functions: used_delegated_functions.to_s
         }
       }
     end
@@ -46,12 +48,14 @@ RSpec.describe Providers::UsedDelegatedFunctionsController, type: :request do
       )
     end
 
-    it 'update the application' do
-      expect(legal_aid_application.reload.used_delegated_functions_on).to eq(used_delegated_functions_on)
+    it 'updates the application' do
+      legal_aid_application.reload
+      expect(legal_aid_application.used_delegated_functions_on).to eq(used_delegated_functions_on)
+      expect(legal_aid_application.used_delegated_functions).to eq(used_delegated_functions)
     end
 
-    it 'redirects to the next page' do
-      expect(response).to redirect_to(flow_forward_path)
+    it 'redirects to the substantive application page' do
+      expect(response).to redirect_to(providers_legal_aid_application_substantive_application_path(legal_aid_application))
     end
 
     context 'when not authenticated' do
@@ -59,11 +63,88 @@ RSpec.describe Providers::UsedDelegatedFunctionsController, type: :request do
       it_behaves_like 'a provider not authenticated'
     end
 
-    context 'when incomplete' do
+    context 'when date incomplete' do
       let(:month) { '' }
 
       it 'renders show' do
         expect(response).to have_http_status(:ok)
+      end
+
+      it 'displays error' do
+        expect(response.body).to include('govuk-error-summary')
+        expect(response.body).to include('Enter a valid date')
+      end
+    end
+
+    context 'when date not entered' do
+      let(:day) { '' }
+      let(:month) { '' }
+      let(:year) { '' }
+
+      it 'renders show' do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'displays error' do
+        expect(response.body).to include('govuk-error-summary')
+        expect(response.body).to include('Enter the date you used delegated functions')
+      end
+    end
+
+    context 'when not using delegated functions' do
+      let(:used_delegated_functions) { false }
+
+      it 'updates the application' do
+        legal_aid_application.reload
+        expect(legal_aid_application.used_delegated_functions_on).to be_nil
+        expect(legal_aid_application.used_delegated_functions).to eq(used_delegated_functions)
+      end
+
+      it 'redirects to the online banking page' do
+        expect(response).to redirect_to(providers_legal_aid_application_online_banking_path(legal_aid_application))
+      end
+    end
+
+    context 'Form submitted using Save as draft button' do
+      let(:button_clicked) { { draft_button: 'Save as draft' } }
+
+      it "redirects provider to provider's applications page" do
+        expect(response).to redirect_to(providers_legal_aid_applications_path)
+      end
+
+      it 'updates the application' do
+        legal_aid_application.reload
+        expect(legal_aid_application.used_delegated_functions_on).to eq(used_delegated_functions_on)
+        expect(legal_aid_application.used_delegated_functions).to eq(used_delegated_functions)
+      end
+
+      context 'when date incomplete' do
+        let(:month) { '' }
+
+        it 'renders show' do
+          expect(response).to have_http_status(:ok)
+        end
+
+        it 'displays error' do
+          expect(response.body).to include('govuk-error-summary')
+          expect(response.body).to include('Enter a valid date')
+        end
+      end
+
+      context 'when date not entered' do
+        let(:day) { '' }
+        let(:month) { '' }
+        let(:year) { '' }
+
+        it "redirects provider to provider's applications page" do
+          expect(response).to redirect_to(providers_legal_aid_applications_path)
+        end
+
+        it 'updates the application' do
+          legal_aid_application.reload
+          expect(legal_aid_application.used_delegated_functions_on).to be_nil
+          expect(legal_aid_application.used_delegated_functions).to eq(used_delegated_functions)
+        end
       end
     end
   end


### PR DESCRIPTION
[Jira AP-662](https://dsdmoj.atlassian.net/browse/AP-662)

This adds a page for the provider to input whether they used Delegated Functions, and if so when.

On building this I found that I was copying into the form a lot of complication from other forms that use date. So I created `DateFieldBuilder` to put all that complication into one object that could be reused across such forms. To test it's reuse, I refactored `Incidents::LatestIncidentForm` to check that the functionality worked in another form. I've add a tech debt ticket for other Forms to be likewise refactored ([AP-740](https://dsdmoj.atlassian.net/browse/AP-740)).

I have added a holding action controller `Providers::SubstantiveApplicationsController`. The functionality for this should be added in PR-663