### PR TITLE
Remove column width full due to local cucumber issues

### DIFF
--- a/app/views/providers/check_benefits/_check_benefits_result.html.erb
+++ b/app/views/providers/check_benefits/_check_benefits_result.html.erb
@@ -1,5 +1,5 @@
 <div class="interruption-panel">
-  <%= page_template(page_title: t("#{result_namespace}.title", name: @legal_aid_application.applicant.full_name), column_width: 'full', template: :basic) do %>
+  <%= page_template(page_title: t("#{result_namespace}.title", name: @legal_aid_application.applicant.full_name), template: :basic) do %>
     <%= page_heading(size: 'l') %>
     <div class="govuk-grid-column-two-thirds">
       <% if result_namespace == '.negative_result' %>


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-XXX)

Removed the .`column_width: 'full` on the  interruption panel - for some reason it was stopping cucumber from clicking on the Continue button on our local dev machines (but not CircleCI)

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
