### PR TITLE
AP-1035 fix bug where saved applications showing as submitted

### DIFF
--- a/app/controllers/providers/merits_declarations_controller.rb
+++ b/app/controllers/providers/merits_declarations_controller.rb
@@ -5,10 +5,11 @@ module Providers
     def update
       unless draft_selected?
         legal_aid_application.generate_reports! if legal_aid_application.may_generate_reports?
-        merits_assessment.update!(submitted_at: Time.current) unless merits_assessment.submitted_at?
+        merits_assessment.submit!
       end
       continue_or_draft
     end
+
 
     private
 

--- a/app/controllers/providers/merits_declarations_controller.rb
+++ b/app/controllers/providers/merits_declarations_controller.rb
@@ -3,8 +3,10 @@ module Providers
     def show; end
 
     def update
-      legal_aid_application.generate_reports! unless draft_selected? || !legal_aid_application.may_generate_reports?
-      merits_assessment.update!(submitted_at: Time.current) unless merits_assessment.submitted_at?
+      unless draft_selected?
+        legal_aid_application.generate_reports! if legal_aid_application.may_generate_reports?
+        merits_assessment.update!(submitted_at: Time.current) unless merits_assessment.submitted_at?
+      end
       continue_or_draft
     end
 

--- a/app/controllers/providers/merits_declarations_controller.rb
+++ b/app/controllers/providers/merits_declarations_controller.rb
@@ -10,7 +10,6 @@ module Providers
       continue_or_draft
     end
 
-
     private
 
     def merits_assessment

--- a/app/models/merits_assessment.rb
+++ b/app/models/merits_assessment.rb
@@ -14,6 +14,6 @@ class MeritsAssessment < ApplicationRecord
   end
 
   def submit!
-    self.update!(submitted_at: Time.current) unless submitted_at?
+    update!(submitted_at: Time.current) unless submitted_at?
   end
 end

--- a/app/models/merits_assessment.rb
+++ b/app/models/merits_assessment.rb
@@ -12,4 +12,8 @@ class MeritsAssessment < ApplicationRecord
   def self.prospects_unlikely_to_succeed
     success_prospects.except(:likely).keys
   end
+
+  def submit!
+    self.update!(submitted_at: Time.current) unless submitted_at?
+  end
 end

--- a/spec/requests/providers/merits_declarations_spec.rb
+++ b/spec/requests/providers/merits_declarations_spec.rb
@@ -5,6 +5,10 @@ RSpec.describe Providers::MeritsDeclarationsController, type: :request do
   let(:legal_aid_application) { create :legal_aid_application, :with_proceeding_types, :with_everything, state: :checked_merits_answers }
   let(:provider) { legal_aid_application.provider }
 
+  before do
+    legal_aid_application.merits_assessment.update submitted_at: nil
+  end
+
   describe 'GET /providers/applications/:id/merits_declaration' do
     subject { get providers_legal_aid_application_merits_declaration_path(legal_aid_application) }
 
@@ -55,6 +59,11 @@ RSpec.describe Providers::MeritsDeclarationsController, type: :request do
           subject
           ReportsCreatorWorker.drain
         end
+
+        it 'sets the merits assessment to submitted' do
+          subject
+          expect(legal_aid_application.reload.summary_state).to eq :submitted
+        end
       end
 
       context 'Form submitted using Save as draft button' do
@@ -68,6 +77,11 @@ RSpec.describe Providers::MeritsDeclarationsController, type: :request do
         it 'sets the application as draft' do
           subject
           expect(legal_aid_application.reload).to be_draft
+        end
+
+        it 'does not set it to submitted' do
+          subject
+          expect(legal_aid_application.reload.summary_state).to eq :in_progress
         end
       end
     end


### PR DESCRIPTION
## Bug fix - saved applications showing as submitted

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1035)

If the user pressed Save as Draft on the Merits Declaration page, the `submitted_at` field was being set on the `MeritsAssessment` which in turn caused the application to be shown as 'Submitted` on the index page.

- Amended  conditions under which `submitted_at` was set
- wrote specs to test the behaviour for both Save as Draft and Continue scenarios

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
