### PR TITLE
AP-1446 Flow around offline bank accounts

### DIFF
--- a/app/controllers/citizens/additional_accounts_controller.rb
+++ b/app/controllers/citizens/additional_accounts_controller.rb
@@ -1,6 +1,9 @@
 module Citizens
   class AdditionalAccountsController < CitizenBaseController
-    def index; end
+    def index
+      legal_aid_application.update!(has_offline_accounts: nil)
+      legal_aid_application.update!(state: 'provider_submitted')
+    end
 
     def create
       case params[:additional_account]

--- a/app/controllers/citizens/additional_accounts_controller.rb
+++ b/app/controllers/citizens/additional_accounts_controller.rb
@@ -2,7 +2,7 @@ module Citizens
   class AdditionalAccountsController < CitizenBaseController
     def index
       legal_aid_application.update!(has_offline_accounts: nil)
-      legal_aid_application.update!(state: 'provider_submitted')
+      legal_aid_application.provider_submit! unless legal_aid_application.provider_submitted?
     end
 
     def create

--- a/spec/requests/citizens/additional_accounts_spec.rb
+++ b/spec/requests/citizens/additional_accounts_spec.rb
@@ -16,6 +16,19 @@ RSpec.describe 'citizen additional accounts request test', type: :request do
     end
   end
 
+  context 'when an applicant revisits the page to change their answer' do
+    before do
+      application.update!(has_offline_accounts: true)
+      application.update!(state: 'use_ccms')
+    end
+
+    it 'checks that offline account is reset to nil' do
+      get citizens_additional_accounts_path
+      expect(application.reload.has_offline_accounts).to be_nil
+      expect(application.reload.state).to eq 'provider_submitted'
+    end
+  end
+
   describe 'POST /citizens/additional_accounts' do
     let(:params) { {} }
     before { post citizens_additional_accounts_path, params: params }

--- a/spec/requests/citizens/additional_accounts_spec.rb
+++ b/spec/requests/citizens/additional_accounts_spec.rb
@@ -18,14 +18,13 @@ RSpec.describe 'citizen additional accounts request test', type: :request do
 
   context 'when an applicant revisits the page to change their answer' do
     before do
-      application.update!(has_offline_accounts: true)
-      application.update!(state: 'use_ccms')
+      application.update!(has_offline_accounts: true, state: 'use_ccms')
     end
 
     it 'checks that offline account is reset to nil' do
       get citizens_additional_accounts_path
       expect(application.reload.has_offline_accounts).to be_nil
-      expect(application.reload.state).to eq 'provider_submitted'
+      expect(application.state).to eq 'provider_submitted'
     end
   end
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1446)

Describe what you did and why.

When the client arrives on the 'citizens/additional_accounts' page, the state is reverted to 'provider_submitted' and the boolean 'has_offline_accounts' is set to nil. This requires the client to make a selection before leaving the page (particularly relevant on a re-visit, as currently the initial response is stored and not changed). This allows the user to change their mind about additional accounts at any point in the subflow and to use the back buttons to amend their answers.

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
