### PR TITLE
DAC: fix master UAT deploys

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -394,6 +394,10 @@ workflows:
       - hold_master_uat_notification:
           requires:
             - lint_checks
+      - hold_master_uat:
+          type: approval
+          requires:
+            - hold_master_uat_notification
       - deploy_master_uat:
           requires:
             - hold_master_uat_notification


### PR DESCRIPTION
## What

Add hold_master_uat approval step, this allows us to hold back code changes from UAT master
I added the notification, but forgot the approval step!

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
