### PR TITLE
AP-824 persist none_selected checkboxes

### DIFF
--- a/app/controllers/citizens/identify_types_of_incomes_controller.rb
+++ b/app/controllers/citizens/identify_types_of_incomes_controller.rb
@@ -5,7 +5,7 @@ module Citizens
 
     def show
       legal_aid_application
-      @none_selected = legal_aid_application.no_credit_transaction_types_selected == true
+      @none_selected = legal_aid_application.no_credit_transaction_types_selected?
     end
 
     def update
@@ -26,17 +26,22 @@ module Citizens
     end
 
     def none_selected?
-      params[:none_selected] == 'true' &&
-        remove_existing_transaction_types &&
+      return unless params[:none_selected] == 'true'
+
+      LegalAidApplication.transaction do
+        remove_existing_transaction_types
         legal_aid_application.update!(no_credit_transaction_types_selected: true)
+      end
     end
 
     def transactions_added
       return if transaction_types.empty?
 
-      remove_existing_transaction_types
-      legal_aid_application.update!(no_credit_transaction_types_selected: false)
-      legal_aid_application.transaction_types << transaction_types
+      LegalAidApplication.transaction do
+        remove_existing_transaction_types
+        legal_aid_application.update!(no_credit_transaction_types_selected: false)
+        legal_aid_application.transaction_types << transaction_types
+      end
     end
 
     def remove_existing_transaction_types

--- a/app/controllers/citizens/identify_types_of_incomes_controller.rb
+++ b/app/controllers/citizens/identify_types_of_incomes_controller.rb
@@ -5,6 +5,7 @@ module Citizens
 
     def show
       legal_aid_application
+      @none_selected = legal_aid_application.no_credit_transaction_types_selected == true
     end
 
     def update
@@ -25,13 +26,16 @@ module Citizens
     end
 
     def none_selected?
-      params[:none_selected] == 'true' && remove_existing_transaction_types
+      params[:none_selected] == 'true' &&
+        remove_existing_transaction_types &&
+        legal_aid_application.update!(no_credit_transaction_types_selected: true)
     end
 
     def transactions_added
       return if transaction_types.empty?
 
       remove_existing_transaction_types
+      legal_aid_application.update!(no_credit_transaction_types_selected: false)
       legal_aid_application.transaction_types << transaction_types
     end
 

--- a/app/controllers/citizens/identify_types_of_outgoings_controller.rb
+++ b/app/controllers/citizens/identify_types_of_outgoings_controller.rb
@@ -5,6 +5,7 @@ module Citizens
 
     def show
       legal_aid_application
+      @none_selected = legal_aid_application.no_debit_transaction_types_selected == true
     end
 
     def update
@@ -25,13 +26,16 @@ module Citizens
     end
 
     def none_selected?
-      params[:none_selected] == 'true' && remove_existing_transaction_types
+      params[:none_selected] == 'true' &&
+        remove_existing_transaction_types &&
+        legal_aid_application.update!(no_debit_transaction_types_selected: true)
     end
 
     def transactions_added
       return if transaction_types.empty?
 
       remove_existing_transaction_types
+      legal_aid_application.update!(no_debit_transaction_types_selected: false)
       legal_aid_application.transaction_types << transaction_types
     end
 

--- a/app/controllers/citizens/identify_types_of_outgoings_controller.rb
+++ b/app/controllers/citizens/identify_types_of_outgoings_controller.rb
@@ -5,7 +5,7 @@ module Citizens
 
     def show
       legal_aid_application
-      @none_selected = legal_aid_application.no_debit_transaction_types_selected == true
+      @none_selected = legal_aid_application.no_debit_transaction_types_selected?
     end
 
     def update
@@ -26,17 +26,22 @@ module Citizens
     end
 
     def none_selected?
-      params[:none_selected] == 'true' &&
-        remove_existing_transaction_types &&
+      return unless params[:none_selected] == 'true'
+
+      LegalAidApplication.transaction do
+        remove_existing_transaction_types
         legal_aid_application.update!(no_debit_transaction_types_selected: true)
+      end
     end
 
     def transactions_added
       return if transaction_types.empty?
 
-      remove_existing_transaction_types
-      legal_aid_application.update!(no_debit_transaction_types_selected: false)
-      legal_aid_application.transaction_types << transaction_types
+      LegalAidApplication.transaction do
+        remove_existing_transaction_types
+        legal_aid_application.update!(no_debit_transaction_types_selected: false)
+        legal_aid_application.transaction_types << transaction_types
+      end
     end
 
     def remove_existing_transaction_types

--- a/app/controllers/providers/identify_types_of_incomes_controller.rb
+++ b/app/controllers/providers/identify_types_of_incomes_controller.rb
@@ -1,6 +1,8 @@
 module Providers
   class IdentifyTypesOfIncomesController < ProviderBaseController
