### PR TITLE
AP-1486: true layer date formatting

### DIFF
--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -129,8 +129,8 @@ class LegalAidApplication < ApplicationRecord # rubocop:disable Metrics/ClassLen
     date_from = date_to - 3.months
 
     update!(
-      transaction_period_start_on: date_from,
-      transaction_period_finish_on: date_to
+      transaction_period_start_on: date_from.beginning_of_day,
+      transaction_period_finish_on: date_to.beginning_of_day
     )
   end
 

--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -129,8 +129,8 @@ class LegalAidApplication < ApplicationRecord # rubocop:disable Metrics/ClassLen
     date_from = date_to - 3.months
 
     update!(
-      transaction_period_start_on: date_from.beginning_of_day,
-      transaction_period_finish_on: date_to.beginning_of_day
+      transaction_period_start_on: date_from,
+      transaction_period_finish_on: date_to
     )
   end
 

--- a/app/services/true_layer/api_client.rb
+++ b/app/services/true_layer/api_client.rb
@@ -21,8 +21,8 @@ module TrueLayer
 
     def transactions(account_id, date_from, date_to)
       params = {
-        from: date_from.to_datetime.iso8601,
-        to: date_to.to_datetime.iso8601
+        from: date_from.to_datetime.utc.iso8601,
+        to: date_to.to_datetime.utc.iso8601
       }
       perform_lookup("/data/v1/accounts/#{account_id}/transactions?#{params.to_query}")
     end

--- a/app/services/true_layer/api_client.rb
+++ b/app/services/true_layer/api_client.rb
@@ -21,8 +21,8 @@ module TrueLayer
 
     def transactions(account_id, date_from, date_to)
       params = {
-        from: date_from.to_date.iso8601,
-        to: date_to.to_date.iso8601
+        from: date_from.to_datetime.iso8601,
+        to: date_to.to_datetime.iso8601
       }
       perform_lookup("/data/v1/accounts/#{account_id}/transactions?#{params.to_query}")
     end

--- a/spec/services/true_layer/bank_data_import_service_spec.rb
+++ b/spec/services/true_layer/bank_data_import_service_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe TrueLayer::BankDataImportService do
       end
     end
 
-    context 'a aubsequent API call is failing' do
+    context 'a subsequent API call is failing' do
       before do
         endpoint = TrueLayer::ApiClient::TRUE_LAYER_URL + '/data/v1/accounts'
         stub_request(:get, endpoint).to_return(body: api_error.to_json, status: 501)

--- a/spec/services/true_layer/importers/import_transactions_service_spec.rb
+++ b/spec/services/true_layer/importers/import_transactions_service_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe TrueLayer::Importers::ImportTransactionsService do
   let(:api_client) { TrueLayer::ApiClient.new(bank_account.bank_provider.token) }
 
   describe '#call' do
-    let(:now) { '6/11/2018'.to_date }
-    let(:now_minus_3_month) { '5/08/2018'.to_date }
+    let(:now) { '6/11/2018'.to_datetime.beginning_of_day }
+    let(:now_minus_3_month) { '5/08/2018'.to_datetime.beginning_of_day }
     let(:mock_transaction_1) { mock_account[:transactions][0] }
     let(:mock_transaction_2) { mock_account[:transactions][1] }
     let(:transaction_1) { bank_account.bank_transactions.find_by(true_layer_id: mock_transaction_1[:transaction_id]) }
@@ -57,8 +57,8 @@ RSpec.describe TrueLayer::Importers::ImportTransactionsService do
 
         expect(WebMock).to have_requested(:get, expected_request_url)
           .with(query: {
-                  from: now_minus_3_month.iso8601,
-                  to: now.iso8601
+                  from: now_minus_3_month.beginning_of_day.iso8601,
+                  to: now.beginning_of_day.iso8601
                 })
       end
     end

--- a/spec/services/true_layer/importers/import_transactions_service_spec.rb
+++ b/spec/services/true_layer/importers/import_transactions_service_spec.rb
@@ -57,8 +57,8 @@ RSpec.describe TrueLayer::Importers::ImportTransactionsService do
 
         expect(WebMock).to have_requested(:get, expected_request_url)
           .with(query: {
-                  from: now_minus_3_month.beginning_of_day.iso8601,
-                  to: now.beginning_of_day.iso8601
+                  from: '2018-08-05T00:00:00Z',
+                  to: '2018-11-06T00:00:00Z'
                 })
       end
     end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1486)

TrueLayer have confirmed that it is because we are asking for transactions in the future, i.e. our end date isn't in the past.

Reverted the calls to truelayer to be `DateTime` instead of simply `Date`
According to #771 
> because TrueLayer's filter is only granular to the date anyway, not the time
This reverts the `to_date` to the beginning of the chosen day, either today or the delegated_permission date, depending.

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
