### PR TITLE
AP-826 Prevent double submit when selecting proceeding type

### DIFF
--- a/app/javascript/src/proceeding_types.js
+++ b/app/javascript/src/proceeding_types.js
@@ -7,6 +7,7 @@ $(function() {
 function searchProceedingTypes() {
   var submitForm = proceedingItem => {
     $(proceedingItem).find('form').submit();
+    return false;
   }
 
   $.getJSON("/v1/proceeding_types", function (proceedings_data) {
@@ -85,12 +86,12 @@ function searchProceedingTypes() {
     });
 
     $('.proceeding-item').on('click', function(e){
-      submitForm(this);
+      return submitForm(this);
     });
 
     $('.proceeding-item').on('keydown', function(e){
       if (e.which == 13) {
-        submitForm(this);
+        return submitForm(this);
       }
     });
   });


### PR DESCRIPTION
[Link to story](https://dsdmoj.atlassian.net/browse/AP-826)

A javascript event has been added to allow the user to select a proceeding type by clicking on the whole row and not necessarily on the button.
However, if you click on the button, you're basically clicking on the row and the button at the same time. Therefore, the javascript event gets triggered and the normal HTML form event gets also triggered. This submits the form twice.

Ending the JavaScript event with `return false` stops the event from propagating to its default event.

![image](https://user-images.githubusercontent.com/482806/62121209-1146ec80-b2bb-11e9-9765-66bc2ad95091.png)

## Checklist

Before you ask people to review this PR:

- [X] Tests and rubocop should be passing: `bundle exec rake`
- [X] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [X] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [X] The PR description should say what you changed and why, with a link to the JIRA story.
- [X] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [X] You should have checked that the commit messages say why the change was made.
