### PR TITLE
AP 512 homepage table styling and functionality

### DIFF
--- a/app/assets/stylesheets/table-category-column.scss
+++ b/app/assets/stylesheets/table-category-column.scss
@@ -1,14 +1,3 @@
-p.table-category {
-  padding: 4px 1px 1px;
-  color: #1d70b8;
-  border: 2px solid;
-  margin: 0 1px 2px;
-  background: white;
-  white-space: nowrap;
-  text-transform:none;
-  text-align:center;
-}
-
 .table-category.table-category-vacant {
   visibility: hidden;
   &.table-category-preview {
@@ -17,15 +6,4 @@ p.table-category {
 }
 .govuk-table__cell.tag-cell {
   text-align:center;
-}
-
-@media (min-width: 555px) {
-  p.table-category {
-    padding: 4px 3px 1px;
-  }
-}
-@media (min-width: 655px) {
-  p.table-category {
-    padding: 4px 8px 1px;
-  }
 }

--- a/app/assets/stylesheets/tags.scss
+++ b/app/assets/stylesheets/tags.scss
@@ -1,6 +1,6 @@
 .govuk-tag {
   &.accessible-text-in-tag {
-    padding: 4px 1px 1px;
+    padding: 3px 1px 2px;
     color: #1d70b8;
     border: 2px solid;
     margin: 0 1px 2px;
@@ -12,12 +12,12 @@
 
   @media (min-width: 555px) {
     &.accessible-text-in-tag {
-      padding: 4px 3px 1px;
+      padding: 3px 3px 2px;
     }
   }
   @media (min-width: 655px) {
     &.accessible-text-in-tag {
-      padding: 4px 8px 1px;
+      padding: 3px 8px 2px;
     }
   }
 

--- a/app/assets/stylesheets/tags.scss
+++ b/app/assets/stylesheets/tags.scss
@@ -1,0 +1,37 @@
+.govuk-tag {
+  &.accessible-text-in-tag {
+    padding: 4px 1px 1px;
+    color: #1d70b8;
+    border: 2px solid;
+    margin: 0 1px 2px;
+    background: white;
+    white-space: nowrap;
+    text-transform:none;
+    text-align:center;
+  }
+
+  @media (min-width: 555px) {
+    &.accessible-text-in-tag {
+      padding: 4px 3px 1px;
+    }
+  }
+  @media (min-width: 655px) {
+    &.accessible-text-in-tag {
+      padding: 4px 8px 1px;
+    }
+  }
+
+  &.in-progress-tag {
+    @extend .accessible-text-in-tag;
+  }
+
+  &.table-category {
+    @extend .accessible-text-in-tag;
+  }
+
+  &.submitted-tag {
+    @extend .accessible-text-in-tag;
+    color: #00703c;
+    border-color: #00703c;
+  }
+}

--- a/app/controllers/providers/about_the_financial_assessments_controller.rb
+++ b/app/controllers/providers/about_the_financial_assessments_controller.rb
@@ -1,6 +1,8 @@
 module Providers
   class AboutTheFinancialAssessmentsController < ProviderBaseController
     def show
+      redirect_to start_after_means_complete_path if legal_aid_application.means_completed?
+
       @applicant = legal_aid_application.applicant
     end
 
@@ -12,6 +14,16 @@ module Providers
         CitizenEmailService.new(legal_aid_application).send_email
       end
       go_forward
+    end
+
+    private
+
+    def start_after_means_complete_path
+      Flow::KeyPoint.path_for(
+        key_point: :start_after_applicant_completes_means,
+        journey: :providers,
+        legal_aid_application: legal_aid_application
+      )
     end
   end
 end

--- a/app/controllers/providers/legal_aid_applications_controller.rb
+++ b/app/controllers/providers/legal_aid_applications_controller.rb
@@ -12,6 +12,7 @@ module Providers
         items: params.fetch(:page_size, DEFAULT_PAGE_SIZE),
         size: [1, 1, 1, 1] # control of how many elements shown in page info
       )
+      @initial_sort = { created_at: :desc }
     end
 
     # POST /provider/applications

--- a/app/forms/legal_aid_applications/substantive_application_form.rb
+++ b/app/forms/legal_aid_applications/substantive_application_form.rb
@@ -3,32 +3,10 @@ module LegalAidApplications
     include BaseForm
     form_for LegalAidApplication
 
-    after_validation :substantive_application_deadline_on
-
     attr_accessor :substantive_application
 
     validates :substantive_application, presence: { unless: :draft? }
 
-    def substantive_application_deadline_on
-      return model.substantive_application_deadline_on if model.substantive_application_deadline_on?
-
-      attributes['substantive_application_deadline_on'] ||= substantive_application_deadline
-    end
-
-    private
-
-    def substantive_application_deadline
-      return if continuing_substantive_application_selected?
-
-      WorkingDayCalculator.call working_days: working_days_to_complete, from: model.used_delegated_functions_on
-    end
-
-    def continuing_substantive_application_selected?
-      ActiveModel::Type::Boolean.new.cast(attributes['substantive_application'])
-    end
-
-    def working_days_to_complete
-      LegalAidApplication::WORKING_DAYS_TO_COMPLETE_SUBSTANTIVE_APPLICATION
-    end
+    delegate :substantive_application_deadline_on, to: :model
   end
 end

--- a/app/forms/legal_aid_applications/used_delegated_functions_form.rb
+++ b/app/forms/legal_aid_applications/used_delegated_functions_form.rb
@@ -11,6 +11,8 @@ module LegalAidApplications
     validates :used_delegated_functions_on, presence: { unless: :date_not_required? }
     validates :used_delegated_functions_on, date: { not_in_the_future: true }, allow_nil: true
 
+    after_validation :update_substantive_application_deadline
+
     def initialize(*args)
       super
       set_instance_variables_for_attributes_if_not_set_but_in_model(
@@ -59,6 +61,16 @@ module LegalAidApplications
         method: :used_delegated_functions_on,
         prefix: :used_delegated_functions_
       )
+    end
+
+    def substantive_application_deadline
+      return unless used_delegated_functions_on && used_delegated_functions_on != :invalid
+
+      SubstantiveApplicationDeadlineCalculator.call self
+    end
+
+    def update_substantive_application_deadline
+      model.substantive_application_deadline_on = substantive_application_deadline
     end
   end
 end

--- a/app/helpers/gov_uk_form_helper.rb
+++ b/app/helpers/gov_uk_form_helper.rb
@@ -79,6 +79,14 @@ module GovUkFormHelper
     args.merge(class: class_text.join(' '))
   end
 
+  def merge_with_class!(args, class_text)
+    p ['FOOOOOO', args, class_text]
+    class_text = [class_text, args[:class]]
+    class_text.compact!
+    class_text.flatten!
+    args.merge!(class: class_text.join(' '))
+  end
+
   def aria_describedby(*elements)
     elements.compact!
     return if elements.empty?

--- a/app/helpers/gov_uk_form_helper.rb
+++ b/app/helpers/gov_uk_form_helper.rb
@@ -80,7 +80,6 @@ module GovUkFormHelper
   end
 
   def merge_with_class!(args, class_text)
-    p ['FOOOOOO', args, class_text]
     class_text = [class_text, args[:class]]
     class_text.compact!
     class_text.flatten!

--- a/app/helpers/providers_helper.rb
+++ b/app/helpers/providers_helper.rb
@@ -1,4 +1,8 @@
 module ProvidersHelper
+  def link_to_application(text, legal_aid_application)
+    link_to text, url_for_application(legal_aid_application)
+  end
+
   def url_for_application(legal_aid_application)
     name = legal_aid_application.provider_step.presence || :proceedings_types
 

--- a/app/helpers/table_sort_helper.rb
+++ b/app/helpers/table_sort_helper.rb
@@ -1,0 +1,84 @@
+module TableSortHelper
+  # Usage
+  #   For a th tag for a sortable date column with the text content of "Foo":
+  #     sort_column_th type: :date, content: 'Foo'
+  #
+  #   types are :date, :numeric, and :alphabetic
+  #
+  #   If the column is already sorted add `currently_sorted` with the direction:
+  #      sort_column_th type: :date, content: 'Foo', currently_sorted: :desc
+  #
+  #   directions are :desc and :asc
+  #
+  #   If the column is to be combined right on small screens:
+  #     sort_column_th type: :date, content: 'Foo', combine_right: {at: 470, append: 'Bar}
+  #
+  #   where at: is the width below which the column will be combined (options are 470 and 555)
+  #   and append: is the contented that will be appended to the main content when the columns are combined
+  #
+  def sort_column_th(type:, content:, combine_right: {}, currently_sorted: nil)
+    combine_right_at = combine_right[:at]
+    klasses = %w[govuk-table__header sort]
+    klasses += ['table-combine_right_if_narrow', "narrow_#{combine_right_at}"] if combine_right_at
+    klasses << 'govuk-table__header--numeric' if type == :numeric
+    klasses << "header-sort-#{currently_sorted}" if currently_sorted
+    content_tag(:th, class: klasses, scope: 'col', 'data-sort-type' => type) do
+      sort_span_by +
+        sort_span_content(content) +
+        sort_span_combine_right(combine_right) +
+        sort_span_sort_indicator(type, currently_sorted)
+    end
+  end
+
+  def sort_span_by
+    content_tag :span, "#{t('sorting.sort_by')} ", class: 'govuk-visually-hidden'
+  end
+
+  def sort_span_content(content)
+    content_tag :span, content, class: 'aria-sort-description'
+  end
+
+  def sort_span_sort_indicator(type = nil, currently_sorted = nil)
+    content_tag(
+      :span,
+      sort_span_screen_reader_sort_indicator(type, currently_sorted),
+      class: 'sort-direction-indicator'
+    )
+  end
+
+  def sort_span_screen_reader_sort_indicator(type, currently_sorted)
+    screen_reader_hint = sort_hint(type: type, direction: currently_sorted)
+    content = screen_reader_hint && "(#{screen_reader_hint})".html_safe
+    content_tag(
+      :span,
+      content,
+      class: 'screen-reader-sort-indicator govuk-visually-hidden'
+    )
+  end
+
+  def sort_span_combine_right(options = {})
+    return '' if options.empty?
+
+    content_tag :span, " #{options[:append]}", class: 'table-hidden_right_title'
+  end
+
+  def sort_hint(type: :numeric, direction: :desc)
+    return unless direction
+
+    labels = sort_hint_labels[type]
+    return I18n.t("sorted_#{direction}_html") unless labels
+
+    labels.reverse! if direction == :desc
+    labels.map! { |label| I18n.t("sorting.#{label}") }
+    from, to = labels
+    I18n.t('sorting.currently_sorted_html', from: from, to: to)
+  end
+
+  def sort_hint_labels
+    {
+      numeric: %i[smallest largest],
+      alphabetic: %i[a z],
+      date: %i[newest oldest]
+    }
+  end
+end

--- a/app/helpers/table_sort_helper.rb
+++ b/app/helpers/table_sort_helper.rb
@@ -1,4 +1,18 @@
 module TableSortHelper
+  def sort_column_cell(args, &block)
+    combine_right = args.delete(:combine_right)
+    sort_by = args.delete(:sort_by)
+    content = args.delete(:content) || capture(&block)
+    merge_with_class! args, ['table-combine_right_if_narrow', "narrow_#{combine_right}"] if combine_right
+    merge_with_class! args, %w[govuk-table__cell sortable-cell]
+    args['data-sort-value'] = sort_by.is_a?(Array) ? sort_by.join : sort_by
+    if args.delete(:numeric)
+      merge_with_class! args, 'govuk-table__cell--numeric'
+      args['data-sort-type'] = 'number'
+    end
+    content_tag :td, content, args
+  end
+
   # Usage
   #   For a th tag for a sortable date column with the text content of "Foo":
   #     sort_column_th type: :date, content: 'Foo'

--- a/app/helpers/table_sort_helper.rb
+++ b/app/helpers/table_sort_helper.rb
@@ -1,4 +1,31 @@
 module TableSortHelper
+  # Usage
+  #   For a sortable cell (td) within a sortable column with content 'Bar'
+  #     sort_column_cell content: 'Bar'
+  #
+  #   or
+  #     sort_column_cell do
+  #       'Bar'
+  #     end
+  #
+  #   If the sort criteria is to be specified (that is not sorting on content), use the `sort_by` option
+  #     sort_column_cell content: 'Bar', sort_by 'x'
+  #
+  #   An array can also be used:
+  #     sort_column_cell content: 'Bar', sort_by [1,:a]
+  #
+  #   with the resultant sort criteria being taken from the concatinated array contents.
+  #
+  #   If the cells needs to combine right on small screens:
+  #     sort_column_cell content: 'Bar', combine_right: 470
+  #
+  #   Options are 470 and 555
+  #
+  #   Other options will be passed through to the `content_tag` used to build the `td` tag
+  #     sort_column_cell content: 'Bar', id: 2
+  #
+  #   will generate a `td` tag with id '2'
+  #
   def sort_column_cell(args, &block)
     combine_right = args.delete(:combine_right)
     sort_by = args.delete(:sort_by)

--- a/app/helpers/tag_helper.rb
+++ b/app/helpers/tag_helper.rb
@@ -1,0 +1,6 @@
+module TagHelper
+  def gov_uk_tag(text:, type:)
+    type_class = "#{type.to_s.dasherize}-tag"
+    content_tag :strong, text, class: "govuk-tag #{type_class}"
+  end
+end

--- a/app/helpers/tag_helper.rb
+++ b/app/helpers/tag_helper.rb
@@ -1,6 +1,7 @@
 module TagHelper
-  def gov_uk_tag(text:, type:)
-    type_class = "#{type.to_s.dasherize}-tag"
-    content_tag :strong, text, class: "govuk-tag #{type_class}"
+  def gov_uk_tag(text:, type: nil, classes: [])
+    classes << 'govuk-tag'
+    classes << "#{type.to_s.dasherize}-tag" if type
+    content_tag :strong, text, class: classes
   end
 end

--- a/app/helpers/transaction_type_helper.rb
+++ b/app/helpers/transaction_type_helper.rb
@@ -11,4 +11,28 @@ module TransactionTypeHelper
       label_method: "#{journey_type}_label_name"
     )
   end
+
+  def sort_category_column_cell(object, transaction_type)
+    return sort_category_column_cell_vacant(object, transaction_type) unless object.transaction_type_id?
+
+    tag_classes = %w[table-category govuk-body-s]
+    label = t("transaction_types.table_label.#{object.transaction_type.name}")
+
+    sort_column_cell(
+      id: "Category-#{object.id}",
+      sort_by: label,
+      content: gov_uk_tag(text: label, classes: tag_classes).html_safe
+    )
+  end
+
+  def sort_category_column_cell_vacant(object, transaction_type)
+    label = t("transaction_types.table_label.#{transaction_type.name}")
+    tag_classes = %w[table-category govuk-body-s table-category-vacant]
+
+    sort_column_cell(
+      id: "Category-#{object.id}",
+      sort_by: 'ZZZ',
+      content: gov_uk_tag(text: label, classes: tag_classes).html_safe
+    )
+  end
 end

--- a/app/models/concerns/legal_aid_application_state_machine.rb
+++ b/app/models/concerns/legal_aid_application_state_machine.rb
@@ -4,6 +4,12 @@ module LegalAidApplicationStateMachine
   included do # rubocop:disable Metrics/BlockLength
     include AASM
 
+    def summary_state
+      return :submitted if state.to_sym == :assessment_submitted
+
+      :in_progress
+    end
+
     aasm column: :state do # rubocop:disable Metrics/BlockLength
       state :initiated, initial: true
       state :checking_client_details_answers

--- a/app/services/substantive_application_deadline_calculator.rb
+++ b/app/services/substantive_application_deadline_calculator.rb
@@ -1,0 +1,23 @@
+class SubstantiveApplicationDeadlineCalculator
+  def self.call(legal_aid_application)
+    new(legal_aid_application).deadline
+  end
+
+  attr_reader :legal_aid_application
+
+  def initialize(legal_aid_application)
+    @legal_aid_application = legal_aid_application
+  end
+  delegate :used_delegated_functions_on, to: :legal_aid_application
+
+  def deadline
+    WorkingDayCalculator.call(
+      working_days: number_of_days_to_deadline,
+      from: used_delegated_functions_on
+    )
+  end
+
+  def number_of_days_to_deadline
+    LegalAidApplication::WORKING_DAYS_TO_COMPLETE_SUBSTANTIVE_APPLICATION
+  end
+end

--- a/app/views/providers/legal_aid_applications/_legal_aid_applications.html.erb
+++ b/app/views/providers/legal_aid_applications/_legal_aid_applications.html.erb
@@ -5,9 +5,10 @@
       <thead class="govuk-table__head">
         <tr class="govuk-table__row">
           <%= sort_column_th type: :alphabetic, content: t('.applicant_name'),   currently_sorted: @initial_sort[:applicant_name] %>
-          <%= sort_column_th type: :date,       content: t('.created_at'),       currently_sorted: @initial_sort[:created_at] %>
+          <%= sort_column_th type: :date,       content: t('.created_at'),       currently_sorted: @initial_sort[:created_at],       combine_right: { at: 555, append: t('.col_and_ref') } %>
           <%= sort_column_th type: :alphabetic, content: t('.application_ref'),  currently_sorted: @initial_sort[:applicant_ref] %>
-          <%= sort_column_th type: :alphabetic, content: t('.certificate_type'), currently_sorted: @initial_sort[:certificate_type] %>
+          <th class="nullcell"></th>
+          <%= sort_column_th type: :alphabetic, content: t('.certificate_type'), currently_sorted: @initial_sort[:certificate_type], combine_right: { at: 555, append: t('.col_and_state') } %>
           <%= sort_column_th type: :alphabetic, content: t('.status'),           currently_sorted: @initial_sort[:status] %>
         </tr>
       </thead>
@@ -22,12 +23,13 @@
 
             <%= sort_column_cell(
                   content: l(application.created_at.to_date, format: :short_date),
-                  sort_by: application.created_at.to_i
+                  sort_by: application.created_at.to_i,
+                  combine_right: 555
                 ) %>
 
             <%= sort_column_cell(content: application.application_ref) %>
-
-            <%= sort_column_cell(sort_by: application.used_delegated_functions?.to_s) do %>
+            <td class="nullcell"></td>
+            <%= sort_column_cell(sort_by: application.used_delegated_functions?.to_s, combine_right: 555) do %>
               <% if application.used_delegated_functions? %>
                 <%= t('.emergency') %>
                 <% if application.substantive_application_deadline_on? %>

--- a/app/views/providers/legal_aid_applications/_legal_aid_applications.html.erb
+++ b/app/views/providers/legal_aid_applications/_legal_aid_applications.html.erb
@@ -26,7 +26,7 @@
                 <% if application.substantive_application_deadline_on? %>
                   <br>
                   <span class="govuk-body-s">
-                    <%=  t('.substantive_due', date: l(application.substantive_application_deadline_on, format: :short_date)) %>
+                    <%= t('.substantive_due', date: l(application.substantive_application_deadline_on, format: :short_date)) %>
                   </span>
                 <% end %>
               <% else %>

--- a/app/views/providers/legal_aid_applications/_legal_aid_applications.html.erb
+++ b/app/views/providers/legal_aid_applications/_legal_aid_applications.html.erb
@@ -1,26 +1,34 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <table class="govuk-table">
+    <table class="govuk-table sortable table-merge_columns">
       <caption class="govuk-table__caption"><%= t('.current_application') %></caption>
       <thead class="govuk-table__head">
         <tr class="govuk-table__row">
-          <th class="govuk-table__header" scope="col"><%= t('.applicant_name') %></th>
-          <th class="govuk-table__header" scope="col"><%= t('.created_at') %></th>
-          <th class="govuk-table__header" scope="col"><%= t('.application_ref') %></th>
-          <th class="govuk-table__header" scope="col"><%= t('.certificate_type') %></th>
-          <th class="govuk-table__header" scope="col"><%= t('.status') %></th>
+          <%= sort_column_th type: :alphabetic, content: t('.applicant_name'),   currently_sorted: @initial_sort[:applicant_name] %>
+          <%= sort_column_th type: :date,       content: t('.created_at'),       currently_sorted: @initial_sort[:created_at] %>
+          <%= sort_column_th type: :alphabetic, content: t('.application_ref'),  currently_sorted: @initial_sort[:applicant_ref] %>
+          <%= sort_column_th type: :alphabetic, content: t('.certificate_type'), currently_sorted: @initial_sort[:certificate_type] %>
+          <%= sort_column_th type: :alphabetic, content: t('.status'),           currently_sorted: @initial_sort[:status] %>
         </tr>
       </thead>
 
       <% legal_aid_applications.each do |application| %>
         <tbody class="govuk-table__body">
           <tr class="govuk-table__row">
-            <td class="govuk-table__cell">
-              <%= link_to_application (application.applicant_full_name || t('generic.undefined')), application %>
-            </td>
-            <td class="govuk-table__cell"><%= l(application.created_at.to_date, format: :short_date) %></td>
-            <td class="govuk-table__cell"><%= application.application_ref %></td>
-            <td class="govuk-table__cell">
+            <% link_text = application.applicant_full_name || t('generic.undefined') %>
+            <%= sort_column_cell(
+                  content: link_to_application(link_text, application),
+                  sort_by: link_text
+                ) %>
+
+            <%= sort_column_cell(
+                  content: l(application.created_at.to_date, format: :short_date),
+                  sort_by: application.created_at.to_i
+                ) %>
+
+            <%= sort_column_cell(content: application.application_ref) %>
+
+            <%= sort_column_cell(sort_by: application.used_delegated_functions?.to_s) do %>
               <% if application.used_delegated_functions? %>
                 <%= t('.emergency') %>
                 <% if application.substantive_application_deadline_on? %>
@@ -32,10 +40,11 @@
               <% else %>
                 <%= t('.substantive') %>
               <% end %>
-            </td>
-            <td class="govuk-table__cell">
+            <% end %>
+
+            <%= sort_column_cell(sort_by: application.enum_t(:summary_state)) do %>
               <%= gov_uk_tag text: application.enum_t(:summary_state), type: application.summary_state %>
-            </td>
+            <% end %>
           </tr>
         </tbody>
       <% end %>

--- a/app/views/providers/legal_aid_applications/_legal_aid_applications.html.erb
+++ b/app/views/providers/legal_aid_applications/_legal_aid_applications.html.erb
@@ -7,22 +7,34 @@
           <th class="govuk-table__header" scope="col"><%= t('.applicant_name') %></th>
           <th class="govuk-table__header" scope="col"><%= t('.created_at') %></th>
           <th class="govuk-table__header" scope="col"><%= t('.application_ref') %></th>
+          <th class="govuk-table__header" scope="col"><%= t('.certificate_type') %></th>
           <th class="govuk-table__header" scope="col"><%= t('.status') %></th>
-          <th class="govuk-table__header" scope="col"></th>
         </tr>
       </thead>
 
       <% legal_aid_applications.each do |application| %>
         <tbody class="govuk-table__body">
           <tr class="govuk-table__row">
-            <td class="govuk-table__cell"><%= application.applicant_full_name || t('generic.undefined') %></td>
-            <td class="govuk-table__cell"><%= l(application.created_at.to_date, format: :long_date) %></td>
+            <td class="govuk-table__cell">
+              <%= link_to_application (application.applicant_full_name || t('generic.undefined')), application %>
+            </td>
+            <td class="govuk-table__cell"><%= l(application.created_at.to_date, format: :short_date) %></td>
             <td class="govuk-table__cell"><%= application.application_ref %></td>
             <td class="govuk-table__cell">
-              <%= gov_uk_tag text: application.enum_t(:summary_state), type: application.summary_state %>
+              <% if application.used_delegated_functions? %>
+                <%= t('.emergency') %>
+                <% if application.substantive_application_deadline_on? %>
+                  <br>
+                  <span class="govuk-body-s">
+                    <%=  t('.substantive_due', date: l(application.substantive_application_deadline_on, format: :short_date)) %>
+                  </span>
+                <% end %>
+              <% else %>
+                <%= t('.substantive') %>
+              <% end %>
             </td>
             <td class="govuk-table__cell">
-              <%= link_to t('generic.view'), url_for_application(application) %>
+              <%= gov_uk_tag text: application.enum_t(:summary_state), type: application.summary_state %>
             </td>
           </tr>
         </tbody>

--- a/app/views/providers/legal_aid_applications/_legal_aid_applications.html.erb
+++ b/app/views/providers/legal_aid_applications/_legal_aid_applications.html.erb
@@ -11,9 +11,8 @@
           <%= sort_column_th type: :alphabetic, content: t('.status'),           currently_sorted: @initial_sort[:status] %>
         </tr>
       </thead>
-
-      <% legal_aid_applications.each do |application| %>
-        <tbody class="govuk-table__body">
+      <tbody class="govuk-table__body">
+        <% legal_aid_applications.each do |application| %>
           <tr class="govuk-table__row">
             <% link_text = application.applicant_full_name || t('generic.undefined') %>
             <%= sort_column_cell(
@@ -46,8 +45,8 @@
               <%= gov_uk_tag text: application.enum_t(:summary_state), type: application.summary_state %>
             <% end %>
           </tr>
-        </tbody>
-      <% end %>
+        <% end %>
+      </tbody>
     </table>
     <% if local_assigns[:pagy] %>
       <div class="govuk-body pagination-container">

--- a/app/views/providers/legal_aid_applications/_legal_aid_applications.html.erb
+++ b/app/views/providers/legal_aid_applications/_legal_aid_applications.html.erb
@@ -18,7 +18,9 @@
             <td class="govuk-table__cell"><%= application.applicant_full_name || t('generic.undefined') %></td>
             <td class="govuk-table__cell"><%= l(application.created_at.to_date, format: :long_date) %></td>
             <td class="govuk-table__cell"><%= application.application_ref %></td>
-            <td class="govuk-table__cell"><%= application.enum_t(:state) %></td>
+            <td class="govuk-table__cell">
+              <%= gov_uk_tag text: application.enum_t(:summary_state), type: application.summary_state %>
+            </td>
             <td class="govuk-table__cell">
               <%= link_to t('generic.view'), url_for_application(application) %>
             </td>

--- a/app/views/providers/transactions/show.html.erb
+++ b/app/views/providers/transactions/show.html.erb
@@ -18,24 +18,20 @@
             data-copy-select="<%= t '.col_select_all' %>"
             data-copy-clear="<%= t '.col_clear_all' %>">
           </th>
-          <th data-sort-type="date" class="govuk-table__header sort header-sort-desc table-combine_right_if_narrow narrow_555" scope="col">
-            <span class="govuk-visually-hidden">Sort by </span>
-            <span class="aria-sort-description"><%= t('.col_date') %></span><span class="table-hidden_right_title"> <%= t('.col_and_description') %></span><span class="sort-direction-indicator"><span class="screen-reader-sort-indicator govuk-visually-hidden"> (<%= t('.sorted_currently') %> <%= t('.sort_new_old_html') %>)</span></span>
-          </th>
-          <th data-sort-type="alphabetic" class="govuk-table__header sort" scope="col">
-            <span class="govuk-visually-hidden">Sort by </span>
-            <span class="aria-sort-description"><%= t('.col_description') %></span><span class="sort-direction-indicator"><span class="screen-reader-sort-indicator govuk-visually-hidden"></span></span>
-          </th>
-          <th class="nullcell">
-          </th>
-          <th data-sort-type="numeric" class="govuk-table__header sort govuk-table__header--numeric table-combine_right_if_narrow narrow_470" scope="col">
-            <span class="govuk-visually-hidden">Sort by </span>
-            <span class="aria-sort-description"><%= t('.col_amount') %></span><span class="table-hidden_right_title"> <%= t('.col_and_category') %></span><span class="sort-direction-indicator"><span class="screen-reader-sort-indicator govuk-visually-hidden"></span></span>
-          </th>
-          <th data-sort-type="alphabetic" class="govuk-table__header sort" scope="col">
-            <span class="govuk-visually-hidden">Sort by </span>
-            <span class="aria-sort-description"><%= t('.col_category') %></span><span class="sort-direction-indicator"><span class="screen-reader-sort-indicator govuk-visually-hidden"></span></span>
-          </th>
+          <%= sort_column_th(
+                type: :date,
+                content: t('.col_date'),
+                combine_right: { at: 555, append: t('.col_and_description') },
+                currently_sorted: :desc
+              ) %>
+          <%= sort_column_th type: :alphabetic, content: t('.col_description') %>
+          <th class="nullcell"></th>
+          <%= sort_column_th(
+                type: :numeric,
+                content: t('.col_amount'),
+                combine_right: { at: 470, append: t('.col_and_category') }
+              ) %>
+          <%= sort_column_th type: :alphabetic, content: t('.col_category') %>
         </tr>
       </thead>
       <tbody class="govuk-table__body">

--- a/app/views/providers/transactions/show.html.erb
+++ b/app/views/providers/transactions/show.html.erb
@@ -18,19 +18,24 @@
             data-copy-select="<%= t '.col_select_all' %>"
             data-copy-clear="<%= t '.col_clear_all' %>">
           </th>
+
           <%= sort_column_th(
                 type: :date,
                 content: t('.col_date'),
                 combine_right: { at: 555, append: t('.col_and_description') },
                 currently_sorted: :desc
               ) %>
+
           <%= sort_column_th type: :alphabetic, content: t('.col_description') %>
+
           <th class="nullcell"></th>
+
           <%= sort_column_th(
                 type: :numeric,
                 content: t('.col_amount'),
                 combine_right: { at: 470, append: t('.col_and_category') }
               ) %>
+
           <%= sort_column_th type: :alphabetic, content: t('.col_category') %>
         </tr>
       </thead>
@@ -46,29 +51,30 @@
                 </div>
               <% end %>
             </td>
-            <td class="govuk-table__cell sortable-cell table-combine_right_if_narrow narrow_555" id="Date-<%= builder.object.id %>" data-sort-value="<%= "#{builder.object.happened_at.to_i}#{builder.object.description}" %>">
-              <%= l(builder.object.happened_at.to_date, format: :short_date) %>
-            </td>
-            <td class="govuk-table__cell sortable-cell" id="Description-<%= builder.object.id %>">
-              <%= builder.object.description %>
-            </td>
+
+            <%= sort_column_cell(
+                  id: "Date-#{builder.object.id}",
+                  content: l(builder.object.happened_at.to_date, format: :short_date),
+                  combine_right: 555,
+                  sort_by: [builder.object.happened_at.to_i, builder.object.description]
+                ) %>
+
+            <%= sort_column_cell(
+                  id: "Description-#{builder.object.id}",
+                  content: builder.object.description
+                ) %>
+
             <td class="nullcell"></td>
-            <td class="govuk-table__cell sortable-cell govuk-table__cell--numeric table-combine_right_if_narrow narrow_470" id="Amount-<%= builder.object.id %>" data-sort-value="<%= builder.object.amount %>" data-sort-type="number">
-              <%= value_with_currency_unit(builder.object.amount, builder.object.currency) %>
-            </td>
-            <% if builder.object.transaction_type_id != nil && builder.object.transaction_type_id != @transaction_type.id %>
-              <td class="govuk-table__cell sortable-cell tag-cell" id="Category-<%= builder.object.id %>" data-sort-value="<%= t("transaction_types.table_label.#{builder.object.transaction_type.name}") %>">
-                <p class="table-category govuk-body-s govuk-tag">
-                  <%= t("transaction_types.table_label.#{builder.object.transaction_type.name}") %>
-                </p>
-              </td>
-            <% else %>
-              <td class="govuk-table__cell sortable-cell tag-cell" id="Category-<%= builder.object.id %>" data-sort-value="ZZZ">
-                <strong class="table-category table-category-vacant govuk-body-s govuk-tag">
-                  <%= t("transaction_types.table_label.#{@transaction_type.name}") %>
-                </strong>
-              </td>
-            <% end %>
+
+            <%= sort_column_cell(
+                  id: "Amount-#{builder.object.id}",
+                  content: value_with_currency_unit(builder.object.amount, builder.object.currency),
+                  combine_right: 470,
+                  sort_by: builder.object.amount,
+                  numeric: true
+                ) %>
+
+            <%= sort_category_column_cell builder.object, @transaction_type %>
           </tr>
         <% end %>
       </tbody>

--- a/app/views/providers/transactions/show.html.erb
+++ b/app/views/providers/transactions/show.html.erb
@@ -68,9 +68,9 @@
               </td>
             <% else %>
               <td class="govuk-table__cell sortable-cell tag-cell" id="Category-<%= builder.object.id %>" data-sort-value="ZZZ">
-                <p class="table-category table-category-vacant govuk-body-s govuk-tag">
+                <strong class="table-category table-category-vacant govuk-body-s govuk-tag">
                   <%= t("transaction_types.table_label.#{@transaction_type.name}") %>
-                </p>
+                </strong>
               </td>
             <% end %>
           </tr>

--- a/config/locales/en/model_enum_translations.yml
+++ b/config/locales/en/model_enum_translations.yml
@@ -24,3 +24,6 @@ en:
         provider_checking_citizens_means_answers: Means test completed
         provider_checked_citizens_means_answers: Means test completed
         generating_reports: Generating reports
+      summary_state:
+        in_progress: In progress
+        submitted: Submitted

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -184,9 +184,9 @@ en:
         heading_1: Your legal aid applications
         make_new_application: Make a new application
       legal_aid_applications:
-        applicant_name: Client's name
-        application_ref: Case reference
-        created_at: Date started
+        applicant_name: Name
+        application_ref: LAA Ref
+        created_at: Start date
         current_application: Current applications
         certificate_type: Certificate type
         status: Status

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -193,6 +193,8 @@ en:
         emergency: Emergency
         substantive: Substantive
         substantive_due: 'Substantive due: %{date}'
+        col_and_ref: and Ref
+        col_and_state: and Status
     limitations:
       show:
         h1-heading: What you're applying for

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -420,13 +420,6 @@ en:
         col_and_description: and description
         col_select_all: Select all
         sorted: Sorted
-        sorted_currently: "currently sorted "
-        sort_new_old_html: " from <em>newest</em> to <em>oldest</em>"
-        sort_old_new_html: " from <em>oldest</em> to <em>newest</em>"
-        sort_a_z_html: " from <em>A.</em> to <em>Zed</em>"
-        sort_z_a_html: " from <em>Zed</em> to <em>A</em>"
-        sort_small_large_html: " from <em>smallest</em> to <em>largest</em>"
-        sort_large_small_html: "from <em>largest</em> to <em>smallest</em>"
     used_delegated_functions:
       show:
         heading: Have you used delegated functions?

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -188,7 +188,11 @@ en:
         application_ref: Case reference
         created_at: Date started
         current_application: Current applications
+        certificate_type: Certificate type
         status: Status
+        emergency: Emergency
+        substantive: Substantive
+        substantive_due: 'Substantive due: %{date}'
     limitations:
       show:
         h1-heading: What you're applying for

--- a/config/locales/en/sorting.yml
+++ b/config/locales/en/sorting.yml
@@ -1,0 +1,13 @@
+---
+en:
+  sorting:
+    oldest: oldest
+    newest: newest
+    a: A.
+    z: Zed
+    smallest: smallest
+    largest: largest
+    sort_by: Sort by
+    currently_sorted_html: "currently sorted from <em>%{from}</em> to <em>%{to}</em>"
+    sorted_asc_html: 'currently sorted in <em>ascending</em> order'
+    sorted_desc_html: 'currently sorted in <em>descending</em> order'

--- a/features/providers/check_your_answers.feature
+++ b/features/providers/check_your_answers.feature
@@ -236,5 +236,5 @@ Feature: Checking answers backwards and forwards
       Then I am on the read only version of the check your answers page
       Then I click 'Back to your applications'
       Then I should be on a page showing 'Your legal aid applications'
-      Then I click view on an application
+      Then I view the previously created application
       Then I am on the read only version of the check your answers page

--- a/features/step_definitions/civil_journey_steps.rb
+++ b/features/step_definitions/civil_journey_steps.rb
@@ -54,7 +54,7 @@ Given('I previously created a passported application with no assets and left on 
 end
 
 Given(/^I view the previously created application$/) do
-  find(:xpath, "//tr[contains(.,'#{@legal_aid_application.application_ref}')]/td/a", text: 'View').click
+  find(:xpath, "//tr[contains(.,'#{@legal_aid_application.application_ref}')]/td/a").click
 end
 
 Given('I start the journey as far as the applicant page') do
@@ -230,16 +230,16 @@ Given('I complete the application and view the check your answers page') do
   )
   proceeding_type = ProceedingType.all.sample
 
-  legal_aid_application = create(
+  @legal_aid_application = create(
     :legal_aid_application,
     applicant: applicant,
     proceeding_types: [proceeding_type],
     state: :provider_submitted
   )
-  legal_aid_application.add_default_substantive_scope_limitation!
-  legal_aid_applicaiton.add_default_delegated_functions_scope_limitation! if legal_aid_application.used_delegated_functions?
-  login_as legal_aid_application.provider
-  visit(providers_legal_aid_application_check_provider_answers_path(legal_aid_application))
+  @legal_aid_application.add_default_substantive_scope_limitation!
+  @legal_aid_applicaiton.add_default_delegated_functions_scope_limitation! if @legal_aid_application.used_delegated_functions?
+  login_as @legal_aid_application.provider
+  visit(providers_legal_aid_application_check_provider_answers_path(@legal_aid_application))
 end
 
 Given('The means questions have been answered by the applicant') do
@@ -435,12 +435,6 @@ end
 Then('I am on the read only version of the check your answers page') do
   expect(page).to have_content('Home')
   expect(page).not_to have_css('.change-link')
-end
-
-Then('I click view on an application') do
-  steps %(
-    And I click link "View"
-  )
 end
 
 # rubocop:disable Lint/Debugger

--- a/spec/forms/legal_aid_applications/substantive_application_form_spec.rb
+++ b/spec/forms/legal_aid_applications/substantive_application_form_spec.rb
@@ -1,13 +1,11 @@
 require 'rails_helper'
 
-RSpec.describe LegalAidApplications::SubstantiveApplicationForm, type: :form, vcr: { cassette_name: 'gov_uk_bank_holiday_api' } do
+RSpec.describe LegalAidApplications::SubstantiveApplicationForm, type: :form do
   let(:used_delegated_functions_on) { 1.day.ago.to_date }
   let(:application) do
-    create :legal_aid_application, state: :client_details_answers_checked, used_delegated_functions_on: used_delegated_functions_on
+    create :legal_aid_application, state: :client_details_answers_checked
   end
   let(:substantive_application) { false }
-  let(:working_days_to_complete) { LegalAidApplication::WORKING_DAYS_TO_COMPLETE_SUBSTANTIVE_APPLICATION }
-  let(:deadline) { WorkingDayCalculator.call working_days: working_days_to_complete, from: used_delegated_functions_on }
   let(:params) do
     {
       substantive_application: substantive_application.to_s,
@@ -25,35 +23,13 @@ RSpec.describe LegalAidApplications::SubstantiveApplicationForm, type: :form, vc
         .to(substantive_application)
     end
 
-    it 'generates a deadline date' do
-      subject.save
-      expect(application.reload.substantive_application_deadline_on).to eq(deadline)
-    end
-
     it 'updates application' do
       expect(subject.save).to be true
       expect(application).not_to be_substantive_application
     end
 
-    context 'when a deadline is already set' do
-      let(:deadline) { 3.days.from_now.to_date }
-      let(:application) do
-        create :legal_aid_application, substantive_application_deadline_on: deadline, state: :client_details_answers_checked
-      end
-
-      it 'does not change deadline' do
-        subject.save
-        expect(application.reload.substantive_application_deadline_on).to eq(deadline)
-      end
-    end
-
     context 'when completing substantive application now selected' do
       let(:substantive_application) { true }
-
-      it 'does not generates a deadline date' do
-        subject.save
-        expect(application.reload.substantive_application_deadline_on).to be_nil
-      end
 
       it 'updates application' do
         expect(subject.save).to be true

--- a/spec/forms/legal_aid_applications/used_delegated_functions_form_spec.rb
+++ b/spec/forms/legal_aid_applications/used_delegated_functions_form_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe LegalAidApplications::UsedDelegatedFunctionsForm, type: :form do
+RSpec.describe LegalAidApplications::UsedDelegatedFunctionsForm, type: :form, vcr: { cassette_name: 'gov_uk_bank_holiday_api' } do
   let(:legal_aid_application) { create :legal_aid_application }
   let(:used_delegated_functions) { true }
   let(:used_delegated_functions_on) { rand(20).days.ago.to_date }
@@ -33,6 +33,11 @@ RSpec.describe LegalAidApplications::UsedDelegatedFunctionsForm, type: :form do
       expect(legal_aid_application.used_delegated_functions).to be used_delegated_functions
     end
 
+    it 'updates the substantive application deadline' do
+      deadline = SubstantiveApplicationDeadlineCalculator.call(legal_aid_application.reload)
+      expect(legal_aid_application.substantive_application_deadline_on).to eq(deadline)
+    end
+
     context 'when not using delegated functions selected' do
       let(:used_delegated_functions) { false }
 
@@ -42,6 +47,10 @@ RSpec.describe LegalAidApplications::UsedDelegatedFunctionsForm, type: :form do
 
       it 'does not update the date' do
         expect(legal_aid_application.used_delegated_functions_on).to be_nil
+      end
+
+      it 'does not update the substantive application deadline' do
+        expect(legal_aid_application.substantive_application_deadline_on).to be_nil
       end
     end
 
@@ -55,6 +64,10 @@ RSpec.describe LegalAidApplications::UsedDelegatedFunctionsForm, type: :form do
 
       it 'deletes the date' do
         expect(legal_aid_application.used_delegated_functions_on).to be_nil
+      end
+
+      it 'deletes the substantive application deadline' do
+        expect(legal_aid_application.substantive_application_deadline_on).to be_nil
       end
     end
 

--- a/spec/models/legal_aid_application_spec.rb
+++ b/spec/models/legal_aid_application_spec.rb
@@ -149,6 +149,31 @@ RSpec.describe LegalAidApplication, type: :model do
     end
   end
 
+  describe '#summary_state' do
+    let(:state) { :initiated }
+    subject(:legal_aid_application) { create(:legal_aid_application, state: state) }
+
+    it 'returns :in_progress summary state' do
+      expect(legal_aid_application.summary_state).to eq(:in_progress)
+    end
+
+    context 'with later state' do
+      let(:state) { :means_completed }
+
+      it 'still returns :in_progress summary state' do
+        expect(legal_aid_application.summary_state).to eq(:in_progress)
+      end
+    end
+
+    context 'on submission' do
+      let(:state) { :assessment_submitted }
+
+      it 'returns :in_progress summary state' do
+        expect(legal_aid_application.summary_state).to eq(:submitted)
+      end
+    end
+  end
+
   describe '#shared_ownership?' do
     subject(:legal_aid_application) { create(:legal_aid_application, shared_ownership: shared_ownership_reason) }
 

--- a/spec/requests/providers/about_the_financial_assessments_spec.rb
+++ b/spec/requests/providers/about_the_financial_assessments_spec.rb
@@ -18,6 +18,14 @@ RSpec.describe 'about financial assessments requests', type: :request do
         subject
       end
 
+      it 'returns success' do
+        expect(response).to be_successful
+      end
+
+      it 'displays the correct page' do
+        expect(unescaped_response_body).to include('About the online financial assessment')
+      end
+
       context 'when the application does not exist' do
         let(:application_id) { SecureRandom.uuid }
 
@@ -26,12 +34,26 @@ RSpec.describe 'about financial assessments requests', type: :request do
         end
       end
 
-      it 'returns success' do
-        expect(response).to be_successful
-      end
+      context 'when means completed' do
+        let(:application) do
+          create(
+            :legal_aid_application,
+            :with_proceeding_types,
+            :with_applicant_and_address,
+            state: :means_completed
+          )
+        end
+        let(:target_path) do
+          Flow::KeyPoint.path_for(
+            key_point: :start_after_applicant_completes_means,
+            journey: :providers,
+            legal_aid_application: application
+          )
+        end
 
-      it 'displays the correct page' do
-        expect(unescaped_response_body).to include('About the online financial assessment')
+        it 'redirects to start after completed means' do
+          expect(response).to redirect_to(target_path)
+        end
       end
     end
   end

--- a/spec/requests/providers/substantive_applications_spec.rb
+++ b/spec/requests/providers/substantive_applications_spec.rb
@@ -46,7 +46,6 @@ RSpec.describe Providers::UsedDelegatedFunctionsController, type: :request, vcr:
     it 'updates the application' do
       legal_aid_application.reload
       expect(legal_aid_application.substantive_application).to eq(substantive_application)
-      expect(legal_aid_application.substantive_application_deadline_on).to be_nil
       expect(legal_aid_application.state).to eq('delegated_functions_used')
     end
 
@@ -78,7 +77,6 @@ RSpec.describe Providers::UsedDelegatedFunctionsController, type: :request, vcr:
       it 'updates the application' do
         legal_aid_application.reload
         expect(legal_aid_application.substantive_application).to eq(substantive_application)
-        expect(legal_aid_application.substantive_application_deadline_on).to be_present
         expect(legal_aid_application.state).to eq('delegated_functions_used')
       end
 

--- a/spec/requests/providers/used_delegated_functions_spec.rb
+++ b/spec/requests/providers/used_delegated_functions_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
-RSpec.describe Providers::UsedDelegatedFunctionsController, type: :request do
+RSpec.describe Providers::UsedDelegatedFunctionsController, type: :request, vcr: { cassette_name: 'gov_uk_bank_holiday_api' } do
   let(:legal_aid_application) { create :legal_aid_application }
   let(:login_provider) { login_as legal_aid_application.provider }
 


### PR DESCRIPTION
[Jira AP-512](https://dsdmoj.atlassian.net/browse/AP-512)

The main purpose of this PR is to modify the appearance of the `providers/applications` page, and add sorting. However, to achieve that a number of prior steps were required.

**Note: the sorting applied in this PR does not work across pagination. This is a known issue and will be addressed in another ticket.**

# Tasks done include

- Fixed a bug where if you hit back and then save as draft after sending the client the email link, and the client then completed their journey, the provider couldn't then proceed beyond the `Providers::AboutTheFinancialAssessmentsController`
- Move the calculation of the emergency application deadline from the page first showing that deadline (where they choose where to submit a substantive application now or later), to the page where they enter the date when delegated functions were used (so that the deadline date can be shown if the provider saves as draft between those two points). Also extracted the code that makes the calculation so that it is easier to move to the best point in the flow.
- Added helper functions and refactored the CSS for tags so that they could be reused more easily.
- Added `summary_state` to the `LegalAidApplication` state machine, to manage the higher level state shown to the providers. At the moment, there are only two summary states, but this will probably develop with time.
- Refactored the sorting on the bank transactions pages so that it was easier to reuse the code on `providers/application` - mainly by wrapping up `th` and `td` tag generation into helper methods.
- Updated the `providers/applications` to match the prototype.