### PR TITLE
revert to prod credentials for backup scripts:

### DIFF
--- a/bin/cleanup_manual_snapshots
+++ b/bin/cleanup_manual_snapshots
@@ -9,11 +9,11 @@ regex_identifer='\..*'
 
 unset AWS_PROFILE
 
-export ADDRESS=$(kubectl -n laa-apply-for-legalaid-staging get secret apply-for-legal-aid-rds-instance-output -o json | jq -r '.data["rds_instance_address"] | @base64d' | sed 's/\..*//g' )
+export ADDRESS=$(kubectl -n laa-apply-for-legalaid-production get secret apply-for-legal-aid-rds-instance-output -o json | jq -r '.data["rds_instance_address"] | @base64d' | sed 's/\..*//g' )
 
-export AWS_ACCESS_KEY_ID=$(kubectl -n laa-apply-for-legalaid-staging get secret apply-for-legal-aid-rds-instance-output -o json | jq -r '.data["access_key_id"] | @base64d')
+export AWS_ACCESS_KEY_ID=$(kubectl -n laa-apply-for-legalaid-production get secret apply-for-legal-aid-rds-instance-output -o json | jq -r '.data["access_key_id"] | @base64d')
 
-export AWS_SECRET_ACCESS_KEY=$(kubectl -n laa-apply-for-legalaid-staging get secret apply-for-legal-aid-rds-instance-output -o json | jq -r '.data["secret_access_key"] | @base64d')
+export AWS_SECRET_ACCESS_KEY=$(kubectl -n laa-apply-for-legalaid-production get secret apply-for-legal-aid-rds-instance-output -o json | jq -r '.data["secret_access_key"] | @base64d')
 
 # uncomment the line below to print a list of the current backups to the console
 # aws rds describe-db-snapshots --region=eu-west-2 --db-instance-identifier $ADDRESS | jq -r '.DBSnapshots[] | "\(.DBSnapshotIdentifier) created at \(.SnapshotCreateTime)"'

--- a/bin/create_manual_snapshot
+++ b/bin/create_manual_snapshot
@@ -9,10 +9,10 @@ new_fileName=$file_name-$current_time
 
 unset AWS_PROFILE
 
-export AWS_ACCESS_KEY_ID=$(kubectl -n laa-apply-for-legalaid-staging get secret apply-for-legal-aid-rds-instance-output -o json | jq -r '.data["access_key_id"] | @base64d')
+export AWS_ACCESS_KEY_ID=$(kubectl -n laa-apply-for-legalaid-production get secret apply-for-legal-aid-rds-instance-output -o json | jq -r '.data["access_key_id"] | @base64d')
 
-export AWS_SECRET_ACCESS_KEY=$(kubectl -n laa-apply-for-legalaid-staging get secret apply-for-legal-aid-rds-instance-output -o json | jq -r '.data["secret_access_key"] | @base64d')
+export AWS_SECRET_ACCESS_KEY=$(kubectl -n laa-apply-for-legalaid-production get secret apply-for-legal-aid-rds-instance-output -o json | jq -r '.data["secret_access_key"] | @base64d')
 
-export ADDRESS=$(kubectl -n laa-apply-for-legalaid-staging get secret apply-for-legal-aid-rds-instance-output -o json | jq -r '.data["rds_instance_address"] | @base64d' | sed 's/\..*//g' )
+export ADDRESS=$(kubectl -n laa-apply-for-legalaid-production get secret apply-for-legal-aid-rds-instance-output -o json | jq -r '.data["rds_instance_address"] | @base64d' | sed 's/\..*//g' )
 
 aws rds create-db-snapshot --region=eu-west-2 --db-instance-identifier $ADDRESS --db-snapshot-identifier $new_fileName


### PR DESCRIPTION
No ticket for this. A sentry error was being created because of failing backups.

Revert the changes made to the backup DB script, testing was done in staging. The script/cronjobs all work now in staging so these changes revery just the credentials, which will allow the scripts to work in prod only.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
