### PR TITLE
AP1583 Update feedback difficulty text for provider and citizen

### DIFF
--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -2,6 +2,7 @@ class FeedbackController < ApplicationController
   before_action :update_return_path
 
   def new
+    @journey = source
     @feedback = Feedback.new
   end
 

--- a/app/views/feedback/new.html.erb
+++ b/app/views/feedback/new.html.erb
@@ -16,7 +16,7 @@
             order: :reverse,
             args: {
                 title: {
-                  text: t('.difficulty'),
+                  text: t(".difficulty.#{@journey}"),
                   size: :m
                 }
             }

--- a/config/locales/en/feedback.yml
+++ b/config/locales/en/feedback.yml
@@ -2,7 +2,9 @@
 en:
   feedback:
     new:
-      difficulty: How easy or difficult was it to apply for legal aid using the new service?
+      difficulty: 
+        Provider: How easy or difficult was it to apply for legal aid using the new service?
+        Citizen: How easy or difficult was it to use this service?
       done_all_needed: Were you able to do what you needed today?
       satisfaction: Overall, how satisfied were you with this service?
       signed_out: You are signed out

--- a/features/citizens/citizens.feature
+++ b/features/citizens/citizens.feature
@@ -76,6 +76,8 @@ Feature: Citizen journey
     Then I should be on a page showing "Declaration"
     Then I click "Agree and submit"
     Then I should be on a page showing "You've shared your financial information"
+    Then I click link "feedback"
+    Then I should be on a page showing "How easy or difficult was it to use this service?"
 
   @javascript
   Scenario: I want to change income types via the check your answers page

--- a/features/providers/civil_application_journey.feature
+++ b/features/providers/civil_application_journey.feature
@@ -658,6 +658,7 @@ Feature: Civil application journeys
   Scenario: View feedback form within provider journey
     Given I start the journey as far as the applicant page
     Then I click link "feedback"
+    Then I should be on a page showing "How easy or difficult was it to apply for legal aid using the new service?"
     Then I click link "Back"
     Then I should be on the Applicant page
 


### PR DESCRIPTION
AP1583 Update feedback difficulty text for provider and citizen

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1583)

- Update the feedback page to show two different texts for the difficulty question - one for the citizen and one for the provider.

- Update the feature tests to test this.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
