### PR TITLE
AP-764 Record XML payloads in submission histories

### DIFF
--- a/app/services/ccms/add_applicant_service.rb
+++ b/app/services/ccms/add_applicant_service.rb
@@ -2,14 +2,13 @@ module CCMS
   class AddApplicantService < BaseSubmissionService
     def call
       if applicant_add_response_parser.success?
-        # binding.pry
         submission.applicant_add_transaction_id = applicant_add_requestor.transaction_request_id
         create_history('case_ref_obtained', submission.aasm_state, xml_request) if submission.submit_applicant!
       else
-        handle_failure(response)
+        handle_failure(response, xml_request)
       end
     rescue CcmsError => e
-      handle_failure(e)
+      handle_failure(e, xml_request)
     end
 
     private
@@ -22,16 +21,16 @@ module CCMS
       @applicant_add_response_parser ||= ApplicantAddResponseParser.new(applicant_add_requestor.transaction_request_id, response)
     end
 
-    def xml_request
-      @xml_request ||= applicant_add_requestor.formatted_xml
-    end
-
     def response
       @response ||= applicant_add_requestor.call
     end
 
     def legal_aid_application
       submission.legal_aid_application
+    end
+
+    def xml_request
+      @xml_request ||= applicant_add_requestor.formatted_xml
     end
   end
 end

--- a/app/services/ccms/add_applicant_service.rb
+++ b/app/services/ccms/add_applicant_service.rb
@@ -3,12 +3,12 @@ module CCMS
     def call
       if applicant_add_response_parser.success?
         submission.applicant_add_transaction_id = applicant_add_requestor.transaction_request_id
-        create_history('case_ref_obtained', submission.aasm_state, xml_request) if submission.submit_applicant!
+        create_history('case_ref_obtained', submission.aasm_state, xml_request, response) if submission.submit_applicant!
       else
-        handle_failure(response, xml_request)
+        handle_unsuccessful_response(xml_request, response)
       end
     rescue CcmsError => e
-      handle_failure(e, xml_request)
+      handle_exception(e, xml_request)
     end
 
     private

--- a/app/services/ccms/add_applicant_service.rb
+++ b/app/services/ccms/add_applicant_service.rb
@@ -2,8 +2,9 @@ module CCMS
   class AddApplicantService < BaseSubmissionService
     def call
       if applicant_add_response_parser.success?
+        # binding.pry
         submission.applicant_add_transaction_id = applicant_add_requestor.transaction_request_id
-        create_history('case_ref_obtained', submission.aasm_state) if submission.submit_applicant!
+        create_history('case_ref_obtained', submission.aasm_state, xml_request) if submission.submit_applicant!
       else
         handle_failure(response)
       end
@@ -19,6 +20,10 @@ module CCMS
 
     def applicant_add_response_parser
       @applicant_add_response_parser ||= ApplicantAddResponseParser.new(applicant_add_requestor.transaction_request_id, response)
+    end
+
+    def xml_request
+      @xml_request ||= applicant_add_requestor.formatted_xml
     end
 
     def response

--- a/app/services/ccms/add_case_service.rb
+++ b/app/services/ccms/add_case_service.rb
@@ -4,16 +4,16 @@ module CCMS
       new(submission).call(options)
     end
 
-    def call(options = {})
+    def call(options = {}) # rubocop:disable Metrics/AbcSize
       @options = options
       if case_add_response_parser.success?
         submission.case_add_transaction_id = case_add_requestor.transaction_request_id
-        create_history(submission.submission_document.empty? ? 'applicant_ref_obtained' : 'document_ids_obtained', submission.aasm_state, xml_request) if submission.submit_case!
+        create_history(submission.submission_document.empty? ? 'applicant_ref_obtained' : 'document_ids_obtained', submission.aasm_state, xml_request, response) if submission.submit_case!
       else
-        handle_failure(response, xml_request)
+        handle_unsuccessful_response(xml_request, response)
       end
     rescue CcmsError => e
-      handle_failure(e, xml_request)
+      handle_exception(e, xml_request)
     end
 
     private

--- a/app/services/ccms/add_case_service.rb
+++ b/app/services/ccms/add_case_service.rb
@@ -8,7 +8,7 @@ module CCMS
       @options = options
       if case_add_response_parser.success?
         submission.case_add_transaction_id = case_add_requestor.transaction_request_id
-        create_history(submission.submission_document.empty? ? 'applicant_ref_obtained' : 'document_ids_obtained', submission.aasm_state) if submission.submit_case!
+        create_history(submission.submission_document.empty? ? 'applicant_ref_obtained' : 'document_ids_obtained', submission.aasm_state, case_add_requestor) if submission.submit_case!
       else
         handle_failure(response)
       end

--- a/app/services/ccms/add_case_service.rb
+++ b/app/services/ccms/add_case_service.rb
@@ -8,12 +8,12 @@ module CCMS
       @options = options
       if case_add_response_parser.success?
         submission.case_add_transaction_id = case_add_requestor.transaction_request_id
-        create_history(submission.submission_document.empty? ? 'applicant_ref_obtained' : 'document_ids_obtained', submission.aasm_state, case_add_requestor) if submission.submit_case!
+        create_history(submission.submission_document.empty? ? 'applicant_ref_obtained' : 'document_ids_obtained', submission.aasm_state, xml_request) if submission.submit_case!
       else
-        handle_failure(response)
+        handle_failure(response, xml_request)
       end
     rescue CcmsError => e
-      handle_failure(e)
+      handle_failure(e, xml_request)
     end
 
     private
@@ -28,6 +28,10 @@ module CCMS
 
     def response
       @response ||= case_add_requestor.call
+    end
+
+    def xml_request
+      @xml_request ||= case_add_requestor.formatted_xml
     end
   end
 end

--- a/app/services/ccms/base_requestor.rb
+++ b/app/services/ccms/base_requestor.rb
@@ -55,8 +55,10 @@ module CCMS
     def soap_header(xml)
       xml.__send__('ns1:Security') do
         xml.__send__('ns1:UsernameToken') do
-          xml.__send__('ns1:Username', Rails.configuration.x.ccms_soa.client_username)
-          xml.__send__('ns1:Password', 'Type' => Rails.configuration.x.ccms_soa.client_password_type) { xml.text Rails.configuration.x.ccms_soa.client_password }
+          xml.__send__('ns1:Username', config.client_username)
+          xml.__send__('ns1:Password', 'Type' => config.client_password_type) do
+            xml.text(config.client_password)
+          end
         end
       end
     end

--- a/app/services/ccms/base_requestor.rb
+++ b/app/services/ccms/base_requestor.rb
@@ -37,7 +37,7 @@ module CCMS
         pretty_print_xml: true,
         convert_request_keys_to: :none,
         namespace_identifier: 'ns2',
-        log: true,
+        log: false,
         log_level: :debug
       )
     end
@@ -55,19 +55,17 @@ module CCMS
     def soap_header(xml)
       xml.__send__('ns1:Security') do
         xml.__send__('ns1:UsernameToken') do
-          xml.__send__('ns1:Username', config.client_username)
-          xml.__send__('ns1:Password', 'Type' => config.client_password_type) do
-            xml.text(config.client_password)
-          end
+          xml.__send__('ns1:Username', Rails.configuration.x.ccms_soa.client_username)
+          xml.__send__('ns1:Password', 'Type' => Rails.configuration.x.ccms_soa.client_password_type) { xml.text Rails.configuration.x.ccms_soa.client_password }
         end
       end
     end
 
-    def ns3_header_rq(xml, provider_username)
+    def ns3_header_rq(xml, _provider_username)
       xml.__send__('ns3:TransactionRequestID', transaction_request_id)
       xml.__send__('ns3:Language', 'ENG')
-      xml.__send__('ns3:UserLoginID', provider_username)
-      xml.__send__('ns3:UserRole', config.user_role)
+      xml.__send__('ns3:UserLoginID', Rails.configuration.x.ccms_soa.user_login)
+      xml.__send__('ns3:UserRole', Rails.configuration.x.ccms_soa.user_role)
     end
 
     def wsdl_location

--- a/app/services/ccms/base_requestor.rb
+++ b/app/services/ccms/base_requestor.rb
@@ -61,11 +61,11 @@ module CCMS
       end
     end
 
-    def ns3_header_rq(xml, _provider_username)
+    def ns3_header_rq(xml, provider_username)
       xml.__send__('ns3:TransactionRequestID', transaction_request_id)
       xml.__send__('ns3:Language', 'ENG')
-      xml.__send__('ns3:UserLoginID', Rails.configuration.x.ccms_soa.user_login)
-      xml.__send__('ns3:UserRole', Rails.configuration.x.ccms_soa.user_role)
+      xml.__send__('ns3:UserLoginID', provider_username)
+      xml.__send__('ns3:UserRole', config.user_role)
     end
 
     def wsdl_location

--- a/app/services/ccms/base_submission_service.rb
+++ b/app/services/ccms/base_submission_service.rb
@@ -45,12 +45,13 @@ module CCMS
     end
 
     def handle_unsuccessful_response(xml_request, xml_response)
-      # Raven.capture_exception(error)
+      Raven.capture_exception(xml_response)
       create_failure_history(submission.aasm_state, nil, xml_request, xml_response)
       submission.fail!
     end
 
     def handle_exception(exception, xml_request)
+      Raven.capture_exception(exception)
       create_ccms_failure_history(submission.aasm_state, exception, xml_request)
       submission.fail!
     end

--- a/app/services/ccms/base_submission_service.rb
+++ b/app/services/ccms/base_submission_service.rb
@@ -21,11 +21,12 @@ module CCMS
                                # response: response.doc
     end
 
-    def create_failure_history(from_state, error)
+    def create_failure_history(from_state, error, request)
       SubmissionHistory.create submission: submission,
                                from_state: from_state,
                                to_state: :failed,
                                success: false,
+                               request: request,
                                details: error.is_a?(Exception) ? format_exception(error) : error
     end
 

--- a/app/services/ccms/base_submission_service.rb
+++ b/app/services/ccms/base_submission_service.rb
@@ -12,11 +12,13 @@ module CCMS
 
     private
 
-    def create_history(from_state, to_state)
+    def create_history(from_state, to_state, request)
       SubmissionHistory.create submission: submission,
                                from_state: from_state,
                                to_state: to_state,
-                               success: true
+                               success: true,
+                               request: request#.formatted_xml
+                               # response: response.doc
     end
 
     def create_failure_history(from_state, error)

--- a/app/services/ccms/check_applicant_status_service.rb
+++ b/app/services/ccms/check_applicant_status_service.rb
@@ -28,10 +28,6 @@ module CCMS
       @applicant_add_status_requestor ||= ApplicantAddStatusRequestor.new(submission.applicant_add_transaction_id, submission.legal_aid_application.provider.username)
     end
 
-    def applicant_add_status_response_parser
-      @applicant_add_status_response_parser ||= ApplicantAddStatusResponseParser.new(applicant_add_status_requestor.transaction_request_id, response)
-    end
-
     def response
       @response ||= applicant_add_status_requestor.call
     end

--- a/app/services/ccms/check_applicant_status_service.rb
+++ b/app/services/ccms/check_applicant_status_service.rb
@@ -8,24 +8,34 @@ module CCMS
       parser = ApplicantAddStatusResponseParser.new(tx_id, response)
       process_response(parser)
     rescue CcmsError => e
-      handle_failure(e, xml_request)
+      handle_exception(e, xml_request)
     end
 
     private
 
-    def process_response(parser)
+    def process_response(parser) # rubocop:disable Metrics/AbcSize
       if parser.success?
         submission.applicant_ccms_reference = parser.applicant_ccms_reference
-        create_history(:applicant_submitted, submission.aasm_state, xml_request) if submission.obtain_applicant_ref!
+        create_history(:applicant_submitted, submission.aasm_state, xml_request, response) if submission.obtain_applicant_ref!
       elsif submission.applicant_poll_count >= Submission::POLL_LIMIT
-        handle_failure('Poll limit exceeded', xml_request)
+        raise CcmsError, 'Poll limit exceeded'
+        # handle_exception(exception, xml_request)
+        # handle_unsuccessful_response('Poll limit exceeded', xml_request, response)
       else
-        create_history(submission.aasm_state, submission.aasm_state, xml_request)
+        create_history(submission.aasm_state, submission.aasm_state, xml_request, response)
       end
     end
 
     def applicant_add_status_requestor
       @applicant_add_status_requestor ||= ApplicantAddStatusRequestor.new(submission.applicant_add_transaction_id, submission.legal_aid_application.provider.username)
+    end
+
+    def applicant_add_status_response_parser
+      @applicant_add_status_response_parser ||= ApplicantAddStatusResponseParser.new(applicant_add_status_requestor.transaction_request_id, response)
+    end
+
+    def response
+      @response ||= applicant_add_status_requestor.call
     end
 
     def xml_request

--- a/app/services/ccms/check_applicant_status_service.rb
+++ b/app/services/ccms/check_applicant_status_service.rb
@@ -18,7 +18,7 @@ module CCMS
         submission.applicant_ccms_reference = parser.applicant_ccms_reference
         create_history(:applicant_submitted, submission.aasm_state, xml_request, response) if submission.obtain_applicant_ref!
       elsif submission.applicant_poll_count >= Submission::POLL_LIMIT
-        raise CcmsError, 'Poll limit exceeded'
+        handle_exception('Poll limit exceeded', xml_request)
       else
         create_history(submission.aasm_state, submission.aasm_state, xml_request, response)
       end

--- a/app/services/ccms/check_applicant_status_service.rb
+++ b/app/services/ccms/check_applicant_status_service.rb
@@ -8,7 +8,7 @@ module CCMS
       parser = ApplicantAddStatusResponseParser.new(tx_id, response)
       process_response(parser)
     rescue CcmsError => e
-      handle_failure(e)
+      handle_failure(e, xml_request)
     end
 
     private
@@ -16,16 +16,20 @@ module CCMS
     def process_response(parser)
       if parser.success?
         submission.applicant_ccms_reference = parser.applicant_ccms_reference
-        create_history(:applicant_submitted, submission.aasm_state, applicant_add_status_requestor) if submission.obtain_applicant_ref!
+        create_history(:applicant_submitted, submission.aasm_state, xml_request) if submission.obtain_applicant_ref!
       elsif submission.applicant_poll_count >= Submission::POLL_LIMIT
-        handle_failure('Poll limit exceeded')
+        handle_failure('Poll limit exceeded', xml_request)
       else
-        create_history(submission.aasm_state, submission.aasm_state,applicant_add_status_requestor)
+        create_history(submission.aasm_state, submission.aasm_state, xml_request)
       end
     end
 
     def applicant_add_status_requestor
       @applicant_add_status_requestor ||= ApplicantAddStatusRequestor.new(submission.applicant_add_transaction_id, submission.legal_aid_application.provider.username)
+    end
+
+    def xml_request
+      @xml_request ||= applicant_add_status_requestor.formatted_xml
     end
   end
 end

--- a/app/services/ccms/check_applicant_status_service.rb
+++ b/app/services/ccms/check_applicant_status_service.rb
@@ -19,8 +19,6 @@ module CCMS
         create_history(:applicant_submitted, submission.aasm_state, xml_request, response) if submission.obtain_applicant_ref!
       elsif submission.applicant_poll_count >= Submission::POLL_LIMIT
         raise CcmsError, 'Poll limit exceeded'
-        # handle_exception(exception, xml_request)
-        # handle_unsuccessful_response('Poll limit exceeded', xml_request, response)
       else
         create_history(submission.aasm_state, submission.aasm_state, xml_request, response)
       end

--- a/app/services/ccms/check_applicant_status_service.rb
+++ b/app/services/ccms/check_applicant_status_service.rb
@@ -16,11 +16,11 @@ module CCMS
     def process_response(parser)
       if parser.success?
         submission.applicant_ccms_reference = parser.applicant_ccms_reference
-        create_history(:applicant_submitted, submission.aasm_state) if submission.obtain_applicant_ref!
+        create_history(:applicant_submitted, submission.aasm_state, applicant_add_status_requestor) if submission.obtain_applicant_ref!
       elsif submission.applicant_poll_count >= Submission::POLL_LIMIT
         handle_failure('Poll limit exceeded')
       else
-        create_history(submission.aasm_state, submission.aasm_state)
+        create_history(submission.aasm_state, submission.aasm_state,applicant_add_status_requestor)
       end
     end
 

--- a/app/services/ccms/check_case_status_service.rb
+++ b/app/services/ccms/check_case_status_service.rb
@@ -7,18 +7,18 @@ module CCMS
       parser = CaseAddStatusResponseParser.new(tx_id, response)
       process_response(parser)
     rescue CcmsError => e
-      handle_failure(e, xml_request)
+      handle_exception(e, xml_request)
     end
 
     private
 
-    def process_response(parser)
+    def process_response(parser) # rubocop:disable Metrics/AbcSize
       if parser.success?
-        create_history(:case_submitted, submission.aasm_state, xml_request) if submission.confirm_case_created!
+        create_history(:case_submitted, submission.aasm_state, xml_request, response) if submission.confirm_case_created!
       elsif submission.case_poll_count >= Submission::POLL_LIMIT
-        handle_failure('Poll limit exceeded', case_add_status_requestor.formatted_xml)
+        handle_exception('Poll limit exceeded', xml_request)
       else
-        create_history(submission.aasm_state, submission.aasm_state, xml_request)
+        create_history(submission.aasm_state, submission.aasm_state, xml_request, response)
       end
     end
 

