### PR TITLE
AP-939 Add savings amounts to capitals payload

### DIFF
--- a/app/forms/savings_amounts/savings_amounts_form.rb
+++ b/app/forms/savings_amounts/savings_amounts_form.rb
@@ -5,7 +5,7 @@ module SavingsAmounts
     form_for SavingsAmount
 
     ATTRIBUTES = %i[
-      isa
+      offline_accounts
       cash
       other_person_account
       national_savings

--- a/app/services/ccms/attribute_value_generator.rb
+++ b/app/services/ccms/attribute_value_generator.rb
@@ -141,7 +141,7 @@ module CCMS
     end
 
     def applicant_has_other_savings?(_options)
-      not_zero? savings.isa
+      not_zero? savings.offline_accounts
     end
 
     def applicant_has_other_policies?(_options)

--- a/app/services/cfe/create_capitals_service.rb
+++ b/app/services/cfe/create_capitals_service.rb
@@ -10,7 +10,7 @@ module CFE
     }.freeze
 
     SAVINGS_AMOUNT_FIELDS = {
-      isa: 'Off-line bank accounts',
+      offline_accounts: 'Off-line bank accounts',
       cash: 'Cash',
       other_person_account: "Signatory on other person's account",
       national_savings: 'National savings',

--- a/app/services/cfe/create_capitals_service.rb
+++ b/app/services/cfe/create_capitals_service.rb
@@ -7,7 +7,7 @@ module CFE
       inherited_assets_value: 'Inherited assets',
       money_owed_value: 'Money owed to applicant',
       trust_value: 'Trusts'
-    }
+    }.freeze
 
     SAVINGS_AMOUNT_FIELDS = {
       isa: 'Off-line bank accounts',
@@ -17,7 +17,7 @@ module CFE
       plc_shares: 'Shares in PLC',
       peps_unit_trusts_capital_bonds_gov_stocks: 'PEPs, unit trusts, capital bonds and government stocks',
       life_assurance_endowment_policy: 'Life assurance and endowment policies not linked to a mortgage'
-    }
+    }.freeze
 
     private
 
@@ -60,6 +60,7 @@ module CFE
 
     def array_of_hashes_for(model, field_names_and_descriptions)
       return nil if model.nil?
+
       items = []
       field_names_and_descriptions.each do |field_name, field_description|
         value = model.__send__(field_name)
@@ -82,8 +83,5 @@ module CFE
     def savings_amount
       @savings_amount ||= legal_aid_application.savings_amount
     end
-
-
-
   end
 end

--- a/app/services/cfe/create_capitals_service.rb
+++ b/app/services/cfe/create_capitals_service.rb
@@ -1,13 +1,23 @@
 module CFE
   class CreateCapitalsService < BaseService
-    OTHER_ASSET_FIELDS = %i[
-      timeshare_property_value
-      land_value
-      valuable_items_value
-      inherited_assets_value
-      money_owed_value
-      trust_value
-    ].freeze
+    OTHER_ASSET_FIELDS = {
+      timeshare_property_value: 'Timeshare property',
+      land_value: 'Land',
+      valuable_items_value: 'Valuable items',
+      inherited_assets_value: 'Inherited assets',
+      money_owed_value: 'Money owed to applicant',
+      trust_value: 'Trusts'
+    }
+
+    SAVINGS_AMOUNT_FIELDS = {
+      isa: 'Off-line bank accounts',
+      cash: 'Cash',
+      other_person_account: "Signatory on other person's account",
+      national_savings: 'National savings',
+      plc_shares: 'Shares in PLC',
+      peps_unit_trusts_capital_bonds_gov_stocks: 'PEPs, unit trusts, capital bonds and government stocks',
+      life_assurance_endowment_policy: 'Life assurance and endowment policies not linked to a mortgage'
+    }
 
     private
 
@@ -17,9 +27,7 @@ module CFE
 
     def request_body
       {
-        "bank_accounts": [
-          # passported clients do not have bank accounts
-        ],
+        "bank_accounts": bank_account_assets,
         "non_liquid_capital": itemised_other_assets
       }.to_json
     end
