### PR TITLE
AP-851 Increase time to submit substantive application

### DIFF
--- a/app/forms/legal_aid_applications/substantive_application_form.rb
+++ b/app/forms/legal_aid_applications/substantive_application_form.rb
@@ -20,7 +20,7 @@ module LegalAidApplications
     def substantive_application_deadline
       return if continuing_substantive_application_selected?
 
-      WorkingDayCalculator.working_days_from_now(working_days_to_complete)
+      WorkingDayCalculator.call working_days: working_days_to_complete, from: model.used_delegated_functions_on
     end
 
     def continuing_substantive_application_selected?

--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -7,7 +7,7 @@ class LegalAidApplication < ApplicationRecord # rubocop:disable Metrics/ClassLen
   SHARED_OWNERSHIP_NO_REASONS = %w[no_sole_owner].freeze
   SHARED_OWNERSHIP_REASONS =  SHARED_OWNERSHIP_YES_REASONS + SHARED_OWNERSHIP_NO_REASONS
   SECURE_ID_DAYS_TO_EXPIRE = 7
-  WORKING_DAYS_TO_COMPLETE_SUBSTANTIVE_APPLICATION = 10
+  WORKING_DAYS_TO_COMPLETE_SUBSTANTIVE_APPLICATION = 20
 
   belongs_to :applicant, optional: true
   belongs_to :provider, optional: false

--- a/app/services/working_day_calculator.rb
+++ b/app/services/working_day_calculator.rb
@@ -1,11 +1,19 @@
 class WorkingDayCalculator
+  ParameterError = Class.new(StandardError)
+
   def self.working_days_from_now(number)
-    new(Date.today).add_working_days(number)
+    call(working_days: number)
+  end
+
+  def self.call(working_days:, from: Date.today)
+    new(from).add_working_days(working_days)
   end
 
   attr_reader :date
 
   def initialize(date)
+    raise ParameterError, 'No date present' unless date
+
     @date = date
   end
 

--- a/features/step_definitions/civil_journey_steps.rb
+++ b/features/step_definitions/civil_journey_steps.rb
@@ -141,7 +141,8 @@ Given('I complete the journey as far as check your answers') do
   @legal_aid_application = create(
     :legal_aid_application,
     applicant: applicant,
-    proceeding_types: [proceeding_type]
+    proceeding_types: [proceeding_type],
+    used_delegated_functions_on: 1.day.ago
   )
   @legal_aid_application.add_default_substantive_scope_limitation!
   @legal_aid_applicaiton.add_default_delegated_functions_scope_limitation! if @legal_aid_application.used_delegated_functions?
@@ -172,7 +173,8 @@ Given('I complete the passported journey as far as check your answers') do
   @legal_aid_application = create(
     :legal_aid_application,
     :with_substantive_scope_limitation,
-    applicant: applicant
+    applicant: applicant,
+    used_delegated_functions_on: 1.day.ago
   )
   login_as @legal_aid_application.provider
   visit(providers_legal_aid_application_check_provider_answers_path(@legal_aid_application))

--- a/spec/forms/legal_aid_applications/substantive_application_form_spec.rb
+++ b/spec/forms/legal_aid_applications/substantive_application_form_spec.rb
@@ -1,11 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe LegalAidApplications::SubstantiveApplicationForm, type: :form, vcr: { cassette_name: 'gov_uk_bank_holiday_api' } do
-  let(:application) { create :legal_aid_application, state: :client_details_answers_checked }
+  let(:used_delegated_functions_on) { 1.day.ago.to_date }
+  let(:application) do
+    create :legal_aid_application, state: :client_details_answers_checked, used_delegated_functions_on: used_delegated_functions_on
+  end
   let(:substantive_application) { false }
-  let(:working_day_calculator) { WorkingDayCalculator.new(Date.today) }
   let(:working_days_to_complete) { LegalAidApplication::WORKING_DAYS_TO_COMPLETE_SUBSTANTIVE_APPLICATION }
-  let(:deadline) { working_day_calculator.add_working_days(working_days_to_complete) }
+  let(:deadline) { WorkingDayCalculator.call working_days: working_days_to_complete, from: used_delegated_functions_on }
   let(:params) do
     {
       substantive_application: substantive_application.to_s,

--- a/spec/requests/providers/substantive_applications_spec.rb
+++ b/spec/requests/providers/substantive_applications_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 RSpec.describe Providers::UsedDelegatedFunctionsController, type: :request, vcr: { cassette_name: 'gov_uk_bank_holiday_api' } do
-  let(:legal_aid_application) { create :legal_aid_application, state: :client_details_answers_checked }
+  let(:legal_aid_application) do
+    create :legal_aid_application, state: :client_details_answers_checked, used_delegated_functions_on: 1.day.ago
+  end
   let(:login_provider) { login_as legal_aid_application.provider }
 
   before do

--- a/spec/services/working_day_calculator_spec.rb
+++ b/spec/services/working_day_calculator_spec.rb
@@ -2,21 +2,30 @@ require 'rails_helper'
 
 RSpec.describe WorkingDayCalculator, vcr: { cassette_name: 'gov_uk_bank_holiday_api' } do
   let(:day) { Date.parse('17-Dec-2018') }
+  let(:three_working_days_later) { Date.parse('20-Dec-2018') } # No skip
+  let(:five_working_days_later) { Date.parse('24-Dec-2018') } # Weekend skip
+  let(:six_working_days_later) { Date.parse('27-Dec-2018') } # Weekend and bank holiday skip
+  let(:number_to_target_dates) do
+    {
+      3 => three_working_days_later,
+      5 => five_working_days_later,
+      6 => six_working_days_later
+    }
+  end
   let(:working_day) { described_class.new(day) }
 
   describe '#working_days_from_now' do
-    let(:day) { Date.parse('17-Dec-2018') }
-    let(:three_working_days_later) { Date.parse('20-Dec-2018') } # No skip
-    let(:five_working_days_later) { Date.parse('24-Dec-2018') } # Weekend skip
-    let(:six_working_days_later) { Date.parse('27-Dec-2018') } # Weekend and bank holiday skip
-
     it 'returns expected dates' do
-      {
-        3 => three_working_days_later,
-        5 => five_working_days_later,
-        6 => six_working_days_later
-      }.each do |number, date|
+      number_to_target_dates.each do |number, date|
         expect(working_day.add_working_days(number)).to eq(date)
+      end
+    end
+
+    context 'with no date' do
+      let(:day) { nil }
+
+      it 'raises an error if no date' do
+        expect { working_day.add_working_days(3) }.to raise_error(WorkingDayCalculator::ParameterError)
       end
     end
   end
@@ -29,6 +38,15 @@ RSpec.describe WorkingDayCalculator, vcr: { cassette_name: 'gov_uk_bank_holiday_
       result = described_class.working_days_from_now(number)
       expected = working_day.add_working_days(number)
       expect(result).to eq(expected)
+    end
+  end
+
+  describe '.call' do
+    it 'returns expected dates' do
+      number_to_target_dates.each do |number, date|
+        result = described_class.call working_days: number, from: day
+        expect(result).to eq(date)
+      end
     end
   end
 end


### PR DESCRIPTION
[Jira AP-851](https://dsdmoj.atlassian.net/browse/AP-851)

- Modified `WorkingDayCalculator` to make it easier to pass a start day in as well as number of days
- Increased days defined by `LegalAidApplication::WORKING_DAYS_TO_COMPLETE_SUBSTANTIVE_APPLICATION` to 20
- Modified `substantive_application_deadline` calculation to set date from date delegated function used rather than Today.
- Updated specs to match.