### PR TITLE
Fix TrueLayer access denied issue

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,0 +1,1 @@
+Rails.application.config.session_store :cookie_store, key: '_app_session'


### PR DESCRIPTION
## What

Requests to TrueLayer are intermittently failing due to CORS errors. This is occurring because the `state` value returned in their responses does not match the `state` value in our session.

https://github.com/omniauth/omniauth-oauth2/issues/58 suggests various solutions for this.

The one that appears to work involves adding `config/initializers/session_store.rb` configured to use `cookie_store`.  This should not be necessary as since Rails 5 this config has been handled implicitly by Rails, but it appears to work 🤷 

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
