### PR TITLE
Stop Faker warnings

### DIFF
--- a/spec/factories/bank_accounts.rb
+++ b/spec/factories/bank_accounts.rb
@@ -6,6 +6,6 @@ FactoryBot.define do
     currency { Faker::Currency.code }
     account_number { Faker::Number.number(10) }
     sort_code { Faker::Number.number(6) }
-    balance { Faker::Number.decimal(2).to_f }
+    balance { rand(1...1_000_000.0).round(2) }
   end
 end

--- a/spec/factories/bank_transactions.rb
+++ b/spec/factories/bank_transactions.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
     merchant { Faker::Lorem.sentence }
     happened_at { Faker::Date.between(3.months.ago + 2.days, Time.now - 2.days) }
     currency { Faker::Currency.code }
-    amount { Faker::Number.decimal(2) }
+    amount { rand(1...1_000_000.0).round(2) }
 
     trait :debit do
       operation { :debit }

--- a/spec/factories/legal_aid_applications.rb
+++ b/spec/factories/legal_aid_applications.rb
@@ -133,10 +133,10 @@ FactoryBot.define do
       with_savings_amount
       with_other_assets_declaration
       with_own_home_mortgaged
-      property_value { Faker::Number.decimal.to_d }
-      outstanding_mortgage_amount { Faker::Number.decimal.to_d }
+      property_value { rand(1...1_000_000.0).round(2) }
+      outstanding_mortgage_amount { rand(1...1_000_000.0).round(2) }
       shared_ownership { LegalAidApplication::SHARED_OWNERSHIP_YES_REASONS.sample }
-      percentage_home { Faker::Number.decimal(2).to_d }
+      percentage_home { rand(1...99.0).round(2) }
       with_merits_assessment
       with_merits_statement_of_case
       with_respondent

--- a/spec/factories/merits_assessments.rb
+++ b/spec/factories/merits_assessments.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
       application_purpose { Faker::Lorem.paragraph }
       proceedings_before_the_court { true }
       details_of_proceedings_before_the_court { Faker::Lorem.paragraph }
-      estimated_legal_cost { Faker::Number.decimal.to_d }
+      estimated_legal_cost { rand(1...10_000.0).round(2) }
       success_prospect { 'marginal' }
       success_prospect_details { Faker::Lorem.paragraph }
       submitted_at { Faker::Time.backward }
@@ -18,7 +18,7 @@ FactoryBot.define do
       application_purpose { nil }
       proceedings_before_the_court { false }
       details_of_proceedings_before_the_court { nil }
-      estimated_legal_cost { Faker::Number.decimal.to_d }
+      estimated_legal_cost { rand(1...10_000.0).round(2) }
       success_prospect { 'likely' }
       success_prospect_details { nil }
       submitted_at { Faker::Time.backward }

--- a/spec/factories/other_assets_declarations.rb
+++ b/spec/factories/other_assets_declarations.rb
@@ -3,21 +3,21 @@ FactoryBot.define do
     legal_aid_application
 
     trait :with_second_home do
-      second_home_value { Faker::Number.decimal(6, 2) }
-      second_home_mortgage { Faker::Number.decimal(6, 2) }
-      second_home_percentage { Faker::Number.decimal(2, 2) }
+      second_home_value { rand(1...1_000_000.0).round(2) }
+      second_home_mortgage { rand(1...1_000_000.0).round(2) }
+      second_home_percentage { rand(1...99.0).round(2) }
     end
 
     trait :with_all_values do
-      second_home_value { Faker::Number.decimal(6, 2) }
-      second_home_mortgage { Faker::Number.decimal(6, 2) }
-      second_home_percentage { Faker::Number.decimal(2, 2) }
-      timeshare_property_value { Faker::Number.decimal(6, 2) }
-      land_value { Faker::Number.decimal(6, 2) }
-      valuable_items_value { Faker::Number.decimal(6, 2) }
-      money_assets_value { Faker::Number.decimal(6, 2) }
-      money_owed_value { Faker::Number.decimal(6, 2) }
-      trust_value { Faker::Number.decimal(6, 2) }
+      second_home_value { rand(1...1_000_000.0).round(2) }
+      second_home_mortgage { rand(1...1_000_000.0).round(2) }
+      second_home_percentage { rand(1...99.0).round(2) }
+      timeshare_property_value { rand(1...1_000_000.0).round(2) }
+      land_value { rand(1...1_000_000.0).round(2) }
+      valuable_items_value { rand(1...1_000_000.0).round(2) }
+      money_assets_value { rand(1...1_000_000.0).round(2) }
+      money_owed_value { rand(1...1_000_000.0).round(2) }
+      trust_value { rand(1...1_000_000.0).round(2) }
     end
 
     trait :all_nil do
