### PR TITLE
Ap764 save xml

### DIFF
--- a/app/services/ccms/add_applicant_service.rb
+++ b/app/services/ccms/add_applicant_service.rb
@@ -3,7 +3,7 @@ module CCMS
     def call
       if applicant_add_response_parser.success?
         submission.applicant_add_transaction_id = applicant_add_requestor.transaction_request_id
-        create_history('case_ref_obtained', submission.aasm_state) if submission.submit_applicant!
+        create_history('case_ref_obtained', submission.aasm_state, applicant_add_requestor, applicant_add_response_parser) if submission.submit_applicant!
       else
         handle_failure(response)
       end
@@ -19,6 +19,11 @@ module CCMS
 
     def applicant_add_response_parser
       @applicant_add_response_parser ||= ApplicantAddResponseParser.new(applicant_add_requestor.transaction_request_id, response)
+    end
+
+    def save_applicant_request
+      # @applicant_add_requestor ||= ApplicantAddRequestor.new(submission.legal_aid_application.applicant)
+      # @save_applicant_request ||=
     end
 
     def response

--- a/app/services/ccms/add_applicant_service.rb
+++ b/app/services/ccms/add_applicant_service.rb
@@ -2,8 +2,9 @@ module CCMS
   class AddApplicantService < BaseSubmissionService
     def call
       if applicant_add_response_parser.success?
+        # binding.pry
         submission.applicant_add_transaction_id = applicant_add_requestor.transaction_request_id
-        create_history('case_ref_obtained', submission.aasm_state, applicant_add_requestor, applicant_add_response_parser) if submission.submit_applicant!
+        create_history('case_ref_obtained', submission.aasm_state, xml_request) if submission.submit_applicant!
       else
         handle_failure(response)
       end
@@ -21,9 +22,8 @@ module CCMS
       @applicant_add_response_parser ||= ApplicantAddResponseParser.new(applicant_add_requestor.transaction_request_id, response)
     end
 
-    def save_applicant_request
-      # @applicant_add_requestor ||= ApplicantAddRequestor.new(submission.legal_aid_application.applicant)
-      # @save_applicant_request ||=
+    def xml_request
+      @xml_request ||= applicant_add_requestor.formatted_xml
     end
 
     def response

--- a/app/services/ccms/add_applicant_service.rb
+++ b/app/services/ccms/add_applicant_service.rb
@@ -2,14 +2,13 @@ module CCMS
   class AddApplicantService < BaseSubmissionService
     def call
       if applicant_add_response_parser.success?
-        # binding.pry
         submission.applicant_add_transaction_id = applicant_add_requestor.transaction_request_id
-        create_history('case_ref_obtained', submission.aasm_state, xml_request) if submission.submit_applicant!
+        create_history('case_ref_obtained', submission.aasm_state, applicant_add_requestor.formatted_xml) if submission.submit_applicant!
       else
-        handle_failure(response)
+        handle_failure(response, applicant_add_requestor.formatted_xml)
       end
     rescue CcmsError => e
-      handle_failure(e)
+      handle_failure(e, applicant_add_requestor.formatted_xml)
     end
 
     private
@@ -20,10 +19,6 @@ module CCMS
 
     def applicant_add_response_parser
       @applicant_add_response_parser ||= ApplicantAddResponseParser.new(applicant_add_requestor.transaction_request_id, response)
-    end
-
-    def xml_request
-      @xml_request ||= applicant_add_requestor.formatted_xml
     end
 
     def response

--- a/app/services/ccms/add_applicant_service.rb
+++ b/app/services/ccms/add_applicant_service.rb
@@ -3,12 +3,12 @@ module CCMS
     def call
       if applicant_add_response_parser.success?
         submission.applicant_add_transaction_id = applicant_add_requestor.transaction_request_id
-        create_history('case_ref_obtained', submission.aasm_state, applicant_add_requestor.formatted_xml) if submission.submit_applicant!
+        create_history('case_ref_obtained', submission.aasm_state, xml_request, xml_response ) if submission.submit_applicant!
       else
-        handle_failure(response, applicant_add_requestor.formatted_xml)
+        handle_failure(response, xml_request, xml_response)
       end
     rescue CcmsError => e
-      handle_failure(e, applicant_add_requestor.formatted_xml)
+      handle_failure(e, xml_request, xml_response)
     end
 
     private
@@ -23,6 +23,14 @@ module CCMS
 
     def response
       @response ||= applicant_add_requestor.call
+    end
+
+    def xml_request
+      @xml_request ||= applicant_add_requestor.formatted_xml
+    end
+
+    def xml_response
+      @xml_response ||= applicant_add_response_parser.response
     end
   end
 end

--- a/app/services/ccms/add_case_service.rb
+++ b/app/services/ccms/add_case_service.rb
@@ -8,12 +8,12 @@ module CCMS
       @options = options
       if case_add_response_parser.success?
         submission.case_add_transaction_id = case_add_requestor.transaction_request_id
-        create_history(submission.submission_document.empty? ? 'applicant_ref_obtained' : 'document_ids_obtained', submission.aasm_state, case_add_requestor.formatted_xml) if submission.submit_case!
+        create_history(submission.submission_document.empty? ? 'applicant_ref_obtained' : 'document_ids_obtained', submission.aasm_state, xml_request, xml_response) if submission.submit_case!
       else
-        handle_failure(response, case_add_requestor.formatted_xml)
+        handle_failure(response, xml_request, xml_response)
       end
     rescue CcmsError => e
-      handle_failure(e, case_add_requestor.formatted_xml)
+      handle_failure(e, xml_request, xml_response)
     end
 
     private
@@ -28,6 +28,14 @@ module CCMS
 
     def response
       @response ||= case_add_requestor.call
+    end
+
+    def xml_request
+      @xml_request ||= case_add_requestor.formatted_xml
+    end
+
+    def xml_response
+      @xml_response ||= case_add_response_parser.response
     end
   end
 end

--- a/app/services/ccms/add_case_service.rb
+++ b/app/services/ccms/add_case_service.rb
@@ -8,7 +8,7 @@ module CCMS
       @options = options
       if case_add_response_parser.success?
         submission.case_add_transaction_id = case_add_requestor.transaction_request_id
