### PR TITLE
AP-1641 Improve display of TrueLayer errors

### DIFF
--- a/app/controllers/citizens/accounts_controller.rb
+++ b/app/controllers/citizens/accounts_controller.rb
@@ -2,6 +2,7 @@ module Citizens
   class AccountsController < CitizenBaseController
     class TrueLayerWorkerError < StandardError; end
     skip_back_history_for :gather
+    helper_method :error_description
 
     def index
       @applicant_banks = current_applicant.bank_providers.collect do |bank_provider|
@@ -55,6 +56,14 @@ module Citizens
 
     def reset_worker
       session[:worker_id] = nil
+    end
+
+    def error_description
+      truelayer_error_description || I18n.t('citizens.accounts.gather.default_error')
+    end
+
+    def truelayer_error_description
+      JSON.parse(worker_errors[2])&.dig('TrueLayerError', 'error_description') unless worker_errors[2].nil?
     end
   end
 end

--- a/app/controllers/citizens/consents_controller.rb
+++ b/app/controllers/citizens/consents_controller.rb
@@ -2,7 +2,6 @@ module Citizens
   class ConsentsController < CitizenBaseController
     def show
       @form = Applicants::OpenBankingConsentForm.new(model: legal_aid_application)
-      @form.errors.add(:open_banking_consent, I18n.t('citizens.consents.show.true_layer_auth_error_html')) if params[:auth_failure]
     end
 
     def update

--- a/app/services/true_layer/api_client.rb
+++ b/app/services/true_layer/api_client.rb
@@ -42,7 +42,7 @@ module TrueLayer
       # TODO: implement white list of inevitable errors
       # some errors are inevitable (like "Feature not supported by the provider")
       # standard errors should be logged in Sentry
-      raise ApiError, "TrueLayer Error : #{response.body}" unless response.success?
+      raise ApiError, "{\"TrueLayerError\" : #{response.body}}" unless response.success?
 
       SimpleResult.new(value: parsed_response.deep_symbolize_keys[:results])
     rescue JSON::ParserError => e

--- a/app/views/citizens/accounts/gather.html.erb
+++ b/app/views/citizens/accounts/gather.html.erb
@@ -1,7 +1,9 @@
 <% if @errors %>
-  <div class="govuk-error-summary" role="alert" tabindex="-1" data-module="govuk-error-summary">
-    <h2 class="govuk-error-summary__title" id="error-summary-title"><%= @errors %></h2>
-  </div>
+  <%= page_template do %>
+    <div class="govuk-error-summary" role="alert" tabindex="-1" data-module="govuk-error-summary">
+      <h2 class="govuk-error-summary__title" id="error-summary-title"><%= error_description %></h2>
+    </div>
+  <% end %>
 <% else %>
   <div class="worker-waiter" data-worker-id="<%= session[:worker_id] %>" align="center">
     <%= image_tag('loading.gif') %>

--- a/config/locales/en/citizens.yml
+++ b/config/locales/en/citizens.yml
@@ -4,6 +4,7 @@ en:
     accounts:
       gather:
         retrieving_transactions: Retrieving bank transactions
+        default_error: Sorry, we are experiencing technical difficulties. Please try again later.
       index:
         account_holder_address_heading: Account holder address
         account_holder_name_heading: Account holder name
@@ -60,9 +61,7 @@ en:
         title_html: Do you agree to share your bank account information with the <abbr title='Legal Aid Agency'>LAA</abbr>?
         inset_text: We only use your financial information to support your legal aid application. We do not use it for anything else.
         summary_heading: What information will the LAA be able to see?
-        true_layer_auth_error: Select yes if you agree to share your bank account information with the LAA
         summary_heading_html: What information will the <abbr title='Legal Aid Agency'>LAA</abbr> be able to see?
-        true_layer_auth_error_html: Select yes if you agree to share your bank account information with the <abbr title='Legal Aid Agency'>LAA</abbr>
         able_to_see:
           heading: "We'll be able to see your:"
           list: |

--- a/spec/requests/citizens/accounts_spec.rb
+++ b/spec/requests/citizens/accounts_spec.rb
@@ -114,8 +114,20 @@ RSpec.describe 'citizen accounts request', type: :request do
         expect(response).to have_http_status(:ok)
       end
 
-      it 'displays the error' do
-        expect(response.body).to include(error)
+      it 'displays the default error' do
+        expect(response.body).to include(I18n.t('citizens.accounts.gather.default_error'))
+      end
+
+      context 'a realistic TrueLayerError is received' do
+        let(:truelayer_error_description) { 'The provider service is currently unavailable or experiencing technical difficulties. Please try again later.' }
+        let(:error_1) { { bank_data_import: {} } }
+        let(:error_2) { { import_account_holders: {} } }
+        let(:error_3) { { TrueLayerError: { error_description: truelayer_error_description, error: :provider_error, error_details: {} } } }
+        let(:worker) { { 'status' => 'complete', 'errors' => [error_1.to_json, error_2.to_json, error_3.to_json].to_json } }
+
+        it 'displays the TrueLayer error description' do
+          expect(response.body).to include('The provider service is currently unavailable or experiencing technical difficulties. Please try again later')
+        end
       end
     end
   end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1641)

If errors are received when authenticating with a bank through TrueLayer an ugly error string is displayed on the page. This change improves that by extracting the description of the error and displaying it, or a default error if no description can be found.

It does several things:

- Add methods to the `accounts_controller` to parse the error and extract the relevant description or provide a default error.
- Amends the error generated by the `api_client` to make it easier to parse.
- Removes an error status that was being set by `consents_controller` if authentication failed. This was having the effect of making it look as if the error was caused by the user not giving consent, when this was not the case.
- Wraps the error in a `page_template` so that a back button is generated to allow the user to navigate away from the error.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
