### PR TITLE
AP-1310: Update `none of these` checkbox handling

### DIFF
--- a/app/views/shared/forms/_savings_and_investments_form.html.erb
+++ b/app/views/shared/forms/_savings_and_investments_form.html.erb
@@ -21,7 +21,7 @@
 
       <div class="govuk-checkboxes">
         <div class="govuk-checkboxes__item">
-          <%= form.check_box :none_selected, { class: 'govuk-checkboxes__input' }, 'true', @form.none_selected %>
+          <%= form.check_box :none_selected, { class: 'govuk-checkboxes__input' }, true, '' %>
           <%= form.label :none_selected, none_selected, class: 'govuk-label govuk-checkboxes__label' %>
         </div>
       </div>

--- a/app/views/shared/forms/other_assets/_form.html.erb
+++ b/app/views/shared/forms/other_assets/_form.html.erb
@@ -23,7 +23,7 @@
 
       <div class="govuk-checkboxes">
         <div class="govuk-checkboxes__item">
-          <%= form.check_box :none_selected, { class: 'govuk-checkboxes__input' }, 'true', @form.none_selected %>
+          <%= form.check_box :none_selected, { class: 'govuk-checkboxes__input', include_hidden: true }, true, '' %>
           <%= form.label :none_selected, none_selected, class: 'govuk-label govuk-checkboxes__label' %>
         </div>
       </div>

--- a/features/providers/civil_application_journey.feature
+++ b/features/providers/civil_application_journey.feature
@@ -640,7 +640,6 @@ Feature: Civil application journeys
     Then I click link "Search applications"
     Then I should be on a page showing "Search applications"
 
-
   @javascript @vcr
   Scenario: Using the back button to change none_of_these checkboxes
     Given I am checking the applicant's means answers

--- a/features/providers/civil_application_journey.feature
+++ b/features/providers/civil_application_journey.feature
@@ -639,3 +639,33 @@ Feature: Civil application journeys
     Then I click link "Start"
     Then I click link "Search applications"
     Then I should be on a page showing "Search applications"
+
+
+  @javascript @vcr
+  Scenario: Using the back button to change none_of_these checkboxes
+    Given I am checking the applicant's means answers
+    When I click Check Your Answers Change link for 'Savings and investments'
+    Then I should be on the "savings_and_investment" page showing "Which types of savings or investments does your client have?"
+    When I select "None of these"
+    And I click "Save and continue"
+    Then I should be on the 'means_summary' page showing 'Check your answers'
+    When I click link "Back"
+    Then I should be on the "savings_and_investment" page showing "Which types of savings or investments does your client have?"
+    When I deselect "None of these"
+    And I click "Save and continue"
+    Then I should be on the "savings_and_investment" page showing "Select if your client has any of these savings or investments"
+    When I select "None of these"
+    And I click "Save and continue"
+    Then I should be on the 'means_summary' page showing 'Check your answers'
+    When I click Check Your Answers Change link for 'Other assets'
+    Then I should be on the "other_assets" page showing "Which types of assets does your client have?"
+    When I select "None of these"
+    And I click "Save and continue"
+    Then I should be on a page showing "Check your answers"
+    When I click link "Back"
+    Then I should be on the "other_assets" page showing "Which types of assets does your client have?"
+    When I deselect "None of these"
+    And I click "Save and continue"
+    Then I should be on the "other_assets" page showing "Select if your client has any of these types of assets"
+    Then I select "None of these"
+    Then I click "Save and continue"


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1310)

Update the `none of these` checkboxes on savings and investments and assets views for providers

It was possible, after going backward and forwards to submit the forms with no checkboxes selected

This was because the `true` value was being stored as the value of the attribute rather than just true or empty

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
