### PR TITLE
AP1133 police notified

### DIFF
--- a/app/forms/respondents/respondent_form.rb
+++ b/app/forms/respondents/respondent_form.rb
@@ -29,7 +29,7 @@ module Respondents
     validates(
       :police_notified_details,
       presence: true,
-      if: proc { |form| !form.draft? && form.police_notified.to_s == 'false' }
+      if: proc { |form| !form.draft? && (%w[true false].include? form.police_notified.to_s) }
     )
 
     validates :bail_conditions_set, presence: true, unless: :draft?
@@ -42,11 +42,7 @@ module Respondents
     private
 
     def clear_details
-      %i[
-        understands_terms_of_court_order
-        warning_letter_sent
-        police_notified
-      ].each do |attr|
+      %i[understands_terms_of_court_order warning_letter_sent].each do |attr|
         details = "#{attr}_details".to_sym
         attr_value = __send__(attr)
         __send__(details)&.clear if attr_value.to_s == 'true'

--- a/app/javascript/src/respondent_detail.js
+++ b/app/javascript/src/respondent_detail.js
@@ -1,0 +1,60 @@
+$(document).ready(() => {
+  const govuk_hidden_class = 'govuk-visually-hidden'
+  const police_notified_label = $("label[for='police_notified_details']")
+  const police_notified = $('#police_notified_details')
+
+  const police_notified_no = police_notified.data('police-notified-no')
+  const police_notified_yes = police_notified.data('police-notified-yes')
+
+  const police_notified_blank_error_yes = police_notified.data('police-notified-blank-error-yes')
+  const police_notified_blank_error_no = police_notified.data('police-notified-blank-error-no')
+
+  const police_notified_checked = "input[type=radio][name='respondent[police_notified]']:checked"
+
+  if ($("#police_notified").length) {
+    policeNotifiedHideTextArea()
+    setPoliceNotifiedLabel()
+    updatePoliceNotifiedLabel()
+    updateError()
+  }
+
+  function policeNotifiedHideTextArea(){
+    // If there is an error on the details text area then don't hide text area
+    if ($('#police_notified_details-error').length) return
+    if (typeof $(police_notified_checked).val() == 'undefined') {
+      $('#police_notified_conditional')
+        .addClass(govuk_hidden_class)
+        .attr('aria-expanded', 'false');
+    }
+  }
+
+  function updatePoliceNotifiedLabel() {  
+    $("#police_notified input").on("change", function () {
+      updateError()
+
+      // show textarea regardless of what is selected
+      $('#police_notified_conditional')
+        .removeClass(govuk_hidden_class)
+        .attr('aria-expanded', 'true');
+
+      // js ternary, if true , do nothing, else show the other data label
+      setPoliceNotifiedLabel()
+    });
+  }
+
+  function setPoliceNotifiedLabel() {
+    $(police_notified_checked).val() == 'true' ? police_notified_label.text(police_notified_yes) : police_notified_label.text(police_notified_no)
+  }
+
+  function updateError() {
+    if (!$('#police_notified_details-error').length) return
+
+    const error = selectedPoliceNotifiedError()
+    $('#police_notified_details-error').text(error)
+    $('[href="#police_notified_details"]').text(error)
+  }
+
+  function selectedPoliceNotifiedError() {
+    return $(police_notified_checked).val() == 'true' ? police_notified_blank_error_yes : police_notified_blank_error_no
+  }
+})

--- a/app/views/providers/respondents/_respondent_detail.html.erb
+++ b/app/views/providers/respondents/_respondent_detail.html.erb
@@ -1,6 +1,7 @@
 <%
  conditional_id = "#{question.attribute}_conditional"
  has_error = form.errors[question.attribute].any? || form.errors[question.attribute_details].any?
+ always_showing = question.show_details_when.nil? ? '' : 'govuk-radios__conditional--hidden'
 %>
 <div class="govuk-form-group <%= has_error ? 'govuk-form-group--error' : '' %>">
   <div id="<%= question.attribute %>" class="govuk-radios govuk-radios--conditional" data-module="govuk-radios">
