### PR TITLE
AP-1018 Change hard coded applicant gender

### DIFF
--- a/app/services/ccms/applicant_add_requestor.rb
+++ b/app/services/ccms/applicant_add_requestor.rb
@@ -55,7 +55,7 @@ module CCMS
     # this is all mandatory: we don't hold any of this data except date of birth
     def personal_information(xml)
       xml.__send__('ns5:DateOfBirth', applicant.date_of_birth.to_s(:ccms_date))
-      xml.__send__('ns5:Gender', 'FEMALE')
+      xml.__send__('ns5:Gender', 'UNSPECIFIED')
       xml.__send__('ns5:MaritalStatus', 'U')
       xml.__send__('ns5:VulnerableClient', false)
       xml.__send__('ns5:HighProfileClient', false)


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1018)

Apply does not ask for the applicant's gender, but all CCMS applicant creation payloads need to contain it. This is currently hardcoded as `FEMALE` which results in all correspondence from CCMS being addressed to 'Ms.'.

This PR changes the hard coded gender to `UNSPECIFIED`.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
