### PR TITLE
AP-1001 Fix CCMS scope limitations

### DIFF
--- a/app/services/ccms/case_add_requestor.rb
+++ b/app/services/ccms/case_add_requestor.rb
@@ -166,11 +166,11 @@ module CCMS
       xml.__send__('ns2:LevelOfService', proceeding_type.default_level_of_service.service_level_number)
       xml.__send__('ns2:Stage', 8) # TODO: CCMS placeholder
       xml.__send__('ns2:ClientInvolvementType', 'A') # TODO: CCMS placeholder
-      xml.__send__('ns2:ScopeLimitations') { generate_scope_limitations(xml, proceeding_type) }
+      xml.__send__('ns2:ScopeLimitations') { generate_scope_limitations(xml) }
     end
 
-    def generate_scope_limitations(xml, proceeding)
-      proceeding.scope_limitations.each { |limitation| generate_scope_limitation(xml, limitation) }
+    def generate_scope_limitations(xml)
+      @legal_aid_application.scope_limitations.each { |limitation| generate_scope_limitation(xml, limitation) }
     end
 
     def generate_scope_limitation(xml, limitation)

--- a/ccms_integration/ccms_spec.rb
+++ b/ccms_integration/ccms_spec.rb
@@ -40,20 +40,11 @@ module CCMS
              description: ':EMPLOYMENT_CLIENT_001:CLI_NON_HM_WAGE_SLIP_001'
     end
 
-    let(:firm) { create :firm, ccms_id: 22_381, name: 'Desor & Co' }
+    let(:firm) { create :firm, ccms_id: 19_148, name: 'Desor & Co' }
     let(:office) { create :office, ccms_id: 81_693, firm: firm }
+    let(:provider) { create :provider, :with_provider_details_api_username, firm: firm }
 
-    let(:provider) do
-      double Provider,
-             username: 'NEETADESOR',
-             firm: firm,
-             selected_office_id: 81_693,
-             user_login_id: 2_016_472,
-             supervisor_contact_id: 2_016_673,
-             fee_earner_contact_id: 2_016_673,
-             marked_for_destruction?: false,
-             email: 'test@test.com'
-    end
+    let(:statement_of_case) { create :statement_of_case, :with_attached_files }
 
     let(:substantive_scope_limitation) do
       create :scope_limitation,
@@ -75,6 +66,11 @@ module CCMS
              scope_limitations: [substantive_scope_limitation]
     end
 
+    let(:cfe_submission_1) { create :cfe_submission, legal_aid_application: substantive_legal_aid_application }
+    let(:cfe_submission_2) { create :cfe_submission, legal_aid_application: delegated_functions_legal_aid_application }
+    let!(:cfe_result_1) { create :cfe_result, submission: cfe_submission_1 }
+    let!(:cfe_result_2) { create :cfe_result, submission: cfe_submission_2 }
+
     let(:substantive_legal_aid_application) do
       create :legal_aid_application,
              :with_applicant_and_address,
@@ -85,7 +81,7 @@ module CCMS
              :with_merits_assessment,
              :with_means_report,
              :with_merits_report,
-             statement_of_case: @statement_of_case,
+             statement_of_case: statement_of_case,
              proceeding_types: [substantive_proceeding_type],
              state: :submitting_assessment,
              office: office
@@ -122,15 +118,14 @@ module CCMS
              :with_merits_assessment,
              :with_means_report,
              :with_merits_report,
-             statement_of_case: @statement_of_case,
+             statement_of_case: statement_of_case,
              proceeding_types: [delegated_functions_proceeding_type],
              state: :submitting_assessment,
              office: office
     end
 
     before do
-      @statement_of_case = create :statement_of_case, :with_attached_files
-      PdfConverter.call(PdfFile.find_or_create_by(original_file_id: @statement_of_case.original_files.first.id).id)
+      PdfConverter.call(PdfFile.find_or_create_by(original_file_id: statement_of_case.original_files.first.id).id)
       allow_any_instance_of(LegalAidApplication).to receive(:opponents).and_return([other_party_2, other_party_1])
       allow_any_instance_of(LegalAidApplication).to receive(:vehicle).and_return(vehicle)
       allow_any_instance_of(LegalAidApplication).to receive(:wage_slips).and_return([wage_slip])

--- a/spec/services/ccms/case_add_requestor_spec.rb
+++ b/spec/services/ccms/case_add_requestor_spec.rb
@@ -135,7 +135,6 @@ module CCMS # rubocop:disable Metrics/ModuleLength
                proceeding_level_of_service: 'Full Representation',
                reason_no_injunction_warning_letter: 'Too dangerous',
                requested_scope: 'MULTIPLE',
-               scope_limitations: [scope_limitation_1, scope_limitation_2],
                status: 'draft',
                warning_letter_sent?: false,
                default_level_of_service: service_level,
@@ -268,7 +267,8 @@ module CCMS # rubocop:disable Metrics/ModuleLength
                merits_assessment: merits_assessment,
                default_cost_limitation: 25_000.0,
                office: office,
-               cfe_result: cfe_result
+               cfe_result: cfe_result,
+               scope_limitations: [scope_limitation_1, scope_limitation_2]
       end
 
       let(:cfe_result) do


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1001)

The case creation payload to CCMS is including multiple scope
limitations when it should contain only one.

This is occurring because proceeding_type.scope_limitations returns all
possible scope limitations for that proceeding type.

Instead use @legal_aid_application.scope_limitations, which returns the
scope limitation actually selected for the proceeding type.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
