### PR TITLE
AP1562 Proceeding Types: Inform screen reader users to tab out of serach box to see results

### DIFF
--- a/app/javascript/src/modules/proceedings.js
+++ b/app/javascript/src/modules/proceedings.js
@@ -83,6 +83,10 @@ function filterData(inputText, search) {
         const parent = $('#proceeding-list')
         element.detach().prependTo(parent)
         element.show()
+
+        // the below alerts screen reader users that results appeared on the page
+        const accessibilityAlertMessage = document.querySelector("#proceedingTypes").dataset.message
+        document.querySelector("#proceedingTypes").innerHTML = accessibilityAlertMessage
       })
     }
     else {

--- a/app/views/providers/proceedings_types/index.html.erb
+++ b/app/views/providers/proceedings_types/index.html.erb
@@ -14,7 +14,7 @@
       <%= t '.heading_2' %>
       <span class="govuk-hint govuk-!-margin-top-0">
         <%= t '.search_help_example' %>
-        <span class="govuk-visually-hidden" id="proceedingTypes" role="alert" data-message="<%= t '.accessibility_message' %>"></span>
+        <span class="govuk-visually-hidden" id="proceedingTypes" role="alert" aria-live="assertive" data-message="<%= t '.accessibility_message' %>"></span>
       </span>
     </label>
   </h2>
@@ -22,7 +22,7 @@
   <div class="govuk-grid-row search-field govuk-!-margin-top-0">
     <div class="govuk-grid-column-two-thirds govuk-!-margin-top-0">
       <%= govuk_error_message(error_message) %>
-      <input class="govuk-input <%= input_error_class %>" id="proceeding-search-input" name="proceeding-search-input" type="text">
+      <input class="govuk-input <%= input_error_class %>" id="proceeding-search-input" name="proceeding-search-input" type="text" aria-label="<%= t '.accessibility_message_safari_browser' %>">
     </div>
 
     <div class="govuk-grid-column-one-third govuk-!-margin-top-2 clear-search">

--- a/app/views/providers/proceedings_types/index.html.erb
+++ b/app/views/providers/proceedings_types/index.html.erb
@@ -14,6 +14,7 @@
       <%= t '.heading_2' %>
       <span class="govuk-hint govuk-!-margin-top-0">
         <%= t '.search_help_example' %>
+        <span class="govuk-visually-hidden" id="proceedingTypes" role="alert" data-message="<%= t '.accessibility_message' %>"></span>
       </span>
     </label>
   </h2>

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -489,6 +489,7 @@ en:
         no_results: No results found.
         proceeding: proceeding
         search_help_example: For example, 'non-molestation order', or search by category of law or matter type
+        accessibility_message: Tab out of this box to select returned options
         you_have_selected: You have selected %{count}
     property_values:
       hint:

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -490,6 +490,7 @@ en:
         proceeding: proceeding
         search_help_example: For example, 'non-molestation order', or search by category of law or matter type
         accessibility_message: Tab out of this box to select returned options
+        accessibility_message_safari_browser: "You are in a search field, tab out to see results"
         you_have_selected: You have selected %{count}
     property_values:
       hint:


### PR DESCRIPTION
AP1562 Proceeding Types: Inform screen reader users to tab out of serach box to see results

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1562)

- Add a span tag with class attribute 'govuk-visually-hidden' and a role attribute with alert.

- Update the span tag with javascript when proceeding types result is returned. This causes the role alert to alert a screen reader that a change has been made and reads out the message to tab out of the search box when results appear below the search box.

The above should work for Chrome and JAWS users etc.

**Extra for Safari browser:**

The Safari browser doesn’t alert messages when the focus is on the search box - Not to my knowledge. Instead it reads out the content of the input field and overrides any alerts / role='alert' 

Similar to this [accessibility test](https://a11ysupport.io/tests/tech__aria__aria_describedby_with_role_alert#assertion-aria-aria-describedby_attribute-convey_value_if_valid-html-input(type-text)_element-vo_macos-safari)

I overcame this by adding an aria-label to the search box

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
