### PR TITLE
Include Webhint into tests

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,5 +7,5 @@ Rails.application.load_tasks
 
 unless Rails.env.production?
   task(:default).clear
-  task default: %i[rubocop erblint javascript_tests spec cucumber]
+  task default: %i[rubocop erblint javascript_tests spec webhint:generate_reports]
 end


### PR DESCRIPTION
Include webhint:generate_reports into tests and replace cucumber (bundle execute rake) with it. This is because webhint also runs cucumber tests.

## Checklist

Before you ask people to review this PR:

- [X] Tests and rubocop should be passing: `bundle exec rake`
- [X] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [X] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [X] The PR description should say what you changed and why, with a link to the JIRA story.
- [X] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [X] You should have checked that the commit messages say why the change was made.
