### PR TITLE
AP-916 Inject means and merits reports into CCMS

### DIFF
--- a/app/models/ccms/submission.rb
+++ b/app/models/ccms/submission.rb
@@ -8,7 +8,7 @@ module CCMS
 
     validates :legal_aid_application_id, presence: true
 
-    serialize :documents, Hash
+    serialize :documents, Array
 
     POLL_LIMIT = 10
 

--- a/app/models/ccms/submission.rb
+++ b/app/models/ccms/submission.rb
@@ -8,7 +8,7 @@ module CCMS
 
     validates :legal_aid_application_id, presence: true
 
-    serialize :documents, Array
+    has_many :submission_document
 
     POLL_LIMIT = 10
 

--- a/app/models/ccms/submission_document.rb
+++ b/app/models/ccms/submission_document.rb
@@ -1,0 +1,7 @@
+module CCMS
+  class SubmissionDocument < ApplicationRecord
+    self.table_name = :ccms_submission_documents
+
+    belongs_to :submission
+  end
+end

--- a/app/services/ccms/add_case_service.rb
+++ b/app/services/ccms/add_case_service.rb
@@ -8,7 +8,7 @@ module CCMS
       @options = options
       if case_add_response_parser.success?
         submission.case_add_transaction_id = case_add_requestor.transaction_request_id
-        create_history(submission.documents.empty? ? 'applicant_ref_obtained' : 'document_ids_obtained', submission.aasm_state) if submission.submit_case!
+        create_history(submission.submission_document.empty? ? 'applicant_ref_obtained' : 'document_ids_obtained', submission.aasm_state) if submission.submit_case!
       else
         handle_failure(response)
       end

--- a/app/services/ccms/case_add_requestor.rb
+++ b/app/services/ccms/case_add_requestor.rb
@@ -81,10 +81,10 @@ module CCMS
     end
 
     def generate_case_docs(xml)
-      @submission.documents.each do |document|
+      @submission.submission_document.each do |document|
         xml.__send__('ns2:CaseDoc') do
-          xml.__send__('ns2:CCMSDocumentID', document[:ccms_document_id])
-          xml.__send__('ns2:DocumentSubject', document[:type])
+          xml.__send__('ns2:CCMSDocumentID', document.ccms_document_id)
+          xml.__send__('ns2:DocumentSubject', document.document_type)
         end
       end
     end

--- a/app/services/ccms/case_add_requestor.rb
+++ b/app/services/ccms/case_add_requestor.rb
@@ -81,12 +81,10 @@ module CCMS
     end
 
     def generate_case_docs(xml)
-      @submission.documents.each do |key|
+      @submission.documents.each do |document|
         xml.__send__('ns2:CaseDoc') do
-          xml.__send__('ns2:CCMSDocumentID', PdfFile.find_by(original_file_id: key).ccms_document_id)
-          # TODO: at present only statements of case are uploaded. at some point uploads will also include means and
-          # merits reports; at that point the following element will need to vary based on document type
-          xml.__send__('ns2:DocumentSubject', 'statement_of_case')
+          xml.__send__('ns2:CCMSDocumentID', document[:ccms_document_id])
+          xml.__send__('ns2:DocumentSubject', document[:type])
         end
       end
     end

--- a/app/services/ccms/case_add_requestor.rb
+++ b/app/services/ccms/case_add_requestor.rb
@@ -140,7 +140,7 @@ module CCMS
 
     def generate_provider_details(xml)
       xml.__send__('ns2:ProviderCaseReferenceNumber', 'PC4') # TODO: insert @legal_aid_application.provider_case_reference_number when it is available in Apply
-      xml.__send__('ns2:ProviderFirmID', provider.firm_id)
+      xml.__send__('ns2:ProviderFirmID', provider.firm.id)
       xml.__send__('ns2:ProviderOfficeID', provider.selected_office_id)
       xml.__send__('ns2:ContactUserID') do
         xml.__send__('ns0:UserLoginID', provider.user_login_id)

--- a/app/services/ccms/obtain_document_id_service.rb
+++ b/app/services/ccms/obtain_document_id_service.rb
@@ -16,10 +16,34 @@ module CCMS
 
     def populate_documents
       submission.documents = []
