### PR TITLE
AP-1513 change passported client details

### DIFF
--- a/app/models/concerns/legal_aid_application_state_machine.rb
+++ b/app/models/concerns/legal_aid_application_state_machine.rb
@@ -35,6 +35,7 @@ module LegalAidApplicationStateMachine # rubocop:disable Metrics/ModuleLength
       event :check_your_answers do
         transitions from: :initiated, to: :checking_client_details_answers
         transitions from: :client_details_answers_checked, to: :checking_client_details_answers
+        transitions from: :use_ccms, to: :checking_client_details_answers
       end
 
       event :client_details_answers_checked do

--- a/app/views/providers/check_benefits/_check_benefits_result.html.erb
+++ b/app/views/providers/check_benefits/_check_benefits_result.html.erb
@@ -7,21 +7,7 @@
       <% if result_namespace == '.negative_result' %>
         <p class="govuk-body">
           <%= t '.because_not_receiving_benefits' %>
-          <details class="govuk-details" data-module="govuk-details">
-            <summary style="color:white" class="govuk-details__summary">
-             <span class="govuk-details__summary-text" id="checked-status">
-              <%= t '.how_we_checked' %>
-             </span>
-            </summary>
-            <p><%= t '.details_used' %></p>
-
-            <p>
-              <strong><%= t 'citizens.legal_aid_applications.index.name' %></strong> <%= @applicant.full_name %><br>
-              <strong><%= t 'shared.forms.date_input_fields.date_of_birth_label' %>:</strong> <%= @applicant.date_of_birth %><br>
-              <strong> <%= t 'shared.forms.applicant_form.nino_label' %>:</strong> <%= @applicant.national_insurance_number %></p>
-
-            <p id='change-client-link'><%= t '.change_client_details_html' %></p>
-          </details>
+          <%= render 'how_we_checked' %>
         </p>
 
       <% end %>

--- a/app/views/providers/check_benefits/_how_we_checked.html.erb
+++ b/app/views/providers/check_benefits/_how_we_checked.html.erb
@@ -1,0 +1,15 @@
+<details class="govuk-details" data-module="govuk-details">
+  <summary style="color:white" class="govuk-details__summary">
+   <span class="govuk-details__summary-text" id="checked-status">
+    <%= t '.how_we_checked' %>
+   </span>
+  </summary>
+  <p><%= t '.details_used' %></p>
+
+  <p>
+    <strong><%= t 'citizens.legal_aid_applications.index.name' %></strong> <%= @applicant.full_name %><br>
+    <strong><%= t 'shared.forms.date_input_fields.date_of_birth_label' %>:</strong> <%= @applicant.date_of_birth %><br>
+    <strong> <%= t 'shared.forms.applicant_form.nino_label' %>:</strong> <%= @applicant.national_insurance_number %></p>
+
+  <p id='change-client-link'><%= t '.change_client_details_html' %></p>
+</details>

--- a/app/views/providers/check_benefits/_use_ccms.html.erb
+++ b/app/views/providers/check_benefits/_use_ccms.html.erb
@@ -5,6 +5,7 @@
       <p class="govuk-body"><%= t '.we_checked' %></p>
       <%= list_from_translation_path '.check_benefits.use_ccms.benefits' %>
       <p class="govuk-body"><%= t '.accept_only' %></p>
+      <%= render 'how_we_checked' %>
     </div>
 
     <div>

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -168,9 +168,6 @@ en:
       check_benefits_result:
         what_happens_next: What happens next
         because_not_receiving_benefits: This is because they do not receive benefits that qualify for legal aid.
-        how_we_checked: How we checked your client's benefits status
-        details_used: "We used the following details to check your client's benefits status with the DWP:"
-        change_client_details_html: <a href="applicant_details">Change your client's details</a> if you entered them incorrectly.
         you_need_to: "You'll need to:"
         negative_result:
           tab_title: Your client must complete a financial assessment
