### PR TITLE
Fix document upload processing

### DIFF
--- a/app/services/ccms/obtain_document_id_service.rb
+++ b/app/services/ccms/obtain_document_id_service.rb
@@ -63,6 +63,7 @@ module CCMS
         response = document_id_requestor.call
         document.ccms_document_id = DocumentIdResponseParser.new(tx_id, response).document_id
         document.status = :id_obtained
+        submission.save!
       rescue CcmsError => e
         document.status = :failed
         raise CcmsError, e

--- a/app/services/ccms/upload_documents_service.rb
+++ b/app/services/ccms/upload_documents_service.rb
@@ -26,6 +26,7 @@ module CCMS
       tx_id = document_upload_requestor.transaction_request_id
       response = document_upload_requestor.call
       update_document_status(document, tx_id, response)
+      submission.save!
     rescue CcmsError => e
       document.status = :failed
       raise CcmsError, e


### PR DESCRIPTION
## What

Sidekiq is attempting to request document ids/upload documents multiple times.

To fix this, update the database by calling `submission.save` each time a document is processed by either the `obtain_document_id_service` or the `upload_documents_service`.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
