### PR TITLE
AP-602 Standardise date formats across the app

### DIFF
--- a/app/views/admin/legal_aid_applications/_legal_aid_applications.html.erb
+++ b/app/views/admin/legal_aid_applications/_legal_aid_applications.html.erb
@@ -15,7 +15,7 @@
         <% @applications.each do |application| %>
           <tr class="govuk-table__row">
             <td class="govuk-table__cell case-full-name"><%= application.applicant_full_name || t('generic.undefined') %></td>
-            <td class="govuk-table__cell"><%= l(application.created_at, format: :date) %></td>
+            <td class="govuk-table__cell"><%= l(application.created_at.to_date, format: :long_date) %></td>
             <td class="govuk-table__cell case-reference-number"><%= application.application_ref %></td>
             <td class="govuk-table__cell"><%= application.enum_t(:state) %></td>
             <td class="govuk-table__cell"><%= button_to(

--- a/app/views/providers/legal_aid_applications/_legal_aid_applications.html.erb
+++ b/app/views/providers/legal_aid_applications/_legal_aid_applications.html.erb
@@ -16,7 +16,7 @@
         <tbody class="govuk-table__body">
           <tr class="govuk-table__row">
             <td class="govuk-table__cell"><%= application.applicant_full_name || t('generic.undefined') %></td>
-            <td class="govuk-table__cell"><%= l(application.created_at, format: :date) %></td>
+            <td class="govuk-table__cell"><%= l(application.created_at.to_date, format: :long_date) %></td>
             <td class="govuk-table__cell"><%= application.application_ref %></td>
             <td class="govuk-table__cell"><%= application.enum_t(:state) %></td>
             <td class="govuk-table__cell">


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-602)

Ensure all dates are in GDS style, eg ‘4 June 2019’.

Update all pages not using this format to use the 'long_date' format
defined in config/locales/en/date.yml (or 'short_date' if it appears in
a table).

There only appears to be two to change:

- views/admin/legal_aid_applications/_legal_aid_applications.html.erb
- views/providers/legal_aid_applications/_legal_aid_applications.html.erb

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
