### PR TITLE
Added new line to Gemfile for Windows users

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,6 +73,8 @@ gem 'faker', '>=1.9.1'
 
 gem 'webpacker', '~> 4.x'
 
+gem 'wdm', '>= 0.1.0' if Gem.win_platform?
+
 group :development, :test do
   gem 'awesome_print', '~> 1.8.0'
   gem 'byebug', platforms: %i[mri mingw x64_mingw]


### PR DESCRIPTION
## What

Added line `gem 'wdm', '>= 0.1.0' if Gem.win_platform?` to Gemfile for Ruby on Windows

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
