### PR TITLE
BugFix: Prometheus alerts

### DIFF
--- a/helm_deploy/prometheus/prometheus-alerts-production.yaml
+++ b/helm_deploy/prometheus/prometheus-alerts-production.yaml
@@ -1,0 +1,84 @@
+#
+# -- Prometheus Alerts --
+# Alerts are set manually for each namespace with this command:
+# kubectl apply -f helm_deploy/prometheus/prometheus-alerts-production.yaml -n laa-apply-for-legalaid-production
+#
+# you can see current alerts of a namespace with the command:
+# kubectl describe prometheusrule -n laa-apply-for-legalaid-production
+#
+# CloudPlatform has set alerts to be forwarded to slack via the `severity` attribute.
+#
+#  severity                    | slack channel
+#  ---------------------------------------------------
+#  apply-for-legal-aid-prod    | #apply-alerts-prod
+#  apply-for-legal-aid-staging | #apply-alerts-staging
+#  apply-for-legal-aid-uat     | #apply-alerts-uat
+#
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  namespace: laa-apply-for-legalaid-production
+  labels:
+    role: alert-rules
+  name: prometheus-custom-rules-laa-apply-for-legal-aid
+spec:
+  groups:
+  - name: application-rules
+    rules:
+    - alert: Instance-Down
+      expr: absent(up{namespace="laa-apply-for-legalaid-production"}) == 1
+      for: 1m
+      labels:
+        severity: apply-for-legal-aid-prod
+    - alert: Quota-Exceeded
+      expr: 100 * kube_resourcequota{job="kube-state-metrics",type="used",namespace="laa-apply-for-legalaid-production"} / ignoring(instance, job, type) (kube_resourcequota{job="kube-state-metrics",type="hard",namespace="laa-apply-for-legalaid-production"} > 0) > 90
+      for: 1m
+      labels:
+        severity: apply-for-legal-aid-prod
+      annotations:
+        message: Namespace {{ $labels.namespace }} is using {{ printf "%0.0f" $value}}% of its {{ $labels.resource }} quota.
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubequotaexceeded
+    - alert: NotFound-Threshold-Reached
+      expr: sum(rate(ruby_http_requests_total{status="404", namespace="laa-apply-for-legalaid-production"}[86400s])) * 86400 > 100
+      for: 1m
+      labels:
+        severity: apply-for-legal-aid-prod
+      annotations:
+        message: More than one hundred 404 errors in one day
+        runbook_url: https://kibana.apps.cloud-platform-live-0.k8s.integration.dsd.io/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-24h,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:ec9109a0-2b35-11e9-ac82-95e56bd45b02,key:kubernetes.namespace_name,negate:!f,params:(query:laa-apply-for-legalaid-production,type:phrase),type:phrase,value:laa-apply-for-legalaid-production),query:(match:(kubernetes.namespace_name:(query:laa-apply-for-legalaid-production,type:phrase))))),index:ec9109a0-2b35-11e9-ac82-95e56bd45b02,interval:auto,query:(language:lucene,query:'log:%22RoutingError%22'),sort:!('@timestamp',desc))
+    - alert: nginx-5xx-error
+      expr: sum(rate(nginx_ingress_controller_requests{exported_namespace="laa-apply-for-legalaid-production", status=~"5.."}[5m]))*270 > 0
+      for: 1m
+      labels:
+        severity: apply-for-legal-aid-prod
+      annotations:
+        message: An HTTP 5xx error has occurred
+        runbook_url: https://kibana.cloud-platform.service.justice.gov.uk/_plugin/kibana/app/kibana#/discover?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-24h,to:now))&_a=(columns:!(log_processed.status,log_processed.http_referer,log_processed.request_uri),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',key:log_processed.kubernetes_namespace,negate:!f,params:(query:laa-apply-for-legalaid-production),type:phrase,value:laa-apply-for-legalaid-production),query:(match:(log_processed.kubernetes_namespace:(query:laa-apply-for-legalaid-production,type:phrase)))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',key:log_processed.status,negate:!f,params:(query:'500'),type:phrase,value:'500'),query:(match:(log_processed.status:(query:'500',type:phrase))))),index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',interval:auto,query:(language:lucene,query:''),sort:!(!('@timestamp',desc)))
+    - alert: SidekiqQueueSize-Threshold-Reached
+      expr: sum(ruby_sidekiq_queue_size{namespace="laa-apply-for-legalaid-production"}) > 10
+      for: 1m
+      labels:
+        severity: apply-for-legal-aid-prod
+      annotations:
+        message: Sidekiq queue size is more than 10
+    - alert: SidekiqQueue-absent
+      expr: absent(ruby_sidekiq_queue_size{namespace="laa-apply-for-legalaid-production"})
+      for: 1m
+      labels:
+        severity: apply-for-legal-aid-prod
+      annotations:
+        message: Sidekiq queue size is not reported, cronjob may not be submitting metrics
+    - alert: DiskSpace-Threshold-Reached
+      expr: container_fs_usage_bytes{namespace="laa-apply-for-legalaid-production"} / 1024 / 1024 > 150 or absent(container_fs_usage_bytes{namespace="laa-apply-for-legalaid-production"})
+      for: 1m
+      labels:
+        severity: apply-for-legal-aid-prod
+      annotations:
+        message: Container disk space usage is more than 150Mb or is not reported
+    - alert: Long-Request
+      expr: ruby_http_duration_seconds{namespace="laa-apply-for-legalaid-production"} > 2
+      for: 1m
+      labels:
+        severity: apply-for-legal-aid-prod
+      annotations:
+        message: Request is taking more than 2 seconds

