### PR TITLE
AP-1059 CCMS warning letter and savings attributes

### DIFF
--- a/app/services/ccms/attribute_value_generator.rb
+++ b/app/services/ccms/attribute_value_generator.rb
@@ -120,10 +120,6 @@ module CCMS
       not_zero? other_assets.second_home_value
     end
 
-    def applicant_has_bank_accounts?(_options)
-      applicant.bank_accounts.any?
-    end
-
     def applicant_has_other_capital?(_options)
       not_zero? savings.peps_unit_trusts_capital_bonds_gov_stocks
     end
@@ -138,6 +134,10 @@ module CCMS
 
     def applicant_has_shares?(_options)
       not_zero? savings.plc_shares
+    end
+
+    def applicant_is_signatory_to_other_person_accounts?(_options)
+      not_zero? savings.other_person_account
     end
 
     def lead_proceeding_type_default_level_of_service(_options)

--- a/app/services/ccms/attribute_value_generator.rb
+++ b/app/services/ccms/attribute_value_generator.rb
@@ -180,6 +180,10 @@ module CCMS
       @legal_aid_application.used_delegated_functions? ? 'Both' : 'Substantive'
     end
 
+    def no_warning_letter_sent?(_options)
+      !@legal_aid_application.respondent.warning_letter_sent
+    end
+
     PROSPECTS_OF_SUCCESS = {
       likely: 'Good',
       marginal: 'Marginal',

--- a/config/ccms/ccms_keys.yml
+++ b/config/ccms/ccms_keys.yml
@@ -4653,7 +4653,7 @@ proceeding_merits:
     :user_defined: false
     :generate_block?: false
   WARNING_LETTER_SENT:
-    :value: false
+    :value: "#respondent_warning_letter_sent"
     :response_type: boolean
     :user_defined: true
   POLICE_NOTIFIED:
@@ -4888,7 +4888,8 @@ proceeding_merits:
     :response_type: boolean
     :user_defined: true
   INJ_REASON_NO_WARNING_LETTER:
-    :value: 'Apply Service application. See uploaded provider statement and report'
+    :generate_block?: '#no_warning_letter_sent?'
+    :value: '#respondent_warning_letter_sent_details'
     :br100_meaning: 'Inj: The Reason Why No Warning Letter Has Been Sent'
     :response_type: text
     :user_defined: true

--- a/config/ccms/ccms_keys.yml
+++ b/config/ccms/ccms_keys.yml
@@ -438,7 +438,7 @@ global_means:
     :response_type: boolean
     :user_defined: false
   GB_INPUT_B_8WP2_1A:
-    :value: false
+    :value: '#applicant_is_signatory_to_other_person_accounts?'
     :br100_meaning: '3rd party accounts: The client is signatory to bank accounts?'
     :response_type: boolean
     :user_defined: true
@@ -893,7 +893,7 @@ global_means:
     :response_type: currency
     :user_defined: false
   GB_INPUT_B_17WP2_7A:
-    :value: '#applicant_has_other_capital?'
+    :value: false
     :br100_meaning: 'Other capital: The client has other capital?'
     :response_type: boolean
     :user_defined: true
@@ -1189,7 +1189,7 @@ global_means:
     :response_type: text
     :user_defined: false
   GB_INPUT_B_7WP2_1A:
-    :value: '#applicant_has_bank_accounts?'
+    :value: '#applicant_has_other_savings?'
     :br100_meaning: 'Bank accounts: The client has bank accounts?'
     :response_type: boolean
     :user_defined: true
@@ -1683,7 +1683,7 @@ global_means:
     :response_type: boolean
     :user_defined: false
   GB_INPUT_B_10WP2_1A:
-    :value: '#applicant_has_other_savings?'
+    :value: '#applicant_has_other_capital?'
     :br100_meaning: 'Other savings: The client has other savings?'
     :response_type: boolean
     :user_defined: true

--- a/spec/services/ccms/case_add_requestor_spec.rb
+++ b/spec/services/ccms/case_add_requestor_spec.rb
@@ -221,7 +221,7 @@ module CCMS # rubocop:disable Metrics/ModuleLength
         double Respondent,
                understands_terms_of_court_order?: true,
                understands_terms_of_court_order_details: '',
-               warning_letter_sent?: false,
+               warning_letter_sent: false,
                warning_letter_sent_details: 'Standard cease and desist letter',
                police_notified?: true,
                police_notified_details: '',

--- a/spec/services/ccms/case_add_requestor_xml_blocks_spec.rb
+++ b/spec/services/ccms/case_add_requestor_xml_blocks_spec.rb
@@ -392,11 +392,30 @@ module CCMS # rubocop:disable Metrics/ModuleLength
         end
       end
 
-      context 'WARNING_LETTER_SENT not sent' do
-        before { respondent.update(warning_letter_sent: false) }
-        it 'generates WARNING_LETTER_SENT block with false value' do
-          block = XmlExtractor.call(xml, :global_merits, 'WARNING_LETTER_SENT')
-          expect(block).to have_boolean_response false
+      context 'WARNING_LETTER_SENT' do
+        context 'letter has not been sent' do
+          it 'generates WARNING_LETTER_SENT block with false value' do
+            block = XmlExtractor.call(xml, :global_merits, 'WARNING_LETTER_SENT')
+            expect(block).to have_boolean_response false
+          end
+
+          it 'includes correct text in INJ_REASON_NO_WARNING_LETTER block' do
+            block = XmlExtractor.call(xml, :global_merits, 'INJ_REASON_NO_WARNING_LETTER')
+            expect(block).to have_text_response respondent.warning_letter_sent_details
+          end
+        end
+
+        context 'letter has been sent' do
+          before { respondent.update(warning_letter_sent: true) }
+          it 'generates WARNING_LETTER_SENT block with true value' do
+            block = XmlExtractor.call(xml, :global_merits, 'WARNING_LETTER_SENT')
+            expect(block).to have_boolean_response true
+          end
+
+          it 'does not generate the INJ_REASON_NO_WARNING_LETTER block' do
+            block = XmlExtractor.call(xml, :global_merits, 'INJ_REASON_NO_WARNING_LETTER')
+            expect(block).not_to be_present, 'Expected block for attribute INJ_REASON_NO_WARNING_LETTER not to be generated, but was in global_merits'
+          end
         end
       end
 
@@ -1127,10 +1146,8 @@ module CCMS # rubocop:disable Metrics/ModuleLength
 
         it 'should be hard coded with the correct notification' do
           attributes = [
-            [:proceeding_merits, 'INJ_REASON_NO_WARNING_LETTER'],
             [:proceeding_merits, 'INJ_RECENT_INCIDENT_DETAIL'],
             [:global_merits, 'INJ_REASON_POLICE_NOT_NOTIFIED'],
-            [:global_merits, 'INJ_REASON_NO_WARNING_LETTER']
           ]
           attributes.each do |entity_attribute_pair|
             entity, attribute = entity_attribute_pair
@@ -2103,8 +2120,7 @@ module CCMS # rubocop:disable Metrics/ModuleLength
         [:opponent, 'RELATIONSHIP_SOL_BARRISTER'],
         [:opponent, 'RELATIONSHIP_STEP_PARENT'],
         [:opponent, 'RELATIONSHIP_SUPPLIER'],
-        [:opponent, 'RELATIONSHIP_TENANT'],
-        [:proceeding_merits, 'WARNING_LETTER_SENT']
+        [:opponent, 'RELATIONSHIP_TENANT']
       ]
     end
   end

