### PR TITLE
AP1567 Add a page break before sections for print view

### DIFF
--- a/app/assets/stylesheets/helpers.scss
+++ b/app/assets/stylesheets/helpers.scss
@@ -24,3 +24,7 @@
     display: inherit !important;
   }
 }
+
+.page_break_before {
+  page-break-before: always;
+}

--- a/app/views/providers/submitted_applications/show.html.erb
+++ b/app/views/providers/submitted_applications/show.html.erb
@@ -44,6 +44,7 @@
     </section>
 
     <section class="income_payments_and_assets page_break_before">
+      <div class="govuk-!-padding-bottom-6"></div>
       <h2 class="govuk-heading-l"><%= t('.income_payments_and_assets_heading') %></h2>
       <section class="print-no-break">
         <h3 class="govuk-heading-m"><%= t('.income') %></h3>
@@ -80,6 +81,7 @@
     </section>
 
     <section class="merits page_break_before">
+      <div class="govuk-!-padding-bottom-6"></div>
       <%= render(
         'shared/check_answers/merits',
         incident: @legal_aid_application.latest_incident,
@@ -90,9 +92,8 @@
       ) %>
     </section>
 
-    <div class="govuk-!-padding-bottom-6"></div>
-
     <section id="client-declaration" class="only-print print-no-break page_break_before">
+      <div class="govuk-!-padding-bottom-6"></div>
       <h2 class="govuk-heading-l"><%= t('.client_declaration.heading') %></h2>
 
       <%= render 'shared/applicant_declaration' %>

--- a/app/views/providers/submitted_applications/show.html.erb
+++ b/app/views/providers/submitted_applications/show.html.erb
@@ -43,7 +43,7 @@
           ) %>
     </section>
 
-    <section class="income_payments_and_assets">
+    <section class="income_payments_and_assets page_break_before">
       <h2 class="govuk-heading-l"><%= t('.income_payments_and_assets_heading') %></h2>
       <section class="print-no-break">
         <h3 class="govuk-heading-m"><%= t('.income') %></h3>
@@ -79,7 +79,7 @@
       </section>
     </section>
 
-    <section class="merits">
+    <section class="merits page_break_before">
       <%= render(
         'shared/check_answers/merits',
         incident: @legal_aid_application.latest_incident,
@@ -92,7 +92,7 @@
 
     <div class="govuk-!-padding-bottom-6"></div>
 
-    <section id="client-declaration" class="only-print print-no-break">
+    <section id="client-declaration" class="only-print print-no-break page_break_before">
       <h2 class="govuk-heading-l"><%= t('.client_declaration.heading') %></h2>
 
       <%= render 'shared/applicant_declaration' %>


### PR DESCRIPTION
AP1567 Add a page break before sections for print view

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1567)

Update the print view of the submitted applications page by adding a css style page break
before certain sections: 
- Income, regular payments and assets
- merits
- client declaration (signature)

The image below shows that 'Income, regular payments and assets' heading is now on its own page rather than on the first page. This means that it's easier to read.

![image](https://user-images.githubusercontent.com/25043924/89878452-77966880-dbb9-11ea-99c3-f8c3a7e6090f.png)


## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
