### PR TITLE
AP 588 schedule job to process submissions

### DIFF
--- a/app/models/ccms/submission.rb
+++ b/app/models/ccms/submission.rb
@@ -32,5 +32,9 @@ module CCMS
         raise CcmsError, 'Unknown state'
       end
     end
+
+    def process_async!
+      SubmissionProcessWorker.perform_async(id, aasm_state)
+    end
   end
 end

--- a/app/models/concerns/ccms_submission_state_machine.rb
+++ b/app/models/concerns/ccms_submission_state_machine.rb
@@ -15,28 +15,28 @@ module CCMSSubmissionStateMachine
       state :completed
       state :failed
 
-      event :obtain_case_ref do
+      event :obtain_case_ref, after: :process_async! do
         transitions from: :initialised, to: :case_ref_obtained
       end
 
-      event :submit_applicant do
+      event :submit_applicant, after: :process_async! do
         transitions from: :case_ref_obtained, to: :applicant_submitted
       end
 
-      event :obtain_applicant_ref do
+      event :obtain_applicant_ref, after: :process_async! do
         transitions from: :applicant_submitted, to: :applicant_ref_obtained
         transitions from: :case_ref_obtained, to: :applicant_ref_obtained
       end
 
-      event :submit_case do
+      event :submit_case, after: :process_async! do
         transitions from: :applicant_ref_obtained, to: :case_submitted
       end
 
-      event :confirm_case_created do
+      event :confirm_case_created, after: :process_async! do
         transitions from: :case_submitted, to: :case_created
       end
 
-      event :obtain_document_ids do
+      event :obtain_document_ids, after: :process_async! do
         transitions from: :case_created, to: :document_ids_obtained
       end
 

--- a/app/services/ccms/add_applicant_service.rb
+++ b/app/services/ccms/add_applicant_service.rb
@@ -7,7 +7,7 @@ module CCMS
       else
         handle_failure(response)
       end
-    rescue CcmsError, StandardError => e # TODO: Replace `StandardError` with list of known expected errors
+    rescue CcmsError => e
       handle_failure(e)
     end
 

--- a/app/services/ccms/add_case_service.rb
+++ b/app/services/ccms/add_case_service.rb
@@ -7,7 +7,7 @@ module CCMS
       else
         handle_failure(response)
       end
-    rescue CcmsError, StandardError => e # TODO: Replace `StandardError` with list of known expected errors
+    rescue CcmsError => e
       handle_failure(e)
     end
 

--- a/app/services/ccms/case_add_requestor.rb
+++ b/app/services/ccms/case_add_requestor.rb
@@ -411,7 +411,7 @@ module CCMS
       when 'date'
         raw_value.is_a?(Date) ? raw_value.strftime('%d-%m-%Y') : raw_value
       else
-        raise "Unknown response type: #{config[:response_type]}"
+        raise CcmsError, "Unknown response type: #{config[:response_type]}"
       end
     end
 

--- a/app/services/ccms/check_applicant_status_service.rb
+++ b/app/services/ccms/check_applicant_status_service.rb
@@ -6,7 +6,7 @@ module CCMS
       response = applicant_add_status_requestor.call
       parser = ApplicantAddStatusResponseParser.new(tx_id, response)
       process_response(parser)
-    rescue CcmsError, StandardError => e # TODO: Replace `StandardError` with list of known expected errors
+    rescue CcmsError => e
       handle_failure(e)
     end
 

--- a/app/services/ccms/check_case_status_service.rb
+++ b/app/services/ccms/check_case_status_service.rb
@@ -5,7 +5,7 @@ module CCMS
       submission.case_poll_count += 1
       parser = CaseAddStatusResponseParser.new(tx_id, response)
       process_response(parser)
-    rescue CcmsError, StandardError => e # TODO: Replace `StandardError` with list of known expected errors
+    rescue CcmsError => e
       handle_failure(e)
     end
 

