### PR TITLE
AP-1057 Amend hard coded text in CCMS payloads

### DIFF
--- a/config/ccms/ccms_keys.yml
+++ b/config/ccms/ccms_keys.yml
@@ -2588,7 +2588,7 @@ global_merits:
     :response_type: text
     :user_defined: false
   REASON_APPLYING_FHH_LR:
-    :value: Apply Service application. See provider statement of case and report uploaded as evidence
+    :value: .
     :br100_meaning: 'PrevLA: The ReasonThe Client Is Applying For Family Help (Higher)
       Or Legal Rep'
     :response_type: text
@@ -2713,7 +2713,7 @@ global_merits:
     :response_type: boolean
     :user_defined: false
   EMERGENCY_FC_CRITERIA:
-    :value: Apply Service application - see uploaded provider statement of case
+    :value: .
     :br100_meaning: 'Emg: The Reason Why The Application Meets The Emergency Criteria '
     :response_type: text
     :user_defined: true
@@ -3083,7 +3083,7 @@ global_merits:
     :response_type: boolean
     :user_defined: true
   MAIN_PURPOSE_OF_APPLICATION:
-    :value: Apply Service application - see report and uploaded statement in CCMS upload section
+    :value: .
     :br100_meaning: 'App: The Main Purpose Of The Application'
     :response_type: text
     :user_defined: true
@@ -3660,7 +3660,7 @@ global_merits:
     :response_type: boolean
     :user_defined: false
   REASON_SEPARATE_REP_REQ:
-    :value: Apply Service application. See provider statement of case and report uploaded as evidence
+    :value: .
     :br100_meaning: 'Rep: The reason client requires separate representation in proceedings'
     :response_type: text
     :user_defined: true
@@ -3774,7 +3774,7 @@ global_merits:
     :response_type: boolean
     :user_defined: false
   REASON_NO_ATTEMPT_TO_SETTLE:
-    :value: Apply Service application. See provider statement of case and report uploaded as evidence
+    :value: .
     :br100_meaning: 'Settle: The Reason Why No Attempts To Settle Have Been Made'
     :response_type: text
     :user_defined: true
@@ -4013,7 +4013,7 @@ global_merits:
     :user_defined: true
   EMERGENCY_FURTHER_INFORMATION:
     :generate_block?: '#application_used_delegated_functions?'
-    :value: 'Apply Service application - see uploaded provider statement of case'
+    :value: .
     :br100_meaning: 'Emg: Additional Information'
     :response_type: text
     :user_defined: true
@@ -4889,7 +4889,7 @@ proceeding_merits:
     :user_defined: true
   INJ_REASON_NO_WARNING_LETTER:
     :generate_block?: '#no_warning_letter_sent?'
-    :value: '#respondent_warning_letter_sent_details'
+    :value: .
     :br100_meaning: 'Inj: The Reason Why No Warning Letter Has Been Sent'
     :response_type: text
     :user_defined: true
@@ -4967,12 +4967,12 @@ proceeding_merits:
     :user_defined: false
     :generate_block?: false
   INJ_RECENT_INCIDENT_DETAIL:
-    :value: Apply Service application. See uploaded provider statement and report
+    :value: .
     :br100_meaning: 'Inj: The Detail Of The Most Recent Incident'
     :response_type: text
     :user_defined: true
   INJ_REASON_POLICE_NOT_NOTIFIED:
-    :value: Apply Service application. See uploaded provider statement and report
+    :value: .
     :br100_meaning: 'Inj: The Reason Why The Police  Have Not Been Notified'
     :response_type: text
     :user_defined: true

--- a/spec/services/ccms/case_add_requestor_xml_blocks_spec.rb
+++ b/spec/services/ccms/case_add_requestor_xml_blocks_spec.rb
@@ -320,7 +320,7 @@ module CCMS # rubocop:disable Metrics/ModuleLength
       context 'EMERGENCY_FC_CRITERIA' do
         it 'inserts emergency_fc criteria as hard coded string' do
           block = XmlExtractor.call(xml, :global_merits, 'EMERGENCY_FC_CRITERIA')
