### PR TITLE
AP-816 Fix providers-offices relation

### DIFF
--- a/app/controllers/providers/applicants_controller.rb
+++ b/app/controllers/providers/applicants_controller.rb
@@ -25,7 +25,7 @@ module Providers
     def legal_aid_application
       @legal_aid_application ||= LegalAidApplication.create!(
         provider: current_provider,
-        office: current_provider.office
+        office: current_provider.selected_office
       )
     end
 

--- a/app/controllers/providers/confirm_offices_controller.rb
+++ b/app/controllers/providers/confirm_offices_controller.rb
@@ -5,12 +5,12 @@ module Providers
 
     def show
       if firm.offices.count == 1
-        current_provider.update!(office: firm.offices.first)
+        current_provider.update!(selected_office: firm.offices.first)
         redirect_to providers_legal_aid_applications_path
         return
       end
 
-      redirect_to providers_select_office_path unless current_provider.office
+      redirect_to providers_select_office_path unless current_provider.selected_office
     end
 
     def update
@@ -18,7 +18,7 @@ module Providers
       when 'yes'
         redirect_to providers_legal_aid_applications_path
       when 'no'
-        current_provider.update!(office: nil)
+        current_provider.update!(selected_office: nil)
         redirect_to providers_select_office_path
       else
         @error = I18n.t('providers.confirm_offices.show.error')

--- a/app/controllers/providers/select_offices_controller.rb
+++ b/app/controllers/providers/select_offices_controller.rb
@@ -27,7 +27,7 @@ module Providers
       merge_with_model(current_provider) do
         next {} unless params[:provider]
 
-        params.require(:provider).permit(:office_id)
+        params.require(:provider).permit(:selected_office_id)
       end
     end
   end

--- a/app/forms/providers/office_form.rb
+++ b/app/forms/providers/office_form.rb
@@ -4,14 +4,14 @@ module Providers
 
     form_for Provider
 
-    attr_accessor :office_id
+    attr_accessor :selected_office_id
 
-    validates :office_id, presence: true
+    validates :selected_office_id, presence: true
 
     delegate :firm, to: :model
 
     before_validation do
-      self.office_id = nil unless office_id.in?(firm.offices.pluck(:id))
+      self.selected_office_id = nil unless selected_office_id.in?(model.offices.pluck(:id))
     end
   end
 end

--- a/app/models/office.rb
+++ b/app/models/office.rb
@@ -1,6 +1,5 @@
 class Office < ApplicationRecord
-  has_many :providers
-  has_many :legal_aid_applications
-
   belongs_to :firm
+  has_many :legal_aid_applications
+  has_and_belongs_to_many :providers
 end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -4,9 +4,9 @@ class Provider < ApplicationRecord
   serialize :offices
 
   belongs_to :firm, optional: true
-  belongs_to :office, optional: true
-
+  belongs_to :selected_office, class_name: :Office, foreign_key: :selected_office_id, optional: true
   has_many :legal_aid_applications
+  has_and_belongs_to_many :offices
 
   def update_details
     return update_details_directly unless firm

--- a/app/services/ccms/case_add_requestor.rb
+++ b/app/services/ccms/case_add_requestor.rb
@@ -132,7 +132,7 @@ module CCMS
     def generate_provider_details(xml)
       xml.__send__('ns2:ProviderCaseReferenceNumber', 'PC4') # TODO: insert @legal_aid_application.provider_case_reference_number when it is available in Apply
       xml.__send__('ns2:ProviderFirmID', provider.firm_id)
-      xml.__send__('ns2:ProviderOfficeID', provider.office_id)
+      xml.__send__('ns2:ProviderOfficeID', provider.selected_office_id)
       xml.__send__('ns2:ContactUserID') do
         xml.__send__('ns0:UserLoginID', provider.username)
       end

--- a/app/services/provider_details_creator.rb
+++ b/app/services/provider_details_creator.rb
@@ -12,11 +12,18 @@ class ProviderDetailsCreator
   def call
     provider.update!(
       firm: firm,
-      details_response: provider_details
+      details_response: provider_details,
+      offices: offices
     )
