### PR TITLE
AP-1315 Remove details_response from Provider

### DIFF
--- a/app/services/provider_details_creator.rb
+++ b/app/services/provider_details_creator.rb
@@ -13,7 +13,6 @@ class ProviderDetailsCreator
   def call
     provider.update!(
       firm: firm,
-      details_response: provider_details,
       offices: offices,
       name: provider_name,
       user_login_id: contact_user_id

--- a/db/migrate/20200803154318_remove_details_response_from_providers.rb
+++ b/db/migrate/20200803154318_remove_details_response_from_providers.rb
@@ -1,0 +1,5 @@
+class RemoveDetailsResponseFromProviders < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :providers, :details_response, :json
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_29_140115) do
+ActiveRecord::Schema.define(version: 2020_08_03_154318) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -567,7 +567,6 @@ ActiveRecord::Schema.define(version: 2020_07_29_140115) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.text "office_codes"
-    t.json "details_response"
     t.uuid "firm_id"
     t.uuid "selected_office_id"
     t.string "name"


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1315)

The field `details_response` is no longer needed on the `Provider` model. This PR removes it and any references to it in code.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
