### PR TITLE
AP-1020 Store provider user_login_id

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -19,9 +19,4 @@ class Provider < ApplicationRecord
   def update_details_directly
     ProviderDetailsCreator.call(self)
   end
-
-  # TODO: replace with real data once we have it from the provider details API
-  def user_login_id
-    2_016_472
-  end
 end

--- a/app/services/provider_details_creator.rb
+++ b/app/services/provider_details_creator.rb
@@ -14,7 +14,8 @@ class ProviderDetailsCreator
       firm: firm,
       details_response: provider_details,
       offices: offices,
-      name: provider_name
+      name: provider_name,
+      user_login_id: contact_id
     )
 
     provider.update!(selected_office: nil) if should_clear_selected_office?
@@ -53,6 +54,10 @@ class ProviderDetailsCreator
     # Remove the code at the end.
     # "Pearson & Pearson -0A1234" becomes "Pearson & Pearson"
     provider_details[:providerOffices].first[:officeName].split('-')[0..-2].join('-').strip
+  end
+
+  def contact_id
+    provider_details[:contactId]
   end
 
   def provider_details

--- a/db/migrate/20191025151150_add_user_login_id_to_provider.rb
+++ b/db/migrate/20191025151150_add_user_login_id_to_provider.rb
@@ -1,0 +1,5 @@
+class AddUserLoginIdToProvider < ActiveRecord::Migration[5.2]
+  def change
+    add_column :providers, :user_login_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_25_135756) do
+ActiveRecord::Schema.define(version: 2019_10_25_151150) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -547,6 +547,7 @@ ActiveRecord::Schema.define(version: 2019_10_25_135756) do
     t.uuid "selected_office_id"
     t.string "name"
     t.string "email"
+    t.string "user_login_id"
     t.index ["firm_id"], name: "index_providers_on_firm_id"
     t.index ["selected_office_id"], name: "index_providers_on_selected_office_id"
     t.index ["type"], name: "index_providers_on_type"

--- a/spec/services/provider_details_creator_spec.rb
+++ b/spec/services/provider_details_creator_spec.rb
@@ -49,8 +49,12 @@ RSpec.describe ProviderDetailsCreator do
       expect(office_2.code).to eq(ccms_office_2.code)
     end
 
-    it 'update the name of the provider' do
+    it 'updates the name of the provider' do
       expect { subject }.to change { provider.reload.name }.to(api_response[:contactName])
+    end
+
+    it 'updates the user_login_id of the provider' do
+      expect { subject }.to change { provider.reload.user_login_id }.to(api_response[:contactId].to_s)
     end
 
     context 'selected office of provider is not returned by the API' do


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1020)

A provider user's user_login_id is currently mocked by the Provider
model, which means that all submissions to CCMS contain the same id.
This is incorrect.

Add a column to the providers table to hold this data, and extract it
from the provider details api payload when creating a provider.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
