### PR TITLE
AP-1162: Implement new status controller setup

### DIFF
--- a/app/controllers/status_controller.rb
+++ b/app/controllers/status_controller.rb
@@ -1,24 +1,58 @@
 class StatusController < ApiController
-  def index
-    render json: {
-      redis: redis_connection,
-      db: db,
+  def status
+    checks = {
+      database: database_alive?,
+      redis: redis_alive?,
+      sidekiq: sidekiq_alive?,
+      sidekiq_queue: sidekiq_queue_healthy?,
+
       malware_scanner: {
         positive: malware_scanner_positive,
         negative: malware_scanner_negative
       }
     }
+
+    status = :bad_gateway unless checks.except(:sidekiq_queue).values.all?
+    render status: status, json: { checks: checks }
+  end
+
+  def ping
+    render json: {
+      'build_date' => ENV['BUILD_DATE'] || 'Not Available',
+      'commit_id' => ENV['COMMIT_ID'] || 'Not Available',
+      'build_tag' => ENV['BUILD_TAG'] || 'Not Available',
+      'app_branch' => ENV['APP_BRANCH'] || 'Not Available'
+    }
   end
 
   private
 
-  def db
-    LegalAidApplication.select(:id).first
+  def redis_alive?
+    Sidekiq.redis(&:info)
     true
+  rescue StandardError
+    false
   end
 
-  def redis_connection
-    Sidekiq.redis(&:ping) == 'PONG'
+  def sidekiq_alive?
+    ps = Sidekiq::ProcessSet.new
+    !ps.size.zero?
+  rescue StandardError
+    false
+  end
+
+  def sidekiq_queue_healthy?
+    dead = Sidekiq::DeadSet.new
+    retries = Sidekiq::RetrySet.new
+    dead.size.zero? && retries.size.zero?
+  rescue StandardError
+    false
+  end
+
+  def database_alive?
+    ActiveRecord::Base.connection.active?
+  rescue PG::ConnectionBad
+    false
   end
 
   def malware_scanner_positive

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,8 +38,10 @@ Rails.application.routes.draw do
   end
 
   get 'auth/failure', to: 'auth#failure'
+  get 'ping', to: 'status#ping', format: :json
+  get 'healthcheck', to: 'status#status', format: :json
+  get 'status', to: 'status#status', format: :json
 
-  resources :status, only: [:index]
   resource :contact, only: [:show]
   resources :privacy_policy, only: [:index]
   resources :feedback, only: %i[new create show]

--- a/spec/requests/status_spec.rb
+++ b/spec/requests/status_spec.rb
@@ -1,28 +1,175 @@
 require 'rails_helper'
 
-RSpec.describe 'status requests' do
-  let(:response_json) { JSON.parse(response.body) }
-  let(:expected_json) do
-    {
-      'redis' => true,
-      'db' => true,
-      'malware_scanner' => {
-        'positive' => true,
-        'negative' => true
-      }
-    }
-  end
-
-  describe 'GET /status' do
-    subject { get('/status') }
-    before { subject }
-
-    it 'is successful' do
-      expect(response).to be_successful
+RSpec.describe StatusController, type: :request do
+  describe '#healthcheck' do
+    before do
+      allow(Sidekiq::ProcessSet).to receive(:new).and_return(instance_double(Sidekiq::ProcessSet, size: 1))
+      allow(Sidekiq::RetrySet).to receive(:new).and_return(instance_double(Sidekiq::RetrySet, size: 0))
+      allow(Sidekiq::DeadSet).to receive(:new).and_return(instance_double(Sidekiq::DeadSet, size: 0))
+      connection = double('connection')
+      allow(connection).to receive(:info).and_return(redis_version: '5.0.0')
+      allow(Sidekiq).to receive(:redis).and_yield(connection)
     end
 
-    it 'checks external connections' do
-      expect(response_json).to eq(expected_json)
+    context 'when failed Sidekiq jobs exist' do
+      let(:failed_job_healthcheck) do
+        {
+          checks: {
+            database: true,
+            redis: true,
+            sidekiq: true,
+            sidekiq_queue: false,
+            'malware_scanner': {
+              'positive': true,
+              'negative': true
+            }
+          }
+        }.to_json
+      end
+
+      context 'dead set exists' do
+        before do
+          allow(Sidekiq::DeadSet).to receive(:new).and_return(instance_double(Sidekiq::DeadSet, size: 1))
+          get '/healthcheck'
+        end
+
+        it 'returns ok http status' do
+          expect(response).to have_http_status :ok
+        end
+
+        it 'returns the expected response report' do
+          expect(response.body).to eq(failed_job_healthcheck)
+        end
+      end
+
+      context 'retry set exists' do
+        before do
+          allow(Sidekiq::RetrySet).to receive(:new).and_return(instance_double(Sidekiq::RetrySet, size: 1))
+          get '/healthcheck'
+        end
+
+        it 'returns ok http status' do
+          expect(response).to have_http_status :ok
+        end
+
+        it 'returns the expected response report' do
+          expect(response.body).to eq(failed_job_healthcheck)
+        end
+      end
+    end
+
+    context 'when an infrastructure problem exists' do
+      before do
+        allow(ActiveRecord::Base.connection).to receive(:active?).and_raise(PG::ConnectionBad)
+        allow(Sidekiq::ProcessSet).to receive(:new).and_return(instance_double(Sidekiq::ProcessSet, size: 0))
+
+        connection = double('connection')
+        allow(connection).to receive(:info).and_raise(Redis::CannotConnectError)
+        allow(Sidekiq).to receive(:redis).and_yield(connection)
+
+        get '/healthcheck'
+      end
+
+      let(:failed_healthcheck) do
+        {
+          'checks': {
+            'database': false,
+            'redis': false,
+            'sidekiq': false,
+            'sidekiq_queue': true,
+            'malware_scanner': {
+              'positive': true,
+              'negative': true
+            }
+          }
+        }.to_json
+      end
+
+      it 'returns status bad gateway' do
+        expect(response).to have_http_status :bad_gateway
+      end
+
+      it 'returns the expected response report' do
+        expect(response.body).to eq(failed_healthcheck)
+      end
+    end
+
+    context 'when everything is ok' do
+      before do
+        allow(ActiveRecord::Base.connection).to receive(:active?).and_return(true)
+
+        connection = double('connection', info: {})
+        allow(Sidekiq).to receive(:redis).and_yield(connection)
+
+        get '/healthcheck'
+      end
+
+      let(:expected_response) do
+        {
+          'checks': {
+            'database': true,
+            'redis': true,
+            'sidekiq': true,
+            'sidekiq_queue': true,
+            'malware_scanner': {
+              'positive': true,
+              'negative': true
+            }
+          }
+        }.to_json
+      end
+
+      it 'returns HTTP success' do
+        get '/healthcheck'
+        expect(response.status).to eq(200)
+      end
+
+      it 'returns the expected response report' do
+        get '/healthcheck'
+        expect(response.body).to eq(expected_response)
+      end
+    end
+  end
+
+  describe '#ping' do
+    context 'when environment variables set' do
+      let(:expected_json) do
+        {
+          'build_date' => '20150721',
+          'commit_id' => 'afb12cb3',
+          'build_tag' => 'test',
+          'app_branch' => 'test_branch'
+        }
+      end
+
+      before do
+        ENV['BUILD_DATE']       = '20150721'
+        ENV['COMMIT_ID']        = 'afb12cb3'
+        ENV['BUILD_TAG']        = 'test'
+        ENV['APP_BRANCH']       = 'test_branch'
+
+        get('/ping')
+      end
+
+      it 'returns JSON with app information' do
+        expect(JSON.parse(response.body)).to eq(expected_json)
+      end
+    end
+
+    context 'when environment variables not set' do
+      before do
+        ENV['VERSION_NUMBER']   = nil
+        ENV['BUILD_DATE']       = nil
+        ENV['COMMIT_ID']        = nil
+        ENV['BUILD_TAG']        = nil
+        ENV['APP_BRANCH']       = nil
+
+        get '/ping'
+      end
+
+      it 'returns "Not Available"' do
+        expect(JSON.parse(response.body).values).to be_all('Not Available')
+      end
     end
   end
 end


### PR DESCRIPTION
## What

[Update the status page of Apply](https://dsdmoj.atlassian.net/browse/AP-1162)
This provides:
* a simple `/ping` endpoint that will display static values
(separate PR required to configure values in K8S and CircleCI)
* a dynamic `/healthcheck` endpoint that displays values indicating
up-state of required dependencies

By default the `/status` endpoint will still return the dynamic data
this means that monitoring & K8S should not be impacted.

There will be a subsequent commit to change it to see if K8S deploys
are affected when deployed to UAT

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
