### PR TITLE
revert cronjob schedule in UAT and staging

### DIFF
--- a/helm_deploy/apply-for-legal-aid/templates/_helpers.tpl
+++ b/helm_deploy/apply-for-legal-aid/templates/_helpers.tpl
@@ -70,7 +70,7 @@ In UAT and Staging, we dont run the job by scheduling it for 31st February.
   {{- if contains "-production" .Release.Namespace -}}
     {{ "3 7-21 * * *"}}
   {{- else -}}
-    {{ "*/5 * * * *" }}
+    {{ "0 0 31 2 *" }}
   {{- end -}}
 {{- end -}}
 
@@ -83,6 +83,6 @@ In UAT and Staging, we dont run the job by scheduling it for 31st February
   {{- if contains "-production" .Release.Namespace -}}
     {{ "0 7 * * *"}}
   {{- else -}}
-    {{ "45 * * * *" }}
+    {{ "0 0 31 2 *" }}
   {{- end -}}
 {{- end -}}


### PR DESCRIPTION
## What

After fixing the DB backup issue in prod I forgot to reset the schedules for UAT and Staging, which meant these cronjobs were making lots of failing pods on both environments.


Describe what you did and why.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
