### PR TITLE
AP-1667 Reset sessions on login

### DIFF
--- a/app/controllers/citizens/legal_aid_applications_controller.rb
+++ b/app/controllers/citizens/legal_aid_applications_controller.rb
@@ -21,6 +21,7 @@ module Citizens
 
     def start_applicant_flow
       sign_out current_provider if provider_signed_in?
+      reset_session
       session[:current_application_id] = legal_aid_application.id
       sign_applicant_in_via_devise(legal_aid_application.applicant)
       redirect_to citizens_legal_aid_applications_path

--- a/app/controllers/providers/confirm_offices_controller.rb
+++ b/app/controllers/providers/confirm_offices_controller.rb
@@ -4,6 +4,8 @@ module Providers
     helper_method :firm
 
     def show
+      # keep session size small by emptying page history on login
+      session[:page_history] = []
       if firm.offices.count == 1
         current_provider.update!(selected_office: firm.offices.first)
         redirect_to providers_legal_aid_applications_path

--- a/spec/requests/applicants/omniauth_callbacks_spec.rb
+++ b/spec/requests/applicants/omniauth_callbacks_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe 'applicants omniauth call back', type: :request do
 
     it 'does not add its url to page history' do
       subject
-      expect(session[:page_history]).not_to include(applicant_true_layer_omniauth_callback_path)
+      expect(session.keys).not_to include(:page_history)
     end
 
     context 'with a string time' do
@@ -92,9 +92,9 @@ RSpec.describe 'applicants omniauth call back', type: :request do
         expect(response).to redirect_to(error_path(:access_denied))
       end
 
-      it 'does not add page to history' do
+      it 'has reset the session and has no page history' do
         subject
-        expect(session[:page_history]).not_to include(applicant_true_layer_omniauth_callback_path)
+        expect(session.keys).not_to include(:page_history)
       end
     end
   end

--- a/spec/requests/citizens/accounts_spec.rb
+++ b/spec/requests/citizens/accounts_spec.rb
@@ -81,8 +81,8 @@ RSpec.describe 'citizen accounts request', type: :request do
       expect(response).to redirect_to(citizens_accounts_path)
     end
 
-    it 'does not add its url to history' do
-      expect(session[:page_history]).not_to include(gather_citizens_accounts_path)
+    it 'has reset the session and has no page history' do
+      expect(session.keys).not_to include(:page_history)
     end
 
     context 'background worker is still working' do

--- a/spec/services/cfe/create_capitals_service_spec.rb
+++ b/spec/services/cfe/create_capitals_service_spec.rb
@@ -18,7 +18,8 @@ module CFE
 
     describe '#request payload' do
       it 'creates the expected payload from the values in the applicant' do
-        expect(service.request_body).to eq expected_payload_hash.to_json
+        response_hash = JSON.parse(service.request_body, symbolize_names: true)
+        expect(response_hash).to match_array(expected_payload_hash)
       end
     end
 


### PR DESCRIPTION
## Reset session on login

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1667)

The purpose of this ticket is to stop sessions (which are stored in the cookie) from getting too large.  We suspect that this is the reason we are occasionally getting Access Denied error on the callback from TrueLayer, because the session which holds a state variable has been truncated.

The session contains a history of pages visited, which is used by the back buttons to determine where to go back to.

This ticket does two things:
1) on login by the applicant (i.e. clicking on the link that has been sent them in the mail), it resets the session
2) On logging in by the provider, resetting the session isn't an option because devise has already put something it needs there, so we simply reset the page history to an empty array

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
