### PR TITLE
AP-1558 Fix back button behaviour in merits screens

### DIFF
--- a/app/controllers/providers/check_merits_answers_controller.rb
+++ b/app/controllers/providers/check_merits_answers_controller.rb
@@ -15,7 +15,7 @@ module Providers
 
     def reset
       legal_aid_application.reset!
-      redirect_to back_path
+      redirect_to providers_legal_aid_application_success_likely_index_path
     end
 
     private

--- a/app/views/providers/date_client_told_incidents/show.html.erb
+++ b/app/views/providers/date_client_told_incidents/show.html.erb
@@ -1,4 +1,8 @@
-<%= page_template page_title: t('.h1-heading'), template: :basic do %>
+<%= page_template(
+      page_title: t('.h1-heading'),
+      template: :basic,
+      back_link: { path: providers_legal_aid_application_start_merits_assessment_path(@legal_aid_application) }
+    ) do %>
 
   <%= form_with(
         model: @form,

--- a/app/views/providers/respondents/show.html.erb
+++ b/app/views/providers/respondents/show.html.erb
@@ -1,4 +1,7 @@
-<%= page_template page_title: t('.h1-heading') do %>
+<%= page_template(
+      page_title: t('.h1-heading'),
+      back_link: { path: providers_legal_aid_application_date_client_told_incident_path(@legal_aid_application) }
+    ) do %>
   <%= form_with(
         model: @form,
         url: providers_legal_aid_application_respondent_path,

--- a/app/views/providers/start_merits_assessments/show.html.erb
+++ b/app/views/providers/start_merits_assessments/show.html.erb
@@ -1,4 +1,7 @@
-<%= page_template page_title: t('.h1-heading') do %>
+<%= page_template(
+      page_title: t('.h1-heading'),
+      back_link: { path: providers_legal_aid_application_capital_assessment_result_path(@legal_aid_application) }
+    ) do %>
   <%= simple_format t('.do_merits_of_case_qualify') %>
 
   <%= list_from_translation_path '.start_merits_assessments.show.do_merits_of_case_qualify_list' %>

--- a/app/views/providers/statement_of_cases/show.html.erb
+++ b/app/views/providers/statement_of_cases/show.html.erb
@@ -6,7 +6,12 @@
                     else
                       t('.h1-heading')
                     end %>
-<%= page_template page_title: t('.h1-heading'), head_title: new_head_title, template: :basic do %>
+<%= page_template(
+      page_title: t('.h1-heading'),
+      head_title: new_head_title,
+      template: :basic,
+      back_link: { path: providers_legal_aid_application_respondent_path(@legal_aid_application) }
+    ) do %>
 
   <%= govuk_form_group(
         input: :proceedings_before_the_court,

--- a/app/views/providers/success_likely/index.html.erb
+++ b/app/views/providers/success_likely/index.html.erb
@@ -1,4 +1,8 @@
-<%= page_template page_title: t('.h1-heading'), template: :basic do %>
+<%= page_template(
+      page_title: t('.h1-heading'),
+      template: :basic,
+      back_link: { path: providers_legal_aid_application_statement_of_case_path(@legal_aid_application) }
+    ) do %>
   <%= form_with(
         model: @form,
         url: providers_legal_aid_application_success_likely_index_path,

--- a/app/views/providers/success_prospects/show.html.erb
+++ b/app/views/providers/success_prospects/show.html.erb
@@ -1,4 +1,8 @@
-<%= page_template page_title: t('.h1-heading'), template: :basic do %>
+<%= page_template(
+      page_title: t('.h1-heading'),
+      template: :basic,
+      back_link: { path: providers_legal_aid_application_success_likely_index_path(@legal_aid_application) }
+    ) do %>
   <%= render(
         'shared/forms/success_prospect_form',
         form_path: providers_legal_aid_application_success_prospects_path(@legal_aid_application),

--- a/features/providers/civil_application_journey.feature
+++ b/features/providers/civil_application_journey.feature
@@ -639,6 +639,22 @@ Feature: Civil application journeys
     Then I should be on a page showing "Check your answers"
     And the answer for 'Statement of case' should be 'This is some test data for the statement of case'
     And I should be on a page showing "Confirm the following"
+    Then I click link "Back"
+    Then I should be on a page showing "Is the chance of a successful outcome 50% or better?"
+    Then I click link "Back"
+    Then I should be on a page showing "Provide a statement of case"
+    Then I click link "Back"
+    Then I should be on a page showing "Opponent details"
+    Then I click link "Back"
+    Then I should be on a page showing "Latest incident details"
+    Then I click link "Back"
+    Then I should be on a page showing "Provide details of the case"
+    Then I click 'Continue'
+    Then I click 'Save and continue'
+    Then I click 'Save and continue'
+    Then I click 'Save and continue'
+    Then I click 'Save and continue'
+    Then I click 'Save and continue'
     Then I click 'Submit and continue'
     Then I should be on a page showing "Application complete"
     Then I click 'View completed application'

--- a/spec/requests/providers/check_merits_answers_spec.rb
+++ b/spec/requests/providers/check_merits_answers_spec.rb
@@ -198,8 +198,8 @@ RSpec.describe 'check merits answers requests', type: :request do
       end
 
       describe 'redirection' do
-        it 'redirects to end of application page' do
-          expect(response).to redirect_to providers_legal_aid_application_end_of_application_path(application, back: true)
+        it 'redirects to success_likely page' do
+          expect(response).to redirect_to providers_legal_aid_application_success_likely_index_path
         end
       end
     end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1558)

There is inconsistent behaviour when using the back links in the merits screens. It often takes the user back much further than required, into the means screens, and results in a lot of clicking to get back to the correct place.

This commit hardcodes the correct back link path into each view in the merits flow.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