-    def show; end
+    def show
+      @none_selected = legal_aid_application.no_credit_transaction_types_selected == true
+    end
 
     def update
       return continue_or_draft if none_selected? || transactions_added || draft_selected?
@@ -20,13 +22,16 @@ module Providers
     end
 
     def none_selected?
-      params[:none_selected] == 'true' && remove_existing_transaction_types
+      params[:none_selected] == 'true' &&
+        remove_existing_transaction_types &&
+        legal_aid_application.update!(no_credit_transaction_types_selected: true)
     end
 
     def transactions_added
       return if transaction_types.empty?
 
       remove_existing_transaction_types
+      legal_aid_application.update!(no_credit_transaction_types_selected: false)
       legal_aid_application.transaction_types << transaction_types
     end
 

--- a/app/controllers/providers/identify_types_of_incomes_controller.rb
+++ b/app/controllers/providers/identify_types_of_incomes_controller.rb
@@ -1,7 +1,7 @@
 module Providers
   class IdentifyTypesOfIncomesController < ProviderBaseController
     def show
-      @none_selected = legal_aid_application.no_credit_transaction_types_selected == true
+      @none_selected = legal_aid_application.no_credit_transaction_types_selected?
     end
 
     def update
@@ -22,17 +22,22 @@ module Providers
     end
 
     def none_selected?
-      params[:none_selected] == 'true' &&
-        remove_existing_transaction_types &&
+      return unless params[:none_selected] == 'true'
+
+      LegalAidApplication.transaction do
+        remove_existing_transaction_types
         legal_aid_application.update!(no_credit_transaction_types_selected: true)
+      end
     end
 
     def transactions_added
       return if transaction_types.empty?
 
-      remove_existing_transaction_types
-      legal_aid_application.update!(no_credit_transaction_types_selected: false)
-      legal_aid_application.transaction_types << transaction_types
+      LegalAidApplication.transaction do
+        remove_existing_transaction_types
+        legal_aid_application.update!(no_credit_transaction_types_selected: false)
+        legal_aid_application.transaction_types << transaction_types
+      end
     end
 
     def remove_existing_transaction_types

--- a/app/controllers/providers/identify_types_of_outgoings_controller.rb
+++ b/app/controllers/providers/identify_types_of_outgoings_controller.rb
@@ -1,7 +1,7 @@
 module Providers
   class IdentifyTypesOfOutgoingsController < ProviderBaseController
     def show
-      @none_selected = legal_aid_application.no_debit_transaction_types_selected == true
+      @none_selected = legal_aid_application.no_debit_transaction_types_selected?
     end
 
     def update
@@ -22,17 +22,22 @@ module Providers
     end
 
     def none_selected?
-      params[:none_selected] == 'true' &&
-        remove_existing_transaction_types &&
+      return unless params[:none_selected] == 'true'
+
+      LegalAidApplication.transaction do
+        remove_existing_transaction_types
         legal_aid_application.update!(no_debit_transaction_types_selected: true)
+      end
     end
 
     def transactions_added
       return if transaction_types.empty?
 
-      remove_existing_transaction_types
-      legal_aid_application.update!(no_debit_transaction_types_selected: false)
-      legal_aid_application.transaction_types << transaction_types
+      LegalAidApplication.transaction do
+        remove_existing_transaction_types
+        legal_aid_application.update!(no_debit_transaction_types_selected: false)
+        legal_aid_application.transaction_types << transaction_types
+      end
     end
 
     def remove_existing_transaction_types

--- a/app/controllers/providers/identify_types_of_outgoings_controller.rb
+++ b/app/controllers/providers/identify_types_of_outgoings_controller.rb
@@ -1,6 +1,8 @@
 module Providers
   class IdentifyTypesOfOutgoingsController < ProviderBaseController
-    def show; end
+    def show
+      @none_selected = legal_aid_application.no_debit_transaction_types_selected == true
+    end
 
     def update
       return continue_or_draft if none_selected? || transactions_added || draft_selected?
@@ -20,13 +22,16 @@ module Providers
     end
 
     def none_selected?
-      params[:none_selected] == 'true' && remove_existing_transaction_types
+      params[:none_selected] == 'true' &&
+        remove_existing_transaction_types &&
+        legal_aid_application.update!(no_debit_transaction_types_selected: true)
     end
 
     def transactions_added
       return if transaction_types.empty?
 
       remove_existing_transaction_types
+      legal_aid_application.update!(no_debit_transaction_types_selected: false)
       legal_aid_application.transaction_types << transaction_types
     end
 

