### PR TITLE
Bug Fix : prevent showing hint for each radio button when using govuk_collection_radio_buttons

### DIFF
--- a/app/lib/govuk_elements_form_builder/form_builder.rb
+++ b/app/lib/govuk_elements_form_builder/form_builder.rb
@@ -5,7 +5,7 @@ module GovukElementsFormBuilder
     # https://guides.rubyonrails.org/configuring.html#configuring-action-view
     ActionView::Base.field_error_proc = proc { |html_tag| html_tag.html_safe }
 
-    CUSTOM_OPTIONS = %i[label input_prefix field_with_error hint title inline text_input input_attributes].freeze
+    CUSTOM_OPTIONS = %i[label input_prefix field_with_error hint title inline text_input input_attributes collection].freeze
 
     delegate :content_tag, to: :@template
     delegate :errors, to: :@object
@@ -114,7 +114,7 @@ module GovukElementsFormBuilder
                 value = value_attr ? obj[value_attr] : obj
                 label = label_attr ? obj[label_attr] : nil
                 input_attributes = options.dig(:input_attributes, value.to_s) || {}
-                govuk_radio_button(attribute, value, options.merge(input_attributes).merge(label: label))
+                govuk_radio_button(attribute, value, options.merge(input_attributes).merge(label: label, collection: true))
               end
               concat_tags(inputs)
             end
@@ -228,7 +228,7 @@ module GovukElementsFormBuilder
     end
 
     def hint_message(attribute, options)
-      return options[:hint] if options.key?(:radio_button_value)
+      return nil if options[:collection]
 
       options[:hint].presence || I18n.translate("helpers.hint.#{@object_name}.#{attribute}", default: nil)
     end

--- a/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
+++ b/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
@@ -281,6 +281,15 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
       expect(fieldset.classes).to include('govuk-fieldset')
     end
 
+    context 'when a hint message is passed as a parameter' do
+      let(:hint_message) { 'Choose an option' }
+      let(:params) { [:uses_online_banking, options, hint: hint_message] }
+
+      it 'the hint message appears only once' do
+        expect(parsed_html.css('span.govuk-hint').count).to eq(1)
+      end
+    end
+
     context 'when there is a hint message defined' do
       let(:hint_message) { 'Choose an option' }
       let(:span_hint) { parsed_html.at_css('span.govuk-hint') }


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-762)

Bug Fix : prevent showing hint for each radio button when using govuk_collection_radio_buttons

## Checklist

Before you ask people to review this PR:

- [X] Tests and rubocop should be passing: `bundle exec rake`
- [X] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [X] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [X] The PR description should say what you changed and why, with a link to the JIRA story.
- [X] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [X] You should have checked that the commit messages say why the change was made.
