### PR TITLE
Fix intermittent failing tests

### DIFF
--- a/spec/factories/dependants.rb
+++ b/spec/factories/dependants.rb
@@ -4,7 +4,12 @@ FactoryBot.define do
     number { Faker::Number.number(2) }
     name { Faker::Name.name }
     date_of_birth { Faker::Date.birthday(7, 77) }
-    relationship {  Dependant.relationships.keys.sample }
+    relationship { Dependant.relationships.keys.sample }
+    monthly_income { rand(1...10_000.0).round(2) }
+    has_income { Faker::Boolean.boolean }
+    in_full_time_education { Faker::Boolean.boolean }
+    has_assets_more_than_threshold { Faker::Boolean.boolean }
+    assets_value { rand(1...10_000.0).round(2) }
 
     trait :over_18 do
       date_of_birth { Faker::Date.birthday(19, 65) }

--- a/spec/factories/incidents.rb
+++ b/spec/factories/incidents.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :incident do
     told_on { Faker::Date.backward(90) }
-    occurred_on { Faker::Date.backward(90) }
+    occurred_on { Faker::Date.backward(90) - 1.year }
     details { Faker::Lorem.paragraph }
     legal_aid_application
   end

--- a/spec/requests/citizens/dependants/full_time_educations_spec.rb
+++ b/spec/requests/citizens/dependants/full_time_educations_spec.rb
@@ -6,17 +6,18 @@ RSpec.describe Citizens::Dependants::FullTimeEducationsController, type: :reques
 
   before do
     get citizens_legal_aid_application_path(legal_aid_application.generate_secure_id)
-    subject
   end
 
   describe 'GET /citizens/dependants/:dependant_id/full_time_education' do
     subject { get citizens_dependant_full_time_education_path(dependant) }
 
     it 'returns http success' do
+      subject
       expect(response).to have_http_status(:ok)
     end
 
     it "contains dependant's informations" do
+      subject
       expect(unescaped_response_body).to include(dependant.name)
     end
   end
@@ -36,11 +37,13 @@ RSpec.describe Citizens::Dependants::FullTimeEducationsController, type: :reques
     end
 
     it 'updates the dependant' do
+      subject
       dependant.reload
       expect(dependant).to be_in_full_time_education
     end
 
     it 'redirects to the dependant income page' do
+      subject
       expect(response).to redirect_to(citizens_dependant_monthly_income_path(dependant))
     end
 
@@ -48,11 +51,13 @@ RSpec.describe Citizens::Dependants::FullTimeEducationsController, type: :reques
       let(:in_full_time_education) { false }
 
       it 'updates the dependant' do
+        subject
         dependant.reload
         expect(dependant).not_to be_in_full_time_education
       end
 
       it 'redirects to the dependant income page' do
+        subject
         expect(response).to redirect_to(citizens_dependant_monthly_income_path(dependant))
       end
     end
@@ -66,11 +71,11 @@ RSpec.describe Citizens::Dependants::FullTimeEducationsController, type: :reques
       end
 
       it 'does not update the dependant' do
-        dependant.reload
-        expect(dependant.in_full_time_education).to be_nil
+        expect { subject }.not_to change { dependant.reload.in_full_time_education }
       end
 
       it 'displays an error' do
+        subject
         expect(unescaped_response_body).to match(I18n.t('activemodel.errors.models.dependant.attributes.in_full_time_education.blank_message', name: dependant.name))
         expect(response.body).to match('govuk-error-message')
         expect(response.body).to match('govuk-form-group--error')

--- a/spec/requests/citizens/dependants/monthly_incomes_spec.rb
+++ b/spec/requests/citizens/dependants/monthly_incomes_spec.rb
@@ -2,17 +2,17 @@ require 'rails_helper'
 
 RSpec.describe Citizens::Dependants::MonthlyIncomesController, type: :request do
   let(:legal_aid_application) { create :legal_aid_application, :with_applicant, :with_transaction_period }
-  let(:dependant) { create :dependant, legal_aid_application: legal_aid_application }
+  let(:dependant) { create :dependant, :over_18, in_full_time_education: false, legal_aid_application: legal_aid_application }
 
   before do
     get citizens_legal_aid_application_path(legal_aid_application.generate_secure_id)
