### PR TITLE
AP-1106 exclude providers not on whitelist from dashboard stats

### DIFF
--- a/app/models/dashboard/widget_data_providers/daily_new_providers.rb
+++ b/app/models/dashboard/widget_data_providers/daily_new_providers.rb
@@ -28,7 +28,7 @@ module Dashboard
 
       def self.signup_count(date)
         # if we're using whitelisted users, don't count providers that aren't in the whitelist
-        if Rails.configuration.x.application.whitelisted_users?
+        if Rails.configuration.x.application.whitelisted_users&.any?
           Provider.where('DATE(created_at) = ? AND username IN (?)', date, Rails.configuration.x.application.whitelisted_users).count
         else
           Provider.where('DATE(created_at) = ?', date).count

--- a/app/models/dashboard/widget_data_providers/daily_new_providers.rb
+++ b/app/models/dashboard/widget_data_providers/daily_new_providers.rb
@@ -27,7 +27,12 @@ module Dashboard
       end
 
       def self.signup_count(date)
-        Provider.where('DATE(created_at) = ?', date).count
+        # if we're using whitelisted users, don't count providers that aren't in the whitelist
+        if Rails.configuration.x.application.whitelisted_users?
+          Provider.where('DATE(created_at) = ? AND username IN (?)', date, Rails.configuration.x.application.whitelisted_users).count
+        else
+          Provider.where('DATE(created_at) = ?', date).count
+        end
       end
 
       def self.handle

--- a/app/models/dashboard/widget_data_providers/number_provider_firms.rb
+++ b/app/models/dashboard/widget_data_providers/number_provider_firms.rb
@@ -12,9 +12,15 @@ module Dashboard
       end
 
       def self.data
+        # if we're using whitelisted users, don't count firms that belong to users that aren't in the whitelist
+        provider_count = if Rails.configuration.x.application.whitelisted_users&.any?
+                           Provider.where(username: Rails.configuration.x.application.whitelisted_users).group(:firm_id).count.size
+                         else
+                           Provider.all.group(:firm_id).count.size
+                         end
         [
           {
-            'number' => Provider.all.group(:firm_id).count.size
+            'number' => provider_count
           }
         ]
       end

--- a/spec/models/dashboard/widget_data_providers/daily_new_providers_spec.rb
+++ b/spec/models/dashboard/widget_data_providers/daily_new_providers_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 module Dashboard
-  module WidgetDataProviders
+  module WidgetDataProviders # rubocop:disable Metrics/ModuleLength
     RSpec.describe DailyNewProviders do
       describe '.handle' do
         it 'returns the unqualified widget name' do
@@ -17,56 +17,105 @@ module Dashboard
       end
 
       describe '.data' do
-        it 'returns the expected data' do
-          create_providers
-          expect(described_class.data).to eq expected_data
-        end
+        context 'no whitelist' do
+          before { Rails.configuration.x.application.whitelisted_users = nil }
+          it 'returns the expected data' do
+            create_providers
+            expect(described_class.data).to eq expected_data
+          end
 
-        def expected_data # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
-          [
-            {
-              'date' => 6.days.ago.strftime('%Y-%m-%d'),
-              'number' => 3
-            },
-            {
-              'date' => 5.days.ago.strftime('%Y-%m-%d'),
-              'number' => 0
-            },
-            {
-              'date' => 4.days.ago.strftime('%Y-%m-%d'),
-              'number' => 0
-            },
-            {
-              'date' => 3.days.ago.strftime('%Y-%m-%d'),
-              'number' => 1
-            },
-            {
-              'date' => 2.days.ago.strftime('%Y-%m-%d'),
-              'number' => 5
-            },
-            {
-              'date' => 1.days.ago.strftime('%Y-%m-%d'),
-              'number' => 3
-            },
-            {
-              'date' => Date.today.strftime('%Y-%m-%d'),
-              'number' => 1
-            }
-          ]
-        end
+          def expected_data # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+            [
+              {
+                'date' => 6.days.ago.strftime('%Y-%m-%d'),
+                'number' => 3
+              },
+              {
+                'date' => 5.days.ago.strftime('%Y-%m-%d'),
+                'number' => 0
+              },
+              {
+                'date' => 4.days.ago.strftime('%Y-%m-%d'),
+                'number' => 0
+              },
+              {
+                'date' => 3.days.ago.strftime('%Y-%m-%d'),
+                'number' => 1
+              },
+              {
+                'date' => 2.days.ago.strftime('%Y-%m-%d'),
+                'number' => 5
+              },
+              {
+                'date' => 1.days.ago.strftime('%Y-%m-%d'),
+                'number' => 3
+              },
+              {
+                'date' => Date.today.strftime('%Y-%m-%d'),
+                'number' => 1
+              }
+            ]
+          end
 
