### PR TITLE
AP-963 Replace hardcoded level_of_service in CCMS payloads

### DIFF
--- a/app/services/ccms/case_add_requestor.rb
+++ b/app/services/ccms/case_add_requestor.rb
@@ -172,7 +172,7 @@ module CCMS
       xml.__send__('ns2:ProceedingType', proceeding_type.ccms_code)
       xml.__send__('ns2:ProceedingDescription', proceeding_type.description)
       xml.__send__('ns2:MatterType', proceeding_type.ccms_matter_code)
-      xml.__send__('ns2:LevelOfService', 3) # TODO: CCMS placeholder
+      xml.__send__('ns2:LevelOfService', proceeding_type.default_level_of_service.service_level_number)
       xml.__send__('ns2:Stage', 8) # TODO: CCMS placeholder
       xml.__send__('ns2:ClientInvolvementType', 'A') # TODO: CCMS placeholder
       xml.__send__('ns2:ScopeLimitations') { generate_scope_limitations(xml, proceeding_type) }


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-XXX)

LevelOfService in the CCMS case creation payload is currently hardcoded as '3'.

Replace this with a call to get this from the database- `proceeding_type.default_level_of_service.service_level_number` (which will always return 3 anyway as that's the only level of service we're currently using).

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