+
+    provider.update!(selected_office: nil) if should_clear_selected_office?
   end
 
   private
+
+  def should_clear_selected_office?
+    !provider.selected_office.nil? && !provider.selected_office.id.in?(offices.pluck(:id))
+  end
 
   def firm
     Firm.find_or_create_by!(ccms_id: firm_id).tap do |firm|

--- a/app/views/providers/confirm_offices/show.html.erb
+++ b/app/views/providers/confirm_offices/show.html.erb
@@ -25,7 +25,7 @@
 
       <div class="govuk-!-padding-bottom-6"></div>
       <p class="govuk-body">
-        <strong><%= t('.account_number') %></strong> <%= current_provider.office.code %>
+        <strong><%= t('.account_number') %></strong> <%= current_provider.selected_office.code %>
       </p>
 
       <div class="govuk-!-padding-bottom-2"></div>

--- a/app/views/providers/select_offices/show.html.erb
+++ b/app/views/providers/select_offices/show.html.erb
@@ -3,7 +3,7 @@
 
     <%= govuk_fieldset_header(content_for(:page_title), padding_below: 6) %>
 
-    <%= form.govuk_collection_radio_buttons(:office_id, firm.offices, :id, :code) %>
+    <%= form.govuk_collection_radio_buttons(:selected_office_id, @form.model.offices, :id, :code) %>
 
     <div class="govuk-!-padding-bottom-2"></div>
 

--- a/ccms_integration/ccms_spec.rb
+++ b/ccms_integration/ccms_spec.rb
@@ -136,7 +136,7 @@ module CCMS
     let(:provider) do
       double 'Provider',
              firm_id: 22_381,
-             office_id: 81_693,
+             selected_office_id: 81_693,
              user_login_id: 2_016_472,
              supervisor_contact_id: 3_982_723,
              fee_earner_contact_id: 34_419

--- a/config/attribute-map.yml
+++ b/config/attribute-map.yml
@@ -1,2 +1,2 @@
 "LAA_APP_ROLES": "roles"
-"LAA_ACCOUNTS": "offices"
+"LAA_ACCOUNTS": "office_codes"

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -267,7 +267,7 @@ en:
                 none_selected: Select if your client has any of these types of assets
         provider:
           attributes:
-            office_id:
+            selected_office_id:
               blank: Select the office responsible for your applications
         respondent:
           attributes:

--- a/db/migrate/20190725130335_rename_provider_selected_office.rb
+++ b/db/migrate/20190725130335_rename_provider_selected_office.rb
@@ -1,0 +1,5 @@
+class RenameProviderSelectedOffice < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :providers, :office_id, :selected_office_id
+  end
+end

--- a/db/migrate/20190725130416_create_offices_providers.rb
+++ b/db/migrate/20190725130416_create_offices_providers.rb
@@ -1,0 +1,8 @@
+class CreateOfficesProviders < ActiveRecord::Migration[5.2]
+  def change
+    create_table :offices_providers, id: false do |t|
+      t.belongs_to :office, foreign_key: true, null: false, type: :uuid
+      t.belongs_to :provider, foreign_key: true, null: false, type: :uuid
+    end
+  end
+end

--- a/db/migrate/20190729100602_rename_provider_offices.rb
+++ b/db/migrate/20190729100602_rename_provider_offices.rb
@@ -1,0 +1,5 @@
+class RenameProviderOffices < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :providers, :offices, :office_codes
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_25_093333) do
+ActiveRecord::Schema.define(version: 2019_07_29_100602) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -339,6 +339,13 @@ ActiveRecord::Schema.define(version: 2019_07_25_093333) do
     t.index ["firm_id"], name: "index_offices_on_firm_id"
   end
 
