### PR TITLE
AP-939 Query CFE service - create capitals

### DIFF
--- a/app/services/cfe/base_service.rb
+++ b/app/services/cfe/base_service.rb
@@ -33,7 +33,7 @@ module CFE
 
     def query_cfe_service
       raw_response = post_request
-      parsed_response = JSON.parse(raw_response.body)
+      parse_json_response(raw_response.body)
       write_submission_history(raw_response)
       case raw_response.status
       when 200
@@ -43,6 +43,12 @@ module CFE
       else
         raise CFE::SubmissionError.new('Unsuccessful HTTP response code', raw_response.status)
       end
+    end
+
+    def parse_json_response(response_body)
+      JSON.parse(response_body)
+    rescue JSON::ParserError, TypeError
+      response_body || ''
     end
 
     def post_request

--- a/app/services/cfe/base_service.rb
+++ b/app/services/cfe/base_service.rb
@@ -37,7 +37,7 @@ module CFE
       write_submission_history(raw_response)
       case raw_response.status
       when 200
-        return parsed_response
+        return JSON.parse(raw_response.body)
       when 422
         raise CFE::SubmissionError.new('Unprocessable entity', 422)
       else

--- a/app/services/cfe/create_capitals_service.rb
+++ b/app/services/cfe/create_capitals_service.rb
@@ -1,0 +1,56 @@
+module CFE
+  class CreateCapitalsService < BaseService
+    OTHER_ASSET_FIELDS = %i[
+      timeshare_property_value
+      land_value
+      valuable_items_value
+      inherited_assets_value
+      money_owed_value
+      trust_value
+    ].freeze
+
+    private
+
+    def cfe_url_path
+      "/assessments/#{@submission.assessment_id}/capitals"
+    end
+
+    def request_body
+      {
+        "bank_accounts": [
+          # passported clients do not have bank accounts
+        ],
+        "non_liquid_capital": itemised_other_assets
+      }.to_json
+    end
+
+    def process_response
+      @submission.capitals_created!
+    end
+
+    def other_assets_declaration
+      @other_assets_declaration ||= legal_aid_application.other_assets_declaration
+    end
+
+    def itemised_other_assets
+      items = []
+      OTHER_ASSET_FIELDS.each do |field_name|
+        description = field_name.to_s.sub(/_value$/, '').humanize
+        value = other_assets_declaration.__send__(field_name)
+        items << description_and_value(description, value) if not_nil_or_zero?(value)
+      end
+      items
+    end
+
+    def not_nil_or_zero?(value)
+      value.present? && value.nonzero?
+    end
+
+    def description_and_value(description, value)
+      {
+        'description' => description,
+        'value' => value
+      }
+    end
+  end
+end

--- a/app/services/cfe/submission_manager.rb
+++ b/app/services/cfe/submission_manager.rb
@@ -16,10 +16,11 @@ module CFE
         CFE::CreateApplicantService.call(assessment)
 
         # TODO: add these steps as we write the services
-        # assessment.create_capitals! unless assessment.failed?
-        # assessment.create_properties! unless assessment.failed?
-        # assessment.create_vehicles! unless assessment.failed?
-        # assessment.obtain_results unless assessment.failed?
+        # CFE::CreateCapitalsService.call(assessment)
+        # CFE::CreateVehiclesService.call(assessment)
+        # CFE::CreatePropertiesService.call(assessment)
+        # CFE::ObtainAssessmentResultService.call(assessment)
+
       rescue CFE::SubmissionError => e
         assessment.error_message = e.message
         assessment.fail!

--- a/app/services/cfe/submission_manager.rb
+++ b/app/services/cfe/submission_manager.rb
@@ -14,9 +14,9 @@ module CFE
       begin
         CFE::CreateAssessmentService.call(assessment)
         CFE::CreateApplicantService.call(assessment)
+        CFE::CreateCapitalsService.call(assessment)
 
         # TODO: add these steps as we write the services
-        # CFE::CreateCapitalsService.call(assessment)
         # CFE::CreateVehiclesService.call(assessment)
         # CFE::CreatePropertiesService.call(assessment)
         # CFE::ObtainAssessmentResultService.call(assessment)

