### PR TITLE
AP-1428 add WSDL location to non-passported case add requestor

### DIFF
--- a/app/services/ccms/requestors/non_passported_case_add_requestor.rb
+++ b/app/services/ccms/requestors/non_passported_case_add_requestor.rb
@@ -1,6 +1,8 @@
 module CCMS
   module Requestors
     class NonPassportedCaseAddRequestor < CaseAddRequestor
+      wsdl_from Rails.configuration.x.ccms_soa.caseServicesWsdl
+
       uses_namespaces(
         'xmlns:soap' => 'http://schemas.xmlsoap.org/soap/envelope/',
         'xmlns:ns6' => 'http://legalservices.gov.uk/Enterprise/Common/1.0/Header',

--- a/config/ccms/attribute_block_configs/non_passported.yml
+++ b/config/ccms/attribute_block_configs/non_passported.yml
@@ -516,6 +516,11 @@ global_means:
     user_defined: true
     response_type: text
     generate_block?: true
+  IS_PASSPORTED:
+    value: 'NO'
+    br100_meaning: 'DWP Benefit Check: Response'
+    response_type: text
+    user_defined: true
   MARITIAL_STATUS:
     value: U
     br100_meaning: marital status

--- a/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_attributes_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_attributes_spec.rb
@@ -462,6 +462,13 @@ module CCMS
           end
         end
 
+        context 'attributes with specific hard coded values' do
+          it 'IS_PASSPORTED should be hard coded to NO' do
+            block = XmlExtractor.call(xml, :global_means, 'IS_PASSPORTED')
+            expect(block).to have_text_response 'NO'
+          end
+        end
+
         context 'PROC_PREDICTED_COST_FAMILY' do
           it 'generates the block with the standard value' do
             block = XmlExtractor.call(xml, :global_merits, 'PROC_PREDICTED_COST_FAMILY')

--- a/spec/services/ccms/requestors/case_add_requestor_xml_blocks/passported_attributes_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_xml_blocks/passported_attributes_spec.rb
@@ -1134,7 +1134,7 @@ module CCMS
             expect(block).to have_boolean_response true
           end
 
-          it 'returns false when application is passported' do
+          it 'returns false when application is not passported' do
             allow(legal_aid_application).to receive(:applicant_receives_benefit?).and_return(false)
             block = XmlExtractor.call(xml, :global_means, 'GB_DECL_B_38WP3_11A')
             expect(block).to have_boolean_response false


### PR DESCRIPTION
## Add WSDL location to NonPassportedCaseAddRequestor

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1428)

The `NonPassportedCaseAddRequestor` derives from the `CaseAddRequestor` - however it doesn't inherit the value of the class method `wsdl_location`.  This fixes that.

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
