### PR TITLE
Ap 878 Applicant Identity Attributes

### DIFF
--- a/app/services/ccms/attribute_value_generator.rb
+++ b/app/services/ccms/attribute_value_generator.rb
@@ -84,8 +84,12 @@ module CCMS
       @legal_aid_application.used_delegated_functions? ? 'SUBDP' : 'SUB'
     end
 
-    def application_firmname(_options)
-      @legal_aid_application.provider.firm.name
+    def provider_firm_id(_options)
+      @legal_aid_application.provider.firm.id
+    end
+
+    def applicant_national_insurance_number(_options)
+      applicant.national_insurance_number
     end
 
     def applicant_owed_money?(_options)

--- a/app/services/ccms/attribute_value_generator.rb
+++ b/app/services/ccms/attribute_value_generator.rb
@@ -84,6 +84,10 @@ module CCMS
       @legal_aid_application.used_delegated_functions? ? 'SUBDP' : 'SUB'
     end
 
+    def application_firmname(_options)
+      @legal_aid_application.provider.firm.name
+    end
+
     def applicant_owed_money?(_options)
       not_zero? other_assets.money_owed_value
     end
@@ -145,6 +149,10 @@ module CCMS
 
     def lead_proceeding_type_default_level_of_service_name(_options)
       @legal_aid_application.lead_proceeding_type.default_level_of_service.name
+    end
+
+    def applicant_postcode(_options)
+      applicant.address.postcode
     end
 
     private

--- a/config/ccms/ccms_keys.yml
+++ b/config/ccms/ccms_keys.yml
@@ -124,6 +124,21 @@ family_statement:
     :response_type: text
     :user_defined: false
 global_means:
+  BEN_DOB:
+    :value: '#applicant_date_of_birth'
+    :br100_meaning: "DWP Benefit Check: Recipient's DOB"
+    :response_type: date
+    :user_defined: false
+  BEN_NI_NO:
+    :value: '#applicant_national_insurance_number'
+    :br100_meaning: "DWP Benefit Check: National Insurance Number"
+    :response_type: text
+    :user_defined: false
+  BEN_SURNAME:
+    :value: '#applicant_last_name'
+    :br100_meaning: "DWP Benefit Check: Recipient's Surname"
+    :response_type: text
+    :user_defined: false
   COUNTRY:
     :value: GBR
     :br100_meaning: "Applicant's country of residence"
@@ -2011,7 +2026,7 @@ global_means:
     :response_type: boolean
     :user_defined: false
   USER_PROVIDER_FIRM_ID:
-    :value: '#application_firmname'
+    :value: '#provider_firm_id'
     :br100_meaning: the user provider firm id
     :response_type: number
     :user_defined: true
@@ -3459,7 +3474,7 @@ global_merits:
     :response_type: boolean
     :user_defined: false
   USER_PROVIDER_FIRM_ID:
-    :value: '#application_firmname'
+    :value: '#provider_firm_id'
     :br100_meaning: the user provider firm id
     :response_type: number
     :user_defined: true

--- a/config/ccms/ccms_keys.yml
+++ b/config/ccms/ccms_keys.yml
@@ -315,7 +315,7 @@ global_means:
     :response_type: currency
     :user_defined: false
   SURNAME_AT_BIRTH:
-    :value: Fabby
+    :value: '#applicant_last_name'
     :br100_meaning: 'Client: Surname at birth'
     :response_type: text
     :user_defined: true
@@ -592,7 +592,7 @@ global_means:
     :response_type: currency
     :user_defined: false
   SURNAME:
-    :value: Fabby
+    :value: '#applicant_last_name'
     :br100_meaning: 'Client: Surname'
     :response_type: text
     :user_defined: true
@@ -769,7 +769,7 @@ global_means:
     :response_type: currency
     :user_defined: false
   POST_CODE:
-    :value: CH1 1DW
+    :value: '#applicant_postcode'
     :br100_meaning: Post Code
     :response_type: text
     :user_defined: true
@@ -2011,7 +2011,7 @@ global_means:
     :response_type: boolean
     :user_defined: false
   USER_PROVIDER_FIRM_ID:
-    :value: 19148
+    :value: '#application_firmname'
     :br100_meaning: the user provider firm id
     :response_type: number
     :user_defined: true
@@ -2643,7 +2643,7 @@ global_merits:
     :response_type: boolean
     :user_defined: false
   SURNAME_AT_BIRTH:
-    :value: Fabby
+    :value: '#applicant_last_name'
     :br100_meaning: 'Client: Surname at birth'
     :response_type: text
     :user_defined: true
@@ -2855,7 +2855,7 @@ global_merits:
     :response_type: boolean
     :user_defined: true
   DATE_CLIENT_VISITED_FIRM:
