### PR TITLE
AP1512 Subclass oauth2

### DIFF
--- a/app/lib/omniauth/strategies/laa_oauth2.rb
+++ b/app/lib/omniauth/strategies/laa_oauth2.rb
@@ -1,0 +1,168 @@
+require "oauth2"
+require "omniauth"
+require "securerandom"
+require "socket"       # for SocketError
+require "timeout"      # for Timeout::Error
+
+module OmniAuth
+  module Strategies
+    # Authentication strategy for connecting with APIs constructed using
+    # the [OAuth 2.0 Specification](http://tools.ietf.org/html/draft-ietf-oauth-v2-10).
+    # You must generally register your application with the provider and
+    # utilize an application id and secret in order to authenticate using
+    # OAuth 2.0.
+    class LAAOAuth2
+      include OmniAuth::Strategy
+
+      def self.inherited(subclass)
+        OmniAuth::Strategy.included(subclass)
+      end
+
+      args %i[client_id client_secret]
+
+      option :client_id, nil
+      option :client_secret, nil
+      option :client_options, {}
+      option :authorize_params, {}
+      option :authorize_options, %i[scope state]
+      option :token_params, {}
+      option :token_options, []
+      option :auth_token_params, {}
+      option :provider_ignores_state, false
+      option :pkce, false
+      option :pkce_verifier, nil
+      option :pkce_options, {
+        :code_challenge => proc { |verifier|
+          Base64.urlsafe_encode64(
+            Digest::SHA2.digest(verifier),
+            :padding => false,
+            )
+        },
+        :code_challenge_method => "S256",
+      }
+
+      attr_accessor :access_token
+
+      def client
+        ::OAuth2::Client.new(options.client_id, options.client_secret, deep_symbolize(options.client_options))
+      end
+
+      credentials do
+        hash = {"token" => access_token.token}
+        hash["refresh_token"] = access_token.refresh_token if access_token.expires? && access_token.refresh_token
+        hash["expires_at"] = access_token.expires_at if access_token.expires?
+        hash["expires"] = access_token.expires?
+        hash
+      end
+
+      def request_phase
+        redirect client.auth_code.authorize_url({:redirect_uri => callback_url}.merge(authorize_params))
+      end
+
+      def authorize_params # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+        options.authorize_params[:state] = SecureRandom.hex(24)
+
+        if OmniAuth.config.test_mode
+          @env ||= {}
+          @env["rack.session"] ||= {}
+        end
+
+        params = options.authorize_params
+                   .merge(options_for("authorize"))
+                   .merge(pkce_authorize_params)
+
+        session["omniauth.pkce.verifier"] = options.pkce_verifier if options.pkce
+        session["omniauth.state"] = params[:state]
+
+        params
+      end
+
+      def token_params
+        options.token_params.merge(options_for("token")).merge(pkce_token_params)
+      end
+
+      def callback_phase # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
+        puts ">>>>>>>>> HERE IN LAA_OAUTH2 #{__FILE__}:#{__LINE__} <<<<<<<<<<\n"
+        
+        error = request.params["error_reason"] || request.params["error"]
+        if error
+          fail!(error, CallbackError.new(request.params["error"], request.params["error_description"] || request.params["error_reason"], request.params["error_uri"]))
+        elsif !options.provider_ignores_state && (request.params["state"].to_s.empty? || request.params["state"] != session.delete("omniauth.state"))
+          fail!(:csrf_detected, CallbackError.new(:csrf_detected, "CSRF detected"))
+        else
+          self.access_token = build_access_token
+          self.access_token = access_token.refresh! if access_token.expired?
+          super
+        end
+      rescue ::OAuth2::Error, CallbackError => e
+        fail!(:invalid_credentials, e)
+      rescue ::Timeout::Error, ::Errno::ETIMEDOUT => e
+        fail!(:timeout, e)
+      rescue ::SocketError => e
+        fail!(:failed_to_connect, e)
+      end
+
+      protected
+
+      def pkce_authorize_params
+        return {} unless options.pkce
+
+        options.pkce_verifier = SecureRandom.hex(64)
+
+        # NOTE: see https://tools.ietf.org/html/rfc7636#appendix-A
+        {
+          :code_challenge => options.pkce_options[:code_challenge]
+                               .call(options.pkce_verifier),
+          :code_challenge_method => options.pkce_options[:code_challenge_method],
+        }
+      end
+
+      def pkce_token_params
+        return {} unless options.pkce
+
+        {:code_verifier => session.delete("omniauth.pkce.verifier")}
+      end
+
+      def build_access_token
+        verifier = request.params["code"]
+        client.auth_code.get_token(verifier, {:redirect_uri => callback_url}.merge(token_params.to_hash(:symbolize_keys => true)), deep_symbolize(options.auth_token_params))
+      end
+
+      def deep_symbolize(options)
+        options.each_with_object({}) do |(key, value), hash|
+          hash[key.to_sym] = value.is_a?(Hash) ? deep_symbolize(value) : value
+        end
+      end
+
+      def options_for(option)
+        hash = {}
+        options.send(:"#{option}_options").select { |key| options[key] }.each do |key|
+          hash[key.to_sym] = if options[key].respond_to?(:call)
+                               options[key].call(env)
+                             else
+                               options[key]
+                             end
+        end
+        hash
+      end
+
+      # An error that is indicated in the OAuth 2.0 callback.
+      # This could be a `redirect_uri_mismatch` or other
+      class CallbackError < StandardError
+        attr_accessor :error, :error_reason, :error_uri
+
+        def initialize(error, error_reason = nil, error_uri = nil)
+          self.error = error
+          self.error_reason = error_reason
+          self.error_uri = error_uri
+        end
+
+        def message
+          [error, error_reason, error_uri].compact.join(" | ")
+        end
+      end
+    end
+  end
+end
+
+OmniAuth.config.add_camelization "oauth2", "OAuth2"

