### PR TITLE
BugFix InvalidTransition error after clicking back button to get back to /substantive_application page

### DIFF
--- a/app/models/concerns/legal_aid_application_state_machine.rb
+++ b/app/models/concerns/legal_aid_application_state_machine.rb
@@ -81,6 +81,7 @@ module LegalAidApplicationStateMachine # rubocop:disable Metrics/ModuleLength La
                               provider_entering_means
                               applicant_details_checked
                               delegated_functions_used
+                              provider_confirming_applicant_eligibility
                              ],
                     to: :delegated_functions_used
       end


### PR DESCRIPTION
Invalid transition caused an error when clicking the back button to go back to the /substantive_application

Fix the above issue by updating the state machine

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
