### PR TITLE
FIX: remove webhints accessibility warning

### DIFF
--- a/app/helpers/page_template_helper.rb
+++ b/app/helpers/page_template_helper.rb
@@ -39,7 +39,7 @@ module PageTemplateHelper
   #
 
   def page_template( # rubocop:disable Metrics/ParameterLists, Metrics/MethodLength
-    page_title:,
+    page_title: nil,
     head_title: nil,
     back_link: {},
     column_width: 'two-thirds',

--- a/app/views/providers/application_confirmations/show.html.erb
+++ b/app/views/providers/application_confirmations/show.html.erb
@@ -14,7 +14,7 @@
 <%= page_template page_title: nil do %>
 
   <p class="govuk-body"><%= t '.sent_email_text', email: @legal_aid_application.applicant.email %></p>
-  <h3 class="govuk-heading-m"><%= t '.happen_next_heading' %></h3>
+  <h2 class="govuk-heading-m"><%= t '.happen_next_heading' %></h2>
   <p class="govuk-body">
    <%= t '.happen_next_text' %>
   </p>

--- a/app/views/shared/page_templates/_default_page_template.html.erb
+++ b/app/views/shared/page_templates/_default_page_template.html.erb
@@ -6,9 +6,11 @@
     <% if content_for?(:panel) %>
       <%= content_for(:panel) %>
       <div class="govuk-!-padding-top-4"></div>
-      <h2 class="govuk-heading-m">
-        <%= content_for(:page_title) %>
-      </h2>
+      <% if content_for(:page_title) %>
+        <h2 class="govuk-heading-m">
+          <%= content_for(:page_title) %>
+        </h2>
+      <% end %>
     <% else %>
       <%= page_heading page_heading_options %>
     <% end %>


### PR DESCRIPTION
## What

allow nil page_titles as this supresses a `Headings must not be empty` accessibility warning in the nightly build

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