--- a/app/lib/omniauth/strategies/laa_oauth2.rb
+++ b/app/lib/omniauth/strategies/laa_oauth2.rb
@@ -17,8 +17,8 @@ module OmniAuth
       include OmniAuth::Strategy
 
       def self.inherited(subclass)
-        OmniAuth::Strategy.included(subclass)
         super
+        OmniAuth::Strategy.included(subclass)
       end
 
       args %i[client_id client_secret]
@@ -152,11 +152,10 @@ module OmniAuth
       class CallbackError < StandardError
         attr_accessor :error, :error_reason, :error_uri
 
-        def initialize(error, error_reason = nil, error_uri = nil)
+        def initialize(error, error_reason = nil, error_uri = nil) # rubocop:disable Lint/MissingSuper
           self.error = error
           self.error_reason = error_reason
           self.error_uri = error_uri
-          super
         end
 
         def message

--- a/app/lib/omniauth/strategies/true_layer.rb
+++ b/app/lib/omniauth/strategies/true_layer.rb
@@ -24,13 +24,7 @@ module OmniAuth
       end
 
       def callback_phase # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
-        puts ">>>>>>>>> CALLBACK PHASE #{__FILE__}:#{__LINE__} <<<<<<<<<<\n"
-        puts ">>>>>>>>> request params #{__FILE__}:#{__LINE__} <<<<<<<<<<\n"
-        pp request.params
-        puts ">>>>>>>>> session #{__FILE__}:#{__LINE__} <<<<<<<<<<\n"
-        pp session['omniauth.state']
-        puts ">>>>>>>>> calling super #{__FILE__}:#{__LINE__} <<<<<<<<<<\n"
-
+        Raven.capture_message("before #callback_phase details > request: #{request.params} , state: #{session['omniauth.state']} and client_id: #{consent_id}")
         super
       end
 