--- a/app/services/cfe/submission_manager.rb
+++ b/app/services/cfe/submission_manager.rb
@@ -20,7 +20,6 @@ module CFE
         # CFE::CreateVehiclesService.call(assessment)
         # CFE::CreatePropertiesService.call(assessment)
         # CFE::ObtainAssessmentResultService.call(assessment)
-
       rescue CFE::SubmissionError => e
         assessment.error_message = e.message
         assessment.fail!

--- a/spec/services/cfe/create_assessment_service_spec.rb
+++ b/spec/services/cfe/create_assessment_service_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-module CFE
+module CFE # rubocop:disable Metrics/ModuleLength
   RSpec.describe CreateAssessmentService do
     # uncomment this if you need to connect to a real instance of Check Financial Eligibility service
     # running on localhost
@@ -83,36 +83,63 @@ module CFE
     end
 
     describe 'unsuccessful post' do
-      let(:faraday_response) { double Faraday::Response, status: 422, body: error_response }
+      context 'http status 422' do
+        let(:faraday_response) { double Faraday::Response, status: 422, body: error_response }
 
-      it 'raises an exception' do
-        expect {
-          CreateAssessmentService.call(submission)
-        }.to raise_error CFE::SubmissionError, 'Unprocessable entity'
+        it 'raises an exception' do
+          expect {
+            CreateAssessmentService.call(submission)
+          }.to raise_error CFE::SubmissionError, 'Unprocessable entity'
+        end
+
+        it 'updates the submission record from initialised to failed' do
+          expect(submission.submission_histories).to be_empty
+          expect { CreateAssessmentService.call(submission) }.to raise_error CFE::SubmissionError
+
+          expect(submission.submission_histories.count).to eq 1
+          history = submission.submission_histories.last
+          expect(history.submission_id).to eq submission.id
+          expect(history.url).to eq 'http://localhost:3001/assessments'
+          expect(history.http_method).to eq 'POST'
+          expect(history.request_payload).to eq expected_payload
+          expect(history.http_response_status).to eq 422
+          expect(history.response_payload).to eq error_response
+          expect(history.error_message).to be_nil
+        end
+
+        def error_response
+          {
+            errors: [
+              'error creating record'
+            ],
+            success: false
+          }.to_json
+        end
       end
 
-      it 'updates the submission record from initialised to failed' do
-        expect(submission.submission_histories).to be_empty
-        expect { CreateAssessmentService.call(submission) }.to raise_error CFE::SubmissionError
+      context 'other http status' do
+        let(:faraday_response) { double Faraday::Response, status: 503, body: nil }
 
-        expect(submission.submission_histories.count).to eq 1
-        history = submission.submission_histories.last
-        expect(history.submission_id).to eq submission.id
-        expect(history.url).to eq 'http://localhost:3001/assessments'
-        expect(history.http_method).to eq 'POST'
-        expect(history.request_payload).to eq expected_payload
-        expect(history.http_response_status).to eq 422
-        expect(history.response_payload).to eq error_response
-        expect(history.error_message).to be_nil
-      end
+        it 'raises an exception' do
+          expect {
+            CreateAssessmentService.call(submission)
+          }.to raise_error CFE::SubmissionError, 'Unsuccessful HTTP response code'
+        end
 
-      def error_response
-        {
-          errors: [
-            'error creating record'
-          ],
-          success: false
-        }.to_json
+        it 'updates the submission record from initialised to failed' do
+          expect(submission.submission_histories).to be_empty
+          expect { CreateAssessmentService.call(submission) }.to raise_error CFE::SubmissionError
+
+          expect(submission.submission_histories.count).to eq 1
+          history = submission.submission_histories.last
+          expect(history.submission_id).to eq submission.id
+          expect(history.url).to eq 'http://localhost:3001/assessments'
+          expect(history.http_method).to eq 'POST'
+          expect(history.request_payload).to eq expected_payload
+          expect(history.http_response_status).to eq 503
+          expect(history.response_payload).to be_nil
+          expect(history.error_message).to be_nil
+        end
       end
     end
   end