--- a/app/services/ccms/check_case_status_service.rb
+++ b/app/services/ccms/check_case_status_service.rb
@@ -14,11 +14,11 @@ module CCMS
 
     def process_response(parser)
       if parser.success?
-        create_history(:case_submitted, submission.aasm_state) if submission.confirm_case_created!
+        create_history(:case_submitted, submission.aasm_state, case_add_status_requestor) if submission.confirm_case_created!
       elsif submission.case_poll_count >= Submission::POLL_LIMIT
         handle_failure('Poll limit exceeded')
       else
-        create_history(submission.aasm_state, submission.aasm_state)
+        create_history(submission.aasm_state, submission.aasm_state, case_add_status_requestor)
       end
     end
 

--- a/app/services/ccms/check_case_status_service.rb
+++ b/app/services/ccms/check_case_status_service.rb
@@ -7,18 +7,18 @@ module CCMS
       parser = CaseAddStatusResponseParser.new(tx_id, response)
       process_response(parser)
     rescue CcmsError => e
-      handle_failure(e)
+      handle_failure(e, xml_request)
     end
 
     private
 
     def process_response(parser)
       if parser.success?
-        create_history(:case_submitted, submission.aasm_state, case_add_status_requestor) if submission.confirm_case_created!
+        create_history(:case_submitted, submission.aasm_state, xml_request) if submission.confirm_case_created!
       elsif submission.case_poll_count >= Submission::POLL_LIMIT
-        handle_failure('Poll limit exceeded')
+        handle_failure('Poll limit exceeded', case_add_status_requestor.formatted_xml)
       else
-        create_history(submission.aasm_state, submission.aasm_state, case_add_status_requestor)
+        create_history(submission.aasm_state, submission.aasm_state, xml_request)
       end
     end
 
@@ -28,6 +28,10 @@ module CCMS
 
     def response
       @response ||= case_add_status_requestor.call
+    end
+
+    def xml_request
+      @xml_request ||= case_add_status_requestor.formatted_xml
     end
   end
 end

--- a/app/services/ccms/obtain_applicant_reference_service.rb
+++ b/app/services/ccms/obtain_applicant_reference_service.rb
@@ -18,9 +18,11 @@ module CCMS
       @applicant_search_requestor ||= ApplicantSearchRequestor.new(legal_aid_application.applicant, legal_aid_application.provider.username)
     end
 
-    def process_records(parser)
+    def process_records(parser) # rubocop:disable Metrics/AbcSize
       if parser.record_count.to_i.zero?
+        create_history(:case_ref_obtained, submission.aasm_state, xml_request, response)
         AddApplicantService.new(submission).call
+        # create_history(:case_ref_obtained, submission.aasm_state, xml_request, response)
       else
         submission.applicant_ccms_reference = parser.applicant_ccms_reference
         create_history(:case_ref_obtained, submission.aasm_state, xml_request, response) if submission.obtain_applicant_ref!

--- a/app/services/ccms/obtain_applicant_reference_service.rb
+++ b/app/services/ccms/obtain_applicant_reference_service.rb
@@ -2,11 +2,14 @@ module CCMS
   class ObtainApplicantReferenceService < BaseSubmissionService
     def call
       tx_id = applicant_search_requestor.transaction_request_id
-      response = applicant_search_requestor.call
       parser = ApplicantSearchResponseParser.new(tx_id, response)
       process_records(parser)
     rescue CcmsError => e
-      handle_failure(e, xml_request)
+      handle_exception(e, xml_request)
+    end
+
+    def response
+      @response ||= applicant_search_requestor.call
     end
 
     private
@@ -20,7 +23,7 @@ module CCMS
         AddApplicantService.new(submission).call
       else
         submission.applicant_ccms_reference = parser.applicant_ccms_reference
-        create_history(:case_ref_obtained, submission.aasm_state, xml_request) if submission.obtain_applicant_ref!
+        create_history(:case_ref_obtained, submission.aasm_state, xml_request, response) if submission.obtain_applicant_ref!
       end
     end
 

--- a/app/services/ccms/obtain_applicant_reference_service.rb
+++ b/app/services/ccms/obtain_applicant_reference_service.rb
@@ -20,7 +20,7 @@ module CCMS
         AddApplicantService.new(submission).call
       else
         submission.applicant_ccms_reference = parser.applicant_ccms_reference
-        create_history(:case_ref_obtained, submission.aasm_state) if submission.obtain_applicant_ref!
+        create_history(:case_ref_obtained, submission.aasm_state, applicant_search_requestor) if submission.obtain_applicant_ref!
       end
     end
 

--- a/app/services/ccms/obtain_applicant_reference_service.rb
+++ b/app/services/ccms/obtain_applicant_reference_service.rb
@@ -22,7 +22,6 @@ module CCMS
       if parser.record_count.to_i.zero?
         create_history(:case_ref_obtained, submission.aasm_state, xml_request, response)
         AddApplicantService.new(submission).call
-        # create_history(:case_ref_obtained, submission.aasm_state, xml_request, response)
       else
         submission.applicant_ccms_reference = parser.applicant_ccms_reference
         create_history(:case_ref_obtained, submission.aasm_state, xml_request, response) if submission.obtain_applicant_ref!

--- a/app/services/ccms/obtain_applicant_reference_service.rb
+++ b/app/services/ccms/obtain_applicant_reference_service.rb
@@ -6,7 +6,7 @@ module CCMS
       parser = ApplicantSearchResponseParser.new(tx_id, response)
       process_records(parser)
     rescue CcmsError => e
-      handle_failure(e)
+      handle_failure(e, xml_request)
     end
 
     private
@@ -20,12 +20,16 @@ module CCMS
         AddApplicantService.new(submission).call
       else
         submission.applicant_ccms_reference = parser.applicant_ccms_reference
-        create_history(:case_ref_obtained, submission.aasm_state, applicant_search_requestor) if submission.obtain_applicant_ref!
+        create_history(:case_ref_obtained, submission.aasm_state, xml_request) if submission.obtain_applicant_ref!
       end
     end
 
     def legal_aid_application
       submission.legal_aid_application
+    end
+
+    def xml_request
+      @xml_request ||= applicant_search_requestor.formatted_xml
     end
   end
 end

--- a/app/services/ccms/obtain_case_reference_service.rb
+++ b/app/services/ccms/obtain_case_reference_service.rb
@@ -2,7 +2,7 @@ module CCMS
   class ObtainCaseReferenceService < BaseSubmissionService
     def call
       submission.case_ccms_reference = reference_id
-      create_history(:initialised, submission.aasm_state) if submission.obtain_case_ref!
+      create_history(:initialised, submission.aasm_state, reference_data_requestor) if submission.obtain_case_ref!
     rescue CcmsError => e
       handle_failure(e)
     end

--- a/app/services/ccms/obtain_case_reference_service.rb
+++ b/app/services/ccms/obtain_case_reference_service.rb
@@ -2,9 +2,9 @@ module CCMS
   class ObtainCaseReferenceService < BaseSubmissionService
     def call
       submission.case_ccms_reference = reference_id
-      create_history(:initialised, submission.aasm_state, reference_data_requestor) if submission.obtain_case_ref!
+      create_history(:initialised, submission.aasm_state, xml_request) if submission.obtain_case_ref!
     rescue CcmsError => e
-      handle_failure(e)
+      handle_failure(e, xml_request)
     end
 
     def reference_id
@@ -23,6 +23,10 @@ module CCMS
 
     def reference_data_requestor
       @reference_data_requestor ||= ReferenceDataRequestor.new(submission.legal_aid_application.provider.username)
+    end
+
+    def xml_request
+      @xml_request ||= reference_data_requestor.formatted_xml
     end
   end
 end

--- a/app/services/ccms/obtain_case_reference_service.rb
+++ b/app/services/ccms/obtain_case_reference_service.rb
@@ -2,9 +2,9 @@ module CCMS
   class ObtainCaseReferenceService < BaseSubmissionService
     def call
       submission.case_ccms_reference = reference_id
-      create_history(:initialised, submission.aasm_state, xml_request) if submission.obtain_case_ref!
+      create_history(:initialised, submission.aasm_state, xml_request, response) if submission.obtain_case_ref!
     rescue CcmsError => e
-      handle_failure(e, xml_request)
+      handle_exception(e, xml_request)
     end
 
     def reference_id
@@ -12,7 +12,7 @@ module CCMS
     end
 
     def response
-      reference_data_requestor.call
+      @response ||= reference_data_requestor.call
     end
 
     def transaction_request_id
@@ -26,7 +26,7 @@ module CCMS
     end
 
     def xml_request
-      @xml_request ||= reference_data_requestor.formatted_xml
+      reference_data_requestor.request_xml
     end
   end
 end

--- a/app/services/ccms/obtain_document_id_service.rb
+++ b/app/services/ccms/obtain_document_id_service.rb
@@ -3,13 +3,13 @@ module CCMS
     def call
       populate_documents
       if submission.submission_document.empty?
-        create_history('applicant_ref_obtained', submission.aasm_state, document_id_requestor) if submission.submit_case!
+        create_history('applicant_ref_obtained', submission.aasm_state, xml_request) if submission.submit_case!
       else
         request_document_ids
-        create_history('applicant_ref_obtained', submission.aasm_state, document_id_requestor) if submission.obtain_document_ids!
+        create_history('applicant_ref_obtained', submission.aasm_state, xml_request) if submission.obtain_document_ids!
       end
     rescue CcmsError => e
-      handle_failure(e)
+      handle_failure(e, xml_request)
     end
 
     private
@@ -73,6 +73,10 @@ module CCMS
 
     def document_id_requestor
       @document_id_requestor ||= DocumentIdRequestor.new(submission.case_ccms_reference, submission.legal_aid_application.provider.username)
+    end
+
+    def xml_request
+      @xml_request ||= document_id_requestor.formatted_xml
     end
   end
 end

--- a/app/services/ccms/obtain_document_id_service.rb
+++ b/app/services/ccms/obtain_document_id_service.rb
@@ -1,15 +1,19 @@
 module CCMS
   class ObtainDocumentIdService < BaseSubmissionService
-    def call
+    def call # rubocop:disable Metrics/AbcSize
       populate_documents
       if submission.submission_document.empty?
-        create_history('applicant_ref_obtained', submission.aasm_state, xml_request) if submission.submit_case!
+        create_history('applicant_ref_obtained', submission.aasm_state, xml_request, response) if submission.submit_case!
       else
         request_document_ids
-        create_history('applicant_ref_obtained', submission.aasm_state, xml_request) if submission.obtain_document_ids!
+        create_history('applicant_ref_obtained', submission.aasm_state, xml_request, response) if submission.obtain_document_ids!
       end
     rescue CcmsError => e
-      handle_failure(e, xml_request)
+      handle_exception(e, xml_request)
+    end
+
+    def response
+      @response ||= document_id_requestor.call
     end
 
     private

--- a/app/services/ccms/obtain_document_id_service.rb
+++ b/app/services/ccms/obtain_document_id_service.rb
@@ -3,10 +3,10 @@ module CCMS
     def call
       populate_documents
       if submission.submission_document.empty?
-        create_history('applicant_ref_obtained', submission.aasm_state) if submission.submit_case!
+        create_history('applicant_ref_obtained', submission.aasm_state, document_id_requestor) if submission.submit_case!
       else
         request_document_ids
-        create_history('applicant_ref_obtained', submission.aasm_state) if submission.obtain_document_ids!
+        create_history('applicant_ref_obtained', submission.aasm_state, document_id_requestor) if submission.obtain_document_ids!
       end
     rescue CcmsError => e
       handle_failure(e)

--- a/app/services/ccms/reference_data_requestor.rb
+++ b/app/services/ccms/reference_data_requestor.rb
@@ -21,11 +21,11 @@ module CCMS
       soap_client.call(:process, xml: request_xml)
     end
 
-    private
-
     def request_xml
       soap_envelope(namespaces).to_xml
     end
+
+    private
 
     def soap_body(xml)
       xml.__send__('ns2:ReferenceDataInqRQ') do

--- a/app/services/ccms/upload_documents_service.rb
+++ b/app/services/ccms/upload_documents_service.rb
@@ -8,12 +8,12 @@ module CCMS
       failed_uploads = submission.submission_document.select { |document| document.status == 'failed' }
 
       if failed_uploads.empty?
-        create_history('case_created', submission.aasm_state) if submission.complete!
+        create_history('case_created', submission.aasm_state, xml_request) if submission.complete!
       else
-        handle_failure("#{failed_uploads} failed to upload to CCMS")
+        handle_failure("#{failed_uploads} failed to upload to CCMS", xml_request)
       end
     rescue CcmsError => e
-      handle_failure(e)
+      handle_failure(e, xml_request)
     end
 
     private
@@ -51,5 +51,13 @@ module CCMS
                           :failed
                         end
     end
+
+    # def document_upload_requestor(document)
+    #   @document_upload_requestor ||= DocumentUploadRequestor.new(submission.case_ccms_reference, document.ccms_document_id, Base64.strict_encode64(pdf_binary(document)))
+    # end
+
+    # def xml_request
+    #   @xml_request ||= document_upload_requestor.formatted_xml
+    # end
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -72,6 +72,12 @@ module LaaApplyForLegalAid
     config.x.true_layer.enable_mock = ENV['TRUE_LAYER_ENABLE_MOCK'] == 'true'
     config.x.true_layer.banks = YAML.load_file(Rails.root.join('config/banks.yml'))['banks']
 
+    config.x.ccms_soa.client_username = ENV['CCMS_SOA_CLIENT_USERNAME']
+    config.x.ccms_soa.client_password_type = ENV['CCMS_SOA_CLIENT_PASSWORD_TYPE']
+    config.x.ccms_soa.client_password = ENV['CCMS_SOA_CLIENT_PASSWORD']
+    config.x.ccms_soa.user_login = ENV['CCMS_SOA_USER_LOGIN']
+    config.x.ccms_soa.user_role = ENV['CCMS_SOA_USER_ROLE']
+
     require Rails.root.join 'app/lib/govuk_elements_form_builder/form_builder'
     ActionView::Base.default_form_builder = GovukElementsFormBuilder::FormBuilder
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -72,12 +72,6 @@ module LaaApplyForLegalAid
     config.x.true_layer.enable_mock = ENV['TRUE_LAYER_ENABLE_MOCK'] == 'true'
     config.x.true_layer.banks = YAML.load_file(Rails.root.join('config/banks.yml'))['banks']
 
-    config.x.ccms_soa.client_username = ENV['CCMS_SOA_CLIENT_USERNAME']
-    config.x.ccms_soa.client_password_type = ENV['CCMS_SOA_CLIENT_PASSWORD_TYPE']
-    config.x.ccms_soa.client_password = ENV['CCMS_SOA_CLIENT_PASSWORD']
-    config.x.ccms_soa.user_login = ENV['CCMS_SOA_USER_LOGIN']
-    config.x.ccms_soa.user_role = ENV['CCMS_SOA_USER_ROLE']
-
     require Rails.root.join 'app/lib/govuk_elements_form_builder/form_builder'
     ActionView::Base.default_form_builder = GovukElementsFormBuilder::FormBuilder
 

--- a/db/migrate/20190925105003_add_columns_to_ccms_submission_histories.rb
+++ b/db/migrate/20190925105003_add_columns_to_ccms_submission_histories.rb
@@ -1,6 +1,6 @@
 class AddColumnsToCcmsSubmissionHistories < ActiveRecord::Migration[5.2]
   def change
-      add_column :ccms_submission_histories, :request, :xml
-      add_column :ccms_submission_histories, :response, :xml
+    add_column :ccms_submission_histories, :request, :xml
+    add_column :ccms_submission_histories, :response, :xml
   end
 end

--- a/db/migrate/20190925105003_add_columns_to_ccms_submission_histories.rb
+++ b/db/migrate/20190925105003_add_columns_to_ccms_submission_histories.rb
@@ -1,0 +1,6 @@
+class AddColumnsToCcmsSubmissionHistories < ActiveRecord::Migration[5.2]
+  def change
+      add_column :ccms_submission_histories, :request, :xml
+      add_column :ccms_submission_histories, :response, :xml
+  end
+end

--- a/db/migrate/20190925105003_add_columns_to_ccms_submission_histories.rb
+++ b/db/migrate/20190925105003_add_columns_to_ccms_submission_histories.rb
@@ -1,6 +1,6 @@
 class AddColumnsToCcmsSubmissionHistories < ActiveRecord::Migration[5.2]
   def change
-    add_column :ccms_submission_histories, :request, :xml
-    add_column :ccms_submission_histories, :response, :xml
+    add_column :ccms_submission_histories, :request, :text
+    add_column :ccms_submission_histories, :response, :text
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,6 +11,7 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 2019_10_11_142505) do
+
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -267,8 +268,8 @@ ActiveRecord::Schema.define(version: 2019_10_11_142505) do
     t.text "details"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.xml "request"
-    t.xml "response"
+    t.text "request"
+    t.text "response"
     t.index ["submission_id"], name: "index_ccms_submission_histories_on_submission_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,6 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 2019_10_11_142505) do
-
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -267,6 +267,8 @@ ActiveRecord::Schema.define(version: 2019_10_11_142505) do
     t.text "details"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.xml "request"
+    t.xml "response"
     t.index ["submission_id"], name: "index_ccms_submission_histories_on_submission_id"
   end
 

