### PR TITLE
AP1197 Add legal_aid and maintenance_out attributes to CCMS payload

### DIFF
--- a/app/models/transaction_type.rb
+++ b/app/models/transaction_type.rb
@@ -49,6 +49,11 @@ class TransactionType < ApplicationRecord
     I18n.t("transaction_types.names.#{journey}.#{name}")
   end
 
+  def self.for_outgoing_type?(transaction_type_name)
+    transaction_type = TransactionType.where(name: transaction_type_name, operation: :debit).first
+    transaction_type.present?
+  end
+
   def citizens_label_name
     label_name(journey: :citizens)
   end

--- a/app/models/transaction_type.rb
+++ b/app/models/transaction_type.rb
@@ -24,6 +24,7 @@ class TransactionType < ApplicationRecord
   scope :debits, -> { active.where(operation: :debit) }
   scope :credits, -> { active.where(operation: :credit) }
   scope :income_for, ->(transaction_type_name) { active.where(operation: :credit, name: transaction_type_name) }
+  scope :outgoing_for, ->(transaction_type_name) { active.where(operation: :debit, name: transaction_type_name) }
 
   def self.populate
     populate_records
@@ -50,8 +51,7 @@ class TransactionType < ApplicationRecord
   end
 
   def self.for_outgoing_type?(transaction_type_name)
-    transaction_type = TransactionType.where(name: transaction_type_name, operation: :debit).first
-    transaction_type.present?
+    outgoing_for(transaction_type_name).any?
   end
 
   def citizens_label_name

--- a/app/services/ccms/attribute_value_generator.rb
+++ b/app/services/ccms/attribute_value_generator.rb
@@ -32,6 +32,7 @@ module CCMS
                                 |other_assets_declaration
                                 |other_party
                                 |proceeding
+                                |outgoing
                                 |respondent
                                 |savings_amount
                                 |income_type

--- a/app/services/ccms/attribute_value_generator.rb
+++ b/app/services/ccms/attribute_value_generator.rb
@@ -53,6 +53,9 @@ module CCMS
     INCOME_TYPE_REGEX = /^income_type_(\S+)$/.freeze
     VEHICLE_REGEX = /^vehicle_(\S+)$/.freeze
     WAGE_SLIP_REGEX = /^wage_slip_(\S+)$/.freeze