-    :value: 01-04-2019
+    :value: '#application_calculation_date'
     :br100_meaning: 'App: The Date The Client First Visited The Firm About This Case'
     :response_type: date
     :user_defined: true
@@ -3069,7 +3069,7 @@ global_merits:
     :response_type: boolean
     :user_defined: true
   CLIENT_AGE:
-    :value: '41'
+    :value: '#applicant_age'
     :br100_meaning: 'Client: The Client''s Age'
     :response_type: number
     :user_defined: false
@@ -3108,7 +3108,7 @@ global_merits:
     :response_type: boolean
     :user_defined: false
   SURNAME:
-    :value: Fabby
+    :value: '#applicant_last_name'
     :br100_meaning: 'Client: Surname'
     :response_type: text
     :user_defined: true
@@ -3320,7 +3320,7 @@ global_merits:
     :response_type: boolean
     :user_defined: false
   POST_CODE:
-    :value: CH1 1DW
+    :value: '#applicant_postcode'
     :br100_meaning: Post Code
     :response_type: text
     :user_defined: true
@@ -3459,7 +3459,7 @@ global_merits:
     :response_type: boolean
     :user_defined: false
   USER_PROVIDER_FIRM_ID:
-    :value: 19148
+    :value: '#application_firmname'
     :br100_meaning: the user provider firm id
     :response_type: number
     :user_defined: true

--- a/spec/factories/legal_aid_applications.rb
+++ b/spec/factories/legal_aid_applications.rb
@@ -13,7 +13,10 @@ FactoryBot.define do
     end
 
     trait :with_applicant_and_address do
-      applicant { create :applicant, :with_address }
+      transient do
+        with_bank_accounts { 0 }
+      end
+      applicant { create :applicant, :with_address, with_bank_accounts: with_bank_accounts }
     end
 
     trait :with_applicant_and_address_lookup do

--- a/spec/services/ccms/case_add_requestor_spec.rb
+++ b/spec/services/ccms/case_add_requestor_spec.rb
@@ -62,19 +62,26 @@ module CCMS # rubocop:disable Metrics/ModuleLength
                account_type_label: 'Bank Current'
       end
 
+      let(:address) { double Address, postcode: 'E15TR' }
+
       let(:applicant) do
         double Applicant,
                ccms_reference_number: '7263259',
                first_name: 'Dave',
+               age: '65',
                last_name: 'Fabby',
                date_of_birth: Date.today,
+               address: address,
                preferred_address: 'CLIENT',
                bank_accounts: [bank_account_1]
       end
 
+      let(:firm) { double Firm, firm_id: 19_148, name: 'Firm1' }
+
       let(:provider) do
         double Provider,
                firm_id: 19_148,
+               firm: firm,
                selected_office_id: 137_570,
                user_login_id: 4_953_649,
                username: 4_953_649,
@@ -339,7 +346,7 @@ module CCMS # rubocop:disable Metrics/ModuleLength
     end
 
     describe '#call' do
-      let(:legal_aid_application) { create :legal_aid_application, :with_proceeding_types, :with_everything, populate_vehicle: true }
+      let(:legal_aid_application) { create :legal_aid_application, :with_proceeding_types, :with_everything, :with_applicant_and_address, populate_vehicle: true }
       let(:submission) { create :submission, :case_ref_obtained, legal_aid_application: legal_aid_application }
       let(:requestor) { described_class.new(submission, {}) }
       let(:soap_client_double) { Savon.client(env_namespace: :soap, wsdl: requestor.__send__(:wsdl_location)) }

--- a/spec/services/ccms/case_add_requestor_spec.rb
+++ b/spec/services/ccms/case_add_requestor_spec.rb
@@ -70,13 +70,14 @@ module CCMS # rubocop:disable Metrics/ModuleLength
                first_name: 'Dave',
                age: '65',
                last_name: 'Fabby',
+               national_insurance_number: 'JH125029B',
                date_of_birth: Date.today,
                address: address,
                preferred_address: 'CLIENT',
                bank_accounts: [bank_account_1]
       end
 
-      let(:firm) { double Firm, firm_id: 19_148, name: 'Firm1' }
+      let(:firm) { double Firm, id: 19_148, name: 'Firm1' }
 
       let(:provider) do
         double Provider,

--- a/spec/services/ccms/case_add_requestor_xml_blocks_spec.rb
+++ b/spec/services/ccms/case_add_requestor_xml_blocks_spec.rb
@@ -248,6 +248,57 @@ module CCMS # rubocop:disable Metrics/ModuleLength
             end
           end
         end
