### PR TITLE
AP-1490 Disregarded benefits not being sent to CFE

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,12 @@ credentials that will return 'Yes' for has qualifying benefits.
 
 This environment variable should be set to ```false``` when recording new vcr cassettes otherwise the test will pass locally and fail on CircleCI. 
 
+### Mock TrueLayer Data
+
+TrueLayer test data can be replaced by mock data from db/sample_data/bank_transactions.csv. This can be toggled in the Admin Portal at `/admin/settings`.
+
+This mock data allows for testing with more meaningful bank transactions, including benefits data tagged with correct DWP codes. To ensure that this benefits data is correctly analysed, so it can be processed successfully by CFE, an applicant with the National Insurance Number `AA123456A` must be used.
+
 ## Admin Portal
 
 The admin portal is at `/admin`. To access it, there must be an `AdminUser` defined.

--- a/app/services/cfe/create_state_benefits_service.rb
+++ b/app/services/cfe/create_state_benefits_service.rb
@@ -43,9 +43,13 @@ module CFE
     def bank_transactions
       @bank_transactions ||= legal_aid_application
                              .bank_transactions
-                             .for_type(:benefits)
+                             .where(transaction_type_id: benefit_transaction_type_ids)
                              .order(:happened_at)
                              .group_by(&:meta_data)
+    end
+
+    def benefit_transaction_type_ids
+      TransactionType.where(name: %i[benefits excluded_benefits]).pluck :id
     end
   end
 end

--- a/app/services/cfe/create_state_benefits_service.rb
+++ b/app/services/cfe/create_state_benefits_service.rb
@@ -22,7 +22,7 @@ module CFE
       raise CFE::SubmissionError, 'Benefit transactions un-coded' if bank_transactions.keys.any?(nil)
 
       bank_transactions.each do |meta_data, array|
-        type_hash = { name: meta_data[:name], "payments": transactions(array) }
+        type_hash = { name: meta_data[:label], "payments": transactions(array) }
         result << type_hash
       end
       result

--- a/spec/factories/bank_transactions.rb
+++ b/spec/factories/bank_transactions.rb
@@ -34,7 +34,7 @@ FactoryBot.define do
 
     trait :disregarded_benefits do
       operation { 'credit' }
-      transaction_type { TransactionType.where(name: 'benefits').first || create(:transaction_type, :benefits) }
+      transaction_type { TransactionType.where(name: 'excluded_benefits').first || create(:transaction_type, :benefits) }
       meta_data { { code: nil, label: 'grenfell_payments', name: 'Grenfell Tower fire victims payments' } }
     end
 

--- a/spec/services/cfe/create_state_benefits_service_spec.rb
+++ b/spec/services/cfe/create_state_benefits_service_spec.rb
@@ -90,7 +90,7 @@ module CFE
 
     def with_disregarded_hash
       {
-        "name": 'Grenfell Tower fire victims payments',
+        "name": 'grenfell_payments',
         "payments": [
           {
             "date": DAY_SEQUENCE[0].days.ago.strftime('%Y-%m-%d'),
@@ -103,7 +103,7 @@ module CFE
 
     def basic_payload_hash # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
       {
-        "name": 'Child Benefit',
+        "name": 'child_benefit',
         "payments": [
           {
             "date": DAY_SEQUENCE[2].days.ago.strftime('%Y-%m-%d'),


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1490)

There are two issues here:

* When the `state_benefits` payload is created to be sent to CFE, it is only including transactions marked as `benefits` by the solicitor, not `excluded_benefits`.
* When the `state_benefits` payload is created to be sent to CFE, it includes the metadata `name` of the benefit type, however CFE is expecting to receive the metadata `label`. This means all benefits are being classified as `other` in CFE.

This PR:
*  adds `excluded_benefits` to the select logic in `CreateStateBenefitsService` so that all benefit transactions are passed to CFE. It also fixes a bug in the `bank_transactions` factory which was masking this problem.
* amends `CreateStateBenefitsService` to use the metadat `label` , not name.
* adds details of how to use the mock TrueLayer data, so that testing this is easier in future!

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