+  create_table "offices_providers", id: false, force: :cascade do |t|
+    t.uuid "office_id", null: false
+    t.uuid "provider_id", null: false
+    t.index ["office_id"], name: "index_offices_providers_on_office_id"
+    t.index ["provider_id"], name: "index_offices_providers_on_provider_id"
+  end
+
   create_table "opponents", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "other_party_id"
     t.string "title"
@@ -421,12 +428,12 @@ ActiveRecord::Schema.define(version: 2019_07_25_093333) do
     t.inet "last_sign_in_ip"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.text "offices"
+    t.text "office_codes"
     t.json "details_response"
     t.uuid "firm_id"
-    t.uuid "office_id"
+    t.uuid "selected_office_id"
     t.index ["firm_id"], name: "index_providers_on_firm_id"
-    t.index ["office_id"], name: "index_providers_on_office_id"
+    t.index ["selected_office_id"], name: "index_providers_on_selected_office_id"
     t.index ["type"], name: "index_providers_on_type"
     t.index ["username"], name: "index_providers_on_username", unique: true
   end
@@ -545,11 +552,13 @@ ActiveRecord::Schema.define(version: 2019_07_25_093333) do
   add_foreign_key "legal_aid_applications", "providers"
   add_foreign_key "merits_assessments", "legal_aid_applications"
   add_foreign_key "offices", "firms"
+  add_foreign_key "offices_providers", "offices"
+  add_foreign_key "offices_providers", "providers"
   add_foreign_key "proceeding_type_scope_limitations", "proceeding_types"
   add_foreign_key "proceeding_type_scope_limitations", "scope_limitations"
   add_foreign_key "proceeding_types", "service_levels", column: "default_service_level_id", primary_key: "service_id"
   add_foreign_key "providers", "firms"
-  add_foreign_key "providers", "offices"
+  add_foreign_key "providers", "offices", column: "selected_office_id"
   add_foreign_key "respondents", "legal_aid_applications"
   add_foreign_key "savings_amounts", "legal_aid_applications"
   add_foreign_key "statement_of_cases", "legal_aid_applications"

--- a/features/step_definitions/civil_journey_steps.rb
+++ b/features/step_definitions/civil_journey_steps.rb
@@ -3,8 +3,9 @@
 Given(/^I am logged in as a provider$/) do
   @registered_provider = create(:provider, username: 'test_provider')
   login_as @registered_provider
-  @registered_provider.firm.offices << create(:office, code: 'London')
-  @registered_provider.firm.offices << create(:office, code: 'Manchester')
+  firm = @registered_provider.firm
+  @registered_provider.offices << create(:office, firm: firm, code: 'London')
+  @registered_provider.offices << create(:office, firm: firm, code: 'Manchester')
 end
 
 Given(/^I visit the application service$/) do
@@ -21,7 +22,7 @@ end
 
 Given('I have an existing office') do
   office = @registered_provider.firm.offices.find_by(code: 'London')
-  @registered_provider.update!(office: office)
+  @registered_provider.update!(selected_office: office)
 end
 
 Given(/^I visit the applications page$/) do

--- a/spec/factories/offices.rb
+++ b/spec/factories/offices.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :office do
-    ccms_id { rand(1..1000) }
-    code { rand(1..1000).to_s }
+    ccms_id { Faker::Number.unique.number(10) }
+    code { Faker::Number.unique.number(10) }
     firm
   end
 end

--- a/spec/requests/providers/applicants_spec.rb
+++ b/spec/requests/providers/applicants_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Providers::ApplicantsController, type: :request do
   let(:office) { create :office }
-  let(:provider) { create :provider, office: office }
+  let(:provider) { create :provider, selected_office: office }
   let(:login) { login_as provider }
 
   before { login }
@@ -36,7 +36,7 @@ RSpec.describe Providers::ApplicantsController, type: :request do
 
     it "creates an application with the provider's office" do
       expect { subject }.to change { provider.legal_aid_applications.count }.by(1)
-      expect(legal_aid_application.office.id).to eq(provider.office.id)
+      expect(legal_aid_application.office.id).to eq(provider.selected_office.id)
     end
 
     it 'creates an applicant' do

