### PR TITLE
AP1375 Contact Solicitor if additional bank accounts are offline

### DIFF
--- a/app/controllers/citizens/additional_accounts_controller.rb
+++ b/app/controllers/citizens/additional_accounts_controller.rb
@@ -17,17 +17,29 @@ module Citizens
     def new; end
 
     def update
-      case params[:has_offline_accounts]
+      case params[:has_online_accounts]
       when 'yes'
+        online_accounts_update
         redirect_to citizens_banks_path
       when 'no'
-        legal_aid_application.update(has_offline_accounts: true)
-        legal_aid_application.use_ccms! unless legal_aid_application.use_ccms?
+        offline_accounts_update
         go_forward
       else
         @error = I18n.t('generic.errors.yes_or_no')
         render :new
       end
+    end
+
+    private
+
+    def online_accounts_update
+      legal_aid_application.provider_submit! unless legal_aid_application.provider_submitted?
+      legal_aid_application.update(has_offline_accounts: false)
+    end
+
+    def offline_accounts_update
+      legal_aid_application.update(has_offline_accounts: true)
+      legal_aid_application.use_ccms! unless legal_aid_application.use_ccms?
     end
   end
 end

--- a/app/controllers/citizens/additional_accounts_controller.rb
+++ b/app/controllers/citizens/additional_accounts_controller.rb
@@ -22,6 +22,7 @@ module Citizens
         redirect_to citizens_banks_path
       when 'no'
         legal_aid_application.update(has_offline_accounts: true)
+        legal_aid_application.use_ccms! unless legal_aid_application.use_ccms?
         go_forward
       else
         @error = I18n.t('generic.errors.yes_or_no')

--- a/app/services/flow/flows/citizen_start.rb
+++ b/app/services/flow/flows/citizen_start.rb
@@ -31,7 +31,9 @@ module Flow
         },
         additional_accounts: {
           path: ->(_) { urls.citizens_additional_accounts_path },
-          forward: :identify_types_of_incomes
+          forward: ->(application) do
+            application.has_offline_accounts? ? :contact_providers : :identify_types_of_incomes
+          end
         }
       }.freeze
     end

--- a/app/views/citizens/additional_accounts/new.html.erb
+++ b/app/views/citizens/additional_accounts/new.html.erb
@@ -3,7 +3,7 @@
 
     <%= govuk_form_group(
           show_error_if: @error,
-          input: :has_offline_accounts
+          input: :has_online_accounts
         ) do %>
 
       <%
@@ -15,7 +15,7 @@
 
       <%= govuk_fieldset_header(content_for(:page_title)) %>
 
-      <%= form.govuk_collection_radio_buttons :has_offline_accounts, options, :value, :label, error: @error %>
+      <%= form.govuk_collection_radio_buttons :has_online_accounts, options, :value, :label, error: @error %>
 
     <% end %>
 

--- a/config/locales/en/citizens.yml
+++ b/config/locales/en/citizens.yml
@@ -21,7 +21,6 @@ en:
         field_set_header: Do you have accounts with other banks?
       new:
         field_set_header: Do you have online access to your accounts with other banks?
-        hint: If you do not, you will need to provide paper evidence for these accounts.
     banks:
       index:
         title: Select your bank

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -12,7 +12,6 @@ en:
         postcode: This must be a valid UK postcode
       applicant:
         national_insurance_number: For example, 'QQ 12 34 56 C'
-      has_offline_accounts: If you do not, you will need to provide paper evidence for these accounts.
       legal_aid_application:
         outstanding_mortgage_amount:
           citizens: Check the statement from your mortgage provider or lender

