### PR TITLE
AP-1462 Rename states on LegalAidAppllication

### DIFF
--- a/app/controllers/providers/address_selections_controller.rb
+++ b/app/controllers/providers/address_selections_controller.rb
@@ -3,6 +3,8 @@ module Providers
     def show # rubocop:disable Metrics/AbcSize
       return redirect_to back_path unless address.postcode
 
+      legal_aid_application.enter_applicant_details! unless no_state_change_required?
+
       if address_lookup.success?
         @addresses = address_lookup.result
         titleize_addresses
@@ -21,6 +23,10 @@ module Providers
     end
 
     private
+
+    def no_state_change_required?
+      legal_aid_application.entering_applicant_details? || legal_aid_application.checking_applicant_details?
+    end
 
     def address_lookup
       @address_lookup ||= AddressLookupService.call(address.postcode)

--- a/app/controllers/providers/capital_introductions_controller.rb
+++ b/app/controllers/providers/capital_introductions_controller.rb
@@ -1,6 +1,8 @@
 module Providers
   class CapitalIntroductionsController < ProviderBaseController
-    def show; end
+    def show
+      legal_aid_application.provider_enter_means!
+    end
 
     def update
       continue_or_draft

--- a/app/controllers/providers/check_provider_answers_controller.rb
+++ b/app/controllers/providers/check_provider_answers_controller.rb
@@ -4,7 +4,7 @@ module Providers
       return redirect_to_means_summary if legal_aid_application.provider_assessing_means?
 
       set_variables
-      legal_aid_application.check_your_answers! unless status_change_not_required?
+      legal_aid_application.check_applicant_details! unless status_change_not_required?
     end
 
     def reset
@@ -13,7 +13,7 @@ module Providers
     end
 
     def continue
-      legal_aid_application.client_details_answers_checked! unless draft_selected?
+      legal_aid_application.applicant_details_checked! unless draft_selected?
       continue_or_draft
     end
 
@@ -32,7 +32,7 @@ module Providers
     end
 
     def status_change_not_required?
-      legal_aid_application.checking_client_details_answers? ||
+      legal_aid_application.checking_applicant_details? ||
         legal_aid_application.provider_submitted? ||
         legal_aid_application.checking_citizen_answers?
     end

--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -223,7 +223,7 @@ class LegalAidApplication < ApplicationRecord # rubocop:disable Metrics/ClassLen
   end
 
   def checking_answers?
-    checking_client_details_answers? ||
+    checking_applicant_details? ||
       checking_citizen_answers? ||
       checking_passported_answers? ||
       checking_merits_answers? ||

