### PR TITLE
BugFix - Make whitelisted users check case insensitive

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -25,7 +25,7 @@ class Provider < ApplicationRecord
   end
 
   def whitelisted_user?
-    username.in?(whitelisted_users)
+    whitelisted_users.any? { |user| user.casecmp(username).zero? }
   end
 
   private

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -33,9 +33,17 @@ RSpec.describe Provider, type: :model do
     end
 
     context 'user is whitelisted' do
-      let(:provider) { create :provider, username: Rails.configuration.x.application.whitelisted_users.sample }
-      it 'returns true' do
-        expect(provider.whitelisted_user?).to be true
+      context 'provider username is in lower case' do
+        let(:provider) { create :provider, username: Rails.configuration.x.application.whitelisted_users.sample.downcase }
+        it 'returns true' do
+          expect(provider.whitelisted_user?).to be true
+        end
+      end
+      context 'provider username is in upper case' do
+        let(:provider) { create :provider, username: Rails.configuration.x.application.whitelisted_users.sample.upcase }
+        it 'returns true' do
+          expect(provider.whitelisted_user?).to be true
+        end
       end
     end
     context 'user is not whitelisted' do


### PR DESCRIPTION
BugFix - Make whitelisted users check case insensitive

Update condition to test if provider username is in whitelisted user to be case insensitive
Write test to check for this

## Checklist

Before you ask people to review this PR:

- [X] Tests and rubocop should be passing: `bundle exec rake`
- [X] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [X] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [X] The PR description should say what you changed and why, with a link to the JIRA story.
- [X] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [X] You should have checked that the commit messages say why the change was made.
