### PR TITLE
AP-1592: Ensure provider contact ID presence

### DIFF
--- a/app/services/provider_details_creator.rb
+++ b/app/services/provider_details_creator.rb
@@ -15,7 +15,8 @@ class ProviderDetailsCreator
       firm: firm,
       offices: offices,
       name: provider_name,
-      user_login_id: contact_user_id
+      user_login_id: contact_user_id,
+      contact_id: contact_id
     )
     provider.update!(selected_office: nil) if should_clear_selected_office?
   end
@@ -64,6 +65,14 @@ class ProviderDetailsCreator
 
   def contact_user_id
     provider_details[:contactUserId]
+  end
+
+  def contact_id
+    provider_details[:contacts].map { |contact| contact[:id] if provider_details_match(contact) }.compact.first
+  end
+
+  def provider_details_match(contact)
+    [provider.name&.upcase, provider.email&.upcase].include?(contact[:name]&.upcase)
   end
 
   def provider_details


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1592)

Update the ProviderDetailsCreator to add methods to set the contact_id for the provider.  Having read the README and
looking at the SamlSessionsController, I think this will update details each
time a user logs in.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
