### PR TITLE
Disable deploying master UAT during security test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -385,12 +385,14 @@ workflows:
       - build_and_push:
           requires:
           - lint_checks
-      - deploy_master_uat:
-          requires:
-            - build_and_push
+      # Disable deploying master UAT while security tets is ongoing.
+      # - deploy_master_uat:
+      #     requires:
+      #       - build_and_push
       - delete_uat_branch:
           requires:
-            - deploy_master_uat
+            - build_and_push
+          #   - deploy_master_uat
       - unit_tests:
           requires:
             - lint_checks


### PR DESCRIPTION
## What

There's no story for this.

This PR disables deploying master UAT. This is to avoid wiping the database and keeping master UAT stable during the security test. It's not ideal, but the other option meant getting VPN access to the security testers. So we'll have to live without master UAT for a week.

Once the security test is over on 4 September 2020 we should revert this commit. I've left the code commented out, just in case we somehow forget...

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
