### PR TITLE
Fix issue with overlong cronjob name

### DIFF
--- a/helm_deploy/apply-for-legal-aid/templates/.dashboard_template_cron.yaml.sample
+++ b/helm_deploy/apply-for-legal-aid/templates/.dashboard_template_cron.yaml.sample
@@ -1,8 +1,9 @@
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  # NOTE The release name must not be more than 2 characters in total
-  name: {{ .Release.Name |" trunc 26 }}-ttl-submitted-applications
+  # NOTE The cronjob name must not exceed 25 characters so that when appended to the release name
+  # it doesn't exceed the limit of 52 characters
+  name: {{ .Release.Name |" trunc 26 }}-total-submitted-applics
   labels:
     app: {{ template "apply-for-legal-aid.name" . }}
     chart: {{ template "apply-for-legal-aid.chart" . }}
@@ -22,7 +23,7 @@ spec:
       template:
         spec:
           containers:
-            - name: ttl-submitted-applications
+            - name: total-submitted-applics
               image: '{{ .Values.image.repository }}:{{ .Values.image.tag }}'
               imagePullPolicy: IfNotPresent
               command: ['rake', 'job:dashboard:update[TotalSubmittedApplications]']

--- a/helm_deploy/apply-for-legal-aid/templates/.dashboard_template_cron.yaml.sample
+++ b/helm_deploy/apply-for-legal-aid/templates/.dashboard_template_cron.yaml.sample
@@ -1,7 +1,8 @@
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name: {{ .Release.Name }}-dashboard-total-submitted-applications
+  # NOTE The release name must not be more than 2 characters in total
+  name: {{ .Release.Name |" trunc 26 }}-ttl-submitted-applications
   labels:
     app: {{ template "apply-for-legal-aid.name" . }}
     chart: {{ template "apply-for-legal-aid.chart" . }}
@@ -21,7 +22,7 @@ spec:
       template:
         spec:
           containers:
-            - name: dashboard-total-submitted-applications
+            - name: ttl-submitted-applications
               image: '{{ .Values.image.repository }}:{{ .Values.image.tag }}'
               imagePullPolicy: IfNotPresent
               command: ['rake', 'job:dashboard:update[TotalSubmittedApplications]']

--- a/helm_deploy/apply-for-legal-aid/templates/dashboard_total_submitted_applications_cron.yml
+++ b/helm_deploy/apply-for-legal-aid/templates/dashboard_total_submitted_applications_cron.yml
@@ -1,7 +1,9 @@
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name: {{ .Release.Name | trunc 26 }}-ttl-submitted-applications
+  # NOTE The cronjob name must not exceed 25 characters so that when appended to the release name
+  # it doesn't exceed the limit of 52 characters
+  name: {{ .Release.Name | trunc 26 }}-total-submitted-applics
   labels:
     app: {{ template "apply-for-legal-aid.name" . }}
     chart: {{ template "apply-for-legal-aid.chart" . }}
@@ -21,7 +23,7 @@ spec:
       template:
         spec:
           containers:
-          - name: ttl-submitted-applications
+          - name: total-submitted-applics
             image: '{{ .Values.image.repository }}:{{ .Values.image.tag }}'
             imagePullPolicy: IfNotPresent
             command: ['rake', 'job:dashboard:update[TotalSubmittedApplications]']

--- a/helm_deploy/apply-for-legal-aid/templates/dashboard_total_submitted_applications_cron.yml
+++ b/helm_deploy/apply-for-legal-aid/templates/dashboard_total_submitted_applications_cron.yml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name: {{ .Release.Name | trunc 26 }}-total-submitted-applications
+  name: {{ .Release.Name | trunc 26 }}-ttl-submitted-applications
   labels:
     app: {{ template "apply-for-legal-aid.name" . }}
     chart: {{ template "apply-for-legal-aid.chart" . }}
@@ -21,7 +21,7 @@ spec:
       template:
         spec:
           containers:
-          - name: total-submitted-applications
+          - name: ttl-submitted-applications
             image: '{{ .Values.image.repository }}:{{ .Values.image.tag }}'
             imagePullPolicy: IfNotPresent
             command: ['rake', 'job:dashboard:update[TotalSubmittedApplications]']


### PR DESCRIPTION
## Fix overlong cronjob name


Changed the name of cronjob `total-submitted-applications` to `ttl-submitted-applications` so that it conformed to the 26-character limit for cronjob names

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
