### PR TITLE
Remove date filter from pending ccms failures dashboard

### DIFF
--- a/app/models/dashboard/widget_data_providers/pending_ccms_submissions.rb
+++ b/app/models/dashboard/widget_data_providers/pending_ccms_submissions.rb
@@ -23,7 +23,7 @@ module Dashboard
       end
 
       def self.pending_submissions
-        CCMS::Submission.where(created_at: 6.days.ago.beginning_of_day..Time.now).where.not(aasm_state: %w[failed completed]).count
+        CCMS::Submission.where.not(aasm_state: %w[failed completed]).count
       end
     end
   end


### PR DESCRIPTION
Remove date filter from the pending ccms submissions geckoboard dataset

This is so that older pending ccms submissions are visible

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
