### PR TITLE
Fix failing clean_up_ecr job in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ references:
     run:
       name: Setup aws on debian environment
       command: |
-        if [ "${CIRCLE_NODE_INDEX}" == "1" ]; then
+        if [ "${CIRCLE_NODE_INDEX}" == "1" ] || [ "${CIRCLE_JOB}" == "clean_up_ecr" ]; then
           sudo apt-get --assume-yes install python3-pip
           sudo pip3 install awscli
           $(aws ecr get-login --region eu-west-1 --no-include-email)


### PR DESCRIPTION
## What

The `clean_up_ecr` CircleCI job is failing since I introduced the parallelism.

## Checklist

Before you ask people to review this PR:

- [X] Tests and rubocop should be passing: `bundle exec rake`
- [X] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [X] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [X] The PR description should say what you changed and why, with a link to the JIRA story.
- [X] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [X] You should have checked that the commit messages say why the change was made.