-        def create_providers
-          {
-            7 => 2,
-            6 => 3,
-            3 => 1,
-            2 => 5,
-            1 => 3,
-            0 => 1
-          }.each do |num_days, num_providers|
-            num_providers.times do
-              FactoryBot.create :provider, created_at: num_days.days.ago
+          def create_providers
+            {
+              7 => 2,
+              6 => 3,
+              3 => 1,
+              2 => 5,
+              1 => 3,
+              0 => 1
+            }.each do |num_days, num_providers|
+              num_providers.times do
+                FactoryBot.create :provider, created_at: num_days.days.ago
+              end
             end
+          end
+        end
+
+        context 'with whitelist' do
+          before do
+            Rails.configuration.x.application.whitelisted_users = %w[user-1 user-3]
+            create :provider, username: 'user-1', created_at: 2.days.ago
+            create :provider, username: 'user-2', created_at: 2.days.ago
+            create :provider, username: 'user-3', created_at: 4.days.ago
+          end
+
+          it 'only counts those users in the whitelist' do
+            expect(described_class.data).to eq expected_data
+          end
+
+          def expected_data # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+            [
+              {
+                'date' => 6.days.ago.strftime('%Y-%m-%d'),
+                'number' => 0
+              },
+              {
+                'date' => 5.days.ago.strftime('%Y-%m-%d'),
+                'number' => 0
+              },
+              {
+                'date' => 4.days.ago.strftime('%Y-%m-%d'),
+                'number' => 1
+              },
+              {
+                'date' => 3.days.ago.strftime('%Y-%m-%d'),
+                'number' => 0
+              },
+              {
+                'date' => 2.days.ago.strftime('%Y-%m-%d'),
+                'number' => 1
+              },
+              {
+                'date' => 1.days.ago.strftime('%Y-%m-%d'),
+                'number' => 0
+              },
+              {
+                'date' => Date.today.strftime('%Y-%m-%d'),
+                'number' => 0
+              }
+            ]
           end
         end
       end

--- a/spec/models/dashboard/widget_data_providers/number_provider_firms_spec.rb
+++ b/spec/models/dashboard/widget_data_providers/number_provider_firms_spec.rb
@@ -24,18 +24,31 @@ module Dashboard
           end
         end
 
-        context 'three users over two firms' do
+        context 'five users over three firms' do
+          let(:firm1) { create :firm }
+          let(:firm2) { create :firm }
+          let(:firm3) { create :firm }
+
           before do
-            firm1 = create :firm
-            firm2 = create :firm
-            create :provider, firm: firm1
-            create :provider, firm: firm1
-            create :provider, firm: firm2
+            create :provider, username: 'user1-firm1', firm: firm1
+            create :provider, username: 'user2-firm1', firm: firm1
+            create :provider, username: 'user1-firm2', firm: firm2
+            create :provider, username: 'user2-firm2', firm: firm2
+            create :provider, username: 'user1-firm3', firm: firm3
           end
 
-          let(:expected_data) { [{ 'number' => 2 }] }
-          it 'sends expected data' do
-            expect(described_class.data).to eq expected_data
+          context 'no whitelisted users' do
+            before { Rails.configuration.x.application.whitelisted_users = nil }
+            it 'expects the firm count to include all firms' do
+              expect(described_class.data).to eq [{ 'number' => 3 }]
+            end
+          end
+
+          context 'with whitelisted users' do
+            before { Rails.configuration.x.application.whitelisted_users = %w[user1-firm1 user1-firm2 user2-firm2)] }
+            it 'expects the firm count to only to include those for whitelisted users' do
+              expect(described_class.data).to eq [{ 'number' => 2 }]
+            end
           end
         end
       end


### PR DESCRIPTION
## Only include whitelisted users in stats

When a user that is not on the whitelist attempts to login, a Provider record is created by the devise authentication before being refused entry.  We don't want that record to be counted in the Geckoboard dashboard stats.

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1106)

- changed  the Dashboard data providers for User sign ups and number of firms signed up to only count records that are in the whitelist.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
