### PR TITLE
AP-1316 - Add users

### DIFF
--- a/app/controllers/admin/firms_controller.rb
+++ b/app/controllers/admin/firms_controller.rb
@@ -1,0 +1,10 @@
+module Admin
+  class FirmsController < ApplicationController
+    before_action :authenticate_admin_user!
+    layout 'admin'.freeze
+
+    def index
+      @firms = Firm.order(:name)
+    end
+  end
+end

--- a/app/controllers/admin/providers_controller.rb
+++ b/app/controllers/admin/providers_controller.rb
@@ -1,0 +1,39 @@
+module Admin
+  class ProvidersController < ApplicationController
+    before_action :authenticate_admin_user!
+    before_action :new_provider, only: %i[check create]
+    layout 'admin'.freeze
+
+    def new
+      @provider = Provider.new
+    end
+
+    def check
+      service = ProviderDetailsService.new(@provider)
+      if service.check == :success
+        @firm_name = service.firm_name
+        render :check
+      else
+        @provider.errors[:username] << service.message
+        render :new
+      end
+    end
+
+    def create
+      service = ProviderDetailsService.new(@provider)
+      if service.create == :success
+        flash.notice = "User #{@provider.username} created"
+        redirect_to new_admin_provider_path
+      else
+        @provider.errors[:username] << service.message
+        render :new
+      end
+    end
+
+    private
+
+    def new_provider
+      @provider = Provider.new(username: params[:provider][:username].downcase)
+    end
+  end
+end

--- a/app/controllers/admin/providers_controller.rb
+++ b/app/controllers/admin/providers_controller.rb
@@ -8,6 +8,16 @@ module Admin
       @provider = Provider.new
     end
 
+    def index
+      if params[:firm_id] == '0'
+        @providers = Provider.order(:username)
+        @firm = nil
+      else
+        @firm = Firm.find(params[:firm_id])
+        @providers = @firm.providers.order(:username)
+      end
+    end
+
     def check
       service = ProviderDetailsService.new(@provider)
       if service.check == :success

--- a/app/controllers/admin/user_dashboard_controller.rb
+++ b/app/controllers/admin/user_dashboard_controller.rb
@@ -1,0 +1,8 @@
+module Admin
+  class UserDashboardController < ApplicationController
+    before_action :authenticate_admin_user!
+    layout 'admin'.freeze
+
+    def index; end
+  end
+end

--- a/app/services/admin/provider_details_service.rb
+++ b/app/services/admin/provider_details_service.rb
@@ -77,7 +77,7 @@ module Admin
       @provider.username.upcase.gsub(' ', '%20')
     end
 
-    def provider_details_url # rubocop:disable Metrics/AbcSize
+    def provider_details_url
       File.join(Rails.configuration.x.provider_details.url, normalized_username)
     end
 

