### PR TITLE
AP-1333 Create Dependants Service

### DIFF
--- a/app/services/cfe/create_dependants_service.rb
+++ b/app/services/cfe/create_dependants_service.rb
@@ -1,0 +1,29 @@
+module CFE
+  class CreateDependantsService < BaseService
+    def cfe_url_path
+      "/assessments/#{@submission.assessment_id}/dependants"
+    end
+
+    def request_body
+      {
+        dependants: dependants_data
+      }.to_json
+    end
+
+    private
+
+    def process_response
+      @submission.dependants_created!
+    end
+
+    def dependants_data
+      array = []
+      legal_aid_application.dependants.each { |d| array << dependant_data(d) }
+      array
+    end
+
+    def dependant_data(dependant)
+      dependant.as_json(only: %i[date_of_birth in_full_time_education relationship monthly_income assets_value])
+    end
+  end
+end

--- a/spec/services/cfe/create_dependants_service_spec.rb
+++ b/spec/services/cfe/create_dependants_service_spec.rb
@@ -1,0 +1,149 @@
+require 'rails_helper'
+
+module CFE
+  RSpec.describe CreateDependantsService do
+    let(:application) { create :legal_aid_application, :with_negative_benefit_check_result }
+    let(:submission) { create :cfe_submission, aasm_state: 'properties_created', legal_aid_application: application }
+    let(:service) { described_class.new(submission) }
+    let(:dummy_response) { dummy_response_hash.to_json }
+
+    describe '#cfe_url' do
+      it 'contains the submission assessment id' do
+        expect(service.cfe_url)
+          .to eq "#{Rails.configuration.x.check_finanical_eligibility_host}/assessments/#{submission.assessment_id}/dependants"
+      end
+    end
+
+    describe '.call' do
+      before do
+        stub_request(:post, service.cfe_url).with(body: expected_payload_hash.to_json).to_return(body: dummy_response)
+      end
+
+      context 'successful calls' do
+        context 'no dependants' do
+          describe 'successful calls' do
+            let(:expected_payload_hash) { empty_payload }
+
+            it 'updates the submission record from properties_created to dependants_created' do
+              expect(submission.aasm_state).to eq 'properties_created'
+              described_class.call(submission)
+              expect(submission.aasm_state).to eq 'dependants_created'
+            end
+          end
+
+          context 'with dependants' do
+            let(:expected_payload_hash) { loaded_payload }
+
+            before { create_dependants }
+
+            it 'updates the submission record from properties_created to dependants_created' do
+              expect(submission.aasm_state).to eq 'properties_created'
+              described_class.call(submission)
+              expect(submission.aasm_state).to eq 'dependants_created'
+            end
+
+            it 'creates a submission_history record' do
+              expect {
+                described_class.call(submission)
+              }.to change { submission.submission_histories.count }.by 1
+              history = CFE::SubmissionHistory.last
+              expect(history.submission_id).to eq submission.id
+              expect(history.url).to eq service.cfe_url
+              expect(history.http_method).to eq 'POST'
+              expect(history.request_payload).to eq expected_payload_hash.to_json
+              expect(history.http_response_status).to eq 200
+              expect(history.response_payload).to eq dummy_response
+              expect(history.error_message).to be_nil
+            end
+          end
+        end
+      end
+
+      context 'failed calls to CFE' do
+        let(:expected_payload_hash) { loaded_payload }
+        it_behaves_like 'a failed call to CFE'
+      end
+    end
+
+    def dummy_response_hash
+      {
+        objects: [
+          {
+            id: '89449cd5-02cc-487d-a334-cf439aaafebf',
+            assessment_id: 'b4e3443c-bdf5-479d-820c-f1dd3213360e',
+            date_of_birth: '1987-03-29',
+            in_full_time_education: true,
+            created_at: '2020-03-27T13:08:21.438Z',
+            updated_at: '2020-03-27T13:08:21.438Z',
+            relationship: 'adult_relative',
+            monthly_income: '1352.55',
+            assets_value: '0.0',
+            dependant_allowance: '0.0'
+          },
+          {
+            id: 'ee01c68c-f465-4a8e-a292-3f0cb1f2cd2d',
+            assessment_id: 'b4e3443c-bdf5-479d-820c-f1dd3213360e',
+            date_of_birth: '2001-11-23',
+            in_full_time_education: true,
+            created_at: '2020-03-27T13:08:21.441Z',
+            updated_at: '2020-03-27T13:08:21.441Z',
+            relationship: 'child_relative',
+            monthly_income: '8665.97',
+            assets_value: '0.0',
+            dependant_allowance: '0.0'
+          }
+        ],
+        errors: [],
+        success: true
+      }
+    end
+
+    def empty_payload
+      {
+        dependants: []
+      }
+    end
+
+    def create_dependants
+      create :dependant, :over_18,
+             number: 1,
+             date_of_birth: 19.years.ago,
+             relationship: 'adult_relative',
+             legal_aid_application: application,
+             name: 'Stepriponikas Bonstart',
+             monthly_income: 180.0,
+             in_full_time_education: false,
+             assets_value: 10_000.0
+      create :dependant, :under_18,
+             number: 2,
+             relationship: 'child_relative',
+             date_of_birth: 10.years.ago,
+             legal_aid_application: application,
+             name: 'Aztec Bonstart',
+             monthly_income: 0.0,
+             in_full_time_education: true,
+             assets_value: 0.0
+    end
+
+    def loaded_payload
+      {
+        dependants: [
+          {
+            date_of_birth: 19.years.ago.strftime('%Y-%m-%d'),
+            relationship: 'adult_relative',
+            monthly_income: '180.0',
+            in_full_time_education: false,
+            assets_value: '10000.0'
+          },
+          {
+            date_of_birth: 10.years.ago.strftime('%Y-%m-%d'),
+            relationship: 'child_relative',
+            monthly_income: '0.0',
+            in_full_time_education: true,
+            assets_value: '0.0'
+          }
+        ]
+      }
+    end
+  end
+end

--- a/spec/services/cfe/create_other_income_service_spec.rb
+++ b/spec/services/cfe/create_other_income_service_spec.rb
@@ -22,12 +22,6 @@ module CFE
     describe '.call' do
       before { stub_request(:post, service.cfe_url).with(body: expected_payload_hash.to_json).to_return(body: dummy_response) }
 
-      around do |example|
-        VCR.turn_off!
-        example.run
-        VCR.turn_on!
-      end
-
       context 'successful calls' do
         context 'no bank transactions at all' do
           describe 'successful calls' do


### PR DESCRIPTION
## Uploads Dependants data to the Check Financial Eligibility Service

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1333)

- Added `CFE::CreateDependantsService`

## Note
This branch was taken from Ap-1335, so contains those changes as well.  best reviewed after AP-1335 has been merged to master, and this branch rebased on master.

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
