### PR TITLE
FIX: Store coverage output as artifact

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,6 +176,8 @@ jobs:
         command: bundle exec rspec --format progress --format RspecJunitFormatter -o /tmp/test-results/rspec/rspec.xml
     - store_test_results:
         path: /tmp/test-results/rspec
+    - store_artifacts:
+        path: coverage
 
   integration_tests:
     executor: test-executor


### PR DESCRIPTION
## What
In an attempt to help debug the dropping code-coverage issue I have added this output in circle
If your unit-test job fails with code-coverage of 99.94% it will output the simplecov report to the artifacts tab.  
![image](https://user-images.githubusercontent.com/6757677/85376217-56a58580-b52f-11ea-8e8c-affd45d27b58.png)
You can double click on index to open the report and see what has failed.  This may be of use longer-term but it is primarily to diagnose the issue currently occurring.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why ~, with a link to the JIRA story.~
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
