### PR TITLE
AP-930 Hard code CCMS dummy opponent

### DIFF
--- a/app/services/ccms/attribute_value_generator.rb
+++ b/app/services/ccms/attribute_value_generator.rb
@@ -233,8 +233,8 @@ module CCMS
         options[:wage_slip].__send__(Regexp.last_match(1))
       when PROCEEDING_REGEX
         options[:proceeding].__send__(Regexp.last_match(1))
-      when OTHER_PARTY
-        options[:other_party].__send__(Regexp.last_match(1))
+      # when OTHER_PARTY  # TODO enable this when a decision is made on how to handle other parties
+      #   options[:other_party].__send__(Regexp.last_match(1))
       when OPPONENT
         options[:opponent].__send__(Regexp.last_match(1))
       when RESPONDENT

--- a/app/services/ccms/case_add_requestor.rb
+++ b/app/services/ccms/case_add_requestor.rb
@@ -90,29 +90,24 @@ module CCMS
     end
 
     def generate_other_parties(xml)
-      @legal_aid_application.opponent_other_parties.each do |opponent|
-        generate_other_party(xml, opponent)
-      end
+      # @legal_aid_application.opponent_other_parties.each do |opponent|
+      generate_other_party(xml)
+      # end
     end
 
-    def generate_other_party(xml, opponent) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+    def generate_other_party(xml) # rubocop:disable Metrics/MethodLength
       xml.__send__('ns2:OtherParty') do
-        xml.__send__('ns2:OtherPartyID', opponent.other_party_id)
-        xml.__send__('ns2:SharedInd', opponent.shared_ind)
+        xml.__send__('ns2:OtherPartyID', 'OPPONENT_7713451')
+        xml.__send__('ns2:SharedInd', false)
         xml.__send__('ns2:OtherPartyDetail') do
-          xml.__send__('ns2:Person') do
-            xml.__send__('ns2:Name') do
-              xml.__send__('ns0:Title', opponent.title)
-              xml.__send__('ns0:Surname', opponent.surname)
-              xml.__send__('ns0:FirstName', opponent.first_name)
-            end
-            xml.__send__('ns2:DateOfBirth', opponent.date_of_birth.strftime('%Y-%m-%d'))
+          xml.__send__('ns2:Organization') do
+            xml.__send__('ns2:OrganizationName', 'APPLY service application')
+            xml.__send__('ns2:OrganizationType', 'GOVT')
+            xml.__send__('ns2:RelationToClient', 'NONE')
+            xml.__send__('ns2:RelationToCase', 'OPP')
             xml.__send__('ns2:Address')
-            xml.__send__('ns2:RelationToClient', opponent.relationship_to_client)
-            xml.__send__('ns2:RelationToCase', opponent.relationship_to_case)
             xml.__send__('ns2:ContactDetails')
-            xml.__send__('ns2:AssessedIncome', opponent.assessed_income)
-            xml.__send__('ns2:AssessedAsstes', opponent.assessed_assets)
+            xml.__send__('ns2:OtherInformation', 'Dummy opponent for Apply Service')
           end
         end
       end
@@ -290,13 +285,11 @@ module CCMS
     def generate_other_parties_entity(xml, sequence_no)
       xml.__send__('ns0:SequenceNumber', sequence_no)
       xml.__send__('ns0:EntityName', 'OPPONENT_OTHER_PARTIES')
-      @legal_aid_application.opponents.each do |opponent|
-        xml.__send__('ns0:Instances') do
-          xml.__send__('ns0:InstanceLabel', opponent.other_party_id)
-          xml.__send__('ns0:Attributes') do
-            generate_attributes_for(xml, :other_party, other_party: opponent)
-          end
-        end
+      # @legal_aid_application.opponents.each do |opponent|
+      xml.__send__('ns0:Instances') do
+        xml.__send__('ns0:InstanceLabel', 'OPPONENT_7713451')
+        xml.__send__('ns0:Attributes') { generate_attributes_for(xml, :other_party) }
+        # end
       end
     end
 
@@ -372,11 +365,11 @@ module CCMS
     def generate_opponent_other_parties(xml, sequence_no)
       xml.__send__('ns0:SequenceNumber', sequence_no)
       xml.__send__('ns0:EntityName', 'OPPONENT_OTHER_PARTIES')