--- a/app/forms/citizens/other_assets_form.rb
+++ b/app/forms/citizens/other_assets_form.rb
@@ -20,7 +20,7 @@ module Citizens
       second_home_percentage
     ].freeze
 
-    OTHER_CHECKBOXES = %i[check_box_second_home check_box_valuable_items_value check_box_none_selected].freeze
+    OTHER_CHECKBOXES = %i[check_box_second_home check_box_valuable_items_value none_selected].freeze
 
     ALL_ATTRIBUTES = (SECOND_HOME_ATTRIBUTES + SINGLE_VALUE_ATTRIBUTES + VALUABLE_ITEMS_VALUE_ATTRIBUTE).freeze
 
@@ -38,7 +38,7 @@ module Citizens
 
     attr_accessor(*ALL_ATTRIBUTES)
     attr_accessor(*CHECK_BOXES_ATTRIBUTES)
-    attr_accessor :check_box_second_home, :check_box_none_selected, :mode
+    attr_accessor :mode
 
     before_validation :empty_unchecked_values
 
@@ -56,7 +56,7 @@ module Citizens
     end
 
     def exclude_from_model
-      CHECK_BOXES_ATTRIBUTES + [:mode]
+      CHECK_BOXES_ATTRIBUTES + [:mode] - [:none_selected]
     end
 
     def attributes_to_clean

--- a/app/forms/savings_amounts/savings_amounts_form.rb
+++ b/app/forms/savings_amounts/savings_amounts_form.rb
@@ -14,7 +14,7 @@ module SavingsAmounts
       life_assurance_endowment_policy
     ].freeze
 
-    CHECK_BOXES_ATTRIBUTES = (ATTRIBUTES.map { |attribute| "check_box_#{attribute}".to_sym } + %i[check_box_none_selected]).freeze
+    CHECK_BOXES_ATTRIBUTES = (ATTRIBUTES.map { |attribute| "check_box_#{attribute}".to_sym } + %i[none_selected]).freeze
 
     ATTRIBUTES.each do |attribute|
       check_box_attribute = "check_box_#{attribute}".to_sym
@@ -23,7 +23,7 @@ module SavingsAmounts
 
     attr_accessor(*ATTRIBUTES)
     attr_accessor(*CHECK_BOXES_ATTRIBUTES)
-    attr_accessor :check_box_none_selected, :journey
+    attr_accessor :journey
 
     validates(*ATTRIBUTES, allow_blank: true, currency: { greater_than_or_equal_to: 0 })
 
@@ -32,7 +32,7 @@ module SavingsAmounts
     validate :any_checkbox_checked_or_draft
 
     def exclude_from_model
-      CHECK_BOXES_ATTRIBUTES + [:journey]
+      CHECK_BOXES_ATTRIBUTES + [:journey] - [:none_selected]
     end
 
     def attributes_to_clean

--- a/app/javascript/src/checkbox_control.js
+++ b/app/javascript/src/checkbox_control.js
@@ -57,7 +57,7 @@ $(function() {
       If one is selected, deselect the control.
     */
     checkboxes.change( function() {
-      if(this.checked) { control.prop("checked", false )}
+      if(this.checked) { control.prop("checked", false ).val(false) }
     })
   })
 })

--- a/app/models/concerns/capital.rb
+++ b/app/models/concerns/capital.rb
@@ -4,6 +4,6 @@ module Capital
   end
 
   def amount_attributes
-    attributes.except('id', 'legal_aid_application_id', 'updated_at', 'created_at')
+    attributes.except('id', 'legal_aid_application_id', 'updated_at', 'created_at', 'none_selected')
   end
 end

--- a/app/views/shared/forms/_identify_types_of_outgoings_form.html.erb
+++ b/app/views/shared/forms/_identify_types_of_outgoings_form.html.erb
@@ -20,7 +20,7 @@
 
     <div class="govuk-checkboxes">
       <div class="govuk-checkboxes__item">
-        <%= check_box_tag :none_selected, 'true', false, class: 'govuk-checkboxes__input' %>
+        <%= check_box_tag :none_selected, 'true', @none_selected, class: 'govuk-checkboxes__input' %>
         <%= label_tag :none_selected, t('.none_selected'), class: 'govuk-label govuk-checkboxes__label' %>
       </div>
     </div>

--- a/app/views/shared/forms/_savings_and_investments_form.html.erb
+++ b/app/views/shared/forms/_savings_and_investments_form.html.erb
@@ -8,7 +8,7 @@
     <% end %>
     <fieldset class="govuk-fieldset">
       <div class="govuk-checkboxes" data-module="govuk-checkboxes">
