### PR TITLE
AP-775 Confirm/Select Office

### DIFF
--- a/app/controllers/providers/applicants_controller.rb
+++ b/app/controllers/providers/applicants_controller.rb
@@ -23,7 +23,10 @@ module Providers
     private
 
     def legal_aid_application
-      @legal_aid_application ||= LegalAidApplication.create!(provider: current_provider)
+      @legal_aid_application ||= LegalAidApplication.create!(
+        provider: current_provider,
+        office: current_provider.office
+      )
     end
 
     def applicant

--- a/app/controllers/providers/confirm_offices_controller.rb
+++ b/app/controllers/providers/confirm_offices_controller.rb
@@ -1,0 +1,35 @@
+module Providers
+  class ConfirmOfficesController < ProviderBaseController
+    legal_aid_application_not_required!
+    helper_method :firm
+
+    def show
+      if firm.offices.count == 1
+        current_provider.update!(office: firm.offices.first)
+        redirect_to providers_legal_aid_applications_path
+        return
+      end
+
+      redirect_to providers_select_office_path unless current_provider.office
+    end
+
+    def update
+      case params[:correct]
+      when 'yes'
+        redirect_to providers_legal_aid_applications_path
+      when 'no'
+        current_provider.update!(office: nil)
+        redirect_to providers_select_office_path
+      else
+        @error = I18n.t('providers.confirm_offices.show.error')
+        render :show
+      end
+    end
+
+    private
+
+    def firm
+      current_provider.firm
+    end
+  end
+end

--- a/app/controllers/providers/select_offices_controller.rb
+++ b/app/controllers/providers/select_offices_controller.rb
@@ -1,0 +1,34 @@
+module Providers
+  class SelectOfficesController < ProviderBaseController
+    legal_aid_application_not_required!
+    helper_method :firm
+
+    def show
+      @form = Providers::OfficeForm.new(model: current_provider)
+    end
+
+    def update
+      @form = Providers::OfficeForm.new(form_params)
+
+      if @form.save
+        redirect_to providers_legal_aid_applications_path
+      else
+        render :show
+      end
+    end
+
+    private
+
+    def firm
+      current_provider.firm
+    end
+
+    def form_params
+      merge_with_model(current_provider) do
+        next {} unless params[:provider]
+
+        params.require(:provider).permit(:office_id)
+      end
+    end
+  end
+end

--- a/app/controllers/saml_sessions_controller.rb
+++ b/app/controllers/saml_sessions_controller.rb
@@ -15,6 +15,10 @@ class SamlSessionsController < Devise::SamlSessionsController
     end
   end
 
+  def after_sign_in_path_for(_provider)
+    providers_confirm_office_path
+  end
+
   private
 
   def update_provider_details

--- a/app/forms/providers/office_form.rb
+++ b/app/forms/providers/office_form.rb
@@ -1,0 +1,17 @@
+module Providers
+  class OfficeForm
+    include BaseForm
+
+    form_for Provider
+
+    attr_accessor :office_id
+
+    validates :office_id, presence: true
+
+    delegate :firm, to: :model
+
+    before_validation do
+      self.office_id = nil unless office_id.in?(firm.offices.pluck(:id))
+    end
+  end
+end

--- a/app/lib/govuk_elements_form_builder/form_builder.rb
+++ b/app/lib/govuk_elements_form_builder/form_builder.rb
@@ -92,6 +92,9 @@ module GovukElementsFormBuilder
     # You can pass a title with the :title parameter.
     # e.g., <%= form.govuk_collection_radio_buttons(:gender, ['f', 'm'], title: 'What is your gender?') %>
     #
+    # You can pass an error with the :error parameter.
+    # e.g., <%= form.govuk_collection_radio_buttons(:gender, ['f', 'm'], error: 'Please select a gender') %>
+    #
     # If you wish to specify the size of the heading pass a hash into title with text and size:
     # <%= form.govuk_collection_radio_buttons(:gender, ['f', 'm'], title: { text: 'What is your gender?', size: :m } ) %>
     #
@@ -246,13 +249,15 @@ module GovukElementsFormBuilder
     def error_tag(attribute, options)
       return unless error?(attribute, options)
 
-      message = object.errors[attribute].first
+      message = options[:error] || object.errors[attribute].first
       return unless message.present?
 
       content_tag(:span, message, class: 'govuk-error-message', id: "#{attribute}-error")
     end
 
     def error?(attribute, options)
