### PR TITLE
AP-982 Populate CCMS attributes from assessment results

### DIFF
--- a/app/models/cfe/result.rb
+++ b/app/models/cfe/result.rb
@@ -2,5 +2,21 @@ module CFE
   class Result < ApplicationRecord
     belongs_to :legal_aid_application
     belongs_to :submission
+
+    def result_hash
+      JSON.parse(result, symbolize_names: true)
+    end
+
+    def capital_contribution_required?
+      assessment_result == 'contribution_required'
+    end
+
+    def assessment_result
+      result_hash[:assessment_result]
+    end
+
+    def capital_contribution
+      result_hash[:capital][:capital_contribution].to_d
+    end
   end
 end

--- a/app/services/ccms/attribute_value_generator.rb
+++ b/app/services/ccms/attribute_value_generator.rb
@@ -195,6 +195,21 @@ module CCMS
       PROSPECTS_OF_SUCCESS[merits_assessment.success_prospect.to_sym]
     end
 
+    def client_eligibility(_options)
+      case cfe_result.assessment_result
+      when 'eligible', 'contribution_required'
+        'In Scope'
+      when 'not_eligible'
+        'Out Of Scope'
+      else
+        raise "Unexpected assessment result: #{cfe_result.assessment_result}"
+      end
+    end
+
+    def means_assessment_capital_contribution(_options)
+      cfe_result.capital_contribution_required? ? cfe_result.capital_contribution : 0.0
+    end
+
     private
 
     def applicant
@@ -215,6 +230,10 @@ module CCMS
 
     def other_assets
       @other_assets ||= @legal_aid_application.other_assets_declaration
+    end
+
+    def cfe_result
+      @cfe_result ||= @legal_aid_application.cfe_result
     end
 
     def call_standard_method(method, options) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity

--- a/config/ccms/ccms_keys.yml
+++ b/config/ccms/ccms_keys.yml
@@ -741,7 +741,7 @@ global_means:
     :response_type: currency
     :user_defined: true
   PUI_CLIENT_CAP_CONT:
-    :value: 0.0
+    :value: '#means_assessment_capital_contribution'
     :br100_meaning: Client Provisional Capital Contribution
     :response_type: currency
     :user_defined: false
@@ -1138,7 +1138,7 @@ global_means:
     :response_type: boolean
     :user_defined: false
   PUI_CLIENT_ELIGIBILITY:
-    :value: In Scope
+    :value: '#client_eligibility'
     :br100_meaning: Client Overall Provisonal Eligibility
     :response_type: text
     :user_defined: false
@@ -2067,7 +2067,7 @@ global_means:
     :response_type: currency
     :user_defined: false
   CLIENT_ELIGIBILITY:
-    :value: In Scope
+    :value: '#client_eligibility'
     :br100_meaning: Client Overall Eligibility
     :response_type: text
     :user_defined: false

--- a/config/ccms/ccms_keys.yml
+++ b/config/ccms/ccms_keys.yml
@@ -186,8 +186,7 @@ global_means:
     :response_type: boolean
     :user_defined: true
   OUT_CAP_CONT:
-    :generate_block?: false
-    :value: 0.0
+    :value: "#means_assessment_capital_contribution"
     :br100_meaning: 'RESULT: Capital - Capital contribution'
     :response_type: currency
     :user_defined: false
@@ -2295,7 +2294,6 @@ global_means:
     :response_type: date
     :user_defined: true
   CAP_CONT:
-    :generate_block?: false
     :value: "#means_assessment_capital_contribution"
     :br100_meaning: 'RESULT: Capital- Capital contribution'
     :response_type: currency

--- a/spec/factories/cfe_results.rb
+++ b/spec/factories/cfe_results.rb
@@ -2,11 +2,14 @@ FactoryBot.define do
   factory :cfe_result, class: CFE::Result do
     submission { create :cfe_submission }
     legal_aid_application { submission.legal_aid_application }
-    result do
-      {
-        a: 'A',
-        b: 'B'
-      }.to_json
+    result { CFEResults::MockResults.eligible.to_json }
+
+    trait :not_eligible do
+      result { CFEResults::MockResults.not_eligible.to_json }
+    end
+
+    trait :contribution_required do
+      result { CFEResults::MockResults.contribution_required.to_json }
     end
   end
 end

