### PR TITLE
AP-917 Remove mode as alias for journey

### DIFF
--- a/app/controllers/citizens/other_assets_controller.rb
+++ b/app/controllers/citizens/other_assets_controller.rb
@@ -18,7 +18,7 @@ module Citizens
     end
 
     def form_params
-      merge_with_model(declaration, mode: :citizen) do
+      merge_with_model(declaration, journey: :citizens) do
         attrs = Citizens::OtherAssetsForm::ALL_ATTRIBUTES + Citizens::OtherAssetsForm::CHECK_BOXES_ATTRIBUTES
         params[:other_assets_declaration].permit(*attrs)
       end

--- a/app/controllers/citizens/restrictions_controller.rb
+++ b/app/controllers/citizens/restrictions_controller.rb
@@ -14,7 +14,7 @@ module Citizens
     private
 
     def form_params
-      merge_with_model(legal_aid_application, mode: :citizen) do
+      merge_with_model(legal_aid_application, journey: :citizens) do
         return {} unless params[:legal_aid_application]
 
         params.require(:legal_aid_application).permit(:has_restrictions, :restrictions_details)

--- a/app/controllers/citizens/vehicles/purchase_dates_controller.rb
+++ b/app/controllers/citizens/vehicles/purchase_dates_controller.rb
@@ -22,7 +22,7 @@ module Citizens
       end
 
       def form_params
-        merge_with_model(vehicle, journey: :citizen) do
+        merge_with_model(vehicle, journey: :citizens) do
           params.require(:vehicle).permit(:purchased_on_year, :purchased_on_month, :purchased_on_day)
         end
       end

--- a/app/controllers/citizens/vehicles_controller.rb
+++ b/app/controllers/citizens/vehicles_controller.rb
@@ -18,7 +18,7 @@ module Citizens
     private
 
     def form_params
-      merge_with_model(legal_aid_application, mode: :citizen) do
+      merge_with_model(legal_aid_application, journey: :citizens) do
         next {} unless params[:legal_aid_application]
 
         params.require(:legal_aid_application).permit(:own_vehicle)

--- a/app/controllers/providers/other_assets_controller.rb
+++ b/app/controllers/providers/other_assets_controller.rb
@@ -16,7 +16,7 @@ module Providers
     end
 
     def form_params
-      merge_with_model(declaration, mode: :provider) do
+      merge_with_model(declaration, journey: :providers) do
         attrs = Citizens::OtherAssetsForm::ALL_ATTRIBUTES + Citizens::OtherAssetsForm::CHECK_BOXES_ATTRIBUTES
         params[:other_assets_declaration].permit(*attrs)
       end

--- a/app/controllers/providers/property_values_controller.rb
+++ b/app/controllers/providers/property_values_controller.rb
@@ -13,7 +13,7 @@ module Providers
     private
 
     def edit_params
-      merge_with_model(legal_aid_application, mode: :provider) do
+      merge_with_model(legal_aid_application, journey: :providers) do
         params.require(:legal_aid_application).permit(:property_value)
       end
     end

--- a/app/controllers/providers/restrictions_controller.rb
+++ b/app/controllers/providers/restrictions_controller.rb
@@ -12,7 +12,7 @@ module Providers
     private
 
     def form_params
-      merge_with_model(legal_aid_application, mode: :provider) do
+      merge_with_model(legal_aid_application, journey: :providers) do
         return {} unless params[:legal_aid_application]
 
         params.require(:legal_aid_application).permit(:has_restrictions, :restrictions_details)

--- a/app/controllers/providers/vehicles/purchase_dates_controller.rb
+++ b/app/controllers/providers/vehicles/purchase_dates_controller.rb
@@ -19,7 +19,7 @@ module Providers
       end
 
       def form_params
-        merge_with_model(vehicle, journey: :provider) do
+        merge_with_model(vehicle, journey: :providers) do
           params.require(:vehicle).permit(:purchased_on_year, :purchased_on_month, :purchased_on_day)
         end
       end

