### PR TITLE
Fix ccms_spec.rb

### DIFF
--- a/ccms_integration/ccms_spec.rb
+++ b/ccms_integration/ccms_spec.rb
@@ -85,7 +85,8 @@ module CCMS
              :with_means_report,
              :with_merits_report,
              statement_of_case: @statement_of_case,
-             proceeding_types: [substantive_proceeding_type]
+             proceeding_types: [substantive_proceeding_type],
+             state: :submitting_assessment
     end
 
     let(:delegated_functions_scope_limitation) do
@@ -120,7 +121,8 @@ module CCMS
              :with_means_report,
              :with_merits_report,
              statement_of_case: @statement_of_case,
-             proceeding_types: [delegated_functions_proceeding_type]
+             proceeding_types: [delegated_functions_proceeding_type],
+             state: :submitting_assessment
     end
 
     before do


### PR DESCRIPTION
## What
Changes in AP-936 (https://github.com/ministryofjustice/laa-apply-for-legal-aid/pull/876)
mean that tests in `ccms_spec.rb` now fail as the `legal_aid_application` is not in the expected state.

Set the `legal_aid_application` to be in the state of `:submitting_assessment` before running the tests, so that all state machine transitions are correct

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
