### PR TITLE
Ap835 hard coded ccms true results and 839 APP_AMEND_TYPE

### DIFF
--- a/app/models/ccms/submission.rb
+++ b/app/models/ccms/submission.rb
@@ -20,14 +20,14 @@ module CCMS
         ObtainApplicantReferenceService.call(self)
       when 'applicant_submitted'
         CheckApplicantStatusService.call(self)
-      when 'applicant_ref_obtained'
-        AddCaseService.call(self, options)
-      when 'case_submitted'
-        CheckCaseStatusService.call(self)
       when 'case_created'
         ObtainDocumentIdService.call(self)
       when 'document_ids_obtained'
         UploadDocumentsService.call(self)
+      when 'applicant_ref_obtained'
+        AddCaseService.call(self, options)
+      when 'case_submitted'
+        CheckCaseStatusService.call(self)
       else
         raise CcmsError, "Unknown state: #{aasm_state}"
       end

--- a/app/services/ccms/attribute_value_generator.rb
+++ b/app/services/ccms/attribute_value_generator.rb
@@ -86,7 +86,7 @@ module CCMS
       @legal_aid_application.used_delegated_functions_on.strftime('%d-%m-%Y')
     end
 
-    def app_ammendment_type(_options)
+    def app_amendment_type(_options)
       @legal_aid_application.used_delegated_functions? ? 'SUBDP' : 'SUB'
     end
 

--- a/app/services/ccms/attribute_value_generator.rb
+++ b/app/services/ccms/attribute_value_generator.rb
@@ -86,6 +86,10 @@ module CCMS
       @legal_aid_application.used_delegated_functions_on.strftime('%d-%m-%Y')
     end
 
+    def app_ammendment_type(_options)
+      @legal_aid_application.used_delegated_functions? ? 'SUBDP' : 'SUB'
+    end
+
     private
 
     def standardly_named_method?(method)

--- a/config/ccms/ccms_keys.yml
+++ b/config/ccms/ccms_keys.yml
@@ -253,7 +253,7 @@ global_means:
     :response_type: currency
     :user_defined: false
   APP_AMEND_TYPE:
-    :value: "#app_ammendment_type"
+    :value: "#app_amendment_type"
     :br100_meaning: 'App: The application or amendment type'
     :response_type: text
     :user_defined: true
@@ -2355,7 +2355,7 @@ global_merits:
     :response_type: boolean
     :user_defined: false
   APP_AMEND_TYPE:
-    :value: "#app_ammendment_type"
+    :value: "#app_amendment_type"
     :br100_meaning: 'App: The application or amendment type'
     :response_type: text
     :user_defined: true

--- a/config/ccms/ccms_keys.yml
+++ b/config/ccms/ccms_keys.yml
@@ -253,7 +253,7 @@ global_means:
     :response_type: currency
     :user_defined: false
   APP_AMEND_TYPE:
-    :value: SUBDP
+    :value: "#app_ammendment_type"
     :br100_meaning: 'App: The application or amendment type'
     :response_type: text
     :user_defined: true
@@ -2355,7 +2355,7 @@ global_merits:
     :response_type: boolean
     :user_defined: false
   APP_AMEND_TYPE:
-    :value: SUBDP
+    :value: "#app_ammendment_type"
     :br100_meaning: 'App: The application or amendment type'
     :response_type: text
     :user_defined: true

--- a/spec/services/ccms/case_add_requestor_xml_blocks_spec.rb
+++ b/spec/services/ccms/case_add_requestor_xml_blocks_spec.rb
@@ -195,6 +195,52 @@ module CCMS # rubocop:disable Metrics/ModuleLength
           end
         end
       end
