### PR TITLE
FIX: Add cucumber to guard

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -113,6 +113,7 @@ end
 group :development do
   gem 'better_errors', '>= 2.7.1'
   gem 'binding_of_caller'
+  gem 'guard-cucumber'
   gem 'guard-livereload'
   gem 'guard-rspec'
   gem 'guard-rubocop'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -231,6 +231,9 @@ GEM
       shellany (~> 0.0)
       thor (>= 0.18.1)
     guard-compat (1.2.1)
+    guard-cucumber (3.0.0)
+      cucumber (>= 3.1)
+      nenv (>= 0.1)
     guard-livereload (2.5.2)
       em-websocket (~> 0.5)
       guard (~> 2.8)
@@ -618,6 +621,7 @@ DEPENDENCIES
   faker (>= 1.9.1)
   geckoboard-ruby
   govuk_notify_rails (~> 2.1.2)
+  guard-cucumber
   guard-livereload
   guard-rspec
   guard-rubocop

--- a/Guardfile
+++ b/Guardfile
@@ -18,3 +18,12 @@ guard :rubocop, all_on_start: false do
   watch(%r{.+\.rb$})
   watch(%r{(?:.+/)?\.(rubocop|rubocop_todo)\.yml$}) { |m| File.dirname(m[0]) }
 end
+
+guard 'cucumber', all_on_start: false do
+  watch(%r{^features/.+\.feature$})
+  watch(%r{^features/support/.+$}) { 'features' }
+
+  watch(%r{^features/step_definitions/(.+)_steps\.rb$}) do |m|
+    Dir[File.join("**/#{m[1]}.feature")][0] || 'features'
+  end
+end


### PR DESCRIPTION
## What
Add cucumber to guard
A patch release when I implemented this originally and broken the cucumber-guard integration, now they've re-aligned the versions and it's functioning again

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