-        <div class="deselect-group" data-deselect-ctrl="#savings_amount_none_selected">
+        <div class="deselect-group" data-deselect-ctrl="[name='savings_amount[none_selected]']">
           <%= render partial: 'shared/forms/revealing_checkbox/attribute',
                      collection: attributes,
                      locals: { model: @form, form: form } %>
@@ -19,7 +19,7 @@
 
       <div class="govuk-checkboxes">
         <div class="govuk-checkboxes__item">
-          <%= form.check_box :none_selected, { class: 'govuk-checkboxes__input' }, 'true', '' %>
+          <%= form.check_box :none_selected, { class: 'govuk-checkboxes__input' }, 'true', @form.none_selected %>
           <%= form.label :none_selected, none_selected, class: 'govuk-label govuk-checkboxes__label' %>
         </div>
       </div>

--- a/app/views/shared/forms/_savings_and_investments_form.html.erb
+++ b/app/views/shared/forms/_savings_and_investments_form.html.erb
@@ -8,7 +8,7 @@
     <% end %>
     <fieldset class="govuk-fieldset">
       <div class="govuk-checkboxes" data-module="govuk-checkboxes">
-        <div class="deselect-group" data-deselect-ctrl="#savings_amount_check_box_none_selected">
+        <div class="deselect-group" data-deselect-ctrl="#savings_amount_none_selected">
           <%= render partial: 'shared/forms/revealing_checkbox/attribute',
                      collection: attributes,
                      locals: { model: @form, form: form } %>
@@ -19,8 +19,8 @@
 
       <div class="govuk-checkboxes">
         <div class="govuk-checkboxes__item">
-          <%= form.check_box('check_box_none_selected', { class: 'govuk-checkboxes__input' }, 'true', false) %>
-          <%= form.label('check_box_none_selected', none_selected, class: 'govuk-label govuk-checkboxes__label') %>
+          <%= form.check_box :none_selected, { class: 'govuk-checkboxes__input' }, 'true', '' %>
+          <%= form.label :none_selected, none_selected, class: 'govuk-label govuk-checkboxes__label' %>
         </div>
       </div>
 

--- a/app/views/shared/forms/_types_of_income_form.html.erb
+++ b/app/views/shared/forms/_types_of_income_form.html.erb
@@ -23,7 +23,7 @@
 
     <div class="govuk-checkboxes">
       <div class="govuk-checkboxes__item">
-        <%= check_box_tag :none_selected, 'true', false, class: 'govuk-checkboxes__input' %>
+        <%= check_box_tag :none_selected, 'true', @none_selected, class: 'govuk-checkboxes__input' %>
         <%= label_tag :none_selected, t('.none_selected'), class: 'govuk-label govuk-checkboxes__label' %>
       </div>
     </div>

--- a/app/views/shared/forms/other_assets/_form.html.erb
+++ b/app/views/shared/forms/other_assets/_form.html.erb
@@ -1,5 +1,5 @@
 <%
-none_selected_id = '#other_assets_declaration_check_box_none_selected'
+none_selected_id = '#other_assets_declaration_none_selected'
 %>
 <%= form_with(model: model, url: url, method: :patch, local: true) do |form| %>
 
@@ -24,8 +24,8 @@ none_selected_id = '#other_assets_declaration_check_box_none_selected'
 
     <div class="govuk-checkboxes">
       <div class="govuk-checkboxes__item">
-        <%= form.check_box('check_box_none_selected', { class: 'govuk-checkboxes__input' }, 'true', false) %>
-        <%= form.label('check_box_none_selected', none_selected, class: 'govuk-label govuk-checkboxes__label') %>
+        <%= form.check_box :none_selected, { class: 'govuk-checkboxes__input' }, 'true', '' %>
+        <%= form.label :none_selected, none_selected, class: 'govuk-label govuk-checkboxes__label' %>
       </div>
     </div>
   <% end %>

--- a/app/views/shared/forms/other_assets/_form.html.erb
+++ b/app/views/shared/forms/other_assets/_form.html.erb
@@ -1,6 +1,3 @@
-<%
-none_selected_id = '#other_assets_declaration_none_selected'
-%>
 <%= form_with(model: model, url: url, method: :patch, local: true) do |form| %>
 
   <%= govuk_form_group show_error_if: (@form.errors.present? && !@form.any_checkbox_checked?) do %>
@@ -9,7 +6,7 @@ none_selected_id = '#other_assets_declaration_none_selected'
       <h2 class="govuk-heading-m"><%= sub_heading %></h2>
     <% end %>
     <div class="govuk-checkboxes" data-module="govuk-checkboxes">
