### PR TITLE
AP-1098 Convert satisfaction scores to GDS standard

### DIFF
--- a/app/models/dashboard/widget.rb
+++ b/app/models/dashboard/widget.rb
@@ -14,9 +14,6 @@ module Dashboard
     end
 
     def data
-      puts ">>>>>>>>>>>>  #{__FILE__}:#{__LINE__} <<<<<<<<<<<<\n"
-      pp @widget_klass.data
-      puts @widget_klass
       @data ||= @widget_klass.data
     end
 

--- a/app/models/dashboard/widget.rb
+++ b/app/models/dashboard/widget.rb
@@ -14,6 +14,9 @@ module Dashboard
     end
 
     def data
+      puts ">>>>>>>>>>>>  #{__FILE__}:#{__LINE__} <<<<<<<<<<<<\n"
+      pp @widget_klass.data
+      puts @widget_klass
       @data ||= @widget_klass.data
     end
 

--- a/app/models/dashboard/widget_data_providers/past_three_weeks_average_feedback_score.rb
+++ b/app/models/dashboard/widget_data_providers/past_three_weeks_average_feedback_score.rb
@@ -25,7 +25,7 @@ module Dashboard
       def self.calculate_average
         records = Feedback.where(created_at: 3.weeks.ago.beginning_of_day..Time.now)
         total = records.map(&:satisfaction_before_type_cast).sum
-        (total.to_f / records.size).round(1)
+        ((total * 25.0) / records.size).round(1)
       end
     end
   end

--- a/app/models/dashboard/widget_data_providers/past_weeks_average_feedback_score.rb
+++ b/app/models/dashboard/widget_data_providers/past_weeks_average_feedback_score.rb
@@ -25,7 +25,7 @@ module Dashboard
       def self.calculate_average
         records = Feedback.where(created_at: 7.days.ago.beginning_of_day..Time.now)
         total = records.map(&:satisfaction_before_type_cast).sum
-        (total.to_f / records.size).round(1)
+        ((total * 25.0) / records.size).round(1)
       end
     end
   end

--- a/app/models/dashboard/widget_data_providers/started_applications.rb
+++ b/app/models/dashboard/widget_data_providers/started_applications.rb
@@ -14,28 +14,24 @@ module Dashboard
       end
 
       def self.data
-        start_time = 7.days.ago
-        result_set = query_database(start_time)
-        dataset_query = []
-        result_set.each { |row| dataset_query << row }
-        dataset_query
+        dates = (6.days.ago.to_date..Date.today).to_a
+        result_set = []
+        dates.each do |date|
+          result_set << { 'date' => format_date(date), 'number' => started_applications(date) }
+        end
+        result_set
       end
 
       def self.handle
         'started_applications'
       end
 
-      def self.query_database(start_time)
-        sql = <<-EOSQL
-          SELECT
-            date(created_at) as date,
-            count(*) as number
-          FROM legal_aid_applications
-          WHERE date(created_at) >= '#{start_time.strftime('%Y-%m-%d')} 00:00:00'
-          GROUP BY date
-          ORDER by date
-        EOSQL
-        LegalAidApplication.connection.execute(sql)
+      def self.format_date(date)
+        date.strftime('%Y-%m-%d')
+      end
+
+      def self.started_applications(date)
+        LegalAidApplication.where('DATE(created_at) = ?', date).count
       end
     end
   end

--- a/app/models/dashboard/widget_data_providers/submitted_applications.rb
+++ b/app/models/dashboard/widget_data_providers/submitted_applications.rb
@@ -14,28 +14,24 @@ module Dashboard
       end
 
       def self.data
-        start_time = 7.days.ago
-        result_set = query_database(start_time)
-        dataset_query = []
-        result_set.each { |row| dataset_query << row }
-        dataset_query
+        dates = (6.days.ago.to_date..Date.today).to_a
+        result_set = []
+        dates.each do |date|
+          result_set << { 'date' => format_date(date), 'number' => submitted_applications(date) }
+        end
+        result_set
       end
 
       def self.handle
         'submitted_applications'
       end
 