--- a/features/cassettes/Citizen_journey/Follow_citizen_journey_from_Accounts_page.yml
+++ b/features/cassettes/Citizen_journey/Follow_citizen_journey_from_Accounts_page.yml
@@ -1,0 +1,125 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://auth.truelayer.com/api/providers/oauth/openbanking
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - auth.truelayer.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store
+      - no-store
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 19 May 2020 11:41:25 GMT
+      Referrer-Policy:
+      - no-referrer
+      - no-referrer
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      - max-age=31536000; includeSubdomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Request-Id:
+      - 0HLVRSG3DQM73:00000001
+      X-Xss-Protection:
+      - 1; mode=block
+      - 1; mode=block
+      Content-Length:
+      - '6886'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '[{"provider_id":"ob-monzo","display_name":"Monzo","country":"uk","logo_url":"https://truelayer-provider-assets.s3.amazonaws.com/global/logos/monzo.svg","scopes":["direct_debits","standing_orders","accounts","balance","info","transactions","offline_access"]},{"provider_id":"ob-barclays","display_name":"Barclays","country":"uk","logo_url":"https://truelayer-provider-assets.s3.amazonaws.com/global/logos/barclays.svg","scopes":["accounts","balance","cards","direct_debits","standing_orders","transactions","offline_access","info"]},{"provider_id":"ob-barclays-business","display_name":"Barclays
+        Business","country":"uk","logo_url":"https://truelayer-provider-assets.s3.amazonaws.com/global/logos/barclays.svg","scopes":["accounts","balance","cards","direct_debits","standing_orders","transactions","offline_access","info"]},{"provider_id":"ob-hsbc","display_name":"HSBC","country":"uk","logo_url":"https://truelayer-provider-assets.s3.amazonaws.com/global/logos/hsbc.svg","scopes":["accounts","balance","standing_orders","direct_debits","info","transactions","offline_access"]},{"provider_id":"ob-hsbc-business","display_name":"HSBC
+        Business","country":"uk","logo_url":"https://truelayer-provider-assets.s3.amazonaws.com/global/logos/hsbc.svg","scopes":["accounts","balance","direct_debits","standing_orders","info","transactions","offline_access"]},{"provider_id":"ob-natwest","display_name":"Natwest","country":"uk","logo_url":"https://truelayer-provider-assets.s3.amazonaws.com/global/logos/natwest.svg","scopes":["accounts","balance","transactions","standing_orders","direct_debits","info","cards","offline_access"]},{"provider_id":"ob-lloyds","display_name":"Lloyds
+        Bank","country":"uk","logo_url":"https://truelayer-provider-assets.s3.amazonaws.com/global/logos/lloyds.svg","scopes":["accounts","balance","cards","direct_debits","standing_orders","info","transactions","offline_access"]},{"provider_id":"ob-lloyds-business","display_name":"Lloyds
+        Business Bank","country":"uk","logo_url":"https://truelayer-provider-assets.s3.amazonaws.com/global/logos/lloyds.svg","scopes":["accounts","balance","cards","direct_debits","standing_orders","info","transactions","offline_access"]},{"provider_id":"ob-halifax","display_name":"Halifax","country":"uk","logo_url":"https://truelayer-provider-assets.s3.amazonaws.com/uk/logos/halifax.svg","scopes":["accounts","balance","transactions","cards","direct_debits","standing_orders","info","offline_access"]},{"provider_id":"ob-santander","display_name":"Santander","country":"uk","logo_url":"https://truelayer-provider-assets.s3.amazonaws.com/global/logos/santander.svg","scopes":["accounts","balance","cards","direct_debits","info","standing_orders","transactions","offline_access"]},{"provider_id":"ob-nationwide","display_name":"Nationwide","country":"uk","logo_url":"https://truelayer-provider-assets.s3.amazonaws.com/uk/logos/nationwide.svg","scopes":["accounts","balance","direct_debits","standing_orders","transactions","info","cards","offline_access"]},{"provider_id":"ob-rbs","display_name":"RBS","country":"uk","logo_url":"https://truelayer-provider-assets.s3.amazonaws.com/global/logos/rbs.svg","scopes":["accounts","balance","transactions","direct_debits","standing_orders","info","cards","offline_access"]},{"provider_id":"ob-first-direct","display_name":"First
+        Direct","country":"uk","logo_url":"https://truelayer-provider-assets.s3.amazonaws.com/uk/logos/first-direct.svg","scopes":["accounts","balance","direct_debits","standing_orders","info","transactions","offline_access"]},{"provider_id":"ob-bos","display_name":"Bank
+        of Scotland","country":"uk","logo_url":"https://truelayer-provider-assets.s3.amazonaws.com/uk/logos/bos.svg","scopes":["accounts","balance","transactions","cards","direct_debits","standing_orders","info","offline_access"]},{"provider_id":"ob-revolut","display_name":"Revolut","country":"uk","logo_url":"https://truelayer-provider-assets.s3.amazonaws.com/global/logos/revolut.svg","scopes":["accounts","balance","direct_debits","standing_orders","info","transactions","offline_access"]},{"provider_id":"ob-revolut","display_name":"Revolut","country":"ie","logo_url":"https://truelayer-provider-assets.s3.amazonaws.com/global/logos/revolut.svg","scopes":["accounts","balance","info","transactions","offline_access"]},{"provider_id":"ob-barclaycard","display_name":"Barclaycard","country":"uk","logo_url":"https://truelayer-provider-assets.s3.amazonaws.com/global/logos/barclaycard.svg","scopes":["cards","balance","transactions","offline_access"]},{"provider_id":"ob-ulster","display_name":"Ulster
+        Bank","country":"uk","logo_url":"https://truelayer-provider-assets.s3.amazonaws.com/global/logos/ulster.svg","scopes":["accounts","balance","transactions","direct_debits","standing_orders","info","cards","offline_access"]},{"provider_id":"ob-ms","display_name":"Marks
+        & Spencer","country":"uk","logo_url":"https://truelayer-provider-assets.s3.amazonaws.com/uk/logos/ms.svg","scopes":["accounts","balance","direct_debits","standing_orders","info","transactions","offline_access"]},{"provider_id":"ob-mbna","display_name":"MBNA","country":"uk","logo_url":"https://truelayer-provider-assets.s3.amazonaws.com/uk/logos/mbna.svg","scopes":["cards","balance","direct_debits","standing_orders","transactions","info","offline_access"]},{"provider_id":"ob-danske","display_name":"Danske","country":"uk","logo_url":"https://truelayer-provider-assets.s3.amazonaws.com/global/logos/danske.svg","scopes":["accounts","balance","info","direct_debits","standing_orders","transactions","offline_access"]},{"provider_id":"ob-tsb","display_name":"TSB","country":"uk","logo_url":"https://truelayer-provider-assets.s3.amazonaws.com/uk/logos/tsb.svg","scopes":["accounts","balance","cards","direct_debits","standing_orders","transactions","offline_access"]},{"provider_id":"ob-ptsb","display_name":"PTSB","country":"ie","logo_url":"https://truelayer-provider-assets.s3.amazonaws.com/ie/logos/ptsb.svg","scopes":["accounts","balance","cards","direct_debits","standing_orders","transactions","offline_access"]},{"provider_id":"ob-aib","display_name":"AIB","country":"ie","logo_url":"https://truelayer-provider-assets.s3.amazonaws.com/global/logos/aib.svg","scopes":["accounts","balance","cards","direct_debits","standing_orders","transactions","offline_access"]},{"provider_id":"ob-ulster-ie","display_name":"Ulster
+        Bank Republic of Ireland","country":"ie","logo_url":"https://truelayer-provider-assets.s3.amazonaws.com/global/logos/ulster.svg","scopes":["accounts","balance","direct_debits","standing_orders","transactions","info","cards","offline_access"]},{"provider_id":"ob-boi-ie","display_name":"Bank
+        of Ireland (ROI)","country":"ie","logo_url":"https://truelayer-provider-assets.s3.amazonaws.com/global/logos/boi.svg","scopes":["accounts","balance","direct_debits","standing_orders","transactions","cards","offline_access"]}]'
+    http_version: null
+  recorded_at: Tue, 19 May 2020 11:41:25 GMT
+- request:
+    method: get
+    uri: https://auth.truelayer.com/api/providers/oauth
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - auth.truelayer.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store
+      - no-store
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 19 May 2020 11:41:25 GMT
+      Referrer-Policy:
+      - no-referrer
+      - no-referrer
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      - max-age=31536000; includeSubdomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Request-Id:
+      - 0HLVRSG3DQM74:00000001
+      X-Xss-Protection:
+      - 1; mode=block
+      - 1; mode=block
+      Content-Length:
+      - '236'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '[{"provider_id":"oauth-starling","display_name":"Starling","country":"uk","logo_url":"https://truelayer-provider-assets.s3.amazonaws.com/global/logos/starling.svg","scopes":["accounts","balance","info","transactions","offline_access"]}]'
+    http_version: null
+  recorded_at: Tue, 19 May 2020 11:41:25 GMT
+recorded_with: VCR 5.1.0

