### PR TITLE
Ap 852 split bank accounts

### DIFF
--- a/app/forms/savings_amounts/savings_amounts_form.rb
+++ b/app/forms/savings_amounts/savings_amounts_form.rb
@@ -5,7 +5,8 @@ module SavingsAmounts
     form_for SavingsAmount
 
     ATTRIBUTES = %i[
-      offline_accounts
+      offline_current_accounts
+      offline_savings_accounts
       cash
       other_person_account
       national_savings

--- a/app/services/ccms/attribute_value_generator.rb
+++ b/app/services/ccms/attribute_value_generator.rb
@@ -129,7 +129,7 @@ module CCMS
     end
 
     def applicant_has_other_savings?(_options)
-      not_zero? savings.offline_accounts
+      not_zero?(savings.offline_current_accounts) || not_zero?(savings.offline_savings_accounts)
     end
 
     def applicant_has_other_policies?(_options)

--- a/app/services/cfe/create_capitals_service.rb
+++ b/app/services/cfe/create_capitals_service.rb
@@ -10,7 +10,8 @@ module CFE
     }.freeze
 
     SAVINGS_AMOUNT_FIELDS = {
-      offline_accounts: 'Off-line bank accounts',
+      offline_current_accounts: 'Off-line current accounts',
+      offline_savings_accounts: 'Off-line savings accounts',
       cash: 'Cash',
       other_person_account: "Signatory on other person's account",
       national_savings: 'National savings',

--- a/app/views/shared/forms/revealing_checkbox/_attribute.html.erb
+++ b/app/views/shared/forms/revealing_checkbox/_attribute.html.erb
@@ -2,6 +2,7 @@
   check_box_attribute = "check_box_#{attribute}"
   conditional_div_id = "conditional_#{attribute}"
   hint = controller_t "hint.#{check_box_attribute}", default: ''
+  revealing_hint = controller_t "hint.revealing_#{check_box_attribute}", default: ''
   value = model.send(attribute)
   checked = value.present? || model.send(check_box_attribute).present? ? 'checked' : ''
 %>
@@ -12,5 +13,9 @@
   <%= govuk_hint(hint, class: 'govuk-checkboxes__hint') if hint.present? %>
 </div>
 <div class="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden" id="<%= conditional_div_id %>">
-  <%= form.govuk_text_field attribute, label: controller_t(attribute), input_prefix: t('currency.gbp'), value: number_to_currency_or_original_string(value), class: 'govuk-!-width-one-third' %>
+  <%= form.govuk_text_field attribute, label: controller_t(attribute),
+                                       hint: (govuk_hint(revealing_hint, class: 'govuk-checkboxes__hint') if revealing_hint.present?),
+                                       input_prefix: t('currency.gbp'),
+                                       value: number_to_currency_or_original_string(value),
+                                       class: 'govuk-!-width-one-third' %>
 </div>

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -310,11 +310,16 @@ en:
               greater_than_or_equal_to: Total cash savings must be 0 or more
               not_a_number: Total cash savings must be an amount of money, like 60,000
               too_many_decimals: Estimated cash value must not include more than 2 decimal numbers
-            offline_accounts:
-              blank: Enter the estimated total in all accounts
-              greater_than_or_equal_to: Total in accounts must be 0 or more
-              not_a_number: Total in accounts must be an amount of money, like 60,000
-              too_many_decimals: Estimated total in accounts must not include more than 2 decimal numbers
+            offline_current_accounts:
+              blank: Enter the estimated total in all current accounts
+              greater_than_or_equal_to: Total in current accounts must be 0 or more
+              not_a_number: Total in current accounts must be an amount of money, like 60,000
+              too_many_decimals: Estimated total in current accounts must not include more than 2 decimal numbers
+            offline_savings_accounts:
+              blank: Enter the estimated total in all savings accounts
+              greater_than_or_equal_to: Total in savings accounts must be 0 or more
+              not_a_number: Total in savings accounts must be an amount of money, like 60,000
+              too_many_decimals: Estimated total in savings accounts must not include more than 2 decimal numbers
             life_assurance_endowment_policy:
               blank: Enter the total value of life assurance policies
               greater_than_or_equal_to: Total of life assurance policies must be 0 or more

--- a/config/locales/en/shared.yml
+++ b/config/locales/en/shared.yml
@@ -188,19 +188,22 @@ en:
               hint:
                 check_box_valuable_items_value: For example, jewellery, art or antiques. Do not include wedding or engagement rings, furniture, clothing or tools used for work.
             savings_and_investments:
-              cash: Enter total amount
-              check_box_cash: Cash savings
-              check_box_offline_accounts: Money in accounts you do not access with online banking
+              cash: Enter the total amount
+              check_box_cash: Money not in a bank account
+              check_box_offline_current_accounts: Current account
+              check_box_offline_savings_accounts: Savings account
               check_box_life_assurance_endowment_policy: Life assurance and endowment policies not linked to a mortgage
               check_box_national_savings: National Savings Certificates and Premium Bonds
-              check_box_other_person_account: Signatory on a child's or other person's bank account
+              check_box_other_person_account: Access to another person's bank account
               check_box_peps_unit_trusts_capital_bonds_gov_stocks: PEPs, unit trusts, capital bonds and government stocks
               check_box_plc_shares: Shares in a PLC (public limited company)
               hint:
-                check_box_offline_accounts: Include bank, building society, Post Office and ISA accounts
+                revealing_check_box_offline_current_accounts: If you have multiple accounts, take the lowest balance from each account last month, add them, then enter the total
+                check_box_cash: For example, cash kept at home
                 check_box_life_assurance_endowment_policy: Do not include policies that only pay out on death
-                check_box_other_person_account: For example, if you have power of attorney
-              offline_accounts: Enter the estimated total in all accounts
+                check_box_other_person_account: For example, you are a signatory on a child's account
+              offline_current_accounts: Enter the lowest balance last month
+              offline_savings_accounts: Enter the total in all accounts
               life_assurance_endowment_policy: Enter the total value of all you own
               national_savings: Enter the total value of all you own
               other_person_account: Enter the estimated total in all accounts
@@ -226,19 +229,22 @@ en:
               hint:
                 check_box_valuable_items_value: For example, jewellery, art or antiques. Do not include wedding or engagement rings, furniture, clothing or tools used for work.
             savings_and_investments:
-              cash: Enter total amount
-              check_box_cash: Cash savings
-              check_box_offline_accounts: Money in accounts they do not access with online banking
+              cash: Enter the total amount
+              check_box_cash: Money not in a bank account
+              check_box_offline_current_accounts: Current account
+              check_box_offline_savings_accounts: Savings account
               check_box_life_assurance_endowment_policy: Life assurance and endowment policies not linked to a mortgage
               check_box_national_savings: National Savings Certificates and Premium Bonds
-              check_box_other_person_account: Signatory on a child's or other person's bank account
+              check_box_other_person_account: Access to another person's bank account
               check_box_peps_unit_trusts_capital_bonds_gov_stocks: PEPs, unit trusts, capital bonds and government stocks
               check_box_plc_shares: Shares in a PLC (public limited company)
               hint:
-                check_box_offline_accounts: Include bank, building society, Post Office and ISA accounts.
+                revealing_check_box_offline_current_accounts: If your client has multiple accounts, take the lowest balance from each account last month, add them, then enter the total
+                check_box_cash: For example, cash kept at home
                 check_box_life_assurance_endowment_policy: Do not include policies that only pay out on death
-                check_box_other_person_account: For example, a junior ISA for a child
-              offline_accounts: Enter the estimated total in all accounts
+                check_box_other_person_account: For example, your client is a signatory on a child's account
+              offline_current_accounts: Enter the lowest balance last month
+              offline_savings_accounts: Enter the total in all accounts
               life_assurance_endowment_policy: Enter the total value of all owned
               national_savings: Enter the total value of all owned
               other_person_account: Enter the estimated total in all accounts

--- a/db/migrate/20191018174252_add_column_and_rename_existing_on_savings_amounts.rb
+++ b/db/migrate/20191018174252_add_column_and_rename_existing_on_savings_amounts.rb
@@ -1,0 +1,6 @@
+class AddColumnAndRenameExistingOnSavingsAmounts < ActiveRecord::Migration[5.2]
+  def change
+    add_column :savings_amounts, :offline_savings_accounts, :numeric
+    rename_column :savings_amounts, :offline_accounts, :offline_current_accounts
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_11_142505) do
+ActiveRecord::Schema.define(version: 2019_10_18_174252) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -568,7 +568,7 @@ ActiveRecord::Schema.define(version: 2019_10_11_142505) do
 
   create_table "savings_amounts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "legal_aid_application_id", null: false