-      @legal_aid_application.opponent_other_parties.reverse_each do |oop|
-        xml.__send__('ns0:Instances') do
-          xml.__send__('ns0:InstanceLabel', oop.other_party_id)
-          xml.__send__('ns0:Attributes') { generate_attributes_for(xml, :opponent, opponent: oop) }
-        end
+      # @legal_aid_application.opponent_other_parties.reverse_each do |oop|
+      xml.__send__('ns0:Instances') do
+        xml.__send__('ns0:InstanceLabel', 'OPPONENT_7713451')
+        xml.__send__('ns0:Attributes') { generate_attributes_for(xml, :opponent) }
+        # end
       end
     end
 

--- a/app/services/ccms/case_add_requestor.rb
+++ b/app/services/ccms/case_add_requestor.rb
@@ -90,9 +90,7 @@ module CCMS
     end
 
     def generate_other_parties(xml)
-      # @legal_aid_application.opponent_other_parties.each do |opponent|
       generate_other_party(xml)
-      # end
     end
 
     def generate_other_party(xml) # rubocop:disable Metrics/MethodLength
@@ -285,11 +283,9 @@ module CCMS
     def generate_other_parties_entity(xml, sequence_no)
       xml.__send__('ns0:SequenceNumber', sequence_no)
       xml.__send__('ns0:EntityName', 'OPPONENT_OTHER_PARTIES')
-      # @legal_aid_application.opponents.each do |opponent|
       xml.__send__('ns0:Instances') do
         xml.__send__('ns0:InstanceLabel', 'OPPONENT_7713451')
         xml.__send__('ns0:Attributes') { generate_attributes_for(xml, :other_party) }
-        # end
       end
     end
 
@@ -365,11 +361,9 @@ module CCMS
     def generate_opponent_other_parties(xml, sequence_no)
       xml.__send__('ns0:SequenceNumber', sequence_no)
       xml.__send__('ns0:EntityName', 'OPPONENT_OTHER_PARTIES')
-      # @legal_aid_application.opponent_other_parties.reverse_each do |oop|
       xml.__send__('ns0:Instances') do
         xml.__send__('ns0:InstanceLabel', 'OPPONENT_7713451')
         xml.__send__('ns0:Attributes') { generate_attributes_for(xml, :opponent) }
-        # end
       end
     end
 

--- a/config/ccms/ccms_keys.yml
+++ b/config/ccms/ccms_keys.yml
@@ -3997,210 +3997,184 @@ global_merits:
     :user_defined: false
 other_party:
   OTHER_PARTY_NAME:
-    :value: "#other_party_full_name"
+    :value: APPLY service application
     :br100_meaning: The name of the other party
     :response_type: text
     :user_defined: true
   OTHER_PARTY_TYPE:
-    :value: "#other_party_opponent_type"
+    :value: ORGANISATION
     :br100_meaning: The other party type
     :response_type: text
     :user_defined: true
   OTHER_PARTY_ID:
-    :value: "#other_party_other_party_id"
+    :value: OPPONENT_7713451
     :br100_meaning: The CCMS id of the other party
     :response_type: text
     :user_defined: true
   RELATIONSHIP_TO_CASE:
-    :value: "#other_party_relationship_to_case"
+    :value: OPP
     :br100_meaning: The relationship of the other party to the case
     :response_type: text
     :user_defined: true
   RELATIONSHIP_TO_CLIENT:
-    :value: "#other_party_relationship_to_client"
+    :value: UNKNOWN
     :br100_meaning: The relationship of the other party to the applicant
     :response_type: text
     :user_defined: true
 opponent:
   RELATIONSHIP_CIVIL_PARTNER:
-    :generate_block?: false
-    :value: "#opponent_relationship_client_civil_partner?"
+    :value: false
     :br100_meaning: The Opponent & Other Parties Relationship To Client Is Civil Partner
     :response_type: boolean
     :user_defined: false
   RELATIONSHIP_CASE_INTERVENOR:
-    :generate_block?: false
-    :value: "#opponent_relationship_case_intervenor?"
+    :value: false
     :br100_meaning: The Opponent & Other Parties Relationship To Case Is Intervener
     :response_type: boolean
     :user_defined: false
   RELATIONSHIP_TENANT:
-    :generate_block?: false
-    :value: "#opponent_relationship_client_tenant?"
+    :value: false
     :br100_meaning: The Opponent & Other Parties Relationship To Client Is Tenant
     :response_type: boolean
     :user_defined: false
   RELATIONSHIP_MEDICAL_PRO:
-    :generate_block?: false
-    :value: "#opponent_relationship_client_medical_professional?"
+    :value: false
     :br100_meaning: The Opponent & Other Parties Relationship To Client Is Medical
       Professional
     :response_type: boolean
     :user_defined: false
   RELATIONSHIP_CASE_OPPONENT:
-    :generate_block?: false
-    :value: "#opponent_relationship_case_opponent?"
+    :value: true
     :br100_meaning: The Opponent & Other Parties Relationship To Case Is Opponent
     :response_type: boolean
     :user_defined: false
   RELATIONSHIP_EMPLOYER:
-    :generate_block?: false
-    :value: "#opponent_relationship_client_employer?"
+    :value: false
     :br100_meaning: The Opponent & Other Parties Relationship To Client Is Employer
     :response_type: boolean
     :user_defined: false
   RELATIONSHIP_NONE:
-    :generate_block?: false
-    :value: "#opponent_relationship_client_none?"
+    :value: true
     :br100_meaning: The Opponent & Other Parties Relationship To Client Is None
     :response_type: boolean
     :user_defined: false
   OTHER_PARTY_PERSON:
-    :generate_block?: false
-    :value: "#opponent_person?"
+    :value: false
     :br100_meaning: Meaning not defined in BR100
     :response_type: boolean
     :user_defined: false
   PARTY_IS_A_CHILD:
-    :generate_block?: false
-    :value: "#opponent_child?"
+    :value: false
     :br100_meaning: Meaning not defined in BR100
     :response_type: boolean
     :user_defined: false
   OTHER_PARTY_ORG:
-    :generate_block?: false
-    :value: "#opponent_organisation?"
+    :value: true
     :br100_meaning: Meaning not defined in BR100
     :response_type: boolean
     :user_defined: false
   RELATIONSHIP_STEP_PARENT:
-    :generate_block?: false
-    :value: "#opponent_relationship_client_step_parent?"
+    :value: false
     :br100_meaning: The Opponent & Other Parties Relationship To Client Is Step Parent
     :response_type: boolean
     :user_defined: false
   RELATIONSHIP_CASE_GAL:
-    :generate_block?: false
-    :value: "#opponent_relationship_case_guardian?"
+    :value: false
     :br100_meaning: The Opponent & Other Parties Relationship To Case Is Guardian
       Ad Litem
     :response_type: boolean
     :user_defined: false
   RELATIONSHIP_EX_HUSBAND_WIFE:
-    :generate_block?: false
-    :value: "#opponent_relationship_client_ex_husband_wife?"
+    :value: false
     :br100_meaning: The Opponent & Other Parties Relationship To Client Is Ex-Husband/Wife
     :response_type: boolean
     :user_defined: false
   RELATIONSHIP_LEGAL_GUARDIAN:
-    :generate_block?: false
-    :value: "#opponent_relationship_client_legal_guardian?"
+    :value: false
     :br100_meaning: The Opponent & Other Parties Relationship To Client Is Legal Guardian
     :response_type: boolean
     :user_defined: false
   RELATIONSHIP_SOL_BARRISTER:
-    :generate_block?: false
-    :value: "#opponent_relationship_client_solicitor_barrister?"
+    :value: false
     :br100_meaning: The Opponent & Other Parties Relationship To Client Is Solicitor
       Or Barrister
     :response_type: boolean
     :user_defined: false
   RELATIONSHIP_EX_CIVIL_PARTNER:
-    :generate_block?: false
-    :value: "#opponent_relationship_client_ex_civil_partner?"
+    :value: false
     :br100_meaning: The Opponent & Other Parties Relationship To Client Is Ex-Civil
       Partner
     :response_type: boolean
     :user_defined: false
   RELATIONSHIP_LOCAL_AUTHORITY:
-    :generate_block?: false
-    :value: "#opponent_relationship_client_local_authority?"
+    :value: false
     :br100_meaning: The Opponent & Other Parties Relationship To Client Is Local Authority
     :response_type: boolean
     :user_defined: false
   OPP_RELATIONSHIP_TO_CASE:
-    :generate_block?: false
-    :value: "#opponent_opp_relationship_to_case"
+    :value: Opponent
     :br100_meaning: 'OthPart: The Opponent & Other Parties Relationship To Case'
     :response_type: text
     :user_defined: false
   RELATIONSHIP_PARENT:
-    :generate_block?: false
-    :value: "#opponent_relationship_client_parent?"
+    :value: false
     :br100_meaning: The Opponent & Other Parties Relationship To Client Is Parent
     :response_type: boolean
     :user_defined: false
   RELATIONSHIP_OTHER_FAM_MEMBER:
-    :generate_block?: false
-    :value: "#opponent_relationship_client_other_family_member?"
+    :value: false
     :br100_meaning: The Opponent & Other Parties Relationship To Client Is Other Family
       Member
     :response_type: boolean
     :user_defined: false
   RELATIONSHIP_CASE_BENEFICIARY:
-    :generate_block?: false
-    :value: "#opponent_relationship_case_beneficiary?"
+    :value: false
     :br100_meaning: The Opponent & Other Parties Relationship To Case Is Beneficiary
     :response_type: boolean
     :user_defined: false
   OTHER_PARTY_ID:
-    :value: "#opponent_other_party_id"
+    :value: OPPONENT_7713451
     :br100_meaning: Other Party Id
     :response_type: text
     :user_defined: true
   RELATIONSHIP_GRANDPARENT:
-    :generate_block?: false
-    :value: "#opponent_relationship_client_grandparent?"
+    :value: false
     :br100_meaning: The Opponent & Other Parties Relationship To Client Is Grandparent
     :response_type: boolean
     :user_defined: false
   OPPONENT_DOB:
+    :generate_block?: false
     :value: "#opponent_date_of_birth"
     :br100_meaning: Date of Birth
     :response_type: date
     :user_defined: true
   RELATIONSHIP_LANDLORD:
-    :generate_block?: false
-    :value: "#opponent_relationship_client_landlord?"
+    :value: false
     :br100_meaning: Meaning not defined in BR100
     :response_type: boolean
     :user_defined: false
   RELATIONSHIP_CHILD:
-    :generate_block?: false
-    :value: "#opponent_child?"
+    :value: false
     :br100_meaning: The Opponent & Other Parties Relationship To Client Is Child
     :response_type: boolean
     :user_defined: false
   OTHER_PARTY_NAME:
-    :value: 'APPLY service application. See uploaded statement of case'
+    :value: APPLY service application
     :br100_meaning: Other Party Name
     :response_type: text
     :user_defined: true
   RELATIONSHIP_CUSTOMER:
-    :generate_block?: false
-    :value: "#opponent_relationship_client_customer?"
+    :value: false
     :br100_meaning: The Opponent & Other Parties Relationship To Client Is Customer
     :response_type: boolean
     :user_defined: false
   OTHER_PARTY_NAME_MERITS:
-    :generate_block?: false
-    :value: "#opponent_full_name"
+    :value: APPLY service application
     :br100_meaning: 'OthPart: Other Party Name'
     :response_type: text
     :user_defined: false
   RELATIONSHIP_CASE_INT_PARTY:
-    :generate_block?: false
-    :value: "#opponent_relationship_case_interested_party?"
+    :value: false
     :br100_meaning: The Opponent & Other Parties Relationship To Case Is Interested
       Party
     :response_type: boolean
@@ -4211,60 +4185,54 @@ opponent:
     :response_type: text
     :user_defined: true
   RELATIONSHIP_PROPERTY_OWNER:
-    :generate_block?: false
-    :value: "#opponent_relationship_client_property_owner?"
+    :value: false
     :br100_meaning: The Opponent & Other Parties Relationship To Client Is Property
       Owner
     :response_type: boolean
     :user_defined: false
   RELATIONSHIP_SUPPLIER:
-    :generate_block?: false
-    :value: "#opponent_relationship_client_supplier?"
+    :value: false
     :br100_meaning: The Opponent & Other Parties Relationship To Client Is Supplier
     :response_type: boolean
     :user_defined: false
   RELATIONSHIP_EMPLOYEE:
-    :generate_block?: false
-    :value: "#opponent_relationship_client_employee?"
+    :value: false
     :br100_meaning: The Opponent & Other Parties Relationship To Client Is Employee
     :response_type: boolean
     :user_defined: false
   RELATIONSHIP_CASE_CHILD:
-    :generate_block?: false
-    :value: "#opponent_relationship_case_child?"
+    :value: false
     :br100_meaning: The Opponent & Other Parties Relationship To Case Is Child
     :response_type: boolean
     :user_defined: false
   OPPONENT_DOB_MERITS:
+    :generate_block?: false
     :value: "#opponent_date_of_birth"
     :br100_meaning: 'OthPart: Date of Birth'
     :response_type: date
     :user_defined: false
   RELATIONSHIP_CASE_AGENT:
-    :generate_block?: false
-    :value: "#opponent_relationship_case_agent?"
+    :value: false
     :br100_meaning: The Opponent & Other Parties Relationship To Case Is Agent
     :response_type: boolean
     :user_defined: false
   OTHER_PARTY_TYPE:
-    :value: PERSON
+    :value: ORGANISATION
     :br100_meaning: Other Party Type
     :response_type: text
     :user_defined: true
   OPP_RELATIONSHIP_TO_CLIENT:
-    :generate_block?: false
-    :value: "#opponent_opp_relationship_to_client"
+    :value: None
     :br100_meaning: 'OthPart: The Opponent & Other Parties Relationship To Client'
     :response_type: text
     :user_defined: false
   RELATIONSHIP_TO_CLIENT:
-    :value: UNKNOWN
+    :value: OPP
     :br100_meaning: Opponent relationship to client
     :response_type: text
     :user_defined: true
   RELATIONSHIP_HUSBAND_WIFE:
-    :generate_block?: false
-    :value: "#opponent_relationship_client_husband_wife?"
+    :value: false
     :br100_meaning: The Opponent & Other Parties Relationship To Client Is Husband/Wife
     :response_type: boolean
     :user_defined: false

--- a/spec/models/legal_aid_application_spec.rb
+++ b/spec/models/legal_aid_application_spec.rb
@@ -400,6 +400,12 @@ RSpec.describe LegalAidApplication, type: :model do
     end
   end
 
+  describe '#opponents' do
+    it 'returns the opponent data' do
+      expect(legal_aid_application.opponents).to eq [Opponent.dummy_opponent]
+    end
+  end
+
   describe '#opponent_other_parties' do
     it 'returns the opponent other parties data' do
       expect(legal_aid_application.opponent_other_parties).to eq [Opponent.dummy_opponent]

--- a/spec/models/opponent_spec.rb
+++ b/spec/models/opponent_spec.rb
@@ -119,4 +119,22 @@ RSpec.describe Opponent, type: :model do
       expect(opponent.organisation?).to be true
     end
   end
+
+  describe '#shared_ind' do
+    it 'returns false' do
+      expect(opponent.shared_ind).to eq false
+    end
+  end
+
+  describe '#assessed_income' do
+    it 'returns 0' do
+      expect(opponent.assessed_income).to eq 0
+    end
+  end
+
+  describe '#assessed_assets' do
+    it 'returns 0' do
+      expect(opponent.assessed_assets).to eq 0
+    end
+  end
 end

--- a/spec/services/ccms/case_add_requestor_xml_blocks_spec.rb
+++ b/spec/services/ccms/case_add_requestor_xml_blocks_spec.rb
@@ -975,11 +975,6 @@ module CCMS # rubocop:disable Metrics/ModuleLength
           expect(block).to have_text_response 'GBR'
         end
 
-        it 'RELATIONSHIP_TO_CLIENT should be hard coded to UNKNOWN' do
-          block = XmlExtractor.call(xml, :global_merits, 'RELATIONSHIP_TO_CLIENT')
-          expect(block).to have_text_response 'UNKNOWN'
-        end
-
         it 'MARITIAL_STATUS should be hard coded to UNKNOWN' do
           block = XmlExtractor.call(xml, :global_means, 'MARITIAL_STATUS')
           expect(block).to have_text_response 'UNKNOWN'
@@ -1005,16 +1000,6 @@ module CCMS # rubocop:disable Metrics/ModuleLength
             block = XmlExtractor.call(xml, entity, attribute)
             expect(block).to have_text_response 'NEW'
           end
-        end
-
-        it 'RELATIONSHIP_TO_CASE should be hard coded to OPP' do
-          block = XmlExtractor.call(xml, :opponent, 'RELATIONSHIP_TO_CASE')
-          expect(block).to have_text_response 'OPP'
-        end
-
-        it 'OTHER_PARTY_TYPE should be hard coded to PERSON' do
-          block = XmlExtractor.call(xml, :opponent, 'OTHER_PARTY_TYPE')
-          expect(block).to have_text_response 'PERSON'
         end
 
         it 'POA_OR_BILL_FLAG should be hard coded to N/A' do
@@ -1067,11 +1052,6 @@ module CCMS # rubocop:disable Metrics/ModuleLength
         it 'MAIN_PURPOSE_OF_APPLICATION should be hard coded with the correct notification' do
           block = XmlExtractor.call(xml, :global_merits, 'MAIN_PURPOSE_OF_APPLICATION')
           expect(block).to have_text_response 'Apply Service application - see report and uploaded statement in CCMS upload section'