--- a/app/services/flow/flows/provider_start.rb
+++ b/app/services/flow/flows/provider_start.rb
@@ -12,7 +12,7 @@ module Flow
         applicant_details: {
           path: ->(application) { urls.providers_legal_aid_application_applicant_details_path(application) },
           forward: ->(application) do
-            if application.client_details_answers_checked?
+            if application.applicant_details_checked?
               :check_provider_answers
             else
               :address_lookups

--- a/app/services/migration_helpers/state_changer.rb
+++ b/app/services/migration_helpers/state_changer.rb
@@ -1,0 +1,52 @@
+module MigrationHelpers
+  class StateChanger
+    STATE_CHANGES = [
+      [:initiated, :entering_applicant_details, %(provider_step != 'address_lookups')],
+      [:checking_client_details_answers, :checking_applicant_details, nil],
+      [:client_details_answers_checked, :applicant_details_checked, %(provider_step = 'check_benefits')],
+      [:client_details_answers_checked, :provider_entering_means, %|provider_step not in ('check_benefits', 'open_banking_consents', 'email_addresses', 'about_the_financial_assessments')|]
+    ].freeze
+
+    def initialize(dummy_run:)
+      @dummy_run = dummy_run
+    end
+
+    def up
+      run(:up)
+    end
+
+    def down
+      run(:down)
+    end
+
+    private
+
+    def run(migration_direction)
+      STATE_CHANGES.each do |change_details|
+        old_state, new_state, where_clause = change_details
+        sql = form_sql(old_state, new_state, where_clause, migration_direction)
+        if @dummy_run
+          puts sql
+        else
+          ActiveRecord::Base.connection.execute(sql)
+        end
+      end
+    end
+
+    def form_sql(old_state, new_state, where_clause, migration_direction)
+      migration_direction == :up ? form_up_sql(old_state, new_state, where_clause) : form_down_sql(old_state, new_state, where_clause)
+    end
+
+    def form_up_sql(old_state, new_state, where_clause)
+      sql = %(UPDATE legal_aid_applications SET state = '#{new_state}' WHERE state = '#{old_state}' )
+      sql += %( AND #{where_clause}) unless where_clause.nil?
+      sql
+    end
+
+    def form_down_sql(old_state, new_state, where_clause)
+      sql = %(UPDATE legal_aid_applications SET state = '#{old_state}' WHERE state = '#{new_state}')
+      sql += %( AND #{where_clause}) unless where_clause.nil?
+      sql
+    end
+  end
+end

--- a/app/services/test_application_creation_service.rb
+++ b/app/services/test_application_creation_service.rb
@@ -1,9 +1,9 @@
 class TestApplicationCreationService
   APPLICATION_TEST_TRAITS = %i[
     at_initiated
-    at_checking_client_details_answers
+    at_checking_applicant_details
     at_checking_passported_answers
-    at_client_details_answers_checked
+    at_applicant_details_checked
     at_provider_submitted
     at_provider_assessing_means
     at_checking_merits_answers

--- a/config/locales/en/model_enum_translations.yml
+++ b/config/locales/en/model_enum_translations.yml
@@ -27,6 +27,7 @@ en:
         initiated: In progress
         analysing_bank_transactions: Analysing Bank Transactions
         provider_assessing_means: Means test completed
+        provider_entering_means: In progress
         assessment_submitted: Application submitted
         provider_submitted: Submitted by provider
         provider_checking_citizens_means_answers: Means test completed

--- a/config/locales/en/model_enum_translations.yml
+++ b/config/locales/en/model_enum_translations.yml
@@ -16,13 +16,14 @@ en:
         very_easy: Very easy
     legal_aid_application:
       state:
-        client_details_answers_checked: Answers checked
-        checking_client_details_answers: Checking answers
+        applicant_details_checked: Answers checked
+        checking_applicant_details: Checking answers
         checking_citizen_answers: Applicant checking answers
         checking_merits_answers: Provider checking merits test answers
         checked_merits_answers: Provider checked merits test answers
         checking_passported_answers: Provider checking means test answers
         delegated_functions_used: Delegated functions used
+        entering_applicant_details: In progress
         initiated: In progress
         analysing_bank_transactions: Analysing Bank Transactions
         provider_assessing_means: Means test completed

--- a/db/migrate/20200625135809_update_states.rb
+++ b/db/migrate/20200625135809_update_states.rb
@@ -1,46 +1,9 @@
 class UpdateStates < ActiveRecord::Migration[6.0]
-  STATE_CHANGES = {
-    initiated: {
-      new_state: :entering_applicant_details,
-      conditions: nil
-    },
-    checking_client_details_answers: {
-      new_state: :checking_applicant_details,
-      conditions: nil
-    },
-    client_details_answers_checked: {
-      new_state: :applicant_details_checked,
-      conditions: %|provider_step = 'check_benefits'|
-    },
-    client_details_answers_checked: {
-      new_state: :provider_entering_means,
-      conditions: %|provider_step != 'check_benefits'|
-    }
-  }
-
-
-  STATE_CHANGES = {
-    initiated: :entering_applicant_details,
-    checking_client_details_answers: :checking_applicant_details
-    # client_details_answers_checked: :applicant_details_checked
-  }.freeze
-
   def up
-    STATE_CHANGES.each do |old_state_name, new_state_name|
-      sql = "UPDATE legal_aid_applications SET state = '#{new_state_name}' WHERE state = '#{old_state_name}'"
-      puts sql
-      execute sql
-    end
-
-    sql = "UPDATE legal_aid_applications SET state = 'applicant_details_checked' WHERE state = 'client_details_answers_checked' AND provider_step = 'check_provider_answers'"
-    sql =
+    MigrationHelpers::StateChanger.new(dummy_run: true).up
   end
 
   def down
-    STATE_CHANGES.each do |old_state_name, new_state_name|
-      sql = "UPDATE legal_aid_applications SET state = '#{old_state_name}' WHERE state = '#{new_state_name}'"
-      puts sql
-      execute sql
-    end
+    MigrationHelpers::StateChanger.new(dummy_run: true).down
   end
 end

--- a/db/migrate/20200625135809_update_states.rb
+++ b/db/migrate/20200625135809_update_states.rb
@@ -1,0 +1,23 @@
+class UpdateStates < ActiveRecord::Migration[6.0]
+  STATE_CHANGES = {
+    initiated: :entering_applicant_details,
+    checking_client_details_answers: :checking_applicant_details,
+    client_details_answers_checked: :applicant_details_checked
+  }.freeze
+
+  def up
+    STATE_CHANGES.each do |old_state_name, new_state_name|
+      sql = "UPDATE legal_aid_applications SET state = '#{new_state_name}' WHERE state = '#{old_state_name}'"
+      puts sql
+      execute sql
+    end
+  end
+
+  def down
+    STATE_CHANGES.each do |old_state_name, new_state_name|
+      sql = "UPDATE legal_aid_applications SET state = '#{old_state_name}' WHERE state = '#{new_state_name}'"
+      puts sql
+      execute sql
+    end
+  end
+end

--- a/db/migrate/20200625135809_update_states.rb
+++ b/db/migrate/20200625135809_update_states.rb
@@ -1,8 +1,28 @@
 class UpdateStates < ActiveRecord::Migration[6.0]
   STATE_CHANGES = {
+    initiated: {
+      new_state: :entering_applicant_details,
+      conditions: nil
+    },
+    checking_client_details_answers: {
+      new_state: :checking_applicant_details,
+      conditions: nil
+    },
+    client_details_answers_checked: {
+      new_state: :applicant_details_checked,
+      conditions: %|provider_step = 'check_benefits'|
+    },
+    client_details_answers_checked: {
+      new_state: :provider_entering_means,
+      conditions: %|provider_step != 'check_benefits'|
+    }
+  }
+
+
+  STATE_CHANGES = {
     initiated: :entering_applicant_details,
-    checking_client_details_answers: :checking_applicant_details,
-    client_details_answers_checked: :applicant_details_checked
+    checking_client_details_answers: :checking_applicant_details
+    # client_details_answers_checked: :applicant_details_checked
   }.freeze
 
   def up
@@ -11,6 +31,9 @@ class UpdateStates < ActiveRecord::Migration[6.0]
       puts sql
       execute sql
     end
+
+    sql = "UPDATE legal_aid_applications SET state = 'applicant_details_checked' WHERE state = 'client_details_answers_checked' AND provider_step = 'check_provider_answers'"
+    sql =
   end
 
   def down

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_16_135325) do
+ActiveRecord::Schema.define(version: 2020_06_25_135809) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_25_135809) do
+ActiveRecord::Schema.define(version: 2020_06_16_135325) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"

--- a/features/step_definitions/civil_journey_steps.rb
+++ b/features/step_definitions/civil_journey_steps.rb
@@ -208,6 +208,7 @@ Given('I complete the journey as far as check your answers') do
   proceeding_type = ProceedingType.all.sample
   @legal_aid_application = create(
     :legal_aid_application,
+    :at_entering_applicant_details,
     applicant: applicant,
     proceeding_types: [proceeding_type],
     used_delegated_functions_on: 1.day.ago
@@ -240,6 +241,7 @@ Given('I complete the passported journey as far as check your answers') do
   )
   @legal_aid_application = create(
     :legal_aid_application,
+    :at_entering_applicant_details,
     :with_substantive_scope_limitation,
     applicant: applicant,
     used_delegated_functions_on: 1.day.ago
@@ -271,7 +273,7 @@ Given('I complete the passported journey as far as capital check your answers') 
     :legal_aid_application,
     :with_everything,
     :with_proceeding_types,
-    :client_details_answers_checked,
+    :applicant_details_checked,
     applicant: applicant
   )
   login_as @legal_aid_application.provider

--- a/spec/factories/legal_aid_applications.rb
+++ b/spec/factories/legal_aid_applications.rb
@@ -31,8 +31,8 @@ FactoryBot.define do
       state { 'use_ccms' }
     end
 
-    trait :client_details_answers_checked do
-      state { 'client_details_answers_checked' }
+    trait :applicant_details_checked do
+      state { 'applicant_details_checked' }
     end
 
     trait :checking_passported_answers do
@@ -69,8 +69,8 @@ FactoryBot.define do
       state { 'analysing_bank_transactions' }
     end
 
-    trait :checking_client_details_answers do
-      state { :checking_client_details_answers }
+    trait :checking_applicant_details do
+      state { :checking_applicant_details }
     end
 
     trait :with_proceeding_types do
@@ -276,14 +276,19 @@ FactoryBot.define do
       provider_step { :applicants }
     end
 
+    trait :at_entering_applicant_details do
+      state { :entering_applicant_details }
+      provider_step { :applicants }
+    end
+
     trait :at_use_ccms do
       state { :use_ccms }
       provider_step { :use_ccms }
     end
 
-    trait :at_checking_client_details_answers do
+    trait :at_checking_applicant_details do
       with_proceeding_types
-      state { :checking_client_details_answers }
+      state { :checking_applicant_details }
       provider_step { :check_provider_answers }
     end
 
@@ -293,9 +298,9 @@ FactoryBot.define do
       provider_step { :check_passported_answers }
     end
 
-    trait :at_client_details_answers_checked do
+    trait :at_applicant_details_checked do
       with_proceeding_types
-      state { :client_details_answers_checked }
+      state { :applicant_details_checked }
       provider_step { :check_benefits }
     end
 

--- a/spec/forms/legal_aid_applications/substantive_application_form_spec.rb
+++ b/spec/forms/legal_aid_applications/substantive_application_form_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe LegalAidApplications::SubstantiveApplicationForm, type: :form do
   let(:used_delegated_functions_on) { 1.day.ago.to_date }
   let(:application) do
-    create :legal_aid_application, state: :client_details_answers_checked
+    create :legal_aid_application, state: :applicant_details_checked
   end
   let(:substantive_application) { false }
   let(:params) do

--- a/spec/models/legal_aid_application_spec.rb
+++ b/spec/models/legal_aid_application_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe LegalAidApplication, type: :model do
   end
 
   describe 'benefit_check_result_needs_updating?' do
-    let!(:legal_aid_application) { create :legal_aid_application, :with_applicant }
+    let!(:legal_aid_application) { create :legal_aid_application, :with_applicant, :at_entering_applicant_details }
     let(:applicant) { legal_aid_application.applicant }
     it 'is true if no benefit check results' do
       expect(legal_aid_application).to be_benefit_check_result_needs_updating
@@ -118,7 +118,7 @@ RSpec.describe LegalAidApplication, type: :model do
 
       context 'but later, state changes' do
         before do
-          legal_aid_application.check_your_answers!
+          legal_aid_application.check_applicant_details!
         end
 
         it 'returns false' do
@@ -373,16 +373,16 @@ RSpec.describe LegalAidApplication, type: :model do
     end
   end
 
-  describe 'attributes are synced on client_details_answers_checked' do
-    let(:legal_aid_application) { create :legal_aid_application, :with_everything, :without_own_home, state: :checking_client_details_answers }
+  describe 'attributes are synced on applicant_details_checked' do
+    let(:legal_aid_application) { create :legal_aid_application, :with_everything, :without_own_home, state: :checking_applicant_details }
     it 'passes application to keep in sync service' do
       expect(CleanupCapitalAttributes).to receive(:call).with(legal_aid_application)
-      legal_aid_application.client_details_answers_checked!
+      legal_aid_application.applicant_details_checked!
     end
 
     context 'and attributes changed' do
       before do
-        legal_aid_application.client_details_answers_checked!
+        legal_aid_application.applicant_details_checked!
         legal_aid_application.reload
       end
       it 'resets property values' do

--- a/spec/models/scheduled_mailing_spec.rb
+++ b/spec/models/scheduled_mailing_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe ScheduledMailing do
     context 'mailer_class does override #eligble for delivery' do
       let(:scheduled_mail) { create :scheduled_mailing, :due, legal_aid_application: legal_aid_application }
       context 'the mail is eligible' do
-        let(:legal_aid_application) { create :legal_aid_application, :at_checking_client_details_answers }
+        let(:legal_aid_application) { create :legal_aid_application, :at_checking_applicant_details }
 
         it 'delivers the mail' do
           Timecop.freeze(now) do

--- a/spec/requests/providers/applicant_details_spec.rb
+++ b/spec/requests/providers/applicant_details_spec.rb
@@ -91,8 +91,8 @@ RSpec.describe Providers::ApplicantDetailsController, type: :request do
           end
         end
 
-        context 'when the legal aid application is in checking_client_details_answers state' do
-          let(:application) { create(:legal_aid_application, state: :checking_client_details_answers) }
+        context 'when the legal aid application is in checking_applicant_details state' do
+          let(:application) { create(:legal_aid_application, state: :checking_applicant_details) }
 
           it 'redirects to check_your_answers page' do
             subject
@@ -101,8 +101,8 @@ RSpec.describe Providers::ApplicantDetailsController, type: :request do
           end
         end
 
-        context 'when the application is in client_details_answers_checked state' do
-          let(:application) { create(:legal_aid_application, state: :client_details_answers_checked) }
+        context 'when the application is in applicant_details_checked state' do
+          let(:application) { create(:legal_aid_application, state: :applicant_details_checked) }
 
           it 'redirects to check_your_answers page' do
             subject

--- a/spec/requests/providers/capital_introductions_spec.rb
+++ b/spec/requests/providers/capital_introductions_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Providers::CapitalIntroductionsController, type: :request do
-  let(:legal_aid_application) { create :legal_aid_application }
+  let(:legal_aid_application) { create :legal_aid_application, :at_applicant_details_checked }
   let(:provider) { legal_aid_application.provider }
 
   describe 'GET /providers/applications/:id/capital_introduction' do

--- a/spec/requests/providers/check_passported_answers_spec.rb
+++ b/spec/requests/providers/check_passported_answers_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'check passported answers requests', type: :request do
     let!(:application) do
       create :legal_aid_application,
              :with_everything,
-             :client_details_answers_checked,
+             :applicant_details_checked,
              vehicle: vehicle,
              own_vehicle: own_vehicle
     end
@@ -63,28 +63,28 @@ RSpec.describe 'check passported answers requests', type: :request do
       end
 
       context 'applicant does not have any savings' do
-        let(:application) { create :legal_aid_application, :with_everything, :with_no_savings, :client_details_answers_checked }
+        let(:application) { create :legal_aid_application, :with_everything, :with_no_savings, :applicant_details_checked }
         it 'displays that no savings have been declared' do
           expect(response.body).to include(I18n.t('.generic.none_declared'))
         end
       end
 
       context 'applicant does not have any other assets' do
-        let(:application) { create :legal_aid_application, :with_everything, :with_no_other_assets, :client_details_answers_checked }
+        let(:application) { create :legal_aid_application, :with_everything, :with_no_other_assets, :applicant_details_checked }
         it 'displays that no other assets have been declared' do
           expect(response.body).to include(I18n.t('.generic.none_declared'))
         end
       end
 
       context 'applicant does not have any capital restrictions' do
-        let(:application) { create :legal_aid_application, :with_everything, :client_details_answers_checked, has_restrictions: false }
+        let(:application) { create :legal_aid_application, :with_everything, :applicant_details_checked, has_restrictions: false }
         it 'displays that no capital restrictions have been declared' do
           expect(response.body).to include(I18n.t('.generic.no'))
         end
       end
 
       context 'applicant does not have any capital' do
-        let(:application) { create :legal_aid_application, :provider_submitted, :with_applicant, :without_own_home, :client_details_answers_checked }
+        let(:application) { create :legal_aid_application, :provider_submitted, :with_applicant, :without_own_home, :applicant_details_checked }
         it 'does not display capital restrictions' do
           expect(response.body).not_to include('restrictions')
         end
@@ -122,7 +122,7 @@ RSpec.describe 'check passported answers requests', type: :request do
       end
 
       context 'applicant does not own home' do
-        let(:application) { create :legal_aid_application, :with_everything, :without_own_home, :client_details_answers_checked }
+        let(:application) { create :legal_aid_application, :with_everything, :without_own_home, :applicant_details_checked }
         it 'does not display property value' do
           expect(response.body).not_to include(number_to_currency(application.property_value, unit: '£'))
           expect(response.body).not_to include('Property value')
@@ -135,7 +135,7 @@ RSpec.describe 'check passported answers requests', type: :request do
       end
 
       context 'applicant owns home without mortgage' do
-        let(:application) { create :legal_aid_application, :with_everything, :with_own_home_owned_outright, :client_details_answers_checked }
+        let(:application) { create :legal_aid_application, :with_everything, :with_own_home_owned_outright, :applicant_details_checked }
         it 'does not display property value' do
           expect(response.body).not_to include(number_to_currency(application.outstanding_mortgage_amount, unit: '£'))
           expect(response.body).not_to include('Outstanding mortgage')
@@ -143,7 +143,7 @@ RSpec.describe 'check passported answers requests', type: :request do
       end
 
       context 'applicant is sole owner of home' do
-        let(:application) { create :legal_aid_application, :with_everything, :with_no_other_assets, :with_home_sole_owner, :client_details_answers_checked }
+        let(:application) { create :legal_aid_application, :with_everything, :with_no_other_assets, :with_home_sole_owner, :applicant_details_checked }
         it 'does not display percentage owned' do
           expect(response.body).not_to include(number_to_percentage(application.percentage_home, precision: 2))
           expect(response.body).not_to include('Percentage')
@@ -247,7 +247,7 @@ RSpec.describe 'check passported answers requests', type: :request do
     end
 
     context 'logged in as an authenticated provider' do
-      let(:application) { create :legal_aid_application, :with_everything, :client_details_answers_checked }
+      let(:application) { create :legal_aid_application, :with_everything, :applicant_details_checked }
 
       before do
         login_as application.provider
@@ -257,7 +257,7 @@ RSpec.describe 'check passported answers requests', type: :request do
       end
 
       it 'transitions to provider_assessing_means state' do
-        expect(application.reload.client_details_answers_checked?).to be true
+        expect(application.reload.applicant_details_checked?).to be true
       end
 
       it 'redirects to the previous page' do

--- a/spec/requests/providers/check_provider_answers_spec.rb
+++ b/spec/requests/providers/check_provider_answers_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe 'check your answers requests', type: :request do
   let(:application) do
     create(
       :legal_aid_application,
+      :at_entering_applicant_details,
       :with_proceeding_types,
       :with_substantive_scope_limitation,
       :with_delegated_functions_scope_limitation,
@@ -156,7 +157,7 @@ RSpec.describe 'check your answers requests', type: :request do
     context 'when the provider is authenticated' do
       before do
         login_as application.provider
-        application.check_your_answers!
+        application.check_applicant_details!
         get providers_legal_aid_application_proceedings_types_path(application)
         get providers_legal_aid_application_check_provider_answers_path(application)
         subject
@@ -166,9 +167,9 @@ RSpec.describe 'check your answers requests', type: :request do
         expect(response).to redirect_to(providers_legal_aid_application_proceedings_types_path(application, back: true))
       end
 
-      it 'should change the stage back to "initialized' do
+      it 'should change the stage back to "entering_applicant_details' do
         subject
-        expect(application.reload.initiated?).to be_truthy
+        expect(application.reload.entering_applicant_details?).to be_truthy
       end
     end
   end
@@ -185,7 +186,7 @@ RSpec.describe 'check your answers requests', type: :request do
 
       before do
         login_as application.provider
-        application.check_your_answers!
+        application.check_applicant_details!
       end
 
       it 'redirects to next step' do
@@ -193,9 +194,9 @@ RSpec.describe 'check your answers requests', type: :request do
         expect(response).to redirect_to(providers_legal_aid_application_check_benefits_path(application))
       end
 
-      it 'changes the state to "client_details_answers_checked"' do
+      it 'changes the state to "applicant_details_checked"' do
         subject
-        expect(application.reload.client_details_answers_checked?).to be_truthy
+        expect(application.reload.applicant_details_checked?).to be_truthy
       end
 
       it 'syncs the application' do
@@ -215,7 +216,7 @@ RSpec.describe 'check your answers requests', type: :request do
 
       before do
         login_as application.provider
-        application.check_your_answers!
+        application.check_applicant_details!
         subject
         application.reload
       end
@@ -224,8 +225,8 @@ RSpec.describe 'check your answers requests', type: :request do
         expect(response).to redirect_to(providers_legal_aid_applications_path)
       end
 
-      it 'changes the state to "client_details_answers_checked"' do
-        expect(application).not_to be_client_details_answers_checked
+      it 'changes the state to "applicant_details_checked"' do
+        expect(application).not_to be_applicant_details_checked
       end
 
       it 'sets application as draft' do

--- a/spec/requests/providers/substantive_applications_spec.rb
+++ b/spec/requests/providers/substantive_applications_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 RSpec.describe Providers::UsedDelegatedFunctionsController, type: :request, vcr: { cassette_name: 'gov_uk_bank_holiday_api' } do
   let(:legal_aid_application) do
-    create :legal_aid_application, state: :client_details_answers_checked, used_delegated_functions_on: 1.day.ago
+    create :legal_aid_application, state: :applicant_details_checked, used_delegated_functions_on: 1.day.ago
   end
   let(:login_provider) { login_as legal_aid_application.provider }
 
@@ -60,7 +60,7 @@ RSpec.describe Providers::UsedDelegatedFunctionsController, type: :request, vcr:
         create(
           :legal_aid_application,
           :with_positive_benefit_check_result,
-          state: :client_details_answers_checked
+          state: :applicant_details_checked
         )
       end
 

--- a/spec/services/migration_helpers/state_changer_spec.rb
+++ b/spec/services/migration_helpers/state_changer_spec.rb
@@ -1,0 +1,108 @@
+require 'rails_helper'
+
+module MigrationHelpers
+  RSpec.describe 'MigrationHelpers::StateChanger' do
+    let!(:initiated_address_lookups) { create_app(:initiated, :address_lookups) }
+    let!(:initiated_address_selections) { create_app(:initiated, :address_selections) }
+    let!(:initiated_proceedings_types) { create_app(:initiated, :proceedings_types) }
+    let!(:initiated_used_delegated_functions) { create_app(:initiated, :used_delegated_functions) }
+    let!(:initiated_limitations) { create_app(:initiated, :limitations) }
+    let!(:checking_client_details_answers_check_provider_answers) { create_app(:checking_client_details_answers, :check_provider_answers) }
+    let!(:client_details_answers_checked_check_benefits) { create_app(:client_details_answers_checked, :check_benefits) }
+    let!(:client_details_answers_checked_capital_introductions) { create_app(:client_details_answers_checked, :capital_introductions) }
+    let!(:client_details_answers_checked_own_homes) { create_app(:client_details_answers_checked, :own_homes) }
+    let!(:client_details_answers_checked_open_banking_consents) { create_app(:client_details_answers_checked, :open_banking_consents) }
+    let!(:client_details_answers_checked_email_addresses) { create_app(:client_details_answers_checked, :email_addresses) }
+    let!(:client_details_answers_checked_about_the_financial_assessments) { create_app(:client_details_answers_checked, :about_the_financial_assessments) }
+
+    context 'not a dummy run' do
+      describe '#up' do
+        it 'allocates the correct states' do
+          StateChanger.new(dummy_run: false).up
+          expect_state_changed(:initiated_address_lookups, :initiated)
+          expect_state_changed(:initiated_address_selections, :entering_applicant_details)
+          expect_state_changed(:initiated_proceedings_types, :entering_applicant_details)
+          expect_state_changed(:initiated_used_delegated_functions, :entering_applicant_details)
+          expect_state_changed(:initiated_limitations, :entering_applicant_details)
+          expect_state_changed(:checking_client_details_answers_check_provider_answers, :checking_applicant_details)
+          expect_state_changed(:client_details_answers_checked_check_benefits, :applicant_details_checked)
+          expect_state_changed(:client_details_answers_checked_capital_introductions, :provider_entering_means)
+          expect_state_changed(:client_details_answers_checked_own_homes, :provider_entering_means)
+          expect_state_changed(:client_details_answers_checked_open_banking_consents, :client_details_answers_checked)
+          expect_state_changed(:client_details_answers_checked_email_addresses, :client_details_answers_checked)
+          expect_state_changed(:client_details_answers_checked_about_the_financial_assessments, :client_details_answers_checked)
+        end
+      end
+
+      describe '#down' do
+        it 'changes states back to their orignal state' do
+          StateChanger.new(dummy_run: false).up
+          StateChanger.new(dummy_run: false).down
+          expect_state_changed(:initiated_address_lookups, :initiated)
+          expect_state_changed(:initiated_address_selections, :initiated)
+          expect_state_changed(:initiated_proceedings_types, :initiated)
+          expect_state_changed(:initiated_used_delegated_functions, :initiated)
+          expect_state_changed(:initiated_limitations, :initiated)
+          expect_state_changed(:checking_client_details_answers_check_provider_answers, :checking_client_details_answers)
+          expect_state_changed(:client_details_answers_checked_check_benefits, :client_details_answers_checked)
+          expect_state_changed(:client_details_answers_checked_capital_introductions, :client_details_answers_checked)
+          expect_state_changed(:client_details_answers_checked_own_homes, :client_details_answers_checked)
+          expect_state_changed(:client_details_answers_checked_open_banking_consents, :client_details_answers_checked)
+          expect_state_changed(:client_details_answers_checked_email_addresses, :client_details_answers_checked)
+          expect_state_changed(:client_details_answers_checked_about_the_financial_assessments, :client_details_answers_checked)
+        end
+      end
+    end
+
+    context 'dummy run' do
+      it 'outputs to SQL statements to stdout' do
+        expected_sql_statements.each do |sql|
+          expect($stdout).to receive(:puts).with(sql)
+        end
+        StateChanger.new(dummy_run: true).up
+      end
+
+      it 'does not change the records' do
+        StateChanger.new(dummy_run: true).up
+        expect_state_not_to_have_changed(:initiated_address_lookups)
+        expect_state_not_to_have_changed(:initiated_address_selections)
+        expect_state_not_to_have_changed(:initiated_proceedings_types)
+        expect_state_not_to_have_changed(:initiated_used_delegated_functions)
+        expect_state_not_to_have_changed(:initiated_limitations)
+        expect_state_not_to_have_changed(:checking_client_details_answers_check_provider_answers)
+        expect_state_not_to_have_changed(:client_details_answers_checked_check_benefits)
+        expect_state_not_to_have_changed(:client_details_answers_checked_capital_introductions)
+        expect_state_not_to_have_changed(:client_details_answers_checked_own_homes)
+        expect_state_not_to_have_changed(:client_details_answers_checked_open_banking_consents)
+        expect_state_not_to_have_changed(:client_details_answers_checked_email_addresses)
+        expect_state_not_to_have_changed(:client_details_answers_checked_about_the_financial_assessments)
+      end
+    end
+
+    def create_app(state, provider_step)
+      rec = build :legal_aid_application, state: state, provider_step: provider_step
+      rec.save(validate: false)
+      rec
+    end
+
+    def expect_state_changed(rec, new_state)
+      expect(__send__(rec).reload.state).to eq new_state.to_s
+    end
+
+    def expect_state_not_to_have_changed(rec)
+      original_rec  = __send__(rec)
+      reloaded_rec = __send__(rec).reload
+      expect(reloaded_rec.state).to eq original_rec.state
+    end
+
+    def expected_sql_statements
+      [
+      %|UPDATE legal_aid_applications SET state = 'entering_applicant_details' WHERE state = 'initiated'  AND provider_step != 'address_lookups'|,
+      %|UPDATE legal_aid_applications SET state = 'checking_applicant_details' WHERE state = 'checking_client_details_answers' |,
+      %|UPDATE legal_aid_applications SET state = 'applicant_details_checked' WHERE state = 'client_details_answers_checked'  AND provider_step = 'check_benefits'|,
+      %|UPDATE legal_aid_applications SET state = 'provider_entering_means' WHERE state = 'client_details_answers_checked'  AND provider_step not in ('check_benefits', 'open_banking_consents', 'email_addresses', 'about_the_financial_assessments')|
+      ]
+      end
+  end
+end
+


### PR DESCRIPTION
## Rename states on LegalAidApplication

This is stage 1 of a task to rename most of the legal aid application states to make them more descriptive of what is actually going on.  This PR covers the following:



| New state name | Old state name |
| -------------| -----------| 
| entering_applicant_details | new state (between initiated and checking_client_details_answers) |
| checking_applicant_details  |  checking_client_details_answers |
| applicant_details_checked | client_details_answers_checked |
| client_details_answers_checked | provider_entering_means |


[Link to story](https://dsdmoj.atlassian.net/browse/AP-1462)

Describe what you did and why.

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
``