### PR TITLE
AP-813 Display addresses better

### DIFF
--- a/app/controllers/providers/address_selections_controller.rb
+++ b/app/controllers/providers/address_selections_controller.rb
@@ -5,6 +5,7 @@ module Providers
 
       if address_lookup.success?
         @addresses = address_lookup.result
+        titleize_addresses
         @form = Addresses::AddressSelectionForm.new(model: address)
       else
         @form = Addresses::AddressForm.new(model: address, lookup_error: address_lookup.errors[:lookup].first)
@@ -42,6 +43,15 @@ module Providers
     def build_addresses_from_form_data
       address_list_params.to_a.map do |address_params|
         Address.from_json(address_params)
+      end
+    end
+
+    def titleize_addresses
+      @addresses.each do |a|
+        a[:organisation] = a[:organisation]&.titleize
+        a[:address_line_one] = a[:address_line_one]&.titleize
+        a[:address_line_two] = a[:address_line_two]&.titleize
+        a[:city] = a[:city]&.titleize
       end
     end
   end

--- a/app/helpers/address_helper.rb
+++ b/app/helpers/address_helper.rb
@@ -2,9 +2,9 @@ module AddressHelper
   def address_with_line_breaks(address)
     return unless address
 
-    sanitize [address.organisation&.titleize,
-              "#{address.address_line_one} #{address.address_line_two}"&.titleize,
-              address.city&.titleize,
+    sanitize [address.organisation,
+              "#{address.address_line_one} #{address.address_line_two}",
+              address.city,
               address.pretty_postcode].compact.reject(&:blank?).join('<br>'), tags: ['br']
   end
 end

--- a/app/helpers/address_helper.rb
+++ b/app/helpers/address_helper.rb
@@ -2,10 +2,9 @@ module AddressHelper
   def address_with_line_breaks(address)
     return unless address
 
-    sanitize [address.organisation,
-              address.address_line_one,
-              address.address_line_two,
-              address.city,
-              address.postcode].compact.reject(&:blank?).join('<br>'), tags: ['br']
+    sanitize [address.organisation&.titleize,
+              "#{address.address_line_one} #{address.address_line_two}"&.titleize,
+              address.city&.titleize,
+              address.pretty_postcode].compact.reject(&:blank?).join('<br>'), tags: ['br']
   end
 end

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -12,6 +12,7 @@ class Address < ApplicationRecord
   validates :city, :postcode, presence: true
 
   before_validation :normalize_postcode
+  before_save :titleize_address
 
   validates :postcode, format: { with: POSTCODE_REGEXP }
   validate :validate_address_lines
@@ -61,5 +62,13 @@ class Address < ApplicationRecord
 
     postcode.delete!(' ')
     postcode.upcase!
+  end
+
+  def titleize_address
+    self.organisation = organisation&.titleize
+    self.address_line_one = address_line_one&.titleize
+    self.address_line_two = address_line_two&.titleize
+    self.city = city&.titleize
+    self.county = county&.titleize
   end
 end

--- a/features/providers/civil_application_journey.feature
+++ b/features/providers/civil_application_journey.feature
@@ -48,7 +48,7 @@ Feature: Civil application journeys
     Then I am on the postcode entry page
     Then I enter a postcode 'DA74NG'
     Then I click find address
-    Then I select an address '3, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG'
+    Then I select an address '3, Lonsdale Road, Bexleyheath, DA7 4NG'
     Then I click 'Save and continue'
     When the search for "cakes" is not successful
     Then the result list on page returns a "No results found." message
@@ -67,7 +67,7 @@ Feature: Civil application journeys
     Then I am on the postcode entry page
     Then I enter a postcode 'DA74NG'
     Then I click find address
-    Then I select an address '3, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG'
+    Then I select an address '3, Lonsdale Road, Bexleyheath, DA7 4NG'
     Then I click 'Save and continue'
     And I search for proceeding 'app'
     Then proceeding suggestions has results
@@ -87,7 +87,7 @@ Feature: Civil application journeys
     Then I am on the postcode entry page
     Then I enter a postcode 'DA74NG'
     Then I click find address
-    Then I select an address '3, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG'
+    Then I select an address '3, Lonsdale Road, Bexleyheath, DA7 4NG'
     Then I click 'Save and continue'
     Then I expect to see 0 proceeding types selected
     And I search for proceeding 'app'
@@ -121,7 +121,7 @@ Feature: Civil application journeys
     Then I am on the postcode entry page
     Then I enter a postcode 'DA74NG'
     Then I click find address
-    Then I select an address '3, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG'
+    Then I select an address '3, Lonsdale Road, Bexleyheath, DA7 4NG'
     Then I click 'Save and continue'
     Then I search for proceeding 'Non-molestation order'
     Then proceeding suggestions has results
@@ -194,7 +194,7 @@ Feature: Civil application journeys
     Then I am on the postcode entry page
     Then I enter a postcode 'DA74NG'
     Then I click find address
-    Then I select an address '3, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG'
+    Then I select an address '3, Lonsdale Road, Bexleyheath, DA7 4NG'
     Then I click 'Save and continue'
     Then I search for proceeding 'Non-molestation order'
     Then proceeding suggestions has results
@@ -223,7 +223,7 @@ Feature: Civil application journeys
     Then I am on the postcode entry page
     Then I enter a postcode 'DA74NG'
     Then I click find address
-    Then I select an address '3, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG'
+    Then I select an address '3, Lonsdale Road, Bexleyheath, DA7 4NG'
     Then I click 'Save and continue'
     Then I search for proceeding 'Non-molestation order'
     Then proceeding suggestions has results
@@ -291,7 +291,7 @@ Feature: Civil application journeys
     Then I am on the postcode entry page
     Then I enter a postcode 'DA74NG'
     Then I click find address
-    Then I select an address '3, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG'
+    Then I select an address '3, Lonsdale Road, Bexleyheath, DA7 4NG'
     Then I click 'Save and continue'
     Then I should be on a page showing 'Check your answers'
 

--- a/spec/forms/addresses/address_form_spec.rb
+++ b/spec/forms/addresses/address_form_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Addresses::AddressForm, type: :form do
-  let(:address_line_one) { 'Ministry of Justice' }
+  let(:address_line_one) { 'Ministry Of Justice' }
   let(:address_line_two) { '102 Petty France' }
   let(:city) { 'London' }
   let(:county) { '' }

--- a/spec/requests/providers/check_provider_answers_spec.rb
+++ b/spec/requests/providers/check_provider_answers_spec.rb
@@ -3,15 +3,17 @@ require 'rails_helper'
 RSpec.describe 'check your answers requests', type: :request do
   let(:used_delegated_functions) { false }
   let(:used_delegated_functions_on) { nil }
+  let(:address) { create :address }
+  let(:applicant) { create :applicant, address: address }
   let(:application) do
     create(
       :legal_aid_application,
       :with_proceeding_types,
-      :with_applicant_and_address,
       :with_substantive_scope_limitation,
       :with_delegated_functions_scope_limitation,
       used_delegated_functions: used_delegated_functions,
-      used_delegated_functions_on: used_delegated_functions_on
+      used_delegated_functions_on: used_delegated_functions_on,
+      applicant: applicant
     )
   end
   let(:application_id) { application.id }
@@ -74,15 +76,24 @@ RSpec.describe 'check your answers requests', type: :request do
 
       it 'displays the correct client details' do
         applicant = application.applicant
-        address = applicant.addresses[0]
 
         expect(unescaped_response_body).to include(applicant.first_name)
         expect(unescaped_response_body).to include(applicant.last_name)
         expect(unescaped_response_body).to include(applicant.date_of_birth.to_s)
         expect(unescaped_response_body).to include(applicant.national_insurance_number)
-        expect(unescaped_response_body).to include(address.address_line_one)
-        expect(unescaped_response_body).to include(address.city)
-        expect(unescaped_response_body).to include(address.pretty_postcode)
+      end
+
+      it 'formats the address correctly' do
+        address = application.applicant.addresses[0]
+
+        expect(unescaped_response_body).to include("#{address.address_line_one} #{address.address_line_two}<br>#{address.city}<br>#{address.pretty_postcode}")
+      end
+
+      context 'when an address includes an organisation but no address_line_one' do
+        let(:address) { create :address, organisation: 'Honeysuckle Cottage', address_line_one: nil, address_line_two: 'Station Road', city: 'Dartford', postcode: 'DA4 0EN' }
+        it 'formats the address correctly' do
+          expect(unescaped_response_body).to include('Honeysuckle Cottage<br> Station Road<br>Dartford<br>DA4 0EN')
+        end
       end
 
       context 'when the application is in provider submitted state' do

--- a/spec/requests/providers/check_provider_answers_spec.rb
+++ b/spec/requests/providers/check_provider_answers_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe 'check your answers requests', type: :request do
         expect(unescaped_response_body).to include(applicant.national_insurance_number)
         expect(unescaped_response_body).to include(address.address_line_one)
         expect(unescaped_response_body).to include(address.city)
-        expect(unescaped_response_body).to include(address.postcode)
+        expect(unescaped_response_body).to include(address.pretty_postcode)
       end
 
       context 'when the application is in provider submitted state' do
@@ -113,7 +113,7 @@ RSpec.describe 'check your answers requests', type: :request do
           expect(unescaped_response_body).to include(applicant.national_insurance_number)
           expect(unescaped_response_body).to include(address.address_line_one)
           expect(unescaped_response_body).to include(address.city)
-          expect(unescaped_response_body).to include(address.postcode)
+          expect(unescaped_response_body).to include(address.pretty_postcode)
         end
       end
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-813)

Addresses are currently displayed like this on the first check your answers page:

2
DENMAN ROAD
LONDON
SE155NP

They should be displayed as

2 Denman Road
London
SE15 5NP

ie - in title case, with line 1 and line 2 combined and a space in the
postcode.

Implement this by amending `address_helper.rb `to
- concatenate `address_line_1` and `address_line_2`
- calling `titelize` on the first three lines
- calling the `address` model's `pretty_postcode` method

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
