### PR TITLE
BugFix jest(jsdom) issue for window.location.reload

### DIFF
--- a/spec/javascript/worker_waiter.spec.js
+++ b/spec/javascript/worker_waiter.spec.js
@@ -1,12 +1,11 @@
 import axios from 'axios'
 jest.mock('axios')
 
-const location_reload = window.location.reload
 beforeAll(() => {
-  Object.defineProperty(window.location, 'reload', { configurable: true })
-  window.location.reload = jest.fn()
-})
-afterAll(() => { window.location.reload = location_reload })
+  Object.defineProperty(window, 'location', {
+    value: { reload: jest.fn() }
+  })
+});
 
 beforeEach(() => jest.resetAllMocks() )
 


### PR DESCRIPTION
The error was "TypeError: Cannot assign to read only property 'reload' of object '[object Location]'"

This is related to this issue https://github.com/facebook/jest/issues/9471

It is a workaround to fix the yarn test failure by mocking out window.location

This was caused when upgrading jest to version 26

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
