### PR TITLE
AP1444 Use new CFE Assessment POST response

### DIFF
--- a/app/services/cfe/create_assessment_service.rb
+++ b/app/services/cfe/create_assessment_service.rb
@@ -15,7 +15,7 @@ module CFE
     private
 
     def process_response
-      @submission.assessment_id = @response['objects'].first['id']
+      @submission.assessment_id = @response['assessment_id']
       @submission.assessment_created!
       true
     end

--- a/spec/cassettes/CFE_SubmissionManager/_call/completes_process.yml
+++ b/spec/cassettes/CFE_SubmissionManager/_call/completes_process.yml
@@ -5,12 +5,12 @@ http_interactions:
     uri: https://check-financial-eligibility-staging.apps.live-1.cloud-platform.service.justice.gov.uk/assessments
     body:
       encoding: UTF-8
-      string: '{"client_reference_id":"L-YB0-M31","submission_date":"2019-09-26","matter_proceeding_type":"domestic_abuse"}'
+      string: '{"client_reference_id":"L-226-BAB","submission_date":"2019-07-27","matter_proceeding_type":"domestic_abuse"}'
     headers:
-      User-Agent:
-      - Faraday v0.15.4
       Content-Type:
       - application/json
+      User-Agent:
+      - Faraday v1.0.0
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -21,9 +21,9 @@ http_interactions:
       message: OK
     headers:
       Server:
-      - nginx/1.15.8
+      - nginx/1.17.8
       Date:
-      - Thu, 26 Sep 2019 10:17:16 GMT
+      - Thu, 28 May 2020 15:24:11 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -45,31 +45,31 @@ http_interactions:
       Referrer-Policy:
       - strict-origin-when-cross-origin
       Etag:
-      - W/"e87d75bbc5c726c5650e16b1361562c0"
+      - W/"75303e349a4ff935dc9694d0d723ff1c"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - e6e54beb74a9c61fc65bc32f111e7459
+      - 434e86e7f91d53f3dae7cdf3562b5755
       X-Runtime:
-      - '0.092029'
+      - '0.076015'
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: ASCII-8BIT
-      string: '{"success":true,"objects":[{"id":"82c29e5a-58ff-4fc1-8d3e-fab96505893e","client_reference_id":"L-YB0-M31","remote_ip":{"family":2,"addr":1380268825,"mask_addr":4294967295},"created_at":"2019-09-26T10:17:16.895Z","updated_at":"2019-09-26T10:17:16.895Z","submission_date":"2019-09-26","matter_proceeding_type":"domestic_abuse","assessment_result":"pending"}],"errors":[]}'
-    http_version: 
-  recorded_at: Thu, 26 Sep 2019 10:17:16 GMT
+      string: '{"success":true,"objects":[{"id":"1f87e3db-4163-41f1-9abb-ee1c1bd58f0c","client_reference_id":"L-226-BAB","remote_ip":{"family":2,"addr":1365861740,"mask_addr":4294967295},"created_at":"2020-05-28T15:24:11.666Z","updated_at":"2020-05-28T15:24:11.666Z","submission_date":"2019-07-27","matter_proceeding_type":"domestic_abuse","assessment_result":"pending","remarks":{}}],"assessment_id":"1f87e3db-4163-41f1-9abb-ee1c1bd58f0c","errors":[]}'
+    http_version: null
+  recorded_at: Thu, 28 May 2020 15:24:11 GMT
 - request:
     method: post
-    uri: https://check-financial-eligibility-staging.apps.live-1.cloud-platform.service.justice.gov.uk/assessments/82c29e5a-58ff-4fc1-8d3e-fab96505893e/applicant
+    uri: https://check-financial-eligibility-staging.apps.live-1.cloud-platform.service.justice.gov.uk/assessments/1f87e3db-4163-41f1-9abb-ee1c1bd58f0c/applicant
     body:
       encoding: UTF-8
-      string: '{"applicant":{"date_of_birth":"1975-09-12","involvement_type":"applicant","has_partner_opponent":false,"receives_qualifying_benefit":false}}'
+      string: '{"applicant":{"date_of_birth":"1992-06-24","involvement_type":"applicant","has_partner_opponent":false,"receives_qualifying_benefit":true}}'
     headers:
-      User-Agent:
-      - Faraday v0.15.4
       Content-Type:
       - application/json
+      User-Agent:
+      - Faraday v1.0.0
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -80,9 +80,9 @@ http_interactions:
       message: OK
     headers:
       Server:
-      - nginx/1.15.8
+      - nginx/1.17.8
       Date:
-      - Thu, 26 Sep 2019 10:17:17 GMT
+      - Thu, 28 May 2020 15:24:11 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -104,38 +104,41 @@ http_interactions:
       Referrer-Policy:
       - strict-origin-when-cross-origin
       Etag:
-      - W/"0b4757162b738d03ce1bc79055ae6184"
+      - W/"e156c1de751f0fc41f3ce5edefd256d2"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 143b4e41c47b9da6f3ddf0a3a87c73de
+      - 2f24305f11809d7c2ba660bb21eec1a6
       X-Runtime:
-      - '0.009516'
+      - '0.009749'
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: ASCII-8BIT
-      string: '{"objects":[{"id":"5e32f804-1b2f-4361-ab47-251c83a65b24","assessment_id":"82c29e5a-58ff-4fc1-8d3e-fab96505893e","date_of_birth":"1975-09-12","involvement_type":"applicant","has_partner_opponent":false,"receives_qualifying_benefit":false,"created_at":"2019-09-26T10:17:17.066Z","updated_at":"2019-09-26T10:17:17.066Z"}],"errors":[],"success":true}'
-    http_version: 
-  recorded_at: Thu, 26 Sep 2019 10:17:17 GMT
+      string: '{"success":true,"errors":[]}'
+    http_version: null
+  recorded_at: Thu, 28 May 2020 15:24:11 GMT
 - request:
     method: post
-    uri: https://check-financial-eligibility-staging.apps.live-1.cloud-platform.service.justice.gov.uk/assessments/82c29e5a-58ff-4fc1-8d3e-fab96505893e/capitals
+    uri: https://check-financial-eligibility-staging.apps.live-1.cloud-platform.service.justice.gov.uk/assessments/1f87e3db-4163-41f1-9abb-ee1c1bd58f0c/capitals
     body:
       encoding: UTF-8
-      string: '{"bank_accounts":[{"description":"Off-line bank accounts","value":"256813.96"},{"description":"Cash","value":"929463.53"},{"description":"Signatory
-        on other person''s account","value":"247263.33"},{"description":"National
-        savings","value":"631488.6"},{"description":"Shares in PLC","value":"30317.69"},{"description":"PEPs,
-        unit trusts, capital bonds and government stocks","value":"267758.38"},{"description":"Life
-        assurance and endowment policies not linked to a mortgage","value":"961122.07"}],"non_liquid_capital":[{"description":"Timeshare
-        property","value":"98807.39"},{"description":"Land","value":"825874.26"},{"description":"Valuable
-        items","value":"406113.56"},{"description":"Inherited assets","value":"512724.02"},{"description":"Money
-        owed to applicant","value":"758681.72"},{"description":"Trusts","value":"914692.73"}]}'
+      string: '{"bank_accounts":[{"description":"Current accounts","value":"-345560.75"},{"description":"Savings
+        accounts","value":"5546.82"},{"description":"Money not in a bank account","value":"301508.83"},{"description":"Access
+        to another person''s bank account","value":"140619.63"},{"description":"National
+        Savings Certificates and Premium Bonds","value":"105897.11"},{"description":"Shares
+        in a public limited company","value":"371723.16"},{"description":"PEPs, unit
+        trusts, capital bonds and government stocks","value":"474675.81"},{"description":"Life
+        assurance and endowment policies not linked to a mortgage","value":"545466.32"}],"non_liquid_capital":[{"description":"Timeshare
+        property","value":"443589.73"},{"description":"Land","value":"585628.54"},{"description":"Any
+        valuable items worth more than £500","value":"981771.44"},{"description":"Money
+        or assets from the estate of a person who has died","value":"551244.81"},{"description":"Money
+        owed to applicant","value":"325033.7"},{"description":"Interest in a trust","value":"338558.47"}]}'
     headers:
-      User-Agent:
-      - Faraday v0.15.4
       Content-Type:
       - application/json
+      User-Agent:
+      - Faraday v1.0.0
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -146,9 +149,9 @@ http_interactions:
       message: OK
     headers:
       Server:
-      - nginx/1.15.8
+      - nginx/1.17.8
       Date:
-      - Thu, 26 Sep 2019 10:17:17 GMT
+      - Thu, 28 May 2020 15:24:12 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -170,31 +173,31 @@ http_interactions:
       Referrer-Policy:
       - strict-origin-when-cross-origin
       Etag:
-      - W/"19ac0337bcb049ee395ff7dab5dec3ef"
+      - W/"e156c1de751f0fc41f3ce5edefd256d2"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - fbf9c1524e9ff6b72a8eee2aa54ef82e
+      - cd3fb83fca8cd8315e1daae73e332199
       X-Runtime:
-      - '0.192168'
+      - '0.025861'
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: ASCII-8BIT
-      string: '{"objects":{"id":"02e0714f-0543-4ff3-bb73-500bdc46889d","assessment_id":"82c29e5a-58ff-4fc1-8d3e-fab96505893e","total_liquid":"0.0","total_non_liquid":"0.0","total_vehicle":"0.0","total_property":"0.0","total_mortgage_allowance":"0.0","total_capital":"0.0","pensioner_capital_disregard":"0.0","assessed_capital":"0.0","capital_contribution":"0.0","lower_threshold":"0.0","upper_threshold":"0.0","capital_assessment_result":"pending","created_at":"2019-09-26T10:17:16.900Z","updated_at":"2019-09-26T10:17:16.900Z"},"errors":[],"success":true}'
-    http_version: 
-  recorded_at: Thu, 26 Sep 2019 10:17:17 GMT
+      string: '{"success":true,"errors":[]}'
+    http_version: null
+  recorded_at: Thu, 28 May 2020 15:24:12 GMT
 - request:
     method: post
-    uri: https://check-financial-eligibility-staging.apps.live-1.cloud-platform.service.justice.gov.uk/assessments/82c29e5a-58ff-4fc1-8d3e-fab96505893e/vehicles
+    uri: https://check-financial-eligibility-staging.apps.live-1.cloud-platform.service.justice.gov.uk/assessments/1f87e3db-4163-41f1-9abb-ee1c1bd58f0c/vehicles
     body:
       encoding: UTF-8
-      string: '{"vehicles":[{"value":"4069.0","loan_amount_outstanding":"873.0","date_of_purchase":"2002-10-01","in_regular_use":true}]}'
+      string: '{"vehicles":[{"value":"6641.0","loan_amount_outstanding":"104.0","date_of_purchase":"2001-08-03","in_regular_use":true}]}'
     headers:
-      User-Agent:
-      - Faraday v0.15.4
       Content-Type:
       - application/json
+      User-Agent:
+      - Faraday v1.0.0
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -205,9 +208,9 @@ http_interactions:
       message: OK
     headers:
       Server:
-      - nginx/1.15.8
+      - nginx/1.17.8
       Date:
-      - Thu, 26 Sep 2019 10:17:17 GMT
+      - Thu, 28 May 2020 15:24:12 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -229,31 +232,31 @@ http_interactions:
       Referrer-Policy:
       - strict-origin-when-cross-origin
       Etag:
-      - W/"d5f43da6ce2ba2878a37119cb1f3f31f"
+      - W/"e156c1de751f0fc41f3ce5edefd256d2"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 981586736db6d4413a381a8aabb37541
+      - d56fa59ec13de4a5606487e824674a56
       X-Runtime:
-      - '0.024666'
+      - '0.009614'
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: ASCII-8BIT
-      string: '{"vehicles":[{"id":"89fd2145-3e5b-48a6-a0eb-75d389b93f79","value":"4069.0","loan_amount_outstanding":"873.0","date_of_purchase":"2002-10-01","in_regular_use":true,"created_at":"2019-09-26T10:17:17.494Z","updated_at":"2019-09-26T10:17:17.494Z","capital_summary_id":"02e0714f-0543-4ff3-bb73-500bdc46889d","included_in_assessment":false,"assessed_value":"0.0"}],"errors":[],"success":true}'
-    http_version: 
-  recorded_at: Thu, 26 Sep 2019 10:17:17 GMT
+      string: '{"success":true,"errors":[]}'
+    http_version: null
+  recorded_at: Thu, 28 May 2020 15:24:12 GMT
 - request:
     method: post