--- a/helm_deploy/prometheus/prometheus-alerts-staging.yaml
+++ b/helm_deploy/prometheus/prometheus-alerts-staging.yaml
@@ -1,0 +1,84 @@
+#
+# -- Prometheus Alerts --
+# Alerts are set manually for each namespace with this command:
+# kubectl apply -f helm_deploy/prometheus/prometheus-alerts-staging.yaml -n laa-apply-for-legalaid-staging
+#
+# you can see current alerts of a namespace with the command:
+# kubectl describe prometheusrule -n laa-apply-for-legalaid-staging
+#
+# CloudPlatform has set alerts to be forwarded to slack via the `severity` attribute.
+#
+#  severity                    | slack channel
+#  ---------------------------------------------------
+#  apply-for-legal-aid-prod    | #apply-alerts-prod
+#  apply-for-legal-aid-staging | #apply-alerts-staging
+#  apply-for-legal-aid-uat     | #apply-alerts-uat
+#
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  namespace: laa-apply-for-legalaid-staging
+  labels:
+    role: alert-rules
+  name: prometheus-custom-rules-laa-apply-for-legal-aid
+spec:
+  groups:
+  - name: application-rules
+    rules:
+    - alert: Instance-Down
+      expr: absent(up{namespace="laa-apply-for-legalaid-staging"}) == 1
+      for: 1m
+      labels:
+        severity: apply-for-legal-aid-staging
+    - alert: Quota-Exceeded
+      expr: 100 * kube_resourcequota{job="kube-state-metrics",type="used",namespace="laa-apply-for-legalaid-staging"} / ignoring(instance, job, type) (kube_resourcequota{job="kube-state-metrics",type="hard",namespace="laa-apply-for-legalaid-staging"} > 0) > 90
+      for: 1m
+      labels:
+        severity: apply-for-legal-aid-staging
+      annotations:
+        message: Namespace {{ $labels.namespace }} is using {{ printf "%0.0f" $value}}% of its {{ $labels.resource }} quota.
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubequotaexceeded
+    - alert: NotFound-Threshold-Reached
+      expr: sum(rate(ruby_http_requests_total{status="404", namespace="laa-apply-for-legalaid-staging"}[86400s])) * 86400 > 100
+      for: 1m
+      labels:
+        severity: apply-for-legal-aid-staging
+      annotations:
+        message: More than one hundred 404 errors in one day
+        runbook_url: https://kibana.apps.cloud-platform-live-0.k8s.integration.dsd.io/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-24h,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:ec9109a0-2b35-11e9-ac82-95e56bd45b02,key:kubernetes.namespace_name,negate:!f,params:(query:laa-apply-for-legalaid-staging,type:phrase),type:phrase,value:laa-apply-for-legalaid-staging),query:(match:(kubernetes.namespace_name:(query:laa-apply-for-legalaid-staging,type:phrase))))),index:ec9109a0-2b35-11e9-ac82-95e56bd45b02,interval:auto,query:(language:lucene,query:'log:%22RoutingError%22'),sort:!('@timestamp',desc))
+    - alert: nginx-5xx-error
+      expr: sum(rate(nginx_ingress_controller_requests{exported_namespace="laa-apply-for-legalaid-staging", status=~"5.."}[5m]))*270 > 0
+      for: 1m
+      labels:
+        severity: apply-for-legal-aid-staging
+      annotations:
+        message: An HTTP 5xx error has occurred
+        runbook_url: https://kibana.cloud-platform.service.justice.gov.uk/_plugin/kibana/app/kibana#/discover?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-24h,to:now))&_a=(columns:!(log_processed.status,log_processed.http_referer,log_processed.request_uri),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',key:log_processed.kubernetes_namespace,negate:!f,params:(query:laa-apply-for-legalaid-staging),type:phrase,value:laa-apply-for-legalaid-staging),query:(match:(log_processed.kubernetes_namespace:(query:laa-apply-for-legalaid-staging,type:phrase)))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',key:log_processed.status,negate:!f,params:(query:'500'),type:phrase,value:'500'),query:(match:(log_processed.status:(query:'500',type:phrase))))),index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',interval:auto,query:(language:lucene,query:''),sort:!(!('@timestamp',desc)))
+    - alert: SidekiqQueueSize-Threshold-Reached
+      expr: sum(ruby_sidekiq_queue_size{namespace="laa-apply-for-legalaid-staging"}) > 10
+      for: 1m
+      labels:
+        severity: apply-for-legal-aid-staging
+      annotations:
+        message: Sidekiq queue size is more than 10
+    - alert: SidekiqQueue-absent
+      expr: absent(ruby_sidekiq_queue_size{namespace="laa-apply-for-legalaid-staging"})
+      for: 1m
+      labels:
+        severity: apply-for-legal-aid-staging
+      annotations:
+        message: Sidekiq queue size is not reported, cronjob may not be submitting metrics
+    - alert: DiskSpace-Threshold-Reached
+      expr: container_fs_usage_bytes{namespace="laa-apply-for-legalaid-staging"} / 1024 / 1024 > 150 or absent(container_fs_usage_bytes{namespace="laa-apply-for-legalaid-staging"})
+      for: 1m
+      labels:
+        severity: apply-for-legal-aid-staging
+      annotations:
+        message: Container disk space usage is more than 150Mb or is not reported
+    - alert: Long-Request
+      expr: ruby_http_duration_seconds{namespace="laa-apply-for-legalaid-staging"} > 2
+      for: 1m
+      labels:
+        severity: apply-for-legal-aid-staging
+      annotations:
+        message: Request is taking more than 2 seconds

