### PR TITLE
AP-1177 Update README to explain Provider details retrieval process

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,14 @@ Not that the provider firm_id is the same for `firm1-user1` and `firm1-user2`; a
 different firms.  The password for all users is `password`.
 
 
+### Post-authentication provider details retrieval
+Once the provider has been authenticated, either by the portal or by the mock-saml mechanism described above,
+an after_action method `#update_provider_details` on the `SamlSsessionsController` is executed. This will call the `update_details` method on the current_provider (a Provider object supplied by Devise).
+
+The first time someone logs in, there will be no firm for the provider, and `update_details_directly` will be called immediately, otherwise a job to do that in the background will be scheduled.
+
+The `update_details-directly` method will instantiate and call the ProviderDetailsCreator which in turn calls the `ProviderDetailsRetriever` to get the details from the API, and create the necessary firm, contact records.  The `ProviderDetailsRetriever` will in fact delegate this task to the `MockProviderDetailsRetriever` if the rails configuration item `provider_details.mock` is set to true.
+
 ### Benefits checker
 
 To mock the benefits check in development and testing add the following environment


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1177)

This ticket was to update the apply system to consume the new format returned by the provider details API.  In fact there is nothing to do: the API now returns a new element in it's response to detail the Fee Earners, but we don't use that data and the rest of the structure remains the same.

I have used this opportunity to add a little section to the README to explain how this process works.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
