### PR TITLE
Update sprockets to version 4 and remove precompile commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,8 +77,6 @@ EXPOSE 3002
 
 COPY . .
 
-RUN bundle exec rake assets:precompile SECRET_KEY_BASE=a-real-secret-key-is-not-needed-here
-
 # tidy up installation
 RUN apk del build-dependencies
 

--- a/Gemfile
+++ b/Gemfile
@@ -58,7 +58,7 @@ gem 'sidekiq_alive'
 
 # Transformer that converts ES6 code into vanilla ES5 using babel via asset pipeline
 # Default to 3.7.2 as https://github.com/sass/sassc-rails/issues/122 sassc loading is causing a segmentation error
-gem 'sprockets', '~> 3.7.2'
+gem 'sprockets', '~> 4.0'
 gem 'sprockets-es6'
 
 # URL and path parsing

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -484,7 +484,7 @@ GEM
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
       spring (>= 1.2, < 3.0)
-    sprockets (3.7.2)
+    sprockets (4.0.0)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-es6 (0.9.2)
@@ -604,7 +604,7 @@ DEPENDENCIES
   slack-notifier
   spring
   spring-watcher-listen (~> 2.0.0)
-  sprockets (~> 3.7.2)
+  sprockets (~> 4.0)
   sprockets-es6
   timecop
   tzinfo-data

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,2 +1,2 @@
 //= link_tree ../images
-//= link_directory ../stylesheets .css
+//= link_directory ../javascripts .js

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,2 +1,3 @@
 //= link_tree ../images
-//= link_directory ../javascripts .js
+//= link_directory ../stylesheets .css
+//= link_directory ../../javascript .js

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -3,5 +3,3 @@ Rails.application.config.assets.version = '1.0'
 Rails.application.config.assets.paths << Rails.root.join('node_modules')
 
 Rails.application.config.assets.paths << Rails.root.join('app', 'assets', 'fonts')
-
-Rails.application.config.assets.precompile += ['application.css']

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -3,3 +3,5 @@ Rails.application.config.assets.version = '1.0'
 Rails.application.config.assets.paths << Rails.root.join('node_modules')
 
 Rails.application.config.assets.paths << Rails.root.join('app', 'assets', 'fonts')
+
+Rails.application.config.assets.precompile += ['application.css']


### PR DESCRIPTION
Update Sprockets to version 4 after the Rails 6 upgrade here https://github.com/ministryofjustice/laa-apply-for-legal-aid/pull/1240


Update Sprockets to version 4
Remove precompile command calls and allow mainfest.js to do that work.

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
