### PR TITLE
AP-912 Add CCMS case reference to merits report PDF

### DIFF
--- a/app/controllers/providers/merits_reports_controller.rb
+++ b/app/controllers/providers/merits_reports_controller.rb
@@ -1,11 +1,21 @@
 module Providers
   class MeritsReportsController < ProviderBaseController
     authorize_with_policy :show_submitted_application?
+    before_action :ensure_case_ccms_reference_exists
 
     def show
       render pdf: 'Merit report',
              layout: 'pdf',
              show_as_html: params.key?(:debug)
+    end
+
+    private
+
+    def ensure_case_ccms_reference_exists
+      return if legal_aid_application.case_ccms_reference
+
+      legal_aid_application.create_ccms_submission unless legal_aid_application.ccms_submission
+      legal_aid_application.ccms_submission.process!
     end
   end
 end

--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -24,8 +24,7 @@ class LegalAidApplication < ApplicationRecord # rubocop:disable Metrics/ClassLen
   has_many :legal_aid_application_transaction_types, dependent: :destroy
   has_many :transaction_types, through: :legal_aid_application_transaction_types
   has_many :dependants, dependent: :destroy
-  has_many :ccms_submissions, class_name: 'CCMS::Submission', dependent: :destroy
-  has_one :most_recent_ccms_submission, -> { order(:created_at) }, class_name: 'CCMS::Submission'
+  has_one :ccms_submission, -> { order(created_at: :desc) }, class_name: 'CCMS::Submission', dependent: :destroy
   has_one :vehicle, dependent: :destroy
   has_many :application_scope_limitations, dependent: :destroy
   has_many :scope_limitations, through: :application_scope_limitations
@@ -41,6 +40,7 @@ class LegalAidApplication < ApplicationRecord # rubocop:disable Metrics/ClassLen
 
   delegate :full_name, to: :applicant, prefix: true, allow_nil: true
   delegate :substantive_scope_limitation, :delegated_functions_scope_limitation, to: :application_scope_limitations
+  delegate :case_ccms_reference, to: :ccms_submission, allow_nil: true
 
   scope :latest, -> { order(created_at: :desc) }
 
@@ -167,10 +167,6 @@ class LegalAidApplication < ApplicationRecord # rubocop:disable Metrics/ClassLen
 
   def opponent_other_parties
     [Opponent.dummy_opponent]
-  end
-
-  def ccms_case_reference
-    most_recent_ccms_submission.case_ccms_reference
   end
 
   def add_default_substantive_scope_limitation!

--- a/app/services/ccms/attribute_value_generator.rb
+++ b/app/services/ccms/attribute_value_generator.rb
@@ -74,7 +74,7 @@ module CCMS
     end
 
     def submission_case_ccms_reference(_options)
-      @submission.case_ccms_reference
+      @legal_aid_application.case_ccms_reference
     end
 
     def used_delegated_functions_on(_options)

--- a/app/services/ccms/case_add_requestor.rb
+++ b/app/services/ccms/case_add_requestor.rb
@@ -288,7 +288,7 @@ module CCMS
 
     def generate_means_proceeding_instance(xml, application_proceeding_type)
       xml.__send__('ns0:Instances') do
