### PR TITLE
AP-1078 Refactor CCMS ref on means/merits reports

### DIFF
--- a/app/controllers/providers/means_reports_controller.rb
+++ b/app/controllers/providers/means_reports_controller.rb
@@ -1,21 +1,11 @@
 module Providers
   class MeansReportsController < ProviderBaseController
     authorize_with_policy :show_submitted_application?
-    before_action :ensure_case_ccms_reference_exists
 
     def show
       render pdf: 'Means report',
              layout: 'pdf',
              show_as_html: params.key?(:debug)
-    end
-
-    private
-
-    def ensure_case_ccms_reference_exists
-      return if legal_aid_application.case_ccms_reference
-
-      legal_aid_application.create_ccms_submission unless legal_aid_application.ccms_submission
-      legal_aid_application.ccms_submission.process!
     end
   end
 end

--- a/app/controllers/providers/merits_reports_controller.rb
+++ b/app/controllers/providers/merits_reports_controller.rb
@@ -1,21 +1,10 @@
 module Providers
   class MeritsReportsController < ProviderBaseController
     authorize_with_policy :show_submitted_application?
-    before_action :ensure_case_ccms_reference_exists
-
     def show
       render pdf: 'Merit report',
              layout: 'pdf',
              show_as_html: params.key?(:debug)
-    end
-
-    private
-
-    def ensure_case_ccms_reference_exists
-      return if legal_aid_application.case_ccms_reference
-
-      legal_aid_application.create_ccms_submission unless legal_aid_application.ccms_submission
-      legal_aid_application.ccms_submission.process!
     end
   end
 end

--- a/app/services/reports/base_report_creator.rb
+++ b/app/services/reports/base_report_creator.rb
@@ -1,0 +1,28 @@
+module Reports
+  class BaseReportCreator
+    def self.call(legal_aid_application)
+      new(legal_aid_application).call
+    end
+
+    attr_reader :legal_aid_application
+
+    def initialize(legal_aid_application)
+      @legal_aid_application = legal_aid_application
+    end
+
+    private
+
+    def pdf_report
+      WickedPdf.new.pdf_from_string(html_report)
+    end
+
+    def ensure_case_ccms_reference_exists
+      return if legal_aid_application.case_ccms_reference
+
+      legal_aid_application.create_ccms_submission unless legal_aid_application.ccms_submission
+      legal_aid_application.ccms_submission.process!
+    end
+
+    def html_report; end
+  end
+end

--- a/app/services/reports/means_report_creator.rb
+++ b/app/services/reports/means_report_creator.rb
@@ -1,15 +1,5 @@
 module Reports
-  class MeansReportCreator
-    def self.call(legal_aid_application)
-      new(legal_aid_application).call
-    end
-
-    attr_reader :legal_aid_application
-
-    def initialize(legal_aid_application)
-      @legal_aid_application = legal_aid_application
-    end
-
+  class MeansReportCreator < BaseReportCreator
     def call
       return if legal_aid_application.means_report
 
@@ -25,11 +15,9 @@ module Reports
 
     private
 
-    def pdf_report
-      WickedPdf.new.pdf_from_string(html_report)
-    end
-
     def html_report
