### PR TITLE
Fix: list-item display

### DIFF
--- a/app/views/shared/forms/_list_items.html.erb
+++ b/app/views/shared/forms/_list_items.html.erb
@@ -2,7 +2,7 @@
   <% if translation_path.include? 'warning' %>
     <ul class="govuk-list govuk-list--bullet">
       <% t("#{translation_path}.list", params).each_line do |item| %>
-        <strong><li><%= item %></li></strong>
+        <li><strong><%= item %></strong></li>
       <% end %>
     </ul>
     <% else %>


### PR DESCRIPTION
## What

Webhint raised an issue where `li` tags should be directly inside `ul` tags
Moving the `strong` tag inside the `li` tags makes webhint happy

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
