### PR TITLE
Remove buggy migration and align DB with migrations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,8 +116,10 @@ jobs:
         command: |
           if [ "${CIRCLE_NODE_INDEX}" == "0" ]; then
             sudo apt install -y postgresql-client || true
-            bundle exec rake db:setup
-            bundle exec rake db:migrate
+            git checkout origin/master
+            bundle exec rake db:create db:schema:load
+            git checkout -
+            bundle exec rake db:migrate db:seed
           fi
     - restore_cache:
         keys:

--- a/db/migrate/20190724135655_add_enum_column_to_application_scope_limitations.rb
+++ b/db/migrate/20190724135655_add_enum_column_to_application_scope_limitations.rb
@@ -1,5 +1,0 @@
-class AddEnumColumnToApplicationScopeLimitations < ActiveRecord::Migration[5.2]
-  def change
-    add_column :application_scope_limitations, :substantive, :boolean, default: true
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,6 +11,7 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 2019_07_29_100602) do
+
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -91,7 +92,6 @@ ActiveRecord::Schema.define(version: 2019_07_29_100602) do
     t.uuid "proceeding_type_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["legal_aid_application_id", "proceeding_type_id"], name: "app_proceeding_type_index", unique: true
     t.index ["legal_aid_application_id"], name: "index_application_proceeding_types_on_legal_aid_application_id"
     t.index ["proceeding_type_id"], name: "index_application_proceeding_types_on_proceeding_type_id"
   end
@@ -99,10 +99,9 @@ ActiveRecord::Schema.define(version: 2019_07_29_100602) do
   create_table "application_scope_limitations", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "legal_aid_application_id"
     t.uuid "scope_limitation_id"
+    t.boolean "substantive", default: true
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.boolean "substantive", default: true
-    t.index ["legal_aid_application_id", "scope_limitation_id"], name: "scope_limitations_index", unique: true
     t.index ["legal_aid_application_id"], name: "index_application_scope_limitations_on_legal_aid_application_id"
   end
 
@@ -277,23 +276,23 @@ ActiveRecord::Schema.define(version: 2019_07_29_100602) do
     t.boolean "open_banking_consent"
     t.datetime "open_banking_consent_choice_at"
     t.string "own_home"
-    t.decimal "percentage_home"
     t.decimal "property_value", precision: 10, scale: 2
     t.string "shared_ownership"
     t.decimal "outstanding_mortgage_amount"
+    t.decimal "percentage_home"
     t.string "provider_step"
     t.uuid "provider_id"
     t.boolean "draft"
     t.datetime "transaction_period_start_at"
     t.datetime "transaction_period_finish_at"
     t.boolean "transactions_gathered"
+    t.datetime "completed_at"
     t.json "applicant_means_answers"
     t.datetime "declaration_accepted_at"
-    t.datetime "completed_at"
     t.json "provider_step_params"
-    t.boolean "own_vehicle"
     t.date "used_delegated_functions_on"
     t.boolean "used_delegated_functions"
+    t.boolean "own_vehicle"
     t.date "substantive_application_deadline_on"
     t.boolean "substantive_application"
     t.boolean "has_dependants"
@@ -325,9 +324,9 @@ ActiveRecord::Schema.define(version: 2019_07_29_100602) do
     t.text "application_purpose"
     t.boolean "proceedings_before_the_court"
     t.text "details_of_proceedings_before_the_court"
-    t.decimal "estimated_legal_cost", precision: 10, scale: 2
     t.string "success_prospect"
     t.text "success_prospect_details"
+    t.decimal "estimated_legal_cost", precision: 10, scale: 2
     t.datetime "submitted_at"
     t.boolean "success_likely"
     t.index ["legal_aid_application_id"], name: "index_merits_assessments_on_legal_aid_application_id"
@@ -367,15 +366,15 @@ ActiveRecord::Schema.define(version: 2019_07_29_100602) do
 
   create_table "other_assets_declarations", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "legal_aid_application_id", null: false
-    t.decimal "second_home_value", precision: 14, scale: 2
-    t.decimal "second_home_mortgage", precision: 14, scale: 2
-    t.decimal "second_home_percentage", precision: 14, scale: 2
-    t.decimal "timeshare_property_value", precision: 14, scale: 2
-    t.decimal "land_value", precision: 14, scale: 2
-    t.decimal "valuable_items_value", precision: 14, scale: 2
-    t.decimal "money_assets_value", precision: 14, scale: 2
-    t.decimal "money_owed_value", precision: 14, scale: 2
-    t.decimal "trust_value", precision: 14, scale: 2
+    t.decimal "second_home_value"
+    t.decimal "second_home_mortgage"
+    t.decimal "second_home_percentage"
+    t.decimal "timeshare_property_value"
+    t.decimal "land_value"
+    t.decimal "valuable_items_value"
+    t.decimal "money_assets_value"
+    t.decimal "money_owed_value"
+    t.decimal "trust_value"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["legal_aid_application_id"], name: "index_other_assets_declarations_on_legal_aid_application_id", unique: true


### PR DESCRIPTION
[Sentry Error](https://sentry.service.dsd.io/mojds/apply-for-legal-aid-staging/issues/36929/)

PR https://github.com/ministryofjustice/laa-apply-for-legal-aid/pull/683 adds two migrations adding the same column so the second is crashing and preventing `db:migrate` to work.

- I'm removing this migration
- Changing CircleCI to use `db:schema:load` from master and then `db:migrate` from the branch. In order to mimic the behaviour in live but without having to run old migrations.
- I also took the opportunity to align our `schema.rb` file with what is really generated by the migrations and is, therefore, the real state of the DB in production envs.

## Checklist

Before you ask people to review this PR:

- [X] Tests and rubocop should be passing: `bundle exec rake`
- [X] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [X] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [X] The PR description should say what you changed and why, with a link to the JIRA story.
- [X] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [X] You should have checked that the commit messages say why the change was made.