-        create_history(submission.submission_document.empty? ? 'applicant_ref_obtained' : 'document_ids_obtained', submission.aasm_state) if submission.submit_case!
+        create_history(submission.submission_document.empty? ? 'applicant_ref_obtained' : 'document_ids_obtained', submission.aasm_state, case_add_requestor) if submission.submit_case!
       else
         handle_failure(response)
       end

--- a/app/services/ccms/add_case_service.rb
+++ b/app/services/ccms/add_case_service.rb
@@ -8,12 +8,12 @@ module CCMS
       @options = options
       if case_add_response_parser.success?
         submission.case_add_transaction_id = case_add_requestor.transaction_request_id
-        create_history(submission.submission_document.empty? ? 'applicant_ref_obtained' : 'document_ids_obtained', submission.aasm_state, case_add_requestor) if submission.submit_case!
+        create_history(submission.submission_document.empty? ? 'applicant_ref_obtained' : 'document_ids_obtained', submission.aasm_state, case_add_requestor.formatted_xml) if submission.submit_case!
       else
-        handle_failure(response)
+        handle_failure(response, case_add_requestor.formatted_xml)
       end
     rescue CcmsError => e
-      handle_failure(e)
+      handle_failure(e, case_add_requestor.formatted_xml)
     end
 
     private

--- a/app/services/ccms/base_submission_service.rb
+++ b/app/services/ccms/base_submission_service.rb
@@ -21,11 +21,12 @@ module CCMS
                                # response: response.doc
     end
 
-    def create_failure_history(from_state, error)
+    def create_failure_history(from_state, error, request)
       SubmissionHistory.create submission: submission,
                                from_state: from_state,
                                to_state: :failed,
                                success: false,
+                               request: request,
                                details: error.is_a?(Exception) ? format_exception(error) : error
     end
 
@@ -33,8 +34,8 @@ module CCMS
       [error.class, error.message, error.backtrace].flatten.join("\n")
     end
 
-    def handle_failure(error)
-      create_failure_history(submission.aasm_state, error)
+    def handle_failure(error, request)
+      create_failure_history(submission.aasm_state, error, request)
       submission.fail!
     end
   end

--- a/app/services/ccms/base_submission_service.rb
+++ b/app/services/ccms/base_submission_service.rb
@@ -12,11 +12,13 @@ module CCMS
 
     private
 
-    def create_history(from_state, to_state)
+    def create_history(from_state, to_state, request, response)
       SubmissionHistory.create submission: submission,
                                from_state: from_state,
                                to_state: to_state,
-                               success: true
+                               success: true,
+                               request: request.formatted_xml,
+                               response: response.doc
     end
 
     def create_failure_history(from_state, error)

--- a/app/services/ccms/base_submission_service.rb
+++ b/app/services/ccms/base_submission_service.rb
@@ -12,30 +12,31 @@ module CCMS
 
     private
 
-    def create_history(from_state, to_state, request)
+    def create_history(from_state, to_state, request, response)
       SubmissionHistory.create submission: submission,
                                from_state: from_state,
                                to_state: to_state,
                                success: true,
-                               request: request#.formatted_xml
-                               # response: response.doc
+                               request: request,
+                               response: response
     end
 
-    def create_failure_history(from_state, error, request)
+    def create_failure_history(from_state, error, request, response)
       SubmissionHistory.create submission: submission,
                                from_state: from_state,
                                to_state: :failed,
                                success: false,
                                request: request,
-                               details: error.is_a?(Exception) ? format_exception(error) : error
+                               details: error.is_a?(Exception) ? format_exception(error) : error,
+                               response: response
     end
 
     def format_exception(error)
       [error.class, error.message, error.backtrace].flatten.join("\n")
     end
 
-    def handle_failure(error, request)
-      create_failure_history(submission.aasm_state, error, request)
+    def handle_failure(error, request, response)
+      create_failure_history(submission.aasm_state, error, request, response)
       submission.fail!
     end
   end

--- a/app/services/ccms/base_submission_service.rb
+++ b/app/services/ccms/base_submission_service.rb
@@ -12,13 +12,13 @@ module CCMS
 
     private
 
-    def create_history(from_state, to_state, request, response)
+    def create_history(from_state, to_state, request)
       SubmissionHistory.create submission: submission,
                                from_state: from_state,
                                to_state: to_state,
                                success: true,
-                               request: request.formatted_xml,
-                               response: response.doc
+                               request: request#.formatted_xml
+                               # response: response.doc
     end
 
     def create_failure_history(from_state, error)

--- a/app/services/ccms/check_applicant_status_service.rb
+++ b/app/services/ccms/check_applicant_status_service.rb
@@ -7,7 +7,7 @@ module CCMS
       parser = ApplicantAddStatusResponseParser.new(tx_id, response)
       process_response(parser)
     rescue CcmsError => e
-      handle_failure(e)
+      handle_failure(e, xml_request)
     end
 
     private
@@ -15,16 +15,20 @@ module CCMS
     def process_response(parser)
       if parser.success?
         submission.applicant_ccms_reference = parser.applicant_ccms_reference
-        create_history(:applicant_submitted, submission.aasm_state, applicant_add_status_requestor) if submission.obtain_applicant_ref!
+        create_history(:applicant_submitted, submission.aasm_state, xml_request) if submission.obtain_applicant_ref!
       elsif submission.applicant_poll_count >= Submission::POLL_LIMIT
-        handle_failure('Poll limit exceeded')
+        handle_failure('Poll limit exceeded', applicant_add_status_requestor.formatted_xml)
       else
-        create_history(submission.aasm_state, submission.aasm_state,applicant_add_status_requestor)
+        create_history(submission.aasm_state, submission.aasm_state, applicant_add_status_requestor.formatted_xml)
       end
     end
 
     def applicant_add_status_requestor
       @applicant_add_status_requestor ||= ApplicantAddStatusRequestor.new(submission.applicant_add_transaction_id)
+    end
+
+    def xml_request
+      @xml_request ||= applicant_add_status_requestor.formatted_xml
     end
   end
 end

--- a/app/services/ccms/check_applicant_status_service.rb
+++ b/app/services/ccms/check_applicant_status_service.rb
@@ -15,11 +15,11 @@ module CCMS
     def process_response(parser)
       if parser.success?
         submission.applicant_ccms_reference = parser.applicant_ccms_reference
-        create_history(:applicant_submitted, submission.aasm_state) if submission.obtain_applicant_ref!
+        create_history(:applicant_submitted, submission.aasm_state, applicant_add_status_requestor) if submission.obtain_applicant_ref!
       elsif submission.applicant_poll_count >= Submission::POLL_LIMIT
         handle_failure('Poll limit exceeded')
       else
