### PR TITLE
Amend the <abbr> styling

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -22,3 +22,7 @@
     }
   }
 }
+
+abbr[title] {
+  text-decoration:none;
+}


### PR DESCRIPTION
## What

The <abbr> tag for screen readers adds some styling below acronyms. This removes that styling (dots below abbreviations).

I have put the css in` layout.scss` as it applies across the service, however if there s a more appropriate place for it let me know, happy to move it.


## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
