### PR TITLE
AP-538 Add "Error: " prefix to page head title if error present

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -9,9 +9,10 @@ module ApplicationHelper
 
   def html_title
     default = t('shared.page-title.suffix')
-    return default unless content_for?(:page_title)
+    return default unless content_for?(:head_title) || content_for?(:page_title)
 
-    "#{content_for(:page_title)} - #{default}".html_safe
+    title = content_for?(:head_title) ? content_for(:head_title) : content_for(:page_title)
+    "#{title} - #{default}".html_safe
   end
 
   def controller_t(lazy_t, *args)

--- a/app/helpers/page_template_helper.rb
+++ b/app/helpers/page_template_helper.rb
@@ -48,7 +48,7 @@ module PageTemplateHelper
   )
     template = :default unless %i[form basic].include?(template)
     content_for(:navigation) { back_link(back_link) unless back_link == :none }
-    content_for(:page_title) { page_title }
+    page_title_possibly_with_error(page_title, show_errors_for&.errors)
     content = capture(&content) if content
     render(
       "shared/page_templates/#{template}_page_template",
@@ -71,5 +71,19 @@ module PageTemplateHelper
 
   def page_title
     content_for(:page_title) if content_for?(:page_title)
+  end
+
+  def page_title_possibly_with_error(text, errors)
+    errors&.present? ? error_page_title(text) : simple_page_title(text)
+  end
+
+  def simple_page_title(text)
+    content_for(:page_title) { text }
+  end
+
+  def error_page_title(text)
+    prefix = t('errors.title_prefix')
+    content_for(:page_title) { text }
+    content_for(:head_title) { "#{prefix}: #{text}" }
   end
 end

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -1,6 +1,7 @@
 ---
 en:
   errors:
+    title_prefix: Error
     messages:
       already_confirmed: was already confirmed, please try signing in
       confirmation_period_expired: needs to be confirmed within %{period}, please request a new one

--- a/spec/requests/providers/applicants_spec.rb
+++ b/spec/requests/providers/applicants_spec.rb
@@ -14,6 +14,11 @@ RSpec.describe Providers::ApplicantsController, type: :request do
       subject
       expect(response).to have_http_status(:ok)
     end
+
+    it 'does not prefix page title with error label' do
+      subject
+      expect(response.body).not_to match(/\<title\>#{I18n.t('errors.title_prefix')}\:/)
+    end
   end
 
   describe 'POST /providers/applicants' do
@@ -67,6 +72,11 @@ RSpec.describe Providers::ApplicantsController, type: :request do
       it 'displays errors' do
         subject
         expect(response.body).to include('govuk-error-summary')
+      end
+
+      it 'prefixes page title with error label' do
+        subject
+        expect(response.body).to match(/\<title\>#{I18n.t('errors.title_prefix')}\:/)
       end
 
       it 'does not create applicant' do


### PR DESCRIPTION
[Jira AP-538](https://dsdmoj.atlassian.net/browse/AP-538)

Modifies the way page the header is defined so that the header within `head` can be set differently to that used within the `body`. Then set the `head` title to be prefixed with "Error: " when an error occurs.