### PR TITLE
Modify CircleCI to auto deploy master merges

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -333,7 +333,7 @@ workflows:
     - hold_staging:
         type: approval
         requires:
-        - deploy_uat_auto
+        - build_and_push
         filters:
           branches:
             only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -314,14 +314,26 @@ workflows:
     - build_and_push
     - hold_uat:
         type: approval
+        filters:
+          branches:
+            ignore: master
     - deploy_uat:
         requires:
         - hold_uat
         - build_and_push
+        filters:
+          branches:
+            ignore: master
+    - deploy_uat_auto:
+        requires:
+          - build_and_push
+        filters:
+          branches:
+            only: master
     - hold_staging:
         type: approval
         requires:
-        - build_and_push
+        - deploy_uat_auto
         filters:
           branches:
             only: master


### PR DESCRIPTION
## What
deploy_uat will be an optional step on non-master branches but, when code is merged to master, it will build and deploy to UAT then wait for approval to push to staging and prod environments.
This was deployed in January, but a corruption in the master branch kubernetes pods on UAT caused a false positive so the changes were reverted. 

## Why
This will ensure that UAT master is always up to date and surface any issues around the deploy step before it gets to the staging environment.  e.g. a dependabot merge that breaks deploy could be merged to master but not actually deployed until some days later when code is changed and we may not be sure if the code or gem update broke the deploy

## How
Update the circle config file to:-
* make hold_uat and deploy_uat ignore the master branch
* add an auto_deploy_uat workflow step that will _only_ run on master branch

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, ~~with a link to the JIRA story~~.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
