### PR TITLE
AP-1644 Prevent duplicate bank providers

### DIFF
--- a/app/services/true_layer/importers/import_provider_service.rb
+++ b/app/services/true_layer/importers/import_provider_service.rb
@@ -24,7 +24,7 @@ module TrueLayer
 
       def import_provider
         bank_provider = applicant.bank_providers.find_or_create_by!(
-          credentials_id: provider[:credentials_id]
+          true_layer_provider_id: provider[:provider][:provider_id]
         )
 
         bank_provider.update!(mapped_resource)

--- a/spec/services/true_layer/importers/import_provider_service_spec.rb
+++ b/spec/services/true_layer/importers/import_provider_service_spec.rb
@@ -8,9 +8,9 @@ RSpec.describe TrueLayer::Importers::ImportProviderService do
 
   describe '#call' do
     let(:mock_provider) { TrueLayerHelpers::MOCK_DATA[:provider] }
-    let(:bank_provider) { applicant.bank_providers.find_by(credentials_id: mock_provider[:credentials_id]) }
-    let(:existing_credentials_id) { SecureRandom.hex }
-    let!(:existing_provider) { create :bank_provider, applicant: applicant, credentials_id: existing_credentials_id }
+    let(:bank_provider) { applicant.bank_providers.find_by(true_layer_provider_id: mock_provider[:provider][:provider_id]) }
+    let(:existing_true_layer_provider_id) { SecureRandom.hex }
+    let!(:existing_provider) { create :bank_provider, applicant: applicant, true_layer_provider_id: existing_true_layer_provider_id }
 
     subject { described_class.call(api_client: api_client, applicant: applicant, token_expires_at: token_expires_at) }
 
@@ -34,8 +34,8 @@ RSpec.describe TrueLayer::Importers::ImportProviderService do
         expect(command.result).to eq(bank_provider)
       end
 
-      context 'existing provider has same credentials_id' do
-        let(:existing_credentials_id) { mock_provider[:credentials_id] }
+      context 'existing provider has same true_layer_provider_id' do
+        let(:existing_true_layer_provider_id) { mock_provider[:provider][:provider_id] }
 
         it 'does not create another bank provider' do
           expect { subject }.not_to change { applicant.bank_providers.count }


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1644)

If a user authenticates twice with the same bank through TrueLayer, a duplicate `bank_provider` record is created resulting in duplicate `bank_account`, `bank_account_holder`, and `bank_transaction` records.

This duplication occurs because `ImportProviderService` checks for existing `bank_provider` based on `credentials_id`, however `credentials_id` is always unique and so no duplicate will ever be found.

This PR changes this functionality so that it instead checks for duplicates based on `true_layer_provider_id`, which will be consistent for all bank details retrieved from a given bank.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