--- a/app/services/ccms/obtain_applicant_reference_service.rb
+++ b/app/services/ccms/obtain_applicant_reference_service.rb
@@ -5,7 +5,7 @@ module CCMS
       response = applicant_search_requestor.call
       parser = ApplicantSearchResponseParser.new(tx_id, response)
       process_records(parser)
-    rescue CcmsError, StandardError => e # TODO: Replace `StandardError` with list of known expected errors
+    rescue CcmsError => e
       handle_failure(e)
     end
 

--- a/app/services/ccms/obtain_case_reference_service.rb
+++ b/app/services/ccms/obtain_case_reference_service.rb
@@ -5,7 +5,7 @@ module CCMS
       response = reference_data_requestor.call
       submission.case_ccms_reference = ReferenceDataResponseParser.new(tx_id, response).reference_id
       create_history(:initialised, submission.aasm_state) if submission.obtain_case_ref!
-    rescue CcmsError, StandardError => e # TODO: Replace `StandardError` with list of known expected errors
+    rescue CcmsError => e
       handle_failure(e)
     end
 

--- a/app/services/ccms/obtain_document_id_service.rb
+++ b/app/services/ccms/obtain_document_id_service.rb
@@ -8,7 +8,7 @@ module CCMS
         request_document_ids
         create_history('case_created', submission.aasm_state) if submission.obtain_document_ids!
       end
-    rescue CcmsError, StandardError => e # TODO: Replace `StandardError` with list of known expected errors
+    rescue CcmsError => e
       handle_failure(e)
     end
 
@@ -25,7 +25,7 @@ module CCMS
         response = document_id_requestor.call
         PdfFile.update(original_file_id: key, ccms_document_id: DocumentIdResponseParser.new(tx_id, response).document_id)
         submission.documents[key] = :id_obtained
-      rescue CcmsError, StandardError => e # TODO: Replace `StandardError` with list of known expected errors
+      rescue CcmsError => e
         submission.documents[key] = :failed
         raise CcmsError, e
       end

--- a/app/services/ccms/upload_documents_service.rb
+++ b/app/services/ccms/upload_documents_service.rb
@@ -12,7 +12,7 @@ module CCMS
       else
         handle_failure("#{failed_uploads.keys} failed to upload to CCMS")
       end
-    rescue CcmsError, StandardError => e # TODO: Replace `StandardError` with list of known expected errors
+    rescue CcmsError => e
       handle_failure(e)
     end
 
@@ -24,7 +24,7 @@ module CCMS
       tx_id = document_upload_requestor.transaction_request_id
       response = document_upload_requestor.call
       update_document_status(key, tx_id, response)
-    rescue CcmsError, StandardError => e # TODO: Replace `StandardError` with list of known expected errors
+    rescue CcmsError => e
       submission.documents[key] = :failed
       raise CcmsError, e
     end

--- a/app/workers/ccms/submission_process_worker.rb
+++ b/app/workers/ccms/submission_process_worker.rb
@@ -1,0 +1,11 @@
+module CCMS
+  class SubmissionProcessWorker
+    include Sidekiq::Worker
+    include Sidekiq::Status::Worker
+
+    def perform(submission_id, state)
+      submission = Submission.find(submission_id)
+      submission.process! if submission.aasm_state == state.to_s # skip if state has already changed
+    end
+  end
+end

--- a/spec/models/ccms/submission_spec.rb
+++ b/spec/models/ccms/submission_spec.rb
@@ -1,9 +1,11 @@
 require 'rails_helper'
+require 'sidekiq/testing'
 
-module CCMS
+module CCMS # rubocop:disable Metrics/ModuleLength
   RSpec.describe Submission do
+    let(:state) { :initialised }
     let(:legal_aid_application) { create :legal_aid_application, :with_applicant }
-    let(:submission) { create :submission, legal_aid_application: legal_aid_application }
+    let(:submission) { create :submission, legal_aid_application: legal_aid_application, aasm_state: state }
 
     context 'Validations' do
       it 'errors if no legal aid application id is present' do
