### PR TITLE
AP-692 split prospects of success

### DIFF
--- a/app/controllers/providers/success_likely_controller.rb
+++ b/app/controllers/providers/success_likely_controller.rb
@@ -1,0 +1,33 @@
+module Providers
+  class SuccessLikelyController < ProviderBaseController
+    before_action :authorize_legal_aid_application
+
+    def index
+      @form = MeritsAssessments::SuccessLikelyForm.new(model: merits_assessment)
+    end
+
+    def create
+      @form = MeritsAssessments::SuccessLikelyForm.new(form_params)
+
+      render :index unless save_continue_or_draft(@form)
+    end
+
+    private
+
+    def merits_assessment
+      @merits_assessment ||= legal_aid_application.merits_assessment || legal_aid_application.build_merits_assessment
+    end
+
+    def authorize_legal_aid_application
+      authorize @legal_aid_application
+    end
+
+    def form_params
+      merge_with_model(merits_assessment) do
+        next {} unless params[:merits_assessment]
+
+        params.require(:merits_assessment).permit(:success_likely)
+      end
+    end
+  end
+end

--- a/app/forms/merits_assessments/success_likely_form.rb
+++ b/app/forms/merits_assessments/success_likely_form.rb
@@ -1,0 +1,23 @@
+module MeritsAssessments
+  class SuccessLikelyForm
+    include BaseForm
+
+    form_for MeritsAssessment
+
+    attr_accessor :success_likely
+
+    validates :success_likely, presence: true, unless: :draft?
+    before_validation :set_success_prospect
+
+    private
+
+    def set_success_prospect
+      if success_likely == 'true'
+        model.success_prospect = :likely
+        model.success_prospect_details = nil
+      elsif model.success_prospect_likely?
+        model.success_prospect = nil
+      end
+    end
+  end
+end

--- a/app/forms/merits_assessments/success_prospect_form.rb
+++ b/app/forms/merits_assessments/success_prospect_form.rb
@@ -6,23 +6,17 @@ module MeritsAssessments
 
     attr_accessor :success_prospect, :success_prospect_details
 
-    before_validation :clear_success_prospect_details
     validates :success_prospect, presence: true, unless: :draft?
     validates :success_prospect_details,
               presence: true,
-              unless: :details_not_required?
+              if: :details_required?
 
     private
 
-    def clear_success_prospect_details
-      success_prospect_details&.clear if success_prospect.to_s == MeritsAssessment.prospect_likely_to_succeed.to_s
-    end
+    def details_required?
+      return false if draft?
 
-    def details_not_required?
-      return true if success_prospect.to_s == MeritsAssessment.prospect_likely_to_succeed.to_s
-      return true if draft? && success_prospect.blank?
-
-      false
+      success_prospect.present?
     end
   end
 end

--- a/app/lib/govuk_elements_form_builder/form_builder.rb
+++ b/app/lib/govuk_elements_form_builder/form_builder.rb
@@ -67,9 +67,10 @@ module GovukElementsFormBuilder
 
       label_options = { value: value.to_s, class: 'govuk-label govuk-radios__label' }
       label_html = label(attribute, options[:label], label_options)
+      hint_html = hint_tag(attribute, options.merge(radio_button_value: value))
 
       content_tag(:div, class: 'govuk-radios__item') do
-        concat_tags(radio_html, label_html)
+        concat_tags(radio_html, label_html, hint_html)
       end
     end
 
@@ -227,13 +228,19 @@ module GovukElementsFormBuilder
     end
 
     def hint_message(attribute, options)
+      return options[:hint] if options.key?(:radio_button_value)
+
       options[:hint].presence || I18n.translate("helpers.hint.#{@object_name}.#{attribute}", default: nil)
     end
 
     def hint_tag(attribute, options)
       return unless hint?(attribute, options)
 
-      content_tag(:span, hint_message(attribute, options), class: 'govuk-hint', id: "#{attribute}-hint")
+      classes = ['govuk-hint']
+      classes << 'govuk-radios__hint' if options.key?(:radio_button_value)
+
+      id = [attribute, options[:radio_button_value], 'hint'].compact.join('-')
+      content_tag(:span, hint_message(attribute, options), class: classes.join(' '), id: id)
     end
 
     def error_tag(attribute, options)

