### PR TITLE
Fix yarn security issue

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -11915,7 +11915,7 @@ tar-stream@^1.1.2:
   resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-1.6.2.tgz#8ea55dab37972253d9a9af90fdcd559ae435c555"
   integrity sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==
   dependencies:
-    bl "^1.0.0"
+    bl "^2.2.1"
     buffer-alloc "^1.2.0"
     end-of-stream "^1.0.0"
     fs-constants "^1.0.0"


### PR DESCRIPTION
## What

Github has flagged a security issue with the `bl` package. [CVE-2020-8244](https://github.com/advisories/GHSA-pp7h-53gx-mx7r).  'bl' is an indirect dependency of the `@hint/configuration-web-recommended` library. This has been resolved by updating `bl` to 2.2.1 as recommended.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
