### PR TITLE
Revert circle UAT changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -317,17 +317,10 @@ workflows:
         filters:
           branches:
             ignore: master
-    - deploy_uat_auto:
-        requires:
-        - build_and_push
-        filters:
-          branches:
-            only: master
     - hold_staging:
         type: approval
         requires:
         - build_and_push
-        - deploy_uat_auto
         filters:
           branches:
             only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -311,9 +311,6 @@ workflows:
         requires:
         - hold_uat
         - build_and_push
-        filters:
-          branches:
-            ignore: master
     - hold_staging:
         type: approval
         requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -307,9 +307,6 @@ workflows:
     - build_and_push
     - hold_uat:
         type: approval
-        filters:
-          branches:
-            ignore: master
     - deploy_uat:
         requires:
         - hold_uat


### PR DESCRIPTION
## What

Revert the UAT deploy changes to circle config. 
Deploying master to UAT is needed sometimes.  This reverts the changes that removed the option and tried to make it automatic

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
