### PR TITLE
BugFix Run JavaScript tests in CircleCI as part of unit tests job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -172,6 +172,9 @@ jobs:
     - *install_js_packages
     - *save_js_packages_cache
     - run:
+        name: Run JavaScript tests
+        command: bin/rails javascript_tests
+    - run:
         name: Run ruby tests
         command: bundle exec rspec --format progress --format RspecJunitFormatter -o /tmp/test-results/rspec/rspec.xml
     - store_test_results:


### PR DESCRIPTION
BugFix Run JavaScript tests in CircleCI as part of unit tests job

The problem was that JavaScript tests weren't running as part of CircleCI.


- Reuse the javascript_tests rake command to run our javascript tests in circle ci job called unit_tests

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
