### PR TITLE
Fix incorrect Notify template ID

### DIFF
--- a/config/govuk_notify_templates.yml
+++ b/config/govuk_notify_templates.yml
@@ -20,4 +20,4 @@ production:
   feedback_notification: 246379d9-14f5-470e-a8a4-31c4b61e64b2
   new_link_request: 3cc3be57-e072-4095-9caa-c0cd52193405
   submission_confirmation: 5472b10b-bc11-432a-a18d-9f20de5b2854
-  reminder_to_submit_an_application: c4ac858d-68ae-437b-9353-06e632cd88f2
+  reminder_to_submit_an_application: 96e58b6c-83e2-4ae8-be67-028803e98398


### PR DESCRIPTION
## What

The production Notify template ID for the `reminder_to_submit_an_application` email is currently incorrect - it is set to the same value as the development template. This causes errors on staging and production.

This commit adds the correct template ID.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
