### PR TITLE
AP-948 Improve means result page

### DIFF
--- a/app/models/cfe/result.rb
+++ b/app/models/cfe/result.rb
@@ -144,7 +144,7 @@ module CFE
     end
 
     def liquid_capital_items
-      capital[:liquid_capital_items].sort{ |a, b| a[:description] <=> b[:description] }
+      capital[:liquid_capital_items].sort_by { |a| a[:description] }
     end
 
     def total_property

--- a/app/models/cfe/result.rb
+++ b/app/models/cfe/result.rb
@@ -3,12 +3,25 @@ module CFE
     belongs_to :legal_aid_application
     belongs_to :submission
 
+    # returns the name of the partial to display at the top of the results page
+    def overview
+      if legal_aid_application.has_restrictions? && !eligible?
+        'manual_check_required'
+      else
+        assessment_result
+      end
+    end
+
     def result_hash
       JSON.parse(result, symbolize_names: true)
     end
 
     def capital_contribution_required?
       assessment_result == 'contribution_required'
+    end
+
+    def eligible?
+      assessment_result == 'eligible'
     end
 
     def assessment_result

--- a/app/models/cfe/result.rb
+++ b/app/models/cfe/result.rb
@@ -57,10 +57,6 @@ module CFE
       main_home[:allowable_outstanding_mortgage].to_d * -1
     end
 
-    def main_home_disregards_and_deductions
-      main_home_transaction_allowance + main_home_equity_disregard
-    end
-
     def main_home_transaction_allowance
       main_home[:transaction_allowance].to_d * -1
     end
@@ -148,7 +144,7 @@ module CFE
     end
 
     def liquid_capital_items
-      capital[:liquid_capital_items]
+      capital[:liquid_capital_items].sort{ |a, b| a[:description] <=> b[:description] }
     end
 
     def total_property

--- a/app/models/cfe/result.rb
+++ b/app/models/cfe/result.rb
@@ -1,5 +1,5 @@
 module CFE
-  class Result < ApplicationRecord
+  class Result < ApplicationRecord # rubocop:disable Metrics/ClassLength
     belongs_to :legal_aid_application
     belongs_to :submission
 
@@ -31,6 +31,11 @@ module CFE
       property[:main_home]
     end
 
+    ################################################################
+    #                                                              #
+    #  MAIN HOME VALUES                                            #
+    #                                                              #
+    ################################################################
     def main_home_value
       main_home[:value].to_d
     end
@@ -55,8 +60,14 @@ module CFE
       main_home[:assessed_equity].to_d.positive? ? main_home[:assessed_equity].to_d : 0.0
     end
 
+    ################################################################
+    #                                                              #
+    #  ADDITIONAL PROPERTY                                         #
+    #                                                              #
+    ################################################################
+
     def additional_property?
-      property[:additional_properties]&.any?
+      existing_and_not_all_zero?(property[:additional_properties].first)
     end
 
     def additional_property
@@ -74,6 +85,16 @@ module CFE
     def additional_property_mortgage
       additional_property[:allowable_outstanding_mortgage].to_d * -1
     end
+
+    def additional_property_assessed_equity
+      additional_property[:assessed_equity].to_d.positive? ? additional_property[:assessed_equity].to_d : 0.0
+    end
+
+    ################################################################
+    #                                                              #
+    #  VEHICLE                                                     #
+    #                                                              #
+    ################################################################
 
     def vehicle
       result_hash[:vehicles][:vehicles].first
@@ -99,6 +120,16 @@ module CFE
       vehicle[:assessed_amount].to_d
     end
 
+    def total_vehicles
+      result_hash[:vehicles][:total_vehicle].to_d
+    end
+
+    ################################################################
+    #                                                              #
+    #  CAPITAL ITEMS                                               #
+    #                                                              #
+    ################################################################
+
     def non_liquid_capital_items
       capital[:non_liquid_capital_items]
     end
@@ -108,25 +139,43 @@ module CFE
     end
 
     def total_property