-    t.decimal "offline_accounts"
+    t.decimal "offline_current_accounts"
     t.decimal "cash"
     t.decimal "other_person_account"
     t.decimal "national_savings"
@@ -578,6 +578,7 @@ ActiveRecord::Schema.define(version: 2019_10_11_142505) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "none_selected"
+    t.decimal "offline_savings_accounts"
     t.index ["legal_aid_application_id"], name: "index_savings_amounts_on_legal_aid_application_id"
   end
 

--- a/features/cassettes/Civil_application_journeys/Receives_benefits_and_completes_the_application.yml
+++ b/features/cassettes/Civil_application_journeys/Receives_benefits_and_completes_the_application.yml
@@ -400,4 +400,296 @@ http_interactions:
       string: '{"assessment_result":"contribution_required","applicant":{"receives_qualifying_benefit":true,"age_at_submission":39},"capital":{"total_liquid":"10000.0","total_non_liquid":"50000.0","pensioner_capital_disregard":"0.0","total_capital":"7000.0","capital_contribution":"0.0","liquid_capital_items":[{"description":"Cash","value":"10000.0"}],"non_liquid_capital_items":[{"description":"Land","value":"50000.0"}]},"property":{"total_mortgage_allowance":"100000.0","total_property":"-53000.0","main_home":{"value":"200000.0","transaction_allowance":"6000.0","allowable_outstanding_mortgage":"100000.0","percentage_owned":"50.0","net_equity":"47000.0","main_home_equity_disregard":"100000.0","assessed_equity":"-53000.0","shared_with_housing_assoc":false},"additional_properties":[{"value":"0.0","transaction_allowance":"0.0","allowable_outstanding_mortgage":"0.0","percentage_owned":"0.0","assessed_equity":"0.0"}]},"vehicles":{"total_vehicle":"0.0","vehicles":[]}}'
     http_version: 
   recorded_at: Tue, 08 Oct 2019 09:08:46 GMT