@@ -186,6 +183,10 @@ en:
           title: "%{name} receives benefits that qualify for legal aid"
           must_answer_financial_questions: 'answer questions about your client''s property, savings and other assets'
           provide_access/details: provide details of the case
+      how_we_checked:
+        how_we_checked: How we checked your client's benefits status
+        details_used: "We used the following details to check your client's benefits status with the DWP:"
+        change_client_details_html: <a href="applicant_details">Change your client's details</a> if you entered them incorrectly.   
       use_ccms:
         accept_only: We currently only accept applications for people receiving one of these benefits.
         apply_in_ccms: Apply using CCMS
@@ -333,7 +334,7 @@ en:
         remove_link: Remove
       index:
         subheading: Your client told us they receive the following types of income.
-        you_need_to: 
+        you_need_to:
           text: "You need to:"
           list: |
             view your client's bank statements

--- a/features/cassettes/Civil_application_journeys/I_am_instructed_to_use_CCMS_on_the_passported_journey_with_an_applicant_does_not_receive_benefits.yml
+++ b/features/cassettes/Civil_application_journeys/I_am_instructed_to_use_CCMS_on_the_passported_journey_with_an_applicant_does_not_receive_benefits.yml
@@ -1,0 +1,418 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?key=<ORDNANACE_SURVEY_API_KEY>&lr=EN&postcode=DA74NG
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.0.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 09 Jul 2020 14:39:17 GMT
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Tx-Id:
+      - 1594305557312:312
+      Status:
+      - success
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "header" : {
+            "uri" : "https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?lr=EN&postcode=DA74NG",
+            "query" : "postcode=DA74NG",
+            "offset" : 0,
+            "totalresults" : 11,
+            "format" : "JSON",
+            "dataset" : "DPA",
+            "lr" : "EN",
+            "maxresults" : 100,
+            "epoch" : "76",
+            "output_srs" : "EPSG:27700"
+          },
+          "results" : [ {
+            "DPA" : {
+              "UPRN" : "100020211558",
+              "UDPRN" : "6248161",
+              "ADDRESS" : "1, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "1",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "2",
+              "X_COORDINATE" : 548894.0,
+              "Y_COORDINATE" : 176139.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD02",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE" : null,
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095093",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211559",
+              "UDPRN" : "6248164",
+              "ADDRESS" : "2, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "2",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548861.0,
+              "Y_COORDINATE" : 176156.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE" : null,
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095079",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211560",
+              "UDPRN" : "6248165",
+              "ADDRESS" : "3, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "3",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "2",
+              "X_COORDINATE" : 548888.0,
+              "Y_COORDINATE" : 176131.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD02",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE" : null,
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb5000005153955102",
+              "LAST_UPDATE_DATE" : "23/04/2020",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211561",
+              "UDPRN" : "6248166",
+              "ADDRESS" : "4, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "4",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548858.0,
+              "Y_COORDINATE" : 176150.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE" : null,
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095080",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211562",
+              "UDPRN" : "6248167",
+              "ADDRESS" : "5, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "5",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548884.0,
+              "Y_COORDINATE" : 176118.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD02",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE" : null,
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095091",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211563",
+              "UDPRN" : "6248168",
+              "ADDRESS" : "6, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "6",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548849.0,
+              "Y_COORDINATE" : 176141.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE" : null,
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095082",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211564",
+              "UDPRN" : "6248169",
+              "ADDRESS" : "7, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "7",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548874.0,
+              "Y_COORDINATE" : 176106.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE" : null,
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095089",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "19/03/2001",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211565",
+              "UDPRN" : "6248170",
+              "ADDRESS" : "8, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "8",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548846.0,
+              "Y_COORDINATE" : 176133.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE" : null,
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095083",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211566",
+              "UDPRN" : "6248171",
+              "ADDRESS" : "9, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "9",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548868.0,
+              "Y_COORDINATE" : 176104.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE" : null,
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095088",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211567",
+              "UDPRN" : "6248162",
+              "ADDRESS" : "10, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "10",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "1",
+              "X_COORDINATE" : 548848.0,
+              "Y_COORDINATE" : 176115.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE" : null,
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095085",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          }, {
+            "DPA" : {
+              "UPRN" : "100020211568",
+              "UDPRN" : "6248163",
+              "ADDRESS" : "12, LONSDALE ROAD, BEXLEYHEATH, DA7 4NG",
+              "BUILDING_NUMBER" : "12",
+              "THOROUGHFARE_NAME" : "LONSDALE ROAD",
+              "POST_TOWN" : "BEXLEYHEATH",
+              "POSTCODE" : "DA7 4NG",
+              "RPC" : "2",
+              "X_COORDINATE" : 548854.0,
+              "Y_COORDINATE" : 176110.0,
+              "STATUS" : "APPROVED",
+              "LOGICAL_STATUS_CODE" : "1",
+              "CLASSIFICATION_CODE" : "RD03",
+              "CLASSIFICATION_CODE_DESCRIPTION" : "Semi-Detached",
+              "LOCAL_CUSTODIAN_CODE" : 5120,
+              "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : "BEXLEY",
+              "POSTAL_ADDRESS_CODE" : "D",
+              "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+              "BLPU_STATE_CODE" : null,
+              "BLPU_STATE_CODE_DESCRIPTION" : "Unknown/Not applicable",
+              "TOPOGRAPHY_LAYER_TOID" : "osgb1000000095086",
+              "LAST_UPDATE_DATE" : "10/02/2016",
+              "ENTRY_DATE" : "04/06/2005",
+              "LANGUAGE" : "EN",
+              "MATCH" : 1.0,
+              "MATCH_DESCRIPTION" : "EXACT"
+            }
+          } ]
+        }
+  recorded_at: Thu, 09 Jul 2020 14:39:17 GMT
+- request:
+    method: post
+    uri: https://benefitchecker.stg.legalservices.gov.uk/lsx/lsc-services/benefitChecker?wsdl
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:wsdl="https://lsc.gov.uk/benefitchecker/service/1.0/API_1.0_Check"
+        xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Body><wsdl:check><clientReference>55685032-2718-4667-b9f2-1b571dd72e95</clientReference><nino>JA293483B</nino><surname>PAUL</surname><dateOfBirth>19611210</dateOfBirth><dateOfAward>20200709</dateOfAward><lscServiceName><BC_LSC_SERVICE_NAME></lscServiceName><clientOrgId><BC_CLIENT_ORG_ID></clientOrgId><clientUserId><BC_CLIENT_USER_ID></clientUserId></wsdl:check></env:Body></env:Envelope>
+    headers:
+      Soapaction:
+      - '"check"'
+      Content-Type:
+      - text/xml;charset=UTF-8
+      Content-Length:
+      - '649'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Thu, 09 Jul 2020 14:39:18 GMT
+      Content-Type:
+      - text/xml;charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Amzn-Trace-Id:
+      - Root=1-5f072c16-4752cca9e982c7e540fda9af;
+      Vary:
+      - Accept-Encoding
+    body:
+      encoding: ASCII-8BIT
+      string: <?xml version="1.0" encoding="UTF-8"?><soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
+        xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><soapenv:Body><benefitCheckerResponse
+        xmlns="https://lsc.gov.uk/benefitchecker/service/1.0/API_1.0_Check"><ns1:originalClientRef
+        xmlns:ns1="http://lsc.gov.uk/benefitchecker/data/1.0">55685032-2718-4667-b9f2-1b571dd72e95</ns1:originalClientRef><ns2:benefitCheckerStatus
+        xmlns:ns2="http://lsc.gov.uk/benefitchecker/data/1.0">No</ns2:benefitCheckerStatus><ns3:confirmationRef
+        xmlns:ns3="http://lsc.gov.uk/benefitchecker/data/1.0">T1594305558801</ns3:confirmationRef></benefitCheckerResponse></soapenv:Body></soapenv:Envelope>
+  recorded_at: Thu, 09 Jul 2020 14:39:18 GMT
+recorded_with: VCR 6.0.0

