### PR TITLE
AP1340 Validation for categorising bank transactions

### DIFF
--- a/app/controllers/providers/income_summary_controller.rb
+++ b/app/controllers/providers/income_summary_controller.rb
@@ -18,7 +18,7 @@ module Providers
     private
 
     def uncategorized_transactions?
-      @legal_aid_application.uncategorised_bank_transactions?
+      @legal_aid_application.uncategorised_income_transactions?
     end
 
     def bank_transactions

--- a/app/controllers/providers/income_summary_controller.rb
+++ b/app/controllers/providers/income_summary_controller.rb
@@ -1,14 +1,31 @@
 module Providers
   class IncomeSummaryController < ProviderBaseController
     def index
-      @bank_transactions = @legal_aid_application.bank_transactions
-                                                 .credit
-                                                 .order(happened_at: :desc)
-                                                 .by_type
+      @bank_transactions = bank_transactions
     end
 
     def create
-      continue_or_draft
+      return continue_or_draft if draft_selected?
+
+      if uncategorized_transactions?
+        @bank_transactions = bank_transactions
+        render :index
+      else
+        go_forward
+      end
+    end
+
+    private
+
+    def uncategorized_transactions?
+      @legal_aid_application.uncategorised_bank_transactions?
+    end
+
+    def bank_transactions
+      @legal_aid_application.bank_transactions
+                            .credit
+                            .order(happened_at: :desc)
+                            .by_type
     end
   end
 end

--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -133,9 +133,9 @@ class LegalAidApplication < ApplicationRecord # rubocop:disable Metrics/ClassLen
   end
 
   def uncategorised_income_transactions?
-    @bank_transactions = bank_transactions.credit.order(happened_at: :desc).by_type
+    grouped_transactions = bank_transactions.credit.order(happened_at: :desc).by_type
     transaction_types.credits.each do |transaction_type|
-      uncategorised_transactions_errors(transaction_type.name) if @bank_transactions[transaction_type].blank?
+      uncategorised_transactions_errors(transaction_type.name) if grouped_transactions[transaction_type].blank?
     end
     errors.present?
   end

--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -132,6 +132,18 @@ class LegalAidApplication < ApplicationRecord # rubocop:disable Metrics/ClassLen
     )
   end
 
+  def uncategorised_bank_transactions?
+    @bank_transactions = bank_transactions.credit.order(happened_at: :desc).by_type
+    transaction_types.credits.each do |transaction_type|
+      uncategorised_transactions_errors(transaction_type.name) if @bank_transactions[transaction_type].blank?
+    end
+    errors.present?
+  end
+
+  def uncategorised_transactions_errors(transaction_type_name)
+    errors.add(transaction_type_name, I18n.t('activemodel.errors.models.legal_aid_application.attributes.uncategorised_bank_transactions.message'))
+  end
+
   def proceeding_type_codes=(codes)
     @proceeding_type_codes = codes
     self.proceeding_types = ProceedingType.where(code: codes)

--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -132,7 +132,7 @@ class LegalAidApplication < ApplicationRecord # rubocop:disable Metrics/ClassLen
     )
   end
 
-  def uncategorised_bank_transactions?
+  def uncategorised_income_transactions?
     @bank_transactions = bank_transactions.credit.order(happened_at: :desc).by_type
     transaction_types.credits.each do |transaction_type|
       uncategorised_transactions_errors(transaction_type.name) if @bank_transactions[transaction_type].blank?

--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -140,10 +140,6 @@ class LegalAidApplication < ApplicationRecord # rubocop:disable Metrics/ClassLen
     errors.present?
   end
 
-  def uncategorised_transactions_errors(transaction_type_name)
-    errors.add(transaction_type_name, I18n.t('activemodel.errors.models.legal_aid_application.attributes.uncategorised_bank_transactions.message'))
-  end
-
   def proceeding_type_codes=(codes)
     @proceeding_type_codes = codes
     self.proceeding_types = ProceedingType.where(code: codes)
@@ -287,6 +283,10 @@ class LegalAidApplication < ApplicationRecord # rubocop:disable Metrics/ClassLen
     return unless proceeding_type_codes.present?
 
     errors.add(:proceeding_type_codes, :invalid) if proceeding_types.size != proceeding_type_codes.size
+  end
+
+  def uncategorised_transactions_errors(transaction_type_name)
+    errors.add(transaction_type_name, I18n.t('activemodel.errors.models.legal_aid_application.attributes.uncategorised_bank_transactions.message'))
   end
 
   def create_app_ref

