### PR TITLE
AP-1090 Add capital contribution attributes

### DIFF
--- a/config/ccms/ccms_keys.yml
+++ b/config/ccms/ccms_keys.yml
@@ -2446,6 +2446,16 @@ global_means:
     :br100_meaning: The email address of the provider responsible for the application
     :response_type: text
     :user_defined: true
+  GB_INFER_C_40WP2_100A:
+    :value: "#means_assessment_capital_contribution"
+    :br100_meaning: 'the LAR capital contribution for EBS'
+    :response_type: currency
+    :user_defined: false
+  GB_INFER_C_46WP3_9:
+    :value: "#means_assessment_capital_contribution"
+    :br100_meaning: 'the caseworker report capital contribution provisional value'
+    :response_type: currency
+    :user_defined: false
 global_merits:
   APP_INCLUDES_IMMIGRATION_PROCS:
     :generate_block?: false

--- a/spec/services/ccms/case_add_requestor_xml_blocks_spec.rb
+++ b/spec/services/ccms/case_add_requestor_xml_blocks_spec.rb
@@ -113,7 +113,7 @@ module CCMS # rubocop:disable Metrics/ModuleLength
       end
 
       context 'CAP_CONT and similar attributes' do
-        let(:attributes) { %w[PUI_CLIENT_CAP_CONT CAP_CONT OUT_CAP_CONT] }
+        let(:attributes) { %w[PUI_CLIENT_CAP_CONT CAP_CONT OUT_CAP_CONT GB_INFER_C_40WP2_100A GB_INFER_C_46WP3_9] }
         context 'eligble' do
           let!(:cfe_result) { create :cfe_result, submission: cfe_submission }
           it 'returns zero' do


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1090)

Two capital contribution attributes are missing from CCMS payloads.

Add `GB_INFER_C_40WP2_100A` and `GB_INFER_C_46WP3_9` so that they are populated with the capital contribution amount.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
