### PR TITLE
AP-956 Fix incorrect CCMS test data

### DIFF
--- a/app/services/ccms/case_add_requestor.rb
+++ b/app/services/ccms/case_add_requestor.rb
@@ -183,11 +183,10 @@ module CCMS
     end
 
     def generate_scope_limitation(xml, limitation)
-      application_limitation = ApplicationScopeLimitation.find_by(scope_limitation_id: limitation.id, legal_aid_application_id: @legal_aid_application.id)
       xml.__send__('ns2:ScopeLimitation') do
         xml.__send__('ns2:ScopeLimitation', limitation.code)
         xml.__send__('ns2:ScopeLimitationWording', limitation.description)
-        xml.__send__('ns2:DelegatedFunctionsApply', !application_limitation.substantive)
+        xml.__send__('ns2:DelegatedFunctionsApply', !limitation.substantive)
       end
     end
 

--- a/ccms_integration/ccms_spec.rb
+++ b/ccms_integration/ccms_spec.rb
@@ -40,7 +40,7 @@ module CCMS
              description: ':EMPLOYMENT_CLIENT_001:CLI_NON_HM_WAGE_SLIP_001'
     end
 
-    let(:firm) { double Firm, id: 19_148, name: 'Firm1' }
+    let(:firm) { double Firm, id: 22_381, name: 'Desor & Co' }
 
     let(:provider) do
       double Provider,
@@ -48,17 +48,35 @@ module CCMS
              firm: firm,
              selected_office_id: 81_693,
              user_login_id: 2_016_472,
-             supervisor_contact_id: 3_982_723,
-             fee_earner_contact_id: 34_419,
+             supervisor_contact_id: 2_016_673,
+             fee_earner_contact_id: 2_016_673,
              marked_for_destruction?: false,
              email: 'test@test.com'
+    end
+
+    let(:substantive_scope_limitation) do
+      create :scope_limitation,
+             :with_real_data,
+             code:'CV117',
+             meaning: 'Interim order inc. return date',
+             description: 'Limited to all steps necessary to apply for an interim order; where application is made without notice to include representation on the return date.',
+             substantive: true,
+             delegated_functions: false
+    end
+
+    let(:substantive_proceeding_type) do
+      create :proceeding_type,
+             :with_real_data,
+             code:'PR0211',
+             ccms_code: 'DA004',
+             meaning: 'Non-molestation order',
+             description: 'to be represented on an application for a non-molestation order.',
+             scope_limitations: [substantive_scope_limitation]
     end
 
     let(:substantive_legal_aid_application) do
       create :legal_aid_application,
              :with_applicant_and_address,
-             :with_proceeding_types,
-             :with_substantive_scope_limitation,
              :with_other_assets_declaration,
              :with_savings_amount,
              :with_respondent,
@@ -66,15 +84,34 @@ module CCMS
              :with_merits_assessment,
              :with_means_report,
              :with_merits_report,
-             statement_of_case: @statement_of_case
+             statement_of_case: @statement_of_case,
+             proceeding_types: [substantive_proceeding_type]
+    end
+
+    let(:delegated_functions_scope_limitation) do
+      create :scope_limitation,
+             :with_real_data,
+             code:'CV117',
+             meaning: 'Interim order inc. return date',
+             description: 'Limited to all steps necessary to apply for an interim order; where application is made without notice to include representation on the return date.',
+             substantive: false,
+             delegated_functions: true
+    end
+
+    let(:delegated_functions_proceeding_type) do
+      create :proceeding_type,
+             :with_real_data,
+             code:'PR0211',
+             ccms_code: 'DA004',
+             meaning: 'Non-molestation order',
+             description: 'to be represented on an application for a non-molestation order.',
+             scope_limitations: [delegated_functions_scope_limitation]
     end
 
     let(:delegated_functions_legal_aid_application) do
       create :legal_aid_application,
              :with_applicant_and_address,
-             :with_proceeding_types,
              :with_delegated_functions,
-             :with_delegated_functions_scope_limitation,
              :with_other_assets_declaration,
              :with_savings_amount,
              :with_respondent,
@@ -82,7 +119,8 @@ module CCMS
              :with_merits_assessment,
              :with_means_report,
              :with_merits_report,
-             statement_of_case: @statement_of_case
+             statement_of_case: @statement_of_case,
+             proceeding_types: [delegated_functions_proceeding_type]
     end
 
     before do

--- a/spec/services/ccms/case_add_requestor_spec.rb
+++ b/spec/services/ccms/case_add_requestor_spec.rb
@@ -15,7 +15,8 @@ module CCMS # rubocop:disable Metrics/ModuleLength
                id: 1,
                code: 'CV118',
                description: 'Limited to all steps up to and including the hearing on 01/04/2019',
-               delegated_functions_apply: true
+               delegated_functions_apply: true,
+               substantive: false
       end
 
       let(:aa019_text) do
@@ -34,7 +35,8 @@ module CCMS # rubocop:disable Metrics/ModuleLength
                id: 2,
                code: 'AA019',
                description: aa019_text,
-               delegated_functions_apply: false
+               delegated_functions_apply: false,
+               substantive: true
       end
 
       let(:scope_limitation_3) do
@@ -42,7 +44,8 @@ module CCMS # rubocop:disable Metrics/ModuleLength
                id: 3,
                code: 'FM049',
                description: 'Limited to all steps up to and including trial/final hearing and any action necessary to implement (but not enforce) the judgment or order.',
-               delegated_functions_apply: false
+               delegated_functions_apply: false,
+               substantive: true
       end
 
       let(:bank_provider) do


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-956)

`ccms_spec.rb` uses factories to create proceeding types and scope
limitations for test applications. The data produced by these factories
by default is not compatible with CCMS and so the cases produced are
not useable. 

Additionally, `ccms_spec.rb` is using incorrect provider details. Some of
the details it currently populates is related to a different firm to
the rest of the provider data.

* create proceeding types and scope limitations for substantive and
delegated functions cases using valid data

* fix incorrect provider details by using data for Desor & Co

* replace an unnecessary ActiveRecord call in `case_add_requestor` with a
method call to the scope limitation model

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
