### PR TITLE
AP-914 - Add details to means report

### DIFF
--- a/app/controllers/providers/means_reports_controller.rb
+++ b/app/controllers/providers/means_reports_controller.rb
@@ -1,11 +1,21 @@
 module Providers
   class MeansReportsController < ProviderBaseController
     authorize_with_policy :show_submitted_application?
+    before_action :ensure_case_ccms_reference_exists
 
     def show
       render pdf: 'Means report',
              layout: 'pdf',
              show_as_html: params.key?(:debug)
+    end
+
+    private
+
+    def ensure_case_ccms_reference_exists
+      return if legal_aid_application.case_ccms_reference
+
+      legal_aid_application.create_ccms_submission unless legal_aid_application.ccms_submission
+      legal_aid_application.ccms_submission.process!
     end
   end
 end

--- a/app/views/providers/means_reports/show.html.erb
+++ b/app/views/providers/means_reports/show.html.erb
@@ -25,6 +25,12 @@
   </dl>
 
   <h2 class="govuk-heading-m">
+    <%= t('.capital_result_heading') %>
+  </h2>
+
+  <%= render 'shared/check_answers/capital_result', read_only: true %>
+
+  <h2 class="govuk-heading-m">
     <%= t('.assets_heading') %>
   </h2>
 

--- a/app/views/shared/check_answers/_capital_result.html.erb
+++ b/app/views/shared/check_answers/_capital_result.html.erb
@@ -1,0 +1,35 @@
+<section class="print-no-break">
+  <% read_only = false unless local_assigns.key?(:read_only) %>
+  <dl class="govuk-summary-list govuk-!-margin-bottom-9">
+    <%= check_answer_link(
+          name: :total_capital_assessed,
+          question: t('.total'),
+          answer: number_to_currency(JSON.parse(@legal_aid_application.cfe_result.result)['capital']['total_capital']),
+          read_only: read_only,
+          align_right: read_only
+        ) %>
+
+    <%= check_answer_link(
+          name: :capital_lower_limit,
+          question: t('.lower_limit_label'),
+          answer: t('.lower_limit'),
+          read_only: read_only,
+          align_right: read_only
+        ) %>
+
+    <%= check_answer_link(
+          name: :capital_upper_limit,
+          question: t('.upper_limit_label'),
+          answer: t('.upper_limit'),
+          read_only: read_only,
+          align_right: read_only
+        ) %>
+
+    <%= check_answer_link(
+          name: :capital_contribution,
+          question: t('.contribution'),
+          answer: number_to_currency(JSON.parse(@legal_aid_application.cfe_result.result)['capital']['capital_contribution']),
+          read_only: read_only,
+          align_right: read_only
+        ) %>
+</section>

--- a/ccms_integration/ccms_spec.rb
+++ b/ccms_integration/ccms_spec.rb
@@ -66,11 +66,6 @@ module CCMS
              scope_limitations: [substantive_scope_limitation]
     end
 
-    let(:cfe_submission_1) { create :cfe_submission, legal_aid_application: substantive_legal_aid_application }
-    let(:cfe_submission_2) { create :cfe_submission, legal_aid_application: delegated_functions_legal_aid_application }
-    let!(:cfe_result_1) { create :cfe_result, submission: cfe_submission_1 }
-    let!(:cfe_result_2) { create :cfe_result, submission: cfe_submission_2 }
-
     let(:substantive_legal_aid_application) do
       create :legal_aid_application,
              :with_applicant_and_address,
@@ -81,6 +76,7 @@ module CCMS
              :with_merits_assessment,
              :with_means_report,
              :with_merits_report,
+             :with_cfe_result,
              statement_of_case: statement_of_case,
              proceeding_types: [substantive_proceeding_type],
              state: :submitting_assessment,
@@ -118,6 +114,7 @@ module CCMS
              :with_merits_assessment,
              :with_means_report,
              :with_merits_report,
+             :with_cfe_result,
              statement_of_case: statement_of_case,
              proceeding_types: [delegated_functions_proceeding_type],
              state: :submitting_assessment,

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -251,6 +251,7 @@ en:
         heading: Means report
         client_details_heading: Client details
         benefit_check_heading: Passported means
