### PR TITLE
Add webhint rake task

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,9 +84,13 @@ VCR_RECORD_MODE=all bin/rake
 
 webhint (https://webhint.io/) is used to check if pages are accessible.
 
-- Run `SAVE_PAGES=true bin/rails cucumber` to run the feature tests and save all pages to `tmp/webhint_inputs`
-- Run `./bin/generate_webhint_reports.sh` to check these pages with webhint.
-- The result will be printed as a JSON result and you can also find HTML reports in the `hint-report` folder.
+Run `rake webhint:generate_reports`. This will
+
+- delete any existing files from previous runs
+- execute `SAVE_PAGES=true bin/rails cucumber` to run the feature tests and save all pages to `tmp/webhint_inputs`
+- and the execute `./bin/generate_webhint_reports.sh` to check those pages with webhint.
+
+The result will be printed as a JSON result and you can also find HTML reports in the `hint-report` folder.
 
 ## Deployment
 

--- a/lib/tasks/webhint.rake
+++ b/lib/tasks/webhint.rake
@@ -1,0 +1,9 @@
+namespace :webhint do
+  desc 'Run webhint and output reports'
+  task :generate_reports do
+    sh 'rm -rf hint-report/*'
+    sh 'rm -rf tmp/webhint_inputs/*'
+    sh 'SAVE_PAGES=true ./bin/rails cucumber'
+    sh './bin/generate_webhint_reports.sh'
+  end
+end


### PR DESCRIPTION
## What

Add a rake task to run related webhint tasks with a single command, rather than running several commands independently.

Running `rake webhint:generate_reports` will delete any existing files from previous runs, generate new pages, and run webhint against each page.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