-      property[:total_property]
-    end
-
-    def total_vehicles
-      result_hash[:vehicles][:total_vehicle]
+      property[:total_property].to_d
     end
 
     def total_savings
-      capital[:total_liquid]
+      capital[:total_liquid].to_d
     end
 
     def total_other_assets
-      total = capital[:total_non_liquid].to_d
-      if additional_property?
-        total += additional_property_value
-        total += additional_property_transaction_allowance
-        total += additional_property_mortgage
-      end
-      total
+      capital[:total_non_liquid].to_d
+    end
+
+    ################################################################
+    #                                                              #
+    #  TOTALS                                                      #
+    #                                                              #
+    ################################################################
+
+    def pensioner_capital_disregard
+      capital[:pensioner_capital_disregard].to_d * -1
+    end
+
+    def total_capital_before_pensioner_disregard
+      total_property + total_savings + total_vehicles + total_other_assets
+    end
+
+    def total_disposable_capital
+      [0, (total_capital_before_pensioner_disregard + pensioner_capital_disregard)].max
+    end
+
+    ################################################################
+    #                                                              #
+    #  UTILITY METHODS                                             #
+    #                                                              #
+    ################################################################
+
+    def existing_and_not_all_zero?(property)
+      property.present? && property[:value].to_d > 0.0
     end
   end
 end

--- a/app/models/cfe/result.rb
+++ b/app/models/cfe/result.rb
@@ -140,11 +140,11 @@ module CFE
     ################################################################
 
     def non_liquid_capital_items
-      capital[:non_liquid_capital_items]
+      capital[:non_liquid_capital_items].sort_by { |item| item[:description] }
     end
 
     def liquid_capital_items
-      capital[:liquid_capital_items].sort_by { |a| a[:description] }
+      capital[:liquid_capital_items].sort_by { |item| item[:description] }
     end
 
     def total_property

--- a/app/services/cfe/create_capitals_service.rb
+++ b/app/services/cfe/create_capitals_service.rb
@@ -10,8 +10,8 @@ module CFE
     }.freeze
 
     SAVINGS_AMOUNT_FIELDS = {
-      offline_current_accounts: 'Off-line current accounts',
-      offline_savings_accounts: 'Off-line savings accounts',
+      offline_current_accounts: 'Current accounts',
+      offline_savings_accounts: 'Savings accounts',
       cash: 'Cash',
       other_person_account: "Signatory on other person's account",
       national_savings: 'National savings',
@@ -26,8 +26,8 @@ module CFE
 
     def request_body
       {
-        "bank_accounts": bank_account_assets,
-        "non_liquid_capital": itemised_other_assets
+        bank_accounts: bank_account_assets,
+        non_liquid_capital: itemised_other_assets
       }.to_json
     end
 

--- a/app/services/cfe/create_capitals_service.rb
+++ b/app/services/cfe/create_capitals_service.rb
@@ -3,19 +3,19 @@ module CFE
     OTHER_ASSET_FIELDS = {
       timeshare_property_value: 'Timeshare property',
       land_value: 'Land',
-      valuable_items_value: 'Valuable items',
-      inherited_assets_value: 'Inherited assets',
+      valuable_items_value: 'Any valuable items worth more than £500',
+      inherited_assets_value: 'Money or assets from the estate of a person who has died',
       money_owed_value: 'Money owed to applicant',
-      trust_value: 'Trusts'
+      trust_value: 'Interest in a trust'
     }.freeze
 
     SAVINGS_AMOUNT_FIELDS = {
       offline_current_accounts: 'Current accounts',
       offline_savings_accounts: 'Savings accounts',
-      cash: 'Cash',
-      other_person_account: "Signatory on other person's account",
-      national_savings: 'National savings',
-      plc_shares: 'Shares in PLC',
+      cash: 'Money not in a bank account',
+      other_person_account: "Access to another person's bank account",
+      national_savings: 'National Savings Certificates and Premium Bonds',
+      plc_shares: 'Shares in a public limited company',
       peps_unit_trusts_capital_bonds_gov_stocks: 'PEPs, unit trusts, capital bonds and government stocks',
       life_assurance_endowment_policy: 'Life assurance and endowment policies not linked to a mortgage'
     }.freeze

--- a/app/services/mock_benefit_check_service.rb
+++ b/app/services/mock_benefit_check_service.rb
@@ -5,6 +5,7 @@ class MockBenefitCheckService
     'SMITH' => { nino: 'ZZ123459A', dob: '11-Jan-99' },
     'JONES' => { nino: 'ZZ123458A', dob: '1-Jun-80' },
     'BLOGGS' => { nino: 'ZZ123457A', dob: '4-Jan-90' },
+    'WRINKLE' => { nino: 'ZZ010150A', dob: '01-Jan-50' },
     'WALKER' => { nino: 'JA293483A', dob: '10-Jan-80' } # Used in cucumber tests and specs
   }.freeze
 

