### PR TITLE
AP-1118 add an alert for screenreaders

### DIFF
--- a/app/views/providers/address_selections/show.html.erb
+++ b/app/views/providers/address_selections/show.html.erb
@@ -16,7 +16,7 @@
 
       <p class="govuk-label">
         <%= t('generic.address.postcode') %>
-        <p class='govuk-body govuk-!-font-weight-bold'>
+        <p class='govuk-body govuk-!-font-weight-bold' role='alert'>
           <%= @form.postcode.insert(-4, " ") %>
           <%= link_to(
                 t('generic.change'),


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1118)

added an alert to the postcode so that screenreaders will use this to confirm to the user the postcode they have selected

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