--- a/app/controllers/providers/vehicles_controller.rb
+++ b/app/controllers/providers/vehicles_controller.rb
@@ -18,7 +18,7 @@ module Providers
     private
 
     def form_params
-      merge_with_model(legal_aid_application, mode: :provider) do
+      merge_with_model(legal_aid_application, journey: :providers) do
         next {} unless params[:legal_aid_application]
 
         params.require(:legal_aid_application).permit(:own_vehicle)

--- a/app/forms/citizens/other_assets_form.rb
+++ b/app/forms/citizens/other_assets_form.rb
@@ -38,7 +38,7 @@ module Citizens
 
     attr_accessor(*ALL_ATTRIBUTES)
     attr_accessor(*CHECK_BOXES_ATTRIBUTES)
-    attr_accessor :mode
+    attr_accessor :journey
 
     before_validation :empty_unchecked_values
 
@@ -56,7 +56,7 @@ module Citizens
     end
 
     def exclude_from_model
-      CHECK_BOXES_ATTRIBUTES + [:mode] - [:none_selected]
+      CHECK_BOXES_ATTRIBUTES + [:journey] - [:none_selected]
     end
 
     def attributes_to_clean
@@ -103,7 +103,7 @@ module Citizens
     end
 
     def error_message_for_none_selected
-      I18n.t("activemodel.errors.models.other_assets_declaration.attributes.base.#{mode}.none_selected")
+      I18n.t("activemodel.errors.models.other_assets_declaration.attributes.base.#{journey}.none_selected")
     end
 
     def present_and_not_zero?(attr)

--- a/app/forms/legal_aid_applications/own_vehicle_form.rb
+++ b/app/forms/legal_aid_applications/own_vehicle_form.rb
@@ -4,18 +4,18 @@ module LegalAidApplications
 
     form_for LegalAidApplication
 
-    attr_accessor :own_vehicle, :mode
+    attr_accessor :own_vehicle, :journey
 
     validate :own_vehicle_presence
 
     def own_vehicle_presence
       return if draft? || own_vehicle.present?
 
-      errors.add(:own_vehicle, I18n.t("activemodel.errors.models.legal_aid_application.attributes.own_vehicle.#{mode}.blank"))
+      errors.add(:own_vehicle, I18n.t("activemodel.errors.models.legal_aid_application.attributes.own_vehicle.#{journey}.blank"))
     end
 
     def exclude_from_model
-      [:mode]
+      [:journey]
     end
   end
 end

--- a/app/forms/legal_aid_applications/property_value_form.rb
+++ b/app/forms/legal_aid_applications/property_value_form.rb
@@ -4,14 +4,14 @@ module LegalAidApplications
 
     form_for LegalAidApplication
 
-    attr_accessor :property_value, :mode
+    attr_accessor :property_value, :journey
 
     validate :value_presence
     validates :property_value, allow_blank: true, currency: { greater_than_or_equal_to: 0.0 }
 
     def initialize(*args)
       super
-      @mode = :citizen unless @mode == :provider
+      @journey = :citizens unless @journey == :providers
     end
 
     def attributes_to_clean
@@ -27,11 +27,11 @@ module LegalAidApplications
     end
 
     def error_message_for(error_type)
-      I18n.t("activemodel.errors.models.legal_aid_application.attributes.property_value.#{mode}.#{error_type}")
+      I18n.t("activemodel.errors.models.legal_aid_application.attributes.property_value.#{journey}.#{error_type}")
     end
 
     def exclude_from_model
-      [:mode]
+      [:journey]
     end
   end
 end

--- a/app/forms/legal_aid_applications/restrictions_form.rb
+++ b/app/forms/legal_aid_applications/restrictions_form.rb
@@ -4,7 +4,7 @@ module LegalAidApplications
 
     form_for LegalAidApplication
 
-    attr_accessor :has_restrictions, :restrictions_details, :mode
+    attr_accessor :has_restrictions, :restrictions_details, :journey
 
     before_validation :clear_restrictions_details
 