--- a/app/views/providers/capital_assessment_results/_other_assets.html.erb
+++ b/app/views/providers/capital_assessment_results/_other_assets.html.erb
@@ -7,10 +7,6 @@
           <%= render partial: 'results_detail_row', locals: { caption: item[:description], value: number_to_currency(item[:value]) } %>
         <% end %>
 
-        <% if @cfe_result.additional_property? %>
-          <%= render partial: 'additional_property' %>
-        <% end %>
-
         <%= render partial: 'results_total_row', locals: { caption: t('.assessed_amount'), value: number_to_currency(@cfe_result.total_other_assets) } %>
       </tbody>
     </table>

--- a/app/views/providers/capital_assessment_results/_property_results.html.erb
+++ b/app/views/providers/capital_assessment_results/_property_results.html.erb
@@ -3,8 +3,9 @@
   <table class="govuk-table">
     <tbody>
       <%= render partial: 'results_detail_row', locals: { caption: t('.value'), value: number_to_currency(@cfe_result.main_home_value) } %>
-      <%= render partial: 'results_detail_row', locals: { caption: t('.outstanding_mortgage'), value: number_to_currency(@cfe_result.main_home_outstanding_mortgage) } %>
-      <%= render partial: 'results_detail_row', locals: { caption: t('.disregards'), value: number_to_currency(@cfe_result.main_home_disregards_and_deductions) } %>
+      <%= render partial: 'results_detail_row', locals: { caption: t('.sale_cost'), value: number_to_currency(@cfe_result.main_home_transaction_allowance) } %>
+      <%= render partial: 'results_detail_row', locals: { caption: t('.mortgage_deduction'), value: number_to_currency(@cfe_result.main_home_outstanding_mortgage) } %>
+      <%= render partial: 'results_detail_row', locals: { caption: t('.main_home_disregard'), value: number_to_currency(@cfe_result.main_home_equity_disregard) } %>
       <%= render partial: 'results_total_row', locals: { caption: t('.assessment_amount'), value: number_to_currency(@cfe_result.main_home_assessed_equity) } %>
     </tbody>
   </table>
@@ -14,8 +15,8 @@
     <table class="govuk-table">
       <tbody>
       <%= render partial: 'results_detail_row', locals: { caption: t('.value'), value: number_to_currency(@cfe_result.additional_property_value) } %>
-      <%= render partial: 'results_detail_row', locals: { caption: t('.outstanding_mortgage'), value: number_to_currency(@cfe_result.additional_property_mortgage) } %>
-      <%= render partial: 'results_detail_row', locals: { caption: t('.disregards'), value: number_to_currency(@cfe_result.additional_property_transaction_allowance) } %>
+      <%= render partial: 'results_detail_row', locals: { caption: t('.sale_cost'), value: number_to_currency(@cfe_result.additional_property_transaction_allowance) } %>
+      <%= render partial: 'results_detail_row', locals: { caption: t('.mortgage_deduction'), value: number_to_currency(@cfe_result.additional_property_mortgage) } %>
       <%= render partial: 'results_total_row', locals: { caption: t('.assessment_amount'), value: number_to_currency(@cfe_result.additional_property_assessed_equity) } %>
       </tbody>
     </table>

