### PR TITLE
Ap 810 fix ccms document upload

### DIFF
--- a/app/models/ccms/submission.rb
+++ b/app/models/ccms/submission.rb
@@ -21,11 +21,11 @@ module CCMS
       when 'applicant_submitted'
         CheckApplicantStatusService.call(self)
       when 'case_created'
-        ObtainDocumentIdService.call(self)
-      when 'document_ids_obtained'
         UploadDocumentsService.call(self)
-      when 'applicant_ref_obtained'
+      when 'document_ids_obtained'
         AddCaseService.call(self, options)
+      when 'applicant_ref_obtained'
+        ObtainDocumentIdService.call(self)
       when 'case_submitted'
         CheckCaseStatusService.call(self)
       else

--- a/app/models/ccms/submission.rb
+++ b/app/models/ccms/submission.rb
@@ -20,14 +20,14 @@ module CCMS
         ObtainApplicantReferenceService.call(self)
       when 'applicant_submitted'
         CheckApplicantStatusService.call(self)
-      when 'case_created'
-        UploadDocumentsService.call(self)
-      when 'document_ids_obtained'
-        AddCaseService.call(self, options)
       when 'applicant_ref_obtained'
         ObtainDocumentIdService.call(self)
+      when 'document_ids_obtained'
+        AddCaseService.call(self, options)
       when 'case_submitted'
         CheckCaseStatusService.call(self)
+      when 'case_created'
+        UploadDocumentsService.call(self)
       else
         raise CcmsError, "Unknown state: #{aasm_state}"
       end

--- a/app/models/concerns/ccms_submission_state_machine.rb
+++ b/app/models/concerns/ccms_submission_state_machine.rb
@@ -30,6 +30,7 @@ module CCMSSubmissionStateMachine
 
       event :submit_case, after: :process_async! do
         transitions from: :applicant_ref_obtained, to: :case_submitted
+        transitions from: :document_ids_obtained, to: :case_submitted
       end
 
       event :confirm_case_created, after: :process_async! do
@@ -37,12 +38,11 @@ module CCMSSubmissionStateMachine
       end
 
       event :obtain_document_ids, after: :process_async! do
-        transitions from: :case_created, to: :document_ids_obtained
+        transitions from: :applicant_ref_obtained, to: :document_ids_obtained
       end
 
       event :complete do
         transitions from: :case_created, to: :completed
-        transitions from: :document_ids_obtained, to: :completed
       end
 
       event :fail do

--- a/app/models/concerns/ccms_submission_state_machine.rb
+++ b/app/models/concerns/ccms_submission_state_machine.rb
@@ -9,9 +9,9 @@ module CCMSSubmissionStateMachine
       state :case_ref_obtained
       state :applicant_submitted
       state :applicant_ref_obtained
+      state :document_ids_obtained
       state :case_submitted
       state :case_created
-      state :document_ids_obtained
       state :completed
       state :failed
 
@@ -28,6 +28,10 @@ module CCMSSubmissionStateMachine
         transitions from: :case_ref_obtained, to: :applicant_ref_obtained
       end
 
+      event :obtain_document_ids, after: :process_async! do
+        transitions from: :applicant_ref_obtained, to: :document_ids_obtained
+      end
+
       event :submit_case, after: :process_async! do
         transitions from: :applicant_ref_obtained, to: :case_submitted
         transitions from: :document_ids_obtained, to: :case_submitted
@@ -35,10 +39,6 @@ module CCMSSubmissionStateMachine
 
       event :confirm_case_created, after: :process_async! do
         transitions from: :case_submitted, to: :case_created
-      end
-
-      event :obtain_document_ids, after: :process_async! do
-        transitions from: :applicant_ref_obtained, to: :document_ids_obtained
       end
 
       event :complete do

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -19,7 +19,10 @@ class Provider < ApplicationRecord
   end
 
   # TODO: replace with real data once we have it from the provider details API
-  # :nocov:
+  def user_login_id
+    2_016_472
+  end
+
   def supervisor_contact_id
     7_008_010
   end
@@ -27,5 +30,4 @@ class Provider < ApplicationRecord
   def fee_earner_contact_id
     4_925_152
   end