--- a/app/models/merits_assessment.rb
+++ b/app/models/merits_assessment.rb
@@ -1,23 +1,15 @@
 class MeritsAssessment < ApplicationRecord
   belongs_to :legal_aid_application
 
-  # defining before enum so it can be used in the enum
-  def self.prospect_likely_to_succeed
-    :likely
-  end
-
-  enum(
-    success_prospect: {
-      prospect_likely_to_succeed => '50% or better'.freeze,
-      marginal: 'Marginal 45 - 50%'.freeze,
-      borderline: 'borderline'.freeze,
-      uncertain: 'uncertain'.freeze,
-      poor: 'poor'.freeze
-    },
-    _prefix: true
-  )
+  enum success_prospect: {
+    likely: 'likely'.freeze,
+    marginal: 'marginal'.freeze,
+    poor: 'poor'.freeze,
+    borderline: 'borderline'.freeze,
+    not_known: 'not_known'.freeze
+  }, _prefix: true
 
   def self.prospects_unlikely_to_succeed
-    @prospects_unlikely_to_succeed ||= success_prospects.except(prospect_likely_to_succeed.to_s)
+    MeritsAssessment.success_prospects.except(:likely).keys
   end
 end

--- a/app/services/flow/flows/provider_merits.rb
+++ b/app/services/flow/flows/provider_merits.rb
@@ -37,7 +37,7 @@ module Flow
         },
         statement_of_cases: {
           path: ->(application) { urls.providers_legal_aid_application_statement_of_case_path(application) },
-          forward: :success_prospects,
+          forward: :success_likely,
           check_answers: :check_merits_answers
         },
         estimated_legal_costs: {
@@ -46,10 +46,13 @@ module Flow
           forward: :success_prospects,
           check_answers: :check_merits_answers
         },
