### PR TITLE
AP-778 Save provider name and email

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,7 @@ gem 'pagy'
 gem 'browser'
 
 # Used to mock saml request in UAT
-gem 'ruby-saml-idp'
+gem 'ruby-saml-idp', github: 'dev-develop/ruby-saml-idp', branch: 'master'
 
 # Used to encrypt JSON stored in SecureData
 gem 'jwt'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,10 @@
+GIT
+  remote: https://github.com/dev-develop/ruby-saml-idp.git
+  revision: e8c9ba90a0f868e03d033133df1d2b035b9b65a9
+  branch: master
+  specs:
+    ruby-saml-idp (0.3.2)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -346,7 +353,6 @@ GEM
     ruby-progressbar (1.10.1)
     ruby-saml (1.9.0)
       nokogiri (>= 1.5.10)
-    ruby-saml-idp (0.3.5)
     ruby_dep (1.5.0)
     rubyzip (1.2.3)
     safe_yaml (1.0.5)
@@ -501,7 +507,7 @@ DEPENDENCIES
   rspec-rails (~> 3.8)
   rubocop
   rubocop-performance
-  ruby-saml-idp
+  ruby-saml-idp!
   sass-rails (~> 5.0)
   savon (~> 2.12.0)
   selenium-webdriver

--- a/app/services/provider_details_creator.rb
+++ b/app/services/provider_details_creator.rb
@@ -13,13 +13,18 @@ class ProviderDetailsCreator
     provider.update!(
       firm: firm,
       details_response: provider_details,
-      offices: offices
+      offices: offices,
+      name: provider_name
     )
 
     provider.update!(selected_office: nil) if should_clear_selected_office?
   end
 
   private
+
+  def provider_name
+    provider_details[:contactName]
+  end
 
   def should_clear_selected_office?
     !provider.selected_office.nil? && !provider.selected_office.id.in?(offices.pluck(:id))

--- a/app/views/providers/providers/show.html.erb
+++ b/app/views/providers/providers/show.html.erb
@@ -6,11 +6,15 @@
     <tbody class="govuk-table__body">
       <tr class="govuk-table__row">
         <th class="govuk-table__header" scope="row"><%= t('.name') %></th>
+        <td class="govuk-table__cell"><%= @provider.name %></td>
+      </tr>
+      <tr class="govuk-table__row">
+        <th class="govuk-table__header" scope="row"><%= t('.username') %></th>
         <td class="govuk-table__cell"><%= @provider.username %></td>
       </tr>
       <tr class="govuk-table__row">
         <th class="govuk-table__header" scope="row"><%= t('.email') %></th>
-        <td class="govuk-table__cell"></td>
+        <td class="govuk-table__cell"><%= @provider.email %></td>
       </tr>
       <tr class="govuk-table__row">
         <th class="govuk-table__header" scope="row"><%= t('.role') %></th>

--- a/config/attribute-map.yml
+++ b/config/attribute-map.yml
@@ -1,2 +1,3 @@
 "LAA_APP_ROLES": "roles"
 "LAA_ACCOUNTS": "office_codes"
+"USER_EMAIL": "email"

