### PR TITLE
AP-1032 Make admin delete all work

### DIFF
--- a/app/models/ccms/submission.rb
+++ b/app/models/ccms/submission.rb
@@ -3,7 +3,8 @@ module CCMS
     include CCMSSubmissionStateMachine
 
     belongs_to :legal_aid_application
-    has_many :submission_document
+    has_many :submission_document, dependent: :destroy
+    has_many :submission_history, dependent: :destroy
 
     validates :legal_aid_application_id, presence: true
 

--- a/db/migrate/20191114151820_add_on_delete_to_merits_assessment_fk.rb
+++ b/db/migrate/20191114151820_add_on_delete_to_merits_assessment_fk.rb
@@ -1,0 +1,6 @@
+class AddOnDeleteToMeritsAssessmentFk < ActiveRecord::Migration[5.2]
+  def change
+    remove_foreign_key :merits_assessments, :legal_aid_applications
+    add_foreign_key :merits_assessments, :legal_aid_applications, on_delete: :cascade
+  end
+end

--- a/db/migrate/20191114152212_add_on_delete_to_statement_of_case_fk.rb
+++ b/db/migrate/20191114152212_add_on_delete_to_statement_of_case_fk.rb
@@ -1,0 +1,6 @@
+class AddOnDeleteToStatementOfCaseFk < ActiveRecord::Migration[5.2]
+  def change
+    remove_foreign_key :statement_of_cases, :legal_aid_applications
+    add_foreign_key :statement_of_cases, :legal_aid_applications, on_delete: :cascade
+  end
+end

--- a/db/migrate/20191114193807_add_on_delete_to_ccms_submissions_fk.rb
+++ b/db/migrate/20191114193807_add_on_delete_to_ccms_submissions_fk.rb
@@ -1,0 +1,6 @@
+class AddOnDeleteToCcmsSubmissionsFk < ActiveRecord::Migration[5.2]
+  def change
+    remove_foreign_key :ccms_submissions, :legal_aid_applications
+    add_foreign_key :ccms_submissions, :legal_aid_applications, on_delete: :cascade
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_25_151150) do
+ActiveRecord::Schema.define(version: 2019_11_14_193807) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -665,13 +665,13 @@ ActiveRecord::Schema.define(version: 2019_10_25_151150) do
   add_foreign_key "benefit_check_results", "legal_aid_applications"
   add_foreign_key "ccms_submission_documents", "ccms_submissions", column: "submission_id"
   add_foreign_key "ccms_submission_histories", "ccms_submissions", column: "submission_id"
-  add_foreign_key "ccms_submissions", "legal_aid_applications"
+  add_foreign_key "ccms_submissions", "legal_aid_applications", on_delete: :cascade
   add_foreign_key "cfe_submissions", "legal_aid_applications"
   add_foreign_key "dependants", "legal_aid_applications"
   add_foreign_key "legal_aid_applications", "applicants"
   add_foreign_key "legal_aid_applications", "offices"
   add_foreign_key "legal_aid_applications", "providers"
-  add_foreign_key "merits_assessments", "legal_aid_applications"
+  add_foreign_key "merits_assessments", "legal_aid_applications", on_delete: :cascade
   add_foreign_key "offices", "firms"
   add_foreign_key "offices_providers", "offices"
   add_foreign_key "offices_providers", "providers"
@@ -681,7 +681,7 @@ ActiveRecord::Schema.define(version: 2019_10_25_151150) do
   add_foreign_key "providers", "offices", column: "selected_office_id"
   add_foreign_key "respondents", "legal_aid_applications"
   add_foreign_key "savings_amounts", "legal_aid_applications"
-  add_foreign_key "statement_of_cases", "legal_aid_applications"
+  add_foreign_key "statement_of_cases", "legal_aid_applications", on_delete: :cascade
   add_foreign_key "statement_of_cases", "providers", column: "provider_uploader_id"
   add_foreign_key "vehicles", "legal_aid_applications"
 end

--- a/spec/factories/ccms_submission_documents.rb
+++ b/spec/factories/ccms_submission_documents.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :ccms_submission_document, class: CCMS::SubmissionDocument do
+    submission
+
+    document_id { Faker::Number.number(digits: 8) }
+    status { 'uploaded' }
+    document_type { 'means_report' }
+    ccms_document_id { Faker::Number.number(digits: 8) }
+  end
+end

--- a/spec/factories/ccms_submission_histories.rb
+++ b/spec/factories/ccms_submission_histories.rb
@@ -1,0 +1,12 @@
+FactoryBot.define do
+  factory :ccms_submission_history, class: CCMS::SubmissionHistory do
+    submission
+
+    from_state { 'initialised' }
+    to_state { 'case_ref_obtained' }
+    success { Faker::Boolean.boolean }
+    details { Faker::Lorem.word }
+    request { Faker::Lorem.word }
+    response { Faker::Lorem.word }
+  end
+end

