### PR TITLE
Update packages before install Python dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,7 @@ references:
     run:
       name: Setup aws login
       command: |
+        sudo apt-get update
         sudo apt-get install -y python3-pip
         sudo pip3 install awscli
         $(aws ecr get-login --region eu-west-2 --no-include-email)
@@ -195,7 +196,6 @@ jobs:
     steps:
     - checkout
     - setup_remote_docker
-    - *update_packages
     - *setup_aws_login
     - run:
         name: Delete old images from ecr repo


### PR DESCRIPTION
## What

On circle CI "build & push" job, we started having errors on the build when trying to install Python dependencies.
The errors are related with missing remote .deb packages. And this is happening as we do not "apt-get update" before "apt-get install".
Adding the update before the install calls fixes it.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
