### PR TITLE
Ap 1314 provider details

### DIFF
--- a/app/services/mock_provider_details_retriever.rb
+++ b/app/services/mock_provider_details_retriever.rb
@@ -41,7 +41,7 @@ class MockProviderDetailsRetriever # rubocop:disable Metrics/ClassLength
       contacts: [
         {
           id: 34_419,
-          name: contact_name(1)
+          name: contact_name
         }
       ],
       providerOffices: [
@@ -60,7 +60,7 @@ class MockProviderDetailsRetriever # rubocop:disable Metrics/ClassLength
       contacts: [
         {
           id: 34_419,
-          name: contact_name(1)
+          name: contact_name
         }
       ],
       providerOffices: [
@@ -79,7 +79,7 @@ class MockProviderDetailsRetriever # rubocop:disable Metrics/ClassLength
       contacts: [
         {
           id: 34_419,
-          name: contact_name(1)
+          name: contact_name
         }
       ],
       providerOffices: [
@@ -108,7 +108,7 @@ class MockProviderDetailsRetriever # rubocop:disable Metrics/ClassLength
   def contact_hash(index)
     {
       id: contact_id(index),
-      name: contact_name(index)
+      name: contact_name
     }
   end
 
@@ -139,8 +139,8 @@ class MockProviderDetailsRetriever # rubocop:disable Metrics/ClassLength
     @firm_name ||= "#{@username.sub(/-user\d+$/, '')} & Co."
   end
 
-  def contact_name(index)
-    "#{username.snakecase.titlecase}-#{index}"
+  def contact_name
+    username
   end
 
   # Generates a number from the username which is used to generate the values from the response

--- a/db/migrate/20200722120356_add_new_provider_fields.rb
+++ b/db/migrate/20200722120356_add_new_provider_fields.rb
@@ -1,0 +1,6 @@
+class AddNewProviderFields < ActiveRecord::Migration[6.0]
+  def change
+    add_column :providers, :portal_enabled, :boolean, default: false
+    add_column :providers, :contact_id, :int
+  end
+end

--- a/db/migrate/20200722131513_test_field_providers.rb
+++ b/db/migrate/20200722131513_test_field_providers.rb
@@ -1,0 +1,5 @@
+class TestFieldProviders < ActiveRecord::Migration[6.0]
+  def change
+    add_column :providers, :test_json, :json
+  end
+end

--- a/db/migrate/20200722131513_test_field_providers.rb
+++ b/db/migrate/20200722131513_test_field_providers.rb
@@ -1,5 +1,0 @@
-class TestFieldProviders < ActiveRecord::Migration[6.0]
-  def change
-    add_column :providers, :test_json, :json
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_22_131513) do
+ActiveRecord::Schema.define(version: 2020_07_22_120356) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -576,7 +576,6 @@ ActiveRecord::Schema.define(version: 2020_07_22_131513) do
     t.string "user_login_id"
     t.boolean "portal_enabled", default: false
     t.integer "contact_id"
-    t.json "test_json"
     t.index ["firm_id"], name: "index_providers_on_firm_id"
     t.index ["selected_office_id"], name: "index_providers_on_selected_office_id"
     t.index ["type"], name: "index_providers_on_type"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_09_135901) do
+ActiveRecord::Schema.define(version: 2020_07_22_131513) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -574,6 +574,9 @@ ActiveRecord::Schema.define(version: 2020_07_09_135901) do
     t.string "name"
     t.string "email"
     t.string "user_login_id"
+    t.boolean "portal_enabled", default: false
+    t.integer "contact_id"
+    t.json "test_json"
     t.index ["firm_id"], name: "index_providers_on_firm_id"
     t.index ["selected_office_id"], name: "index_providers_on_selected_office_id"
     t.index ["type"], name: "index_providers_on_type"

--- a/lib/tasks/update_provider_fields.rake
+++ b/lib/tasks/update_provider_fields.rake
@@ -1,10 +1,11 @@
 namespace :update_provider_fields do
-  desc "TODO"
+  desc "Set existing providers to have portal access enabled"
   task update_portal_enabled: :environment do
+    Provider.update_all portal_enabled: true
   end
 
-  desc "TODO"
+  desc "Set existing providers contact_id"
   task update_contact_id: :environment do
+    Provider.update_all contact_id: 999
   end
-
 end

--- a/lib/tasks/update_provider_fields.rake
+++ b/lib/tasks/update_provider_fields.rake
@@ -1,0 +1,10 @@
+namespace :update_provider_fields do
+  desc "TODO"
+  task update_portal_enabled: :environment do
+  end
+
+  desc "TODO"
+  task update_contact_id: :environment do
+  end
+
+end

--- a/lib/tasks/update_provider_fields.rake
+++ b/lib/tasks/update_provider_fields.rake
@@ -1,44 +1,27 @@
 namespace :update_provider_fields do
-  desc "Set existing providers to have portal access enabled"
+  desc 'Set existing providers to have portal access enabled'
   task update_portal_enabled: :environment do
     Provider.update_all portal_enabled: true, updated_at: Time.now
   end
 
-  desc "Set existing providers contact_id"
+  desc 'Set existing providers contact_id'
   task update_contact_id: :environment do
-    # js = Provider.last.details_response['contacts']
-    # cc_id = js.find{|contact| contact['name'] == 'Test2-2' }
-    # Provider.update test_json: cc_id['id']
-
-    # Provider.where(username: 'will-c').each do |q|
-    #   q.update(test_json: 987)
-    # end
-
-    # Provider.all.each do |user|
-    #   ap user.details_response['contacts'].where user.details_response['contacts']['name'] == user.username
-    #   user.update(test_json: user.details_response['contacts'][0]['id'])
-    # end
-
     Provider.find_each do |user|
-      ap 'capitalize name'
-      ap "#{user.username}-1".capitalize
-
       id = user.details_response['contacts']
 
+      # this is the version for localhost/uat as we prepend a number to the username
+
       id.each do |contact|
-        puts contact
-        if contact['name'] == "#{user.username}-1".capitalize
-          puts contact['name']
-          puts user.username
-          user.update(test_json: id[0]['id'] )
-        else
-          puts "No Match found"
-        end
+        user.update(contact_id: id[0]['id']) if contact['name'] == "#{user.username}-1".capitalize
       end
 
-      # ap 22222
-      # user.update(test_json: user.details_response['contacts'][0]['id'])
+      # this is the version for prod makes usernames downcase to ensure matches
+
+      # id.each do |contact|
+      #   if contact['name'].downcase == user.username.downcase
+      #     user.update(contact_id: id[0]['id'])
+      #   end
+      # end
     end
   end
 end
-

--- a/lib/tasks/update_provider_fields.rake
+++ b/lib/tasks/update_provider_fields.rake
@@ -1,11 +1,44 @@
 namespace :update_provider_fields do
   desc "Set existing providers to have portal access enabled"
   task update_portal_enabled: :environment do
-    Provider.update_all portal_enabled: true
+    Provider.update_all portal_enabled: true, updated_at: Time.now
   end
 
   desc "Set existing providers contact_id"
   task update_contact_id: :environment do
-    Provider.update_all contact_id: 999
+    # js = Provider.last.details_response['contacts']
+    # cc_id = js.find{|contact| contact['name'] == 'Test2-2' }
+    # Provider.update test_json: cc_id['id']
+
+    # Provider.where(username: 'will-c').each do |q|
+    #   q.update(test_json: 987)
+    # end
+
+    # Provider.all.each do |user|
+    #   ap user.details_response['contacts'].where user.details_response['contacts']['name'] == user.username
+    #   user.update(test_json: user.details_response['contacts'][0]['id'])
+    # end
+
+    Provider.find_each do |user|
+      ap 'capitalize name'
+      ap "#{user.username}-1".capitalize
+
+      id = user.details_response['contacts']
+
+      id.each do |contact|
+        puts contact
+        if contact['name'] == "#{user.username}-1".capitalize
+          puts contact['name']
+          puts user.username
+          user.update(test_json: id[0]['id'] )
+        else
+          puts "No Match found"
+        end
+      end
+
+      # ap 22222
+      # user.update(test_json: user.details_response['contacts'][0]['id'])
+    end
   end
 end
+

--- a/spec/services/mock_provider_details_retriever_spec.rb
+++ b/spec/services/mock_provider_details_retriever_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe MockProviderDetailsRetriever do
 
   context 'a mock user is logged in' do
     let(:username) { Faker::Internet.username }
-    let(:contact_name) { "#{username.snakecase.titlecase}-1" }
+    let(:contact_name) { username }
 
     subject { described_class.call(username) }
 
@@ -36,7 +36,6 @@ RSpec.describe MockProviderDetailsRetriever do
 
   context 'CCMS user NEETADESOR is logged in' do
     let(:username) { 'NEETADESOR' }
-    let(:contact_name) { username.snakecase.titlecase }
 
     subject { described_class.call(username) }
 
@@ -51,7 +50,6 @@ RSpec.describe MockProviderDetailsRetriever do
 
   context 'CCMS user MARTIN.RONAN@DAVIDGRAY.CO.UK is logged in' do
     let(:username) { 'MARTIN.RONAN@DAVIDGRAY.CO.UK' }
-    let(:contact_name) { username.snakecase.titlecase }
 
     subject { described_class.call(username) }
 
@@ -85,7 +83,7 @@ RSpec.describe MockProviderDetailsRetriever do
 
   context 'CCMS user HFITZSIMONS@EDWARDHAYES.CO.UK is logged in' do
     let(:username) { 'HFITZSIMONS@EDWARDHAYES.CO.UK' }
-    let(:contact_name) { username.snakecase.titlecase }
+    let(:contact_name) { username }
 
     subject { described_class.call(username) }
 
@@ -95,7 +93,7 @@ RSpec.describe MockProviderDetailsRetriever do
         expect(subject[:providerFirmId]).to eq 20_726
         expect(subject[:contactUserId]).to eq 284_410
         expect(subject[:contacts].first[:id]).to eq 34_419
-        expect(subject[:contacts].first[:name]).to eq 'Hfitzsimons@Edwardhayes Co Uk-1'
+        expect(subject[:contacts].first[:name]).to eq 'HFITZSIMONS@EDWARDHAYES.CO.UK'
         expect(subject[:providerOffices].first[:name]).to eq 'Edward Hayes-137570'
       end
     end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1314)

Added 2 new columns to the provider table
Added a rake task to update the new fields, using transaction to ensure it completes before commit
Amended `app/services/mock_provider_details_retriever.rb ` so we don't undertake any formatting of the username. We did this for mock provider details, in production usernames will be unique.

***QUERY***
In `app/services/provider_details_creator.rb` there is an attribute `contact_user_id` that takes a value from `provider_details[:contactUserId]`. Based on the Provider Details API response this appears to me to be a ProviderFirm ID and not a ProviderUser ID. On the model we are storing this as `user_login_id` which makes me thing this should be user specific for our application.

If this is a user specific ID then do we also need the new `contact_id` attribute that is added by this ticket?



## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
