### PR TITLE
Bump jQuery from v1.12.4 to v3.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@rails/webpacker": "^4.0.7",
     "axios": "^0.19.0",
     "govuk-frontend": "^2.13.0",
-    "jquery": "^1.12.4",
+    "jquery": "^3.4.1",
     "js-search": "^1.4.3"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5618,10 +5618,10 @@ jest@^24.8.0:
     import-local "^2.0.0"
     jest-cli "^24.8.0"
 
-jquery@^1.12.4:
-  version "1.12.4"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-1.12.4.tgz#01e1dfba290fe73deba77ceeacb0f9ba2fec9e0c"
-  integrity sha1-AeHfuikP5z3rp3zurLD5ui/sngw=
+jquery@^3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.4.1.tgz#714f1f8d9dde4bdfa55764ba37ef214630d80ef2"
+  integrity sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==
 
 js-base64@^2.1.8:
   version "2.5.1"


### PR DESCRIPTION
## What

Bump jQuery from v1.12.4 to v3.4.1

UAT: https://bump-jquery-version-applyforlegalaid-uat.apps.cloud-platform-live-0.k8s.integration.dsd.io/
I went through the whole flow in UAT and it works well.

Dependabot tried to upgrade to v3.4.0 the other day (https://github.com/ministryofjustice/laa-apply-for-legal-aid/pull/614) but the feature tests were failing.

v3.4.1 seems to be OK.

## Checklist

Before you ask people to review this PR:

- [X] Tests and rubocop should be passing: `bundle exec rake`
- [X] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [X] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [X] The PR description should say what you changed and why, with a link to the JIRA story.
- [X] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [X] You should have checked that the commit messages say why the change was made.
