### PR TITLE
Fix the cronjob fix

### DIFF
--- a/helm_deploy/apply-for-legal-aid/templates/cronjob-reset-dashboard-overnight.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/cronjob-reset-dashboard-overnight.yaml
@@ -24,7 +24,7 @@ spec:
           - name: reset-dashboard
             image: '{{ .Values.image.repository }}:{{ .Values.image.tag }}'
             imagePullPolicy: IfNotPresent
-            command: ['rake', "job:dashboard:update['Applications FeedbackScores']"]
+            command: ['rake', "job:dashboard:update[Applications FeedbackScores]"]
 {{ include "apply-for-legal-aid.envs" . | nindent 12 }}
             resources:
               limits:


### PR DESCRIPTION
## What
When running the command 
```shell
rake job:dashboard:update['Applications FeedbackScores']
```
on the server, it successfully runs the dashboard update for both `Applications` and `FeedbackScores`.

However, when docker/helm executes 
```shell
command: ['rake', "job:dashboard:update[\'Applications FeedbackScores\']"]
```
sidekiq complains about executing `'Applications` and `FeedbackScores'`.

Each has a quote pre- or suffix-ed.

This PR addresses the issue by removing the quotes inside the rake task call.
This is counter-intuitive as it will not work locally or indeed from a command line on the server, but after deploying the build to UAT and manually running the cronjob it seems to work :man_shrugging: 

Attempt 1: escape the quotes : `command: ['rake', "job:dashboard:update[\'Applications FeedbackScores\']"]`
Attempt 2: remove the quotes : `command: ['rake', "job:dashboard:update[Applications FeedbackScores]"]`

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