--- a/spec/data/ccms/applicant_add_status_response_no_such_party.xml
+++ b/spec/data/ccms/applicant_add_status_response_no_such_party.xml
@@ -18,7 +18,7 @@
         </header:RequestDetails>
         <header:Status>
           <header:Status>Success</header:Status>
-          <header:StatusFreeText>Party Successfully Created.</header:StatusFreeText>
+          <header:StatusFreeText>No such party.</header:StatusFreeText>
         </header:Status>
       </header:HeaderRS>
       <ns2:ClientReferenceNumber>20910584</ns2:ClientReferenceNumber>

--- a/spec/data/ccms/case_add_response.xml
+++ b/spec/data/ccms/case_add_response.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" standalone="yes"?>
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <ns8:CaseAddRS
   xmlns:ns2="http://legalservices.gov.uk/Enterprise/Common/1.0/Common"
   xmlns="http://legalservices.gov.uk/Enterprise/Common/1.0/Header"

--- a/spec/data/ccms/case_add_response_failure.xml
+++ b/spec/data/ccms/case_add_response_failure.xml
@@ -16,7 +16,7 @@
       <UserRole>my_role</UserRole>
     </RequestDetails>
     <Status>
-      <Status>Success</Status>
+      <Status>Fail</Status>
       <StatusFreeText></StatusFreeText>
     </Status>
   </HeaderRS>

--- a/spec/data/ccms/reference_data_request.xml
+++ b/spec/data/ccms/reference_data_request.xml
@@ -1,17 +1,17 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<soap:Envelope xmlns:xsd='http://www.w3.org/2001/XMLSchema' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xmlns:ns2='http://legalservices.gov.uk/CCMS/Common/ReferenceData/1.0/ReferenceDataBIM' xmlns:soap='http://schemas.xmlsoap.org/soap/envelope/' xmlns:ns1='http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd' xmlns:ns3='http://legalservices.gov.uk/Enterprise/Common/1.0/Header' xmlns:ns4='http://legalservices.gov.uk/Enterprise/Common/1.0/Common' xmlns:ns5='http://legalservices.gov.uk/CCMS/Common/ReferenceData/1.0/ReferenceDataBIO'>
+<?xml version="1.0" encoding="UTF-8"?>
+<soap:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns2="http://legalservices.gov.uk/CCMS/Common/ReferenceData/1.0/ReferenceDataBIM" xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd" xmlns:ns3="http://legalservices.gov.uk/Enterprise/Common/1.0/Header" xmlns:ns4="http://legalservices.gov.uk/Enterprise/Common/1.0/Common" xmlns:ns5="http://legalservices.gov.uk/CCMS/Common/ReferenceData/1.0/ReferenceDataBIO">
   <soap:Header>
     <ns1:Security>
       <ns1:UsernameToken>
         <ns1:Username>my_soap_client_username</ns1:Username>
-        <ns1:Password Type='password_type'>xxxxx</ns1:Password>
+        <ns1:Password Type="password_type">xxxxx</ns1:Password>
       </ns1:UsernameToken>
     </ns1:Security>
   </soap:Header>
   <soap:Body>
     <ns2:ReferenceDataInqRQ>
       <ns3:HeaderRQ>
-        <ns3:TransactionRequestID>20190101121530123456</ns3:TransactionRequestID>
+        <ns3:TransactionRequestID>20190301030405123456</ns3:TransactionRequestID>
         <ns3:Language>ENG</ns3:Language>
         <ns3:UserLoginID>my_login</ns3:UserLoginID>
         <ns3:UserRole>my_role</ns3:UserRole>

--- a/spec/factories/legal_aid_applications.rb
+++ b/spec/factories/legal_aid_applications.rb
@@ -174,6 +174,25 @@ FactoryBot.define do
     end
 
     trait :with_everything do
+      with_applicant
+      provider_submitted
+      with_savings_amount
+      with_other_assets_declaration
+      with_own_home_mortgaged
+      property_value { rand(1...1_000_000.0).round(2) }
+      outstanding_mortgage_amount { rand(1...1_000_000.0).round(2) }
+      shared_ownership { LegalAidApplication::SHARED_OWNERSHIP_YES_REASONS.sample }
+      percentage_home { rand(1...99.0).round(2) }
+      with_merits_assessment
+      with_merits_statement_of_case
+      with_respondent
+      with_restrictions
+      with_incident
+      with_vehicle
+      with_transaction_period
+    end
+
+    trait :with_everything_and_address do
       with_applicant_and_address
       provider_submitted
       with_savings_amount

--- a/spec/factories/legal_aid_applications.rb
+++ b/spec/factories/legal_aid_applications.rb
@@ -174,7 +174,7 @@ FactoryBot.define do
     end
 
     trait :with_everything do
-      with_applicant
+      with_applicant_and_address
       provider_submitted
       with_savings_amount
       with_other_assets_declaration

--- a/spec/factories/submissions.rb
+++ b/spec/factories/submissions.rb
@@ -29,5 +29,9 @@ FactoryBot.define do
         create :submission_document, :id_obtained, submission: submission
       end
     end
+
+    # trait :with_xml_request do
+    #   request {'Some text for now will be xml?'}
+    # end
   end
 end

--- a/spec/factories/submissions.rb
+++ b/spec/factories/submissions.rb
@@ -29,9 +29,5 @@ FactoryBot.define do
         create :submission_document, :id_obtained, submission: submission
       end
     end
-
-    # trait :with_xml_request do
-    #   request {'Some text for now will be xml?'}
-    # end
   end
 end

--- a/spec/requests/providers/merits_reports_spec.rb
+++ b/spec/requests/providers/merits_reports_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe Providers::MeritsReportsController, type: :request do
       let(:case_ccms_reference) { Faker::Number.number(digits: 6).to_s }
       let(:before_subject) do
         allow_any_instance_of(CCMS::ObtainCaseReferenceService).to receive(:reference_id).and_return(case_ccms_reference)
+        allow_any_instance_of(CCMS::ObtainCaseReferenceService).to receive(:response).and_return('dummy response')
       end
 
       it 'obtains the case reference remotely' do

--- a/spec/services/ccms/add_applicant_service_spec.rb
+++ b/spec/services/ccms/add_applicant_service_spec.rb
@@ -1,110 +1,140 @@
 require 'rails_helper'
 
-RSpec.describe CCMS::AddApplicantService do
-  let(:legal_aid_application) { create :legal_aid_application, :with_applicant }
-  let(:submission) { create :submission, :case_ref_obtained, legal_aid_application: legal_aid_application }
-  let(:history) { CCMS::SubmissionHistory.find_by(submission_id: submission.id) }
-  let(:applicant_add_requestor) { double CCMS::ApplicantAddRequestor }
-  # let(:applicant_add_response_parser) { double CCMS::ApplicantAddResponseParser }
-  let(:transaction_request_id_in_example_response) { '20190301030405123456' }
-  let(:applicant_add_request) { ccms_data_from_file 'applicant_add_request.xml' }
-  subject { described_class.new(submission) }
+module CCMS # rubocop:disable Metrics/ModuleLength
+  RSpec.describe AddApplicantService do
+    let(:legal_aid_application) { create :legal_aid_application, :with_applicant_and_address }
+    let(:applicant) { legal_aid_application.applicant }
+    let(:address) { applicant.address }
+    let(:submission) { create :submission, :case_ref_obtained, legal_aid_application: legal_aid_application }
+    let(:history) { SubmissionHistory.find_by(submission_id: submission.id) }
+    let(:endpoint) { 'https://sitsoa10.laadev.co.uk/soa-infra/services/default/ClientServices/ClientServices_ep' }
+    let(:response_body) { ccms_data_from_file 'applicant_add_response_success.xml' }
 
-  before do
-    allow(subject).to receive(:applicant_add_requestor).and_return(applicant_add_requestor)
-    allow(applicant_add_requestor).to receive(:transaction_request_id).and_return(transaction_request_id_in_example_response)
-    allow(applicant_add_requestor).to receive(:formatted_xml).and_return(applicant_add_request)
-  end
+    subject { described_class.new(submission) }
 
-  context 'operation successful' do
-    context 'no applicant exists on the CCMS system' do
-      let(:applicant_add_response) { ccms_data_from_file 'applicant_add_response_success.xml' }
-
-      before do
-        expect(applicant_add_requestor).to receive(:call).and_return(applicant_add_response)
-      end
-
-      it 'sets state to applicant_submitted' do
-        subject.call
-        expect(submission.aasm_state).to eq 'applicant_submitted'
-      end
-
-      it 'records the transaction id of the request' do
-        subject.call
-        expect(submission.applicant_add_transaction_id).to eq transaction_request_id_in_example_response
-      end
-
-      it 'writes a history record' do
-        expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
-        expect(history.from_state).to eq 'case_ref_obtained'
-        expect(history.to_state).to eq 'applicant_submitted'
-        expect(history.success).to be true
-        expect(history.details).to be_nil
-        expect("<?xml version='1.0' encoding='UTF-8'?>\n" + history.request).to eq applicant_add_request
-        expect(history.request).to_not be_nil
-        # expect(history.response).to eq applicant_add_response
-        # expect(history.response).to_not be_nil
-      end
+    around do |example|
+      VCR.turn_off!
+      example.run
+      VCR.turn_on!
     end
-  end
 
-  context 'operation in error' do
-    context 'error when adding an applicant' do
-      before do
-        expect(applicant_add_requestor).to receive(:call).and_raise(CCMS::CcmsError, 'oops')
-      end
+    before do
+      # stub a post request - any body, any headers
+      stub_request(:post, endpoint).to_return(body: response_body, status: 200)
 
-      it 'puts it into failed state' do
-        subject.call
-        expect(submission.aasm_state).to eq 'failed'
-      end
+      # stub the transaction request id that we expect in the response
+      allow_any_instance_of(ApplicantAddRequestor).to receive(:transaction_request_id).and_return('20190301030405123456')
+    end
 
-      it 'records the error in the submission history' do
-        expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
-        expect(history.from_state).to eq 'case_ref_obtained'
-        expect(history.to_state).to eq 'failed'
-        expect(history.success).to be false
-        expect("<?xml version='1.0' encoding='UTF-8'?>\n"+history.request).to eq applicant_add_request
-        expect(history.request).to_not be_nil
-        expect(history.details).to match(/CCMS::CcmsError/)
-        expect(history.details).to match(/oops/)
+    context 'operation successful' do
+      context 'no applicant exists on the CCMS system' do
+        it 'sets state to applicant_submitted' do
+          subject.call
+          expect(submission.aasm_state).to eq 'applicant_submitted'
+        end
+
+        it 'records the transaction id of the request' do
+          subject.call
+          expect(submission.applicant_add_transaction_id).to eq '20190301030405123456'
+        end
+
+        it 'writes a history record' do
+          expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
+          expect(history.from_state).to eq 'case_ref_obtained'
+          expect(history.to_state).to eq 'applicant_submitted'
+          expect(history.success).to be true
+          expect(history.details).to be_nil
+        end
+
+        it 'stores the reqeust body in the  submission history record' do
+          subject.call
+          expect(history.request).to be_soap_envelope_with(
+            command: 'ns2:ClientAddRQ',
+            transaction_id: '20190301030405123456',
+            matching: [
+              "<ns4:Surname>#{applicant.last_name}</ns4:Surname>",
+              "<ns4:FirstName>#{applicant.first_name}</ns4:FirstName>",
+              "<ns4:AddressLine1>#{address.first_lines}</ns4:AddressLine1>",
+              "<ns4:City>#{address.city}</ns4:City>",
+              "<ns4:PostalCode>#{address.postcode}</ns4:PostalCode>"
+            ]
+          )
+        end
+
+        it 'stores the response body in the submission history record' do
+          subject.call
+          expect(history.response).to eq response_body
+        end
       end
     end
 
-    context 'failed response from CCMS adding an applicant' do
-      let(:applicant_add_response) { ccms_data_from_file 'applicant_add_response_failure.xml' }
+    context 'operation in error' do
+      context 'error when adding an applicant' do
+        before do
+          expect_any_instance_of(ApplicantAddRequestor).to receive(:call).and_raise(CCMS::CcmsError, 'oops')
+        end
 
-      before do
-        expect(applicant_add_requestor).to receive(:call).and_return(applicant_add_response)
-        expect(applicant_add_requestor).to receive(:transaction_request_id).and_return(transaction_request_id_in_example_response)
+        it 'puts it into failed state' do
+          subject.call
+          expect(submission.aasm_state).to eq 'failed'
+        end
+
+        it 'records the error in the submission history' do
+          expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
+          expect(history.from_state).to eq 'case_ref_obtained'
+          expect(history.to_state).to eq 'failed'
+          expect(history.success).to be false
+          expect(history.details).to match(/CCMS::CcmsError/)
+          expect(history.details).to match(/oops/)
+          expect(history.request).to be_soap_envelope_with(
+            command: 'ns2:ClientAddRQ',
+            transaction_id: '20190301030405123456',
+            matching: [
+              "<ns4:Surname>#{applicant.last_name}</ns4:Surname>",
+              "<ns4:FirstName>#{applicant.first_name}</ns4:FirstName>",
+              "<ns4:AddressLine1>#{address.first_lines}</ns4:AddressLine1>",
+              "<ns4:City>#{address.city}</ns4:City>",
+              "<ns4:PostalCode>#{address.postcode}</ns4:PostalCode>"
+            ]
+          )
+        end
       end
 
-      it 'puts it into failed state' do
-        subject.call
-        expect(submission.aasm_state).to eq 'failed'
-      end
+      context 'unsuccessful response from CCMS adding an applicant' do
+        let(:response_body) { ccms_data_from_file 'applicant_add_response_failure.xml' }
 
-      it 'records the error in the submission history' do
-        expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
-        expect(history.from_state).to eq 'case_ref_obtained'
-        expect("<?xml version='1.0' encoding='UTF-8'?>\n"+history.request).to eq applicant_add_request
-        expect(history.request).to_not be_nil
-        expect(history.to_state).to eq 'failed'
-        expect(history.success).to be false
-        expect(history.details).to eq(applicant_add_response)
-      end
-    end
-  end
+        it 'puts it into failed state' do
+          subject.call
+          expect(submission.aasm_state).to eq 'failed'
+        end
 
-  # private method tested here because it is mocked out above
-  #
-  describe '#applicant_add_requestor' do
-    let(:service_double) { CCMS::AddApplicantService.new(submission) }
-    let(:requestor1) { service_double.__send__(:applicant_add_requestor) }
-    let(:requestor2) { service_double.__send__(:applicant_add_requestor) }
-    it 'only instantiates one copy of the ApplicantAddRequestor' do
-      expect(requestor1).to be_instance_of(CCMS::ApplicantAddRequestor)
-      expect(requestor1.object_id).to eq requestor2.object_id
+        it 'records the error in the submission history' do
+          expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
+          expect(history.from_state).to eq 'case_ref_obtained'
+          expect(history.to_state).to eq 'failed'
+          expect(history.success).to be false
+        end
+
+        it 'stores the reqeust body in the  submission history record' do
+          subject.call
+          expect(history.request).to be_soap_envelope_with(
+            command: 'ns2:ClientAddRQ',
+            transaction_id: '20190301030405123456',
+            matching: [
+              "<ns4:Surname>#{applicant.last_name}</ns4:Surname>",
+              "<ns4:FirstName>#{applicant.first_name}</ns4:FirstName>",
+              "<ns4:AddressLine1>#{address.first_lines}</ns4:AddressLine1>",
+              "<ns4:City>#{address.city}</ns4:City>",
+              "<ns4:PostalCode>#{address.postcode}</ns4:PostalCode>"
+            ]
+          )
+        end
+
+        it 'stores the response body in the submission history record' do
+          subject.call
+          expect(history.response).to eq response_body
+        end
+      end
     end
   end
 end

--- a/spec/services/ccms/add_applicant_service_spec.rb
+++ b/spec/services/ccms/add_applicant_service_spec.rb
@@ -5,14 +5,15 @@ RSpec.describe CCMS::AddApplicantService do
   let(:submission) { create :submission, :case_ref_obtained, legal_aid_application: legal_aid_application }
   let(:history) { CCMS::SubmissionHistory.find_by(submission_id: submission.id) }
   let(:applicant_add_requestor) { double CCMS::ApplicantAddRequestor }
+  # let(:applicant_add_response_parser) { double CCMS::ApplicantAddResponseParser }
   let(:transaction_request_id_in_example_response) { '20190301030405123456' }
-  let(:expected_xml) { ccms_data_from_file 'applicant_add_request.xml' }
+  let(:applicant_add_request) { ccms_data_from_file 'applicant_add_request.xml' }
   subject { described_class.new(submission) }
 
   before do
     allow(subject).to receive(:applicant_add_requestor).and_return(applicant_add_requestor)
     allow(applicant_add_requestor).to receive(:transaction_request_id).and_return(transaction_request_id_in_example_response)
-    allow(applicant_add_requestor).to receive(:formatted_xml).and_return(expected_xml)
+    allow(applicant_add_requestor).to receive(:formatted_xml).and_return(applicant_add_request)
   end
 
   context 'operation successful' do
@@ -37,14 +38,12 @@ RSpec.describe CCMS::AddApplicantService do
         expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
         expect(history.from_state).to eq 'case_ref_obtained'
         expect(history.to_state).to eq 'applicant_submitted'
-        ap 111111
-        ap "<?xml version='1.0' encoding='UTF-8'?>\n"+history.request
-        ap 3333333
-        ap expected_xml
-        expect("<?xml version='1.0' encoding='UTF-8'?>\n"+history.request).to eq expected_xml
-        expect(history.request).to_not be_nil
         expect(history.success).to be true
         expect(history.details).to be_nil
