### PR TITLE
AP-667 Bank selection page for OpenBanking

### DIFF
--- a/app/assets/stylesheets/bank-selection.scss
+++ b/app/assets/stylesheets/bank-selection.scss
@@ -1,0 +1,46 @@
+.bank-selection {
+  .govuk-radios__item {
+    border: 1px solid #0b0c0c;
+    cursor: pointer;
+    background: #ffffff; /* Old browsers */
+    background: -moz-linear-gradient(left,  #ffffff 0%, #ffffff 31%, #ffffff 31%, #f8f8f8 31%, #f8f8f8 31%, #f8f8f8 31%, #f8f8f8 100%); /* FF3.6-15 */
+    background: -webkit-linear-gradient(left,  #ffffff 0%,#ffffff 31%,#ffffff 31%,#f8f8f8 31%,#f8f8f8 31%,#f8f8f8 31%,#f8f8f8 100%); /* Chrome10-25,Safari5.1-6 */
+    background: linear-gradient(to right,  #ffffff 0%,#ffffff 31%,#ffffff 31%,#f8f8f8 31%,#f8f8f8 31%,#f8f8f8 31%,#f8f8f8 100%); /* W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+ */
+    filter: progid:D
+  }
+
+  .govuk-radios__input {
+    text-align: center;
+  }
+
+  .bank-logo {
+    display: inline-block;
+    width: 100px;
+    height: 50px;
+    text-align: center;
+    margin: 0px 30px 0px 20px;
+
+    img {
+      width: 100%;
+      height: 50px;
+    }
+  }
+
+  label {
+    width: 100%;
+
+    span {
+      vertical-align: 20px;
+    }
+  }
+
+  .govuk-radios__input + .govuk-radios__label::before {
+    top: 15px;
+    left: 10px;
+  }
+
+  .govuk-radios__input + .govuk-radios__label::after {
+    top:25px;
+    left: 20px
+  }
+}

--- a/app/controllers/citizens/additional_accounts_controller.rb
+++ b/app/controllers/citizens/additional_accounts_controller.rb
@@ -19,7 +19,7 @@ module Citizens
     def update
       case params[:has_offline_accounts]
       when 'yes'
-        redirect_to applicant_true_layer_omniauth_authorize_path
+        redirect_to citizens_banks_path
       when 'no'
         legal_aid_application.update(has_offline_accounts: true)
         go_forward

--- a/app/controllers/citizens/banks_controller.rb
+++ b/app/controllers/citizens/banks_controller.rb
@@ -1,0 +1,15 @@
+module Citizens
+  class BanksController < CitizenBaseController
+    def index; end
+
+    def create
+      if params[:provider_id].present?
+        session[:provider_id] = params[:provider_id]
+        go_forward
+      else
+        @error = t('.error')
+        render :index
+      end
+    end
+  end
+end

--- a/app/models/true_layer_bank.rb
+++ b/app/models/true_layer_bank.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class TrueLayerBank < ApplicationRecord
+  serialize :banks, Array
+
+  scope :by_updated_at, -> { order(updated_at: :asc) }
+  before_validation :populate_banks
+
+  validates :banks, presence: true
+
+  MOCK_BANK = {
+    provider_id: 'mock',
+    display_name: 'Mock Bank',
+    logo_url: 'https://truelayer-client-logos.s3-eu-west-1.amazonaws.com/banks/banks-icons/mock-icon.svg'
+  }.freeze
+
+  def self.banks
+    TrueLayerBanksUpdateWorker.perform_in 10.seconds
+    instance = by_updated_at.last || create!
+    return instance.banks unless mock_bank
+
+    [mock_bank] + instance.banks
+  end
+
+  def self.mock_bank
+    Rails.configuration.x.true_layer.enable_mock ? MOCK_BANK : nil
+  end
+
+  def populate_banks
+    self.banks = TrueLayer::BanksRetriever.banks unless banks.present?
+  end
+end

--- a/app/services/flow/flows/citizen_start.rb
+++ b/app/services/flow/flows/citizen_start.rb
@@ -11,6 +11,10 @@ module Flow
         },
         consents: {
           path: ->(_) { urls.citizens_consent_path },
+          forward: :banks
+        },
+        banks: {
+          path: ->(_) { urls.citizens_banks_path },
           forward: :true_layer
         },
         true_layer: {

--- a/app/services/true_layer/banks_retriever.rb
+++ b/app/services/true_layer/banks_retriever.rb
@@ -1,0 +1,30 @@
+module TrueLayer
+  class BanksRetriever
+    UnsuccessfulRetrievalError = Class.new(StandardError)
+    API_URL = 'https://auth.truelayer.com/api/providers/oauth/openbanking'.freeze
+
+    def self.banks
+      new.banks
+    end
+
+    def banks
+      return raise_error unless response.is_a?(Net::HTTPOK)
+
+      JSON.parse(response.body, symbolize_names: true)
+    end
+
+    private
+
+    def response
+      @response ||= Net::HTTP.get_response(uri)
+    end
+
+    def uri
+      URI.parse(API_URL)
+    end
+
+    def raise_error
+      raise UnsuccessfulRetrievalError, "Retrieval Failed: #{response.message} (#{response.code}) #{response.body}"
+    end
+  end
+end

--- a/app/views/citizens/accounts/index.html.erb
+++ b/app/views/citizens/accounts/index.html.erb
@@ -50,7 +50,7 @@
       </table>
     <% end %>
 
-    <p><%= link_to t('.link_other_account'), applicant_true_layer_omniauth_authorize_path, class: 'govuk-link' %></p>
+    <p><%= link_to t('.link_other_account'), citizens_banks_path, class: 'govuk-link' %></p>
 
     <div class="govuk-!-padding-top-3">
       <%= next_action_link(continue_text: t('generic.continue')) %>

--- a/app/views/citizens/banks/_bank.html.erb
+++ b/app/views/citizens/banks/_bank.html.erb
@@ -1,0 +1,9 @@
+<div class="govuk-radios__item">
+  <%= form.radio_button :provider_id, bank[:provider_id], class: 'govuk-radios__input' %>
+  <%= form.label :provider_id, bank[:display_name], value: bank[:provider_id], class: 'govuk-label govuk-radios__label' do %>
+    <div class="bank-logo">
+      <%= image_tag(bank[:logo_url], alt: bank[:display_name]) if bank[:logo_url] %>
+    </div>
+    <span><%= bank[:display_name] %></span>
+  <% end %>
+</div>

--- a/app/views/citizens/banks/_error.html.erb
+++ b/app/views/citizens/banks/_error.html.erb
@@ -1,0 +1,12 @@
+<div class="govuk-error-summary" id="error_explanation">
+  <h2 class="govuk-error-summary__title" id="error-summary-title">
+    <%= t('generic.errors.problem_text') %>
+  </h2>
+  <div class="govuk-error-summary__body">
+    <ul class="govuk-list govuk-error-summary__list">
+      <li>
+        <%= link_to @error, "#correct" %>
+      </li>
+    </ul>
+  </div>
+</div>

--- a/app/views/citizens/banks/index.html.erb
+++ b/app/views/citizens/banks/index.html.erb
@@ -1,0 +1,19 @@
+<%= page_template page_title: t('.title'), template: :basic do %>
+
+  <%= render 'error' if @error %>
+
+  <%= form_with(local: true) do |form| %>
+    <%= govuk_form_group(show_error_if: @error) do %>
+      <h1 class="govuk-heading-xl"><%= content_for(:page_title) %></h1>
+
+      <div class="govuk-radios bank-selection">
+        <%= render partial: 'bank', collection: TrueLayerBank.banks, locals: { form: form } %>
+      </div>
+    <% end %>
+
+    <h2 class="govuk-heading-m"><%= t('.what_happens_next') %></h2>
+    <p class="govuk-body"><%= t('.connect') %></p>
+
+    <%= form.submit(t('generic.continue'), class: 'govuk-button form-button') %>
+  <% end %>
+<% end %>

--- a/app/workers/true_layer_banks_update_worker.rb
+++ b/app/workers/true_layer_banks_update_worker.rb
@@ -1,0 +1,30 @@
+class TrueLayerBanksUpdateWorker
+  DataRetrievalError = Class.new(StandardError)
+  include Sidekiq::Worker
+  include Sidekiq::Status::Worker
+
+  UPDATE_INTERVAL = 1.hour
+
+  def perform
+    return true if last_updated && last_updated.updated_at > UPDATE_INTERVAL.ago
+    return last_updated.touch if last_updated && stored_data_current?
+
+    lastest_data.save!
+  end
+
+  def last_updated
+    @last_updated ||= TrueLayerBank.by_updated_at.last
+  end
+
+  def lastest_data
+    @lastest_data ||= begin
+      true_layer_bank = TrueLayerBank.new
+      true_layer_bank.populate_banks
+      true_layer_bank
+    end
+  end
+
+  def stored_data_current?
+    last_updated.banks == lastest_data.banks
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -67,6 +67,10 @@ module LaaApplyForLegalAid
     config.x.slack_alerts_webhook = ENV['SLACK_ALERTS_WEBHOOK']
     config.x.check_finanical_eligibility_host = ENV['CHECK_FINANCIAL_ELIGIBILITY_HOST']
 
+    config.x.true_layer.client_id      = ENV['TRUE_LAYER_CLIENT_ID']
+    config.x.true_layer.client_sercret = ENV['TRUE_LAYER_CLIENT_SECRET']
+    config.x.true_layer.enable_mock    = ENV['TRUE_LAYER_ENABLE_MOCK'] == 'true'
+
     require Rails.root.join 'app/lib/govuk_elements_form_builder/form_builder'
     ActionView::Base.default_form_builder = GovukElementsFormBuilder::FormBuilder
 

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -318,8 +318,8 @@ Devise.setup do |config|
   require Rails.root.join 'app/lib/omniauth/omniauth_true_layer'
   config.omniauth(
     :true_layer,
-    ENV['TRUE_LAYER_CLIENT_ID'],
-    ENV['TRUE_LAYER_CLIENT_SECRET'],
+    Rails.configuration.x.true_layer.client_id,
+    Rails.configuration.x.true_layer.client_sercret,
     scope: 'info accounts balance transactions'
   )
 

--- a/config/locales/en/citizens.yml
+++ b/config/locales/en/citizens.yml
@@ -22,6 +22,13 @@ en:
       new:
         field_set_header: Do you have online access to your accounts with other banks?
         hint: If you do not, you will need to provide paper evidence for these accounts.
+    banks:
+      index:
+        title: Select your bank
+        what_happens_next: What happens next
+        connect: We'll connect you to your bank using a secure service so you can share your bank transactions with us.
+      create:
+        error: Select a bank
     check_answers:
       index:
         assets:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,6 +44,7 @@ Rails.application.routes.draw do
     resources :legal_aid_applications, only: %i[show index]
     resources :resend_link_requests, only: %i[show update], path: 'resend_link'
     resource :consent, only: %i[show create]
+    resources :banks, only: %i[index create]
     resource :property_value, only: %i[show update]
     resource :information, only: [:show]
     resources :accounts, only: [:index] do

--- a/db/migrate/20190925095224_create_true_layer_banks.rb
+++ b/db/migrate/20190925095224_create_true_layer_banks.rb
@@ -1,0 +1,9 @@
+class CreateTrueLayerBanks < ActiveRecord::Migration[5.2]
+  def change
+    create_table :true_layer_banks, id: :uuid do |t|
+      t.text :banks
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_18_102038) do
+ActiveRecord::Schema.define(version: 2019_09_25_095224) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -566,6 +566,12 @@ ActiveRecord::Schema.define(version: 2019_09_18_102038) do
     t.datetime "updated_at", null: false
     t.integer "sort_order"
     t.datetime "archived_at"
+  end
+
+  create_table "true_layer_banks", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.text "banks"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "vehicles", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/features/citizens/citizens.feature
+++ b/features/citizens/citizens.feature
@@ -2,6 +2,7 @@ Feature: Citizen journey
   @javascript
   Scenario: Start citizen journey until TrueLayer Auth
     Given An application has been created
+    And a "true layer bank" exists in the database
     Then I visit the start of the financial assessment
     Then I should be on a page showing 'Complete your legal aid financial assessment'
     Then I click link 'Start'
@@ -10,6 +11,9 @@ Feature: Citizen journey
     Then I should be on a page showing 'Do you agree to share your bank transactions with us?'
     Then I select 'I agree for you to check 3 months of bank transactions'
     Then I click 'Save and continue'
+    Then I should be on a page showing 'Select your bank'
+    Then I choose 'HSBC'
+    Then I click 'Continue'
     Then I am directed to TrueLayer
 
   @javascript @webhint

--- a/spec/cassettes/true_layer_banks_api.yml
+++ b/spec/cassettes/true_layer_banks_api.yml
@@ -1,0 +1,50 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://auth.truelayer.com/api/providers/oauth/openbanking
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - auth.truelayer.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 26 Sep 2019 16:39:52 GMT
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubdomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      X-Request-Id:
+      - 0HLQ2E0IROA81:00000001
+      Content-Length:
+      - '4585'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '[{"provider_id":"ob-barclaycard","display_name":"Barclaycard","logo_url":"https://truelayer-client-logos.s3-eu-west-1.amazonaws.com/banks/banks-icons/ob-barclaycard-icon.svg","scopes":["accounts","cards","balance","transactions","offline_access"]},{"provider_id":"ob-barclays","display_name":"Barclays","logo_url":"https://truelayer-client-logos.s3-eu-west-1.amazonaws.com/banks/banks-icons/ob-barclays-icon.svg","scopes":["accounts","cards","balance","direct_debits","standing_orders","transactions","offline_access"]},{"provider_id":"ob-bos","display_name":"Bank
+        of Scotland","logo_url":"https://truelayer-client-logos.s3-eu-west-1.amazonaws.com/banks/banks-icons/ob-bos-icon.svg","scopes":["accounts","balance","transactions","cards","direct_debits","standing_orders","info","offline_access"]},{"provider_id":"ob-danske","display_name":"Danske","logo_url":"https://truelayer-client-logos.s3-eu-west-1.amazonaws.com/banks/banks-icons/ob-danske-icon.svg","scopes":["accounts","balance","info","direct_debits","standing_orders","transactions","offline_access"]},{"provider_id":"ob-first-direct","display_name":"First
+        Direct","logo_url":"https://truelayer-client-logos.s3-eu-west-1.amazonaws.com/banks/banks-icons/ob-first-direct-icon.svg","scopes":["accounts","balance","info","transactions","offline_access"]},{"provider_id":"ob-halifax","display_name":"Halifax","logo_url":"https://truelayer-client-logos.s3-eu-west-1.amazonaws.com/banks/banks-icons/ob-halifax-icon.svg","scopes":["accounts","balance","transactions","cards","direct_debits","standing_orders","info","offline_access"]},{"provider_id":"ob-hsbc","display_name":"HSBC","logo_url":"https://truelayer-client-logos.s3-eu-west-1.amazonaws.com/banks/banks-icons/ob-hsbc-icon.svg","scopes":["accounts","balance","info","transactions","offline_access"]},{"provider_id":"ob-hsbc-business","display_name":"HSBC
+        Business","logo_url":"https://truelayer-client-logos.s3-eu-west-1.amazonaws.com/banks/banks-icons/ob-hsbc-business-icon.svg","scopes":["accounts","balance","info","transactions","offline_access"]},{"provider_id":"ob-lloyds","display_name":"Lloyds
+        Bank","logo_url":"https://truelayer-client-logos.s3-eu-west-1.amazonaws.com/banks/banks-icons/ob-lloyds-icon.svg","scopes":["accounts","balance","cards","direct_debits","standing_orders","info","transactions","offline_access"]},{"provider_id":"ob-mbna","display_name":"MBNA","logo_url":"https://truelayer-client-logos.s3-eu-west-1.amazonaws.com/banks/banks-icons/ob-mbna-icon.svg","scopes":["accounts","balance","direct_debits","standing_orders","transactions","offline_access"]},{"provider_id":"ob-ms","display_name":"Marks
+        & Spencer","logo_url":"https://truelayer-client-logos.s3-eu-west-1.amazonaws.com/banks/banks-icons/ob-ms-icon.svg","scopes":["accounts","balance","info","transactions","offline_access"]},{"provider_id":"ob-nationwide","display_name":"Nationwide","logo_url":"https://truelayer-client-logos.s3-eu-west-1.amazonaws.com/banks/banks-icons/ob-nationwide-icon.svg","scopes":["accounts","balance","direct_debits","standing_orders","transactions","info","cards","offline_access"]},{"provider_id":"ob-natwest","display_name":"Natwest","logo_url":"https://truelayer-client-logos.s3-eu-west-1.amazonaws.com/banks/banks-icons/ob-natwest-icon.svg","scopes":["accounts","balance","transactions","info","cards","offline_access"]},{"provider_id":"ob-rbs","display_name":"RBS","logo_url":"https://truelayer-client-logos.s3-eu-west-1.amazonaws.com/banks/banks-icons/ob-rbs-icon.svg","scopes":["accounts","balance","transactions","info","cards","offline_access"]},{"provider_id":"ob-revolut","display_name":"Revolut","logo_url":"https://truelayer-client-logos.s3-eu-west-1.amazonaws.com/banks/banks-icons/ob-revolut-icon.svg","scopes":["accounts","balance","direct_debits","standing_orders","transactions","offline_access"]},{"provider_id":"ob-santander","display_name":"Santander","logo_url":"https://truelayer-client-logos.s3-eu-west-1.amazonaws.com/banks/banks-icons/ob-santander-icon.svg","scopes":["accounts","balance","transactions","info","offline_access"]},{"provider_id":"ob-tsb","display_name":"TSB","logo_url":"https://truelayer-client-logos.s3-eu-west-1.amazonaws.com/banks/banks-icons/ob-tsb-icon.svg","scopes":["accounts","balance","cards","direct_debits","standing_orders","transactions","offline_access"]},{"provider_id":"ob-ulster","display_name":"Ulster
+        Bank","logo_url":"https://truelayer-client-logos.s3-eu-west-1.amazonaws.com/banks/banks-icons/ob-ulster-icon.svg","scopes":["accounts","balance","transactions","info","cards","offline_access"]}]'
+    http_version: 
+  recorded_at: Thu, 26 Sep 2019 16:39:52 GMT
+recorded_with: VCR 5.0.0

--- a/spec/factories/true_layer_banks.rb
+++ b/spec/factories/true_layer_banks.rb
@@ -1,0 +1,18 @@
+FactoryBot.define do
+  factory :true_layer_bank do
+    banks do
+      [
+        {
+          provider_id: 'ob-bos',
+          display_name: 'Bank of Scotland',
+          logo_url: 'https://truelayer-client-logos.s3-eu-west-1.amazonaws.com/banks/banks-icons/ob-bos-icon.svg'
+        },
+        {
+          provider_id: 'ob-hsbc',
+          display_name: 'HSBC',
+          logo_url: 'https://truelayer-client-logos.s3-eu-west-1.amazonaws.com/banks/banks-icons/ob-hsbc-icon.svg'
+        }
+      ]
+    end
+  end
+end

--- a/spec/lib/omniauth/strategies/true_layer_spec.rb
+++ b/spec/lib/omniauth/strategies/true_layer_spec.rb
@@ -28,19 +28,20 @@ module OmniAuth
       end
 
       describe '#authorize_params' do
+        let(:enable_mock) { [true, false].sample }
+        let(:provider_id) { [nil, 'hsbc'].sample }
+
         before do
-          allow(subject).to receive(:session).and_return({})
-        end
-        it 'disables mock as default' do
-          with_modified_env TRUE_LAYER_ENABLE_MOCK: nil do
-            expect(subject.authorize_params[:enable_mock]).to be_falsey
-          end
+          allow(subject).to receive(:session).and_return(provider_id: provider_id)
+          allow(Rails.configuration.x.true_layer).to receive(:enable_mock).and_return(enable_mock)
         end
 
-        it 'can be set with an environment varialbe' do
-          with_modified_env TRUE_LAYER_ENABLE_MOCK: 'true' do
-            expect(subject.authorize_params[:enable_mock]).to be_truthy
-          end
+        it 'can be set with an environment variable' do
+          expect(subject.authorize_params[:enable_mock]).to eq(enable_mock)
+        end
+
+        it 'sets provider_id from session' do
+          expect(subject.authorize_params[:provider_id]).to eq(provider_id)
         end
       end
 

--- a/spec/models/true_layer_bank_spec.rb
+++ b/spec/models/true_layer_bank_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+RSpec.describe TrueLayerBank, type: :model, vcr: { cassette_name: 'true_layer_banks_api', allow_playback_repeats: true } do
+  let(:api_banks) { TrueLayer::BanksRetriever.banks }
+  let!(:true_layer_bank) { create :true_layer_bank }
+  let(:enable_mock) { false }
+
+  before do
+    allow(Rails.configuration.x.true_layer).to receive(:enable_mock).and_return(enable_mock)
+  end
+
+  describe '.banks' do
+    it 'returns banks from instance' do
+      expect(described_class.banks).to eq(true_layer_bank.banks)
+    end
+
+    it 'triggers and update process' do
+      expect(TrueLayerBanksUpdateWorker).to receive(:perform_in)
+      described_class.banks
+    end
+
+    context 'without an existing instances' do
+      let!(:true_layer_bank) { nil }
+
+      before { described_class.delete_all }
+
+      it 'creates a new instance' do
+        expect { described_class.banks }.to change { described_class.count }.from(0).to(1)
+      end
+
+      it 'does not create duplicates' do
+        expect {
+          described_class.banks
+          described_class.banks
+        }.to change { described_class.count }.from(0).to(1)
+      end
+
+      it 'returns api banks' do
+        expect(described_class.banks).to eq(api_banks)
+      end
+
+      context 'mock bank is enabled' do
+        let(:enable_mock) { true }
+
+        it 'returns mock bank + api banks' do
+          expect(described_class.banks).to eq([described_class::MOCK_BANK] + api_banks)
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/citizens/accounts_spec.rb
+++ b/spec/requests/citizens/accounts_spec.rb
@@ -60,8 +60,8 @@ RSpec.describe 'citizen accounts request', type: :request do
       expect(session[:page_history]).to include(citizens_accounts_path)
     end
 
-    it 'has a link to ad another account' do
-      expect(response.body).to include(applicant_true_layer_omniauth_authorize_path)
+    it 'has a link to select another bank' do
+      expect(response.body).to include(citizens_banks_path)
     end
   end
 

--- a/spec/requests/citizens/additional_accounts_spec.rb
+++ b/spec/requests/citizens/additional_accounts_spec.rb
@@ -76,9 +76,8 @@ RSpec.describe 'citizen additional accounts request test', type: :request do
     context 'with Yes submitted' do
       let(:params) { { has_offline_accounts: 'yes' } }
 
-      it 'redirects to back to the True Layer steps' do
-        # TODO: - set redirect path when known
-        expect(response).to redirect_to(applicant_true_layer_omniauth_authorize_path)
+      it 'redirects to select another bank' do
+        expect(response).to redirect_to(citizens_banks_path)
       end
 
       it 'does not record choice on legal_aid_application' do

--- a/spec/requests/citizens/bank_spec.rb
+++ b/spec/requests/citizens/bank_spec.rb
@@ -1,0 +1,62 @@
+require 'rails_helper'
+
+RSpec.describe Citizens::BanksController, type: :request do
+  let(:application) { create :application, :with_applicant }
+  let(:secure_id) { application.generate_secure_id }
+  let!(:banks) { create(:true_layer_bank).banks }
+  let(:enable_mock) { false }
+
+  before do
+    get citizens_legal_aid_application_path(secure_id)
+    allow(Rails.configuration.x.true_layer).to receive(:enable_mock).and_return(enable_mock)
+  end
+
+  describe 'GET citizens/banks' do
+    before { get citizens_banks_path }
+
+    it 'shows the banks' do
+      banks.each do |bank|
+        expect(response.body).to include(bank[:display_name])
+        expect(response.body).to include(bank[:provider_id])
+        expect(response.body).to include(bank[:logo_url])
+      end
+    end
+
+    it 'does not show the mock bank' do
+      expect(response.body).not_to include('mock')
+    end
+
+    context 'enable_mock is set to true' do
+      let(:enable_mock) { true }
+
+      it 'shows the mock bank' do
+        expect(response.body).to include('mock')
+      end
+    end
+  end
+
+  describe 'POST citizens/banks' do
+    let(:provider_id) { Faker::Bank.name }
+    before { post citizens_banks_path, params: { provider_id: provider_id } }
+
+    it 'redirects to true layer' do
+      expect(response).to redirect_to(applicant_true_layer_omniauth_authorize_path)
+    end
+
+    it 'sets provider_id in the session' do
+      expect(session[:provider_id]).to eq(provider_id)
+    end
+
+    context 'no bank was selected' do
+      let(:provider_id) { nil }
+
+      it 'returns http success' do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'shows an error' do
+        expect(response.body).to include(I18n.t('citizens.banks.create.error'))
+      end
+    end
+  end
+end

--- a/spec/requests/citizens/consents_spec.rb
+++ b/spec/requests/citizens/consents_spec.rb
@@ -24,8 +24,7 @@ RSpec.describe Citizens::ConsentsController, type: :request do
       let(:params) { { legal_aid_application: { open_banking_consent: 'true' } } }
 
       it 'redirects to new action' do
-        expect(response).to redirect_to(applicant_true_layer_omniauth_authorize_path)
-        expect(unescaped_response_body).to include('true')
+        expect(response).to redirect_to(citizens_banks_path)
       end
 
       it 'records the decision on the legal aid application' do

--- a/spec/services/true_layer/banks_retriever_spec.rb
+++ b/spec/services/true_layer/banks_retriever_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe TrueLayer::BanksRetriever, vcr: { cassette_name: 'true_layer_banks_api', allow_playback_repeats: true } do
+  let(:group) { 'england-and-wales' }
+
+  subject { described_class.new }
+
+  describe '.banks' do
+    it 'returns same as instance banks' do
+      expect(described_class.banks).to eq(subject.banks)
+    end
+
+    context 'on failure' do
+      let(:uri) { URI.parse(described_class::API_URL) }
+      before do
+        allow(Net::HTTP).to receive(:get_response).with(uri).and_return(OpenStruct.new)
+      end
+      it 'raises error' do
+        expect { described_class.banks }.to raise_error(described_class::UnsuccessfulRetrievalError)
+      end
+    end
+  end
+
+  describe '#banks' do
+    let(:banks) { subject.banks }
+
+    it 'is an array' do
+      expect(banks).to be_a(Array)
+    end
+
+    it 'contains data about the banks' do
+      bank = banks.first
+      expect(bank[:provider_id]).to be_a(String)
+      expect(bank[:display_name]).to be_a(String)
+      expect(bank[:logo_url]).to start_with('https://')
+      expect(bank[:logo_url]).to end_with('.svg')
+    end
+  end
+end

--- a/spec/workers/true_layer_banks_update_worker_spec.rb
+++ b/spec/workers/true_layer_banks_update_worker_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+RSpec.describe TrueLayerBanksUpdateWorker, vcr: { cassette_name: 'true_layer_banks_api', allow_playback_repeats: true } do
+  let(:true_layer_banks_update_worker) { described_class.new }
+  let(:stale_date) { Time.now.utc - described_class::UPDATE_INTERVAL - 2.hours }
+  let!(:true_layer_bank) { create :true_layer_bank }
+
+  subject { true_layer_banks_update_worker.perform }
+
+  it 'returns true' do
+    expect(subject).to be true
+  end
+
+  it 'does not change the true_layer_bank object' do
+    expect { subject }.not_to change { true_layer_bank.reload }
+  end
+
+  it 'does not create a new true_layer_bank object' do
+    expect { subject }.not_to change { TrueLayerBank.count }
+  end
+
+  context 'when outdated' do
+    let!(:true_layer_bank) { create :true_layer_bank, updated_at: stale_date }
+
+    it 'creates a new bank holiday instance' do
+      expect { subject }.to change { TrueLayerBank.count }.by(1)
+    end
+  end
+
+  context 'when outdated has current data' do
+    let!(:true_layer_bank) { TrueLayerBank.create!(updated_at: stale_date) }
+
+    it 'does not create a new true_layer_bank object' do
+      expect { subject }.not_to change { TrueLayerBank.count }
+    end
+
+    it 'touches the existing true_layer_bank object' do
+      subject
+      expect(true_layer_bank.reload.updated_at).to be_between(2.seconds.ago, 1.second.from_now)
+    end
+  end
+
+  context 'when data retrieval fails' do
+    let!(:true_layer_bank) { create :true_layer_bank, updated_at: stale_date }
+
+    it 'raises error' do
+      allow(TrueLayer::BanksRetriever).to receive(:banks).and_raise(TrueLayer::BanksRetriever::UnsuccessfulRetrievalError)
+      expect { subject }.to raise_error(TrueLayer::BanksRetriever::UnsuccessfulRetrievalError)
+    end
+  end
+end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-667)

- Fetch and save list of banks the same way Rob did it for bank holidays
- Implement bank selection before TrueLayer
- Forward selected bank go TrueLayer

UAT: https://ap-667-replace-truelayer-scree-applyforlegalaid-uat.apps.live-1.cloud-platform.service.justice.gov.uk/

## Checklist

Before you ask people to review this PR:

- [X] Tests and rubocop should be passing: `bundle exec rake`
- [X] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [X] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [X] The PR description should say what you changed and why, with a link to the JIRA story.
- [X] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [X] You should have checked that the commit messages say why the change was made.
