### PR TITLE
AP-1517 Send correct income contribution to CCMS

### DIFF
--- a/app/services/ccms/attribute_value_generator.rb
+++ b/app/services/ccms/attribute_value_generator.rb
@@ -307,6 +307,10 @@ module CCMS
       cfe_result.capital_contribution_required? ? cfe_result.capital_contribution : 0.0
     end
 
+    def means_assessment_income_contribution(_options)
+      cfe_result.income_contribution_required? ? cfe_result.income_contribution : 0.0
+    end
+
     def benefit_check_passed?(_options)
       @legal_aid_application.benefit_check_result.result == 'Yes'
     end

--- a/config/ccms/attribute_block_configs/base.yml
+++ b/config/ccms/attribute_block_configs/base.yml
@@ -356,7 +356,7 @@ global_means:
     response_type: currency
     user_defined: false
   INCOME_CONT:
-    value: 0.0
+    value: '#means_assessment_income_contribution'
     br100_meaning: 'RESULT: Disposable income- Income contribution'
     response_type: currency
     user_defined: false
@@ -1457,12 +1457,6 @@ global_means:
     br100_meaning: 'Int.Result: Client Bus. Part. Income'
     response_type: currency
     user_defined: false
-  PUI_CLIENT_INCOME_CONT:
-    generate_block?: false
-    value: 0.0
-    br100_meaning: Client Provisional Income Contribution
-    response_type: currency
-    user_defined: false
   OUT_GB_PROC_C_34WP3_12A:
     generate_block?: false
     value: 733.0
@@ -2399,12 +2393,6 @@ global_means:
     value: Signed:_______________________________
     br100_meaning: The means declaration 1a paragraph 19
     response_type: text
-    user_defined: false
-  OUT_INCOME_CONT:
-    generate_block?: false
-    value: 0.0
-    br100_meaning: 'RESULT: Disposable income - Income contribution'
-    response_type: currency
     user_defined: false
   MARITIAL_STATUS:
     value: 'UNKNOWN'

--- a/config/ccms/attribute_block_configs/non_passported.yml
+++ b/config/ccms/attribute_block_configs/non_passported.yml
@@ -754,7 +754,13 @@ global_means:
     br100_meaning: 'Client Provisional Income Contribution'
     response_type: currency
     generate_block?: true
-    value: '#means_assessment_capital_contribution'
+    value: '#means_assessment_income_contribution'
+  OUT_INCOME_CONT:
+    generate_block?: true
+    value: '#means_assessment_income_contribution'
+    br100_meaning: 'RESULT: Disposable income - Income contribution'
+    response_type: currency
+    user_defined: false
   LAND_INPUT_B_5WP2_26A:
     user_defined: true
     br100_meaning: 'Land: The client owns land?'

--- a/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_variable_attributes_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_variable_attributes_spec.rb
@@ -630,19 +630,39 @@ module CCMS
         end
 
         describe 'PUI_CLIENT_INCOME_CONT' do
-          context 'when the applicant has to make a contribution' do
-            let!(:cfe_result) { create :cfe_v2_result, :with_capital_contribution_required, submission: cfe_submission }
+          context 'when the applicant has to make an income contribution' do
+            let!(:cfe_result) { create :cfe_v2_result, :with_income_contribution_required, submission: cfe_submission }
 
             it 'returns the expected values' do
               block = XmlExtractor.call(xml, :global_means, 'PUI_CLIENT_INCOME_CONT')
-              expect(block).to have_currency_response 465.66
+              expect(block).to have_currency_response 366.82
               expect(block).not_to be_user_defined
             end
           end
 
-          context 'when the applicant does not have to make a contribution' do
+          context 'when the applicant does not have to make an income contribution' do
             it 'returns no block' do
               block = XmlExtractor.call(xml, :global_means, 'PUI_CLIENT_INCOME_CONT')
+              expect(block).to be_present
+              expect(block).to have_currency_response 0.0
+            end
+          end
+        end
+
+        describe 'OUT_INCOME_CONT' do
+          context 'when the applicant has to make an income contribution' do
+            let!(:cfe_result) { create :cfe_v2_result, :with_income_contribution_required, submission: cfe_submission }
+
+            it 'returns the expected values' do
+              block = XmlExtractor.call(xml, :global_means, 'OUT_INCOME_CONT')
+              expect(block).to have_currency_response 366.82
+              expect(block).not_to be_user_defined
+            end
+          end
+
+          context 'when the applicant does not have to make an income contribution' do
+            it 'returns no block' do
+              block = XmlExtractor.call(xml, :global_means, 'OUT_INCOME_CONT')
               expect(block).to be_present
               expect(block).to have_currency_response 0.0
             end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1517)

To ensure the income contribution amount calculated by CFE is received by CCMS so that it can be displayed in PUI and correspondece, the attributes `INCOME_CONT` and `OUT_INCOME_CONT` and `PUI_CLIENT_INCOME_CONT` need to be included in the case creation payload populated with the income contribution value.

To achieve this:

- remove `OUT_INCOME_CONT` and `PUI_CLIENT_INCOME_CONT` from `attribute_block_configs/base.yml`
- add `OUT_INCOME_CONT` to `attribute_block_configs/non-passported.yml`
- fix `PUI_CLIENT_INCOME_CONT` in `attribute_block_configs/non-passported.yml` so that it includes the income contribution, not the capital contribution
- leave `INCOME_CONT` in `attribute_block_configs/base.yml` as it is currently being used there for passported cases, but remove hardcoded 0.00 value and replace it with the income contribution amount from CFE
- add a method to `AttributeValueGenerator` to return the income contribution

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