+        expect("<?xml version='1.0' encoding='UTF-8'?>\n" + history.request).to eq applicant_add_request
+        expect(history.request).to_not be_nil
+        # expect(history.response).to eq applicant_add_response
+        # expect(history.response).to_not be_nil
       end
     end
   end
@@ -65,6 +64,8 @@ RSpec.describe CCMS::AddApplicantService do
         expect(history.from_state).to eq 'case_ref_obtained'
         expect(history.to_state).to eq 'failed'
         expect(history.success).to be false
+        expect("<?xml version='1.0' encoding='UTF-8'?>\n"+history.request).to eq applicant_add_request
+        expect(history.request).to_not be_nil
         expect(history.details).to match(/CCMS::CcmsError/)
         expect(history.details).to match(/oops/)
       end
@@ -86,6 +87,8 @@ RSpec.describe CCMS::AddApplicantService do
       it 'records the error in the submission history' do
         expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
         expect(history.from_state).to eq 'case_ref_obtained'
+        expect("<?xml version='1.0' encoding='UTF-8'?>\n"+history.request).to eq applicant_add_request
+        expect(history.request).to_not be_nil
         expect(history.to_state).to eq 'failed'
         expect(history.success).to be false
         expect(history.details).to eq(applicant_add_response)

--- a/spec/services/ccms/add_applicant_service_spec.rb
+++ b/spec/services/ccms/add_applicant_service_spec.rb
@@ -6,11 +6,13 @@ RSpec.describe CCMS::AddApplicantService do
   let(:history) { CCMS::SubmissionHistory.find_by(submission_id: submission.id) }
   let(:applicant_add_requestor) { double CCMS::ApplicantAddRequestor }
   let(:transaction_request_id_in_example_response) { '20190301030405123456' }
+  let(:expected_xml) { ccms_data_from_file 'applicant_add_request.xml' }
   subject { described_class.new(submission) }
 
   before do
     allow(subject).to receive(:applicant_add_requestor).and_return(applicant_add_requestor)
     allow(applicant_add_requestor).to receive(:transaction_request_id).and_return(transaction_request_id_in_example_response)
+    allow(applicant_add_requestor).to receive(:formatted_xml).and_return(expected_xml)
   end
 
   context 'operation successful' do
@@ -35,6 +37,12 @@ RSpec.describe CCMS::AddApplicantService do
         expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
         expect(history.from_state).to eq 'case_ref_obtained'
         expect(history.to_state).to eq 'applicant_submitted'
+        ap 111111
+        ap "<?xml version='1.0' encoding='UTF-8'?>\n"+history.request
+        ap 3333333
+        ap expected_xml
+        expect("<?xml version='1.0' encoding='UTF-8'?>\n"+history.request).to eq expected_xml
+        expect(history.request).to_not be_nil
         expect(history.success).to be true
         expect(history.details).to be_nil
       end

--- a/spec/services/ccms/add_case_service_spec.rb
+++ b/spec/services/ccms/add_case_service_spec.rb
@@ -1,125 +1,152 @@
 require 'rails_helper'
 
-RSpec.describe CCMS::AddCaseService do
-  let(:legal_aid_application) { create :legal_aid_application, :with_applicant }
-  let(:submission) { create :submission, :applicant_ref_obtained, legal_aid_application: legal_aid_application }
-  let(:history) { CCMS::SubmissionHistory.find_by(submission_id: submission.id) }
-  let(:case_add_requestor) { double CCMS::CaseAddRequestor }
-  let(:expected_xml) { ccms_data_from_file 'case_add_request.xml' }
-  let(:transaction_request_id_in_example_response) { '20190301030405123456' }
-  subject { described_class.new(submission) }
+module CCMS # rubocop:disable Metrics/ModuleLength
+  RSpec.describe AddCaseService do
+    let(:legal_aid_application) { create :legal_aid_application, :with_proceeding_types, :with_everything, office_id: office.id, populate_vehicle: true }
+    let(:applicant) { legal_aid_application.applicant }
+    let(:office) { create :office }
+    let(:submission) { create :submission, :applicant_ref_obtained, legal_aid_application: legal_aid_application }
+    let(:history) { SubmissionHistory.find_by(submission_id: submission.id) }
+    let(:endpoint) { 'https://sitsoa10.laadev.co.uk/soa-infra/services/default/CaseServices/CaseServices_ep' }
+    let(:response_body) { ccms_data_from_file 'case_add_response.xml' }
 
-  before do
-    allow(subject).to receive(:case_add_requestor).and_return(case_add_requestor)
-    allow(case_add_requestor).to receive(:transaction_request_id).and_return(transaction_request_id_in_example_response)
-    allow(case_add_requestor).to receive(:formatted_xml).and_return(expected_xml)
-  end
+    subject { described_class.new(submission) }
 
-  context 'operation successful' do
-    let(:case_add_response) { ccms_data_from_file 'case_add_response.xml' }
+    around do |example|
+      VCR.turn_off!
+      example.run
+      VCR.turn_on!
+    end
 
     before do
-      expect(case_add_requestor).to receive(:call).and_return(case_add_response)
+      # stub a post request - any body, any headers
+      stub_request(:post, endpoint).to_return(body: response_body, status: 200)
+
+      # stub the transaction request id that we expect in the response
+      allow_any_instance_of(CaseAddRequestor).to receive(:transaction_request_id).and_return('20190301030405123456')
     end
 
-    it 'sets state to case_submitted' do
-      subject.call
-      expect(submission.aasm_state).to eq 'case_submitted'
-    end
-
-    it 'records the transaction id of the request' do
-      subject.call
-      expect(submission.case_add_transaction_id).to eq transaction_request_id_in_example_response
-    end
-
-    context 'there are documents to upload' do
-      let(:submission) { create :submission, :document_ids_obtained, legal_aid_application: legal_aid_application }
-      it 'writes a history record' do
-        expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
-        expect(history.from_state).to eq 'document_ids_obtained'
-        expect(history.to_state).to eq 'case_submitted'
-        expect("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"+history.request).to eq expected_xml
-        expect(history.request).to_not be_nil
-        expect(history.success).to be true
-        expect(history.details).to be_nil
-      end
-    end
-
-    context 'there are no documents to upload' do
-      it 'writes a history record' do
-        expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
-        expect(history.from_state).to eq 'applicant_ref_obtained'
-        expect(history.to_state).to eq 'case_submitted'
-        expect("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"+history.request).to eq expected_xml
-        expect(history.request).to_not be_nil
-        expect(history.success).to be true
-        expect(history.details).to be_nil
-      end
-    end
-  end
-
-  context 'operation in error' do
-    context 'error when adding a case' do
-      before do
-        allow(case_add_requestor).to receive(:formatted_xml).and_return(expected_xml)
-        expect(case_add_requestor).to receive(:call).and_raise(CCMS::CcmsError, 'oops')
-      end
-
-      it 'puts it into failed state' do
+    context 'operation successful' do
+      it 'sets state to case_submitted' do
         subject.call
-        expect(submission.aasm_state).to eq 'failed'
+        expect(submission.aasm_state).to eq 'case_submitted'
       end
 
-      it 'records the error in the submission history' do
-        expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
-        expect(history.from_state).to eq 'applicant_ref_obtained'
-        expect(history.to_state).to eq 'failed'
-        expect("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"+history.request).to eq expected_xml
-        expect(history.request).to_not be_nil
-        expect(history.success).to be false
-        expect(history.details).to match(/CCMS::CcmsError/)
-        expect(history.details).to match(/oops/)
-      end
-    end
-
-    context 'failed response from CCMS adding a case' do
-      let(:case_add_response) { ccms_data_from_file 'case_add_response.xml' }
-      let(:case_add_response_parser) { double CCMS::CaseAddResponseParser }
-
-      before do
-        allow(case_add_requestor).to receive(:formatted_xml).and_return(case_add_response)
-        expect(case_add_requestor).to receive(:call).and_return(case_add_response)
-        allow(subject).to receive(:case_add_response_parser).and_return(case_add_response_parser)
-        expect(case_add_response_parser).to receive(:success?).and_return(false)
-      end
-
-      it 'puts it into failed state' do
+      it 'records the transaction id of the request' do
         subject.call
-        expect(submission.aasm_state).to eq 'failed'
+        expect(submission.case_add_transaction_id).to eq '20190301030405123456'
       end
 
-      it 'records the error in the submission history' do
-        expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
-        expect(history.from_state).to eq 'applicant_ref_obtained'
-        # TO DO - check the xml for this as it is not matching the first part, encoding is missing
-        # expect(history.request).to eq case_add_response
-        expect(history.request).to_not be_nil
-        expect(history.to_state).to eq 'failed'
-        expect(history.success).to be false
-        expect(history.details).to eq(case_add_response)
+      context 'there are documents to upload' do
+        let(:submission) { create :submission, :document_ids_obtained, legal_aid_application: legal_aid_application }
+        it 'writes a history record' do
+          expect { subject.call }.to change { SubmissionHistory.count }.by(1)
+          expect(history.from_state).to eq 'document_ids_obtained'
+          expect(history.to_state).to eq 'case_submitted'
+          expect(history.success).to be true
+          expect(history.details).to be_nil
+        end
+
+        it 'stores the reqeust body in the  submission history record' do
+          subject.call
+          expect(history.request).to be_soap_envelope_with(
+            command: 'ns4:CaseAddRQ',
+            transaction_id: '20190301030405123456',
+            matching: [
+              '<ns2:PreferredAddress>CLIENT</ns2:PreferredAddress>',
+              "<ns2:ProviderOfficeID>#{legal_aid_application.office.ccms_id}</ns2:ProviderOfficeID>"
+            ]
+          )
+        end
+
+        it 'stores the response body in the submission history record' do
+          subject.call
+          expect(history.response).to eq response_body
+        end
+      end
+
+      context 'there are no documents to upload' do
+        it 'writes a history record' do
+          expect { subject.call }.to change { SubmissionHistory.count }.by(1)
+          expect(history.from_state).to eq 'applicant_ref_obtained'
+          expect(history.to_state).to eq 'case_submitted'
+          expect(history.success).to be true
+          expect(history.details).to be_nil
+        end
+
+        it 'stores the reqeust body in the  submission history record' do
+          subject.call
+          expect(history.request).to be_soap_envelope_with(
+            command: 'ns4:CaseAddRQ',
+            transaction_id: '20190301030405123456',
+            matching: [
+              "<ns2:ProviderOfficeID>#{legal_aid_application.office.ccms_id}</ns2:ProviderOfficeID>"
+            ]
+          )
+        end
       end
     end
-  end
 
-  # private method tested here because it is mocked out above
-  #
-  describe '#case_add_requestor' do
-    let(:service_double) { CCMS::AddCaseService.new(submission) }
-    let(:requestor1) { service_double.__send__(:case_add_requestor) }
-    let(:requestor2) { service_double.__send__(:case_add_requestor) }
-    it 'only instantiates one copy of the CaseAddRequestor' do
-      expect(requestor1).to be_instance_of(CCMS::CaseAddRequestor)
-      expect(requestor1).to eq requestor2
+    context 'operation in error' do
+      context 'error when adding a case' do
+        before do
+          expect_any_instance_of(CaseAddRequestor).to receive(:call).and_raise(CCMS::CcmsError, 'oops')
+        end
+
+        it 'puts it into failed state' do
+          subject.call
+          expect(submission.aasm_state).to eq 'failed'
+        end
+
+        it 'records the error in the submission history' do
+          expect { subject.call }.to change { SubmissionHistory.count }.by(1)
+          expect(history.from_state).to eq 'applicant_ref_obtained'
+          expect(history.to_state).to eq 'failed'
+          expect(history.success).to be false
+          expect(history.details).to match(/CCMS::CcmsError/)
+          expect(history.details).to match(/oops/)
+          expect(history.request).to be_soap_envelope_with(
+            command: 'ns4:CaseAddRQ',
+            transaction_id: '20190301030405123456',
+            matching: [
+              '<ns2:PreferredAddress>CLIENT</ns2:PreferredAddress>',
+              "<ns2:ProviderOfficeID>#{legal_aid_application.office.ccms_id}</ns2:ProviderOfficeID>"
+            ]
+          )
+        end
+      end
+
+      context 'unsuccessful response from CCMS adding a case' do
+        let(:response_body) { ccms_data_from_file 'case_add_response_failure.xml' }
+
+        it 'puts it into failed state' do
+          subject.call
+          expect(submission.aasm_state).to eq 'failed'
+        end
+
+        it 'records the error in the submission history' do
+          expect { subject.call }.to change { SubmissionHistory.count }.by(1)
+          expect(history.from_state).to eq 'applicant_ref_obtained'
+          expect(history.to_state).to eq 'failed'
+          expect(history.success).to be false
+        end
+
+        it 'stores the reqeust body in the  submission history record' do
+          subject.call
+          expect(history.request).to be_soap_envelope_with(
+            command: 'ns4:CaseAddRQ',
+            transaction_id: '20190301030405123456',
+            matching: [
+              "<ns2:ProviderOfficeID>#{legal_aid_application.office.ccms_id}</ns2:ProviderOfficeID>"
+            ]
+          )
+        end
+
+        it 'stores the response body in the submission history record' do
+          subject.call
+          expect(history.response).to eq response_body
+        end
+      end
     end
   end
 end

--- a/spec/services/ccms/add_case_service_spec.rb
+++ b/spec/services/ccms/add_case_service_spec.rb
@@ -9,6 +9,8 @@ module CCMS # rubocop:disable Metrics/ModuleLength
     let(:history) { SubmissionHistory.find_by(submission_id: submission.id) }
     let(:endpoint) { 'https://sitsoa10.laadev.co.uk/soa-infra/services/default/CaseServices/CaseServices_ep' }
     let(:response_body) { ccms_data_from_file 'case_add_response.xml' }
+    let(:cfe_submission) { create :cfe_submission, legal_aid_application: legal_aid_application }
+    let!(:cfe_result) { create :cfe_result, submission: cfe_submission }
 
     subject { described_class.new(submission) }
 

--- a/spec/services/ccms/add_case_service_spec.rb
+++ b/spec/services/ccms/add_case_service_spec.rb
@@ -5,12 +5,14 @@ RSpec.describe CCMS::AddCaseService do
   let(:submission) { create :submission, :applicant_ref_obtained, legal_aid_application: legal_aid_application }
   let(:history) { CCMS::SubmissionHistory.find_by(submission_id: submission.id) }
   let(:case_add_requestor) { double CCMS::CaseAddRequestor }
+  let(:expected_xml) { ccms_data_from_file 'case_add_request.xml' }
   let(:transaction_request_id_in_example_response) { '20190301030405123456' }
   subject { described_class.new(submission) }
 
   before do
     allow(subject).to receive(:case_add_requestor).and_return(case_add_requestor)
     allow(case_add_requestor).to receive(:transaction_request_id).and_return(transaction_request_id_in_example_response)
+    allow(case_add_requestor).to receive(:formatted_xml).and_return(expected_xml)
   end
 
   context 'operation successful' do
@@ -36,6 +38,8 @@ RSpec.describe CCMS::AddCaseService do
         expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
         expect(history.from_state).to eq 'document_ids_obtained'
         expect(history.to_state).to eq 'case_submitted'
+        expect("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"+history.request).to eq expected_xml
+        expect(history.request).to_not be_nil
         expect(history.success).to be true
         expect(history.details).to be_nil
       end
@@ -46,6 +50,8 @@ RSpec.describe CCMS::AddCaseService do
         expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
         expect(history.from_state).to eq 'applicant_ref_obtained'
         expect(history.to_state).to eq 'case_submitted'
+        expect("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"+history.request).to eq expected_xml
+        expect(history.request).to_not be_nil
         expect(history.success).to be true
         expect(history.details).to be_nil
       end
@@ -55,6 +61,7 @@ RSpec.describe CCMS::AddCaseService do
   context 'operation in error' do
     context 'error when adding a case' do
       before do
+        allow(case_add_requestor).to receive(:formatted_xml).and_return(expected_xml)
         expect(case_add_requestor).to receive(:call).and_raise(CCMS::CcmsError, 'oops')
       end
 
@@ -67,6 +74,8 @@ RSpec.describe CCMS::AddCaseService do
         expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
         expect(history.from_state).to eq 'applicant_ref_obtained'
         expect(history.to_state).to eq 'failed'
+        expect("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"+history.request).to eq expected_xml
+        expect(history.request).to_not be_nil
         expect(history.success).to be false
         expect(history.details).to match(/CCMS::CcmsError/)
         expect(history.details).to match(/oops/)
@@ -78,6 +87,7 @@ RSpec.describe CCMS::AddCaseService do
       let(:case_add_response_parser) { double CCMS::CaseAddResponseParser }
 
       before do
+        allow(case_add_requestor).to receive(:formatted_xml).and_return(case_add_response)
         expect(case_add_requestor).to receive(:call).and_return(case_add_response)
         allow(subject).to receive(:case_add_response_parser).and_return(case_add_response_parser)
         expect(case_add_response_parser).to receive(:success?).and_return(false)
@@ -91,6 +101,9 @@ RSpec.describe CCMS::AddCaseService do
       it 'records the error in the submission history' do
         expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
         expect(history.from_state).to eq 'applicant_ref_obtained'