+        success_likely: {
+          path: ->(application) { urls.providers_legal_aid_application_success_likely_index_path(application) },
+          forward: ->(application) { application.merits_assessment.success_likely? ? :check_merits_answers : :success_prospects }
+        },
         success_prospects: {
           path: ->(application) { urls.providers_legal_aid_application_success_prospects_path(application) },
-          forward: :check_merits_answers,
-          check_answers: :check_merits_answers
+          forward: :check_merits_answers
         },
         check_merits_answers: {
           path: ->(application) { urls.providers_legal_aid_application_check_merits_answers_path(application) },

--- a/app/views/providers/check_merits_answers/show.html.erb
+++ b/app/views/providers/check_merits_answers/show.html.erb
@@ -103,7 +103,7 @@
   <dl class="govuk-summary-list govuk-!-margin-bottom-2">
     <%= check_answer_link(
           name: :prospects_of_success,
-          url: providers_legal_aid_application_success_prospects_path,
+          url: providers_legal_aid_application_success_likely_index_path,
           question: t('.items.prospects_of_success'),
           answer: t("shared.forms.success_prospect.success_prospect_item.#{@merits.success_prospect}")
         ) %>

--- a/app/views/providers/success_likely/index.html.erb
+++ b/app/views/providers/success_likely/index.html.erb
@@ -1,0 +1,17 @@
+<%= page_template page_title: t('.h1-heading'), template: :basic do %>
+  <%= form_with(
+        model: @form,
+        url: providers_legal_aid_application_success_likely_index_path,
+        method: :post,
+        local: true
+      ) do |form| %>
+
+    <%= form.govuk_collection_radio_buttons(
+          :success_likely,
+          [true, false],
+          title: content_for(:page_title)
+        ) %>
+
+    <%= next_action_buttons(show_draft: true, form: form) %>
+  <% end %>
+<% end %>

--- a/app/views/shared/forms/_success_prospect_form.html.erb
+++ b/app/views/shared/forms/_success_prospect_form.html.erb
@@ -13,10 +13,8 @@
     <%= govuk_error_message(form.object.errors[:client_received_legal_help].first) %>
 
     <div class="govuk-radios govuk-radios--conditional govuk-!-padding-top-2" data-module="radios">
-      <%= form.govuk_radio_button(:success_prospect, MeritsAssessment.prospect_likely_to_succeed, label: t('.likely')) %>
-
       <%= render partial: 'shared/forms/success_prospect/success_prospect_item',
-                 collection: MeritsAssessment.prospects_unlikely_to_succeed, as: :success_prospects,
+                 collection: MeritsAssessment.prospects_unlikely_to_succeed, as: :prospect,
                  locals: { form: form,
                            group_error_class: group_error_class,
                            input_error_class: input_error_class } %>

--- a/app/views/shared/forms/success_prospect/_success_prospect_item.html.erb
+++ b/app/views/shared/forms/success_prospect/_success_prospect_item.html.erb
@@ -1,11 +1,11 @@
 <%
- prospect = success_prospects.first
  conditional = "conditional-#{prospect}"
  text_area_name = "success_prospect_details_#{prospect}"
 %>
 
 <%= form.govuk_radio_button(:success_prospect,
                             prospect,
+                            hint: t(".hint.#{prospect}"),
                             label: t(".#{prospect}"),
                             class: 'success_prospect_option',
                             'data-aria-controls' => conditional,

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -173,9 +173,11 @@ en:
             proceedings_before_the_court:
               blank: Select Yes if the proceedings for which funding is being sought are currently before the court
             success_prospect:
-              blank: Select the prospects of success
+              blank: Select the chance of a successful outcome
+            success_likely:
+              blank: Select yes if the chance of a successful outcome is 50% or better
             success_prospect_details:
-              blank: Enter explanation of why you think legal aid should be granted
+              blank: Tell us why legal aid should be granted
         other_assets_declaration:
           attributes:
             valuable_items_value:

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -32,7 +32,9 @@ en:
         details_of_proceedings_before_the_court: Please give details.
         proceedings_before_the_court:
           <<: *true_false
-        success_prospect_details: Please explain why you believe legal aid should be granted
+        success_prospect_details: Tell us why legal aid should be granted
+        success_likely:
+          <<: *true_false
       other_assets_declaration:
         check_box_second_home: Second property or holiday home
         second_home_mortgage: Enter outstanding mortgage amount

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -359,7 +359,10 @@ en:
         must_submit_by: You must submit a full application by %{deadline}
     success_prospects:
       show:
-        h1-heading: What are the prospects of success?
+        h1-heading: What is the chance of a successful outcome?
+    success_likely:
+      index:
+        h1-heading: Is the chance of a successful outcome 50% or better?
     transactions:
       show:
         col_category: Category

--- a/config/locales/en/shared.yml
+++ b/config/locales/en/shared.yml
@@ -158,13 +158,16 @@ en:
           partner_or_ex_partner: Yes, a partner or ex-partner
       success_prospect:
         success_prospect_item:
-          borderline: Borderline
           likely: 50% or better
-          marginal: Marginal 45 - 50%
-          poor: Poor
-          uncertain: Uncertain
-      success_prospect_form:
-        likely: 50% or better
+          marginal: 45% to 49%
+          poor: Less than 45%
+          borderline: Borderline
+          not_known: I do not know yet
+          hint:
+            marginal: The chance of a successful outcome is marginal.
+            poor: The chance of a successful outcome is poor.
+            borderline: You cannot predict the outcome.
+            not_known: Work still needs to be done to determine the likelihood of success.
       types_of_income_form:
         select_all_that_apply: Select all that apply
         financial_help_examples: For example, money from a family member for rent or bills.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -131,6 +131,7 @@ Rails.application.routes.draw do
       resource :client_received_legal_help, only: %i[show update]
       resource :proceedings_before_the_court, only: %i[show update]
       resource :estimated_legal_costs, only: %i[show update]
+      resources :success_likely, only: %i[index create]
       resource :success_prospects, only: %i[show update]
       resource :check_merits_answers, only: [:show] do
         patch :continue

--- a/db/migrate/20190617103359_add_success_likely_to_merits_assessments.rb
+++ b/db/migrate/20190617103359_add_success_likely_to_merits_assessments.rb
@@ -1,0 +1,5 @@
+class AddSuccessLikelyToMeritsAssessments < ActiveRecord::Migration[5.2]
+  def change
+    add_column :merits_assessments, :success_likely, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_17_093116) do
+ActiveRecord::Schema.define(version: 2019_06_17_103359) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -300,6 +300,7 @@ ActiveRecord::Schema.define(version: 2019_06_17_093116) do
     t.string "success_prospect"
     t.text "success_prospect_details"
     t.datetime "submitted_at"
+    t.boolean "success_likely"
     t.index ["legal_aid_application_id"], name: "index_merits_assessments_on_legal_aid_application_id"
   end
 

--- a/features/providers/civil_application_journey.feature
+++ b/features/providers/civil_application_journey.feature
@@ -409,7 +409,10 @@ Feature: Civil application journeys
     Then I should be on a page showing "Statement of case"
     Then I fill "Statement" with "Statement of case"
     Then I click 'Save and continue'
-    Then I should be on a page showing "What are the prospects of success?"
+    Then I should be on a page showing "Is the chance of a successful outcome 50% or better?"
+    Then I choose "No"
+    Then I click 'Save and continue'
+    Then I should be on a page showing "What is the chance of a successful outcome?"
     Then I choose "Borderline"
     Then I fill "Success prospect details" with "Prospects of success"
     Then I click 'Save and continue'
@@ -510,7 +513,10 @@ Feature: Civil application journeys
     Then I should be on a page showing "hello_world.pdf"
     Then I should be on a page showing "UPLOADED"
     Then I click 'Save and continue'
-    Then I should be on a page showing "What are the prospects of success?"
+    Then I should be on a page showing "Is the chance of a successful outcome 50% or better?"
+    Then I choose "No"
+    Then I click 'Save and continue'
+    Then I should be on a page showing "What is the chance of a successful outcome?"
     Then I choose "Borderline"
     Then I fill "Success prospect details" with "Prospects of success"
     Then I click 'Save and continue'

--- a/spec/requests/providers/check_merits_answers_spec.rb
+++ b/spec/requests/providers/check_merits_answers_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe 'check merits answers requests', type: :request do
         expect(response.body).to have_change_link(:details_of_latest_incident, providers_legal_aid_application_details_latest_incident_path(application))
         expect(response.body).to have_change_link(:respondent_details, providers_legal_aid_application_respondent_path)
         expect(response.body).to have_change_link(:statement_of_case, providers_legal_aid_application_statement_of_case_path(application))
-        expect(response.body).to have_change_link(:prospects_of_success, providers_legal_aid_application_success_prospects_path(application))
+        expect(response.body).to have_change_link(:prospects_of_success, providers_legal_aid_application_success_likely_index_path(application))
       end
 
       it 'displays the details of wether the respondent understands the terms of court order' do

--- a/spec/requests/providers/statement_of_case_spec.rb
+++ b/spec/requests/providers/statement_of_case_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe 'provider statement of case requests', type: :request do
 
     it 'redirects to the next page' do
       subject
-      expect(response).to redirect_to providers_legal_aid_application_success_prospects_path(legal_aid_application)
+      expect(response).to redirect_to providers_legal_aid_application_success_likely_index_path(legal_aid_application)
     end
 
     context '2 files are uploaded' do

--- a/spec/requests/providers/success_likely_spec.rb
+++ b/spec/requests/providers/success_likely_spec.rb
@@ -1,0 +1,123 @@
+require 'rails_helper'
+
+RSpec.describe Providers::SuccessLikelyController, type: :request do
+  let(:merits_assessment) { create :merits_assessment }
+  let(:legal_aid_application) { create :legal_aid_application, merits_assessment: merits_assessment }
+  let(:login) { login_as legal_aid_application.provider }
+
+  before { login }
+
+  describe 'GET /providers/applications/:id/success_likely' do
+    subject { get providers_legal_aid_application_success_likely_index_path(legal_aid_application) }
+
+    it 'renders successfully' do
+      subject
+      expect(response).to have_http_status(:ok)
+    end
+
+    context 'when the provider is not authenticated' do
+      let(:login) { nil }
+      before { subject }
+      it_behaves_like 'a provider not authenticated'
+    end
+  end
+
+  describe 'POST /providers/applications/:legal_aid_application_id/vehicle' do
+    let(:success_prospect) { :poor }
+    let(:merits_assessment) { create :merits_assessment, success_prospect: success_prospect, success_prospect_details: 'details' }
+    let(:success_likely) { 'true' }
+    let(:params) do
+      { merits_assessment: { success_likely: success_likely } }
+    end
+    let(:submit_button) { {} }
+    let(:next_url) { providers_legal_aid_application_check_merits_answers_path(legal_aid_application) }
+
+    subject do
+      post(
+        providers_legal_aid_application_success_likely_index_path(legal_aid_application),
+        params: params.merge(submit_button)
+      )
+    end
+
+    it 'sets success_likely to true' do
+      expect { subject }.to change { merits_assessment.reload.success_likely }.to(true)
+    end
+
+    it 'sets success_prospect to likely' do
+      expect { subject }.to change { merits_assessment.reload.success_prospect }.to('likely')
+    end
+
+    it 'sets success_prospect_details to nil' do
+      expect { subject }.to change { merits_assessment.reload.success_prospect_details }.to(nil)
+    end
+
+    it 'redirects to next page' do
+      subject
+      expect(response).to redirect_to(next_url)
+    end
+
+    context 'false is selected' do
+      let(:next_url) { providers_legal_aid_application_success_prospects_path(legal_aid_application) }
+      let(:success_likely) { 'false' }
+
+      it 'sets success_likely to false' do
+        expect { subject }.to change { merits_assessment.reload.success_likely }.to(false)
+      end
+
+      it 'does not change success_prospect' do
+        expect { subject }.not_to change { merits_assessment.reload.success_prospect }
+      end
+
+      it 'does not change success_prospect_details' do
+        expect { subject }.not_to change { merits_assessment.reload.success_prospect_details }
+      end
+
+      it 'redirects to next page' do
+        subject
+        expect(response).to redirect_to(next_url)
+      end
+
+      context 'success_prospect was :likely' do
+        let(:success_prospect) { :likely }
+
+        it 'sets success_prospect to nil' do
+          expect { subject }.to change { merits_assessment.reload.success_prospect }.to(nil)
+        end
+      end
+    end
+
+    context 'nothing is selected' do
+      let(:params) { {} }
+
+      it 'renders successfully' do
+        subject
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'displays error' do
+        subject
+        expect(response.body).to include('govuk-error-summary')
+      end
+    end
+
+    context 'Form submitted using Save as draft button' do
+      let(:submit_button) { { draft_button: 'Save as draft' } }
+
+      it "redirects provider to provider's applications page" do
+        subject
+        expect(response).to redirect_to(providers_legal_aid_applications_path)
+      end
+
+      it 'sets the application as draft' do
+        expect { subject }.to change { legal_aid_application.reload.draft? }.from(false).to(true)
+      end
+
+      it 'updates the model' do
+        subject
+        merits_assessment.reload
+        expect(merits_assessment.success_likely).to eq(true)
+        expect(merits_assessment.success_prospect).to eq('likely')
+      end
+    end
+  end
+end

--- a/spec/requests/providers/success_prospects_spec.rb
+++ b/spec/requests/providers/success_prospects_spec.rb
@@ -84,25 +84,6 @@ RSpec.describe Providers::SuccessProspectsController, type: :request do
             expect(response).to redirect_to providers_legal_aid_applications_path
           end
         end
-
-        context 'option select that does not require details' do
-          let(:success_prospect) { MeritsAssessment.prospect_likely_to_succeed.to_s }
-          let(:success_prospect_details) { '' }
-
-          it 'redirects to provider applications home page' do
-            expect(response).to redirect_to providers_legal_aid_applications_path
-          end
-        end
-
-        context 'invalid params - application_purpose missing' do
-          let(:success_prospect) { 'marginal' }
-          let(:success_prospect_details) { '' }
-
-          it 'renders an error' do
-            expect(response).to have_http_status(:ok)
-            expect(response.body).to include('id="error_explanation"')
-          end
-        end
       end
     end
   end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-692)

- Add new **Is the chance of a successful outcome 50% or better?** page
- Remove **more than 50%** from `success_prospect` page and change copy
- Modify FormBuilder to allow passing hint option to radio buttons

## Checklist

Before you ask people to review this PR:

- [X] Tests and rubocop should be passing: `bundle exec rake`
- [X] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [X] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [X] The PR description should say what you changed and why, with a link to the JIRA story.
- [X] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [X] You should have checked that the commit messages say why the change was made.