### PR TITLE
Fix issues with feature tests

### DIFF
--- a/features/providers/check_your_answers.feature
+++ b/features/providers/check_your_answers.feature
@@ -60,7 +60,7 @@ Feature: Checking answers backwards and forwards
     And the answer for 'Own home' should be 'Yes, with a mortgage or loan'
     And the answer for 'Property value' should be '£200,000.00'
     And the answer for 'Outstanding mortgage' should be '£100,000.00'
-    And the answer for 'Shared ownership' should be 'No, they're the sole owner'
+    And the answer for 'Shared ownership' should be "No, they're the sole owner"
     And the answer for 'Restrictions' should be 'Yes'
     And the answer for 'Restrictions' should be 'Restrictions include:'
 

--- a/features/step_definitions/civil_journey_steps.rb
+++ b/features/step_definitions/civil_journey_steps.rb
@@ -271,7 +271,7 @@ And('I search for proceeding {string}') do |proceeding_search|
 end
 
 And(/^I should not see "(.*?)"$/) do |arg1|
-  page.should have_no_content(arg1)
+  expect(page).to have_no_content(arg1)
 end
 
 When(/^I click clear search$/) do


### PR DESCRIPTION
## What

```features/providers/check_your_answers.feature:36```
was failing due to an ```'``` in the matching text, however instead of failing noticeably it reported ```You can implement step definitions for undefined steps with these snippets:``` and as a ```pending test``` it is skipped over by any of the checks.

```bundle exec cucumber features/providers/civil_application_journey.feature:429```
was showing a deprecation warning over the use of ```should```. I changed this to use the preferred ```expect```

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
