### PR TITLE
Circle CI update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -308,6 +308,9 @@ workflows:
     - build_and_push
     - hold_uat:
         type: approval
+        filters:
+          branches:
+            ignore: master
     - deploy_uat:
         requires:
         - hold_uat


### PR DESCRIPTION
## What

This is the second part of #1132, it removes the `hold_uat` job
![image](https://user-images.githubusercontent.com/6757677/71254628-81661580-2323-11ea-9bca-4f5b1b6b314e.png)

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
