### PR TITLE
Notify sentry when a Firm has no permission

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -32,8 +32,12 @@ class Provider < ApplicationRecord
   end
 
   def user_permissions
-    firm_permissions = firm.nil? ? [] : firm.permissions
     permissions.empty? ? firm_permissions : permissions
+  end
+
+  def firm_permissions
+    Raven.capture_message("Provider Firm has no permissions with firm id: #{firm.id}") if firm&.permissions&.empty?
+    firm.nil? ? [] : firm.permissions
   end
 
   def passported_permissions?

--- a/spec/factories/firms.rb
+++ b/spec/factories/firms.rb
@@ -12,6 +12,10 @@ FactoryBot.define do
     permissions { [Permission.find_by(role: 'application.non_passported.*') || create(:permission, :non_passported)] }
   end
 
+  trait :with_no_permissions do
+    permissions { [] }
+  end
+
   trait :with_passported_and_non_passported_permissions do
     permissions do
       [

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -64,6 +64,21 @@ RSpec.describe Provider, type: :model do
       end
     end
 
+    context 'no permissions for provider and their firm' do
+      let(:firm) { create :firm, :with_no_permissions }
+      let(:provider) { create :provider, :with_no_permissions, firm: firm }
+      let(:Raven) { instance_double(Tracker) }
+
+      it 'returns false' do
+        expect(provider.user_permissions).to be_empty
+      end
+
+      it 'notifies sentry' do
+        expect(Raven).to receive(:capture_message).with("Provider Firm has no permissions with firm id: #{firm.id}")
+        provider.user_permissions
+      end
+    end
+
     context 'permissions exist for both firm and provider' do
       let(:firm) { create :firm, :with_passported_and_non_passported_permissions }
       let(:provider) { create :provider, :with_passported_permissions, firm: firm }


### PR DESCRIPTION
Firms' should have a default permission of passported and therefore if there is none then
send a message to sentry via raven.

Unlikely but it's better to be safe than sorry.

- Add Raven capture message if a Firm has no permissions at all using `Raven.capture_message`

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
