### PR TITLE
AP-941 Add service to pass property data to eligibility API

### DIFF
--- a/app/models/concerns/cfe_submission_state_machine.rb
+++ b/app/models/concerns/cfe_submission_state_machine.rb
@@ -35,7 +35,7 @@ module CFESubmissionStateMachine
       end
 
       event :results_obtained do
-        transitions from: :vehicles_created, to: :results_obtained
+        transitions from: :properties_created, to: :results_obtained
       end
 
       event :fail do

--- a/app/services/cfe/base_service.rb
+++ b/app/services/cfe/base_service.rb
@@ -4,6 +4,8 @@ module CFE
       new(submission).call
     end
 
+    attr_reader :submission
+
     def initialize(submission)
       @submission = submission
     end

--- a/app/services/cfe/create_properties_service.rb
+++ b/app/services/cfe/create_properties_service.rb
@@ -20,7 +20,7 @@ module CFE
         value: legal_aid_application.property_value,
         outstanding_mortgage: legal_aid_application.outstanding_mortgage_amount,
         percentage_owned: legal_aid_application.percentage_home,
-        shared_with_housing_assoc: false # Place holder - Expect param to be removed from API
+        shared_with_housing_assoc: main_home_shared_with_housing_association_or_landlord?
       }
     end
 
@@ -29,7 +29,7 @@ module CFE
         value: or_zero(other_assets_declaration&.second_home_value),
         outstanding_mortgage: or_zero(other_assets_declaration&.second_home_mortgage),
         percentage_owned: or_zero(other_assets_declaration&.second_home_percentage),
-        shared_with_housing_assoc: false # Place holder - Expect param to be removed from API
+        shared_with_housing_assoc: false # Data not gathered for second home
       }
     end
 
@@ -39,6 +39,10 @@ module CFE
 
     def process_response
       submission.properties_created!
+    end
+
+    def main_home_shared_with_housing_association_or_landlord?
+      legal_aid_application.shared_ownership == 'housing_assocation_or_landlord'
     end
   end
 end

--- a/app/services/cfe/create_properties_service.rb
+++ b/app/services/cfe/create_properties_service.rb
@@ -1,0 +1,44 @@
+module CFE
+  class CreatePropertiesService < BaseService
+    delegate :other_assets_declaration, to: :legal_aid_application
+
+    def cfe_url_path
+      "/assessments/#{@submission.assessment_id}/properties"
+    end
+
+    def request_body
+      {
+        properties: {
+          main_home: main_home,
+          additional_properties: [second_home]
+        }
+      }.to_json
+    end
+
+    def main_home
+      {
+        value: legal_aid_application.property_value,
+        outstanding_mortgage: legal_aid_application.outstanding_mortgage_amount,
+        percentage_owned: legal_aid_application.percentage_home,
+        shared_with_housing_assoc: false # Place holder - Expect param to be removed from API
+      }
+    end
+
+    def second_home
+      {
+        value: or_zero(other_assets_declaration&.second_home_value),
+        outstanding_mortgage: or_zero(other_assets_declaration&.second_home_mortgage),
+        percentage_owned: or_zero(other_assets_declaration&.second_home_percentage),
+        shared_with_housing_assoc: false # Place holder - Expect param to be removed from API
+      }
+    end
+
+    def or_zero(number)
+      number || 0
+    end
+
+    def process_response
+      submission.properties_created!
+    end
+  end
+end

--- a/app/services/cfe/create_vehicles_service.rb
+++ b/app/services/cfe/create_vehicles_service.rb
@@ -10,7 +10,7 @@ module CFE
           {
             value: vehicle.estimated_value,
             loan_amount_outstanding: vehicle.payment_remaining,
-            date_of_purchase: vehicle.purchased_on.strftime('%Y-%m-%d'),
+            date_of_purchase: vehicle.purchased_on&.strftime('%Y-%m-%d'),
             in_regular_use: vehicle.used_regularly
           }
         ]