--- a/spec/factories/cfe_results/mock_results.rb
+++ b/spec/factories/cfe_results/mock_results.rb
@@ -1,0 +1,71 @@
+module CFEResults
+  class MockResults
+    def self.eligible # rubocop:disable Metrics/MethodLength
+      {
+        assessment_result: 'eligible',
+        applicant: {
+          receives_qualifying_benefit: true,
+          age_at_submission: 39
+        },
+        capital: {
+          total_liquid: '350.0',
+          total_non_liquid: '0.0',
+          pensioner_capital_disregard: '0.0',
+          total_capital: '-99650.0',
+          capital_contribution: '0.0',
+          liquid_capital_items: [
+            {
+              description: 'Off-line bank accounts',
+              value: '350.0'
+            }
+          ],
+          non_liquid_capital_items: []
+        },
+        property: {
+          total_mortgage_allowance: '100000.0',
+          total_property: '-100000.0',
+          main_home: { value: '0.0',
+                       transaction_allowance: '0.0',
+                       allowable_outstanding_mortgage: '0.0',
+                       percentage_owned: '0.0',
+                       net_equity: '0.0',
+                       main_home_equity_disregard: '100000.0',
+                       assessed_equity: '-100000.0',
+                       shared_with_housing_assoc: false },
+          additional_properties: [
+            {
+              value: '0.0',
+              transaction_allowance: '0.0',
+              allowable_outstanding_mortgage: '0.0',
+              percentage_owned: '0.0',
+              assessed_equity: '0.0'
+            }
+          ]
+        },
+        vehicles: {
+          total_vehicle: '0.0',
+          vehicles: [
+            {
+              in_regular_use: true,
+              value: '900.0',
+              loan_amount_outstanding: '0.0',
+              date_of_purchase: '2013-06-01',
+              included_in_assessment: false,
+              assessed_value: '0.0'
+            }
+          ]
+        }
+      }
+    end
+
+    def self.not_eligible
+      eligible.merge assessment_result: 'not_eligible'
+    end
+
+    def self.contribution_required
+      new_capital_section = eligible[:capital]
+      new_capital_section[:capital_contribution] = '465.66'
+      eligible.merge assessment_result: 'contribution_required', capital: new_capital_section
+    end
+  end
+end

--- a/spec/models/cfe/result_spec.rb
+++ b/spec/models/cfe/result_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+module CFE
+  RSpec.describe Result, type: :model do
+    let(:eligible_result) { create :cfe_result }
+    let(:not_eligible_result) { create :cfe_result, :not_eligible }
+    let(:contibution_required_result) { create :cfe_result, :contribution_required }
+
+    describe '#assessment_result' do
+      context 'eligible' do
+        it 'returns eligible' do
+          expect(eligible_result.assessment_result).to eq 'eligible'
+        end
+      end
+
+      context 'not_eligible' do
+        it 'returns not_eligible' do
+          expect(not_eligible_result.assessment_result).to eq 'not_eligible'
+        end
+      end
+
+      context 'contribution_required' do
+        it 'returns contribution_required' do
+          expect(contibution_required_result.assessment_result).to eq 'contribution_required'
+        end
+      end
+    end
+
+    describe '#capital_contribution' do
+      it 'returns the value of the capital contribution' do
+        expect(contibution_required_result.capital_contribution).to eq 465.66
+      end
+    end
+  end
+end

--- a/spec/services/ccms/case_add_requestor_spec.rb
+++ b/spec/services/ccms/case_add_requestor_spec.rb
@@ -267,7 +267,15 @@ module CCMS # rubocop:disable Metrics/ModuleLength
                benefit_check_result: true,
                merits_assessment: merits_assessment,
                default_cost_limitation: 25_000.0,
-               office: office
+               office: office,
+               cfe_result: cfe_result
+      end
+
+      let(:cfe_result) do
+        double CFE::Result,
+               result: { assessment_result: 'eligible' },
+               capital_contribution_required?: false,
+               assessment_result: 'eligible'
       end
 
       let(:other_party_1) { create :opponent, :child }
