### PR TITLE
Guard against transitioning to use_ccms if already there

### DIFF
--- a/app/controllers/providers/check_benefits_controller.rb
+++ b/app/controllers/providers/check_benefits_controller.rb
@@ -24,7 +24,7 @@ module Providers
 
       return false if Setting.allow_non_passported_route?
 
-      legal_aid_application.use_ccms!
+      legal_aid_application.use_ccms! unless legal_aid_application.use_ccms?
       true
     end
 


### PR DESCRIPTION
## Guard against transitioning to use_ccms if already in that state

We got an invalid transition exception on the live system - this fixes that.

[Link to story](https://dsdmoj.atlassian.net/browse/AP-XXX)

Describe what you did and why.

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
