### PR TITLE
CCMS Omit change_in_circumstance from ccms payload

### DIFF
--- a/spec/services/ccms/case_add_requestor_xml_blocks_spec.rb
+++ b/spec/services/ccms/case_add_requestor_xml_blocks_spec.rb
@@ -1266,6 +1266,8 @@ module CCMS # rubocop:disable Metrics/ModuleLength
       [:main_dwelling, 'MAINTHIRD_INPUT_N_3WP2_11A'],
       [:family_statement, 'FAMILY_STMT_DETAIL'],
       [:family_statement, 'FAMILY_STATEMENT_INSTANCE'],
+      [:change_in_circumstances],
+      [:change_in_circumstances, 'CHANGE_CIRC_INPUT_T_33WP3_6A'],
       [:global_means, 'BEN_AWARD_DATE'],
       [:global_means, 'CAP_CONT'],
       [:global_means, 'CLIENT_NASS'],

--- a/spec/support/xml_extractor.rb
+++ b/spec/support/xml_extractor.rb
@@ -12,7 +12,9 @@ class XmlExtractor
     vehicle_entity: %(/Envelope/Body/CaseAddRQ/Case/CaseDetails/ApplicationDetails/MeansAssesments/AssesmentResults/AssesmentDetails/AssessmentScreens/Entity[EntityName = "CARS_AND_MOTOR_VEHICLES"]//Attributes/Attribute),
     wage_slip_entity: %(/Envelope/Body/CaseAddRQ/Case/CaseDetails/ApplicationDetails/MeansAssesments/AssesmentResults/AssesmentDetails/AssessmentScreens/Entity[EntityName = "CLI_NON_HM_WAGE_SLIP"]),
     bank_accounts_entity: %(/Envelope/Body/CaseAddRQ/Case/CaseDetails/ApplicationDetails/MeansAssesments/AssesmentResults/AssesmentDetails/AssessmentScreens/Entity[EntityName = "BANKACC"]),
-    other_party: %(/Envelope/Body/CaseAddRQ/Case/CaseDetails/ApplicationDetails/MeansAssesments/AssesmentResults/AssesmentDetails/AssessmentScreens/Entity[EntityName = "OPPONENT_OTHER_PARTIES"]//Attributes/Attribute)
+    other_party: %(/Envelope/Body/CaseAddRQ/Case/CaseDetails/ApplicationDetails/MeansAssesments/AssesmentResults/AssesmentDetails/AssessmentScreens/Entity[EntityName = "OPPONENT_OTHER_PARTIES"]//Attributes/Attribute),
+    change_in_circumstances: %(/Envelope/Body/CaseAddRQ/Case/CaseDetails/ApplicationDetails/MeritsAssesments/AssesmentResults/AssesmentDetails/AssessmentScreens/Entity[EntityName = "CHANGE_IN_CIRCUMSTANCES"]//Attributes/Attribute)
+
   }.freeze
   # rubocop:enable Metrics/LineLength
 


### PR DESCRIPTION
CCMS Omit change_in_circumstance from ccms payload

Missed change_in_circumstance attribute from the AP960 ticket

[Link to story](https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=233&projectKey=AP&modal=detail&selectedIssue=AP-960)

Set the generation of the xml block to false for this attribute.

## Checklist

Before you ask people to review this PR:

- [X] Tests and rubocop should be passing: `bundle exec rake`
- [X] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [X] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [X] The PR description should say what you changed and why, with a link to the JIRA story.
- [X] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
