### PR TITLE
Revert "Bump rubocop from 0.71.0 to 0.72.0"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -342,7 +342,7 @@ GEM
       rspec-mocks (~> 3.8.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
-    rubocop (0.72.0)
+    rubocop (0.71.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.6)


### PR DESCRIPTION
This reverts commit 64b3fa516a8916b8c229d059572ebb05160b2697.

Yesterday's update of Rubocop https://github.com/ministryofjustice/laa-apply-for-legal-aid/pull/610 seems to have broken `erblint`.
I spent 10 minutes trying to fix it but did not succeed.
I suggest we revert the update until we find a solution.