### PR TITLE
AP-1557 Display correct means result when manual_check_required is set

### DIFF
--- a/app/models/cfe/base_result.rb
+++ b/app/models/cfe/base_result.rb
@@ -10,7 +10,7 @@ module CFE
     end
 
     def overview
-      return 'manual_check_required' if manual_check_required?
+      return 'manual_check_required' if manual_check_required? && legal_aid_application.has_restrictions
 
       return determine_type_of_contribution if assessment_result == 'contribution_required'
 

--- a/features/providers/civil_application_journey.feature
+++ b/features/providers/civil_application_journey.feature
@@ -432,7 +432,12 @@ Feature: Civil application journeys
     Then I select "None of these"
     Then I click 'Save and continue'
     Then I should be on a page showing "Which types of assets does your client have?"
-    Then I select "None of these"
+    Then I select "Land"
+    Then I fill "Land value" with "50000"
+    Then I click 'Save and continue'
+    Then I should be on a page showing "Are there any legal restrictions that prevent your client from selling or borrowing against their assets?"
+    Then I choose 'Yes'
+    Then I fill 'Restrictions details' with 'Yes, there are restrictions. They include...'
     Then I click 'Save and continue'
     Then I should be on the 'means_summary' page showing 'Check your answers'
     Then I click link 'View/change declared income'
@@ -478,8 +483,7 @@ Feature: Civil application journeys
     Then I click 'Save and continue'
     Then I should be on a page showing 'Check your answers'
     Then I click 'Save and continue'
-    Then I should be on a page showing 'We need to check if '
-    Then I should be on a page showing 'should pay towards legal aid'
+    Then I should be on a page showing 'may need to pay towards legal aid'
     Then I click 'Save and continue'
     Then I should be on a page showing 'Provide details of the case'
     Then I click 'Continue'

--- a/spec/models/cfe/v2/result_spec.rb
+++ b/spec/models/cfe/v2/result_spec.rb
@@ -59,8 +59,50 @@ module CFE
           end
         end
 
-        context 'manual check IS required' do
+        context 'manual check IS required and restrictions do not exist' do
           before { allow(CCMS::ManualReviewDeterminer).to receive(:call).with(application).and_return(true) }
+
+          context 'eligible' do
+            let(:cfe_result) { create :cfe_v2_result, :eligible }
+            it 'returns eligible' do
+              expect(subject).to eq 'eligible'
+            end
+          end
+
+          context 'not_eligible' do
+            let(:cfe_result) { create :cfe_v2_result, :not_eligible }
+            it 'returns not_eligible' do
+              expect(subject).to eq 'not_eligible'
+            end
+          end
+
+          context 'capital_contribution_required' do
+            let(:cfe_result) { create :cfe_v2_result, :with_capital_contribution_required }
+            it 'returns capital_contribution_required' do
+              expect(subject).to eq 'capital_contribution_required'
+            end
+          end
+
+          context 'income_contribution_required' do
+            let(:cfe_result) { create :cfe_v2_result, :with_income_contribution_required }
+            it 'returns income_contribution_required' do
+              expect(subject).to eq 'income_contribution_required'
+            end
+          end
+
+          context 'capital_and_income_contribution_required' do
+            let(:cfe_result) { create :cfe_v2_result, :with_capital_and_income_contributions_required }
+            it 'returns capital_and_income_contribution_required' do
+              expect(subject).to eq 'capital_and_income_contribution_required'
+            end
+          end
+        end
+
+        context 'manual check IS required and restrictions exist' do
+          before do
+            allow(CCMS::ManualReviewDeterminer).to receive(:call).with(application).and_return(true)
+            application.has_restrictions = true
+          end
 
           context 'eligible' do
             let(:cfe_result) { create :cfe_v2_result, :eligible }


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1557)

When the feature to require manual checking of applications is enabled, incorrect means results are displayed. The same text is always displayed regardless of the result, and refers to restrictions on assets, even if restrictions do not apply. This text should only be displayed if restrictions do apply; in all other cases the correct result text should be displayed.

To fix this, this PR amends the logic in the `overview` method of the `CFE::BaseResult` class so that `manual_check_required` is only returned when restrictions apply. In all other scenarios the correct result will be returned and the relevant text displayed on screen.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
