### PR TITLE
Mitigate Omniauth CSRF vulnerability

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ gem 'devise_saml_authenticatable'
 gem 'omniauth'
 gem 'omniauth-google-oauth2'
 gem 'omniauth-oauth2' # Provide Oauth2 strategy framework
+gem 'omniauth-rails_csrf_protection', '~> 0.1'
 
 # Improve backtrace in nested error recues
 gem 'nesty'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -296,6 +296,9 @@ GEM
     omniauth-oauth2 (1.6.0)
       oauth2 (~> 1.1)
       omniauth (~> 1.9)
+    omniauth-rails_csrf_protection (0.1.2)
+      actionpack (>= 4.2)
+      omniauth (>= 1.3.1)
     orm_adapter (0.5.0)
     pagy (3.7.0)
     parallel (1.19.0)
@@ -557,6 +560,7 @@ DEPENDENCIES
   omniauth
   omniauth-google-oauth2
   omniauth-oauth2
+  omniauth-rails_csrf_protection (~> 0.1)
   pagy
   pg
   prometheus_exporter

--- a/app/views/admin_users/sessions/new.html.erb
+++ b/app/views/admin_users/sessions/new.html.erb
@@ -17,4 +17,4 @@
   <% end %>
 <% end %>
 
-<%= link_to t('.google_login'), omniauth_login_start_path(:google_oauth2) %>
+<%= link_to(t('.google_login'), omniauth_login_start_path(:google_oauth2), method: :post) %>

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,6 +1,7 @@
 require Rails.root.join 'app/lib/omniauth/omniauth_true_layer'
 require Rails.root.join 'app/controllers/applicants/omniauth_callbacks_controller.rb'
 
+OmniAuth.config.allowed_request_methods = %i[post get]
 OmniAuth.config.logger = Rails.logger
 
 Rails.application.config.middleware.use OmniAuth::Builder do

--- a/spec/requests/omniauth_csrf_vulnerability_spec.rb
+++ b/spec/requests/omniauth_csrf_vulnerability_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+# Make sure that https://nvd.nist.gov/vuln/detail/CVE-2015-9284 is mitigated
+# You can track the issue here: https://github.com/omniauth/omniauth/pull/809
+RSpec.describe 'CVE-2015-9284', type: :request do
+  describe 'POST /auth/:provider without CSRF token' do
+    before do
+      @allow_forgery_protection = ActionController::Base.allow_forgery_protection
+      ActionController::Base.allow_forgery_protection = true
+    end
+
+    it 'is not allowed' do
+      expect {
+        post '/auth/google_oauth2'
+      }.to raise_error(ActionController::InvalidAuthenticityToken)
+    end
+
+    after do
+      ActionController::Base.allow_forgery_protection = @allow_forgery_protection
+    end
+  end
+end


### PR DESCRIPTION
## What

Fixes https://github.com/ministryofjustice/laa-apply-for-legal-aid/issues/1002

Omniauth has a severe CSRF vulnerability when combined with Rails that has not been patched.
In order to mitigate it there are mainly two actions to take:
1. Turn GET requests links to `/auth/:provider` routes into POST requests.
2. Install `omniauth-rails_csrf_protection` gem.

The architecture of our service (a flow redirecting to different steps) contains a step redirecting to TrueLayer `/auth/truelayer`.
Redirections cannot easily be turned into POST requests and trying to fix that would break the templated "flow with steps" approach.

Due to that, we had to explicitly enable GET requests on Omniauth, as Omniauth rails csrf protection gem enforces POST by default.

## LINKS
CVE: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-9284

Solution directions:
https://github.com/omniauth/omniauth/wiki/Resolving-CVE-2015-9284

Full context on the issue:
omniauth/omniauth#809


![Screen Shot 2019-11-26 at 16 14 40](https://user-images.githubusercontent.com/1227578/69652523-b2776100-1069-11ea-9681-ad5d582ed143.png)

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