--- a/app/services/admin/provider_details_service.rb
+++ b/app/services/admin/provider_details_service.rb
@@ -1,0 +1,127 @@
+module Admin
+  class ProviderDetailsService # rubocop:disable Metrics/ClassLength
+    attr_reader :message
+
+    def initialize(provider)
+      @provider = provider
+    end
+
+    def check
+      return :error unless provider_eligible_to_be_added?
+
+      format_check_success_message
+      :success
+    end
+
+    def create
+      return :error unless provider_eligible_to_be_added?
+
+      Provider.transaction do
+        find_or_create_firm
+
+        @provider.update!(
+          firm: firm,
+          offices: offices,
+          user_login_id: user_login_id,
+          contact_id: contact_id
+        )
+      end
+      @message = "User #{@provider.username} successfully created"
+      :success
+    end
+
+    def firm_name
+      # Remove the code at the end.
+      # "Pearson & Pearson -0A1234" becomes "Pearson & Pearson"
+      #
+      @firm_name ||= parsed_response[:providerOffices].first[:name].sub(/-\S{6}$/, '').strip
+    end
+
+    private
+
+    def provider_eligible_to_be_added?
+      if Provider.exists?(username: @provider.username)
+        @message = "User #{@provider.username} already exists in database"
+        return false
+      end
+
+      if raw_response.code != '200'
+        format_error_message
+        return false
+      end
+
+      if contact_id.nil?
+        format_no_contact_message
+        return false
+      end
+      true
+    end
+
+    def format_error_message
+      @message = if raw_response.code == '404'
+                   "User #{@provider.username} not known to CCMS"
+                 else
+                   "Bad response from Provider Details API: HTTP status #{raw_response.code}"
+                 end
+    end
+
+    def format_check_success_message
+      @message = "User #{@provider.username} confirmed for firm #{firm_name}"
+    end
+
+    def format_no_contact_message
+      @message = "No entry for user #{@provider.username} found in list of contacts returned by CCMS"
+    end
+
+    def normalized_username
+      @provider.username.upcase.gsub(' ', '%20')
+    end
+
+    def provider_details_url # rubocop:disable Metrics/AbcSize
+      File.join(Rails.configuration.x.provider_details.url, normalized_username)
+    end
+
+    def parsed_response
+      @parsed_response ||= JSON.parse(raw_response.body, symbolize_names: true)
+    end
+
+    def raw_response
+      @raw_response ||= Net::HTTP.get_response(URI.parse(provider_details_url))
+    end
+
+    def firm
+      @firm ||= find_or_create_firm
+    end
+
+    def offices
+      @parsed_response[:providerOffices].map do |ccms_office|
+        Office.find_or_initialize_by(ccms_id: ccms_office[:id]) do |office|
+          ccms_office[:name] =~ /-(\S{6})$/
+          office.code = Regexp.last_match(1)
+          office.firm = firm
+        end
+      end
+    end
+
+    def user_login_id
+      parsed_response[:contactUserId]
+    end
+
+    def contact_id
+      username = @provider.username.upcase
+      contact = parsed_response[:contacts].detect { |c| c[:name] == username }
+      contact&.fetch(:id)
+    end
+
+    def find_or_create_firm
+      ccms_firm_id = parsed_response[:providerFirmId]
+      firm = Firm.find_by(ccms_id: ccms_firm_id)
+      if firm.present?
+        firm.update(name: firm_name) unless firm.name == firm_name
+      else
+        firm = Firm.create(name: firm_name, ccms_id: ccms_firm_id)
+      end
+      @firm = firm
+    end
+  end
+end

--- a/app/views/admin/firms/index.html.erb
+++ b/app/views/admin/firms/index.html.erb
@@ -1,0 +1,29 @@
+<%= govuk_fieldset_header do %>
+  <h1 class="govuk-fieldset__heading">
+    <%= label_tag(t('.heading_1'), page_title) %>
+  </h1>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <table class="govuk-table">
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th class="govuk-table__header" scope="col"><%= t('.firm') %></th>
+          <th class="govuk-table__header" scope="col"><%= t('.num_users') %></th>
+          <th class="govuk-table__header" scope="col"><%= t('.action') %></th>
+        </tr>
+      </thead>
+
+      <tbody class="govuk-table__body">
+      <% @firms.each do |firm| %>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell case-full-name"><%= firm.name %></td>
+          <td class="govuk-table__cell case-reference-number"><%= firm.providers.count %></td>
+          <td class="govuk-table__cell case-reference-number"><%= link_to t('.view_users'), admin_firm_providers_path(firm), id: "firm-#{firm.id}", method: :get %></td>
+        </tr>
+      <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/app/views/admin/providers/check.html.erb
+++ b/app/views/admin/providers/check.html.erb
@@ -1,0 +1,25 @@
+
+<%= form_with(model: @provider, url: admin_providers_path, method: :post, local: true) do |form| %>
+
+  <%= govuk_form_group show_error_if: @provider.errors.present? do %>
+    <%= govuk_fieldset_header do %>
+      <h1 class="govuk-fieldset__heading">
+        <%= label_tag(t('.heading_1', username: @provider.username), page_title) %>
+      </h1>
+      <br>
+      <h2 class="govuk-heading-l">User is in firm <%= @firm_name %></h2>
+      <br>
+      <p>Press continue to create user and firm if it doesn't already exist.</p>
+    <% end %>
+
+  <% end %>
+
+  <%= form.hidden_field :username %>
+
+  <%= next_action_buttons(
+          show_draft: local_assigns.key?(:show_draft) ? show_draft : false,
+          form: form,
+          continue_button_text: t('generic.continue')
+      ) %>
+
+<% end %>