-  # :nocov:
 end

--- a/app/services/ccms/add_case_service.rb
+++ b/app/services/ccms/add_case_service.rb
@@ -8,7 +8,7 @@ module CCMS
       @options = options
       if case_add_response_parser.success?
         submission.case_add_transaction_id = case_add_requestor.transaction_request_id
-        create_history('applicant_ref_obtained', submission.aasm_state) if submission.submit_case!
+        create_history(submission.documents.empty? ? 'applicant_ref_obtained' : 'document_ids_obtained', submission.aasm_state) if submission.submit_case!
       else
         handle_failure(response)
       end

--- a/app/services/ccms/case_add_requestor.rb
+++ b/app/services/ccms/case_add_requestor.rb
@@ -62,7 +62,7 @@ module CCMS
       xml.__send__('ns2:CaseDetails') do
         xml.__send__('ns2:ApplicationDetails') { generate_application_details(xml) }
         xml.__send__('ns2:RecordHistory') { generate_record_history(xml) }
-        xml.__send__('ns2:CaseDocs')
+        xml.__send__('ns2:CaseDocs') { generate_case_docs(xml) }
       end
     end
 
@@ -78,6 +78,17 @@ module CCMS
       xml.__send__('ns2:DevolvedPowersDate', '2019-04-01')  # TODO: CCMS placeholder
       xml.__send__('ns2:ApplicationAmendmentType', 'SUBDP') # TODO: CCMS placeholder
       xml.__send__('ns2:LARDetails') { generate_lar_details(xml) }
+    end
+
+    def generate_case_docs(xml)
+      @submission.documents.each do |key|
+        xml.__send__('ns2:CaseDoc') do
+          xml.__send__('ns2:CCMSDocumentID', PdfFile.find_by(original_file_id: key).ccms_document_id)
+          # TODO: at present only statements of case are uploaded. at some point uploads will also include means and
+          # merits reports; at that point the following element will need to vary based on document type
+          xml.__send__('ns2:DocumentSubject', 'statement_of_case')
+        end
+      end
     end
 
     def generate_other_parties(xml)

--- a/app/services/ccms/obtain_document_id_service.rb
+++ b/app/services/ccms/obtain_document_id_service.rb
@@ -3,10 +3,10 @@ module CCMS
     def call
       populate_documents
       if submission.documents.empty?
-        create_history('case_created', submission.aasm_state) if submission.complete!
+        create_history('applicant_ref_obtained', submission.aasm_state) if submission.submit_case!
       else
         request_document_ids
-        create_history('case_created', submission.aasm_state) if submission.obtain_document_ids!
+        create_history('applicant_ref_obtained', submission.aasm_state) if submission.obtain_document_ids!
       end
     rescue CcmsError => e
       handle_failure(e)

--- a/app/services/ccms/upload_documents_service.rb
+++ b/app/services/ccms/upload_documents_service.rb
@@ -8,7 +8,7 @@ module CCMS
       failed_uploads = submission.documents.select { |_key, value| value == :failed }
 
       if failed_uploads.empty?
-        create_history('document_ids_obtained', submission.aasm_state) if submission.complete!
+        create_history('case_created', submission.aasm_state) if submission.complete!
       else
         handle_failure("#{failed_uploads.keys} failed to upload to CCMS")
       end

--- a/ccms_integration/ccms_spec.rb
+++ b/ccms_integration/ccms_spec.rb
@@ -41,7 +41,7 @@ module CCMS
     end
 
     let(:provider) do
-      double 'Provider',
+      double Provider,
              username: 'user1',
              firm_id: 22_381,
              selected_office_id: 81_693,

--- a/ccms_integration/ccms_spec.rb
+++ b/ccms_integration/ccms_spec.rb
@@ -175,7 +175,7 @@ module CCMS
       print 'Submitting case... '
       @submission.process!
       expect(@submission.aasm_state).to eq 'case_submitted'
-      expect(history.from_state).to eq 'applicant_ref_obtained'
+      expect(history.from_state).to eq 'document_ids_obtained'
       expect(history.to_state).to eq 'case_submitted'
       expect(history.success).to be true
       expect(history.details).to be_nil
