### PR TITLE
AP-1042 Remove hardcoded provider reference

### DIFF
--- a/app/services/ccms/case_add_requestor.rb
+++ b/app/services/ccms/case_add_requestor.rb
@@ -131,7 +131,6 @@ module CCMS
     end
 
     def generate_provider_details(xml)
-      xml.__send__('ns2:ProviderCaseReferenceNumber', 'PC4') # TODO: insert @legal_aid_application.provider_case_reference_number when it is available in Apply
       xml.__send__('ns2:ProviderFirmID', provider.firm.ccms_id)
       xml.__send__('ns2:ProviderOfficeID', @legal_aid_application.office.ccms_id)
       xml.__send__('ns2:ContactUserID') do


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1042)

All cases injected to CCMS are including a ProviderCaseReferenceNumber
of 'PC4'. This will be confusing for solicitors.

Apply doesn't currently ask the provider for their reference as part of
the application process.

For now the agreed fix is to remove the ProviderCaseReferenceNumber
from the case creation payload. If solicitor feedback from beta testing
indicates they need it, then it can be added back along with a change to
the Apply journey to allow a solicitor to enter it.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
