### PR TITLE
Fix: Circle CI automatically deploy master branches to UAT

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -215,7 +215,7 @@ jobs:
             docker push "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${REPO_NAME}:latest"
           fi
 
-  deploy_uat:
+  deploy_uat: &deploy_uat
     <<: *cloud_platform_container_config
     steps:
     - checkout
@@ -226,6 +226,9 @@ jobs:
         name: Helm deployment to UAT
         command: |
           ./bin/uat_deploy
+
+  deploy_uat_auto:
+    <<: *deploy_uat
 
   deploy_staging:
     <<: *cloud_platform_container_config


### PR DESCRIPTION
## What

Fix the master auto-uat deploy

This solution was tested multiple times on the branch prior to rebasing. 
In all cases, the branch successfully built and deployed to UAT with no user intervention.
I then reverted the step to only run on master and squashed the commits

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