@@ -33,17 +41,31 @@ module CFE
     end
 
     def itemised_other_assets
-      items = []
-      OTHER_ASSET_FIELDS.each do |field_name|
-        description = field_name.to_s.sub(/_value$/, '').humanize
-        value = other_assets_declaration.__send__(field_name)
-        items << description_and_value(description, value) if not_nil_or_zero?(value)
-      end
-      items
+      array_of_hashes_for(other_assets_declaration, OTHER_ASSET_FIELDS)
     end
 
-    def not_nil_or_zero?(value)
-      value.present? && value.nonzero?
+    def bank_account_assets
+      [savings_amounts, bank_accounts].flatten.compact
+    end
+
+    def bank_accounts
+      # passported applicants don't have online bank accounts, so this is always empty until
+      # such time as non-passported applicants are added to the system
+      []
+    end
+
+    def savings_amounts
+      array_of_hashes_for(savings_amount, SAVINGS_AMOUNT_FIELDS)
+    end
+
+    def array_of_hashes_for(model, field_names_and_descriptions)
+      return nil if model.nil?
+      items = []
+      field_names_and_descriptions.each do |field_name, field_description|
+        value = model.__send__(field_name)
+        items << description_and_value(field_description, value) if not_nil_or_zero?(value)
+      end
+      items
     end
 
     def description_and_value(description, value)
@@ -52,5 +74,16 @@ module CFE
         'value' => value
       }
     end
+
+    def not_nil_or_zero?(value)
+      value.present? && value.nonzero?
+    end
+
+    def savings_amount
+      @savings_amount ||= legal_aid_application.savings_amount
+    end
+
+
+
   end
 end

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -310,11 +310,11 @@ en:
               greater_than_or_equal_to: Total cash savings must be 0 or more
               not_a_number: Total cash savings must be an amount of money, like 60,000
               too_many_decimals: Estimated cash value must not include more than 2 decimal numbers
-            isa:
+            offline_accounts:
               blank: Enter the estimated total in all accounts
               greater_than_or_equal_to: Total in accounts must be 0 or more
               not_a_number: Total in accounts must be an amount of money, like 60,000
-              too_many_decimals: Estimated isa value must not include more than 2 decimal numbers
+              too_many_decimals: Estimated offline_accounts value must not include more than 2 decimal numbers
             life_assurance_endowment_policy:
               blank: Enter the total value of life assurance policies
               greater_than_or_equal_to: Total of life assurance policies must be 0 or more

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -314,7 +314,7 @@ en:
               blank: Enter the estimated total in all accounts
               greater_than_or_equal_to: Total in accounts must be 0 or more
               not_a_number: Total in accounts must be an amount of money, like 60,000
-              too_many_decimals: Estimated offline_accounts value must not include more than 2 decimal numbers
+              too_many_decimals: Estimated total in accounts must not include more than 2 decimal numbers
             life_assurance_endowment_policy:
               blank: Enter the total value of life assurance policies
               greater_than_or_equal_to: Total of life assurance policies must be 0 or more

--- a/config/locales/en/shared.yml
+++ b/config/locales/en/shared.yml
@@ -190,17 +190,17 @@ en:
             savings_and_investments:
               cash: Enter total amount
               check_box_cash: Cash savings
-              check_box_isa: Money in accounts you do not access with online banking
+              check_box_offline_accounts: Money in accounts you do not access with online banking
               check_box_life_assurance_endowment_policy: Life assurance and endowment policies not linked to a mortgage
               check_box_national_savings: National Savings Certificates and Premium Bonds
               check_box_other_person_account: Signatory on a child's or other person's bank account
               check_box_peps_unit_trusts_capital_bonds_gov_stocks: PEPs, unit trusts, capital bonds and government stocks
               check_box_plc_shares: Shares in a PLC (public limited company)
               hint:
-                check_box_isa: Include bank, building society, Post Office and ISA accounts
+                check_box_offline_accounts: Include bank, building society, Post Office and ISA accounts
                 check_box_life_assurance_endowment_policy: Do not include policies that only pay out on death
                 check_box_other_person_account: For example, if you have power of attorney