--- a/spec/services/ccms/case_add_requestor_xml_blocks_spec.rb
+++ b/spec/services/ccms/case_add_requestor_xml_blocks_spec.rb
@@ -904,8 +904,24 @@ module CCMS # rubocop:disable Metrics/ModuleLength
 
         context 'GB_INPUT_B_7WP2_1A no bank accounts' do
           it 'returns false when applicant does NOT have bank accounts' do
-            allow(legal_aid_application.applicant).to receive(:bank_accounts).and_return([])
+            allow(legal_aid_application.savings_amount).to receive(:offline_current_accounts).and_return(nil)
+            allow(legal_aid_application.savings_amount).to receive(:offline_savings_accounts).and_return(nil)
             block = XmlExtractor.call(xml, :global_means, 'GB_INPUT_B_7WP2_1A')
+            expect(block).to have_boolean_response false
+          end
+        end
+      end
+
+      context 'GB_INPUT_B_8WP2_1A client is signatory to other bank accounts' do
+        it 'returns true when client is a signatory to other bank accounts' do
+          block = XmlExtractor.call(xml, :global_means, 'GB_INPUT_B_8WP2_1A')
+          expect(block).to have_boolean_response true
+        end
+
+        context 'GB_INPUT_B_8WP2_1A client is not a signatory to other bank accounts' do
+          it 'returns false when applicant is NOT a signatory to other bank accounts' do
+            allow(legal_aid_application.savings_amount).to receive(:other_person_account).and_return(nil)
+            block = XmlExtractor.call(xml, :global_means, 'GB_INPUT_B_8WP2_1A')
             expect(block).to have_boolean_response false
           end
         end
