### PR TITLE
Avoid Prometheus duplicated targets in UAT

### DIFF
--- a/helm_deploy/apply-for-legal-aid/templates/service-monitor.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/service-monitor.yaml
@@ -7,6 +7,7 @@ spec:
   selector:
     matchLabels:
       app: {{ .Chart.Name }}
+      service: {{ template "apply-for-legal-aid.fullname" . }}-metrics
   namespaceSelector:
     matchNames:
     - {{ .Release.Namespace }}


### PR DESCRIPTION
## What

[Link to Cloud Platform Issue](https://github.com/ministryofjustice/cloud-platform-environments/issues/1105)

Our current k8s UAT namespace deployment sets an individual release per branch. These releases run in parallel under the same namespace, effectively simulating the praised Heroku Pull Review feature.

Because we use the standard configuration for Prometheus Service Monitors that just matches by the application name, we were getting multiple matches/targets for each release on UAT.
This was causing that every release in UAT namespace was creating a Prometheus target against itself but also against every other release under the same namespace.

As a consequence of that, Prometheus receives multiple different samples with identical labels and timestamp, so discards the duplicated and raises an alert.

### Solution

The solution sets a match label in the service monitor that will be unique per release. 
When Prometheus Service Monitor needs to set the scraping target, will do it against the ones matching the Service Monitor matching labels, that now are unique per release instead of being a generic "apply-for-legal-aid" matched by every release.

In this way we achieve setting and individual scrape target per release.

## Before --> After
![image](https://user-images.githubusercontent.com/1227578/68147432-ed3a1d80-ff31-11e9-8228-68f7f0eb9078.png)


## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
