### PR TITLE
Ap 952 create valid substantive case

### DIFF
--- a/app/services/ccms/attribute_value_generator.rb
+++ b/app/services/ccms/attribute_value_generator.rb
@@ -184,6 +184,14 @@ module CCMS
       lead_proceeding_type.ccms_category_law_code
     end
 
+    def application_substantive?(_options)
+      !@legal_aid_application.used_delegated_functions?
+    end
+
+    def proceeding_proceeding_application_type(_options)
+      @legal_aid_application.used_delegated_functions? ? 'Both' : 'Substantive'
+    end
+
     PROSPECTS_OF_SUCCESS = {
       likely: 'Good',
       marginal: 'Marginal',

--- a/app/services/ccms/case_add_requestor.rb
+++ b/app/services/ccms/case_add_requestor.rb
@@ -75,8 +75,8 @@ module CCMS
       xml.__send__('ns2:Proceedings') { generate_proceedings(xml) }
       xml.__send__('ns2:MeansAssesments') { generate_means_assessment(xml) }
       xml.__send__('ns2:MeritsAssesments') { generate_merits_assessment(xml) }
-      xml.__send__('ns2:DevolvedPowersDate', '2019-04-01')  # TODO: CCMS placeholder
-      xml.__send__('ns2:ApplicationAmendmentType', 'SUBDP') # TODO: CCMS placeholder
+      xml.__send__('ns2:DevolvedPowersDate', '2019-04-01') # TODO: CCMS placeholder
+      xml.__send__('ns2:ApplicationAmendmentType', @legal_aid_application.used_delegated_functions? ? 'SUBDP' : 'SUB')
       xml.__send__('ns2:LARDetails') { generate_lar_details(xml) }
     end
 

--- a/ccms_integration/ccms_spec.rb
+++ b/ccms_integration/ccms_spec.rb
@@ -50,7 +50,8 @@ module CCMS
              user_login_id: 2_016_472,
              supervisor_contact_id: 3_982_723,
              fee_earner_contact_id: 34_419,
-             marked_for_destruction?: false
+             marked_for_destruction?: false,
+             email: 'test@test.com'
     end
 
     let(:substantive_legal_aid_application) do

--- a/config/ccms/ccms_keys.yml
+++ b/config/ccms/ccms_keys.yml
@@ -2679,14 +2679,12 @@ global_merits:
     :response_type: text
     :user_defined: true
   CURRENT_CERT_SUBSTANTIVE:
-    :generate_block?: false
     :value: false
     :br100_meaning: 'App: The Current Certificate Is Substantive'
     :response_type: boolean
     :user_defined: false
   SUBSTANTIVE_APP:
-    :generate_block?: false
-    :value: false
+    :value: '#application_substantive?'
     :br100_meaning: The Application Is A Substantive Application
     :response_type: boolean
     :user_defined: false
@@ -4527,7 +4525,6 @@ proceeding_merits:
     :br100_meaning: The Proceeding Application Type
     :response_type: text
     :user_defined: false
-    :generate_block?: false
   CLIENT_INV_TYPE_BRING_3RD_PTY:
     :generate_block?: false
     :value: "#proceeding_client_inv_type_bring_3rd_pty"

--- a/spec/services/ccms/case_add_requestor_xml_blocks_spec.rb
+++ b/spec/services/ccms/case_add_requestor_xml_blocks_spec.rb
@@ -464,55 +464,59 @@ module CCMS # rubocop:disable Metrics/ModuleLength
 
       context 'APP_AMEND_TYPE' do
         context 'delegated function used' do
-          context 'in global_merits section' do
-            it 'returns SUBDP' do
-              allow(legal_aid_application).to receive(:used_delegated_functions?).and_return(true)
-              allow(legal_aid_application).to receive(:used_delegated_functions_on).and_return(Date.today)
-              block = XmlExtractor.call(xml, :global_merits, 'APP_AMEND_TYPE')
-              expect(block).to have_text_response 'SUBDP'
-            end
+          let(:legal_aid_application) do
+            create :legal_aid_application,
+                   :with_everything,
+                   :with_applicant_and_address,
+                   populate_vehicle: true,
+                   with_bank_accounts: 2,
+                   proceeding_types: [proceeding_type],
+                   provider: provider,
+                   used_delegated_functions: true,
+                   used_delegated_functions_on: Date.today
           end
-          context 'in global_means section;' do
-            it 'returns SUBDP' do
-              allow(legal_aid_application).to receive(:used_delegated_functions?).and_return(true)
-              allow(legal_aid_application).to receive(:used_delegated_functions_on).and_return(Date.today)
-              block = XmlExtractor.call(xml, :global_means, 'APP_AMEND_TYPE')
+
+          it 'returns SUBDP' do
+            %i[global_means global_merits].each do |entity|
+              block = XmlExtractor.call(xml, entity, 'APP_AMEND_TYPE')
               expect(block).to have_text_response 'SUBDP'
             end
           end
         end
 
         context 'delegated functions not used' do
-          context 'in global_merits section' do
-            it 'returns SUB' do
-              block = XmlExtractor.call(xml, :global_merits, 'APP_AMEND_TYPE')
+          it 'returns SUB' do
+            %i[global_means global_merits].each do |entity|
+              block = XmlExtractor.call(xml, entity, 'APP_AMEND_TYPE')
               expect(block).to have_text_response 'SUB'
-            end
-
-            context 'in global_means section;' do
-              it 'returns SUB' do
-                block = XmlExtractor.call(xml, :global_means, 'APP_AMEND_TYPE')
-                expect(block).to have_text_response 'SUB'
-              end
             end
           end
         end
       end
 
       context 'EMERGENCY_FURTHER_INFORMATION' do
+        let(:block) { XmlExtractor.call(xml, :global_merits, 'EMERGENCY_FURTHER_INFORMATION') }
+
         context 'delegated function used' do
+          let(:legal_aid_application) do
+            create :legal_aid_application,
+                   :with_everything,
+                   :with_applicant_and_address,
+                   populate_vehicle: true,
+                   with_bank_accounts: 2,
+                   proceeding_types: [proceeding_type],
+                   provider: provider,
+                   used_delegated_functions: true,
+                   used_delegated_functions_on: Date.today
+          end
+
           it 'returns hard coded statement' do
-            allow(legal_aid_application).to receive(:used_delegated_functions?).and_return(true)
-            allow(legal_aid_application).to receive(:used_delegated_functions_on).and_return(Date.today)
-            block = XmlExtractor.call(xml, :global_merits, 'EMERGENCY_FURTHER_INFORMATION')
             expect(block).to have_text_response 'Apply Service application - see uploaded provider statement of case'
           end
         end
 
         context 'delegated function not used' do
           it 'EMERGENCY_FURTHER_INFORMATION block is not present' do
-            allow(legal_aid_application).to receive(:used_delegated_functions?).and_return(false)
-            block = XmlExtractor.call(xml, :global_merits, 'EMERGENCY_FURTHER_INFORMATION')
             expect(block).not_to be_present
           end
         end

--- a/spec/services/ccms/case_add_requestor_xml_blocks_spec.rb
+++ b/spec/services/ccms/case_add_requestor_xml_blocks_spec.rb
@@ -1054,16 +1054,58 @@ module CCMS # rubocop:disable Metrics/ModuleLength
       end
 
       context 'SUBSTANTIVE_APP populates correctly' do
-        it 'returns true when application is substantive' do
-          block = XmlExtractor.call(xml, :global_merits, 'SUBSTANTIVE_APP')
-          expect(block).to have_boolean_response true
+        let(:block) { XmlExtractor.call(xml, :global_merits, 'SUBSTANTIVE_APP') }
+
+        context 'substantive' do
+          it 'returns true' do
+            expect(block).to have_boolean_response true
+          end
+        end
+
+        context 'delegated_functions' do
+          let(:legal_aid_application) do
+            create :legal_aid_application,
+                   :with_everything,
+                   :with_applicant_and_address,
+                   populate_vehicle: true,
+                   with_bank_accounts: 2,
+                   proceeding_types: [proceeding_type],
+                   provider: provider,
+                   used_delegated_functions: true,
+                   used_delegated_functions_on: Date.today
+          end
+
+          it 'returns false' do
+            expect(block).to have_boolean_response false
+          end
         end
       end
 
       context 'PROCEEDING_APPLICATION_TYPE populates correctly' do
-        it 'returns Substantive when application is substantive' do
-          block = XmlExtractor.call(xml, :proceeding_merits, 'PROCEEDING_APPLICATION_TYPE')
-          expect(block).to have_text_response 'Substantive'
+        let(:block) { XmlExtractor.call(xml, :proceeding_merits, 'PROCEEDING_APPLICATION_TYPE') }
+
+        context 'substantive' do
+          it 'returns Substantive' do
+            expect(block).to have_text_response 'Substantive'
+          end
+        end
+
+        context 'delegated functions' do
+          let(:legal_aid_application) do
+            create :legal_aid_application,
+                   :with_everything,
+                   :with_applicant_and_address,
+                   populate_vehicle: true,
+                   with_bank_accounts: 2,
+                   proceeding_types: [proceeding_type],
+                   provider: provider,
+                   used_delegated_functions: true,
+                   used_delegated_functions_on: Date.today
+          end
+
+          it 'returns Both' do
+            expect(block).to have_text_response 'Both'
+          end
         end
       end
     end

--- a/spec/services/ccms/case_add_requestor_xml_blocks_spec.rb
+++ b/spec/services/ccms/case_add_requestor_xml_blocks_spec.rb
@@ -471,33 +471,13 @@ module CCMS # rubocop:disable Metrics/ModuleLength
               block = XmlExtractor.call(xml, :global_merits, 'APP_AMEND_TYPE')
               expect(block).to have_text_response 'SUBDP'
             end
-
-            context 'in global_means section;' do
-              it 'returns SUBDP' do
-                allow(legal_aid_application).to receive(:used_delegated_functions?).and_return(true)
-                allow(legal_aid_application).to receive(:used_delegated_functions_on).and_return(Date.today)
-                block = XmlExtractor.call(xml, :global_means, 'APP_AMEND_TYPE')
-                expect(block).to have_text_response 'SUBDP'
-              end
-            end
           end
-        end
-
-        context 'EMERGENCY_FURTHER_INFORMATION' do
-          context 'delegated function used' do
-            it 'returns hard coded statement' do
+          context 'in global_means section;' do
+            it 'returns SUBDP' do
               allow(legal_aid_application).to receive(:used_delegated_functions?).and_return(true)
               allow(legal_aid_application).to receive(:used_delegated_functions_on).and_return(Date.today)
-              block = XmlExtractor.call(xml, :global_merits, 'EMERGENCY_FURTHER_INFORMATION')
-              expect(block).to have_text_response 'Apply Service application - see uploaded provider statement of case'
-            end
-          end
-
-          context 'delegated function not used' do
-            it 'EMERGENCY_FURTHER_INFORMATION block is not present' do
-              allow(legal_aid_application).to receive(:used_delegated_functions?).and_return(false)
-              block = XmlExtractor.call(xml, :global_merits, 'EMERGENCY_FURTHER_INFORMATION')
-              expect(block).not_to be_present
+              block = XmlExtractor.call(xml, :global_means, 'APP_AMEND_TYPE')
+              expect(block).to have_text_response 'SUBDP'
             end
           end
         end
@@ -515,6 +495,25 @@ module CCMS # rubocop:disable Metrics/ModuleLength
                 expect(block).to have_text_response 'SUB'
               end
             end
+          end
+        end
+      end
+
+      context 'EMERGENCY_FURTHER_INFORMATION' do
+        context 'delegated function used' do
+          it 'returns hard coded statement' do
+            allow(legal_aid_application).to receive(:used_delegated_functions?).and_return(true)
+            allow(legal_aid_application).to receive(:used_delegated_functions_on).and_return(Date.today)
+            block = XmlExtractor.call(xml, :global_merits, 'EMERGENCY_FURTHER_INFORMATION')
+            expect(block).to have_text_response 'Apply Service application - see uploaded provider statement of case'
+          end
+        end
+
+        context 'delegated function not used' do
+          it 'EMERGENCY_FURTHER_INFORMATION block is not present' do
+            allow(legal_aid_application).to receive(:used_delegated_functions?).and_return(false)
+            block = XmlExtractor.call(xml, :global_merits, 'EMERGENCY_FURTHER_INFORMATION')
+            expect(block).not_to be_present
           end
         end
       end
@@ -1049,6 +1048,20 @@ module CCMS # rubocop:disable Metrics/ModuleLength
           expect(block).to have_text_response application_proceeding_type.proceeding_type.ccms_code
         end
       end
+
+      context 'SUBSTANTIVE_APP populates correctly' do
+        it 'returns true when application is substantive' do
+          block = XmlExtractor.call(xml, :global_merits, 'SUBSTANTIVE_APP')
+          expect(block).to have_boolean_response true
+        end
+      end
+
+      context 'PROCEEDING_APPLICATION_TYPE populates correctly' do
+        it 'returns Substantive when application is substantive' do
+          block = XmlExtractor.call(xml, :proceeding_merits, 'PROCEEDING_APPLICATION_TYPE')
+          expect(block).to have_text_response 'Substantive'
+        end
+      end
     end
   end
 
@@ -1233,7 +1246,6 @@ module CCMS # rubocop:disable Metrics/ModuleLength
       [:global_merits, 'CRIME'],
       [:global_merits, 'CROWN_COURT'],
       [:global_merits, 'CURRENT_CERT_EMERGENCY'],
-      [:global_merits, 'CURRENT_CERT_SUBSTANTIVE'],
       [:global_merits, 'DEC_AGAINST_INSTRUCTIONS'],
       [:global_merits, 'DEC_CLIENT_TEXT_PARA02A'],
       [:global_merits, 'DEC_CLIENT_TEXT_PARA10A'],
@@ -1311,7 +1323,6 @@ module CCMS # rubocop:disable Metrics/ModuleLength
       [:global_merits, 'SMOD_APPLICABLE_TO_MATTER'],
       [:global_merits, 'SPECIAL_CHILDREN_ACT_APP'],
       [:global_merits, 'SPECIAL_IMM_APPEAL_COMMISSION'],
-      [:global_merits, 'SUBSTANTIVE_APP'],
       [:global_merits, 'SUPREME_COURT'],
       [:global_merits, 'UPPER_TRIBUNAL_IMM_ASY'],
       [:global_merits, 'UPPER_TRIBUNAL_MENTAL_HEALTH'],
@@ -1434,7 +1445,6 @@ module CCMS # rubocop:disable Metrics/ModuleLength
       [:proceeding_merits, 'PROC_SUBJECT_TO_DP_CHECK'],
       [:proceeding_merits, 'PROC_SUBJECT_TO_MEDIATION'],
       [:proceeding_merits, 'PROC_UPPER_TRIBUNAL'],
-      [:proceeding_merits, 'PROCEEDING_APPLICATION_TYPE'],
       [:proceeding_merits, 'PROCEEDING_CASE_OWNER_SCU'],
       [:proceeding_merits, 'PROCEEDING_DESCRIPTION'],
       [:proceeding_merits, 'PROCEEDING_INCLUDES_CHILD'],
@@ -1587,6 +1597,7 @@ module CCMS # rubocop:disable Metrics/ModuleLength
       [:global_merits, 'COST_LIMIT_CHANGED'],
       [:global_merits, 'COST_LIMIT_CHANGED_FLAG'],
       [:global_merits, 'COURT_ATTEND_IN_LAST_12_MONTHS'],
+      [:global_merits, 'CURRENT_CERT_SUBSTANTIVE'],
       [:global_merits, 'DECLARATION_IDENTIFIER'],
       [:global_merits, 'ECF_FLAG'],
       [:global_merits, 'EVID_DEC_AGAINST_INSTRUCTIONS'],


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-952)

There are issues with substantive case payloads being injected in CCMS. This PR fixes the following issues:

* `ApplicationAmendmentType` is incorrectly being set as `SUBDP` for all cases. It should be `SUB` for substantive cases and `SUBDP` for delegated functions cases.
*  `CURRENT_CERT_SUBSTANTIVE`, `SUBSTANTIVE_APP` and `PROCEEDING_APPLICATION_TYPE` attributes are currently omitted. These should be included with values of `false`, `true` and `Substantive` for substantive cases, and `false`, `false` and `Both` for delegated functions cases.
* Fix a bug caused by a change to the `provider` model which was causing the `ccms_spec` to fail - add an email address to the provider double.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