-    uri: https://check-financial-eligibility-staging.apps.live-1.cloud-platform.service.justice.gov.uk/assessments/82c29e5a-58ff-4fc1-8d3e-fab96505893e/properties
+    uri: https://check-financial-eligibility-staging.apps.live-1.cloud-platform.service.justice.gov.uk/assessments/1f87e3db-4163-41f1-9abb-ee1c1bd58f0c/properties
     body:
       encoding: UTF-8
-      string: '{"properties":{"main_home":{"value":"727864.08","outstanding_mortgage":"188024.24","percentage_owned":"43.75","shared_with_housing_assoc":false},"additional_properties":[{"value":"897453.03","outstanding_mortgage":"73722.46","percentage_owned":"66.32","shared_with_housing_assoc":false}]}}'
+      string: '{"properties":{"main_home":{"value":"161385.53","outstanding_mortgage":"512950.28","percentage_owned":"49.78","shared_with_housing_assoc":true},"additional_properties":[{"value":"716290.88","outstanding_mortgage":"227501.38","percentage_owned":"78.01","shared_with_housing_assoc":false}]}}'
     headers:
-      User-Agent:
-      - Faraday v0.15.4
       Content-Type:
       - application/json
+      User-Agent:
+      - Faraday v1.0.0
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -264,9 +267,9 @@ http_interactions:
       message: OK
     headers:
       Server:
-      - nginx/1.15.8
+      - nginx/1.17.8
       Date:
-      - Thu, 26 Sep 2019 10:17:17 GMT
+      - Thu, 28 May 2020 15:24:12 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -288,42 +291,44 @@ http_interactions:
       Referrer-Policy:
       - strict-origin-when-cross-origin
       Etag:
-      - W/"b6dd27fc7c654cc37fc064a1f572bde6"
+      - W/"e156c1de751f0fc41f3ce5edefd256d2"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 7e7b4d80357025fccc74677e9a1058c1
+      - 9ee81de8bfe93cab7a1f259d24873280
       X-Runtime:
-      - '0.116632'
+      - '0.013787'
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: ASCII-8BIT
-      string: '{"objects":[{"id":"7d5d1825-0de3-4ed5-a5e9-b1c366daa842","value":"727864.08","outstanding_mortgage":"188024.24","percentage_owned":"43.75","main_home":true,"shared_with_housing_assoc":false,"created_at":"2019-09-26T10:17:17.688Z","updated_at":"2019-09-26T10:17:17.688Z","capital_summary_id":"02e0714f-0543-4ff3-bb73-500bdc46889d","transaction_allowance":"0.0","allowable_outstanding_mortgage":"0.0","net_value":"0.0","net_equity":"0.0","assessed_equity":"0.0","main_home_equity_disregard":"0.0"},{"id":"c7d5f438-76f6-4e7d-89e3-f5a03ca0d24a","value":"897453.03","outstanding_mortgage":"73722.46","percentage_owned":"66.32","main_home":false,"shared_with_housing_assoc":false,"created_at":"2019-09-26T10:17:17.701Z","updated_at":"2019-09-26T10:17:17.701Z","capital_summary_id":"02e0714f-0543-4ff3-bb73-500bdc46889d","transaction_allowance":"0.0","allowable_outstanding_mortgage":"0.0","net_value":"0.0","net_equity":"0.0","assessed_equity":"0.0","main_home_equity_disregard":"0.0"}],"errors":[],"success":true}'
-    http_version: 
-  recorded_at: Thu, 26 Sep 2019 10:17:17 GMT
+      string: '{"success":true,"errors":[]}'
+    http_version: null
+  recorded_at: Thu, 28 May 2020 15:24:12 GMT
 - request:
     method: get
