### PR TITLE
AP-1126 Add new cronjob for database backups

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 FROM ruby:2.6.3-alpine3.10
 MAINTAINER apply for legal aid team
 
+ENV \
+  KUBECTL_VERSION=1.13.11
+
 # fail early and print all commands
 RUN set -ex
 
@@ -17,15 +20,26 @@ RUN apk --no-cache add --virtual build-dependencies \
                     libxslt-dev \
                     postgresql-dev \
                     git \
+                    bash \
+                    curl \
 && apk --no-cache add \
                   postgresql-client \
                   nodejs \
                   yarn \
+                  jq \
                   linux-headers \
                   clamav-daemon \
                   libreoffice \
                   ttf-ubuntu-font-family \
-                  wkhtmltopdf
+                  wkhtmltopdf \
+ && pip3 install awscli
+
+#  # Install kubectl
+# RUN curl -LO /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl
+RUN curl -sLo /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl
+
+# Ensure everything is executable
+RUN chmod +x /usr/local/bin/*
 
 # add non-root user and group with alpine first available uid, 1000
 RUN addgroup -g 1000 -S appgroup \

--- a/README.md
+++ b/README.md
@@ -207,9 +207,9 @@ This will then allow you to connect to the database, eg:
 
 ###Backups###
 
-Backups are taking daily at 5:40am and stored for 7 days, these are automated backups and cannot be deleted. The retention date can be changed.
+Backups are taken daily at 5:40am and stored for 7 days, these are automated backups and cannot be deleted. The retention date can be changed.
 
-A CronJOB takes hourly snapshots of production between 6am and 9pm. These need to be periodically deleted as a maximum of 100 can be stored.
+A CronJOB takes hourly snapshots of production between 6am and 9pm. These need to be periodically deleted as a maximum of 100 can be stored. At present all but the most recent 32 manual snapshots (approx 2 days of hourly backups) are deleted every 4 days.
 
 ## 3rd party integrations
 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ To allow reset mode within the admin portal, `ENV['ADMIN_ALLOW_RESET']` must ret
 The non-passported user journey is turned off in production. It can be toggled in
 Staging and UAT at `/admin/settings`
 
-To test the non-passported user journey, the 
+To test the non-passported user journey, the
 `ENV['ALLOW_NON_PASSPORTED_ROUTE']` must return "true". This is only available in the
 Staging and UAT environments.
 
@@ -205,6 +205,12 @@ This will then allow you to connect to the database, eg:
 - Change `staging` to `production` in the above commands to access production.
 - Port 5433 is used in the above examples instead of the usual 5432 for postgres, as 5432 will not work if postgres is running locally.
 
+###Backups###
+
+Backups are taking daily at 5:40am and stored for 7 days, these are automated backups and cannot be deleted. The retention date can be changed.
+
+A CronJOB takes hourly snapshots of production between 6am and 9pm. These need to be periodically deleted as a maximum of 100 can be stored.
+
 ## 3rd party integrations
 
 ### True Layer
@@ -229,7 +235,7 @@ Several sets of statistics are exported to Geckoboard for displaying on an appli
 
 ### How to add a new widget to the dashboard
 
-There are three steps to creating a new widget for the Geckoboard dashboard 
+There are three steps to creating a new widget for the Geckoboard dashboard
 
 ### 1. Create a widget data provider
 
@@ -257,4 +263,3 @@ Once the job has been run at least once, you will be able to select the dataset 
 ## Troubleshooting
 
 Refer to the specific [README](./docs/troubleshooting.md)
-

--- a/bin/cleanup_manual_snapshots
+++ b/bin/cleanup_manual_snapshots
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+echo "Logging into RDS"
+
+regex_manual='apply-manual-snapshot'
+
+regex_automatic='rds:cloud-platform'
+
+unset AWS_PROFILE
+
+read AWS_ACCESS_KEY_ID name pass user addr endp AWS_SECRET_ACCESS_KEY url \
+      <<<$(kubectl -n laa-apply-for-legalaid-staging get secret apply-for-legal-aid-rds-instance-output -o json | jq -r '.data[] | @base64d')
+
+export AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
+
+
+# uncomment the line below to print a list of the current backups to the console
+aws rds describe-db-snapshots --db-instance-identifier cloud-platform-464651662c253592 | jq -r '.DBSnapshots[] | "\(.DBSnapshotIdentifier) created at \(.SnapshotCreateTime)"'
+
+# snapshots="$(aws rds describe-db-snapshots --db-instance-identifier cloud-platform-464651662c253592 \
+#                   | jq -r '.DBSnapshots[] | "\(.DBSnapshotIdentifier) created at \(.SnapshotCreateTime)"')"
+
+manual_snapshots=$(aws rds describe-db-snapshots --db-instance-identifier cloud-platform-464651662c253592 \
+                  | jq -r '.DBSnapshots[] | "\(.DBSnapshotIdentifier)"' | grep $regex_manual )
+
+snapshot_count=$(aws rds describe-db-snapshots --db-instance-identifier cloud-platform-464651662c253592 \
+                  | jq -r '.DBSnapshots[] | "\(.DBSnapshotIdentifier)"' | grep $regex_automatic | wc -l)
+
+man_snap_count=$(aws rds describe-db-snapshots --db-instance-identifier cloud-platform-464651662c253592 \
+                  | jq -r '.DBSnapshots[] | "\(.DBSnapshotIdentifier)"' | grep $regex_manual | wc -l)
+
+echo 'There are' $man_snap_count 'hourly backups'
+
+echo 'There are' $snapshot_count 'automatic daily DB backups'
+
+if [ $man_snap_count -gt 4 ]
+    then
+      echo "$man_snap_count is greater than 4 you should delete some backups"
+      # counter=$man_snap_count
+      counter=$man_snap_count
+      # while[ $counter -gt 2 ]
+      while [ $counter -gt 4 ]
+      do
+        for i in $manual_snapshots;
+        do
+          (aws rds delete-db-snapshot --db-snapshot-identifier $i)
+          ((counter--))
+          echo $i 'has been deleted'
+        done
+      done
+    else
+      echo "No need to delete any backups today"
+fi
+# for i in $manual_snapshots; do (aws rds delete-db-snapshot --db-snapshot-identifier $i)
+# $man_snap_count-- ; done
+
+# echo $man_snap_count

--- a/bin/cleanup_manual_snapshots
+++ b/bin/cleanup_manual_snapshots
@@ -1,24 +1,27 @@
-#!/usr/bin/env bash
+#!/bin/sh
 echo "Logging into RDS"
 
 regex_manual='apply-manual-snapshot'
 
 regex_automatic='rds:cloud-platform'
 
+regex_identifer='\..*'
+
 unset AWS_PROFILE
 
-read AWS_ACCESS_KEY_ID name pass user addr endp AWS_SECRET_ACCESS_KEY url \
-      <<<$(kubectl -n laa-apply-for-legalaid-staging get secret apply-for-legal-aid-rds-instance-output -o json | jq -r '.data[] | @base64d')
+export ADDRESS=$(kubectl -n laa-apply-for-legalaid-staging get secret apply-for-legal-aid-rds-instance-output -o json | jq -r '.data["rds_instance_address"] | @base64d' | sed 's/\..*//g' )
 