@@ -927,22 +943,8 @@ module CCMS # rubocop:disable Metrics/ModuleLength
         end
 
         it 'returns false when client does NOT have other savings' do
-          allow(legal_aid_application.savings_amount).to receive(:offline_current_accounts).and_return(nil)
-          allow(legal_aid_application.savings_amount).to receive(:offline_savings_accounts).and_return(nil)
-          block = XmlExtractor.call(xml, :global_means, 'GB_INPUT_B_10WP2_1A')
-          expect(block).to have_boolean_response false
-        end
-      end
-
-      context 'GB_INPUT_B_17WP2_7A client other capital' do
-        it 'returns true when client has other capital' do
-          block = XmlExtractor.call(xml, :global_means, 'GB_INPUT_B_17WP2_7A')
-          expect(block).to have_boolean_response true
-        end
-
-        it 'returns false when client does NOT have other capital' do
           allow(legal_aid_application.savings_amount).to receive(:peps_unit_trusts_capital_bonds_gov_stocks).and_return(nil)
-          block = XmlExtractor.call(xml, :global_means, 'GB_INPUT_B_17WP2_7A')
+          block = XmlExtractor.call(xml, :global_means, 'GB_INPUT_B_10WP2_1A')
           expect(block).to have_boolean_response false
         end
       end
@@ -1147,7 +1149,7 @@ module CCMS # rubocop:disable Metrics/ModuleLength
         it 'should be hard coded with the correct notification' do
           attributes = [
             [:proceeding_merits, 'INJ_RECENT_INCIDENT_DETAIL'],
-            [:global_merits, 'INJ_REASON_POLICE_NOT_NOTIFIED'],
+            [:global_merits, 'INJ_REASON_POLICE_NOT_NOTIFIED']
           ]
           attributes.each do |entity_attribute_pair|
             entity, attribute = entity_attribute_pair
@@ -1902,6 +1904,7 @@ module CCMS # rubocop:disable Metrics/ModuleLength
         [:global_means, 'GB_INPUT_B_1WP3_165A'],
         [:global_means, 'GB_INFER_B_1WP1_1A'],
         [:global_means, 'GB_INPUT_B_14WP2_7A'],
+        [:global_means, 'GB_INPUT_B_17WP2_7A'],
         [:global_means, 'GB_INPUT_B_18WP2_2A'],
         [:global_means, 'GB_INPUT_B_18WP2_4A'],
         [:global_means, 'GB_INPUT_B_1WP1_2A'],
@@ -1912,7 +1915,6 @@ module CCMS # rubocop:disable Metrics/ModuleLength
         [:global_means, 'GB_INPUT_B_41WP3_40A'],
         [:global_means, 'GB_INPUT_B_5WP1_22A'],
         [:global_means, 'GB_INPUT_B_5WP1_3A'],
-        [:global_means, 'GB_INPUT_B_8WP2_1A'],
         [:global_means, 'GB_PROC_B_39WP3_14A'],
         [:global_means, 'GB_PROC_B_39WP3_15A'],
         [:global_means, 'GB_PROC_B_39WP3_16A'],


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1059)

This PR fixes a number of issues with attributes being injected into CCMS:

- `WARNING_LETTER_SENT` - will populate the correct value from the database
- `INJ_REASON_NO_WARNING_LETTER` - will populate the correct value from the database if `WARNING_LETTER_SENT` is `false`, and be omitted otherwise

- `GB_INPUT_B_7WP2_1A` - will be `true` if `offline_current_accounts` or `offline_savings_accounts` are populated in the database, otherwise `false`

- `GB_INPUT_B_8WP2_1A` - this will be `true` if `other_person_account` is populated in the database, otherwise `false`

- `GB_INPUT_B_10WP2_1A` - this will be `true` if `peps_unit_trusts_capital_bonds_gov_stocks` is populated in the database, otherwise `false`

- `GB_INPUT_B_17WP2_7A` - this will be hardcoded to `false`

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
