### PR TITLE
BugFix: Remove COMMIT_ID from status controller

### DIFF
--- a/app/controllers/status_controller.rb
+++ b/app/controllers/status_controller.rb
@@ -19,7 +19,6 @@ class StatusController < ApiController
   def ping
     render json: {
       'build_date' => ENV['BUILD_DATE'] || 'Not Available',
-      'commit_id' => ENV['COMMIT_ID'] || 'Not Available',
       'build_tag' => ENV['BUILD_TAG'] || 'Not Available',
       'app_branch' => ENV['APP_BRANCH'] || 'Not Available'
     }

--- a/spec/requests/status_spec.rb
+++ b/spec/requests/status_spec.rb
@@ -199,7 +199,6 @@ RSpec.describe StatusController, type: :request do
       let(:expected_json) do
         {
           'build_date' => '20150721',
-          'commit_id' => 'afb12cb3',
           'build_tag' => 'test',
           'app_branch' => 'test_branch'
         }
@@ -207,7 +206,6 @@ RSpec.describe StatusController, type: :request do
 
       before do
         ENV['BUILD_DATE']       = '20150721'
-        ENV['COMMIT_ID']        = 'afb12cb3'
         ENV['BUILD_TAG']        = 'test'
         ENV['APP_BRANCH']       = 'test_branch'
 
@@ -223,7 +221,6 @@ RSpec.describe StatusController, type: :request do
       before do
         ENV['VERSION_NUMBER']   = nil
         ENV['BUILD_DATE']       = nil
-        ENV['COMMIT_ID']        = nil
         ENV['BUILD_TAG']        = nil
         ENV['APP_BRANCH']       = nil
 


### PR DESCRIPTION
## What
Remove COMMIT_ID from the status controller

It got removed from the setup in #1164 but not from the display

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