+      return true if options[:error]
+
       attr = options[:field_with_error] || attribute
       object.respond_to?(:errors) &&
         errors.messages.key?(attr) &&

--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -11,6 +11,7 @@ class LegalAidApplication < ApplicationRecord # rubocop:disable Metrics/ClassLen
 
   belongs_to :applicant, optional: true
   belongs_to :provider, optional: false
+  belongs_to :office, optional: true
   has_many :application_proceeding_types, dependent: :destroy
   has_many :proceeding_types, through: :application_proceeding_types
   has_one :benefit_check_result, dependent: :destroy

--- a/app/models/office.rb
+++ b/app/models/office.rb
@@ -2,5 +2,5 @@ class Office < ApplicationRecord
   has_many :providers
   has_many :legal_aid_applications
 
-  belongs_to :firm, optional: true
+  belongs_to :firm
 end

--- a/app/views/citizens/additional_accounts/index.html.erb
+++ b/app/views/citizens/additional_accounts/index.html.erb
@@ -6,8 +6,6 @@
           input: :additional_account
         ) do %>
 
-      <%= govuk_error_message @error %>
-
       <%
         options = [
           { value: :yes, label: t('generic.yes') },

--- a/app/views/citizens/additional_accounts/new.html.erb
+++ b/app/views/citizens/additional_accounts/new.html.erb
@@ -6,8 +6,6 @@
           input: :has_offline_accounts
         ) do %>
 
-      <%= govuk_error_message @error %>
-
       <%
         options = [
           { value: :yes, label: t('generic.yes') },
@@ -17,7 +15,7 @@
 
       <%= govuk_fieldset_header(content_for(:page_title)) %>
 
-      <%= form.govuk_collection_radio_buttons :has_offline_accounts, options, :value, :label %>
+      <%= form.govuk_collection_radio_buttons :has_offline_accounts, options, :value, :label, error: @error %>
 
     <% end %>
 

--- a/app/views/citizens/has_other_dependants/show.html.erb
+++ b/app/views/citizens/has_other_dependants/show.html.erb
@@ -6,8 +6,6 @@
           input: :other_dependant
         ) do %>
 
-      <%= govuk_error_message @error %>
-
       <%= govuk_fieldset_header(content_for(:page_title)) %>
 
       <%

--- a/app/views/providers/confirm_offices/show.html.erb
+++ b/app/views/providers/confirm_offices/show.html.erb
@@ -1,0 +1,46 @@
+<%= page_template page_title: t('.h1-heading', firm: firm.name), template: :basic do %>
+  <%= form_with(url: providers_confirm_office_path, method: :patch, local: true) do |form| %>
+
+    <% if @error %>
+      <div class="govuk-error-summary" id="error_explanation">
+        <h2 class="govuk-error-summary__title" id="error-summary-title">
+          <%= t('generic.errors.problem_text') %>
+        </h2>
+        <div class="govuk-error-summary__body">
+          <ul class="govuk-list govuk-error-summary__list">
+            <li>
+              <%= link_to @error, "#correct" %>
+            </li>
+          </ul>
+        </div>
+      </div>
+    <% end %>
+
+    <%= govuk_form_group(
+          show_error_if: @error,
+          input: :correct
+        ) do %>
+
+      <%= govuk_fieldset_header(content_for(:page_title)) %>
+
+      <div class="govuk-!-padding-bottom-6"></div>
+      <p class="govuk-body">
+        <strong><%= t('.account_number') %></strong> <%= current_provider.office.code %>
+      </p>
+
+      <div class="govuk-!-padding-bottom-2"></div>
+      <h2 class="govuk-heading-m"><%= t('.is_this_correct') %></h2>
+
+      <%
+        options = [
+          { value: :yes, label: t('generic.yes') },
+          { value: :no,  label: t('.no_another_office') }
+        ]
+      %>
+      <%= form.govuk_collection_radio_buttons :correct, options, :value, :label, error: @error %>
+
+    <% end %>
+
+    <%= next_action_buttons(form: form) %>
+  <% end %>
+<% end %>