+        # TO DO - check the xml for this as it is not matching the first part, encoding is missing
+        # expect(history.request).to eq case_add_response
+        expect(history.request).to_not be_nil
         expect(history.to_state).to eq 'failed'
         expect(history.success).to be false
         expect(history.details).to eq(case_add_response)

--- a/spec/services/ccms/add_case_service_spec.rb
+++ b/spec/services/ccms/add_case_service_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 module CCMS # rubocop:disable Metrics/ModuleLength
   RSpec.describe AddCaseService do
-    let(:legal_aid_application) { create :legal_aid_application, :with_proceeding_types, :with_everything, office_id: office.id, populate_vehicle: true }
+    let(:legal_aid_application) { create :legal_aid_application, :with_proceeding_types, :with_everything_and_address, office_id: office.id, populate_vehicle: true }
     let(:applicant) { legal_aid_application.applicant }
     let(:office) { create :office }
     let(:submission) { create :submission, :applicant_ref_obtained, legal_aid_application: legal_aid_application }

--- a/spec/services/ccms/applicant_add_requestor_spec.rb
+++ b/spec/services/ccms/applicant_add_requestor_spec.rb
@@ -28,7 +28,14 @@ module CCMS
 
       it 'generates the expected XML' do
         allow(requestor).to receive(:transaction_request_id).and_return(expected_tx_id)
-        expect(requestor.formatted_xml).to eq expected_xml.chomp
+        expect(requestor.formatted_xml).to be_soap_envelope_with(
+          command: 'ns2:ClientAddRQ',
+          transaction_id: expected_tx_id,
+          matching: [
+            "<ns4:AddressLine1>#{applicant.address.address_line_one} #{applicant.address.address_line_two}</ns4:AddressLine1>",
+            "<ns4:City>#{applicant.address.city}</ns4:City>"
+          ]
+        )
       end
     end
 

--- a/spec/services/ccms/applicant_add_status_requestor_spec.rb
+++ b/spec/services/ccms/applicant_add_status_requestor_spec.rb
@@ -11,7 +11,13 @@ module CCMS
 
       it 'generates the expected XML' do
         allow(requestor).to receive(:transaction_request_id).and_return(expected_tx_id)
-        expect(requestor.formatted_xml).to eq expected_xml.chomp
+        expect(requestor.formatted_xml).to be_soap_envelope_with(
+          command: 'ns2:ClientAddUpdtStatusRQ',
+          transaction_id: expected_tx_id,
+          matching: [
+            '<ns3:Language>ENG</ns3:Language>'
+          ]
+        )
       end
     end
 

--- a/spec/services/ccms/applicant_search_requestor_spec.rb
+++ b/spec/services/ccms/applicant_search_requestor_spec.rb
@@ -18,7 +18,14 @@ module CCMS
 
       it 'generates the expected XML' do
         allow(requestor).to receive(:transaction_request_id).and_return(expected_tx_id)
-        expect(requestor.formatted_xml).to eq expected_xml.chomp
+        expect(requestor.formatted_xml).to be_soap_envelope_with(
+          command: 'ns2:ClientInqRQ',
+          transaction_id: expected_tx_id,
+          matching: [
+            "<ns5:Surname>#{applicant.last_name}</ns5:Surname>",
+            "<ns5:FirstName>#{applicant.first_name}</ns5:FirstName>"
+          ]
+        )
       end
     end
 

--- a/spec/services/ccms/case_add_status_requestor_spec.rb
+++ b/spec/services/ccms/case_add_status_requestor_spec.rb
@@ -11,7 +11,10 @@ module CCMS
 
       it 'generates the expected XML' do
         allow(requestor).to receive(:transaction_request_id).and_return(expected_tx_id)
-        expect(requestor.formatted_xml).to eq expected_xml.chomp
+        expect(requestor.formatted_xml).to be_soap_envelope_with(
+          command: 'ns2:CaseAddUpdtStatusRQ',
+          transaction_id: expected_tx_id
+        )
       end
     end
 

--- a/spec/services/ccms/check_applicant_status_service_spec.rb
+++ b/spec/services/ccms/check_applicant_status_service_spec.rb
@@ -94,7 +94,6 @@ module CCMS # rubocop:disable Metrics/ModuleLength
           let(:expected_applicant_ccms_reference) { Faker::Number.number.to_s }
 
           before do
-            allow_any_instance_of(ApplicantAddStatusResponseParser).to receive(:success?).and_return(true)
             allow_any_instance_of(ApplicantAddStatusResponseParser).to receive(:applicant_ccms_reference).and_return(expected_applicant_ccms_reference)
           end
 

--- a/spec/services/ccms/check_applicant_status_service_spec.rb
+++ b/spec/services/ccms/check_applicant_status_service_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe CCMS::CheckApplicantStatusService do
   let(:applicant_add_status_requestor) { double CCMS::ApplicantAddStatusRequestor }
   let(:history) { CCMS::SubmissionHistory.find_by(submission_id: submission.id) }
   let(:applicant_add_status_response) { ccms_data_from_file 'applicant_add_status_response.xml' }
+  let(:applicant_add_status_request) { ccms_data_from_file 'applicant_add_status_request.xml' }
   subject { described_class.new(submission) }
 
   before do
@@ -19,6 +20,7 @@ RSpec.describe CCMS::CheckApplicantStatusService do
         before do
           expect(applicant_add_status_requestor).to receive(:call).and_return(applicant_add_status_response)
           expect(applicant_add_status_requestor).to receive(:transaction_request_id).and_return(transaction_request_id_in_example_response)
+          allow(applicant_add_status_requestor).to receive(:formatted_xml).and_return(applicant_add_status_request)
           allow_any_instance_of(CCMS::ApplicantAddStatusResponseParser).to receive(:success?).and_return(false)
         end
 
@@ -35,6 +37,8 @@ RSpec.describe CCMS::CheckApplicantStatusService do
             expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
             expect(history.from_state).to eq 'applicant_submitted'
             expect(history.to_state).to eq 'applicant_submitted'
+            expect("<?xml version=\'1.0\' encoding=\'UTF-8\'?>\n"+history.request).to eq applicant_add_status_request
+            expect(history.request).to_not be_nil
             expect(history.success).to be true
             expect(history.details).to be_nil
           end
@@ -57,6 +61,8 @@ RSpec.describe CCMS::CheckApplicantStatusService do
             expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
             expect(history.from_state).to eq 'applicant_submitted'
             expect(history.to_state).to eq 'failed'
+            expect("<?xml version=\'1.0\' encoding=\'UTF-8\'?>\n"+history.request).to eq applicant_add_status_request
+            expect(history.request).to_not be_nil
             expect(history.success).to be false
             expect(history.details).to eq 'Poll limit exceeded'
           end
@@ -68,6 +74,7 @@ RSpec.describe CCMS::CheckApplicantStatusService do
 
         before do
           expect(applicant_add_status_requestor).to receive(:call).and_return(applicant_add_status_response)
+          allow(applicant_add_status_requestor).to receive(:formatted_xml).and_return(applicant_add_status_request)
           expect(applicant_add_status_requestor).to receive(:transaction_request_id).and_return(transaction_request_id_in_example_response)
           allow_any_instance_of(CCMS::ApplicantAddStatusResponseParser).to receive(:success?).and_return(true)
           allow_any_instance_of(CCMS::ApplicantAddStatusResponseParser).to receive(:applicant_ccms_reference).and_return(expected_applicant_ccms_reference)
@@ -85,6 +92,8 @@ RSpec.describe CCMS::CheckApplicantStatusService do
           expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
           expect(history.from_state).to eq 'applicant_submitted'
           expect(history.to_state).to eq 'applicant_ref_obtained'
+          expect("<?xml version=\'1.0\' encoding=\'UTF-8\'?>\n"+history.request).to eq applicant_add_status_request
+          expect(history.request).to_not be_nil
           expect(history.success).to be true
           expect(history.details).to be_nil
         end
@@ -96,6 +105,7 @@ RSpec.describe CCMS::CheckApplicantStatusService do
 
       before do
         expect(applicant_add_status_requestor).to receive(:call).and_raise(CCMS::CcmsError, 'oops')
+        allow(applicant_add_status_requestor).to receive(:formatted_xml).and_return(applicant_add_status_request)
         expect(applicant_add_status_requestor).to receive(:transaction_request_id).and_return(transaction_request_id_in_example_response)
       end
 
@@ -111,6 +121,8 @@ RSpec.describe CCMS::CheckApplicantStatusService do
         expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
         expect(history.from_state).to eq 'applicant_submitted'
         expect(history.to_state).to eq 'failed'
+        expect("<?xml version=\'1.0\' encoding=\'UTF-8\'?>\n"+history.request).to eq applicant_add_status_request
+        expect(history.request).to_not be_nil
         expect(history.success).to be false
         expect(history.details).to match(/CCMS::CcmsError/)
         expect(history.details).to match(/oops/)

--- a/spec/services/ccms/check_applicant_status_service_spec.rb
+++ b/spec/services/ccms/check_applicant_status_service_spec.rb
@@ -1,144 +1,155 @@
 require 'rails_helper'
 
-RSpec.describe CCMS::CheckApplicantStatusService do
-  let(:submission) { create :submission, :applicant_submitted }
-  let(:applicant_add_status_requestor) { double CCMS::ApplicantAddStatusRequestor }
-  let(:history) { CCMS::SubmissionHistory.find_by(submission_id: submission.id) }
-  let(:applicant_add_status_response) { ccms_data_from_file 'applicant_add_status_response.xml' }
-  let(:applicant_add_status_request) { ccms_data_from_file 'applicant_add_status_request.xml' }
-  subject { described_class.new(submission) }
+module CCMS # rubocop:disable Metrics/ModuleLength
+  RSpec.describe CheckApplicantStatusService do
+    let(:submission) { create :submission, :applicant_submitted }
+    let(:history) { SubmissionHistory.find_by(submission_id: submission.id) }
+    let(:response_body) { ccms_data_from_file 'applicant_add_status_response.xml' }
+    let(:endpoint) { 'https://sitsoa10.laadev.co.uk/soa-infra/services/default/ClientServices/ClientServices_ep' }
 
-  before do
-    allow(subject).to receive(:applicant_add_status_requestor).and_return(applicant_add_status_requestor)
-  end
+    subject { described_class.new(submission) }
 
-  context 'applicant_submitted state' do
-    context 'operation successful' do
-      let(:transaction_request_id_in_example_response) { '20190301030405123456' }
+    around do |example|
+      VCR.turn_off!
+      example.run
+      VCR.turn_on!
+    end
 
-      context 'applicant not yet created' do
-        before do
-          expect(applicant_add_status_requestor).to receive(:call).and_return(applicant_add_status_response)
-          expect(applicant_add_status_requestor).to receive(:transaction_request_id).and_return(transaction_request_id_in_example_response)
-          allow(applicant_add_status_requestor).to receive(:formatted_xml).and_return(applicant_add_status_request)
-          allow_any_instance_of(CCMS::ApplicantAddStatusResponseParser).to receive(:success?).and_return(false)
-        end
+    before do
+      # stub a post request - any body, any headers
+      stub_request(:post, endpoint).to_return(body: response_body, status: 200)
 
-        context 'poll count remains below limit' do
-          it 'increments the poll count' do
-            expect { subject.call }.to change { submission.applicant_poll_count }.by 1
+      # stub the transaction request id that we expect in the response
+      allow_any_instance_of(ApplicantAddStatusRequestor).to receive(:transaction_request_id).and_return('20190301030405123456')
+    end
+
+    context 'applicant_submitted state' do
+      context 'operation successful' do
+        context 'applicant not yet created' do
+          let(:response_body) { ccms_data_from_file 'applicant_add_status_response_no_such_party.xml' }
+          context 'poll count remains below limit' do
+            it 'increments the poll count' do
+              expect { subject.call }.to change { submission.applicant_poll_count }.by 1
+            end
+
+            it 'does not change the state' do
+              expect { subject.call }.not_to change { submission.aasm_state }
+            end
+
+            it 'writes a history record' do
+              expect { subject.call }.to change { SubmissionHistory.count }.by(1)
+              expect(history.from_state).to eq 'applicant_submitted'
+              expect(history.to_state).to eq 'applicant_submitted'
+              expect(history.success).to be true
+              expect(history.details).to be_nil
+              expect(history.request).not_to be_nil
+            end
+
+            it 'stores the reqeust body in the  submission history record' do
+              subject.call
+              expect(history.request).to be_soap_envelope_with(
+                command: 'ns2:ClientAddUpdtStatusRQ',
+                transaction_id: '20190301030405123456'
+              )
+            end
+
+            it 'stores the response body in the submission history record' do
+              subject.call
+              expect(history.response).to eq response_body
+            end
           end
 
-          it 'does not change the state' do
-            expect { subject.call }.not_to change { submission.aasm_state }
+          context 'poll count reaches limit' do
+            before do
+              submission.applicant_poll_count = Submission::POLL_LIMIT - 1
+            end
+
+            it 'increments the poll count' do
+              expect { subject.call }.to change { submission.applicant_poll_count }.by 1
+            end
+
+            it 'changes the state to failed' do
+              expect { subject.call }.to change { submission.aasm_state }.to 'failed'
+            end
+
+            it 'writes a history record' do
+              expect { subject.call }.to change { SubmissionHistory.count }.by(1)
+              expect(history.from_state).to eq 'applicant_submitted'
+              expect(history.to_state).to eq 'failed'
+              expect(history.success).to be false
+              expect(history.details).to match(/CCMS::CcmsError\nPoll limit exceeded/)
+            end
+
+            it 'stores the reqeust body in the  submission history record' do
+              subject.call
+              expect(history.request).to be_soap_envelope_with(
+                command: 'ns2:ClientAddUpdtStatusRQ',
+                transaction_id: '20190301030405123456'
+              )
+            end
+          end
+        end
+
+        context 'applicant is created' do
+          let(:expected_applicant_ccms_reference) { Faker::Number.number.to_s }
+
+          before do
+            allow_any_instance_of(ApplicantAddStatusResponseParser).to receive(:success?).and_return(true)
+            allow_any_instance_of(ApplicantAddStatusResponseParser).to receive(:applicant_ccms_reference).and_return(expected_applicant_ccms_reference)
+          end
+
+          it 'changes the state to applicant_ref_obtained' do
+            expect { subject.call }.to change { submission.aasm_state }.to 'applicant_ref_obtained'
+          end
+
+          it 'updates the applicant_ccms_reference' do
+            expect { subject.call }.to change { submission.applicant_ccms_reference }.to expected_applicant_ccms_reference
           end
 
           it 'writes a history record' do
-            expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
+            expect { subject.call }.to change { SubmissionHistory.count }.by(1)
             expect(history.from_state).to eq 'applicant_submitted'
-            expect(history.to_state).to eq 'applicant_submitted'
-            expect("<?xml version=\'1.0\' encoding=\'UTF-8\'?>\n"+history.request).to eq applicant_add_status_request
-            expect(history.request).to_not be_nil
+            expect(history.to_state).to eq 'applicant_ref_obtained'
             expect(history.success).to be true
             expect(history.details).to be_nil
           end
-        end
 
-        context 'poll count reaches limit' do
-          before do
-            submission.applicant_poll_count = CCMS::Submission::POLL_LIMIT - 1
-          end
-
-          it 'increments the poll count' do
-            expect { subject.call }.to change { submission.applicant_poll_count }.by 1
-          end
-
-          it 'changes the state to failed' do
-            expect { subject.call }.to change { submission.aasm_state }.to 'failed'
-          end
-
-          it 'writes a history record' do
-            expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
-            expect(history.from_state).to eq 'applicant_submitted'
-            expect(history.to_state).to eq 'failed'
-            expect("<?xml version=\'1.0\' encoding=\'UTF-8\'?>\n"+history.request).to eq applicant_add_status_request
-            expect(history.request).to_not be_nil
-            expect(history.success).to be false
-            expect(history.details).to eq 'Poll limit exceeded'
+          it 'stores the reqeust body in the  submission history record' do
+            subject.call
+            expect(history.request).to be_soap_envelope_with(
+              command: 'ns2:ClientAddUpdtStatusRQ',
+              transaction_id: '20190301030405123456'
+            )
           end
         end
       end
 
-      context 'applicant is created' do
-        let(:expected_applicant_ccms_reference) { Faker::Number.number.to_s }
-
+      context 'operation unsuccessful' do
         before do
-          expect(applicant_add_status_requestor).to receive(:call).and_return(applicant_add_status_response)
-          allow(applicant_add_status_requestor).to receive(:formatted_xml).and_return(applicant_add_status_request)
-          expect(applicant_add_status_requestor).to receive(:transaction_request_id).and_return(transaction_request_id_in_example_response)
-          allow_any_instance_of(CCMS::ApplicantAddStatusResponseParser).to receive(:success?).and_return(true)
-          allow_any_instance_of(CCMS::ApplicantAddStatusResponseParser).to receive(:applicant_ccms_reference).and_return(expected_applicant_ccms_reference)
+          expect_any_instance_of(ApplicantAddStatusRequestor).to receive(:call).and_raise(CcmsError, 'oops')
         end
 
-        it 'changes the state to applicant_ref_obtained' do
-          expect { subject.call }.to change { submission.aasm_state }.to 'applicant_ref_obtained'
+        it 'increments the poll count' do
+          expect { subject.call }.to change { submission.applicant_poll_count }.by 1
         end
 