+    OUTGOING = /^outgoing_(\S+)$/.freeze
+    OTHER_ASSETS_DECLARATION = /^other_assets_declaration_(\S+)$/.freeze
+    LEAD_PROCEEDING_TYPE = /^lead_proceeding_type_(\S+)$/.freeze
 
     PROSPECTS_OF_SUCCESS = {
       likely: 'Good',
@@ -327,6 +330,8 @@ module CCMS
         @legal_aid_application.transaction_types.for_income_type?(Regexp.last_match(1).chomp('?'))
       when OPPONENT
         options[:opponent].__send__(Regexp.last_match(1))
+      when OUTGOING
+        @legal_aid_application.transaction_types.for_outgoing_type?(Regexp.last_match(1).chomp('?'))
       when RESPONDENT
         options[:respondent].__send__(Regexp.last_match(1))
       when MERITS_ASSESSMENT

--- a/config/ccms/attribute_block_configs/base.yml
+++ b/config/ccms/attribute_block_configs/base.yml
@@ -2266,8 +2266,7 @@ global_means:
   GB_INPUT_B_14WP3_1A:
     generate_block?: false
     value: false
-    br100_meaning: 'Client Crim Legal Aid: Pays a contribution towards criminal legal
-      aid?'
+    br100_meaning: 'Client Criminal Legal Aid: Pays a contribution towards criminal legal aid?'
     response_type: boolean
     user_defined: true
   GB_INPUT_B_6WP3_232A:

--- a/config/ccms/attribute_block_configs/non_passported.yml
+++ b/config/ccms/attribute_block_configs/non_passported.yml
@@ -335,7 +335,7 @@ global_means:
     value: '#outgoing_legal_aid?'
   GB_INPUT_B_12WP3_3A:
     generate_block?: true
-    value: '#outgoing_maintenance?'
+    value: '#outgoing_maintenance_out?'
   GB_INFER_B_26WP3_214A:
     generate_block?: true
     value: false

--- a/config/ccms/attribute_block_configs/non_passported.yml
+++ b/config/ccms/attribute_block_configs/non_passported.yml
@@ -330,6 +330,12 @@ global_means:
   CLIENT_VULNERABLE:
     generate_block?: true
     value: false
+  GB_INPUT_B_14WP3_1A:
+    generate_block?: true
+    value: '#outgoing_legal_aid?'
+  GB_INPUT_B_12WP3_3A:
+    generate_block?: true
+    value: '#outgoing_maintenance?'
   GB_INFER_B_26WP3_214A:
     generate_block?: true
     value: false

--- a/spec/factories/transaction_types.rb
+++ b/spec/factories/transaction_types.rb
@@ -41,5 +41,23 @@ FactoryBot.define do
       operation { 'credit' }
       sort_order { 20 }
     end
+
+    trait :salary do
+      name { 'salary' }
+      operation { 'credit' }
+      sort_order { 10 }
+    end
+
+    trait :maintenance_out do
+      name { 'maintenance_out' }
+      operation { 'debit' }
+      sort_order { 50 }
+    end
+
+    trait :child_care do
+      name { 'child_care' }
+      operation { 'credit' }
+      sort_order { 60 }
+    end
   end
 end

--- a/spec/models/legal_aid_application_spec.rb
+++ b/spec/models/legal_aid_application_spec.rb
@@ -659,6 +659,34 @@ RSpec.describe LegalAidApplication, type: :model do
     end
   end
 
+  describe '#transaction_types' do
+    let(:legal_aid_application) { create :legal_aid_application }
+    let!(:ff) { create :transaction_type, :friends_or_family }
+    let!(:salary) { create :transaction_type, :salary }
+    let!(:maintenance) { create :transaction_type, :maintenance_out }
+    let!(:child_care) { create :transaction_type, :child_care }
+    let!(:ff_tt) { create :legal_aid_application_transaction_type, transaction_type: ff, legal_aid_application: legal_aid_application }
+    let!(:maintenance_tt) { create :legal_aid_application_transaction_type, transaction_type: maintenance, legal_aid_application: legal_aid_application }
+
+    it 'returns an array of transaction type records' do
+      expect(legal_aid_application.transaction_types).to eq [ff, maintenance]
+    end
+
+    describe '#transaction_type.for_outgoing_type?' do
+      context 'there is no legal aid transaction type of the required type' do
+        it 'returns false' do
+          expect(legal_aid_application.transaction_types.for_outgoing_type?('child_care')).to be false
+        end
+      end
+
+      context 'there is a legal aid transaction type of the rrquired type' do
+        it 'returns true' do
+          expect(legal_aid_application.transaction_types.for_outgoing_type?('maintenance_out')).to be true
+        end
+      end
+    end
+  end
+
   describe 'after_save hook' do
     context 'when an application is created' do
       let(:application) { create :legal_aid_application }

--- a/spec/models/transaction_type_spec.rb
+++ b/spec/models/transaction_type_spec.rb
@@ -70,4 +70,20 @@ RSpec.describe TransactionType, type: :model do
       end
     end
   end
+
+  describe '#for_outgoing_type?' do
+    before { create :transaction_type, :child_care }
+    context 'no such outgoing types exist' do
+      it 'returns false' do
+        expect(TransactionType.for_outgoing_type?('maintenance_out')).to be false
+      end
+    end
+
+    context 'outgoing types do exist' do
+      before { create :transaction_type, :maintenance_out }
+      it 'returns true' do
+        expect(TransactionType.for_outgoing_type?('maintenance_out')).to be true
+      end
+    end
+  end
 end

--- a/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_attributes_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_attributes_spec.rb
@@ -319,6 +319,46 @@ module CCMS
           end
         end
 
+        context 'global means outgoing attributes' do
+          context 'maintenance payments' do
+            let(:maintenance_transaction) { create :transaction_type, :debit, name: 'maintenance_out' }
+
+            before do
+              create(:legal_aid_application_transaction_type, legal_aid_application: legal_aid_application, transaction_type: maintenance_transaction)
+            end
+            it 'has attributes' do
+              block = XmlExtractor.call(xml, :global_means, 'GB_INPUT_B_12WP3_3A')
+              expect(block).to have_boolean_response true
+              expect(block).to be_user_defined
+            end
+            context 'no payments' do
+              before { legal_aid_application.transaction_types.delete_all }
+              it 'does not have attributes' do
+                block = XmlExtractor.call(xml, :global_means, 'GB_INPUT_B_12WP3_3A')
+                expect(block).to have_boolean_response false
+              end
+            end
+          end
+          context 'applicant criminal legal aid payments' do
+            let(:criminal_legal_aid_transaction) { create :transaction_type, :debit, name: 'legal_aid' }
+            before do
+              create(:legal_aid_application_transaction_type, legal_aid_application: legal_aid_application, transaction_type: criminal_legal_aid_transaction)
+            end
+            it 'has attributes' do
+              block = XmlExtractor.call(xml, :global_means, 'GB_INPUT_B_14WP3_1A')
+              expect(block).to have_boolean_response true
+              expect(block).to be_user_defined
+            end
+            context 'no payments' do
+              before { legal_aid_application.transaction_types.delete_all }
+              it 'does not have attributes' do
+                block = XmlExtractor.call(xml, :global_means, 'GB_INPUT_B_14WP3_1A')
+                expect(block).to have_boolean_response false
+              end
+            end
+          end
+        end
+
         context 'attributes for WILL' do
           it 'generates the attributes' do
             will_attributes.each do |attr_name|


### PR DESCRIPTION
AP1197 Add non-passported outgoing transaction attributes for legal_aid and maintenance_out to CCMS payload

[Link to story](https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=233&projectKey=AP&modal=detail&selectedIssue=AP-1197)

- Add two outgoing transactions attributes maintenance_out and legal_aid (criminal legal aid payments) into the non-passsported flow.

- Add `.for_outgoing_type?` to help with retrieval of required outgoing transactions data.

- Update tests

To note: The method calls for outgoing_* attributes should end in a '?' as it returns a boolean value. I've amended the case for OUTGOING attributes in the attribute_value_generator to use `.chomp('?'))`
## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
