### PR TITLE
Ap 1615 a11y start button

### DIFF
--- a/app/javascript/src/start_button.js
+++ b/app/javascript/src/start_button.js
@@ -1,0 +1,9 @@
+$(document).ready(function(){
+    const link = document.getElementById("start");
+
+    link.onkeydown = function (e) {
+        if (e.keyCode == 32) {
+            link.click();
+        }
+    };
+});

--- a/app/views/citizens/legal_aid_applications/index.html.erb
+++ b/app/views/citizens/legal_aid_applications/index.html.erb
@@ -23,8 +23,10 @@
 
   <p class="govuk-body"><%= t('.online_banking_details') %></p>
 
-  <%= link_to start_button_label(:start),
+  <%= link_to start_button_label(:start_now),
               forward_path,
               class: 'govuk-button govuk-button--start govuk-!-margin-top-2',
+              role: 'button',
               id: 'start' %>
+
 <% end %>

--- a/app/views/providers/legal_aid_applications/index.html.erb
+++ b/app/views/providers/legal_aid_applications/index.html.erb
@@ -11,6 +11,7 @@
   <%= link_to(start_button_label(:start_now),
               providers_declaration_path,
               class: 'govuk-button govuk-button--start',
+              role: 'button',
               id: 'start',
               method: :get
       ) %>

--- a/app/views/providers/start/index.html.erb
+++ b/app/views/providers/start/index.html.erb
@@ -16,8 +16,9 @@
 
     <%= list_from_translation_path '.start.index.use_ccms_list' %>
 
-    <%= link_to start_button_label(:start),
+    <%= link_to start_button_label(:start_now),
                 providers_legal_aid_applications_path,
+                role: 'button',
                 class: 'govuk-button govuk-button--start',
                 id: 'start' %>
   </div>


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1615)

Add `role=button` to start links/buttons
Reword so they say Start now
Add in a click event handler so that start buttons all respond to the spacebar as well as enter key

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
