### PR TITLE
FIX: Update check_passported_answers event

### DIFF
--- a/app/models/concerns/passported_state_machine.rb
+++ b/app/models/concerns/passported_state_machine.rb
@@ -17,6 +17,7 @@ class PassportedStateMachine < BaseStateMachine # rubocop:disable Metrics/ClassL
       transitions from: %i[
         provider_entering_means
         delegated_functions_used
+        provider_entering_merits
       ],
                   to: :checking_passported_answers
     end


### PR DESCRIPTION
## What

Allow transitioning, via the back button (presumably) from provider_entering_merits

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