--- a/app/views/providers/capital_assessment_results/_property_results.html.erb
+++ b/app/views/providers/capital_assessment_results/_property_results.html.erb
@@ -1,5 +1,5 @@
 <div class="govuk-details__text">
-  <h2 class="govuk-heading-m"><%= t('.property') %></h2>
+  <h2 class="govuk-heading-m"><%= t('.main_home') %></h2>
   <table class="govuk-table">
     <tbody>
       <%= render partial: 'results_detail_row', locals: { caption: t('.value'), value: number_to_currency(@cfe_result.main_home_value) } %>
@@ -8,4 +8,16 @@
       <%= render partial: 'results_total_row', locals: { caption: t('.assessment_amount'), value: number_to_currency(@cfe_result.main_home_assessed_equity) } %>
     </tbody>
   </table>
+
+  <% if @cfe_result.additional_property? %>
+    <h2 class="govuk-heading-m"><%= t('.additional_property') %></h2>
+    <table class="govuk-table">
+      <tbody>
+      <%= render partial: 'results_detail_row', locals: { caption: t('.value'), value: number_to_currency(@cfe_result.additional_property_value) } %>
+      <%= render partial: 'results_detail_row', locals: { caption: t('.outstanding_mortgage'), value: number_to_currency(@cfe_result.additional_property_mortgage) } %>
+      <%= render partial: 'results_detail_row', locals: { caption: t('.disregards'), value: number_to_currency(@cfe_result.additional_property_transaction_allowance) } %>
+      <%= render partial: 'results_total_row', locals: { caption: t('.assessment_amount'), value: number_to_currency(@cfe_result.additional_property_assessed_equity) } %>
+      </tbody>
+    </table>
+    <% end %>
 </div>

--- a/app/views/providers/capital_assessment_results/_result_details.html.erb
+++ b/app/views/providers/capital_assessment_results/_result_details.html.erb
@@ -12,6 +12,3 @@
   <%= render 'total_capital' %>
   <%= render 'restrictions' %>
 </details>
-
-
-<%= debug JSON.parse(@cfe_result.result)  %>

--- a/app/views/providers/capital_assessment_results/_result_details.html.erb
+++ b/app/views/providers/capital_assessment_results/_result_details.html.erb
@@ -12,3 +12,6 @@
   <%= render 'total_capital' %>
   <%= render 'restrictions' %>
 </details>
+
+
+<%= debug JSON.parse(@cfe_result.result)  %>

--- a/app/views/providers/capital_assessment_results/_total_capital.html.erb
+++ b/app/views/providers/capital_assessment_results/_total_capital.html.erb
@@ -6,6 +6,9 @@
     <%= render partial: 'results_detail_row', locals: { caption: t('.vehicles'), value: number_to_currency(@cfe_result.total_vehicles) } %>
     <%= render partial: 'results_detail_row', locals: { caption: t('.savings_and_investments'), value: number_to_currency(@cfe_result.total_savings) } %>
     <%= render partial: 'results_detail_row', locals: { caption: t('.other_assets'), value: number_to_currency(@cfe_result.total_other_assets) } %>
+    <%= render partial: 'results_total_row', locals: { caption: t('.total_capital'), value: number_to_currency(@cfe_result.total_capital_before_pensioner_disregard) } %>
+    <%= render partial: 'results_detail_row', locals: { caption: t('.pensioner_disregard'), value: number_to_currency(@cfe_result.pensioner_capital_disregard) } %>
+    <%= render partial: 'results_total_row', locals: { caption: t('.disposable_capital'), value: number_to_currency(@cfe_result.total_disposable_capital) } %>
     </tbody>
   </table>
 </div>

--- a/app/views/providers/capital_assessment_results/show.html.erb
+++ b/app/views/providers/capital_assessment_results/show.html.erb
@@ -5,11 +5,7 @@
     ) do %>
 
   <div class="interruption-panel">
