### PR TITLE
AP-879 Add legal framework data to CCMS payload

### DIFF
--- a/app/services/ccms/attribute_value_generator.rb
+++ b/app/services/ccms/attribute_value_generator.rb
@@ -159,10 +159,34 @@ module CCMS
       applicant.address.postcode
     end
 
+    def lead_proceeding_cost_limitation_substantive(_options)
+      lead_proceeding_type.default_cost_limitation_substantive
+    end
+
+    def lead_proceeding_category_of_law(_options)
+      lead_proceeding_type.ccms_category_law
+    end
+
+    def lead_proceeding_category_of_law_is_family?(_options)
+      lead_proceeding_type.ccms_category_law == 'Family'
+    end
+
+    def lead_proceeding_category_of_law_meaning(_options)
+      lead_proceeding_type.meaning
+    end
+
+    def lead_proceeding_category_of_law_code(_options)
+      lead_proceeding_type.ccms_category_law_code
+    end
+
     private
 
     def applicant
       @applicant ||= @legal_aid_application.applicant
+    end
+
+    def lead_proceeding_type
+      @lead_proceeding_type ||= @legal_aid_application.lead_proceeding_type
     end
 
     def standardly_named_method?(method)

--- a/config/ccms/ccms_keys.yml
+++ b/config/ccms/ccms_keys.yml
@@ -297,7 +297,7 @@ global_means:
     :response_type: text
     :user_defined: false
   CATEGORY_OF_LAW:
-    :value: FAMILY
+    :value: '#lead_proceeding_category_of_law_code'
     :br100_meaning: the category of law
     :response_type: text
     :user_defined: true
@@ -723,7 +723,7 @@ global_means:
     :response_type: currency
     :user_defined: false
   REQ_COST_LIMITATION:
-    :value: 5000.0
+    :value: '#lead_proceeding_cost_limitation_substantive'
     :br100_meaning: 'App: Requested Cost Limitation'
     :response_type: currency
     :user_defined: true
@@ -2611,12 +2611,12 @@ global_merits:
     :response_type: text
     :user_defined: false
   CAT_OF_LAW_DESCRIPTION:
-    :value: Family
+    :value: '#lead_proceeding_category_of_law'
     :br100_meaning: The Category Of Law Description
     :response_type: text
     :user_defined: false
   CATEGORY_OF_LAW:
-    :value: MAT
+    :value: '#lead_proceeding_category_of_law_code'
     :br100_meaning: the category of law
     :response_type: text
     :user_defined: true
@@ -3224,7 +3224,7 @@ global_merits:
     :response_type: boolean
     :user_defined: false
   APP_IS_FAMILY:
-    :value: true
+    :value: '#lead_proceeding_category_of_law_is_family?'
     :br100_meaning: The Application Is A Family Application
     :response_type: boolean
     :user_defined: false
@@ -3284,7 +3284,7 @@ global_merits:
     :response_type: boolean
     :user_defined: true
   REQ_COST_LIMITATION:
-    :value: 5000
+    :value: '#lead_proceeding_cost_limitation_substantive'
     :br100_meaning: 'App: Requested Cost Limitation'
     :response_type: currency
     :user_defined: true
@@ -3640,7 +3640,7 @@ global_merits:
     :response_type: boolean
     :user_defined: false
   CAT_OF_LAW_HIGH_LEVEL:
-    :value: Family
+    :value: '#lead_proceeding_category_of_law'
     :br100_meaning: The Category Of Law High Level
     :response_type: text
     :user_defined: false
@@ -3754,7 +3754,7 @@ global_merits:
     :response_type: boolean
     :user_defined: true
   CAT_OF_LAW_MEANING:
-    :value: Family
+    :value: '#lead_proceeding_category_of_law_meaning'
     :br100_meaning: 'App: The Category Of Law Meaning'
     :response_type: text
     :user_defined: false