--- a/spec/requests/providers/confirm_offices_spec.rb
+++ b/spec/requests/providers/confirm_offices_spec.rb
@@ -1,10 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe 'provider confirm office', type: :request do
-  let(:provider) { create :provider, firm: firm, office: office }
   let(:firm) { create :firm }
   let!(:office) { create :office, firm: firm }
   let!(:office2) { create :office, firm: firm }
+  let(:provider) { create :provider, firm: firm, selected_office: office }
 
   describe 'GET providers/confirm_office' do
     subject { get providers_confirm_office_path }
@@ -36,7 +36,7 @@ RSpec.describe 'provider confirm office', type: :request do
         let!(:office) { nil }
 
         it 'assigns office 2 to the provider' do
-          expect(provider.reload.office).to eq office2
+          expect(provider.reload.selected_office).to eq office2
         end
 
         it 'redirects to the legal aid applications page' do
@@ -45,7 +45,7 @@ RSpec.describe 'provider confirm office', type: :request do
       end
 
       context 'provider has not selected office' do
-        let(:provider) { create :provider, firm: firm, office: nil }
+        let(:provider) { create :provider, firm: firm, selected_office: nil }
 
         it 'redirects to the select office page' do
           expect(response).to redirect_to providers_select_office_path
@@ -88,7 +88,7 @@ RSpec.describe 'provider confirm office', type: :request do
         end
 
         it 'clears the existing office' do
-          expect(provider.reload.office).to eq nil
+          expect(provider.reload.selected_office).to eq nil
         end
       end
     end

--- a/spec/requests/saml_sessions_spec.rb
+++ b/spec/requests/saml_sessions_spec.rb
@@ -4,7 +4,7 @@ require 'sidekiq/testing'
 RSpec.describe 'SamlSessionsController', type: :request do
   let(:firm) { nil }
   let(:office) { nil }
-  let(:provider) { create :provider, firm: firm, office: office }
+  let(:provider) { create :provider, firm: firm, selected_office: office }
 
   describe 'DELETE /providers/sign_out' do
     before { sign_in provider }

--- a/spec/services/ccms/case_add_requestor_spec.rb
+++ b/spec/services/ccms/case_add_requestor_spec.rb
@@ -65,7 +65,7 @@ module CCMS # rubocop:disable Metrics/ModuleLength
       let(:provider) do
         double Provider,
                firm_id: 19_148,
-               office_id: 137_570,
+               selected_office_id: 137_570,
                username: 4_953_649,
                contact_user_id: 4_953_649,
                supervisor_contact_id: 7_008_010,

--- a/spec/services/provider_details_creator_spec.rb
+++ b/spec/services/provider_details_creator_spec.rb
@@ -3,8 +3,8 @@ require 'rails_helper'
 RSpec.describe ProviderDetailsCreator do
   let(:provider) { create :provider }
   let(:ccms_firm) { OpenStruct.new(id: rand(1..1000), name: Faker::Company.name) }
-  let(:ccms_office_1) { OpenStruct.new(id: rand(1..1000), code: rand(1..1000).to_s) }
-  let(:ccms_office_2) { OpenStruct.new(id: rand(1..1000), code: rand(1..1000).to_s) }
+  let(:ccms_office_1) { OpenStruct.new(id: rand(1..100), code: rand(1..100).to_s) }
+  let(:ccms_office_2) { OpenStruct.new(id: rand(101..200), code: rand(101..200).to_s) }
   let(:api_response) do
     {
       providerOffices: [
@@ -12,18 +12,18 @@ RSpec.describe ProviderDetailsCreator do
           providerfirmId: ccms_firm.id,
           officeId: ccms_office_1.id,
           officeName: "#{ccms_firm.name}-#{ccms_office_1.code}",
-          smsVendorNum: rand(1..1000),
+          smsVendorNum: rand(1..100),
           smsVendorSite: ccms_office_1.code
         },
         {
           providerfirmId: ccms_firm.id,
           officeId: ccms_office_2.id,
           officeName: "#{ccms_firm.name}-#{ccms_office_2.code}",
-          smsVendorNum: rand(1..1000),
+          smsVendorNum: rand(101..200),
           smsVendorSite: ccms_office_2.code
         }
       ],