-        create_history(submission.aasm_state, submission.aasm_state)
+        create_history(submission.aasm_state, submission.aasm_state,applicant_add_status_requestor)
       end
     end
 

--- a/app/services/ccms/check_case_status_service.rb
+++ b/app/services/ccms/check_case_status_service.rb
@@ -13,11 +13,11 @@ module CCMS
 
     def process_response(parser)
       if parser.success?
-        create_history(:case_submitted, submission.aasm_state) if submission.confirm_case_created!
+        create_history(:case_submitted, submission.aasm_state, case_add_status_requestor) if submission.confirm_case_created!
       elsif submission.case_poll_count >= Submission::POLL_LIMIT
         handle_failure('Poll limit exceeded')
       else
-        create_history(submission.aasm_state, submission.aasm_state)
+        create_history(submission.aasm_state, submission.aasm_state, case_add_status_requestor)
       end
     end
 

--- a/app/services/ccms/check_case_status_service.rb
+++ b/app/services/ccms/check_case_status_service.rb
@@ -6,18 +6,18 @@ module CCMS
       parser = CaseAddStatusResponseParser.new(tx_id, response)
       process_response(parser)
     rescue CcmsError => e
-      handle_failure(e)
+      handle_failure(e, case_add_status_requestor.formatted_xml)
     end
 
     private
 
     def process_response(parser)
       if parser.success?
-        create_history(:case_submitted, submission.aasm_state, case_add_status_requestor) if submission.confirm_case_created!
+        create_history(:case_submitted, submission.aasm_state, case_add_status_requestor.formatted_xml) if submission.confirm_case_created!
       elsif submission.case_poll_count >= Submission::POLL_LIMIT
-        handle_failure('Poll limit exceeded')
+        handle_failure('Poll limit exceeded', case_add_status_requestor.formatted_xml)
       else
-        create_history(submission.aasm_state, submission.aasm_state, case_add_status_requestor)
+        create_history(submission.aasm_state, submission.aasm_state, case_add_status_requestor.formatted_xml)
       end
     end
 

--- a/app/services/ccms/obtain_applicant_reference_service.rb
+++ b/app/services/ccms/obtain_applicant_reference_service.rb
@@ -20,7 +20,7 @@ module CCMS
         AddApplicantService.new(submission).call
       else
         submission.applicant_ccms_reference = parser.applicant_ccms_reference
-        create_history(:case_ref_obtained, submission.aasm_state) if submission.obtain_applicant_ref!
+        create_history(:case_ref_obtained, submission.aasm_state, applicant_search_requestor) if submission.obtain_applicant_ref!
       end
     end
   end

--- a/app/services/ccms/obtain_applicant_reference_service.rb
+++ b/app/services/ccms/obtain_applicant_reference_service.rb
@@ -6,7 +6,7 @@ module CCMS
       parser = ApplicantSearchResponseParser.new(tx_id, response)
       process_records(parser)
     rescue CcmsError => e
-      handle_failure(e)
+      handle_failure(e, applicant_search_requestor.formatted_xml)
     end
 
     private
@@ -20,7 +20,7 @@ module CCMS
         AddApplicantService.new(submission).call
       else
         submission.applicant_ccms_reference = parser.applicant_ccms_reference
-        create_history(:case_ref_obtained, submission.aasm_state, applicant_search_requestor) if submission.obtain_applicant_ref!
+        create_history(:case_ref_obtained, submission.aasm_state, applicant_search_requestor.formatted_xml) if submission.obtain_applicant_ref!
       end
     end
   end

--- a/app/services/ccms/obtain_case_reference_service.rb
+++ b/app/services/ccms/obtain_case_reference_service.rb
@@ -2,7 +2,7 @@ module CCMS
   class ObtainCaseReferenceService < BaseSubmissionService
     def call
       submission.case_ccms_reference = reference_id
-      create_history(:initialised, submission.aasm_state) if submission.obtain_case_ref!
+      create_history(:initialised, submission.aasm_state, reference_data_requestor) if submission.obtain_case_ref!
     rescue CcmsError => e
       handle_failure(e)
     end

--- a/app/services/ccms/obtain_case_reference_service.rb
+++ b/app/services/ccms/obtain_case_reference_service.rb
@@ -2,9 +2,9 @@ module CCMS
   class ObtainCaseReferenceService < BaseSubmissionService
     def call
       submission.case_ccms_reference = reference_id
-      create_history(:initialised, submission.aasm_state, reference_data_requestor) if submission.obtain_case_ref!
+      create_history(:initialised, submission.aasm_state, reference_data_requestor.formatted_xml) if submission.obtain_case_ref!
     rescue CcmsError => e
-      handle_failure(e)
+      handle_failure(e, reference_data_requestor.formatted_xml)
     end
 
     def reference_id

--- a/app/services/ccms/obtain_document_id_service.rb
+++ b/app/services/ccms/obtain_document_id_service.rb
@@ -3,13 +3,13 @@ module CCMS
     def call
       populate_documents
       if submission.submission_document.empty?
-        create_history('applicant_ref_obtained', submission.aasm_state, document_id_requestor) if submission.submit_case!
+        create_history('applicant_ref_obtained', submission.aasm_state, document_id_requestor.formatted_xml) if submission.submit_case!
       else
         request_document_ids
-        create_history('applicant_ref_obtained', submission.aasm_state, document_id_requestor) if submission.obtain_document_ids!
+        create_history('applicant_ref_obtained', submission.aasm_state, document_id_requestor.formatted_xml) if submission.obtain_document_ids!
       end
     rescue CcmsError => e
-      handle_failure(e)
+      handle_failure(e, document_id_requestor.formatted_xml)
     end
 
     private

--- a/app/services/ccms/obtain_document_id_service.rb
+++ b/app/services/ccms/obtain_document_id_service.rb
@@ -3,10 +3,10 @@ module CCMS
     def call
       populate_documents
       if submission.submission_document.empty?
-        create_history('applicant_ref_obtained', submission.aasm_state) if submission.submit_case!
+        create_history('applicant_ref_obtained', submission.aasm_state, document_id_requestor) if submission.submit_case!
       else
         request_document_ids
