### PR TITLE
Hotfix: Call both dashboard widgets when MeritsAssessment saved

### DIFF
--- a/app/services/dashboard_event_handler.rb
+++ b/app/services/dashboard_event_handler.rb
@@ -60,5 +60,6 @@ class DashboardEventHandler
 
   def merits_assessment_submitted
     Dashboard::UpdaterJob.perform_later('SubmittedApplications')
+    Dashboard::UpdaterJob.perform_later('TotalSubmittedApplications')
   end
 end

--- a/spec/events_spec.rb
+++ b/spec/events_spec.rb
@@ -97,6 +97,7 @@ RSpec.describe DashboardEventHandler do
     end
     it 'fires the submitted applications job' do
       expect(Dashboard::UpdaterJob).to receive(:perform_later).with('SubmittedApplications')
+      expect(Dashboard::UpdaterJob).to receive(:perform_later).with('TotalSubmittedApplications')
       merits_assessment = create :merits_assessment
       merits_assessment.submit!
     end


### PR DESCRIPTION
## What

No-story: Hotfix

This addresses the issue where applications appear on the graph but not the total.
Work to address this long term will be covered by ap-1109 but as that is a day or so away this fixes it short term.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
