### PR TITLE
AP-1657 account details on transaction csv

### DIFF
--- a/app/models/bank_account.rb
+++ b/app/models/bank_account.rb
@@ -20,6 +20,10 @@ class BankAccount < ApplicationRecord
     "#{bank_provider.name} Acct #{account_number}"
   end
 
+  def bank_and_account_name
+    "#{bank_provider.name} #{name}"
+  end
+
   # rubocop:disable Naming/PredicateName
   def has_tax_credits?
     true # TODO: CCMS placeholder

--- a/app/presenters/bank_transaction_presenter.rb
+++ b/app/presenters/bank_transaction_presenter.rb
@@ -7,6 +7,8 @@ class BankTransactionPresenter
     description: 'description',
     merchant: 'merchant',
     running_balance: 'balance/running total',
+    account_type: 'account type',
+    account_name: 'account name',
     category: 'category',
     flagged: 'flagged'
   }.freeze
@@ -75,6 +77,18 @@ class BankTransactionPresenter
   end
 
   def transaction_running_balance
-    @transaction.running_balance
+    @transaction.running_balance || 'Not available'
+  end
+
+  def transaction_account_type
+    account_for_transaction.account_type_label
+  end
+
+  def transaction_account_name
+    account_for_transaction.bank_and_account_name
+  end
+
+  def account_for_transaction
+    @transaction.bank_account
   end
 end

--- a/app/views/citizens/accounts/index.html.erb
+++ b/app/views/citizens/accounts/index.html.erb
@@ -39,7 +39,7 @@
         <tbody class="govuk-table__body">
           <% applicant_bank.bank_accounts.each do |bank_account| %>
             <tr class="govuk-table__row">
-              <td class="govuk-table__cell"><%= "#{applicant_bank.name} #{bank_account.name}" %></td>
+              <td class="govuk-table__cell"><%= bank_account.bank_and_account_name %></td>
               <td class="govuk-table__cell"><%= bank_account.account_number %></td>
               <td class="govuk-table__cell"><%= bank_account.sort_code %></td>
               <td class="govuk-table__cell govuk-table__cell--numeric"><%= value_with_currency_unit(bank_account.balance, bank_account.currency) %></td>

--- a/app/views/providers/applicant_bank_accounts/show.html.erb
+++ b/app/views/providers/applicant_bank_accounts/show.html.erb
@@ -36,7 +36,7 @@
                   <strong><%= t('.account') %></strong>
                 </dt>
                 <dd class="govuk-summary-list__value">
-                  <%= "#{applicant_account.name} #{bank_account.name}" %>
+                  <%= bank_account.bank_and_account_name %>
                 </dd>
               </div>
               <div class="govuk-summary-list__row">

--- a/spec/presenters/bank_transaction_presenter_spec.rb
+++ b/spec/presenters/bank_transaction_presenter_spec.rb
@@ -2,8 +2,8 @@ require 'rails_helper'
 
 RSpec.describe BankTransactionPresenter do
   subject(:presenter) { described_class.new(transaction, remarks) }
-
-  let(:transaction) { create :bank_transaction, :uncategorised_credit_transaction }
+  let(:account) { create :bank_account, account_type: 'SAVINGS' }
+  let(:transaction) { create :bank_transaction, :uncategorised_credit_transaction, bank_account: account }
   let(:remarks) { [] }
 
   it { is_expected.to be_a BankTransactionPresenter }
@@ -12,7 +12,7 @@ RSpec.describe BankTransactionPresenter do
     subject(:headers) { described_class.headers }
 
     it { is_expected.to be_a Array }
-    it { expect(headers.count).to eq 9 }
+    it { expect(headers.count).to eq 11 }
   end
 
   describe '.present!' do
@@ -106,6 +106,29 @@ RSpec.describe BankTransactionPresenter do
       context 'when there is a running balance value' do
         it { is_expected.to eq transaction.running_balance }
       end
+
+      context 'when there is no running balance value' do
+        before { transaction.running_balance = nil }
+        it { is_expected.to eq 'Not available' }
+      end
+    end
+
+    describe 'account_type' do
+      subject(:account_type) { presenter.build_transaction_hash[:account_type] }
+      context 'when the transaction is from a savings account' do
+        it { is_expected.to eq 'Savings' }
+      end
+
+      context 'when the transaction is from a current account' do
+        let(:account) { create :bank_account, account_type: 'TRANSACTION' }
+        it { is_expected.to eq 'Current' }
+      end
+    end
+
+    describe 'account_name' do
+      subject(:account_name) { presenter.build_transaction_hash[:account_name] }
+
+      it { is_expected.to eq account.bank_and_account_name }
     end
   end
 end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1657)

Caseworkers need to know more information about transactions on the bank transaction csv report. This change adds the account name and account type to the report.

The account name should be displayed on the report in a particular format used elsewhere in the application (ie "bank_name account_name". As part of this change a method has been added to the `bank_account` model to provide this name, and this also has been added to the two views display that data. 

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