+      add_statements_of_case
+      add_means_report
+      add_merits_report
+    end
+
+    def add_statements_of_case
       files = StatementOfCase.find_by(legal_aid_application_id: submission.legal_aid_application_id)&.original_files
       files&.each do |document|
         submission.documents << { id: document.id, status: :new, type: :statement_of_case, ccms_document_id: nil }
       end
+    end
+
+    def add_means_report
+      return unless submission.legal_aid_application.means_report.attachment
+
+      submission.documents << { id: submission.legal_aid_application.means_report.id,
+                                status: :new,
+                                type: :means_report,
+                                ccms_document_id: nil }
+    end
+
+    def add_merits_report
+      return unless submission.legal_aid_application.merits_report.attachment
+
+      submission.documents << { id: submission.legal_aid_application.merits_report.id,
+                                status: :new,
+                                type: :merits_report,
+                                ccms_document_id: nil }
     end
 
     def request_document_ids

--- a/app/services/ccms/obtain_document_id_service.rb
+++ b/app/services/ccms/obtain_document_id_service.rb
@@ -2,7 +2,7 @@ module CCMS
   class ObtainDocumentIdService < BaseSubmissionService
     def call
       populate_documents
-      if submission.documents.empty?
+      if submission.submission_document.empty?
         create_history('applicant_ref_obtained', submission.aasm_state) if submission.submit_case!
       else
         request_document_ids
@@ -15,7 +15,6 @@ module CCMS
     private
 
     def populate_documents
-      submission.documents = []
       add_statements_of_case
       add_means_report
       add_merits_report
@@ -24,36 +23,48 @@ module CCMS
     def add_statements_of_case
       files = StatementOfCase.find_by(legal_aid_application_id: submission.legal_aid_application_id)&.original_files
       files&.each do |document|
-        submission.documents << { id: document.id, status: :new, type: :statement_of_case, ccms_document_id: nil }
+        SubmissionDocument.create!(
+          submission: submission,
+          document_id: document.id,
+          status: :new,
+          document_type: :statement_of_case,
+          ccms_document_id: nil
+        )
       end
     end
 
     def add_means_report
       return unless submission.legal_aid_application.means_report.attachment
 
-      submission.documents << { id: submission.legal_aid_application.means_report.id,
-                                status: :new,
-                                type: :means_report,
-                                ccms_document_id: nil }
+      SubmissionDocument.create!(
+        submission: submission,
+        document_id: submission.legal_aid_application.means_report.id,
+        status: :new,
+        document_type: :means_report,
+        ccms_document_id: nil
+      )
     end
 
     def add_merits_report
       return unless submission.legal_aid_application.merits_report.attachment
 
-      submission.documents << { id: submission.legal_aid_application.merits_report.id,
-                                status: :new,
-                                type: :merits_report,
-                                ccms_document_id: nil }
+      SubmissionDocument.create!(
+        submission: submission,
+        document_id: submission.legal_aid_application.merits_report.id,
+        status: :new,
+        document_type: :merits_report,
+        ccms_document_id: nil
+      )
     end
 
     def request_document_ids
-      submission.documents.each do |document|
+      submission.submission_document.each do |document|
         tx_id = document_id_requestor.transaction_request_id
         response = document_id_requestor.call
-        document[:ccms_document_id] = DocumentIdResponseParser.new(tx_id, response).document_id
-        document[:status] = :id_obtained
+        document.ccms_document_id = DocumentIdResponseParser.new(tx_id, response).document_id
+        document.status = :id_obtained
       rescue CcmsError => e
-        document[:status] = :failed
+        document.status = :failed
         raise CcmsError, e
       end
     end

--- a/app/services/ccms/upload_documents_service.rb
+++ b/app/services/ccms/upload_documents_service.rb
@@ -1,11 +1,11 @@
 module CCMS
   class UploadDocumentsService < BaseSubmissionService
     def call
-      submission.documents.each do |document|
+      submission.submission_document.each do |document|
         upload_document(document)
       end
 
-      failed_uploads = submission.documents.select { |document| document[:status] == :failed }
+      failed_uploads = submission.submission_document.select { |document| document.status == 'failed' }
 
       if failed_uploads.empty?
         create_history('case_created', submission.aasm_state) if submission.complete!