@@ -209,7 +209,7 @@ module CCMS
       expect(@submission.documents).to_not be_empty
       expect(@submission.documents.values[0]).to eq :id_obtained
       expect(@submission.aasm_state).to eq 'document_ids_obtained'
-      expect(history.from_state).to eq 'case_created'
+      expect(history.from_state).to eq 'applicant_ref_obtained'
       expect(history.to_state).to eq 'document_ids_obtained'
       expect(history.success).to be true
       expect(history.details).to be_nil
@@ -221,7 +221,7 @@ module CCMS
       @submission.process!
       expect(@submission.documents.values[0]).to eq :uploaded
       expect(@submission.aasm_state).to eq 'completed'
-      expect(history.from_state).to eq 'document_ids_obtained'
+      expect(history.from_state).to eq 'case_created'
       expect(history.to_state).to eq 'completed'
       expect(history.success).to be true
       expect(history.details).to be_nil
@@ -233,9 +233,9 @@ module CCMS
       request_case_id
       create_an_applicant
       poll_applicant_creation
+      request_document_ids
       create_case
       poll_case_creation_result
-      request_document_ids
       upload_documents
     end
   end

--- a/spec/factories/submissions.rb
+++ b/spec/factories/submissions.rb
@@ -25,6 +25,7 @@ FactoryBot.define do
 
     trait :document_ids_obtained do
       aasm_state { 'document_ids_obtained' }
+      documents { { '12345' => :id_obtained } }
     end
   end
 end

--- a/spec/models/ccms/submission_spec.rb
+++ b/spec/models/ccms/submission_spec.rb
@@ -4,7 +4,7 @@ require 'sidekiq/testing'
 module CCMS # rubocop:disable Metrics/ModuleLength
   RSpec.describe Submission do
     let(:state) { :initialised }
-    let(:legal_aid_application) { create :legal_aid_application, :with_applicant }
+    let(:legal_aid_application) { create :legal_aid_application, :with_applicant, :with_other_assets_declaration, :with_savings_amount }
     let(:submission) { create :submission, legal_aid_application: legal_aid_application, aasm_state: state }
 
     context 'Validations' do
@@ -66,9 +66,9 @@ module CCMS # rubocop:disable Metrics/ModuleLength
 
         context 'applicant_ref_obtained state' do
           let(:state) { :applicant_ref_obtained }
-          let(:service) { AddCaseService }
+          let(:service) { ObtainDocumentIdService }
           it 'calls the add_case service' do
-            expect(service_instance).to receive(:call).with({})
+            expect(service_instance).to receive(:call).with(no_args)
           end
         end
 
@@ -82,7 +82,7 @@ module CCMS # rubocop:disable Metrics/ModuleLength
 
         context 'case_created state' do
           let(:state) { :case_created }
-          let(:service) { ObtainDocumentIdService }
+          let(:service) { UploadDocumentsService }
           it 'calls the obtain_document_id service' do
             expect(service_instance).to receive(:call).with(no_args)
           end
@@ -90,9 +90,9 @@ module CCMS # rubocop:disable Metrics/ModuleLength
 
         context 'document_ids_obtained state' do
           let(:state) { :document_ids_obtained }
-          let(:service) { UploadDocumentsService }
+          let(:service) { AddCaseService }
           it 'calls the upload_documents service' do
-            expect(service_instance).to receive(:call).with(no_args)
+            expect(service_instance).to receive(:call).with({})
           end
         end
       end

--- a/spec/services/ccms/add_case_service_spec.rb
+++ b/spec/services/ccms/add_case_service_spec.rb
@@ -30,12 +30,25 @@ RSpec.describe CCMS::AddCaseService do
       expect(submission.case_add_transaction_id).to eq transaction_request_id_in_example_response
     end
 
