### PR TITLE
AP1141 Feedback on Signout

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -39,7 +39,7 @@ Metrics/CyclomaticComplexity:
 # Offense count: 2
 # Configuration parameters: CountComments.
 Metrics/MethodLength:
-  Max: 13
+  Max: 14
 
 # Offense count: 1
 Metrics/PerceivedComplexity:

--- a/app/assets/stylesheets/success_message.scss
+++ b/app/assets/stylesheets/success_message.scss
@@ -1,0 +1,5 @@
+@import "govuk-frontend/govuk/settings/colours-applied";
+
+.govuk-error-summary.success_summary {
+  border-color: govuk-colour("green");
+}

--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -37,7 +37,16 @@ class FeedbackController < ApplicationController
   def back_path
     session.fetch(:feedback_return_path, :back)
   end
-  helper_method :back_path
+
+  def success_message
+    provider_signed_in? ? {} : I18n.t('feedback.new.signed_out')
+  end
+
+  def back_button
+    provider_signed_in? ? {} : :none
+  end
+
+  helper_method :back_path, :back_button, :success_message
 
   def update_return_path
     return if request.referer&.include?(feedback_index_path)

--- a/app/controllers/saml_sessions_controller.rb
+++ b/app/controllers/saml_sessions_controller.rb
@@ -11,7 +11,7 @@ class SamlSessionsController < Devise::SamlSessionsController
     if IdPSettingsAdapter.mock_saml?
       redirect_to providers_root_url
     else
-      redirect_to idp_sign_out_provider_session_url(SAMLRequest: 1)
+      redirect_to new_feedback_path
     end
   end
 

--- a/app/helpers/page_template_helper.rb
+++ b/app/helpers/page_template_helper.rb
@@ -43,6 +43,7 @@ module PageTemplateHelper
     column_width: 'two-thirds',
     template: nil,
     show_errors_for: @form,
+    success_message: nil,
     page_heading_options: {},
     &content
   )
@@ -57,6 +58,7 @@ module PageTemplateHelper
       column_width: column_width,
       content: content,
       show_errors_for: show_errors_for,
+      success_message: success_message,
       page_heading_options: page_heading_options
     )
   end

--- a/app/views/feedback/new.html.erb
+++ b/app/views/feedback/new.html.erb
@@ -1,5 +1,4 @@
-<%= page_template page_title: t('.title') do %>
-
+<%= page_template page_title: t('.title'), back_link: back_button, success_message: success_message do %>
     <%= form_for(@feedback, url: feedback_index_path) do |form| %>
 
       <%= form.govuk_collection_radio_buttons(

--- a/app/views/feedback/show.html.erb
+++ b/app/views/feedback/show.html.erb
@@ -1,5 +1,9 @@
-<%= page_template page_title: t('.title') do %>
-  <p class="govuk-body">
-    <%= link_to t('.link'), back_path, class: 'govuk-link govuk-link--no-visited-state' %>
-  </p>
+<%= page_template page_title: t('.title'), back_link: back_button do %>
+  <% if back_button == :none %>
+    <p><%= t('.close_tab') %></p>
+  <% else %>
+    <p class="govuk-body">
+      <%= link_to t('.link'), back_path, class: 'govuk-link govuk-link--no-visited-state' %>
+    </p>
+  <% end %>
 <% end %>

--- a/app/views/shared/forms/_success_message.html.erb
+++ b/app/views/shared/forms/_success_message.html.erb
@@ -1,0 +1,8 @@
+<div aria-labelledby="notice-summary-heading" class="notice-summary" role="group" tabindex="-1">
+  <div class="govuk-error-summary success_summary" id="error_explanation">
+    <h2 class="govuk-error-summary__title" id="error-summary-title">
+      <%= success_message %>
+    </h2>
+  </div>
+
+</div>

--- a/app/views/shared/page_templates/_default_page_template.html.erb
+++ b/app/views/shared/page_templates/_default_page_template.html.erb
@@ -1,4 +1,6 @@
 <%= render(partial: 'shared/forms/error_summary', locals: { model: show_errors_for }) if show_errors_for %>
+<%= render(partial: 'shared/forms/success_message', locals: { success_message: success_message }) if success_message.present? %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-<%= column_width %>">
     <% if content_for?(:panel) %>

--- a/config/locales/en/feedback.yml
+++ b/config/locales/en/feedback.yml
@@ -5,7 +5,9 @@ en:
       done_all_needed: Were you able to do what you needed today?
       improvement_suggestion: How could we improve this service?
       satisfaction: Overall, how satisfied were you with this service?
+      signed_out: You have signed out
       title: Help us improve this service
     show:
+      close_tab: You can close this tab or page.
       link: Back to your application
       title: Thank you for your feedback

--- a/spec/requests/feedbacks_spec.rb
+++ b/spec/requests/feedbacks_spec.rb
@@ -78,12 +78,34 @@ RSpec.describe 'FeedbacksController', type: :request do
     it 'renders the page' do
       expect(response).to have_http_status(:ok)
     end
+
+    context 'provider signed out' do
+      let(:provider) { create :provider }
+
+      before do
+        sign_in provider
+        delete destroy_provider_session_path
+        get new_feedback_path
+      end
+
+      it 'displays success message' do
+        expect(unescaped_response_body).to match(I18n.t('.feedback.new.signed_out'))
+      end
+
+      it 'does not display a back button' do
+        expect(unescaped_response_body).not_to match(I18n.t('.generic.back'))
+      end
+    end
   end
 
   describe 'GET /feedback/:id' do
     let(:feedback) { create :feedback }
+    let(:provider) { create :provider }
 
-    before { get feedback_path(feedback) }
+    before do
+      sign_in provider
+      get feedback_path(feedback)
+    end
 
     it 'renders the page' do
       expect(response).to have_http_status(:ok)
@@ -91,6 +113,20 @@ RSpec.describe 'FeedbacksController', type: :request do
 
     it 'displays a message' do
       expect(unescaped_response_body).to match(I18n.t('feedback.show.title'))
+    end
+
+    context 'provider signed out' do
+      let(:provider) { create :provider }
+
+      before do
+        sign_in provider
+        delete destroy_provider_session_path
+        get feedback_path(feedback)
+      end
+
+      it 'displays close tab message' do
+        expect(unescaped_response_body).to match(I18n.t('.feedback.show.close_tab'))
+      end
     end
   end
 end

--- a/spec/requests/saml_sessions_spec.rb
+++ b/spec/requests/saml_sessions_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'SamlSessionsController', type: :request do
 
       it 'redirects to the SAML sign_out URL' do
         subject
-        expect(response).to redirect_to(idp_sign_out_provider_session_url(SAMLRequest: 1))
+        expect(response).to redirect_to(new_feedback_path)
       end
     end
 


### PR DESCRIPTION
AP1141 - Display the feedback survey upon sign out

[Link to story](https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=233&projectKey=AP&modal=detail&selectedIssue=AP-1141)


- Add a successful sign-out message with custom styling

- Update feedback controller

- Remove `redirect_to idp_sign_out_provider_session_url(SAMLRequest: 1)` as we'll no longer be using the LAA Online portal logout page.

- Update tests and relevant I18n translation files

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
