### PR TITLE
AP-964 Fix CCMS datetime format

### DIFF
--- a/config/initializers/date_formats.rb
+++ b/config/initializers/date_formats.rb
@@ -4,7 +4,7 @@ Time::DATE_FORMATS[:datetime] = '%H:%M %d-%b-%Y'
 
 ccms_formats = {
   ccms_date: '%Y-%m-%d',
-  ccms_date_time: '%Y-%m-%ddT%H:%M:%S.%3N'
+  ccms_date_time: '%Y-%m-%dT%H:%M:%S.%3N'
 }
 
 Time::DATE_FORMATS.merge! ccms_formats


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-964)

Date-times formatted for inclusion in CCMS payloads are appearing incorrectly.

The format is coded as `%Y-%m-%ddT%H:%M:%S.%3N`, which includes an erroneous `d`. This  `d` is appearing in the resulting date string.

Change the format to `%Y-%m-%dT%H:%M:%S.%3N` to prevent the `d` appearing.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
