### PR TITLE
AP-1643 Clear TrueLayer errors

### DIFF
--- a/app/controllers/citizens/accounts_controller.rb
+++ b/app/controllers/citizens/accounts_controller.rb
@@ -15,8 +15,9 @@ module Citizens
       if worker_errors.any?
         @errors = worker_errors.join(', ')
         Raven.capture_exception(TrueLayerWorkerError.new(@errors))
+        reset_worker
       else
-        session[:worker_id] = nil
+        reset_worker
         redirect_to action: :index
       end
     end
@@ -50,6 +51,10 @@ module Citizens
     def start_worker_to_get_transactions
       legal_aid_application.set_transaction_period
       ImportBankDataWorker.perform_async(legal_aid_application.id)
+    end
+
+    def reset_worker
+      session[:worker_id] = nil
     end
   end
 end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1643)

After receiving an error authenticating with TrueLayer, if a user tries again and successfully authenticates, the same error is still displayed. This change fixes this problem by setting `session[:worker_id] = nil` in `accounts_controller` after the error has been handled. This removes the worker from the session and when the second attempt is made a new worker
is created. This prevents the error from being replayed.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
