### PR TITLE
AP-795 Generate unique Proceeding Case ID

### DIFF
--- a/app/models/application_proceeding_type.rb
+++ b/app/models/application_proceeding_type.rb
@@ -1,4 +1,10 @@
 class ApplicationProceedingType < ApplicationRecord
+  FIRST_PROCEEDING_CASE_ID = 55_000_001
+
   belongs_to :legal_aid_application
   belongs_to :proceeding_type
+
+  def proceeding_case_p_num
+    "P_#{proceeding_case_id}"
+  end
 end

--- a/app/services/ccms/attribute_value_generator.rb
+++ b/app/services/ccms/attribute_value_generator.rb
@@ -20,8 +20,9 @@ module CCMS
   # 'vehicle_registration_number'  will call the registration_number method on options[:vehicle] in order to get the
   # value to insert.
   class AttributeValueGenerator
-    STANDARD_METHOD_NAMES = /^(application|bank_account|vehicle|wage_slip|proceeding|other_party|opponent|respondent)_(\S+)$/.freeze
+    STANDARD_METHOD_NAMES = /^(application|bank_account|vehicle|wage_slip|appl_proceeding_type|proceeding|other_party|opponent|respondent)_(\S+)$/.freeze
     APPLICATION_REGEX = /^application_(\S+)$/.freeze
+    APPLICATION_PROCEEDING_TYPE_REGEX = /^appl_proceeding_type_(\S+)$/.freeze
     BANK_REGEX = /^bank_account_(\S+)$/.freeze
     VEHICLE_REGEX = /^vehicle_(\S+)$/.freeze
     WAGE_SLIP_REGEX = /^wage_slip_(\S+)$/.freeze
@@ -96,10 +97,12 @@ module CCMS
       STANDARD_METHOD_NAMES.match?(method)
     end
 
-    def call_standard_method(method, options) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+    def call_standard_method(method, options) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity
       case method
       when APPLICATION_REGEX
         @legal_aid_application.__send__(Regexp.last_match(1))
+      when APPLICATION_PROCEEDING_TYPE_REGEX
+        options[:appl_proceeding_type].__send__(Regexp.last_match(1))
       when BANK_REGEX
         options[:bank_acct].__send__(Regexp.last_match(1))
       when VEHICLE_REGEX

--- a/app/services/ccms/case_add_requestor.rb
+++ b/app/services/ccms/case_add_requestor.rb
@@ -477,10 +477,6 @@ module CCMS
       @application_proceeding_types ||= @legal_aid_application.application_proceeding_types
     end
 
-    # def proceedings
-    #   @proceedings ||= @legal_aid_application.proceeding_types
-    # end
-
     def bank_accounts
       @bank_accounts ||= applicant.bank_accounts
     end

--- a/app/services/ccms/case_add_requestor.rb
+++ b/app/services/ccms/case_add_requestor.rb
@@ -147,24 +147,26 @@ module CCMS
     end
 
     def generate_proceedings(xml)
-      @legal_aid_application.proceeding_types.each { |p| generate_proceeding(xml, p) }
+      @legal_aid_application.application_proceeding_types.each { |apt| generate_proceeding(xml, apt) }
     end
 
-    def generate_proceeding(xml, proceeding) # rubocop:disable Metrics/MethodLength
+    def generate_proceeding(xml, application_proceeding_type)
       xml.__send__('ns2:Proceeding') do
-        xml.__send__('ns2:ProceedingCaseID', @legal_aid_application.ccms_case_reference)
+        xml.__send__('ns2:ProceedingCaseID', application_proceeding_type.proceeding_case_p_num)
         xml.__send__('ns2:Status', 'Draft')
         xml.__send__('ns2:LeadProceedingIndicator', true)
-        xml.__send__('ns2:ProceedingDetails') do
-          xml.__send__('ns2:ProceedingType', proceeding.ccms_code)
-          xml.__send__('ns2:ProceedingDescription', proceeding.description)
-          xml.__send__('ns2:MatterType', proceeding.ccms_matter_code)
-          xml.__send__('ns2:LevelOfService', 3) # TODO: CCMS placeholder
-          xml.__send__('ns2:Stage', 8) # TODO: CCMS placeholder
-          xml.__send__('ns2:ClientInvolvementType', 'A') # TODO: CCMS placeholder
-          xml.__send__('ns2:ScopeLimitations') { generate_scope_limitations(xml, proceeding) }
-        end
+        xml.__send__('ns2:ProceedingDetails') { generate_proceeding_type(xml, application_proceeding_type.proceeding_type) }
       end
