### PR TITLE
AP-670 fix wrong error messages

### DIFF
--- a/app/controllers/citizens/identify_types_of_incomes_controller.rb
+++ b/app/controllers/citizens/identify_types_of_incomes_controller.rb
@@ -10,7 +10,7 @@ module Citizens
     def update
       return go_forward if none_selected? || transactions_added
 
-      legal_aid_application.errors.add :base, :none_selected
+      legal_aid_application.errors.add :base, t('.none_selected')
       render :show
     end
 

--- a/app/controllers/citizens/identify_types_of_outgoings_controller.rb
+++ b/app/controllers/citizens/identify_types_of_outgoings_controller.rb
@@ -10,7 +10,7 @@ module Citizens
     def update
       return go_forward if none_selected? || transactions_added
 
-      legal_aid_application.errors.add :base, :none_selected
+      legal_aid_application.errors.add :base, t('.none_selected')
       render :show
     end
 

--- a/app/controllers/providers/identify_types_of_incomes_controller.rb
+++ b/app/controllers/providers/identify_types_of_incomes_controller.rb
@@ -8,7 +8,7 @@ module Providers
       authorize legal_aid_application
       return continue_or_draft if none_selected? || transactions_added || draft_selected?
 
-      legal_aid_application.errors.add :base, :none_selected
+      legal_aid_application.errors.add :base, t('.none_selected')
       render :show
     end
 

--- a/app/controllers/providers/identify_types_of_outgoings_controller.rb
+++ b/app/controllers/providers/identify_types_of_outgoings_controller.rb
@@ -7,7 +7,7 @@ module Providers
     def update
       return continue_or_draft if none_selected? || transactions_added || draft_selected?
 
-      legal_aid_application.errors.add :base, :none_selected
+      legal_aid_application.errors.add :base, t('.none_selected')
       render :show
     end
 

--- a/config/locales/en/activerecord.yml
+++ b/config/locales/en/activerecord.yml
@@ -15,7 +15,3 @@ en:
               invalid: address is not in the right format
             national_insurance_number:
               invalid: is not in the right format
-        legal_aid_application:
-          attributes:
-            base:
-              none_selected: Select if you receive any types of income

--- a/config/locales/en/citizens.yml
+++ b/config/locales/en/citizens.yml
@@ -68,9 +68,13 @@ en:
     identify_types_of_incomes:
       show:
         page_heading: Which types of income do you receive?
+      update:
+        none_selected: Select if you receive any types of income
     identify_types_of_outgoings:
       show:
         page_heading: What regular payments do you make?
+      update:
+        none_selected: Select if you make any regular payments
     information:
       show:
         heading: Give one-time access to your bank accounts

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -134,9 +134,13 @@ en:
     identify_types_of_incomes:
       show:
         page_heading: Which types of income does your client receive?
+      update:
+        none_selected: Select if your client receives any types of income
     identify_types_of_outgoings:
       show:
         page_heading: Which regular payments does your client make?
+      update:
+        none_selected: Select if your client makes any regular payments
     income_summary:
       add_other_income:
         add_other_income: Add another type of income

--- a/spec/requests/citizens/identify_types_of_incomes_spec.rb
+++ b/spec/requests/citizens/identify_types_of_incomes_spec.rb
@@ -42,6 +42,8 @@ RSpec.describe Citizens::IdentifyTypesOfIncomesController do
     it 'should display an error' do
       subject
       expect(response.body).to match('govuk-error-summary')
+      expect(unescaped_response_body).to match(I18n.t('citizens.identify_types_of_incomes.update.none_selected'))
+      expect(unescaped_response_body).not_to include('translation missing')
     end
 
     it 'returns http success' do

--- a/spec/requests/citizens/identify_types_of_outgoings_spec.rb
+++ b/spec/requests/citizens/identify_types_of_outgoings_spec.rb
@@ -43,6 +43,8 @@ RSpec.describe 'IndentifyTypesOfOutgoingsController' do
     it 'should display an error' do
       subject
       expect(response.body).to match('govuk-error-summary')
+      expect(unescaped_response_body).to match(I18n.t('citizens.identify_types_of_outgoings.update.none_selected'))
+      expect(unescaped_response_body).not_to include('translation missing')
     end
 
     it 'returns http success' do

--- a/spec/requests/providers/identify_types_of_incomes_spec.rb
+++ b/spec/requests/providers/identify_types_of_incomes_spec.rb
@@ -54,6 +54,8 @@ RSpec.describe Providers::IdentifyTypesOfIncomesController do
     it 'should display an error' do
       subject
       expect(response.body).to match('govuk-error-summary')
+      expect(unescaped_response_body).to match(I18n.t('providers.identify_types_of_incomes.update.none_selected'))
+      expect(unescaped_response_body).not_to include('translation missing')
     end
 
     it 'returns http success' do

--- a/spec/requests/providers/identify_types_of_outgoings_spec.rb
+++ b/spec/requests/providers/identify_types_of_outgoings_spec.rb
@@ -52,6 +52,8 @@ RSpec.describe Providers::IdentifyTypesOfOutgoingsController do
     it 'should display an error' do
       subject
       expect(response.body).to match('govuk-error-summary')
+      expect(unescaped_response_body).to match(I18n.t('providers.identify_types_of_outgoings.update.none_selected'))
+      expect(unescaped_response_body).not_to include('translation missing')
     end
 
     it 'returns http success' do


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-670)

Fix wrong error messages on **select types of incomes/outgoings** pages

## Checklist

Before you ask people to review this PR:

- [X] Tests and rubocop should be passing: `bundle exec rake`
- [X] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [X] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [X] The PR description should say what you changed and why, with a link to the JIRA story.
- [X] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [X] You should have checked that the commit messages say why the change was made.
