### PR TITLE
AP-927 Add provider email to CCMS attribute blocks

### DIFF
--- a/app/services/ccms/attribute_value_generator.rb
+++ b/app/services/ccms/attribute_value_generator.rb
@@ -88,6 +88,10 @@ module CCMS
       @legal_aid_application.provider.firm.id
     end
 
+    def provider_email(_options)
+      @legal_aid_application.provider.email
+    end
+
     def applicant_national_insurance_number(_options)
       applicant.national_insurance_number
     end

--- a/app/views/shared/_application_ref.html.erb
+++ b/app/views/shared/_application_ref.html.erb
@@ -12,6 +12,7 @@
       <%= t('.ccms_ref') %>
     </dt>
     <dd class="govuk-summary-list__value">
+      <%= legal_aid_application.most_recent_ccms_submission %>
     </dd>
   </div>
 </dl>

--- a/config/ccms/ccms_keys.yml
+++ b/config/ccms/ccms_keys.yml
@@ -2346,6 +2346,11 @@ global_means:
     :br100_meaning: 'The application means assessment needs a caseworker to manually review'
     :response_type: boolean
     :user_defined: false
+  _SYSTEM_PUI_USERID:
+    :value: '#provider_email'
+    :br100_meaning: The email address of the provider responsible for the application
+    :response_type: text
+    :user_defined: true
 global_merits:
   APP_INCLUDES_IMMIGRATION_PROCS:
     :generate_block?: false
@@ -2937,6 +2942,11 @@ global_merits:
     :generate_block?: false
     :value: Unused
     :br100_meaning: Meaning not defined in BR100
+    :response_type: text
+    :user_defined: true
+  _SYSTEM_PUI_USERID:
+    :value: '#provider_email'
+    :br100_meaning: The email address of the provider responsible for the application
     :response_type: text
     :user_defined: true
   EVIDENCE_PRE_ACTION_DISCLOSURE:

--- a/spec/services/ccms/case_add_requestor_spec.rb
+++ b/spec/services/ccms/case_add_requestor_spec.rb
@@ -88,7 +88,8 @@ module CCMS # rubocop:disable Metrics/ModuleLength
                username: 4_953_649,
                contact_user_id: 4_953_649,
                supervisor_contact_id: 7_008_010,
-               fee_earner_contact_id: 4_925_152
+               fee_earner_contact_id: 4_925_152,
+               email: 'testemail@emailtest.com'
       end
 
       let(:application_proceeding_type_1) do

--- a/spec/services/ccms/case_add_requestor_xml_blocks_spec.rb
+++ b/spec/services/ccms/case_add_requestor_xml_blocks_spec.rb
@@ -338,6 +338,15 @@ module CCMS # rubocop:disable Metrics/ModuleLength
         end
       end
 
+      context '_SYSTEM_PUI_USERID' do
+        it "inserts provider's email address" do
+          %i[global_means global_merits].each do |entity|
+            block = XmlExtractor.call(xml, entity, '_SYSTEM_PUI_USERID')
+            expect(block).to have_text_response legal_aid_application.provider.email
+          end
+        end
+      end
+
       context 'USER_PROVIDER_FIRM_ID' do
         it "inserts provider's firm id as a number" do
           %i[global_means global_merits].each do |entity|


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-927)

Added a block that assigns the providers email address to the application for submission to CCMS.



## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
