### PR TITLE
AP-904 - Create substantive cases with CCMS integration spec

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -19,6 +19,7 @@ class Provider < ApplicationRecord
   end
 
   # TODO: replace with real data once we have it from the provider details API
+  # :nocov:
   def supervisor_contact_id
     7_008_010
   end
@@ -26,4 +27,5 @@ class Provider < ApplicationRecord
   def fee_earner_contact_id
     4_925_152
   end
+  # :nocov:
 end

--- a/config/ccms/ccms_keys.yml
+++ b/config/ccms/ccms_keys.yml
@@ -2950,7 +2950,8 @@ global_merits:
     :response_type: boolean
     :user_defined: false
   DELEG_FUNCTIONS_DATE_MERITS:
-    :value: 01-04-2019
+    :generate_block?: '#application_used_delegated_functions?'
+    :value: '#used_delegated_functions_on'
     :br100_meaning: 'Emg: The Delegated Functions Date'
     :response_type: date
     :user_defined: false

--- a/spec/services/ccms/case_add_requestor_xml_blocks_spec.rb
+++ b/spec/services/ccms/case_add_requestor_xml_blocks_spec.rb
@@ -12,12 +12,24 @@ module CCMS # rubocop:disable Metrics/ModuleLength
                with_bank_accounts: 2
       end
 
+      let(:provider) do
+        double Provider,
+               firm_id: 19_148,
+               selected_office_id: 137_570,
+               user_login_id: 4_953_649,
+               username: 4_953_649,
+               contact_user_id: 4_953_649,
+               supervisor_contact_id: 7_008_010,
+               fee_earner_contact_id: 4_925_152
+      end
+
       let(:application_proceeding_type) { legal_aid_application.application_proceeding_types.first }
       let(:respondent) { legal_aid_application.respondent }
       let(:submission) { create :submission, :case_ref_obtained, legal_aid_application: legal_aid_application }
       let(:requestor) { described_class.new(submission, {}) }
       let(:xml) { requestor.formatted_xml }
       before { allow(requestor).to receive(:transaction_request_id).and_return(expected_tx_id) }
+      before { allow(requestor).to receive(:provider).and_return(provider) }
 
       # enable this context if  you need to create a file of the payload for manual inspection
       xcontext 'saving to a temporary file' do


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-904)

Amend `ccms_integration/ccms_spec.rb` so that it injects two cases into
CCMS when it is run - one delegated functions (as it does already) and
one substantive.

- Add an extra `context` to account for the substantive case. This
involves some refactoring of the existing spec.

- Amend `save_request` functionality so that it includes the case type in
the filename, to make it easier to see what each payload is.

- Use factories to create `proceeding_types` and `scope_limitations`,
instead of doubles.

- Changes to `case_add_requestor` and `ccms_keys` to ensure correct values
are being populated in the payload.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
