### PR TITLE
add a hold for releases to UAT master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -352,6 +352,12 @@ jobs:
       - hold-notification:
           message: "$CIRCLE_USERNAME has a pending production approval for $CIRCLE_BRANCH"
 
+  hold_master_uat_notification:
+    executor: notification-executor
+    steps:
+      - hold-notification:
+          message: "$CIRCLE_USERNAME - ONLY APPROVE IF THIS CODE WAS NEEDED FOR PEN TESTING\n There is a pending MASTER UAT approval for $CIRCLE_BRANCH"
+
 workflows:
   version: 2
   open_pr:
@@ -385,12 +391,19 @@ workflows:
       - build_and_push:
           requires:
           - lint_checks
+      - hold_master_uat_notification:
+          requires:
+            - lint_checks
+      - hold_master_uat_approval:
+          type: approval
+          requires:
+            - hold_master_uat_notification
       - deploy_master_uat:
           requires:
-            - build_and_push
+            - hold_master_uat_approval
       - delete_uat_branch:
           requires:
-            - deploy_master_uat
+            - lint_checks
       - unit_tests:
           requires:
             - lint_checks
@@ -408,6 +421,7 @@ workflows:
       - hold_production_notification:
           requires:
             - deploy_staging
+            - delete_uat_branch
       - hold_production:
           type: approval
           requires:


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-XXX)

Add in the hold on master UAT for the pentesting
This PR essentially re-implements/reverts the DAC changes made here

https://github.com/ministryofjustice/laa-apply-for-legal-aid/pull/1680/files

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