@@ -355,6 +363,8 @@ module CCMS # rubocop:disable Metrics/ModuleLength
     describe '#call' do
       let(:legal_aid_application) { create :legal_aid_application, :with_proceeding_types, :with_everything, :with_applicant_and_address, populate_vehicle: true, office: office }
       let(:submission) { create :submission, :case_ref_obtained, legal_aid_application: legal_aid_application }
+      let(:cfe_submission) { create :cfe_submission, legal_aid_application: legal_aid_application }
+      let!(:cfe_result) { create :cfe_result, submission: cfe_submission }
       let(:office) { create :office }
       let(:requestor) { described_class.new(submission, {}) }
       let(:soap_client_double) { Savon.client(env_namespace: :soap, wsdl: requestor.__send__(:wsdl_location)) }

--- a/spec/services/ccms/case_add_requestor_xml_blocks_spec.rb
+++ b/spec/services/ccms/case_add_requestor_xml_blocks_spec.rb
@@ -91,28 +91,35 @@ module CCMS # rubocop:disable Metrics/ModuleLength
         end
       end
 
-      context 'PUI_CLIENT_CAP_CONT' do
+      context 'CAP_CONT and similar attributes' do
+        let(:attributes) { %w[PUI_CLIENT_CAP_CONT CAP_CONT OUT_CAP_CONT] }
         context 'eligble' do
           let!(:cfe_result) { create :cfe_result, submission: cfe_submission }
           it 'returns zero' do
-            block = XmlExtractor.call(xml, :global_means, 'PUI_CLIENT_CAP_CONT')
-            expect(block).to have_currency_response '0.00'
+            attributes.each do |attribute|
+              block = XmlExtractor.call(xml, :global_means, attribute)
+              expect(block).to have_currency_response '0.00'
+            end
           end
         end
 
         context 'not eligble' do
           let!(:cfe_result) { create :cfe_result, :not_eligible, submission: cfe_submission }
           it 'returns zero' do
-            block = XmlExtractor.call(xml, :global_means, 'PUI_CLIENT_CAP_CONT')
-            expect(block).to have_currency_response '0.00'
+            attributes.each do |attribute|
+              block = XmlExtractor.call(xml, :global_means, attribute)
+              expect(block).to have_currency_response '0.00'
+            end
           end
         end
 
         context 'contribution_required' do
           let!(:cfe_result) { create :cfe_result, :contribution_required, submission: cfe_submission }
           it 'returns the capital contribution' do
-            block = XmlExtractor.call(xml, :global_means, 'PUI_CLIENT_CAP_CONT')
-            expect(block).to have_currency_response '465.66'
+            attributes.each do |attribute|
+              block = XmlExtractor.call(xml, :global_means, attribute)
+              expect(block).to have_currency_response '465.66'
+            end
           end
         end
       end
@@ -1349,7 +1356,6 @@ module CCMS # rubocop:disable Metrics/ModuleLength
       [:change_in_circumstances],
       [:change_in_circumstances, 'CHANGE_CIRC_INPUT_T_33WP3_6A'],
       [:global_means, 'BEN_AWARD_DATE'],
-      [:global_means, 'CAP_CONT'],
       [:global_means, 'CLIENT_NASS'],
       [:global_means, 'CLIENT_PRISONER'],
       [:global_means, 'CONFIRMED_NOT_PASSPORTED'],
@@ -1367,7 +1373,6 @@ module CCMS # rubocop:disable Metrics/ModuleLength
       [:global_means, 'MEANS_REPORT_BACKLOG_TAG'],
       [:global_means, 'MEANS_REQD'],
       [:global_means, 'MEANS_ROUTING'],
-      [:global_means, 'OUT_CAP_CONT'],
       [:global_means, 'OUT_GB_INFER_C_14WP4_19A'],
       [:global_means, 'OUT_GB_INFER_C_14WP4_3A'],
       [:global_means, 'OUT_GB_INFER_C_15WP3_133A'],

--- a/spec/services/ccms/case_add_requestor_xml_blocks_spec.rb
+++ b/spec/services/ccms/case_add_requestor_xml_blocks_spec.rb
@@ -29,6 +29,8 @@ module CCMS # rubocop:disable Metrics/ModuleLength
       let(:respondent) { legal_aid_application.respondent }
       let(:ccms_reference) { '300000054005' }
       let(:submission) { create :submission, :case_ref_obtained, legal_aid_application: legal_aid_application, case_ccms_reference: ccms_reference }
