### PR TITLE
AP1451 Don't show disregarded benefits on the applicants check answers page

### DIFF
--- a/app/helpers/user_transactions_helper.rb
+++ b/app/helpers/user_transactions_helper.rb
@@ -1,6 +1,8 @@
 module UserTransactionsHelper
   def incomings_list(incomings, locale_namespace:)
     items = TransactionType.credits&.map do |income_type|
+      next if income_type.excluded_benefit?
+
       OpenStruct.new(
         label: t("#{locale_namespace}.#{income_type.name}"),
         name: income_type.name,
@@ -11,7 +13,7 @@ module UserTransactionsHelper
     return nil unless items.present?
 
     {
-      items: items
+      items: items.compact
     }
   end
 

--- a/app/models/transaction_type.rb
+++ b/app/models/transaction_type.rb
@@ -20,6 +20,8 @@ class TransactionType < ApplicationRecord
     ]
   }.freeze
 
+  EXCLUDED_BENEFITS = 'excluded_benefits'.freeze
+
   OTHER_INCOME_TYPES = %w[
     friends_or_family
     maintenance_in
@@ -73,6 +75,10 @@ class TransactionType < ApplicationRecord
 
   def providers_label_name
     label_name(journey: :providers)
+  end
+
+  def excluded_benefit?
+    name == EXCLUDED_BENEFITS
   end
 
   def child?

--- a/features/citizens/citizens.feature
+++ b/features/citizens/citizens.feature
@@ -72,6 +72,7 @@ Feature: Citizen journey
     Then I select "Rent or mortgage"
     Then I click 'Save and continue'
     Then I should be on a page showing "Check your answers"
+    Then I should be on a page not showing 'Excluded Benefits'
     Then I click "Save and continue"
     Then I should be on a page showing "Declaration"
     Then I click "Agree and submit"

--- a/spec/factories/legal_aid_applications.rb
+++ b/spec/factories/legal_aid_applications.rb
@@ -384,10 +384,6 @@ FactoryBot.define do
       end
     end
 
-    trait :with_transaction_types do
-      transaction_types { TransactionType.where(name: 'benefits').first || create(:transaction_type, :benefits) }
-    end
-
     trait :with_uncategorised_credit_transactions do
       after :create do |application|
         bank_provider = create :bank_provider, applicant: application.applicant

--- a/spec/helpers/user_transactions_helper_spec.rb
+++ b/spec/helpers/user_transactions_helper_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+RSpec.describe UserTransactionsHelper, type: :helper do
+  let(:transaction_type) { create :transaction_type, :salary }
+  let(:legal_aid_application) do
+    create :legal_aid_application, :with_applicant, transaction_types: [transaction_type]
+  end
+  let(:locale_namespace) { '' }
+
+  before do
+    allow(helper).to(
+      receive(:yes_no).with(boolean).and_return(true)
+    )
+  end
+
+  describe '#incomings_list' do
+    subject { helper.incomings_list(legal_aid_application.transaction_types.credits, locale_namespace: locale_namespace) }
+
+    context 'for citizen' do
+      let(:locale_namespace) { 'transaction_types.names.citizens' }
+
+      it 'returns correct hash' do
+        expect(subject[:items].first.to_h).to match hash_result
+      end
+
+      context 'with excluded state benefit' do
+        let(:transaction_type) { create :transaction_type, :excluded_benefits }
+        it 'returns correct hash' do
+          expect(subject[:items]).to be_empty
+        end
+      end
+      context 'no transactions' do
+        let(:legal_aid_application) { create :legal_aid_application }
+        it 'returns nil' do
+          expect(subject).to be_nil
+        end
+      end
+    end
+  end
+
+  describe '#payments_list' do
+    let(:transaction_type) { create :transaction_type, :maintenance_out }
+    subject { helper.payments_list(legal_aid_application.transaction_types.debits, locale_namespace: locale_namespace) }
+
+    context 'for citizen' do
+      let(:locale_namespace) { 'transaction_types.names.citizens' }
+
+      it 'returns correct hash' do
+        expect(subject[:items].first.to_h).to match hash_result
+      end
+
+      context 'no transactions' do
+        let(:legal_aid_application) { create :legal_aid_application }
+        it 'returns nil' do
+          expect(subject).to be_nil
+        end
+      end
+    end
+  end
+
+  def hash_result
+    {
+      label: I18n.t("#{locale_namespace}.#{transaction_type.name}"),
+      name: transaction_type.name,
+      amount_text: true
+    }
+  end
+end

--- a/spec/models/transaction_type_spec.rb
+++ b/spec/models/transaction_type_spec.rb
@@ -111,6 +111,19 @@ RSpec.describe TransactionType, type: :model do
       end
     end
 
+    describe '#excluded_benefit?' do
+      context 'is excluded benefit type' do
+        it 'returns true' do
+          expect(excluded_benefits.excluded_benefit?).to eq true
+        end
+      end
+      context 'not an excluded benefit type' do
+        it 'returns false' do
+          expect(pension.excluded_benefit?).to eq false
+        end
+      end
+    end
+
     describe '#children' do
       context 'record with no children' do
         it 'returns an empty array' do


### PR DESCRIPTION
AP1451 Don't show disregarded benefits on the applicants check answers page

[Link to story](https://dsdmoj.atlassian.net/browse/AP-XXX)

- Update the UserTransactionsHelper to skip excluded benefit transaction types from showing on the citizen check answers.

- Update TransactionType model with method #excluded_benefit? instead of doing that logic in the above helper

- Add test for UserTransactionsHelper

- Update Feature Tests and TransactionType tests

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