-        it 'updates the applicant_ccms_reference' do
-          expect { subject.call }.to change { submission.applicant_ccms_reference }.to expected_applicant_ccms_reference
+        it 'changes the state to failed' do
+          expect { subject.call }.to change { submission.aasm_state }.to 'failed'
         end
 
-        it 'writes a history record' do
-          expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
+        it 'records the error in the submission history' do
+          expect { subject.call }.to change { SubmissionHistory.count }.by(1)
           expect(history.from_state).to eq 'applicant_submitted'
-          expect(history.to_state).to eq 'applicant_ref_obtained'
-          expect("<?xml version=\'1.0\' encoding=\'UTF-8\'?>\n"+history.request).to eq applicant_add_status_request
-          expect(history.request).to_not be_nil
-          expect(history.success).to be true
-          expect(history.details).to be_nil
+          expect(history.to_state).to eq 'failed'
+          expect(history.success).to be false
+          expect(history.details).to match(/CCMS::CcmsError/)
+          expect(history.details).to match(/oops/)
+          expect(history.request).to be_soap_envelope_with(
+            command: 'ns2:ClientAddUpdtStatusRQ',
+            transaction_id: '20190301030405123456'
+          )
         end
       end
-    end
-
-    context 'operation unsuccessful' do
-      let(:transaction_request_id_in_example_response) { '20190301030405123456' }
-
-      before do
-        expect(applicant_add_status_requestor).to receive(:call).and_raise(CCMS::CcmsError, 'oops')
-        allow(applicant_add_status_requestor).to receive(:formatted_xml).and_return(applicant_add_status_request)
-        expect(applicant_add_status_requestor).to receive(:transaction_request_id).and_return(transaction_request_id_in_example_response)
-      end
-
-      it 'increments the poll count' do
-        expect { subject.call }.to change { submission.applicant_poll_count }.by 1
-      end
-
-      it 'changes the state to failed' do
-        expect { subject.call }.to change { submission.aasm_state }.to 'failed'
-      end
-
-      it 'records the error in the submission history' do
-        expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
-        expect(history.from_state).to eq 'applicant_submitted'
-        expect(history.to_state).to eq 'failed'
-        expect("<?xml version=\'1.0\' encoding=\'UTF-8\'?>\n"+history.request).to eq applicant_add_status_request
-        expect(history.request).to_not be_nil
-        expect(history.success).to be false
-        expect(history.details).to match(/CCMS::CcmsError/)
-        expect(history.details).to match(/oops/)
-      end
-    end
-  end
-
-  # private method tested here because it is mocked out above
-  #
-  describe '#applicant_add_status_requestor' do
-    let(:service_double) { CCMS::CheckApplicantStatusService.new(submission) }
-    let(:requestor1) { service_double.__send__(:applicant_add_status_requestor) }
-    let(:requestor2) { service_double.__send__(:applicant_add_status_requestor) }
-    it 'only instantiates one copy of the ApplicantAddStatusRequestor' do
-      expect(requestor1).to be_instance_of(CCMS::ApplicantAddStatusRequestor)
-      expect(requestor1).to eq requestor2
     end
   end
 end

--- a/spec/services/ccms/check_applicant_status_service_spec.rb
+++ b/spec/services/ccms/check_applicant_status_service_spec.rb
@@ -77,7 +77,7 @@ module CCMS # rubocop:disable Metrics/ModuleLength
               expect(history.from_state).to eq 'applicant_submitted'
               expect(history.to_state).to eq 'failed'
               expect(history.success).to be false
-              expect(history.details).to match(/CCMS::CcmsError\nPoll limit exceeded/)
+              expect(history.details).to match 'Poll limit exceeded'
             end
 
             it 'stores the reqeust body in the  submission history record' do

--- a/spec/services/ccms/check_case_status_service_spec.rb
+++ b/spec/services/ccms/check_case_status_service_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe CCMS::CheckCaseStatusService do
           expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
           expect(history.from_state).to eq 'case_submitted'
           expect(history.to_state).to eq 'case_created'
-          expect("<?xml version=\'1.0\' encoding=\'UTF-8\'?>\n" + history.request).to eq case_add_status_request
+          expect(history.request).to eq case_add_status_request
           expect(history.request).to_not be_nil
           expect(history.success).to be true
           expect(history.details).to be_nil
@@ -149,7 +149,7 @@ RSpec.describe CCMS::CheckCaseStatusService do
         expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
         expect(history.from_state).to eq 'case_submitted'
         expect(history.to_state).to eq 'failed'
-        expect("<?xml version=\'1.0\' encoding=\'UTF-8\'?>\n" + history.request).to eq case_add_status_request
+        expect(history.request).to eq case_add_status_request
         expect(history.request).to_not be_nil
         expect(history.success).to be false
         expect(history.details).to match(/CCMS::CcmsError/)

--- a/spec/services/ccms/check_case_status_service_spec.rb
+++ b/spec/services/ccms/check_case_status_service_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe CCMS::CheckCaseStatusService do
   let(:case_add_status_requestor) { double CCMS::CaseAddStatusRequestor }
   let(:history) { CCMS::SubmissionHistory.find_by(submission_id: submission.id) }
   let(:case_add_status_response) { ccms_data_from_file 'case_add_status_response.xml' }
+  let(:case_add_status_request) { ccms_data_from_file 'case_add_status_request.xml' }
   subject { described_class.new(submission) }
 
   before do
@@ -17,6 +18,7 @@ RSpec.describe CCMS::CheckCaseStatusService do
 
       context 'case not yet created' do
         before do
+          allow(case_add_status_requestor).to receive(:formatted_xml).and_return(case_add_status_request)
           expect(case_add_status_requestor).to receive(:call).and_return(case_add_status_response)
           expect(case_add_status_requestor).to receive(:transaction_request_id).and_return(transaction_request_id_in_example_response)
           allow_any_instance_of(CCMS::CaseAddStatusResponseParser).to receive(:success?).and_return(false)
@@ -35,6 +37,8 @@ RSpec.describe CCMS::CheckCaseStatusService do
             expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
             expect(history.from_state).to eq 'case_submitted'
             expect(history.to_state).to eq 'case_submitted'
+            expect("<?xml version=\'1.0\' encoding=\'UTF-8\'?>\n"+history.request).to eq case_add_status_request
+            expect(history.request).to_not be_nil
             expect(history.success).to be true
             expect(history.details).to be_nil
           end
@@ -57,6 +61,8 @@ RSpec.describe CCMS::CheckCaseStatusService do
             expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
             expect(history.from_state).to eq 'case_submitted'
             expect(history.to_state).to eq 'failed'
+            expect("<?xml version=\'1.0\' encoding=\'UTF-8\'?>\n"+history.request).to eq case_add_status_request
+            expect(history.request).to_not be_nil
             expect(history.success).to be false
             expect(history.details).to eq 'Poll limit exceeded'
           end
@@ -65,6 +71,7 @@ RSpec.describe CCMS::CheckCaseStatusService do
 
       context 'case is created' do
         before do
+          allow(case_add_status_requestor).to receive(:formatted_xml).and_return(case_add_status_request)
           expect(case_add_status_requestor).to receive(:call).and_return(case_add_status_response)
           expect(case_add_status_requestor).to receive(:transaction_request_id).and_return(transaction_request_id_in_example_response)
           allow_any_instance_of(CCMS::CaseAddStatusResponseParser).to receive(:success?).and_return(true)
@@ -78,6 +85,8 @@ RSpec.describe CCMS::CheckCaseStatusService do
           expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
           expect(history.from_state).to eq 'case_submitted'
           expect(history.to_state).to eq 'case_created'
+          expect("<?xml version=\'1.0\' encoding=\'UTF-8\'?>\n"+history.request).to eq case_add_status_request
+          expect(history.request).to_not be_nil
           expect(history.success).to be true
           expect(history.details).to be_nil
         end
@@ -88,6 +97,7 @@ RSpec.describe CCMS::CheckCaseStatusService do
       let(:transaction_request_id_in_example_response) { '20190301030405123456' }
 
       before do
+        allow(case_add_status_requestor).to receive(:formatted_xml).and_return(case_add_status_request)
         expect(case_add_status_requestor).to receive(:call).and_raise(CCMS::CcmsError, 'oops')
         expect(case_add_status_requestor).to receive(:transaction_request_id).and_return(transaction_request_id_in_example_response)
       end
@@ -104,6 +114,8 @@ RSpec.describe CCMS::CheckCaseStatusService do
         expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
         expect(history.from_state).to eq 'case_submitted'
         expect(history.to_state).to eq 'failed'
+        expect("<?xml version=\'1.0\' encoding=\'UTF-8\'?>\n"+history.request).to eq case_add_status_request
+        expect(history.request).to_not be_nil
         expect(history.success).to be false
         expect(history.details).to match(/CCMS::CcmsError/)
         expect(history.details).to match(/oops/)

--- a/spec/services/ccms/check_case_status_service_spec.rb
+++ b/spec/services/ccms/check_case_status_service_spec.rb
@@ -37,10 +37,21 @@ RSpec.describe CCMS::CheckCaseStatusService do
             expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
             expect(history.from_state).to eq 'case_submitted'
             expect(history.to_state).to eq 'case_submitted'
-            expect("<?xml version=\'1.0\' encoding=\'UTF-8\'?>\n"+history.request).to eq case_add_status_request
-            expect(history.request).to_not be_nil
             expect(history.success).to be true
             expect(history.details).to be_nil
+          end
+
+          it 'stores the reqeust body in the  submission history record' do
+            subject.call
+            expect(history.request).to be_soap_envelope_with(
+              command: 'ns2:CaseAddUpdtStatusRQ',
+              transaction_id: '20190101121530123456'
+            )
+          end
+
+          it 'stores the response body in the submission history record' do
+            subject.call
+            expect(history.response).to eq case_add_status_response
           end
         end
 
@@ -61,10 +72,21 @@ RSpec.describe CCMS::CheckCaseStatusService do
             expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
             expect(history.from_state).to eq 'case_submitted'
             expect(history.to_state).to eq 'failed'
-            expect("<?xml version=\'1.0\' encoding=\'UTF-8\'?>\n"+history.request).to eq case_add_status_request
-            expect(history.request).to_not be_nil
             expect(history.success).to be false
             expect(history.details).to eq 'Poll limit exceeded'
+          end
+
+          it 'stores the reqeust body in the  submission history record' do
+            subject.call
+            expect(history.request).to be_soap_envelope_with(
+              command: 'ns2:CaseAddUpdtStatusRQ',
+              transaction_id: '20190101121530123456'
+            )
+          end
+
+          it 'does not store a response body in the submission history record' do
+            subject.call
+            expect(history.response).to be_nil
           end
         end
       end
@@ -85,10 +107,23 @@ RSpec.describe CCMS::CheckCaseStatusService do
           expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
           expect(history.from_state).to eq 'case_submitted'
           expect(history.to_state).to eq 'case_created'
-          expect("<?xml version=\'1.0\' encoding=\'UTF-8\'?>\n"+history.request).to eq case_add_status_request
+          expect("<?xml version=\'1.0\' encoding=\'UTF-8\'?>\n" + history.request).to eq case_add_status_request
           expect(history.request).to_not be_nil
           expect(history.success).to be true
           expect(history.details).to be_nil
+        end
+
+        it 'stores the reqeust body in the  submission history record' do
+          subject.call
+          expect(history.request).to be_soap_envelope_with(
+            command: 'ns2:CaseAddUpdtStatusRQ',
+            transaction_id: '20190101121530123456'
+          )
+        end
+
+        it 'stores the response body in the submission history record' do
+          subject.call
+          expect(history.response).to eq case_add_status_response
         end
       end
     end
@@ -114,11 +149,24 @@ RSpec.describe CCMS::CheckCaseStatusService do
         expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
         expect(history.from_state).to eq 'case_submitted'
         expect(history.to_state).to eq 'failed'
-        expect("<?xml version=\'1.0\' encoding=\'UTF-8\'?>\n"+history.request).to eq case_add_status_request
+        expect("<?xml version=\'1.0\' encoding=\'UTF-8\'?>\n" + history.request).to eq case_add_status_request
         expect(history.request).to_not be_nil
         expect(history.success).to be false
         expect(history.details).to match(/CCMS::CcmsError/)
         expect(history.details).to match(/oops/)
+      end
+
+      it 'stores the reqeust body in the  submission history record' do
+        subject.call
+        expect(history.request).to be_soap_envelope_with(
+          command: 'ns2:CaseAddUpdtStatusRQ',
+          transaction_id: '20190101121530123456'
+        )
+      end
+
+      it 'does not store the response body in the submission history record' do
+        subject.call
+        expect(history.response).to be_nil
       end
     end
   end

--- a/spec/services/ccms/document_id_requestor_spec.rb
+++ b/spec/services/ccms/document_id_requestor_spec.rb
@@ -12,7 +12,14 @@ module CCMS
 
       it 'generates the expected XML' do
         allow(requestor).to receive(:transaction_request_id).and_return(expected_tx_id)
-        expect(requestor.formatted_xml).to eq expected_xml.chomp
+        expect(requestor.formatted_xml).to be_soap_envelope_with(
+          command: 'ns2:DocumentUploadRQ',
+          transaction_id: expected_tx_id,
+          matchers: [
+            '<ns4:DocumentType>ADMIN1</ns4:DocumentType>',
+            '<ns4:Channel>E</ns4:Channel>'
+          ]
+        )
       end
     end
 

--- a/spec/services/ccms/document_upload_requestor_spec.rb
+++ b/spec/services/ccms/document_upload_requestor_spec.rb
@@ -14,7 +14,14 @@ module CCMS
 
       it 'generates the expected XML' do
         allow(requestor).to receive(:transaction_request_id).and_return(expected_tx_id)
-        expect(requestor.formatted_xml).to eq expected_xml.chomp
+        expect(requestor.formatted_xml).to be_soap_envelope_with(
+          command: 'ns2:DocumentUploadRQ',
+          transaction_id: expected_tx_id,
+          matchers: [
+            '<ns4:DocumentType>ADMIN1</ns4:DocumentType>',
+            '<ns4:FileExtension>pdf</ns4:FileExtension>'
+          ]
+        )
       end
     end
 

--- a/spec/services/ccms/obtain_applicant_reference_service_spec.rb
+++ b/spec/services/ccms/obtain_applicant_reference_service_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe CCMS::ObtainApplicantReferenceService do
   let(:legal_aid_application) { create :legal_aid_application, :with_applicant }
   let(:submission) { create :submission, :case_ref_obtained, legal_aid_application: legal_aid_application }
   let(:history) { CCMS::SubmissionHistory.find_by(submission_id: submission.id) }
+  let(:applicant_search_request) { ccms_data_from_file 'applicant_search_request.xml' }
   let(:applicant_search_requestor) { double CCMS::ApplicantSearchRequestor }
   subject { described_class.new(submission) }
 
@@ -13,6 +14,7 @@ RSpec.describe CCMS::ObtainApplicantReferenceService do
 
   context 'operation successful' do
     before do
+      allow(applicant_search_requestor).to receive(:formatted_xml).and_return(applicant_search_request)
       expect(applicant_search_requestor).to receive(:call).and_return(applicant_search_response)
       expect(applicant_search_requestor).to receive(:transaction_request_id).and_return(transaction_request_id_in_example_response)
     end
@@ -36,6 +38,8 @@ RSpec.describe CCMS::ObtainApplicantReferenceService do
         expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
         expect(history.from_state).to eq 'case_ref_obtained'
         expect(history.to_state).to eq 'applicant_ref_obtained'
+        expect("<?xml version=\'1.0\' encoding=\'UTF-8\'?>\n"+history.request).to eq applicant_search_request
+        expect(history.request).to_not be_nil
         expect(history.success).to be true
         expect(history.details).to be_nil
       end
@@ -57,6 +61,7 @@ RSpec.describe CCMS::ObtainApplicantReferenceService do
   context 'operation in error' do
     context 'error when searching for applicant' do
       before do
+        allow(applicant_search_requestor).to receive(:formatted_xml).and_return(applicant_search_request)
         allow(applicant_search_requestor).to receive(:transaction_request_id).and_return(Faker::Number.number(digits: 8))
         expect(applicant_search_requestor).to receive(:call).and_raise(CCMS::CcmsError, 'oops')
       end
@@ -70,6 +75,8 @@ RSpec.describe CCMS::ObtainApplicantReferenceService do
         expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
         expect(history.from_state).to eq 'case_ref_obtained'
         expect(history.to_state).to eq 'failed'
+        expect("<?xml version=\'1.0\' encoding=\'UTF-8\'?>\n"+history.request).to eq applicant_search_request
+        expect(history.request).to_not be_nil
         expect(history.success).to be false
         expect(history.details).to match(/CCMS::CcmsError/)
         expect(history.details).to match(/oops/)

--- a/spec/services/ccms/obtain_applicant_reference_service_spec.rb
+++ b/spec/services/ccms/obtain_applicant_reference_service_spec.rb
@@ -1,14 +1,16 @@
 require 'rails_helper'
 
-module CCMS
+module CCMS # rubocop:disable Metrics/ModuleLength
   RSpec.describe ObtainApplicantReferenceService do
-    let(:legal_aid_application) { create :legal_aid_application, :with_proceeding_types, :with_everything, populate_vehicle: true }
+    let(:legal_aid_application) { create :legal_aid_application, :with_proceeding_types, :with_everything_and_address, populate_vehicle: true }
     let(:applicant) { legal_aid_application.applicant }
     let(:submission) { create :submission, :case_ref_obtained, legal_aid_application: legal_aid_application }
     let(:history) { SubmissionHistory.find_by(submission_id: submission.id) }
     let(:request_body) { ccms_data_from_file 'applicant_search_request.xml' }
     let(:response_body) { ccms_data_from_file 'applicant_search_response_one_result.xml' }