@@ -26,11 +26,11 @@ module LegalAidApplications
     end
 
     def add_blank_error_for(attribute)
-      errors.add(attribute, I18n.t("activemodel.errors.models.legal_aid_application.attributes.#{attribute}.#{mode}.blank"))
+      errors.add(attribute, I18n.t("activemodel.errors.models.legal_aid_application.attributes.#{attribute}.#{journey}.blank"))
     end
 
     def exclude_from_model
-      [:mode]
+      [:journey]
     end
 
     def clear_restrictions_details

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -155,9 +155,9 @@ en:
             has_dependants:
               blank: Select yes if you have dependants
             has_restrictions:
-              citizen:
+              citizens:
                 blank: Select yes if there are restrictions that prevent you from selling or borrowing against your assets
-              provider:
+              providers:
                 blank: Select yes if there are restrictions that prevent your client from selling or borrowing against their assets
             outstanding_mortgage_amount:
               blank: Enter the outstanding mortgage amount
@@ -167,9 +167,9 @@ en:
             own_home:
               blank: Select yes if you own the home you live in
             own_vehicle:
-              citizen:
+              citizens:
                 blank: Select yes if you own a vehicle
-              provider:
+              providers:
                 blank: Select yes if your client owns a vehicle
             percentage_home:
               blank: Enter the percentage (%) share
@@ -177,20 +177,20 @@ en:
               less_than_or_equal_to: Share must be a percentage amount under 100, like 60
               not_a_number: Share must be a percentage amount under 100, like 60
             property_value:
-              citizen:
+              citizens:
                 blank: Enter an estimated value for your home
                 not_a_number: The estimated value of your home must be an amount of money, like 60,000
               greater_than: Estimated value must be 0 or more
               greater_than_or_equal_to: Estimated value must be 0 or more
               not_a_number: Estimated value must be an amount of money, like 60,000
-              provider:
+              providers:
                 blank: Enter an estimated value for your client's home
                 not_a_number: The estimated value of your client's home must be an amount of money, like 60,000
               too_many_decimals: Estimated value must not include more than 2 decimal numbers
             restrictions_details:
-              citizen:
+              citizens:
                 blank: Enter the assets you cannot sell or borrow against, and why
-              provider:
+              providers:
                 blank: Enter the assets your client cannot sell or borrow against, and why
             shared_ownership:
               blank: Select yes if you own your home with someone else
@@ -271,9 +271,9 @@ en:
               not_a_number: Estimated trust value must be an amount of money, like 60,000
               too_many_decimals: Estimated trust value must not include more than 2 decimal numbers
             base:
-              citizen:
+              citizens:
                 none_selected: Select if you have any of these types of assets
-              provider:
+              providers:
                 none_selected: Select if your client has any of these types of assets
         provider:
           attributes:
@@ -373,9 +373,9 @@ en:
             purchased_on:
               blank: Enter a valid date
               date_not_valid: Enter a valid date
-              citizen:
+              citizens:
                 date_is_in_the_future: Date you bought the vehicle must be in the past
-              provider:
+              providers:
                 date_is_in_the_future: Date your client bought the vehicle must be in the past
             used_regularly:
               blank: Select yes if the vehicle is in regular use

--- a/spec/forms/legal_aid_applications/restrictions_form_spec.rb
+++ b/spec/forms/legal_aid_applications/restrictions_form_spec.rb
@@ -2,16 +2,16 @@ require 'rails_helper'
 
 RSpec.describe LegalAidApplications::RestrictionsForm, type: :form do
   let(:application) { create :legal_aid_application, :with_applicant }
+  let(:journey) { %i[providers citizens].sample }
+  let(:restrictions_details) { Faker::Lorem.paragraph }
+  let(:has_restrictions) { 'true' }
   let(:params) do
     {
       has_restrictions: has_restrictions,
       restrictions_details: restrictions_details,
-      mode: mode
+      journey: journey
     }
   end
