### PR TITLE
AP-1016 Fix CCMS delegated functions flag

### DIFF
--- a/app/services/ccms/case_add_requestor.rb
+++ b/app/services/ccms/case_add_requestor.rb
@@ -175,7 +175,7 @@ module CCMS
       xml.__send__('ns2:ScopeLimitation') do
         xml.__send__('ns2:ScopeLimitation', limitation.code)
         xml.__send__('ns2:ScopeLimitationWording', limitation.description)
-        xml.__send__('ns2:DelegatedFunctionsApply', !limitation.substantive)
+        xml.__send__('ns2:DelegatedFunctionsApply', limitation.delegated_functions)
       end
     end
 

--- a/spec/services/ccms/case_add_requestor_spec.rb
+++ b/spec/services/ccms/case_add_requestor_spec.rb
@@ -15,7 +15,7 @@ module CCMS # rubocop:disable Metrics/ModuleLength
                id: 1,
                code: 'CV118',
                description: 'Limited to all steps up to and including the hearing on 01/04/2019',
-               delegated_functions_apply: true,
+               delegated_functions: true,
                substantive: false
       end
 
@@ -35,7 +35,7 @@ module CCMS # rubocop:disable Metrics/ModuleLength
                id: 2,
                code: 'AA019',
                description: aa019_text,
-               delegated_functions_apply: false,
+               delegated_functions: false,
                substantive: true
       end
 
@@ -44,7 +44,7 @@ module CCMS # rubocop:disable Metrics/ModuleLength
                id: 3,
                code: 'FM049',
                description: 'Limited to all steps up to and including trial/final hearing and any action necessary to implement (but not enforce) the judgment or order.',
-               delegated_functions_apply: false,
+               delegated_functions: false,
                substantive: true
       end
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1016)

The `DelegatedFunctionsApply` attribute is not being correctly populated. It is being set to false on DF cases when it should be true.

This is occurring because the attribute is populated with `!limitation.substantive`, I think on the assumption that if it’s not a substantive limitation then it must be delegated functions. However this is not the case, a limitation can apply to both substantive and delegated functions cases.

This PR changes that functionality so that `DelegatedFunctionsApply` is populated with `limitation.delegated_functions`.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
