### PR TITLE
AP-1311: Move provider declaration

### DIFF
--- a/app/controllers/providers/declarations_controller.rb
+++ b/app/controllers/providers/declarations_controller.rb
@@ -1,0 +1,7 @@
+module Providers
+  class DeclarationsController < ProviderBaseController
+    legal_aid_application_not_required!
+
+    def show; end
+  end
+end

--- a/app/views/providers/declarations/show.html.erb
+++ b/app/views/providers/declarations/show.html.erb
@@ -1,0 +1,14 @@
+<%= page_template page_title: t('.h1-heading') do %>
+  <p class="govuk-body"><%= t('.statement') %></p>
+  <ul class="govuk-list govuk-list--bullet print-add-bullet">
+    <%- t('.statement-bullets').each do |bullet| %>
+      <li><%= bullet %></li>
+    <% end %>
+  </ul>
+  <%= next_action_buttons_with_form(
+          url: providers_legal_aid_applications_path,
+          method: :post,
+          show_draft: false,
+          continue_button_text: t('.continue_button')
+      ) %>
+<% end %>

--- a/app/views/providers/legal_aid_applications/index.html.erb
+++ b/app/views/providers/legal_aid_applications/index.html.erb
@@ -9,10 +9,10 @@
   </p>
 
   <%= link_to(start_button_label(:start_now),
-              providers_legal_aid_applications_path,
+              providers_declaration_path,
               class: 'govuk-button govuk-button--start',
               id: 'start',
-              method: :post
+              method: :get
       ) %>
 
 <% end %>

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -223,6 +223,16 @@ en:
     date_client_told_incidents:
       show:
         h1-heading: Latest incident details
+    declarations:
+      show:
+        h1-heading: Declaration
+        statement: 'By continuing, you agree that:'
+        statement-bullets:
+        - your client has instructed you to represent them
+        - you'll go through all parts of the application with your client
+        - you'll explain the statutory charge to your client
+        - you'll provide complete and correct information
+        continue_button: Agree and continue
     delegated_confirmation:
       index:
         page-heading: You told us you've used delegated functions

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -123,6 +123,7 @@ Rails.application.routes.draw do
     resources :applicants, only: %i[new create]
     resource :confirm_office, only: %i[show update]
     resource :select_office, only: %i[show update]
+    resource :declaration, only: %i[show update]
 
     resources :legal_aid_applications, path: 'applications', only: %i[index create] do
       get :search, on: :collection

--- a/features/providers/civil_application_journey.feature
+++ b/features/providers/civil_application_journey.feature
@@ -40,6 +40,8 @@ Feature: Civil application journeys
     Given I visit the application service
     And I click link "Start"
     And I click link "Start now"
+    Then I should be on the 'providers/declaration' page showing 'Declaration'
+    When I click 'Agree and continue'
     Then I should be on the Applicant page
     Then I enter name 'Test', 'User'
     Then I enter the date of birth '03-04-1999'
@@ -59,6 +61,8 @@ Feature: Civil application journeys
     Given I visit the application service
     And I click link "Start"
     And I click link "Start now"
+    Then I should be on the 'providers/declaration' page showing 'Declaration'
+    When I click 'Agree and continue'
     Then I should be on the Applicant page
     Then I enter name 'Test', 'User'
     Then I enter the date of birth '03-04-1999'
@@ -109,6 +113,8 @@ Feature: Civil application journeys
     Given I visit the application service
     And I click link "Start"
     And I click link "Start now"
+    Then I should be on the 'providers/declaration' page showing 'Declaration'
+    When I click 'Agree and continue'
     Then I should be on the Applicant page
 
   @javascript @vcr @webhint

--- a/features/step_definitions/civil_journey_steps.rb
+++ b/features/step_definitions/civil_journey_steps.rb
@@ -63,6 +63,8 @@ Given('I start the journey as far as the applicant page') do
     Given I visit the application service
     And I click link "Start"
     And I click link "Start now"
+    Then I should be on the 'providers/declaration' page showing 'Declaration'
+    When I click 'Agree and continue'
     Then I should be on the Applicant page
   )
 end

--- a/spec/requests/providers/declarations_spec.rb
+++ b/spec/requests/providers/declarations_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe Providers::DeclarationsController, type: :request do
+  let(:provider) { create :provider }
+  subject(:visit_page) { get(providers_declaration_path) }
+
+  describe 'GET /providers/declaration' do
+    before do
+      login_as provider
+      visit_page
+    end
+
+    it 'returns http success' do
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'displays the correct page' do
+      expect(unescaped_response_body).to include('Declaration')
+    end
+  end
+end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1311)

Implement a new view and route handling for a provider declaration before they add the user data

## outstanding work
- [x] check wording of links on the new page
- [x] clarify removal of previous declaration

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