--- a/app/views/providers/select_offices/show.html.erb
+++ b/app/views/providers/select_offices/show.html.erb
@@ -1,0 +1,12 @@
+<%= page_template page_title: t('.h1-heading', firm: firm.name), template: :basic do %>
+  <%= form_with(model: @form, url: providers_select_office_path, method: :patch, local: true) do |form| %>
+
+    <%= govuk_fieldset_header(content_for(:page_title), padding_below: 6) %>
+
+    <%= form.govuk_collection_radio_buttons(:office_id, firm.offices, :id, :code) %>
+
+    <div class="govuk-!-padding-bottom-2"></div>
+
+    <%= next_action_buttons(form: form) %>
+  <% end %>
+<% end %>

--- a/config/initializers/mock_saml.rb
+++ b/config/initializers/mock_saml.rb
@@ -2,7 +2,8 @@ Rails.configuration.x.application.mock_saml = OpenStruct.new(
   usernames: [
     'really-really-long-email-address@example.com'.freeze,
     'test1@example.com'.freeze,
-    'test2@example.com'.freeze
+    'test2@example.com'.freeze,
+    '1.office@example.com'.freeze
   ],
   password: 'password'.freeze
 )

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -268,7 +268,7 @@ en:
         provider:
           attributes:
             office_id:
-              blank: Please select an office
+              blank: Select the office responsible for your applications
         respondent:
           attributes:
             understands_terms_of_court_order:

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -265,6 +265,10 @@ en:
                 none_selected: Select if you have any of these types of assets
               provider:
                 none_selected: Select if your client has any of these types of assets
+        provider:
+          attributes:
+            office_id:
+              blank: Please select an office
         respondent:
           attributes:
             understands_terms_of_court_order:

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -131,6 +131,13 @@ en:
         review-advice: You can review their answers and make corrections before their application is submitted.
         client: Client
         case-reference: Case reference
+    confirm_offices:
+      show:
+        h1-heading: Confirm the %{firm} office responsible for this application
+        error: Select yes if these details are correct
+        no_another_office: No, another office is responsible for this application
+        account_number: 'Legal Aid Agency account number: '
+        is_this_correct: Is this correct?
     date_client_told_incidents:
       show:
         h1-heading: Latest incident details
@@ -291,6 +298,9 @@ en:
       show:
         h1-heading: What types of savings or investments does your client have?
         none_selected: None of these
+    select_offices:
+      show:
+        h1-heading: Which %{firm} office is responsible for your applications?
     shared_ownerships:
       show:
         heading_1: Does your client own their home with anyone else?

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -134,7 +134,7 @@ en:
     confirm_offices:
       show:
         h1-heading: Confirm the %{firm} office responsible for this application
-        error: Select yes if these details are correct
+        error: Select yes if this office is responsible for your applications
         no_another_office: No, another office is responsible for this application
         account_number: 'Legal Aid Agency account number: '
         is_this_correct: Is this correct?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -95,6 +95,8 @@ Rails.application.routes.draw do
     root to: 'start#index' # TODO: In the live app this will point at an external url
     resource :provider, only: [:show], path: 'your_profile'
     resources :applicants, only: %i[new create]
+    resource :confirm_office, only: %i[show update]
+    resource :select_office, only: %i[show update]
 
     resources :legal_aid_applications, path: 'applications', only: %i[index create] do
       resources :proceedings_types, only: %i[index create update]

--- a/features/providers/civil_application_journey.feature
+++ b/features/providers/civil_application_journey.feature
@@ -8,6 +8,32 @@ Feature: Civil application journeys
     And I click link "Apply for Legal Aid"
     Then I am on the legal aid applications
 
+  @javascript
+  Scenario: I am able to select an office
+    Given I am logged in as a provider
+    Then I visit the select office page
+    Then I choose 'London'
+    Then I click 'Save and continue'
+    Then I should be on a page showing 'Your legal aid applications'
+
+  @javascript
+  Scenario: I am able to confirm my office
+    Given I am logged in as a provider
+    Given I have an existing office
+    Then I visit the confirm office page
+    Then I choose 'Yes'
+    Then I click 'Save and continue'
+    Then I should be on a page showing 'Your legal aid applications'
+
+  @javascript
+  Scenario: I am able to change my registered office
+    Given I am logged in as a provider
+    Given I have an existing office
+    Then I visit the confirm office page
+    Then I choose 'No'
+    Then I click 'Save and continue'
+    Then I should be on a page showing 'office is responsible for your applications?'
+
   @javascript @vcr
   Scenario: No results returned is seen on screen when invalid proceeding search entered
     Given I am logged in as a provider