-    uri: https://check-financial-eligibility-staging.apps.live-1.cloud-platform.service.justice.gov.uk/assessments/82c29e5a-58ff-4fc1-8d3e-fab96505893e
+    uri: https://check-financial-eligibility-staging.apps.live-1.cloud-platform.service.justice.gov.uk/assessments/1f87e3db-4163-41f1-9abb-ee1c1bd58f0c
     body:
       encoding: US-ASCII
       string: ''
     headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json;version=2
       User-Agent:
-      - Faraday v0.15.4
+      - Faraday v1.0.0
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
   response:
     status:
       code: 200
       message: OK
     headers:
       Server:
-      - nginx/1.15.8
+      - nginx/1.17.8
       Date:
-      - Tue, 01 Oct 2019 16:24:01 GMT
+      - Thu, 28 May 2020 15:24:12 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -345,26 +350,19 @@ http_interactions:
       Referrer-Policy:
       - strict-origin-when-cross-origin
       Etag:
-      - W/"bfd127548bb99e85b4fabfc4e65c2609"
+      - W/"e69b211e2880ad1541a463dfa1bb56be"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - a75132441fde7287ed98274191dabda5
+      - 04fec1f115819512bef763bf814bc86a
       X-Runtime:
-      - '0.180821'
+      - '0.093600'
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: ASCII-8BIT
-      string: '{"assessment_result":"not_eligible","applicant":{"receives_qualifying_benefit":false,"age_at_submission":44},"capital":{"total_liquid":"3324227.56","total_non_liquid":"3516893.68","pensioner_capital_disregard":"0.0","total_capital":"7566954.53","capital_contribution":"0.0","liquid_capital_items":[{"description":"Off-line
-        bank accounts","value":"256813.96"},{"description":"Cash","value":"929463.53"},{"description":"Signatory
-        on other person''s account","value":"247263.33"},{"description":"National
-        savings","value":"631488.6"},{"description":"Shares in PLC","value":"30317.69"},{"description":"PEPs,
-        unit trusts, capital bonds and government stocks","value":"267758.38"},{"description":"Life
-        assurance and endowment policies not linked to a mortgage","value":"961122.07"}],"non_liquid_capital_items":[{"description":"Timeshare
-        property","value":"98807.39"},{"description":"Land","value":"825874.26"},{"description":"Valuable
-        items","value":"406113.56"},{"description":"Inherited assets","value":"512724.02"},{"description":"Money
-        owed to applicant","value":"758681.72"},{"description":"Trusts","value":"914692.73"}]},"property":{"total_mortgage_allowance":"100000.0","total_property":"725833.29","main_home":{"value":"727864.08","transaction_allowance":"21835.92","allowable_outstanding_mortgage":"26277.54","percentage_owned":"43.75","net_equity":"297390.9","main_home_equity_disregard":"100000.0","assessed_equity":"197390.9","shared_with_housing_assoc":false},"additional_properties":[{"value":"897453.03","transaction_allowance":"26923.59","allowable_outstanding_mortgage":"73722.46","percentage_owned":"66.32","assessed_equity":"528442.39"}]},"vehicles":{"total_vehicle":"0.0","vehicles":[{"in_regular_use":true,"value":"4069.0","loan_amount_outstanding":"873.0","date_of_purchase":"2002-10-01","included_in_assessment":false,"assessed_value":"0.0"}]}}'
-    http_version: 
-  recorded_at: Tue, 01 Oct 2019 16:22:12 GMT
-recorded_with: VCR 5.0.0
+      string: !binary |-
+        eyJ2ZXJzaW9uIjoiMiIsInRpbWVzdGFtcCI6IjIwMjAtMDUtMjhUMTU6MjQ6MTIuNDg5KzAwOjAwIiwic3VjY2VzcyI6dHJ1ZSwiYXNzZXNzbWVudCI6eyJpZCI6IjFmODdlM2RiLTQxNjMtNDFmMS05YWJiLWVlMWMxYmQ1OGYwYyIsImNsaWVudF9yZWZlcmVuY2VfaWQiOiJMLTIyNi1CQUIiLCJzdWJtaXNzaW9uX2RhdGUiOiIyMDE5LTA3LTI3IiwibWF0dGVyX3Byb2NlZWRpbmdfdHlwZSI6ImRvbWVzdGljX2FidXNlIiwiYXNzZXNzbWVudF9yZXN1bHQiOiJjb250cmlidXRpb25fcmVxdWlyZWQiLCJhcHBsaWNhbnQiOnsiZGF0ZV9vZl9iaXJ0aCI6IjE5OTItMDYtMjQiLCJpbnZvbHZlbWVudF90eXBlIjoiYXBwbGljYW50IiwiaGFzX3BhcnRuZXJfb3Bwb25lbnQiOmZhbHNlLCJyZWNlaXZlc19xdWFsaWZ5aW5nX2JlbmVmaXQiOnRydWUsInNlbGZfZW1wbG95ZWQiOmZhbHNlfSwiZ3Jvc3NfaW5jb21lIjp7Im1vbnRobHlfb3RoZXJfaW5jb21lIjpudWxsLCJtb250aGx5X3N0YXRlX2JlbmVmaXRzIjoiMC4wIiwidG90YWxfZ3Jvc3NfaW5jb21lIjoiMC4wIiwidXBwZXJfdGhyZXNob2xkIjoiMC4wIiwiYXNzZXNzbWVudF9yZXN1bHQiOiJwZW5kaW5nIiwibW9udGhseV9pbmNvbWVfZXF1aXZhbGVudHMiOnsiZnJpZW5kc19vcl9mYW1pbHkiOiIwLjAiLCJtYWludGVuYW5jZV9pbiI6IjAuMCIsInByb3BlcnR5X29yX2xvZGdlciI6IjAuMCIsInN0dWRlbnRfbG9hbiI6IjAuMCIsInBlbnNpb24iOiIwLjAifSwibW9udGhseV9vdXRnb2luZ19lcXVpdmFsZW50cyI6eyJjaGlsZF9jYXJlIjoiMC4wIiwibWFpbnRlbmFuY2Vfb3V0IjoiMC4wIiwicmVudF9vcl9tb3J0Z2FnZSI6IjAuMCIsImxlZ2FsX2FpZCI6IjAuMCJ9LCJzdGF0ZV9iZW5lZml0cyI6W10sIm90aGVyX2luY29tZSI6W119LCJkaXNwb3NhYmxlX2luY29tZSI6eyJtb250aGx5X291dGdvaW5nX2VxdWl2YWxlbnRzIjp7ImNoaWxkX2NhcmUiOiIwLjAiLCJtYWludGVuYW5jZV9vdXQiOiIwLjAiLCJyZW50X29yX21vcnRnYWdlIjoiMC4wIiwibGVnYWxfYWlkIjoiMC4wIn0sImNoaWxkY2FyZV9hbGxvd2FuY2UiOiIwLjAiLCJkZWR1Y3Rpb25zIjp7ImRlcGVuZGFudHNfYWxsb3dhbmNlIjoiMC4wIiwiZGlzcmVnYXJkZWRfc3RhdGVfYmVuZWZpdHMiOjAuMH0sImRlcGVuZGFudF9hbGxvd2FuY2UiOiIwLjAiLCJtYWludGVuYW5jZV9hbGxvd2FuY2UiOiIwLjAiLCJncm9zc19ob3VzaW5nX2Nvc3RzIjoiMC4wIiwiaG91c2luZ19iZW5lZml0IjoiMC4wIiwibmV0X2hvdXNpbmdfY29zdHMiOiIwLjAiLCJ0b3RhbF9vdXRnb2luZ3NfYW5kX2FsbG93YW5jZXMiOiIwLjAiLCJ0b3RhbF9kaXNwb3NhYmxlX2luY29tZSI6IjAuMCIsImxvd2VyX3RocmVzaG9sZCI6IjAuMCIsInVwcGVyX3RocmVzaG9sZCI6IjAuMCIsImFzc2Vzc21lbnRfcmVzdWx0IjoicGVuZGluZyIsImluY29tZV9jb250cmlidXRpb24iOiIwLjAifSwiY2FwaXRhbCI6eyJjYXBpdGFsX2l0ZW1zIjp7ImxpcXVpZCI6W3siZGVzY3JpcHRpb24iOiJDdXJyZW50IGFjY291bnRzIiwidmFsdWUiOiItMzQ1NTYwLjc1In0seyJkZXNjcmlwdGlvbiI6IlNhdmluZ3MgYWNjb3VudHMiLCJ2YWx1ZSI6IjU1NDYuODIifSx7ImRlc2NyaXB0aW9uIjoiTW9uZXkgbm90IGluIGEgYmFuayBhY2NvdW50IiwidmFsdWUiOiIzMDE1MDguODMifSx7ImRlc2NyaXB0aW9uIjoiQWNjZXNzIHRvIGFub3RoZXIgcGVyc29uJ3MgYmFuayBhY2NvdW50IiwidmFsdWUiOiIxNDA2MTkuNjMifSx7ImRlc2NyaXB0aW9uIjoiTmF0aW9uYWwgU2F2aW5ncyBDZXJ0aWZpY2F0ZXMgYW5kIFByZW1pdW0gQm9uZHMiLCJ2YWx1ZSI6IjEwNTg5Ny4xMSJ9LHsiZGVzY3JpcHRpb24iOiJTaGFyZXMgaW4gYSBwdWJsaWMgbGltaXRlZCBjb21wYW55IiwidmFsdWUiOiIzNzE3MjMuMTYifSx7ImRlc2NyaXB0aW9uIjoiUEVQcywgdW5pdCB0cnVzdHMsIGNhcGl0YWwgYm9uZHMgYW5kIGdvdmVybm1lbnQgc3RvY2tzIiwidmFsdWUiOiI0NzQ2NzUuODEifSx7ImRlc2NyaXB0aW9uIjoiTGlmZSBhc3N1cmFuY2UgYW5kIGVuZG93bWVudCBwb2xpY2llcyBub3QgbGlua2VkIHRvIGEgbW9ydGdhZ2UiLCJ2YWx1ZSI6IjU0NTQ2Ni4zMiJ9XSwibm9uX2xpcXVpZCI6W3siZGVzY3JpcHRpb24iOiJUaW1lc2hhcmUgcHJvcGVydHkiLCJ2YWx1ZSI6IjQ0MzU4OS43MyJ9LHsiZGVzY3JpcHRpb24iOiJMYW5kIiwidmFsdWUiOiI1ODU2MjguNTQifSx7ImRlc2NyaXB0aW9uIjoiQW55IHZhbHVhYmxlIGl0ZW1zIHdvcnRoIG1vcmUgdGhhbiDCozUwMCIsInZhbHVlIjoiOTgxNzcxLjQ0In0seyJkZXNjcmlwdGlvbiI6Ik1vbmV5IG9yIGFzc2V0cyBmcm9tIHRoZSBlc3RhdGUgb2YgYSBwZXJzb24gd2hvIGhhcyBkaWVkIiwidmFsdWUiOiI1NTEyNDQuODEifSx7ImRlc2NyaXB0aW9uIjoiTW9uZXkgb3dlZCB0byBhcHBsaWNhbnQiLCJ2YWx1ZSI6IjMyNTAzMy43In0seyJkZXNjcmlwdGlvbiI6IkludGVyZXN0IGluIGEgdHJ1c3QiLCJ2YWx1ZSI6IjMzODU1OC40NyJ9XSwidmVoaWNsZXMiOlt7InZhbHVlIjoiNjY0MS4wIiwibG9hbl9hbW91bnRfb3V0c3RhbmRpbmciOiIxMDQuMCIsImRhdGVfb2ZfcHVyY2hhc2UiOiIyMDAxLTA4LTAzIiwiaW5fcmVndWxhcl91c2UiOnRydWUsImluY2x1ZGVkX2luX2Fzc2Vzc21lbnQiOmZhbHNlLCJhc3Nlc3NlZF92YWx1ZSI6IjAuMCJ9XSwicHJvcGVydGllcyI6eyJtYWluX2hvbWUiOnsidmFsdWUiOiIxNjEzODUuNTMiLCJvdXRzdGFuZGluZ19tb3J0Z2FnZSI6IjUxMjk1MC4yOCIsInBlcmNlbnRhZ2Vfb3duZWQiOiI0OS43OCIsIm1haW5faG9tZSI6dHJ1ZSwic2hhcmVkX3dpdGhfaG91c2luZ19hc3NvYyI6dHJ1ZSwidHJhbnNhY3Rpb25fYWxsb3dhbmNlIjoiNDg0MS41NyIsImFsbG93YWJsZV9vdXRzdGFuZGluZ19tb3J0Z2FnZSI6IjAuMCIsIm5ldF92YWx1ZSI6IjE1NjU0My45NiIsIm5ldF9lcXVpdHkiOiI3NTQ5Ni4xNSIsIm1haW5faG9tZV9lcXVpdHlfZGlzcmVnYXJkIjoiMTAwMDAwLjAiLCJhc3Nlc3NlZF9lcXVpdHkiOiIwLjAifSwiYWRkaXRpb25hbF9wcm9wZXJ0aWVzIjpbeyJ2YWx1ZSI6IjcxNjI5MC44OCIsIm91dHN0YW5kaW5nX21vcnRnYWdlIjoiMjI3NTAxLjM4IiwicGVyY2VudGFnZV9vd25lZCI6Ijc4LjAxIiwibWFpbl9ob21lIjpmYWxzZSwic2hhcmVkX3dpdGhfaG91c2luZ19hc3NvYyI6ZmFsc2UsInRyYW5zYWN0aW9uX2FsbG93YW5jZSI6IjIxNDg4LjczIiwiYWxsb3dhYmxlX291dHN0YW5kaW5nX21vcnRnYWdlIjoiMTAwMDAwLjAiLCJuZXRfdmFsdWUiOiI1OTQ4MDIuMTUiLCJuZXRfZXF1aXR5IjoiNDY0MDA1LjE2IiwibWFpbl9ob21lX2VxdWl0eV9kaXNyZWdhcmQiOiIwLjAiLCJhc3Nlc3NlZF9lcXVpdHkiOiI0NjQwMDUuMTYifV19fSwidG90YWxfbGlxdWlkIjoiMTk0NTQzNy42OCIsInRvdGFsX25vbl9saXF1aWQiOiIzMjI1ODI2LjY5IiwidG90YWxfdmVoaWNsZSI6IjAuMCIsInRvdGFsX3Byb3BlcnR5IjoiNDY0MDA1LjE2IiwidG90YWxfbW9ydGdhZ2VfYWxsb3dhbmNlIjoiMTAwMDAwLjAiLCJ0b3RhbF9jYXBpdGFsIjoiNTYzNTI2OS41MyIsInBlbnNpb25lcl9jYXBpdGFsX2Rpc3JlZ2FyZCI6IjAuMCIsImFzc2Vzc2VkX2NhcGl0YWwiOiI1NjM1MjY5LjUzIiwibG93ZXJfdGhyZXNob2xkIjoiMzAwMC4wIiwidXBwZXJfdGhyZXNob2xkIjoiOTk5OTk5OTk5OTk5LjAiLCJhc3Nlc3NtZW50X3Jlc3VsdCI6ImNvbnRyaWJ1dGlvbl9yZXF1aXJlZCIsImNhcGl0YWxfY29udHJpYnV0aW9uIjoiNTYzMjI2OS41MyJ9LCJyZW1hcmtzIjp7fX19
+    http_version: null
+  recorded_at: Thu, 28 May 2020 15:24:12 GMT
+recorded_with: VCR 5.1.0

--- a/spec/services/cfe/create_assessment_service_spec.rb
+++ b/spec/services/cfe/create_assessment_service_spec.rb
@@ -82,6 +82,7 @@ module CFE
             client_reference_id: 'L-XYZ-999'
           }
         ],
+        assessment_id: '1b2aa5eb-3763-445e-9407-2397ec3968f6',
         errors: []
       }
     end


### PR DESCRIPTION
AP1444 Use new CFE Assessment POST response

[Link to story](https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=233&projectKey=AP&modal=detail&selectedIssue=AP-1444)

Get assessment_id from the response instead of the :objects key (which is soon to be removed/deprecated)

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