+- request:
+    method: post
+    uri: http://localhost:3000/assessments
+    body:
+      encoding: UTF-8
+      string: '{"client_reference_id":"L-6RU-R4N","submission_date":"2019-10-21","matter_proceeding_type":"domestic_abuse"}'
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"89f9bcf445273d7c19a00b3efb954d9c"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - abe4dedd-e9ee-405f-aa12-8a6de49012e2
+      X-Runtime:
+      - '0.064257'
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '{"success":true,"objects":[{"id":"7a9d6f34-8df8-4c4d-b52e-8bbf1bac5902","client_reference_id":"L-6RU-R4N","remote_ip":{"family":30,"addr":1,"mask_addr":340282366920938463463374607431768211455},"created_at":"2019-10-21T15:08:27.552Z","updated_at":"2019-10-21T15:08:27.552Z","submission_date":"2019-10-21","matter_proceeding_type":"domestic_abuse","assessment_result":"pending"}],"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 21 Oct 2019 15:08:27 GMT
+- request:
+    method: post
+    uri: http://localhost:3000/assessments/7a9d6f34-8df8-4c4d-b52e-8bbf1bac5902/applicant
+    body:
+      encoding: UTF-8
+      string: '{"applicant":{"date_of_birth":"1980-01-10","involvement_type":"applicant","has_partner_opponent":false,"receives_qualifying_benefit":true}}'
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"cd1b5fe6d352f60d47d12838beb27f2e"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 3239c488-c7d4-4501-9b66-49301cf72183
+      X-Runtime:
+      - '0.022326'
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '{"objects":[{"id":"d5c32f2e-6724-46d5-98a1-9ada61335984","assessment_id":"7a9d6f34-8df8-4c4d-b52e-8bbf1bac5902","date_of_birth":"1980-01-10","involvement_type":"applicant","has_partner_opponent":false,"receives_qualifying_benefit":true,"created_at":"2019-10-21T15:08:27.627Z","updated_at":"2019-10-21T15:08:27.627Z"}],"errors":[],"success":true}'
+    http_version: 
+  recorded_at: Mon, 21 Oct 2019 15:08:27 GMT
+- request:
+    method: post
+    uri: http://localhost:3000/assessments/7a9d6f34-8df8-4c4d-b52e-8bbf1bac5902/capitals
+    body:
+      encoding: UTF-8
+      string: '{"bank_accounts":[{"description":"Cash","value":"10000.0"}],"non_liquid_capital":[{"description":"Land","value":"50000.0"}]}'
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"1271713a1c82e4c902e54abb85037779"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - dd21c02e-3a61-4a5d-8dad-3a0e3d52e8e8
+      X-Runtime:
+      - '0.023063'
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '{"objects":{"id":"7362e3ae-2a9e-44ff-b54c-2329c2cd3673","assessment_id":"7a9d6f34-8df8-4c4d-b52e-8bbf1bac5902","total_liquid":"0.0","total_non_liquid":"0.0","total_vehicle":"0.0","total_property":"0.0","total_mortgage_allowance":"0.0","total_capital":"0.0","pensioner_capital_disregard":"0.0","assessed_capital":"0.0","capital_contribution":"0.0","lower_threshold":"0.0","upper_threshold":"0.0","capital_assessment_result":"pending","created_at":"2019-10-21T15:08:27.578Z","updated_at":"2019-10-21T15:08:27.578Z"},"errors":[],"success":true}'
+    http_version: 
+  recorded_at: Mon, 21 Oct 2019 15:08:27 GMT
+- request:
+    method: post
+    uri: http://localhost:3000/assessments/7a9d6f34-8df8-4c4d-b52e-8bbf1bac5902/vehicles
+    body:
+      encoding: UTF-8
+      string: '{"vehicles":[]}'
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"7eb7dee5a8f69a7b4580e1e2bd9fa86a"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 2326b628-f5f3-4be8-8298-dc4dba08b22c
+      X-Runtime:
+      - '0.005252'
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '{"vehicles":[],"errors":[],"success":true}'
+    http_version: 
+  recorded_at: Mon, 21 Oct 2019 15:08:27 GMT
+- request:
+    method: post
+    uri: http://localhost:3000/assessments/7a9d6f34-8df8-4c4d-b52e-8bbf1bac5902/properties
+    body:
+      encoding: UTF-8
+      string: '{"properties":{"main_home":{"value":"200000.0","outstanding_mortgage":"100000.0","percentage_owned":"50.0","shared_with_housing_assoc":false},"additional_properties":[{"value":0,"outstanding_mortgage":0,"percentage_owned":0,"shared_with_housing_assoc":false}]}}'
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"1608e96f413d9a96b175523ff95f48d9"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - a5cb7dae-ebbd-4a32-a603-17e5738d73ee
+      X-Runtime:
+      - '0.021300'
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '{"objects":[{"id":"a856f0be-58a5-491a-baec-816cbcdbb323","value":"200000.0","outstanding_mortgage":"100000.0","percentage_owned":"50.0","main_home":true,"shared_with_housing_assoc":false,"created_at":"2019-10-21T15:08:27.736Z","updated_at":"2019-10-21T15:08:27.736Z","capital_summary_id":"7362e3ae-2a9e-44ff-b54c-2329c2cd3673","transaction_allowance":"0.0","allowable_outstanding_mortgage":"0.0","net_value":"0.0","net_equity":"0.0","assessed_equity":"0.0","main_home_equity_disregard":"0.0"},{"id":"d855bcff-e2cc-4cc4-a219-ffb47fad6f73","value":"0.0","outstanding_mortgage":"0.0","percentage_owned":"0.0","main_home":false,"shared_with_housing_assoc":false,"created_at":"2019-10-21T15:08:27.747Z","updated_at":"2019-10-21T15:08:27.747Z","capital_summary_id":"7362e3ae-2a9e-44ff-b54c-2329c2cd3673","transaction_allowance":"0.0","allowable_outstanding_mortgage":"0.0","net_value":"0.0","net_equity":"0.0","assessed_equity":"0.0","main_home_equity_disregard":"0.0"}],"errors":[],"success":true}'
+    http_version: 
+  recorded_at: Mon, 21 Oct 2019 15:08:27 GMT
+- request:
+    method: get
+    uri: http://localhost:3000/assessments/7a9d6f34-8df8-4c4d-b52e-8bbf1bac5902
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"4fbfb308148a06bb5bdf3ed2b8512440"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 54b13ff9-d3da-4d6c-baa7-ef40353a65ce
+      X-Runtime:
+      - '0.053780'
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '{"assessment_result":"contribution_required","applicant":{"receives_qualifying_benefit":true,"age_at_submission":39},"capital":{"total_liquid":"10000.0","total_non_liquid":"50000.0","pensioner_capital_disregard":"0.0","total_capital":"60000.0","capital_contribution":"57000.0","liquid_capital_items":[{"description":"Cash","value":"10000.0"}],"non_liquid_capital_items":[{"description":"Land","value":"50000.0"}]},"property":{"total_mortgage_allowance":"100000.0","total_property":"0.0","main_home":{"value":"200000.0","transaction_allowance":"6000.0","allowable_outstanding_mortgage":"100000.0","shared_with_housing_assoc":false,"percentage_owned":"50.0","net_equity":"47000.0","main_home_equity_disregard":"100000.0","assessed_equity":"0.0"},"additional_properties":[{"value":"0.0","transaction_allowance":"0.0","allowable_outstanding_mortgage":"0.0","percentage_owned":"0.0","assessed_equity":"0.0"}]},"vehicles":{"total_vehicle":"0.0","vehicles":[]}}'
+    http_version: 
+  recorded_at: Mon, 21 Oct 2019 15:08:27 GMT
 recorded_with: VCR 5.0.0