--- a/app/views/admin/providers/index.html.erb
+++ b/app/views/admin/providers/index.html.erb
@@ -1,0 +1,30 @@
+<%= govuk_fieldset_header do %>
+  <h1 class="govuk-fieldset__heading">
+    <% title = @firm.present? ? t('.heading_1', firm_name: @firm.name) : t('.all_firms_heading_1') %>
+    <label for="#{title.downcase}">
+      <%= title %>
+    </label>
+  </h1>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <table class="govuk-table">
+      <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th class="govuk-table__header" scope="col"><%= t('.username') %></th>
+        <th class="govuk-table__header" scope="col"><%= t('.email_address') %></th>
+      </tr>
+      </thead>
+
+      <tbody class="govuk-table__body">
+      <% @providers.each do |provider| %>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell case-full-name"><%= provider.username %></td>
+          <td class="govuk-table__cell case-reference-number"><%= provider.email %></td>
+        </tr>
+      <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/app/views/admin/providers/new.html.erb
+++ b/app/views/admin/providers/new.html.erb
@@ -1,0 +1,23 @@
+<%= form_with(model: @provider, url: admin_provider_check_path, local: true) do |form| %>
+
+  <%= govuk_form_group show_error_if: @provider.errors.present? do %>
+    <%= govuk_fieldset_header do %>
+      <h1 class="govuk-fieldset__heading">
+        <%= label_tag(t('.heading_1'), page_title) %>
+      </h1>
+    <% end %>
+    <%= form.govuk_text_field(
+            :username,
+            hint: controller_t('hint.username'),
+            label: nil,
+            value: @provider.username,
+            class: 'govuk-!-width-one-third'
+        ) %>
+  <% end %>
+
+  <%= next_action_buttons(
+          show_draft: local_assigns.key?(:show_draft) ? show_draft : false,
+          form: form
+      ) %>
+
+<% end %>

--- a/app/views/admin/user_dashboard/index.html.erb
+++ b/app/views/admin/user_dashboard/index.html.erb
@@ -7,4 +7,5 @@
 <br>
 
 <%= link_to t('.firm_permissions'), admin_roles_path, class: 'govuk-heading-m', id: 'firm_permissions', method: :get %>
+<%= link_to t('.firms'), admin_firms_path,  class: 'govuk-heading-m', id: 'firm_permissions', method: :get %>
 <%= link_to t('.add_user'), new_admin_provider_path, class: 'govuk-heading-m', id: 'add_user', method: :get %>

--- a/app/views/admin/user_dashboard/index.html.erb
+++ b/app/views/admin/user_dashboard/index.html.erb
@@ -1,0 +1,10 @@
+<%= govuk_fieldset_header do %>
+  <h1 class="govuk-fieldset__heading">
+    <%= label_tag(t('.heading_1'), page_title) %>
+  </h1>
+<% end %>
+
+<br>
+
+<%= link_to t('.firm_permissions'), admin_roles_path, class: 'govuk-heading-m', id: 'firm_permissions', method: :get %>
+<%= link_to t('.add_user'), new_admin_provider_path, class: 'govuk-heading-m', id: 'add_user', method: :get %>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -6,7 +6,7 @@
       <%= admin_nav_to t('.submitted_applications_report'), admin_submitted_applications_report_path %>
       <%= admin_nav_to t('.feedback'), admin_feedback_path %>
       <%= admin_nav_to t('.reports'), admin_reports_path %>