--- a/features/step_definitions/civil_journey_steps.rb
+++ b/features/step_definitions/civil_journey_steps.rb
@@ -3,10 +3,25 @@
 Given(/^I am logged in as a provider$/) do
   @registered_provider = create(:provider, username: 'test_provider')
   login_as @registered_provider
+  @registered_provider.firm.offices << create(:office, code: 'London')
+  @registered_provider.firm.offices << create(:office, code: 'Manchester')
 end
 
 Given(/^I visit the application service$/) do
   visit providers_root_path
+end
+
+Given('I visit the select office page') do
+  visit providers_select_office_path
+end
+
+Given('I visit the confirm office page') do
+  visit providers_confirm_office_path
+end
+
+Given('I have an existing office') do
+  office = @registered_provider.firm.offices.find_by(code: 'London')
+  @registered_provider.update!(office: office)
 end
 
 Given(/^I visit the applications page$/) do

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :provider do
+    firm
     username { Faker::Internet.unique.user_name(10) }
 
     trait :with_provider_details_api_username do

--- a/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
+++ b/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
@@ -290,6 +290,15 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
       end
     end
 
+    context 'when an error message is passed as a parameter' do
+      let(:error_message) { 'Something wrong' }
+      let(:params) { [:uses_online_banking, options, error: error_message] }
+
+      it 'the error message is shown' do
+        expect(parsed_html.at_css('span.govuk-error-message').content).to eq(error_message)
+      end
+    end
+
     context 'when there is a hint message defined' do
       let(:hint_message) { 'Choose an option' }
       let(:span_hint) { parsed_html.at_css('span.govuk-hint') }

--- a/spec/requests/providers/applicants_spec.rb
+++ b/spec/requests/providers/applicants_spec.rb
@@ -1,7 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe Providers::ApplicantsController, type: :request do
-  let(:provider) { create :provider }
+  let(:office) { create :office }
+  let(:provider) { create :provider, office: office }
   let(:login) { login_as provider }
 
   before { login }
@@ -33,8 +34,9 @@ RSpec.describe Providers::ApplicantsController, type: :request do
 
     subject { post providers_applicants_path, params: params.merge(submit_button) }
 
-    it 'creates an application' do
+    it "creates an application with the provider's office" do
       expect { subject }.to change { provider.legal_aid_applications.count }.by(1)
+      expect(legal_aid_application.office.id).to eq(provider.office.id)
     end
 
     it 'creates an applicant' do