-        create_history('applicant_ref_obtained', submission.aasm_state) if submission.obtain_document_ids!
+        create_history('applicant_ref_obtained', submission.aasm_state, document_id_requestor) if submission.obtain_document_ids!
       end
     rescue CcmsError => e
       handle_failure(e)

--- a/db/migrate/20190925105003_add_columns_to_ccms_submission_histories.rb
+++ b/db/migrate/20190925105003_add_columns_to_ccms_submission_histories.rb
@@ -1,0 +1,6 @@
+class AddColumnsToCcmsSubmissionHistories < ActiveRecord::Migration[5.2]
+  def change
+      add_column :ccms_submission_histories, :request, :xml
+      add_column :ccms_submission_histories, :response, :xml
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_18_102038) do
+ActiveRecord::Schema.define(version: 2019_09_25_105003) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -213,6 +213,8 @@ ActiveRecord::Schema.define(version: 2019_09_18_102038) do
     t.text "details"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.xml "request"
+    t.xml "response"
     t.index ["submission_id"], name: "index_ccms_submission_histories_on_submission_id"
   end
 

--- a/spec/factories/submissions.rb
+++ b/spec/factories/submissions.rb
@@ -29,5 +29,9 @@ FactoryBot.define do
         create :submission_document, :id_obtained, submission: submission
       end
     end
+
+    # trait :with_xml_request do
+    #   request {'Some text for now will be xml?'}
+    # end
   end
 end

--- a/spec/services/ccms/add_applicant_service_spec.rb
+++ b/spec/services/ccms/add_applicant_service_spec.rb
@@ -6,12 +6,13 @@ RSpec.describe CCMS::AddApplicantService do
   let(:history) { CCMS::SubmissionHistory.find_by(submission_id: submission.id) }
   let(:applicant_add_requestor) { double CCMS::ApplicantAddRequestor }
   let(:transaction_request_id_in_example_response) { '20190301030405123456' }
-  # let(:expected_xml) { ccms_data_from_file 'applicant_add_request.xml' }
+  let(:expected_xml) { ccms_data_from_file 'applicant_add_request.xml' }
   subject { described_class.new(submission) }
 
   before do
     allow(subject).to receive(:applicant_add_requestor).and_return(applicant_add_requestor)
     allow(applicant_add_requestor).to receive(:transaction_request_id).and_return(transaction_request_id_in_example_response)
+    allow(applicant_add_requestor).to receive(:formatted_xml).and_return(expected_xml)
   end
 
   context 'operation successful' do
@@ -32,20 +33,16 @@ RSpec.describe CCMS::AddApplicantService do
         expect(submission.applicant_add_transaction_id).to eq transaction_request_id_in_example_response
       end
 
-      # it 'records a copy of the xml request' do
-      #   subject.call
-      #   expect(submission.save_applicant_request).to eq expected_xml
-      # end
-
-      # it 'records a copy of the xml response' do
-      #   subject.call
-      #   # expect(submission.applicant_add_requestor).to eq transaction_request_id_in_example_response
-      # end
-
       it 'writes a history record' do
         expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
         expect(history.from_state).to eq 'case_ref_obtained'
         expect(history.to_state).to eq 'applicant_submitted'
+        ap 111111
+        ap "<?xml version='1.0' encoding='UTF-8'?>\n"+history.request
+        ap 3333333
+        ap expected_xml
+        expect("<?xml version='1.0' encoding='UTF-8'?>\n"+history.request).to eq expected_xml
+        expect(history.request).to_not be_nil
         expect(history.success).to be true
         expect(history.details).to be_nil
       end

--- a/spec/services/ccms/add_applicant_service_spec.rb
+++ b/spec/services/ccms/add_applicant_service_spec.rb
@@ -37,10 +37,10 @@ RSpec.describe CCMS::AddApplicantService do
         expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
         expect(history.from_state).to eq 'case_ref_obtained'
         expect(history.to_state).to eq 'applicant_submitted'
-        ap 111111
-        ap "<?xml version='1.0' encoding='UTF-8'?>\n"+history.request
-        ap 3333333
-        ap expected_xml
+        # ap 111111
+        # ap "<?xml version='1.0' encoding='UTF-8'?>\n"+history.request
+        # ap 3333333
+        # ap expected_xml
         expect("<?xml version='1.0' encoding='UTF-8'?>\n"+history.request).to eq expected_xml
         expect(history.request).to_not be_nil
         expect(history.success).to be true
@@ -65,6 +65,8 @@ RSpec.describe CCMS::AddApplicantService do
         expect(history.from_state).to eq 'case_ref_obtained'
         expect(history.to_state).to eq 'failed'
         expect(history.success).to be false
+        expect("<?xml version='1.0' encoding='UTF-8'?>\n"+history.request).to eq expected_xml
+        expect(history.request).to_not be_nil
         expect(history.details).to match(/CCMS::CcmsError/)
         expect(history.details).to match(/oops/)
       end
@@ -86,6 +88,8 @@ RSpec.describe CCMS::AddApplicantService do
       it 'records the error in the submission history' do
         expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
         expect(history.from_state).to eq 'case_ref_obtained'
+        expect("<?xml version='1.0' encoding='UTF-8'?>\n"+history.request).to eq expected_xml
+        expect(history.request).to_not be_nil
         expect(history.to_state).to eq 'failed'
         expect(history.success).to be false
         expect(history.details).to eq(applicant_add_response)

--- a/spec/services/ccms/add_applicant_service_spec.rb
+++ b/spec/services/ccms/add_applicant_service_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe CCMS::AddApplicantService do
   let(:history) { CCMS::SubmissionHistory.find_by(submission_id: submission.id) }
   let(:applicant_add_requestor) { double CCMS::ApplicantAddRequestor }
   let(:transaction_request_id_in_example_response) { '20190301030405123456' }
+  # let(:expected_xml) { ccms_data_from_file 'applicant_add_request.xml' }
   subject { described_class.new(submission) }
 
   before do
@@ -30,6 +31,16 @@ RSpec.describe CCMS::AddApplicantService do
         subject.call
         expect(submission.applicant_add_transaction_id).to eq transaction_request_id_in_example_response
       end
+
+      # it 'records a copy of the xml request' do
+      #   subject.call
+      #   expect(submission.save_applicant_request).to eq expected_xml
+      # end
+
+      # it 'records a copy of the xml response' do
+      #   subject.call
+      #   # expect(submission.applicant_add_requestor).to eq transaction_request_id_in_example_response
+      # end
 
       it 'writes a history record' do
         expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)

