### PR TITLE
AP-949 Address Fixes

### DIFF
--- a/app/controllers/providers/address_selections_controller.rb
+++ b/app/controllers/providers/address_selections_controller.rb
@@ -46,12 +46,16 @@ module Providers
       end
     end
 
+    def address_titleize(sentence)
+      sentence.to_s&.split(' ')&.map(&:capitalize)&.join(' ')
+    end
+
     def titleize_addresses
       @addresses.each do |a|
-        a[:organisation] = a[:organisation]&.titleize
-        a[:address_line_one] = a[:address_line_one]&.titleize
-        a[:address_line_two] = a[:address_line_two]&.titleize
-        a[:city] = a[:city]&.titleize
+        a[:address_line_one] = address_titleize(a[:address_line_one])
+        a[:address_line_two] = address_titleize(a[:address_line_two])
+        a[:city] = address_titleize(a[:city])
+        a[:county] = address_titleize(a[:county])
       end
     end
   end

--- a/app/controllers/providers/address_selections_controller.rb
+++ b/app/controllers/providers/address_selections_controller.rb
@@ -46,16 +46,16 @@ module Providers
       end
     end
 
-    def address_titleize(sentence)
+    def hyphen_safe_titleize(sentence)
       sentence.to_s&.split(' ')&.map(&:capitalize)&.join(' ')
     end
 
     def titleize_addresses
       @addresses.each do |a|
-        a[:address_line_one] = address_titleize(a[:address_line_one])
-        a[:address_line_two] = address_titleize(a[:address_line_two])
-        a[:city] = address_titleize(a[:city])
-        a[:county] = address_titleize(a[:county])
+        a[:address_line_one] = hyphen_safe_titleize(a[:address_line_one])
+        a[:address_line_two] = hyphen_safe_titleize(a[:address_line_two])
+        a[:city] = hyphen_safe_titleize(a[:city])
+        a[:county] = hyphen_safe_titleize(a[:county])
       end
     end
   end

--- a/app/forms/addresses/address_selection_form.rb
+++ b/app/forms/addresses/address_selection_form.rb
@@ -4,7 +4,7 @@ module Addresses
 
     form_for Address
 
-    attr_accessor :addresses, :postcode, :address_line_one, :address_line_two, :city, :organisation, :lookup_id
+    attr_accessor :addresses, :postcode, :address_line_one, :address_line_two, :city, :county, :lookup_id
 
     before_validation :deserialize_address
 
@@ -20,10 +20,10 @@ module Addresses
     def deserialize_address
       return unless lookup_id.present?
 
-      attributes[:organisation] = selected_address.organisation
       attributes[:address_line_one] = selected_address.address_line_one
       attributes[:address_line_two] = selected_address.address_line_two
       attributes[:city] = selected_address.city
+      attributes[:county] = selected_address.county
       attributes[:lookup_id] = selected_address.lookup_id
     end
 

--- a/app/helpers/address_helper.rb
+++ b/app/helpers/address_helper.rb
@@ -2,9 +2,10 @@ module AddressHelper
   def address_with_line_breaks(address)
     return unless address
 
