### PR TITLE
AP-858 Avoid webhint false positives

### DIFF
--- a/.hintrc
+++ b/.hintrc
@@ -15,6 +15,7 @@
     "highest-available-document-mode": "error",
     "html-checker": ["error", {
         "ignore": [
+          "Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.",
           "Attribute “src” not allowed on element “image” at this point.",
           "The “banner” role is unnecessary for element “header”.",
           "The “button” role is unnecessary for element “button”.",

--- a/app/services/html_page_saver.rb
+++ b/app/services/html_page_saver.rb
@@ -1,0 +1,35 @@
+class HtmlPageSaver
+  attr_accessor :html, :file_path, :asset_host
+
+  def self.call(*args)
+    new(*args).call
+  end
+
+  def initialize(html:, file_path:, asset_host:)
+    @html = html
+    @file_path = file_path
+    @asset_host = asset_host
+  end
+
+  def call
+    add_asset_host
+    save_file
+  end
+
+  private
+
+  def save_file
+    File.write(prepared_path, html, mode: 'wb')
+  end
+
+  def prepared_path
+    File.expand_path(file_path).tap do |path|
+      FileUtils.mkdir_p(File.dirname(path))
+    end
+  end
+
+  def add_asset_host
+    match = html.match(/charset=['"]utf-8['"] *>/) || html.match(/<head[^<]*?>/) || return
+    html.insert(match.end(0), "<base href=\"#{asset_host}\" />")
+  end
+end

--- a/spec/services/html_page_saver_spec.rb
+++ b/spec/services/html_page_saver_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe HtmlPageSaver do
+  describe '.call' do
+    let(:html) { '<html><head><meta charset="utf-8"><meta a="b"></head></html>' }
+    let(:file_path) { Rails.root.join('tmp', 'page.html') }
+    let(:asset_host) { 'http://localhost:3004' }
+    let(:expected_html) { html.sub('"utf-8">', '"utf-8"><base href="http://localhost:3004" />') }
+    let(:expected_file) { File.expand_path(file_path) }
+
+    subject { described_class.call(html: html, file_path: file_path, asset_host: asset_host) }
+
+    before { expect(File).to receive(:write).with(expected_file, expected_html, mode: 'wb') }
+
+    it 'writes the right html to the right file' do
+      subject
+    end
+
+    context 'html does not have meta charset' do
+      let(:html) { '<html><head><meta a="b"></head></html>' }
+      let(:expected_html) { html.sub('head>', 'head><base href="http://localhost:3004" />') }
+
+      it 'writes the base tag after <head>' do
+        subject
+      end
+    end
+
+    context 'html does not have <head>' do
+      let(:html) { '<html></html>' }
+      let(:expected_html) { html }
+
+      it 'does not crash' do
+        subject
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-858)

Avoid these WebHint false positives:
 - Don't check pages from TrueLayer
 - Doctype not being present
 -  "'charset' meta element should be the first thing in '<head>'."

The last one happened because Capybara's `page.save_page` inserts `<base href="http://localhost:3004" />`  as the first element in the `<head>` tag.
So this PR implements it better to avoid the WebHint error.

For the Doctype error, the problem is that the page saved to file does not include the Doctype and I didn't manage to fix that so I added this error as an exception in Webhint's config.

## Checklist

Before you ask people to review this PR:

- [X] Tests and rubocop should be passing: `bundle exec rake`
- [X] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [X] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [X] The PR description should say what you changed and why, with a link to the JIRA story.
- [X] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [X] You should have checked that the commit messages say why the change was made.