--- a/features/citizens/citizens.feature
+++ b/features/citizens/citizens.feature
@@ -76,7 +76,7 @@ Feature: Citizen journey
     Then I choose "Yes"
     Then I click 'Save and continue'
     Then I should be on a page showing "What types of savings or investments do you have?"
-    Then I select "Cash savings"
+    Then I select "Money not in a bank account"
     Then I fill "Cash" with "100"
     Then I click 'Save and continue'
     Then I should be on a page showing "Which types of assets do you have?"
@@ -160,7 +160,7 @@ Feature: Citizen journey
     Then I should be on a page showing 'Are there any legal restrictions that prevent you from selling or borrowing against your assets?'
     Then I click 'Save and continue'
     Then I should be on a page showing 'Check your answers'
-    And the answer for 'Savings and investments' should be 'Cash savings'
+    And the answer for 'Savings and investments' should be 'Money not in a bank account'
     And the answer for 'Savings and investments' should be '£1,000.00'
 
   @javascript
@@ -169,13 +169,13 @@ Feature: Citizen journey
     And I complete the citizen journey as far as check your answers
     And I click Check Your Answers Change link for 'Savings and investments'
     Then I should be on a page showing 'What types of savings or investments do you have?'
-    Then I select 'Money in accounts you do not access with online banking'
-    Then I fill 'Offline accounts' with '5000'
+    Then I select 'Current account'
+    Then I fill 'Offline current accounts' with '5000'
     Then I click 'Save and continue'
     Then I should be on a page showing 'Are there any legal restrictions that prevent you from selling or borrowing against your assets?'
     Then I click 'Save and continue'
     Then I should be on a page showing 'Check your answers'
