### PR TITLE
AP1563 Accessibility: Abbreviation tags for screen readers

### DIFF
--- a/app/controllers/citizens/consents_controller.rb
+++ b/app/controllers/citizens/consents_controller.rb
@@ -2,7 +2,7 @@ module Citizens
   class ConsentsController < CitizenBaseController
     def show
       @form = Applicants::OpenBankingConsentForm.new(model: legal_aid_application)
-      @form.errors.add(:open_banking_consent, I18n.t('citizens.consents.show.true_layer_auth_error')) if params[:auth_failure]
+      @form.errors.add(:open_banking_consent, I18n.t('citizens.consents.show.true_layer_auth_error_html')) if params[:auth_failure]
     end
 
     def update

--- a/app/forms/applicants/open_banking_consent_form.rb
+++ b/app/forms/applicants/open_banking_consent_form.rb
@@ -13,7 +13,7 @@ module Applicants
     def open_banking_consent_presence
       return if open_banking_consent.present?
 
-      errors.add(:open_banking_consent, I18n.t('activemodel.errors.models.legal_aid_application.attributes.open_banking_consents.citizens.blank'))
+      errors.add(:open_banking_consent, I18n.t('activemodel.errors.models.legal_aid_application.attributes.open_banking_consents.citizens.blank_html'))
     end
   end
 end

--- a/app/views/admin/submitted_applications_reports/_submitted_applications.html.erb
+++ b/app/views/admin/submitted_applications_reports/_submitted_applications.html.erb
@@ -5,7 +5,7 @@
           <tr class="govuk-table__row">
             <th class="govuk-table__header" scope="col"><%= t('.applicant_name') %></th>
             <th class="govuk-table__header" scope="col"><%= t('.application_ref') %></th>
-            <th class="govuk-table__header" scope="col"><%= t('.ccms_ref') %></th>
+            <th class="govuk-table__header" scope="col"><%= t('.ccms_ref_html') %></th>
             <th class="govuk-table__header" scope="col"><%= t('.provider_firm') %></th>
             <th class="govuk-table__header" scope="col"><%= t('.provider_username') %></th>
             <th class="govuk-table__header" scope="col"><%= t('.submission_date') %></th>

