### PR TITLE
Rubocop Update: update cops and fixes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -210,6 +210,30 @@ Style/SingleArgumentDig:
 Style/StringConcatenation:
   Enabled: true
 
+Lint/DuplicateRequire:
+  Enabled: true
+
+Lint/EmptyFile:
+  Enabled: true
+
+Lint/TrailingCommaInAttributeDeclaration:
+  Enabled: true
+
+Lint/UselessMethodDefinition:
+  Enabled: true
+
+Style/CombinableLoops:
+  Enabled: true
+
+Style/KeywordParametersOrder:
+  Enabled: true
+
+Style/RedundantSelfAssignment:
+  Enabled: true
+
+Style/SoleNestedConditional:
+  Enabled: false
+
 Metrics/PerceivedComplexity:
   IgnoredMethods:
     - 'cli_arg_version' # from bin/bundle - auto generated method

--- a/app/helpers/check_answers_helper.rb
+++ b/app/helpers/check_answers_helper.rb
@@ -3,7 +3,7 @@ module CheckAnswersHelper
   #     <dl class="govuk-summary-list govuk-!-margin-bottom-9">
   #       <%= check_answer_link ..... %>
   #     </dl>
-  def check_answer_link(url: nil, question:, answer:, name:, read_only: false, align_right: false, no_border: false) # rubocop:disable Metrics/ParameterLists
+  def check_answer_link(question:, answer:, name:, url: nil, read_only: false, align_right: false, no_border: false) # rubocop:disable Metrics/ParameterLists
     render(
       'shared/check_answers/item',
       name: name,
@@ -16,7 +16,7 @@ module CheckAnswersHelper
     )
   end
 
-  def check_answer_no_link(question:, answer:, no_border: false, name:, align_right: false)
+  def check_answer_no_link(question:, answer:, name:, no_border: false, align_right: false)
     render(
       'shared/check_answers/no_link_item',
       name: name,
@@ -60,7 +60,7 @@ module CheckAnswersHelper
     )
   end
 
-  def check_long_question_no_link(question:, answer:, no_border: false, name:, align_right: false)
+  def check_long_question_no_link(question:, answer:, name:, no_border: false, align_right: false)
     render(
       'shared/check_answers/no_link_long_item',
       name: name,


### PR DESCRIPTION
## What


Turned on all new cops in rubocop 0.90 and added fixes for all suggestions.

The `SoleNestedConditional` cop threw up 3 issues in:

`app/controllers/providers/transactions_controller.rb`
and
`spec/support/soap_matchers.rb`

The changes I made in these files to pass the cop, do not appear to me to be the most readable, essentially due to the use of `!` to indicate a negative/false requirement.

I am happy to revert these changes and use a `rubocop ignore/disable` if that is preferable, or if anyone has an alternatvie suggestion I am all ears. 👂
## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
