### PR TITLE
AP867 Update Submitted Application for passported

### DIFF
--- a/app/assets/stylesheets/check-your-answers.scss
+++ b/app/assets/stylesheets/check-your-answers.scss
@@ -75,3 +75,7 @@ $govuk-fonts-path: "/assets/";
 .align-text-right {
   text-align: right;
 }
+
+strong.app-tag--capitalize {
+  text-transform: capitalize
+}

--- a/app/views/providers/submitted_applications/show.html.erb
+++ b/app/views/providers/submitted_applications/show.html.erb
@@ -36,20 +36,30 @@
   <section class="income_payments_and_assets">
     <h2 class="govuk-heading-l"><%= t('.income_payments_and_assets_heading') %></h2>
 
-    <h3 class="govuk-heading-m"><%= t('.income') %></h3>
-    <%= render(
-          'shared/check_answers/bank_transaction_table',
-          transaction_types: TransactionType.credits,
-          read_only: true
-        ) %>
-
-    <h3 class="govuk-heading-m govuk-!-padding-top-8"><%= t('.payments') %></h3>
-    <%= render(
-          'shared/check_answers/bank_transaction_table',
-          transaction_types: TransactionType.debits,
-          read_only: true
-        ) %>
-
+      <h3 class="govuk-heading-m"><%= t('.income') %></h3>
+        <% if @legal_aid_application.benefit_check_result&.positive? %>
+            <strong class="govuk-tag app-tag--capitalize">
+              <%= t('.passported') %>
+            </strong>
+        <% else %>
+          <%= render(
+                'shared/check_answers/bank_transaction_table',
+                transaction_types: TransactionType.credits,
+                read_only: true
+              ) %>
+        <% end %>
+      <h3 class="govuk-heading-m govuk-!-padding-top-8"><%= t('.payments') %></h3>
+        <% if @legal_aid_application.benefit_check_result&.positive? %>
+          <strong class="govuk-tag app-tag--capitalize">
+            <%= t('.passported') %>
+          </strong>
+        <% else %>
+          <%= render(
+                'shared/check_answers/bank_transaction_table',
+                transaction_types: TransactionType.debits,
+                read_only: true
+              ) %>
+        <% end %>
     <h3 class="govuk-heading-m govuk-!-padding-top-8"><%= t('.property') %></h3>
     <%= render 'shared/check_answers/assets', read_only: true %>
   </section>

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -346,6 +346,7 @@ en:
         proceedings_details_heading: What you're applying for
         income_payments_and_assets_heading: Income, regular payments and assets
         income: Income
+        passported: Passported
         payments: Regular payments
         property: Property
         section_client:

--- a/features/providers/civil_application_journey.feature
+++ b/features/providers/civil_application_journey.feature
@@ -426,6 +426,7 @@ Feature: Civil application journeys
     Then I should be on a page showing "Application complete"
     Then I click 'View completed application'
     Then I should be on a page showing "Application for civil legal aid certificate"
+    And I should not see "Passported"
 
   @javascript @vcr
   Scenario: Receives benefits and completes the application
@@ -535,6 +536,7 @@ Feature: Civil application journeys
     Then I should be on a page showing "Application complete"
     Then I click 'View completed application'
     Then I should be on a page showing "Application for civil legal aid certificate"
+    Then I should be on a page showing "Passported"
 
   @javascript @vcr
   Scenario: View feedback form within provider journey


### PR DESCRIPTION
Remove income and payments from /submitted_application for passported applications and replace with govuk-tag 'Passported'

[Link to story](https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=233&projectKey=AP&modal=detail&selectedIssue=AP-867)

- Update the view and replace incomes and outgoing details with 'Passported' govuk-tag when the application is passported.

- Override govuk-tag style to capitalize and not be all capitals
(I read about overriding govuk styles here https://design-system.service.gov.uk/get-started/extending-and-modifying-components/#small-modifications-to-components )

- Update feature test and locales

## Checklist

Before you ask people to review this PR:

- [X] Tests and rubocop should be passing: `bundle exec rake`
- [X] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [X] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [X] The PR description should say what you changed and why, with a link to the JIRA story.
- [X] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [X] You should have checked that the commit messages say why the change was made.
