### PR TITLE
AP-1091 Change hardcoded opponent name

### DIFF
--- a/app/services/ccms/case_add_requestor.rb
+++ b/app/services/ccms/case_add_requestor.rb
@@ -99,7 +99,7 @@ module CCMS
         xml.__send__('ns2:SharedInd', false)
         xml.__send__('ns2:OtherPartyDetail') do
           xml.__send__('ns2:Organization') do
-            xml.__send__('ns2:OrganizationName', 'APPLY service application')
+            xml.__send__('ns2:OrganizationName', '.')
             xml.__send__('ns2:OrganizationType', 'GOVT')
             xml.__send__('ns2:RelationToClient', 'NONE')
             xml.__send__('ns2:RelationToCase', 'OPP')

--- a/config/ccms/ccms_keys.yml
+++ b/config/ccms/ccms_keys.yml
@@ -415,7 +415,7 @@ global_means:
     :response_type: boolean
     :user_defined: true
   LAR_INPUT_T_1WP2_8A:
-    :value: Apply Service Application. See uploaded means report in CCMS
+    :value: .
     :br100_meaning: 'Foreign Assets: Exchange rate & currency details'
     :response_type: text
     :user_defined: true
@@ -4128,7 +4128,7 @@ global_merits:
     :user_defined: false
 other_party:
   OTHER_PARTY_NAME:
-    :value: APPLY service application
+    :value: .
     :br100_meaning: The name of the other party
     :response_type: text
     :user_defined: true
@@ -4290,7 +4290,7 @@ opponent:
     :response_type: boolean
     :user_defined: false
   OTHER_PARTY_NAME:
-    :value: APPLY service application
+    :value: .
     :br100_meaning: Other Party Name
     :response_type: text
     :user_defined: true
@@ -4300,7 +4300,7 @@ opponent:
     :response_type: boolean
     :user_defined: false
   OTHER_PARTY_NAME_MERITS:
-    :value: APPLY service application
+    :value: .
     :br100_meaning: 'OthPart: Other Party Name'
     :response_type: text
     :user_defined: false

--- a/spec/services/ccms/case_add_requestor_xml_blocks_spec.rb
+++ b/spec/services/ccms/case_add_requestor_xml_blocks_spec.rb
@@ -1297,11 +1297,6 @@ module CCMS # rubocop:disable Metrics/ModuleLength
           expect(block).to have_text_response 'N/A'
         end
 
-        it 'LAR_INPUT_T_1WP2_8A should be hard coded correctly' do
-          block = XmlExtractor.call(xml, :global_means, 'LAR_INPUT_T_1WP2_8A')
-          expect(block).to have_text_response 'Apply Service Application. See uploaded means report in CCMS'
-        end
-
         it 'MERITS_ROUTING should be hard coded to SFM' do
           block = XmlExtractor.call(xml, :global_merits, 'MERITS_ROUTING')
           expect(block).to have_text_response 'SFM'
@@ -1319,7 +1314,8 @@ module CCMS # rubocop:disable Metrics/ModuleLength
             [:global_merits, 'REASON_APPLYING_FHH_LR'],
             [:global_merits, 'REASON_NO_ATTEMPT_TO_SETTLE'],
             [:global_merits, 'REASON_SEPARATE_REP_REQ'],
-            [:global_merits, 'MAIN_PURPOSE_OF_APPLICATION']
+            [:global_merits, 'MAIN_PURPOSE_OF_APPLICATION'],
+            [:global_means, 'LAR_INPUT_T_1WP2_8A']
           ]
           attributes.each do |entity_attribute_pair|
             entity, attribute = entity_attribute_pair
@@ -1469,12 +1465,12 @@ module CCMS # rubocop:disable Metrics/ModuleLength
 
         it 'harcodes OTHER_PARTY_NAME' do
           block = XmlExtractor.call(xml, :opponent, 'OTHER_PARTY_NAME')
-          expect(block).to have_text_response 'APPLY service application'
+          expect(block).to have_text_response '.'
         end
 
         it 'harcodes OTHER_PARTY_NAME_MERITS' do
           block = XmlExtractor.call(xml, :opponent, 'OTHER_PARTY_NAME_MERITS')
-          expect(block).to have_text_response 'APPLY service application'
+          expect(block).to have_text_response '.'
         end
 
         it 'harcodes OTHER_PARTY_ORG' do
@@ -1516,7 +1512,7 @@ module CCMS # rubocop:disable Metrics/ModuleLength
 
         it 'harcodes OTHER_PARTY_NAME' do
           block = XmlExtractor.call(xml, :other_party, 'OTHER_PARTY_NAME')
-          expect(block).to have_text_response 'APPLY service application'
+          expect(block).to have_text_response '.'
         end
 
         it 'harcodes OTHER_PARTY_TYPE' do


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1091)

Opponent name is hardcoded as 'APPLY service application' in several places. This is appearing on correspondence sent to solicitors and so needs to be changed.

Replace `APPLY service application` with `.` in three places where it occurs:

`OTHER_PARTY_NAME` (in other party section)
`OTHER_PARTY_NAME` (in opponent section)
`OTHER_PARTY_NAME_MERITS` (in opponent section)

Additionally replace the text hardcoded for `LAR_INPUT_T_1WP2_8A` ('Apply Service Application. See uploaded means report in CCMS') with `.` as it is also incorrect.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
