### PR TITLE
AP-1575 Add hint text to bank selection screen

### DIFF
--- a/app/views/citizens/banks/index.html.erb
+++ b/app/views/citizens/banks/index.html.erb
@@ -5,7 +5,7 @@
   <%= form_with(local: true) do |form| %>
     <%= govuk_form_group(show_error_if: @error) do %>
       <h1 class="govuk-heading-xl"><%= content_for(:page_title) %></h1>
-
+      <%= govuk_hint t('.hint') %>
       <div class="govuk-radios bank-selection">
         <%= render partial: 'bank', collection: TrueLayerBank.available_banks, locals: { form: form } %>
       </div>

--- a/config/locales/en/citizens.yml
+++ b/config/locales/en/citizens.yml
@@ -26,6 +26,7 @@ en:
         title: Select your bank
         what_happens_next: What happens next
         connect: We'll connect you to your bank using a secure service so you can share your bank transactions with us.
+        hint: Select one bank at a time. You'll be able to select more later if you have accounts with different banks.
       create:
         error: Select a bank
     check_answers:

--- a/features/citizens/citizens.feature
+++ b/features/citizens/citizens.feature
@@ -12,6 +12,7 @@ Feature: Citizen journey
     Then I choose 'Yes'
     Then I click 'Continue'
     Then I should be on a page showing 'Select your bank'
+    Then I should be on a page showing "Select one bank at a time. You'll be able to select more later if you have accounts with different banks."
     Then I click link "Back"
     Then I should be on a page showing 'Do you agree to share your bank account information with the LAA?'
     Then I choose 'No'


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1575)

Add hint to text to bank selection screen so that the citizen is clear what they need to do. This PR adds the relevant text to the translation file and changes the view to display it.


## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