-        xml.__send__('ns0:InstanceLabel', @legal_aid_application.ccms_case_reference)
+        xml.__send__('ns0:InstanceLabel', @legal_aid_application.case_ccms_reference)
         xml.__send__('ns0:Attributes') do
           generate_attributes_for(xml,
                                   :proceeding,
@@ -379,7 +379,7 @@ module CCMS
 
     def generate_merits_proceeding_instance(xml, application_proceeding_type)
       xml.__send__('ns0:Instances') do
-        xml.__send__('ns0:InstanceLabel', @legal_aid_application.ccms_case_reference)
+        xml.__send__('ns0:InstanceLabel', @legal_aid_application.case_ccms_reference)
         xml.__send__('ns0:Attributes') do
           generate_attributes_for(xml,
                                   :proceeding_merits,

--- a/app/services/ccms/case_add_requestor.rb
+++ b/app/services/ccms/case_add_requestor.rb
@@ -288,7 +288,7 @@ module CCMS
 
     def generate_means_proceeding_instance(xml, application_proceeding_type)
       xml.__send__('ns0:Instances') do
-        xml.__send__('ns0:InstanceLabel', @legal_aid_application.case_ccms_reference)
+        xml.__send__('ns0:InstanceLabel', @submission.case_ccms_reference)
         xml.__send__('ns0:Attributes') do
           generate_attributes_for(xml,
                                   :proceeding,
@@ -379,7 +379,7 @@ module CCMS
 
     def generate_merits_proceeding_instance(xml, application_proceeding_type)
       xml.__send__('ns0:Instances') do
-        xml.__send__('ns0:InstanceLabel', @legal_aid_application.case_ccms_reference)
+        xml.__send__('ns0:InstanceLabel', @submission.case_ccms_reference)
         xml.__send__('ns0:Attributes') do
           generate_attributes_for(xml,
                                   :proceeding_merits,

--- a/app/services/ccms/obtain_case_reference_service.rb
+++ b/app/services/ccms/obtain_case_reference_service.rb
@@ -1,12 +1,22 @@
 module CCMS
   class ObtainCaseReferenceService < BaseSubmissionService
     def call
-      tx_id = reference_data_requestor.transaction_request_id
-      response = reference_data_requestor.call
-      submission.case_ccms_reference = ReferenceDataResponseParser.new(tx_id, response).reference_id
+      submission.case_ccms_reference = reference_id
       create_history(:initialised, submission.aasm_state) if submission.obtain_case_ref!
     rescue CcmsError => e
       handle_failure(e)
+    end
+
+    def reference_id
+      ReferenceDataResponseParser.new(transaction_request_id, response).reference_id
+    end
+
+    def response
+      reference_data_requestor.call
+    end
+
+    def transaction_request_id
+      reference_data_requestor.transaction_request_id
     end
 
     private

--- a/app/views/shared/_application_ref.html.erb
+++ b/app/views/shared/_application_ref.html.erb
@@ -12,6 +12,7 @@
       <%= t('.ccms_ref') %>
     </dt>
     <dd class="govuk-summary-list__value">
+      <%= legal_aid_application.case_ccms_reference %>
     </dd>
   </div>
 </dl>

--- a/spec/factories/applicants.rb
+++ b/spec/factories/applicants.rb
@@ -16,7 +16,7 @@ FactoryBot.define do
     end
 
     trait :with_true_layer_tokens do
-      after(:create) do |applicant|
+      after(:build) do |applicant|
         applicant.store_true_layer_token(
           token: SecureRandom.hex,
           expires: 1.hour.from_now
@@ -29,7 +29,7 @@ FactoryBot.define do
       with_bank_accounts { 0 }
     end
 
-    after(:create) do |applicant, evaluator|
+    after(:build) do |applicant, evaluator|
       if evaluator.with_bank_accounts > 0
         provider = create :bank_provider, applicant: applicant
         evaluator.with_bank_accounts.times do

--- a/spec/factories/cfe_submissions.rb
+++ b/spec/factories/cfe_submissions.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :cfe_submission, class: CFE::Submission do
-    legal_aid_application { create :legal_aid_application }
+    legal_aid_application
   end
 end

--- a/spec/factories/legal_aid_applications.rb
+++ b/spec/factories/legal_aid_applications.rb
@@ -9,25 +9,22 @@ FactoryBot.define do
       transient do
         with_bank_accounts { 0 }
       end
-      applicant { create :applicant, with_bank_accounts: with_bank_accounts }
+      applicant { build :applicant, with_bank_accounts: with_bank_accounts }
     end
 
     trait :with_applicant_and_address do
       transient do
         with_bank_accounts { 0 }
       end
-      applicant { create :applicant, :with_address, with_bank_accounts: with_bank_accounts }
+      applicant { build :applicant, :with_address, with_bank_accounts: with_bank_accounts }
     end
 
     trait :with_applicant_and_address_lookup do
-      applicant { create :applicant, :with_address_lookup }
+      applicant { build :applicant, :with_address_lookup }
     end
 
     trait :provider_submitted do
       state { 'provider_submitted' }
-      after :create do |application|
-        create :submission, :case_ref_obtained, legal_aid_application: application
-      end
     end
 
     trait :client_details_answers_checked do
@@ -108,15 +105,15 @@ FactoryBot.define do
     end
 
     trait :with_other_assets_declaration do
-      other_assets_declaration { create :other_assets_declaration, :with_all_values }
+      other_assets_declaration { build :other_assets_declaration, :with_all_values }
     end
 
     trait :with_no_other_assets do
-      other_assets_declaration { create :other_assets_declaration, :all_nil }
+      other_assets_declaration { build :other_assets_declaration, :all_nil }
     end
 
     trait :with_savings_amount do
-      savings_amount { create :savings_amount, :with_values }
+      savings_amount { build :savings_amount, :with_values }
     end
 
     trait :with_delegated_functions do
@@ -128,11 +125,11 @@ FactoryBot.define do
     end
 
     trait :with_no_savings do
-      savings_amount { create :savings_amount, :all_nil }
+      savings_amount { build :savings_amount, :all_nil }
     end
 
     trait :with_no_other_assets do
-      other_assets_declaration { create :other_assets_declaration, :all_nil }
+      other_assets_declaration { build :other_assets_declaration, :all_nil }
     end
 
     trait :with_merits_assessment do
@@ -148,7 +145,7 @@ FactoryBot.define do
     end
 
     trait :with_respondent do
-      respondent { create :respondent }
+      respondent { build :respondent }
     end
 
     trait :with_restrictions do
@@ -161,11 +158,11 @@ FactoryBot.define do
         populate_vehicle { false }
       end
       own_vehicle { true }
-      vehicle { populate_vehicle ? create(:vehicle, :populated) : create(:vehicle) }
+      vehicle { populate_vehicle ? build(:vehicle, :populated) : build(:vehicle) }
     end
 
     trait :with_incident do
-      latest_incident { create :incident }
+      latest_incident { build :incident }
     end
 
     trait :with_everything do

--- a/spec/requests/providers/merits_reports_spec.rb
+++ b/spec/requests/providers/merits_reports_spec.rb
@@ -3,12 +3,15 @@ require 'rails_helper'
 RSpec.describe Providers::MeritsReportsController, type: :request do
   let(:legal_aid_application) { create :legal_aid_application, :with_proceeding_types, :with_everything, :assessment_submitted }
   let(:login_provider) { login_as legal_aid_application.provider }
+  let!(:submission) { create :submission, legal_aid_application: legal_aid_application }
+  let(:before_subject) { nil }
 
   describe 'GET /providers/applications/:legal_aid_application_id/merits_report' do
     subject { get providers_legal_aid_application_merits_report_path(legal_aid_application, debug: true) }
 
     before do
       login_provider
+      before_subject
       subject
     end
 
@@ -18,6 +21,22 @@ RSpec.describe Providers::MeritsReportsController, type: :request do
 
     it 'displays the application ref number' do
       expect(unescaped_response_body).to include(legal_aid_application.application_ref)
+    end
+
+    it 'displays the CCMS case reference' do
+      expect(unescaped_response_body).to include(submission.case_ccms_reference)
+    end
+
+    context 'when no CCMS case reference present' do
+      let!(:submission) { create :submission, legal_aid_application: legal_aid_application, case_ccms_reference: nil }
+      let(:case_ccms_reference) { Faker::Number.number(digits: 6).to_s }
+      let(:before_subject) do
+        allow_any_instance_of(CCMS::ObtainCaseReferenceService).to receive(:reference_id).and_return(case_ccms_reference)
+      end
+
+      it 'obtains the case reference remotely' do
+        expect(unescaped_response_body).to include(case_ccms_reference)
+      end
     end
 
     context 'when not authenticated' do

--- a/spec/services/ccms/case_add_requestor_spec.rb
+++ b/spec/services/ccms/case_add_requestor_spec.rb
@@ -245,13 +245,12 @@ module CCMS # rubocop:disable Metrics/ModuleLength
                main_dwelling_third_party_relationship: 'Ex-Partner',
                main_dwelling_third_party_percentage: 50,
                opponents: [other_party_2],
-               ccms_submissions: ccms_submissions_collection,
                opponent_other_parties: [other_party_1, other_party_2],
-               most_recent_ccms_submission: ccms_submission,
+               ccms_submission: ccms_submission,
                used_delegated_functions?: true,
                used_delegated_functions_on: Date.today,
                default_substantive_cost_limitation: '2.00',
-               ccms_case_reference: 'P_88000001',
+               case_ccms_reference: 'P_88000001',
                respondent: respondent,
                own_vehicle?: true,
                own_home?: true,
@@ -294,11 +293,6 @@ module CCMS # rubocop:disable Metrics/ModuleLength
                plc_shares: 1_980,
                peps_unit_trusts_capital_bonds_gov_stocks: 10_000,
                life_assurance_endowment_policy: 3_000
-      end
-
-      let(:ccms_submissions_collection) do
-        double 'Collection of CCMS::Submission records',
-               most_recent: ccms_submission
       end
 
       let(:ccms_submission) do

--- a/spec/services/ccms/case_add_requestor_xml_blocks_spec.rb
+++ b/spec/services/ccms/case_add_requestor_xml_blocks_spec.rb
@@ -71,8 +71,7 @@ module CCMS # rubocop:disable Metrics/ModuleLength
       end
 
       context 'APPLICATION_CASE_REF' do
-        let(:ccms_reference) { '400012345678' }
-        let(:submission) { create :submission, :case_ref_obtained, legal_aid_application: legal_aid_application, case_ccms_reference: ccms_reference }
+        let(:case_reference) { legal_aid_application.case_ccms_reference }
         it 'inserts the case reference from the submission record into both global means and merits sections' do
           %i[global_means global_merits].each do |entity|
             block = XmlExtractor.call(xml, entity, 'APPLICATION_CASE_REF')

--- a/spec/services/ccms/case_add_requestor_xml_blocks_spec.rb
+++ b/spec/services/ccms/case_add_requestor_xml_blocks_spec.rb
@@ -5,40 +5,35 @@ module CCMS # rubocop:disable Metrics/ModuleLength
     context 'XML request' do
       let(:expected_tx_id) { '201904011604570390059770666' }
       let(:proceeding_type) { create :proceeding_type, :with_real_data }
+      let(:firm) { create :firm, name: 'Firm1' }
+      let(:office) { create :office, firm: firm }
+      let(:provider) do
+        create :provider,
+               firm: firm,
+               selected_office: office,
+               username: 4_953_649
+      end
+
       let(:legal_aid_application) do
         create :legal_aid_application,
                :with_everything,
                :with_applicant_and_address,
                populate_vehicle: true,
                with_bank_accounts: 2,
-               proceeding_types: [proceeding_type]
-      end
-
-      let(:firm) { double Firm, id: 19_148, name: 'Firm1' }
-
-      let(:provider) do
-        double Provider,
-               firm: firm,
-               selected_office_id: 137_570,
-               user_login_id: 4_953_649,
-               username: 4_953_649,
-               contact_user_id: 4_953_649,
-               supervisor_contact_id: 7_008_010,
-               fee_earner_contact_id: 4_925_152
+               proceeding_types: [proceeding_type],
+               provider: provider
       end
 
       let(:application_proceeding_type) { legal_aid_application.application_proceeding_types.first }
       let(:respondent) { legal_aid_application.respondent }
-      let(:ccms_reference) { '300000000001' }
+      let(:ccms_reference) { '300000054005' }
       let(:submission) { create :submission, :case_ref_obtained, legal_aid_application: legal_aid_application, case_ccms_reference: ccms_reference }
       let(:requestor) { described_class.new(submission, {}) }
       let(:xml) { requestor.formatted_xml }
       let(:success_prospect) { :likely }
       let(:merits_assessment) { create :merits_assessment, success_prospect: success_prospect, success_prospect_details: 'details' }
-      before { allow(requestor).to receive(:transaction_request_id).and_return(expected_tx_id) }
-      before { allow(requestor).to receive(:provider).and_return(provider) }
 
-      # enable this context if  you need to create a file of the payload for manual inspection
+      # enable this context if you need to create a file of the payload for manual inspection
       xcontext 'saving to a temporary file' do
         it 'creates a file' do
           filename = Rails.root.join('tmp/generated_ccms_payload.xml')
@@ -49,7 +44,7 @@ module CCMS # rubocop:disable Metrics/ModuleLength
 
       context 'ProceedingCaseId' do
         context 'ProceedingCaseId section' do
-          it 'has  a p number' do
+          it 'has a p number' do
             block = XmlExtractor.call(xml, :proceeding_case_id)
             expect(block.text).to eq application_proceeding_type.proceeding_case_p_num
           end
@@ -71,12 +66,14 @@ module CCMS # rubocop:disable Metrics/ModuleLength
       end
 
       context 'APPLICATION_CASE_REF' do
-        let(:case_reference) { legal_aid_application.case_ccms_reference }
-        it 'inserts the case reference from the submission record into both global means and merits sections' do
-          %i[global_means global_merits].each do |entity|
-            block = XmlExtractor.call(xml, entity, 'APPLICATION_CASE_REF')
-            expect(block).to have_text_response ccms_reference
-          end
+        it 'inserts the case reference from the submission record the global means sections' do
+          block = XmlExtractor.call(xml, :global_means, 'APPLICATION_CASE_REF')
+          expect(block).to have_text_response submission.case_ccms_reference
+        end
+
+        it 'inserts the case reference from the submission record the global merits sections' do
+          block = XmlExtractor.call(xml, :global_merits, 'APPLICATION_CASE_REF')
+          expect(block).to have_text_response ccms_reference
         end
       end
 
@@ -157,7 +154,6 @@ module CCMS # rubocop:disable Metrics/ModuleLength
       end
 
       context 'APPLICATION_CASE_REF' do
-        let(:ccms_reference) { '400000099991' }
         it 'inserts the ccms case reference from the submission into the attribute block' do
           block = XmlExtractor.call(xml, :global_means, 'APPLICATION_CASE_REF')
           expect(block).to have_text_response ccms_reference


### PR DESCRIPTION
[AP-912](https://dsdmoj.atlassian.net/browse/AP-912)

Updated the partial used the report PDF so that it includes the CCMS case reference.

Added some code to gather the case reference from CCMS, if that hasn't already occurred when the report is called.

Also a little tidying up - mainly to remove the inconsistency of the name of the attribute holding the case reference.