### PR TITLE
AP564 Content change to 'Provide details of the case' page

### DIFF
--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -294,10 +294,9 @@ en:
           You'll need to enter:
         do_merits_of_case_qualify_list:
           list: |
-            details about the most recent incident
+            details about the latest domestic abuse incident
             information about the respondent
             a statement of case
-            the estimated costs of doing the work
             the chances of a successful outcome
     statement_of_cases:
       show:

--- a/spec/requests/providers/start_merits_assessments_spec.rb
+++ b/spec/requests/providers/start_merits_assessments_spec.rb
@@ -22,6 +22,12 @@ RSpec.describe Providers::StartMeritsAssessmentsController, type: :request do
         expect(response).to have_http_status(:ok)
         expect(response.body).to include('Provide details of the case')
       end
+
+      it 'displays do merits of case qualify list' do
+        I18n.t('.providers.start_merits_assessments.show.do_merits_of_case_qualify_list.list').each_line do |item|
+          expect(response.body).to include(item)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Update content on 'Provide details of the case' page

[Link to story](https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=233&modal=detail&selectedIssue=AP-564)

- Changed 'details about the most recent incident' to 'details about the latest domestic abuse incident'
- Removed 'the estimated costs of doing the work'
- Wrote tests

- [X] Tests and rubocop should be passing: `bundle exec rake`
- [X] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [X] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [X] The PR description should say what you changed and why, with a link to the JIRA story.
- [X] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [X] You should have checked that the commit messages say why the change was made.
