### PR TITLE
Auto screenshot cucumber failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,6 +147,8 @@ jobs:
     - run:
         name: Run integration tests
         command: SAVE_PAGES=true bin/rails cucumber
+    - store_artifacts:
+      path: tmp/capybara
     - persist_to_workspace:
         root: tmp
         paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,7 +148,7 @@ jobs:
         name: Run integration tests
         command: SAVE_PAGES=true bin/rails cucumber
     - store_artifacts:
-      path: tmp/capybara
+        path: tmp/capybara
     - persist_to_workspace:
         root: tmp
         paths:

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -113,6 +113,11 @@ end
 World(FactoryBot::Syntax::Methods)
 World(Warden::Test::Helpers)
 
+After do |scenario|
+  name = scenario.location.file.gsub('features/','').gsub(/\.|\//, '-')
+  screenshot_image(name) if scenario.failed?
+end
+
 AfterStep do
   next unless ENV['SAVE_PAGES'] == 'true'
   next unless page.current_host

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -114,7 +114,7 @@ World(FactoryBot::Syntax::Methods)
 World(Warden::Test::Helpers)
 
 After do |scenario|
-  name = scenario.location.file.gsub('features/','').gsub(/\.|\//, '-')
+  name = scenario.location.file.gsub('features/', '').gsub(%r{/\.|\/}, '-')
   screenshot_image(name) if scenario.failed?
 end
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -114,8 +114,10 @@ World(FactoryBot::Syntax::Methods)
 World(Warden::Test::Helpers)
 
 After do |scenario|
-  name = scenario.location.file.gsub('features/', '').gsub(%r{/\.|\/}, '-')
-  screenshot_image(name) if scenario.failed?
+  if scenario.failed?
+    name = scenario.location.file.gsub('features/', '').gsub(%r{/\.|\/}, '-')
+    screenshot_image(name)
+  end
 end
 
 AfterStep do

--- a/features/support/screenshot_helper.rb
+++ b/features/support/screenshot_helper.rb
@@ -1,0 +1,25 @@
+module ScreenshotHelper
+   # selenium headless chrome solution for full screenshot
+  def screenshot_and_open_image
+    file_path = screenshot_image
+    Launchy.open file_path
+  end
+
+  def screenshot_image(name = 'capybara-screenshot')
+    window = Capybara.current_session.driver.browser.manage.window
+    window.resize_to(*dimensions)
+    screenshot_name = "#{name}-#{Time.now.utc.iso8601.gsub('-', '').gsub(':', '')}.png"
+    file_path = Rails.root.join("tmp/capybara/#{screenshot_name}").to_s
+    save_screenshot(file_path)
+    file_path
+  end
+
+  def dimensions
+    driver = Capybara.current_session.driver
+    total_width = driver.execute_script("return document.body.offsetWidth")
+    total_height = driver.execute_script("return document.body.scrollHeight")
+    return [total_width, total_height]
+  end
+end
+
+World(ScreenshotHelper)

--- a/features/support/screenshot_helper.rb
+++ b/features/support/screenshot_helper.rb
@@ -1,24 +1,26 @@
 module ScreenshotHelper
-   # selenium headless chrome solution for full screenshot
+  # selenium headless chrome solution for full screenshot
   def screenshot_and_open_image
     file_path = screenshot_image
     Launchy.open file_path
   end
 
+  # rubocop:disable Lint/Debugger
   def screenshot_image(name = 'capybara-screenshot')
     window = Capybara.current_session.driver.browser.manage.window
     window.resize_to(*dimensions)
-    screenshot_name = "#{name}-#{Time.now.utc.iso8601.gsub('-', '').gsub(':', '')}.png"
+    screenshot_name = "#{name}-#{Time.now.utc.iso8601.delete('-').delete(':')}.png"
     file_path = Rails.root.join("tmp/capybara/#{screenshot_name}").to_s
     save_screenshot(file_path)
     file_path
   end
+  # rubocop:enable Lint/Debugger
 
   def dimensions
     driver = Capybara.current_session.driver
-    total_width = driver.execute_script("return document.body.offsetWidth")
-    total_height = driver.execute_script("return document.body.scrollHeight")
-    return [total_width, total_height]
+    total_width = driver.execute_script('return document.body.offsetWidth')
+    total_height = driver.execute_script('return document.body.scrollHeight')
+    [total_width, total_height]
   end
 end
 


### PR DESCRIPTION
## What

Updates cucumber to save screenshot when features fail
The screenshots will be stored in `tmp/capybara` so the screenshots will be ignored by .gitignore.
The file pattern is:
`folder`-`feature_file_name`-feature-`yearmonthday`T`time`.png
this allows you to see to the state of the page at failure

It will also upload the files in CircleCI, these will be available in the artifacts folder and means that you won't need to scroll through the list of jobs to find the failures

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