--- a/db/migrate/20190903092600_change_default_cost_limitations_from_integer_to_decimal.rb
+++ b/db/migrate/20190903092600_change_default_cost_limitations_from_integer_to_decimal.rb
@@ -1,0 +1,11 @@
+class ChangeDefaultCostLimitationsFromIntegerToDecimal < ActiveRecord::Migration[5.2]
+  def up
+    change_column :proceeding_types, :default_cost_limitation_substantive, :decimal, precision: 8, scale: 2
+    change_column :proceeding_types, :default_cost_limitation_delegated_functions, :decimal, precision: 8, scale: 2
+  end
+
+  def down
+    change_column :proceeding_types, :default_cost_limitation_substantive, :integer
+    change_column :proceeding_types, :default_cost_limitation_delegated_functions, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_28_133153) do
+ActiveRecord::Schema.define(version: 2019_09_03_092600) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -424,8 +424,8 @@ ActiveRecord::Schema.define(version: 2019_08_28_133153) do
     t.string "ccms_category_law_code"
     t.string "ccms_matter"
     t.string "ccms_matter_code"
-    t.integer "default_cost_limitation_delegated_functions"
-    t.integer "default_cost_limitation_substantive"
+    t.decimal "default_cost_limitation_delegated_functions", precision: 8, scale: 2
+    t.decimal "default_cost_limitation_substantive", precision: 8, scale: 2
     t.boolean "involvement_type_applicant"
     t.string "additional_search_terms"
     t.uuid "default_service_level_id"

--- a/spec/services/ccms/case_add_requestor_spec.rb
+++ b/spec/services/ccms/case_add_requestor_spec.rb
@@ -132,7 +132,8 @@ module CCMS # rubocop:disable Metrics/ModuleLength
                scope_limitations: [scope_limitation_1, scope_limitation_2],
                status: 'draft',
                warning_letter_sent?: false,
-               default_level_of_service: service_level
+               default_level_of_service: service_level,
+               default_cost_limitation_substantive: 25_000
       end
 
       let(:application_proceeding_type_2) do
@@ -176,7 +177,8 @@ module CCMS # rubocop:disable Metrics/ModuleLength
                scope_limitations: [scope_limitation_1, scope_limitation_3],
                status: 'draft',
                warning_letter_sent?: false,
-               default_level_of_service: service_level
+               default_level_of_service: service_level,
+               default_cost_limitation_substantive: 25_000
       end
 
       let(:service_level) { double ServiceLevel, service_level_number: 3, name: 'Full representation' }
@@ -320,6 +322,7 @@ module CCMS # rubocop:disable Metrics/ModuleLength
       let(:requestor) { described_class.new(submission, {}) }
 
       before do
+        allow(legal_aid_application).to receive(:lead_proceeding_type).and_return(proceeding_type_1)
         allow(ProceedingType).to receive(:find).with(1).and_return(proceeding_type_1)
         allow(ProceedingType).to receive(:find).with(2).and_return(proceeding_type_2)
         allow(ApplicationScopeLimitation).to receive(:find_by).and_return(application_scope_limitation_1)


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-879)

A number of legal framework data items are being hardcoded in the create case payload. These can now be replaced with real data.

* Add correctly sourced data for

`REQ_COST_LIMITATION`
`APP_IS_FAMILY`
`CAT_OF_LAW_DESCRIPTION`
`CAT_OF_LAW_HIGH_LEVEL`
`CAT_OF_LAW_MEANING`
`CATEGORY_OF_LAW`
`DEFAULT_COST_LIMITATION`
`DEFAULT_COST_LIMITATION_MERITS`
`MATTER_TYPE`
`PROCEEDING_NAME`

to `ccms_keys`.

* Remove any hardcoded values.

* Update tests appropriately.

* Amend `proceeding_types` database table to use `decimal`s for both `cost_limitation`s, as this is more appropriate for monetary values than `integer`s.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
