### PR TITLE
AP-1612 Make screen readers ignore null table cells

### DIFF
--- a/app/views/providers/legal_aid_applications/_legal_aid_applications.html.erb
+++ b/app/views/providers/legal_aid_applications/_legal_aid_applications.html.erb
@@ -6,7 +6,7 @@
           <%= sort_column_th type: :alphabetic, content: t('.applicant_name'),   currently_sorted: @initial_sort[:applicant_name] %>
           <%= sort_column_th type: :date,       content: t('.created_at'),       currently_sorted: @initial_sort[:created_at],       combine_right: { at: 555, append: t('.col_and_ref') } %>
           <%= sort_column_th type: :alphabetic, content: t('.application_ref_html'),  currently_sorted: @initial_sort[:applicant_ref] %>
-          <th class="nullcell"></th>
+          <th class="nullcell" aria-hidden="true"></th>
           <%= sort_column_th type: :alphabetic, content: t('.certificate_type'), currently_sorted: @initial_sort[:certificate_type], combine_right: { at: 555, append: t('.col_and_state') } %>
           <%= sort_column_th type: :alphabetic, content: t('.status'),           currently_sorted: @initial_sort[:status] %>
         </tr>
@@ -27,7 +27,7 @@
                 ) %>
 
             <%= sort_column_cell(content: application.application_ref) %>
-            <td class="nullcell"></td>
+            <td class="nullcell" aria-hidden="true"></td>
             <%= sort_column_cell(sort_by: application.used_delegated_functions?.to_s, combine_right: 555) do %>
               <% if application.used_delegated_functions? %>
                 <%= t('.emergency') %>

--- a/app/views/providers/transactions/show.html.erb
+++ b/app/views/providers/transactions/show.html.erb
@@ -53,7 +53,7 @@
 
           <%= sort_column_th type: :alphabetic, content: t('.col_description') %>
 
-          <th class="nullcell"></th>
+          <th class="nullcell" aria-hidden="true"></th>
 
           <%= sort_column_th(
                 type: :numeric,
@@ -89,7 +89,7 @@
                   content: builder.object.description
                 ) %>
 
-            <td class="nullcell"></td>
+            <td class="nullcell" aria-hidden="true"></td>
 
             <%= sort_column_cell(
                   id: "Amount-#{builder.object.id}",


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1612)

In two places there are tables that contain deliberately empty cells - the provider's applications list and the transaction selection screens.

These are read out by screen readers which is confusing for users. The null cells cannot be easily removed as they are used to rearrange the layout of the pages on small screens.

Instead to prevent the cells being announced by screen readers, mark them as `aria-hidden="true"`.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