--- a/app/services/cfe/submission_manager.rb
+++ b/app/services/cfe/submission_manager.rb
@@ -13,8 +13,8 @@ module CFE
       CFE::CreateAssessmentService.call(submission)
       CFE::CreateApplicantService.call(submission)
       CFE::CreateCapitalsService.call(submission)
-      CFE::CreatePropertiesService.call(submission)
       CFE::CreateVehiclesService.call(submission)
+      CFE::CreatePropertiesService.call(submission)
 
       # TODO: add these steps as we write the services
       # CFE::ObtainAssessmentResultService.call(submission)

--- a/spec/cassettes/CFE_SubmissionManager/_call/completes_process.yml
+++ b/spec/cassettes/CFE_SubmissionManager/_call/completes_process.yml
@@ -1,0 +1,305 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://check-financial-eligibility-staging.apps.live-1.cloud-platform.service.justice.gov.uk/assessments
+    body:
+      encoding: UTF-8
+      string: '{"client_reference_id":"L-YB0-M31","submission_date":"2019-09-26","matter_proceeding_type":"domestic_abuse"}'
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.15.8
+      Date:
+      - Thu, 26 Sep 2019 10:17:16 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Etag:
+      - W/"e87d75bbc5c726c5650e16b1361562c0"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - e6e54beb74a9c61fc65bc32f111e7459
+      X-Runtime:
+      - '0.092029'
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: ASCII-8BIT
+      string: '{"success":true,"objects":[{"id":"82c29e5a-58ff-4fc1-8d3e-fab96505893e","client_reference_id":"L-YB0-M31","remote_ip":{"family":2,"addr":1380268825,"mask_addr":4294967295},"created_at":"2019-09-26T10:17:16.895Z","updated_at":"2019-09-26T10:17:16.895Z","submission_date":"2019-09-26","matter_proceeding_type":"domestic_abuse","assessment_result":"pending"}],"errors":[]}'
+    http_version: 
+  recorded_at: Thu, 26 Sep 2019 10:17:16 GMT
+- request:
+    method: post
+    uri: https://check-financial-eligibility-staging.apps.live-1.cloud-platform.service.justice.gov.uk/assessments/82c29e5a-58ff-4fc1-8d3e-fab96505893e/applicant
+    body:
+      encoding: UTF-8
+      string: '{"applicant":{"date_of_birth":"1975-09-12","involvement_type":"applicant","has_partner_opponent":false,"receives_qualifying_benefit":false}}'
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.15.8
+      Date:
+      - Thu, 26 Sep 2019 10:17:17 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Etag:
+      - W/"0b4757162b738d03ce1bc79055ae6184"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 143b4e41c47b9da6f3ddf0a3a87c73de
+      X-Runtime:
+      - '0.009516'
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: ASCII-8BIT
+      string: '{"objects":[{"id":"5e32f804-1b2f-4361-ab47-251c83a65b24","assessment_id":"82c29e5a-58ff-4fc1-8d3e-fab96505893e","date_of_birth":"1975-09-12","involvement_type":"applicant","has_partner_opponent":false,"receives_qualifying_benefit":false,"created_at":"2019-09-26T10:17:17.066Z","updated_at":"2019-09-26T10:17:17.066Z"}],"errors":[],"success":true}'
+    http_version: 
+  recorded_at: Thu, 26 Sep 2019 10:17:17 GMT
+- request:
+    method: post
+    uri: https://check-financial-eligibility-staging.apps.live-1.cloud-platform.service.justice.gov.uk/assessments/82c29e5a-58ff-4fc1-8d3e-fab96505893e/capitals
+    body:
+      encoding: UTF-8
+      string: '{"bank_accounts":[{"description":"Off-line bank accounts","value":"256813.96"},{"description":"Cash","value":"929463.53"},{"description":"Signatory
+        on other person''s account","value":"247263.33"},{"description":"National
+        savings","value":"631488.6"},{"description":"Shares in PLC","value":"30317.69"},{"description":"PEPs,
+        unit trusts, capital bonds and government stocks","value":"267758.38"},{"description":"Life
+        assurance and endowment policies not linked to a mortgage","value":"961122.07"}],"non_liquid_capital":[{"description":"Timeshare
+        property","value":"98807.39"},{"description":"Land","value":"825874.26"},{"description":"Valuable
+        items","value":"406113.56"},{"description":"Inherited assets","value":"512724.02"},{"description":"Money
+        owed to applicant","value":"758681.72"},{"description":"Trusts","value":"914692.73"}]}'
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.15.8
+      Date:
+      - Thu, 26 Sep 2019 10:17:17 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Etag:
+      - W/"19ac0337bcb049ee395ff7dab5dec3ef"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - fbf9c1524e9ff6b72a8eee2aa54ef82e
+      X-Runtime:
+      - '0.192168'
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: ASCII-8BIT
+      string: '{"objects":{"id":"02e0714f-0543-4ff3-bb73-500bdc46889d","assessment_id":"82c29e5a-58ff-4fc1-8d3e-fab96505893e","total_liquid":"0.0","total_non_liquid":"0.0","total_vehicle":"0.0","total_property":"0.0","total_mortgage_allowance":"0.0","total_capital":"0.0","pensioner_capital_disregard":"0.0","assessed_capital":"0.0","capital_contribution":"0.0","lower_threshold":"0.0","upper_threshold":"0.0","capital_assessment_result":"pending","created_at":"2019-09-26T10:17:16.900Z","updated_at":"2019-09-26T10:17:16.900Z"},"errors":[],"success":true}'
+    http_version: 
+  recorded_at: Thu, 26 Sep 2019 10:17:17 GMT
+- request:
+    method: post
+    uri: https://check-financial-eligibility-staging.apps.live-1.cloud-platform.service.justice.gov.uk/assessments/82c29e5a-58ff-4fc1-8d3e-fab96505893e/vehicles
+    body:
+      encoding: UTF-8
+      string: '{"vehicles":[{"value":"4069.0","loan_amount_outstanding":"873.0","date_of_purchase":"2002-10-01","in_regular_use":true}]}'
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.15.8
+      Date:
+      - Thu, 26 Sep 2019 10:17:17 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Etag:
+      - W/"d5f43da6ce2ba2878a37119cb1f3f31f"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 981586736db6d4413a381a8aabb37541
+      X-Runtime:
+      - '0.024666'
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: ASCII-8BIT
+      string: '{"vehicles":[{"id":"89fd2145-3e5b-48a6-a0eb-75d389b93f79","value":"4069.0","loan_amount_outstanding":"873.0","date_of_purchase":"2002-10-01","in_regular_use":true,"created_at":"2019-09-26T10:17:17.494Z","updated_at":"2019-09-26T10:17:17.494Z","capital_summary_id":"02e0714f-0543-4ff3-bb73-500bdc46889d","included_in_assessment":false,"assessed_value":"0.0"}],"errors":[],"success":true}'
+    http_version: 
+  recorded_at: Thu, 26 Sep 2019 10:17:17 GMT
+- request:
+    method: post
+    uri: https://check-financial-eligibility-staging.apps.live-1.cloud-platform.service.justice.gov.uk/assessments/82c29e5a-58ff-4fc1-8d3e-fab96505893e/properties
+    body:
+      encoding: UTF-8
+      string: '{"properties":{"main_home":{"value":"727864.08","outstanding_mortgage":"188024.24","percentage_owned":"43.75","shared_with_housing_assoc":false},"additional_properties":[{"value":"897453.03","outstanding_mortgage":"73722.46","percentage_owned":"66.32","shared_with_housing_assoc":false}]}}'
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.15.8
+      Date:
+      - Thu, 26 Sep 2019 10:17:17 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Etag:
+      - W/"b6dd27fc7c654cc37fc064a1f572bde6"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 7e7b4d80357025fccc74677e9a1058c1
+      X-Runtime:
+      - '0.116632'
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: ASCII-8BIT
+      string: '{"objects":[{"id":"7d5d1825-0de3-4ed5-a5e9-b1c366daa842","value":"727864.08","outstanding_mortgage":"188024.24","percentage_owned":"43.75","main_home":true,"shared_with_housing_assoc":false,"created_at":"2019-09-26T10:17:17.688Z","updated_at":"2019-09-26T10:17:17.688Z","capital_summary_id":"02e0714f-0543-4ff3-bb73-500bdc46889d","transaction_allowance":"0.0","allowable_outstanding_mortgage":"0.0","net_value":"0.0","net_equity":"0.0","assessed_equity":"0.0","main_home_equity_disregard":"0.0"},{"id":"c7d5f438-76f6-4e7d-89e3-f5a03ca0d24a","value":"897453.03","outstanding_mortgage":"73722.46","percentage_owned":"66.32","main_home":false,"shared_with_housing_assoc":false,"created_at":"2019-09-26T10:17:17.701Z","updated_at":"2019-09-26T10:17:17.701Z","capital_summary_id":"02e0714f-0543-4ff3-bb73-500bdc46889d","transaction_allowance":"0.0","allowable_outstanding_mortgage":"0.0","net_value":"0.0","net_equity":"0.0","assessed_equity":"0.0","main_home_equity_disregard":"0.0"}],"errors":[],"success":true}'
+    http_version: 
+  recorded_at: Thu, 26 Sep 2019 10:17:17 GMT
+recorded_with: VCR 5.0.0