-      <div class="deselect-group" data-deselect-ctrl="<%= none_selected_id %>">
+      <div class="deselect-group" data-deselect-ctrl="[name='other_assets_declaration[none_selected]']">
         <%= render partial: '/shared/forms/revealing_checkbox/attribute',
                    collection: Citizens::OtherAssetsForm::VALUABLE_ITEMS_VALUE_ATTRIBUTE,
                    locals: { model: model, form: form } %>
@@ -24,7 +21,7 @@ none_selected_id = '#other_assets_declaration_none_selected'
 
     <div class="govuk-checkboxes">
       <div class="govuk-checkboxes__item">
-        <%= form.check_box :none_selected, { class: 'govuk-checkboxes__input' }, 'true', '' %>
+        <%= form.check_box :none_selected, { class: 'govuk-checkboxes__input' }, 'true', @form.none_selected %>
         <%= form.label :none_selected, none_selected, class: 'govuk-label govuk-checkboxes__label' %>
       </div>
     </div>

--- a/db/migrate/20190827122038_add_none_selected.rb
+++ b/db/migrate/20190827122038_add_none_selected.rb
@@ -1,0 +1,8 @@
+class AddNoneSelected < ActiveRecord::Migration[5.2]
+  def change
+    add_column :legal_aid_applications, :no_credit_transaction_types_selected, :boolean
+    add_column :legal_aid_applications, :no_debit_transaction_types_selected, :boolean
+    add_column :savings_amounts, :none_selected, :boolean
+    add_column :other_assets_declarations, :none_selected, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -92,7 +92,7 @@ ActiveRecord::Schema.define(version: 2019_08_27_122038) do
     t.uuid "proceeding_type_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "proceeding_case_id", default: -> { "nextval('case_proceeding_sequence'::regclass)" }
+    t.integer "proceeding_case_id"
     t.index ["legal_aid_application_id"], name: "index_application_proceeding_types_on_legal_aid_application_id"
     t.index ["proceeding_type_id"], name: "index_application_proceeding_types_on_proceeding_type_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_23_093923) do
+ActiveRecord::Schema.define(version: 2019_08_27_122038) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -92,7 +92,7 @@ ActiveRecord::Schema.define(version: 2019_08_23_093923) do
     t.uuid "proceeding_type_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "proceeding_case_id"
+    t.integer "proceeding_case_id", default: -> { "nextval('case_proceeding_sequence'::regclass)" }
     t.index ["legal_aid_application_id"], name: "index_application_proceeding_types_on_legal_aid_application_id"
     t.index ["proceeding_type_id"], name: "index_application_proceeding_types_on_proceeding_type_id"
   end
@@ -309,6 +309,8 @@ ActiveRecord::Schema.define(version: 2019_08_23_093923) do
     t.uuid "office_id"
     t.boolean "has_restrictions"
     t.string "restrictions_details"
+    t.boolean "no_credit_transaction_types_selected"
+    t.boolean "no_debit_transaction_types_selected"
     t.index ["applicant_id"], name: "index_legal_aid_applications_on_applicant_id"
     t.index ["application_ref"], name: "index_legal_aid_applications_on_application_ref", unique: true
     t.index ["office_id"], name: "index_legal_aid_applications_on_office_id"
@@ -387,6 +389,7 @@ ActiveRecord::Schema.define(version: 2019_08_23_093923) do
     t.decimal "trust_value"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "none_selected"
     t.index ["legal_aid_application_id"], name: "index_other_assets_declarations_on_legal_aid_application_id", unique: true
   end
 
@@ -478,6 +481,7 @@ ActiveRecord::Schema.define(version: 2019_08_23_093923) do
     t.decimal "life_assurance_endowment_policy"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "none_selected"
     t.index ["legal_aid_application_id"], name: "index_savings_amounts_on_legal_aid_application_id"
   end
 

--- a/spec/forms/citizens/other_assets_form_spec.rb
+++ b/spec/forms/citizens/other_assets_form_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Citizens::OtherAssetsForm do
-  let(:empty_oad) { create :other_assets_declaration }
+  let(:empty_oad) { create :other_assets_declaration, none_selected: true }
   let(:oad_with_second_home) { create :other_assets_declaration, :with_second_home }
   let(:oad_with_all_values) { create :other_assets_declaration, :with_all_values }
 
@@ -18,7 +18,7 @@ RSpec.describe Citizens::OtherAssetsForm do
         second_home_value: '',
         second_home_mortgage: '',
         second_home_percentage: '',
-        check_box_none_selected: 'true' }
+        none_selected: 'true' }
     end
 
     let(:alpha_second_home_params) do
@@ -107,7 +107,7 @@ RSpec.describe Citizens::OtherAssetsForm do
         money_owed_value: '0.45',
         check_box_trust_value: 'true',
         trust_value: '3,560,622.77',
-        check_box_none_selected: '' }
+        none_selected: '' }
     end
 
     describe 'instantiation' do
