### PR TITLE
AP1540 Accessibility fix for Savings and Investments and other assets page

### DIFF
--- a/app/views/shared/forms/_offline_accounts_form.html.erb
+++ b/app/views/shared/forms/_offline_accounts_form.html.erb
@@ -5,7 +5,7 @@
   <%= govuk_form_group show_error_if: @form.errors.present? do %>
     <fieldset class="govuk-fieldset" aria-describedby="select-all-that-apply-hint">
       <%= govuk_fieldset_header page_title %>
-      <h2 class="govuk-heading-m"><%= t('generic.select_all_that_apply') %></h2>
+      <span id="select-all-that-apply-hint" class="govuk-hint"><%= t('generic.select_all_that_apply') %></span>
 
       <%= render 'shared/show_errors' %>
 

--- a/app/views/shared/forms/_savings_and_investments_form.html.erb
+++ b/app/views/shared/forms/_savings_and_investments_form.html.erb
@@ -5,9 +5,9 @@
   <%= govuk_form_group show_error_if: @form.errors.present? do %>
     <fieldset class="govuk-fieldset" aria-describedby="select-all-that-apply-hint">
       <%= govuk_fieldset_header page_title %>
-      <h2 class="govuk-heading-m"><%= t('generic.select_all_that_apply') %></h2>
+      <h2 class="govuk-heading-m" id="select-all-that-apply-hint"><%= t('generic.select_all_that_apply') %></h2>
 
-      <%= render 'shared/show_errors' %>
+      <%= render 'shared/show_errors' unless @form.any_checkbox_checked? %>
 
       <div class="govuk-checkboxes" data-module="govuk-checkboxes">
         <div class="deselect-group" data-deselect-ctrl="[name='savings_amount[none_selected]']">

--- a/app/views/shared/forms/_savings_and_investments_form.html.erb
+++ b/app/views/shared/forms/_savings_and_investments_form.html.erb
@@ -5,7 +5,7 @@
   <%= govuk_form_group show_error_if: @form.errors.present? do %>
     <fieldset class="govuk-fieldset" aria-describedby="select-all-that-apply-hint">
       <%= govuk_fieldset_header page_title %>
-      <h2 class="govuk-heading-m" id="select-all-that-apply-hint"><%= t('generic.select_all_that_apply') %></h2>
+      <span id="select-all-that-apply-hint" class="govuk-hint"><%= t('generic.select_all_that_apply') %></span>
 
       <%= render 'shared/show_errors' unless @form.any_checkbox_checked? %>
 

--- a/app/views/shared/forms/other_assets/_form.html.erb
+++ b/app/views/shared/forms/other_assets/_form.html.erb
@@ -3,7 +3,7 @@
   <%= govuk_form_group show_error_if: (@form.errors.present? && !@form.any_checkbox_checked?) do %>
     <fieldset class="govuk-fieldset" aria-describedby="select-all-that-apply-hint">
       <%= govuk_fieldset_header page_title %>
-      <h2 class="govuk-heading-m" id="select-all-that-apply-hint"><%= t('generic.select_all_that_apply') %></h2>
+      <span id="select-all-that-apply-hint" class="govuk-hint"><%= t('generic.select_all_that_apply') %></span>
 
       <%= render 'shared/show_errors' %>
 

--- a/app/views/shared/forms/other_assets/_form.html.erb
+++ b/app/views/shared/forms/other_assets/_form.html.erb
@@ -3,7 +3,7 @@
   <%= govuk_form_group show_error_if: (@form.errors.present? && !@form.any_checkbox_checked?) do %>
     <fieldset class="govuk-fieldset" aria-describedby="select-all-that-apply-hint">
       <%= govuk_fieldset_header page_title %>
-      <h2 class="govuk-heading-m"><%= t('generic.select_all_that_apply') %></h2>
+      <h2 class="govuk-heading-m" id="select-all-that-apply-hint"><%= t('generic.select_all_that_apply') %></h2>
 
       <%= render 'shared/show_errors' %>
 

--- a/spec/requests/providers/savings_and_investments_spec.rb
+++ b/spec/requests/providers/savings_and_investments_spec.rb
@@ -124,6 +124,22 @@ RSpec.describe 'providers savings and investments', type: :request do
               expect(response.body).to match('govuk-form-group--error')
             end
           end
+
+          context 'checkbox checked with no value entered' do
+            let(:params) do
+              {
+                savings_amount: {
+                  cash: '',
+                  check_box_cash: 'true'
+                }
+              }
+            end
+
+            it 'displays error for field' do
+              subject
+              expect(response.body).to match(I18n.t('activemodel.errors.models.savings_amount.attributes.cash.blank'))
+            end
+          end
         end
 
         context 'when in checking passported answers state' do


### PR DESCRIPTION
AP1540 Accessibility fix for Savings and Investments and other assets page

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1540)

- Add the aria-describedby id to the select_all_that_apply field as it broke WAVE testing of aria tags for other assets page and savings and investments page

- Turn all elements with the html class 'select-all-that-apply-hint' to a span tag with class govuk-hint in order to standardise it with gds design system [here](https://design-system.service.gov.uk/components/checkboxes/)

- Fix the problem where error messages are being bunched underneath the select_all_that_apply heading when checkboxes are selected but they have no nested values. Do this by not duplicating those errors under the heading. However, allow for when no checkboxes are selected error which is just a one line message.

- Test the above

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
