### PR TITLE
ap-1542 accessibility on statement of case page

### DIFF
--- a/app/views/providers/statement_of_cases/show.html.erb
+++ b/app/views/providers/statement_of_cases/show.html.erb
@@ -1,4 +1,4 @@
-<div id="files-errors-container" role="alert" tabindex="0"></div>
+<div id="files-errors-container" role="alert" tabindex="-1"></div>
 <% new_head_title = if @successfully_deleted
                       @successfully_deleted
                     elsif @error_message || @successful_upload


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1542)

Accessibility fixes:
Page Title was already fixed for this page
Page orientation issue - keyboard hides text field in landscape mode - this seems to be a mobile device issue, regardless of webpage or app, in landscape the full size keyboard obscures half of the screen.
Navigation using Tab/Keyboard - removed the focus from a hidden error element to remove the second tab required to move from `Back` link to the `Upload File `button. Users can now go directly to this button from the `Skip to Main Content` option

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