-    <% if @legal_aid_application.has_restrictions? %>
-      <%= render 'manual_check_required' %>
-    <% else %>
-      <%= render @cfe_result.assessment_result %>
-    <% end %>
+    <%= render @cfe_result.overview %>
   </div>
 
   <%= render 'result_details' %>

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -74,11 +74,13 @@ en:
           - We’ll check the details you provided and let you know our decision.
       property_results:
         value: Value
-        outstanding_mortgage: Outstanding mortgage
-        disregards: Disregards and deductions
+        sale_cost: '3% sale cost'
+        mortgage_deduction: Mortgage deduction
+        disregards: Main home disregard
         assessment_amount: Amount included in assessment
-        additional_property: Additional property
+        main_home_disregard: Main home disregard
         main_home: Main home
+        additional_property: Additional property
       vehicle_results:
         vehicles: Vehicles
         value: Value

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -73,11 +73,12 @@ en:
           - We calculated that your client should pay a contribution, but the amount depends on the restrictions.
           - We’ll check the details you provided and let you know our decision.
       property_results:
-        property: Property
         value: Value
         outstanding_mortgage: Outstanding mortgage
         disregards: Disregards and deductions
         assessment_amount: Amount included in assessment
+        additional_property: Additional property
+        main_home: Main home
       vehicle_results:
         vehicles: Vehicles
         value: Value
@@ -96,6 +97,9 @@ en:
         vehicles: Vehicles
         savings_and_investments: Savings and investments
         other_assets: Other assets
+        disposable_capital: Disposable capital
+        pensioner_disregard: Pensioner disregard
+        total_capital: Total capital
       restrictions:
         restrictions: Restrictions on your client's assets
         none: None

--- a/spec/factories/cfe_results.rb
+++ b/spec/factories/cfe_results.rb
@@ -11,5 +11,13 @@ FactoryBot.define do
     trait :contribution_required do
       result { CFEResults::MockResults.contribution_required.to_json }
     end
+
+    trait :no_additional_properties do
+      result { CFEResults::MockResults.no_additional_properties.to_json }
+    end
+
+    trait :with_additional_properties do
+      result { CFEResults::MockResults.with_additional_properties.to_json }
+    end
   end
 end

--- a/spec/factories/cfe_results/mock_results.rb
+++ b/spec/factories/cfe_results/mock_results.rb
@@ -67,5 +67,24 @@ module CFEResults
       new_capital_section[:capital_contribution] = '465.66'
       eligible.merge assessment_result: 'contribution_required', capital: new_capital_section
     end
+
+    def self.no_additional_properties
+      result = eligible
+      result[:property][:additional_properties] = []
+      result
+    end
+
+    def self.with_additional_properties
+      result = eligible
+      property = {
+        value: '350255.0',
+        transaction_allowance: '012550',
+        allowable_outstanding_mortgage: '45000.0',
+        percentage_owned: '100.0',
+        assessed_equity: '224000'
+      }
+      result[:property][:additional_properties] = [property]
+      result
+    end
   end
 end

--- a/spec/models/cfe/result_spec.rb
+++ b/spec/models/cfe/result_spec.rb
@@ -5,6 +5,8 @@ module CFE
     let(:eligible_result) { create :cfe_result }
     let(:not_eligible_result) { create :cfe_result, :not_eligible }
     let(:contibution_required_result) { create :cfe_result, :contribution_required }
+    let(:no_additional_properties) { create :cfe_result, :no_additional_properties }
+    let(:additional_property) { create :cfe_result, :with_additional_properties }
 
     describe '#assessment_result' do
       context 'eligible' do
@@ -29,6 +31,48 @@ module CFE
     describe '#capital_contribution' do
       it 'returns the value of the capital contribution' do
         expect(contibution_required_result.capital_contribution).to eq 465.66