--- a/features/providers/civil_application_journey.feature
+++ b/features/providers/civil_application_journey.feature
@@ -247,6 +247,37 @@ Feature: Civil application journeys
     Then I should be on a page showing "We need to check your client's financial eligibility"
 
   @javascript @vcr
+  Scenario: I am instructed to use CCMS on the passported journey with an applicant does not receive benefits
+    Given I start the passported journey
+    When I start the journey as far as the applicant page
+    Then I enter name 'Test', 'Paul'
+    Then I enter the date of birth '10-12-1961'
+    Then I enter national insurance number 'JA293483B'
+    Then I click 'Save and continue'
+    Then I am on the postcode entry page
+    Then I enter a postcode 'DA74NG'
+    Then I click find address
+    Then I select an address '3 Lonsdale Road, Bexleyheath, DA7 4NG'
+    Then I click 'Save and continue'
+    Then I search for proceeding 'Non-molestation order'
+    Then proceeding suggestions has results
+    Then I select a proceeding type and continue
+    Then I should be on a page showing 'Have you used delegated functions?'
+    Then I choose 'No'
+    Then I click 'Save and continue'
+    Then I should be on a page showing "What you're applying for"
+    Then I should be on a page showing "Covered under a substantive certificate"
+    Then I click 'Save and continue'
+    Then I should be on a page showing 'Check your answers'
+    Then I click 'Save and continue'
+    Then I should be on a page showing 'You need to use CCMS for this application'
+    Then I click How we checked your client's benefits status
+    Then I should be on a page showing "Change your client's details"
+    Then I click link "Change your client's details"
+    Then I see the client details page
+    Then I complete the passported journey
+
+  @javascript @vcr
   Scenario: I want to change first name from the check your answers page
     Given I complete the journey as far as check your answers
     And I click Check Your Answers Change link for 'First name'