@@ -14,12 +16,13 @@ module CCMS
     end
 
     describe 'initial state' do
+      let(:submission) { create :submission }
       it 'puts new records into the initial state' do
         expect(submission.aasm_state).to eq 'initialised'
       end
     end
 
-    describe '#process' do
+    describe '#process!' do
       let(:history) { SubmissionHistory.find_by(submission_id: submission.id) }
 
       context 'invalid state' do
@@ -32,69 +35,103 @@ module CCMS
       end
 
       context 'valid state' do
-        after(:each) do
-          submission.process!
+        let(:service) { ObtainCaseReferenceService }
+        let(:service_instance) { service.new(submission) }
+
+        before do
+          allow(service).to receive(:new).with(submission).and_return(service_instance)
         end
 
-        context 'initialised state' do
-          let(:obtain_case_reference_service_double) { ObtainCaseReferenceService.new(submission) }
-          it 'calls the obtain_case_reference service' do
-            expect(ObtainCaseReferenceService).to receive(:new).with(submission).and_return(obtain_case_reference_service_double)
-            expect(obtain_case_reference_service_double).to receive(:call).with(no_args)
-          end
+        after { submission.process! }
+
+        it 'calls the obtain_case_reference service' do
+          expect(service_instance).to receive(:call).with(no_args)
         end
 
         context 'case_ref_obtained state' do
-          let(:obtain_applicant_reference_service_double) { ObtainApplicantReferenceService.new(submission) }
-          let(:submission) { create :submission, :case_ref_obtained }
+          let(:state) { :case_ref_obtained }
+          let(:service) { ObtainApplicantReferenceService }
           it 'calls the obtain_applicant_reference service' do
-            expect(ObtainApplicantReferenceService).to receive(:new).with(submission).and_return(obtain_applicant_reference_service_double)
-            expect(obtain_applicant_reference_service_double).to receive(:call).with(no_args)
+            expect(service_instance).to receive(:call).with(no_args)
           end
         end
 
         context 'applicant_submitted state' do
-          let(:check_applicant_status_service_double) { CheckApplicantStatusService.new(submission) }
-          let(:submission) { create :submission, :applicant_submitted }
+          let(:state) { :applicant_submitted }
+          let(:service) { CheckApplicantStatusService }
           it 'calls the check_applicant_status service' do
-            expect(CheckApplicantStatusService).to receive(:new).with(submission).and_return(check_applicant_status_service_double)
-            expect(check_applicant_status_service_double).to receive(:call).with(no_args)
+            expect(service_instance).to receive(:call).with(no_args)
           end
         end
 
         context 'applicant_ref_obtained state' do
-          let(:add_case_service_double) { AddCaseService.new(submission) }
-          let(:submission) { create :submission, :applicant_ref_obtained }
+          let(:state) { :applicant_ref_obtained }
+          let(:service) { AddCaseService }
           it 'calls the add_case service' do
-            expect(AddCaseService).to receive(:new).with(submission).and_return(add_case_service_double)
-            expect(add_case_service_double).to receive(:call).with(no_args)
+            expect(service_instance).to receive(:call).with(no_args)
           end
         end
 
         context 'case_submitted state' do
-          let(:check_case_status_service_double) { CheckCaseStatusService.new(submission) }
-          let(:submission) { create :submission, :case_submitted }
+          let(:state) { :case_submitted }
+          let(:service) { CheckCaseStatusService }
           it 'calls the check_case_status service' do
-            expect(CheckCaseStatusService).to receive(:new).with(submission).and_return(check_case_status_service_double)
-            expect(check_case_status_service_double).to receive(:call)
+            expect(service_instance).to receive(:call).with(no_args)
           end
         end
 
         context 'case_created state' do
