### PR TITLE
Ap 882 remove redirect message fix

### DIFF
--- a/app/controllers/concerns/providers/authorizable.rb
+++ b/app/controllers/concerns/providers/authorizable.rb
@@ -31,8 +31,7 @@ module Providers
           format.html do
             if current_policy.show_submitted_application?
               redirect_to(
-                providers_legal_aid_application_submitted_application_path(legal_aid_application),
-                notice: I18n.t('errors.messages.update_denied')
+                providers_legal_aid_application_submitted_application_path(legal_aid_application)
               )
             else
               redirect_to error_path(:access_denied)

--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -165,6 +165,12 @@ class LegalAidApplication < ApplicationRecord # rubocop:disable Metrics/ClassLen
     checking_citizen_answers? || provider_submitted?
   end
 
+  def submitted?
+    generating_reports? ||
+      submitting_assessment? ||
+      assessment_submitted?
+  end
+
   def checking_answers?
     checking_client_details_answers? ||
       checking_citizen_answers? ||

--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -165,7 +165,7 @@ class LegalAidApplication < ApplicationRecord # rubocop:disable Metrics/ClassLen
     checking_citizen_answers? || provider_submitted?
   end
 
-  def submitted?
+  def submitted_to_ccms?
     generating_reports? ||
       submitting_assessment? ||
       assessment_submitted?

--- a/app/policies/legal_aid_application_policy.rb
+++ b/app/policies/legal_aid_application_policy.rb
@@ -37,12 +37,8 @@ class LegalAidApplicationPolicy < ApplicationPolicy
 
   private
 
-  def application_submitted_states
-    %w[submitting_assessment assessment_submitted generating_reports]
-  end
-
   def my_firms_unsubmitted_record?
-    my_firms_record? && application_submitted_states.exclude?(record.state)
+    my_firms_record? && !record.submitted?
   end
 
   def my_firms_record?

--- a/app/policies/legal_aid_application_policy.rb
+++ b/app/policies/legal_aid_application_policy.rb
@@ -37,8 +37,12 @@ class LegalAidApplicationPolicy < ApplicationPolicy
 
   private
 
+  def application_submitted_states
+    %w[submitting_assessment assessment_submitted generating_reports]
+  end
+
   def my_firms_unsubmitted_record?
-    my_firms_record? && !record.assessment_submitted?
+    my_firms_record? && application_submitted_states.exclude?(record.state)
   end
 
   def my_firms_record?

--- a/app/policies/legal_aid_application_policy.rb
+++ b/app/policies/legal_aid_application_policy.rb
@@ -38,7 +38,7 @@ class LegalAidApplicationPolicy < ApplicationPolicy
   private
 
   def my_firms_unsubmitted_record?
-    my_firms_record? && !record.submitted?
+    my_firms_record? && !record.submitted_to_ccms?
   end
 
   def my_firms_record?

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -11,7 +11,6 @@ en:
       not_saved:
         one: '1 error prohibited this %{resource} from being saved:'
         other: "%{count} errors prohibited this %{resource} from being saved:"
-      update_denied: 'Update denied: redirecting to submitted application'
     show:
       assessment_already_completed:
         page_title: You've already completed your financial assessment

--- a/spec/factories/legal_aid_applications.rb
+++ b/spec/factories/legal_aid_applications.rb
@@ -47,6 +47,10 @@ FactoryBot.define do
       state { 'checking_merits_answers' }
     end
 
+    trait :submitted_application do
+      state { %w[assessment_submitted generating_reports submitting_assessment].sample }
+    end
+
     trait :assessment_submitted do
       state { 'assessment_submitted' }
     end

--- a/spec/factories/legal_aid_applications.rb
+++ b/spec/factories/legal_aid_applications.rb
@@ -47,7 +47,7 @@ FactoryBot.define do
       state { 'checking_merits_answers' }
     end
 
-    trait :submitted_application do
+    trait :submitted_to_ccms do
       state { %w[assessment_submitted generating_reports submitting_assessment].sample }
     end
 

--- a/spec/models/legal_aid_application_spec.rb
+++ b/spec/models/legal_aid_application_spec.rb
@@ -285,18 +285,18 @@ RSpec.describe LegalAidApplication, type: :model do
     end
   end
 
-  describe '#submitted?' do
-    context 'provider application not submitted' do
+  describe '#submitted_to_ccms?' do
+    context 'application not submitted to ccms' do
       let(:legal_aid_application) { create :legal_aid_application }
       it 'returns false' do
-        expect(legal_aid_application.submitted?).to be(false)
+        expect(legal_aid_application.submitted_to_ccms?).to be(false)
       end
     end
 
-    context 'provider submitted' do
-      let(:legal_aid_application) { create :legal_aid_application, :submitted_application }
+    context 'application submitted to ccms' do
+      let(:legal_aid_application) { create :legal_aid_application, :submitted_to_ccms }
       it 'returns true' do
-        expect(legal_aid_application.submitted?).to be(true)
+        expect(legal_aid_application.submitted_to_ccms?).to be(true)
       end
     end
   end

--- a/spec/models/legal_aid_application_spec.rb
+++ b/spec/models/legal_aid_application_spec.rb
@@ -285,6 +285,22 @@ RSpec.describe LegalAidApplication, type: :model do
     end
   end
 
+  describe '#submitted?' do
+    context 'provider application not submitted' do
+      let(:legal_aid_application) { create :legal_aid_application }
+      it 'returns false' do
+        expect(legal_aid_application.submitted?).to be(false)
+      end
+    end
+
+    context 'provider submitted' do
+      let(:legal_aid_application) { create :legal_aid_application, :submitted_application }
+      it 'returns true' do
+        expect(legal_aid_application.submitted?).to be(true)
+      end
+    end
+  end
+
   describe '#read_only?' do
     context 'provider application not submitted' do
       let(:legal_aid_application) { create :legal_aid_application }


### PR DESCRIPTION
This is the same as the ticket https://github.com/ministryofjustice/laa-apply-for-legal-aid/pull/926
I've requested a pull-request on this new branch because i've merged the old 926 before pushing into UAT.

**Remove redirect message on submitted applications**

[Link to story](https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=233&projectKey=AP&modal=detail&selectedIssue=AP-882)

- Remove Update denied notification

- Prevent a provider from editing an already submitted application by adding a #submitted_to_ccms? method to the legal aid application model then call this method from the pundit policy.

- Add tests

The #submitted_to_ccms? method considers the below states as a submitted application:

:generating_reports
:submitting_assessment
:assessment_submitted

## Checklist

Before you ask people to review this PR:

- [X] Tests and rubocop should be passing: `bundle exec rake`
- [X] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [X] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [X] The PR description should say what you changed and why, with a link to the JIRA story.
- [X] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [X] You should have checked that the commit messages say why the change was made.
