### PR TITLE
AP-1132: Split the sidekiq prometheus alerts into two

### DIFF
--- a/helm_deploy/prometheus-alerts.yaml
+++ b/helm_deploy/prometheus-alerts.yaml
@@ -54,12 +54,19 @@ spec:
       annotations:
         message: An HTTP 5xx error has occurred
     - alert: SidekiqQueueSize-Threshold-Reached
-      expr: sum(ruby_sidekiq_queue_size{namespace="laa-apply-for-legalaid-production"}) > 10 or absent(ruby_sidekiq_queue_size{namespace="laa-apply-for-legalaid-production"})
+      expr: sum(ruby_sidekiq_queue_size{namespace="laa-apply-for-legalaid-production"}) > 10
       for: 1m
       labels:
         severity: apply-for-legal-aid-prod
       annotations:
-        message: Sidekiq queue size is more than 10 or is not reported
+        message: Sidekiq queue size is more than 10
+    - alert: SidekiqQueue-absent
+      expr: absent(ruby_sidekiq_queue_size{namespace="laa-apply-for-legalaid-production"})
+      for: 1m
+      labels:
+        severity: apply-for-legal-aid-prod
+      annotations:
+        message: Sidekiq queue size is not reported, cronjob may not be submitting metrics
     - alert: DiskSpace-Threshold-Reached
       expr: container_fs_usage_bytes{namespace="laa-apply-for-legalaid-production"} / 1024 / 1024 > 150 or absent(container_fs_usage_bytes{namespace="laa-apply-for-legalaid-production"})
       for: 1m


### PR DESCRIPTION
## What
[Sidekiq errors in prometheus](https://dsdmoj.atlassian.net/browse/AP-1132)

There are two (immediate, obvious) errors with the prometheus/sidekiq reports
1) A single report exists for sidekiq being down or too busy
2) The metrics cronjob stopped working on 28th November
This PR addresses the first issues as having a single alert for missing or too busy was making debugging hard!

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