@@ -19,32 +19,32 @@ module CCMS
     private
 
     def upload_document(document)
-      document_upload_requestor = DocumentUploadRequestor.new(submission.case_ccms_reference, document[:ccms_document_id], Base64.strict_encode64(pdf_binary(document)))
+      document_upload_requestor = DocumentUploadRequestor.new(submission.case_ccms_reference, document.ccms_document_id, Base64.strict_encode64(pdf_binary(document)))
       tx_id = document_upload_requestor.transaction_request_id
       response = document_upload_requestor.call
       update_document_status(document, tx_id, response)
     rescue CcmsError => e
-      document[:status] = :failed
+      document.status = :failed
       raise CcmsError, e
     end
 
     def pdf_binary(document)
-      case document[:type]
-      when :statement_of_case
-        PdfFile.find_by(original_file_id: document[:id]).file.download
-      when :means_report
+      case document.document_type
+      when 'statement_of_case'
+        PdfFile.find_by(original_file_id: document.document_id).file.download
+      when 'means_report'
         submission.legal_aid_application.means_report.attachment.download
-      when :merits_report
+      when 'merits_report'
         submission.legal_aid_application.merits_report.attachment.download
       end
     end
 
     def update_document_status(document, tx_id, response)
-      document[:status] = if DocumentUploadResponseParser.new(tx_id, response).success?
-                            :uploaded
-                          else
-                            :failed
-                          end
+      document.status = if DocumentUploadResponseParser.new(tx_id, response).success?
+                          :uploaded
+                        else
+                          :failed
+                        end
     end
   end
 end

--- a/app/services/ccms/upload_documents_service.rb
+++ b/app/services/ccms/upload_documents_service.rb
@@ -1,16 +1,16 @@
 module CCMS
   class UploadDocumentsService < BaseSubmissionService
     def call
-      submission.documents.each do |key, _value|
-        upload_document(key)
+      submission.documents.each do |document|
+        upload_document(document)
       end
 
-      failed_uploads = submission.documents.select { |_key, value| value == :failed }
+      failed_uploads = submission.documents.select { |document| document[:status] == :failed }
 
       if failed_uploads.empty?
         create_history('case_created', submission.aasm_state) if submission.complete!
       else
-        handle_failure("#{failed_uploads.keys} failed to upload to CCMS")
+        handle_failure("#{failed_uploads} failed to upload to CCMS")
       end
     rescue CcmsError => e
       handle_failure(e)
@@ -18,23 +18,23 @@ module CCMS
 
     private
 
-    def upload_document(key)
-      pdf_file = PdfFile.find_by(original_file_id: key)
-      document_upload_requestor = DocumentUploadRequestor.new(submission.case_ccms_reference, pdf_file.ccms_document_id, Base64.strict_encode64(pdf_file.file.download))
+    def upload_document(document)
+      pdf_file = PdfFile.find_by(original_file_id: document[:id])
+      document_upload_requestor = DocumentUploadRequestor.new(submission.case_ccms_reference, document[:ccms_document_id], Base64.strict_encode64(pdf_file.file.download))
       tx_id = document_upload_requestor.transaction_request_id
       response = document_upload_requestor.call
-      update_document_status(key, tx_id, response)
+      update_document_status(document, tx_id, response)
     rescue CcmsError => e
-      submission.documents[key] = :failed
+      document[:status] = :failed
       raise CcmsError, e
     end
 
-    def update_document_status(key, tx_id, response)
-      submission.documents[key] = if DocumentUploadResponseParser.new(tx_id, response).success?
-                                    :uploaded
-                                  else
-                                    :failed
-                                  end
+    def update_document_status(document, tx_id, response)
+      document[:status] = if DocumentUploadResponseParser.new(tx_id, response).success?
+                            :uploaded
+                          else
+                            :failed
+                          end
     end
   end
 end

--- a/ccms_integration/ccms_spec.rb
+++ b/ccms_integration/ccms_spec.rb
@@ -53,6 +53,37 @@ module CCMS
              marked_for_destruction?: false
     end
 
