### PR TITLE
AP-1566 Display firm name to citizen

### DIFF
--- a/app/views/citizens/legal_aid_applications/index.html.erb
+++ b/app/views/citizens/legal_aid_applications/index.html.erb
@@ -8,6 +8,7 @@
     <%= current_applicant.legal_aid_application.application_ref %>
     <br>
     <b><%= t('.your_solicitor') %></b>
+    <%= current_applicant.legal_aid_application.provider.firm.name %>
   </p>
 
   <p class="govuk-body"><%= t('.we_need_to_check') %></p>

--- a/spec/requests/citizens/legal_aid_applications_spec.rb
+++ b/spec/requests/citizens/legal_aid_applications_spec.rb
@@ -77,6 +77,7 @@ RSpec.describe 'citizen home requests', type: :request do
       subject
       expect(unescaped_response_body).to include(applicant_first_name.html_safe)
       expect(unescaped_response_body).to include(applicant_last_name.html_safe)
+      expect(unescaped_response_body).to include(application.provider.firm.name.html_safe)
     end
 
     context 'if a provider is logged in' do


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1566)

Include the provider firm name on `citizens/legal_aid_applications` so that it displayed to the applicant.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