-    And the answer for 'Savings and investments' should be 'Money in accounts you do not access with online banking'
+    And the answer for 'Savings and investments' should be 'Current account'
     And the answer for 'Savings and investments' should be '£5,000.00'
 
   @javascript
@@ -189,7 +189,7 @@ Feature: Citizen journey
     Then I should be on a page showing 'Are there any legal restrictions that prevent you from selling or borrowing against your assets?'
     Then I click 'Save and continue'
     Then I should be on a page showing 'Check your answers'
-    And the answer for 'Savings and investments' should be 'Cash savings'
+    And the answer for 'Savings and investments' should be 'Money not in a bank account'
     And the answer for 'Savings and investments' should be '£100.00'
 
   @javascript

--- a/features/providers/check_your_answers.feature
+++ b/features/providers/check_your_answers.feature
@@ -84,7 +84,7 @@ Feature: Checking answers backwards and forwards
     Then I am on the check your answers page for other assets
     And I click Check Your Answers Change link for 'savings and investments'
     Then I should be on a page showing 'What types of savings or investments does your client have?'
-    Then I select 'Cash savings'
+    Then I select 'Money not in a bank account'
     Then I fill 'cash' with '456.33'
     Then I click 'Save and continue'
     Then I should be on a page showing 'Are there any legal restrictions that prevent your client from selling or borrowing against their assets?'

