### PR TITLE
AP-1223 Add hint text to email field

### DIFF
--- a/app/views/providers/email_addresses/show.html.erb
+++ b/app/views/providers/email_addresses/show.html.erb
@@ -14,7 +14,8 @@
 
     <%= form.govuk_text_field(
           :email,
-          class: 'govuk-!-width-three-quarters'
+          class: 'govuk-!-width-three-quarters',
+          hint: t('.hint')
         ) %>
 
     <div class="govuk-!-padding-bottom-2"></div>

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -674,6 +674,7 @@ en:
     email_addresses:
       show:
         page_title: Enter your client's email address
+        hint: We'll use this to send your client a link to the service.
     has_dependants:
       show:
         page_title: "Does your client have any dependants?"

--- a/features/providers/civil_application_journey.feature
+++ b/features/providers/civil_application_journey.feature
@@ -146,6 +146,7 @@ Feature: Civil application journeys
     Then I choose 'Yes'
     Then I click 'Save and continue'
     Then I should be on a page showing "Enter your client's email address"
+    Then I should be on a page showing "We'll use this to send your client a link to the service."
     Then I fill 'email' with 'test@test.com'
     Then I click 'Save and continue'
     Then I am on the About the Financial Assessment page


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1223)

Add hint text to the field used by solicitors to enter their client's email address by adding it to the translation file and form.


## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
