### PR TITLE
Circle CI job name error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,7 +129,7 @@ jobs:
     - *save_gems_cache
     - *setup_database
     - run:
-        name: Run ruby tegsts
+        name: Run ruby tests
         command: bin/rails spec
 
   integration_tests:


### PR DESCRIPTION
Minor spelling error in circle ci config

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
