### PR TITLE
Bump prometheus_exporter from 0.4.16 to 0.4.17

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -305,7 +305,7 @@ GEM
     parser (2.7.0.2)
       ast (~> 2.4.0)
     pg (1.2.2)
-    prometheus_exporter (0.4.16)
+    prometheus_exporter (0.4.17)
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)

--- a/helm_deploy/apply-for-legal-aid/templates/cronjob-deliver-scheduled-mail.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/cronjob-deliver-scheduled-mail.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name: {{ .Release.Name }}-scheduled-mailings
+  name: {{ .Release.Name | trunc 26 }}-scheduled-mailings
   labels:
     app: {{ template "apply-for-legal-aid.name" . }}
     chart: {{ template "apply-for-legal-aid.chart" . }}


### PR DESCRIPTION
there was an issue with the name of the branch failing to deply to UAT. the original dependabot update failed, this allows it to be tested in uat before merging

Bumps [prometheus_exporter](https://github.com/discourse/prometheus_exporter) from 0.4.16 to 0.4.17.
- [Release notes](https://github.com/discourse/prometheus_exporter/releases)
- [Changelog](https://github.com/discourse/prometheus_exporter/blob/master/CHANGELOG)
- [Commits](https://github.com/discourse/prometheus_exporter/compare/v0.4.16...v0.4.17)

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>


## What



## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