-          let(:obtain_document_id_service_double) { ObtainDocumentIdService.new(submission) }
-          let(:submission) { create :submission, :case_created }
+          let(:state) { :case_created }
+          let(:service) { ObtainDocumentIdService }
           it 'calls the obtain_document_id service' do
-            expect(ObtainDocumentIdService).to receive(:new).with(submission).and_return(obtain_document_id_service_double)
-            expect(obtain_document_id_service_double).to receive(:call)
+            expect(service_instance).to receive(:call).with(no_args)
           end
         end
 
         context 'document_ids_obtained state' do
-          let(:upload_documents_service_double) { UploadDocumentsService.new(submission) }
-          let(:submission) { create :submission, :document_ids_obtained }
+          let(:state) { :document_ids_obtained }
+          let(:service) { UploadDocumentsService }
           it 'calls the upload_documents service' do
-            expect(UploadDocumentsService).to receive(:new).with(submission).and_return(upload_documents_service_double)
-            expect(upload_documents_service_double).to receive(:call)
+            expect(service_instance).to receive(:call).with(no_args)
+          end
+        end
+      end
+    end
+
+    context 'state change:' do
+      describe '#obtain_case_ref' do
+        it 'changes state' do
+          expect { submission.obtain_case_ref }.to change { submission.aasm_state }.to('case_ref_obtained')
+        end
+
+        Sidekiq::Testing.fake! do
+          it 'triggers a worker to start the next step' do
+            expect { submission.obtain_case_ref }.to change { SubmissionProcessWorker.jobs.size }.by(1)
+          end
+        end
+
+        context 'with event fail' do
+          it 'changes state' do
+            expect { submission.fail }.to change { submission.aasm_state }.to('failed')
+          end
+
+          Sidekiq::Testing.fake! do
+            it 'does not triggers a worker' do
+              expect { submission.fail }.not_to change { SubmissionProcessWorker.jobs.size }
+            end
+          end
+        end
+
+        context 'with event complete' do
+          let(:state) { :case_created }
+          it 'changes state' do
+            expect { submission.complete }.to change { submission.aasm_state }.to('completed')
+          end
+
+          Sidekiq::Testing.fake! do
+            it 'does not triggers a worker' do
+              expect { submission.fail }.not_to change { SubmissionProcessWorker.jobs.size }
+            end
           end
         end
       end

--- a/spec/services/ccms/add_applicant_service_spec.rb
+++ b/spec/services/ccms/add_applicant_service_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe CCMS::AddApplicantService do
   context 'operation in error' do
     context 'error when adding an applicant' do
       before do
-        expect(applicant_add_requestor).to receive(:call).and_raise(RuntimeError, 'oops')
+        expect(applicant_add_requestor).to receive(:call).and_raise(CCMS::CcmsError, 'oops')
       end
 
       it 'puts it into failed state' do
@@ -57,7 +57,7 @@ RSpec.describe CCMS::AddApplicantService do
         expect(history.from_state).to eq 'case_ref_obtained'
         expect(history.to_state).to eq 'failed'
         expect(history.success).to be false
-        expect(history.details).to match(/RuntimeError/)
+        expect(history.details).to match(/CCMS::CcmsError/)
         expect(history.details).to match(/oops/)
       end
     end

--- a/spec/services/ccms/add_case_service_spec.rb
+++ b/spec/services/ccms/add_case_service_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe CCMS::AddCaseService do
   context 'operation in error' do
     context 'error when adding a case' do
       before do
-        expect(case_add_requestor).to receive(:call).and_raise(RuntimeError, 'oops')
+        expect(case_add_requestor).to receive(:call).and_raise(CCMS::CcmsError, 'oops')
       end
 
       it 'puts it into failed state' do
@@ -55,7 +55,7 @@ RSpec.describe CCMS::AddCaseService do
         expect(history.from_state).to eq 'applicant_ref_obtained'
         expect(history.to_state).to eq 'failed'
         expect(history.success).to be false
