### PR TITLE
AP-1064 CCMS valuable possessions

### DIFF
--- a/app/services/ccms/attribute_value_generator.rb
+++ b/app/services/ccms/attribute_value_generator.rb
@@ -50,7 +50,7 @@ module CCMS
     end
 
     def valuable_possessions_aggregate_value(_options)
-      1000.0 # TODO: CCMS placeholder
+      other_assets.valuable_items_value
     end
 
     def bank_name(options)

--- a/app/services/ccms/attribute_value_generator.rb
+++ b/app/services/ccms/attribute_value_generator.rb
@@ -93,7 +93,7 @@ module CCMS
       not_zero? other_assets.trust_value
     end
 
-    def applicant_has_valuable_posessions?(_options)
+    def applicant_has_valuable_possessions?(_options)
       not_zero? other_assets.valuable_items_value
     end
 

--- a/config/ccms/ccms_keys.yml
+++ b/config/ccms/ccms_keys.yml
@@ -2221,7 +2221,7 @@ global_means:
     :response_type: currency
     :user_defined: false
   GB_INPUT_B_12WP2_2A:
-    :value: '#applicant_has_valuable_posessions?'
+    :value: '#applicant_has_valuable_possessions?'
     :br100_meaning: 'Val. possessions: The client has valuable possessions valued
       at £500+?'
     :response_type: boolean
@@ -5123,13 +5123,13 @@ proceeding_merits:
     :generate_block?: false
 valuable_possessions:
   VALPOSSESS_INPUT_T_12WP2_7A:
-    :generate_block?: '#applicant_has_valuable_posessions?'
+    :generate_block?: '#applicant_has_valuable_possessions?'
     :value: Aggregate of valuable possessions
     :br100_meaning: 'Val. possessions: What it is'
     :response_type: text
     :user_defined: true
   VALPOSSESS_INPUT_C_12WP2_8A:
-    :generate_block?: '#applicant_has_valuable_posessions?'
+    :generate_block?: '#applicant_has_valuable_possessions?'
     :value: "#valuable_possessions_aggregate_value"
     :br100_meaning: 'Val. possessions: Sale value'
     :response_type: currency

--- a/config/ccms/ccms_keys.yml
+++ b/config/ccms/ccms_keys.yml
@@ -5123,11 +5123,13 @@ proceeding_merits:
     :generate_block?: false
 valuable_possessions:
   VALPOSSESS_INPUT_T_12WP2_7A:
+    :generate_block?: '#applicant_has_valuable_posessions?'
     :value: Aggregate of valuable possessions
     :br100_meaning: 'Val. possessions: What it is'
     :response_type: text
     :user_defined: true
   VALPOSSESS_INPUT_C_12WP2_8A:
+    :generate_block?: '#applicant_has_valuable_posessions?'
     :value: "#valuable_possessions_aggregate_value"
     :br100_meaning: 'Val. possessions: Sale value'
     :response_type: currency

--- a/spec/services/ccms/case_add_requestor_xml_blocks_spec.rb
+++ b/spec/services/ccms/case_add_requestor_xml_blocks_spec.rb
@@ -777,15 +777,35 @@ module CCMS # rubocop:disable Metrics/ModuleLength
       end
 
       context 'GB_INPUT_B_12WP2_2A client valuable possessions' do
-        it 'returns true when client has valuable possessions' do
+        it 'returns true' do
           block = XmlExtractor.call(xml, :global_means, 'GB_INPUT_B_12WP2_2A')
           expect(block).to have_boolean_response true
         end
 
-        it 'returns false when client has NO valuable possessions' do
-          allow(legal_aid_application.other_assets_declaration).to receive(:valuable_items_value).and_return(nil)
-          block = XmlExtractor.call(xml, :global_means, 'GB_INPUT_B_12WP2_2A')
-          expect(block).to have_boolean_response false
+        it 'displays VALPOSSESS_INPUT_T_12WP2_7A' do
+          block = XmlExtractor.call(xml, :global_means, 'VALPOSSESS_INPUT_T_12WP2_7A')
+          expect(block).to have_text_response 'Aggregate of valuable possessions'
+        end
+
+        it 'displays VALPOSSESS_INPUT_C_12WP2_8A' do
+          block = XmlExtractor.call(xml, :global_means, 'VALPOSSESS_INPUT_C_12WP2_8A')
+          expect(block).to have_currency_response legal_aid_application.other_assets_declaration.valuable_items_value
+        end
+
+        context 'when client has NO valuable possessions' do
+          before { allow(legal_aid_application.other_assets_declaration).to receive(:valuable_items_value).and_return(nil) }
+
+          it 'returns false' do
+            block = XmlExtractor.call(xml, :global_means, 'GB_INPUT_B_12WP2_2A')
+            expect(block).to have_boolean_response false
+          end
+
+          it 'does not display VALPOSSESS_INPUT_T_12WP2_7A or VALPOSSESS_INPUT_C_12WP2_8A' do
+            %i[VALPOSSESS_INPUT_T_12WP2_7A VALPOSSESS_INPUT_T_12WP2_8A].each do |attribute|
+              block = XmlExtractor.call(xml, :global_means, attribute)
+              expect(block).not_to be_present, "Expected block for attribute #{attribute} not to be generated, but was \n #{block}"
+            end
+          end
         end
       end
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1064)

`VALPOSSESS_INPUT_C_12WP2_8A` is being hard coded as 1000, resulting in incorrect data being injected to CCMS.

This PR amends the valuable_possessions_aggregate_value method in `attribute_value_generator.rb` so that it returns the correct value (`other_assets_declaration.valuable_items_value`).

It also adds some validation so that `VALPOSSESS_INPUT_C_12WP2_7A` and `VALPOSSESS_INPUT_C_12WP2_8A` are only populated in the payload if `GB_INPUT_B_12WP2_2A` is `true` (ie valuable possessions exist).

It also corrects some minor typoes.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