+      ensure_case_ccms_reference_exists
+
       Providers::MeansReportsController.default_url_options = {
         _recall: {
           legal_aid_application_id: legal_aid_application.id

--- a/app/services/reports/merits_report_creator.rb
+++ b/app/services/reports/merits_report_creator.rb
@@ -1,15 +1,5 @@
 module Reports
-  class MeritsReportCreator
-    def self.call(legal_aid_application)
-      new(legal_aid_application).call
-    end
-
-    attr_reader :legal_aid_application
-
-    def initialize(legal_aid_application)
-      @legal_aid_application = legal_aid_application
-    end
-
+  class MeritsReportCreator < BaseReportCreator
     def call
       return if legal_aid_application.merits_report
 
@@ -25,11 +15,9 @@ module Reports
 
     private
 
-    def pdf_report
-      WickedPdf.new.pdf_from_string(html_report)
-    end
-
     def html_report
+      ensure_case_ccms_reference_exists
+
       Providers::MeritsReportsController.default_url_options = {
         _recall: {
           legal_aid_application_id: legal_aid_application.id

--- a/spec/requests/providers/means_reports_spec.rb
+++ b/spec/requests/providers/means_reports_spec.rb
@@ -28,19 +28,6 @@ RSpec.describe Providers::MeansReportsController, type: :request do
       expect(unescaped_response_body).to include(submission.case_ccms_reference)
     end
 
-    context 'when no CCMS case reference present' do
-      let!(:submission) { create :submission, legal_aid_application: legal_aid_application, case_ccms_reference: nil }
-      let(:case_ccms_reference) { Faker::Number.number(digits: 6).to_s }
-      let(:before_subject) do
-        allow_any_instance_of(CCMS::ObtainCaseReferenceService).to receive(:reference_id).and_return(case_ccms_reference)
-        allow_any_instance_of(CCMS::ObtainCaseReferenceService).to receive(:response).and_return('dummy response')
-      end
-
-      it 'obtains the case reference remotely' do
-        expect(unescaped_response_body).to include(case_ccms_reference)
-      end
-    end
-
     it 'displays the total capital assessed' do
       expect(unescaped_response_body).to include(capital_result['total_capital'])
     end

--- a/spec/requests/providers/merits_reports_spec.rb
+++ b/spec/requests/providers/merits_reports_spec.rb
@@ -27,19 +27,6 @@ RSpec.describe Providers::MeritsReportsController, type: :request do
       expect(unescaped_response_body).to include(submission.case_ccms_reference)
     end
 
-    context 'when no CCMS case reference present' do
-      let!(:submission) { create :submission, legal_aid_application: legal_aid_application, case_ccms_reference: nil }
-      let(:case_ccms_reference) { Faker::Number.number(digits: 6).to_s }
-      let(:before_subject) do
-        allow_any_instance_of(CCMS::ObtainCaseReferenceService).to receive(:reference_id).and_return(case_ccms_reference)
-        allow_any_instance_of(CCMS::ObtainCaseReferenceService).to receive(:response).and_return('dummy response')
-      end
-
-      it 'obtains the case reference remotely' do
-        expect(unescaped_response_body).to include(case_ccms_reference)
-      end
-    end
-
     context 'when not authenticated' do
       let(:login_provider) { nil }
       it_behaves_like 'a provider not authenticated'

--- a/spec/services/reports/means_report_creator_spec.rb
+++ b/spec/services/reports/means_report_creator_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Reports::MeansReportCreator do
 
   describe '.call' do
     it 'attaches means_report.pdf to the application' do
+      expect_any_instance_of(CCMS::ReferenceDataRequestor).to receive(:call)
       expect(Providers::MeansReportsController.renderer).to receive(:render).and_call_original
       subject
       legal_aid_application.reload

--- a/spec/services/reports/merits_report_creator_spec.rb
+++ b/spec/services/reports/merits_report_creator_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Reports::MeritsReportCreator do
 
   describe '.call' do
     it 'attaches merits_report.pdf to the application' do
+      expect_any_instance_of(CCMS::ReferenceDataRequestor).to receive(:call)
       expect(Providers::MeritsReportsController.renderer).to receive(:render).and_call_original
       subject
       legal_aid_application.reload


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1078)

The CCMS case reference is not appearing on means and merits reports. This was working but has stopped, due to a change in the CCMS submission process. Previously the call to CCMS to get the case reference always took place before the reports were generated but this is no longer the case.

To fix this, move the `ensure_case_ccms_reference_exists` functionality from the `means_`/`merits_report_controller`s (where it wasn't being called) into the `means_`/`merits_report_creator` services, and ensure a CCMS case reference is always present before creating the reports.

This includes a refactor of the `report_creator`s, creating a `base_report_creator` to provide common functionality.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
