### PR TITLE
AP1387 Scheduled Mailing bug when used delegated functions is false

### DIFF
--- a/app/controllers/providers/used_delegated_functions_controller.rb
+++ b/app/controllers/providers/used_delegated_functions_controller.rb
@@ -17,6 +17,7 @@ module Providers
 
     def submit_application_reminder
       return if legal_aid_application.provider_submitted?
+      return unless @form.model.used_delegated_functions?
 
       SubmitApplicationReminderService.new(legal_aid_application).send_email
     end

--- a/spec/requests/providers/used_delegated_functions_spec.rb
+++ b/spec/requests/providers/used_delegated_functions_spec.rb
@@ -145,6 +145,10 @@ RSpec.describe Providers::UsedDelegatedFunctionsController, type: :request, vcr:
       it 'redirects to the online banking page' do
         expect(response).to redirect_to(providers_legal_aid_application_limitations_path(legal_aid_application))
       end
+
+      it 'does not send a reminder email' do
+        expect(SubmitApplicationReminderService).not_to receive(:new).with(legal_aid_application)
+      end
     end
 
     context 'Form submitted using Save as draft button' do

--- a/spec/requests/providers/used_delegated_functions_spec.rb
+++ b/spec/requests/providers/used_delegated_functions_spec.rb
@@ -147,7 +147,7 @@ RSpec.describe Providers::UsedDelegatedFunctionsController, type: :request, vcr:
       end
 
       it 'does not send a reminder email' do
-        expect(SubmitApplicationReminderService).not_to receive(:new).with(legal_aid_application)
+        expect(SubmitApplicationReminderService).not_to have_received(:new).with(legal_aid_application)
       end
     end
 


### PR DESCRIPTION
A Scheduled Mailing ERROR was being sent to sentry [here](https://sentry.service.dsd.io/mojds/apply-for-legal-aid/issues/48883/). 

Scheduled Mailing was sending and retrying to send SubmitApplicationReminderMailer email even though one of its values needed used_delegated_functions. The solution was to not send that email when the used_delegated_functions is false.

[Link to story](https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=233&projectKey=AP&modal=detail&selectedIssue=AP-1387)

- Don't send reminder mailer when the provider did not use delegated functions.
- Update tests

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