@@ -737,4 +768,3 @@ Feature: Civil application journeys
     Then I choose 'No'
     Then I click 'Save and continue'
     Then I should be on a page showing "Does your client own a vehicle?"
-

--- a/features/providers/non_passported_journey.feature
+++ b/features/providers/non_passported_journey.feature
@@ -31,7 +31,7 @@ Feature: Non-passported applicant journeys
 
   @javascript @vcr
   Scenario: Selects and categorises bank transactions into transaction types
-    Given I start the merits application with brank transactions with no transaction type category
+    Given I start the merits application with bank transactions with no transaction type category
     Then I should be on the 'client_completed_means' page showing 'Your client has completed their financial assessment'
     Then I click 'Continue'
     Then I should be on the 'income_summary' page showing "Sort your client's income into categories"

--- a/features/step_definitions/civil_journey_steps.rb
+++ b/features/step_definitions/civil_journey_steps.rb
@@ -139,7 +139,7 @@ Given('I start the merits application') do
   )
 end
 
-Given('I start the merits application with brank transactions with no transaction type category') do
+Given('I start the merits application with bank transactions with no transaction type category') do
   @legal_aid_application = create(
     :application,
     :with_applicant,

--- a/features/step_definitions/civil_journey_steps.rb
+++ b/features/step_definitions/civil_journey_steps.rb
@@ -563,3 +563,11 @@ Then('wait a bit') do
   sleep 2
 end
 # rubocop:enable Lint/Debugger
+
+Given('I start the passported journey') do
+  LaaApplyForLegalAid::Application.config.x.allow_non_passported_route = false
+end
+
+Then('I complete the passported journey') do
+  LaaApplyForLegalAid::Application.config.x.allow_non_passported_route = true
+end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1513)

When a provider receives a negative DWP check result on the passported journey, they do not have the option to change the applicant's details. They do have this option on the non-passported journey.

This commit moves the code which displays the applicant's details, including the link to change them, to a new partial which is now used on both pages. It also refactors the providers translations to move wordings to the new partial, and adds a feature test for this scenario.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