-    it 'writes a history record' do
-      expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
-      expect(history.from_state).to eq 'applicant_ref_obtained'
-      expect(history.to_state).to eq 'case_submitted'
-      expect(history.success).to be true
-      expect(history.details).to be_nil
+    context 'there are documents to upload' do
+      let(:submission) { create :submission, :document_ids_obtained, legal_aid_application: legal_aid_application }
+      it 'writes a history record' do
+        expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
+        expect(history.from_state).to eq 'document_ids_obtained'
+        expect(history.to_state).to eq 'case_submitted'
+        expect(history.success).to be true
+        expect(history.details).to be_nil
+      end
+    end
+
+    context 'there are no documents to upload' do
+      it 'writes a history record' do
+        expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
+        expect(history.from_state).to eq 'applicant_ref_obtained'
+        expect(history.to_state).to eq 'case_submitted'
+        expect(history.success).to be true
+        expect(history.details).to be_nil
+      end
     end
   end
 

--- a/spec/services/ccms/case_add_requestor_spec.rb
+++ b/spec/services/ccms/case_add_requestor_spec.rb
@@ -73,7 +73,7 @@ module CCMS # rubocop:disable Metrics/ModuleLength
       end
 
       let(:provider) do
-        double 'Provider',
+        double Provider,
                firm_id: 19_148,
                selected_office_id: 137_570,
                user_login_id: 4_953_649,
@@ -339,21 +339,10 @@ module CCMS # rubocop:disable Metrics/ModuleLength
       let(:soap_client_double) { Savon.client(env_namespace: :soap, wsdl: requestor.__send__(:wsdl_location)) }
       let(:expected_soap_operation) { :create_case_application }
       let(:expected_xml) { requestor.__send__(:request_xml) }
-      let(:provider) do
-        double 'Provider',
-               firm_id: 19_148,
-               selected_office_id: 137_570,
-               user_login_id: 4_953_649,
-               username: 4_953_649,
-               contact_user_id: 4_953_649,
-               supervisor_contact_id: 7_008_010,
-               fee_earner_contact_id: 4_925_152
-      end
 
       before do
         Timecop.freeze
         expect(requestor).to receive(:soap_client).and_return(soap_client_double)
-        allow(requestor).to receive(:provider).and_return(provider)
       end
 
       it 'calls the savon soap client' do

--- a/spec/services/ccms/case_add_requestor_spec.rb
+++ b/spec/services/ccms/case_add_requestor_spec.rb
@@ -288,17 +288,29 @@ module CCMS # rubocop:disable Metrics/ModuleLength
       let(:expected_tx_id) { '201904011604570390059770759' }
 
       let(:submission) do
-        double Submission,
+        double CCMS::Submission,
                legal_aid_application: legal_aid_application,
                case_ccms_reference: 1_234_567_890,
                applicant_ccms_reference: 9_876_543_210
       end
+
+      let(:documents) { { '2b4ccb59-5161-498d-a27a-79110de7b67e' => :id_obtained } }
+
+      let(:pdf_file) do
+        double PdfFile,
+               id: 'd9e0444d-dad0-4228-afe0-14b5397e48dc',
+               original_file_id: '2b4ccb59-5161-498d-a27a-79110de7b67e',
+               ccms_document_id: '4427475'
+      end
+
       let(:requestor) { described_class.new(submission, {}) }
 
       before do
         allow(ProceedingType).to receive(:find).with(1).and_return(proceeding_type_1)
         allow(ProceedingType).to receive(:find).with(2).and_return(proceeding_type_2)
         allow(ApplicationScopeLimitation).to receive(:find_by).and_return(application_scope_limitation_1)
+        allow(PdfFile).to receive(:find_by).and_return(pdf_file)
+        allow(submission).to receive(:documents).and_return(documents)
       end
 
       describe 'Full XML request' do

--- a/spec/services/ccms/obtain_document_id_service_spec.rb
+++ b/spec/services/ccms/obtain_document_id_service_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe CCMS::ObtainDocumentIdService do
   let(:legal_aid_application) { create :legal_aid_application, statement_of_case: statement_of_case }
-  let(:submission) { create :submission, :case_created, legal_aid_application: legal_aid_application, case_ccms_reference: Faker::Number.number }
+  let(:submission) { create :submission, :applicant_ref_obtained, legal_aid_application: legal_aid_application, case_ccms_reference: Faker::Number.number }
   let(:statement_of_case) { create :statement_of_case }
   let(:history) { CCMS::SubmissionHistory.find_by(submission_id: submission.id) }
   let(:document_id_requestor) { double CCMS::DocumentIdRequestor.new(submission.case_ccms_reference) }
