### PR TITLE
AP-1647 Re-fix DWP text

### DIFF
--- a/app/views/providers/check_benefits/_check_benefits_result.html.erb
+++ b/app/views/providers/check_benefits/_check_benefits_result.html.erb
@@ -18,16 +18,10 @@
         </p>
         <ul class="govuk-list govuk-list--bullet">
           <li><%= t "#{result_namespace}.must_answer_financial_questions" %></li>
-          <li><%= t "#{result_namespace}.provide_access_html" %></li>
+          <li><%= t "#{result_namespace}.provide_details" %></li>
         </ul>
       <% else %>
-
         <%= render 'applicant_details' %>
-
-        <p class="govuk-body"><%= t "#{result_namespace}.must_answer_financial_questions" %></p>
-        <%= list_from_translation_path '.check_benefits.check_benefits_result.negative_result.actions' %>
-        <p class="govuk-body"><%= t "#{result_namespace}.provide_access_html" %></p>
-
       <% end %>
     </div>
     <%= next_action_buttons_with_form(

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -173,17 +173,11 @@ en:
         negative_result:
           tab_title: Your client must complete a financial assessment
           title: "We need to check your client's financial eligibility"
-          must_answer_financial_questions: "If your client uses online banking and agrees to share their financial information with us, we'll ask them to:"
-          actions:
-            list: |
-              share their bank transactions from the past 3 months
-              tell us about their income and regular payments
-          provide_access_html: "If they do not, you'll need to continue your application in <abbr title='Client and Cost Management System'>CCMS</abbr>"
         positive_result:
           tab_title: Your client receives benefits that qualify for legal aid
           title: "%{name} receives benefits that qualify for legal aid"
           must_answer_financial_questions: 'answer questions about your client''s property, savings and other assets'
-          provide_access_html: "If they do not, you'll need to continue your application in <abbr title='Client and Cost Management System'>CCMS</abbr>"
+          provide_details: provide details of the case
       how_we_checked: &how_we_checked
         how_we_checked: How we checked your client's benefits status
         details_used: "We used the following details to check your client's benefits status with the DWP:"


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1647)

AP-1409 made changes to the changes to the `/check_benefits` page when the result from DWP was negative.

Some of these changes appear to have been lost, probably as a result of a rebase or merge conflict resolution.

This PR reinstates those changes.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