+    let(:substantive_legal_aid_application) do
+      create :legal_aid_application,
+             :with_applicant_and_address,
+             :with_proceeding_types,
+             :with_substantive_scope_limitation,
+             :with_other_assets_declaration,
+             :with_savings_amount,
+             :with_respondent,
+             :with_transaction_period,
+             :with_merits_assessment,
+             :with_means_report,
+             :with_merits_report,
+             statement_of_case: @statement_of_case
+    end
+
+    let(:delegated_functions_legal_aid_application) do
+      create :legal_aid_application,
+             :with_applicant_and_address,
+             :with_proceeding_types,
+             :with_delegated_functions,
+             :with_delegated_functions_scope_limitation,
+             :with_other_assets_declaration,
+             :with_savings_amount,
+             :with_respondent,
+             :with_transaction_period,
+             :with_merits_assessment,
+             :with_means_report,
+             :with_merits_report,
+             statement_of_case: @statement_of_case
+    end
+
     before do
       @statement_of_case = create :statement_of_case, :with_attached_files
       PdfConverter.call(PdfFile.find_or_create_by(original_file_id: @statement_of_case.original_files.first.id).id)
@@ -74,8 +105,7 @@ module CCMS
 
     context 'delegated functions case' do
       before do
-        @legal_aid_application = create :legal_aid_application, :with_applicant_and_address, :with_proceeding_types, :with_delegated_functions, :with_delegated_functions_scope_limitation, :with_other_assets_declaration, :with_savings_amount, :with_respondent, statement_of_case: @statement_of_case
-        @submission = create :submission, legal_aid_application: @legal_aid_application
+        @submission = create :submission, legal_aid_application: delegated_functions_legal_aid_application
       end
 
       describe 'generate case payload only' do
@@ -100,8 +130,7 @@ module CCMS
 
     context 'substantive case' do
       before do
-        @legal_aid_application = create :legal_aid_application, :with_applicant_and_address, :with_proceeding_types, :with_substantive_scope_limitation, :with_other_assets_declaration, :with_savings_amount, :with_respondent, :with_transaction_period, statement_of_case: @statement_of_case
-        @submission = create :submission, legal_aid_application: @legal_aid_application
+        @submission = create :submission, legal_aid_application: substantive_legal_aid_application
       end
 
       describe 'generate case payload only' do

--- a/ccms_integration/ccms_spec.rb
+++ b/ccms_integration/ccms_spec.rb
@@ -40,10 +40,12 @@ module CCMS
              description: ':EMPLOYMENT_CLIENT_001:CLI_NON_HM_WAGE_SLIP_001'
     end
 
+    let(:firm) { double Firm, id: 19_148, name: 'Firm1' }
+
     let(:provider) do
       double Provider,
              username: 'user1',
-             firm_id: 22_381,
+             firm: firm,
              selected_office_id: 81_693,
              user_login_id: 2_016_472,
              supervisor_contact_id: 3_982_723,
@@ -98,7 +100,7 @@ module CCMS
 
     context 'substantive case' do
       before do
-        @legal_aid_application = create :legal_aid_application, :with_applicant_and_address, :with_proceeding_types, :with_substantive_scope_limitation, :with_other_assets_declaration, :with_savings_amount, :with_respondent, statement_of_case: @statement_of_case
+        @legal_aid_application = create :legal_aid_application, :with_applicant_and_address, :with_proceeding_types, :with_substantive_scope_limitation, :with_other_assets_declaration, :with_savings_amount, :with_respondent, :with_transaction_period, statement_of_case: @statement_of_case
         @submission = create :submission, legal_aid_application: @legal_aid_application
       end
 

--- a/ccms_integration/ccms_spec.rb
+++ b/ccms_integration/ccms_spec.rb
@@ -237,26 +237,26 @@ module CCMS
     def request_document_ids
       print 'Requesting document IDs... '
       @submission.process!
-      expect(@submission.documents).to_not be_empty
-      expect(@submission.documents[0][:status]).to eq :id_obtained
+      expect(@submission.submission_document).to_not be_empty
+      expect(@submission.submission_document.first.status).to eq 'id_obtained'
       expect(@submission.aasm_state).to eq 'document_ids_obtained'
       expect(history.from_state).to eq 'applicant_ref_obtained'
       expect(history.to_state).to eq 'document_ids_obtained'
       expect(history.success).to be true
       expect(history.details).to be_nil