@@ -15,14 +15,14 @@ RSpec.describe CCMS::ObtainDocumentIdService do
         expect(submission.documents&.size).to eq 0
       end
 
-      it 'changes the submission state to completed' do
-        expect { subject.call }.to change { submission.aasm_state }.to 'completed'
+      it 'changes the submission state to case_submitted' do
+        expect { subject.call }.to change { submission.aasm_state }.to 'case_submitted'
       end
 
       it 'writes a history record' do
         expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
-        expect(history.from_state).to eq 'case_created'
-        expect(history.to_state).to eq 'completed'
+        expect(history.from_state).to eq 'applicant_ref_obtained'
+        expect(history.to_state).to eq 'case_submitted'
         expect(history.success).to be true
         expect(history.details).to be_nil
       end
@@ -79,7 +79,7 @@ RSpec.describe CCMS::ObtainDocumentIdService do
 
       it 'writes a history record' do
         expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
-        expect(history.from_state).to eq 'case_created'
+        expect(history.from_state).to eq 'applicant_ref_obtained'
         expect(history.to_state).to eq 'failed'
         expect(history.success).to be false
         expect(history.details).to match(/CCMS::CcmsError/)
@@ -106,7 +106,7 @@ RSpec.describe CCMS::ObtainDocumentIdService do
 
       it 'writes a history record' do
         expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
-        expect(history.from_state).to eq 'case_created'
+        expect(history.from_state).to eq 'applicant_ref_obtained'
         expect(history.to_state).to eq 'failed'
         expect(history.success).to be false
         expect(history.details).to match(/CCMS::CcmsError/)

--- a/spec/services/ccms/upload_documents_service_spec.rb
+++ b/spec/services/ccms/upload_documents_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe CCMS::UploadDocumentsService do
   let(:document_id) { statement_of_case.original_files.first.id }
   let(:submission) do
     create :submission,
-           :document_ids_obtained,
+           :case_created,
            legal_aid_application: legal_aid_application,
            case_ccms_reference: Faker::Number.number(digits: 9),
            documents: { document_id => :id_obtained }
@@ -51,7 +51,7 @@ RSpec.describe CCMS::UploadDocumentsService do
 
     it 'writes a history record' do
       expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
-      expect(history.from_state).to eq 'document_ids_obtained'
+      expect(history.from_state).to eq 'case_created'
       expect(history.to_state).to eq 'completed'
       expect(history.success).to be true
       expect(history.details).to be_nil
@@ -74,7 +74,7 @@ RSpec.describe CCMS::UploadDocumentsService do
 
       it 'writes a history record' do
         expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
-        expect(history.from_state).to eq 'document_ids_obtained'
+        expect(history.from_state).to eq 'case_created'
         expect(history.to_state).to eq 'failed'
         expect(history.success).to be false
         expect(history.details).to match(/CCMS::CcmsError/)
@@ -98,7 +98,7 @@ RSpec.describe CCMS::UploadDocumentsService do
 
       it 'writes a history record' do
         expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
-        expect(history.from_state).to eq 'document_ids_obtained'
+        expect(history.from_state).to eq 'case_created'
         expect(history.to_state).to eq 'failed'
         expect(history.success).to be false
         expect(history.details).to match('failed to upload to CCMS')


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-810)

Documents (eg statement of case PDFs) aren't currently being uploaded to CCMS correctly. The current, incorrect, process is:

1. request_case_id
2. create_an_applicant
3. poll_applicant_creation
4. create_case
5. poll_case_creation_result
6. request_document_ids
7. upload_documents

This is incorrect as document ids need to be included in the
create_case payload.

This commit changes the order of CCMS requests to

1. request_case_id
2. create_an_applicant
3. poll_applicant_creation
4. request_document_ids
5. create_case
6. poll_case_creation_result
7. upload_documents

by amending the logic in `ccms_submission_state_machine`, and changing various CCMS `_service` classes appropriately.

It also amends `case_add_requestor.rb` so that `ccms_document_id`s are included in the `CaseDocs` section of the case creation payload.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
