### PR TITLE
Circle CI config update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -312,6 +312,9 @@ workflows:
         requires:
         - hold_uat
         - build_and_push
+        filters:
+          branches:
+            ignore: master
     - hold_staging:
         type: approval
         requires:


### PR DESCRIPTION
## What

Ignore the `uat deploy` job when merging to master. 

Once a PR is merged to master, we shouldn't be deploying to UAT anyway.  This means that the master branch status should be able to be green, as all steps will be completed, rather than remaining amber as at present
![image](https://user-images.githubusercontent.com/6757677/71252408-d6eaf400-231c-11ea-98ec-673b512c1866.png)

This should allow us to still deploy non-master branches to UAT

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