-        end
-
-        it 'OTHER_PARTY_NAME should be hard coded with the correct notification' do
-          block = XmlExtractor.call(xml, :opponent, 'OTHER_PARTY_NAME')
-          expect(block).to have_text_response 'APPLY service application. See uploaded statement of case'
         end
       end
 
@@ -1188,6 +1168,90 @@ module CCMS # rubocop:disable Metrics/ModuleLength
           it 'returns Both' do
             expect(block).to have_text_response 'Both'
           end
+        end
+      end
+
+      context 'dummy opponent' do
+        it 'harcodes OPP_RELATIONSHIP_TO_CASE' do
+          block = XmlExtractor.call(xml, :opponent, 'OPP_RELATIONSHIP_TO_CASE')
+          expect(block).to have_text_response 'Opponent'
+        end
+
+        it 'harcodes OPP_RELATIONSHIP_TO_CLIENT' do
+          block = XmlExtractor.call(xml, :opponent, 'OPP_RELATIONSHIP_TO_CLIENT')
+          expect(block).to have_text_response 'None'
+        end
+
+        it 'harcodes OTHER_PARTY_ID' do
+          block = XmlExtractor.call(xml, :opponent, 'OTHER_PARTY_ID')
+          expect(block).to have_text_response 'OPPONENT_7713451'
+        end
+
+        it 'harcodes OTHER_PARTY_NAME' do
+          block = XmlExtractor.call(xml, :opponent, 'OTHER_PARTY_NAME')
+          expect(block).to have_text_response 'APPLY service application'
+        end
+
+        it 'harcodes OTHER_PARTY_NAME_MERITS' do
+          block = XmlExtractor.call(xml, :opponent, 'OTHER_PARTY_NAME_MERITS')
+          expect(block).to have_text_response 'APPLY service application'
+        end
+
+        it 'harcodes OTHER_PARTY_ORG' do
+          block = XmlExtractor.call(xml, :opponent, 'OTHER_PARTY_ORG')
+          expect(block).to have_boolean_response true
+        end
+
+        it 'harcodes OTHER_PARTY_TYPE' do
+          block = XmlExtractor.call(xml, :opponent, 'OTHER_PARTY_TYPE')
+          expect(block).to have_text_response 'ORGANISATION'
+        end
+
+        it 'harcodes RELATIONSHIP_CASE_OPPONENT' do
+          block = XmlExtractor.call(xml, :opponent, 'RELATIONSHIP_CASE_OPPONENT')
+          expect(block).to have_boolean_response true
+        end
+
+        it 'harcodes RELATIONSHIP_NONE' do
+          block = XmlExtractor.call(xml, :opponent, 'RELATIONSHIP_NONE')
+          expect(block).to have_boolean_response true
+        end
+
+        it 'harcodes RELATIONSHIP_TO_CASE' do
+          block = XmlExtractor.call(xml, :opponent, 'RELATIONSHIP_TO_CASE')
+          expect(block).to have_text_response 'OPP'
+        end
+
+        it 'harcodes RELATIONSHIP_TO_CLIENT' do
+          block = XmlExtractor.call(xml, :opponent, 'RELATIONSHIP_TO_CLIENT')
+          expect(block).to have_text_response 'OPP'
+        end
+      end
+
+      context 'dummy other_party' do
+        it 'harcodes OTHER_PARTY_ID' do
+          block = XmlExtractor.call(xml, :other_party, 'OTHER_PARTY_ID')
+          expect(block).to have_text_response 'OPPONENT_7713451'
+        end
+
+        it 'harcodes OTHER_PARTY_NAME' do
+          block = XmlExtractor.call(xml, :other_party, 'OTHER_PARTY_NAME')
+          expect(block).to have_text_response 'APPLY service application'
+        end
+
+        it 'harcodes OTHER_PARTY_TYPE' do
+          block = XmlExtractor.call(xml, :other_party, 'OTHER_PARTY_TYPE')
+          expect(block).to have_text_response 'ORGANISATION'
+        end
+
+        it 'harcodes RELATIONSHIP_TO_CASE' do
+          block = XmlExtractor.call(xml, :other_party, 'RELATIONSHIP_TO_CASE')
+          expect(block).to have_text_response 'OPP'
+        end
+
+        it 'harcodes RELATIONSHIP_TO_CLIENT' do
+          block = XmlExtractor.call(xml, :other_party, 'RELATIONSHIP_TO_CLIENT')
+          expect(block).to have_text_response 'UNKNOWN'
         end
       end
     end
