### PR TITLE
Bugfix: move flags in curl command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN apk --no-cache add --virtual build-dependencies \
 #  # Install kubectl
 # RUN curl -LO /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl
 RUN echo $KUBECTL_VERSION
-RUN curl -Lo --retry 3 --retry-delay 3 /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl
+RUN curl -Lo /usr/local/bin/kubectl --retry 3 --retry-delay 3 https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl
 
 # Ensure everything is executable
 RUN chmod +x /usr/local/bin/*


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-XXX)

The database backup cronjob was failing due to `kubectl` not being installed on the docker image. The install was failing because of an incorrectly formatted curl command.

Moved the `--retry` and `--retry-delay `flags to after the filename.b

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
