### PR TITLE
Bugfix 2807 add permissions to new firms as they are created

### DIFF
--- a/app/services/provider_details_creator.rb
+++ b/app/services/provider_details_creator.rb
@@ -36,7 +36,7 @@ class ProviderDetailsCreator
       firm.update!(name: firm_name)
       firm.offices << offices
     end
-    # TODO For the timebeing, we add passported permissions to every new firm, but this may change in the future.
+    # TODO: For the timebeing, we add passported permissions to every new firm, but this may change in the future.
     current_firm.permissions << @passported_permission unless current_firm.permissions.include?(@passported_permission)
     current_firm
   end

--- a/app/services/provider_details_creator.rb
+++ b/app/services/provider_details_creator.rb
@@ -36,6 +36,7 @@ class ProviderDetailsCreator
       firm.update!(name: firm_name)
       firm.offices << offices
     end
+    # TODO For the timebeing, we add passported permissions to every new firm, but this may change in the future.
     current_firm.permissions << @passported_permission unless current_firm.permissions.include?(@passported_permission)
     current_firm
   end

--- a/app/services/provider_details_creator.rb
+++ b/app/services/provider_details_creator.rb
@@ -32,11 +32,12 @@ class ProviderDetailsCreator
   end
 
   def firm
-    firm = Firm.find_or_create_by!(ccms_id: firm_id).tap do |firm|
+    current_firm = Firm.find_or_create_by!(ccms_id: firm_id).tap do |firm|
       firm.update!(name: firm_name)
       firm.offices << offices
     end
-    firm.permissions << @passported_permission unless firm.permissions.include?(@passported_permission)
+    current_firm.permissions << @passported_permission unless current_firm.permissions.include?(@passported_permission)
+    current_firm
   end
 
   def offices

--- a/app/services/provider_details_creator.rb
+++ b/app/services/provider_details_creator.rb
@@ -7,6 +7,7 @@ class ProviderDetailsCreator
 
   def initialize(provider)
     @provider = provider
+    @passported_permission = Permission.find_by(role: 'application.passported.*')
   end
 
   def call
@@ -31,10 +32,11 @@ class ProviderDetailsCreator
   end
 
   def firm
-    Firm.find_or_create_by!(ccms_id: firm_id).tap do |firm|
+    firm = Firm.find_or_create_by!(ccms_id: firm_id).tap do |firm|
       firm.update!(name: firm_name)
       firm.offices << offices
     end
+    firm.permissions << @passported_permission unless firm.permissions.include?(@passported_permission)
   end
 
   def offices


### PR DESCRIPTION
## What
We now use permissions to decide whether or not provider firms can process passported or non-passported applications beyond the DWP check, but we forgot to assign passported permissions as a default to all new firms being created (which happens when a provider user from that firm logs in for the very first time).

This bugfix rectifies that.

Describe what you did and why.

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
