### PR TITLE
Delete unused 'clean_old_releases' code

### DIFF
--- a/bin/uat_deploy
+++ b/bin/uat_deploy
@@ -1,25 +1,5 @@
 #!/bin/sh
 
-clean_old_releases() {
-  RELEASES=$(helm list --tiller-namespace=laa-apply-for-legalaid-uat --namespace=laa-apply-for-legalaid-uat --all -d -r -q)
-  RELEASE_COUNT=$(helm list --tiller-namespace=laa-apply-for-legalaid-uat --namespace=laa-apply-for-legalaid-uat --all -d -r -q | wc -l)
-  RELEASES_TO_KEEP=2
-  DIFF=$((RELEASE_COUNT-RELEASES_TO_KEEP))
-
-  echo "There are currently $RELEASE_COUNT releases."
-
-  if [[ $DIFF -gt -0 ]]; then
-    RELEASES_TO_DELETE=$(helm list --tiller-namespace=laa-apply-for-legalaid-uat --namespace=laa-apply-for-legalaid-uat --all -d -r -q | tail -n $DIFF)
-
-    echo "Cleaning the $DIFF most old ones..."
-    for release in $RELEASES_TO_DELETE; do
-      echo "[DRY-RUN] Deleting release $release..."
-    done
-  else
-    echo "No old releases to clean. Yay!"
-  fi
-}
-
 deploy() {
   IMG_REPO="$ECR_ENDPOINT/$GITHUB_TEAM_NAME_SLUG/$REPO_NAME"
   RELEASE_BRANCH=$(echo $CIRCLE_BRANCH | sed 's:^\w*\/::' | tr -s ' _/[]()' '-' | cut -c1-30 | sed 's/-$//')
@@ -39,5 +19,4 @@ deploy() {
                 --set ingress.hosts="{$RELEASE_HOST}"
 }
 
-clean_old_releases
 deploy


### PR DESCRIPTION
## What

`bin/uat_deploy` contains some old code which was intended to delete old UAT releases to prevent the number building up. It was never implemented properly and didn't actually delete anything, but gave the impression to the user that it did.

Following the recent change to delete old UAT instances when their branch is deleted in GitHub this code is completely redundant as well as being misleading, so I think we should remove it.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