-              isa: Enter the estimated total in all accounts
+              offline_accounts: Enter the estimated total in all accounts
               life_assurance_endowment_policy: Enter the total value of all you own
               national_savings: Enter the total value of all you own
               other_person_account: Enter the estimated total in all accounts
@@ -228,17 +228,17 @@ en:
             savings_and_investments:
               cash: Enter total amount
               check_box_cash: Cash savings
-              check_box_isa: Money in accounts they do not access with online banking
+              check_box_offline_accounts: Money in accounts they do not access with online banking
               check_box_life_assurance_endowment_policy: Life assurance and endowment policies not linked to a mortgage
               check_box_national_savings: National Savings Certificates and Premium Bonds
               check_box_other_person_account: Signatory on a child's or other person's bank account
               check_box_peps_unit_trusts_capital_bonds_gov_stocks: PEPs, unit trusts, capital bonds and government stocks
               check_box_plc_shares: Shares in a PLC (public limited company)
               hint:
-                check_box_isa: Include bank, building society, Post Office and ISA accounts.
+                check_box_offline_accounts: Include bank, building society, Post Office and ISA accounts.
                 check_box_life_assurance_endowment_policy: Do not include policies that only pay out on death
                 check_box_other_person_account: For example, a junior ISA for a child
-              isa: Enter the estimated total in all accounts
+              offline_accounts: Enter the estimated total in all accounts
               life_assurance_endowment_policy: Enter the total value of all owned
               national_savings: Enter the total value of all owned
               other_person_account: Enter the estimated total in all accounts

--- a/db/migrate/20190918102038_rename_isa_to_offline_accounts.rb
+++ b/db/migrate/20190918102038_rename_isa_to_offline_accounts.rb
@@ -1,0 +1,5 @@
+class RenameIsaToOfflineAccounts < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :savings_amounts, :isa, :offline_accounts
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_13_092309) do
+ActiveRecord::Schema.define(version: 2019_09_18_102038) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -100,10 +100,9 @@ ActiveRecord::Schema.define(version: 2019_09_13_092309) do
   create_table "application_scope_limitations", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "legal_aid_application_id"
     t.uuid "scope_limitation_id"
+    t.boolean "substantive", default: true
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.boolean "substantive", default: true
-    t.index ["legal_aid_application_id", "scope_limitation_id"], name: "scope_limitations_index", unique: true
     t.index ["legal_aid_application_id"], name: "index_application_scope_limitations_on_legal_aid_application_id"
   end
 
@@ -505,7 +504,7 @@ ActiveRecord::Schema.define(version: 2019_09_13_092309) do
 
   create_table "savings_amounts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "legal_aid_application_id", null: false
-    t.decimal "isa"
+    t.decimal "offline_accounts"
     t.decimal "cash"
     t.decimal "other_person_account"
     t.decimal "national_savings"

--- a/features/citizens/citizens.feature
+++ b/features/citizens/citizens.feature
@@ -156,7 +156,7 @@ Feature: Citizen journey
     And I click Check Your Answers Change link for 'Savings and investments'
     Then I should be on a page showing 'What types of savings or investments do you have?'
     Then I select 'Money in accounts you do not access with online banking'
-    Then I fill 'Isa' with '5000'
+    Then I fill 'Offline accounts' with '5000'
     Then I click 'Save and continue'
     Then I should be on a page showing 'Are there any legal restrictions that prevent you from selling or borrowing against your assets?'
     Then I click 'Save and continue'

--- a/spec/factories/savings_amounts.rb
+++ b/spec/factories/savings_amounts.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     legal_aid_application
 
     trait :with_values do
-      isa { rand(1...1_000_000.0).round(2) }
+      offline_accounts { rand(1...1_000_000.0).round(2) }
       cash { rand(1...1_000_000.0).round(2) }
       other_person_account { rand(1...1_000_000.0).round(2) }
       national_savings { rand(1...1_000_000.0).round(2) }
@@ -13,7 +13,7 @@ FactoryBot.define do
     end
 
     trait :all_nil do
