### PR TITLE
AP-1531: Add focus state to button-as-link

### DIFF
--- a/app/assets/stylesheets/providers/legal_aid_applications.scss
+++ b/app/assets/stylesheets/providers/legal_aid_applications.scss
@@ -31,6 +31,14 @@ div.no-results {
   text-decoration: underline;
   cursor: pointer;
   outline: none;
+
+  &:focus {
+    color: $govuk-focus-text-colour;
+    background-color: $govuk-focus-colour;
+    box-shadow: 0 -2px $govuk-focus-colour, 0 4px $govuk-focus-text-colour;
+    outline: 3px solid transparent;
+    text-decoration: none;
+  }
 }
 
 .govuk-header {


### PR DESCRIPTION
## What
[Link to story](https://dsdmoj.atlassian.net/browse/AP-1531)

The page shows a table with a form embedded in the final cell for removing the transaction.  
As it’s a form it uses an input type button to submit the form.
GOVUK design system buttons should look like this 
![image](https://user-images.githubusercontent.com/6757677/88278515-6c4ace00-ccda-11ea-8138-1787b02d2721.png)

---

To make the submission look like a link it was styled with a css class `button-as-link` that spoofs the look of a `govuk-link` but did not include the focus state.
I have extended the hacky CSS override with a focus state that also mimics a `govuk-link` this should work for keyboard users but may need further investigations after the in depth accessibility review
![image](https://user-images.githubusercontent.com/6757677/88278611-92706e00-ccda-11ea-84d9-2e883e79b82b.png)




## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
