### PR TITLE
AP1164 Redirect provider when citizen completes means

### DIFF
--- a/app/services/provider_email_service.rb
+++ b/app/services/provider_email_service.rb
@@ -28,7 +28,7 @@ class ProviderEmailService
   end
 
   def application_url
-    @application_url ||= providers_legal_aid_applications_url
+    @application_url ||= providers_legal_aid_application_client_completed_means_url(application)
   end
 
   def applicant

--- a/spec/services/provider_email_service_spec.rb
+++ b/spec/services/provider_email_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ProviderEmailService do
   let(:applicant) { create(:applicant, first_name: 'John', last_name: 'Doe') }
   let(:provider) { create :provider, email: smoke_test_email }
   let(:application) { create(:application, applicant: applicant, provider: provider) }
-  let(:application_url) { 'http://www.example.com/providers/applications' }
+  let(:application_url) { "http://www.example.com/providers/applications/#{application.id}/client_completed_means" }
   subject { described_class.new(application) }
 
   describe '#send_email' do


### PR DESCRIPTION
Redirect provider when citizen completes means

[Link to story](https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=233&projectKey=AP&modal=detail&selectedIssue=AP-1164)

Update the url to redirect the provider to the application that the citizen completed means on

To note:

Unfortunately, If the provider is signed out and clicks the link, they will be sent directly to the /providers index page after sign in, instead of the providers_legal_aid_application_client_completed_means_url

## Checklist

Before you ask people to review this PR:

- [X] Tests and rubocop should be passing: `bundle exec rake`
- [X] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [X] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [X] The PR description should say what you changed and why, with a link to the JIRA story.
- [X] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [X] You should have checked that the commit messages say why the change was made.