+      let(:cfe_submission) { create :cfe_submission, legal_aid_application: legal_aid_application }
+      let!(:cfe_result) { create :cfe_result, submission: cfe_submission }
       let(:requestor) { described_class.new(submission, {}) }
       let(:xml) { requestor.formatted_xml }
       let(:success_prospect) { :likely }
@@ -40,6 +42,78 @@ module CCMS # rubocop:disable Metrics/ModuleLength
           filename = Rails.root.join('tmp/generated_ccms_payload.xml')
           File.open(filename, 'w') { |f| f.puts xml }
           expect(File.exist?(filename)).to be true
+        end
+      end
+
+      context 'CLIENT_ELIGIBILITY and PUI_CLIENT_ELIGIBILITY' do
+        context 'eligible' do
+          let!(:cfe_result) { create :cfe_result, submission: cfe_submission }
+          it 'returns In Scope' do
+            block = XmlExtractor.call(xml, :global_means, 'CLIENT_ELIGIBILITY')
+            expect(block).to have_text_response 'In Scope'
+            block = XmlExtractor.call(xml, :global_means, 'PUI_CLIENT_ELIGIBILITY')
+            expect(block).to have_text_response 'In Scope'
+          end
+        end
+
+        context 'not_eligible' do
+          let!(:cfe_result) { create :cfe_result, :not_eligible, submission: cfe_submission }
+          it 'returns Out Of Scope' do
+            block = XmlExtractor.call(xml, :global_means, 'CLIENT_ELIGIBILITY')
+            expect(block).to have_text_response 'Out Of Scope'
+            block = XmlExtractor.call(xml, :global_means, 'PUI_CLIENT_ELIGIBILITY')
+            expect(block).to have_text_response 'Out Of Scope'
+          end
+        end
+
+        context 'contribution_required' do
+          let!(:cfe_result) { create :cfe_result, :contribution_required, submission: cfe_submission }
+          it 'returns In Scope' do
+            block = XmlExtractor.call(xml, :global_means, 'CLIENT_ELIGIBILITY')
+            expect(block).to have_text_response 'In Scope'
+            block = XmlExtractor.call(xml, :global_means, 'PUI_CLIENT_ELIGIBILITY')
+            expect(block).to have_text_response 'In Scope'
+          end
+        end
+
+        context 'invalid response' do
+          let!(:cfe_result) { create :cfe_result, :contribution_required, submission: cfe_submission, result: { assessment_result: 'Unknown' }.to_json }
+          it 'raises' do
+            expect { xml }.to raise_error RuntimeError, 'Unexpected assessment result: Unknown'
+          end
+        end
+      end
+
+      context 'INCOME_CONT' do
+        it 'always returns zero' do
+          block = XmlExtractor.call(xml, :global_means, 'INCOME_CONT')
+          expect(block).to have_currency_response '0.00'
+        end
+      end
+
+      context 'PUI_CLIENT_CAP_CONT' do
+        context 'eligble' do
+          let!(:cfe_result) { create :cfe_result, submission: cfe_submission }
+          it 'returns zero' do
+            block = XmlExtractor.call(xml, :global_means, 'PUI_CLIENT_CAP_CONT')
+            expect(block).to have_currency_response '0.00'
+          end
+        end
+
+        context 'not eligble' do
+          let!(:cfe_result) { create :cfe_result, :not_eligible, submission: cfe_submission }
+          it 'returns zero' do
+            block = XmlExtractor.call(xml, :global_means, 'PUI_CLIENT_CAP_CONT')
+            expect(block).to have_currency_response '0.00'
+          end
+        end
+
+        context 'contribution_required' do
+          let!(:cfe_result) { create :cfe_result, :contribution_required, submission: cfe_submission }
+          it 'returns the capital contribution' do
+            block = XmlExtractor.call(xml, :global_means, 'PUI_CLIENT_CAP_CONT')
+            expect(block).to have_currency_response '465.66'
+          end
         end
       end
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-982)

Populated the four CCMS attributes whose source is the result returned from the Check Financial Eligibility service from the `CFE::Result` model.

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
