### PR TITLE
Ap-775-add-offices-and-firms

### DIFF
--- a/app/controllers/v1/fake_providers_controller.rb
+++ b/app/controllers/v1/fake_providers_controller.rb
@@ -8,7 +8,7 @@ module V1
 
     def provider_details
       {
-        providerOffices: number_of_offices.times.map do |office_index|
+        providerOffices: Array.new(number_of_offices) do |office_index|
           provider_office(office_index)
         end,
         contactId: username_number * 3,
@@ -45,7 +45,7 @@ module V1
     end
 
     def contact_name
-      @contact_name ||=  params[:username].snakecase.titlecase
+      @contact_name ||= params[:username].snakecase.titlecase
     end
 
     def username_number

--- a/app/controllers/v1/fake_providers_controller.rb
+++ b/app/controllers/v1/fake_providers_controller.rb
@@ -1,5 +1,10 @@
 module V1
   class FakeProvidersController < ApiController
+    # Fake API simulating a CCMS API to get information about providers.
+    # It accepts a provider username as a parameter.
+    # In order for the response to be consistent per username but also not always the same for each username,
+    # we generate a number from the username and use that number to generate the values from the response.
+
     def show
       render json: provider_details
     end
@@ -21,7 +26,7 @@ module V1
       office_id = username_number * 2 + office_index
 
       # unique office_number for each office
-      office_number = "0A#{office_id}"
+      office_number = "office_#{office_id}"
 
       {
         providerfirmId: firm_id,
@@ -48,6 +53,7 @@ module V1
       @contact_name ||= params[:username].snakecase.titlecase
     end
 
+    # Generates a number from the username which is used to generate the values from the response
     def username_number
       @username_number ||= params[:username].upcase.chars.map(&:ord).sum
     end

--- a/app/controllers/v1/fake_providers_controller.rb
+++ b/app/controllers/v1/fake_providers_controller.rb
@@ -8,24 +8,48 @@ module V1
 
     def provider_details
       {
-        providerOffices: Array.new(rand(1..3)).map { provider_office },
-        contactId: rand(1..100_000),
-        contactName: params[:username]
+        providerOffices: number_of_offices.times.map do |office_index|
+          provider_office(office_index)
+        end,
+        contactId: username_number * 3,
+        contactName: contact_name
       }
     end
 
-    def provider_office
+    def provider_office(office_index)
+      # unique office_id for each office
+      office_id = username_number * 2 + office_index
+
+      # unique office_number for each office
+      office_number = "0A#{office_id}"
+
       {
         providerfirmId: firm_id,
-        officeId: rand(1..100_000),
-        officeName: Faker::Lorem.sentence,
-        smsVendorNum: rand(1..10_000).to_s,
-        smsVendorSite: Faker::Lorem.word
+        officeId: office_id,
+        officeName: "#{firm_name}-#{office_number}",
+        smsVendorNum: ((office_id + firm_id) * 4).to_s,
+        smsVendorSite: office_number
       }
+    end
+
+    def number_of_offices
+      (username_number & 3) + 1
     end
 
     def firm_id
-      @firm_id ||= rand(1..100_000)
+      @firm_id ||= username_number
+    end
+
+    def firm_name
+      @firm_name ||= "#{contact_name} & Co."
+    end
+
+    def contact_name
+      @contact_name ||=  params[:username].snakecase.titlecase
+    end
+
+    def username_number
+      @username_number ||= params[:username].upcase.chars.map(&:ord).sum
     end
   end
 end

--- a/app/models/firm.rb
+++ b/app/models/firm.rb
@@ -1,6 +1,4 @@
 class Firm < ApplicationRecord
-
   has_many :offices
   has_many :providers
-
 end

--- a/app/models/firm.rb
+++ b/app/models/firm.rb
@@ -1,0 +1,6 @@
+class Firm < ApplicationRecord
+
+  has_many :offices
+  has_many :providers
+
+end

--- a/app/models/office.rb
+++ b/app/models/office.rb
@@ -1,0 +1,8 @@
+class Office < ApplicationRecord
+
+  has_many :providers
+  has_many :legal_aid_applications
+
+  belongs_to :firm, optional: true
+
+end

--- a/app/models/office.rb
+++ b/app/models/office.rb
@@ -1,8 +1,6 @@
 class Office < ApplicationRecord
-
   has_many :providers
   has_many :legal_aid_applications
 
   belongs_to :firm, optional: true
-
 end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -3,6 +3,9 @@ class Provider < ApplicationRecord
   serialize :roles
   serialize :offices
 
+  belongs_to :firm, optional: true
+  belongs_to :office, optional: true
+
   has_many :legal_aid_applications
 
   def update_details

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -9,13 +9,12 @@ class Provider < ApplicationRecord
   has_many :legal_aid_applications
 
   def update_details
-    return update_details_directly unless details_response
+    return update_details_directly unless firm
 
-    ProviderDetailsRetrieverWorker.perform_async(id)
+    ProviderDetailsCreatorWorker.perform_async(id)
   end
 
   def update_details_directly
-    details = ProviderDetailsRetriever.call(username)
-    update!(details_response: details)
+    ProviderDetailsCreator.call(self)
   end
 end

--- a/app/services/provider_details_creator.rb
+++ b/app/services/provider_details_creator.rb
@@ -1,0 +1,50 @@
+class ProviderDetailsCreator
+
+  def self.call(provider)
+    new(provider).call
+  end
+
+  attr_reader :provider
+
+  def initialize(provider)
+    @provider = provider
+  end
+
+  def call
+    provider.update!(
+      firm: firm,
+      details_response: provider_details
+    )
+  end
+
+  private
+
+  def firm
+    Firm.find_or_create_by!(ccms_id: firm_id).tap do |firm|
+      firm.update!(name: firm_name)
+      firm.offices << offices
+    end
+  end
+
+  def offices
+    provider_details[:providerOffices].map do |ccms_office|
+      Office.find_or_initialize_by(ccms_id: ccms_office[:officeId]) do |office|
+        office.code = ccms_office[:smsVendorSite]
+      end
+    end
+  end
+
+  def firm_id
+    provider_details[:providerOffices].first[:providerfirmId]
+  end
+
+  def firm_name
+    # Remove the code at the end.
+    # "Pearson & Pearson -0A1234" becomes "Pearson & Pearson"
+    provider_details[:providerOffices].first[:officeName].split('-')[0..-2].join('-').strip
+  end
+
+  def provider_details
+    @provider_details ||= ProviderDetailsRetriever.call(provider.username)
+  end
+end

--- a/app/services/provider_details_creator.rb
+++ b/app/services/provider_details_creator.rb
@@ -1,5 +1,4 @@
 class ProviderDetailsCreator
-
   def self.call(provider)
     new(provider).call
   end

--- a/app/workers/provider_details_creator_worker.rb
+++ b/app/workers/provider_details_creator_worker.rb
@@ -1,4 +1,4 @@
-class ProviderDetailsRetrieverWorker
+class ProviderDetailsCreatorWorker
   include Sidekiq::Worker
   include Sidekiq::Status::Worker
 

--- a/db/migrate/20190712133912_create_firms_and_offices.rb
+++ b/db/migrate/20190712133912_create_firms_and_offices.rb
@@ -1,0 +1,20 @@
+class CreateFirmsAndOffices < ActiveRecord::Migration[5.2]
+  def change
+    create_table :firms, id: :uuid do |t|
+      t.timestamps
+      t.string :ccms_id
+      t.string :name
+    end
+
+    create_table :offices, id: :uuid do |t|
+      t.timestamps
+      t.string :ccms_id
+      t.string :code
+      t.references :firm, foreign_key: true, type: :uuid
+    end
+
+    add_reference :providers, :firm, type: :uuid, index: true, foreign_key: true
+    add_reference :providers, :office, type: :uuid, index: true, foreign_key: true
+    add_reference :legal_aid_applications, :office, type: :uuid, index: true, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_08_151000) do
+ActiveRecord::Schema.define(version: 2019_07_12_133912) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -229,6 +229,13 @@ ActiveRecord::Schema.define(version: 2019_07_08_151000) do
     t.string "source"
   end
 
+  create_table "firms", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "ccms_id"
+    t.string "name"
+  end
+
   create_table "incidents", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.date "occurred_on"
     t.text "details"
@@ -287,8 +294,10 @@ ActiveRecord::Schema.define(version: 2019_07_08_151000) do
     t.date "substantive_application_deadline_on"
     t.boolean "substantive_application"
     t.boolean "has_dependants"
+    t.uuid "office_id"
     t.index ["applicant_id"], name: "index_legal_aid_applications_on_applicant_id"
     t.index ["application_ref"], name: "index_legal_aid_applications_on_application_ref", unique: true
+    t.index ["office_id"], name: "index_legal_aid_applications_on_office_id"
     t.index ["provider_id"], name: "index_legal_aid_applications_on_provider_id"
   end
 
@@ -317,6 +326,15 @@ ActiveRecord::Schema.define(version: 2019_07_08_151000) do
     t.datetime "submitted_at"
     t.boolean "success_likely"
     t.index ["legal_aid_application_id"], name: "index_merits_assessments_on_legal_aid_application_id"
+  end
+
+  create_table "offices", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "ccms_id"
+    t.string "code"
+    t.uuid "firm_id"
+    t.index ["firm_id"], name: "index_offices_on_firm_id"
   end
 
   create_table "opponents", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -384,6 +402,10 @@ ActiveRecord::Schema.define(version: 2019_07_08_151000) do
     t.datetime "updated_at", null: false
     t.text "offices"
     t.json "details_response"
+    t.uuid "firm_id"
+    t.uuid "office_id"
+    t.index ["firm_id"], name: "index_providers_on_firm_id"
+    t.index ["office_id"], name: "index_providers_on_office_id"
     t.index ["type"], name: "index_providers_on_type"
     t.index ["username"], name: "index_providers_on_username", unique: true
   end
@@ -492,8 +514,12 @@ ActiveRecord::Schema.define(version: 2019_07_08_151000) do
   add_foreign_key "legal_aid_application_restrictions", "legal_aid_applications"
   add_foreign_key "legal_aid_application_restrictions", "restrictions"
   add_foreign_key "legal_aid_applications", "applicants"
+  add_foreign_key "legal_aid_applications", "offices"
   add_foreign_key "legal_aid_applications", "providers"
   add_foreign_key "merits_assessments", "legal_aid_applications"
+  add_foreign_key "offices", "firms"
+  add_foreign_key "providers", "firms"
+  add_foreign_key "providers", "offices"
   add_foreign_key "respondents", "legal_aid_applications"
   add_foreign_key "savings_amounts", "legal_aid_applications"
   add_foreign_key "statement_of_cases", "legal_aid_applications"

--- a/spec/factories/firms.rb
+++ b/spec/factories/firms.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :firm do
+    ccms_id { rand(1..1000) }
+    name { Faker::Company.name }
+  end
+end

--- a/spec/factories/offices.rb
+++ b/spec/factories/offices.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :office do
+    ccms_id { rand(1..1000) }
+    code { rand(1..1000).to_s }
+    firm
+  end
+end

--- a/spec/requests/v1/fake_providers_spec.rb
+++ b/spec/requests/v1/fake_providers_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe V1::FakeProvidersController, type: :request do
   describe 'GET /v1/fake_providers/:username' do
     let(:username) { Faker::Internet.username }
+    let(:contact_name) { username.snakecase.titlecase }
 
     subject { get v1_fake_provider_path(username) }
 
@@ -14,7 +15,7 @@ RSpec.describe V1::FakeProvidersController, type: :request do
     end
 
     it 'returns the expected data structure' do
-      expect(json['contactName']).to eq(username)
+      expect(json['contactName']).to eq(contact_name)
       expected_keys = %w[providerOffices contactId contactName]
       expect(json.keys).to match_array(expected_keys)
 

--- a/spec/services/provider_details_creator_spec.rb
+++ b/spec/services/provider_details_creator_spec.rb
@@ -1,0 +1,70 @@
+require 'rails_helper'
+
+RSpec.describe ProviderDetailsCreator do
+  let(:provider) { create :provider }
+  let(:ccms_firm) { OpenStruct.new(id: rand(1..1000), name: Faker::Company.name) }
+  let(:ccms_office_1) { OpenStruct.new(id: rand(1..1000), code: rand(1..1000).to_s) }
+  let(:ccms_office_2) { OpenStruct.new(id: rand(1..1000), code: rand(1..1000).to_s) }
+  let(:api_response) do
+    {
+      providerOffices: [
+        {
+          providerfirmId: ccms_firm.id,
+          officeId: ccms_office_1.id,
+          officeName: "#{ccms_firm.name}-#{ccms_office_1.code}",
+          smsVendorNum: rand(1..1000),
+          smsVendorSite: ccms_office_1.code
+        },
+        {
+          providerfirmId: ccms_firm.id,
+          officeId: ccms_office_2.id,
+          officeName: "#{ccms_firm.name}-#{ccms_office_2.code}",
+          smsVendorNum: rand(1..1000),
+          smsVendorSite: ccms_office_2.code
+        }
+      ],
+      contactId: rand(1..1000),
+      contactName: Faker::Name.name
+    }
+  end
+  let(:firm) { provider.firm }
+  let(:office_1) { firm.offices.find_by(ccms_id: ccms_office_1.id) }
+  let(:office_2) { firm.offices.find_by(ccms_id: ccms_office_2.id) }
+
+  before { allow(ProviderDetailsRetriever).to receive(:call).with(provider.username).and_return(api_response) }
+
+  subject { described_class.call(provider) }
+
+  describe '.call' do
+    it 'creates the right firm' do
+      expect { subject }.to change { Firm.count }.by(1)
+      expect(firm.ccms_id).to eq(ccms_firm.id.to_s)
+      expect(firm.name).to eq(ccms_firm.name)
+    end
+
+    it 'creates the right offices' do
+      expect { subject }.to change { Office.count }.by(2)
+      expect(firm.offices.count).to eq(2)
+      expect(office_1.code).to eq(ccms_office_1.code)
+      expect(office_2.code).to eq(ccms_office_2.code)
+    end
+
+    context 'firm already exists with one of the offices' do
+      let!(:existing_firm) { create :firm, ccms_id: ccms_firm.id, name: 'foobar' }
+      let!(:existing_office) { create :office, firm: existing_firm }
+
+      it 'uses existing firm' do
+        expect { subject }.not_to change { Firm.count }
+        expect(provider.firm_id).to eq(existing_firm.id)
+      end
+
+      it 'should add the new offices' do
+        expect { subject }.to change { existing_firm.reload.offices.count }.by(2)
+      end
+
+      it 'should update the namne of the firm' do
+        expect { subject }.to change { existing_firm.reload.name }.to(ccms_firm.name)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-775)
Paired with Julien

This is the first part of AP-775, sectioned of as its own PR so that there is not one huge PR at the end. None of the work is visible on the front end for this change.

Added new tables for offices and firms.
Updated the fake provider name api to return the same provider code code for each office, to add the legal aid code to the name to match the expected data from CCMS

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