-      puts @submission.documents.to_s.green
+      puts 'done'.green
     end
 
     def upload_documents
       print 'Uploading documents... '
       @submission.process!
-      expect(@submission.documents[0][:status]).to eq :uploaded
+      expect(@submission.submission_document.first.status).to eq 'uploaded'
       expect(@submission.aasm_state).to eq 'completed'
       expect(history.from_state).to eq 'case_created'
       expect(history.to_state).to eq 'completed'
       expect(history.success).to be true
       expect(history.details).to be_nil
-      puts @submission.documents.to_s.green
+      puts 'done'.green
     end
 
     def run_everything

--- a/ccms_integration/ccms_spec.rb
+++ b/ccms_integration/ccms_spec.rb
@@ -207,7 +207,7 @@ module CCMS
       print 'Requesting document IDs... '
       @submission.process!
       expect(@submission.documents).to_not be_empty
-      expect(@submission.documents.values[0]).to eq :id_obtained
+      expect(@submission.documents[0][:status]).to eq :id_obtained
       expect(@submission.aasm_state).to eq 'document_ids_obtained'
       expect(history.from_state).to eq 'applicant_ref_obtained'
       expect(history.to_state).to eq 'document_ids_obtained'
@@ -219,7 +219,7 @@ module CCMS
     def upload_documents
       print 'Uploading documents... '
       @submission.process!
-      expect(@submission.documents.values[0]).to eq :uploaded
+      expect(@submission.documents[0][:status]).to eq :uploaded
       expect(@submission.aasm_state).to eq 'completed'
       expect(history.from_state).to eq 'case_created'
       expect(history.to_state).to eq 'completed'

--- a/db/migrate/20190904151326_remove_ccms_document_id_from_pdf_files.rb
+++ b/db/migrate/20190904151326_remove_ccms_document_id_from_pdf_files.rb
@@ -1,0 +1,5 @@
+class RemoveCcmsDocumentIdFromPdfFiles < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :pdf_files, :ccms_document_id, :string
+  end
+end

--- a/db/migrate/20190909095604_create_submission_documents.rb
+++ b/db/migrate/20190909095604_create_submission_documents.rb
@@ -1,0 +1,14 @@
+class CreateSubmissionDocuments < ActiveRecord::Migration[5.2]
+  def change
+    create_table :ccms_submission_documents, id: :uuid do |t|
+      t.uuid :submission_id
+      t.string :document_id
+      t.string :status
+      t.string :document_type
+      t.string :ccms_document_id
+      t.timestamps
+    end
+
+    add_foreign_key :ccms_submission_documents, :ccms_submissions, column: :submission_id
+  end
+end

--- a/db/migrate/20190909101523_remove_documents_from_ccms_submission.rb
+++ b/db/migrate/20190909101523_remove_documents_from_ccms_submission.rb
@@ -1,0 +1,5 @@
+class RemoveDocumentsFromCcmsSubmission < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :ccms_submissions, :documents, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_04_151326) do
+ActiveRecord::Schema.define(version: 2019_09_09_101523) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -196,6 +196,16 @@ ActiveRecord::Schema.define(version: 2019_09_04_151326) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "ccms_submission_documents", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "submission_id"
+    t.string "document_id"
+    t.string "status"
+    t.string "document_type"
+    t.string "ccms_document_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "ccms_submission_histories", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "submission_id", null: false
     t.string "from_state"
@@ -218,7 +228,6 @@ ActiveRecord::Schema.define(version: 2019_09_04_151326) do
     t.integer "applicant_poll_count", default: 0
     t.string "case_add_transaction_id"
     t.integer "case_poll_count", default: 0
-    t.text "documents"
     t.index ["legal_aid_application_id"], name: "index_ccms_submissions_on_legal_aid_application_id"
   end
 
@@ -557,6 +566,7 @@ ActiveRecord::Schema.define(version: 2019_09_04_151326) do
   add_foreign_key "bank_providers", "applicants"
   add_foreign_key "bank_transactions", "bank_accounts"
   add_foreign_key "benefit_check_results", "legal_aid_applications"
