### PR TITLE
Update ProviderDetailsRetriever to replace space with %20 in url

### DIFF
--- a/app/services/mock_provider_details_retriever.rb
+++ b/app/services/mock_provider_details_retriever.rb
@@ -44,6 +44,7 @@ class MockProviderDetailsRetriever # rubocop:disable Metrics/ClassLength
           name: contact_name(1)
         }
       ],
+      feeEarners: [],
       providerOffices: [
         {
           id: 81_693,
@@ -63,6 +64,7 @@ class MockProviderDetailsRetriever # rubocop:disable Metrics/ClassLength
           name: contact_name(1)
         }
       ],
+      feeEarners: [],
       providerOffices: [
         {
           id: 137_570,
@@ -82,6 +84,7 @@ class MockProviderDetailsRetriever # rubocop:disable Metrics/ClassLength
           name: contact_name(1)
         }
       ],
+      feeEarners: [],
       providerOffices: [
         {
           id: 85_487,
@@ -96,6 +99,7 @@ class MockProviderDetailsRetriever # rubocop:disable Metrics/ClassLength
       providerFirmId: firm_number,
       contactUserId: username_number,
       contacts: Array.new(number_of_contacts) { |index| contact_hash(index + 1) },
+      feeEarners: [],
       providerOffices: Array.new(number_of_offices) { |index| office_hash(index + 1) }
 
     }

--- a/app/services/provider_details_retriever.rb
+++ b/app/services/provider_details_retriever.rb
@@ -31,7 +31,11 @@ class ProviderDetailsRetriever
   end
 
   def url # rubocop:disable Lint/UriEscapeUnescape
-    File.join(Rails.configuration.x.provider_details.url, URI.encode_www_form_component(username))
+    File.join(Rails.configuration.x.provider_details.url, encoded_uri)
+  end
+
+  def encoded_uri
+    URI.encode_www_form_component(username).gsub('+', '%20')
   end
 
   def raise_error

--- a/spec/cassettes/encoded_provider_details_api.yml
+++ b/spec/cassettes/encoded_provider_details_api.yml
@@ -1,0 +1,43 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://ccms-pda.stg.legalservices.gov.uk/api/providerDetails/ROB%20R
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - ccms-pda.stg.legalservices.gov.uk
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Mon, 27 Jul 2020 14:10:48 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"providerFirmId":27358,"contactUserId":21025,"contacts":[{"id":9467190,"name":"MANDYBRADSHAW"},{"id":822444,"name":"ROB
+        R"},{"id":3293283,"name":"ANNALISAMOSCARDINI@KYLESLEGALPRACTICE.CO.UK"},{"id":521356,"name":"GAYNORHIGGINBOTHAM@KYLESLEGALPRACTICE.CO.UK"},{"id":5767233,"name":"NICKPEACOCK2"},{"id":5106865,"name":"DAVIDPARISH@KYLESLEGALPRACTICE.CO.UK"},{"id":8677372,"name":"VICKYLANT@KYLESLEGAL.CO.UK"},{"id":8677374,"name":"VICTORIALANT@KYLESLEGAL.CO.UK"},{"id":504182,"name":"ROB@ROWANLEGALCOSTS.CO.UK"},{"id":2441136,"name":"AMYHOSSACK@KYLESLEGALPRACTICE.CO.UK"},{"id":2835394,"name":"PMASON"},{"id":3293287,"name":"GOODLUCK
+        JONATHAN"},{"id":6564073,"name":"CLIFFD"}],"feeEarners":[],"providerOffices":[{"id":146464,"name":"KYLES
+        LEGAL PRACTICE-2M341C"},{"id":5900725,"name":"KYLES LEGAL PRACTICE-2P467N"},{"id":146466,"name":"KYLES
+        LEGAL PRACTICE-2M342D"},{"id":5989512,"name":"KYLES LEGAL PRACTICE-2P541U"},{"id":145934,"name":"KYLES
+        LEGAL PRACTICE-2M058V"},{"id":146462,"name":"KYLES LEGAL PRACTICE-2M340B"},{"id":5989510,"name":"KYLES
+        LEGAL PRACTICE-2P540T"},{"id":7561116,"name":"KYLES LEGAL PRACTICE-2P649L"},{"id":146454,"name":"KYLES
+        LEGAL PRACTICE-2M336X"},{"id":146460,"name":"KYLES LEGAL PRACTICE-2M339A"},{"id":146456,"name":"KYLES
+        LEGAL PRACTICE-2M337Y"}]}'
+  recorded_at: Mon, 27 Jul 2020 14:10:48 GMT
+recorded_with: VCR 6.0.0

--- a/spec/cassettes/provider_details_api.yml
+++ b/spec/cassettes/provider_details_api.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://sitsoa10.laadev.co.uk/CCMSInformationService/api/providerDetails/NEETADESOR
+    uri: https://ccms-pda.stg.legalservices.gov.uk/api/providerDetails/NEETADESOR
     body:
       encoding: US-ASCII
       string: ''
@@ -14,24 +14,25 @@ http_interactions:
       User-Agent:
       - Ruby
       Host:
-      - sitsoa10.laadev.co.uk
+      - ccms-pda.stg.legalservices.gov.uk
   response:
     status:
       code: 200
-      message: OK
+      message: ''
     headers:
       Date:
-      - Wed, 13 Nov 2019 16:31:19 GMT
-      Server:
-      - Oracle-HTTP-Server
+      - Mon, 27 Jul 2020 13:49:17 GMT
       Content-Type:
-      - application/json;charset=UTF-8
+      - application/json
       Transfer-Encoding:
       - chunked
+      Connection:
+      - keep-alive
     body:
       encoding: UTF-8
-      string: '{"providerFirmId":22381,"contactUserId":2016472,"contacts":[{"id":34419,"name":"Neeta
-        Desor"}],"providerOffices":[{"id":81693,"name":"DESOR & CO-0B721W"}]}'
-    http_version: 
-  recorded_at: Wed, 13 Nov 2019 16:31:20 GMT
-recorded_with: VCR 5.0.0
+      string: '{"providerFirmId":22381,"contactUserId":29562,"contacts":[{"id":568352,"name":"SALLYCORNHILL"},{"id":2017809,"name":"KAREN@HMLAWCOSTS.CO.UK"},{"id":3577068,"name":"DES@ELITELAWSOLICITORS.CO.UK"},{"id":2017801,"name":"JOHN@HMLAWCOSTS.CO.UK"},{"id":2017805,"name":"JO@HMLAWCOSTS.CO.UK"},{"id":2016496,"name":"BERYLCURLING"},{"id":2016486,"name":"ANITAANTHONY"},{"id":6751872,"name":"DURGA@DESORANDCO.CO.UK"},{"id":2016472,"name":"NEETADESOR"},{"id":8555414,"name":"BALWINDER@DESORANDCO.CO.UK"},{"id":2016500,"name":"LAURA@DESORANDCO.CO.UK"},{"id":8178598,"name":"ALINA@DESORANDCO.CO.UK"},{"id":2016508,"name":"KAMAL@DESORANDCO.CO.UK"},{"id":3763746,"name":"MARILYN@DESORANDCO.CO.UK"},{"id":2017811,"name":"MARK@HMLAWCOSTS.CO.UK"},{"id":2890641,"name":"SALLY@DESORANDCO.CO.UK"},{"id":4055523,"name":"LAURAGUSATU"},{"id":9111821,"name":"BALWINDERUBHA"},{"id":2016490,"name":"MAANSIKHOSA"}],"feeEarners":[{"id":9111793,"name":"Balwinder
+        Kaur Ubha"},{"id":9174953,"name":"Marilyn Willows"},{"id":2016673,"name":"Kamal
+        Desor"},{"id":34419,"name":"Neeta Desor"}],"providerOffices":[{"id":81693,"name":"DESOR
+        & CO-0B721W"}]}'
+  recorded_at: Mon, 27 Jul 2020 13:49:17 GMT
+recorded_with: VCR 6.0.0

--- a/spec/services/mock_provider_details_retriever_spec.rb
+++ b/spec/services/mock_provider_details_retriever_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe MockProviderDetailsRetriever do
-  let(:expected_keys) { %i[providerFirmId contactUserId contacts providerOffices] }
+  let(:expected_keys) { %i[providerFirmId contactUserId contacts providerOffices feeEarners] }
 
   context 'a mock user is logged in' do
     let(:username) { Faker::Internet.username }

--- a/spec/services/provider_details_retriever_spec.rb
+++ b/spec/services/provider_details_retriever_spec.rb
@@ -4,8 +4,9 @@ RSpec.describe ProviderDetailsRetriever do
   let(:api_url) { 'https://sitsoa10.laadev.co.uk/CCMSInformationService/api/providerDetails' }
   let(:mock) { true }
   let(:provider) { create :provider }
+  let(:username) { provider.username }
 
-  subject { described_class.call(provider.username) }
+  subject { described_class.call(username) }
 
   before do
     allow(Rails.configuration.x.provider_details).to receive(:url).and_return(api_url)
@@ -37,6 +38,16 @@ RSpec.describe ProviderDetailsRetriever do
       it 'encode properly the username' do
         expect(URI).to receive(:parse).at_least(:once).with(/#{escaped_username}/).and_call_original
         subject
+      end
+
+      context 'username with space' do
+        let(:provider) { create :provider, username: 'JOHN LANG' }
+        let(:escaped_username) { 'JOHN%20LANG' }
+
+        it 'encodes with a %20 in place of a space' do
+          expect(URI).to receive(:parse).at_least(:once).with(/#{escaped_username}/).and_call_original
+          subject
+        end
       end
 
       context 'on failure' do

--- a/spec/services/provider_details_retriever_spec.rb
+++ b/spec/services/provider_details_retriever_spec.rb
@@ -1,7 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe ProviderDetailsRetriever do
-  let(:api_url) { 'https://sitsoa10.laadev.co.uk/CCMSInformationService/api/providerDetails' }
+  let(:api_url) { 'https://ccms-pda.stg.legalservices.gov.uk/api/providerDetails' }
+
   let(:mock) { true }
   let(:provider) { create :provider }
   let(:username) { provider.username }
@@ -16,7 +17,7 @@ RSpec.describe ProviderDetailsRetriever do
   describe '.call' do
     shared_examples_for 'get response from API' do
       it 'returns the expected data structure' do
-        expected_keys = %i[providerFirmId contactUserId contacts providerOffices]
+        expected_keys = %i[providerFirmId contactUserId contacts providerOffices feeEarners]
         expect(subject.keys).to match_array(expected_keys)
 
         expected_office_keys = %i[id name]
@@ -40,9 +41,9 @@ RSpec.describe ProviderDetailsRetriever do
         subject
       end
 
-      context 'username with space' do
-        let(:provider) { create :provider, username: 'JOHN LANG' }
-        let(:escaped_username) { 'JOHN%20LANG' }
+      context 'username with space', vcr: { cassette_name: 'encoded_provider_details_api' } do
+        let(:provider) { create :provider, username: 'ROB R' }
+        let(:escaped_username) { URI.encode_www_form_component(provider.username).gsub('+', '%20') }
 
         it 'encodes with a %20 in place of a space' do
           expect(URI).to receive(:parse).at_least(:once).with(/#{escaped_username}/).and_call_original


### PR DESCRIPTION
Bug Fix this sentry issue [ProviderDetailsRetriever::ApiError](https://sentry.service.dsd.io/mojds/apply-for-legal-aid/issues/40113/)

In the ProviderDetailsRetriever the method [encode_www_form_component](https://apidock.com/ruby/v1_9_3_125/URI/encode_www_form_component/class) method converts a space to a + which fails to retreive information for a provider username that has a space in it "John Lang" > "John+Lang" but instead use %20 which works "John Lang" > "/John%20Lang"

Update tests

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