-        expect(history.details).to match(/RuntimeError/)
+        expect(history.details).to match(/CCMS::CcmsError/)
         expect(history.details).to match(/oops/)
       end
     end

--- a/spec/services/ccms/applicant_add_response_parser_spec.rb
+++ b/spec/services/ccms/applicant_add_response_parser_spec.rb
@@ -15,7 +15,7 @@ module CCMS
         expect {
           parser = described_class.new(Faker::Number.number(20), response_xml)
           parser.success?
-        }.to raise_error CcmsError, 'Invalid transaction request id'
+        }.to raise_error CCMS::CcmsError, 'Invalid transaction request id'
       end
     end
   end

--- a/spec/services/ccms/applicant_add_status_response_parser_spec.rb
+++ b/spec/services/ccms/applicant_add_status_response_parser_spec.rb
@@ -11,7 +11,7 @@ module CCMS
         expect {
           parser = described_class.new(Faker::Number.number(20), response_xml)
           parser.success?
-        }.to raise_error CcmsError, 'Invalid transaction request id'
+        }.to raise_error CCMS::CcmsError, 'Invalid transaction request id'
       end
 
       it 'returns true if extracted_status_free_text = "Party Successfully Created."' do

--- a/spec/services/ccms/applicant_search_response_parser_spec.rb
+++ b/spec/services/ccms/applicant_search_response_parser_spec.rb
@@ -12,7 +12,7 @@ module CCMS
       it 'raises if the transaction_request_ids dont match' do
         expect {
           parser.record_count
-        }.to raise_error CcmsError, 'Invalid transaction request id'
+        }.to raise_error CCMS::CcmsError, 'Invalid transaction request id'
       end
 
       context 'there are no applicants returned' do

--- a/spec/services/ccms/case_add_requestor_spec.rb
+++ b/spec/services/ccms/case_add_requestor_spec.rb
@@ -275,7 +275,7 @@ module CCMS # rubocop:disable Metrics/ModuleLength
           }
           expect {
             requestor.__send__(:extract_response_value, config, options)
-          }.to raise_error RuntimeError, 'Unknown response type: numeric'
+          }.to raise_error CCMS::CcmsError, 'Unknown response type: numeric'
         end
       end
     end

--- a/spec/services/ccms/case_add_response_parser_spec.rb
+++ b/spec/services/ccms/case_add_response_parser_spec.rb
@@ -15,7 +15,7 @@ module CCMS
         expect {
           parser = described_class.new(Faker::Number.number(20), response_xml)
           parser.success?
-        }.to raise_error CcmsError, 'Invalid transaction request id'
+        }.to raise_error CCMS::CcmsError, 'Invalid transaction request id'
       end
     end
   end

--- a/spec/services/ccms/case_add_status_response_parser_spec.rb
+++ b/spec/services/ccms/case_add_status_response_parser_spec.rb
@@ -15,7 +15,7 @@ module CCMS
         expect {
           parser = described_class.new(Faker::Number.number(20), response_xml)
           parser.success?
-        }.to raise_error CcmsError, 'Invalid transaction request id'
+        }.to raise_error CCMS::CcmsError, 'Invalid transaction request id'
       end
     end
   end

--- a/spec/services/ccms/check_applicant_status_service_spec.rb
+++ b/spec/services/ccms/check_applicant_status_service_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe CCMS::CheckApplicantStatusService do
       let(:transaction_request_id_in_example_response) { '20190301030405123456' }
 
       before do
-        expect(applicant_add_status_requestor).to receive(:call).and_raise(RuntimeError, 'oops')
+        expect(applicant_add_status_requestor).to receive(:call).and_raise(CCMS::CcmsError, 'oops')
         expect(applicant_add_status_requestor).to receive(:transaction_request_id).and_return(transaction_request_id_in_example_response)
       end
 
@@ -112,7 +112,7 @@ RSpec.describe CCMS::CheckApplicantStatusService do
         expect(history.from_state).to eq 'applicant_submitted'
         expect(history.to_state).to eq 'failed'
         expect(history.success).to be false
