### PR TITLE
AP-602 Standardise date formats

### DIFF
--- a/app/views/providers/bank_transactions/_list_selected.html.erb
+++ b/app/views/providers/bank_transactions/_list_selected.html.erb
@@ -11,7 +11,7 @@
     <% bank_transactions.each do |bank_transaction| %>
       <tr class="govuk-table__row">
         <td class="govuk-table__cell">
-          <%= l(bank_transaction.happened_at, format: :transaction_date) %>
+          <%= l(bank_transaction.happened_at.to_date, format: :short_date) %>
         </td>
         <td class="govuk-table__cell">
           <%= bank_transaction.description %>

--- a/config/locales/en/date.yml
+++ b/config/locales/en/date.yml
@@ -4,5 +4,5 @@ en:
     date_period: "%{from} to %{to}"
     formats:
       default: "%a, %d %b %Y"
-      long_date: "%d %B %Y"
-      short_date: "%d %b %Y"
+      long_date: "%-d %B %Y"
+      short_date: "%-d %b %Y"

--- a/config/locales/en/time.yml
+++ b/config/locales/en/time.yml
@@ -3,5 +3,4 @@ en:
   time:
     formats:
       date: "%a, %d %b %Y"
-      transaction_date: "%-d %b %Y"
       default: "%Y-%m-%d %H:%M:%S"

--- a/config/locales/en/time.yml
+++ b/config/locales/en/time.yml
@@ -3,5 +3,5 @@ en:
   time:
     formats:
       date: "%a, %d %b %Y"
-      transaction_date: "%d %b %Y"
+      transaction_date: "%-d %b %Y"
       default: "%Y-%m-%d %H:%M:%S"


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-602)

Dates should be formatted '1 July 2019' not '01 July 2019' - ie with no leading 0 on the day.

This PR amends the formatting in `locales/en/date.yml` so that dates are displayed correctly.

While changing this I noticed that the `transaction_date` format in `locales/en/time.yml` is a duplicate of the `short_date` format in `locales/en/date.yml`. `transaction_date` is only
used in one place so to avoid confusion I've removed it from `time.yml` and replaced that one instance with `short_date` instead.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
