### PR TITLE
BUGFIX AASM Transition error on check provider answers page

### DIFF
--- a/app/models/concerns/base_state_machine.rb
+++ b/app/models/concerns/base_state_machine.rb
@@ -1,4 +1,4 @@
-class BaseStateMachine < ApplicationRecord
+class BaseStateMachine < ApplicationRecord  # rubocop:disable Metrics/ClassLength
   self.table_name = 'state_machine_proxies'
 
   belongs_to :legal_aid_application
@@ -41,6 +41,7 @@ class BaseStateMachine < ApplicationRecord
 
     event :applicant_details_checked do
       transitions from: %i[
+        provider_entering_means
         checking_applicant_details
         provider_confirming_applicant_eligibility
         use_ccms

--- a/spec/requests/providers/check_benefits_spec.rb
+++ b/spec/requests/providers/check_benefits_spec.rb
@@ -80,6 +80,15 @@ RSpec.describe Providers::CheckBenefitsController, type: :request do
       expect(application.reload.state).to eq 'applicant_details_checked'
     end
 
+    context 'state is provider_entering_means' do
+      let(:application) { create :application, :provider_entering_means, applicant: applicant }
+
+      it 'transitions from provider_entering_means' do
+        subject
+        expect(application.reload.state).to eq 'applicant_details_checked'
+      end
+    end
+
     context 'when the check_benefit_result already exists' do
       let!(:benefit_check_result) { create :benefit_check_result, legal_aid_application: application }
 


### PR DESCRIPTION
Bug fix for a transition error on the check provider answers

A transition error occurred [here](https://sentry.service.dsd.io/mojds/apply-for-legal-aid/issues/62316/?referrer=slack)
> AASM::InvalidTransitionProviders::CheckBenefitsController#index
> Event 'applicant_details_checked' cannot transition from 'provider_entering_means'

This happens when the provider clicks the back button on the check provider answers page instead of clicking the change links on that page.

- Fix the above error by allowing providers to click the back button on the check provider answers page.

- Test this.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