-      <%= admin_nav_to t('.roles'), admin_roles_path %>
+      <%= admin_nav_to t('.user_admin'), admin_user_dashboard_path %>
     </ul>
   </nav>
 

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -302,6 +302,8 @@ en:
           attributes:
             selected_office_id:
               blank: Select an account number
+            username:
+              already_exists: There is already a user with that username
         respondent:
           attributes:
             understands_terms_of_court_order:

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -62,3 +62,17 @@ en:
       permissions:
         show:
           heading_1: 'Select Firm permissions for %{firm_name}'
+    providers:
+      new:
+        admin:
+          providers:
+            hint:
+              username: Enter the username the provider uses to log into the portal and we'll get the details from the Provider Details API.
+        heading_1: Add new provider user
+      check:
+        heading_1: Add provider user %{username}
+    user_dashboard:
+      index:
+        heading_1: User administration main menu
+        firm_permissions: Manage permissions for provider firms
+        add_user: Add provider users

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -53,6 +53,13 @@ en:
         satisfaction: Satisfaction rating
         suggestion: Improvement suggestion
         source: Source
+    firms:
+      index:
+        heading_1: List of firms
+        action: Action
+        firm: Firm name
+        num_users: Number of provider users
+        view_users: View provider users
     reports:
       index:
         heading_1: 'Admin reports and downloads'
@@ -63,6 +70,11 @@ en:
         show:
           heading_1: 'Select Firm permissions for %{firm_name}'
     providers:
+      index:
+        heading_1: Provider users for firm %{firm_name}
+        all_firms_heading_1: All provider users
+        email_address: Email address
+        username: Username
       new:
         admin:
           providers:
@@ -76,3 +88,4 @@ en:
         heading_1: User administration main menu
         firm_permissions: Manage permissions for provider firms
         add_user: Add provider users
+        firms: List Provider firms

--- a/config/locales/en/layouts.yml
+++ b/config/locales/en/layouts.yml
@@ -7,7 +7,7 @@ en:
       submitted_applications_report: Submitted Applications
       feedback: Feedback
       reports: Reports
-      roles: User Roles
+      user_admin: User admin
     application:
       footer:
         contact: Contact

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,10 +59,14 @@ Rails.application.routes.draw do
     resource :feedback, controller: :feedback, only: %i[show]
     resources :ccms_connectivity_tests, only: [:show]
     resources :reports, only: [:index]
+    get 'user_dashboard', to: 'user_dashboard#index', as: 'user_dashboard'
     resources :roles, only: %i[index create update]
     namespace :roles do
       resources :permissions, only: %i[show update]
     end
+    resources :providers, only: %i[new create]
+
+    post 'provider/check', to: 'providers#check', as: 'provider_check'
     get 'admin_report_submitted', to: 'reports#download_submitted', as: 'reports_submitted_csv'
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -65,6 +65,9 @@ Rails.application.routes.draw do
       resources :permissions, only: %i[show update]
     end
     resources :providers, only: %i[new create]
+    resources :firms, only: :index do
+      resources :providers, only: :index
+    end
 
     post 'provider/check', to: 'providers#check', as: 'provider_check'
     get 'admin_report_submitted', to: 'reports#download_submitted', as: 'reports_submitted_csv'

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_28_081000) do
+ActiveRecord::Schema.define(version: 2020_07_29_140115) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -402,7 +402,6 @@ ActiveRecord::Schema.define(version: 2020_07_28_081000) do
     t.datetime "updated_at", null: false
     t.uuid "applicant_id"
     t.boolean "has_offline_accounts"
-    t.string "state"
     t.boolean "open_banking_consent"
     t.datetime "open_banking_consent_choice_at"
     t.string "own_home"

