### PR TITLE
AP1115 Fix screen reader issues with multiple H1s on the Respondants page

### DIFF
--- a/app/javascript/src/respondent_detail.js
+++ b/app/javascript/src/respondent_detail.js
@@ -1,5 +1,6 @@
 $(document).ready(() => {
-  const govuk_hidden_class = 'govuk-visually-hidden'
+  // conditional--hidden will hide from voiceover/screen readers compared to visually hidden
+  const govuk_hidden_class = 'govuk-radios__conditional--hidden'
   const police_notified_label = $("label[for='police_notified_details']")
   const police_notified = $('#police_notified_details')
 

--- a/app/lib/govuk_elements_form_builder/form_builder.rb
+++ b/app/lib/govuk_elements_form_builder/form_builder.rb
@@ -95,8 +95,8 @@ module GovukElementsFormBuilder
     # You can pass an error with the :error parameter.
     # e.g., <%= form.govuk_collection_radio_buttons(:gender, ['f', 'm'], error: 'Please select a gender') %>
     #
-    # If you wish to specify the size of the heading pass a hash into title with text and size:
-    # <%= form.govuk_collection_radio_buttons(:gender, ['f', 'm'], title: { text: 'What is your gender?', size: :m } ) %>
+    # If you wish to specify the size of the heading and/or which header tag to use, pass a hash into title with text and size:
+    # <%= form.govuk_collection_radio_buttons(:gender, ['f', 'm'], title: { text: 'What is your gender?', size: :m, htag: :h2 } ) %>
     #
     # Use the :inline parameter to have the radio buttons displayed horizontally rather than vertically
     # e.g., <%= form.govuk_collection_radio_buttons(:gender, ['f', 'm'], inline: true) %>
@@ -205,11 +205,16 @@ module GovukElementsFormBuilder
       aria_describedby.join(' ')
     end
 
+    # title param can either be:
+    # * a text string, e.g  "My title"
+    # * a hash, e.g { text: "My title", size: :m, htag: :h2 }
+    #
     def fieldset_legend(title)
       title = text_hash(title)
       size = title.fetch(:size, 'xl')
+      htag = title.fetch(:htag, :h1)
       content_tag(:legend, class: "govuk-fieldset__legend govuk-fieldset__legend--#{size}") do
-        content_tag(:h1, title[:text], class: 'govuk-fieldset__heading')
+        content_tag(htag, title[:text], class: 'govuk-fieldset__heading')
       end
     end
 

--- a/app/lib/govuk_elements_form_builder/form_builder.rb
+++ b/app/lib/govuk_elements_form_builder/form_builder.rb
@@ -96,6 +96,7 @@ module GovukElementsFormBuilder
     # e.g., <%= form.govuk_collection_radio_buttons(:gender, ['f', 'm'], error: 'Please select a gender') %>
     #
     # If you wish to specify the size of the heading and/or which header tag to use, pass a hash into title with text and size:
+    # And the default for header tag, if no htag is supplied, is h1
     # <%= form.govuk_collection_radio_buttons(:gender, ['f', 'm'], title: { text: 'What is your gender?', size: :m, htag: :h2 } ) %>
     #
     # Use the :inline parameter to have the radio buttons displayed horizontally rather than vertically

--- a/app/views/providers/respondents/_respondent_detail.html.erb
+++ b/app/views/providers/respondents/_respondent_detail.html.erb
@@ -9,7 +9,7 @@
             question.attribute,
             [true, false],
             inline: true,
-            title: { size: :m, text: question.title },
+            title: { size: :m, text: question.title, htag: :h2 },
             input_attributes: question.show_details_when ? { question.show_details_when.to_s => { 'data-aria-controls' => conditional_id } } : nil
           ) %>
 

--- a/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
+++ b/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
@@ -97,6 +97,45 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
     end
   end
 
+  describe 'fieldset_legend' do
+    subject { builder.__send__(:fieldset_legend, params) }
+
+    context 'with just text title' do
+      let(:params) { 'This is my title' }
+      it 'returns the html' do
+        expected_html = '<legend class="govuk-fieldset__legend govuk-fieldset__legend--xl"><h1 class="govuk-fieldset__heading">This is my title</h1></legend>'
+        expect(subject).to eq expected_html
+      end
+    end
+
+    context 'passing in a title hash' do
+      let(:params) do
+        {
+          text: 'My text',
+          size: :m
+        }
+      end
+      it 'returns html with medium size' do
+        expected_html = '<legend class="govuk-fieldset__legend govuk-fieldset__legend--m"><h1 class="govuk-fieldset__heading">My text</h1></legend>'
+        expect(subject).to eq expected_html
+      end
+    end
+
+    context 'passing in a title hash' do
+      let(:params) do
+        {
+          text: 'My text',
+          size: :m,
+          htag: :h2
+        }
+      end
+      it 'returns html with medium size' do
+        expected_html = '<legend class="govuk-fieldset__legend govuk-fieldset__legend--m"><h2 class="govuk-fieldset__heading">My text</h2></legend>'
+        expect(subject).to eq expected_html
+      end
+    end
+  end
+
   describe 'govuk_text_field' do
     let(:attribute) { 'national_insurance_number' }
     let(:params) { [attribute.to_sym] }


### PR DESCRIPTION
AP1115 Fix screen reader issues with multiple H1s on the Respondants page

[Link to story](https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=233&projectKey=AP&modal=detail&selectedIssue=AP-1115)

- Allow the use of a h2 tag for govuk_collection_radio_buttons
- Add htag param to fieldset_legend method on form builder
- Update the respondent page to use this instead
- Update tests

**Another bugfix:**

- Fix voiceover bug with using class 'govuk-visually-hidden' because the screen reader reads whatever is inside it aloud even if it's hidden. Instead use class 'govuk-radios__conditional--hidden' for this, which hides it from the screen reader too if it's not showing on the page.

e.g. visually hidden (visually hides) but doesn't hide from the screenreaders/the ear.

Co-authored-by: @stephenrichards 

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