-    subject
   end
 
   describe 'GET /citizens/dependants/:id/monthly_income' do
     subject { get citizens_dependant_monthly_income_path(dependant) }
 
     it 'returns http status success' do
+      subject
       expect(response).to have_http_status(:ok)
     end
 
@@ -37,13 +37,33 @@ RSpec.describe Citizens::Dependants::MonthlyIncomesController, type: :request do
     subject { patch citizens_dependant_monthly_income_path(dependant), params: params }
 
     it 'updates the dependant' do
+      subject
       dependant.reload
       expect(dependant.has_income).to eq(has_income)
       expect(dependant.monthly_income).to eq(monthly_income)
     end
 
     it 'redirects to the assets page' do
+      subject
       expect(response).to redirect_to(citizens_dependant_assets_value_path(dependant))
+    end
+
+    context 'dependant is less than 18' do
+      let(:dependant) { create :dependant, :under_18, legal_aid_application: legal_aid_application }
+
+      it 'redirects to the assets page' do
+        subject
+        expect(response).to redirect_to(citizens_has_other_dependant_path)
+      end
+    end
+
+    context 'dependant is full time education' do
+      let(:dependant) { create :dependant, :over_18, in_full_time_education: true, legal_aid_application: legal_aid_application }
+
+      it 'redirects to the assets page' do
+        subject
+        expect(response).to redirect_to(citizens_has_other_dependant_path)
+      end
     end
 
     context 'invalid params' do
@@ -52,21 +72,26 @@ RSpec.describe Citizens::Dependants::MonthlyIncomesController, type: :request do
         let(:monthly_income) { '' }
 
         it 'shows errors' do
+          subject
           expect(unescaped_response_body).to include(I18n.t('activemodel.errors.models.dependant.attributes.has_income.blank_message', name: dependant.name))
           expect(response.body).to include(I18n.t('activemodel.errors.models.dependant.attributes.monthly_income.blank'))
         end
 
-        it 'does not update the dependant' do
-          dependant.reload
-          expect(dependant.has_income).to be_nil
-          expect(dependant.monthly_income).to be_nil
+        it 'does not update dependant.has_income' do
+          expect { subject }.not_to change { dependant.reload.has_income }
+        end
+
+        it 'does not update dependant.monthly_income' do
+          expect { subject }.not_to change { dependant.reload.monthly_income }
         end
       end
+
       context 'invalid values' do
         let(:has_income) { true }
         let(:monthly_income) { '0' }
 
         it 'shows error' do
+          subject
           expect(response.body).to include(I18n.t('activemodel.errors.models.dependant.attributes.monthly_income.greater_than'))
         end
       end


### PR DESCRIPTION
## What

I noticed that the `it 'redirects to the assets page'` test of `monthly_incomes_spec.rb` is intermittently failing if the dependant happens to be less than 18 years old.
So I fixed this test by fixing the age of the dependant using the `:over_18` factory trait.
- I also added another test for the scenario if the dependant is less than 18.
- Added all attributes in the dependant's factory.
- Removed a duplicate in `schema.rb`

---

Additionally, this test is also failing intermittently: https://github.com/ministryofjustice/laa-apply-for-legal-aid/blob/master/spec/forms/incidents/told_on_form_spec.rb#L99
![image](https://user-images.githubusercontent.com/482806/61369341-c8893f80-a887-11e9-86a9-e1665569c9f8.png)
Because the test only passed `told_on` as a parameter to the form but not `occurred_on`, it can happen that `occurred_on` which is generated as `Faker::Date.backward(90)` by the factory could be after the `told_on` in the param (`3.days.ago.to_date`). In that case, the validation error `"Occurred on Date the incident occurred must be before the date your client told you about it"` prevents the `.save` and the test fails.
Modifying the factory to make `occurred_on` to be much earlier prevents this from happening.

## Checklist

Before you ask people to review this PR:a

- [X] Tests and rubocop should be passing: `bundle exec rake`
- [X] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [X] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [X] The PR description should say what you changed and why, with a link to the JIRA story.
- [X] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [X] You should have checked that the commit messages say why the change was made.