--- a/spec/requests/admin/firms_spec.rb
+++ b/spec/requests/admin/firms_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+module Admin
+  RSpec.describe FirmsController, type: :request do
+    let(:admin_user) { create :admin_user }
+    let!(:firms) { create_list :firm, 3 }
+
+    before { sign_in admin_user }
+
+    describe 'GET admin/firms' do
+      before { get admin_firms_path }
+
+      it 'renders successfully' do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'displays page heading' do
+        expect(response.body).to include('List of firms')
+      end
+
+      it 'the name of every firm' do
+        expect(response.body).to include(firms[0].name)
+        expect(response.body).to include(firms[1].name)
+        expect(response.body).to include(firms[2].name)
+      end
+    end
+  end
+end

--- a/spec/requests/admin/providers_spec.rb
+++ b/spec/requests/admin/providers_spec.rb
@@ -1,0 +1,103 @@
+require 'rails_helper'
+
+module Admin
+  RSpec.describe ProvidersController, type: :request do
+    let(:admin_user) { create :admin_user }
+    before { sign_in admin_user }
+
+    describe 'GET admin/providers/new' do
+      before { get new_admin_provider_path }
+
+      it 'renders successfully' do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'displays Add new provider user page' do
+        expect(response.body).to include('Add new provider user')
+      end
+    end
+
+    describe 'POST admin/provider/check' do
+      let(:params) { { provider: { username: username } } }
+      let(:username) { 'stepriponikas bonstart' }
+      let(:firm_name) { 'Cudmore and Fabby Ltd.' }
+
+      before do
+        expect(Admin::ProviderDetailsService).to receive(:new).and_return(service)
+      end
+
+      subject { post admin_provider_check_path, params: params }
+
+      context 'ProviderDetailsService returns :success' do
+        let(:service) { double Admin::ProviderDetailsService, check: :success, firm_name: firm_name }
+
+        it 'renders successfully' do
+          subject
+          expect(response).to have_http_status(:ok)
+        end
+
+        it 'renders the check page with the username and firm name' do
+          subject
+          expect(response.body).to include("Add provider user #{username}")
+          expect(response.body).to include("User is in firm #{firm_name}")
+        end
+      end
+
+      context 'ProviderDetailsService returns :error' do
+        let(:service) { double Admin::ProviderDetailsService, check: :error, message: 'my error message' }
+
+        it 'renders successfully' do
+          subject
+          expect(response).to have_http_status(:ok)
+        end
+
+        it 'renders the check page with the username and firm name' do
+          subject
+          expect(response.body).to include('Add new provider user')
+          expect(response.body).to include('my error message')
+        end
+      end
+    end
+
+    describe 'POST admin/providers' do
+      let(:params) { { provider: { username: username } } }
+      let(:username) { 'stepriponikas bonstart' }
+      let(:firm_name) { 'Cudmore and Fabby Ltd.' }
+
+      before do
+        expect(Admin::ProviderDetailsService).to receive(:new).and_return(service)
+      end
+
+      subject { post admin_providers_path, params: params }
+
+      context 'ProviderDetailsService returns :success' do
+        let(:service) { double Admin::ProviderDetailsService, create: :success, firm_name: firm_name }
+        it 'redirects' do
+          subject
+          expect(response).to redirect_to new_admin_provider_path
+        end
+
+        it 'renders the new page with a confirmatory flash message' do
+          subject
+          follow_redirect!
+          expect(response.body).to include("User #{username} created")
+          expect(response.body).to include('Add new provider user')
+        end
+      end
+
+      context 'ProviderDetailsService returns :error' do
+        let(:service) { double Admin::ProviderDetailsService, create: :error, message: 'my error message' }
+        it 'redirects' do
+          subject
+          expect(response).to have_http_status(:ok)
+        end
+
+        it 'renders the new page with the error message' do
+          subject
+          expect(response.body).to include('Add new provider user')
+          expect(response.body).to include('my error message')
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/admin/providers_spec.rb
+++ b/spec/requests/admin/providers_spec.rb
@@ -17,6 +17,47 @@ module Admin
       end
     end
 
