### PR TITLE
AP-831a Update Citizen pages so to prevent update after declaration.

### DIFF
--- a/app/controllers/base_controller.rb
+++ b/app/controllers/base_controller.rb
@@ -1,6 +1,15 @@
 class BaseController < ApplicationController
   include Flowable
 
+  # This stops the browser caching these pages.
+  # This is done so that someone can't use the Back button to return to a users pages
+  # after they have logged out. There is a cost to page load speeds as a result
+  def set_cache_buster
+    response.headers['Cache-Control'] = 'no-cache, no-store, max-age=0, must-revalidate'
+    response.headers['Pragma'] = 'no-cache'
+    response.headers['Expires'] = 'Fri, 01 Jan 1990 00:00:00 GMT'
+  end
+
   def merge_with_model(model, options = {})
     yield.tap do |hash|
       hash.merge! options if options.present?

--- a/app/controllers/citizens/accounts_controller.rb
+++ b/app/controllers/citizens/accounts_controller.rb
@@ -1,7 +1,5 @@
 module Citizens
   class AccountsController < CitizenBaseController
-    before_action :authenticate_applicant!
-
     skip_back_history_for :gather
 
     def index

--- a/app/controllers/citizens/accounts_controller.rb
+++ b/app/controllers/citizens/accounts_controller.rb
@@ -1,6 +1,5 @@
 module Citizens
-  class AccountsController < BaseController
-    include ApplicationFromSession
+  class AccountsController < CitizenBaseController
     before_action :authenticate_applicant!
 
     skip_back_history_for :gather

--- a/app/controllers/citizens/additional_accounts_controller.rb
+++ b/app/controllers/citizens/additional_accounts_controller.rb
@@ -1,6 +1,5 @@
 module Citizens
-  class AdditionalAccountsController < BaseController
-    include ApplicationFromSession
+  class AdditionalAccountsController < CitizenBaseController
     def index; end
 
     def create

--- a/app/controllers/citizens/check_answers_controller.rb
+++ b/app/controllers/citizens/check_answers_controller.rb
@@ -1,6 +1,5 @@
 module Citizens
-  class CheckAnswersController < BaseController
-    include ApplicationFromSession
+  class CheckAnswersController < CitizenBaseController
     before_action :authenticate_applicant!
 
     def index

--- a/app/controllers/citizens/check_answers_controller.rb
+++ b/app/controllers/citizens/check_answers_controller.rb
@@ -1,7 +1,5 @@
 module Citizens
   class CheckAnswersController < CitizenBaseController
-    before_action :authenticate_applicant!
-
     def index
       legal_aid_application.check_citizen_answers! unless legal_aid_application.checking_citizen_answers?
     end

--- a/app/controllers/citizens/citizen_base_controller.rb
+++ b/app/controllers/citizens/citizen_base_controller.rb
@@ -3,6 +3,7 @@ module Citizens
     include ApplicationFromSession
     before_action :authenticate_applicant!
     before_action :check_not_complete
+    before_action :set_cache_buster
 
     private
 

--- a/app/controllers/citizens/citizen_base_controller.rb
+++ b/app/controllers/citizens/citizen_base_controller.rb
@@ -1,0 +1,26 @@
+module Citizens
+  class CitizenBaseController < BaseController
+    include ApplicationFromSession
+    before_action :authenticate_applicant!
+    before_action :check_not_complete
+
+    private
+
+    class << self
+      attr_reader :view_when_complete
+      def allow_view_when_complete
+        @view_when_complete = true
+      end
+    end
+
+    def check_not_complete
+      return if self.class.view_when_complete
+
+      completed if legal_aid_application&.completed_at?
+    end
+
+    def completed
+      redirect_to error_path(:assessment_already_completed)
+    end
+  end
+end

--- a/app/controllers/citizens/consents_controller.rb
+++ b/app/controllers/citizens/consents_controller.rb
@@ -1,7 +1,5 @@
 module Citizens
-  class ConsentsController < BaseController
-    include ApplicationFromSession
-
+  class ConsentsController < CitizenBaseController
     def show; end
 
     def create

--- a/app/controllers/citizens/declarations_controller.rb
+++ b/app/controllers/citizens/declarations_controller.rb
@@ -1,6 +1,5 @@
 module Citizens
-  class DeclarationsController < BaseController
-    include ApplicationFromSession
+  class DeclarationsController < CitizenBaseController
     before_action :authenticate_applicant!
 
     def show; end

