### PR TITLE
Make test sequence random

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,3 @@
 --require spec_helper
+--color
+--order rand

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -25,7 +25,7 @@ class Provider < ApplicationRecord
   end
 
   def whitelisted_user?
-    whitelisted_users.any? { |user| user.casecmp(username).zero? }
+    whitelisted_users&.any? { |user| user.casecmp(username).zero? }
   end
 
   private

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -102,6 +102,8 @@ Cucumber::Rails::Database.javascript_strategy = :truncation
 
 Before do |_scenario|
   load Rails.root.join('db/seeds.rb')
+  # Delete previous screenshots from filesystem that were generated during previous feature runs
+  FileUtils.rm_rf("#{Rails.root}/tmp/capybara/**.*")
 end
 
 Around do |_scenario, block|

--- a/spec/models/legal_aid_application_spec.rb
+++ b/spec/models/legal_aid_application_spec.rb
@@ -109,6 +109,7 @@ RSpec.describe LegalAidApplication, type: :model do
 
       context 'but later, applicant first name updated' do
         before { applicant.update(first_name: Faker::Name.first_name) }
+        let!(:benefit_check_result) { travel(-10.minutes) { create :benefit_check_result, legal_aid_application: legal_aid_application } }
 
         it 'returns true' do
           expect(legal_aid_application).to be_benefit_check_result_needs_updating
@@ -646,9 +647,11 @@ RSpec.describe LegalAidApplication, type: :model do
 
   describe '#cfe_result' do
     it 'returns the result associated with the most recent CFE::Submission' do
-      legal_aid_application = create :legal_aid_application
-      submission1 = create :cfe_submission, legal_aid_application: legal_aid_application
-      create :cfe_result, submission: submission1
+      travel(-10.minutes) do
+        legal_aid_application = create :legal_aid_application
+        submission1 = create :cfe_submission, legal_aid_application: legal_aid_application
+        create :cfe_result, submission: submission1
+      end
       submission2 = create :cfe_submission, legal_aid_application: legal_aid_application
       result2 = create :cfe_result, submission: submission2
 

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe Provider, type: :model do
   describe '#whitelisted_user?' do
     before do
       allow(HostEnv).to receive(:production?).and_return(true)
+      Rails.configuration.x.application.whitelisted_users = %w[user1 user2 user3]
     end
 
     context 'user is whitelisted' do

--- a/spec/requests/providers/check_benefits_spec.rb
+++ b/spec/requests/providers/check_benefits_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe 'check benefits requests', type: :request do
 
       context 'and the applicant has since been modified' do
         before { applicant.update(first_name: Faker::Name.first_name) }
-        let!(:benefit_check_result) { create :benefit_check_result, legal_aid_application: application }
+        let!(:benefit_check_result) { travel(-10.minutes) { create :benefit_check_result, legal_aid_application: application } }
 
         it 'updates check_benefit_result' do
           expect(BenefitCheckService).to receive(:call).and_call_original

--- a/spec/requests/providers/legal_aid_applications_spec.rb
+++ b/spec/requests/providers/legal_aid_applications_spec.rb
@@ -24,9 +24,22 @@ RSpec.describe 'providers legal aid application requests', type: :request do
         expect(response).to have_http_status(:ok)
       end
 
+      context 'there are no whitelisted users' do
+        before do
+          allow(HostEnv).to receive(:production?).and_return(true)
+          Rails.configuration.x.application.whitelisted_users = nil
+        end
+
+        it 'redirects to error page' do
+          subject
+          expect(response).to redirect_to(error_path(:access_denied))
+        end
+      end
+
       context 'provider is not a whitelisted user' do
         before do
           allow(HostEnv).to receive(:production?).and_return(true)
+          Rails.configuration.x.application.whitelisted_users = %w[not_this_provider]
         end
 
         it 'redirects to error page' do


### PR DESCRIPTION
## What

Set RSpec to run the tests in random, this helps to ensure that tests truly pass and that early-run tests are not changing the set-up for subsequent ones

1. locally run the tests randomly and fix tests that regularly fail 
1. push each individual commit to github, this will ensure they still work when run sequentially
1. set the .rspec file to `--order rand`

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
