### PR TITLE
AP1527 Accessibility Error Summary fix

### DIFF
--- a/app/lib/govuk_elements_form_builder/form_builder.rb
+++ b/app/lib/govuk_elements_form_builder/form_builder.rb
@@ -255,7 +255,9 @@ module GovukElementsFormBuilder
       message = options[:error] || object.errors[attribute].first
       return unless message.present?
 
-      content_tag(:span, message, class: 'govuk-error-message', id: "#{attribute}-error")
+      content_tag(:span, class: 'govuk-error-message', id: "#{attribute}-error") do
+        content_tag(:span, I18n.translate('helpers.accessibility.error'), class: 'govuk-visually-hidden') + message
+      end
     end
 
     def error?(attribute, options)

--- a/app/views/citizens/accounts/gather.html.erb
+++ b/app/views/citizens/accounts/gather.html.erb
@@ -1,6 +1,6 @@
 <% if @errors %>
-  <div class="govuk-error-summary">
-    <h2 class="govuk-error-summary__title"><%= @errors %></h2>
+  <div class="govuk-error-summary" role="alert" tabindex="-1" data-module="govuk-error-summary">
+    <h2 class="govuk-error-summary__title" id="error-summary-title"><%= @errors %></h2>
   </div>
 <% else %>
   <div class="worker-waiter" data-worker-id="<%= session[:worker_id] %>" align="center">

--- a/app/views/citizens/banks/_error.html.erb
+++ b/app/views/citizens/banks/_error.html.erb
@@ -1,4 +1,4 @@
-<div class="govuk-error-summary" id="error_explanation">
+<div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
   <h2 class="govuk-error-summary__title" id="error-summary-title">
     <%= t('generic.errors.problem_text') %>
   </h2>

--- a/app/views/providers/address_selections/show.html.erb
+++ b/app/views/providers/address_selections/show.html.erb
@@ -37,7 +37,11 @@
       <div class="govuk-form-group <%= group_error_class %>">
         <%= f.label :address, t('.select_address_label'), class: 'govuk-label' %>
         <% if @form.errors[:lookup_id].any? %>
-          <%= content_tag(:span, @form.errors[:lookup_id].first, class: ['govuk-error-message']) %>
+
+      <%= content_tag(:span, @form.errors[:lookup_id].first, class: 'govuk-error-message') do %>
+        <%= content_tag(:span, I18n.translate('helpers.accessibility.error'), class: 'govuk-visually-hidden') + @form.errors[:lookup_id].first %>
+      <% end %>
+
         <% end %>
         <% input_error_class = @form.errors[:lookup_id].any? ? 'govuk-select--error' : '' %>
         <%= f.select(

--- a/app/views/providers/confirm_offices/show.html.erb
+++ b/app/views/providers/confirm_offices/show.html.erb
@@ -2,7 +2,7 @@
   <%= form_with(url: providers_confirm_office_path, method: :patch, local: true) do |form| %>
 
     <% if @error %>
-      <div class="govuk-error-summary" id="error_explanation">
+      <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
         <h2 class="govuk-error-summary__title" id="error-summary-title">
           <%= t('generic.errors.problem_text') %>
         </h2>

--- a/app/views/providers/has_other_dependants/show.html.erb
+++ b/app/views/providers/has_other_dependants/show.html.erb
@@ -1,6 +1,6 @@
 <%= page_template page_title: t('.page_title'), template: :basic do %>
   <% if @error %>
-    <div class="govuk-error-summary" id="error_explanation">
+    <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
       <h2 class="govuk-error-summary__title" id="error-summary-title">
         <%= t('generic.errors.problem_text') %>
       </h2>

--- a/app/views/providers/legal_aid_applications/_error.html.erb
+++ b/app/views/providers/legal_aid_applications/_error.html.erb
@@ -1,4 +1,4 @@
-<div class="govuk-error-summary" id="error_explanation">
+<div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
   <h2 class="govuk-error-summary__title" id="error-summary-title">
     <%= t('generic.errors.problem_text') %>
   </h2>

--- a/app/views/providers/remove_dependant/show.html.erb
+++ b/app/views/providers/remove_dependant/show.html.erb
@@ -1,6 +1,6 @@
 <%= page_template page_title: t('.page_title', name: @dependant.name), template: :basic do %>
   <% if @error %>
-    <div class="govuk-error-summary" id="error_explanation">
+    <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
       <h2 class="govuk-error-summary__title" id="error-summary-title">
         <%= t('generic.errors.problem_text') %>
       </h2>

--- a/app/views/shared/forms/_date_input_fields.html.erb
+++ b/app/views/shared/forms/_date_input_fields.html.erb
@@ -1,3 +1,7 @@
+<%
+accessibility_error_notice = content_tag(:span, I18n.translate('helpers.accessibility.error'), class: 'govuk-visually-hidden')
+%>
+
 <div class="govuk-form-group">
   <div class="govuk-date-input__item <%= group_error_class %>">
 
@@ -22,7 +26,9 @@
       <% end %>
 
       <% if form.object.errors[field_name].any? %>
-        <%= content_tag(:span, form.object.errors[field_name].first, id: "#{field_name}-error".dasherize, class: ['govuk-error-message']) %>
+          <%= content_tag(:span, class: 'govuk-error-message', id: "#{field_name}-error".dasherize) do %>
+            <%= accessibility_error_notice + form.object.errors[field_name].first %>
+          <% end %>
       <% end %>
 
       <div class="govuk-date-input">

--- a/app/views/shared/forms/_error_summary.html.erb
+++ b/app/views/shared/forms/_error_summary.html.erb
@@ -1,6 +1,6 @@
 <% attribute_prefix = local_assigns[:attribute_prefix] ? attribute_prefix : '' %>
 <% if model.errors.any? %>
-  <div class="govuk-error-summary" id="error_explanation" aria-live="polite">
+  <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
     <h2 class="govuk-error-summary__title" id="error-summary-title">
       <%= t('generic.errors.problem_text') %>
     </h2>

--- a/app/views/shared/forms/_next_action_buttons.html.erb
+++ b/app/views/shared/forms/_next_action_buttons.html.erb
@@ -2,7 +2,8 @@
       continue_button_text,
       id: continue_id,
       name: 'continue_button',
-      class: 'govuk-button form-button'
+      class: 'govuk-button form-button',
+      data: { module: 'govuk-button' }
     ) %>
 
 <% if show_draft %>
