### PR TITLE
AP-773 Add substantive application to passported journey

### DIFF
--- a/app/services/benefit_check_service.rb
+++ b/app/services/benefit_check_service.rb
@@ -11,7 +11,7 @@ class BenefitCheckService
     soap_client.call(:check, message: benefit_checker_params).body.dig(:benefit_checker_response)
   rescue Savon::SOAPFault => e
     raise ApiError, "HTTP #{e.http.code}, #{e.to_hash}"
-  rescue Net::ReadTimeout => e
+  rescue Net::ReadTimeout, Net::OpenTimeout => e
     raise ApiError, e
   end
 

--- a/app/services/flow/flows/provider_start.rb
+++ b/app/services/flow/flows/provider_start.rb
@@ -44,7 +44,11 @@ module Flow
         },
         check_benefits: {
           path: ->(application) { urls.providers_legal_aid_application_check_benefits_path(application) },
-          forward: ->(application) { application.benefit_check_result.positive? ? :capital_introductions : :used_delegated_functions }
+          forward: ->(application) do
+            return :substantive_applications if application.used_delegated_functions?
+
+            application.benefit_check_result&.positive? ? :capital_introductions : :online_bankings
+          end
         },
         used_delegated_functions: {
           path: ->(application) { urls.providers_legal_aid_application_used_delegated_functions_path(application) },
@@ -52,7 +56,11 @@ module Flow
         },
         substantive_applications: {
           path: ->(application) { urls.providers_legal_aid_application_substantive_application_path(application) },
-          forward: ->(application) { application.substantive_application? ? :online_bankings : :providers_home }
+          forward: ->(application) do
+            return :providers_home unless application.substantive_application?
+
+            application.benefit_check_result&.positive? ? :capital_introductions : :online_bankings
+          end
         },
         online_bankings: {
           path: ->(application) { urls.providers_legal_aid_application_online_banking_path(application) },

--- a/spec/forms/legal_aid_applications/percentage_home_form_spec.rb
+++ b/spec/forms/legal_aid_applications/percentage_home_form_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe LegalAidApplications::PercentageHomeForm, type: :form do
 
   describe '#save' do
     it 'updates application.percentage_home' do
-      expect { subject.save }.to change { application.reload.percentage_home.to_s.to_d }.to(percentage_home)
+      expect { subject.save }.to change { application.reload.percentage_home.to_s.to_d }.to(percentage_home.to_d)
     end
 
     it 'returns true' do

--- a/spec/requests/providers/check_benefits_spec.rb
+++ b/spec/requests/providers/check_benefits_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe 'check benefits requests', type: :request do
           let(:application) { create :legal_aid_application, :with_negative_benefit_check_result }
 
           it 'displays the online banking page' do
-            expect(response).to redirect_to providers_legal_aid_application_used_delegated_functions_path(application)
+            expect(response).to redirect_to providers_legal_aid_application_online_banking_path(application)
           end
         end
 
@@ -102,7 +102,15 @@ RSpec.describe 'check benefits requests', type: :request do
           let(:application) { create :legal_aid_application, :with_undetermined_benefit_check_result }
 
           it 'displays the online banking page' do
-            expect(response).to redirect_to providers_legal_aid_application_used_delegated_functions_path(application)
+            expect(response).to redirect_to providers_legal_aid_application_online_banking_path(application)
+          end
+        end
+
+        context 'when delegated functions used' do
+          let(:application) { create :legal_aid_application, :with_positive_benefit_check_result, used_delegated_functions: true }
+
+          it 'displays the substantive application page' do
+            expect(response).to redirect_to providers_legal_aid_application_substantive_application_path(application)
           end
         end
       end

--- a/spec/requests/providers/substantive_applications_spec.rb
+++ b/spec/requests/providers/substantive_applications_spec.rb
@@ -54,6 +54,22 @@ RSpec.describe Providers::UsedDelegatedFunctionsController, type: :request, vcr:
       )
     end
 
+    context 'with positive benefit check' do
+      let(:legal_aid_application) do
+        create(
+          :legal_aid_application,
+          :with_positive_benefit_check_result,
+          state: :client_details_answers_checked
+        )
+      end
+
+      it 'redirects to captial introductions' do
+        expect(response).to redirect_to(
+          providers_legal_aid_application_capital_introduction_path(legal_aid_application)
+        )
+      end
+    end
+
     context 'No selected' do
       let(:substantive_application) { false }
 


### PR DESCRIPTION
[AP-773](https://dsdmoj.atlassian.net/browse/AP-773)

Updates the flow logic to match the diagramme in the ticket.

Also:

- Updated the errors being caught when the connection to the benefits checker was timing out
- Updated `percentage_home_form_spec.rb` as change in way decimals were matched was causing intermittent failures

On hold as Julien is carrying on from this point with AP-772