--- a/spec/services/ccms/add_applicant_service_spec.rb
+++ b/spec/services/ccms/add_applicant_service_spec.rb
@@ -5,14 +5,15 @@ RSpec.describe CCMS::AddApplicantService do
   let(:submission) { create :submission, :case_ref_obtained, legal_aid_application: legal_aid_application }
   let(:history) { CCMS::SubmissionHistory.find_by(submission_id: submission.id) }
   let(:applicant_add_requestor) { double CCMS::ApplicantAddRequestor }
+  let(:applicant_add_response_parser) { double CCMS::ApplicantAddResponseParser }
   let(:transaction_request_id_in_example_response) { '20190301030405123456' }
-  let(:expected_xml) { ccms_data_from_file 'applicant_add_request.xml' }
+  let(:applicant_add_request) { ccms_data_from_file 'applicant_add_request.xml' }
   subject { described_class.new(submission) }
 
   before do
     allow(subject).to receive(:applicant_add_requestor).and_return(applicant_add_requestor)
     allow(applicant_add_requestor).to receive(:transaction_request_id).and_return(transaction_request_id_in_example_response)
-    allow(applicant_add_requestor).to receive(:formatted_xml).and_return(expected_xml)
+    allow(applicant_add_requestor).to receive(:formatted_xml).and_return(applicant_add_request)
   end
 
   context 'operation successful' do
@@ -37,11 +38,9 @@ RSpec.describe CCMS::AddApplicantService do
         expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
         expect(history.from_state).to eq 'case_ref_obtained'
         expect(history.to_state).to eq 'applicant_submitted'
-        # ap 111111
-        # ap "<?xml version='1.0' encoding='UTF-8'?>\n"+history.request
-        # ap 3333333
-        # ap expected_xml
-        expect("<?xml version='1.0' encoding='UTF-8'?>\n"+history.request).to eq expected_xml
+        expect(history.response).to eq applicant_add_response # formatting of response is wrong
+        expect(history.response).to_not be_nil
+        expect("<?xml version='1.0' encoding='UTF-8'?>\n"+history.request).to eq applicant_add_request
         expect(history.request).to_not be_nil
         expect(history.success).to be true
         expect(history.details).to be_nil
@@ -50,12 +49,16 @@ RSpec.describe CCMS::AddApplicantService do
   end
 
   context 'operation in error' do
+    let(:applicant_add_response) { ccms_data_from_file 'applicant_add_response_failure.xml' }
+
     context 'error when adding an applicant' do
       before do
-        expect(applicant_add_requestor).to receive(:call).and_raise(CCMS::CcmsError, 'oops')
+        expect(applicant_add_requestor).to receive(:call).and_raise(CCMS::CcmsError, 'oops' )
+        expect(applicant_add_response_parser).to receive(:call).and_return(applicant_add_response)
       end
 
       it 'puts it into failed state' do
+        # binding.pry
         subject.call
         expect(submission.aasm_state).to eq 'failed'
       end
@@ -65,10 +68,12 @@ RSpec.describe CCMS::AddApplicantService do
         expect(history.from_state).to eq 'case_ref_obtained'
         expect(history.to_state).to eq 'failed'
         expect(history.success).to be false
-        expect("<?xml version='1.0' encoding='UTF-8'?>\n"+history.request).to eq expected_xml
+        expect("<?xml version='1.0' encoding='UTF-8'?>\n"+history.request).to eq applicant_add_request
         expect(history.request).to_not be_nil
         expect(history.details).to match(/CCMS::CcmsError/)
         expect(history.details).to match(/oops/)
+        expect(history.response).to eq applicant_add_response
+        expect(history.response).to_not be_nil
       end
     end
 
@@ -88,11 +93,13 @@ RSpec.describe CCMS::AddApplicantService do
       it 'records the error in the submission history' do
         expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
         expect(history.from_state).to eq 'case_ref_obtained'
-        expect("<?xml version='1.0' encoding='UTF-8'?>\n"+history.request).to eq expected_xml
-        expect(history.request).to_not be_nil
         expect(history.to_state).to eq 'failed'
         expect(history.success).to be false
         expect(history.details).to eq(applicant_add_response)
+        expect("<?xml version='1.0' encoding='UTF-8'?>\n"+history.request).to eq applicant_add_request
+        expect(history.request).to_not be_nil
+        expect(history.response).to eq applicant_add_response
+        expect(history.response).to_not be_nil
       end
     end
   end

--- a/spec/services/ccms/add_case_service_spec.rb
+++ b/spec/services/ccms/add_case_service_spec.rb
@@ -5,12 +5,14 @@ RSpec.describe CCMS::AddCaseService do
   let(:submission) { create :submission, :applicant_ref_obtained, legal_aid_application: legal_aid_application }
   let(:history) { CCMS::SubmissionHistory.find_by(submission_id: submission.id) }
   let(:case_add_requestor) { double CCMS::CaseAddRequestor }
+  let(:expected_xml) { ccms_data_from_file 'case_add_request.xml' }
   let(:transaction_request_id_in_example_response) { '20190301030405123456' }
   subject { described_class.new(submission) }
 
   before do
     allow(subject).to receive(:case_add_requestor).and_return(case_add_requestor)
     allow(case_add_requestor).to receive(:transaction_request_id).and_return(transaction_request_id_in_example_response)
+    allow(case_add_requestor).to receive(:formatted_xml).and_return(expected_xml)
   end
 
   context 'operation successful' do
@@ -36,6 +38,8 @@ RSpec.describe CCMS::AddCaseService do
         expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
         expect(history.from_state).to eq 'document_ids_obtained'
         expect(history.to_state).to eq 'case_submitted'
+        expect("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"+history.request).to eq expected_xml
+        expect(history.request).to_not be_nil
         expect(history.success).to be true
         expect(history.details).to be_nil
       end
@@ -46,6 +50,8 @@ RSpec.describe CCMS::AddCaseService do
         expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
         expect(history.from_state).to eq 'applicant_ref_obtained'
         expect(history.to_state).to eq 'case_submitted'
+        expect("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"+history.request).to eq expected_xml
+        expect(history.request).to_not be_nil
         expect(history.success).to be true
         expect(history.details).to be_nil
       end
