### PR TITLE
AP1639 Add selected_by 'System' metadata for bank transactions

### DIFF
--- a/app/services/state_benefit_analyser_service.rb
+++ b/app/services/state_benefit_analyser_service.rb
@@ -60,7 +60,8 @@ class StateBenefitAnalyserService
     {
       code: dwp_code,
       label: "Unknown code #{dwp_code}",
-      name: 'Unknown state benefit'
+      name: 'Unknown state benefit',
+      selected_by: 'System'
     }
   end
 
@@ -73,7 +74,8 @@ class StateBenefitAnalyserService
     {
       code: benefit.code,
       label: benefit.label,
-      name: benefit.name
+      name: benefit.name,
+      selected_by: 'System'
     }
   end
 

--- a/spec/factories/bank_transactions.rb
+++ b/spec/factories/bank_transactions.rb
@@ -20,7 +20,7 @@ FactoryBot.define do
     trait :benefits do
       operation { 'credit' }
       transaction_type { TransactionType.where(name: 'benefits').first || create(:transaction_type, :benefits) }
-      meta_data { { code: 'CHB', label: 'child_benefit', name: 'Child Benefit' } }
+      meta_data { { code: 'CHB', label: 'child_benefit', name: 'Child Benefit', selected_by: 'System' } }
     end
 
     trait :uncategorised_credit_transaction do
@@ -36,7 +36,7 @@ FactoryBot.define do
     trait :disregarded_benefits do
       operation { 'credit' }
       transaction_type { TransactionType.where(name: 'excluded_benefits').first || create(:transaction_type, :benefits) }
-      meta_data { { code: nil, label: 'grenfell_payments', name: 'Grenfell Tower fire victims payments' } }
+      meta_data { { code: nil, label: 'grenfell_payments', name: 'Grenfell Tower fire victims payments', selected_by: 'System' } }
     end
 
     trait :unassigned_benefits do
@@ -47,7 +47,7 @@ FactoryBot.define do
     trait :unknown_benefits do
       operation { 'credit' }
       transaction_type { TransactionType.where(name: 'benefits').first || create(:transaction_type, :benefits) }
-      meta_data { { code: 'xxx', label: 'unknown', name: 'Unrecognised state benefit' } }
+      meta_data { { code: 'xxx', label: 'unknown', name: 'Unrecognised state benefit', selected_by: 'System' } }
     end
 
     trait :friends_or_family do
@@ -97,7 +97,7 @@ FactoryBot.define do
 
     trait :with_meta do
       meta_data do
-        { code: 'UC', label: 'universal_credit', name: 'Universal credit' }
+        { code: 'UC', label: 'universal_credit', name: 'Universal credit', selected_by: 'System' }
       end
     end
   end

--- a/spec/services/state_benefit_analyser_service_spec.rb
+++ b/spec/services/state_benefit_analyser_service_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe StateBenefitAnalyserService do
         it 'updates the meta data with the label of the state benefit' do
           subject
           tx = legal_aid_application.reload.bank_transactions.first
-          expect(tx.meta_data).to eq({ code: 'CWP', label: 'cold_weather_payment', name: 'Cold Weather Payment' })
+          expect(tx.meta_data).to eq({ code: 'CWP', label: 'cold_weather_payment', name: 'Cold Weather Payment', selected_by: 'System' })
         end
 
         it 'adds both included and excluded transaction types to the legal aid application' do
@@ -74,7 +74,7 @@ RSpec.describe StateBenefitAnalyserService do
         it 'updates the meta data with the label of the state benefit' do
           subject
           tx = legal_aid_application.reload.bank_transactions.first
-          expect(tx.meta_data).to eq({ code: 'DLA', label: 'disability_living_allowance', name: 'Disability Living Allowance' })
+          expect(tx.meta_data).to eq({ code: 'DLA', label: 'disability_living_allowance', name: 'Disability Living Allowance', selected_by: 'System' })
         end
 
         it 'adds both included and excluded transaction types to the legal aid application' do
@@ -97,7 +97,7 @@ RSpec.describe StateBenefitAnalyserService do
       it 'updates the meta data with the label of the state benefit' do
         subject
         tx = legal_aid_application.reload.bank_transactions.first
-        expect(tx.meta_data).to eq({ code: 'XXXX', label: 'Unknown code XXXX', name: 'Unknown state benefit' })
+        expect(tx.meta_data).to eq({ code: 'XXXX', label: 'Unknown code XXXX', name: 'Unknown state benefit', selected_by: 'System' })
       end
 
       it 'adds a transaction type of benefits to the legal aid application' do
@@ -115,28 +115,32 @@ RSpec.describe StateBenefitAnalyserService do
           'name' => 'Cold Weather Payment',
           'dwp_code' => 'CWP',
           'exclude_from_gross_income' => false,
-          'category' => nil
+          'category' => nil,
+          'selected_by': 'System'
         },
         {
           'label' => 'disability_living_allowance',
           'name' => 'Disability Living Allowance',
           'dwp_code' => 'DLA',
           'exclude_from_gross_income' => true,
-          'category' => 'carer_disability'
+          'category' => 'carer_disability',
+          'selected_by': 'System'
         },
         {
           'label' => 'employment_support_allowance',
           'name' => 'Employment Support Allowance',
           'dwp_code' => 'ESA',
           'exclude_from_gross_income' => false,
-          'category' => nil
+          'category' => nil,
+          'selected_by': 'System'
         },
         {
           'label' => 'social_fund_payments',
           'name' => 'Social Fund Payment',
           'dwp_code' => nil,
           'exclude_from_gross_income' => false,
-          'category' => nil
+          'category' => nil,
+          'selected_by': 'System'
         }
       ]
     end


### PR DESCRIPTION
Add selected_by 'System' to bank transactions metadata when the system automatically
selects state benefits from the transactions in the bank.

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1639)

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