-          expect(block).to have_text_response 'Apply Service application - see uploaded provider statement of case'
+          expect(block).to have_text_response '.'
         end
       end
 
@@ -401,7 +401,7 @@ module CCMS # rubocop:disable Metrics/ModuleLength
 
           it 'includes correct text in INJ_REASON_NO_WARNING_LETTER block' do
             block = XmlExtractor.call(xml, :global_merits, 'INJ_REASON_NO_WARNING_LETTER')
-            expect(block).to have_text_response respondent.warning_letter_sent_details
+            expect(block).to have_text_response '.'
           end
         end
 
@@ -724,7 +724,7 @@ module CCMS # rubocop:disable Metrics/ModuleLength
           end
 
           it 'returns hard coded statement' do
-            expect(block).to have_text_response 'Apply Service application - see uploaded provider statement of case'
+            expect(block).to have_text_response '.'
           end
         end
 
@@ -1169,31 +1169,17 @@ module CCMS # rubocop:disable Metrics/ModuleLength
         it 'should be hard coded with the correct notification' do
           attributes = [
             [:proceeding_merits, 'INJ_RECENT_INCIDENT_DETAIL'],
-            [:global_merits, 'INJ_REASON_POLICE_NOT_NOTIFIED']
-          ]
-          attributes.each do |entity_attribute_pair|
-            entity, attribute = entity_attribute_pair
-            block = XmlExtractor.call(xml, entity, attribute)
-            expect(block).to have_text_response 'Apply Service application. See uploaded provider statement and report'
-          end
-        end
-
-        it 'should be hard coded with the correct notification' do
-          attributes = [
+            [:global_merits, 'INJ_REASON_POLICE_NOT_NOTIFIED'],
             [:global_merits, 'REASON_APPLYING_FHH_LR'],
             [:global_merits, 'REASON_NO_ATTEMPT_TO_SETTLE'],
-            [:global_merits, 'REASON_SEPARATE_REP_REQ']
+            [:global_merits, 'REASON_SEPARATE_REP_REQ'],
+            [:global_merits, 'MAIN_PURPOSE_OF_APPLICATION']
           ]
           attributes.each do |entity_attribute_pair|
             entity, attribute = entity_attribute_pair
             block = XmlExtractor.call(xml, entity, attribute)
-            expect(block).to have_text_response 'Apply Service application. See provider statement of case and report uploaded as evidence'
+            expect(block).to have_text_response '.'
           end
-        end
-
-        it 'MAIN_PURPOSE_OF_APPLICATION should be hard coded with the correct notification' do
-          block = XmlExtractor.call(xml, :global_merits, 'MAIN_PURPOSE_OF_APPLICATION')
-          expect(block).to have_text_response 'Apply Service application - see report and uploaded statement in CCMS upload section'
         end
       end
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1057)

A number of attributes in CCMS payloads are hardcoded with a string identifying it as being an Apply application.

This text is being exposed to providers when amendments are carried out, which is not desirable (it is intended just for caseworkers).

Replace the string with a `.` to remove this issue for the following attributes:

`EMERGENCY_FC_CRITERIA`
`EMERGENCY_FURTHER_INFORMATION`
`MAIN_PURPOSE_OF_APPLICATION`
`REASON_APPLYING_FHH_LR`
`REASON_NO_ATTEMPT_TO_SETTLE`
`REASON_SEPARATE_REP_REQ`
`INJ_RECENT_INCIDENT_DETAIL`
`INJ_REASON_POLICE_NOT_NOTIFIED`

This also affects one attribute (`INJ_REASON_NO_WARNING_LETTER`) which currently displays a value from the database. It has been decided that for consistency this will also be hardcoded as `.`.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