+        capital_result_heading: Capital result
         assets_heading: Property, savings and other assets
         question_receives_benefit: In receipt of passporting benefit
     online_bankings:

--- a/config/locales/en/shared.yml
+++ b/config/locales/en/shared.yml
@@ -35,6 +35,13 @@ en:
           text: By submitting this application you are confirming that, to the best of your knowledge, the details you are providing are correct.
       bank_transaction_table:
         total: '%{text} total'
+      capital_result:
+        contribution: Capital contribution
+        lower_limit_label: Capital lower limit
+        lower_limit: '£3000.00'
+        upper_limit_label: Capital upper limit
+        upper_limit: '£8000.00'
+        total: Total capital assessed
       client_details:
         address: Correspondence address
         age: "%{years} years old"

--- a/spec/factories/cfe_results/mock_results.rb
+++ b/spec/factories/cfe_results/mock_results.rb
@@ -11,7 +11,7 @@ module CFEResults
           total_liquid: '350.0',
           total_non_liquid: '0.0',
           pensioner_capital_disregard: '0.0',
-          total_capital: '-99650.0',
+          total_capital: '0.0',
           capital_contribution: '0.0',
           liquid_capital_items: [
             {

--- a/spec/factories/legal_aid_applications.rb
+++ b/spec/factories/legal_aid_applications.rb
@@ -275,7 +275,15 @@ FactoryBot.define do
       provider_step { :check_merits_answers }
     end
 
+    trait :with_cfe_result do
+      after :create do |application|
+        cfe_submission = create :cfe_submission, legal_aid_application: application
+        create :cfe_result, submission: cfe_submission
+      end
+    end
+
     trait :with_means_report do
+      with_cfe_result
       after :create do |application|
         Reports::MeansReportCreator.call(application)
       end

--- a/spec/requests/providers/means_reports_spec.rb
+++ b/spec/requests/providers/means_reports_spec.rb
@@ -3,12 +3,15 @@ require 'rails_helper'
 RSpec.describe Providers::MeansReportsController, type: :request do
   let(:legal_aid_application) { create :legal_aid_application, :with_proceeding_types, :with_everything, :assessment_submitted }
   let(:login_provider) { login_as legal_aid_application.provider }
+  let!(:submission) { create :submission, legal_aid_application: legal_aid_application }
+  let(:before_subject) { nil }
 
   describe 'GET /providers/applications/:legal_aid_application_id/means_report' do
     subject { get providers_legal_aid_application_means_report_path(legal_aid_application, debug: true) }
 
     before do
       login_provider
+      before_subject
       subject
     end
 
@@ -18,6 +21,23 @@ RSpec.describe Providers::MeansReportsController, type: :request do
 
     it 'displays the application ref number' do
       expect(unescaped_response_body).to include(legal_aid_application.application_ref)
+    end
+
+    it 'displays the CCMS case reference' do
+      expect(unescaped_response_body).to include(submission.case_ccms_reference)
+    end
+
+    context 'when no CCMS case reference present' do
+      let!(:submission) { create :submission, legal_aid_application: legal_aid_application, case_ccms_reference: nil }
+      let(:case_ccms_reference) { Faker::Number.number(digits: 6).to_s }
+      let(:before_subject) do
+        allow_any_instance_of(CCMS::ObtainCaseReferenceService).to receive(:reference_id).and_return(case_ccms_reference)
+        allow_any_instance_of(CCMS::ObtainCaseReferenceService).to receive(:response).and_return('dummy response')
+      end
+
+      it 'obtains the case reference remotely' do
+        expect(unescaped_response_body).to include(case_ccms_reference)
+      end
     end
 
     context 'when not authenticated' do

--- a/spec/requests/providers/means_reports_spec.rb
+++ b/spec/requests/providers/means_reports_spec.rb
@@ -1,9 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe Providers::MeansReportsController, type: :request do
-  let(:legal_aid_application) { create :legal_aid_application, :with_proceeding_types, :with_everything, :assessment_submitted }
+  let(:legal_aid_application) { create :legal_aid_application, :with_proceeding_types, :with_everything, :with_cfe_result, :assessment_submitted }
   let(:login_provider) { login_as legal_aid_application.provider }
   let!(:submission) { create :submission, legal_aid_application: legal_aid_application }
+  let(:capital_result) { JSON.parse(legal_aid_application.cfe_result.result)['capital'] }
   let(:before_subject) { nil }
 
   describe 'GET /providers/applications/:legal_aid_application_id/means_report' do
@@ -38,6 +39,22 @@ RSpec.describe Providers::MeansReportsController, type: :request do
       it 'obtains the case reference remotely' do
         expect(unescaped_response_body).to include(case_ccms_reference)
       end
+    end
+
+    it 'displays the total capital assessed' do
+      expect(unescaped_response_body).to include(capital_result['total_capital'])
+    end
+
+    it 'displays the capital lower limit' do
+      expect(unescaped_response_body).to include('£3000.00')
+    end
+
+    it 'displays the capital upper limit' do
+      expect(unescaped_response_body).to include('£8000.00')
+    end
+
+    it 'displays the capital contribution' do
+      expect(unescaped_response_body).to include(capital_result['capital_contribution'])
     end
 
     context 'when not authenticated' do

--- a/spec/services/ccms/add_case_service_spec.rb
+++ b/spec/services/ccms/add_case_service_spec.rb
@@ -2,15 +2,13 @@ require 'rails_helper'
 
 module CCMS # rubocop:disable Metrics/ModuleLength
   RSpec.describe AddCaseService do
-    let(:legal_aid_application) { create :legal_aid_application, :with_proceeding_types, :with_everything_and_address, office_id: office.id, populate_vehicle: true }
+    let(:legal_aid_application) { create :legal_aid_application, :with_proceeding_types, :with_everything_and_address, :with_cfe_result, office_id: office.id, populate_vehicle: true }
     let(:applicant) { legal_aid_application.applicant }
     let(:office) { create :office }
     let(:submission) { create :submission, :applicant_ref_obtained, legal_aid_application: legal_aid_application }
     let(:history) { SubmissionHistory.find_by(submission_id: submission.id) }
     let(:endpoint) { 'https://sitsoa10.laadev.co.uk/soa-infra/services/default/CaseServices/CaseServices_ep' }
     let(:response_body) { ccms_data_from_file 'case_add_response.xml' }
-    let(:cfe_submission) { create :cfe_submission, legal_aid_application: legal_aid_application }
-    let!(:cfe_result) { create :cfe_result, submission: cfe_submission }
 
     subject { described_class.new(submission) }
 

--- a/spec/services/ccms/obtain_document_id_service_spec.rb
+++ b/spec/services/ccms/obtain_document_id_service_spec.rb
@@ -8,7 +8,8 @@ module CCMS # rubocop:disable Metrics/ModuleLength
              :with_proceeding_types,
              :with_respondent,
              :with_merits_assessment,
-             :with_transaction_period
+             :with_transaction_period,
+             :with_cfe_result
     end
     let(:submission) { create :submission, :applicant_ref_obtained, legal_aid_application: legal_aid_application, case_ccms_reference: Faker::Number.number }
     let!(:statement_of_case) { create :statement_of_case, legal_aid_application: legal_aid_application }

--- a/spec/services/reports/means_report_creator_spec.rb
+++ b/spec/services/reports/means_report_creator_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Reports::MeansReportCreator do
-  let(:legal_aid_application) { create :legal_aid_application, :with_proceeding_types, :with_everything, state: :generating_reports }
+  let(:legal_aid_application) { create :legal_aid_application, :with_proceeding_types, :with_everything, :with_cfe_result, state: :generating_reports }
 
   subject { described_class.call(legal_aid_application) }
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-914)

Display the CCMS case reference on the means report
 * reuse the pattern used for merits report to add the CCMS reference to the means report

Display the capital assessment result on the means report
 * add a new partial containing the total capital, capital thresholds and capital contribution amount and include it in the means_reports/show.html.erb view
 * add wordings to translation files, including values for the lower and upper capital thresholds which aren't defined anywhere else in the application

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