--- a/helm_deploy/prometheus/prometheus-alerts-uat.yaml
+++ b/helm_deploy/prometheus/prometheus-alerts-uat.yaml
@@ -1,10 +1,10 @@
 #
 # -- Prometheus Alerts --
 # Alerts are set manually for each namespace with this command:
-# kubectl apply -f helm_deploy/prometheus-alerts.yaml -n laa-apply-for-legalaid-production
+# kubectl apply -f helm_deploy/prometheus-alerts.yaml -n laa-apply-for-legalaid-uat
 #
 # you can see current alerts of a namespace with the command:
-# kubectl describe prometheusrule -n laa-apply-for-legalaid-production
+# kubectl describe prometheusrule -n laa-apply-for-legalaid-uat
 #
 # CloudPlatform has set alerts to be forwarded to slack via the `severity` attribute.
 #
@@ -17,7 +17,7 @@
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
-  namespace: laa-apply-for-legalaid-production
+  namespace: laa-apply-for-legalaid-uat
   labels:
     role: alert-rules
   name: prometheus-custom-rules-laa-apply-for-legal-aid
@@ -26,58 +26,59 @@ spec:
   - name: application-rules
     rules:
     - alert: Instance-Down
-      expr: absent(up{namespace="laa-apply-for-legalaid-production"}) == 1
+      expr: absent(up{namespace="laa-apply-for-legalaid-uat"}) == 1
       for: 1m
       labels:
-        severity: apply-for-legal-aid-prod
+        severity: apply-for-legal-aid-uat
     - alert: Quota-Exceeded
-      expr: 100 * kube_resourcequota{job="kube-state-metrics",type="used",namespace="laa-apply-for-legalaid-production"} / ignoring(instance, job, type) (kube_resourcequota{job="kube-state-metrics",type="hard",namespace="laa-apply-for-legalaid-production"} > 0) > 90
+      expr: 100 * kube_resourcequota{job="kube-state-metrics",type="used",namespace="laa-apply-for-legalaid-uat"} / ignoring(instance, job, type) (kube_resourcequota{job="kube-state-metrics",type="hard",namespace="laa-apply-for-legalaid-uat"} > 0) > 90
       for: 1m
       labels:
-        severity: apply-for-legal-aid-prod
+        severity: apply-for-legal-aid-uat
       annotations:
         message: Namespace {{ $labels.namespace }} is using {{ printf "%0.0f" $value}}% of its {{ $labels.resource }} quota.
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubequotaexceeded
     - alert: NotFound-Threshold-Reached
-      expr: sum(rate(ruby_http_requests_total{status="404", namespace="laa-apply-for-legalaid-production"}[86400s])) * 86400 > 100
+      expr: sum(rate(ruby_http_requests_total{status="404", namespace="laa-apply-for-legalaid-uat"}[86400s])) * 86400 > 100
       for: 1m
       labels:
-        severity: apply-for-legal-aid-prod
+        severity: apply-for-legal-aid-uat
       annotations:
         message: More than one hundred 404 errors in one day
         runbook_url: https://kibana.apps.cloud-platform-live-0.k8s.integration.dsd.io/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-24h,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:ec9109a0-2b35-11e9-ac82-95e56bd45b02,key:kubernetes.namespace_name,negate:!f,params:(query:laa-apply-for-legalaid-uat,type:phrase),type:phrase,value:laa-apply-for-legalaid-uat),query:(match:(kubernetes.namespace_name:(query:laa-apply-for-legalaid-uat,type:phrase))))),index:ec9109a0-2b35-11e9-ac82-95e56bd45b02,interval:auto,query:(language:lucene,query:'log:%22RoutingError%22'),sort:!('@timestamp',desc))
     - alert: nginx-5xx-error
-      expr: sum(rate(nginx_ingress_controller_requests{exported_namespace="laa-apply-for-legalaid-production", status=~"5.."}[5m]))*270 > 0
+      expr: sum(rate(nginx_ingress_controller_requests{exported_namespace="laa-apply-for-legalaid-uat", status=~"5.."}[5m]))*270 > 0
       for: 1m
       labels:
-        severity: apply-for-legal-aid-prod
+        severity: apply-for-legal-aid-uat
       annotations:
         message: An HTTP 5xx error has occurred
+        runbook_url: https://kibana.cloud-platform.service.justice.gov.uk/_plugin/kibana/app/kibana#/discover?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-24h,to:now))&_a=(columns:!(log_processed.status,log_processed.http_referer,log_processed.request_uri),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',key:log_processed.kubernetes_namespace,negate:!f,params:(query:laa-apply-for-legalaid-uat),type:phrase,value:laa-apply-for-legalaid-uat),query:(match:(log_processed.kubernetes_namespace:(query:laa-apply-for-legalaid-uat,type:phrase)))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',key:log_processed.status,negate:!f,params:(query:'500'),type:phrase,value:'500'),query:(match:(log_processed.status:(query:'500',type:phrase))))),index:'71644ed0-d648-11ea-b6f0-6bf964cd13a4',interval:auto,query:(language:lucene,query:''),sort:!(!('@timestamp',desc)))
     - alert: SidekiqQueueSize-Threshold-Reached
-      expr: sum(ruby_sidekiq_queue_size{namespace="laa-apply-for-legalaid-production"}) > 10
+      expr: sum(ruby_sidekiq_queue_size{namespace="laa-apply-for-legalaid-uat"}) > 10
       for: 1m
       labels:
-        severity: apply-for-legal-aid-prod
+        severity: apply-for-legal-aid-uat
       annotations:
         message: Sidekiq queue size is more than 10
     - alert: SidekiqQueue-absent
-      expr: absent(ruby_sidekiq_queue_size{namespace="laa-apply-for-legalaid-production"})
+      expr: absent(ruby_sidekiq_queue_size{namespace="laa-apply-for-legalaid-uat"})
       for: 1m
       labels:
-        severity: apply-for-legal-aid-prod
+        severity: apply-for-legal-aid-uat
       annotations:
         message: Sidekiq queue size is not reported, cronjob may not be submitting metrics
     - alert: DiskSpace-Threshold-Reached
-      expr: container_fs_usage_bytes{namespace="laa-apply-for-legalaid-production"} / 1024 / 1024 > 150 or absent(container_fs_usage_bytes{namespace="laa-apply-for-legalaid-production"})
+      expr: container_fs_usage_bytes{namespace="laa-apply-for-legalaid-uat"} / 1024 / 1024 > 150 or absent(container_fs_usage_bytes{namespace="laa-apply-for-legalaid-uat"})
       for: 1m
       labels:
-        severity: apply-for-legal-aid-prod
+        severity: apply-for-legal-aid-uat
       annotations:
         message: Container disk space usage is more than 150Mb or is not reported
     - alert: Long-Request
-      expr: ruby_http_duration_seconds{namespace="laa-apply-for-legalaid-production"} > 2
+      expr: ruby_http_duration_seconds{namespace="laa-apply-for-legalaid-uat"} > 2
       for: 1m
       labels:
-        severity: apply-for-legal-aid-prod
+        severity: apply-for-legal-aid-uat
       annotations:
         message: Request is taking more than 2 seconds


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1456)

The previous handling of prometheus alerts was a single file, hard coded to production. If anyone wanted to make changes they had to do a search and replace for environment names and severity levels.

This resulted in a developer, new to the team, missing some of the references and alerts firing on an all environments when issues happened on live 😬 

This is step one of what should ultimately be incorporated into the helm charts and deployed each time we update stacks.
It adds a file for each of the alerting levels with names set correctly, it also adds a link to kibana for the correct environment for 500 error tracking

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
