### PR TITLE
fix issue of running db backups in non-prod env

### DIFF
--- a/helm_deploy/apply-for-legal-aid/templates/_helpers.tpl
+++ b/helm_deploy/apply-for-legal-aid/templates/_helpers.tpl
@@ -60,3 +60,29 @@ https://pauladamsmith.com/blog/2011/05/go_time.html
     {{ "*/30 * * * *" }}
   {{- end -}}
 {{- end -}}
+
+{{/*
+Defining cron schedule for the backup db job
+In production the job runs once per hour between 7am and 9pm
+In UAT and Staging, we dont run the job by scheduling it for 31st February.
+*/}}
+{{- define "apply-for-legal-aid.cronjob-schedule-hourly-db-backup" -}}
+  {{- if contains "-production" .Release.Namespace -}}
+    {{ "3 7-21 * * *"}}
+  {{- else -}}
+    {{ "0 0 31 2 *" }}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Defining cron schedule for the cleanup db backup job
+In production the job runs once per day at 7am
+In UAT and Staging, we dont run the job by scheduling it for 31st February
+*/}}
+{{- define "apply-for-legal-aid.cronjob-schedule-db-backup-cleanup" -}}
+  {{- if contains "-production" .Release.Namespace -}}
+    {{ "0 7 * * *"}}
+  {{- else -}}
+    {{ "0 0 31 2 *" }}
+  {{- end -}}
+{{- end -}}

--- a/helm_deploy/apply-for-legal-aid/templates/cronjob-db-backup-cleanup.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/cronjob-db-backup-cleanup.yaml
@@ -1,3 +1,4 @@
+{{- $schedule := include "apply-for-legal-aid.cronjob-schedule-db-backup-cleanup" . -}}
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
@@ -8,7 +9,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  schedule: '0 7 * * *'
+  schedule: '{{ $schedule }}'
   selector:
     matchLabels:
       app: {{ template "apply-for-legal-aid.name" . }}

--- a/helm_deploy/apply-for-legal-aid/templates/cronjob-hourly-db-backup.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/cronjob-hourly-db-backup.yaml
@@ -1,3 +1,4 @@
+{{- $schedule := include "apply-for-legal-aid.cronjob-schedule-hourly-db-backup" . -}}
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
@@ -8,7 +9,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  schedule: '3 7-21 * * *'
+  schedule: '{{ $schedule }}'
   selector:
     matchLabels:
       app: {{ template "apply-for-legal-aid.name" . }}


### PR DESCRIPTION
## What

database backup cronjobs were running and failing in UAT and staging due to hard coded production values, also we dont need hourly backups of these DBs.

Describe what you did and why.

Added a helper in `helpers.tpl` to check if the env is `production` and if it isn't then the cronjob is scheduled to run on 31st February, for both the backup and cleanup scripts

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