-    sanitize [address.organisation,
-              "#{address.address_line_one} #{address.address_line_two}",
+    sanitize [address.address_line_one,
+              address.address_line_two,
               address.city,
+              address.county,
               address.pretty_postcode].compact.reject(&:blank?).join('<br>'), tags: ['br']
   end
 end

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -12,18 +12,17 @@ class Address < ApplicationRecord
   validates :city, :postcode, presence: true
 
   before_validation :normalize_postcode
-  before_save :titleize_address
 
   validates :postcode, format: { with: POSTCODE_REGEXP }
   validate :validate_address_lines
 
   def self.from_json(json)
     attrs = JSON.parse(json)
-    new(attrs.slice('organisation', 'address_line_one', 'address_line_two', 'city', 'postcode', 'lookup_id'))
+    new(attrs.slice('address_line_one', 'address_line_two', 'city', 'county', 'postcode', 'lookup_id'))
   end
 
   def full_address
-    [organisation, address_line_one, address_line_two, city, postcode].compact.reject(&:blank?).join(', ')
+    [address_line_one, address_line_two, city, county, postcode].compact.reject(&:blank?).join(', ')
   end
 
   def pretty_postcode
@@ -40,10 +39,10 @@ class Address < ApplicationRecord
 
   def to_json(*_args)
     {
-      organisation: organisation,
       address_line_one: address_line_one,
       address_line_two: address_line_two,
       city: city,
+      county: county,
       postcode: postcode,
       lookup_id: lookup_id
     }.to_json
@@ -62,13 +61,5 @@ class Address < ApplicationRecord
 
     postcode.delete!(' ')
     postcode.upcase!
-  end
-
-  def titleize_address
-    self.organisation = organisation&.titleize
-    self.address_line_one = address_line_one&.titleize
-    self.address_line_two = address_line_two&.titleize
-    self.city = city&.titleize
-    self.county = county&.titleize
   end
 end

--- a/app/serializers/address_serializer.rb
+++ b/app/serializers/address_serializer.rb
@@ -1,3 +1,3 @@
 class AddressSerializer < ActiveModel::Serializer
-  attributes :organisation, :address_line_one, :address_line_two, :city, :county, :postcode, :applicant_id
+  attributes :address_line_one, :address_line_two, :city, :county, :postcode, :applicant_id
 end

--- a/app/services/map_address_lookup_results.rb
+++ b/app/services/map_address_lookup_results.rb
@@ -1,6 +1,10 @@
 class MapAddressLookupResults
-  LINE_ONE_PARTS = %w[SUB_BUILDING_NAME BUILDING_NUMBER BUILDING_NAME].freeze
-  LINE_TWO_PARTS = %w[DEPENDENT_THOROUGHFARE_NAME THOROUGHFARE_NAME].freeze
+  NUMBER = %w[SUB_BUILDING_NAME BUILDING_NUMBER].freeze
+  NUMBER_NAME = %w[SUB_BUILDING_NAME BUILDING_NUMBER BUILDING_NAME].freeze
+  NAME = %w[BUILDING_NAME].freeze
+  FULL_NAME = %w[SUB_BUILDING_NAME BUILDING_NAME].freeze
+  ROAD = %w[DEPENDENT_THOROUGHFARE_NAME THOROUGHFARE_NAME].freeze
+  EVERYTHING = %w[SUB_BUILDING_NAME BUILDING_NUMBER BUILDING_NAME DEPENDENT_THOROUGHFARE_NAME THOROUGHFARE_NAME].freeze
 
   def self.call(results)
     results.map do |result|
@@ -8,12 +12,66 @@ class MapAddressLookupResults
     end
   end
 
+  def self.combine_number(result)
+    result.slice(*NUMBER).values.compact.join(', ')
+  end
+
+  def self.combine_number_name(result)
+    result.slice(*NUMBER_NAME).values.compact.join(', ')
+  end
+
+  def self.combine_full_name(result)
+    result.slice(*FULL_NAME).values.compact.join(', ')
+  end
+
+  def self.combine_road(result)
+    result.slice(*ROAD).values.compact.join(', ')
+  end
+
+  def self.combine_everything(result)
+    result.slice(*EVERYTHING).values.compact.join(', ')
+  end
+
+  def self.combine_number_name_and_road(result)
+    [combine_number_name(result), combine_road(result)].compact.join(' ')
+  end
+
+  def self.combine_number_and_name(result)
+    [combine_number(result), result['BUILDING_NAME']].compact.join(' ')
+  end
+
+  def self.get_line_one(result)
+    if result['BUILDING_NAME'].to_s.length < 9 && result['ORGANISATION_NAME'].nil? # no organisation or building name
+      combine_number_name_and_road(result)
+    elsif result['ORGANISATION_NAME'].nil? && result['BUILDING_NUMBER'].nil? # Building name exists, org doesn't, NO NUMBER
+      combine_full_name(result)
+    elsif result['ORGANISATION_NAME'].nil? # Building name exists, org doesn't, WITH NUMBER
+      combine_number_and_name(result)
+    else # Building name and org both exist # Organisation exists, we put it in address line 1 (where it can be edited), no building name
+      result['ORGANISATION_NAME']
+    end
+  end
+
+  def self.get_line_two(result)
+    if result['BUILDING_NAME'].to_s.length < 9 && result['ORGANISATION_NAME'].nil? # no organisation or building name
+      result['DEPENDENT_LOCALITY']
+    elsif result['ORGANISATION_NAME'].nil? # Building name exists, org doesn't, WITH NUMBER
+      combine_road(result)
+    elsif result['BUILDING_NAME'].to_s.length < 9 # Organisation exists, we put it in address line 1 (where it can be edited), no building name
+      combine_number_name_and_road(result)
+    else # Building name and org both exist
+      combine_everything(result)
+    end
+  end
+
   def self.map_to_address(result)
+    line_one = get_line_one(result)
+    line_two = get_line_two(result)
     Address.new(
-      organisation: result['ORGANISATION_NAME'],
-      address_line_one: result.slice(*LINE_ONE_PARTS).values.compact.join(', '),
-      address_line_two: result.slice(*LINE_TWO_PARTS).values.compact.join(', '),
+      address_line_one: line_one,
+      address_line_two: line_two,
       city: result['POST_TOWN'],
+      county: '',
       postcode: result['POSTCODE'],
       lookup_id: result['UDPRN'] # Unique Delivery Point Reference Number
     )

--- a/app/services/map_address_lookup_results.rb
+++ b/app/services/map_address_lookup_results.rb
@@ -39,12 +39,12 @@ class MapAddressLookupResults
   end
 
   def self.use_dependent_locality?(result)
-    (building_name(result).nil? && organisation_name(result).nil?) ||
-      ((building_name(result).nil? || organisation_name(result).nil?) && thoroughfare_name(result).nil?)
+    (building_name(result).to_s.length < 9 && organisation_name(result).nil?) ||
+      ((building_name(result).to_s.length < 9 || organisation_name(result).nil?) && thoroughfare_name(result).nil?)
   end
 
   def self.get_line_one(result)
-    return combine_with_road(result, *NUMBER_NAME, ' ') if building_name(result).nil? && organisation_name(result).nil?
+    return combine_with_road(result, *NUMBER_NAME, ' ') if building_name(result).to_s.length < 9 && organisation_name(result).nil?
     return combine(result, *FULL_NAME) if organisation_name(result).nil?
 
     organisation_name(result)

--- a/features/providers/civil_application_journey.feature
+++ b/features/providers/civil_application_journey.feature
@@ -48,7 +48,7 @@ Feature: Civil application journeys
     Then I am on the postcode entry page
     Then I enter a postcode 'DA74NG'
     Then I click find address
-    Then I select an address '3, Lonsdale Road, Bexleyheath, DA7 4NG'
+    Then I select an address '3 Lonsdale Road, Bexleyheath, DA7 4NG'
     Then I click 'Save and continue'
     When the search for "cakes" is not successful
     Then the result list on page returns a "No results found." message
@@ -67,7 +67,7 @@ Feature: Civil application journeys
     Then I am on the postcode entry page
     Then I enter a postcode 'DA74NG'
     Then I click find address
-    Then I select an address '3, Lonsdale Road, Bexleyheath, DA7 4NG'
+    Then I select an address '3 Lonsdale Road, Bexleyheath, DA7 4NG'
     Then I click 'Save and continue'
     And I search for proceeding 'app'
     Then proceeding suggestions has results
@@ -87,7 +87,7 @@ Feature: Civil application journeys
     Then I am on the postcode entry page
     Then I enter a postcode 'DA74NG'
     Then I click find address
-    Then I select an address '3, Lonsdale Road, Bexleyheath, DA7 4NG'
+    Then I select an address '3 Lonsdale Road, Bexleyheath, DA7 4NG'
     Then I click 'Save and continue'
     Then I expect to see 0 proceeding types selected
     And I search for proceeding 'app'
@@ -121,7 +121,7 @@ Feature: Civil application journeys
     Then I am on the postcode entry page
     Then I enter a postcode 'DA74NG'
     Then I click find address
-    Then I select an address '3, Lonsdale Road, Bexleyheath, DA7 4NG'
+    Then I select an address '3 Lonsdale Road, Bexleyheath, DA7 4NG'
     Then I click 'Save and continue'
     Then I search for proceeding 'Non-molestation order'
     Then proceeding suggestions has results
@@ -194,7 +194,7 @@ Feature: Civil application journeys
     Then I am on the postcode entry page
     Then I enter a postcode 'DA74NG'
     Then I click find address
-    Then I select an address '3, Lonsdale Road, Bexleyheath, DA7 4NG'
+    Then I select an address '3 Lonsdale Road, Bexleyheath, DA7 4NG'
     Then I click 'Save and continue'
     Then I search for proceeding 'Non-molestation order'
     Then proceeding suggestions has results
@@ -223,7 +223,7 @@ Feature: Civil application journeys
     Then I am on the postcode entry page
     Then I enter a postcode 'DA74NG'
     Then I click find address
-    Then I select an address '3, Lonsdale Road, Bexleyheath, DA7 4NG'
+    Then I select an address '3 Lonsdale Road, Bexleyheath, DA7 4NG'
     Then I click 'Save and continue'
     Then I search for proceeding 'Non-molestation order'
     Then proceeding suggestions has results
@@ -291,7 +291,7 @@ Feature: Civil application journeys
     Then I am on the postcode entry page
     Then I enter a postcode 'DA74NG'
     Then I click find address
-    Then I select an address '3, Lonsdale Road, Bexleyheath, DA7 4NG'
+    Then I select an address '3 Lonsdale Road, Bexleyheath, DA7 4NG'
     Then I click 'Save and continue'
     Then I should be on a page showing 'Check your answers'
 

--- a/spec/requests/providers/check_provider_answers_spec.rb
+++ b/spec/requests/providers/check_provider_answers_spec.rb
@@ -86,13 +86,13 @@ RSpec.describe 'check your answers requests', type: :request do
       it 'formats the address correctly' do
         address = application.applicant.addresses[0]
 
-        expect(unescaped_response_body).to include("#{address.address_line_one} #{address.address_line_two}<br>#{address.city}<br>#{address.pretty_postcode}")
+        expect(unescaped_response_body).to include("#{address.address_line_one}<br>#{address.address_line_two}<br>#{address.city}<br>#{address.county}<br>#{address.pretty_postcode}")
       end
 
       context 'when an address includes an organisation but no address_line_one' do
-        let(:address) { create :address, organisation: 'Honeysuckle Cottage', address_line_one: nil, address_line_two: 'Station Road', city: 'Dartford', postcode: 'DA4 0EN' }
+        let(:address) { create :address, address_line_one: 'Honeysuckle Cottage', address_line_two: 'Station Road', city: 'Dartford', county: '', postcode: 'DA4 0EN' }
         it 'formats the address correctly' do
-          expect(unescaped_response_body).to include('Honeysuckle Cottage<br> Station Road<br>Dartford<br>DA4 0EN')
+          expect(unescaped_response_body).to include('Honeysuckle Cottage<br>Station Road<br>Dartford<br>DA4 0EN')
         end
       end
 

--- a/spec/services/map_address_lookup_results_spec.rb
+++ b/spec/services/map_address_lookup_results_spec.rb
@@ -1,0 +1,219 @@
+require 'rails_helper'
+
+RSpec.describe MapAddressLookupResults do
+  subject(:service) { described_class }
+
+  describe '#call' do
+    context 'building number, street, town, city, postcode' do
+      let(:result) do
+        [{ 'DPA' =>
+         { 'ADDRESS' => '1, BIRKS, SLAITHWAITE, HUDDERSFIELD, HD7 5UZ',
+           'BUILDING_NUMBER' => '1',
+           'THOROUGHFARE_NAME' => 'BIRKS',
+           'DEPENDENT_LOCALITY' => 'SLAITHWAITE',
+           'POST_TOWN' => 'HUDDERSFIELD',
+           'POSTCODE' => 'HD7 5UZ' } }]
+      end
+
+      it 'returns the correct address' do
+        address = service.call(result).first
+        expect(address.address_line_one).to eq '1 BIRKS'
+        expect(address.address_line_two).to eq 'SLAITHWAITE'
+        expect(address.city).to eq 'HUDDERSFIELD'
+        expect(address.county).to be nil
+        expect(address.postcode).to eq 'HD7 5UZ'
+      end
+    end
+
+    context 'building name, street, town, city, postcode' do
+      let(:result) do
+        [{ 'DPA' =>
+         { 'ADDRESS' => 'OWLERS CLOUGH, LOWER LAUNDS, SLAITHWAITE, HUDDERSFIELD, HD7 5UZ',
+           'BUILDING_NAME' => 'OWLERS CLOUGH',
+           'THOROUGHFARE_NAME' => 'LOWER LAUNDS',
+           'DEPENDENT_LOCALITY' => 'SLAITHWAITE',
+           'POST_TOWN' => 'HUDDERSFIELD',
+           'POSTCODE' => 'HD7 5UZ' } }]
+      end
+
+      it 'returns the correct address' do
+        address = service.call(result).first
+        expect(address.address_line_one).to eq 'OWLERS CLOUGH'
+        expect(address.address_line_two).to eq 'LOWER LAUNDS'
+        expect(address.city).to eq 'HUDDERSFIELD'
+        expect(address.county).to be nil
+        expect(address.postcode).to eq 'HD7 5UZ'
+      end
+    end
+
+    context 'organisation, town, city, postcode' do
+      let(:result) do
+        [{ 'DPA' =>
+         { 'ADDRESS' => 'CHAPEL SHRED, SLAITHWAITE, HUDDERSFIELD, HD7 5UZ',
+           'ORGANISATION_NAME' => 'CHAPEL SHRED',
+           'DEPENDENT_LOCALITY' => 'SLAITHWAITE',
+           'POST_TOWN' => 'HUDDERSFIELD',
+           'POSTCODE' => 'HD7 5UZ' } }]
+      end
+
+      it 'returns the correct address' do
+        address = service.call(result).first
+        expect(address.address_line_one).to eq 'CHAPEL SHRED'
+        expect(address.address_line_two).to eq 'SLAITHWAITE'
+        expect(address.city).to eq 'HUDDERSFIELD'
+        expect(address.county).to be nil
+        expect(address.postcode).to eq 'HD7 5UZ'
+      end
+    end
+
+    context 'organisation, building name, town, city, postcode' do
+      let(:result) do
+        [{ 'DPA' =>
+         { 'ADDRESS' => 'GREYSTONES FARM, BRADSHAW LANE, SLAITHWAITE, HUDDERSFIELD, HD7 5UZ',
+           'ORGANISATION_NAME' => 'GREYSTONES FARM',
+           'BUILDING_NAME' => 'BRADSHAW LANE',
+           'DEPENDENT_LOCALITY' => 'SLAITHWAITE',
+           'POST_TOWN' => 'HUDDERSFIELD',
+           'POSTCODE' => 'HD7 5UZ' } }]
+      end
+
+      it 'returns the correct address' do
+        address = service.call(result).first
+        expect(address.address_line_one).to eq 'GREYSTONES FARM'
+        expect(address.address_line_two).to eq 'BRADSHAW LANE'
+        expect(address.city).to eq 'HUDDERSFIELD'
+        expect(address.county).to be nil
+        expect(address.postcode).to eq 'HD7 5UZ'
+      end
+    end
+
+    context 'organisation, building name, street, town, city, postcode' do
+      let(:result) do
+        [{ 'DPA' =>
+         { 'ADDRESS' => 'PHILIP SUNLEY TRANSPORT LTD, LOWER LAUND FARM, LOWER LAUNDS, SLAITHWAITE, HUDDERSFIELD, HD7 5UZ',
+           'ORGANISATION_NAME' => 'PHILIP SUNLEY TRANSPORT LTD',
+           'BUILDING_NAME' => 'LOWER LAUND FARM',
+           'THOROUGHFARE_NAME' => 'LOWER LAUNDS',
+           'DEPENDENT_LOCALITY' => 'SLAITHWAITE',
+           'POST_TOWN' => 'HUDDERSFIELD',
+           'POSTCODE' => 'HD7 5UZ' } }]
+      end
+
+      it 'returns the correct address' do
+        address = service.call(result).first
+        expect(address.address_line_one).to eq 'PHILIP SUNLEY TRANSPORT LTD'
+        expect(address.address_line_two).to eq 'LOWER LAUND FARM, LOWER LAUNDS'
+        expect(address.city).to eq 'HUDDERSFIELD'
+        expect(address.county).to be nil
+        expect(address.postcode).to eq 'HD7 5UZ'
+      end
+    end
+
+    context 'building name, town, city, postcode' do
+      let(:result) do
+        [{ 'DPA' =>
+         { 'ADDRESS' => 'THE LAITHE, SLAITHWAITE, HUDDERSFIELD, HD7 5UZ',
+           'BUILDING_NAME' => 'THE LAITHE',
+           'DEPENDENT_LOCALITY' => 'SLAITHWAITE',
+           'POST_TOWN' => 'HUDDERSFIELD',
+           'POSTCODE' => 'HD7 5UZ' } }]
+      end
+
+      it 'returns the correct address' do
+        address = service.call(result).first
+        expect(address.address_line_one).to eq 'THE LAITHE'
+        expect(address.address_line_two).to eq 'SLAITHWAITE'
+        expect(address.city).to eq 'HUDDERSFIELD'
+        expect(address.county).to be nil
+        expect(address.postcode).to eq 'HD7 5UZ'
+      end
+    end
+
+    context 'organisation, building number, street, town, city, postcode' do
+      let(:result) do
+        [{ 'DPA' =>
+         { 'ADDRESS' => 'GOAT HILL FARM, 2, GOAT HILL, SLAITHWAITE, HUDDERSFIELD, HD7 5UZ',
+           'ORGANISATION_NAME' => 'GOAT HILL FARM',
+           'BUILDING_NUMBER' => '2',
+           'THOROUGHFARE_NAME' => 'GOAT HILL',
+           'DEPENDENT_LOCALITY' => 'SLAITHWAITE',
+           'POST_TOWN' => 'HUDDERSFIELD',
+           'POSTCODE' => 'HD7 5UZ' } }]
+      end
+
+      it 'returns the correct address' do
+        address = service.call(result).first
+        expect(address.address_line_one).to eq 'GOAT HILL FARM'
+        expect(address.address_line_two).to eq '2 GOAT HILL'
+        expect(address.city).to eq 'HUDDERSFIELD'
+        expect(address.county).to be nil
+        expect(address.postcode).to eq 'HD7 5UZ'
+      end
+    end
+
+    context 'organisation, building number, building name, street, town, city, postcode' do
+      let(:result) do
+        [{ 'DPA' =>
+         { 'ADDRESS' => 'HARINGEY COUNCIL, RIVER PARK HOUSE, 225, HIGH ROAD, LONDON, N22 8HQ',
+           'ORGANISATION_NAME' => 'HARINGEY COUNCIL',
+           'BUILDING_NAME' => 'RIVER PARK HOUSE',
+           'BUILDING_NUMBER' => '225',
+           'THOROUGHFARE_NAME' => 'HIGH ROAD',
+           'POST_TOWN' => 'LONDON',
+           'POSTCODE' => 'N22 8HQ' } }]
+      end
+
+      it 'returns the correct address' do
+        address = service.call(result).first
+        expect(address.address_line_one).to eq 'HARINGEY COUNCIL'
+        expect(address.address_line_two).to eq 'RIVER PARK HOUSE, 225 HIGH ROAD'
+        expect(address.city).to eq 'LONDON'
+        expect(address.county).to be nil
+        expect(address.postcode).to eq 'N22 8HQ'
+      end
+    end
+
+    context 'organisation, building sub-name, building number, street, town, city, postcode' do
+      let(:result) do
+        [{ 'DPA' =>
+         { 'ADDRESS' => 'CLYDE OFFICES, 2/3, 48, WEST GEORGE STREET, GLASGOW, G2 1BP',
+           'ORGANISATION_NAME' => 'CLYDE OFFICES',
+           'SUB_BUILDING_NAME' => '2/3',
+           'BUILDING_NUMBER' => '48',
+           'THOROUGHFARE_NAME' => 'WEST GEORGE STREET',
+           'POST_TOWN' => 'GLASGOW',
+           'POSTCODE' => 'G2 1BP' } }]
+      end
+
+      it 'returns the correct address' do
+        address = service.call(result).first
+        expect(address.address_line_one).to eq 'CLYDE OFFICES'
+        expect(address.address_line_two).to eq '2/3, 48 WEST GEORGE STREET'
+        expect(address.city).to eq 'GLASGOW'
+        expect(address.county).to be nil
+        expect(address.postcode).to eq 'G2 1BP'
+      end
+    end
+
+    context 'building name, building number, street, town, city, postcode' do
+      let(:result) do
+        [{ 'DPA' =>
+         { 'ADDRESS' => 'FAKE HOUSE, 161, FAKE STREET, LONDON, W1 1ZZ',
+           'BUILDING_NAME' => 'FAKE HOUSE',
+           'BUILDING_NUMBER' => '161',
+           'THOROUGHFARE_NAME' => 'FAKE STREET',
+           'POST_TOWN' => 'LONDON',
+           'POSTCODE' => 'W1 1ZZ' } }]
+      end
+
+      it 'returns the correct address' do
+        address = service.call(result).first
+        expect(address.address_line_one).to eq 'FAKE HOUSE'
+        expect(address.address_line_two).to eq '161 FAKE STREET'
+        expect(address.city).to eq 'LONDON'
+        expect(address.county).to be nil
+        expect(address.postcode).to eq 'W1 1ZZ'
+      end
+    end
+  end
+end

--- a/spec/services/map_address_lookup_results_spec.rb
+++ b/spec/services/map_address_lookup_results_spec.rb
@@ -46,6 +46,27 @@ RSpec.describe MapAddressLookupResults do
       end
     end
 
+    context 'short building name, street, town, city, postcode' do
+      let(:result) do
+        [{ 'DPA' =>
+         { 'ADDRESS' => '29A, MOOREND ROAD, YARDLEY GOBION, TOWCESTER, NN12 7UF',
+           'BUILDING_NAME' => '29A',
+           'THOROUGHFARE_NAME' => 'MOOREND ROAD',
+           'DEPENDENT_LOCALITY' => 'YARDLEY GOBION',
+           'POST_TOWN' => 'TOWCESTER',
+           'POSTCODE' => 'NN12 7UF' } }]
+      end
+
+      it 'returns the correct address' do
+        address = service.call(result).first
+        expect(address.address_line_one).to eq '29A MOOREND ROAD'
+        expect(address.address_line_two).to eq 'YARDLEY GOBION'
+        expect(address.city).to eq 'TOWCESTER'
+        expect(address.county).to be nil
+        expect(address.postcode).to eq 'NN12 7UF'
+      end
+    end
+
     context 'organisation, town, city, postcode' do
       let(:result) do
         [{ 'DPA' =>


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-949)

- Examined the return from the address API and put different bits into different areas as needed.  Example: If Organisation is there, it goes on line 1, otherwise the street name and number does.  
- Removed the Organisation field (it now goes into line 1) as this was not editable.
- Added in the county field, so manually entered addresses with a county have that shew up on the CYA screen.
- Undid the wrapping of AP-813 - this should no longer be necessary.
- Changed the capitalisation code to keep hyphens and stop putting spaces between numbers and letters.

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
