### PR TITLE
FIX: Update provider_used_delegated_functions event

### DIFF
--- a/app/models/concerns/legal_aid_application_state_machine.rb
+++ b/app/models/concerns/legal_aid_application_state_machine.rb
@@ -78,6 +78,7 @@ module LegalAidApplicationStateMachine # rubocop:disable Metrics/ModuleLength La
 
       event :provider_used_delegated_functions do
         transitions from: %i[
+                              provider_entering_means
                               applicant_details_checked
                               delegated_functions_used
                              ],


### PR DESCRIPTION
## What

Steps to reproduce
* start passported claim
* Say yes to delegated functions
* Yes to make substantive now - save and continue
* back button, change to no
and the transition will fail

This fix allows a user to transition from
:provider_used_delegated_functions to :provider_entering_means
ans allows a user to change their mind around progressing
with a substantive application

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