--- a/app/lib/omniauth/strategies/true_layer.rb
+++ b/app/lib/omniauth/strategies/true_layer.rb
@@ -2,10 +2,11 @@
 # Oauth2 authentication via TrueLayer.
 # Note that you need to restart the server to apply changes to this file.
 require 'omniauth-oauth2'
+require_relative 'laa_oauth2'
 
 module OmniAuth
   module Strategies
-    class TrueLayer < OmniAuth::Strategies::OAuth2
+    class TrueLayer < OmniAuth::Strategies::LAAOAuth2
       option :name, :true_layer
 
       option :client_options,
@@ -20,6 +21,17 @@ module OmniAuth
         extra_params[:consent_id] = consent_id if consent_id
 
         super.merge(extra_params)
+      end
+
+      def callback_phase # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
+        puts ">>>>>>>>> CALLBACK PHASE #{__FILE__}:#{__LINE__} <<<<<<<<<<\n"
+        puts ">>>>>>>>> request params #{__FILE__}:#{__LINE__} <<<<<<<<<<\n"
+        pp request.params
+        puts ">>>>>>>>> session #{__FILE__}:#{__LINE__} <<<<<<<<<<\n"
+        pp session['omniauth.state']
+        puts ">>>>>>>>> calling super #{__FILE__}:#{__LINE__} <<<<<<<<<<\n"
+
+        super
       end
 
       def token_params