@@ -45,10 +45,10 @@ FactoryBot.define do
     end
 
     trait :mix_of_values do
-      second_home_value { Faker::Number.decimal(6, 2) }
-      second_home_mortgage { Faker::Number.decimal(6, 2) }
-      second_home_percentage { Faker::Number.decimal(6, 2) }
-      timeshare_property_value { Faker::Number.decimal(6, 2) }
+      second_home_value { rand(1...1_000_000.0).round(2) }
+      second_home_mortgage { rand(1...1_000_000.0).round(2) }
+      second_home_percentage { rand(1...99.0).round(2) }
+      timeshare_property_value { rand(1...1_000_000.0).round(2) }
       land_value { nil }
       valuable_items_value { 0.0 }
       money_assets_value { 0.0 }

--- a/spec/factories/savings_amounts.rb
+++ b/spec/factories/savings_amounts.rb
@@ -3,13 +3,13 @@ FactoryBot.define do
     legal_aid_application
 
     trait :with_values do
-      isa { Faker::Number.decimal.to_d }
-      cash { Faker::Number.decimal.to_d }
-      other_person_account { Faker::Number.decimal.to_d }
-      national_savings { Faker::Number.decimal.to_d }
-      plc_shares { Faker::Number.decimal.to_d }
-      peps_unit_trusts_capital_bonds_gov_stocks { Faker::Number.decimal.to_d }
-      life_assurance_endowment_policy { Faker::Number.decimal.to_d }
+      isa { rand(1...1_000_000.0).round(2) }
+      cash { rand(1...1_000_000.0).round(2) }
+      other_person_account { rand(1...1_000_000.0).round(2) }
+      national_savings { rand(1...1_000_000.0).round(2) }
+      plc_shares { rand(1...1_000_000.0).round(2) }
+      peps_unit_trusts_capital_bonds_gov_stocks { rand(1...1_000_000.0).round(2) }
+      life_assurance_endowment_policy { rand(1...1_000_000.0).round(2) }
     end
 
     trait :all_nil do
@@ -35,10 +35,10 @@ FactoryBot.define do
     trait :mix_of_values do
       isa { nil }
       cash { 0.0 }
-      other_person_account { Faker::Number.decimal.to_d }
+      other_person_account { rand(1...1_000_000.0).round(2) }
       national_savings { nil }
       plc_shares { 0.0 }
-      peps_unit_trusts_capital_bonds_gov_stocks { Faker::Number.decimal.to_d }
+      peps_unit_trusts_capital_bonds_gov_stocks { rand(1...1_000_000.0).round(2) }
       life_assurance_endowment_policy { 0.0 }
     end
   end

--- a/spec/forms/legal_aid_applications/percentage_home_form_spec.rb
+++ b/spec/forms/legal_aid_applications/percentage_home_form_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe LegalAidApplications::PercentageHomeForm, type: :form do
-  let(:percentage_home) { Faker::Number.decimal(2).to_d }
+  let(:percentage_home) { rand(1...99.0).round(2) }
   let(:application) { create :legal_aid_application }
   let(:params) { { percentage_home: percentage_home } }
   let(:form_params) { params.merge(model: application) }

--- a/spec/forms/outstanding_mortgage_form_spec.rb
+++ b/spec/forms/outstanding_mortgage_form_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe LegalAidApplications::OutstandingMortgageForm, type: :form do
   let(:legal_aid_application) do
     create :legal_aid_application, outstanding_mortgage_amount: nil
   end