-      contactId: rand(1..1000),
+      contactId: rand(1..100),
       contactName: Faker::Name.name
     }
   end
@@ -49,6 +49,15 @@ RSpec.describe ProviderDetailsCreator do
       expect(office_2.code).to eq(ccms_office_2.code)
     end
 
+    context 'selected office of provider is not returned by the API' do
+      let(:selected_office) { create :office, code: 'selected-office' }
+      let(:provider) { create :provider, selected_office: selected_office }
+
+      it 'clears the selected office' do
+        expect { subject }.to change { provider.reload.selected_office }.to(nil)
+      end
+    end
+
     context 'firm already exists with one of the offices' do
       let!(:existing_firm) { create :firm, ccms_id: ccms_firm.id, name: 'foobar' }
       let!(:existing_office) { create :office, firm: existing_firm }
@@ -62,8 +71,50 @@ RSpec.describe ProviderDetailsCreator do
         expect { subject }.to change { existing_firm.reload.offices.count }.by(2)
       end
 
-      it 'should update the namne of the firm' do
+      it 'should update the name of the firm' do
         expect { subject }.to change { existing_firm.reload.name }.to(ccms_firm.name)
+      end
+    end
+
+    context 'another provider has the same firm but a different set of offices' do
+      let(:provider_2) { create :provider }
+      let(:ccms_office_3) { OpenStruct.new(id: rand(201..300), code: rand(201..300).to_s) }
+      let(:api_response_2) do
+        {
+          providerOffices: [
+            {
+              providerfirmId: ccms_firm.id,
+              officeId: ccms_office_2.id,
+              officeName: "#{ccms_firm.name}-#{ccms_office_2.code}",
+              smsVendorNum: rand(101..200),
+              smsVendorSite: ccms_office_2.code
+            },
+            {
+              providerfirmId: ccms_firm.id,
+              officeId: ccms_office_3.id,
+              officeName: "#{ccms_firm.name}-#{ccms_office_3.code}",
+              smsVendorNum: rand(201..300),
+              smsVendorSite: ccms_office_3.code
+            }
+          ],
+          contactId: rand(101..200),
+          contactName: Faker::Name.name
+        }
+      end
+      let(:firm) { provider.firm }
+      let(:office_3) { firm.offices.find_by(ccms_id: ccms_office_3.id) }
+
+      before do
+        allow(ProviderDetailsRetriever).to receive(:call).with(provider_2.username).and_return(api_response_2)
+        described_class.call(provider_2)
+        subject
+        provider.reload
+        provider_2.reload
+      end
+
+      it 'does not add all offices to both providers' do
+        expect(provider.offices).to contain_exactly(office_1, office_2)
+        expect(provider_2.offices).to contain_exactly(office_2, office_3)
       end
     end
   end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-816)

Changing the relations between providers and offices.

**Before:**
- A provider has one firm.
- A firm has several providers
- A firm has several offices

To get the list of offices a provider can access, we would do `provider.firm.offices` because we assumed that a provider could access all offices withing their firm.

**After**
We were wrong.
Providers withing the same firm don't always have access to all offices within their firm.
Therefore, this PR adds the `provider.offices` relation and prevent providers from selecting offices they don't have access to even if they belong to the same firm.
And changed `provider.office` to `provider.selected_office` to make it more obvious that this is the office they selected when they login but they can access all of `provider.offices` if they want.


## Checklist

Before you ask people to review this PR:

- [X] Tests and rubocop should be passing: `bundle exec rake`
- [X] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [X] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [X] The PR description should say what you changed and why, with a link to the JIRA story.
- [X] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [X] You should have checked that the commit messages say why the change was made.
