### PR TITLE
AP-923 Add /.well-known/security.txt

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -206,6 +206,8 @@ Rails.application.routes.draw do
     end
   end
 
+  get '/.well-known/security.txt' => redirect('https://raw.githubusercontent.com/ministryofjustice/security-guidance/master/contact/vulnerability-disclosure-security.txt')
+
   # Catch all route that traps paths not defined above. Must be last route.
   match '*path', to: redirect('error/page_not_found'), via: :all
 end

--- a/spec/requests/security_text_spec.rb
+++ b/spec/requests/security_text_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe 'security text page', type: :request do
+  describe 'GET /.well-known/security.txt' do
+    it 'redirects successfully' do
+      get '/.well-known/security.txt'
+      expect(response).to redirect_to('https://raw.githubusercontent.com/ministryofjustice/security-guidance/master/contact/vulnerability-disclosure-security.txt')
+    end
+  end
+end


### PR DESCRIPTION

## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-923)

[MoJ Security Guidance](https://ministryofjustice.github.io/security-guidance/contact/implement-security-txt/#implementing-securitytxt) states “Domains where the MOJ is primarily responsible for cyber security must  redirect the /.well_known/security.txt location to the central security.txt file.”

This commit adds a route to redirect to the security text here: https://raw.githubusercontent.com/ministryofjustice/security-guidance/master/contact/vulnerability-disclosure-security.txt when a user visits /.well_known/security.txt.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
