### PR TITLE
AP-1518 Gracefully handle True Layer auth errors

### DIFF
--- a/app/controllers/auth_controller.rb
+++ b/app/controllers/auth_controller.rb
@@ -1,12 +1,23 @@
 class AuthController < ApplicationController
   class AuthorizationError < StandardError; end
-  def failure
-    begin
-      raise AuthorizationError, 'Redirecting to access denied page'
-    rescue StandardError => e
-      Raven.capture_exception(e)
-    end
 
-    redirect_to error_path(:access_denied)
+  def failure
+    # redirect to consents page if it was an applicant failing to login at his bank
+    #
+    if auth_error_during_bank_login?
+      redirect_to citizens_consent_path(auth_failure: true)
+    else
+      begin
+        raise AuthorizationError, 'Redirecting to access denied page'
+      rescue StandardError => e
+        Raven.capture_exception(e)
+      end
+      redirect_to error_path(:access_denied)
+    end
+  end
+
+
+  def auth_error_during_bank_login?
+    params&.fetch(:origin).match?(/citizens\/banks$/)
   end
 end

--- a/app/controllers/auth_controller.rb
+++ b/app/controllers/auth_controller.rb
@@ -16,8 +16,10 @@ class AuthController < ApplicationController
     end
   end
 
-
   def auth_error_during_bank_login?
-    params&.fetch(:origin).match?(/citizens\/banks$/)
+    origin = params[:origin]
+    return false if origin.nil?
+
+    URI(origin).path == '/citizens/banks'
   end
 end

--- a/app/controllers/citizens/consents_controller.rb
+++ b/app/controllers/citizens/consents_controller.rb
@@ -2,6 +2,7 @@ module Citizens
   class ConsentsController < CitizenBaseController
     def show
       @form = Applicants::OpenBankingConsentForm.new(model: legal_aid_application)
+      @form.errors.add(:open_banking_consent, 'authorization_failure') if params[:auth_failure]
     end
 
     def update

--- a/app/controllers/citizens/consents_controller.rb
+++ b/app/controllers/citizens/consents_controller.rb
@@ -2,7 +2,7 @@ module Citizens
   class ConsentsController < CitizenBaseController
     def show
       @form = Applicants::OpenBankingConsentForm.new(model: legal_aid_application)
-      @form.errors.add(:open_banking_consent, 'authorization_failure') if params[:auth_failure]
+      @form.errors.add(:open_banking_consent, I18n.t('citizens.consents.show.true_layer_auth_error')) if params[:auth_failure]
     end
 
     def update

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -4,6 +4,15 @@ require Rails.root.join 'app/controllers/applicants/omniauth_callbacks_controlle
 OmniAuth.config.allowed_request_methods = %i[post get]
 OmniAuth.config.logger = Rails.logger
 
+# normally in dev mode, if the user fails to authenticate, an excesption is raised.
+# This block here makes sure that dev behaviour is the same as production, i.e.
+# is redirectied to /auth/failure
+#
+OmniAuth.config.on_failure = Proc.new { |env|
+  OmniAuth::FailureEndpoint.new(env).redirect_to_failure
+}
+
+
 Rails.application.config.middleware.use OmniAuth::Builder do
   provider(
     :true_layer,
@@ -17,3 +26,7 @@ Rails.application.config.middleware.use OmniAuth::Builder do
     Rails.configuration.x.google_oauth2.client_secret
   )
 end
+
+
+
+

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -8,10 +8,9 @@ OmniAuth.config.logger = Rails.logger
 # This block here makes sure that dev behaviour is the same as production, i.e.
 # is redirectied to /auth/failure
 #
-OmniAuth.config.on_failure = Proc.new { |env|
+OmniAuth.config.on_failure = proc do |env|
   OmniAuth::FailureEndpoint.new(env).redirect_to_failure
-}
-
+end
 
 Rails.application.config.middleware.use OmniAuth::Builder do
   provider(
@@ -26,7 +25,3 @@ Rails.application.config.middleware.use OmniAuth::Builder do
     Rails.configuration.x.google_oauth2.client_secret
   )
 end
-
-
-
-

--- a/config/locales/en/citizens.yml
+++ b/config/locales/en/citizens.yml
@@ -59,6 +59,7 @@ en:
         title: Do you agree to share your bank account information with the LAA?
         inset_text: We only use your financial information to support your legal aid application. We do not use it for anything else.
         summary_heading: What information will the LAA be able to see?
+        true_layer_auth_error: Select yes if you agree to share your bank account information with the LAA
         able_to_see: 
           heading: "We'll be able to see your:"
           list: |

--- a/spec/requests/auth_spec.rb
+++ b/spec/requests/auth_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe 'AuthController', type: :request do
+  let(:params) do
+    {
+      'message' => 'provider_error',
+      'origin' => origin_path,
+      'strategy' => 'true_layer'
+    }
+  end
+  describe 'GET failure' do
+    subject { get '/auth/failure', params: params }
+
+    context 'origin from citizens/banks' do
+      let(:origin_path) { citizens_banks_path }
+      it 'redirects to citizens_consent_path' do
+        subject
+        expect(response).to redirect_to citizens_consent_path(auth_failure: true)
+      end
+    end
+
+    context 'origin from elsewhere' do
+      let(:origin_path) { root_path }
+      it 'redirects to access denied' do
+        subject
+        expect(response).to redirect_to error_path(:access_denied)
+      end
+    end
+
+    context 'no origin' do
+      it 'redirects to access denied' do
+        get '/auth/failure'
+        expect(response).to redirect_to error_path(:access_denied)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Gracefully handle True Layer auth errors

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1518)

The applicant authentication at the bank is handled by OmniAuth through True Layer.  If the applicant fails to authenticate, then the default action in development mode is to raise an exception, and in production mode to redirect the callback to `/auth/failure`.  This controller action handles failed provider logins to the Apply system as well as failed applicant bank logins..

### What we did:
- added a configuration directive to the OmniAuth initializer config to keep the same behaviour as in development as in production,  (i.e. to redirect to `/auth/failure`)
- in the `AuthController#failure` action, detect those requests which are as a result of a TrueLayer auth fail (the origin parameter will be `/citizens/banks`) and redirect them to `/citizens/consents` with a parameter to indicate a fail
- display the error on the citizen consents page.

Describe what you did and why.

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
