### PR TITLE
AP-1389 Rename Home and Back liks

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,12 +10,21 @@ AllCops:
   - 'node_modules/**/*'
   - 'ccms_integration/*'
 
+Layout/EmptyLinesAroundAttributeAccessor:
+  Enabled: true
+
 Layout/SpaceAroundMethodCallOperator:
   Enabled: true
 
 Lint/AmbiguousBlockAssociation:
   Exclude:
   - 'spec/**/*'
+
+Lint/DeprecatedOpenSSLConstant:
+  Enabled: true
+
+Lint/MixedRegexpCaptureTypes:
+  Enabled: true
 
 Lint/UriEscapeUnescape:
   Enabled: false
@@ -84,4 +93,14 @@ Style/HashTransformValues:
 
 Style/ExponentialNotation:
   Enabled: true
+
+Style/RedundantRegexpCharacterClass:
+  Enabled: true
+
+Style/RedundantRegexpEscape:
+  Enabled: true
+
+Style/SlicingWithRange:
+  Enabled: true
+
 

--- a/app/controllers/citizens/citizen_base_controller.rb
+++ b/app/controllers/citizens/citizen_base_controller.rb
@@ -9,6 +9,7 @@ module Citizens
 
     class << self
       attr_reader :view_when_complete
+
       def allow_view_when_complete
         @view_when_complete = true
       end

--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -48,6 +48,7 @@ class LegalAidApplication < ApplicationRecord # rubocop:disable Metrics/ClassLen
   end
 
   attr_reader :proceeding_type_codes
+
   validate :proceeding_type_codes_existence
   validates :provider, presence: true
 
@@ -67,7 +68,7 @@ class LegalAidApplication < ApplicationRecord # rubocop:disable Metrics/ClassLen
       left_joins(:applicant, :ccms_submission).where("regexp_replace(lower(#{attribute}),'[^[:alnum:]]', '', 'g') like ?", "%#{clean_term}%")
     end
     applications = queries.first
-    queries[1..-1].each { |query| applications = applications.or(query) }
+    queries[1..].each { |query| applications = applications.or(query) }
     applications
   end
 

--- a/app/presenters/applicant_account_presenter.rb
+++ b/app/presenters/applicant_account_presenter.rb
@@ -1,5 +1,6 @@
 class ApplicantAccountPresenter
   attr_reader :bank_provider
+
   delegate :name, :bank_accounts, to: :bank_provider
 
   def initialize(bank_provider)

--- a/app/services/ccms/attribute_value_generator.rb
+++ b/app/services/ccms/attribute_value_generator.rb
@@ -66,6 +66,7 @@ module CCMS
     }.freeze
 
     attr_reader :legal_aid_application
+
     delegate :merits_assessment,
              :vehicle,
              :substantive_scope_limitation,

--- a/app/services/ccms/requestors/applicant_add_requestor.rb
+++ b/app/services/ccms/requestors/applicant_add_requestor.rb
@@ -15,6 +15,7 @@ module CCMS
       )
 
       attr_reader :applicant
+
       delegate :address, to: :applicant
 
       def initialize(applicant, provider_username)

--- a/app/services/cfe/submission_manager.rb
+++ b/app/services/cfe/submission_manager.rb
@@ -20,6 +20,7 @@ module CFE
     end
 
     attr_reader :legal_aid_application_id
+
     def initialize(legal_aid_application_id)
       @legal_aid_application_id = legal_aid_application_id
     end

--- a/app/services/cleanup_capital_attributes.rb
+++ b/app/services/cleanup_capital_attributes.rb
@@ -4,6 +4,7 @@ class CleanupCapitalAttributes
   end
 
   attr_reader :legal_aid_application
