### PR TITLE
AP1485 BugFix - Return false after a Raven.capture_exception

### DIFF
--- a/app/services/benefit_check_service.rb
+++ b/app/services/benefit_check_service.rb
@@ -22,8 +22,10 @@ class BenefitCheckService
     soap_client.call(:check, message: benefit_checker_params).body.dig(:benefit_checker_response)
   rescue Savon::SOAPFault => e
     Raven.capture_exception(ApiError.new("HTTP #{e.http.code}, #{e.to_hash}"))
+    false
   rescue StandardError => e
     Raven.capture_exception(e)
+    false
   end
 
   private


### PR DESCRIPTION
AP1485 BugFix - Return false after a Raven.capture_exception

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1485)

Return false after a Raven.capture_exception this is because our app gets the result and tries to dig into the hash result
but as it's a Raven event it raises another sentry error of "undefined method `dig' for #<Raven::Event"

Update tests for catching Savon::SOAPFault error and a StandardError

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
