### PR TITLE
AP-1131 - Only count submitted MeritsApplications

### DIFF
--- a/app/models/dashboard/widget_data_providers/total_submitted_applications.rb
+++ b/app/models/dashboard/widget_data_providers/total_submitted_applications.rb
@@ -14,7 +14,7 @@ module Dashboard
       def self.data
         [
           {
-            'number' => MeritsAssessment.count
+            'number' => MeritsAssessment.where('submitted_at IS NOT NULL').count
           }
         ]
       end

--- a/spec/models/dashboard/widget_data_providers/total_submitted_applications_spec.rb
+++ b/spec/models/dashboard/widget_data_providers/total_submitted_applications_spec.rb
@@ -22,15 +22,20 @@ module Dashboard
           expect(described_class.data).to eq expected_data
         end
 
+        it 'ignores draft MeritsAssessments' do
+          create_applications(include_draft: true)
+          expect(described_class.data).to eq expected_data
+        end
+
         def expected_data
           [
             {
-              'number' => MeritsAssessment.count
+              'number' => 15
             }
           ]
         end
 
-        def create_applications
+        def create_applications(include_draft = false)
           {
             7 => 2,
             6 => 3,
@@ -39,6 +44,7 @@ module Dashboard
             1 => 3,
             0 => 1
           }.each do |num_days, num_submitted_applications|
+            FactoryBot.create(:merits_assessment, submitted_at: nil) if include_draft
             num_submitted_applications.times do
               FactoryBot.create(:merits_assessment, submitted_at: num_days.days.ago)
             end


### PR DESCRIPTION
## What

[Fix Total submitted applications widget bug](https://dsdmoj.atlassian.net/browse/AP-1131)

Amend the dashboard widget for `total submitted applications` this was counting _all_ MeritsAssessments rather than limiting it to those with a submitted date

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
