### PR TITLE
AP-989 Add Sentry alerting for postcode lookup

### DIFF
--- a/spec/services/address_lookup_service_spec.rb
+++ b/spec/services/address_lookup_service_spec.rb
@@ -53,6 +53,7 @@ RSpec.describe AddressLookupService do
       end
 
       it 'outcome is unsuccessful' do
+        expect(Raven).to receive(:capture_exception).with(message_contains('Connection refused'))
         outcome = service.call
         expect(outcome).not_to be_success
         expect(outcome.errors).to eq(lookup: [:service_unavailable])
@@ -76,11 +77,21 @@ RSpec.describe AddressLookupService do
       end
 
       it 'outcome is unsuccessful' do
+        expect(Raven).to receive(:capture_exception).with(message_contains('No postcode parameter provided'))
         outcome = service.call
         expect(outcome).not_to be_success
         expect(outcome.errors).to eq(lookup: [:unsuccessful])
         expect(outcome.result).to eq([])
       end
+    end
+  end
+
+  describe '#record_error' do
+    let(:state) { :service_unavailable }
+    let(:error) { StandardError.new 'Service unavailable' }
+    it 'captures error' do
+      expect(Raven).to receive(:capture_exception).with(message_contains('Service unavailable'))
+      service.__send__(:record_error, state, error)
     end
   end
 end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-989)

We want to be alerted when calls to the Ordnance Survey Places API fail.

This commit adds Sentry calls to the `AddressLookupService` class in two places, so that alerts will occur if the service is unavailable and if the service is available but is unsuccessful in returning a response (for example if authentication fails).


## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
