### PR TITLE
BUGFIX: add rake task to clear CCMS submission

### DIFF
--- a/lib/tasks/clear_ccms_queue.rake
+++ b/lib/tasks/clear_ccms_queue.rake
@@ -1,18 +1,21 @@
 namespace :ccms do
   desc 'Clear CCMS submissions with stuck means reports'
-  task clear_queue: :environment do
+  task :clear_queue, [:application_id] => :environment do |_task, args|
+
     include Rails.application.routes.url_helpers
-
-    dry_run = ENV['DRY_RUN'].nil?
-
     # v3
     # get the application_ids
     # delete any application.attachments where attachment_type='means_report'
     # delete any application.ccms_submission.submission_documents where document_type: "means_report"
     # run MeansReportCreator.call(legal_aid_application)
     # output url for accessing the means report e.g. service_url/application_guid/means_report
-
-    application_ids = CCMS::Submission.where("aasm_state NOT IN ('completed', 'failed')").pluck(:legal_aid_application_id)
+    dry_run = ENV['DRY_RUN'].nil?
+    ActiveRecord::Base.logger = nil
+    application_ids = if args[:application_id].nil?
+                        CCMS::Submission.where("aasm_state NOT IN ('completed', 'failed')").pluck(:legal_aid_application_id)
+                      else
+                        [] << args[:application_id]
+                      end
     application_ids.each do |laa_id|
       laa = LegalAidApplication.find(laa_id)
       attachments = laa.attachments.where(attachment_type: 'means_report')

--- a/lib/tasks/clear_ccms_queue.rake
+++ b/lib/tasks/clear_ccms_queue.rake
@@ -1,0 +1,35 @@
+namespace :ccms do
+  desc 'Clear CCMS submissions with stuck means reports'
+  task clear_queue: :environment do
+    include Rails.application.routes.url_helpers
+
+    dry_run = ENV['DRY_RUN'].nil?
+
+    # v3
+    # get the application_ids
+    # delete any application.attachments where attachment_type='means_report'
+    # delete any application.ccms_submission.submission_documents where document_type: "means_report"
+    # run MeansReportCreator.call(legal_aid_application)
+    # output url for accessing the means report e.g. service_url/application_guid/means_report
+
+    application_ids = CCMS::Submission.where("aasm_state NOT IN ('completed', 'failed')").pluck(:legal_aid_application_id)
+    application_ids.each do |laa_id|
+      laa = LegalAidApplication.find(laa_id)
+      attachments = laa.attachments.where(attachment_type: 'means_report')
+      submission_documents = laa.ccms_submission.submission_documents.where(document_type: 'means_report')
+      if dry_run
+        pp "I want to delete the #{attachments.count} attachments with ids #{attachments.pluck(:id)}"
+        pp "I want to delete the #{submission_documents.count} submission_documents with ids #{submission_documents.pluck(:id)}"
+      else
+        submission_documents.delete_all
+        attachments.delete_all
+      end
+      Reports::MeansReportCreator.call(laa) unless dry_run
+      laa.ccms_submission.complete!
+      pp "#{providers_legal_aid_application_means_report_url(laa)}?debug=true#{' would work if not in dry_run mode' if dry_run}"
+    rescue StandardError => e
+      puts e
+      raise
+    end
+  end
+end

--- a/lib/tasks/clear_ccms_queue.rake
+++ b/lib/tasks/clear_ccms_queue.rake
@@ -25,7 +25,7 @@ namespace :ccms do
         attachments.delete_all
       end
       Reports::MeansReportCreator.call(laa) unless dry_run
-      laa.ccms_submission.complete!
+      laa.ccms_submission.complete! unless dry_run
       pp "#{providers_legal_aid_application_means_report_url(laa)}?debug=true#{' would work if not in dry_run mode' if dry_run}"
     rescue StandardError => e
       puts e

--- a/lib/tasks/clear_ccms_queue.rake
+++ b/lib/tasks/clear_ccms_queue.rake
@@ -28,8 +28,8 @@ namespace :ccms do
       else
         submission_documents.delete_all
         attachments.delete_all
-        Reports::MeansReportCreator.call(laa) unless dry_run
-        laa.ccms_submission.complete! unless dry_run
+        Reports::MeansReportCreator.call(laa)
+        laa.ccms_submission.complete!
       end
       pp "#{providers_legal_aid_application_means_report_url(laa)}?debug=true#{' would work if not in dry_run mode' if dry_run}"
     rescue StandardError => e

--- a/lib/tasks/clear_ccms_queue.rake
+++ b/lib/tasks/clear_ccms_queue.rake
@@ -20,12 +20,14 @@ namespace :ccms do
       if dry_run
         pp "I want to delete the #{attachments.count} attachments with ids #{attachments.pluck(:id)}"
         pp "I want to delete the #{submission_documents.count} submission_documents with ids #{submission_documents.pluck(:id)}"
+        pp "I would call Reports::MeansReportCreator.call for LegalAidApplication id:#{laa.id}"
+        pp "I would mark LegalAidApplication id:#{laa.id} as complete"
       else
         submission_documents.delete_all
         attachments.delete_all
+        Reports::MeansReportCreator.call(laa) unless dry_run
+        laa.ccms_submission.complete! unless dry_run
       end
-      Reports::MeansReportCreator.call(laa) unless dry_run
-      laa.ccms_submission.complete! unless dry_run
       pp "#{providers_legal_aid_application_means_report_url(laa)}?debug=true#{' would work if not in dry_run mode' if dry_run}"
     rescue StandardError => e
       puts e

--- a/lib/tasks/clear_ccms_queue.rake
+++ b/lib/tasks/clear_ccms_queue.rake
@@ -1,7 +1,6 @@
 namespace :ccms do
   desc 'Clear CCMS submissions with stuck means reports'
   task :clear_queue, [:application_id] => :environment do |_task, args|
-
     include Rails.application.routes.url_helpers
     # v3
     # get the application_ids


### PR DESCRIPTION
Some ccms submissions are stuck after the means report geneartion failed
This rake task
* gets the application_ids
* deletes any application.attachments where attachment_type='means_report'
* deletes any application.ccms_submission.submission_documents where document_type: "means_report"
* run MeansReportCreator.call(legal_aid_application)
* sets the ccms_submission state to complete
* output url for accessing the means report e.g. service_url/application_guid/means_report

To test it use
``` sh
rake ccms:clear_queue
```

to run for it for real, call
```sh
DRY_RUN=false ccms:clear_queue
```

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