@@ -1466,40 +1530,8 @@ module CCMS # rubocop:disable Metrics/ModuleLength
       [:global_merits, 'URGENT_APPLICATION_TAG'],
       [:global_merits, 'URGENT_DIRECTIONS'],
       [:global_merits, 'CHILD_MUST_BE_INCLUDED'],
-      [:opponent, 'OPP_RELATIONSHIP_TO_CASE'],
-      [:opponent, 'OPP_RELATIONSHIP_TO_CLIENT'],
-      [:opponent, 'OTHER_PARTY_NAME_MERITS'],
-      [:opponent, 'OTHER_PARTY_ORG'],
-      [:opponent, 'OTHER_PARTY_PERSON'],
-      [:opponent, 'PARTY_IS_A_CHILD'],
-      [:opponent, 'RELATIONSHIP_CASE_AGENT'],
-      [:opponent, 'RELATIONSHIP_CASE_BENEFICIARY'],
-      [:opponent, 'RELATIONSHIP_CASE_CHILD'],
-      [:opponent, 'RELATIONSHIP_CASE_GAL'],
-      [:opponent, 'RELATIONSHIP_CASE_INT_PARTY'],
-      [:opponent, 'RELATIONSHIP_CASE_INTERVENOR'],
-      [:opponent, 'RELATIONSHIP_CASE_OPPONENT'],
-      [:opponent, 'RELATIONSHIP_CHILD'],
-      [:opponent, 'RELATIONSHIP_CIVIL_PARTNER'],
-      [:opponent, 'RELATIONSHIP_CUSTOMER'],
-      [:opponent, 'RELATIONSHIP_EMPLOYEE'],
-      [:opponent, 'RELATIONSHIP_EMPLOYER'],
-      [:opponent, 'RELATIONSHIP_EX_CIVIL_PARTNER'],
-      [:opponent, 'RELATIONSHIP_EX_HUSBAND_WIFE'],
-      [:opponent, 'RELATIONSHIP_GRANDPARENT'],
-      [:opponent, 'RELATIONSHIP_HUSBAND_WIFE'],
-      [:opponent, 'RELATIONSHIP_LANDLORD'],
-      [:opponent, 'RELATIONSHIP_LEGAL_GUARDIAN'],
-      [:opponent, 'RELATIONSHIP_LOCAL_AUTHORITY'],
-      [:opponent, 'RELATIONSHIP_MEDICAL_PRO'],
-      [:opponent, 'RELATIONSHIP_NONE'],
-      [:opponent, 'RELATIONSHIP_OTHER_FAM_MEMBER'],
-      [:opponent, 'RELATIONSHIP_PARENT'],
-      [:opponent, 'RELATIONSHIP_PROPERTY_OWNER'],
-      [:opponent, 'RELATIONSHIP_SOL_BARRISTER'],
-      [:opponent, 'RELATIONSHIP_STEP_PARENT'],
-      [:opponent, 'RELATIONSHIP_SUPPLIER'],
-      [:opponent, 'RELATIONSHIP_TENANT'],
+      [:opponent, 'OPPONENT_DOB'],
+      [:opponent, 'OPPONENT_DOB_MERITS'],
       [:proceeding, 'PROC_UPPER_TRIBUNAL'],
       [:proceeding_merits, 'ACTION_DAMAGES_AGAINST_POLICE'],
       [:proceeding_merits, 'APPEAL_IN_SUPREME_COURT'],
@@ -1803,11 +1835,34 @@ module CCMS # rubocop:disable Metrics/ModuleLength
       [:global_merits, 'PROVIDER_CASE_REFERENCE'],
       [:global_merits, 'UPLOAD_SEPARATE_STATEMENT'],
       [:global_merits, 'URGENT_FLAG'],
