### PR TITLE
AP-777 Delete vehicle when deleting application

### DIFF
--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -27,7 +27,7 @@ class LegalAidApplication < ApplicationRecord # rubocop:disable Metrics/ClassLen
   has_many :dependants, dependent: :destroy
   has_many :ccms_submissions, class_name: 'CCMS::Submission', dependent: :destroy
   has_one :most_recent_ccms_submission, -> { order(:created_at) }, class_name: 'CCMS::Submission'
-  has_one :vehicle
+  has_one :vehicle, dependent: :destroy
 
   before_create :create_app_ref
   before_save :set_open_banking_consent_choice_at

--- a/spec/factories/legal_aid_applications.rb
+++ b/spec/factories/legal_aid_applications.rb
@@ -141,6 +141,7 @@ FactoryBot.define do
       with_merits_statement_of_case
       with_respondent
       with_incident
+      with_vehicle
     end
 
     trait :with_negative_benefit_check_result do


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-777)

Fix for this error: https://sentry.service.dsd.io/mojds/apply-for-legal-aid-staging/issues/36456/

![image](https://user-images.githubusercontent.com/482806/60891338-061d1580-a255-11e9-8a81-3ad9591de614.png)

It happens when an admin tries to delete an application which has a vehicle

This fix is covered by this test : https://github.com/ministryofjustice/laa-apply-for-legal-aid/blob/master/spec/models/legal_aid_application_spec.rb#L306

- Adding `with_vehicle` to the `with_everything` trait broke the test.
- Adding  `, dependent: :destroy` to `has_one :vehicle` made the test green again.


## Checklist

Before you ask people to review this PR:

- [X] Tests and rubocop should be passing: `bundle exec rake`
- [X] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [X] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [X] The PR description should say what you changed and why, with a link to the JIRA story.
- [X] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [X] You should have checked that the commit messages say why the change was made.