-  let(:amount) { Faker::Number.decimal(4) }
+  let(:amount) { rand(1...1_000_000.0).round(2).to_s }
   let(:params) do
     {
       model: legal_aid_application,
@@ -14,7 +14,7 @@ RSpec.describe LegalAidApplications::OutstandingMortgageForm, type: :form do
   subject { described_class.new(params) }
 
   describe '#outstanding_mortgage_amount' do
-    let(:existing_amount) { Faker::Number.decimal(4) }
+    let(:existing_amount) { rand(1...1_000_000.0).round(2).to_s }
     let(:legal_aid_application) do
       create :legal_aid_application, outstanding_mortgage_amount: existing_amount
     end

--- a/spec/forms/savings_amounts/savings_amounts_form_spec.rb
+++ b/spec/forms/savings_amounts/savings_amounts_form_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe SavingsAmounts::SavingsAmountsForm, type: :form do
       let(:check_box_params) { check_box_attributes.each_with_object({}) { |attr, hsh| hsh[attr] = 'true' } }
 
       context 'amounts are valid' do
-        let(:amount_params) { attributes.each_with_object({}) { |attr, hsh| hsh[attr] = Faker::Number.decimal.to_s } }
+        let(:amount_params) { attributes.each_with_object({}) { |attr, hsh| hsh[attr] = rand(1...1_000_000.0).round(2).to_s } }
 
         it 'updates all amounts' do
           subject.save
@@ -90,7 +90,7 @@ RSpec.describe SavingsAmounts::SavingsAmountsForm, type: :form do
       end
 
       context 'amounts have a £ symbol' do
-        let(:amount_params) { attributes.each_with_object({}) { |attr, hsh| hsh[attr] = "£#{Faker::Number.decimal}" } }
+        let(:amount_params) { attributes.each_with_object({}) { |attr, hsh| hsh[attr] = "£#{rand(1...1_000_000.0).round(2)}" } }
 
         it 'strips the values of £ symbols' do
           subject.save
@@ -114,7 +114,7 @@ RSpec.describe SavingsAmounts::SavingsAmountsForm, type: :form do
       end
 
       context 'amounts are valid' do
-        let(:amount_params) { attributes.each_with_object({}) { |attr, hsh| hsh[attr] = Faker::Number.decimal.to_s } }
+        let(:amount_params) { attributes.each_with_object({}) { |attr, hsh| hsh[attr] = rand(1...1_000_000.0).round(2).to_s } }
 
         it 'empties amounts if checkbox is unchecked' do
           attributes_except_isa = attributes - [:isa]

--- a/spec/models/other_assets_declaration_spec.rb
+++ b/spec/models/other_assets_declaration_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe OtherAssetsDeclaration, type: :model do
     end
 
     context 'has some savings' do
-      before { subject.update!(land_value: Faker::Number.decimal.to_d) }
+      before { subject.update!(land_value: rand(1...1_000_000.0).round(2)) }
 
       it 'is positive' do
         expect(subject.positive?).to eq(true)

--- a/spec/models/savings_amount_spec.rb
+++ b/spec/models/savings_amount_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe SavingsAmount, type: :model do
     end
 
     context 'has some savings' do
-      before { subject.update!(cash: Faker::Number.decimal.to_d) }
+      before { subject.update!(cash: rand(1...1_000_000.0).round(2)) }
 
       it 'is positive' do
         expect(subject.positive?).to eq(true)

--- a/spec/requests/citizens/accounts_spec.rb
+++ b/spec/requests/citizens/accounts_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe 'citizen accounts request', type: :request do
+  include ActionView::Helpers::NumberHelper
+
   let!(:applicant) { create :applicant }
   let!(:legal_aid_application) { create :legal_aid_application, :with_transaction_period, applicant: applicant }
   let(:addresses) do
@@ -51,7 +53,7 @@ RSpec.describe 'citizen accounts request', type: :request do
     end
 
     it 'display balance with pound symbol' do
-      expect(response.body).to include("£#{applicant_bank_account.balance}")
+      expect(response.body).to include(number_to_currency(applicant_bank_account.balance, unit: '£'))
     end
 
     it 'adds its url to history' do

--- a/spec/requests/citizens/dependants/relationships_spec.rb
+++ b/spec/requests/citizens/dependants/relationships_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Citizens::Dependants::RelationshipsController, type: :request do
 
       it 'redirects to dependant income' do
         subject
-        expect(response.body).to include "[PLACEHOLDER] #{dependant.name} dependants income"
+        expect(unescaped_response_body).to include "[PLACEHOLDER] #{dependant.name} dependants income"
       end
     end
 
@@ -54,7 +54,7 @@ RSpec.describe Citizens::Dependants::RelationshipsController, type: :request do
 
         it 'redirects to dependant income' do
           subject
-          expect(response.body).to include "[PLACEHOLDER] #{dependant.name} dependants income"
+          expect(unescaped_response_body).to include "[PLACEHOLDER] #{dependant.name} dependants income"
         end
       end
 
@@ -63,7 +63,7 @@ RSpec.describe Citizens::Dependants::RelationshipsController, type: :request do
 
         it 'redirects to dependant income' do
           subject
-          expect(response.body).to include "[PLACEHOLDER] #{dependant.name} dependants education"
+          expect(unescaped_response_body).to include "[PLACEHOLDER] #{dependant.name} dependants education"
         end
       end
     end
@@ -79,7 +79,7 @@ RSpec.describe Citizens::Dependants::RelationshipsController, type: :request do
       it 'displays error' do
         subject
         expect(response.body).to include('govuk-error-summary')
-        expect(response.body).to include(I18n.t('activemodel.errors.models.dependant.attributes.relationship.blank', name: dependant.name))
+        expect(unescaped_response_body).to include(I18n.t('activemodel.errors.models.dependant.attributes.relationship.blank', name: dependant.name))
       end
     end
   end

--- a/spec/requests/citizens/outstanding_mortgage_spec.rb
+++ b/spec/requests/citizens/outstanding_mortgage_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'citizen outstanding mortgage request', type: :request do
   end
 
   describe 'PATCH /citizens/outstanding_mortgage' do
-    let(:amount) { Faker::Number.decimal(4) }
+    let(:amount) { rand(1...1_000_000.0).round(2).to_s }
     let(:params) do
       { legal_aid_application: { outstanding_mortgage_amount: amount } }
     end

--- a/spec/requests/citizens/savings_and_investments_spec.rb
+++ b/spec/requests/citizens/savings_and_investments_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe 'citizen savings and investments', type: :request do
   end
 
   describe 'PATCH citizens/savings_and_investment' do
-    let(:isa) { Faker::Number.decimal.to_s }
+    let(:isa) { rand(1...1_000_000.0).round(2).to_s }
     let(:check_box_isa) { 'true' }
     let(:params) { { savings_amount: { isa: isa, check_box_isa: check_box_isa } } }
     subject { patch citizens_savings_and_investment_path, params: params }

--- a/spec/requests/providers/other_assets_spec.rb
+++ b/spec/requests/providers/other_assets_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe 'provider other assets requests', type: :request do
           end
 
           context 'has other_assets' do
-            let(:oad) { create :other_assets_declaration, land_value: Faker::Number.decimal.to_d }
+            let(:oad) { create :other_assets_declaration, land_value: rand(1...1_000_000.0).round(2) }
             let(:application) { oad.legal_aid_application }
 
             before do
@@ -132,7 +132,7 @@ RSpec.describe 'provider other assets requests', type: :request do
 
             before do
               application.create_savings_amount!
-              application.savings_amount.cash = Faker::Number.decimal.to_d
+              application.savings_amount.cash = rand(1...1_000_000.0).round(2)
               application.savings_amount.save!
               patch providers_legal_aid_application_other_assets_path(oad.legal_aid_application), params: empty_params.merge(submit_button)
             end
@@ -269,7 +269,7 @@ RSpec.describe 'provider other assets requests', type: :request do
           end
 
           context 'has other_assets' do
-            let(:oad) { create :other_assets_declaration, land_value: Faker::Number.decimal.to_d }
+            let(:oad) { create :other_assets_declaration, land_value: rand(1...1_000_000.0).round(2) }
             let(:application) { oad.legal_aid_application }
 
             it 'redirects to provider applications page' do
@@ -286,7 +286,7 @@ RSpec.describe 'provider other assets requests', type: :request do
 
             before do
               application.create_savings_amount!
-              application.savings_amount.cash = Faker::Number.decimal.to_d
+              application.savings_amount.cash = rand(1...1_000_000.0).round(2)
               application.savings_amount.save!
               patch providers_legal_aid_application_other_assets_path(application), params: empty_params.merge(submit_button)
             end

--- a/spec/requests/providers/savings_and_investments_spec.rb
+++ b/spec/requests/providers/savings_and_investments_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe 'providers savings and investments', type: :request do
   end
 
   describe 'PATCH /providers/applications/:legal_aid_application_id/savings_and_investment' do
-    let(:isa) { Faker::Number.decimal }
+    let(:isa) { rand(1...1_000_000.0).round(2).to_s }
     let(:check_box_isa) { 'true' }
     let(:params) do
       {

--- a/spec/support/true_layer_mock_data.rb
+++ b/spec/support/true_layer_mock_data.rb
@@ -30,7 +30,7 @@ module TrueLayerHelpers
         sort_code: Faker::Number.number(6)
       },
       balance: {
-        current: Faker::Number.decimal(2).to_f
+        current: rand(1...1_000_000.0).round(2)
       },
       transactions: [{
         transaction_id: SecureRandom.hex,
@@ -60,7 +60,7 @@ module TrueLayerHelpers
         sort_code: Faker::Number.number(6)
       },
       balance: {
-        current: Faker::Number.decimal(2).to_f
+        current: rand(1...1_000_000.0).round(2)
       },
       transactions: [{
         transaction_id: SecureRandom.hex


### PR DESCRIPTION
Remove annoying Faker's deprecation warnings by removing the use of `Faker::Number.decimal`