-      [:global_merits, 'COST_LIMIT_CHANGED'],
-      [:global_merits, 'DECLARATION_IDENTIFIER'],
-      [:global_merits, 'COST_LIMIT_CHANGED_FLAG'],
-      [:global_means, 'COST_LIMIT_CHANGED_FLAG'],
-      [:global_merits, 'PROVIDER_CASE_REFERENCE'],
+      [:opponent, 'OTHER_PARTY_PERSON'],
+      [:opponent, 'PARTY_IS_A_CHILD'],
+      [:opponent, 'RELATIONSHIP_CASE_AGENT'],
+      [:opponent, 'RELATIONSHIP_CASE_BENEFICIARY'],
+      [:opponent, 'RELATIONSHIP_CASE_CHILD'],
+      [:opponent, 'RELATIONSHIP_CASE_GAL'],
+      [:opponent, 'RELATIONSHIP_CASE_INT_PARTY'],
+      [:opponent, 'RELATIONSHIP_CASE_INTERVENOR'],
+      [:opponent, 'RELATIONSHIP_CHILD'],
+      [:opponent, 'RELATIONSHIP_CIVIL_PARTNER'],
+      [:opponent, 'RELATIONSHIP_CUSTOMER'],
+      [:opponent, 'RELATIONSHIP_EMPLOYEE'],
+      [:opponent, 'RELATIONSHIP_EMPLOYER'],
+      [:opponent, 'RELATIONSHIP_EX_CIVIL_PARTNER'],
+      [:opponent, 'RELATIONSHIP_EX_HUSBAND_WIFE'],
+      [:opponent, 'RELATIONSHIP_GRANDPARENT'],
+      [:opponent, 'RELATIONSHIP_HUSBAND_WIFE'],
+      [:opponent, 'RELATIONSHIP_LANDLORD'],
+      [:opponent, 'RELATIONSHIP_LEGAL_GUARDIAN'],
+      [:opponent, 'RELATIONSHIP_LOCAL_AUTHORITY'],
+      [:opponent, 'RELATIONSHIP_MEDICAL_PRO'],
+      [:opponent, 'RELATIONSHIP_OTHER_FAM_MEMBER'],
+      [:opponent, 'RELATIONSHIP_PARENT'],
+      [:opponent, 'RELATIONSHIP_PROPERTY_OWNER'],
+      [:opponent, 'RELATIONSHIP_SOL_BARRISTER'],
+      [:opponent, 'RELATIONSHIP_STEP_PARENT'],
+      [:opponent, 'RELATIONSHIP_SUPPLIER'],
+      [:opponent, 'RELATIONSHIP_TENANT'],
       [:proceeding_merits, 'WARNING_LETTER_SENT']
     ]
   end

--- a/spec/support/xml_extractor.rb
+++ b/spec/support/xml_extractor.rb
@@ -11,7 +11,8 @@ class XmlExtractor
     main_dwelling: %(/Envelope/Body/CaseAddRQ/Case/CaseDetails/ApplicationDetails/MeritsAssesments/AssesmentResults/AssesmentDetails/AssessmentScreens/Entity[EntityName = "MAIN_DWELLING"]//Attributes/Attribute),
     vehicle_entity: %(/Envelope/Body/CaseAddRQ/Case/CaseDetails/ApplicationDetails/MeansAssesments/AssesmentResults/AssesmentDetails/AssessmentScreens/Entity[EntityName = "CARS_AND_MOTOR_VEHICLES"]//Attributes/Attribute),
     wage_slip_entity: %(/Envelope/Body/CaseAddRQ/Case/CaseDetails/ApplicationDetails/MeansAssesments/AssesmentResults/AssesmentDetails/AssessmentScreens/Entity[EntityName = "CLI_NON_HM_WAGE_SLIP"]),
-    bank_accounts_entity: %(/Envelope/Body/CaseAddRQ/Case/CaseDetails/ApplicationDetails/MeansAssesments/AssesmentResults/AssesmentDetails/AssessmentScreens/Entity[EntityName = "BANKACC"])
+    bank_accounts_entity: %(/Envelope/Body/CaseAddRQ/Case/CaseDetails/ApplicationDetails/MeansAssesments/AssesmentResults/AssesmentDetails/AssessmentScreens/Entity[EntityName = "BANKACC"]),
+    other_party: %(/Envelope/Body/CaseAddRQ/Case/CaseDetails/ApplicationDetails/MeansAssesments/AssesmentResults/AssesmentDetails/AssessmentScreens/Entity[EntityName = "OPPONENT_OTHER_PARTIES"]//Attributes/Attribute)
   }.freeze
   # rubocop:enable Metrics/LineLength
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-930)

CCMS is currently unable to handle an API call to create a new opponent. Instead a decision has been taken to hardcode details of a dummy opponent.

This change amends the code used to generate the create case payload to ensure the correct values are populated.

The main changes are:

- update `ccms_keys.yml` to ensure correct values are populated in `opponent` and `other_party` blocks.
- update `ccms_case_requestor.rb` to ensure that correct `ns2:OtherParty` section is created and that `opponent` and `other_party` blocks are always generated exactly once.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
