### PR TITLE
AP1369 Declined open banking consent tracker

### DIFF
--- a/app/models/dashboard/widget_data_providers/total_declined_open_banking.rb
+++ b/app/models/dashboard/widget_data_providers/total_declined_open_banking.rb
@@ -1,0 +1,28 @@
+# count the number of citizens that have denied open banking
+#
+module Dashboard
+  module WidgetDataProviders
+    class TotalDeclinedOpenBanking
+      def self.dataset_definition
+        {
+          fields: [
+            Geckoboard::NumberField.new(:total_declined_open_banking, name: 'Total declined open banking consent')
+          ]
+        }
+      end
+
+      def self.data
+        total_declined_open_banking = LegalAidApplication.where('open_banking_consent=false').count
+        [
+          {
+            'total_declined_open_banking' => total_declined_open_banking
+          }
+        ]
+      end
+
+      def self.handle
+        'total_declined_open_banking'
+      end
+    end
+  end
+end

--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -44,6 +44,7 @@ class LegalAidApplication < ApplicationRecord # rubocop:disable Metrics/ClassLen
 
   after_save do
     ActiveSupport::Notifications.instrument 'dashboard.delegated_functions_used' if saved_change_to_used_delegated_functions?
+    ActiveSupport::Notifications.instrument 'dashboard.total_declined_open_banking' if saved_change_to_open_banking_consent? && !open_banking_consent
   end
 
   attr_reader :proceeding_type_codes

--- a/app/services/dashboard_event_handler.rb
+++ b/app/services/dashboard_event_handler.rb
@@ -33,7 +33,7 @@ class DashboardEventHandler
   end
 
   def valid_events
-    %w[application_created provider_created ccms_submission_saved firm_created feedback_created merits_assessment_submitted delegated_functions_used]
+    %w[application_created provider_created ccms_submission_saved firm_created feedback_created merits_assessment_submitted delegated_functions_used total_declined_open_banking]
   end
 
   def application_created
@@ -47,6 +47,10 @@ class DashboardEventHandler
   def ccms_submission_saved
     Dashboard::UpdaterJob.perform_later('Applications') if payload[:state] == 'failed'
     Dashboard::UpdaterJob.set(wait: 1.minute).perform_later('PendingCcmsSubmissions') unless payload[:state].in?(%w[failed completed])
+  end
+
+  def total_declined_open_banking
+    Dashboard::UpdaterJob.perform_later('TotalDeclinedOpenBanking')
   end
 
   def firm_created

--- a/spec/factories/legal_aid_applications.rb
+++ b/spec/factories/legal_aid_applications.rb
@@ -174,6 +174,10 @@ FactoryBot.define do
       provider_received_citizen_consent { true }
     end
 
+    trait :with_consent do
+      open_banking_consent { true }
+    end
+
     trait :with_vehicle do
       transient do
         populate_vehicle { false }
@@ -206,6 +210,7 @@ FactoryBot.define do
       with_other_assets_declaration
       with_savings_amount
       with_open_banking_consent
+      with_consent
     end
 
     trait :with_everything_and_address do
@@ -228,6 +233,7 @@ FactoryBot.define do
       with_other_assets_declaration
       with_savings_amount
       with_open_banking_consent
+      with_consent
     end
 
     trait :with_negative_benefit_check_result do

--- a/spec/models/dashboard/widget_data_providers/total_declined_open_banking_spec.rb
+++ b/spec/models/dashboard/widget_data_providers/total_declined_open_banking_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+module Dashboard
+  module WidgetDataProviders
+    RSpec.describe TotalDeclinedOpenBanking do
+      describe '.handle' do
+        it 'returns the unqualified widget name' do
+          expect(described_class.handle).to eq 'total_declined_open_banking'
+        end
+      end
+
+      describe '.dataset_definition' do
+        it 'returns hash of field definitions' do
+          expected_definition = '{"fields":[{"name":"Total declined open banking consent","optional":false,"type":"number"}]}'
+          expect(described_class.dataset_definition.to_json).to eq expected_definition
+        end
+      end
+
+      describe '.data' do
+        context 'no to open banking consent' do
+          let(:application) { create :legal_aid_application, open_banking_consent: false }
+          let(:expected_data) { [{ 'total_declined_open_banking' => 1 }] }
+          before { application }
+
+          it 'sends expected data' do
+            expect(described_class.data).to eq expected_data
+          end
+        end
+
+        context 'yes to open banking consent' do
+          let(:application) { create :legal_aid_application, open_banking_consent: true }
+          let(:expected_data) { [{ 'total_declined_open_banking' => 0 }] }
+
+          before { application }
+
+          it 'data is unchanged' do
+            expect(described_class.data).to eq expected_data
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Track total of applicants that have said 'No' to open banking consent

[Link to story](https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=233&projectKey=AP&modal=detail&selectedIssue=AP-1369)

Add dataset for total_declined_open_banking
Update tests

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