-      def self.query_database(start_time)
-        sql = <<-EOSQL
-          SELECT
-            date(submitted_at) as date,
-            count(*) as number
-          FROM merits_assessments
-          WHERE date(submitted_at) >= '#{start_time.strftime('%Y-%m-%d')} 00:00:00'
-          GROUP BY date
-          ORDER by date
-        EOSQL
-        LegalAidApplication.connection.execute(sql)
+      def self.format_date(date)
+        date.strftime('%Y-%m-%d')
+      end
+
+      def self.submitted_applications(date)
+        MeritsAssessment.where('DATE(submitted_at) = ?', date).count
       end
     end
   end

--- a/spec/models/dashboard/widget_data_providers/past_three_weeks_average_feedback_score_spec.rb
+++ b/spec/models/dashboard/widget_data_providers/past_three_weeks_average_feedback_score_spec.rb
@@ -24,7 +24,7 @@ module Dashboard
         end
 
         def expected_data
-          [{ 'number' => (14.0 / 7).round(1) }]
+          [{ 'number' => (14.0 * 25 / 7).round(1) }]
         end
 
         def create_feedbacks # rubocop:disable Metrics/AbcSize

--- a/spec/models/dashboard/widget_data_providers/past_weeks_average_feedback_score_spec.rb
+++ b/spec/models/dashboard/widget_data_providers/past_weeks_average_feedback_score_spec.rb
@@ -24,7 +24,7 @@ module Dashboard
         end
 
         def expected_data
-          [{ 'number' => (8.0 / 4).round(1) }]
+          [{ 'number' => (8.0 * 25 / 4).round(1) }]
         end
 
         def create_feedbacks

--- a/spec/models/dashboard/widget_data_providers/started_applications_spec.rb
+++ b/spec/models/dashboard/widget_data_providers/started_applications_spec.rb
@@ -22,15 +22,19 @@ module Dashboard
           expect(described_class.data).to eq expected_data
         end
 
-        def expected_data # rubocop:disable Metrics/MethodLength
+        def expected_data # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
           [
-            {
-              'date' => 7.days.ago.strftime('%Y-%m-%d'),
-              'number' => 2
-            },
             {
               'date' => 6.days.ago.strftime('%Y-%m-%d'),
               'number' => 3
+            },
+            {
+              'date' => 5.days.ago.strftime('%Y-%m-%d'),
+              'number' => 0
+            },
+            {
+              'date' => 4.days.ago.strftime('%Y-%m-%d'),
+              'number' => 0
             },
             {
               'date' => 3.days.ago.strftime('%Y-%m-%d'),

--- a/spec/models/dashboard/widget_data_providers/submitted_applications_spec.rb
+++ b/spec/models/dashboard/widget_data_providers/submitted_applications_spec.rb
@@ -22,15 +22,19 @@ module Dashboard
           expect(described_class.data).to eq expected_data
         end
 
-        def expected_data # rubocop:disable Metrics/MethodLength
+        def expected_data # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
           [
-            {
-              'date' => 7.days.ago.strftime('%Y-%m-%d'),
-              'number' => 2
-            },
             {
               'date' => 6.days.ago.strftime('%Y-%m-%d'),
               'number' => 3
+            },
+            {
+              'date' => 5.days.ago.strftime('%Y-%m-%d'),
+              'number' => 0
+            },
+            {
+              'date' => 4.days.ago.strftime('%Y-%m-%d'),
+              'number' => 0
             },
             {
               'date' => 3.days.ago.strftime('%Y-%m-%d'),


### PR DESCRIPTION
## Convert satisfaction scores to GDS standard

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1098)

We record individual satisfaction scores on a range from 0 to 4.  The two widgets previously just added the scores together and divided by the number of records, so you get a figure like 3.7.  The GDS standard prefers scores in the range 0-100, so this change is to multiply the scores by 25, thus transforming 3.7 into 67.5 which is much more meaningful.

Also changed all the widgets which return a value for each day to return zero for days where there aren't any, rather than just omit the record as was happening before

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
