### PR TITLE
AP-1044 Correct benefit check result

### DIFF
--- a/app/services/ccms/attribute_value_generator.rb
+++ b/app/services/ccms/attribute_value_generator.rb
@@ -210,6 +210,10 @@ module CCMS
       cfe_result.capital_contribution_required? ? cfe_result.capital_contribution : 0.0
     end
 
+    def benefit_check_passed?(_options)
+      @legal_aid_application.benefit_check_result.result == 'Yes'
+    end
+
     private
 
     def applicant

--- a/config/ccms/ccms_keys.yml
+++ b/config/ccms/ccms_keys.yml
@@ -1704,7 +1704,7 @@ global_means:
     :response_type: date
     :user_defined: true
   LAR_INFER_B_1WP1_36A:
-    :value: "#application_benefit_check_result"
+    :value: "#benefit_check_passed?"
     :br100_meaning: The client is passported
     :response_type: boolean
     :user_defined: false

--- a/spec/services/ccms/add_case_service_spec.rb
+++ b/spec/services/ccms/add_case_service_spec.rb
@@ -2,7 +2,15 @@ require 'rails_helper'
 
 module CCMS # rubocop:disable Metrics/ModuleLength
   RSpec.describe AddCaseService do
-    let(:legal_aid_application) { create :legal_aid_application, :with_proceeding_types, :with_everything_and_address, :with_cfe_result, office_id: office.id, populate_vehicle: true }
+    let(:legal_aid_application) do
+      create :legal_aid_application,
+             :with_proceeding_types,
+             :with_everything_and_address,
+             :with_cfe_result,
+             :with_positive_benefit_check_result,
+             office_id: office.id,
+             populate_vehicle: true
+    end
     let(:applicant) { legal_aid_application.applicant }
     let(:office) { create :office }
     let(:submission) { create :submission, :applicant_ref_obtained, legal_aid_application: legal_aid_application }

--- a/spec/services/ccms/case_add_requestor_spec.rb
+++ b/spec/services/ccms/case_add_requestor_spec.rb
@@ -230,6 +230,8 @@ module CCMS # rubocop:disable Metrics/ModuleLength
                no_warning_letter_sent?: true
       end
 
+      let(:benefit_check_result) { create :benefit_check_result }
+
       let(:legal_aid_application) do
         double LegalAidApplication,
                id: 1,
@@ -263,7 +265,7 @@ module CCMS # rubocop:disable Metrics/ModuleLength
                open_banking_consent: true,
                open_banking_consent_choice_at: Date.new(2019, 6, 1),
                lead_proceeding_type: proceeding_type_1,
-               benefit_check_result: true,
+               benefit_check_result: benefit_check_result,
                merits_assessment: merits_assessment,
                default_cost_limitation: 25_000.0,
                office: office,
@@ -362,7 +364,15 @@ module CCMS # rubocop:disable Metrics/ModuleLength
     end
 
     describe '#call' do
-      let(:legal_aid_application) { create :legal_aid_application, :with_proceeding_types, :with_everything, :with_applicant_and_address, populate_vehicle: true, office: office }
+      let(:legal_aid_application) do
+        create :legal_aid_application,
+               :with_proceeding_types,
+               :with_everything,
+               :with_applicant_and_address,
+               :with_positive_benefit_check_result,
+               populate_vehicle: true,
+               office: office
+      end
       let(:submission) { create :submission, :case_ref_obtained, legal_aid_application: legal_aid_application }
       let(:cfe_submission) { create :cfe_submission, legal_aid_application: legal_aid_application }
       let!(:cfe_result) { create :cfe_result, submission: cfe_submission }

--- a/spec/services/ccms/case_add_requestor_xml_blocks_spec.rb
+++ b/spec/services/ccms/case_add_requestor_xml_blocks_spec.rb
@@ -18,6 +18,7 @@ module CCMS # rubocop:disable Metrics/ModuleLength
         create :legal_aid_application,
                :with_everything,
                :with_applicant_and_address,
+               :with_positive_benefit_check_result,
                populate_vehicle: true,
                with_bank_accounts: 2,
                proceeding_types: [proceeding_type],
@@ -195,6 +196,7 @@ module CCMS # rubocop:disable Metrics/ModuleLength
             create :legal_aid_application,
                    :with_everything,
                    :with_applicant_and_address,
+                   :with_positive_benefit_check_result,
                    with_bank_accounts: 2,
                    vehicle: nil,
                    proceeding_types: [proceeding_type],
@@ -626,9 +628,20 @@ module CCMS # rubocop:disable Metrics/ModuleLength
       end
 
       context 'LAR_INFER_B_1WP1_36A' do
-        it 'uses the DWP benefit check result' do
-          block = XmlExtractor.call(xml, :global_means, 'LAR_INFER_B_1WP1_36A')
-          expect(block).to have_boolean_response legal_aid_application.benefit_check_result
+        context 'benefit check result is yes' do
+          it 'uses the DWP benefit check result' do
+            block = XmlExtractor.call(xml, :global_means, 'LAR_INFER_B_1WP1_36A')
+            expect(block).to have_boolean_response true
+          end
+        end
+
+        context 'benefit check result is no' do
+          let(:benefit_check_result) { create :benefit_check_result, :negative }
+          before { legal_aid_application.benefit_check_result = benefit_check_result }
+          it 'uses the DWP benefit check result' do
+            block = XmlExtractor.call(xml, :global_means, 'LAR_INFER_B_1WP1_36A')
+            expect(block).to have_boolean_response false
+          end
         end
       end
 
@@ -645,6 +658,7 @@ module CCMS # rubocop:disable Metrics/ModuleLength
             create :legal_aid_application,
                    :with_everything,
                    :with_applicant_and_address,
+                   :with_positive_benefit_check_result,
                    populate_vehicle: true,
                    with_bank_accounts: 2,
                    proceeding_types: [proceeding_type],
@@ -680,6 +694,7 @@ module CCMS # rubocop:disable Metrics/ModuleLength
             create :legal_aid_application,
                    :with_everything,
                    :with_applicant_and_address,
+                   :with_positive_benefit_check_result,
                    populate_vehicle: true,
                    with_bank_accounts: 2,
                    proceeding_types: [proceeding_type],
@@ -1217,6 +1232,7 @@ module CCMS # rubocop:disable Metrics/ModuleLength
             create :legal_aid_application,
                    :with_everything,
                    :with_applicant_and_address,
+                   :with_positive_benefit_check_result,
                    populate_vehicle: true,
                    with_bank_accounts: 2,
                    proceeding_types: [proceeding_type],
@@ -1246,6 +1262,7 @@ module CCMS # rubocop:disable Metrics/ModuleLength
             create :legal_aid_application,
                    :with_everything,
                    :with_applicant_and_address,
+                   :with_positive_benefit_check_result,
                    populate_vehicle: true,
                    with_bank_accounts: 2,
                    proceeding_types: [proceeding_type],


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1044)

Attribute `LAR_INFER_B_1WP1_36A` is being populated with `application.benefit_check_result`.

`benefit_check_result` is an object, so this appears in the xml payloads like: `#&lt;BenefitCheckResult:0x000055f9a5681a38&gt;`

This is a boolean attribute, so this PR changes it to populate `true` if `application.benefit_check_result.result` is `yes`, and `false` otherwise.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
