### PR TITLE
Fix AASM deprecation warning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ ruby '2.6.3'
 
 gem 'aasm', '~> 5.1.0'
 gem 'active_model_serializers', '~> 0.10.10'
+gem 'after_commit_everywhere', '~> 0.1', '>= 0.1.5'
 gem 'geckoboard-ruby'
 gem 'govuk_notify_rails', '~> 2.1.2'
 gem 'loofah', '>= 2.2.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,6 +76,8 @@ GEM
       zeitwerk (~> 2.2, >= 2.2.2)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
+    after_commit_everywhere (0.1.5)
+      activerecord (>= 4.2)
     akami (1.3.1)
       gyoku (>= 0.4.0)
       nokogiri
@@ -597,6 +599,7 @@ DEPENDENCIES
   aasm (~> 5.1.0)
   active_model_serializers (~> 0.10.10)
   addressable
+  after_commit_everywhere (~> 0.1, >= 0.1.5)
   awesome_print (~> 1.8.0)
   aws-sdk-s3
   better_errors (>= 2.7.1)


### PR DESCRIPTION
## What

Following a bump of the `aasm` gem from `5.0.8` to `5.1.0`, the following warning is displayed:

```
[DEPRECATION] :after_commit AASM callback is not safe in terms of race conditions and redundant calls.
              Please add `gem 'after_commit_everywhere', '~> 0.1', '>= 0.1.5'` to your Gemfile in order to fix that.
```

This commit adds the `after_commit_everywhere` gem as recommended.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
