### PR TITLE
AP-1606 Display residual balance flag on means report

### DIFF
--- a/app/models/cfe/remarks.rb
+++ b/app/models/cfe/remarks.rb
@@ -1,5 +1,7 @@
 module CFE
   class Remarks
+    REASONS_WITHOUT_CATEGORIES = [:residual_balance].freeze
+
     def initialize(hash)
       @hash = hash
     end
@@ -44,7 +46,7 @@ module CFE
       result = Hash.new([])
       @hash.each do |category, reason_hash|
         reason_hash.each_key do |reason|
-          result[reason] += [category]
+          result[reason] += [category] unless REASONS_WITHOUT_CATEGORIES.include? reason
         end
       end
       result

--- a/app/views/providers/means_reports/_caseworker_review.html.erb
+++ b/app/views/providers/means_reports/_caseworker_review.html.erb
@@ -24,7 +24,7 @@
         </dd>
       </div>
 
-      <% remarks.review_categories_by_reason.each do |reason, categories| %>
+      <% remarks.review_categories_by_reason&.each do |reason, categories| %>
         <div class="<%= "govuk-summary-list__row  normal-word-break govuk-summary-list__row--no-border" %>" id="<%= "means-merits-report__caseworker-review-required" %>">
           <dt class="<%= "govuk-summary-list__key govuk-!-width-one-half" %>">
             <%= t(".category-#{reason}") %>

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -414,9 +414,7 @@ en:
         reason:
           amount_variation: Monthly value unknown (variations)
           unknown_frequency: Frequency unknown
-
-
-
+          residual_balance: Capital Contribution - Residual Balance Check
       show:
         heading: Means report
         caseworker-review-section-heading: Caseworker Review

--- a/spec/models/cfe/remarks_spec.rb
+++ b/spec/models/cfe/remarks_spec.rb
@@ -54,6 +54,18 @@ module CFE
           expect(remarks.review_categories_by_reason).to eq expected_results
         end
       end
+
+      context 'with remarks that do not require a category' do
+        before { populated_hash[:current_account_balance] = { residual_balance: [] } }
+        let(:remarks_hash) { populated_hash }
+        it 'does not include the remarks in the hash of categories by reason' do
+          expected_results = {
+            amount_variation: [:state_benefit_payment],
+            unknown_frequency: %i[state_benefit_payment outgoings_housing_cost]
+          }
+          expect(remarks.review_categories_by_reason).to eq expected_results
+        end
+      end
     end
 
     describe '#review_transactions' do


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1606)

Related to CFE PR https://github.com/ministryofjustice/check-financial-eligibility/pull/300

If a CFE result is received that has a `residual_balance` remark (ie the applicant's capital is greater than the lower threshold and their current account balance is greater than 0), it needs to be flagged for caseworker review on the means report.

This is mostly done automatically by existing functionality. The `residual_balance` flag is slightly different to existing remarks as it does not need a category displayed. This PR amends the remarks model and caseworker review partial to check the type of remark, and only displays the category if appropriate. It also adds a translation to display the correct wording.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
