### PR TITLE
FIX: Update TransactionType seeding to fix broken migration

### DIFF
--- a/app/models/transaction_type.rb
+++ b/app/models/transaction_type.rb
@@ -34,10 +34,14 @@ class TransactionType < ApplicationRecord
   scope :outgoing_for, ->(transaction_type_name) { active.where(operation: :debit, name: transaction_type_name) }
 
   def self.populate
-    populate_records
+    populate_records(true)
   end
 
-  def self.populate_records
+  def self.populate_without_income
+    populate_records(false)
+  end
+
+  def self.populate_records(include_other_income)
     NAMES.each_with_index do |(operation, names), op_index|
       names.each_with_index do |name, index|
         start_number = (op_index * 1000) + (index * 10)
@@ -46,6 +50,8 @@ class TransactionType < ApplicationRecord
       end
     end
     TransactionType.active.where.not(name: TransactionType::NAMES.values.flatten).update(archived_at: Time.now)
+    return unless include_other_income
+
     TransactionType.where(name: OTHER_INCOME_TYPES).each do |tt|
       tt.update!(other_income: true)
     end

--- a/db/migrate/20190313174812_add_archived_at_to_transaction_types.rb
+++ b/db/migrate/20190313174812_add_archived_at_to_transaction_types.rb
@@ -1,7 +1,7 @@
 class AddArchivedAtToTransactionTypes < ActiveRecord::Migration[5.2]
   def up
     add_column(:transaction_types, :archived_at, :datetime)
-    TransactionType.populate
+    TransactionType.populate_without_income
   end
 
   def down

--- a/spec/models/transaction_type_spec.rb
+++ b/spec/models/transaction_type_spec.rb
@@ -53,6 +53,16 @@ RSpec.describe TransactionType, type: :model do
     end
   end
 
+  describe '#populate_without_income' do
+    # this is called from an old migration
+    subject { described_class.populate_without_income }
+
+    it 'does not attempt to update other_income fields' do
+      subject
+      expect(TransactionType.where(other_income: true).count).to eq 0
+    end
+  end
+
   describe '#for_income_type?' do
     context 'checks that a boolean response is returned' do
       let!(:credit_transaction) { create :transaction_type, :credit_with_standard_name }


### PR DESCRIPTION
## What
Change TransactionType populate to add a `populate_without_income` class method

This allows the early migration not to try and update a column that has not been created yet
It was simpler to update one call rather than make all the other calls use a `populate_with_income` variant

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
