### PR TITLE
Fix seeding providers users

### DIFF
--- a/db/seeds/test_provider_populator.rb
+++ b/db/seeds/test_provider_populator.rb
@@ -33,18 +33,22 @@ class TestProviderPopulator
 
   private
 
-  def populate_firm_permissions
+  def populate_firm_permissions # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
     passported_permission = Permission.find_by(role: 'application.passported.*')
     non_passported_permission = Permission.find_by(role: 'application.non_passported.*')
-    Firm.all.each do |f|
-      f.permissions << passported_permission
-      f.save!
+    Firm.all.each do |firm|
+      unless firm.permissions.map(&:role).include?('application.passported.*')
+        firm.permissions << passported_permission
+        firm.save!
+      end
     end
 
     %w[test1 sr MARTIN.RONAN@DAVIDGRAY.CO.UK].each do |firm_name|
       firm = Provider.find_by(username: firm_name).firm
-      firm.permissions << non_passported_permission
-      firm.save!
+      unless firm.permissions.map(&:role).include?('application.non_passported.*')
+        firm.permissions << non_passported_permission
+        firm.save!
+      end
     end
   end
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1319)

The seeding of users on ap-1319 is broken as it falls over when it tries to update an existing user's permissions.
This change checks to see if the user has a permission first and only updates if the permission doesn't already exist

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