@@ -55,6 +61,7 @@ RSpec.describe CCMS::AddCaseService do
   context 'operation in error' do
     context 'error when adding a case' do
       before do
+        allow(case_add_requestor).to receive(:formatted_xml).and_return(expected_xml)
         expect(case_add_requestor).to receive(:call).and_raise(CCMS::CcmsError, 'oops')
       end
 
@@ -67,6 +74,8 @@ RSpec.describe CCMS::AddCaseService do
         expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
         expect(history.from_state).to eq 'applicant_ref_obtained'
         expect(history.to_state).to eq 'failed'
+        expect("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"+history.request).to eq expected_xml
+        expect(history.request).to_not be_nil
         expect(history.success).to be false
         expect(history.details).to match(/CCMS::CcmsError/)
         expect(history.details).to match(/oops/)
@@ -78,6 +87,7 @@ RSpec.describe CCMS::AddCaseService do
       let(:case_add_response_parser) { double CCMS::CaseAddResponseParser }
 
       before do
+        allow(case_add_requestor).to receive(:formatted_xml).and_return(case_add_response)
         expect(case_add_requestor).to receive(:call).and_return(case_add_response)
         allow(subject).to receive(:case_add_response_parser).and_return(case_add_response_parser)
         expect(case_add_response_parser).to receive(:success?).and_return(false)
@@ -91,6 +101,9 @@ RSpec.describe CCMS::AddCaseService do
       it 'records the error in the submission history' do
         expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
         expect(history.from_state).to eq 'applicant_ref_obtained'
+        # TO DO - check the xml for this as it is not matching the first part, encoding is missing
+        # expect(history.request).to eq case_add_response
+        expect(history.request).to_not be_nil
         expect(history.to_state).to eq 'failed'
         expect(history.success).to be false
         expect(history.details).to eq(case_add_response)

--- a/spec/services/ccms/add_case_service_spec.rb
+++ b/spec/services/ccms/add_case_service_spec.rb
@@ -5,14 +5,14 @@ RSpec.describe CCMS::AddCaseService do
   let(:submission) { create :submission, :applicant_ref_obtained, legal_aid_application: legal_aid_application }
   let(:history) { CCMS::SubmissionHistory.find_by(submission_id: submission.id) }
   let(:case_add_requestor) { double CCMS::CaseAddRequestor }
-  let(:expected_xml) { ccms_data_from_file 'case_add_request.xml' }
+  let(:case_add_request) { ccms_data_from_file 'case_add_request.xml' }
   let(:transaction_request_id_in_example_response) { '20190301030405123456' }
   subject { described_class.new(submission) }
 
   before do
     allow(subject).to receive(:case_add_requestor).and_return(case_add_requestor)
     allow(case_add_requestor).to receive(:transaction_request_id).and_return(transaction_request_id_in_example_response)
-    allow(case_add_requestor).to receive(:formatted_xml).and_return(expected_xml)
+    allow(case_add_requestor).to receive(:formatted_xml).and_return(case_add_request)
   end
 
   context 'operation successful' do
@@ -38,7 +38,7 @@ RSpec.describe CCMS::AddCaseService do
         expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
         expect(history.from_state).to eq 'document_ids_obtained'
         expect(history.to_state).to eq 'case_submitted'
-        expect("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"+history.request).to eq expected_xml
+        expect("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"+history.request).to eq case_add_request
         expect(history.request).to_not be_nil
         expect(history.success).to be true
         expect(history.details).to be_nil
@@ -50,7 +50,7 @@ RSpec.describe CCMS::AddCaseService do
         expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
         expect(history.from_state).to eq 'applicant_ref_obtained'
         expect(history.to_state).to eq 'case_submitted'
-        expect("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"+history.request).to eq expected_xml
+        expect("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"+history.request).to eq case_add_request
         expect(history.request).to_not be_nil
         expect(history.success).to be true
         expect(history.details).to be_nil
@@ -61,7 +61,7 @@ RSpec.describe CCMS::AddCaseService do
   context 'operation in error' do
     context 'error when adding a case' do
       before do
-        allow(case_add_requestor).to receive(:formatted_xml).and_return(expected_xml)
+        allow(case_add_requestor).to receive(:formatted_xml).and_return(case_add_request)
         expect(case_add_requestor).to receive(:call).and_raise(CCMS::CcmsError, 'oops')
       end
 
@@ -74,7 +74,7 @@ RSpec.describe CCMS::AddCaseService do
         expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
         expect(history.from_state).to eq 'applicant_ref_obtained'
         expect(history.to_state).to eq 'failed'
-        expect("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"+history.request).to eq expected_xml
+        expect("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"+history.request).to eq case_add_request
         expect(history.request).to_not be_nil
         expect(history.success).to be false
         expect(history.details).to match(/CCMS::CcmsError/)

--- a/spec/services/ccms/check_applicant_status_service_spec.rb
+++ b/spec/services/ccms/check_applicant_status_service_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe CCMS::CheckApplicantStatusService do
   let(:applicant_add_status_requestor) { double CCMS::ApplicantAddStatusRequestor }
   let(:history) { CCMS::SubmissionHistory.find_by(submission_id: submission.id) }
   let(:applicant_add_status_response) { ccms_data_from_file 'applicant_add_status_response.xml' }
+  let(:applicant_add_status_request) { ccms_data_from_file 'applicant_add_status_request.xml' }
   subject { described_class.new(submission) }
 
   before do
@@ -19,6 +20,7 @@ RSpec.describe CCMS::CheckApplicantStatusService do
         before do
           expect(applicant_add_status_requestor).to receive(:call).and_return(applicant_add_status_response)
           expect(applicant_add_status_requestor).to receive(:transaction_request_id).and_return(transaction_request_id_in_example_response)
+          allow(applicant_add_status_requestor).to receive(:formatted_xml).and_return(applicant_add_status_request)
           allow_any_instance_of(CCMS::ApplicantAddStatusResponseParser).to receive(:success?).and_return(false)
         end
 
@@ -35,6 +37,8 @@ RSpec.describe CCMS::CheckApplicantStatusService do
             expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
             expect(history.from_state).to eq 'applicant_submitted'
             expect(history.to_state).to eq 'applicant_submitted'
+            expect("<?xml version=\'1.0\' encoding=\'UTF-8\'?>\n"+history.request).to eq applicant_add_status_request
+            expect(history.request).to_not be_nil
             expect(history.success).to be true
             expect(history.details).to be_nil
           end