--- a/spec/factories/ccms_submissions.rb
+++ b/spec/factories/ccms_submissions.rb
@@ -1,0 +1,70 @@
+FactoryBot.define do
+  factory :ccms_submission, class: CCMS::Submission do
+    legal_aid_application
+
+    trait :initialised do
+      aasm_state { 'initialised' }
+    end
+
+    trait :case_ref_obtained do
+      case_ccms_reference { Faker::Number.number(digits: 12) }
+      aasm_state { 'case_ref_obtained' }
+
+      after(:create) do |submission|
+        create(:ccms_submission_history, submission: submission)
+      end
+    end
+
+    trait :applicant_submitted do
+      case_ccms_reference { Faker::Number.number(digits: 12) }
+      aasm_state { 'applicant_submitted' }
+
+      after(:create) do |submission|
+        create(:ccms_submission_history, submission: submission)
+      end
+    end
+
+    trait :applicant_ref_obtained do
+      case_ccms_reference { Faker::Number.number(digits: 12) }
+      applicant_ccms_reference { Faker::Number.number(digits: 8) }
+      aasm_state { 'applicant_ref_obtained' }
+
+      after(:create) do |submission|
+        create(:ccms_submission_history, submission: submission)
+      end
+    end
+
+    trait :document_ids_obtained do
+      case_ccms_reference { Faker::Number.number(digits: 12) }
+      applicant_ccms_reference { Faker::Number.number(digits: 8) }
+      aasm_state { 'document_ids_obtained' }
+
+      after(:create) do |submission|
+        create(:ccms_submission_history, submission: submission)
+        create(:ccms_submission_document, submission: submission)
+      end
+    end
+
+    trait :case_submitted do
+      case_ccms_reference { Faker::Number.number(digits: 12) }
+      applicant_ccms_reference { Faker::Number.number(digits: 8) }
+      aasm_state { 'case_submitted' }
+
+      after(:create) do |submission|
+        create(:ccms_submission_history, submission: submission)
+        create(:ccms_submission_document, submission: submission)
+      end
+    end
+
+    trait :case_created do
+      case_ccms_reference { Faker::Number.number(digits: 12) }
+      applicant_ccms_reference { Faker::Number.number(digits: 8) }
+      aasm_state { 'case_created' }
+
+      after(:create) do |submission|
+        create(:ccms_submission_history, submission: submission)
+        create(:ccms_submission_document, submission: submission)
+      end
+    end
+  end
+end

--- a/spec/factories/legal_aid_applications.rb
+++ b/spec/factories/legal_aid_applications.rb
@@ -294,5 +294,11 @@ FactoryBot.define do
         Reports::MeritsReportCreator.call(application)
       end
     end
+
+    trait :with_ccms_submission do
+      after :create do |application|
+        create :ccms_submission, :case_created, legal_aid_application: application
+      end
+    end
   end
 end

--- a/spec/factories/legal_aid_applications.rb
+++ b/spec/factories/legal_aid_applications.rb
@@ -190,6 +190,8 @@ FactoryBot.define do
       with_incident
       with_vehicle
       with_transaction_period
+      with_other_assets_declaration
+      with_savings_amount
     end
 
     trait :with_everything_and_address do
@@ -209,6 +211,8 @@ FactoryBot.define do
       with_incident
       with_vehicle
       with_transaction_period
+      with_other_assets_declaration
+      with_savings_amount
     end
 
     trait :with_negative_benefit_check_result do
@@ -273,6 +277,20 @@ FactoryBot.define do
       with_merits_statement_of_case
       state { :checking_merits_answers }
       provider_step { :check_merits_answers }
+    end
+
+    trait :at_assessment_submitted do
+      with_everything_and_address
+      with_positive_benefit_check_result
+      with_substantive_scope_limitation
+      with_delegated_functions_scope_limitation
+      with_delegated_functions
+      with_cfe_result
+      with_means_report
+      with_merits_report
+      with_ccms_submission
+      state { :assessment_submitted }
+      provider_step { :end_of_application }
     end
 
     trait :with_cfe_result do

--- a/spec/requests/admin/legal_aid_applications_spec.rb
+++ b/spec/requests/admin/legal_aid_applications_spec.rb
@@ -162,7 +162,7 @@ RSpec.describe Admin::LegalAidApplicationsController, type: :request do
       end
 
       context 'with a lot of associations' do
-        let!(:application) { create :legal_aid_application, :with_everything }
+        let!(:application) { create :legal_aid_application, :at_assessment_submitted }
 
         it 'gets deleted too' do
           expect { subject }.to change { LegalAidApplication.count }.by(-1)


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1032)

The button in the Admin screen to Delete All cases does not currently work. It fails due to FK violations in various relations.

This PR does three things:

* It fixes the violations by adding `dependent: :destroy` to the `CCMS::Submission` model for `SubmissionHistory` and `SubmissionDocument` associations, and `on_delete: :cascade` to three foreign keys. This will ensure that all data can be successfully deleted.

* Updates the `with a lot of associations` test in `admin/legal_aid_applications_spec`. This test was previously using an application created with the `:with_everything` trait. This trait has not been updated as extra associations have been added to the app, and so the test was passing even though the functionality did not work. Adding extra associations to this trait now is problematic as it causes many other tests to fail and increases the execution time of the test suite dramatically. Instead I've added a new trait `:at_assessment_submitted`, which represents an application at the end of the Apply process, and uses it in the `with a lot of associations` test. This includes all present associations. It will need to be kept up-do-date as more are added otherwise this will become a problem again in future.

* Adds factories for creating CCMS `Submissions`, `SubmissionHistories` and `SubmissionDocuments`, as these are needed for testing.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