-        expect(history.details).to match(/RuntimeError/)
+        expect(history.details).to match(/CCMS::CcmsError/)
         expect(history.details).to match(/oops/)
       end
     end

--- a/spec/services/ccms/check_case_status_service_spec.rb
+++ b/spec/services/ccms/check_case_status_service_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe CCMS::CheckCaseStatusService do
       let(:transaction_request_id_in_example_response) { '20190301030405123456' }
 
       before do
-        expect(case_add_status_requestor).to receive(:call).and_raise(RuntimeError, 'oops')
+        expect(case_add_status_requestor).to receive(:call).and_raise(CCMS::CcmsError, 'oops')
         expect(case_add_status_requestor).to receive(:transaction_request_id).and_return(transaction_request_id_in_example_response)
       end
 
@@ -105,7 +105,7 @@ RSpec.describe CCMS::CheckCaseStatusService do
         expect(history.from_state).to eq 'case_submitted'
         expect(history.to_state).to eq 'failed'
         expect(history.success).to be false
-        expect(history.details).to match(/RuntimeError/)
+        expect(history.details).to match(/CCMS::CcmsError/)
         expect(history.details).to match(/oops/)
       end
     end

--- a/spec/services/ccms/document_id_response_parser_spec.rb
+++ b/spec/services/ccms/document_id_response_parser_spec.rb
@@ -16,7 +16,7 @@ module CCMS
         expect {
           parser = described_class.new(Faker::Number.number(20), response_xml)
           parser.document_id
-        }.to raise_error CcmsError, 'Invalid transaction request id'
+        }.to raise_error CCMS::CcmsError, 'Invalid transaction request id'
       end
     end
   end

--- a/spec/services/ccms/document_upload_response_parser_spec.rb
+++ b/spec/services/ccms/document_upload_response_parser_spec.rb
@@ -16,7 +16,7 @@ module CCMS
         expect {
           parser = described_class.new(Faker::Number.number(20), response_xml)
           parser.success?
-        }.to raise_error CcmsError, 'Invalid transaction request id'
+        }.to raise_error CCMS::CcmsError, 'Invalid transaction request id'
       end
     end
   end

--- a/spec/services/ccms/obtain_applicant_reference_service_spec.rb
+++ b/spec/services/ccms/obtain_applicant_reference_service_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe CCMS::ObtainApplicantReferenceService do
     context 'error when searching for applicant' do
       before do
         allow(applicant_search_requestor).to receive(:transaction_request_id).and_return(Faker::Number.number(8))
-        expect(applicant_search_requestor).to receive(:call).and_raise(RuntimeError, 'oops')
+        expect(applicant_search_requestor).to receive(:call).and_raise(CCMS::CcmsError, 'oops')
       end
 
       it 'puts it into failed state' do
@@ -71,7 +71,7 @@ RSpec.describe CCMS::ObtainApplicantReferenceService do
         expect(history.from_state).to eq 'case_ref_obtained'
         expect(history.to_state).to eq 'failed'
         expect(history.success).to be false
-        expect(history.details).to match(/RuntimeError/)
+        expect(history.details).to match(/CCMS::CcmsError/)
         expect(history.details).to match(/oops/)
       end
     end

--- a/spec/services/ccms/obtain_case_reference_service_spec.rb
+++ b/spec/services/ccms/obtain_case_reference_service_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe CCMS::ObtainCaseReferenceService do
   context 'operation in error' do
     before do
       allow(reference_data_requestor).to receive(:transaction_request_id).and_return(Faker::Number.number(8))
-      expect(reference_data_requestor).to receive(:call).and_raise(RuntimeError, 'oops')
+      expect(reference_data_requestor).to receive(:call).and_raise(CCMS::CcmsError, 'oops')
     end
 
     it 'puts it into failed state' do
