### PR TITLE
AP-1534: Add Error message outputs

### DIFF
--- a/app/views/shared/forms/_identify_types_of_outgoings_form.html.erb
+++ b/app/views/shared/forms/_identify_types_of_outgoings_form.html.erb
@@ -9,7 +9,7 @@
     <fieldset class="govuk-fieldset" aria-describedby="select-all-that-apply-hint">
       <%= govuk_fieldset_header page_title %>
       <span id="select-all-that-apply-hint" class="govuk-hint"><%= t('generic.select_all_that_apply') %></span>
-
+      <span class='govuk-error-message' id="base"><%= @legal_aid_application.errors.messages[:base][0] %></span>
       <div class="deselect-group" data-deselect-ctrl="#none_selected">
         <%= transaction_type_check_boxes(
               form: form,

--- a/app/views/shared/forms/_types_of_income_form.html.erb
+++ b/app/views/shared/forms/_types_of_income_form.html.erb
@@ -9,7 +9,7 @@
     <fieldset class="govuk-fieldset" aria-describedby="select-all-that-apply-hint">
       <%= govuk_fieldset_header page_title %>
       <span id="select-all-that-apply-hint" class="govuk-hint"><%= t('generic.select_all_that_apply') %></span>
-
+      <span class='govuk-error-message' id="base"><%= @legal_aid_application.errors.messages[:base][0] %></span>
       <div class="deselect-group" data-deselect-ctrl="#none_selected">
         <%= transaction_type_check_boxes(
               form: form,


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1534)
Because these pages do not use forms we cannot use the
`shared/show_errors` partial so I've added manual spans using
the usual gov_uk error classes and an ID tag that allows
the header box error link to pass focus to the form group

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