+    end
+
+    def generate_proceeding_type(xml, proceeding_type)
+      xml.__send__('ns2:ProceedingType', proceeding_type.ccms_code)
+      xml.__send__('ns2:ProceedingDescription', proceeding_type.description)
+      xml.__send__('ns2:MatterType', proceeding_type.ccms_matter_code)
+      xml.__send__('ns2:LevelOfService', 3) # TODO: CCMS placeholder
+      xml.__send__('ns2:Stage', 8) # TODO: CCMS placeholder
+      xml.__send__('ns2:ClientInvolvementType', 'A') # TODO: CCMS placeholder
+      xml.__send__('ns2:ScopeLimitations') { generate_scope_limitations(xml, proceeding_type) }
     end
 
     def generate_scope_limitations(xml, proceeding)
@@ -269,13 +271,20 @@ module CCMS
     def generate_means_proceeding_entity(xml, sequence_no)
       xml.__send__('ns0:SequenceNumber', sequence_no)
       xml.__send__('ns0:EntityName', 'PROCEEDING')
-      proceedings.reverse_each { |proceeding| generate_means_proceeding_instance(xml, proceeding) }
+      application_proceeding_types.reverse_each do |application_proceeding_type|
+        generate_means_proceeding_instance(xml, application_proceeding_type)
+      end
     end
 
-    def generate_means_proceeding_instance(xml, proceeding)
+    def generate_means_proceeding_instance(xml, application_proceeding_type)
       xml.__send__('ns0:Instances') do
         xml.__send__('ns0:InstanceLabel', @legal_aid_application.ccms_case_reference)
-        xml.__send__('ns0:Attributes') { generate_attributes_for(xml, :proceeding, proceeding: proceeding) }
+        xml.__send__('ns0:Attributes') do
+          generate_attributes_for(xml,
+                                  :proceeding,
+                                  appl_proceeding_type: application_proceeding_type,
+                                  proceeding: application_proceeding_type.proceeding_type)
+        end
       end
     end
 
@@ -355,13 +364,19 @@ module CCMS
     def generate_merits_proceeding_entity(xml, sequence_no)
       xml.__send__('ns0:SequenceNumber', sequence_no)
       xml.__send__('ns0:EntityName', 'PROCEEDING')
-      @legal_aid_application.proceeding_types.reverse_each { |p| generate_merits_proceeding_instance(xml, p) }
+      application_proceeding_types.reverse_each { |apt| generate_merits_proceeding_instance(xml, apt) }
     end
 
-    def generate_merits_proceeding_instance(xml, proceeding)
+    def generate_merits_proceeding_instance(xml, application_proceeding_type)
       xml.__send__('ns0:Instances') do
         xml.__send__('ns0:InstanceLabel', @legal_aid_application.ccms_case_reference)
-        xml.__send__('ns0:Attributes') { generate_attributes_for(xml, :proceeding_merits, proceeding: proceeding, respondent: @legal_aid_application.respondent) }
+        xml.__send__('ns0:Attributes') do
+          generate_attributes_for(xml,
+                                  :proceeding_merits,
+                                  appl_proceeding_type: application_proceeding_type,
+                                  proceeding: application_proceeding_type.proceeding_type,
+                                  respondent: @legal_aid_application.respondent)
+        end
       end
     end
 
@@ -458,9 +473,13 @@ module CCMS
       @provider ||= @legal_aid_application.provider
     end
 
-    def proceedings
-      @proceedings ||= @legal_aid_application.proceeding_types
+    def application_proceeding_types
+      @application_proceeding_types ||= @legal_aid_application.application_proceeding_types
     end
+
+    # def proceedings
+    #   @proceedings ||= @legal_aid_application.proceeding_types
+    # end
 
     def bank_accounts
       @bank_accounts ||= applicant.bank_accounts

--- a/ccms_integration/ccms_spec.rb
+++ b/ccms_integration/ccms_spec.rb
@@ -135,6 +135,7 @@ module CCMS
 
     let(:provider) do
       double 'Provider',
+             username: 'user1',
              firm_id: 22_381,
              selected_office_id: 81_693,
              user_login_id: 2_016_472,

--- a/config/ccms/ccms_keys.yml
+++ b/config/ccms/ccms_keys.yml
@@ -4228,7 +4228,7 @@ proceeding:
     :response_type: text
     :user_defined: true
   PROCEEDING_ID:
-    :value: "#application_ccms_case_reference"
+    :value: "#appl_proceeding_type_proceeding_case_p_num"
     :br100_meaning: Proceeding ID
     :response_type: text
     :user_defined: true
@@ -4341,7 +4341,7 @@ proceeding_merits:
     :user_defined: false
     :generate_block?: false
   PROCEEDING_ID:
-    :value: "#application_ccms_case_reference"
+    :value: "#appl_proceeding_type_proceeding_case_p_num"
     :br100_meaning: Proceeding ID
     :response_type: text
     :user_defined: true

--- a/db/migrate/20190812135413_add_proceeding_case_id_to_application_proceeding_types.rb
+++ b/db/migrate/20190812135413_add_proceeding_case_id_to_application_proceeding_types.rb
@@ -1,0 +1,5 @@
+class AddProceedingCaseIdToApplicationProceedingTypes < ActiveRecord::Migration[5.2]
+  def change
+    add_column :application_proceeding_types, :proceeding_case_id, :integer, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_08_094323) do
+ActiveRecord::Schema.define(version: 2019_08_12_135413) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -92,6 +92,7 @@ ActiveRecord::Schema.define(version: 2019_08_08_094323) do
     t.uuid "proceeding_type_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "proceeding_case_id"
     t.index ["legal_aid_application_id"], name: "index_application_proceeding_types_on_legal_aid_application_id"
     t.index ["proceeding_type_id"], name: "index_application_proceeding_types_on_proceeding_type_id"
   end

--- a/db/seeds/proceeding_case_id.rb
+++ b/db/seeds/proceeding_case_id.rb
@@ -1,0 +1,10 @@
+# add proceeding_case_id sequence and alter column to use it
+class CreateProceedingCaseId < ActiveRecord::Migration[5.2]
+  def self.run
+    execute 'CREATE SEQUENCE IF NOT EXISTS case_proceeding_sequence MINVALUE 55000001'
+
+    column = ApplicationProceedingType.columns.detect { |c| c.name == 'proceeding_case_id' }
+    execute "ALTER TABLE application_proceeding_types ALTER COLUMN proceeding_case_id SET DEFAULT NEXTVAL('case_proceeding_sequence')" unless /nextval/.match?(column.default_function)
+  end
+end
+CreateProceedingCaseId.run

--- a/spec/factories/submissions.rb
+++ b/spec/factories/submissions.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :submission, class: CCMS::Submission do
     legal_aid_application { create :legal_aid_application }
-    sequence(:case_ccms_reference) { |n| format('P_55%06d', n) }
+    sequence(:case_ccms_reference) { |n| format('300000%06d', n) }
 
     trait :case_ref_obtained do
       aasm_state { 'case_ref_obtained' }

--- a/spec/models/application_proceeding_type_spec.rb
+++ b/spec/models/application_proceeding_type_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe ApplicationProceedingType do
+  describe '#proceeding_case_id' do
+    let(:legal_aid_application) { create :legal_aid_application }
+    let(:proceeding_type) { create :proceeding_type }
+
+    context 'empty_database' do
+      it 'creates record with first proceeding case id' do
+        expect(ApplicationProceedingType.count).to be_zero
+        legal_aid_application.proceeding_types << proceeding_type
+        legal_aid_application.save!
+        application_proceeding_type = legal_aid_application.application_proceeding_types.first
+        expect(application_proceeding_type.proceeding_case_id > 55_000_000).to be true
+      end
+    end
+
+    context 'database with records' do
+      it 'creates a record with the next in sequence' do
+        3.times { create :legal_aid_application, :with_proceeding_types }
+        expect(ApplicationProceedingType.count).to eq 3
+        highest_proceeding_case_id = ApplicationProceedingType.order(:proceeding_case_id).last.proceeding_case_id
+        legal_aid_application.proceeding_types << proceeding_type
+        legal_aid_application.save!
+        application_proceeding_type = legal_aid_application.application_proceeding_types.first
+        expect(application_proceeding_type.proceeding_case_id).to eq highest_proceeding_case_id + 1
+      end
+    end
+  end
+
+  describe '#proceeding_case_p_num' do
+    it 'prefixes the proceeding case id with P_' do
+      legal_aid_application = create :legal_aid_application, :with_proceeding_types
+      application_proceeding_type = legal_aid_application.application_proceeding_types.first
+      allow(application_proceeding_type).to receive(:proceeding_case_id).and_return 55_200_301
+      expect(application_proceeding_type.proceeding_case_p_num).to eq 'P_55200301'
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -66,6 +66,7 @@ RSpec.configure do |config|
   config.include CCMS
   config.before(:suite) do
     Faker::Config.locale = 'en-GB'