--- a/app/controllers/citizens/declarations_controller.rb
+++ b/app/controllers/citizens/declarations_controller.rb
@@ -1,7 +1,5 @@
 module Citizens
   class DeclarationsController < CitizenBaseController
-    before_action :authenticate_applicant!
-
     def show; end
 
     def update

--- a/app/controllers/citizens/dependants/assets_values_controller.rb
+++ b/app/controllers/citizens/dependants/assets_values_controller.rb
@@ -1,7 +1,6 @@
 module Citizens
   module Dependants
-    class AssetsValuesController < BaseController
-      include ApplicationFromSession
+    class AssetsValuesController < CitizenBaseController
       prefix_step_with :dependants
 
       def show

--- a/app/controllers/citizens/dependants/details_controller.rb
+++ b/app/controllers/citizens/dependants/details_controller.rb
@@ -1,7 +1,6 @@
 module Citizens
   module Dependants
-    class DetailsController < BaseController
-      include ApplicationFromSession
+    class DetailsController < CitizenBaseController
       prefix_step_with :dependants
       helper_method :other_dependants
 

--- a/app/controllers/citizens/dependants/full_time_educations_controller.rb
+++ b/app/controllers/citizens/dependants/full_time_educations_controller.rb
@@ -1,7 +1,6 @@
 module Citizens
   module Dependants
-    class FullTimeEducationsController < BaseController
-      include ApplicationFromSession
+    class FullTimeEducationsController < CitizenBaseController
       prefix_step_with :dependants
 
       def show

--- a/app/controllers/citizens/dependants/monthly_incomes_controller.rb
+++ b/app/controllers/citizens/dependants/monthly_incomes_controller.rb
@@ -1,7 +1,6 @@
 module Citizens
   module Dependants
-    class MonthlyIncomesController < BaseController
-      include ApplicationFromSession
+    class MonthlyIncomesController < CitizenBaseController
       prefix_step_with :dependants
 
       def show

--- a/app/controllers/citizens/dependants/relationships_controller.rb
+++ b/app/controllers/citizens/dependants/relationships_controller.rb
@@ -1,7 +1,6 @@
 module Citizens
   module Dependants
-    class RelationshipsController < BaseController
-      include ApplicationFromSession
+    class RelationshipsController < CitizenBaseController
       prefix_step_with :dependants
 
       def show

--- a/app/controllers/citizens/dependants_controller.rb
+++ b/app/controllers/citizens/dependants_controller.rb
@@ -1,6 +1,5 @@
 module Citizens
-  class DependantsController < BaseController
-    include ApplicationFromSession
+  class DependantsController < CitizenBaseController
     helper_method :other_dependants
 
     def index

--- a/app/controllers/citizens/has_dependants_controller.rb
+++ b/app/controllers/citizens/has_dependants_controller.rb
@@ -1,6 +1,5 @@
 module Citizens
-  class HasDependantsController < BaseController
-    include ApplicationFromSession
+  class HasDependantsController < CitizenBaseController
     def show
       @form = LegalAidApplications::HasDependantsForm.new(model: legal_aid_application)
     end

--- a/app/controllers/citizens/has_other_dependants_controller.rb
+++ b/app/controllers/citizens/has_other_dependants_controller.rb
@@ -1,7 +1,5 @@
 module Citizens
-  class HasOtherDependantsController < BaseController
-    include ApplicationFromSession
-
+  class HasOtherDependantsController < CitizenBaseController
     def show; end
 
     def update

--- a/app/controllers/citizens/identify_types_of_incomes_controller.rb
+++ b/app/controllers/citizens/identify_types_of_incomes_controller.rb
@@ -1,7 +1,5 @@
 module Citizens
   class IdentifyTypesOfIncomesController < CitizenBaseController
-    before_action :authenticate_applicant!
-
     def show
       legal_aid_application
       @none_selected = legal_aid_application.no_credit_transaction_types_selected?

--- a/app/controllers/citizens/identify_types_of_incomes_controller.rb
+++ b/app/controllers/citizens/identify_types_of_incomes_controller.rb
@@ -1,6 +1,5 @@
 module Citizens
-  class IdentifyTypesOfIncomesController < BaseController
-    include ApplicationFromSession
+  class IdentifyTypesOfIncomesController < CitizenBaseController
     before_action :authenticate_applicant!
 
     def show

--- a/app/controllers/citizens/identify_types_of_outgoings_controller.rb
+++ b/app/controllers/citizens/identify_types_of_outgoings_controller.rb
@@ -1,6 +1,5 @@
 module Citizens