@@ -12,9 +13,21 @@
             input_attributes: question.show_details_when ? { question.show_details_when.to_s => { 'data-aria-controls' => conditional_id } } : nil
           ) %>
 
-    <% always_showing = question.show_details_when.nil? %>
-    <%= content_tag(:div, id: conditional_id, class: 'govuk-radios__conditional govuk-radios__conditional--hidden') do %>
-      <%= form.govuk_text_area question.attribute_details, id: question.attribute_details, rows: 5 %>
+    <%= content_tag(:div, id: conditional_id, class: "govuk-radios__conditional #{always_showing}") do %>
+      <% if question.attribute == :police_notified %>
+        <%= form.govuk_text_area(
+              question.attribute_details,
+              id: question.attribute_details,
+              rows: 5,
+              label: police_notified_titles[:yes],
+              'data-police-notified-yes' => police_notified_titles[:yes],
+              'data-police-notified-no' => police_notified_titles[:no],
+              'data-police-notified-blank-error-yes' => police_notified_titles[:blank_error],
+              'data-police-notified-blank-error-no' => police_notified_titles[:no]
+            ) %>
+      <% else %>
+          <%= form.govuk_text_area question.attribute_details, id: question.attribute_details, rows: 5 %>
+      <% end %>
     <% end %>
   </div>
 </div>

--- a/app/views/providers/respondents/show.html.erb
+++ b/app/views/providers/respondents/show.html.erb
@@ -9,21 +9,29 @@
     <div class="govuk-!-padding-bottom-7"></div>
 
     <%
-      questions = %i[
-        understands_terms_of_court_order
-        warning_letter_sent
-        police_notified
-        bail_conditions_set
-      ].map do |attr|
+      questions = %i[understands_terms_of_court_order warning_letter_sent].map do |attr|
         OpenStruct.new(
           title: t(".#{attr}"),
           attribute: attr,
           attribute_details: "#{attr}_details".to_sym,
-          show_details_when: attr == :bail_conditions_set ? 'true' : 'false'
+          show_details_when: 'false'
         )
       end
+      questions += %i[police_notified bail_conditions_set].map do |attr|
+        OpenStruct.new(
+          title: t(".#{attr}"),
+          attribute: attr,
+          attribute_details: "#{attr}_details".to_sym,
+          show_details_when: attr == :bail_conditions_set ? 'true' : nil
+        )
+      end
+      police_notified_titles = {
+          yes: t('.police_notified_yes'),
+          no: t('.police_notified_no'),
+          blank_error: t('.police_notified_blank')
+        }
     %>
-    <%= render partial: 'respondent_detail', collection: questions, as: :question, locals: { form: form } %>
+    <%= render partial: 'respondent_detail', collection: questions, as: :question, locals: { form: form, police_notified_titles: police_notified_titles } %>
 
     <%= next_action_buttons(show_draft: true, form: form) %>
   <% end %>

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -299,7 +299,7 @@ en:
             warning_letter_sent_details:
               blank: Tell us why a warning letter has not been sent
             police_notified_details:
-              blank: Tell us why the police have not been notified
+              blank: Tell us what action the police have taken
             bail_conditions_set_details:
               blank: Give details of the bail conditions
         savings_amount:

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -49,8 +49,8 @@ en:
       respondent:
         understands_terms_of_court_order_details: Tell us why you think the court would enforce a breach of an order
         warning_letter_sent_details: Tell us why a warning letter has not been sent
-        police_notified_details: Tell us why the police have not been notified
         bail_conditions_set_details: Give details of the bail conditions, including the date they're likely to end
+        police_notified_details: Tell us what action they've taken (if any), including dates and the outcome        
         understands_terms_of_court_order:
           <<: *true_false
         warning_letter_sent:

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -388,6 +388,9 @@ en:
         police_notified: Have the police been notified?
         bail_conditions_set: Have bail conditions been set?
         bail_conditions_set_yes: Give details of the bail conditions, including the date they're likely to end