--- a/features/providers/civil_application_journey.feature
+++ b/features/providers/civil_application_journey.feature
@@ -452,7 +452,7 @@ Feature: Civil application journeys
     Then I choose "No"
     Then I click 'Save and continue'
     Then I should be on a page showing "What types of savings or investments does your client have?"
-    Then I select "Cash savings"
+    Then I select "Money not in a bank account"
     Then I fill "Cash" with "10000"
     Then I click 'Save and continue'
     Then I should be on a page showing "Which types of assets does your client have?"

--- a/spec/factories/savings_amounts.rb
+++ b/spec/factories/savings_amounts.rb
@@ -3,7 +3,8 @@ FactoryBot.define do
     legal_aid_application
 
     trait :with_values do
-      offline_accounts { rand(1...1_000_000.0).round(2) }
+      offline_current_accounts { rand(1...1_000_000.0).round(2) }
+      offline_savings_accounts { rand(1...1_000_000.0).round(2) }
       cash { rand(1...1_000_000.0).round(2) }
       other_person_account { rand(1...1_000_000.0).round(2) }
       national_savings { rand(1...1_000_000.0).round(2) }
@@ -13,7 +14,8 @@ FactoryBot.define do
     end
 
     trait :all_nil do
-      offline_accounts { nil }
+      offline_current_accounts { nil }
+      offline_savings_accounts { nil }
       cash { nil }
       other_person_account { nil }
       national_savings { nil }
@@ -23,7 +25,8 @@ FactoryBot.define do
     end
 
     trait :all_zero do
-      offline_accounts { 0.0 }
+      offline_current_accounts { 0.0 }
+      offline_savings_accounts { 0.0 }
       cash { 0.0 }
       other_person_account { 0.0 }
       national_savings { 0.0 }
@@ -33,7 +36,8 @@ FactoryBot.define do
     end
 
     trait :mix_of_values do
-      offline_accounts { nil }
+      offline_current_accounts { rand(1...1_000_000.0).round(2) }
+      offline_savings_accounts { nil }
       cash { 0.0 }
       other_person_account { rand(1...1_000_000.0).round(2) }
       national_savings { nil }