+    let(:empty_response_body) { ccms_data_from_file 'applicant_search_response_no_results.xml' }
     let(:endpoint) { 'https://sitsoa10.laadev.co.uk/soa-infra/services/default/ClientServices/ClientServices_ep' }
+    let(:success_add_applicant_response_body) { ccms_data_from_file 'applicant_add_response_success.xml' }
 
     subject { described_class.new(submission) }
 
@@ -19,15 +21,15 @@ module CCMS
     end
 
     before do
-      # stub a post request - any body, any headers
-      stub_request(:post, endpoint).to_return(body: response_body, status: 200)
-
       # stub the transaction request id that we expect in the response
       allow_any_instance_of(ApplicantSearchRequestor).to receive(:transaction_request_id).and_return('20190301030405123456')
     end
 
     context 'operation successful' do
       context 'applicant exists on the CCMS system' do
+        before do
+          stub_request(:post, endpoint).with(body: /ClientInqRQ/).to_return(body: response_body, status: 200)
+        end
         let(:applicant_ccms_reference_in_example_response) { '4390016' }
 
         it 'updates the applicant_ccms_reference' do
@@ -64,6 +66,50 @@ module CCMS
           subject.call
           expect(history.response).to eq response_body
         end
+      end
+    end
+
+    context 'applicant does not exist on CCMS' do
+      before do
+        # stub a post request
+        stub_request(:post, endpoint).with(body: /ClientInqRQ/).to_return(body: empty_response_body, status: 200)
+        stub_request(:post, endpoint).with(body: /ClientAddRQ/).to_return(body: success_add_applicant_response_body, status: 200)
+        expect_any_instance_of(ApplicantAddRequestor).to receive(:transaction_request_id).at_least(1).and_return('20190301030405123456')
+      end
+
+      it 'sets the state to applicant_submitted' do
+        subject.call
+        expect(submission.aasm_state).to eq 'applicant_submitted'
+      end
+
+      it 'writes a history record' do
+        expect { subject.call }.to change { SubmissionHistory.count }.by(2)
+        expect(history.from_state).to eq 'case_ref_obtained'
+        expect(history.to_state).to eq 'applicant_submitted'
+        expect(history.success).to be true
+        expect(history.details).to be_nil
+      end
+
+      it 'stores the reqeust body in the submission history record' do
+        subject.call
+        expect(history.request).to be_soap_envelope_with(
+          command: 'ns2:ClientAddRQ',
+          transaction_id: '20190301030405123456',
+          matching: [
+            "<ns4:Surname>#{applicant.last_name}</ns4:Surname>",
+            "<ns4:FirstName>#{applicant.first_name}</ns4:FirstName>"
+          ]
+        )
+      end
+
+      it 'stores the response body in the submission history record' do
+        subject.call
+        expect(history.response).to eq success_add_applicant_response_body
+      end
+
+      it 'calls the AddApplicant service' do
+        expect(AddApplicantService).to receive(:new).and_call_original
+        subject.call
       end
     end
 

--- a/spec/services/ccms/obtain_case_reference_service_spec.rb
+++ b/spec/services/ccms/obtain_case_reference_service_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe CCMS::ObtainCaseReferenceService do
   let(:legal_aid_application) { create :legal_aid_application }
   let(:submission) { create :submission, legal_aid_application: legal_aid_application }
   let(:history) { CCMS::SubmissionHistory.find_by(submission_id: submission.id) }
+  let(:reference_data_request) { ccms_data_from_file 'reference_data_request.xml' }
   let(:reference_data_requestor) { double CCMS::ReferenceDataRequestor }
   subject { described_class.new(submission) }
 
@@ -17,6 +18,7 @@ RSpec.describe CCMS::ObtainCaseReferenceService do
     let(:ccms_case_ref_in_example_response) { '300000135140' }
 
     before do
+      allow(reference_data_requestor).to receive(:formatted_xml).and_return(reference_data_request)
       expect(reference_data_requestor).to receive(:transaction_request_id).and_return(transaction_request_id_in_example_response)
       expect(reference_data_requestor).to receive(:call).and_return(reference_data_response)
     end
@@ -35,6 +37,8 @@ RSpec.describe CCMS::ObtainCaseReferenceService do
       expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
       expect(history.from_state).to eq 'initialised'
       expect(history.to_state).to eq 'case_ref_obtained'
+      expect("<?xml version=\'1.0\' encoding=\'UTF-8\'?>\n"+history.request).to eq reference_data_request
+      expect(history.request).to_not be_nil
       expect(history.success).to be true
       expect(history.details).to be_nil
     end
@@ -42,6 +46,7 @@ RSpec.describe CCMS::ObtainCaseReferenceService do
 
   context 'operation in error' do
     before do
+      allow(reference_data_requestor).to receive(:formatted_xml).and_return(reference_data_request)
       allow(reference_data_requestor).to receive(:transaction_request_id).and_return(Faker::Number.number(digits: 8))
       expect(reference_data_requestor).to receive(:call).and_raise(CCMS::CcmsError, 'oops')
     end
@@ -55,6 +60,8 @@ RSpec.describe CCMS::ObtainCaseReferenceService do
       expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
       expect(history.from_state).to eq 'initialised'
       expect(history.to_state).to eq 'failed'
+      expect("<?xml version=\'1.0\' encoding=\'UTF-8\'?>\n"+history.request).to eq reference_data_request
+      expect(history.request).to_not be_nil
       expect(history.success).to be false
       expect(history.details).to match(/CCMS::CcmsError/)
       expect(history.details).to match(/oops/)

--- a/spec/services/ccms/obtain_case_reference_service_spec.rb
+++ b/spec/services/ccms/obtain_case_reference_service_spec.rb
@@ -1,82 +1,85 @@
 require 'rails_helper'
 
-RSpec.describe CCMS::ObtainCaseReferenceService do
-  let(:legal_aid_application) { create :legal_aid_application }
-  let(:submission) { create :submission, legal_aid_application: legal_aid_application }
-  let(:history) { CCMS::SubmissionHistory.find_by(submission_id: submission.id) }
-  let(:reference_data_request) { ccms_data_from_file 'reference_data_request.xml' }
-  let(:reference_data_requestor) { double CCMS::ReferenceDataRequestor }
-  subject { described_class.new(submission) }
+module CCMS
+  RSpec.describe ObtainCaseReferenceService do
+    let(:legal_aid_application) { create :legal_aid_application }
+    let(:submission) { create :submission, legal_aid_application: legal_aid_application }
+    let(:history) { SubmissionHistory.find_by(submission_id: submission.id) }
+    let(:endpoint) { 'https://sitsoa10.laadev.co.uk/soa-infra/services/default/GetReferenceData!1.5*soa_92fe5600-6b1b-4d91-a97f-36e3955ae196/getreferencedata_ep' }
+    let(:response_body) { ccms_data_from_file 'reference_data_response.xml' }
 
-  before do
-    allow(subject).to receive(:reference_data_requestor).and_return(reference_data_requestor)
-  end
+    subject { described_class.new(submission) }
 
-  context 'operation successful' do
-    let(:reference_data_response) { ccms_data_from_file 'reference_data_response.xml' }
-    let(:transaction_request_id_in_example_response) { '20190301030405123456' }
-    let(:ccms_case_ref_in_example_response) { '300000135140' }
+    around do |example|
+      VCR.turn_off!
+      example.run
+      VCR.turn_on!
+    end
 
     before do
-      allow(reference_data_requestor).to receive(:formatted_xml).and_return(reference_data_request)
-      expect(reference_data_requestor).to receive(:transaction_request_id).and_return(transaction_request_id_in_example_response)
-      expect(reference_data_requestor).to receive(:call).and_return(reference_data_response)
+      # stub a post request - any body, any headers
+      stub_request(:post, endpoint).to_return(body: response_body, status: 200)
+      # stub the transaction request id that we expect in the response
+      allow_any_instance_of(ReferenceDataRequestor).to receive(:transaction_request_id).and_return('20190301030405123456')
     end
 
-    it 'stores the reference number' do
-      subject.call
-      expect(submission.case_ccms_reference).to eq ccms_case_ref_in_example_response
+    context 'operation successful' do
+      it 'stores the reference number returned in the response_body' do
+        subject.call
+        expect(submission.case_ccms_reference).to eq '300000135140'
+      end
+
+      it 'changes the state to case_ref_obtained' do
+        subject.call
+        expect(submission.aasm_state).to eq 'case_ref_obtained'
+      end
+
+      it 'writes a history record' do
+        expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
+
+        expect(history.from_state).to eq 'initialised'
+        expect(history.to_state).to eq 'case_ref_obtained'
+        expect(history.success).to be true
+        expect(history.details).to be_nil
+      end
+
+      it 'writes the request body to the history record' do
+        subject.call
+        expect(history.request).to be_soap_envelope_with(
+          command: 'ns2:ReferenceDataInqRQ',
+          transaction_id: '20190301030405123456'
+        )
+      end
+
+      it 'writes the response body to the history record' do
+        subject.call
+        expect(history.response).to eq response_body
+      end
     end
 
-    it 'changes the state to case_ref_obtained' do
-      subject.call
-      expect(submission.aasm_state).to eq 'case_ref_obtained'
-    end
+    context 'operation in error' do
+      before do
+        expect_any_instance_of(ReferenceDataRequestor).to receive(:call).and_raise(CCMS::CcmsError, 'oops')
+      end
 
-    it 'writes a history record' do
-      expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
-      expect(history.from_state).to eq 'initialised'
-      expect(history.to_state).to eq 'case_ref_obtained'
-      expect("<?xml version=\'1.0\' encoding=\'UTF-8\'?>\n"+history.request).to eq reference_data_request
-      expect(history.request).to_not be_nil
-      expect(history.success).to be true
-      expect(history.details).to be_nil
-    end
-  end
+      it 'puts it into failed state' do
+        subject.call
+        expect(submission.aasm_state).to eq 'failed'
+      end
 
-  context 'operation in error' do
-    before do
-      allow(reference_data_requestor).to receive(:formatted_xml).and_return(reference_data_request)
-      allow(reference_data_requestor).to receive(:transaction_request_id).and_return(Faker::Number.number(digits: 8))
-      expect(reference_data_requestor).to receive(:call).and_raise(CCMS::CcmsError, 'oops')
-    end
-
-    it 'puts it into failed state' do
-      subject.call
-      expect(submission.aasm_state).to eq 'failed'
-    end
-
-    it 'records the error in the submission history' do
-      expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
-      expect(history.from_state).to eq 'initialised'
-      expect(history.to_state).to eq 'failed'
-      expect("<?xml version=\'1.0\' encoding=\'UTF-8\'?>\n"+history.request).to eq reference_data_request
-      expect(history.request).to_not be_nil
-      expect(history.success).to be false
-      expect(history.details).to match(/CCMS::CcmsError/)
-      expect(history.details).to match(/oops/)
-    end
-  end
-
-  # private method tested here because it is mocked out above
-  #
-  describe '#reference_data_requestor' do
-    let(:service_double) { CCMS::ObtainCaseReferenceService.new(submission) }
-    let(:requestor1) { service_double.__send__(:reference_data_requestor) }
-    let(:requestor2) { service_double.__send__(:reference_data_requestor) }
-    it 'only instantiates one copy of the ReferenceDataRequestor' do
-      expect(requestor1).to be_instance_of(CCMS::ReferenceDataRequestor)
-      expect(requestor1).to eq requestor2
+      it 'records the error in the submission history' do
+        expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
+        expect(history.from_state).to eq 'initialised'
+        expect(history.to_state).to eq 'failed'
+        expect(history.success).to be false
+        expect(history.details).to match(/CCMS::CcmsError/)
+        expect(history.details).to match(/oops/)
+        expect(history.request).to be_soap_envelope_with(
+          command: 'ns2:ReferenceDataInqRQ',
+          transaction_id: '20190301030405123456'
+        )
+        expect(history.response).to be_nil
+      end
     end
   end
 end

--- a/spec/services/ccms/obtain_document_id_service_spec.rb
+++ b/spec/services/ccms/obtain_document_id_service_spec.rb
@@ -12,12 +12,17 @@ RSpec.describe CCMS::ObtainDocumentIdService do
   end
   let(:submission) { create :submission, :applicant_ref_obtained, legal_aid_application: legal_aid_application, case_ccms_reference: Faker::Number.number }
   let(:statement_of_case) { create :statement_of_case }
+  let(:document_id_request) { ccms_data_from_file 'document_id_request.xml' }
   let(:history) { CCMS::SubmissionHistory.find_by(submission_id: submission.id) }
   let(:document_id_requestor) { double CCMS::DocumentIdRequestor.new(submission.case_ccms_reference, 'my_login') }
   subject { described_class.new(submission) }
 
   context 'operation successful' do
     context 'the application has no documents' do
+      before do
+          allow(document_id_requestor).to receive(:formatted_xml).and_return(document_id_request)
+      end
+
       it 'creates an empty documents array' do
         subject.call
         expect(submission.submission_document.count).to eq 0
@@ -31,6 +36,8 @@ RSpec.describe CCMS::ObtainDocumentIdService do
         expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
         expect(history.from_state).to eq 'applicant_ref_obtained'
         expect(history.to_state).to eq 'case_submitted'
+        # expect("<?xml version=\'1.0\' encoding=\'UTF-8\'?>\n"+history.request).to eq document_id_request
+        expect(history.request).to_not be_nil
         expect(history.success).to be true
         expect(history.details).to be_nil
       end
@@ -42,6 +49,7 @@ RSpec.describe CCMS::ObtainDocumentIdService do
       let(:transaction_request_id_in_example_response) { '20190301030405123456' }
 
       before do
+        allow(document_id_requestor).to receive(:formatted_xml).and_return(document_id_request)
         allow(subject).to receive(:document_id_requestor).and_return(document_id_requestor)
         allow(document_id_requestor).to receive(:transaction_request_id).and_return(transaction_request_id_in_example_response)
         allow(document_id_requestor).to receive(:call).and_return(document_id_response)
@@ -79,6 +87,7 @@ RSpec.describe CCMS::ObtainDocumentIdService do
   context 'operation unsuccessful' do
     context 'when populating documents' do
       before do
+        allow(document_id_requestor).to receive(:formatted_xml).and_return(document_id_request)
         expect(subject).to receive(:populate_documents).and_raise(CCMS::CcmsError, 'failure populating document hash')
       end
 
@@ -90,6 +99,8 @@ RSpec.describe CCMS::ObtainDocumentIdService do
         expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
         expect(history.from_state).to eq 'applicant_ref_obtained'
         expect(history.to_state).to eq 'failed'
+        # expect("<?xml version=\'1.0\' encoding=\'UTF-8\'?>\n"+history.request).to eq document_id_request
+        expect(history.request).to_not be_nil
         expect(history.success).to be false
         expect(history.details).to match(/CCMS::CcmsError/)
         expect(history.details).to match(/failure populating document hash/)
@@ -100,6 +111,7 @@ RSpec.describe CCMS::ObtainDocumentIdService do
       let(:statement_of_case) { create :statement_of_case, :with_attached_files }
 
       before do
+        allow(document_id_requestor).to receive(:formatted_xml).and_return(document_id_request)
         allow(subject).to receive(:document_id_requestor).and_return(document_id_requestor)
         expect(document_id_requestor).to receive(:transaction_request_id).and_return(Faker::Number.number(digits: 8))
         expect(document_id_requestor).to receive(:call).and_raise(CCMS::CcmsError, 'failure requesting document ids')
@@ -118,6 +130,8 @@ RSpec.describe CCMS::ObtainDocumentIdService do
         expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
         expect(history.from_state).to eq 'applicant_ref_obtained'
         expect(history.to_state).to eq 'failed'
+        # expect("<?xml version=\'1.0\' encoding=\'UTF-8\'?>\n"+history.request).to eq document_id_request
+        expect(history.request).to_not be_nil
         expect(history.success).to be false
         expect(history.details).to match(/CCMS::CcmsError/)
         expect(history.details).to match(/failure requesting document ids/)

--- a/spec/services/ccms/obtain_document_id_service_spec.rb
+++ b/spec/services/ccms/obtain_document_id_service_spec.rb
@@ -1,153 +1,175 @@
 require 'rails_helper'
 
-RSpec.describe CCMS::ObtainDocumentIdService do
-  let(:legal_aid_application) do
-    create :legal_aid_application,
-           :with_applicant,
-           :with_proceeding_types,
-           :with_respondent,
-           :with_merits_assessment,
-           :with_transaction_period,
-           statement_of_case: statement_of_case
-  end
-  let(:submission) { create :submission, :applicant_ref_obtained, legal_aid_application: legal_aid_application, case_ccms_reference: Faker::Number.number }
-  let(:statement_of_case) { create :statement_of_case }
-  let(:document_id_request) { ccms_data_from_file 'document_id_request.xml' }
-  let(:history) { CCMS::SubmissionHistory.find_by(submission_id: submission.id) }
-  let(:document_id_requestor) { double CCMS::DocumentIdRequestor.new(submission.case_ccms_reference, 'my_login') }
-  subject { described_class.new(submission) }
+module CCMS # rubocop:disable Metrics/ModuleLength
+  RSpec.describe ObtainDocumentIdService do
+    let(:legal_aid_application) do
+      create :legal_aid_application,
+             :with_applicant,
+             :with_proceeding_types,
+             :with_respondent,
+             :with_merits_assessment,
+             :with_transaction_period,
+             statement_of_case: statement_of_case
+    end
+    let(:submission) { create :submission, :applicant_ref_obtained, legal_aid_application: legal_aid_application, case_ccms_reference: Faker::Number.number }
+    let(:statement_of_case) { create :statement_of_case }
+    let(:endpoint) { 'https://sitsoa10.laadev.co.uk/soa-infra/services/default/DocumentServices/DocumentServices_ep' }
+    let(:history) { SubmissionHistory.find_by(submission_id: submission.id) }
+    let(:document_id_request) { ccms_data_from_file 'document_id_request.xml' }
+    let(:response_body) { ccms_data_from_file 'document_id_response.xml' }
 
