### PR TITLE
CircleCI: Update the gemfile cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,11 +96,7 @@ references:
     run:
       name: Database Setup
       command: |
-        git checkout origin/master
-        bundle install --path=vendor/bundle --jobs=4
         bundle exec rake db:create db:schema:load
-        git checkout -
-        bundle install --path=vendor/bundle --jobs=4
         bundle exec rake db:migrate db:seed
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,10 +81,10 @@ references:
         - v1-yarn-packages-cache
 
   save_gems_cache: &save_gems_cache
-    restore_cache:
-        keys:
-          - v1-yarn-packages-cache-{{ checksum "yarn.lock" }}
-          - v1-yarn-packages-cache
+    save_cache:
+        key: v1-gems-cache-{{ checksum "Gemfile.lock" }}
+        paths:
+          - vendor/bundle
 
   save_js_packages_cache: &save_js_packages_cache
     save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,6 +128,9 @@ jobs:
     - *install_gems
     - *save_gems_cache
     - *setup_database
+    - *restore_js_packages_cache
+    - *install_js_packages
+    - *save_js_packages_cache
     - run:
         name: Run ruby tests
         command: bin/rails spec


### PR DESCRIPTION
## What

Saving the gem bundler cache correctly has taken time to run the `Install ruby gems` step in Circle 
from: ![image](https://user-images.githubusercontent.com/6757677/71261109-6ea80c80-2334-11ea-8b47-6bd7e140552c.png)
to:
![image](https://user-images.githubusercontent.com/6757677/71261058-50daa780-2334-11ea-9a4b-457233369613.png)

This is because once CircleCI has run bundle install once, it caches that copy for re-use on subsequent containers.  It will get updated each time we change the Gemfile (i.e. after each dependabot update) but other than that it should speed up the run times.

The test run entirely has moved from:
![image](https://user-images.githubusercontent.com/6757677/71264475-170d9f00-233c-11ea-9730-3a7cadacfdb3.png)
this afternoon to 
![image](https://user-images.githubusercontent.com/6757677/71264373-e0d01f80-233b-11ea-8e04-4fd6f48bd70b.png)
on this build

## Next steps
added issue #1136 for further improvements

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