--- a/spec/services/cfe/create_capitals_service_spec.rb
+++ b/spec/services/cfe/create_capitals_service_spec.rb
@@ -1,0 +1,136 @@
+require 'rails_helper'
+
+module CFE # rubocop:disable Metrics/ModuleLength
+  RSpec.describe CreateCapitalsService do
+    describe '.call' do
+      let(:connection_param) { double.as_null_object }
+      let(:faraday_connection) { double Faraday }
+      let(:application) { create :legal_aid_application }
+      let!(:other_assets_declaration) do
+        create :other_assets_declaration,
+               legal_aid_application: application,
+               timeshare_property_value: 256_000.0,
+               land_value: 100_000.0,
+               valuable_items_value: 32_500.0,
+               inherited_assets_value: nil,
+               money_owed_value: 0.0,
+               trust_value: 99_999.99
+      end
+      let(:submission) { create :cfe_submission, :applicant_created, legal_aid_application: application }
+      let(:expected_payload) do
+        {
+          'bank_accounts' => [],
+          'non_liquid_capital' => [
+            {
+              'description' => 'Timeshare property',
+              'value' => '256000.0'
+            },
+            {
+              'description' => 'Land',
+              'value' => '100000.0'
+            },
+            {
+              'description' => 'Valuable items',
+              'value' => '32500.0'
+            },
+            { 'description' => 'Trust',
+              'value' => '99999.99' }
+          ]
+        }.to_json
+      end
+
+      let(:dummy_response) do
+        {
+          'objects' => {
+            'id' => 'dfc616dc-b8a0-4f18-b721-57dc561aaf07',
+            'assessment_id' => 'f0496616-66b9-4f3e-bf9d-ec51d14d461c',
+            'total_liquid' => '0.0',
+            'total_non_liquid' => '0.0',
+            'total_vehicle' => '0.0',
+            'total_property' => '0.0',
+            'total_mortgage_allowance' => '0.0',
+            'total_capital' => '0.0',
+            'pensioner_capital_disregard' => '0.0',
+            'assessed_capital' => '0.0',
+            'capital_contribution' => '0.0',
+            'lower_threshold' => '0.0',
+            'upper_threshold' => '0.0',
+            'capital_assessment_result' => 'pending',
+            'created_at' => '2019-09-11T14:15:58.953Z',
+            'updated_at' => '2019-09-11T14:15:58.953Z'
+          },
+          "errors": [],
+          "success": true
+        }.to_json
+      end
+
+      before do
+        expect(Faraday).to receive(:new).with(url: 'http://localhost:3001').and_return(faraday_connection)
+        expect(faraday_connection).to receive(:post).and_yield(connection_param).and_return(faraday_response)
+      end
+
+      context 'successful post' do
+        let(:faraday_response) { double Faraday::Response, status: 200, body: dummy_response }
+        it 'calls with expected payload and connection params' do
+          expect(connection_param).to receive(:url).with("/assessments/#{submission.assessment_id}/capitals")
+          expect(connection_param).to receive(:headers)
+          expect(connection_param).to receive(:body=).with(expected_payload)
+
+          CreateCapitalsService.call(submission)
+        end
+
+        it 'updates the submission record from applicant_created to capitals_created' do
+          expect(submission.aasm_state).to eq 'applicant_created'
+          CreateCapitalsService.call(submission)
+          expect(submission.aasm_state).to eq 'capitals_created'
+        end
+
+        it 'creates a submission_history record' do
+          expect {
+            CreateCapitalsService.call(submission)
+          }.to change { submission.submission_histories.count }.by 1
+          history = CFE::SubmissionHistory.last
+          expect(history.submission_id).to eq submission.id
+          expect(history.url).to eq "http://localhost:3001/assessments/#{submission.assessment_id}/capitals"
+          expect(history.http_method).to eq 'POST'
+          expect(history.request_payload).to eq expected_payload
+          expect(history.http_response_status).to eq 200
+          expect(history.response_payload).to eq dummy_response
+          expect(history.error_message).to be_nil
+        end
+      end
+
+      describe 'unsuccessful post' do
+        let(:faraday_response) { double Faraday::Response, status: 422, body: error_response }
+
+        it 'raises an exception' do
+          expect {
+            CreateCapitalsService.call(submission)
+          }.to raise_error CFE::SubmissionError, 'Unprocessable entity'
+        end
+
+        it 'updates the submission record from initialised to failed' do
+          expect(submission.submission_histories).to be_empty
+          expect { CreateCapitalsService.call(submission) }.to raise_error CFE::SubmissionError
+
+          expect(submission.submission_histories.count).to eq 1
+          history = submission.submission_histories.last
+          expect(history.submission_id).to eq submission.id
+          expect(history.url).to eq "http://localhost:3001/assessments/#{submission.assessment_id}/capitals"
+          expect(history.http_method).to eq 'POST'
+          expect(history.request_payload).to eq expected_payload
+          expect(history.http_response_status).to eq 422
+          expect(history.response_payload).to eq error_response
+          expect(history.error_message).to be_nil
+        end
+
+        def error_response
+          {
+            errors: ['Detailed error message'],
+            success: false
+          }.to_json
+        end
+      end
+    end
+  end
+end

