### PR TITLE
AP-1378 Fix colour contrast on check_benefits

### DIFF
--- a/app/assets/stylesheets/providers/legal_aid_applications.scss
+++ b/app/assets/stylesheets/providers/legal_aid_applications.scss
@@ -49,3 +49,11 @@ div.no-results {
     font-weight: 700;
   }
 }
+
+.govuk-details__summary.white_text {
+  color: white;
+}
+
+a.black_text_on_focus{
+  &:focus{ color: black; }
+}

--- a/app/views/providers/check_benefits/_how_we_checked.html.erb
+++ b/app/views/providers/check_benefits/_how_we_checked.html.erb
@@ -1,5 +1,5 @@
 <details class="govuk-details" data-module="govuk-details">
-  <summary style="color:white" class="govuk-details__summary">
+  <summary class="govuk-details__summary white_text">
    <span class="govuk-details__summary-text" id="checked-status">
     <%= t '.how_we_checked' %>
    </span>

--- a/app/views/providers/check_benefits/_use_ccms.html.erb
+++ b/app/views/providers/check_benefits/_use_ccms.html.erb
@@ -11,6 +11,6 @@
     <div>
       <%= link_to t('.apply_in_ccms'), 'https://portal.legalservices.gov.uk', class: 'govuk-button white-button', role: 'button' %>
     </div>
-    <%= link_to t('.back_to_applications'), providers_legal_aid_applications_path, class: 'govuk-body' %>
+    <%= link_to t('.back_to_applications'), providers_legal_aid_applications_path, class: 'govuk-body black_text_on_focus' %>
   <% end %>
 </div>

--- a/app/views/providers/use_ccms/show.html.erb
+++ b/app/views/providers/use_ccms/show.html.erb
@@ -9,6 +9,6 @@
     <div>
       <%= link_to t('.continue_in_ccms'), 'https://portal.legalservices.gov.uk', class: 'govuk-button white-button', role: 'button' %>
     </div>
-    <%= link_to t('.back_to_applications'), providers_legal_aid_applications_path, class: 'govuk-body' %>
+    <%= link_to t('.back_to_applications'), providers_legal_aid_applications_path, class: 'govuk-body black_text_on_focus' %>
   <% end %>
 </div>

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -186,7 +186,7 @@ en:
       how_we_checked:
         how_we_checked: How we checked your client's benefits status
         details_used: "We used the following details to check your client's benefits status with the DWP:"
-        change_client_details_html: <a href="applicant_details">Change your client's details</a> if you entered them incorrectly.   
+        change_client_details_html: <a class="black_text_on_focus" href="applicant_details">Change your client's details</a> if you entered them incorrectly.
       use_ccms:
         accept_only: We currently only accept applications for people receiving one of these benefits.
         apply_in_ccms: Apply using CCMS


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1378)

On `/check_benefits`, there are two places where, when a link has focus, white text is displayed on a yellow background. This contrast is not accessible.

There are two different solutions to fix these:

1) remove inline styling from the `govuk-details__summary` in the `_how_we_checked partial` which was setting the text colour to white, and replace it with CSS. This styling has lower precedence and allows the inherited black colour to be used as expected when the element has focus.

2) add a CSS class to style links as black when they have focus, and add this in the relevant places.

In addition to fixing the two identified issues in the ticket, this also fixes them in two additional places - on the `Back to my applications` links on the `use_ccms` screens after a failed benefit check (on the passported only journey) and if consent to online banking is not given.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