--- a/app/views/providers/income_summary/_income_type_item.html.erb
+++ b/app/views/providers/income_summary/_income_type_item.html.erb
@@ -4,8 +4,11 @@
     providers_legal_aid_application_incoming_transactions_path(transaction_type: name),
     class: 'govuk-body transaction-type-link'
   )
+  form_group_error_class = error.present? ? 'govuk-form-group--error' : ''
+  error_message = error.present? ? error.first : ''
 %>
-<li id="<%= "income-type-#{name}" %>">
+
+<li id="<%= "#{name}" %>" class="<%= form_group_error_class %>">
   <h2 class="app-task-list__section">
     <span class="app-task-list__section-number"><%= number %>. </span>
     <%= t("transaction_types.names.providers.#{name}") %>
@@ -14,6 +17,7 @@
         <%= t("transaction_types.hints.#{name}") %>
       </span>
     <% end %>
+    <% if error_message %><span id="error" class="govuk-error-message"><%= error_message %></span><% end %>
   </h2>
   <%= content_tag(:div, class: 'app-task-list__items', id: "list-item-#{name}") do %>
     <% if bank_transactions.present? %>

--- a/app/views/providers/income_summary/index.html.erb
+++ b/app/views/providers/income_summary/index.html.erb
@@ -1,4 +1,8 @@
-<%= page_template page_title: t('.page_heading') do %>
+<%= page_template page_title: t('.page_heading'), show_errors_for: @legal_aid_application  do %>
+
+<%
+  errors = @legal_aid_application.errors.messages
+%>
 
   <p class="gov-body"><%= t('.subheading') %></p>
 
@@ -6,19 +10,20 @@
   <%= list_from_translation_path('.income_summary.index.you_need_to') %>
 
   <ol class="app-task-list">
-    <% @legal_aid_application.transaction_types.credits.each_with_index do |transaction_type, index| %>
-      <%= render(
-            'income_type_item',
-            name: transaction_type.name,
-            number: index + 1,
-            link_text: t(".select"),
-            bank_transactions: @bank_transactions[transaction_type]
-          ) %>
-    <% end %>
+      <% @legal_aid_application.transaction_types.credits.each_with_index do |transaction_type, index| %>
+        <%= render(
+              'income_type_item',
+              name: transaction_type.name,
+              number: index + 1,
+              link_text: t(".select"),
+              bank_transactions: @bank_transactions[transaction_type],
+              error: errors[transaction_type.name.to_sym]
+            ) %>
+      <% end %>
 
-    <% if @legal_aid_application.transaction_types.credits.count < TransactionType.credits.count %>
-      <%= render partial: 'add_other_income' %>
-    <% end %>
+      <% if @legal_aid_application.transaction_types.credits.count < TransactionType.credits.count %>
+        <%= render partial: 'add_other_income' %>
+      <% end %>
   </ol>
 
   <%= next_action_buttons_with_form(

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -209,6 +209,8 @@ en:
                 blank: Select yes if your client owns their home with anyone else
             substantive_application:
               blank: Select Yes or No
+            uncategorised_bank_transactions:
+              message: Add transactions to this category
             used_delegated_functions:
               blank: Please select Yes or No
             used_delegated_functions_on:

--- a/features/providers/non_passported_journey.feature
+++ b/features/providers/non_passported_journey.feature
@@ -30,6 +30,23 @@ Feature: Non-passported applicant journeys
     And I should see 'Add dependant'
 
   @javascript
+  Scenario: Selects and categorises bank transactions into transaction types
+    Given I start the merits application with brank transactions with no transaction type category
+    Then I should be on the 'client_completed_means' page showing 'Your client has completed their financial assessment'
+    Then I click 'Continue'
+    Then I should be on the 'income_summary' page showing "Sort your client's income into categories"
+    When I click link 'Add another type of income'
+    And I select 'Benefits'
+    And I click 'Save and continue'
+    Then I should be on the 'income_summary' page showing "Sort your client's income into categories"
+    Then I click link 'View statements and add transactions'
+    Then I select the first checkbox
+    And I click 'Save and continue'
+    Then I click 'Save and continue'
+    Then I should be on the 'has_dependants' page showing "Does your client have any dependants?"
+
+
+  @javascript
   Scenario: Complete a merits application for applicant that does not receive benefits with dependants
     Given I start the merits application
     Then I should be on the 'client_completed_means' page showing 'Your client has completed their financial assessment'

--- a/features/step_definitions/civil_journey_steps.rb
+++ b/features/step_definitions/civil_journey_steps.rb
@@ -108,6 +108,23 @@ Given('I start the merits application') do
   )
 end
 
