### PR TITLE
Bug Fix - Update Provider retreiver to use URI.escape instead of CGI.escape

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,6 +14,12 @@ Lint/AmbiguousBlockAssociation:
   Exclude:
   - 'spec/**/*'
 
+Lint/UriEscapeUnescape:
+  Enabled: false
+
+Lint/RedundantCopDisableDirective:
+  Enabled: false
+
 Metrics/AbcSize:
   Exclude:
   - 'db/migrate/*'

--- a/app/services/provider_details_retriever.rb
+++ b/app/services/provider_details_retriever.rb
@@ -30,8 +30,8 @@ class ProviderDetailsRetriever
     @response ||= Net::HTTP.get_response(URI.parse(url))
   end
 
-  def url
-    File.join(Rails.configuration.x.provider_details.url, CGI.escape(username))
+  def url # rubocop:disable Lint/UriEscapeUnescape
+    File.join(Rails.configuration.x.provider_details.url, URI.escape(username))
   end
 
   def raise_error


### PR DESCRIPTION
Bug Fix -Update Provider retreiver to use URI.escape instead of CGI.escape

Disable rubocop methods to allow URI.escape to be used instead.

This will fix the issue with providers getting a 500 error on a login attempt via saml.

## Checklist

Before you ask people to review this PR:

- [X] Tests and rubocop should be passing: `bundle exec rake`
- [X] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [X] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [X] The PR description should say what you changed and why, with a link to the JIRA story.
- [X] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [X] You should have checked that the commit messages say why the change was made.
