### PR TITLE
AP1555 Show expanded detail only for citizen on the types of income and outgoing pages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN apk --no-cache add --virtual build-dependencies \
 #  # Install kubectl
 # RUN curl -LO /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl
 RUN echo $KUBECTL_VERSION
-RUN curl -Lo /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl
+RUN curl -Lo --retry 3 --retry-delay 3 /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl
 
 # Ensure everything is executable
 RUN chmod +x /usr/local/bin/*

--- a/app/views/citizens/identify_types_of_incomes/show.html.erb
+++ b/app/views/citizens/identify_types_of_incomes/show.html.erb
@@ -1,6 +1,7 @@
 <%= page_template page_title: t('.page_heading'), template: :basic, show_errors_for: @legal_aid_application do %>
   <%= render(
         'shared/forms/types_of_income_form',
+        journey: :citizen,
         form_path: citizens_identify_types_of_income_path
       ) %>
 <% end %>

--- a/app/views/citizens/identify_types_of_outgoings/show.html.erb
+++ b/app/views/citizens/identify_types_of_outgoings/show.html.erb
@@ -1,6 +1,7 @@
 <%= page_template page_title: t('.page_heading'), template: :basic, show_errors_for: @legal_aid_application do %>
   <%= render(
         'shared/forms/identify_types_of_outgoings_form',
+        journey: :citizen,
         form_path: citizens_identify_types_of_outgoing_path
       ) %>
 <% end %>

--- a/app/views/providers/identify_types_of_incomes/show.html.erb
+++ b/app/views/providers/identify_types_of_incomes/show.html.erb
@@ -1,6 +1,7 @@
 <%= page_template page_title: t('.page_heading'), template: :basic, show_errors_for: @legal_aid_application do %>
   <%= render(
         'shared/forms/types_of_income_form',
+        journey: :provider,
         form_path: providers_legal_aid_application_identify_types_of_income_path(@legal_aid_application),
         show_draft: true
       ) %>

--- a/app/views/providers/identify_types_of_outgoings/show.html.erb
+++ b/app/views/providers/identify_types_of_outgoings/show.html.erb
@@ -1,6 +1,7 @@
 <%= page_template page_title: t('.page_heading'), template: :basic, show_errors_for: @legal_aid_application do %>
   <%= render(
         'shared/forms/identify_types_of_outgoings_form',
+        journey: :provider,
         form_path: providers_legal_aid_application_identify_types_of_outgoing_path(@legal_aid_application),
         show_draft: true
       ) %>

--- a/app/views/shared/forms/_identify_types_of_outgoings_form.html.erb
+++ b/app/views/shared/forms/_identify_types_of_outgoings_form.html.erb
@@ -28,20 +28,22 @@
     </fieldset>
   <% end %>
 
-  <details class="govuk-details govuk-!-margin-top-4" data-module="govuk-details">
-    <summary class="govuk-details__summary">
-          <span class="govuk-details__summary-text">
-            <%= t('.expanded_explanation.heading') %>
-          </span>
-    </summary>
+  <% if journey == :citizen %>
+    <details class="govuk-details govuk-!-margin-top-4" data-module="govuk-details">
+      <summary class="govuk-details__summary">
+            <span class="govuk-details__summary-text">
+              <%= t('.expanded_explanation.heading') %>
+            </span>
+      </summary>
 
-    <div class="govuk-details__text">
-      <% t('.expanded_explanation.list').each_line do |para| %>
-        <p>
-          <%= para %>
-      <% end %>
-    </div>
-  </details>
+      <div class="govuk-details__text">
+        <% t('.expanded_explanation.list').each_line do |para| %>
+          <p>
+            <%= para %>
+        <% end %>
+      </div>
+    </details>
+  <% end %>
 
   <%= next_action_buttons(
         show_draft: local_assigns.key?(:show_draft) ? show_draft : false,

--- a/app/views/shared/forms/_types_of_income_form.html.erb
+++ b/app/views/shared/forms/_types_of_income_form.html.erb
@@ -33,20 +33,22 @@
     </fieldset>
   <% end %>
 
-  <details class="govuk-details govuk-!-margin-top-4" data-module="govuk-details">
-    <summary class="govuk-details__summary">
-          <span class="govuk-details__summary-text">
-            <%= t('.expanded_explanation.heading') %>
-          </span>
-    </summary>
+  <% if journey == :citizen %>
+    <details class="govuk-details govuk-!-margin-top-4" data-module="govuk-details">
+      <summary class="govuk-details__summary">
+            <span class="govuk-details__summary-text">
+              <%= t('.expanded_explanation.heading') %>
+            </span>
+      </summary>
 
-    <div class="govuk-details__text">
-      <% t('.expanded_explanation.list').each_line do |para| %>
-        <p>
-        <%= para %>
-      <% end %>
-    </div>
-  </details>
+        <div class="govuk-details__text">
+          <% t('.expanded_explanation.list').each_line do |para| %>
+            <p>
+            <%= para %>
+          <% end %>
+        </div>
+    </details>
+  <% end %>
 
   <%= next_action_buttons(
         form: form,

--- a/spec/requests/citizens/identify_types_of_incomes_spec.rb
+++ b/spec/requests/citizens/identify_types_of_incomes_spec.rb
@@ -49,6 +49,11 @@ RSpec.describe Citizens::IdentifyTypesOfIncomesController, type: :request do
       expect(unescaped_response_body).not_to include('translation missing')
     end
 
+    it 'displays expanded details list' do
+      subject
+      expect(unescaped_response_body).to match(I18n.t('shared.forms.types_of_income_form.expanded_explanation.heading'))
+    end
+
     it 'returns http success' do
       subject
       expect(response).to have_http_status(:ok)

--- a/spec/requests/citizens/identify_types_of_outgoings_spec.rb
+++ b/spec/requests/citizens/identify_types_of_outgoings_spec.rb
@@ -16,6 +16,10 @@ RSpec.describe 'IndentifyTypesOfOutgoingsController', type: :request do
       expect(response).to have_http_status(:ok)
     end
 
+    it 'displays expanded explanation' do
+      expect(unescaped_response_body).to match(I18n.t('shared.forms.identify_types_of_outgoings_form.expanded_explanation.heading'))
+    end
+
     it 'displays the outgoing type labels' do
       outgoing_types.map(&:citizens_label_name).each do |label|
         expect(unescaped_response_body).to include(label)

--- a/spec/requests/providers/identify_types_of_incomes_spec.rb
+++ b/spec/requests/providers/identify_types_of_incomes_spec.rb
@@ -28,6 +28,11 @@ RSpec.describe Providers::IdentifyTypesOfIncomesController do
       expect(unescaped_response_body).not_to include('translation missing')
     end
 
+    it 'does not display expanded details list' do
+      subject
+      expect(unescaped_response_body).not_to match(I18n.t('shared.forms.types_of_income_form.expanded_explanation.heading'))
+    end
+
     context 'when the provider is not authenticated' do
       let(:login) { nil }
       before { subject }

--- a/spec/requests/providers/identify_types_of_outgoings_spec.rb
+++ b/spec/requests/providers/identify_types_of_outgoings_spec.rb
@@ -21,6 +21,10 @@ RSpec.describe Providers::IdentifyTypesOfOutgoingsController do
       expect(unescaped_response_body).not_to include('translation missing')
     end
 
+    it 'does not display expanded explanation' do
+      expect(unescaped_response_body).not_to match(I18n.t('shared.forms.identify_types_of_outgoings_form.expanded_explanation.heading'))
+    end
+
     context 'when the provider is not authenticated' do
       let(:login) { nil }
       it_behaves_like 'a provider not authenticated'


### PR DESCRIPTION
AP1555 Show expanded detail only for citizen on the types of income and outgoing pages

## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1555)

Update types of income and outgoing pages for provider and citizen by showing expanded details for the
Citizen but not for the provider

Test the above logic

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
