### PR TITLE
AP 1019 et al - document uploads to CCMS

### DIFF
--- a/app/models/concerns/ccms_submission_state_machine.rb
+++ b/app/models/concerns/ccms_submission_state_machine.rb
@@ -15,29 +15,29 @@ module CCMSSubmissionStateMachine
       state :completed
       state :failed
 
-      event :obtain_case_ref, after: :process_async! do
+      event :obtain_case_ref do
         transitions from: :initialised, to: :case_ref_obtained
       end
 
-      event :submit_applicant, after: :process_async! do
+      event :submit_applicant do
         transitions from: :case_ref_obtained, to: :applicant_submitted
       end
 
-      event :obtain_applicant_ref, after: :process_async! do
+      event :obtain_applicant_ref do
         transitions from: :applicant_submitted, to: :applicant_ref_obtained
         transitions from: :case_ref_obtained, to: :applicant_ref_obtained
       end
 
-      event :obtain_document_ids, after: :process_async! do
+      event :obtain_document_ids do
         transitions from: :applicant_ref_obtained, to: :document_ids_obtained
       end
 
-      event :submit_case, after: :process_async! do
+      event :submit_case do
         transitions from: :applicant_ref_obtained, to: :case_submitted
         transitions from: :document_ids_obtained, to: :case_submitted
       end
 
-      event :confirm_case_created, after: :process_async! do
+      event :confirm_case_created do
         transitions from: :case_submitted, to: :case_created
       end
 

--- a/app/services/ccms/add_applicant_service.rb
+++ b/app/services/ccms/add_applicant_service.rb
@@ -1,8 +1,9 @@
 module CCMS
   class AddApplicantService < BaseSubmissionService
-    def call
+    def call # rubocop:disable Metrics/AbcSize
       if applicant_add_response_parser.success?
         submission.applicant_add_transaction_id = applicant_add_requestor.transaction_request_id
+        submission.save!
         create_history('case_ref_obtained', submission.aasm_state, xml_request, response) if submission.submit_applicant!
       else
         handle_unsuccessful_response(xml_request, response)

--- a/app/services/ccms/add_case_service.rb
+++ b/app/services/ccms/add_case_service.rb
@@ -8,6 +8,7 @@ module CCMS
       @options = options
       if case_add_response_parser.success?
         submission.case_add_transaction_id = case_add_requestor.transaction_request_id
+        submission.save!
         create_history(submission.submission_document.empty? ? 'applicant_ref_obtained' : 'document_ids_obtained', submission.aasm_state, xml_request, response) if submission.submit_case!
       else
         handle_unsuccessful_response(xml_request, response)

--- a/app/services/ccms/check_applicant_status_service.rb
+++ b/app/services/ccms/check_applicant_status_service.rb
@@ -3,7 +3,7 @@ module CCMS
     def call
       tx_id = applicant_add_status_requestor.transaction_request_id
       submission.applicant_poll_count += 1
-      submission.save
+      submission.save!
       response = applicant_add_status_requestor.call
       parser = ApplicantAddStatusResponseParser.new(tx_id, response)
       process_response(parser)

--- a/app/services/ccms/check_case_status_service.rb
+++ b/app/services/ccms/check_case_status_service.rb
@@ -3,7 +3,7 @@ module CCMS
     def call
       tx_id = case_add_status_requestor.transaction_request_id
       submission.case_poll_count += 1
-      submission.save
+      submission.save!
       parser = CaseAddStatusResponseParser.new(tx_id, response)
       process_response(parser)
     rescue CcmsError => e

--- a/app/services/ccms/obtain_applicant_reference_service.rb
+++ b/app/services/ccms/obtain_applicant_reference_service.rb
@@ -24,6 +24,7 @@ module CCMS
         AddApplicantService.new(submission).call
       else
         submission.applicant_ccms_reference = parser.applicant_ccms_reference
+        submission.save!
         create_history(:case_ref_obtained, submission.aasm_state, xml_request, response) if submission.obtain_applicant_ref!
       end
     end

--- a/app/services/ccms/obtain_case_reference_service.rb
+++ b/app/services/ccms/obtain_case_reference_service.rb
@@ -2,6 +2,7 @@ module CCMS
   class ObtainCaseReferenceService < BaseSubmissionService
     def call
       submission.case_ccms_reference = reference_id
+      submission.save!
       create_history(:initialised, submission.aasm_state, xml_request, response) if submission.obtain_case_ref!
     rescue CcmsError => e
       handle_exception(e, xml_request)

--- a/spec/services/ccms/add_case_service_spec.rb
+++ b/spec/services/ccms/add_case_service_spec.rb
@@ -82,7 +82,7 @@ module CCMS # rubocop:disable Metrics/ModuleLength
           expect(history.details).to be_nil
         end
 