--- a/spec/services/cfe/create_properties_service_spec.rb
+++ b/spec/services/cfe/create_properties_service_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe CFE::CreatePropertiesService do
     )
   end
   let(:submission) do
-    create :cfe_submission, assessment_id: SecureRandom.uuid, aasm_state: :capitals_created
+    create :cfe_submission, assessment_id: SecureRandom.uuid, aasm_state: :vehicles_created
   end
 
   subject { described_class.new submission }

--- a/spec/services/cfe/create_properties_service_spec.rb
+++ b/spec/services/cfe/create_properties_service_spec.rb
@@ -4,12 +4,15 @@ RSpec.describe CFE::CreatePropertiesService do
   let(:property_value) { Faker::Number.number(digits: 6) }
   let(:outstanding_mortgage) { property_value / Faker::Number.number(digits: 2) }
   let(:percentage_owned) { Faker::Number.number(digits: 2) }
+  let(:shared_ownership) { 'housing_assocation_or_landlord' }
+
   let(:legal_aid_application) do
     create(
       :legal_aid_application,
       property_value: property_value,
       outstanding_mortgage_amount: outstanding_mortgage,
-      percentage_home: percentage_owned
+      percentage_home: percentage_owned,
+      shared_ownership: shared_ownership
     )
   end
   let(:submission) do