-export AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
+export AWS_ACCESS_KEY_ID=$(kubectl -n laa-apply-for-legalaid-staging get secret apply-for-legal-aid-rds-instance-output -o json | jq -r '.data["access_key_id"] | @base64d')
+
+export AWS_SECRET_ACCESS_KEY=$(kubectl -n laa-apply-for-legalaid-staging get secret apply-for-legal-aid-rds-instance-output -o json | jq -r '.data["secret_access_key"] | @base64d')
 
 # uncomment the line below to print a list of the current backups to the console
-# aws rds describe-db-snapshots --db-instance-identifier cloud-platform-464651662c253592 | jq -r '.DBSnapshots[] | "\(.DBSnapshotIdentifier) created at \(.SnapshotCreateTime)"'
+# aws rds describe-db-snapshots --region=eu-west-2 --db-instance-identifier cloud-platform-464651662c253592 | jq -r '.DBSnapshots[] | "\(.DBSnapshotIdentifier) created at \(.SnapshotCreateTime)"'
 
-manual_snapshots=$(aws rds describe-db-snapshots --db-instance-identifier cloud-platform-464651662c253592 \
+manual_snapshots=$(aws rds describe-db-snapshots --region=eu-west-2 --db-instance-identifier $ADDRESS \
                   | jq -r '.DBSnapshots[] | "\(.DBSnapshotIdentifier)"' | grep $regex_manual )
 
-snapshot_count=$(aws rds describe-db-snapshots --db-instance-identifier cloud-platform-464651662c253592 \
+snapshot_count=$(aws rds describe-db-snapshots --region=eu-west-2 --db-instance-identifier $ADDRESS \
                   | jq -r '.DBSnapshots[] | "\(.DBSnapshotIdentifier)"' | grep $regex_automatic | wc -l)
 
 array=($manual_snapshots)
@@ -27,10 +30,10 @@ echo 'There are' ${#array[@]} 'hourly backups'
 
 echo 'There are' $snapshot_count 'automatic daily DB backups'
 
-if [ ${#array[@]} -gt 32 ]
+if [ ${#array[@]} -gt 12 ]
   then
-    END=$((man_snap_count-32))
-    for ((i=0;i<=$END;++i)); do (aws rds delete-db-snapshot --db-snapshot-identifier ${array[i]}) ; done
+    END=$((${#array[@]} - 12 ))
+    for ((i=0;i<=$END;++i)); do (aws rds delete-db-snapshot --region=eu-west-2 --db-snapshot-identifier ${array[i]}) ; done
   else
     echo "No need to delete any backups today"
 fi

--- a/bin/cleanup_manual_snapshots
+++ b/bin/cleanup_manual_snapshots
@@ -12,12 +12,8 @@ read AWS_ACCESS_KEY_ID name pass user addr endp AWS_SECRET_ACCESS_KEY url \
 
 export AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
 
-
 # uncomment the line below to print a list of the current backups to the console
-aws rds describe-db-snapshots --db-instance-identifier cloud-platform-464651662c253592 | jq -r '.DBSnapshots[] | "\(.DBSnapshotIdentifier) created at \(.SnapshotCreateTime)"'
-
-# snapshots="$(aws rds describe-db-snapshots --db-instance-identifier cloud-platform-464651662c253592 \
-#                   | jq -r '.DBSnapshots[] | "\(.DBSnapshotIdentifier) created at \(.SnapshotCreateTime)"')"
+# aws rds describe-db-snapshots --db-instance-identifier cloud-platform-464651662c253592 | jq -r '.DBSnapshots[] | "\(.DBSnapshotIdentifier) created at \(.SnapshotCreateTime)"'
 
 manual_snapshots=$(aws rds describe-db-snapshots --db-instance-identifier cloud-platform-464651662c253592 \
                   | jq -r '.DBSnapshots[] | "\(.DBSnapshotIdentifier)"' | grep $regex_manual )
@@ -25,32 +21,16 @@ manual_snapshots=$(aws rds describe-db-snapshots --db-instance-identifier cloud-
 snapshot_count=$(aws rds describe-db-snapshots --db-instance-identifier cloud-platform-464651662c253592 \
                   | jq -r '.DBSnapshots[] | "\(.DBSnapshotIdentifier)"' | grep $regex_automatic | wc -l)
 
-man_snap_count=$(aws rds describe-db-snapshots --db-instance-identifier cloud-platform-464651662c253592 \
-                  | jq -r '.DBSnapshots[] | "\(.DBSnapshotIdentifier)"' | grep $regex_manual | wc -l)
+array=($manual_snapshots)
 
-echo 'There are' $man_snap_count 'hourly backups'
+echo 'There are' ${#array[@]} 'hourly backups'
 
 echo 'There are' $snapshot_count 'automatic daily DB backups'
 
-if [ $man_snap_count -gt 4 ]
-    then
-      echo "$man_snap_count is greater than 4 you should delete some backups"
-      # counter=$man_snap_count
-      counter=$man_snap_count
-      # while[ $counter -gt 2 ]
-      while [ $counter -gt 4 ]
-      do
-        for i in $manual_snapshots;
-        do
-          (aws rds delete-db-snapshot --db-snapshot-identifier $i)
-          ((counter--))
-          echo $i 'has been deleted'
-        done
-      done
-    else
-      echo "No need to delete any backups today"
+if [ ${#array[@]} -gt 32 ]
+  then
+    END=$((man_snap_count-32))
+    for ((i=0;i<=$END;++i)); do (aws rds delete-db-snapshot --db-snapshot-identifier ${array[i]}) ; done
+  else
+    echo "No need to delete any backups today"
 fi
-# for i in $manual_snapshots; do (aws rds delete-db-snapshot --db-snapshot-identifier $i)
-# $man_snap_count-- ; done
-
-# echo $man_snap_count

--- a/bin/create_manual_snapshot
+++ b/bin/create_manual_snapshot
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+current_time=$(Date "+%Y%m%d-%H%M")
+
+file_name="apply-manual-snapshot"
+
+new_fileName=$file_name-$current_time
+
+echo "Logging into RDS"
+
+unset AWS_PROFILE
+
+read AWS_ACCESS_KEY_ID name pass user addr endp AWS_SECRET_ACCESS_KEY url <<<$(kubectl -n laa-apply-for-legalaid-staging get secret apply-for-legal-aid-rds-instance-output -o json | jq -r '.data[] | @base64d')
+
+export AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
+
+aws rds create-db-snapshot --region=eu-west-2 --db-instance-identifier cloud-platform-464651662c253592 --db-snapshot-identifier $new_fileName
+
+echo $new_fileName "has been created"

--- a/bin/create_manual_snapshot
+++ b/bin/create_manual_snapshot
@@ -1,17 +1,18 @@
-#!/usr/bin/env bash
+#!/bin/sh
+echo "Logging into RDS"
 
-current_time=$(Date "+%Y%m%d-%H%M")
+current_time=$(date "+%Y%m%d-%H%M")
 
 file_name="apply-manual-snapshot"
 
 new_fileName=$file_name-$current_time
 
-echo "Logging into RDS"
-
 unset AWS_PROFILE
 
-read AWS_ACCESS_KEY_ID name pass user addr endp AWS_SECRET_ACCESS_KEY url <<<$(kubectl -n laa-apply-for-legalaid-staging get secret apply-for-legal-aid-rds-instance-output -o json | jq -r '.data[] | @base64d')
+export AWS_ACCESS_KEY_ID=$(kubectl -n laa-apply-for-legalaid-staging get secret apply-for-legal-aid-rds-instance-output -o json | jq -r '.data["access_key_id"] | @base64d')
 
-export AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
+export AWS_SECRET_ACCESS_KEY=$(kubectl -n laa-apply-for-legalaid-staging get secret apply-for-legal-aid-rds-instance-output -o json | jq -r '.data["secret_access_key"] | @base64d')
 
-aws rds create-db-snapshot --region=eu-west-2 --db-instance-identifier cloud-platform-464651662c253592 --db-snapshot-identifier $new_fileName
+export ADDRESS=$(kubectl -n laa-apply-for-legalaid-staging get secret apply-for-legal-aid-rds-instance-output -o json | jq -r '.data["rds_instance_address"] | @base64d' | sed 's/\..*//g' )
+
+aws rds create-db-snapshot --region=eu-west-2 --db-instance-identifier $ADDRESS --db-snapshot-identifier $new_fileName

--- a/bin/create_manual_snapshot
+++ b/bin/create_manual_snapshot
@@ -15,5 +15,3 @@ read AWS_ACCESS_KEY_ID name pass user addr endp AWS_SECRET_ACCESS_KEY url <<<$(k
 export AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
 
 aws rds create-db-snapshot --region=eu-west-2 --db-instance-identifier cloud-platform-464651662c253592 --db-snapshot-identifier $new_fileName
-
-echo $new_fileName "has been created"

--- a/helm_deploy/apply-for-legal-aid/templates/cronjob-db-backup-cleanup.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/cronjob-db-backup-cleanup.yaml
@@ -1,0 +1,36 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: {{ .Release.Name }}-clean-db-backups
+  labels:
+    app: {{ template "apply-for-legal-aid.name" . }}
+    chart: {{ template "apply-for-legal-aid.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  schedule: '55 5 * * *'
+  selector:
+    matchLabels:
+      app: {{ template "apply-for-legal-aid.name" . }}
+      release: {{ .Release.Name }}
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 0
+  failedJobsHistoryLimit: 0
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: clean-db-backups
+            image: '{{ .Values.image.repository }}:{{ .Values.image.tag }}'
+            imagePullPolicy: IfNotPresent
+            command: ['bin/rails', 'cleanup_manual_snapshots']
+{{ include "apply-for-legal-aid.envs" . | nindent 12 }}
+            resources:
+              limits:
+                cpu: 200m
+                memory: 256Mi
+              requests:
+                cpu: 100m
+                memory: 128Mi
+          restartPolicy: Never

--- a/helm_deploy/apply-for-legal-aid/templates/cronjob-db-backup-cleanup.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/cronjob-db-backup-cleanup.yaml
@@ -8,7 +8,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  schedule: '0 */96 * * *'
+  schedule: '0 7 * * *'
   selector:
     matchLabels:
       app: {{ template "apply-for-legal-aid.name" . }}

--- a/helm_deploy/apply-for-legal-aid/templates/cronjob-db-backup-cleanup.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/cronjob-db-backup-cleanup.yaml
@@ -8,7 +8,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  schedule: '55 5 * * *'
+  schedule: '0 */96 * * *'
   selector:
     matchLabels:
       app: {{ template "apply-for-legal-aid.name" . }}

--- a/helm_deploy/apply-for-legal-aid/templates/cronjob-hourly-db-backup.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/cronjob-hourly-db-backup.yaml
@@ -1,0 +1,36 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: {{ .Release.Name }}-hourly-db-backup
+  labels:
+    app: {{ template "apply-for-legal-aid.name" . }}
+    chart: {{ template "apply-for-legal-aid.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  schedule: '1 6-21 * * *'
+  selector:
+    matchLabels:
+      app: {{ template "apply-for-legal-aid.name" . }}
+      release: {{ .Release.Name }}
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 0
+  failedJobsHistoryLimit: 0
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: manual-snapshot
+            image: '{{ .Values.image.repository }}:{{ .Values.image.tag }}'
+            imagePullPolicy: IfNotPresent
+            command: ['bin/rails', 'create_manual_snapshot']
+{{ include "apply-for-legal-aid.envs" . | nindent 12 }}
+            resources:
+              limits:
+                cpu: 200m
+                memory: 256Mi
+              requests:
+                cpu: 100m
+                memory: 128Mi
+          restartPolicy: Never

--- a/helm_deploy/apply-for-legal-aid/templates/cronjob-hourly-db-backup.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/cronjob-hourly-db-backup.yaml
@@ -1,14 +1,14 @@
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name: {{ .Release.Name }}-hourly-db-backup
+  name: {{ .Release.Name | trunc 26 }}-hourly-db-backup
   labels:
     app: {{ template "apply-for-legal-aid.name" . }}
     chart: {{ template "apply-for-legal-aid.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  schedule: '1 6-21 * * *'
+  schedule: '* 7-21 * * *'
   selector:
     matchLabels:
       app: {{ template "apply-for-legal-aid.name" . }}
@@ -21,11 +21,10 @@ spec:
       template:
         spec:
           containers:
-          - name: manual-snapshot
+          - name: hourly-db-backup
             image: '{{ .Values.image.repository }}:{{ .Values.image.tag }}'
             imagePullPolicy: IfNotPresent
-            command: ['bin/rails', 'create_manual_snapshot']
-{{ include "apply-for-legal-aid.envs" . | nindent 12 }}
+            command: ['bin/create_manual_snapshot']
             resources:
               limits:
                 cpu: 200m


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-XXX)

Added 2 cronjobs to deal with DB backups.

The first take an hourly snapshot and stores this in our RDS backup storage along side the daily snapshots taken by cloud platforms. Daily snapshots are retained for 7 days.

The second cronjob manages deleting the hourly snapshots. It deletes all but the most recent 30 snapshots every 4 days. We are currently taking 32 per day so this should mean we have approx 2 days of hourly snapshots available in case we need to do a restore.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