+    describe 'GET index' do
+      let(:my_firm) { Firm.create(name: 'Me, Myself and I Ltd.') }
+      let(:your_firm) { Firm.create(name: 'You and Yours Partners') }
+
+      before do
+        create :provider, username: 'Johnny Me', firm: my_firm
+        create :provider, username: 'Amy Me', firm: my_firm
+        create :provider, username: 'Edward Yu', firm: your_firm
+
+        get admin_firm_providers_path(firm_id)
+      end
+
+      context 'all firms' do
+        let(:firm_id) { '0' }
+
+        it 'dislays an appropriate heading' do
+          expect(response.body).to include('All provider users')
+        end
+
+        it 'displays all providers' do
+          expect(response.body).to include('Johnny Me')
+          expect(response.body).to include('Amy Me')
+          expect(response.body).to include('Edward Yu')
+        end
+      end
+
+      context 'firm specified' do
+        let(:firm_id) { my_firm.id }
+
+        it 'displays a heading mentioning the firm name' do
+          expect(response.body).to include('Provider users for firm Me, Myself and I Ltd.')
+        end
+
+        it 'displays just the provider for that firm' do
+          expect(response.body).to include('Johnny Me')
+          expect(response.body).to include('Amy Me')
+          expect(response.body).not_to include('Edward Yu')
+        end
+      end
+    end
+
     describe 'POST admin/provider/check' do
       let(:params) { { provider: { username: username } } }
       let(:username) { 'stepriponikas bonstart' }