-  let(:mode) { %i[provider citizen].sample }
-  let(:restrictions_details) { Faker::Lorem.paragraph }
-  let(:has_restrictions) { 'true' }
   let(:form_params) { params.merge(model: application) }
 
   subject { described_class.new(form_params) }
@@ -52,7 +52,7 @@ RSpec.describe LegalAidApplications::RestrictionsForm, type: :form do
       end
 
       it 'generates the expected error message' do
-        expect(subject.errors[:restrictions_details]).to include I18n.t("activemodel.errors.models.legal_aid_application.attributes.restrictions_details.#{mode}.blank")
+        expect(subject.errors[:restrictions_details]).to include I18n.t("activemodel.errors.models.legal_aid_application.attributes.restrictions_details.#{journey}.blank")
       end
 
       context 'no restrictions present' do
@@ -63,7 +63,7 @@ RSpec.describe LegalAidApplications::RestrictionsForm, type: :form do
         end
 
         it 'generates the expected error message' do
-          expect(subject.errors[:has_restrictions]).to include I18n.t("activemodel.errors.models.legal_aid_application.attributes.has_restrictions.#{mode}.blank")
+          expect(subject.errors[:has_restrictions]).to include I18n.t("activemodel.errors.models.legal_aid_application.attributes.has_restrictions.#{journey}.blank")
         end
       end
     end

--- a/spec/requests/citizens/other_assets_spec.rb
+++ b/spec/requests/citizens/other_assets_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe 'citizen other assets requests', type: :request do
           let(:none_selected) { '' }
           before { patch citizens_other_assets_path, params: empty_params }
           it 'the response includes the error message' do
-            expect(response.body).to include(I18n.t('activemodel.errors.models.other_assets_declaration.attributes.base.citizen.none_selected'))
+            expect(response.body).to include(I18n.t('activemodel.errors.models.other_assets_declaration.attributes.base.citizens.none_selected'))
           end
         end
       end

--- a/spec/requests/citizens/restrictions_spec.rb
+++ b/spec/requests/citizens/restrictions_spec.rb
@@ -72,6 +72,6 @@ RSpec.describe 'citizen restrictions request', type: :request do
   end
 
   def translation_for(attr, error)
-    I18n.t("activemodel.errors.models.legal_aid_application.attributes.#{attr}.citizen.#{error}")
+    I18n.t("activemodel.errors.models.legal_aid_application.attributes.#{attr}.citizens.#{error}")
   end
 end

--- a/spec/requests/providers/other_assets_spec.rb
+++ b/spec/requests/providers/other_assets_spec.rb
@@ -209,7 +209,7 @@ RSpec.describe 'provider other assets requests', type: :request do
               let(:none_selected) { '' }
 
               it 'the response includes the error message' do
-                expect(response.body).to include(I18n.t('activemodel.errors.models.other_assets_declaration.attributes.base.provider.none_selected'))
+                expect(response.body).to include(I18n.t('activemodel.errors.models.other_assets_declaration.attributes.base.providers.none_selected'))
               end
             end
           end

--- a/spec/requests/providers/restrictions_spec.rb
+++ b/spec/requests/providers/restrictions_spec.rb
@@ -121,6 +121,6 @@ RSpec.describe 'provider restrictions request', type: :request do
   end
 
   def translation_for(attr, error)
-    I18n.t("activemodel.errors.models.legal_aid_application.attributes.#{attr}.provider.#{error}")
+    I18n.t("activemodel.errors.models.legal_aid_application.attributes.#{attr}.providers.#{error}")
   end
 end


### PR DESCRIPTION
[Jira AP-917](https://dsdmoj.atlassian.net/browse/AP-917)

Removed the inconsistency where `journey` was sometimes aliased as `mode`.

Also removed singular journeys - so now the two current journeys are the plurals `:citizens` and `:providers` which match the controller namespace and therefore can be determined from the current controller's ancestors (see helper method `journey_type` in `app/controllers/concerns/flowable.rb`)