+  add_foreign_key "ccms_submission_documents", "ccms_submissions", column: "submission_id"
   add_foreign_key "ccms_submission_histories", "ccms_submissions", column: "submission_id"
   add_foreign_key "ccms_submissions", "legal_aid_applications"
   add_foreign_key "dependants", "legal_aid_applications"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_03_092600) do
+ActiveRecord::Schema.define(version: 2019_09_04_151326) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -395,7 +395,6 @@ ActiveRecord::Schema.define(version: 2019_09_03_092600) do
 
   create_table "pdf_files", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "original_file_id", null: false
-    t.text "ccms_document_id"
     t.index ["original_file_id"], name: "index_pdf_files_on_original_file_id", unique: true
   end
 

--- a/spec/factories/legal_aid_applications.rb
+++ b/spec/factories/legal_aid_applications.rb
@@ -250,5 +250,17 @@ FactoryBot.define do
       state { :checking_merits_answers }
       provider_step { :check_merits_answers }
     end
+
+    trait :with_means_report do
+      after :create do |application|
+        Reports::MeansReportCreator.call(application)
+      end
+    end
+
+    trait :with_merits_report do
+      after :create do |application|
+        Reports::MeritsReportCreator.call(application)
+      end
+    end
   end
 end

--- a/spec/factories/submission_documents.rb
+++ b/spec/factories/submission_documents.rb
@@ -1,0 +1,26 @@
+FactoryBot.define do
+  factory :submission_document, class: CCMS::SubmissionDocument do
+    submission
+
+    trait :new do
+      document_id { Faker::Number.number(digits: 10) }
+      status { :new }
+      document_type { :statement_of_case }
+      ccms_document_id { nil }
+    end
+
+    trait :id_obtained do
+      document_id { Faker::Number.number(digits: 10) }
+      status { :id_obtained }
+      document_type { :statement_of_case }
+      ccms_document_id { Faker::Number.number(digits: 10) }
+    end
+
+    trait :uploaded do
+      document_id { Faker::Number.number(digits: 10) }
+      status { :uploaded }
+      document_type { :statement_of_case }
+      ccms_document_id { Faker::Number.number(digits: 10) }
+    end
+  end
+end

--- a/spec/factories/submissions.rb
+++ b/spec/factories/submissions.rb
@@ -25,7 +25,7 @@ FactoryBot.define do
 
     trait :document_ids_obtained do
       aasm_state { 'document_ids_obtained' }
-      documents { { '12345' => :id_obtained } }
+      documents { [{ id: '12345', status: :id_obtained, type: :statement_of_case, ccms_document_id: '67890' }] }
     end
   end
 end

--- a/spec/factories/submissions.rb
+++ b/spec/factories/submissions.rb
@@ -25,7 +25,9 @@ FactoryBot.define do
 
     trait :document_ids_obtained do
       aasm_state { 'document_ids_obtained' }
-      documents { [{ id: '12345', status: :id_obtained, type: :statement_of_case, ccms_document_id: '67890' }] }
+      after :create do |submission|
+        create :submission_document, :id_obtained, submission: submission
+      end
     end
   end
 end

--- a/spec/services/ccms/case_add_requestor_spec.rb
+++ b/spec/services/ccms/case_add_requestor_spec.rb
@@ -310,7 +310,7 @@ module CCMS # rubocop:disable Metrics/ModuleLength
                applicant_ccms_reference: 9_876_543_210
       end
 
-      let(:documents) { { '2b4ccb59-5161-498d-a27a-79110de7b67e' => :id_obtained } }
+      let(:documents) { [{ id: '12345', status: :id_obtained, type: :statement_of_case, ccms_document_id: '67890' }] }
 
       let(:pdf_file) do
         double PdfFile,

--- a/spec/services/ccms/case_add_requestor_spec.rb
+++ b/spec/services/ccms/case_add_requestor_spec.rb
@@ -310,7 +310,7 @@ module CCMS # rubocop:disable Metrics/ModuleLength
                applicant_ccms_reference: 9_876_543_210
       end
 
