### PR TITLE
Amend DB backup cronjob schedule

### DIFF
--- a/helm_deploy/apply-for-legal-aid/templates/cronjob-hourly-db-backup.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/cronjob-hourly-db-backup.yaml
@@ -8,7 +8,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  schedule: '* 7-21 * * *'
+  schedule: '3 7-21 * * *'
   selector:
     matchLabels:
       app: {{ template "apply-for-legal-aid.name" . }}


### PR DESCRIPTION
## What

Changed the scheduler, I had misinterpreted and it was running every minute past every hour between 7am and 9pm, this actually meant it was taking a backup every 3 minutes, I assume because thats how long it takes to create a backup. This change now sets it to run at 3 minutes past the hour during the relevant timeframe.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
