### PR TITLE
AP-1470 Fix typo on means report

### DIFF
--- a/config/locales/en/shared.yml
+++ b/config/locales/en/shared.yml
@@ -85,7 +85,7 @@ en:
           pension: Pension
           total_income: Total income
       income_result:
-        total_disposable_income: Total disposable income asssessed
+        total_disposable_income: Total disposable income assessed
         total_gross_income: Total gross income assessed
         gross_income_limit: Gross income limit
         disposable_income_lower_limit: Disposable income lower limit


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1470)

The means report contains `Total disposable income asssessed`. This removes the extra `s` so that `assessed` is spelled correctly.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