--- a/app/views/citizens/consents/show.html.erb
+++ b/app/views/citizens/consents/show.html.erb
@@ -1,4 +1,4 @@
-<%= page_template page_title: t('.title') do %>
+<%= page_template page_title: t('.title_html') do %>
 <%= form_with(
       model: @form,
       url: citizens_consent_path,
@@ -16,7 +16,7 @@
       <details class="govuk-details govuk-!-margin-top-4" data-module="govuk-details">
         <summary class="govuk-details__summary">
           <span class="govuk-details__summary-text">
-            <%= t('.summary_heading') %>
+            <%= t('.summary_heading_html') %>
           </span>
         </summary>
 

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -32,7 +32,7 @@
 
           <li class="govuk-footer__inline-list-item">
             <a class="govuk-footer__link" href="https://mojdigital.blog.gov.uk/">
-              <%= t('layouts.application.footer.digital_services') %>
+              <%= t('layouts.application.footer.digital_services_html') %>
             </a>
           </li>
         </ul>

--- a/app/views/privacy_policy/index.html.erb
+++ b/app/views/privacy_policy/index.html.erb
@@ -53,7 +53,7 @@
   <h2 class="govuk-heading-m"><%= t('.rights.header') %></h2>
   <p class="govuk-body"><%= t('.rights.list_heading') %></p>
   <%= list_from_translation_path 'privacy_policy.index.rights' %>
-  <p class="govuk-body"><%= t('.rights.info') %></p>
+  <p class="govuk-body"><%= t('.rights.info_html') %></p>
 
   <p class="govuk-body">
     <%= t('.rights.data_protection_office_contact_details.title') %>
@@ -71,10 +71,10 @@
 
   <h2 class="govuk-heading-m"><%= t('.contact_or_complaint.header') %></h2>
 
-  <p class="govuk-body"><%= t('.contact_or_complaint.data_protection_office.list_heading') %></p>
+  <p class="govuk-body"><%= t('.contact_or_complaint.data_protection_office.list_heading_html') %></p>
   <%= list_from_translation_path 'privacy_policy.index.contact_or_complaint.data_protection_office' %>
 
-  <p class="govuk-body"><%= t('.contact_or_complaint.commissioner_office.list_heading') %></p>
+  <p class="govuk-body"><%= t('.contact_or_complaint.commissioner_office.list_heading_html') %></p>
   <%= list_from_translation_path 'privacy_policy.index.contact_or_complaint.commissioner_office' %>
 
   <p class="govuk-body">

--- a/app/views/providers/check_benefits/_check_benefits_result.html.erb
+++ b/app/views/providers/check_benefits/_check_benefits_result.html.erb
@@ -18,10 +18,16 @@
         </p>
         <ul class="govuk-list govuk-list--bullet">
           <li><%= t "#{result_namespace}.must_answer_financial_questions" %></li>
-          <li><%= t "#{result_namespace}.provide_access/details" %></li>
+          <li><%= t "#{result_namespace}.provide_access_html" %></li>
         </ul>
       <% else %>
+
         <%= render 'applicant_details' %>
+
+        <p class="govuk-body"><%= t "#{result_namespace}.must_answer_financial_questions" %></p>
+        <%= list_from_translation_path '.check_benefits.check_benefits_result.negative_result.actions' %>
+        <p class="govuk-body"><%= t "#{result_namespace}.provide_access_html" %></p>
+
       <% end %>
     </div>
     <%= next_action_buttons_with_form(

--- a/app/views/providers/check_benefits/_use_ccms.html.erb
+++ b/app/views/providers/check_benefits/_use_ccms.html.erb
@@ -9,7 +9,7 @@
     </div>
 
     <div>
-      <%= link_to t('.apply_in_ccms'), 'https://portal.legalservices.gov.uk', class: 'govuk-button white-button', role: 'button' %>
+      <%= link_to t('.apply_in_ccms_html'), 'https://portal.legalservices.gov.uk', class: 'govuk-button white-button', role: 'button' %>
     </div>
     <%= link_to t('.back_to_applications'), providers_legal_aid_applications_path, class: 'govuk-body black_text_on_focus' %>
   <% end %>

--- a/app/views/providers/check_benefits/_use_ccms.html.erb
+++ b/app/views/providers/check_benefits/_use_ccms.html.erb
@@ -1,5 +1,5 @@
 <div class="interruption-panel">
-  <%= page_template(page_title: t('.title'), column_width: 'full', template: :basic) do %>
+  <%= page_template(page_title: t('.title_html'), column_width: 'full', template: :basic) do %>
     <%= page_heading(size: 'l') %>
     <div class="maximize-text-width">
       <p class="govuk-body"><%= t '.we_checked' %></p>

--- a/app/views/providers/end_of_applications/show.html.erb
+++ b/app/views/providers/end_of_applications/show.html.erb
@@ -19,7 +19,7 @@
     <li><%= t('.keep_file') %></li>
   </ul>
   <p class="govuk-body"><%= t('.application_to_be_checked') %></p>
-  <p class="govuk-body"><%= t('.decision_in_ccms') %></p>
+  <p class="govuk-body"><%= t('.decision_in_ccms_html') %></p>
   <div class="govuk-inset-text">
   <p class="govuk-body govuk-!-padding-bottom-2"><%= t('.feedback_link_html', url: new_feedback_path) %></p>
   </div>

--- a/app/views/providers/legal_aid_applications/_legal_aid_applications.html.erb
+++ b/app/views/providers/legal_aid_applications/_legal_aid_applications.html.erb
@@ -5,7 +5,7 @@
         <tr class="govuk-table__row">
           <%= sort_column_th type: :alphabetic, content: t('.applicant_name'),   currently_sorted: @initial_sort[:applicant_name] %>
           <%= sort_column_th type: :date,       content: t('.created_at'),       currently_sorted: @initial_sort[:created_at],       combine_right: { at: 555, append: t('.col_and_ref') } %>
-          <%= sort_column_th type: :alphabetic, content: t('.application_ref'),  currently_sorted: @initial_sort[:applicant_ref] %>
+          <%= sort_column_th type: :alphabetic, content: t('.application_ref_html'),  currently_sorted: @initial_sort[:applicant_ref] %>
           <th class="nullcell"></th>
           <%= sort_column_th type: :alphabetic, content: t('.certificate_type'), currently_sorted: @initial_sort[:certificate_type], combine_right: { at: 555, append: t('.col_and_state') } %>
           <%= sort_column_th type: :alphabetic, content: t('.status'),           currently_sorted: @initial_sort[:status] %>

--- a/app/views/providers/open_banking_consents/show.html.erb
+++ b/app/views/providers/open_banking_consents/show.html.erb
@@ -3,7 +3,7 @@
         'shared/forms/open_banking_consents',
         form_path: providers_legal_aid_application_open_banking_consents_path(@legal_aid_application),
         info: t('.info'),
-        list: t('.list'),
+        list: t('.list_html'),
         show_draft: true
       ) %>
 <% end %>

--- a/app/views/providers/open_banking_consents/show.html.erb
+++ b/app/views/providers/open_banking_consents/show.html.erb
@@ -3,7 +3,6 @@
         'shared/forms/open_banking_consents',
         form_path: providers_legal_aid_application_open_banking_consents_path(@legal_aid_application),
         info: t('.info'),
-        list: t('.list_html'),
         show_draft: true
       ) %>
 <% end %>