@@ -56,7 +56,7 @@ RSpec.describe CCMS::ObtainCaseReferenceService do
       expect(history.from_state).to eq 'initialised'
       expect(history.to_state).to eq 'failed'
       expect(history.success).to be false
-      expect(history.details).to match(/RuntimeError/)
+      expect(history.details).to match(/CCMS::CcmsError/)
       expect(history.details).to match(/oops/)
     end
   end

--- a/spec/services/ccms/obtain_document_id_service_spec.rb
+++ b/spec/services/ccms/obtain_document_id_service_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe CCMS::ObtainDocumentIdService do
         expect(history.from_state).to eq 'case_created'
         expect(history.to_state).to eq 'failed'
         expect(history.success).to be false
-        expect(history.details).to match(/CcmsError/)
+        expect(history.details).to match(/CCMS::CcmsError/)
         expect(history.details).to match(/failure populating document hash/)
       end
     end
@@ -109,7 +109,7 @@ RSpec.describe CCMS::ObtainDocumentIdService do
         expect(history.from_state).to eq 'case_created'
         expect(history.to_state).to eq 'failed'
         expect(history.success).to be false
-        expect(history.details).to match(/CcmsError/)
+        expect(history.details).to match(/CCMS::CcmsError/)
         expect(history.details).to match(/failure requesting document ids/)
       end
     end

--- a/spec/services/ccms/reference_data_response_parser_spec.rb
+++ b/spec/services/ccms/reference_data_response_parser_spec.rb
@@ -16,7 +16,7 @@ module CCMS
         expect {
           parser = described_class.new(Faker::Number.number(20), response_xml)
           parser.reference_id
-        }.to raise_error CcmsError, 'Invalid transaction request id'
+        }.to raise_error CCMS::CcmsError, 'Invalid transaction request id'
       end
     end
   end

--- a/spec/services/ccms/upload_documents_service_spec.rb
+++ b/spec/services/ccms/upload_documents_service_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe CCMS::UploadDocumentsService do
         expect(history.from_state).to eq 'document_ids_obtained'
         expect(history.to_state).to eq 'failed'
         expect(history.success).to be false
-        expect(history.details).to match(/CcmsError/)
+        expect(history.details).to match(/CCMS::CcmsError/)
         expect(history.details).to match(/failure uploading documents/)
       end
     end

--- a/spec/workers/ccms/submission_process_worker_spec.rb
+++ b/spec/workers/ccms/submission_process_worker_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe CCMS::SubmissionProcessWorker do
+  let(:state) { :initialised }
+  let(:submission) { create :submission, aasm_state: state }
+  let(:worker) { described_class.new }
+
+  before { allow(CCMS::Submission).to receive(:find).with(submission.id).and_return(submission) }
+
+  subject { worker.perform(submission.id, state) }
+
+  it 'calls process! on the submission' do
+    expect(submission).to receive(:process!)
+    subject
+  end
+
+  context 'the state has changed' do
+    let(:submission) { create :submission, aasm_state: :initialised }
+    let(:state) { :case_ref_obtained }
+
+    it 'does nothing' do
+      expect(submission).not_to receive(:process!)
+      subject
+    end
+  end
+end


### PR DESCRIPTION
[Jira AP-588](https://dsdmoj.atlassian.net/browse/AP-588)

- Creates a Sidekiq worker that will process a submission if the state has not changed from that set when the worker was initiated.
- Adds `submission.process_async!` to start a worker with the submission as the target
- Updates the submission state engine so that `process_async` is triggered after each state change except those to fail and complete.

As Sidekiq workers rely on exceptions to determine whether to retry a failed process, the rescuing of `StandardError` was removed from CCMS services. This allows the following behaviour:

- If a failure occurs that should stop the processing - then `CmssError` should be raised.
- If a failure occurs that should cause the process to be tried again later, then a non-`CmssError` should be raised. For example, if a connection failure raises an error, it cause the worker to stop and retry again later.