+
   delegate(
     :own_home_no?, :own_home_owned_outright?, :own_home?, :shared_ownership?,
     to: :legal_aid_application

--- a/app/services/flow/base_flow_service.rb
+++ b/app/services/flow/base_flow_service.rb
@@ -2,6 +2,7 @@ module Flow
   class BaseFlowService
     class << self
       attr_reader :steps
+
       def use_steps(steps)
         @steps = steps
       end

--- a/app/services/legal_aid_applications/calculation_date_service.rb
+++ b/app/services/legal_aid_applications/calculation_date_service.rb
@@ -1,6 +1,7 @@
 module LegalAidApplications
   class CalculationDateService
     attr_accessor :legal_aid_application
+
     delegate(
       :used_delegated_functions_on, :used_delegated_functions?, :merits_assessment, :applicant_receives_benefit?, :transaction_period_finish_on,
       to: :legal_aid_application

--- a/app/services/mock_benefit_check_service.rb
+++ b/app/services/mock_benefit_check_service.rb
@@ -14,6 +14,7 @@ class MockBenefitCheckService
   end
 
   attr_reader :application
+
   delegate :applicant, to: :application, allow_nil: true
   delegate :last_name, :national_insurance_number, :date_of_birth, to: :applicant, allow_nil: true
 

--- a/app/services/true_layer/bank_data_import_service.rb
+++ b/app/services/true_layer/bank_data_import_service.rb
@@ -17,6 +17,7 @@ module TrueLayer
     private
 
     attr_reader :legal_aid_application
+
     delegate(
       :applicant, :transaction_period_start_on, :transaction_period_finish_on,
       to: :legal_aid_application

--- a/app/views/providers/declarations/show.html.erb
+++ b/app/views/providers/declarations/show.html.erb
@@ -1,4 +1,4 @@
-<%= page_template page_title: t('.h1-heading') do %>
+<%= page_template(page_title: t('.h1-heading'), back_link: { text: t('generic.home') }) do %>
   <p class="govuk-body"><%= t('.statement') %></p>
   <ul class="govuk-list govuk-list--bullet print-add-bullet">
     <%- t('.statement-bullets').each do |bullet| %>

--- a/app/views/shared/forms/_applicant_form.html.erb
+++ b/app/views/shared/forms/_applicant_form.html.erb
@@ -1,7 +1,6 @@
-<% back_label = @legal_aid_application&.checking_client_details_answers? ? 'generic.back' : 'generic.home' %>
 <%= page_template(
       page_title: t('.page_title'),
-      back_link: { text: t(back_label) },
+      back_link: { text: t('generic.back') },
       page_heading_options: { margin_bottom: 3 }
     ) do %>
 

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -271,6 +271,7 @@ en:
     declarations:
       show:
         h1-heading: Declaration
+        h1-heading: Declaration
         statement: 'By continuing, you agree that:'
         statement-bullets:
         - your client has instructed you to represent them

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -271,7 +271,6 @@ en:
     declarations:
       show:
         h1-heading: Declaration
-        h1-heading: Declaration
         statement: 'By continuing, you agree that:'
         statement-bullets:
         - your client has instructed you to represent them

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -118,7 +118,7 @@ World(Warden::Test::Helpers)
 
 After do |scenario|
   if scenario.failed?
-    name = scenario.location.file.gsub('features/', '').gsub(%r{/\.|\/}, '-')
+    name = scenario.location.file.gsub('features/', '').gsub(%r{/\.|/}, '-')
     screenshot_image(name)
   end
 end

--- a/spec/requests/providers/applicants_spec.rb
+++ b/spec/requests/providers/applicants_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Providers::ApplicantsController, type: :request do
 
     it 'does not prefix page title with error label' do
       subject
-      expect(response.body).not_to match(/\<title\>#{I18n.t('errors.title_prefix')}\:/)
+      expect(response.body).not_to match(/<title>#{I18n.t('errors.title_prefix')}:/)
     end
   end
 
@@ -75,7 +75,7 @@ RSpec.describe Providers::ApplicantsController, type: :request do
 
       it 'prefixes page title with error label' do
         subject
-        expect(response.body).to match(/\<title\>#{I18n.t('errors.title_prefix')}\:/)
+        expect(response.body).to match(/<title>#{I18n.t('errors.title_prefix')}:/)
       end
 
       it 'does not create applicant' do

--- a/spec/requests/providers/legal_aid_applications_spec.rb
+++ b/spec/requests/providers/legal_aid_applications_spec.rb
@@ -188,7 +188,7 @@ RSpec.describe 'providers legal aid application requests', type: :request do
         it 'shows the application' do
           subject
           expect(unescaped_response_body).to include('Emergency')
-          expect(unescaped_response_body).to match(/Substantive due: [\d]{1,2} [ADFJMNOS]\w* [\d]{4}/)
+          expect(unescaped_response_body).to match(/Substantive due: \d{1,2} [ADFJMNOS]\w* \d{4}/)
           expect(legal_aid_application.summary_state).to eq(:in_progress)
         end
       end
@@ -208,7 +208,7 @@ RSpec.describe 'providers legal aid application requests', type: :request do
           subject
           expect(unescaped_response_body).to include('Emergency')
           expect(legal_aid_application.substantive_application_deadline_on).not_to be_nil
-          expect(unescaped_response_body).not_to match(/Substantive due: [\d]{1,2} [ADFJMNOS]\w* [\d]{4}/)
+          expect(unescaped_response_body).not_to match(/Substantive due: \d{1,2} [ADFJMNOS]\w* \d{4}/)
           expect(legal_aid_application.summary_state).to eq(:submitted)
         end
       end


### PR DESCRIPTION
## Rename Home and Back links on opening pages

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1389)

- renamed the back button to Home on the declarations page
- renamed the home button to Back on the client details page
- implemented latest rubocop checks

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