-      isa { nil }
+      offline_accounts { nil }
       cash { nil }
       other_person_account { nil }
       national_savings { nil }
@@ -23,7 +23,7 @@ FactoryBot.define do
     end
 
     trait :all_zero do
-      isa { 0.0 }
+      offline_accounts { 0.0 }
       cash { 0.0 }
       other_person_account { 0.0 }
       national_savings { 0.0 }
@@ -33,7 +33,7 @@ FactoryBot.define do
     end
 
     trait :mix_of_values do
-      isa { nil }
+      offline_accounts { nil }
       cash { 0.0 }
       other_person_account { rand(1...1_000_000.0).round(2) }
       national_savings { nil }

--- a/spec/forms/savings_amounts/savings_amounts_form_spec.rb
+++ b/spec/forms/savings_amounts/savings_amounts_form_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe SavingsAmounts::SavingsAmountsForm, type: :form do
       shared_examples_for 'it has an error' do
         let(:attribute_map) do
           {
-            isa: /total in.*accounts/i,
+            offline_accounts: /total in.*accounts/i,
             cash: /total.*cash savings/i,
             other_person_account: /other people’s accounts/,
             national_savings: /certificates and bonds/,
@@ -109,7 +109,7 @@ RSpec.describe SavingsAmounts::SavingsAmountsForm, type: :form do
     context 'some check boxes are unchecked' do
       let(:check_box_params) do
         boxes = check_box_attributes.each_with_object({}) { |attr, hsh| hsh[attr] = '' }
-        boxes[:check_box_isa] = 'true'
+        boxes[:check_box_offline_accounts] = 'true'
         boxes
       end
 
@@ -117,7 +117,7 @@ RSpec.describe SavingsAmounts::SavingsAmountsForm, type: :form do
         let(:amount_params) { attributes.each_with_object({}) { |attr, hsh| hsh[attr] = rand(1...1_000_000.0).round(2).to_s } }
 
         it 'empties amounts if checkbox is unchecked' do
-          attributes_except_isa = attributes - [:isa]
+          attributes_except_isa = attributes - [:offline_accounts]
           subject.save
           savings_amount.reload
           attributes_except_isa.each do |attr|
@@ -128,7 +128,7 @@ RSpec.describe SavingsAmounts::SavingsAmountsForm, type: :form do
 
         it 'does not empty amount if a checkbox is checked' do
           subject.save
-          expect(savings_amount.reload.isa).not_to eq(nil)
+          expect(savings_amount.reload.offline_accounts).not_to eq(nil)
         end
 
         it 'returns true' do

--- a/spec/requests/citizens/savings_and_investments_spec.rb
+++ b/spec/requests/citizens/savings_and_investments_spec.rb
@@ -34,13 +34,13 @@ RSpec.describe 'citizen savings and investments', type: :request do
   end
 
   describe 'PATCH citizens/savings_and_investment' do
-    let(:isa) { rand(1...1_000_000.0).round(2).to_s }
-    let(:check_box_isa) { 'true' }
-    let(:params) { { savings_amount: { isa: isa, check_box_isa: check_box_isa } } }
+    let(:offline_accounts) { rand(1...1_000_000.0).round(2).to_s }
+    let(:check_box_offline_accounts) { 'true' }
+    let(:params) { { savings_amount: { offline_accounts: offline_accounts, check_box_offline_accounts: check_box_offline_accounts } } }
     subject { patch citizens_savings_and_investment_path, params: params }
 
-    it 'updates the isa amount' do
-      expect { subject }.to change { savings_amount.reload.isa.to_s }.to(isa)
+    it 'updates the offline_accounts amount' do
+      expect { subject }.to change { savings_amount.reload.offline_accounts.to_s }.to(offline_accounts)
     end
 
     it 'does not displays an error' do
@@ -64,7 +64,7 @@ RSpec.describe 'citizen savings and investments', type: :request do
     end
 
     context 'with invalid input' do
-      let(:isa) { 'fifty' }
+      let(:offline_accounts) { 'fifty' }
 
       it 'renders successfully' do
         subject
@@ -73,7 +73,7 @@ RSpec.describe 'citizen savings and investments', type: :request do
 
       it 'displays an error' do
         subject
-        expect(response.body).to match(I18n.t('activemodel.errors.models.savings_amount.attributes.isa.not_a_number'))
+        expect(response.body).to match(I18n.t('activemodel.errors.models.savings_amount.attributes.offline_accounts.not_a_number'))
         expect(response.body).to match('govuk-error-message')
         expect(response.body).to match('govuk-form-group--error')
       end

--- a/spec/requests/providers/savings_and_investments_spec.rb
+++ b/spec/requests/providers/savings_and_investments_spec.rb
@@ -59,13 +59,13 @@ RSpec.describe 'providers savings and investments', type: :request do
   end
 
   describe 'PATCH /providers/applications/:legal_aid_application_id/savings_and_investment' do
-    let(:isa) { rand(1...1_000_000.0).round(2).to_s }
-    let(:check_box_isa) { 'true' }
+    let(:offline_accounts) { rand(1...1_000_000.0).round(2).to_s }
+    let(:check_box_offline_accounts) { 'true' }
     let(:params) do
       {
         savings_amount: {
-          isa: isa,
-          check_box_isa: check_box_isa
+          offline_accounts: offline_accounts,
+          check_box_offline_accounts: check_box_offline_accounts
         }
       }
     end
@@ -85,8 +85,8 @@ RSpec.describe 'providers savings and investments', type: :request do
         end
 
         context 'not in checking passported answers state' do
-          it 'updates the isa amount' do
-            expect { subject }.to change { savings_amount.reload.isa.to_s }.to(isa)
+          it 'updates the offline_accounts amount' do
+            expect { subject }.to change { savings_amount.reload.offline_accounts.to_s }.to(offline_accounts)
           end
 
           it 'does not displays an error' do
@@ -110,7 +110,7 @@ RSpec.describe 'providers savings and investments', type: :request do
           end
 
           context 'with invalid input' do
-            let(:isa) { 'fifty' }
+            let(:offline_accounts) { 'fifty' }
 
             it 'renders successfully' do
               subject
@@ -119,7 +119,7 @@ RSpec.describe 'providers savings and investments', type: :request do
 
             it 'displays an error' do
               subject
-              expect(response.body).to match(I18n.t('activemodel.errors.models.savings_amount.attributes.isa.not_a_number'))
+              expect(response.body).to match(I18n.t('activemodel.errors.models.savings_amount.attributes.offline_accounts.not_a_number'))
               expect(response.body).to match('govuk-error-message')
               expect(response.body).to match('govuk-form-group--error')
             end
@@ -141,7 +141,7 @@ RSpec.describe 'providers savings and investments', type: :request do
           end
 
           context 'no savings' do
-            let(:isa) { 0 }
+            let(:offline_accounts) { 0 }
 
             it 'redirects to the check passported answers page' do
               expect(response).to redirect_to(providers_legal_aid_application_check_passported_answers_path(application))
@@ -165,8 +165,8 @@ RSpec.describe 'providers savings and investments', type: :request do
           }
         end
 
