### PR TITLE
Reduce number of days that images are retained for

### DIFF
--- a/bin/delete_ecr_images
+++ b/bin/delete_ecr_images
@@ -3,7 +3,7 @@ require 'json'
 require 'date'
 
 repo = 'laa-apply-for-legal-aid/applyforlegalaid-service'
-delete_if_older_than = 30 # days
+delete_if_older_than = 10 # days
 
 puts 'Identifying images to delete'
 


### PR DESCRIPTION
## What

The number of images in ECR is causing alerts as it is exceeding 500.

Reduced the length of time that images are retained for, from 30 days, down to 10 days. 

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
