### PR TITLE
AP-1081 delegated function cost limitation

### DIFF
--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -234,7 +234,7 @@ class LegalAidApplication < ApplicationRecord # rubocop:disable Metrics/ClassLen
   end
 
   def default_cost_limitation
-    used_delegated_functions? ? default_delegated_functions_cost_limitation : default_substantive_cost_limitation
+    default_substantive_cost_limitation
   end
 
   def default_substantive_cost_limitation

--- a/app/services/ccms/case_add_requestor.rb
+++ b/app/services/ccms/case_add_requestor.rb
@@ -75,7 +75,7 @@ module CCMS
       xml.__send__('ns2:Proceedings') { generate_proceedings(xml) }
       xml.__send__('ns2:MeansAssesments') { generate_means_assessment(xml) }
       xml.__send__('ns2:MeritsAssesments') { generate_merits_assessment(xml) }
-      xml.__send__('ns2:DevolvedPowersDate', '2019-04-01') # TODO: CCMS placeholder
+      xml.__send__('ns2:DevolvedPowersDate', @legal_aid_application.used_delegated_functions_on.to_s(:ccms_date)) if @legal_aid_application.used_delegated_functions?
       xml.__send__('ns2:ApplicationAmendmentType', @legal_aid_application.used_delegated_functions? ? 'SUBDP' : 'SUB')
       xml.__send__('ns2:LARDetails') { generate_lar_details(xml) }
     end

--- a/spec/models/legal_aid_application_spec.rb
+++ b/spec/models/legal_aid_application_spec.rb
@@ -487,9 +487,9 @@ RSpec.describe LegalAidApplication, type: :model do
     end
 
     context 'delegated functions' do
-      let(:application) { create :legal_aid_application, :with_delegated_functions,  proceeding_types: [proceeding_type] }
-      it 'returns the delegated fucntions cost limitation for the first proceeding type' do
-        expect(application.default_cost_limitation).to eq 2_500
+      let(:application) { create :legal_aid_application, :with_delegated_functions, proceeding_types: [proceeding_type] }
+      it 'returns the subtantive cost limitation for the first proceeding type' do
+        expect(application.default_cost_limitation).to eq 9_000
       end
     end
   end

--- a/spec/services/ccms/case_add_requestor_xml_blocks_spec.rb
+++ b/spec/services/ccms/case_add_requestor_xml_blocks_spec.rb
@@ -19,6 +19,7 @@ module CCMS # rubocop:disable Metrics/ModuleLength
                :with_everything,
                :with_applicant_and_address,
                :with_positive_benefit_check_result,
+               :with_proceeding_types,
                :with_substantive_scope_limitation,
                populate_vehicle: true,
                with_bank_accounts: 2,
@@ -44,6 +45,24 @@ module CCMS # rubocop:disable Metrics/ModuleLength
           filename = Rails.root.join('tmp/generated_ccms_payload.xml')
           File.open(filename, 'w') { |f| f.puts xml }
           expect(File.exist?(filename)).to be true
+        end
+      end
+
+      context 'DevolvedPowersDate' do
+        context 'on a Substantive case' do
+          it 'is omitted' do
+            block = XmlExtractor.call(xml, :devolved_powers_date)
+            expect(block).not_to be_present, "Expected block for attribute DevolvedPowersDate not to be generated, but was \n #{block}"
+          end
+        end
+
+        context 'on a Delegated Functions case' do
+          before { legal_aid_application.update(used_delegated_functions_on: Date.today, used_delegated_functions: true) }
+
+          it 'is populated with the delegated functions date' do
+            block = XmlExtractor.call(xml, :devolved_powers_date)
+            expect(block.children.text).to eq legal_aid_application.used_delegated_functions_on.to_s(:ccms_date)
+          end
         end
       end
 

--- a/spec/support/xml_extractor.rb
+++ b/spec/support/xml_extractor.rb
@@ -17,8 +17,8 @@ class XmlExtractor
     valuable_possessions_entity: %(/Envelope/Body/CaseAddRQ/Case/CaseDetails/ApplicationDetails/MeansAssesments/AssesmentResults/AssesmentDetails/AssessmentScreens/Entity[EntityName = "VALUABLE_POSSESSION"]),
     means_proceeding_entity: %(/Envelope/Body/CaseAddRQ/Case/CaseDetails/ApplicationDetails/MeansAssesments/AssesmentResults/AssesmentDetails/AssessmentScreens/Entity[EntityName = "PROCEEDING"]),
     employment_entity: %(/Envelope/Body/CaseAddRQ/Case/CaseDetails/ApplicationDetails/MeansAssesments/AssesmentResults/AssesmentDetails/AssessmentScreens/Entity[EntityName = "EMPLOYMENT_CLIENT"]),
-    change_in_circumstances: %(/Envelope/Body/CaseAddRQ/Case/CaseDetails/ApplicationDetails/MeritsAssesments/AssesmentResults/AssesmentDetails/AssessmentScreens/Entity[EntityName = "CHANGE_IN_CIRCUMSTANCES"]//Attributes/Attribute)
-
+    change_in_circumstances: %(/Envelope/Body/CaseAddRQ/Case/CaseDetails/ApplicationDetails/MeritsAssesments/AssesmentResults/AssesmentDetails/AssessmentScreens/Entity[EntityName = "CHANGE_IN_CIRCUMSTANCES"]//Attributes/Attribute),
+    devolved_powers_date: %(/Envelope/Body/CaseAddRQ/Case/CaseDetails/ApplicationDetails/DevolvedPowersDate)
   }.freeze
   # rubocop:enable Metrics/LineLength
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1081)

On any delegated functions case injected into CCMS the cost limit is showing as £1350 (the delegated functions cost limit). However all delegated functions cases also have a substantive part and so the substantive cost limit of £25000 should apply.

This PR amends the legal aid application model so that the substantive cost limitation is always returned.

Investigating this issue highlighted that the `DevolvedPowersDate` attribute in payloads to CCMS is hardcoded as 01/04/2019. This PR fixes it so `delegated_functions_used_on` date is populated  if delegated functions apply, and is omitted otherwise.


## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