+
+      context 'APP_AMEND_TYPE' do
+        context 'delegated function used' do
+          context 'in global_merits section' do
+            it 'returns SUBDP' do
+              allow(legal_aid_application).to receive(:used_delegated_functions?).and_return(true)
+              allow(legal_aid_application).to receive(:used_delegated_functions_on).and_return(Date.today)
+              block = XmlExtractor.call(xml, :global_merits, 'APP_AMEND_TYPE')
+              expect(block).to be_present
+              expect(block).to have_response_type 'text'
+              expect(block).to have_response_value 'SUBDP'
+            end
+
+            context 'in global_means section;' do
+              it 'returns SUBDP' do
+                allow(legal_aid_application).to receive(:used_delegated_functions?).and_return(true)
+                allow(legal_aid_application).to receive(:used_delegated_functions_on).and_return(Date.today)
+                block = XmlExtractor.call(xml, :global_means, 'APP_AMEND_TYPE')
+                expect(block).to be_present
+                expect(block).to have_response_type 'text'
+                expect(block).to have_response_value 'SUBDP'
+              end
+            end
+          end
+        end
+
+        context 'delegated functions not used' do
+          context 'in global_merits section' do
+            it 'returns SUB' do
+              block = XmlExtractor.call(xml, :global_merits, 'APP_AMEND_TYPE')
+              expect(block).to be_present
+              expect(block).to have_response_type 'text'
+              expect(block).to have_response_value 'SUB'
+            end
+
+            context 'in global_means section;' do
+              it 'returns SUB' do
+                block = XmlExtractor.call(xml, :global_means, 'APP_AMEND_TYPE')
+                expect(block).to be_present
+                expect(block).to have_response_type 'text'
+                expect(block).to have_response_value 'SUB'
+              end
+            end
+          end
+        end
+      end
     end
   end
 end

--- a/spec/services/ccms/case_add_requestor_xml_blocks_spec.rb
+++ b/spec/services/ccms/case_add_requestor_xml_blocks_spec.rb
@@ -24,14 +24,14 @@ module CCMS # rubocop:disable Metrics/ModuleLength
           end
 
           it 'generates the delegated functions block in the means assessment section' do
-            block = XmlExtractor.call(xml, :means_assessment, 'DELEGATED_FUNCTIONS_DATE')
+            block = XmlExtractor.call(xml, :global_means, 'DELEGATED_FUNCTIONS_DATE')
             expect(block).to be_present
             expect(block).to have_response_type('date')
             expect(block).to have_response_value(Date.today.strftime('%d-%m-%Y'))
           end
 
           it 'generates the delegated functions block in the merits assessment section' do
-            block = XmlExtractor.call(xml, :merits_assessment, 'DELEGATED_FUNCTIONS_DATE')
+            block = XmlExtractor.call(xml, :global_merits, 'DELEGATED_FUNCTIONS_DATE')
             expect(block).to be_present
             expect(block).to have_response_type('date')
             expect(block).to have_response_value(Date.today.strftime('%d-%m-%Y'))
@@ -40,12 +40,12 @@ module CCMS # rubocop:disable Metrics/ModuleLength
 
         context 'delegated functions not used' do
           it 'does not generate the delegated functions block in the means assessment section' do
-            block = XmlExtractor.call(xml, :means_assessment, 'DELEGATED_FUNCTIONS_DATE')
+            block = XmlExtractor.call(xml, :global_means, 'DELEGATED_FUNCTIONS_DATE')
             expect(block).not_to be_present
           end
 
           it 'does not generates the delegated functions block in the merits assessment section' do
-            block = XmlExtractor.call(xml, :merits_assessment, 'DELEGATED_FUNCTIONS_DATE')
+            block = XmlExtractor.call(xml, :global_merits, 'DELEGATED_FUNCTIONS_DATE')
             expect(block).not_to be_present
           end
         end
@@ -55,7 +55,7 @@ module CCMS # rubocop:disable Metrics/ModuleLength
         context 'police notified' do
           before { respondent.update(police_notified: true) }
           it 'is true' do
-            block = XmlExtractor.call(xml, :merits_assessment, 'POLICE_NOTIFIED')
+            block = XmlExtractor.call(xml, :global_merits, 'POLICE_NOTIFIED')
             expect(block).to be_present
             expect(block).to have_response_type 'boolean'
             expect(block).to have_response_value 'true'
@@ -65,7 +65,7 @@ module CCMS # rubocop:disable Metrics/ModuleLength
         context 'police NOT notified' do
           before { respondent.update(police_notified: false) }
           it 'is false' do
-            block = XmlExtractor.call(xml, :merits_assessment, 'POLICE_NOTIFIED')
+            block = XmlExtractor.call(xml, :global_merits, 'POLICE_NOTIFIED')
             expect(block).to be_present
             expect(block).to have_response_type 'boolean'
             expect(block).to have_response_value 'false'
@@ -77,14 +77,14 @@ module CCMS # rubocop:disable Metrics/ModuleLength
         context 'not sent' do
           before { respondent.update(warning_letter_sent: false) }
           it 'generates WARNING_LETTER_SENT block with false value' do
-            block = XmlExtractor.call(xml, :merits_assessment, 'WARNING_LETTER_SENT')
+            block = XmlExtractor.call(xml, :global_merits, 'WARNING_LETTER_SENT')
             expect(block).to be_present
             expect(block).to have_response_type 'boolean'
             expect(block).to have_response_value 'false'
           end
 
           it 'generates INJ_REASON_NO_WARNING_LETTER block with reason' do
