### PR TITLE
AP-1638 Display running balance on caseworker bank transactions csv

### DIFF
--- a/app/presenters/bank_transaction_presenter.rb
+++ b/app/presenters/bank_transaction_presenter.rb
@@ -6,6 +6,7 @@ class BankTransactionPresenter
     operation: 'type',
     description: 'description',
     merchant: 'merchant',
+    running_balance: 'balance/running total',
     category: 'category',
     flagged: 'flagged'
   }.freeze
@@ -71,5 +72,9 @@ class BankTransactionPresenter
     return nil if @remarks.empty?
 
     @remarks.map { |x| x.to_s.humanize }.join(', ').to_s
+  end
+
+  def transaction_running_balance
+    @transaction.running_balance
   end
 end

--- a/app/services/true_layer/importers/import_transactions_service.rb
+++ b/app/services/true_layer/importers/import_transactions_service.rb
@@ -33,7 +33,8 @@ module TrueLayer
             currency: transaction[:currency],
             amount: transaction[:amount],
             happened_at: transaction[:timestamp],
-            operation: transaction[:transaction_type]&.downcase
+            operation: transaction[:transaction_type]&.downcase,
+            running_balance: transaction.dig(:running_balance, :amount)
           }
         end
       end

--- a/db/migrate/20200903165732_add_running_balance_to_bank_transactions.rb
+++ b/db/migrate/20200903165732_add_running_balance_to_bank_transactions.rb
@@ -1,0 +1,5 @@
+class AddRunningBalanceToBankTransactions < ActiveRecord::Migration[6.0]
+  def change
+    add_column :bank_transactions, :running_balance, :decimal
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_13_132316) do
+ActiveRecord::Schema.define(version: 2020_09_03_165732) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -194,6 +194,7 @@ ActiveRecord::Schema.define(version: 2020_08_13_132316) do
     t.datetime "updated_at", null: false
     t.uuid "transaction_type_id"
     t.string "meta_data"
+    t.decimal "running_balance"
     t.index ["bank_account_id"], name: "index_bank_transactions_on_bank_account_id"
     t.index ["transaction_type_id"], name: "index_bank_transactions_on_transaction_type_id"
   end

--- a/spec/factories/bank_transactions.rb
+++ b/spec/factories/bank_transactions.rb
@@ -7,6 +7,7 @@ FactoryBot.define do
     happened_at { Faker::Date.between(from: 3.months.ago + 2.days, to: Time.now - 2.days) }
     currency { Faker::Currency.code }
     amount { rand(1...1_000_000.0).round(2) }
+    running_balance { rand(1...1_000_000.0).round(2) }
 
     trait :debit do
       operation { :debit }

--- a/spec/presenters/bank_transaction_presenter_spec.rb
+++ b/spec/presenters/bank_transaction_presenter_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe BankTransactionPresenter do
     subject(:headers) { described_class.headers }
 
     it { is_expected.to be_a Array }
-    it { expect(headers.count).to eq 8 }
+    it { expect(headers.count).to eq 9 }
   end
 
   describe '.present!' do
@@ -98,6 +98,13 @@ RSpec.describe BankTransactionPresenter do
         let(:remarks) { %w[amount_variation unknown_frequency] }
 
         it { is_expected.to eq 'Amount variation, Unknown frequency' }
+      end
+    end
+
+    describe 'running_balance' do
+      subject(:running_balance) { presenter.build_transaction_hash[:running_balance] }
+      context 'when there is a running balance value' do
+        it { is_expected.to eq transaction.running_balance }
       end
     end
   end

--- a/spec/services/true_layer/importers/import_transactions_service_spec.rb
+++ b/spec/services/true_layer/importers/import_transactions_service_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe TrueLayer::Importers::ImportTransactionsService do
         expect(transaction_1.amount.to_s).to eq(mock_transaction_1[:amount].to_s)
         expect(transaction_1.happened_at).to eq(Time.zone.parse(mock_transaction_1[:timestamp]))
         expect(transaction_1.operation).to eq(mock_transaction_1[:transaction_type].downcase)
+        expect(transaction_1.running_balance.to_s).to eq(mock_transaction_1.dig(:running_balance, :amount).to_s)
 
         expect(transaction_2.true_layer_response).to eq(mock_transaction_2.deep_stringify_keys)
         expect(transaction_2.true_layer_id).to eq(mock_transaction_2[:transaction_id])
@@ -40,6 +41,7 @@ RSpec.describe TrueLayer::Importers::ImportTransactionsService do
         expect(transaction_2.amount.to_s).to eq(mock_transaction_2[:amount].to_s)
         expect(transaction_2.happened_at).to eq(Time.zone.parse(mock_transaction_2[:timestamp]))
         expect(transaction_2.operation).to eq(mock_transaction_2[:transaction_type].downcase)
+        expect(transaction_2.running_balance.to_s).to eq(mock_transaction_2.dig(:running_balance, :amount).to_s)
       end
 
       it 'removes existing transactions' do

--- a/spec/support/true_layer_mock_data.rb
+++ b/spec/support/true_layer_mock_data.rb
@@ -39,8 +39,11 @@ module TrueLayerHelpers
         amount: -2.99,
         currency: 'GBP',
         transaction_type: 'DEBIT',
-        merchant_name: 'Google play'
-
+        merchant_name: 'Google play',
+        running_balance: {
+          currency: 'GBP',
+          amount: 413.11
+        }
       }, {
         transaction_id: SecureRandom.hex,
         timestamp: '2018-02-18T00:00:00',
@@ -48,7 +51,8 @@ module TrueLayerHelpers
         amount: 25.25,
         currency: 'GBP',
         transaction_type: 'CREDIT',
-        merchant_name: 'Ebay'
+        merchant_name: 'Ebay',
+        running_balance: {}
       }]
     }, {
       account_id: SecureRandom.hex,


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1638)

Caseworkers need to be able to a running balance for a bank account on the bank transactions csv report. We already receive this information from TrueLayer, we just don't do anything with it.

This PR contains two commits:

[2e21f1c](https://github.com/ministryofjustice/laa-apply-for-legal-aid/commit/2e21f1c48a623346120df11ea39a06eaf7ef7eb7) adds a `running_balance` field to the `bank_transaction` model and adds functionality to populate that with the value received from TrueLayer.

[bc0cc87](https://github.com/ministryofjustice/laa-apply-for-legal-aid/commit/bc0cc876c329db9b7e084a5379ec6b9d365ed35b) amends the `bank_transaction_presenter` in order to include that running balance on the report.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
