### PR TITLE
Bug fix for PdfConverter

### DIFF
--- a/app/services/pdf_converter.rb
+++ b/app/services/pdf_converter.rb
@@ -11,7 +11,7 @@ class PdfConverter
   end
 
   def call # rubocop:disable Metrics/MethodLength
-    return if @original_attachment.pdf_attachment_id.present?
+    return if @original_attachment&.pdf_attachment_id.present?
 
     file = converted_file
 


### PR DESCRIPTION
Bug fix for NoMethodError: undefined method `pdf_attachment_id' for nil:NilClass
in PdfConverter

- Use Safe Navigation Operator to fix bug


## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
