### PR TITLE
Ap-899 Add nofollow noindex tags to prevent indexing

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,6 +3,7 @@
   <head>
     <%= render 'layouts/google_tag_manager' if google_tag_present? %>
     <meta charset="utf-8">
+    <meta name="robots" content="noindex, nofollow">
     <title><%= html_title %></title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-899)

Added the relevant nofollow/noindex meta tag to the application.html.erb so that it is applied across all of our pages and in all environments.

There are alternative way stop indexing of page that allows for more granular control, however that seems overkill for now as we want to hide all pages and environments from indexing.


## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