-  class IdentifyTypesOfOutgoingsController < BaseController
-    include ApplicationFromSession
+  class IdentifyTypesOfOutgoingsController < CitizenBaseController
     before_action :authenticate_applicant!
 
     def show

--- a/app/controllers/citizens/identify_types_of_outgoings_controller.rb
+++ b/app/controllers/citizens/identify_types_of_outgoings_controller.rb
@@ -1,7 +1,5 @@
 module Citizens
   class IdentifyTypesOfOutgoingsController < CitizenBaseController
-    before_action :authenticate_applicant!
-
     def show
       legal_aid_application
       @none_selected = legal_aid_application.no_debit_transaction_types_selected?

--- a/app/controllers/citizens/information_controller.rb
+++ b/app/controllers/citizens/information_controller.rb
@@ -1,7 +1,5 @@
 module Citizens
-  class InformationController < BaseController
-    include ApplicationFromSession
-
+  class InformationController < CitizenBaseController
     def show
       legal_aid_application
     end

--- a/app/controllers/citizens/means_test_results_controller.rb
+++ b/app/controllers/citizens/means_test_results_controller.rb
@@ -1,6 +1,7 @@
 module Citizens
-  class MeansTestResultsController < BaseController
-    include ApplicationFromSession
+  class MeansTestResultsController < CitizenBaseController
+    allow_view_when_complete
+
     def show
       @applicant = legal_aid_application.applicant
     end

--- a/app/controllers/citizens/other_assets_controller.rb
+++ b/app/controllers/citizens/other_assets_controller.rb
@@ -1,7 +1,5 @@
 module Citizens
-  class OtherAssetsController < BaseController
-    include ApplicationFromSession
-
+  class OtherAssetsController < CitizenBaseController
     def show
       @form = Citizens::OtherAssetsForm.new(model: declaration)
     end

--- a/app/controllers/citizens/outstanding_mortgages_controller.rb
+++ b/app/controllers/citizens/outstanding_mortgages_controller.rb
@@ -1,6 +1,5 @@
 module Citizens
-  class OutstandingMortgagesController < BaseController
-    include ApplicationFromSession
+  class OutstandingMortgagesController < CitizenBaseController
     before_action :authenticate_applicant!
 
     def show

--- a/app/controllers/citizens/outstanding_mortgages_controller.rb
+++ b/app/controllers/citizens/outstanding_mortgages_controller.rb
@@ -1,7 +1,5 @@
 module Citizens
   class OutstandingMortgagesController < CitizenBaseController
-    before_action :authenticate_applicant!
-
     def show
       @form = LegalAidApplications::OutstandingMortgageForm.new(model: legal_aid_application)
     end

--- a/app/controllers/citizens/own_homes_controller.rb
+++ b/app/controllers/citizens/own_homes_controller.rb
@@ -1,7 +1,5 @@
 module Citizens
-  class OwnHomesController < BaseController
-    include ApplicationFromSession
-
+  class OwnHomesController < CitizenBaseController
     def show
       @form = LegalAidApplications::OwnHomeForm.new(model: legal_aid_application)
     end

--- a/app/controllers/citizens/percentage_homes_controller.rb
+++ b/app/controllers/citizens/percentage_homes_controller.rb
@@ -1,6 +1,5 @@
 module Citizens
-  class PercentageHomesController < BaseController
-    include ApplicationFromSession
+  class PercentageHomesController < CitizenBaseController
     def show
       @form = LegalAidApplications::PercentageHomeForm.new(model: legal_aid_application)
     end

--- a/app/controllers/citizens/property_values_controller.rb
+++ b/app/controllers/citizens/property_values_controller.rb
@@ -1,6 +1,5 @@
 module Citizens
-  class PropertyValuesController < BaseController
-    include ApplicationFromSession
+  class PropertyValuesController < CitizenBaseController
     def show
       @form = LegalAidApplications::PropertyValueForm.new(model: legal_aid_application)
     end

--- a/app/controllers/citizens/restrictions_controller.rb
+++ b/app/controllers/citizens/restrictions_controller.rb
@@ -1,7 +1,5 @@
 module Citizens
-  class RestrictionsController < BaseController
-    include ApplicationFromSession
-
+  class RestrictionsController < CitizenBaseController
     def show
       @form = LegalAidApplications::RestrictionsForm.new(model: legal_aid_application)
     end