+    require Rails.root.join('db/seeds/proceeding_case_id.rb')
   end
 
   # Add support for Devise authentication helpers

--- a/spec/services/ccms/case_add_requestor_spec.rb
+++ b/spec/services/ccms/case_add_requestor_spec.rb
@@ -72,6 +72,12 @@ module CCMS # rubocop:disable Metrics/ModuleLength
                fee_earner_contact_id: 4_925_152
       end
 
+      let(:application_proceeding_type_1) do
+        double ApplicationProceedingType,
+               proceeding_type: proceeding_type_1,
+               proceeding_case_p_num: 'P_55123456'
+      end
+
       let(:proceeding_type_1) do
         double ProceedingType,
                bail_conditions_set?: false,
@@ -106,6 +112,12 @@ module CCMS # rubocop:disable Metrics/ModuleLength
                scope_limitations: [scope_limitation_1, scope_limitation_2],
                status: 'draft',
                warning_letter_sent?: false
+      end
+
+      let(:application_proceeding_type_2) do
+        double ApplicationProceedingType,
+               proceeding_type: proceeding_type_2,
+               proceeding_case_p_num: 'P_55123457'
       end
 
       let(:proceeding_type_2) do
@@ -191,6 +203,7 @@ module CCMS # rubocop:disable Metrics/ModuleLength
                requested_amount: 5000.0,
                applicant: applicant,
                provider: provider,
+               application_proceeding_types: [application_proceeding_type_1, application_proceeding_type_2],
                proceeding_types: [proceeding_type_1, proceeding_type_2],
                lead_proceeding: proceeding_type_1,
                vehicle: vehicle_1,

--- a/spec/services/ccms/case_add_requestor_xml_blocks_spec.rb
+++ b/spec/services/ccms/case_add_requestor_xml_blocks_spec.rb
@@ -11,11 +11,39 @@ module CCMS # rubocop:disable Metrics/ModuleLength
                populate_vehicle: true,
                with_bank_accounts: 2
       end
+      let(:application_proceeding_type) { legal_aid_application.application_proceeding_types.first }
       let(:respondent) { legal_aid_application.respondent }
       let(:submission) { create :submission, :case_ref_obtained, legal_aid_application: legal_aid_application }
       let(:requestor) { described_class.new(submission, {}) }
       let(:xml) { requestor.formatted_xml }
       before { allow(requestor).to receive(:transaction_request_id).and_return(expected_tx_id) }
+
+      context 'ProceedingCaseId' do
+        context 'ProceedingCaseId section' do
+          it 'has  a p number' do
+            block = XmlExtractor.call(xml, :proceeding_case_id)
+            expect(block.text).to eq application_proceeding_type.proceeding_case_p_num
+          end
+        end
+
+        context 'in merits assessment block' do
+          it 'has a p number' do
+            block = XmlExtractor.call(xml, :proceeding_merits, 'PROCEEDING_ID')
+            expect(block).to be_present
+            expect(block).to have_response_type('text')
+            expect(block).to have_response_value(application_proceeding_type.proceeding_case_p_num)
+          end
+        end
+
+        context 'in means assessment block' do
+          it 'has a p number' do
+            block = XmlExtractor.call(xml, :proceeding, 'PROCEEDING_ID')
+            expect(block).to be_present
+            expect(block).to have_response_type('text')
+            expect(block).to have_response_value(application_proceeding_type.proceeding_case_p_num)
+          end
+        end
+      end
 
       context 'DELEGATED_FUNCTIONS_DATE blocks' do
         context 'delegated functions used' do
@@ -24,6 +52,7 @@ module CCMS # rubocop:disable Metrics/ModuleLength
           end
 
           it 'generates the delegated functions block in the means assessment section' do
+            # File.open(Rails.root.join('ccms_integration/generated/tmp.xml'), 'w') {|f| f.puts xml }
             block = XmlExtractor.call(xml, :global_means, 'DELEGATED_FUNCTIONS_DATE')
             expect(block).to be_present
             expect(block).to have_response_type('date')

