### PR TITLE
DAC: Update Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -352,6 +352,12 @@ jobs:
       - hold-notification:
           message: "$CIRCLE_USERNAME has a pending production approval for $CIRCLE_BRANCH"
 
+  hold_master_uat_notification:
+    executor: notification-executor
+    steps:
+      - hold-notification:
+          message: "$CIRCLE_USERNAME - ONLY APPROVE IF THIS CODE WAS NEEDED FOR DAC TESTING\n There is a pending MASTER UAT approval for $CIRCLE_BRANCH"
+
 workflows:
   version: 2
   open_pr:
@@ -385,12 +391,15 @@ workflows:
       - build_and_push:
           requires:
           - lint_checks
+      - hold_master_uat_notification:
+          requires:
+            - lint_checks
       - deploy_master_uat:
           requires:
-            - build_and_push
+            - hold_master_uat_notification
       - delete_uat_branch:
           requires:
-            - deploy_master_uat
+            - lint_checks
       - unit_tests:
           requires:
             - lint_checks
@@ -408,10 +417,11 @@ workflows:
       - hold_production_notification:
           requires:
             - deploy_staging
+            - delete_uat_branch
       - hold_production:
           type: approval
           requires:
-            - hold_production_notification
+            - deploy_staging
             - delete_uat_branch
       - deploy_production:
           requires:


### PR DESCRIPTION
## What

This does two things to the circle merge & deploy process

It makes the deploy to master UAT optional
* for the duration of the DAC tetsing we should avoid merging code
unless it is an accessibility update required for them to complete tests

* it runs the production hold notification as a stub, this allows us to
deploy to production without waiting for the message to appear in slack,
sometimes for bugfixes, we are monitoring closely and the addition 30
second delay can be excruciating.  It also mirrors the flow in CFE, but
I forgot to replicate it back when I made the original changes!


## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
