### PR TITLE
AP-1095 Fix widget to send zero values

### DIFF
--- a/app/models/dashboard/widget_data_providers/daily_new_providers.rb
+++ b/app/models/dashboard/widget_data_providers/daily_new_providers.rb
@@ -14,28 +14,24 @@ module Dashboard
       end
 
       def self.data
-        start_time = 7.days.ago
-        result_set = query_database(start_time)
-        dataset_query = []
-        result_set.each { |row| dataset_query << row }
-        dataset_query
+        dates = (6.days.ago.to_date..Date.today).to_a
+        result_set = []
+        dates.each do |date|
+          result_set << { 'date' => format_date(date), 'number' => signup_count(date) }
+        end
+        result_set
+      end
+
+      def self.format_date(date)
+        date.strftime('%Y-%m-%d')
+      end
+
+      def self.signup_count(date)
+        Provider.where('DATE(created_at) = ?', date).count
       end
 
       def self.handle
         'daily_new_providers'
-      end
-
-      def self.query_database(start_time)
-        sql = <<-EOSQL
-          SELECT
-            date(created_at) as date,
-            count(*) as number
-          FROM providers
-          WHERE date(created_at) >= '#{start_time.strftime('%Y-%m-%d')} 00:00:00'
-          GROUP BY date
-          ORDER by date
-        EOSQL
-        LegalAidApplication.connection.execute(sql)
       end
     end
   end

--- a/spec/models/dashboard/widget_data_providers/daily_new_providers_spec.rb
+++ b/spec/models/dashboard/widget_data_providers/daily_new_providers_spec.rb
@@ -18,19 +18,23 @@ module Dashboard
 
       describe '.data' do
         it 'returns the expected data' do
-          create_applications
+          create_providers
           expect(described_class.data).to eq expected_data
         end
 
-        def expected_data # rubocop:disable Metrics/MethodLength
+        def expected_data # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
           [
-            {
-              'date' => 7.days.ago.strftime('%Y-%m-%d'),
-              'number' => 2
-            },
             {
               'date' => 6.days.ago.strftime('%Y-%m-%d'),
               'number' => 3
+            },
+            {
+              'date' => 5.days.ago.strftime('%Y-%m-%d'),
+              'number' => 0
+            },
+            {
+              'date' => 4.days.ago.strftime('%Y-%m-%d'),
+              'number' => 0
             },
             {
               'date' => 3.days.ago.strftime('%Y-%m-%d'),
@@ -51,7 +55,7 @@ module Dashboard
           ]
         end
 
-        def create_applications
+        def create_providers
           {
             7 => 2,
             6 => 3,


### PR DESCRIPTION
## Ensure Daily User signups sends data even when zero

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1095)

The DailyNewProviders Geckoboard data provider returns an array of hashes, each hash containing a date and the number of first-time Provider logins.  However, a record was not being produced for days when there were no logins. That meant that if there were no logins over the past 7 days, an empty array is returned, which causes Geckoboard to error with "No data to display"

This change ensures that a hash is returned for each of the past 7 days, even if the value is zero.

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