@@ -57,6 +61,8 @@ RSpec.describe CCMS::CheckApplicantStatusService do
             expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
             expect(history.from_state).to eq 'applicant_submitted'
             expect(history.to_state).to eq 'failed'
+            expect("<?xml version=\'1.0\' encoding=\'UTF-8\'?>\n"+history.request).to eq applicant_add_status_request
+            expect(history.request).to_not be_nil
             expect(history.success).to be false
             expect(history.details).to eq 'Poll limit exceeded'
           end
@@ -68,6 +74,7 @@ RSpec.describe CCMS::CheckApplicantStatusService do
 
         before do
           expect(applicant_add_status_requestor).to receive(:call).and_return(applicant_add_status_response)
+          allow(applicant_add_status_requestor).to receive(:formatted_xml).and_return(applicant_add_status_request)
           expect(applicant_add_status_requestor).to receive(:transaction_request_id).and_return(transaction_request_id_in_example_response)
           allow_any_instance_of(CCMS::ApplicantAddStatusResponseParser).to receive(:success?).and_return(true)
           allow_any_instance_of(CCMS::ApplicantAddStatusResponseParser).to receive(:applicant_ccms_reference).and_return(expected_applicant_ccms_reference)
@@ -85,6 +92,8 @@ RSpec.describe CCMS::CheckApplicantStatusService do
           expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
           expect(history.from_state).to eq 'applicant_submitted'
           expect(history.to_state).to eq 'applicant_ref_obtained'
+          expect("<?xml version=\'1.0\' encoding=\'UTF-8\'?>\n"+history.request).to eq applicant_add_status_request
+          expect(history.request).to_not be_nil
           expect(history.success).to be true
           expect(history.details).to be_nil
         end
@@ -96,6 +105,7 @@ RSpec.describe CCMS::CheckApplicantStatusService do
 
       before do
         expect(applicant_add_status_requestor).to receive(:call).and_raise(CCMS::CcmsError, 'oops')
+        allow(applicant_add_status_requestor).to receive(:formatted_xml).and_return(applicant_add_status_request)
         expect(applicant_add_status_requestor).to receive(:transaction_request_id).and_return(transaction_request_id_in_example_response)
       end
 
@@ -111,6 +121,8 @@ RSpec.describe CCMS::CheckApplicantStatusService do
         expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
         expect(history.from_state).to eq 'applicant_submitted'
         expect(history.to_state).to eq 'failed'
+        expect("<?xml version=\'1.0\' encoding=\'UTF-8\'?>\n"+history.request).to eq applicant_add_status_request
+        expect(history.request).to_not be_nil
         expect(history.success).to be false
         expect(history.details).to match(/CCMS::CcmsError/)
         expect(history.details).to match(/oops/)

--- a/spec/services/ccms/check_case_status_service_spec.rb
+++ b/spec/services/ccms/check_case_status_service_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe CCMS::CheckCaseStatusService do
   let(:case_add_status_requestor) { double CCMS::CaseAddStatusRequestor }
   let(:history) { CCMS::SubmissionHistory.find_by(submission_id: submission.id) }
   let(:case_add_status_response) { ccms_data_from_file 'case_add_status_response.xml' }
+  let(:case_add_status_request) { ccms_data_from_file 'case_add_status_request.xml' }
   subject { described_class.new(submission) }
 
   before do
@@ -17,6 +18,7 @@ RSpec.describe CCMS::CheckCaseStatusService do
 
       context 'case not yet created' do
         before do
+          allow(case_add_status_requestor).to receive(:formatted_xml).and_return(case_add_status_request)
           expect(case_add_status_requestor).to receive(:call).and_return(case_add_status_response)
           expect(case_add_status_requestor).to receive(:transaction_request_id).and_return(transaction_request_id_in_example_response)
           allow_any_instance_of(CCMS::CaseAddStatusResponseParser).to receive(:success?).and_return(false)
@@ -35,6 +37,8 @@ RSpec.describe CCMS::CheckCaseStatusService do
             expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
             expect(history.from_state).to eq 'case_submitted'
             expect(history.to_state).to eq 'case_submitted'
+            expect("<?xml version=\'1.0\' encoding=\'UTF-8\'?>\n"+history.request).to eq case_add_status_request
+            expect(history.request).to_not be_nil
             expect(history.success).to be true
             expect(history.details).to be_nil
           end
@@ -57,6 +61,8 @@ RSpec.describe CCMS::CheckCaseStatusService do
             expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
             expect(history.from_state).to eq 'case_submitted'
             expect(history.to_state).to eq 'failed'
+            expect("<?xml version=\'1.0\' encoding=\'UTF-8\'?>\n"+history.request).to eq case_add_status_request
+            expect(history.request).to_not be_nil
             expect(history.success).to be false
             expect(history.details).to eq 'Poll limit exceeded'
           end
@@ -65,6 +71,7 @@ RSpec.describe CCMS::CheckCaseStatusService do
 
       context 'case is created' do
         before do
+          allow(case_add_status_requestor).to receive(:formatted_xml).and_return(case_add_status_request)
           expect(case_add_status_requestor).to receive(:call).and_return(case_add_status_response)
           expect(case_add_status_requestor).to receive(:transaction_request_id).and_return(transaction_request_id_in_example_response)
           allow_any_instance_of(CCMS::CaseAddStatusResponseParser).to receive(:success?).and_return(true)
@@ -78,6 +85,8 @@ RSpec.describe CCMS::CheckCaseStatusService do
           expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
           expect(history.from_state).to eq 'case_submitted'
           expect(history.to_state).to eq 'case_created'
+          expect("<?xml version=\'1.0\' encoding=\'UTF-8\'?>\n"+history.request).to eq case_add_status_request
+          expect(history.request).to_not be_nil
           expect(history.success).to be true
           expect(history.details).to be_nil
         end
@@ -88,6 +97,7 @@ RSpec.describe CCMS::CheckCaseStatusService do
       let(:transaction_request_id_in_example_response) { '20190301030405123456' }
 
       before do
+        allow(case_add_status_requestor).to receive(:formatted_xml).and_return(case_add_status_request)
         expect(case_add_status_requestor).to receive(:call).and_raise(CCMS::CcmsError, 'oops')
         expect(case_add_status_requestor).to receive(:transaction_request_id).and_return(transaction_request_id_in_example_response)
       end