--- a/spec/services/cfe/create_capitals_service_spec.rb
+++ b/spec/services/cfe/create_capitals_service_spec.rb
@@ -16,7 +16,7 @@ module CFE # rubocop:disable Metrics/ModuleLength
                money_owed_value: 0.0,
                trust_value: 99_999.99
       end
-      let(:submission) { create :cfe_submission, :applicant_created, legal_aid_application: application }
+      let(:submission) { create :cfe_submission, aasm_state: 'applicant_created', legal_aid_application: application }
       let(:expected_payload) do
         {
           'bank_accounts' => [],

--- a/spec/services/cfe/submission_manager_spec.rb
+++ b/spec/services/cfe/submission_manager_spec.rb
@@ -11,7 +11,8 @@ module CFE
     context 'No Errors' do
       before do
         allow_any_instance_of(CreateAssessmentService).to receive(:post_request).and_return(assessment_response)
-        allow_any_instance_of(CreateApplicantService).to receive(:post_request).and_return(applicant_response)
+        allow_any_instance_of(CreateApplicantService).to receive(:post_request).and_return(generic_successful_response)
+        allow_any_instance_of(CreateCapitalsService).to receive(:post_request).and_return(generic_successful_response)
       end
 
       it 'creates a submission record for the application' do
@@ -20,16 +21,17 @@ module CFE
         }.to change { Submission.count }.by(1)
 
         submission = Submission.last
+
         expect(submission.legal_aid_application_id).to eq application.id
-        expect(submission.aasm_state).to eq 'applicant_created' # TODO: change this as we add more services to the test
+        expect(submission.aasm_state).to eq 'capitals_created' # TODO: change this as we add more services to the test
       end
 
       it 'calls all the services to post data' do
         expect(CreateAssessmentService).to receive(:call).and_call_original
         expect(CreateApplicantService).to receive(:call).and_call_original
+        expect(CreateCapitalsService).to receive(:call).and_call_original
 
         # TODO: Add these expectations as we add more services to the test
-        # expect(CreateCapitalsService).to receive(:call).and_call_original
         # expect(CreatePropertiesService).to receive(:call).and_call_original
         # expect(CreateVehiclesService).to receive(:call).and_call_original
         # expect(ObtainResultsService).to receive(:call).and_call_original
@@ -40,7 +42,7 @@ module CFE
       it 'writes the expected submission history records' do
         expect {
           SubmissionManager.call(application.id)
-        }.to change { SubmissionHistory.count }.by 2 # TODO: increase this number as we add more services to the spec
+        }.to change { SubmissionHistory.count }.by 3 # TODO: increase this number as we add more services to the spec
       end
     end
 
@@ -88,11 +90,11 @@ module CFE
       }.to_json
     end
 
-    def applicant_response
-      double Faraday::Response, status: 200, body: dummy_applicant_response
+    def generic_successful_response
+      double Faraday::Response, status: 200, body: dummy_successful_response
     end
 
-    def dummy_applicant_response
+    def dummy_successful_response
       {
         'success' => true
       }.to_json


### PR DESCRIPTION
## Query CFE service - create capitals

[Link to story](https://dsdmoj.atlassian.net/browse/AP-939)

In order for the Apply service to query the Check Financial Eligibility
service, it has to perform the  following 6 steps:

1. Create Assessment
2. Create Application
3. Create Capitals
4. Create Vehicles
5. Create Properties
6. Obtain Assessment Result

This PR covers step 3.

- Created `CreateCapitalsService`
- Modified `CFE::SubmissionManager` to call `CreateCapitalsService` as part of the workflow

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
