### PR TITLE
AP-957/AP-958 - Populate category of law attributes from database

### DIFF
--- a/app/services/ccms/case_add_requestor.rb
+++ b/app/services/ccms/case_add_requestor.rb
@@ -143,9 +143,9 @@ module CCMS
     end
 
     def generate_category_of_law(xml)
-      xml.__send__('ns2:CategoryOfLawCode', 'MAT') # TODO: replace with lead_proceeding.ccms_category_law_code when it is available in Apply
-      xml.__send__('ns2:CategoryOfLawDescription', 'Family') # TODO: insert lead_proceeding.ccms_category_law when it is available in Apply
-      xml.__send__('ns2:RequestedAmount', '5000.0') # TODO: replace with as_currency(@legal_aid_application.requested_amount)) when it is available in Apply
+      xml.__send__('ns2:CategoryOfLawCode', @legal_aid_application.lead_proceeding_type.ccms_category_law_code)
+      xml.__send__('ns2:CategoryOfLawDescription', @legal_aid_application.lead_proceeding_type.ccms_category_law)
+      xml.__send__('ns2:RequestedAmount', @legal_aid_application.default_cost_limitation)
     end
 
     def generate_proceedings(xml)

--- a/spec/services/ccms/case_add_requestor_spec.rb
+++ b/spec/services/ccms/case_add_requestor_spec.rb
@@ -263,7 +263,8 @@ module CCMS # rubocop:disable Metrics/ModuleLength
                open_banking_consent_choice_at: Date.new(2019, 6, 1),
                lead_proceeding_type: proceeding_type_1,
                benefit_check_result: true,
-               merits_assessment: merits_assessment
+               merits_assessment: merits_assessment,
+               default_cost_limitation: 25_000.0
       end
 
       let(:other_party_1) { create :opponent, :child }


### PR DESCRIPTION
## What

[AP-957](https://dsdmoj.atlassian.net/browse/AP-957)
[AP-958](https://dsdmoj.atlassian.net/browse/AP-958)

Three CategoryOfLaw attributes in the CCMS create case payload are currently hardcoded. We hold the relevant data in the database so the values should be retrieved from there.

Amend `case_add_requestor` so that `CategoryOfLawCode`, `CategoryOfLawDescription` and `RequestedAmount` are populated correctly.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