+      end
+    end
+
+    describe '#additional_property?' do
+      context 'present' do
+        it 'returns true' do
+          expect(additional_property.additional_property?).to be true
+        end
+      end
+      context 'not present' do
+        it 'returns false' do
+          expect(no_additional_properties.additional_property?).to be false
+        end
+      end
+      context 'present but zero' do
+        it 'returns false' do
+          expect(eligible_result.additional_property?).to be false
+        end
+      end
+    end
+
+    describe 'additional_property_value' do
+      it 'returns the value of the first additional property' do
+        expect(additional_property.additional_property_value).to eq 350_255.0
+      end
+    end
+
+    describe 'additional_property_transaction_allowance' do
+      it 'returns the transaction allowance for the first additional property' do
+        expect(additional_property.additional_property_transaction_allowance).to eq(-12_550.0)
+      end
+    end
+
+    describe 'additional_property_mortgage' do
+      it 'returns the mortgage for the first additional property' do
+        expect(additional_property.additional_property_mortgage).to eq(-45_000.0)
+      end
+    end
+
+    describe 'additional_property_assessed_equity' do
+      it 'returns the assessed equity for the first additional property' do
+        expect(additional_property.additional_property_assessed_equity).to eq 224_000.0
       end
     end
   end

--- a/spec/requests/citizens/legal_aid_applications_spec.rb
+++ b/spec/requests/citizens/legal_aid_applications_spec.rb
@@ -80,7 +80,8 @@ RSpec.describe 'citizen home requests', type: :request do
     end
 
     context 'if a provider is logged in' do
-      let(:provider) { create :provider }
+      let(:provider_username) { 'stepriponikas.bonstart' }
+      let(:provider) { create :provider, username: provider_username }
       before { sign_in provider }
 
       it 'logs out the provider' do

--- a/spec/requests/providers/capital_assessment_results_spec.rb
+++ b/spec/requests/providers/capital_assessment_results_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe Providers::CapitalAssessmentResultsController, type: :request do
         end
 
         it 'displays the correct result' do
-          expect(unescaped_response_body).to include(I18n.t('not_eligible.heading', name: applicant_name, scope: locale_scope))
+          expect(unescaped_response_body).to include(I18n.t('manual_check_required.heading', name: applicant_name, scope: locale_scope))
         end
       end
 
@@ -110,5 +110,4 @@ RSpec.describe Providers::CapitalAssessmentResultsController, type: :request do
       end
     end
   end
-
 end

--- a/spec/requests/providers/capital_assessment_results_spec.rb
+++ b/spec/requests/providers/capital_assessment_results_spec.rb
@@ -17,35 +17,82 @@ RSpec.describe Providers::CapitalAssessmentResultsController, type: :request do
 
     before { before_tasks }
 
-    it 'returns http success' do
-      expect(response).to have_http_status(:ok)
-    end
+    context 'no restrictions' do
+      context 'eligible' do
+        it 'returns http success' do
+          expect(response).to have_http_status(:ok)
+        end
 
-    it 'displays the correct result' do
-      expect(unescaped_response_body).to include(I18n.t('eligible.heading', name: applicant_name, scope: locale_scope))
-    end
-
-    context 'when not eligible' do
-      let(:cfe_result) { create :cfe_result, :not_eligible }
-
-      it 'returns http success' do
-        expect(response).to have_http_status(:ok)
+        it 'displays the correct result' do
+          expect(unescaped_response_body).to include(I18n.t('eligible.heading', name: applicant_name, scope: locale_scope))
+        end
       end
 
-      it 'displays the correct result' do
-        expect(unescaped_response_body).to include(I18n.t('not_eligible.heading', name: applicant_name, scope: locale_scope))
+      context 'when not eligible' do
+        let(:cfe_result) { create :cfe_result, :not_eligible }
+
+        it 'returns http success' do
+          expect(response).to have_http_status(:ok)
+        end
+
+        it 'displays the correct result' do
+          expect(unescaped_response_body).to include(I18n.t('not_eligible.heading', name: applicant_name, scope: locale_scope))
+        end
+      end
+
+      context 'when contribution required' do
+        let(:cfe_result) { create :cfe_result, :contribution_required }
+
+        it 'returns http success' do
+          expect(response).to have_http_status(:ok)
+        end
+
+        it 'displays the correct result' do
+          expect(unescaped_response_body).to include(I18n.t('contribution_required.heading', name: applicant_name, scope: locale_scope))
+        end
       end
     end
 