-        it 'updates the isa amount' do
-          expect { subject }.to change { savings_amount.reload.isa.to_s }.to(isa)
+        it 'updates the offline_accounts amount' do
+          expect { subject }.to change { savings_amount.reload.offline_accounts.to_s }.to(offline_accounts)
         end
 
         it 'does not displays an error' do
@@ -186,7 +186,7 @@ RSpec.describe 'providers savings and investments', type: :request do
         end
 
         context 'with invalid input' do
-          let(:isa) { 'fifty' }
+          let(:offline_accounts) { 'fifty' }
 
           it 'renders successfully' do
             subject
@@ -195,7 +195,7 @@ RSpec.describe 'providers savings and investments', type: :request do
 
           it 'displays an error' do
             subject
-            expect(response.body).to match(I18n.t('activemodel.errors.models.savings_amount.attributes.isa.not_a_number'))
+            expect(response.body).to match(I18n.t('activemodel.errors.models.savings_amount.attributes.offline_accounts.not_a_number'))
             expect(response.body).to match('govuk-error-message')
             expect(response.body).to match('govuk-form-group--error')
           end

--- a/spec/services/ccms/case_add_requestor_spec.rb
+++ b/spec/services/ccms/case_add_requestor_spec.rb
@@ -285,7 +285,7 @@ module CCMS # rubocop:disable Metrics/ModuleLength
 
       let(:savings_amount) do
         double Capital,