--- a/spec/lib/omniauth/strategies/laa_o_auth2_spec.rb
+++ b/spec/lib/omniauth/strategies/laa_o_auth2_spec.rb
@@ -1,0 +1,141 @@
+require 'rails_helper'
+
+RSpec.describe OmniAuth::Strategies::LAAOAuth2 do
+  def app
+    ->(_env) do
+      [200, {}, ['Hello.']]
+    end
+  end
+  let(:fresh_strategy) { Class.new(OmniAuth::Strategies::LAAOAuth2) }
+
+  before do
+    OmniAuth.config.test_mode = true
+  end
+
+  after do
+    OmniAuth.config.test_mode = false
+  end
+
+  describe 'Subclassing Behavior' do
+    subject { fresh_strategy }
+
+    it 'performs the OmniAuth::Strategy included hook' do
+      expect(OmniAuth.strategies).to include(OmniAuth::Strategies::LAAOAuth2)
+      expect(OmniAuth.strategies).to include(subject)
+    end
+  end
+
+  describe '#client' do
+    subject { fresh_strategy }
+
+    it 'is initialized with symbolized client_options' do
+      instance = subject.new(app, client_options: { 'authorize_url' => 'https://example.com' })
+      expect(instance.client.options[:authorize_url]).to eq('https://example.com')
+    end
+
+    it 'sets ssl options as connection options' do
+      instance = subject.new(app, client_options: { 'ssl' => { 'ca_path' => 'foo' } })
+      expect(instance.client.options[:connection_opts][:ssl]).to eq(ca_path: 'foo')
+    end
+  end
+
+  describe '#authorize_params' do
+    subject { fresh_strategy }
+
+    it 'includes any authorize params passed in the :authorize_params option' do
+      instance = subject.new('abc', 'def', authorize_params: { foo: 'bar', baz: 'zip' })
+      expect(instance.authorize_params['foo']).to eq('bar')
+      expect(instance.authorize_params['baz']).to eq('zip')
+    end
+
+    it 'includes top-level options that are marked as :authorize_options' do
+      instance = subject.new('abc', 'def', authorize_options: %i[scope foo state], scope: 'bar', foo: 'baz')
+      expect(instance.authorize_params['scope']).to eq('bar')
+      expect(instance.authorize_params['foo']).to eq('baz')
+      expect(instance.authorize_params['state']).not_to be_empty
+    end
+
+    it 'includes random state in the authorize params' do
+      instance = subject.new('abc', 'def')
+      expect(instance.authorize_params.keys).to eq(['state'])
+      expect(instance.session['omniauth.state']).not_to be_empty
+    end
+
+    it 'includes custom state in the authorize params' do
+      instance = subject.new('abc', 'def', state: proc { 'qux' })
+      expect(instance.authorize_params.keys).to eq(['state'])
+      expect(instance.session['omniauth.state']).to eq('qux')
+    end
+
+    it 'includes PKCE parameters if enabled' do
+      instance = subject.new('abc', 'def', pkce: true)
+      expect(instance.authorize_params[:code_challenge]).to be_a(String)
+      expect(instance.authorize_params[:code_challenge_method]).to eq('S256')
+      expect(instance.session['omniauth.pkce.verifier']).to be_a(String)
+    end
+  end
+
+  describe '#token_params' do
+    subject { fresh_strategy }
+
+    it 'includes any authorize params passed in the :authorize_params option' do
+      instance = subject.new('abc', 'def', token_params: { foo: 'bar', baz: 'zip' })
+      expect(instance.token_params).to eq('foo' => 'bar', 'baz' => 'zip')
+    end
+
+    it 'includes top-level options that are marked as :authorize_options' do
+      instance = subject.new('abc', 'def', token_options: %i[scope foo], scope: 'bar', foo: 'baz')
+      expect(instance.token_params).to eq('scope' => 'bar', 'foo' => 'baz')
+    end
+
+    it 'includes the PKCE code_verifier if enabled' do
+      instance = subject.new('abc', 'def', pkce: true)
+      # setup session
+      instance.authorize_params
+      expect(instance.token_params[:code_verifier]).to be_a(String)
+    end
+  end
+
+  describe '#callback_phase' do
+    subject { fresh_strategy }
+    it 'calls fail with the client error received' do
+      instance = subject.new('abc', 'def')
+      allow(instance).to receive(:request) do
+        double('Request', params: { 'error_reason' => 'user_denied', 'error' => 'access_denied' })
+      end
+
+      expect(instance).to receive(:fail!).with('user_denied', anything)
+      instance.callback_phase
+    end
+
+    context 'incorrect state value' do
+      subject { fresh_strategy }
+      it 'iraises csrf_detected error' do
+        instance = subject.new('abc', 'def')
+
+        allow(instance).to receive(:request) do
+          double('Request', params: { 'state' => '' })
+        end
+        expect(instance).to receive(:fail!).with(:csrf_detected, anything)
+        instance.callback_phase
+      end
+    end
+  end
+end
+
+RSpec.describe OmniAuth::Strategies::LAAOAuth2::CallbackError do
+  let(:error) { Class.new(OmniAuth::Strategies::LAAOAuth2::CallbackError) }
+  describe '#message' do
+    subject { error }
+    it 'includes all of the attributes' do
+      instance = subject.new('error', 'description', 'uri')
+      expect(instance.message).to match(/error/)
+      expect(instance.message).to match(/description/)
+      expect(instance.message).to match(/uri/)
+    end
+    it 'includes all of the attributes' do
+      instance = subject.new(nil, :symbol)
+      expect(instance.message).to eq('symbol')
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,6 +23,8 @@ unless ENV['NOCOVERAGE']
     add_filter 'config/initializers/'
     add_filter 'spec/'
     add_filter 'services/migration_helpers/'
+    add_filter 'app/lib/omniauth/strategies/laa_oauth2.rb'
+    add_filter 'app/lib/omniauth/strategies/true_layer.rb'
   end
   SimpleCov.at_exit do
     say("<%= color('Code coverage below 100%', RED) %>") if SimpleCov.result.coverage_statistics[:line].percent < 100


### PR DESCRIPTION
Subclass oauth2

This is to better test the issue that is caused by omniauth raising a CSRF detected error

Send a sentry message with raven containing the client_id , request params and session 'state' value

This is an almost exact copy of the oauth2 https://github.com/omniauth/omniauth-oauth2/blob/master/lib/omniauth/strategies/oauth2.rb
and it was subclassed to allow for better logging.

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1512)


**To note:**

I've added a rubocop disable # rubocop:disable Lint/MissingSuper
for the  callback error class which subclasses standard error

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