--- a/app/views/providers/start/index.html.erb
+++ b/app/views/providers/start/index.html.erb
@@ -8,7 +8,7 @@
 
     <p class="govuk-body"><%= t('.domestic_violence_or_abuse_only') %></p>
 
-    <p class="govuk-body"><%= t('.use_ccms_para') %></p>
+    <p class="govuk-body"><%= t('.use_ccms_para_html') %></p>
 
     <h2 class="govuk-heading-m"><%= t('.use_ccms_list.heading') %></h2>
 

--- a/app/views/providers/submitted_applications/show.html.erb
+++ b/app/views/providers/submitted_applications/show.html.erb
@@ -6,12 +6,12 @@
         <strong><%= @legal_aid_application.applicant_full_name %></strong>
       </dd>
 
-      <dt><%= t('.case_reference') %>:</dt>
+      <dt><%= t('.case_reference_html') %>:</dt>
       <dd>
         <strong><%= @legal_aid_application.application_ref %></strong>
       </dd>
 
-      <dt><%= t('.ccms_reference') %>:</dt>
+      <dt><%= t('.ccms_reference_html') %>:</dt>
       <dd>
         <strong><%= @legal_aid_application.case_ccms_reference %></strong>
       </dd>

--- a/app/views/providers/use_ccms/show.html.erb
+++ b/app/views/providers/use_ccms/show.html.erb
@@ -1,5 +1,5 @@
 <div class="interruption-panel">
-  <%= page_template(page_title: t('.title'), column_width: 'full', template: :basic) do %>
+  <%= page_template(page_title: t('.title_html'), column_width: 'full', template: :basic) do %>
     <%= page_heading(size: 'l') %>
     <div class="maximize-text-width">
       <p class="govuk-body"><%= t '.sub_heading' %></p>
@@ -7,7 +7,7 @@
     </div>
 
     <div>
-      <%= link_to t('.continue_in_ccms'), 'https://portal.legalservices.gov.uk', class: 'govuk-button white-button', role: 'button' %>
+      <%= link_to t('.continue_in_ccms_html'), 'https://portal.legalservices.gov.uk', class: 'govuk-button white-button', role: 'button' %>
     </div>
     <%= link_to t('.back_to_applications'), providers_legal_aid_applications_path, class: 'govuk-body black_text_on_focus' %>
   <% end %>

--- a/app/views/shared/_application_ref.html.erb
+++ b/app/views/shared/_application_ref.html.erb
@@ -9,7 +9,7 @@
   </div>
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">
-      <%= t('.ccms_ref') %>
+      <%= t('.ccms_ref_html') %>
     </dt>
     <dd class="govuk-summary-list__value">
       <%= legal_aid_application.case_ccms_reference %>

--- a/app/views/shared/forms/_open_banking_consents.html.erb
+++ b/app/views/shared/forms/_open_banking_consents.html.erb
@@ -15,9 +15,8 @@
       </p>
 
       <ul class="govuk-list govuk-list--bullet">