--- a/spec/services/ccms/case_add_requestor_xml_blocks_spec.rb
+++ b/spec/services/ccms/case_add_requestor_xml_blocks_spec.rb
@@ -18,6 +18,15 @@ module CCMS # rubocop:disable Metrics/ModuleLength
       let(:xml) { requestor.formatted_xml }
       before { allow(requestor).to receive(:transaction_request_id).and_return(expected_tx_id) }
 
+      # enable this context if  you need to create a file of the payload for manual inspection
+      xcontext 'saving to a temporary file' do
+        it 'creates a file' do
+          filename = Rails.root.join('tmp/generated_ccms_payload.xml')
+          File.open(filename, 'w') { |f| f.puts xml }
+          expect(File.exist?(filename)).to be true
+        end
+      end
+
       context 'ProceedingCaseId' do
         context 'ProceedingCaseId section' do
           it 'has  a p number' do
@@ -52,7 +61,6 @@ module CCMS # rubocop:disable Metrics/ModuleLength
           end
 
           it 'generates the delegated functions block in the means assessment section' do
-            # File.open(Rails.root.join('ccms_integration/generated/tmp.xml'), 'w') {|f| f.puts xml }
             block = XmlExtractor.call(xml, :global_means, 'DELEGATED_FUNCTIONS_DATE')
             expect(block).to be_present
             expect(block).to have_response_type('date')

--- a/spec/support/xml_extractor.rb
+++ b/spec/support/xml_extractor.rb
@@ -5,11 +5,13 @@ class XmlExtractor
     global_merits: '/Envelope/Body/CaseAddRQ/Case/CaseDetails/ApplicationDetails/MeritsAssesments/AssesmentResults/AssesmentDetails/AssessmentScreens/Entity/Instances/Attributes/Attribute',
     proceeding: %(/Envelope/Body/CaseAddRQ/Case/CaseDetails/ApplicationDetails/MeansAssesments/AssesmentResults/AssesmentDetails/AssessmentScreens/Entity[EntityName = "PROCEEDING"]//Attributes/Attribute),
     proceeding_merits: %(/Envelope/Body/CaseAddRQ/Case/CaseDetails/ApplicationDetails/MeritsAssesments/AssesmentResults/AssesmentDetails/AssessmentScreens/Entity[EntityName = "PROCEEDING"]//Attributes/Attribute),
-    opponent: %(/Envelope/Body/CaseAddRQ/Case/CaseDetails/ApplicationDetails/MeritsAssesments/AssesmentResults/AssesmentDetails/AssessmentScreens/Entity[EntityName = "OPPONENT_OTHER_PARTIES"]//Attributes/Attribute)
+    opponent: %(/Envelope/Body/CaseAddRQ/Case/CaseDetails/ApplicationDetails/MeritsAssesments/AssesmentResults/AssesmentDetails/AssessmentScreens/Entity[EntityName = "OPPONENT_OTHER_PARTIES"]//Attributes/Attribute),
+    proceeding_case_id: %(/Envelope/Body/CaseAddRQ/Case/CaseDetails/ApplicationDetails/Proceedings/Proceeding/ProceedingCaseID)
+
   }.freeze
   # rubocop:enable Metrics/LineLength
 
-  def self.call(xml, section, attribute_name)
+  def self.call(xml, section, attribute_name = nil)
     new(xml, section, attribute_name).extract
   end
 
@@ -21,7 +23,12 @@ class XmlExtractor
 
   def extract
     doc = Nokogiri::XML(@xml).remove_namespaces!
-    xpath = "#{XPATHS[@section]}[Attribute='#{@attribute_name}']"
+    xpath = if @attribute_name.nil?
+              (XPATHS[@section]).to_s
+            else
+              "#{XPATHS[@section]}[Attribute='#{@attribute_name}']"
+            end
+
     doc.xpath(xpath)
   end
 end


### PR DESCRIPTION
## Autogenerate Proceeding Case ids for CCMS payload

[Link to story](https://dsdmoj.atlassian.net/browse/AP-795)

Each proceeding on each case needs a unique id to be assigned and included in the CCMS payload.  The id is in the form `P_nnnnnnnn` where `nnnnnnnn` is a number greater than 55,000,000.

This is achieved by adding a `proceeding_case_id` column to the `application_proceeding_types` table, and linking it to a Postgres sequence starting at 55,000,001.  There is no Rails Migration DSL keyword for adding a sequence, so it needs to be added with a hand-coded `ADD SEQUENCE` SQL statement, which unfortunately means it is not dumped to the `db/schema.rb` file.  It has therefore been added in the seeds, and will only create the sequence and alter the column to use the sequence if it hasn't already been done before.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