--- a/features/citizens/citizens.feature
+++ b/features/citizens/citizens.feature
@@ -35,12 +35,26 @@ Feature: Citizen journey
     Then I click link "Back"
     Then I should be on a page showing 'Share your financial information with us'
 
-  @javascript @webhint
+  @javascript @webhint @vcr
   Scenario: Follow citizen journey from Accounts page
     Given An application has been created
     Then I visit the start of the financial assessment
     Then I visit the accounts page
     Then I click link 'Continue'
+    Then I should be on a page showing "Do you have accounts with other banks?"
+    Then I choose "Yes"
+    Then I click 'Save and continue'
+    Then I should be on a page showing 'Do you have online access'
+    Then I choose "No"
+    Then I click 'Save and continue'
+    Then I should be on a page showing 'Contact your solicitor'
+    Then I click link "Back"
+    Then I should be on a page showing 'Do you have online access'
+    Then I choose "Yes"
+    Then I click 'Save and continue'
+    Then I should be on a page showing "Select your bank"
+    Then I click link "Back"
+    Then I click link "Back"
     Then I should be on a page showing "Do you have accounts with other banks?"
     Then I choose "No"
     Then I click 'Save and continue'

--- a/spec/requests/citizens/additional_accounts_spec.rb
+++ b/spec/requests/citizens/additional_accounts_spec.rb
@@ -39,9 +39,8 @@ RSpec.describe 'citizen additional accounts request test', type: :request do
     context 'with No submitted' do
       let(:params) { { additional_account: 'no' } }
 
