### PR TITLE
CircleCI Update: Enable test timings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,7 +173,7 @@ jobs:
     - *save_js_packages_cache
     - run:
         name: Run ruby tests
-        command: bin/rails spec
+        command: bin/rails rspec --format RspecJunitFormatter -o /tmp/test-results/rspec/rspec.xml
 
   integration_tests:
     executor: test-executor
@@ -190,7 +190,7 @@ jobs:
     - *save_js_packages_cache
     - run:
         name: Run integration tests
-        command: SAVE_PAGES=true bin/rails cucumber
+        command: SAVE_PAGES=true bin/rails cucumber --format junit --out /tmp/test-results/cucumber
     - store_artifacts:
         path: tmp/capybara
     - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,6 +174,8 @@ jobs:
     - run:
         name: Run ruby tests
         command: bundle exec rspec --format RspecJunitFormatter -o /tmp/test-results/rspec/rspec.xml
+    - store_test_results:
+        path: /tmp/test-results/rspec
 
   integration_tests:
     executor: test-executor
@@ -197,6 +199,8 @@ jobs:
         root: tmp
         paths:
          - webhint_inputs
+    - store_test_results:
+        path: /tmp/test-results/cucumber
 
   webhint_reports:
     executor: linting-executor

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,7 +173,7 @@ jobs:
     - *save_js_packages_cache
     - run:
         name: Run ruby tests
-        command: bin/rails rspec --format RspecJunitFormatter -o /tmp/test-results/rspec/rspec.xml
+        command: bundle exec rspec --format RspecJunitFormatter -o /tmp/test-results/rspec/rspec.xml
 
   integration_tests:
     executor: test-executor
@@ -190,7 +190,7 @@ jobs:
     - *save_js_packages_cache
     - run:
         name: Run integration tests
-        command: SAVE_PAGES=true bin/rails cucumber --format junit --out /tmp/test-results/cucumber
+        command: SAVE_PAGES=true bundle exec cucumber --format junit --out /tmp/test-results/cucumber
     - store_artifacts:
         path: tmp/capybara
     - persist_to_workspace:

--- a/Gemfile
+++ b/Gemfile
@@ -102,6 +102,7 @@ group :development, :test do
   gem 'json_expressions'
   gem 'nokogiri'
   gem 'pry-byebug'
+  gem 'rspec_junit_formatter'
   gem 'rubocop', require: false
   gem 'rubocop-performance'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -456,6 +456,8 @@ GEM
       rspec-mocks (~> 3.9)
       rspec-support (~> 3.9)
     rspec-support (3.9.3)
+    rspec_junit_formatter (0.4.1)
+      rspec-core (>= 2, < 4, != 2.12.0)
     rubocop (0.85.1)
       parallel (~> 1.10)
       parser (>= 2.7.0.1)
@@ -642,6 +644,7 @@ DEPENDENCIES
   redis-namespace
   regexp-examples
   rspec-rails (~> 4.0, >= 4.0.1)
+  rspec_junit_formatter
   rubocop
   rubocop-performance
   ruby-saml-idp!


### PR DESCRIPTION
## What

This is a pre-cursor to turning on paralellism.
With these timings in place, we should be able to assess and properly run the test in parallel
should we ever need to.  They will also allow us to use CircleCI insights to monitor the state of the tests for issues.

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
