### PR TITLE
Ap 614 reminder email client

### DIFF
--- a/app/controllers/citizens/resend_link_requests_controller.rb
+++ b/app/controllers/citizens/resend_link_requests_controller.rb
@@ -4,9 +4,6 @@ module Citizens
 
     def update
       ResendLinkRequestMailer.notify(
-        # legal_aid_application,
-        # legal_aid_application.provider,
-        # legal_aid_application.applicant
         legal_aid_application.application_ref,
         legal_aid_application.applicant.email_address,
         application_url,

--- a/app/controllers/citizens/resend_link_requests_controller.rb
+++ b/app/controllers/citizens/resend_link_requests_controller.rb
@@ -4,9 +4,13 @@ module Citizens
 
     def update
       ResendLinkRequestMailer.notify(
-        legal_aid_application,
-        legal_aid_application.provider,
-        legal_aid_application.applicant
+        # legal_aid_application,
+        # legal_aid_application.provider,
+        # legal_aid_application.applicant
+        legal_aid_application.application_ref,
+        legal_aid_application.applicant.email_address,
+        application_url,
+        legal_aid_application.applicant.full_name
       ).deliver_later!
     end
 
@@ -14,6 +18,14 @@ module Citizens
 
     def legal_aid_application
       @legal_aid_application ||= SecureApplicationFinder.new(params[:id]).legal_aid_application
+    end
+
+    def application_url
+      @application_url ||= citizens_legal_aid_application_url(secure_id)
+    end
+
+    def secure_id
+      legal_aid_application.generate_secure_id
     end
   end
 end

--- a/app/mailers/resend_link_request_mailer.rb
+++ b/app/mailers/resend_link_request_mailer.rb
@@ -4,23 +4,12 @@ class ResendLinkRequestMailer < BaseApplyMailer
   require_relative 'concerns/notify_template_methods'
   include NotifyTemplateMethods
 
-  # def notify(legal_aid_application, provider, applicant, to = support_email_address)
-  #   template_name :new_link_request
-  #   set_personalisation(
-  #     applicant_name: "#{applicant['first_name']} #{applicant['last_name']}".strip,
-  #     provider: provider['id'],
-  #     application_ref: legal_aid_application['application_ref'],
-  #     requested_at: Time.current.to_s(:datetime)
-  #   )
-  #   mail to: to
-  # end
-
   def notify(app_id, email, application_url, client_name)
     template_name :new_link_to_client
     set_personalisation(
-        application_url: application_url,
-        client_name: client_name,
-        ref_number: app_id
+      application_url: application_url,
+      client_name: client_name,
+      ref_number: app_id
     )
     mail(to: email)
   end

--- a/app/mailers/resend_link_request_mailer.rb
+++ b/app/mailers/resend_link_request_mailer.rb
@@ -4,14 +4,24 @@ class ResendLinkRequestMailer < BaseApplyMailer
   require_relative 'concerns/notify_template_methods'
   include NotifyTemplateMethods
 
-  def notify(legal_aid_application, provider, applicant, to = support_email_address)
-    template_name :new_link_request
+  # def notify(legal_aid_application, provider, applicant, to = support_email_address)
+  #   template_name :new_link_request
+  #   set_personalisation(
+  #     applicant_name: "#{applicant['first_name']} #{applicant['last_name']}".strip,
+  #     provider: provider['id'],
+  #     application_ref: legal_aid_application['application_ref'],
+  #     requested_at: Time.current.to_s(:datetime)
+  #   )
+  #   mail to: to
+  # end
+
+  def notify(app_id, email, application_url, client_name)
+    template_name :new_link_to_client
     set_personalisation(
-      applicant_name: "#{applicant['first_name']} #{applicant['last_name']}".strip,
-      provider: provider['id'],
-      application_ref: legal_aid_application['application_ref'],
-      requested_at: Time.current.to_s(:datetime)
+        application_url: application_url,
+        client_name: client_name,
+        ref_number: app_id
     )
-    mail to: to
+    mail(to: email)
   end
 end

--- a/app/views/citizens/resend_link_requests/update.html.erb
+++ b/app/views/citizens/resend_link_requests/update.html.erb
@@ -1,5 +1,8 @@
 <%= page_template page_title: t('.page_title'), back_link: :none do %>
   <p class="govuk-body">
-    <%= t('.contact_provider') %>
+    <%= t('.check_inbox') %>
+  </p>
+  <p class="govuk-body">
+    <%= t('.valid_until') %>
   </p>
 <% end %>

--- a/config/govuk_notify_templates.yml
+++ b/config/govuk_notify_templates.yml
@@ -29,4 +29,3 @@ production:
   reminder_to_submit_financial_information_client: 2a07ae35-670a-4753-a7cf-58843068b659
   reminder_to_submit_financial_information_provider: 9843f667-8b11-41c0-9c11-622fffc686ec
   new_link_to_client: b59f52f3-ad0b-45ed-9b2a-a33686f4278a
-  

--- a/config/govuk_notify_templates.yml
+++ b/config/govuk_notify_templates.yml
@@ -17,6 +17,7 @@ development:
   client_completed_means: d04e64ae-0a66-4577-83d6-6ce9f7fa27b4
   reminder_to_submit_financial_information_client: e8052551-2afa-4b11-b3e3-578248d9b582
   reminder_to_submit_financial_information_provider: ec4f423d-498a-4828-ab66-c2453cb42ed3
+  new_link_to_client: 5708ec04-c789-4f7e-8a15-ad7dd3f4f336
 
 production:
   citizen_start_application: 66865f0d-6410-40e2-b862-98724eb6e33a
@@ -27,3 +28,4 @@ production:
   client_completed_means: b343446d-b487-4f8b-9673-2aaf21ea10a1
   reminder_to_submit_financial_information_client: 2a07ae35-670a-4753-a7cf-58843068b659
   reminder_to_submit_financial_information_provider: 9843f667-8b11-41c0-9c11-622fffc686ec
+  new_link_to_client: b59f52f3-ad0b-45ed-9b2a-a33686f4278a

--- a/config/govuk_notify_templates.yml
+++ b/config/govuk_notify_templates.yml
@@ -29,3 +29,4 @@ production:
   reminder_to_submit_financial_information_client: 2a07ae35-670a-4753-a7cf-58843068b659
   reminder_to_submit_financial_information_provider: 9843f667-8b11-41c0-9c11-622fffc686ec
   new_link_to_client: b59f52f3-ad0b-45ed-9b2a-a33686f4278a
+  

--- a/config/locales/en/citizens.yml
+++ b/config/locales/en/citizens.yml
@@ -171,8 +171,9 @@ en:
         page_title: This link has expired
         new_link_request: Request a new link
       update:
-        page_title: Your request for a new link has been sent
-        contact_provider: Speak with your solicitor to check your application status.
+        page_title: We've sent you a new link
+        check_inbox: Check your email inbox.
+        valid_until: Your new link will only remain active for 7 days for security reasons.
     restrictions:
       show:
         h1-heading: Are there any legal restrictions that prevent you from selling or borrowing against your assets?

--- a/spec/mailers/resend_link_request_mailer_spec.rb
+++ b/spec/mailers/resend_link_request_mailer_spec.rb
@@ -2,7 +2,15 @@ require 'rails_helper'
 
 RSpec.describe ResendLinkRequestMailer, type: :mailer do
   let(:legal_aid_application) { create :legal_aid_application, :with_applicant }
-  let(:mail) { described_class.notify(legal_aid_application, legal_aid_application.provider, legal_aid_application.applicant) }
+  let(:application_url) { 'https://this_is_a_test.com' }
+  let(:mail) do
+    described_class.notify(
+      legal_aid_application.application_ref,
+      legal_aid_application.applicant.email_address,
+      application_url,
+      legal_aid_application.applicant.full_name
+    )
+  end
 
   it 'uses GovukNotifyMailerJob' do
     expect(described_class.delivery_job).to eq(GovukNotifyMailerJob)
@@ -10,7 +18,7 @@ RSpec.describe ResendLinkRequestMailer, type: :mailer do
 
   describe '#notify' do
     it 'sends to correct address' do
-      expect(mail.to).to eq([Rails.configuration.x.support_email_address])
+      expect(mail.to).to eq([legal_aid_application.applicant.email_address])
     end
 
     it 'is a govuk_notify delivery' do


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-614)

Most of the work on this ticket had already been done (the pages already existed), however the request for a new link sent an email to the apply-for-legal-services email address, which informed us that a clienbt had requested a new link and it noted which client and which application. I have replaced this functionality  so that a new email is sent to the client with a new link.

As a result we may want to remove the template `new_link_request` as this is no longer used.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