-      let(:documents) { [{ id: '12345', status: :id_obtained, type: :statement_of_case, ccms_document_id: '67890' }] }
+      let(:documents) { [(create :submission_document, :id_obtained, ccms_document_id: '67890')] }
 
       let(:pdf_file) do
         double PdfFile,
@@ -327,7 +327,7 @@ module CCMS # rubocop:disable Metrics/ModuleLength
         allow(ProceedingType).to receive(:find).with(2).and_return(proceeding_type_2)
         allow(ApplicationScopeLimitation).to receive(:find_by).and_return(application_scope_limitation_1)
         allow(PdfFile).to receive(:find_by).and_return(pdf_file)
-        allow(submission).to receive(:documents).and_return(documents)
+        allow(submission).to receive(:submission_document).and_return(documents)
       end
 
       describe 'Full XML request' do

--- a/spec/services/ccms/case_add_requestor_xml_blocks_spec.rb
+++ b/spec/services/ccms/case_add_requestor_xml_blocks_spec.rb
@@ -14,9 +14,11 @@ module CCMS # rubocop:disable Metrics/ModuleLength
                proceeding_types: [proceeding_type]
       end
 
+      let(:firm) { double Firm, id: 19_148, name: 'Firm1' }
+
       let(:provider) do
         double Provider,
-               firm_id: 19_148,
+               firm: firm,
                selected_office_id: 137_570,
                user_login_id: 4_953_649,
                username: 4_953_649,

--- a/spec/services/ccms/obtain_document_id_service_spec.rb
+++ b/spec/services/ccms/obtain_document_id_service_spec.rb
@@ -1,7 +1,15 @@
 require 'rails_helper'
 
 RSpec.describe CCMS::ObtainDocumentIdService do
-  let(:legal_aid_application) { create :legal_aid_application, statement_of_case: statement_of_case }
+  let(:legal_aid_application) do
+    create :legal_aid_application,
+           :with_applicant,
+           :with_proceeding_types,
+           :with_respondent,
+           :with_merits_assessment,
+           :with_transaction_period,
+           statement_of_case: statement_of_case
+  end
   let(:submission) { create :submission, :applicant_ref_obtained, legal_aid_application: legal_aid_application, case_ccms_reference: Faker::Number.number }
   let(:statement_of_case) { create :statement_of_case }
   let(:history) { CCMS::SubmissionHistory.find_by(submission_id: submission.id) }
@@ -32,24 +40,25 @@ RSpec.describe CCMS::ObtainDocumentIdService do
       let(:statement_of_case) { create :statement_of_case, :with_attached_files }
       let(:document_id_response) { ccms_data_from_file 'document_id_response.xml' }
       let(:transaction_request_id_in_example_response) { '20190301030405123456' }
-      let(:ccms_document_id_in_example_response) { '4420073' }
 
       before do
         allow(subject).to receive(:document_id_requestor).and_return(document_id_requestor)
-        expect(document_id_requestor).to receive(:transaction_request_id).and_return(transaction_request_id_in_example_response)
-        expect(document_id_requestor).to receive(:call).and_return(document_id_response)
+        allow(document_id_requestor).to receive(:transaction_request_id).and_return(transaction_request_id_in_example_response)
+        allow(document_id_requestor).to receive(:call).and_return(document_id_response)
+        Reports::MeansReportCreator.call(legal_aid_application)
+        Reports::MeritsReportCreator.call(legal_aid_application)
       end
 
-      it 'populates the documents array with all documents for the application' do
+      it 'populates the documents array with statement_of_case, means_report and merits_report' do
         subject.call
-        expect(submission.documents&.size).to eq statement_of_case.original_files.count
+        expect(submission.documents&.size).to eq 3
       end
 
       context 'when requesting document_ids' do
-        it 'updates the ccms_document_id for each document' do
+        it 'populates the ccms_document_id for each document' do
           subject.call
           submission.documents.each do |document|
-            expect(document[:ccms_document_id]).to eq ccms_document_id_in_example_response
+            expect(document[:ccms_document_id]).to_not be nil
           end
         end
 