+        context 'POST_CODE' do
+          it "inserts applicant's postcode as a string" do
+            %i[global_means global_merits].each do |entity|
+              block = XmlExtractor.call(xml, entity, 'POST_CODE')
+              expect(block).to have_text_response legal_aid_application.applicant.address.postcode
+            end
+          end
+        end
+        context 'SURNAME' do
+          it "inserts applicant's surname as a string" do
+            %i[global_means global_merits].each do |entity|
+              block = XmlExtractor.call(xml, entity, 'SURNAME')
+              expect(block).to have_text_response legal_aid_application.applicant.last_name
+            end
+          end
+        end
+        context 'SURNAME_AT_BIRTH' do
+          it "inserts applicant's surname at birth as a string" do
+            %i[global_means global_merits].each do |entity|
+              block = XmlExtractor.call(xml, entity, 'SURNAME_AT_BIRTH')
+              expect(block).to have_text_response legal_aid_application.applicant.last_name
+            end
+          end
+        end
+        context 'CLIENT_AGE' do
+          it "inserts applicant's age as a number" do
+            %i[global_merits].each do |entity|
+              block = XmlExtractor.call(xml, entity, 'CLIENT_AGE')
+              expect(block).to have_number_response legal_aid_application.applicant.age
+            end
+          end
+        end
+      end
+
+      context 'DATE_CLIENT_VISITED_FIRM' do
+        before { allow(legal_aid_application).to receive(:calculation_date).and_return(Date.today) }
+        it "inserts today's date as a string" do
+          %i[global_merits].each do |entity|
+            block = XmlExtractor.call(xml, entity, 'DATE_CLIENT_VISITED_FIRM')
+            expect(block).to have_date_response Date.today.strftime('%d-%m-%Y')
+          end
+        end
+      end
+
+      context 'USER_PROVIDER_FIRM_ID' do
+        it "inserts provider's firm id as a number" do
+          %i[global_means global_merits].each do |entity|
+            block = XmlExtractor.call(xml, entity, 'USER_PROVIDER_FIRM_ID')
+            expect(block).to have_number_response legal_aid_application.provider.firm.id
+          end
+        end
       end
 
       context 'DATE_ASSESSMENT_STARTED' do
@@ -305,6 +356,26 @@ module CCMS # rubocop:disable Metrics/ModuleLength
           it 'is false' do
             block = XmlExtractor.call(xml, :global_merits, 'BAIL_CONDITIONS_SET')
             expect(block).to have_boolean_response false
+          end
+        end
+      end
+
+      context 'Benefit Checker' do
+        context 'BEN_DOB' do
+          it "inserts applicant's date of birth as a string" do
+            %i[global_means].each do |entity|
+              block = XmlExtractor.call(xml, entity, 'BEN_DOB')
+              expect(block).to have_date_response legal_aid_application.applicant.date_of_birth.strftime('%d-%m-%Y')
+            end
+          end
+        end
+
+        context 'BEN_NI_NO' do
+          it "inserts applicant's national insurance number as a string" do
+            %i[global_means].each do |entity|
+              block = XmlExtractor.call(xml, entity, 'BEN_NI_NO')
+              expect(block).to have_text_response legal_aid_application.applicant.national_insurance_number
+            end
           end
         end
       end

--- a/spec/services/ccms/case_add_requestor_xml_blocks_spec.rb
+++ b/spec/services/ccms/case_add_requestor_xml_blocks_spec.rb
@@ -8,6 +8,7 @@ module CCMS # rubocop:disable Metrics/ModuleLength
         create :legal_aid_application,
                :with_proceeding_types,
                :with_everything,
+               :with_applicant_and_address,
                populate_vehicle: true,
                with_bank_accounts: 2
       end


### PR DESCRIPTION
Attributes relating to the applicant’s identity is generated from the application

[Link to story](https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=233&projectKey=AP&modal=detail&selectedIssue=AP-878)

1. Update ccms_keys to use the application to grab data about the applicant
2. Update and fix tests

The attributes updated to use applicant information are below:
- POST_CODE
- FIRST_NAME
- SURNAME
- SURNAME_AT_BIRTH
- DATE_OF_BIRTH
- USER_PROVIDER_FIRM_ID
- APPLICATION_CASE_REF
- CLIENT_AGE
- DATE_ASSESSMENT_STARTED
- DATE_CLIENT_VISITED_FIRM

Add the following attributes to be generated as a  global_means attribute:
- BEN_DOB
- BEN_NI_NO
- BEN_SURNAME


## Checklist

Before you ask people to review this PR:

- [X] Tests and rubocop should be passing: `bundle exec rake`
- [X] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [X] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [X] The PR description should say what you changed and why, with a link to the JIRA story.
- [X] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [X] You should have checked that the commit messages say why the change was made.
