### PR TITLE
Ap 1160 reset counter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -320,15 +320,15 @@ workflows:
         type: approval
         requires:
         - build_and_push
-        filters:
-          branches:
-            only: master
+        # filters:
+        #   branches:
+        #     only: master
     - deploy_staging:
         requires:
         - hold_staging
-        filters:
-          branches:
-            only: master
+        # filters:
+        #   branches:
+        #     only: master
     - hold_production:
         type: approval
         requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -320,15 +320,15 @@ workflows:
         type: approval
         requires:
         - build_and_push
-        # filters:
-        #   branches:
-        #     only: master
+        filters:
+          branches:
+            only: master
     - deploy_staging:
         requires:
         - hold_staging
-        # filters:
-        #   branches:
-        #     only: master
+        filters:
+          branches:
+            only: master
     - hold_production:
         type: approval
         requires:

--- a/helm_deploy/apply-for-legal-aid/templates/cronjob-reset-started-apps-counter.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/cronjob-reset-started-apps-counter.yaml
@@ -8,7 +8,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  schedule: '1 1 * * *'
+  schedule: '18 0 * * *'
   selector:
     matchLabels:
       app: {{ template "apply-for-legal-aid.name" . }}
@@ -24,7 +24,7 @@ spec:
           - name: reset-counter
             image: '{{ .Values.image.repository }}:{{ .Values.image.tag }}'
             imagePullPolicy: IfNotPresent
-            command: ['rake', 'job:dashboard:update']
+            command: ['rake', 'job:dashboard:update[Applications]']
 {{ include "apply-for-legal-aid.envs" . | nindent 12 }}
             resources:
               limits:

--- a/helm_deploy/apply-for-legal-aid/templates/cronjob-reset-started-apps-counter.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/cronjob-reset-started-apps-counter.yaml
@@ -1,0 +1,36 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: {{ .Release.Name | trunc 26 }}-reset-counter
+  labels:
+    app: {{ template "apply-for-legal-aid.name" . }}
+    chart: {{ template "apply-for-legal-aid.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  schedule: '1 1 * * *'
+  selector:
+    matchLabels:
+      app: {{ template "apply-for-legal-aid.name" . }}
+      release: {{ .Release.Name }}
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 0
+  failedJobsHistoryLimit: 0
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: reset-counter
+            image: '{{ .Values.image.repository }}:{{ .Values.image.tag }}'
+            imagePullPolicy: IfNotPresent
+            command: ['rake', 'job:dashboard:update']
+{{ include "apply-for-legal-aid.envs" . | nindent 12 }}
+            resources:
+              limits:
+                cpu: 200m
+                memory: 256Mi
+              requests:
+                cpu: 100m
+                memory: 128Mi
+          restartPolicy: Never


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1160)

Added a cronjob that updates the geckoboard at midnight with the aim of resetting the started applications widget to zero for each day, actually runs at 18 mins past midnight.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