--- a/spec/services/ccms/obtain_document_id_service_spec.rb
+++ b/spec/services/ccms/obtain_document_id_service_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe CCMS::ObtainDocumentIdService do
     context 'the application has no documents' do
       it 'creates an empty documents array' do
         subject.call
-        expect(submission.documents&.size).to eq 0
+        expect(submission.submission_document.count).to eq 0
       end
 
       it 'changes the submission state to case_submitted' do
@@ -51,21 +51,21 @@ RSpec.describe CCMS::ObtainDocumentIdService do
 
       it 'populates the documents array with statement_of_case, means_report and merits_report' do
         subject.call
-        expect(submission.documents&.size).to eq 3
+        expect(submission.submission_document.count).to eq 3
       end
 
       context 'when requesting document_ids' do
         it 'populates the ccms_document_id for each document' do
           subject.call
-          submission.documents.each do |document|
-            expect(document[:ccms_document_id]).to_not be nil
+          submission.submission_document.each do |document|
+            expect(document.ccms_document_id).to_not be nil
           end
         end
 
         it 'updates the status for each document to id_obtained' do
           subject.call
-          submission.documents.each do |document|
-            expect(document[:status]).to eq :id_obtained
+          submission.submission_document.each do |document|
+            expect(document.status).to eq 'id_obtained'
           end
         end
 
@@ -111,7 +111,7 @@ RSpec.describe CCMS::ObtainDocumentIdService do
 
       it 'changes the document state to failed' do
         subject.call
-        expect(submission.documents.first[:status]).to eq :failed
+        expect(submission.submission_document.first.status).to eq 'failed'
       end
 
       it 'writes a history record' do

--- a/spec/services/ccms/upload_documents_service_spec.rb
+++ b/spec/services/ccms/upload_documents_service_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe CCMS::UploadDocumentsService do
            :case_created,
            legal_aid_application: legal_aid_application,
            case_ccms_reference: Faker::Number.number(digits: 9),
-           documents: { document_id => :id_obtained }
+           documents: [{ id: document_id, status: :id_obtained, type: :statement_of_case, ccms_document_id: '67890' }]
   end
   let(:history) { CCMS::SubmissionHistory.find_by(submission_id: submission.id) }
   let(:document_upload_requestor) { double CCMS::DocumentUploadRequestor.new(submission.case_ccms_reference, document_id, 'base64encodedpdf') }
@@ -40,8 +40,8 @@ RSpec.describe CCMS::UploadDocumentsService do
 
     it 'updates the status for each document to uploaded' do
       subject.call
-      submission.documents.each do |_key, value|
-        expect(value).to eq :uploaded
+      submission.documents.each do |document|
+        expect(document[:status]).to eq :uploaded
       end
     end
 
@@ -69,7 +69,8 @@ RSpec.describe CCMS::UploadDocumentsService do
       end
 
       it 'changes the document state to failed' do
-        expect { subject.call }.to change { submission.documents[statement_of_case.original_files.first.id] }.to eq :failed
+        subject.call
+        expect(submission.documents.first[:status]).to eq :failed
       end
 
       it 'writes a history record' do
@@ -93,7 +94,8 @@ RSpec.describe CCMS::UploadDocumentsService do
       end
 
       it 'changes the document state to failed' do
-        expect { subject.call }.to change { submission.documents[statement_of_case.original_files.first.id] }.to eq :failed
+        subject.call
+        expect(submission.documents.first[:status]).to eq :failed
       end
 
       it 'writes a history record' do


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-916)

CCMS document upload functionality currently only handles statement of case documents. It also needs to include means and merits reports.

* Add `SubmissionDocument` model with `belongs_to`/`has_many` relationship with `Submission` model, to hold details of documents to be uploaded for a submission.

* Refactor code so that documents are held as `SubmissionDocument`s instead of in a hash.

* Amend `obtain_document_id_service` so that means and merits reports are also identified and added to the `documents` array in the `submission` model.

* Amend `upload_documents_service` so that PDF files for the three different types of document are retrieved from the correct locations and uploaded.

* Remove the `ccms_document_id` field from the `PdfFile` model, as this data is now held in the `SubmissionDocument` object.

* Remove the `documents` field from the `Submission` model, as this data is now held in `SubmissionDocument` object.


## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