@@ -127,7 +127,7 @@ RSpec.describe Citizens::OtherAssetsForm do
             end
 
             context 'no form fields present' do
-              let(:submitted_params) { { check_box_none_selected: 'true' } }
+              let(:submitted_params) { { none_selected: 'true' } }
 
               it 'is valid' do
                 expect(form).to be_valid

--- a/spec/forms/savings_amounts/savings_amounts_form_spec.rb
+++ b/spec/forms/savings_amounts/savings_amounts_form_spec.rb
@@ -161,7 +161,7 @@ RSpec.describe SavingsAmounts::SavingsAmountsForm, type: :form do
       context 'if none of the check boxes are checked' do
         let(:check_box_params) do
           boxes = check_box_attributes.each_with_object({}) { |attr, hsh| hsh[attr] = '' }
-          boxes[:check_box_none_selected] = ''
+          boxes[:none_selected] = ''
           boxes
         end
         let(:journey) { 'citizens' }
@@ -175,7 +175,7 @@ RSpec.describe SavingsAmounts::SavingsAmountsForm, type: :form do
       context 'none of these check box is checked' do
         let(:check_box_params) do
           boxes = check_box_attributes.each_with_object({}) { |attr, hsh| hsh[attr] = '' }
-          boxes[:check_box_none_selected] = 'true'
+          boxes[:none_selected] = 'true'
           boxes
         end
 

--- a/spec/requests/citizens/identify_types_of_incomes_spec.rb
+++ b/spec/requests/citizens/identify_types_of_incomes_spec.rb
@@ -52,6 +52,7 @@ RSpec.describe Citizens::IdentifyTypesOfIncomesController do
     end
 
     context 'when transaction types selected' do
+      let(:legal_aid_application) { create :legal_aid_application, :with_applicant, no_credit_transaction_types_selected: true }
       let(:transaction_type_ids) { income_types.map(&:id) }
 
       it 'adds transaction types to the application' do
@@ -61,6 +62,10 @@ RSpec.describe Citizens::IdentifyTypesOfIncomesController do
 
       it 'should redirect to the next step' do
         expect(subject).to redirect_to(flow_forward_path)
+      end
+
+      it 'sets no_credit_transaction_types_selected to false' do
+        expect { subject }.to change { legal_aid_application.reload.no_credit_transaction_types_selected }.to(false)
       end
     end
 
@@ -88,6 +93,10 @@ RSpec.describe Citizens::IdentifyTypesOfIncomesController do
 
       it 'redirects to the next step' do
         expect(subject).to redirect_to(flow_forward_path)
+      end
+
+      it 'sets no_credit_transaction_types_selected to true' do
+        expect { subject }.to change { legal_aid_application.reload.no_credit_transaction_types_selected }.to(true)
       end
 
       context 'and application has transactions' do

--- a/spec/requests/citizens/identify_types_of_outgoings_spec.rb
+++ b/spec/requests/citizens/identify_types_of_outgoings_spec.rb
@@ -63,6 +63,10 @@ RSpec.describe 'IndentifyTypesOfOutgoingsController' do
       it 'should redirect to the next step' do
         expect(subject).to redirect_to(flow_forward_path)
       end
+
+      it 'sets no_debit_transaction_types_selected to false' do
+        expect { subject }.to change { legal_aid_application.reload.no_debit_transaction_types_selected }.to(false)
+      end
     end
 
     context 'when application has transaction types of other kind' do
@@ -87,6 +91,10 @@ RSpec.describe 'IndentifyTypesOfOutgoingsController' do
 
       it 'redirects to the next step' do
         expect(subject).to redirect_to(flow_forward_path)
+      end
+
+      it 'sets no_debit_transaction_types_selected to true' do
+        expect { subject }.to change { legal_aid_application.reload.no_debit_transaction_types_selected }.to(true)
       end
 
       context 'and application has transactions' do

--- a/spec/requests/citizens/other_assets_spec.rb
+++ b/spec/requests/citizens/other_assets_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe 'citizen other assets requests', type: :request do
           money_owed_value: '90,123.45',
           check_box_trust_value: 'true',
           trust_value: '1,234.56',
-          check_box_none_selected: ''
+          none_selected: ''
         },
         commit: 'Continue'
       }
@@ -67,12 +67,12 @@ RSpec.describe 'citizen other assets requests', type: :request do
           money_owed_value: '',
           check_box_trust_value: '',
           trust_value: '',
-          check_box_none_selected: check_box_none_selected
+          none_selected: none_selected
         }
       }
     end
 
-    let(:check_box_none_selected) { '' }
+    let(:none_selected) { '' }
 
     context 'valid params' do
       it 'updates the record' do
