### PR TITLE
BugFix: Property value page had a missing translation for the hint

### DIFF
--- a/app/views/providers/property_values/_form.html.erb
+++ b/app/views/providers/property_values/_form.html.erb
@@ -8,7 +8,7 @@
     <% end %>
     <%= form.govuk_text_field(
           :property_value,
-          hint: controller_t('hint.property_value'),
+          hint: t('.hint.property_value'),
           label: nil,
           value: number_to_currency_or_original_string(model.property_value),
           input_prefix: t('currency.gbp'),

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -493,8 +493,9 @@ en:
         accessibility_message_safari_browser: "You are in a search field, tab out to see results"
         you_have_selected: You have selected %{count}
     property_values:
-      hint:
-        property_value: You can use property websites to find the estimated value
+      form:
+        hint:
+          property_value: You can use property websites to find the estimated value
       show:
         h1-heading: How much is your client's home worth?
     providers:


### PR DESCRIPTION
## What

The hint on the `/property_value` page was missing/moved

I removed the controller_t method that was being used and switched it to t. It is possible to use the controller_t method it just makes the translation path a bit more long winded (as below).

      form:
        providers:
          property_values:
            hint:
              property_value: You can use property websites to find the estimated value 

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