-      it 'redirects to the next step in Citizen jouney' do
-        # TODO: - set redirect path when known
-        expect(response).to redirect_to(next_flow_step)
+      it 'redirects to /citizens/identify_types_of_income(.:format)' do
+        expect(response).to redirect_to(citizens_identify_types_of_income_path)
       end
     end
   end
@@ -74,7 +73,7 @@ RSpec.describe 'citizen additional accounts request test', type: :request do
     end
 
     context 'with Yes submitted' do
-      let(:params) { { has_offline_accounts: 'yes' } }
+      let(:params) { { has_online_accounts: 'yes' } }
 
       it 'redirects to select another bank' do
         expect(response).to redirect_to(citizens_banks_path)
@@ -86,7 +85,7 @@ RSpec.describe 'citizen additional accounts request test', type: :request do
     end
 
     context 'with No submitted' do
-      let(:params) { { has_offline_accounts: 'no' } }
+      let(:params) { { has_online_accounts: 'no' } }
 
       it 'redirects to contact provider path' do
         expect(response).to redirect_to(citizens_contact_provider_path)

--- a/spec/requests/citizens/additional_accounts_spec.rb
+++ b/spec/requests/citizens/additional_accounts_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe 'citizen additional accounts request test', type: :request do
-  let(:application) { create :application, :with_applicant }
+  let(:application) { create :application, :with_applicant, :provider_submitted }
   let(:application_id) { application.id }
   let(:secure_id) { application.generate_secure_id }
   let(:next_flow_step) { flow_forward_path }
@@ -56,7 +56,7 @@ RSpec.describe 'citizen additional accounts request test', type: :request do
 
   describe 'PATCH/PUT /citizens/additional_accounts' do
     let(:params) { {} }
-    let(:legal_aid_application) { create :legal_aid_application, :with_applicant }
+    let(:legal_aid_application) { create :legal_aid_application, :with_applicant, :provider_submitted }
     before do
       get citizens_legal_aid_application_path(legal_aid_application.generate_secure_id)
       patch(
@@ -88,8 +88,8 @@ RSpec.describe 'citizen additional accounts request test', type: :request do
     context 'with No submitted' do
       let(:params) { { has_offline_accounts: 'no' } }
 
-      it 'redirects to the next step in Citizen jouney' do
-        expect(response).to redirect_to(next_flow_step)
+      it 'redirects to contact provider path' do
+        expect(response).to redirect_to(citizens_contact_provider_path)
       end
 
       it 'records choice on legal_aid_application' do


### PR DESCRIPTION
AP1375 Contact Solicitor if additional bank accounts are offline

[Link to story](https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=233&projectKey=AP&modal=detail&selectedIssue=AP-1375)

When a citizen has_offline_accounts:
- Redirect citizen to contact_provider page in the flow.
- Update state to :use_ccms!
- Remove hint text "If you do not, you will need to provide paper evidence for these accounts"
- Allow user to go back and change the answer by updating the state to :provider_submitted

Also:

- Rename param from **:has_offline_accounts** to **:has_online_accounts** since that's what we're asking the user.

Update the feature tests

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