@@ -109,12 +109,24 @@ RSpec.describe 'citizen other assets requests', type: :request do
         end
 
         context 'and none of these checkbox is not selected' do
-          let(:check_box_none_selected) { '' }
+          let(:none_selected) { '' }
           before { patch citizens_other_assets_path, params: empty_params }
           it 'the response includes the error message' do
             expect(response.body).to include(I18n.t('activemodel.errors.models.other_assets_declaration.attributes.base.citizen.none_selected'))
           end
         end
+      end
+    end
+
+    context 'none of these checkbox is selected' do
+      let(:params) do
+        {
+          other_assets_declaration: { none_selected: 'true' }
+        }
+      end
+
+      it 'sets none_selected to true' do
+        expect(oad.reload.none_selected).to eq(true)
       end
     end
 

--- a/spec/requests/citizens/savings_and_investments_spec.rb
+++ b/spec/requests/citizens/savings_and_investments_spec.rb
@@ -54,6 +54,15 @@ RSpec.describe 'citizen savings and investments', type: :request do
       expect(response).to redirect_to(citizens_other_assets_path)
     end
 
+    context 'none of these checkbox is selected' do
+      let(:params) { { savings_amount: { none_selected: 'true' } } }
+
+      it 'sets none_selected to true' do
+        subject
+        expect(savings_amount.reload.none_selected).to eq(true)
+      end
+    end
+
     context 'with invalid input' do
       let(:isa) { 'fifty' }
 

--- a/spec/requests/providers/identify_types_of_incomes_spec.rb
+++ b/spec/requests/providers/identify_types_of_incomes_spec.rb
@@ -74,6 +74,10 @@ RSpec.describe Providers::IdentifyTypesOfIncomesController do
       it 'should redirect to the next step' do
         expect(subject).to redirect_to(flow_forward_path)
       end
+
+      it 'sets no_credit_transaction_types_selected to false' do
+        expect { subject }.to change { legal_aid_application.reload.no_credit_transaction_types_selected }.to(false)
+      end
     end
 
     context 'when application has transaction types of other kind' do
@@ -100,6 +104,10 @@ RSpec.describe Providers::IdentifyTypesOfIncomesController do
 
       it 'redirects to the next step' do
         expect(subject).to redirect_to(flow_forward_path)
+      end
+
+      it 'sets no_credit_transaction_types_selected to true' do
+        expect { subject }.to change { legal_aid_application.reload.no_credit_transaction_types_selected }.to(true)
       end
 
       context 'and application has transactions' do

--- a/spec/requests/providers/identify_types_of_outgoings_spec.rb
+++ b/spec/requests/providers/identify_types_of_outgoings_spec.rb
@@ -73,6 +73,10 @@ RSpec.describe Providers::IdentifyTypesOfOutgoingsController do
         expect(subject).to redirect_to(flow_forward_path)
       end
 
+      it 'sets no_debit_transaction_types_selected to false' do
+        expect { subject }.to change { legal_aid_application.reload.no_debit_transaction_types_selected }.to(false)
+      end
+
       context 'Form submitted with Save as draft button' do
         let(:transaction_type_ids) { [] }
         let(:submit_button) { { draft_button: 'Save as draft' } }
@@ -106,6 +110,10 @@ RSpec.describe Providers::IdentifyTypesOfOutgoingsController do
 
       it 'redirects to the next step' do
         expect(subject).to redirect_to(flow_forward_path)
+      end
+
+      it 'sets no_debit_transaction_types_selected to true' do
+        expect { subject }.to change { legal_aid_application.reload.no_debit_transaction_types_selected }.to(true)
       end
 
       context 'and application has transactions' do

--- a/spec/requests/providers/other_assets_spec.rb
+++ b/spec/requests/providers/other_assets_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe 'provider other assets requests', type: :request do
           money_owed_value: '90,123.45',
           check_box_trust_value: 'true',
           trust_value: '1,234.56',
-          check_box_none_selected: ''
+          none_selected: ''
         }
       }
     end
@@ -74,12 +74,12 @@ RSpec.describe 'provider other assets requests', type: :request do
           money_owed_value: '',
           check_box_trust_value: '',
           trust_value: '',
-          check_box_none_selected: check_box_none_selected
+          none_selected: none_selected
         }
       }
     end
 
-    let(:check_box_none_selected) { '' }
+    let(:none_selected) { '' }
 
     context 'when the provider is authenticated' do
       before do
@@ -128,7 +128,7 @@ RSpec.describe 'provider other assets requests', type: :request do
           context 'has savings and investments' do
             let(:oad) { create :other_assets_declaration }
             let(:application) { oad.legal_aid_application }
-            let(:check_box_none_selected) { 'true' }
+            let(:none_selected) { 'true' }
 
             before do
               application.create_savings_amount!