-            block = XmlExtractor.call(xml, :merits_assessment, 'INJ_REASON_NO_WARNING_LETTER')
+            block = XmlExtractor.call(xml, :global_merits, 'INJ_REASON_NO_WARNING_LETTER')
             expect(block).to be_present
             expect(block).to have_response_type 'text'
             expect(block).to have_response_value legal_aid_application.respondent.warning_letter_sent_details
@@ -94,7 +94,7 @@ module CCMS # rubocop:disable Metrics/ModuleLength
         context 'sent' do
           it 'generates WARNING_LETTER_SENT block with true value' do
             respondent.update(warning_letter_sent: true)
-            block = XmlExtractor.call(xml, :merits_assessment, 'WARNING_LETTER_SENT')
+            block = XmlExtractor.call(xml, :global_merits, 'WARNING_LETTER_SENT')
             expect(block).to be_present
             expect(block).to have_response_type 'boolean'
             expect(block).to have_response_value 'true'
@@ -102,7 +102,7 @@ module CCMS # rubocop:disable Metrics/ModuleLength
 
           it 'does not generates INJ_REASON_NO_WARNING_LETTER block' do
             respondent.update(warning_letter_sent: true)
-            block = XmlExtractor.call(xml, :merits_assessment, 'INJ_REASON_NO_WARNING_LETTER')
+            block = XmlExtractor.call(xml, :global_merits, 'INJ_REASON_NO_WARNING_LETTER')
             expect(block).not_to be_present
           end
         end
@@ -112,7 +112,7 @@ module CCMS # rubocop:disable Metrics/ModuleLength
         context 'respondent has capacity' do
           before { respondent.understands_terms_of_court_order = true }
           it 'is true' do
-            block = XmlExtractor.call(xml, :merits_assessment, 'INJ_RESPONDENT_CAPACITY')
+            block = XmlExtractor.call(xml, :global_merits, 'INJ_RESPONDENT_CAPACITY')
             expect(block).to be_present
             expect(block).to have_response_type 'boolean'
             expect(block).to have_response_value 'true'
@@ -122,7 +122,7 @@ module CCMS # rubocop:disable Metrics/ModuleLength
         context 'respondent does not have capacity' do
           before { respondent.understands_terms_of_court_order = false }
           it 'is false' do
-            block = XmlExtractor.call(xml, :merits_assessment, 'INJ_RESPONDENT_CAPACITY')
+            block = XmlExtractor.call(xml, :global_merits, 'INJ_RESPONDENT_CAPACITY')
             expect(block).to be_present
             expect(block).to have_response_type 'boolean'
             expect(block).to have_response_value 'false'
@@ -132,10 +132,45 @@ module CCMS # rubocop:disable Metrics/ModuleLength
 
       context 'PROC_MATTER_TYPE_MEANING' do
         it 'should be the meaning from the proceeding type record' do
-          block = XmlExtractor.call(xml, :merits_assessment, 'PROC_MATTER_TYPE_MEANING')
+          block = XmlExtractor.call(xml, :global_merits, 'PROC_MATTER_TYPE_MEANING')
           expect(block).to be_present
           expect(block).to have_response_type 'text'
           expect(block).to have_response_value legal_aid_application.lead_proceeding_type.meaning
+        end
+      end
+
+      context 'LAR_SCOPE_FLAG' do
+        it 'should be hard coded to true' do
+          block = XmlExtractor.call(xml, :global_means, 'LAR_SCOPE_FLAG')
+          expect(block).to be_present
+          expect(block).to have_response_type 'boolean'
+          expect(block).to have_response_value 'true'
+        end
+      end
+
+      context 'attributes hard coded to true' do
+        it 'should be hard coded to true' do
+          attributes = [
+            [:global_means, 'LAR_SCOPE_FLAG'],
+            [:global_means, 'GB_INPUT_B_38WP3_2SCREEN'],
+            [:global_means, 'GB_INPUT_B_38WP3_3SCREEN'],
+            [:global_merits, 'MERITS_DECLARATION_SCREEN'],
+            [:global_means, 'GB_DECL_B_38WP3_13A'],
+            [:global_merits, 'CLIENT_HAS_DV_RISK'],
+            [:global_merits,  'CLIENT_REQ_SEP_REP'],
+            [:global_merits,  'DECLARATION_WILL_BE_SIGNED'],
+            [:global_merits,  'DECLARATION_REVOKE_IMP_SUBDP'],
+            [:proceeding, 'SCOPE_LIMIT_IS_DEFAULT'],
+            [:proceeding_merits,  'LEAD_PROCEEDING'],
+            [:proceeding_merits,  'SCOPE_LIMIT_IS_DEFAULT']
+          ]
+          attributes.each do |entity_attribute_pair|
+            entity, attribute = entity_attribute_pair
+            block = XmlExtractor.call(xml, entity, attribute)
+            expect(block).to be_present
+            expect(block).to have_response_type 'boolean'
+            expect(block).to have_response_value 'true'
+          end
         end
       end
 
