### PR TITLE
revert webhint upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@hint/connector-local": "^3.1.1",
+    "@hint/connector-local": "^3.0.2",
     "@rails/activestorage": "^6.0.0-alpha",
     "@rails/ujs": "^6.0.0-alpha",
     "@rails/webpacker": "^4.0.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -816,7 +816,17 @@
   optionalDependencies:
     canvas "^2.5.0"
 
-"@hint/connector-local@^3.0.2", "@hint/connector-local@^3.1.0", "@hint/connector-local@^3.1.1":
+"@hint/connector-local@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@hint/connector-local/-/connector-local-3.0.2.tgz#685276623df7d7f9354ee6bede28836bf7cbe039"
+  integrity sha512-cZmIDz1cIVNNJ7DSu3sqeYO0iYUprtyOVzS+NtQz5SI692vidF6uPEqUUUwGteI5McXfA+pndlkHyno2RnG++Q==
+  dependencies:
+    "@hint/utils" "^2.1.0"
+    chokidar "^3.0.0"
+    globby "^9.2.0"
+    jsdom "^15.1.0"
+
+"@hint/connector-local@^3.1.0":
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/@hint/connector-local/-/connector-local-3.1.1.tgz#502fc8457feeb0b92bd1e03da00099f3cf13115e"
   integrity sha512-eq9wWyBnw9o4hpvFTck/Gy7wUZZq/PEm94XoJ+MdmS9QDwTM8QdAdqyIjSGiNDaiBdVUsSF9p+yW9Up9oH34/w==
@@ -2874,7 +2884,7 @@ chokidar@^2.0.2, chokidar@^2.1.6:
   optionalDependencies:
     fsevents "^1.2.7"
 
-chokidar@^3.0.2:
+chokidar@^3.0.0, chokidar@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.0.2.tgz#0d1cd6d04eb2df0327446188cd13736a3367d681"
   integrity sha512-c4PR2egjNjI1um6bamCQ6bUNPDiyofNQruHvKgHQ4gDUP/ITSVSzNsiI5OWtHOsX323i5ha/kk4YmOZ1Ktg7KA==


### PR DESCRIPTION
## What

I approved this Dependabot PR earlier https://github.com/ministryofjustice/laa-apply-for-legal-aid/pull/697. It seems to be causing failures on `master` now. This reverts it so it can be investigated properly.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