--- a/spec/requests/providers/confirm_offices_spec.rb
+++ b/spec/requests/providers/confirm_offices_spec.rb
@@ -1,0 +1,96 @@
+require 'rails_helper'
+
+RSpec.describe 'provider confirm office', type: :request do
+  let(:provider) { create :provider, firm: firm, office: office }
+  let(:firm) { create :firm }
+  let!(:office) { create :office, firm: firm }
+  let!(:office2) { create :office, firm: firm }
+
+  describe 'GET providers/confirm_office' do
+    subject { get providers_confirm_office_path }
+
+    context 'when the provider is not authenticated' do
+      before { subject }
+      it_behaves_like 'a provider not authenticated'
+    end
+
+    context 'when the provider is authenticated' do
+      before do
+        login_as provider
+        subject
+      end
+
+      it 'returns http success' do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'displays the correct firm name' do
+        expect(unescaped_response_body).to include(firm.name)
+      end
+
+      it 'displays the correct office legal aid code' do
+        expect(unescaped_response_body).to include(office.code)
+      end
+
+      context 'firm has only one office' do
+        let!(:office) { nil }
+
+        it 'assigns office 2 to the provider' do
+          expect(provider.reload.office).to eq office2
+        end
+
+        it 'redirects to the legal aid applications page' do
+          expect(response).to redirect_to providers_legal_aid_applications_path
+        end
+      end
+
+      context 'provider has not selected office' do
+        let(:provider) { create :provider, firm: firm, office: nil }
+
+        it 'redirects to the select office page' do
+          expect(response).to redirect_to providers_select_office_path
+        end
+      end
+    end
+  end
+
+  describe 'PATCH providers/confirm_office' do
+    subject { patch providers_confirm_office_path, params: params }
+    let(:params) { { correct: 'yes' } }
+
+    context 'when the provider is authenticated' do
+      before do
+        login_as provider
+        subject
+      end
+
+      it 'redirects to the legal aid applications page' do
+        expect(response).to redirect_to providers_legal_aid_applications_path
+      end
+
+      context 'invalid params - nothing specified' do
+        let(:params) { {} }
+
+        it 'returns http_success' do
+          expect(response).to have_http_status(:ok)
+        end
+
+        it 'the response includes the error message' do
+          expect(response.body).to include(I18n.t('providers.confirm_offices.show.error'))
+        end
+      end
+
+      context 'no is selected' do
+        let(:params) { { correct: 'no' } }
+
+        it 'redirects to the office select page' do
+          expect(response).to redirect_to providers_select_office_path
+        end
+
+        it 'clears the existing office' do
+          expect(provider.reload.office).to eq nil
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/providers/select_offices_spec.rb
+++ b/spec/requests/providers/select_offices_spec.rb
@@ -1,0 +1,86 @@
+require 'rails_helper'
+
+RSpec.describe 'provider selects office', type: :request do
+  let(:provider) { create :provider, firm: firm }
+  let(:firm) { create :firm }
+
+  describe 'GET providers/select_office' do
+    subject { get providers_select_office_path }
+
+    context 'when the provider is not authenticated' do
+      before { subject }
+      it_behaves_like 'a provider not authenticated'
+    end
+
+    context 'when the provider is authenticated' do
+      before do
+        login_as provider
+        subject
+      end
+
+      it 'returns http success' do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'displays the correct office name' do
+        expect(unescaped_response_body).to include(firm.name)
+      end
+    end
+  end
+
+  describe 'PATCH providers/select_office' do
+    subject { patch providers_select_office_path, params: params }
+    let(:office1) { create :office, firm: firm }
+    let!(:office2) { create :office, firm: firm }
+
+    let(:params) do
+      {
+        provider: { office_id: office1.id }
+      }
+    end
+
+    context 'when the provider is authenticated' do
+      before do
+        login_as provider
+        subject
+      end
+
+      it 'updates the record' do
+        expect(provider.reload.office.id).to eq office1.id
+      end
+
+      it 'redirects to the legal aid applications page' do
+        expect(response).to redirect_to providers_legal_aid_applications_path
+      end
+
+      context 'invalid params - nothing specified' do
+        let(:params) { {} }
+
+        it 'returns http_success' do
+          expect(response).to have_http_status(:ok)
+        end
+
+        it 'the response includes the error message' do
+          expect(response.body).to include(I18n.t('activemodel.errors.models.provider.attributes.office_id.blank'))
+        end
+      end
+
+      context 'invalid params - selects office from different firm' do
+        let(:office3) { create :office }
+        let(:params) do
+          {
+            provider: { office_id: office3.id }
+          }
+        end
+
+        it 'returns http_success' do
+          expect(response).to have_http_status(:ok)
+        end
+
+        it 'the response includes the error message' do
+          expect(response.body).to include(I18n.t('activemodel.errors.models.provider.attributes.office_id.blank'))
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/saml_sessions_spec.rb
+++ b/spec/requests/saml_sessions_spec.rb
@@ -3,7 +3,8 @@ require 'sidekiq/testing'
 
 RSpec.describe 'SamlSessionsController', type: :request do
   let(:firm) { nil }
-  let(:provider) { create :provider, firm: firm }
+  let(:office) { nil }
+  let(:provider) { create :provider, firm: firm, office: office }
 
   describe 'DELETE /providers/sign_out' do
     before { sign_in provider }
@@ -55,6 +56,11 @@ RSpec.describe 'SamlSessionsController', type: :request do
     it 'does not use a worker' do
       expect(ProviderDetailsCreatorWorker).not_to receive(:perform_async)
       subject
+    end
+
+    it 'redirects to the confirm office page' do
+      subject
+      expect(response).to redirect_to(providers_confirm_office_path)
     end
 
     context 'provider already has some provider details' do


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-775)
Paired with Will

After a provider logs in, they need to select which office they belong to.
Here is the logic:
![office selection](https://user-images.githubusercontent.com/482806/61302260-607e1f00-a7dd-11e9-9f04-11aa9ccb3e69.jpg)

In addition to that diagram, if the provider's firm has only one office, we automatically assign the office to the provider and skip the confirm/select pages.

## Checklist

Before you ask people to review this PR:

- [X] Tests and rubocop should be passing: `bundle exec rake`
- [X] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [X] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [X] The PR description should say what you changed and why, with a link to the JIRA story.
- [X] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [X] You should have checked that the commit messages say why the change was made.
