### PR TITLE
Disable HTML-CHECKER on webhint ☹

### DIFF
--- a/.hintrc
+++ b/.hintrc
@@ -21,7 +21,7 @@
     "css-prefix-order": "error",
     "disown-opener": "error",
     "highest-available-document-mode": "error",
-    "html-checker": ["error", {
+    "html-checker": ["off", {
       "ignore": [
         "Could not get results from HTML checker for 'file:///home/circleci/project/tmp/webhint_inputs/apply-citizens-accounts.html'. Error: 'SyntaxError: Unexpected token < in JSON at position 0'.",
         "Could not get results from HTML checker for 'file:///home/circleci/project/tmp/webhint_inputs/apply-citizens-additional_accounts.html'. Error: 'SyntaxError: Unexpected token < in JSON at position 0'.",

--- a/bin/generate_webhint_reports.sh
+++ b/bin/generate_webhint_reports.sh
@@ -39,16 +39,16 @@ then
   echo "\e[41mWebhint issues found - test failed\e[0m"
   exit 1 #exit - 0 non fatal, 1 fatal (make fatal once all tests are in place and existing issues solved)
 else
-  echo "\e[42m      All  Webhint  tests  passed       \e[0m"
-  echo "\e[92m                                        \e[0m"
-  echo "\e[92m  ########     ###     ######   ######  \e[0m"
-  echo "\e[92m  ##     ##   ## ##   ##    ## ##    ## \e[0m"
-  echo "\e[92m  ##     ##  ##   ##  ##       ##       \e[0m"
-  echo "\e[92m  ########  ##     ##  ######   ######  \e[0m"
-  echo "\e[92m  ##        #########       ##       ## \e[0m"
-  echo "\e[92m  ##        ##     ## ##    ## ##    ## \e[0m"
-  echo "\e[92m  ##        ##     ##  ######   ######  \e[0m"
-  echo "\e[92m                                        \e[0m"
-  echo "\e[42m      All  Webhint  tests  passed       \e[0m"
+  echo "\e[42m      All  Webhint  tests  passed        \e[0m"
+  echo "\e[92m                                         \e[0m"
+  echo "\e[92m  ########     ###     ######   ######   \e[0m"
+  echo "\e[92m  ##     ##   ## ##   ##    ## ##    ##  \e[0m"
+  echo "\e[92m  ##     ##  ##   ##  ##       ##        \e[0m"
+  echo "\e[92m  ########  ##     ##  ######   ######   \e[0m"
+  echo "\e[92m  ##        #########       ##       ##  \e[0m"
+  echo "\e[92m  ##        ##     ## ##    ## ##    ##  \e[0m"
+  echo "\e[92m  ##        ##     ##  ######   ######   \e[0m"
+  echo "\e[92m                                         \e[0m"
+  echo "\e[42m      All  Webhint  tests  passed        \e[0m"
 fi
 


### PR DESCRIPTION
## What

Turned off HTML-checker for Webhint as it was causing random errors.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
