### PR TITLE
AP-921 Change provider root

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,3 +1,0 @@
-class HomeController < ApplicationController
-  def index; end
-end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,9 +1,0 @@
-  <% content_for :navigation do %>
-    <!-- no nav needed here -->
-  <% end %>
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-xl"><%= t('.heading_1') %></h1>
-      <%= link_to t('.welcome_home'), providers_root_path, class: 'govuk-body' %>
-    </div>
-  </div>

--- a/config/locales/en/home.yml
+++ b/config/locales/en/home.yml
@@ -1,6 +1,0 @@
----
-en:
-  home:
-    index:
-      heading_1: Apply for Legal Aid
-      welcome_home: Welcome Home

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   mount RailsAdmin::Engine => '/support', as: 'rails_admin'
 
-  root to: 'home#index'
+  root to: 'providers/start#index'
 
   require 'sidekiq/web'
   require 'sidekiq-status/web'


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-921)

A user visiting the application on eg https://apply-for-legal-aid.service.justice.gov.uk is presented with a page displaying 'welcome home'. They should instead see the providers'
start page.

* Amend `routes.rb` so that root instead directs the user to `providers/start#index`
* Remove redundant code for the previous landing page

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
