### PR TITLE
AP-938 Remove provider roles from profile screen

### DIFF
--- a/app/views/providers/providers/show.html.erb
+++ b/app/views/providers/providers/show.html.erb
@@ -17,10 +17,6 @@
         <td class="govuk-table__cell"><%= @provider.email %></td>
       </tr>
       <tr class="govuk-table__row">
-        <th class="govuk-table__header" scope="row"><%= t('.role') %></th>
-        <td class="govuk-table__cell wrap-text"><%= @provider.roles&.gsub(/,(?=\S)/, ', ') %></td>
-      </tr>
-      <tr class="govuk-table__row">
         <th class="govuk-table__header" scope="row"><%= t('.account_number') %></th>
         <td class="govuk-table__cell"></td>
       </tr>

--- a/spec/requests/providers/providers_spec.rb
+++ b/spec/requests/providers/providers_spec.rb
@@ -22,11 +22,4 @@ RSpec.describe Providers::ProvidersController, type: :request do
     expect(unescaped_response_body).to include(provider.username)
     expect(unescaped_response_body).to include(provider.email)
   end
-
-  context 'with unspaced roles' do
-    let(:provider) { create :provider, roles: 'CWA,PUI' }
-    it 'displays roles with spaces' do
-      expect(response.body).to include('CWA, PUI')
-    end
-  end
 end


### PR DESCRIPTION

## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-938)

The profile page shows the role codes for the logged in user, which looks confusing -  the codes are meaningless to the user. This commit removes the roles from the view so they are no longer displayed to the user.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