-        it 'stores the reqeust body in the  submission history record' do
+        it 'stores the request body in the  submission history record' do
           subject.call
           expect(history.request).to be_soap_envelope_with(
             command: 'ns4:CaseAddRQ',
@@ -91,6 +91,11 @@ module CCMS # rubocop:disable Metrics/ModuleLength
               "<ns2:ProviderOfficeID>#{legal_aid_application.office.ccms_id}</ns2:ProviderOfficeID>"
             ]
           )
+        end
+
+        it 'writes the response body to the history record' do
+          subject.call
+          expect(history.response).to eq response_body
         end
       end
     end

--- a/spec/services/ccms/obtain_document_id_service_spec.rb
+++ b/spec/services/ccms/obtain_document_id_service_spec.rb
@@ -36,35 +36,9 @@ module CCMS # rubocop:disable Metrics/ModuleLength
       end
 
       context 'the application has no documents' do
-        it 'creates an empty documents array' do
+        it 'does not create any document objects' do
           subject.call
           expect(submission.submission_document.count).to eq 0
-        end
-
-        it 'changes the submission state to case_submitted' do
-          expect { subject.call }.to change { submission.aasm_state }.to 'case_submitted'
-        end
-
-        it 'writes a history record' do
-          expect { subject.call }.to change { SubmissionHistory.count }.by(1)
-          expect(history.from_state).to eq 'applicant_ref_obtained'
-          expect(history.to_state).to eq 'case_submitted'
-          expect(history.success).to be true
-          expect(history.details).to be_nil
-        end
-
-        it 'writes the request body to the history record' do
-          subject.call
-          expect(history.request).to be_soap_envelope_with(
-            command: 'ns2:DocumentUploadRQ',
-            transaction_id: '20190301030405123456',
-            matching: ['<ns4:DocumentType>ADMIN1</ns4:DocumentType>']
-          )
-        end
-
-        it 'writes the response body to the history record' do
-          subject.call
-          expect(history.response).to eq response_body
         end
       end
 
@@ -98,6 +72,28 @@ module CCMS # rubocop:disable Metrics/ModuleLength
 
           it 'changes the submission state to document_ids_obtained' do
             expect { subject.call }.to change { submission.aasm_state }.to 'document_ids_obtained'
+          end
+
+          it 'writes a history record' do
+            expect { subject.call }.to change { SubmissionHistory.count }.by(1)
+            expect(history.from_state).to eq 'applicant_ref_obtained'
+            expect(history.to_state).to eq 'document_ids_obtained'
+            expect(history.success).to be true
+            expect(history.details).to be_nil
+          end
+
+          it 'writes the request body to the history record' do
+            subject.call
+            expect(history.request).to be_soap_envelope_with(
+              command: 'ns2:DocumentUploadRQ',
+              transaction_id: '20190301030405123456',
+              matching: ['<ns4:DocumentType>ADMIN1</ns4:DocumentType>']
+            )
+          end
+
+          it 'writes the response body to the history record' do
+            subject.call
+            expect(history.response).to eq response_body
           end
         end
       end


### PR DESCRIPTION
## What

[AP-1019](https://dsdmoj.atlassian.net/browse/AP-1019)
[AP-1023](https://dsdmoj.atlassian.net/browse/AP-1023)
[AP-1036](https://dsdmoj.atlassian.net/browse/AP-1036)

This PR fixes multiple issues with document uploads to CCMS.

[84de860](https://github.com/ministryofjustice/laa-apply-for-legal-aid/commit/84de86076b1f04237a9ef7b56aced66f175707c1) - ensures that `submission.save!` is called after any change to the `submission` object. This will mean that any sidekiq worker that subsequently updates the same `submission` will always be working on the latest version of that object. 

[531f45e](https://github.com/ministryofjustice/laa-apply-for-legal-aid/commit/531f45e696409adc692ef9fa5ec29c1c7d1f7f20) - the CCMS submission state machine calls `process_async!` after each change in state. This is duplicating the call done by
`SubmissionProcessWorker` and is causing multiple requests to be sent to CCMS at each step of the process. This commit removes the calls from the CCMS submission state machine to prevent this.

[ca59872](https://github.com/ministryofjustice/laa-apply-for-legal-aid/commit/ca59872b9044480e2b33777524139de4364b2922) - an extra unnecessary document id request is always being made when submitting an application because the memoized `response` method is being called when the history is written, which is causing an additional request to be made. This commit fixes that by changing `response` to an instance variable, which is assigned to in the `request_document_ids` and simply read from when creating the history record. This change highlighted the fact that there is some unnecessary logic present in the `ObtainDocumentIdService` class to create a history record when no documents exist. This is also done in the `AddCaseService` class, so this commit removes that logic and refactors some tests.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