@@ -10,6 +11,7 @@
         draft_button_text,
         name: 'draft_button',
         id: 'draft_button',
-        class: 'govuk-button form-button govuk-secondary-button'
+        class: 'govuk-button form-button govuk-secondary-button',
+        data: { module: 'govuk-button' }
       ) %>
 <% end %>

--- a/app/views/shared/forms/_success_message.html.erb
+++ b/app/views/shared/forms/_success_message.html.erb
@@ -1,8 +1,5 @@
-<div aria-labelledby="notice-summary-heading" class="notice-summary" role="group" tabindex="-1">
-  <div class="govuk-error-summary success_summary" id="error_explanation">
+  <div class="govuk-error-summary success_summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
     <h2 class="govuk-error-summary__title" id="error-summary-title">
       <%= success_message %>
     </h2>
   </div>
-
-</div>

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -4,6 +4,8 @@ en:
     'false': 'No'
     'true': 'Yes'
   helpers:
+    accessibility:
+      error: Error
     hint:
       feedback:
         improvement_suggestion: Please provide your email address if you'd like a response

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -5,7 +5,7 @@ en:
     'true': 'Yes'
   helpers:
     accessibility:
-      error: Error
+      error: "Error:"
     hint:
       feedback:
         improvement_suggestion: Please provide your email address if you'd like a response

--- a/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
+++ b/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
 
       it 'includes an error message' do
         error_span = tag.previous_element
-        expect(error_span.content).to eq(nino_error)
+        expect(error_span.content).to include(nino_error)
         expect(error_span.name).to eq('span')
         expect(error_span.classes).to include('govuk-error-message')
         expect(tag.classes).to include(expected_error_class)
@@ -332,7 +332,7 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
       let(:params) { [:understands_terms_of_court_order, options, { error: error_message }] }
 
       it 'the error message is shown' do
-        expect(parsed_html.at_css('span.govuk-error-message').content).to eq(error_message)
+        expect(parsed_html.at_css('span.govuk-error-message').content).to include(error_message)
       end
     end
 
@@ -366,7 +366,7 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
       it 'includes an error message' do
         expect(fieldset['aria-describedby'].split(' ')).to include("#{attribute}-error")
         expect(span_error[:id]).to eq("#{attribute}-error")
-        expect(span_error.content).to eq(error_message)
+        expect(span_error.content).to include(error_message)
         expect(span_error.parent).to eq(fieldset)
       end
     end

--- a/spec/requests/providers/client_received_legal_helps_spec.rb
+++ b/spec/requests/providers/client_received_legal_helps_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe 'client received legal help', type: :request do
 
           it 'renders an error' do
             expect(response).to have_http_status(:ok)
-            expect(response.body).to include('id="error_explanation"')
+            expect(response.body).to include('data-module="govuk-error-summary"')
           end
         end
       end


### PR DESCRIPTION
AP1527 Accessility Error Summary fix

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1527)

- Update the error summary and error messages to match Govuk design system guidelines. This fixes the accessibility issue where screen readers were not reading out the error summary. 

This includes 'tab-index=-1' which refocusses onto the error summary when a failed form is submitted. Also, 'role="alert"' to read the messsage out from a screen reader. More info here [govuk design system](https://design-system.service.gov.uk/components/error-summary/)

##### Extra:

Add a hidden html span tag with the message 'Error:' which matches [govuk design system](https://design-system.service.gov.uk/components/error-message/) guidelines around error messages. It is a hidden field to make screen readers aware of an error in a field. 

> To help screen reader users, the error message component includes a hidden ‘Error:’ before the error message. These users will hear, for example, “Error: The date your passport was issued must be in the past”

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