-        <% list.each_line do |item| %>
-          <li><%= item %></li>
-        <% end %>
+        <li><%= t('providers.open_banking_consents.show.list_1') %></li>
+        <li><%= t('providers.open_banking_consents.show.list_2_html') %></li>
       </ul>
 
       <%= form.govuk_radio_button(

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -171,7 +171,7 @@ en:
               providers:
                 blank: Select yes if your client uses online banking and agrees to share their bank accounts
               citizens:
-                blank: Select yes if you agree to share your bank account information with the LAA
+                blank: "Select yes if you agree to share your bank account information with the <abbr title='Legal Aid Agency'>LAA</abbr>"
             outstanding_mortgage_amount:
               blank: Enter the outstanding mortgage amount
               greater_than_or_equal_to: Mortgage amount must be 0 or more

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -171,7 +171,7 @@ en:
               providers:
                 blank: Select yes if your client uses online banking and agrees to share their bank accounts
               citizens:
-                blank: "Select yes if you agree to share your bank account information with the <abbr title='Legal Aid Agency'>LAA</abbr>"
+                blank_html: Select yes if you agree to share your bank account information with the <abbr title='Legal Aid Agency'>LAA</abbr>
             outstanding_mortgage_amount:
               blank: Enter the outstanding mortgage amount
               greater_than_or_equal_to: Mortgage amount must be 0 or more

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -40,7 +40,7 @@ en:
       submitted_applications:
         applicant_name: Client's name
         application_ref: Case reference
-        ccms_ref: CCMS reference
+        ccms_ref_html: <abbr title='Client and Cost Management System'>CCMS</abbr> reference
         provider_firm: Provider firm
         provider_username: Provider username
         submission_date: Submission date

--- a/config/locales/en/citizens.yml
+++ b/config/locales/en/citizens.yml
@@ -57,12 +57,12 @@ en:
         they_will_check: They will check whether you qualify for legal aid by asking about your finances.
     consents:
       show:
-        title_html: "Do you agree to share your bank account information with the <abbr title='Legal Aid Agency'>LAA</abbr>?"
+        title_html: Do you agree to share your bank account information with the <abbr title='Legal Aid Agency'>LAA</abbr>?
         inset_text: We only use your financial information to support your legal aid application. We do not use it for anything else.
         summary_heading: What information will the LAA be able to see?
         true_layer_auth_error: Select yes if you agree to share your bank account information with the LAA
-        summary_heading_html: "What information will the <abbr title='Legal Aid Agency'>LAA</abbr> be able to see?"
-        true_layer_auth_error_html: "Select yes if you agree to share your bank account information with the <abbr title='Legal Aid Agency'>LAA</abbr>"
+        summary_heading_html: What information will the <abbr title='Legal Aid Agency'>LAA</abbr> be able to see?
+        true_layer_auth_error_html: Select yes if you agree to share your bank account information with the <abbr title='Legal Aid Agency'>LAA</abbr>
         able_to_see:
           heading: "We'll be able to see your:"
           list: |

--- a/config/locales/en/citizens.yml
+++ b/config/locales/en/citizens.yml
@@ -57,10 +57,12 @@ en:
         they_will_check: They will check whether you qualify for legal aid by asking about your finances.
     consents:
       show:
-        title: Do you agree to share your bank account information with the LAA?
+        title_html: "Do you agree to share your bank account information with the <abbr title='Legal Aid Agency'>LAA</abbr>?"
         inset_text: We only use your financial information to support your legal aid application. We do not use it for anything else.
         summary_heading: What information will the LAA be able to see?
         true_layer_auth_error: Select yes if you agree to share your bank account information with the LAA
+        summary_heading_html: "What information will the <abbr title='Legal Aid Agency'>LAA</abbr> be able to see?"
+        true_layer_auth_error_html: "Select yes if you agree to share your bank account information with the <abbr title='Legal Aid Agency'>LAA</abbr>"
         able_to_see:
           heading: "We'll be able to see your:"
           list: |

--- a/config/locales/en/layouts.yml
+++ b/config/locales/en/layouts.yml
@@ -13,7 +13,7 @@ en:
         contact: Contact
         cookies: Cookies
         copyright: Crown copyright
-        digital_services: MOJ Digital Services
+        digital_services_html:  "<abbr title='Ministry of Justice'>MOJ</abbr> Digital Services"
         feedback: Feedback
         open_gov_link_text: Open Government Licence v3.0
         privacy_policy: Privacy policy

--- a/config/locales/en/layouts.yml
+++ b/config/locales/en/layouts.yml
@@ -13,7 +13,7 @@ en:
         contact: Contact
         cookies: Cookies
         copyright: Crown copyright
-        digital_services_html:  "<abbr title='Ministry of Justice'>MOJ</abbr> Digital Services"
+        digital_services_html: <abbr title='Ministry of Justice'>MOJ</abbr> Digital Services
         feedback: Feedback
         open_gov_link_text: Open Government Licence v3.0
         privacy_policy: Privacy policy

--- a/config/locales/en/privacy_policy.yml
+++ b/config/locales/en/privacy_policy.yml
@@ -8,7 +8,7 @@ en:
         list:
           item_1: personal details like your name, address, date of birth, contact details and National Insurance number
           item_2: financial information to check if you qualify for legal aid
-          item_3_html: your Internet Protocol (IP) address, and details of which version of <a href="https://www.gov.uk/help/browsers">web browser</a> you used
+          item_3_html: your Internet Protocol <abbr title='Internet Protocol'>(IP)</abbr> address, and details of which version of <a href='https://www.gov.uk/help/browsers'>web browser</a> you used
           item_4_html: information on how you use the site, using <a href="https://www.gov.uk/help/cookies">cookies</a> and page tagging techniques
           item_5: any feedback you leave
       google_analytics:
@@ -50,7 +50,7 @@ en:
       where_your_data_is_processed_and_stored:
         header: Where your data is processed and stored
         info_1: We design, build and run our systems to make sure that your data is as safe as possible at all stages, both while it’s processed and when it’s stored.
-        info_2_html: All personal data is stored in the <a href="https://www.gov.uk/eu-eea">European Economic Area</a> (EEA). Google Analytics data may be transferred outside the EEA, but this cannot be used to personally identify you.
+        info_2_html: All personal data is stored in the <a href="https://www.gov.uk/eu-eea">European Economic Area</a> <abbr title='European Economic Area'>(EEA)</abbr>. Google Analytics data may be transferred outside the <abbr title='European Economic Area'>EEA</abbr>, but this cannot be used to personally identify you.
       security:
         header: How we protect your data and keep it secure
         info_1: We are committed to doing all that we can to keep your data secure. We have set up systems and processes to prevent unauthorised access or disclosure of your data – for example, we protect your data using varying levels of encryption.
@@ -72,7 +72,7 @@ en:
           that your personal data is erased if there is no longer a justification for it
           a copy of any data-sharing agreements we have with other organisations
           information on how we instruct staff to collect, use or delete your personal data
-        info: If you have any of these requests, contact the Ministry of Justice (MoJ) Data Protection Officer.
+        info_html: If you have any of these requests, contact the Ministry of Justice <abbr title='Ministry of Justice'>MoJ</abbr> Data Protection Officer.
         data_protection_office_contact_details:
           title: The Data Protection Officer
           email_address_html: <a href="mailto:casework@ico.org.uk">data.compliance@justice.gov.uk</a>
@@ -84,7 +84,7 @@ en:
       contact_or_complaint:
         header: Contact us or make a complaint
         data_protection_office:
-          list_heading: "Contact the (<abbr title='Ministry of Justice'>MOJ</abbr>) Data Protection Officer if you:"
+          list_heading_html: "Contact the (<abbr title='Ministry of Justice'>MoJ</abbr>) Data Protection Officer if you:"
           list: |
             have a question about anything in this privacy notice
             think that your personal data has been misused or 
@@ -95,7 +95,7 @@ en:
             call_hours: "Monday to Friday, 9am to 4:30pm"
             call_costs_html: <a href="https://www.gov.uk/call-charges">Find out about call charges</a>
         commissioner_office:
-          list_heading: "Contact the Information Commissioner's Office (ICO):"
+          list_heading_html: "Contact the Information Commissioner's Office (<abbr title='Information Commissioner's Office'>ICO</abbr>):"
           list: |
             to make a complaint
             for independent advice about data protection

--- a/config/locales/en/privacy_policy.yml
+++ b/config/locales/en/privacy_policy.yml
@@ -72,7 +72,7 @@ en:
           that your personal data is erased if there is no longer a justification for it
           a copy of any data-sharing agreements we have with other organisations
           information on how we instruct staff to collect, use or delete your personal data
-        info_html: If you have any of these requests, contact the Ministry of Justice <abbr title='Ministry of Justice'>MoJ</abbr> Data Protection Officer.
+        info_html: If you have any of these requests, contact the Ministry of Justice <abbr title='Ministry of Justice'>MOJ</abbr> Data Protection Officer.
         data_protection_office_contact_details:
           title: The Data Protection Officer
           email_address_html: <a href="mailto:casework@ico.org.uk">data.compliance@justice.gov.uk</a>
@@ -84,7 +84,7 @@ en:
       contact_or_complaint:
         header: Contact us or make a complaint
         data_protection_office:
-          list_heading_html: "Contact the (<abbr title='Ministry of Justice'>MoJ</abbr>) Data Protection Officer if you:"
+          list_heading_html: "Contact the (<abbr title='Ministry of Justice'>MOJ</abbr>) Data Protection Officer if you:"
           list: |
             have a question about anything in this privacy notice
             think that your personal data has been misused or 

--- a/config/locales/en/privacy_policy.yml
+++ b/config/locales/en/privacy_policy.yml
@@ -72,7 +72,7 @@ en:
           that your personal data is erased if there is no longer a justification for it
           a copy of any data-sharing agreements we have with other organisations
           information on how we instruct staff to collect, use or delete your personal data
-        info_html: If you have any of these requests, contact the Ministry of Justice <abbr title='Ministry of Justice'>MOJ</abbr> Data Protection Officer.
+        info_html: If you have any of these requests, contact the Ministry of Justice <abbr title='Ministry of Justice'>(MOJ)</abbr> Data Protection Officer.
         data_protection_office_contact_details:
           title: The Data Protection Officer
           email_address_html: <a href="mailto:casework@ico.org.uk">data.compliance@justice.gov.uk</a>
@@ -84,7 +84,7 @@ en:
       contact_or_complaint:
         header: Contact us or make a complaint
         data_protection_office:
-          list_heading_html: "Contact the (<abbr title='Ministry of Justice'>MOJ</abbr>) Data Protection Officer if you:"
+          list_heading_html: "Contact the <abbr title='Ministry of Justice'>MOJ</abbr> Data Protection Officer if you:"
           list: |
             have a question about anything in this privacy notice
             think that your personal data has been misused or 

--- a/config/locales/en/privacy_policy.yml
+++ b/config/locales/en/privacy_policy.yml
@@ -84,7 +84,7 @@ en:
       contact_or_complaint:
         header: Contact us or make a complaint
         data_protection_office:
-          list_heading: "Contact the MoJ Data Protection Officer if you:"
+          list_heading: "Contact the (<abbr title='Ministry of Justice'>MOJ</abbr>) Data Protection Officer if you:"
           list: |
             have a question about anything in this privacy notice
             think that your personal data has been misused or 

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -455,7 +455,8 @@ en:
       show:
         heading: Is the following correct?
         info: "Your client:"
-        list_html: "will give the <abbr title='Legal Aid Agency'>LAA</abbr> one-time access to their bank accounts"
+        list_1: uses online banking for all of their bank accounts
+        list_2_html: will give the <abbr title='Legal Aid Agency'>LAA</abbr> one-time access to their bank accounts
     other_assets:
       show:
         h1-heading: Which types of assets does your client have?
@@ -564,7 +565,7 @@ en:
             has a National Insurance number
             is single (unless their partner is the opponent in the case)
           title: 'You can only use this service if your client:'
-        use_ccms_para_html: "Use the Client and Cost Management System (CCMS) for all other applications."
+        use_ccms_para_html: "Use the Client and Cost Management System (<abbr title='Client and Cost Management System'>CCMS</abbr>) for all other applications."
     start_merits_assessments:
       show:
         h1-heading: Provide details of the case
@@ -654,9 +655,9 @@ en:
         sorted: Sorted
     use_ccms:
       show:
-        title_html: "You need to complete this application in <abbr title='Client and Cost Management System'>CCMS</abbr>"
+        title_html: You need to complete this application in <abbr title='Client and Cost Management System'>CCMS</abbr>
         sub_heading: "You cannot continue using this service if your client does not:"
-        continue_in_ccms_html: "Continue in <abbr title='Client and Cost Management System'>CCMS</abbr>"
+        continue_in_ccms_html: Continue in <abbr title='Client and Cost Management System'>CCMS</abbr>
         back_to_applications: Back to my applications
         online_banking_consent:
           list: |

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -560,7 +560,7 @@ en:
             has a National Insurance number
             is single (unless their partner is the opponent in the case)
           title: 'You can only use this service if your client:'
-        use_ccms_para: Use the Client and Cost Management System (CCMS) for all other applications.
+        use_ccms_para_html: "Use the Client and Cost Management System (<abbr title='Client and Cost Management System'>CCMS</abbr>) for all other applications."
     start_merits_assessments:
       show:
         h1-heading: Provide details of the case

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -192,7 +192,7 @@ en:
         <<: *how_we_checked
       use_ccms:
         accept_only: We currently only accept applications for people receiving one of these benefits.
-        apply_in_ccms_html: "Apply using <abbr title='Client and Cost Management System'>CCMS</abbr>"
+        apply_in_ccms_html: Apply using <abbr title='Client and Cost Management System'>CCMS</abbr>
         back_to_applications: Back to my applications
         benefits:
           list: |
@@ -201,7 +201,7 @@ en:
             Jobseeker’s Allowance (JSA)
             Pension Credit (Guarantee Credit)
             Universal Credit
-        title_html: "You need to use <abbr title='Client and Cost Management System'>CCMS</abbr> for this application"
+        title_html: You need to use <abbr title='Client and Cost Management System'>CCMS</abbr> for this application
         we_checked: 'We checked with the DWP and your client does not receive:'
     check_merits_answers:
       show:
@@ -311,7 +311,7 @@ en:
         client_sign: Get your client to sign it.
         keep_file: Keep it on file.
         application_to_be_checked: We'll check your application to see if your client is entitled to legal aid.
-        decision_in_ccms_html: "We'll let you know our decision in <abbr title='Client and Cost Management System'>CCMS</abbr>."
+        decision_in_ccms_html: We'll let you know our decision in <abbr title='Client and Cost Management System'>CCMS</abbr>.
         feedback_link_html: '<a href="%{url}" class="govuk_link">Give feedback</a> to help us improve this service.'
         view_completed_application: View completed application
         back_to_your_applications: Back to your applications
@@ -361,7 +361,7 @@ en:
         search_button: Search
       legal_aid_applications:
         applicant_name: Name
-        application_ref_html: "<abbr title='Legal Aid Agency'>LAA</abbr> reference"
+        application_ref_html: <abbr title='Legal Aid Agency'>LAA</abbr> reference
         created_at: Start date
         certificate_type: Certificate type
         status: Status
@@ -565,7 +565,7 @@ en:
             has a National Insurance number
             is single (unless their partner is the opponent in the case)
           title: 'You can only use this service if your client:'
-        use_ccms_para_html: "Use the Client and Cost Management System (<abbr title='Client and Cost Management System'>CCMS</abbr>) for all other applications."
+        use_ccms_para_html: Use the Client and Cost Management System (<abbr title='Client and Cost Management System'>CCMS</abbr>) for all other applications.
     start_merits_assessments:
       show:
         h1-heading: Provide details of the case
@@ -602,8 +602,8 @@ en:
         back_home: Back to your applications
         heading: Application for civil legal aid certificate
         client_name: Client
-        case_reference_html: "<abbr title='Legal Aid Agency'>LAA</abbr> reference"
-        ccms_reference_html: "<abbr title='Client and Cost Management System'>CCMS</abbr> reference"
+        case_reference_html: <abbr title='Legal Aid Agency'>LAA</abbr> reference
+        ccms_reference_html: <abbr title='Client and Cost Management System'>CCMS</abbr> reference
         print_button: Print application
         client_details_heading: Client details
         proceedings_details_heading: What you're applying for

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -173,6 +173,12 @@ en:
         negative_result:
           tab_title: Your client must complete a financial assessment
           title: "We need to check your client's financial eligibility"
+          must_answer_financial_questions: "If your client uses online banking and agrees to share their financial information with us, we'll ask them to:"
+          actions:
+            list: |
+              share their bank transactions from the past 3 months
+              tell us about their income and regular payments
+          provide_access_html: "If they do not, you'll need to continue your application in <abbr title='Client and Cost Management System'>CCMS</abbr>"
         positive_result:
           tab_title: Your client receives benefits that qualify for legal aid
           title: "%{name} receives benefits that qualify for legal aid"
@@ -186,7 +192,7 @@ en:
         <<: *how_we_checked
       use_ccms:
         accept_only: We currently only accept applications for people receiving one of these benefits.
-        apply_in_ccms: Apply using CCMS
+        apply_in_ccms_html: "Apply using <abbr title='Client and Cost Management System'>CCMS</abbr>"
         back_to_applications: Back to my applications
         benefits:
           list: |
@@ -195,7 +201,7 @@ en:
             Jobseeker’s Allowance (JSA)
             Pension Credit (Guarantee Credit)
             Universal Credit
-        title: You need to use CCMS for this application
+        title_html: "You need to use <abbr title='Client and Cost Management System'>CCMS</abbr> for this application"
         we_checked: 'We checked with the DWP and your client does not receive:'
     check_merits_answers:
       show:
@@ -305,7 +311,7 @@ en:
         client_sign: Get your client to sign it.
         keep_file: Keep it on file.
         application_to_be_checked: We'll check your application to see if your client is entitled to legal aid.
-        decision_in_ccms: We'll let you know our decision in CCMS.
+        decision_in_ccms_html: "We'll let you know our decision in <abbr title='Client and Cost Management System'>CCMS</abbr>."
         feedback_link_html: '<a href="%{url}" class="govuk_link">Give feedback</a> to help us improve this service.'
         view_completed_application: View completed application
         back_to_your_applications: Back to your applications
@@ -355,7 +361,7 @@ en:
         search_button: Search
       legal_aid_applications:
         applicant_name: Name
-        application_ref: LAA reference
+        application_ref_html: "<abbr title='Legal Aid Agency'>LAA</abbr> reference"
         created_at: Start date
         certificate_type: Certificate type
         status: Status
@@ -449,9 +455,7 @@ en:
       show:
         heading: Is the following correct?
         info: "Your client:"
-        list: |
-          uses online banking for all of their bank accounts
-          will give the LAA one-time access to their bank accounts
+        list_html: "will give the <abbr title='Legal Aid Agency'>LAA</abbr> one-time access to their bank accounts"
     other_assets:
       show:
         h1-heading: Which types of assets does your client have?
@@ -560,7 +564,7 @@ en:
             has a National Insurance number
             is single (unless their partner is the opponent in the case)
           title: 'You can only use this service if your client:'
-        use_ccms_para_html: "Use the Client and Cost Management System (<abbr title='Client and Cost Management System'>CCMS</abbr>) for all other applications."
+        use_ccms_para_html: "Use the Client and Cost Management System (CCMS) for all other applications."
     start_merits_assessments:
       show:
         h1-heading: Provide details of the case
@@ -597,8 +601,8 @@ en:
         back_home: Back to your applications
         heading: Application for civil legal aid certificate
         client_name: Client
-        case_reference: LAA reference
-        ccms_reference: CCMS reference
+        case_reference_html: "<abbr title='Legal Aid Agency'>LAA</abbr> reference"
+        ccms_reference_html: "<abbr title='Client and Cost Management System'>CCMS</abbr> reference"
         print_button: Print application
         client_details_heading: Client details
         proceedings_details_heading: What you're applying for
@@ -650,9 +654,9 @@ en:
         sorted: Sorted
     use_ccms:
       show:
-        title: You need to complete this application in CCMS
+        title_html: "You need to complete this application in <abbr title='Client and Cost Management System'>CCMS</abbr>"
         sub_heading: "You cannot continue using this service if your client does not:"
-        continue_in_ccms: Continue in CCMS
+        continue_in_ccms_html: "Continue in <abbr title='Client and Cost Management System'>CCMS</abbr>"
         back_to_applications: Back to my applications
         online_banking_consent:
           list: |

--- a/config/locales/en/shared.yml
+++ b/config/locales/en/shared.yml
@@ -18,7 +18,7 @@ en:
         have your legal aid stopped and have to pay back the costs
     application_ref:
       apply_ref: 'Apply service case reference:'
-      ccms_ref: 'CCMS case reference:'
+      ccms_ref_html: "<abbr title='Client and Cost Management System'>CCMS</abbr> case reference:"
     means_report:
 
 

--- a/spec/requests/citizens/consent_spec.rb
+++ b/spec/requests/citizens/consent_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe Citizens::ConsentsController, type: :request do
       let(:params) { { legal_aid_application: { open_banking_consent: nil } } }
 
       it 'returns an error' do
-        expect(response.body).to include(I18n.t('activemodel.errors.models.legal_aid_application.attributes.open_banking_consents.citizens.blank'))
+        expect(unescaped_response_body).to include(I18n.t('activemodel.errors.models.legal_aid_application.attributes.open_banking_consents.citizens.blank_html'))
       end
     end
   end

--- a/spec/requests/providers/check_benefits_spec.rb
+++ b/spec/requests/providers/check_benefits_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Providers::CheckBenefitsController, type: :request do
 
     EXPECTED_TEXTS = {
       continue: 'receives benefits that qualify for legal aid',
-      ccms: 'You need to use CCMS for this application',
+      ccms: "You need to use <abbr title='Client and Cost Management System'>CCMS</abbr> for this application",
       need_to_check: 'We need to check your client'
     }.freeze
 

--- a/spec/requests/providers/use_ccms_spec.rb
+++ b/spec/requests/providers/use_ccms_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Providers::UseCcmsController, type: :request do
 
       it 'shows text to use CCMS' do
         subject
-        expect(response.body).to include(I18n.t('providers.use_ccms.show.title'))
+        expect(response.body).to include(I18n.t('providers.use_ccms.show.title_html'))
       end
     end
   end


### PR DESCRIPTION
AP1563 Accessibility: Abbreviation tags for screen readers

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1563)

Started with one abbreviation and added a <abbr...> element to it.

Add an abbreviation helper tag for CCMS. This improves accessibility for JAWS users
for reading out abbreviations in capitals.

Initially starting with the first page (index page) and the image shows the hint text for CCMS being it's full name
![image](https://user-images.githubusercontent.com/25043924/89891180-82a6c400-dbcc-11ea-8d1b-21241ee81d3d.png)

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