-  context 'operation successful' do
-    context 'the application has no documents' do
-      before do
-          allow(document_id_requestor).to receive(:formatted_xml).and_return(document_id_request)
+    subject { described_class.new(submission) }
+
+    around do |example|
+      VCR.turn_off!
+      example.run
+      VCR.turn_on!
+    end
+
+    before do
+      # stub a post request - any body, any headers
+      stub_request(:post, endpoint).to_return(body: response_body, status: 200)
+      # stub the transaction request id that we expect in the response
+      allow_any_instance_of(DocumentIdRequestor).to receive(:transaction_request_id).and_return('20190301030405123456')
+    end
+
+    context 'operation successful' do
+      context 'the application has no documents' do
+        it 'creates an empty documents array' do
+          subject.call
+          expect(submission.submission_document.count).to eq 0
+        end
+
+        it 'changes the submission state to case_submitted' do
+          expect { subject.call }.to change { submission.aasm_state }.to 'case_submitted'
+        end
+
+        it 'writes a history record' do
+          expect { subject.call }.to change { SubmissionHistory.count }.by(1)
+          expect(history.from_state).to eq 'applicant_ref_obtained'
+          expect(history.to_state).to eq 'case_submitted'
+          expect(history.success).to be true
+          expect(history.details).to be_nil
+        end
+
+        it 'writes the request body to the history record' do
+          subject.call
+          expect(history.request).to be_soap_envelope_with(
+            command: 'ns2:DocumentUploadRQ',
+            transaction_id: '20190301030405123456',
+            matching: [
+              '<ns4:DocumentType>ADMIN1</ns4:DocumentType>',
+              "<ns2:CaseReferenceNumber>#{legal_aid_application.case_ccms_reference}</ns2:CaseReferenceNumber>"
+            ]
+          )
+        end
+
+        it 'writes the response body to the history record' do
+          subject.call
+          expect(history.response).to eq response_body
+        end
       end
 
-      it 'creates an empty documents array' do
-        subject.call
-        expect(submission.submission_document.count).to eq 0
-      end
+      context 'the application has documents to upload' do
+        let(:statement_of_case) { create :statement_of_case, :with_attached_files }
 
-      it 'changes the submission state to case_submitted' do
-        expect { subject.call }.to change { submission.aasm_state }.to 'case_submitted'
-      end
+        before do
+          Reports::MeansReportCreator.call(legal_aid_application)
+          Reports::MeritsReportCreator.call(legal_aid_application)
+        end
 
-      it 'writes a history record' do
-        expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
-        expect(history.from_state).to eq 'applicant_ref_obtained'
-        expect(history.to_state).to eq 'case_submitted'
-        # expect("<?xml version=\'1.0\' encoding=\'UTF-8\'?>\n"+history.request).to eq document_id_request
-        expect(history.request).to_not be_nil
-        expect(history.success).to be true
-        expect(history.details).to be_nil
+        it 'populates the documents array with statement_of_case, means_report and merits_report' do
+          subject.call
+          expect(submission.submission_document.count).to eq 3
+        end
+
+        context 'when requesting document_ids' do
+          it 'populates the ccms_document_id for each document' do
+            subject.call
+            submission.submission_document.each do |document|
+              expect(document.ccms_document_id).to_not be nil
+            end
+          end
+
+          it 'updates the status for each document to id_obtained' do
+            subject.call
+            submission.submission_document.each do |document|
+              expect(document.status).to eq 'id_obtained'
+            end
+          end
+
+          it 'changes the submission state to document_ids_obtained' do
+            expect { subject.call }.to change { submission.aasm_state }.to 'document_ids_obtained'
+          end
+        end
       end
     end
 
-    context 'the application has documents to upload' do
-      let(:statement_of_case) { create :statement_of_case, :with_attached_files }
-      let(:document_id_response) { ccms_data_from_file 'document_id_response.xml' }
-      let(:transaction_request_id_in_example_response) { '20190301030405123456' }
+    context 'operation unsuccessful' do
+      context 'when populating documents' do
+        before do
+          allow_any_instance_of(DocumentIdRequestor).to receive(:transaction_request_id).and_return('20190301030405123456')
+          expect_any_instance_of(DocumentIdRequestor).to receive(:call).and_raise(CcmsError, 'failure populating document hash')
+        end
 
-      before do
-        allow(document_id_requestor).to receive(:formatted_xml).and_return(document_id_request)
-        allow(subject).to receive(:document_id_requestor).and_return(document_id_requestor)
-        allow(document_id_requestor).to receive(:transaction_request_id).and_return(transaction_request_id_in_example_response)
-        allow(document_id_requestor).to receive(:call).and_return(document_id_response)
-        Reports::MeansReportCreator.call(legal_aid_application)
-        Reports::MeritsReportCreator.call(legal_aid_application)
-      end
+        it 'changes the submission state to failed' do
+          expect { subject.call }.to change { submission.aasm_state }.to 'failed'
+        end
 
-      it 'populates the documents array with statement_of_case, means_report and merits_report' do
-        subject.call
-        expect(submission.submission_document.count).to eq 3
+        it 'writes a history record' do
+          expect { subject.call }.to change { SubmissionHistory.count }.by(1)
+          expect(history.from_state).to eq 'applicant_ref_obtained' # this is failing gets case_submitted
+          expect(history.to_state).to eq 'failed'
+          expect(history.success).to be false
+          expect(history.details).to match(/CCMS::CcmsError/)
+          expect(history.details).to match(/failure populating document hash/)
+          expect(history.request).not_to be_nil
+          expect(history.request).to be_soap_envelope_with(
+            command: 'ns2:DocumentUploadRQ',
+            transaction_id: '20190301030405123456',
+            matching: [
+              '<ns4:DocumentType>ADMIN1</ns4:DocumentType>',
+              "<ns2:CaseReferenceNumber>#{legal_aid_application.case_ccms_reference}</ns2:CaseReferenceNumber>"
+            ]
+          )
+          expect(history.response).to be_nil
+        end
       end
 
       context 'when requesting document_ids' do
-        it 'populates the ccms_document_id for each document' do
+        before do
+          expect_any_instance_of(DocumentIdRequestor).to receive(:call).and_raise(CcmsError, 'failure populating document hash')
+          allow_any_instance_of(DocumentIdRequestor).to receive(:transaction_request_id).and_return('20190301030405123456')
+        end
+
+        let(:statement_of_case) { create :statement_of_case, :with_attached_files }
+
+        it 'changes the submission state to failed' do
+          expect { subject.call }.to change { submission.aasm_state }.to 'failed'
+        end
+
+        it 'changes the document state to failed' do
           subject.call
-          submission.submission_document.each do |document|
-            expect(document.ccms_document_id).to_not be nil
-          end
+          expect(submission.submission_document.first.status).to eq 'failed'
         end
 
-        it 'updates the status for each document to id_obtained' do
-          subject.call
-          submission.submission_document.each do |document|
-            expect(document.status).to eq 'id_obtained'
-          end
+        it 'writes a history record' do
+          expect { subject.call }.to change { SubmissionHistory.count }.by(1)
+          expect(history.from_state).to eq 'applicant_ref_obtained'
+          expect(history.to_state).to eq 'failed'
+          expect(history.success).to be false
+          expect(history.details).to match(/CCMS::CcmsError/)
+          expect(history.details).to match(/failure populating document hash/)
+          expect(history.request).to be_soap_envelope_with(
+            command: 'ns2:DocumentUploadRQ',
+            transaction_id: '20190301030405123456',
+            matching: [
+              "<ns2:CaseReferenceNumber>#{legal_aid_application.case_ccms_reference}</ns2:CaseReferenceNumber>"
+            ]
+          )
+          expect(history.response).to be_nil
         end
-
-        it 'changes the submission state to document_ids_obtained' do
-          expect { subject.call }.to change { submission.aasm_state }.to 'document_ids_obtained'
-        end
       end
-    end
-  end
-
-  context 'operation unsuccessful' do
-    context 'when populating documents' do
-      before do
-        allow(document_id_requestor).to receive(:formatted_xml).and_return(document_id_request)
-        expect(subject).to receive(:populate_documents).and_raise(CCMS::CcmsError, 'failure populating document hash')
-      end
-
-      it 'changes the submission state to failed' do
-        expect { subject.call }.to change { submission.aasm_state }.to 'failed'
-      end
-
-      it 'writes a history record' do
-        expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
-        expect(history.from_state).to eq 'applicant_ref_obtained'
-        expect(history.to_state).to eq 'failed'
-        # expect("<?xml version=\'1.0\' encoding=\'UTF-8\'?>\n"+history.request).to eq document_id_request
-        expect(history.request).to_not be_nil
-        expect(history.success).to be false
-        expect(history.details).to match(/CCMS::CcmsError/)
-        expect(history.details).to match(/failure populating document hash/)
-      end
-    end
-
-    context 'when requesting document_ids' do
-      let(:statement_of_case) { create :statement_of_case, :with_attached_files }
-
-      before do
-        allow(document_id_requestor).to receive(:formatted_xml).and_return(document_id_request)
-        allow(subject).to receive(:document_id_requestor).and_return(document_id_requestor)
-        expect(document_id_requestor).to receive(:transaction_request_id).and_return(Faker::Number.number(digits: 8))
-        expect(document_id_requestor).to receive(:call).and_raise(CCMS::CcmsError, 'failure requesting document ids')
-      end
-
-      it 'changes the submission state to failed' do
-        expect { subject.call }.to change { submission.aasm_state }.to 'failed'
-      end
-
-      it 'changes the document state to failed' do
-        subject.call
-        expect(submission.submission_document.first.status).to eq 'failed'
-      end
-
-      it 'writes a history record' do
-        expect { subject.call }.to change { CCMS::SubmissionHistory.count }.by(1)
-        expect(history.from_state).to eq 'applicant_ref_obtained'
-        expect(history.to_state).to eq 'failed'
-        # expect("<?xml version=\'1.0\' encoding=\'UTF-8\'?>\n"+history.request).to eq document_id_request
-        expect(history.request).to_not be_nil
-        expect(history.success).to be false
-        expect(history.details).to match(/CCMS::CcmsError/)
-        expect(history.details).to match(/failure requesting document ids/)
-      end
-    end
-  end
-
-  # private method tested here because it is mocked out above
-  #
-  describe '#document_id_requestor' do
-    let(:service) { CCMS::ObtainDocumentIdService.new(submission) }
-    let(:requestor1) { service.__send__(:document_id_requestor) }
-    let(:requestor2) { service.__send__(:document_id_requestor) }
-    it 'only instantiates one copy of the DocumentIdRequestor' do
-      expect(requestor1).to be_instance_of(CCMS::DocumentIdRequestor)
-      expect(requestor1).to eq requestor2
     end
   end
 end

--- a/spec/services/ccms/reference_data_requestor_spec.rb
+++ b/spec/services/ccms/reference_data_requestor_spec.rb
@@ -11,7 +11,13 @@ module CCMS
 
       it 'generates the expected XML' do
         allow(requestor).to receive(:transaction_request_id).and_return(expected_tx_id)
-        expect(requestor.formatted_xml).to eq expected_xml.chomp
+        expect(requestor.formatted_xml).to be_soap_envelope_with(
+          command: 'ns2:ReferenceDataInqRQ',
+          transaction_id: expected_tx_id,
+          matchers: [
+            '<ns3:Language>ENG</ns3:Language>'
+          ]
+        )
       end
     end
 

--- a/spec/services/ccms/upload_documents_service_spec.rb
+++ b/spec/services/ccms/upload_documents_service_spec.rb
@@ -75,23 +75,6 @@ RSpec.describe CCMS::UploadDocumentsService do
       expect(history.success).to be true
       expect(history.details).to be_nil
     end
-
-    # it 'writes the request body to the history record' do
-    #   subject.call
-    #   expect(history.request).to be_soap_envelope_with(
-    #     command: 'ns2:DocumentUploadRQ',
-    #     transaction_id: '20190301030405123456',
-    #     matching: [
-    #       '<ns4:DocumentType>ADMIN1</ns4:DocumentType>',
-    #       "<ns2:CaseReferenceNumber>#{legal_aid_application.case_ccms_reference}</ns2:CaseReferenceNumber>"
-    #     ]
-    #   )
-    # end
-    #
-    # it 'writes the response body to the history record' do
-    #   subject.call
-    #   expect(history.response).to eq document_upload_response
-    # end
   end
 
   context 'operation unsuccessful' do

--- a/spec/services/ccms/upload_documents_service_spec.rb
+++ b/spec/services/ccms/upload_documents_service_spec.rb
@@ -31,21 +31,21 @@ RSpec.describe CCMS::UploadDocumentsService do
   end
 
   let(:history) { CCMS::SubmissionHistory.find_by(submission_id: submission.id) }
-  let(:document_upload_requestor) { double CCMS::DocumentUploadRequestor.new(submission.case_ccms_reference, statement_of_case_id, 'base64encodedpdf', 'my_login') }
+  # let(:document_upload_requestor) { double CCMS::DocumentUploadRequestor.new(submission.case_ccms_reference, statement_of_case_id, 'base64encodedpdf', 'my_login') }
   let(:document_upload_response) { ccms_data_from_file 'document_upload_response.xml' }
   let(:transaction_request_id_in_example_response) { '20190301030405123456' }
   subject { described_class.new(submission) }
 
   before do
     PdfConverter.call(PdfFile.find_or_create_by(original_file_id: statement_of_case_id).id)
-    allow(CCMS::DocumentUploadRequestor).to receive(:new).and_return(document_upload_requestor)
-    allow(document_upload_requestor).to receive(:transaction_request_id).and_return(transaction_request_id_in_example_response)
+    # allow(CCMS::DocumentUploadRequestor).to receive(:new).and_return(document_upload_requestor)
+    # allow(document_upload_requestor).to receive(:transaction_request_id).and_return(transaction_request_id_in_example_response)
   end
 
   context 'operation successful' do
-    before do
-      allow(document_upload_requestor).to receive(:call).and_return(document_upload_response)
-    end
+    # before do
+    #   allow(document_upload_requestor).to receive(:call).and_return(document_upload_response)
+    # end
 
     it 'creates a DocumentUploadRequestor object for each document to be uploaded' do
       expect(CCMS::DocumentUploadRequestor).to receive(:new).exactly(submission.submission_document.count).times

--- a/spec/support/file_helpers.rb
+++ b/spec/support/file_helpers.rb
@@ -2,3 +2,11 @@ def ccms_data_from_file(filename)
   path = Rails.root.join 'spec/data/ccms', filename
   File.read path
 end
+
+def squish_xml(xml)
+  xml.gsub(/\n\s+/, "\n ")
+end
+
+def remove_xml_header(xml)
+  xml.gsub("<?xml version='1.0' encoding='UTF-8'?>\n", '')
+end

--- a/spec/support/soap_matchers.rb
+++ b/spec/support/soap_matchers.rb
@@ -1,0 +1,34 @@
+# use as follows:
+#
+# expect(history.request).to be_soap_envelope_with(
+#                                      command: 'ns2:ReferenceDataInqRQ',
+#                                      transaction_id: '20190301030405123456',
+#                                      matching: ['<ns5:ContextKey>CaseReferenceNumber</ns5:ContextKey>', 'ns5:Key>CaseReferenceNumber</ns5:Key']
+#                                    )
+module SoapMatcher
+  RSpec::Matchers.define :be_soap_envelope_with do |options|
+    results = []
+    match do |actual|
+      results << 'String does not start with a soap Envelope declaration' unless /<soap:Envelope xmlns:(soap=|xsd=)/.match?(actual)
+
+      if options[:command]
+        results << "String does not contain the #{options[:command]} command immediately after the soap:Body element" unless /<soap:Body>\n\s*<#{options[:command]}>/.match?(actual)
+      end
+
+      if options[:transaction_id]
+        unless %r{TransactionRequestID>#{options[:transaction_id]}</.+TransactionRequestID>}.match?(actual)
+          results << "String does not contain an ns3:/ns6:TransactionRequestID with a value of #{options[:transaction_id]}"
+        end
+      end
+
+      options[:matching]&.each do |string_to_match|
+        results << "String '#{string_to_match}' not found" unless actual&.match?(Regexp.new(string_to_match))
+      end
+      results.empty?
+    end
+
+    failure_message do
+      "#{results.join("\n")}\n\nThe string being checked was:\n\n#{actual}"
+    end
+  end
+end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-764)

Add ```xml_request``` and ```response``` fields to the ```ccms_submission_history``` table and also as attributes to each of the CCMS services.

Add tests for the new methods and attributes.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