--- a/config/initializers/mock_saml.rb
+++ b/config/initializers/mock_saml.rb
@@ -1,9 +1,10 @@
+# frozen_string_literal: true
+
 Rails.configuration.x.application.mock_saml = OpenStruct.new(
-  usernames: [
-    'really-really-long-email-address@example.com'.freeze,
-    'test1@example.com'.freeze,
-    'test2@example.com'.freeze,
-    '1.office@example.com'.freeze
+  users: [
+    OpenStruct.new(username: 'test1', email: 'test1@example.com'),
+    OpenStruct.new(username: 'test2', email: 'test2@example.com'),
+    OpenStruct.new(username: 'test3', email: 'really-really-long-email-address@example.com')
   ],
-  password: 'password'.freeze
+  password: 'password'
 )

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -287,6 +287,7 @@ en:
         name: Name
         page_title: Your profile
         role: Role
+        username: Username
     respondents:
       show:
         h1-heading: Respondent details
@@ -300,8 +301,8 @@ en:
     restrictions:
       show:
         h1-heading: Are there any legal restrictions that prevent your client from selling or borrowing against their assets?
-        restrictions_details: Tell us which assets they cannot sell or borrow against, and why      
-        for_example: "For example:" 
+        restrictions_details: Tell us which assets they cannot sell or borrow against, and why
+        for_example: "For example:"
         examples:
           list: |
             they're bankrupt

--- a/db/migrate/20190806115955_add_name_and_email_to_providers.rb
+++ b/db/migrate/20190806115955_add_name_and_email_to_providers.rb
@@ -1,0 +1,6 @@
+class AddNameAndEmailToProviders < ActiveRecord::Migration[5.2]
+  def change
+    add_column :providers, :name, :string
+    add_column :providers, :email, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_29_100602) do
+ActiveRecord::Schema.define(version: 2019_08_06_115955) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -434,6 +434,8 @@ ActiveRecord::Schema.define(version: 2019_07_29_100602) do
     t.json "details_response"
     t.uuid "firm_id"
     t.uuid "selected_office_id"
+    t.string "name"
+    t.string "email"
     t.index ["firm_id"], name: "index_providers_on_firm_id"
     t.index ["selected_office_id"], name: "index_providers_on_selected_office_id"
     t.index ["type"], name: "index_providers_on_type"

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -1,7 +1,9 @@
 FactoryBot.define do
   factory :provider do
     firm
+    name { Faker::Name.name }
     username { Faker::Internet.unique.username }
+    email { Faker::Internet.safe_email }
 
     trait :with_provider_details_api_username do
       username { 'NEETADESOR' }

--- a/spec/requests/providers/providers_spec.rb
+++ b/spec/requests/providers/providers_spec.rb
@@ -18,7 +18,9 @@ RSpec.describe Providers::ProvidersController, type: :request do
   end
 
   it 'displays provider data' do
-    expect(response.body).to include(provider.username)
+    expect(unescaped_response_body).to include(provider.name)
+    expect(unescaped_response_body).to include(provider.username)
+    expect(unescaped_response_body).to include(provider.email)
   end
 
   context 'with unspaced roles' do

--- a/spec/services/provider_details_creator_spec.rb
+++ b/spec/services/provider_details_creator_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe ProviderDetailsCreator do
-  let(:provider) { create :provider }
+  let(:provider) { create :provider, name: nil }
   let(:ccms_firm) { OpenStruct.new(id: rand(1..1000), name: Faker::Company.name) }
   let(:ccms_office_1) { OpenStruct.new(id: rand(1..100), code: rand(1..100).to_s) }
   let(:ccms_office_2) { OpenStruct.new(id: rand(101..200), code: rand(101..200).to_s) }
@@ -47,6 +47,10 @@ RSpec.describe ProviderDetailsCreator do
       expect(firm.offices.count).to eq(2)
       expect(office_1.code).to eq(ccms_office_1.code)
       expect(office_2.code).to eq(ccms_office_2.code)
+    end
+
+    it 'update the name of the provider' do
+      expect { subject }.to change { provider.reload.name }.to(api_response[:contactName])
     end
 
     context 'selected office of provider is not returned by the API' do


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-778)

. Get provider email from the SAML response and saves it.
. Save provider name from the provider details API into its own attribute

I had to use a fork of the `ruby-saml-idp` gem in order to have attributes in the mock SAML response 

## Checklist

Before you ask people to review this PR:

- [X] Tests and rubocop should be passing: `bundle exec rake`
- [X] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [X] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [X] The PR description should say what you changed and why, with a link to the JIRA story.
- [X] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [X] You should have checked that the commit messages say why the change was made.