--- a/spec/forms/savings_amounts/savings_amounts_form_spec.rb
+++ b/spec/forms/savings_amounts/savings_amounts_form_spec.rb
@@ -41,7 +41,8 @@ RSpec.describe SavingsAmounts::SavingsAmountsForm, type: :form do
       shared_examples_for 'it has an error' do
         let(:attribute_map) do
           {
-            offline_accounts: /total in.*accounts/i,
+            offline_current_accounts: /total in.*accounts/i,
+            offline_savings_accounts: /total in.*accounts/i,
             cash: /total.*cash savings/i,
             other_person_account: /other people’s accounts/,
             national_savings: /certificates and bonds/,
@@ -109,7 +110,8 @@ RSpec.describe SavingsAmounts::SavingsAmountsForm, type: :form do
     context 'some check boxes are unchecked' do
       let(:check_box_params) do
         boxes = check_box_attributes.each_with_object({}) { |attr, hsh| hsh[attr] = '' }
-        boxes[:check_box_offline_accounts] = 'true'
+        boxes[:check_box_offline_current_accounts] = 'true'
+        boxes[:check_box_offline_savings_accounts] = 'true'
         boxes
       end
 
@@ -117,7 +119,7 @@ RSpec.describe SavingsAmounts::SavingsAmountsForm, type: :form do
         let(:amount_params) { attributes.each_with_object({}) { |attr, hsh| hsh[attr] = rand(1...1_000_000.0).round(2).to_s } }
 
         it 'empties amounts if checkbox is unchecked' do
-          attributes_except_isa = attributes - [:offline_accounts]
+          attributes_except_isa = attributes - %i[offline_current_accounts offline_savings_accounts]
           subject.save
           savings_amount.reload
           attributes_except_isa.each do |attr|
@@ -128,7 +130,7 @@ RSpec.describe SavingsAmounts::SavingsAmountsForm, type: :form do
 
         it 'does not empty amount if a checkbox is checked' do
           subject.save
-          expect(savings_amount.reload.offline_accounts).not_to eq(nil)
+          expect(savings_amount.reload.offline_current_accounts).not_to eq(nil)
         end
 
         it 'returns true' do

--- a/spec/requests/citizens/savings_and_investments_spec.rb
+++ b/spec/requests/citizens/savings_and_investments_spec.rb
@@ -34,13 +34,13 @@ RSpec.describe 'citizen savings and investments', type: :request do
   end
 
   describe 'PATCH citizens/savings_and_investment' do
-    let(:offline_accounts) { rand(1...1_000_000.0).round(2).to_s }
-    let(:check_box_offline_accounts) { 'true' }
-    let(:params) { { savings_amount: { offline_accounts: offline_accounts, check_box_offline_accounts: check_box_offline_accounts } } }
+    let(:offline_current_accounts) { rand(1...1_000_000.0).round(2).to_s }
+    let(:check_box_offline_current_accounts) { 'true' }
+    let(:params) { { savings_amount: { offline_current_accounts: offline_current_accounts, check_box_offline_current_accounts: check_box_offline_current_accounts } } }
     subject { patch citizens_savings_and_investment_path, params: params }
 
-    it 'updates the offline_accounts amount' do
-      expect { subject }.to change { savings_amount.reload.offline_accounts.to_s }.to(offline_accounts)
+    it 'updates the offline_current_accounts amount' do
+      expect { subject }.to change { savings_amount.reload.offline_current_accounts.to_s }.to(offline_current_accounts)
     end
 
     it 'does not displays an error' do
@@ -64,7 +64,7 @@ RSpec.describe 'citizen savings and investments', type: :request do
     end
 
     context 'with invalid input' do
-      let(:offline_accounts) { 'fifty' }
+      let(:offline_current_accounts) { 'fifty' }
 
       it 'renders successfully' do
         subject
@@ -73,7 +73,7 @@ RSpec.describe 'citizen savings and investments', type: :request do
 
       it 'displays an error' do
         subject
-        expect(response.body).to match(I18n.t('activemodel.errors.models.savings_amount.attributes.offline_accounts.not_a_number'))
+        expect(response.body).to match(I18n.t('activemodel.errors.models.savings_amount.attributes.offline_current_accounts.not_a_number'))
         expect(response.body).to match('govuk-error-message')
         expect(response.body).to match('govuk-form-group--error')
       end

--- a/spec/requests/providers/savings_and_investments_spec.rb
+++ b/spec/requests/providers/savings_and_investments_spec.rb
@@ -59,13 +59,13 @@ RSpec.describe 'providers savings and investments', type: :request do
   end
 
   describe 'PATCH /providers/applications/:legal_aid_application_id/savings_and_investment' do
-    let(:offline_accounts) { rand(1...1_000_000.0).round(2).to_s }
-    let(:check_box_offline_accounts) { 'true' }
+    let(:offline_current_accounts) { rand(1...1_000_000.0).round(2).to_s }
+    let(:check_box_offline_current_accounts) { 'true' }
     let(:params) do
       {
         savings_amount: {
-          offline_accounts: offline_accounts,
-          check_box_offline_accounts: check_box_offline_accounts
+          offline_current_accounts: offline_current_accounts,
+          check_box_offline_current_accounts: check_box_offline_current_accounts
         }
       }
     end
@@ -85,8 +85,8 @@ RSpec.describe 'providers savings and investments', type: :request do
         end
 
         context 'not in checking passported answers state' do
-          it 'updates the offline_accounts amount' do
-            expect { subject }.to change { savings_amount.reload.offline_accounts.to_s }.to(offline_accounts)
+          it 'updates the offline_current_accounts amount' do
+            expect { subject }.to change { savings_amount.reload.offline_current_accounts.to_s }.to(offline_current_accounts)
           end
 
           it 'does not displays an error' do
@@ -110,7 +110,7 @@ RSpec.describe 'providers savings and investments', type: :request do
           end
 
           context 'with invalid input' do
-            let(:offline_accounts) { 'fifty' }
+            let(:offline_current_accounts) { 'fifty' }
 
             it 'renders successfully' do
               subject
@@ -119,7 +119,7 @@ RSpec.describe 'providers savings and investments', type: :request do
 
             it 'displays an error' do
               subject
-              expect(response.body).to match(I18n.t('activemodel.errors.models.savings_amount.attributes.offline_accounts.not_a_number'))
+              expect(response.body).to match(I18n.t('activemodel.errors.models.savings_amount.attributes.offline_current_accounts.not_a_number'))
               expect(response.body).to match('govuk-error-message')
               expect(response.body).to match('govuk-form-group--error')
             end
@@ -141,7 +141,8 @@ RSpec.describe 'providers savings and investments', type: :request do
           end
 
           context 'no savings' do
-            let(:offline_accounts) { 0 }
+            let(:offline_current_accounts) { 0 }
+            let(:offline_savings_accounts) { 0 }
 
             it 'redirects to the check passported answers page' do
               expect(response).to redirect_to(providers_legal_aid_application_check_passported_answers_path(application))
@@ -165,8 +166,8 @@ RSpec.describe 'providers savings and investments', type: :request do
           }
         end
 