--- a/spec/services/admin/provider_details_service_spec.rb
+++ b/spec/services/admin/provider_details_service_spec.rb
@@ -1,0 +1,260 @@
+require 'rails_helper'
+
+module Admin
+  RSpec.describe ProviderDetailsService do
+    before do
+      allow(Rails.configuration.x.provider_details).to receive(:url).and_return(dummy_provider_details_host)
+      stub_request(:get, api_url).to_return(body: response_body, status: http_status)
+    end
+
+    let(:dummy_provider_details_host) { 'http://my_dummy_url/' }
+    let(:provider) { Provider.new(username: username) }
+    let(:api_url) { "#{dummy_provider_details_host}#{normalized_username}" }
+    let(:normalized_username) { username.upcase.gsub(' ', '%20') }
+    let(:username) { 'johnny depp' }
+    let(:service) { described_class.new(provider) }
+
+    shared_examples 'service handling error conditions' do
+      context 'user already exists in providers table' do
+        before { Provider.create(username: username) }
+        let(:response_body) { nil }
+        let(:http_status) { nil }
+
+        it 'responds :error' do
+          expect(subject).to eq :error
+        end
+
+        it 'explains in the message' do
+          subject
+          expect(service.message).to eq 'User johnny depp already exists in database'
+        end
+      end
+
+      context 'username not on provider details api' do
+        let(:response_body) { user_not_found_response.to_json }
+        let(:http_status) { 404 }
+        it 'responds :error' do
+          expect(subject).to eq :error
+        end
+
+        it 'explains in message' do
+          subject
+          expect(service.message).to eq 'User johnny depp not known to CCMS'
+        end
+      end
+
+      context 'other non-200 response' do
+        let(:response_body) { '' }
+        let(:http_status) { 505 }
+        it 'responds :error' do
+          expect(subject).to eq :error
+        end
+
+        it 'explains in message' do
+          subject
+          expect(service.message).to eq 'Bad response from Provider Details API: HTTP status 505'
+        end
+      end
+
+      context 'username not in list of contacts' do
+        let(:response_body) { missing_contact_response.to_json }
+        let(:http_status) { 200 }
+        it 'responds :error' do
+          expect(subject).to eq :error
+        end
+        it 'explains in message' do
+          subject
+          expect(service.message).to eq 'No entry for user johnny depp found in list of contacts returned by CCMS'
+        end
+      end
+    end
+
+    describe '#check' do
+      context 'errors' do
+        subject { service.check }
+        it_behaves_like 'service handling error conditions'
+      end
+
+      context 'success' do
+        let(:http_status) { 200 }
+        context 'username in list of contacts' do
+          let(:response_body) { johnny_depp_response.to_json }
+          it 'responds success' do
+            expect(service.check).to eq :success
+          end
+
+          it 'puts firm name in message' do
+            service.check
+            expect(service.message).to eq 'User johnny depp confirmed for firm LOCAL LAW & CO LTD'
+          end
+        end
+      end
+    end
+
+    describe '#create' do
+      context 'errors' do
+        subject { service.create }
+        it_behaves_like 'service handling error conditions'
+      end
+
+      context 'success' do
+        let(:http_status) { 200 }
+        subject { service.create }
+        context 'no firm or offices pre-exist' do
+          let(:response_body) { johnny_depp_response.to_json }
+          it 'creates the provider' do
+            expect { subject }.to change { Provider.count }.by(1)
+            expect(Provider.exists?(username: username)).to be true
+          end
+
+          it 'creates the firm linked to the provider' do
+            expect { subject }.to change { Firm.count }.by(1)
+            provider = Provider.find_by(username: username)
+            firm = provider.firm
+            expect(firm.ccms_id).to eq '24493'
+          end
+
+          it 'creates the offices linked to the firm' do
+            expect { subject }.to change { Office.count }.by(2)
+            firm = Firm.find_by(name: 'LOCAL LAW & CO LTD')
+            offices = firm.offices.order(:code)
+            expect(offices.size).to eq 2
+            expect(offices.first.code).to eq '8B869F'
+            expect(offices.first.ccms_id).to eq '81333'
+            expect(offices.last.code).to eq '8M609S'
+            expect(offices.last.ccms_id).to eq '146988'
+          end
+        end
+
+        context 'firm and all offices pre-exist' do
+          before do
+            create_office firm, '146988', '8M609S'
+            create_office firm, '81333', '8B869F'
+          end
+          let(:firm) { create_firm }
+          let(:response_body) { johnny_depp_response.to_json }
+
+          it 'creates the provider' do
+            expect { subject }.to change { Provider.count }.by(1)
+            expect(Provider.exists?(username: username)).to be true
+          end
+
+          it 'links the provider to the firm' do
+            expect { subject }.not_to change { Firm.count }
+            provider = Provider.find_by(username: username)
+            expect(provider.firm).to eq firm
+          end
+
+          it 'does not add any offices' do
+            expect { subject }.not_to change { Office.count }
+          end
+        end
+
+        context 'firm and some offices pre-exist' do
+          before do
+            create_office firm, '81333', '8B869F'
+          end
+          let(:firm) { create_firm }
+          let(:response_body) { johnny_depp_response.to_json }
+
+          it 'creates the provider' do
+            expect { subject }.to change { Provider.count }.by(1)
+            expect(Provider.exists?(username: username)).to be true
+          end
+
+          it 'links the provider to the firm' do
+            expect { subject }.not_to change { Firm.count }
+            provider = Provider.find_by(username: username)
+            expect(provider.firm).to eq firm
+          end
+
+          it 'creates the additional offices' do
+            expect { subject }.to change { Office.count }.by(1)
+            expect(firm.reload.offices.map(&:code)).to match_array(%w[8M609S 8B869F])
+          end
+        end
+      end
+    end
+
+    def create_firm
+      Firm.create(name: 'LOCAL LAW & CO LTD', ccms_id: '24493')
+    end
+
+    def create_office(firm, ccms_id, code)
+      Office.create(firm: firm, ccms_id: ccms_id, code: code)
+    end
+
+    def johnny_depp_response
+      {
+        'providerFirmId' => 24_493,
+        'contactUserId' => 47_096,
+        'contacts' => [
+          { 'id' => 3_043_807, 'name' => 'DENISE SAIK' },
+          { 'id' => 5_870_075, 'name' => 'ISMAIL@LOCAL-LAW.COM' },
+          { 'id' => 2_047_682, 'name' => 'SSALAM@LOCAL-LAW.COM' },
+          { 'id' => 2_047_672, 'name' => 'CREID@LOCAL-LAW.COM' },
+          { 'id' => 2_047_676, 'name' => 'MGUL@LOCAL-LAW.COM' },
+          { 'id' => 3_043_805, 'name' => 'JOHNNY DEPP' },
+          { 'id' => 3_178_792, 'name' => 'DJXANKAZTAL' }
+        ],
+        'feeEarners' => [],
+        'providerOffices' => [
+          { 'id' => '146988', 'name' => 'LOCAL LAW & CO LTD-8M609S' },
+          { 'id' => '81333', 'name' => 'LOCAL LAW & CO LTD-8B869F' }
+        ]
+      }
+    end
+
+    def user_not_found_response
+      {
+        'timestamp' => '2020-07-28T10:52:01.141+0000',
+        'status' => 404,
+        'error' => 'Not Found',
+        'message' => 'No records found for [JOHNNY%20DEPP]',
+        'path' => '/api/providerDetails/JOHNNY%20DEPP'
+      }
+    end
+
+    def missing_contact_response
+      {
+        'providerFirmId' => 24_493,
+        'contactUserId' => 47_096,
+        'contacts' => [
+          { 'id' => 3_043_807, 'name' => 'DENISE SAIK' },
+          { 'id' => 5_870_075, 'name' => 'ISMAIL@LOCAL-LAW.COM' },
+          { 'id' => 2_047_682, 'name' => 'SSALAM@LOCAL-LAW.COM' },
+          { 'id' => 2_047_672, 'name' => 'CREID@LOCAL-LAW.COM' },
+          { 'id' => 2_047_676, 'name' => 'MGUL@LOCAL-LAW.COM' },
+          { 'id' => 3_178_792, 'name' => 'DJXANKAZTAL' }
+        ],
+        'feeEarners' => [],
+        'providerOffices' => [
+          { 'id' => 146_988, 'name' => 'LOCAL LAW & CO LTD-8M609S' },
+          { 'id' => 81_333, 'name' => 'LOCAL LAW & CO LTD-8B869F' }
+        ]
+      }
+    end
+
+    def additional_office_response
+      {
+        'providerFirmId' => 24_493,
+        'contactUserId' => 47_096,
+        'contacts' => [
+          { 'id' => 3_043_807, 'name' => 'DENISE SAIK' },
+          { 'id' => 5_870_075, 'name' => 'ISMAIL@LOCAL-LAW.COM' },
+          { 'id' => 2_047_682, 'name' => 'SSALAM@LOCAL-LAW.COM' },
+          { 'id' => 2_047_672, 'name' => 'CREID@LOCAL-LAW.COM' },
+          { 'id' => 2_047_676, 'name' => 'MGUL@LOCAL-LAW.COM' },
+          { 'id' => 3_043_805, 'name' => 'JOHNNY DEPP' },
+          { 'id' => 3_178_792, 'name' => 'DJXANKAZTAL' }
+        ],
+        'feeEarners' => [],
+        'providerOffices' => [
+          { 'id' => '146988', 'name' => 'LOCAL LAW & CO LTD-8M609S' },
+          { 'id' => '81333', 'name' => 'LOCAL LAW & CO LTD-8B869F' },
+          { 'id' => '81334', 'name' => 'LOCAL LAW & CO LTD-8M609X' }
+        ]
+      }
+    end
+  end
+end


### PR DESCRIPTION
## User Administration - Add users

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1316)

This PR provides a screen to add new provider users to the system.  It first checks that the username is known to CCMS by contacting the ProviderDetails API, and if it is, displays back the firm name to confirm adding.

The work is done by the `Admin::ProviderDetailsService` which has a `#check` and `#create` methods. The firm and any office records are added as required.

The old `ProviderDetailsRetriever` and `ProviderDetailsCreator` services will be retired once we switch over to using the new method of adding users.

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