--- a/app/controllers/citizens/savings_and_investments_controller.rb
+++ b/app/controllers/citizens/savings_and_investments_controller.rb
@@ -1,6 +1,5 @@
 module Citizens
-  class SavingsAndInvestmentsController < BaseController
-    include ApplicationFromSession
+  class SavingsAndInvestmentsController < CitizenBaseController
     helper_method :bank_accounts, :attributes
 
     def show

--- a/app/controllers/citizens/shared_ownerships_controller.rb
+++ b/app/controllers/citizens/shared_ownerships_controller.rb
@@ -1,7 +1,5 @@
 module Citizens
-  class SharedOwnershipsController < BaseController
-    include ApplicationFromSession
-
+  class SharedOwnershipsController < CitizenBaseController
     def show
       @form = LegalAidApplications::SharedOwnershipForm.new(model: legal_aid_application)
     end

--- a/app/controllers/citizens/vehicles/estimated_values_controller.rb
+++ b/app/controllers/citizens/vehicles/estimated_values_controller.rb
@@ -1,7 +1,6 @@
 module Citizens
   module Vehicles
-    class EstimatedValuesController < BaseController
-      include ApplicationFromSession
+    class EstimatedValuesController < CitizenBaseController
       prefix_step_with :vehicles
 
       def show

--- a/app/controllers/citizens/vehicles/purchase_dates_controller.rb
+++ b/app/controllers/citizens/vehicles/purchase_dates_controller.rb
@@ -1,7 +1,6 @@
 module Citizens
   module Vehicles
-    class PurchaseDatesController < BaseController
-      include ApplicationFromSession
+    class PurchaseDatesController < CitizenBaseController
       prefix_step_with :vehicles
 
       def show

--- a/app/controllers/citizens/vehicles/regular_uses_controller.rb
+++ b/app/controllers/citizens/vehicles/regular_uses_controller.rb
@@ -1,7 +1,6 @@
 module Citizens
   module Vehicles
-    class RegularUsesController < BaseController
-      include ApplicationFromSession
+    class RegularUsesController < CitizenBaseController
       prefix_step_with :vehicles
 
       def show

--- a/app/controllers/citizens/vehicles/remaining_payments_controller.rb
+++ b/app/controllers/citizens/vehicles/remaining_payments_controller.rb
@@ -1,7 +1,6 @@
 module Citizens
   module Vehicles
-    class RemainingPaymentsController < BaseController
-      include ApplicationFromSession
+    class RemainingPaymentsController < CitizenBaseController
       prefix_step_with :vehicles
 
       def show

--- a/app/controllers/citizens/vehicles_controller.rb
+++ b/app/controllers/citizens/vehicles_controller.rb
@@ -1,7 +1,5 @@
 module Citizens
-  class VehiclesController < BaseController
-    include ApplicationFromSession
-
+  class VehiclesController < CitizenBaseController
     def show
       @form = LegalAidApplications::OwnVehicleForm.new(model: legal_aid_application)
     end

--- a/app/controllers/providers/provider_base_controller.rb
+++ b/app/controllers/providers/provider_base_controller.rb
@@ -6,13 +6,16 @@ module Providers
     include Draftable
     include Authorizable
 
-    # This stops the browser caching these pages.
-    # This is done so that someone can't use the Back button to return to a users pages
-    # after they have logged out. There is a cost to page load speeds as a result
-    def set_cache_buster
-      response.headers['Cache-Control'] = 'no-cache, no-store, max-age=0, must-revalidate'
-      response.headers['Pragma'] = 'no-cache'
-      response.headers['Expires'] = 'Fri, 01 Jan 1990 00:00:00 GMT'
+    def pundit_user
+      current_provider
+    end
+
+    private
+
+    def provider_not_authorized
+      respond_to do |format|
+        format.html { render 'shared/access_denied', status: :forbidden }
+      end
     end
   end
 end

--- a/app/controllers/providers/provider_base_controller.rb
+++ b/app/controllers/providers/provider_base_controller.rb
@@ -5,17 +5,5 @@ module Providers
     include ApplicationDependable
     include Draftable
     include Authorizable
-
-    def pundit_user
-      current_provider
-    end
-
-    private
-
-    def provider_not_authorized
-      respond_to do |format|
-        format.html { render 'shared/access_denied', status: :forbidden }
-      end
-    end
   end
 end

--- a/app/views/shared/check_answers/_no_link_item.html.erb
+++ b/app/views/shared/check_answers/_no_link_item.html.erb
@@ -1,5 +1,4 @@
 <% no_border = no_border ? 'govuk-summary-list--no-border' : '' %>
