### PR TITLE
AP-555 Admin Pagination

### DIFF
--- a/app/controllers/admin/legal_aid_applications_controller.rb
+++ b/app/controllers/admin/legal_aid_applications_controller.rb
@@ -1,8 +1,16 @@
 module Admin
   class LegalAidApplicationsController < ApplicationController
+    include Pagy::Backend
     before_action :authenticate_admin_user!
+
+    DEFAULT_PAGE_SIZE = 10
+
     def index
-      @applications = LegalAidApplication.latest.limit(25)
+      @pagy, @applications = pagy(
+        LegalAidApplication.latest,
+        items: params.fetch(:page_size, DEFAULT_PAGE_SIZE),
+        size: [1, 1, 1, 1]
+      )
     end
 
     def create_test_applications

--- a/app/views/admin/legal_aid_applications/_legal_aid_applications.html.erb
+++ b/app/views/admin/legal_aid_applications/_legal_aid_applications.html.erb
@@ -34,5 +34,11 @@
         <% end %>
       </tbody>
     </table>
+    <% if local_assigns[:pagy] %>
+      <div class="govuk-body pagination-container">
+        <%== pagy_nav(pagy) if pagy.pages > 1 %>
+        <span class="page-info"><%== pagy_info(pagy)&.chomp %></span>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/app/views/admin/legal_aid_applications/index.html.erb
+++ b/app/views/admin/legal_aid_applications/index.html.erb
@@ -45,7 +45,7 @@
 <% end %>
 
 <% if @applications.present? %>
-  <%= render('legal_aid_applications') %>
+  <%= render 'legal_aid_applications', pagy: @pagy %>
 <% else %>
   <h2><%= t('.no_applications') %></h2>
 <% end %>

--- a/spec/requests/admin/legal_aid_applications_spec.rb
+++ b/spec/requests/admin/legal_aid_applications_spec.rb
@@ -4,11 +4,12 @@ RSpec.describe Admin::LegalAidApplicationsController, type: :request do
   let(:count) { 3 }
   let!(:legal_aid_applications) { create_list :legal_aid_application, count, :with_applicant }
   let(:admin_user) { create :admin_user }
+  let(:params) { {} }
 
   before { sign_in admin_user }
 
   describe 'GET /admin/legal_aid_applications' do
-    subject { get admin_legal_aid_applications_path }
+    subject { get admin_legal_aid_applications_path(params) }
 
     it 'renders successfully' do
       subject
@@ -25,6 +26,33 @@ RSpec.describe Admin::LegalAidApplicationsController, type: :request do
     it 'has a link to settings' do
       subject
       expect(response.body).to include(admin_settings_path)
+    end
+
+    context 'with pagination' do
+      it 'shows current total information' do
+        subject
+        expect(response.body).to include('Showing 3 of 3')
+      end
+
+      it 'does not show navigation links' do
+        subject
+        expect(parsed_response_body.css('.pagination-container nav')).to be_empty
+      end
+
+      context 'and more applications than page size' do
+        let(:params) { { page_size: 3 } }
+        let(:count) { 5 }
+
+        it 'show page information' do
+          subject
+          expect(response.body).to include('Showing 1 - 3 of 5 results')
+        end
+
+        it 'shows pagination' do
+          subject
+          expect(parsed_response_body.css('.pagination-container nav').text).to match(/Previous\s+1\s+2\s+Next/)
+        end
+      end
     end
 
     context 'when not authenticated' do


### PR DESCRIPTION
Admin index page has pagination on legal aid applications

[Link to story](https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=233&projectKey=AP&modal=detail&selectedIssue=AP-555)

- Add Pagination to admin page using Pagy gem (With maximum of 10 items on each paginated page)
- Remove limit of 25 latest applications shown on admin page
- Create request test for pagination

## Checklist

Before you ask people to review this PR:

- [X] Tests and rubocop should be passing: `bundle exec rake`
- [X] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [X] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [X] The PR description should say what you changed and why, with a link to the JIRA story.
- [X] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [X] You should have checked that the commit messages say why the change was made.