@@ -87,6 +90,11 @@ RSpec.describe CFE::CreatePropertiesService do
       expect(additional_property[:percentage_owned]).to be_zero
     end
 
+    it 'includes sharing data' do
+      expect(request_body.dig(:properties, :main_home, :shared_with_housing_assoc)).to be(false)
+      expect(additional_property[:shared_with_housing_assoc]).to be(false)
+    end
+
     context 'with an own home' do
       let(:submission) do
         create(
@@ -106,6 +114,11 @@ RSpec.describe CFE::CreatePropertiesService do
         expect(additional_property[:value]).to be_zero
         expect(additional_property[:outstanding_mortgage]).to be_zero
         expect(additional_property[:percentage_owned]).to be_zero
+      end
+
+      it 'includes sharing data' do
+        expect(request_body.dig(:properties, :main_home, :shared_with_housing_assoc)).to be(true)
+        expect(additional_property[:shared_with_housing_assoc]).to be(false)
       end
     end
 
@@ -131,6 +144,11 @@ RSpec.describe CFE::CreatePropertiesService do
         expect(additional_property[:value]).to eq(other_assets_declaration.second_home_value.to_s)
         expect(additional_property[:outstanding_mortgage]).to eq(other_assets_declaration.second_home_mortgage.to_s)
         expect(additional_property[:percentage_owned]).to eq(other_assets_declaration.second_home_percentage.to_s)
+      end
+
+      it 'includes sharing data' do
+        expect(request_body.dig(:properties, :main_home, :shared_with_housing_assoc)).to be(true)
+        expect(additional_property[:shared_with_housing_assoc]).to be(false)
       end
     end
   end

--- a/spec/services/cfe/create_properties_service_spec.rb
+++ b/spec/services/cfe/create_properties_service_spec.rb
@@ -1,0 +1,143 @@
+require 'rails_helper'
+
+RSpec.describe CFE::CreatePropertiesService do
+  let(:property_value) { Faker::Number.number(digits: 6) }
+  let(:outstanding_mortgage) { property_value / Faker::Number.number(digits: 2) }
+  let(:percentage_owned) { Faker::Number.number(digits: 2) }
+  let(:legal_aid_application) do
+    create(
+      :legal_aid_application,
+      property_value: property_value,
+      outstanding_mortgage_amount: outstanding_mortgage,
+      percentage_home: percentage_owned
+    )
+  end
+  let(:submission) do
+    create :cfe_submission, assessment_id: SecureRandom.uuid, aasm_state: :capitals_created
+  end
+
+  subject { described_class.new submission }
+
+  describe '#call' do
+    let(:api_response) { { success: true }.to_json }
+    let(:response_status) { 200 }
+    let(:submission_history) { submission.submission_histories.order(created_at: :asc).last }
+
+    around do |example|
+      VCR.turn_off!
+      stub_request(:post, subject.cfe_url)
+        .with(
+          body: subject.request_body,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+        .to_return(
+          status: response_status,
+          body: api_response
+        )
+
+      example.run
+      VCR.turn_on!
+    end
+
+    it 'sends data to endpoint' do
+      subject.call
+    end
+
+    it 'changes the submission state' do
+      expect { subject.call }.to change { submission.reload.properties_created? }.from(false).to(true)
+    end
+
+    it 'generates a Submission History' do
+      expect { subject.call }.to change { submission.submission_histories.count }.by(1)
+      submission_history = submission.submission_histories.last
+      expect(submission_history.response_payload).to eq(api_response)
+    end
+
+    context 'on failure' do
+      let(:api_response) { { success: false }.to_json }
+      let(:response_status) { 400 }
+      let(:call_error) do
+        expect { subject.call }.to raise_error(CFE::SubmissionError)
+      end
+
+      it 'does not change the submission state' do
+        expect { call_error }.not_to change { submission.reload.aasm_state }
+      end
+
+      it 'generates a Submission History' do
+        expect { call_error }.to change { submission.submission_histories.count }.by(1)
+        expect(submission_history.response_payload).to eq(api_response)
+      end
+    end
+  end
+
+  describe '#request_body' do
+    let(:request_body) { JSON.parse subject.request_body, symbolize_names: true }
+    let(:additional_property) { request_body.dig(:properties, :additional_properties)&.first || {} }
+
+    it 'contains main home data as zeros' do
+      expect(request_body.dig(:properties, :main_home, :value).to_i).to be_zero
+      expect(request_body.dig(:properties, :main_home, :outstanding_mortgage).to_i).to be_zero
+      expect(request_body.dig(:properties, :main_home, :percentage_owned).to_i).to be_zero
+    end
+
+    it 'contains an empty additional home' do
+      expect(additional_property[:value]).to be_zero
+      expect(additional_property[:outstanding_mortgage]).to be_zero
+      expect(additional_property[:percentage_owned]).to be_zero
+    end
+
+    context 'with an own home' do
+      let(:submission) do
+        create(
+          :cfe_submission,
+          assessment_id: SecureRandom.uuid,
+          legal_aid_application: legal_aid_application
+        )
+      end
+
+      it 'contains the main home data' do
+        expect(request_body.dig(:properties, :main_home, :value).to_i).to eq(property_value)
+        expect(request_body.dig(:properties, :main_home, :outstanding_mortgage).to_i).to eq(outstanding_mortgage)
+        expect(request_body.dig(:properties, :main_home, :percentage_owned).to_i).to eq(percentage_owned)
+      end
+
+      it 'contains an empty additional home' do
+        expect(additional_property[:value]).to be_zero
+        expect(additional_property[:outstanding_mortgage]).to be_zero
+        expect(additional_property[:percentage_owned]).to be_zero
+      end
+    end
+
+    context 'with two properties' do
+      let!(:other_assets_declaration) do
+        create :other_assets_declaration, :with_second_home, legal_aid_application: legal_aid_application
+      end
+      let(:submission) do
+        create(
+          :cfe_submission,
+          assessment_id: SecureRandom.uuid,
+          legal_aid_application: legal_aid_application
+        )
+      end
+
+      it 'contains the main home data' do
+        expect(request_body.dig(:properties, :main_home, :value).to_i).to eq(property_value)
+        expect(request_body.dig(:properties, :main_home, :outstanding_mortgage).to_i).to eq(outstanding_mortgage)
+        expect(request_body.dig(:properties, :main_home, :percentage_owned).to_i).to eq(percentage_owned)
+      end
+
+      it 'contains an additional home data' do
+        expect(additional_property[:value]).to eq(other_assets_declaration.second_home_value.to_s)
+        expect(additional_property[:outstanding_mortgage]).to eq(other_assets_declaration.second_home_mortgage.to_s)
+        expect(additional_property[:percentage_owned]).to eq(other_assets_declaration.second_home_percentage.to_s)
+      end
+    end
+  end
+
+  describe 'cfe_url' do
+    it 'points to properties end point' do
+      expect(subject.cfe_url).to match(%r{assessments/#{submission.assessment_id}/properties$})
+    end
+  end
+end

--- a/spec/services/cfe/submission_manager_spec.rb
+++ b/spec/services/cfe/submission_manager_spec.rb
@@ -2,21 +2,34 @@ require 'rails_helper'
 
 module CFE
   RSpec.describe SubmissionManager do
-
-    let(:application) { create :legal_aid_application, :with_everything, :at_provider_submitted }
+    let(:vehicle) { build :vehicle, :populated }
+    let(:application) { create :legal_aid_application, :with_everything, :at_provider_submitted, vehicle: vehicle }
     let(:submission_manager) { described_class.new(application.id) }
     let(:submission) { submission_manager.submission }
     let(:call_result) { true }
 
-    before do
-      allow(CreateAssessmentService).to receive(:call).and_return(true)
-      allow(CreateApplicantService).to receive(:call).and_return(true)
-      allow(CreateCapitalsService).to receive(:call).and_return(true)
-      allow(CreatePropertiesService).to receive(:call).and_return(true)
-      allow(CreateVehiclesService).to receive(:call).and_return(true)
+    describe '.call', vcr: { record: :new_episodes } do
+      let(:staging_host) { 'https://check-financial-eligibility-staging.apps.live-1.cloud-platform.service.justice.gov.uk' }
+      let(:last_submission_history) { CFE::SubmissionHistory.order(created_at: :asc).last }
+      before do
+        allow(Rails.configuration.x).to receive(:check_finanical_eligibility_host).and_return(staging_host)
+      end
+
+      it 'completes process' do
+        described_class.call(application.id)
+        expect(last_submission_history.http_response_status).to eq(200), last_submission_history.inspect
+      end
     end
 
     describe '#call' do
+      before do
+        allow(CreateAssessmentService).to receive(:call).and_return(true)
+        allow(CreateApplicantService).to receive(:call).and_return(true)
+        allow(CreateCapitalsService).to receive(:call).and_return(true)
+        allow(CreatePropertiesService).to receive(:call).and_return(true)
+        allow(CreateVehiclesService).to receive(:call).and_return(true)
+      end
+
       it 'creates a submission record' do
         expect { submission_manager.call }.to change { Submission.count }.by(1)
       end
@@ -30,7 +43,7 @@ module CFE
 
         # TODO: Add these expectations as we add more services to the test
         # expect(ObtainResultsService).to receive(:call).and_return(true)
-        
+
         submission_manager.call
       end
 


### PR DESCRIPTION
[Jira AP-941](https://dsdmoj.atlassian.net/browse/AP-941)

Adds the service `CFE::CreatePropertiesService` to manage the passing of property data to the Eligibility API. This service is also added to the CFE Submission manager