-
 <div class="govuk-summary-list__row <%= no_border %> normal-word-break" id="app-check-your-answers__<%= name %>">
   <div class="govuk-summary-list__key check-your-answers-question">
     <%= question %>

--- a/spec/requests/citizens/declarations_spec.rb
+++ b/spec/requests/citizens/declarations_spec.rb
@@ -10,10 +10,17 @@ RSpec.describe Citizens::DeclarationsController, type: :request do
   describe 'GET /citizens/declaration' do
     subject { get citizens_declaration_path }
 
-    before { subject }
-
     it 'returns http success' do
+      subject
       expect(response).to have_http_status(:ok)
+    end
+
+    context 'with completed application' do
+      it 'redirects to already completed' do
+        legal_aid_application.update completed_at: 1.minute.ago
+        subject
+        expect(response).to redirect_to(error_path(:assessment_already_completed))
+      end
     end
   end
 

--- a/spec/requests/citizens/legal_aid_applications_spec.rb
+++ b/spec/requests/citizens/legal_aid_applications_spec.rb
@@ -1,12 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe 'citizen home requests', type: :request do
+  let(:completed_at) { nil }
   let(:application) { create :application, :with_applicant, completed_at: completed_at }
   let(:application_id) { application.id }
   let(:secure_id) { application.generate_secure_id }
   let(:applicant_first_name) { application.applicant.first_name }
   let(:applicant_last_name) { application.applicant.last_name }
-  let(:completed_at) { nil }
 
   describe 'GET citizens/applications/:id' do
     before { get citizens_legal_aid_application_path(secure_id) }
@@ -63,31 +63,38 @@ RSpec.describe 'citizen home requests', type: :request do
       get citizens_legal_aid_applications_path
     end
 
-    context 'when there is a legal aid application that matches the secure data' do
-      it 'returns http success' do
+    it 'returns http success' do
+      subject
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'sets the application_id session variable' do
+      subject
+      expect(session[:current_application_id]).to eq(application_id)
+    end
+
+    it 'returns the correct application' do
+      subject
+      expect(unescaped_response_body).to include(applicant_first_name.html_safe)
+      expect(unescaped_response_body).to include(applicant_last_name.html_safe)
+    end
+
+    context 'if a provider is logged in' do
+      let(:provider) { create :provider }
+      before { sign_in provider }
+
+      it 'logs out the provider' do
         subject
-        expect(response).to have_http_status(:ok)
+        expect(unescaped_response_body).not_to include(provider.username)
       end
+    end
 
-      it 'sets the application_id session variable' do
-        subject
-        expect(session[:current_application_id]).to eq(application_id)
-      end
-
-      it 'returns the correct application' do
-        subject
-        expect(unescaped_response_body).to include(applicant_first_name.html_safe)
-        expect(unescaped_response_body).to include(applicant_last_name.html_safe)
-      end
-
-      context 'if a provider is logged in' do
-        let(:provider) { create :provider }
-        before { sign_in provider }
-
-        it 'logs out the provider' do
-          subject
-          expect(unescaped_response_body).not_to include(provider.username)
-        end
+    context 'when applicant has completed the means assessment' do
+      it 'redirects to error page (assessment already completed)' do
+        get citizens_legal_aid_application_path(secure_id)
+        application.update! completed_at: 1.minute.ago
+        get citizens_legal_aid_applications_path
+        expect(response).to redirect_to(error_path(:assessment_already_completed))
       end
     end
   end

--- a/spec/requests/citizens/means_test_results_spec.rb
+++ b/spec/requests/citizens/means_test_results_spec.rb
@@ -12,5 +12,14 @@ RSpec.describe Citizens::MeansTestResultsController, type: :request do
       subject
       expect(response).to have_http_status(:ok)
     end
+
+    context 'with completed application' do
+      before { legal_aid_application.update completed_at: 1.minute.ago }
+
+      it 'should still be able to view page' do
+        subject
+        expect(response).to have_http_status(:ok)
+      end
+    end
   end
 end


### PR DESCRIPTION
## What

[Jira AP-831](https://dsdmoj.atlassian.net/browse/AP-831)

Updates most Citizen pages to use common parent `CitizenBaseController`.

Adds action to redirect to `error_path(:assessment_already_completed)` for pages on Citizen journey. Adds method to over-write this behaviour for final page, so page can be refreshed.