@@ -143,7 +178,7 @@ module CCMS # rubocop:disable Metrics/ModuleLength
         context 'bail conditions set' do
           before { respondent.bail_conditions_set = true }
           it 'is true' do
-            block = XmlExtractor.call(xml, :merits_assessment, 'BAIL_CONDITIONS_SET')
+            block = XmlExtractor.call(xml, :global_merits, 'BAIL_CONDITIONS_SET')
             expect(block).to be_present
             expect(block).to have_response_type 'boolean'
             expect(block).to have_response_value 'true'
@@ -153,7 +188,7 @@ module CCMS # rubocop:disable Metrics/ModuleLength
         context 'bail conditions NOT set' do
           before { respondent.bail_conditions_set = false }
           it 'is false' do
-            block = XmlExtractor.call(xml, :merits_assessment, 'BAIL_CONDITIONS_SET')
+            block = XmlExtractor.call(xml, :global_merits, 'BAIL_CONDITIONS_SET')
             expect(block).to be_present
             expect(block).to have_response_type 'boolean'
             expect(block).to have_response_value 'false'

--- a/spec/services/ccms/case_add_requestor_xml_blocks_spec.rb
+++ b/spec/services/ccms/case_add_requestor_xml_blocks_spec.rb
@@ -139,15 +139,6 @@ module CCMS # rubocop:disable Metrics/ModuleLength
         end
       end
 
-      context 'LAR_SCOPE_FLAG' do
-        it 'should be hard coded to true' do
-          block = XmlExtractor.call(xml, :global_means, 'LAR_SCOPE_FLAG')
-          expect(block).to be_present
-          expect(block).to have_response_type 'boolean'
-          expect(block).to have_response_value 'true'
-        end
-      end
-
       context 'attributes hard coded to true' do
         it 'should be hard coded to true' do
           attributes = [

--- a/spec/support/xml_extractor.rb
+++ b/spec/support/xml_extractor.rb
@@ -1,8 +1,10 @@
 class XmlExtractor
   # rubocop:disable Metrics/LineLength
   XPATHS = {
-    means_assessment: '/Envelope/Body/CaseAddRQ/Case/CaseDetails/ApplicationDetails/MeansAssesments/AssesmentResults/AssesmentDetails/AssessmentScreens/Entity/Instances/Attributes/Attribute',
-    merits_assessment: '/Envelope/Body/CaseAddRQ/Case/CaseDetails/ApplicationDetails/MeritsAssesments/AssesmentResults/AssesmentDetails/AssessmentScreens/Entity/Instances/Attributes/Attribute'
+    global_means: '/Envelope/Body/CaseAddRQ/Case/CaseDetails/ApplicationDetails/MeansAssesments/AssesmentResults/AssesmentDetails/AssessmentScreens/Entity/Instances/Attributes/Attribute',
+    global_merits: '/Envelope/Body/CaseAddRQ/Case/CaseDetails/ApplicationDetails/MeritsAssesments/AssesmentResults/AssesmentDetails/AssessmentScreens/Entity/Instances/Attributes/Attribute',
+    proceeding: %(/Envelope/Body/CaseAddRQ/Case/CaseDetails/ApplicationDetails/MeansAssesments/AssesmentResults/AssesmentDetails/AssessmentScreens/Entity[EntityName = "PROCEEDING"]//Attributes/Attribute),
+    proceeding_merits: %(/Envelope/Body/CaseAddRQ/Case/CaseDetails/ApplicationDetails/MeritsAssesments/AssesmentResults/AssesmentDetails/AssessmentScreens/Entity[EntityName = "PROCEEDING"]//Attributes/Attribute)
   }.freeze
   # rubocop:enable Metrics/LineLength
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-835)
[Link to story](https://dsdmoj.atlassian.net/browse/AP-839)

renamed merits_assessment and means_assessment in the XmlExtractor to deal with a naming disparity with the xml file.

checked that hard coded true values were correct and added tests for these values.

reordered ccms case submission states to make it more readable

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
