### PR TITLE
AP1181 - Bug fix Proceeding Types in IE11

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -17,6 +17,11 @@
 
 require("@rails/ujs").start()
 require("@rails/activestorage").start()
+
+// require polyfills via core-js
+require("core-js/stable")
+require("regenerator-runtime/runtime")
+
 require("axios")
 
 const context = require.context("../src", true, /\.js$/)


### PR DESCRIPTION
Proceedings list does not work in Internet Explorer 11

[Link to story](https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=233&projectKey=AP&modal=detail&selectedIssue=AP-1181)

Require babel/polyfill via core-js to use promises in javascript
https://babeljs.io/docs/en/babel-polyfill

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