-    context 'when contribution required' do
-      let(:cfe_result) { create :cfe_result, :contribution_required }
-
-      it 'returns http success' do
-        expect(response).to have_http_status(:ok)
+    context 'with restrictions' do
+      let(:before_tasks) do
+        create :applicant, legal_aid_application: legal_aid_application, first_name: 'Stepriponikas', last_name: 'Bonstart'
+        legal_aid_application.update has_restrictions: true, restrictions_details: 'Blah blah'
+        login_provider
+        subject
       end
 
-      it 'displays the correct result' do
-        expect(unescaped_response_body).to include(I18n.t('contribution_required.heading', name: applicant_name, scope: locale_scope))
+      context 'eligible' do
+        it 'returns http success' do
+          expect(response).to have_http_status(:ok)
+        end
+
+        it 'displays the correct result' do
+          expect(unescaped_response_body).to include(I18n.t('eligible.heading', name: applicant_name, scope: locale_scope))
+        end
+      end
+
+      context 'when not eligible' do
+        let(:cfe_result) { create :cfe_result, :not_eligible }
+
+        it 'returns http success' do
+          expect(response).to have_http_status(:ok)
+        end
+
+        it 'displays the correct result' do
+          expect(unescaped_response_body).to include(I18n.t('not_eligible.heading', name: applicant_name, scope: locale_scope))
+        end
+      end
+
+      context 'when contribution required' do
+        let(:cfe_result) { create :cfe_result, :contribution_required }
+
+        it 'returns http success' do
+          expect(response).to have_http_status(:ok)
+        end
+
+        it 'displays manual check required' do
+          expect(unescaped_response_body).to include(I18n.t('manual_check_required.heading', name: applicant_name, scope: locale_scope))
+        end
       end
     end
 
@@ -63,4 +110,5 @@ RSpec.describe Providers::CapitalAssessmentResultsController, type: :request do
       end
     end
   end
+
 end

--- a/spec/services/cfe/create_capitals_service_spec.rb
+++ b/spec/services/cfe/create_capitals_service_spec.rb
@@ -78,11 +78,11 @@ module CFE # rubocop:disable Metrics/ModuleLength
       {
         bank_accounts: [
           {
-            description: 'Off-line current accounts',
+            description: 'Current accounts',
             value: savings_amount.offline_current_accounts.to_s
           },
           {
-            description: 'Off-line savings accounts',
+            description: 'Savings accounts',
             value: savings_amount.offline_savings_accounts.to_s
           },
           {

--- a/spec/services/cfe/create_capitals_service_spec.rb
+++ b/spec/services/cfe/create_capitals_service_spec.rb
@@ -86,15 +86,15 @@ module CFE # rubocop:disable Metrics/ModuleLength
             value: savings_amount.offline_savings_accounts.to_s
           },
           {
-            description: 'Cash',
+            description: 'Money not in a bank account',
             value: savings_amount.cash.to_s
           },
           {
-            description: "Signatory on other person's account",
+            description: "Access to another person's bank account",
             value: savings_amount.other_person_account.to_s
           },
           {
-            description: 'National savings',
+            description: 'National Savings Certificates and Premium Bonds',
             value: savings_amount.national_savings.to_s
           }
         ],
@@ -108,10 +108,10 @@ module CFE # rubocop:disable Metrics/ModuleLength
             value: other_assets_declaration.land_value.to_s
           },
           {
-            description: 'Valuable items',
+            description: 'Any valuable items worth more than £500',
             value: other_assets_declaration.valuable_items_value.to_s
           },
-          { description: 'Trusts',
+          { description: 'Interest in a trust',
             value: other_assets_declaration.trust_value.to_s }
         ]
       }


### PR DESCRIPTION
## Improve layout of Means results page

[Link to story](https://dsdmoj.atlassian.net/browse/AP-948)

- altered position of additional property on page
- Subtotal of disposable capital before deduction of pensioner disregard
- Fixed randomly failing test where Faker-generated text was being found on a page

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