+        police_notified_no: Tell us why the police have not been notified
+        police_notified_yes: Tell us what action they've taken (if any), including dates and the outcome
+        police_notified_blank: Tell us what action the police have taken
     restrictions:
       show:
         h1-heading: Are there any legal restrictions that prevent your client from selling or borrowing against their assets?

--- a/features/providers/civil_application_journey.feature
+++ b/features/providers/civil_application_journey.feature
@@ -403,6 +403,7 @@ Feature: Civil application journeys
     Then I choose option "Respondent police notified True"
     Then I choose option "Respondent bail conditions set True"
     Then I fill "Bail conditions set details" with "Foo bar"
+    Then I fill "Police notified details" with "Foo bar"
     Then I click 'Save and continue'
     And I should not see "Client received legal help"
     And I should not see "Proceedings currently before court"
@@ -506,6 +507,7 @@ Feature: Civil application journeys
     Then I choose option "Respondent police notified True"
     Then I choose option "Respondent bail conditions set True"
     Then I fill "Bail conditions set details" with "Foo bar"
+    Then I fill "Police notified details" with "Foo bar"
     Then I click 'Save and continue'
     And I should not see "Client received legal help"
     Then I should be on a page showing "Provide a statement of case"

--- a/spec/factories/respondents.rb
+++ b/spec/factories/respondents.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     understands_terms_of_court_order_details { Faker::Lorem.paragraph }
     warning_letter_sent { 'false' }
     warning_letter_sent_details { Faker::Lorem.paragraph }
-    police_notified { 'false' }
+    police_notified { %w[true false].sample }
     police_notified_details { Faker::Lorem.paragraph }
     bail_conditions_set { 'true' }
     bail_conditions_set_details { Faker::Lorem.paragraph }

--- a/spec/forms/respondents/respondent_form_spec.rb
+++ b/spec/forms/respondents/respondent_form_spec.rb
@@ -31,20 +31,16 @@ RSpec.describe Respondents::RespondentForm, type: :form do
         {
           understands_terms_of_court_order: 'true',
           warning_letter_sent: 'true',
-          police_notified: 'true',
           understands_terms_of_court_order_details: '',
-          warning_letter_sent_details: '',
-          police_notified_details: ''
+          warning_letter_sent_details: ''
         }
       end
 
       it 'updates the respondent' do
         expect(respondent.understands_terms_of_court_order).to eq(true)
         expect(respondent.warning_letter_sent).to eq(true)
-        expect(respondent.police_notified).to eq(true)
         expect(respondent.understands_terms_of_court_order_details).to eq('')
         expect(respondent.warning_letter_sent_details).to eq('')
-        expect(respondent.police_notified_details).to eq('')
       end
     end
 
@@ -86,7 +82,7 @@ RSpec.describe Respondents::RespondentForm, type: :form do
         {
           understands_terms_of_court_order: 'false',
           warning_letter_sent: 'false',
-          police_notified: 'false',
+          police_notified: %w[true false].sample,
           bail_conditions_set: 'true',
           understands_terms_of_court_order_details: '',
           warning_letter_sent_details: '',


### PR DESCRIPTION
Add text box for the respondent's police notified question for the  'yes' answer.

[Link to story](https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=233&projectKey=AP&modal=detail&selectedIssue=AP-1133)

This was to keep the existing functionality for police notified 'no' answer except allow a textbox to be used for when the answer is 'yes' as-well.

- Update respondent form to validate the text box if the answer is 'yes' or 'no' (true or false)

- Remove :police_notified from the clear_details method as the same text box is used for a yes or no answer and both require it.

- Create respondent javascript file to update the text box label depending on the 'yes' or 'no' answer for police notified. Also update the error messages.

- Update the view to always show the textbox for police notified, which will then be hidden by the javascript. This is because the requirement is to have the text box hidden as default and appear for yes and no answers on police_notified.

- Update tests

To note:

The text box is hidden as default, so when the user first enters the page, the textbox is not shown. This is something i've added to the javascript file.

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