-        it 'updates the offline_accounts amount' do
-          expect { subject }.to change { savings_amount.reload.offline_accounts.to_s }.to(offline_accounts)
+        it 'updates the offline_current_accounts amount' do
+          expect { subject }.to change { savings_amount.reload.offline_current_accounts.to_s }.to(offline_current_accounts)
         end
 
         it 'does not displays an error' do
@@ -186,7 +187,7 @@ RSpec.describe 'providers savings and investments', type: :request do
         end
 
         context 'with invalid input' do
-          let(:offline_accounts) { 'fifty' }
+          let(:offline_current_accounts) { 'fifty' }
 
           it 'renders successfully' do
             subject
@@ -195,7 +196,7 @@ RSpec.describe 'providers savings and investments', type: :request do
 
           it 'displays an error' do
             subject
-            expect(response.body).to match(I18n.t('activemodel.errors.models.savings_amount.attributes.offline_accounts.not_a_number'))
+            expect(response.body).to match(I18n.t('activemodel.errors.models.savings_amount.attributes.offline_current_accounts.not_a_number'))
             expect(response.body).to match('govuk-error-message')
             expect(response.body).to match('govuk-form-group--error')
           end

--- a/spec/services/ccms/case_add_requestor_spec.rb
+++ b/spec/services/ccms/case_add_requestor_spec.rb
@@ -297,7 +297,8 @@ module CCMS # rubocop:disable Metrics/ModuleLength
 
       let(:savings_amount) do
         double Capital,
-               offline_accounts: 1_234,
+               offline_current_accounts: 1_234,
+               offline_savings_accounts: 1_234,
                cash: 1_500,
                other_person_account: 1_000,
                national_savings: 129_00,

--- a/spec/services/ccms/case_add_requestor_xml_blocks_spec.rb
+++ b/spec/services/ccms/case_add_requestor_xml_blocks_spec.rb
@@ -891,7 +891,8 @@ module CCMS # rubocop:disable Metrics/ModuleLength
         end
 
         it 'returns false when client does NOT have other savings' do
-          allow(legal_aid_application.savings_amount).to receive(:offline_accounts).and_return(nil)
+          allow(legal_aid_application.savings_amount).to receive(:offline_current_accounts).and_return(nil)
+          allow(legal_aid_application.savings_amount).to receive(:offline_savings_accounts).and_return(nil)
           block = XmlExtractor.call(xml, :global_means, 'GB_INPUT_B_10WP2_1A')
           expect(block).to have_boolean_response false
         end

--- a/spec/services/cfe/create_capitals_service_spec.rb
+++ b/spec/services/cfe/create_capitals_service_spec.rb
@@ -78,8 +78,12 @@ module CFE # rubocop:disable Metrics/ModuleLength
       {
         bank_accounts: [
           {
-            description: 'Off-line bank accounts',
-            value: savings_amount.offline_accounts.to_s
+            description: 'Off-line current accounts',
+            value: savings_amount.offline_current_accounts.to_s
+          },
+          {
+            description: 'Off-line savings accounts',
+            value: savings_amount.offline_savings_accounts.to_s
           },
           {
             description: 'Cash',


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-852)

The first checkbox on the savings_and_investment screen needs to be
split into two checkboxes to improve user experience.

This PR

* amends the savings_amounts table to hold two values, not just one
* changes label, hint and error text in translation files for both
  provider and citizen screens
* amends the CFE service to ensure all capital values are included
* fixes tests that break as a result of those changes

It also makes a number of other changes to the wordings on the
savings_and_investment screen to bring it line with the prototype (for
example, changing 'Cash savings' to 'Money not in a bank account').

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