@@ -104,6 +114,8 @@ RSpec.describe CCMS::CheckCaseStatusService do
         expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
         expect(history.from_state).to eq 'case_submitted'
         expect(history.to_state).to eq 'failed'
+        expect("<?xml version=\'1.0\' encoding=\'UTF-8\'?>\n"+history.request).to eq case_add_status_request
+        expect(history.request).to_not be_nil
         expect(history.success).to be false
         expect(history.details).to match(/CCMS::CcmsError/)
         expect(history.details).to match(/oops/)

--- a/spec/services/ccms/obtain_applicant_reference_service_spec.rb
+++ b/spec/services/ccms/obtain_applicant_reference_service_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe CCMS::ObtainApplicantReferenceService do
   let(:legal_aid_application) { create :legal_aid_application, :with_applicant }
   let(:submission) { create :submission, :case_ref_obtained, legal_aid_application: legal_aid_application }
   let(:history) { CCMS::SubmissionHistory.find_by(submission_id: submission.id) }
+  let(:applicant_search_request) { ccms_data_from_file 'applicant_search_request.xml' }
   let(:applicant_search_requestor) { double CCMS::ApplicantSearchRequestor }
   subject { described_class.new(submission) }
 
@@ -13,6 +14,7 @@ RSpec.describe CCMS::ObtainApplicantReferenceService do
 
   context 'operation successful' do
     before do
+      allow(applicant_search_requestor).to receive(:formatted_xml).and_return(applicant_search_request)
       expect(applicant_search_requestor).to receive(:call).and_return(applicant_search_response)
       expect(applicant_search_requestor).to receive(:transaction_request_id).and_return(transaction_request_id_in_example_response)
     end
@@ -36,6 +38,8 @@ RSpec.describe CCMS::ObtainApplicantReferenceService do
         expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
         expect(history.from_state).to eq 'case_ref_obtained'
         expect(history.to_state).to eq 'applicant_ref_obtained'
+        expect("<?xml version=\'1.0\' encoding=\'UTF-8\'?>\n"+history.request).to eq applicant_search_request
+        expect(history.request).to_not be_nil
         expect(history.success).to be true
         expect(history.details).to be_nil
       end
@@ -57,6 +61,7 @@ RSpec.describe CCMS::ObtainApplicantReferenceService do
   context 'operation in error' do
     context 'error when searching for applicant' do
       before do
+        allow(applicant_search_requestor).to receive(:formatted_xml).and_return(applicant_search_request)
         allow(applicant_search_requestor).to receive(:transaction_request_id).and_return(Faker::Number.number(digits: 8))
         expect(applicant_search_requestor).to receive(:call).and_raise(CCMS::CcmsError, 'oops')
       end
@@ -70,6 +75,8 @@ RSpec.describe CCMS::ObtainApplicantReferenceService do
         expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
         expect(history.from_state).to eq 'case_ref_obtained'
         expect(history.to_state).to eq 'failed'
+        expect("<?xml version=\'1.0\' encoding=\'UTF-8\'?>\n"+history.request).to eq applicant_search_request
+        expect(history.request).to_not be_nil
         expect(history.success).to be false
         expect(history.details).to match(/CCMS::CcmsError/)
         expect(history.details).to match(/oops/)

--- a/spec/services/ccms/obtain_case_reference_service_spec.rb
+++ b/spec/services/ccms/obtain_case_reference_service_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe CCMS::ObtainCaseReferenceService do
   let(:legal_aid_application) { create :legal_aid_application }
   let(:submission) { create :submission, legal_aid_application: legal_aid_application }
   let(:history) { CCMS::SubmissionHistory.find_by(submission_id: submission.id) }
+  let(:reference_data_request) { ccms_data_from_file 'reference_data_request.xml' }
   let(:reference_data_requestor) { double CCMS::ReferenceDataRequestor }
   subject { described_class.new(submission) }
 
@@ -17,6 +18,7 @@ RSpec.describe CCMS::ObtainCaseReferenceService do
     let(:ccms_case_ref_in_example_response) { '300000135140' }
 
     before do
+      allow(reference_data_requestor).to receive(:formatted_xml).and_return(reference_data_request)
       expect(reference_data_requestor).to receive(:transaction_request_id).and_return(transaction_request_id_in_example_response)
       expect(reference_data_requestor).to receive(:call).and_return(reference_data_response)
     end
@@ -35,6 +37,8 @@ RSpec.describe CCMS::ObtainCaseReferenceService do
       expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
       expect(history.from_state).to eq 'initialised'
       expect(history.to_state).to eq 'case_ref_obtained'
+      expect("<?xml version=\'1.0\' encoding=\'UTF-8\'?>\n"+history.request).to eq reference_data_request
+      expect(history.request).to_not be_nil
       expect(history.success).to be true
       expect(history.details).to be_nil
     end
@@ -42,6 +46,7 @@ RSpec.describe CCMS::ObtainCaseReferenceService do
 
   context 'operation in error' do
     before do
+      allow(reference_data_requestor).to receive(:formatted_xml).and_return(reference_data_request)
       allow(reference_data_requestor).to receive(:transaction_request_id).and_return(Faker::Number.number(digits: 8))
       expect(reference_data_requestor).to receive(:call).and_raise(CCMS::CcmsError, 'oops')
     end
@@ -55,6 +60,8 @@ RSpec.describe CCMS::ObtainCaseReferenceService do
       expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
       expect(history.from_state).to eq 'initialised'
       expect(history.to_state).to eq 'failed'
+      expect("<?xml version=\'1.0\' encoding=\'UTF-8\'?>\n"+history.request).to eq reference_data_request
+      expect(history.request).to_not be_nil
       expect(history.success).to be false
       expect(history.details).to match(/CCMS::CcmsError/)
       expect(history.details).to match(/oops/)


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-764)
Help Please.

I added the xml_response and xml_request as arguments to the create_history method, so that the xml request and response are saved in the database.

The problem - When the tests are run in ```add_applicant_service_spec.rb``` 2 of them currently fail due to an error (line 60 and 66). This seems to be related to the CCMS error function that is being called on line 56 of  ```add_applicant_service_spec.rb``` 

I think I may be failing to set up the spec correctly to handle 'xml_response' however I was able to add 'xml_request' in the same way without causing any issues for the tests. 

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
