### PR TITLE
Delete UAT release when PR gets merged

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,6 +76,14 @@ references:
       name: Update packages
       command: sudo apt-get update
 
+  setup_uat_kubectl: &setup_uat_kubectl
+    run:
+      name: Kubectl deployment setup UAT
+      command: |
+        $(aws ecr get-login --region eu-west-1 --no-include-email)
+        setup-kube-auth
+        kubectl config use-context uat
+
 jobs:
   build_and_test:
     <<: *build_container_config
@@ -165,12 +173,7 @@ jobs:
     - checkout
     - setup_remote_docker:
         docker_layer_caching: true
-    - run:
-        name: Kubectl deployment setup UAT
-        command: |
-          $(aws ecr get-login --region eu-west-1 --no-include-email)
-          setup-kube-auth
-          kubectl config use-context uat
+    - *setup_uat_kubectl
     - *decrypt_secrets
     - deploy:
         name: Helm deployment to UAT
@@ -276,6 +279,16 @@ jobs:
         path: ./hint-report
         destination: webhint-reports
 
+  delete_uat:
+    <<: *deploy_container_config
+    steps:
+    - checkout
+    - *setup_uat_kubectl
+    - run:
+        name: Delete UAT release
+        command: |
+          ./bin/delete_uat_release
+
 workflows:
   version: 2
   build_and_deploy:
@@ -316,6 +329,10 @@ workflows:
     - deploy_production:
         requires:
         - hold_production
+        filters:
+          branches:
+            only: master
+    - delete_uat:
         filters:
           branches:
             only: master

--- a/bin/delete_uat_release
+++ b/bin/delete_uat_release
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+GIT_MESSAGE=$(git log --format=%B -n 1 $CIRCLE_SHA1)
+
+if [[ $GIT_MESSAGE == "Merge pull request #"* ]]
+then
+  MERGED_BRANCH=$(echo $GIT_MESSAGE | sed -n "s/^.*from ministryofjustice\/\s*\(\S*\).*$/\1/p")
+  UAT_RELEASE="apply-$(echo $MERGED_BRANCH | sed 's:^\w*\/::' | tr -s ' _/[]()' '-' | cut -c1-30 | sed 's/-$//')"
+
+  echo "Attempting to delete UAT release $UAT_RELEASE"
+
+  UAT_RELEASES=$(helm list --tiller-namespace=${KUBE_ENV_UAT_NAMESPACE} --all)
+
+  echo "Current UAT releases:"
+  echo "$UAT_RELEASES"
+
+  if [[ $UAT_RELEASES == *"$UAT_RELEASE"* ]]
+  then
+    echo "Deleting UAT release $UAT_RELEASE"
+    helm delete $UAT_RELEASE --tiller-namespace=${KUBE_ENV_UAT_NAMESPACE} --purge
+  else
+    echo "UAT release $UAT_RELEASE was not found"
+  fi
+
+else
+  echo "This commit is not a merged pull request"
+fi


### PR DESCRIPTION
- only runs on master branch
- only runs when git message contains "Merge pull request #"
- Extract branch from git log
- Generate UAT release name the same way it is done when it's created
- Delete UAT release

I tested it by running the different commands in a CircleCI container but we can't really be sure it works until it's merged