### PR TITLE
FIX matching error in XML blocks for decimals ending in 0

### DIFF
--- a/spec/support/xml_attribute_block_matcher.rb
+++ b/spec/support/xml_attribute_block_matcher.rb
@@ -70,12 +70,30 @@ module XMLBlockMatchers
   def validate_expectation(actual, expected_value, expected_response_type)
     return 'Block not found' if actual.blank?
 
+    formatted_expected_value = if formatted_decimal?(expected_value, expected_response_type)
+                                 format('%<val>12.2f', val: expected_value).squish
+                               else
+                                 expected_value
+                               end
+
+    # formatted_expected_value = expected_response_type.in?(%w(number currency)) ? format('%12.2f', expected_value).squish : expected_value
+
     actual_response_type = actual.css('ResponseType').text
     return "Expected response type '#{expected_response_type}', got '#{actual_response_type}'" unless actual_response_type == expected_response_type
 
     actual_value = actual.css('ResponseValue').text
-    return "Expected value '#{expected_value}', got '#{actual_value}'" unless actual_value.squish == expected_value.squish
+    return "Expected value '#{formatted_expected_value}', got '#{actual_value}'" unless actual_value.squish == formatted_expected_value
 
     :ok
+  end
+
+  def formatted_decimal?(expected_value, expected_response_type)
+    return true if expected_response_type == 'currency'
+
+    return false unless expected_response_type == 'numeric'
+
+    return false if expected_value.is_a?(Integer)
+
+    true
   end
 end

--- a/spec/support/xml_attribute_block_matcher.rb
+++ b/spec/support/xml_attribute_block_matcher.rb
@@ -76,8 +76,6 @@ module XMLBlockMatchers
                                  expected_value
                                end
 
-    # formatted_expected_value = expected_response_type.in?(%w(number currency)) ? format('%12.2f', expected_value).squish : expected_value
-
     actual_response_type = actual.css('ResponseType').text
     return "Expected response type '#{expected_response_type}', got '#{actual_response_type}'" unless actual_response_type == expected_response_type
 


### PR DESCRIPTION
## What

The `XMLBlockMatchers` was not correctly matching XML attribute strings when they were decimals with zeros as decimal places.  For example `1234.00` would fail because it didn't match `1234.0`.

Describe what you did and why.
- Chnaged the matcher to recognise currency and numeric decimals and format the expected value to two decimal places before comparison.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
