### PR TITLE
Update Readme Ruby version to 2.6.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ may well be used to fire requests to other services.
 [![CircleCI](https://circleci.com/gh/ministryofjustice/laa-apply-for-legal-aid/tree/master.svg?style=svg)](https://circleci.com/gh/ministryofjustice/laa-apply-for-legal-aid/tree/master)
 
 * Ruby version
-    * Ruby version 2.5.3
+    * Ruby version 2.6.3
     * Rails 5
 
 * System dependencies


### PR DESCRIPTION



## What

Just a char change in the README file to keep the readme up to date. 
Project ruby version got updated but the Readme wasn't reflecting it.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