+Given('I start the merits application with brank transactions with no transaction type category') do
+  @legal_aid_application = create(
+    :application,
+    :with_applicant,
+    :with_proceeding_types,
+    :provider_assessing_means,
+    :with_uncategorised_benefits_transactions
+  )
+
+  login_as @legal_aid_application.provider
+  visit Flow::KeyPoint.path_for(
+    journey: :providers,
+    key_point: :start_after_applicant_completes_means,
+    legal_aid_application: @legal_aid_application
+  )
+end
+
 Given('I start the merits application and the applicant has uploaded transaction data') do
   @legal_aid_application = create(
     :application,
@@ -420,6 +437,10 @@ Then(/^I enter ((a|an|the)\s)?([\w\s]+?) ["']([\w\s]+)["']$/) do |_ignore, field
   field_name.downcase!
   field_name.gsub!(/\s+/, '_')
   fill_in(field_name, with: entry)
+end
+
+Then(/^I select the first checkbox$/) do
+  page.first("input[type='checkbox']", visible: false).click
 end
 
 Then('I am on the postcode entry page') do

--- a/spec/factories/bank_transactions.rb
+++ b/spec/factories/bank_transactions.rb
@@ -22,6 +22,12 @@ FactoryBot.define do
       meta_data { 'child_maintenance' }
     end
 
+    trait :uncategorised_benefit_transactions do
+      operation { 'credit' }
+      transaction_type { nil }
+      meta_data { 'child_maintenance' }
+    end
+
     trait :disregarded_benefits do
       operation { 'credit' }
       transaction_type { TransactionType.where(name: 'benefits').first || create(:transaction_type, :benefits) }

--- a/spec/factories/legal_aid_applications.rb
+++ b/spec/factories/legal_aid_applications.rb
@@ -338,6 +338,20 @@ FactoryBot.define do
       end
     end
 
+    trait :with_transaction_types do
+      transaction_types { TransactionType.where(name: 'benefits').first || create(:transaction_type, :benefits) }
+    end
+
+    trait :with_uncategorised_benefits_transactions do
+      after :create do |application|
+        bank_provider = create :bank_provider, applicant: application.applicant
+        bank_account = create :bank_account, bank_provider: bank_provider
+        [90, 60, 30].each do |count|
+          create :bank_transaction, :uncategorised_benefit_transactions, happened_at: count.days.ago, bank_account: bank_account, operation: 'credit', meta_data: 'benefits'
+        end
+      end
+    end
+
     trait :with_cfe_v1_result do
       after :create do |application|
         cfe_submission = create :cfe_submission, legal_aid_application: application

--- a/spec/models/legal_aid_application_spec.rb
+++ b/spec/models/legal_aid_application_spec.rb
@@ -208,6 +208,33 @@ RSpec.describe LegalAidApplication, type: :model do
     end
   end
 
+  describe '#uncategorised_bank_transactions?' do
+    context 'transaction types have associated bank transactions' do
+      let(:applicant) { create :applicant }
+      let(:bank_provider) { create :bank_provider, applicant: applicant }
+      let(:bank_account) { create :bank_account, bank_provider: bank_provider }
+      let!(:salary) { create :transaction_type, :credit, name: 'salary' }
+      let!(:bank_transaction) { create :bank_transaction, :credit, transaction_type: salary, bank_account: bank_account }
+      let(:legal_aid_application) { create :legal_aid_application, applicant: applicant, transaction_types: [salary] }
+
+      it 'returns true' do
+        expect(legal_aid_application.uncategorised_bank_transactions?).to eq false
+      end
+    end
+    context 'transaction types do not have associated bank transactions' do
+      let(:applicant) { create :applicant }
+      let(:bank_provider) { create :bank_provider, applicant: applicant }
+      let(:bank_account) { create :bank_account, bank_provider: bank_provider }
+      let!(:salary) { create :transaction_type, :credit, name: 'salary' }
+      let!(:bank_transaction) { create :bank_transaction, :credit, transaction_type: nil, bank_account: bank_account }
+      let(:legal_aid_application) { create :legal_aid_application, applicant: applicant, transaction_types: [salary] }
+
+      it 'returns false' do
+        expect(legal_aid_application.uncategorised_bank_transactions?).to eq true
+      end
+    end
+  end
+
   describe '#own_home?' do
     context 'legal_aid_application.own_home is nil' do
       before { legal_aid_application.update!(own_home: nil) }

--- a/spec/models/legal_aid_application_spec.rb
+++ b/spec/models/legal_aid_application_spec.rb
@@ -208,7 +208,7 @@ RSpec.describe LegalAidApplication, type: :model do
     end
   end
 
-  describe '#uncategorised_bank_transactions?' do
+  describe '#uncategorised_income_transactions?' do
     context 'transaction types have associated bank transactions' do
       let(:applicant) { create :applicant }
       let(:bank_provider) { create :bank_provider, applicant: applicant }
@@ -218,10 +218,10 @@ RSpec.describe LegalAidApplication, type: :model do
       let(:legal_aid_application) { create :legal_aid_application, applicant: applicant, transaction_types: [salary] }
 
       it 'returns true' do
-        expect(legal_aid_application.uncategorised_bank_transactions?).to eq false
+        expect(legal_aid_application.uncategorised_income_transactions?).to eq false
       end
     end
-    context 'transaction types do not have associated bank transactions' do
+    context 'transaction types do not have associated income bank transactions' do
       let(:applicant) { create :applicant }
       let(:bank_provider) { create :bank_provider, applicant: applicant }
       let(:bank_account) { create :bank_account, bank_provider: bank_provider }
@@ -230,7 +230,7 @@ RSpec.describe LegalAidApplication, type: :model do
       let(:legal_aid_application) { create :legal_aid_application, applicant: applicant, transaction_types: [salary] }
 
       it 'returns false' do
-        expect(legal_aid_application.uncategorised_bank_transactions?).to eq true
+        expect(legal_aid_application.uncategorised_income_transactions?).to eq true
       end
     end
   end

--- a/spec/requests/providers/income_summary_spec.rb
+++ b/spec/requests/providers/income_summary_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Providers::IncomeSummaryController do
       subject
       [salary, benefits].pluck(:name).each do |name|
         legend = I18n.t("transaction_types.names.providers.#{name}")
-        expect(parsed_response_body.css("ol li#income-type-#{name} h2").text).to match(/#{legend}/)
+        expect(parsed_response_body.css("ol li##{name} h2").text).to match(/#{legend}/)
       end
     end
 
@@ -76,6 +76,12 @@ RSpec.describe Providers::IncomeSummaryController do
   end
 
   describe 'POST /providers/income_summary' do
+    let(:applicant) { create :applicant }
+    let(:bank_provider) { create :bank_provider, applicant: applicant }
+    let(:bank_account) { create :bank_account, bank_provider: bank_provider }
+    let!(:bank_transaction) { create :bank_transaction, :credit, transaction_type: salary, bank_account: bank_account }
+    let(:legal_aid_application) { create :legal_aid_application, applicant: applicant, transaction_types: [salary] }
+
     let(:submit_button) { { continue_button: 'Continue' } }
     subject { post providers_legal_aid_application_income_summary_index_path(legal_aid_application), params: submit_button }
     before { subject }
@@ -94,6 +100,26 @@ RSpec.describe Providers::IncomeSummaryController do
 
       it 'redirects to the list of applications' do
         expect(response).to redirect_to providers_legal_aid_applications_path
+      end
+    end
+
+    context 'The transaction type category has no bank transactions' do
+      let(:applicant) { create :applicant }
+      let(:bank_provider) { create :bank_provider, applicant: applicant }
+      let(:bank_account) { create :bank_account, bank_provider: bank_provider }
+      let!(:bank_transaction) { create :bank_transaction, :credit, transaction_type: nil, bank_account: bank_account }
+      let(:legal_aid_application) { create :legal_aid_application, applicant: applicant, transaction_types: [salary] }
+
+      let(:submit_button) { { continue_button: 'Continue' } }
+      subject { post providers_legal_aid_application_income_summary_index_path(legal_aid_application), params: submit_button }
+      before { subject }
+
+      it 'renders successfully' do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'returns errors' do
+        expect(response.body).to include(I18n.t('activemodel.errors.models.legal_aid_application.attributes.uncategorised_bank_transactions.message'))
       end
     end
   end


### PR DESCRIPTION
AP1340 Validation for categorising bank transactions

[Link to story](https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=233&projectKey=AP&modal=detail&selectedIssue=AP-1340)

The BankTransaction model belongs_to a TransactionType, optionally (optional: true). Therefore, on the income summary page, you could have transaction_types on the model such as '1. Benefits' but no bank transactions were added or are associated with it. I added validation on the legal aid application model to check that those transaction types on the model have one or more bank transactions. If not then add relevant errors.

**I've listed each step in the commit messages instead of overdoing this PR message.** Please have a look at them [here](https://github.com/ministryofjustice/laa-apply-for-legal-aid/pull/1420/commits).

Challenges:

- I was finding it difficult to create a form that wasn't disturbing the routing paths. I would get 'page not found' a lot. Instead, I added this validation into the legal_aid_application model.

- Testing the feature tests was hacky. The categorising bank transactions process wasn't in it so I added it.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
