### PR TITLE
FIX: Update ProviderDetailsCreator

### DIFF
--- a/app/services/provider_details_creator.rb
+++ b/app/services/provider_details_creator.rb
@@ -72,7 +72,7 @@ class ProviderDetailsCreator
   end
 
   def provider_details_match(contact)
-    [provider.name&.upcase, provider.email&.upcase].include?(contact[:name]&.upcase)
+    [provider.name&.upcase, provider.email&.upcase, provider.username&.upcase].include?(contact[:name]&.upcase)
   end
 
   def provider_details

--- a/spec/services/provider_details_creator_spec.rb
+++ b/spec/services/provider_details_creator_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe ProviderDetailsCreator do
   let(:provider) { create :provider, name: Faker::Name.name }
   let(:other_provider) { create :provider, name: nil, email: Faker::Internet.safe_email }
+  let(:third_provider) { create :provider, name: nil, email: nil }
   let(:ccms_firm) { OpenStruct.new(id: rand(1..1000), name: Faker::Company.name) }
   let(:ccms_office_1) { OpenStruct.new(id: rand(1..100), code: random_vendor_code) }
   let(:ccms_office_2) { OpenStruct.new(id: rand(101..200), code: random_vendor_code) }
@@ -19,6 +20,10 @@ RSpec.describe ProviderDetailsCreator do
         {
           id: rand(101..200),
           name: other_provider.email
+        },
+        {
+          id: rand(101..200),
+          name: third_provider.username
         }
       ],
       feeEarners: [],
@@ -67,6 +72,16 @@ RSpec.describe ProviderDetailsCreator do
     context 'when the names match' do
       it 'updates the contact_id of the provider' do
         expect { subject }.to change { provider.reload.contact_id }.to(api_response[:contacts][0][:id])
+      end
+    end
+
+    context 'when the username matches' do
+      before { allow(ProviderDetailsRetriever).to receive(:call).with(third_provider.username).and_return(api_response) }
+
+      subject { described_class.call(third_provider) }
+
+      it 'updates the contact_id of the provider' do
+        expect { subject }.to change { third_provider.reload.contact_id }.to(api_response[:contacts][2][:id])
       end
     end
 


### PR DESCRIPTION
## What

The data returned from the providerDetails API is inconsistent and doesn't always match the MockProviderDetailsRetriever 
Sometimes it returns an encoded name that we store as `provider.name` e.g. FIRST%20LAST_NAME, sometimes it's a value we store as `provider.email` and, it appears, sometimes it's a value we store as `provider.username`

This solution should match any of the local values we store to ensure the record gets updated on login

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