-               isa: 1_234,
+               offline_accounts: 1_234,
                cash: 1_500,
                other_person_account: 1_000,
                national_savings: 129_00,

--- a/spec/services/ccms/case_add_requestor_xml_blocks_spec.rb
+++ b/spec/services/ccms/case_add_requestor_xml_blocks_spec.rb
@@ -711,7 +711,7 @@ module CCMS # rubocop:disable Metrics/ModuleLength
         end
 
         it 'returns false when client does NOT have other savings' do
-          allow(legal_aid_application.savings_amount).to receive(:isa).and_return(nil)
+          allow(legal_aid_application.savings_amount).to receive(:offline_accounts).and_return(nil)
           block = XmlExtractor.call(xml, :global_means, 'GB_INPUT_B_10WP2_1A')
           expect(block).to have_boolean_response false
         end

--- a/spec/services/cfe/create_capitals_service_spec.rb
+++ b/spec/services/cfe/create_capitals_service_spec.rb
@@ -46,7 +46,7 @@ module CFE # rubocop:disable Metrics/ModuleLength
             {
               description: 'National savings',
               value: '750.0'
-            },
+            }
           ],
           'non_liquid_capital' => [
             {

--- a/spec/services/cfe/create_capitals_service_spec.rb
+++ b/spec/services/cfe/create_capitals_service_spec.rb
@@ -16,10 +16,38 @@ module CFE # rubocop:disable Metrics/ModuleLength
                money_owed_value: 0.0,
                trust_value: 99_999.99
       end
+      let!(:savings_amount) do
+        create :savings_amount,
+               legal_aid_application: application,
+               isa: 333.33,
+               cash: 25.00,
+               other_person_account: 100.0,
+               national_savings: 750.0,
+               plc_shares: nil,
+               peps_unit_trusts_capital_bonds_gov_stocks: 0.0,
+               life_assurance_endowment_policy: nil
+      end
       let(:submission) { create :cfe_submission, aasm_state: 'applicant_created', legal_aid_application: application }
       let(:expected_payload) do
         {
-          'bank_accounts' => [],
+          'bank_accounts' => [
+            {
+              description: 'Off-line bank accounts',
+              value: '333.33'
+            },
+            {
+              description: 'Cash',
+              value: '25.0'
+            },
+            {
+              description: "Signatory on other person's account",
+              value: '100.0'
+            },
+            {
+              description: 'National savings',
+              value: '750.0'
+            },
+          ],
           'non_liquid_capital' => [
             {
               'description' => 'Timeshare property',
@@ -33,7 +61,7 @@ module CFE # rubocop:disable Metrics/ModuleLength
               'description' => 'Valuable items',
               'value' => '32500.0'
             },
-            { 'description' => 'Trust',
+            { 'description' => 'Trusts',
               'value' => '99999.99' }
           ]
         }.to_json

--- a/spec/services/cfe/create_capitals_service_spec.rb
+++ b/spec/services/cfe/create_capitals_service_spec.rb
@@ -19,7 +19,7 @@ module CFE # rubocop:disable Metrics/ModuleLength
       let!(:savings_amount) do
         create :savings_amount,
                legal_aid_application: application,
-               isa: 333.33,
+               offline_accounts: 333.33,
                cash: 25.00,
                other_person_account: 100.0,
                national_savings: 750.0,


### PR DESCRIPTION
## Add savings amounts to capitals payloads

This is an addition to the pull request AP-939 that was merged yesterday after discovering that savings amounts should be added to the capitals payload.

[Link to story](https://dsdmoj.atlassian.net/browse/AP-939)

Describe what you did and why.
- rename `isa` field on `SavingsAmount` model to `offline_accounts` to better reflect the data held in that field
- Added the non-zero savings amount fields to the capitals payload

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