@@ -148,7 +148,7 @@ RSpec.describe 'provider other assets requests', type: :request do
           context 'has own home' do
             let(:application) { create :legal_aid_application, :with_own_home_mortgaged }
             let(:oad) { create :other_assets_declaration, legal_aid_application: application }
-            let(:check_box_none_selected) { 'true' }
+            let(:none_selected) { 'true' }
 
             before do
               patch providers_legal_aid_application_other_assets_path(oad.legal_aid_application), params: empty_params.merge(submit_button)
@@ -166,7 +166,7 @@ RSpec.describe 'provider other assets requests', type: :request do
             let(:state) { :checking_passported_answers }
             let(:application) { create :legal_aid_application, :without_own_home, state: state }
             let(:oad) { create :other_assets_declaration, legal_aid_application: application }
-            let(:check_box_none_selected) { 'true' }
+            let(:none_selected) { 'true' }
 
             before do
               patch providers_legal_aid_application_other_assets_path(oad.legal_aid_application), params: empty_params.merge(submit_button)
@@ -191,7 +191,7 @@ RSpec.describe 'provider other assets requests', type: :request do
           context 'has nothing' do
             let(:oad) { create :other_assets_declaration }
             let(:application) { oad.legal_aid_application }
-            let(:check_box_none_selected) { 'true' }
+            let(:none_selected) { 'true' }
 
             before do
               patch providers_legal_aid_application_other_assets_path(oad.legal_aid_application), params: empty_params.merge(submit_button)
@@ -206,12 +206,24 @@ RSpec.describe 'provider other assets requests', type: :request do
               end
             end
             context 'and none of these checkbox is not selected' do
-              let(:check_box_none_selected) { '' }
+              let(:none_selected) { '' }
 
               it 'the response includes the error message' do
                 expect(response.body).to include(I18n.t('activemodel.errors.models.other_assets_declaration.attributes.base.provider.none_selected'))
               end
             end
+          end
+        end
+
+        context 'none of these checkbox is selected' do
+          let(:params) do
+            {
+              other_assets_declaration: { none_selected: 'true' }
+            }
+          end
+
+          it 'sets none_selected to true' do
+            expect(oad.reload.none_selected).to eq(true)
           end
         end
 
@@ -303,7 +315,7 @@ RSpec.describe 'provider other assets requests', type: :request do
             let(:application) { create :legal_aid_application, :with_own_home_mortgaged }
             let(:oad) { create :other_assets_declaration, legal_aid_application: application }
             let(:params) { empty_params }
-            let(:check_box_none_selected) { 'true' }
+            let(:none_selected) { 'true' }
 
             it 'redirects to provider applications page' do
               expect(application.reload.other_assets?).to be false
@@ -317,7 +329,7 @@ RSpec.describe 'provider other assets requests', type: :request do
             let(:oad) { create :other_assets_declaration }
             let(:application) { oad.legal_aid_application }
             let(:params) { empty_params }
-            let(:check_box_none_selected) { 'true' }
+            let(:none_selected) { 'true' }
 
             it 'redirects to provider applications page' do
               expect(application.reload.other_assets?).to be false

--- a/spec/requests/providers/savings_and_investments_spec.rb
+++ b/spec/requests/providers/savings_and_investments_spec.rb
@@ -100,6 +100,15 @@ RSpec.describe 'providers savings and investments', type: :request do
             expect(response).to redirect_to(providers_legal_aid_application_other_assets_path(application))
           end
 
+          context 'none of these checkbox is selected' do
+            let(:params) { { savings_amount: { none_selected: 'true' } } }
+
+            it 'sets none_selected to true' do
+              subject
+              expect(savings_amount.reload.none_selected).to eq(true)
+            end
+          end
+
           context 'with invalid input' do
             let(:isa) { 'fifty' }
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-824)

Fix the issues by persisting "None of these" checkboxes to DB.

pages affected:
- `/citizens/identify_types_of_income`
- `/citizens/identify_types_of_outgoing`
- `/citizens/other_assets`
- `/citizens/savings_and_investment`
- `/providers/applications/:legal_aid_application_id/identify_types_of_income`
- `/providers/applications/:legal_aid_application_id/identify_types_of_outgoing`
- `/providers/applications/:legal_aid_application_id/other_assets`
- `/providers/applications/:legal_aid_application_id/savings_and_investment`

I think that's all of them

## Checklist

Before you ask people to review this PR:

- [X] Tests and rubocop should be passing: `bundle exec rake`
- [X] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [X] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [X] The PR description should say what you changed and why, with a link to the JIRA story.
- [X] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [X] You should have checked that the commit messages say why the change was made.
