### PR TITLE
AP-1616 Make continue link styled as button accessible

### DIFF
--- a/app/javascript/src/continue_button.js
+++ b/app/javascript/src/continue_button.js
@@ -1,0 +1,12 @@
+$(document).ready(function() {
+  const link = document.getElementById("continue");
+
+  if (link != null) {
+    link.onkeydown = function(e) {
+      if (e.keyCode == 32) {
+        e.preventDefault();
+        link.click();
+      }
+    };
+  }
+});

--- a/app/javascript/src/start_button.js
+++ b/app/javascript/src/start_button.js
@@ -1,9 +1,12 @@
-$(document).ready(function(){
-    const link = document.getElementById("start");
+$(document).ready(function() {
+  const link = document.getElementById("start");
 
-    link.onkeydown = function (e) {
-        if (e.keyCode == 32) {
-            link.click();
-        }
+  if (link != null) {
+    link.onkeydown = function(e) {
+      if (e.keyCode == 32) {
+        e.preventDefault();
+        link.click();
+      }
     };
+  }
 });

--- a/app/views/providers/application_confirmations/show.html.erb
+++ b/app/views/providers/application_confirmations/show.html.erb
@@ -25,6 +25,7 @@
         t('.back_button'),
         providers_legal_aid_applications_path,
         class: 'govuk-button govuk-button',
-        id: 'continue'
+        id: 'continue',
+        role: 'button'
       ) %>
 <% end %>


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1616)

On `application_confirmations/show.html.erb`, the 'Back to your application' link has been styled as a button but does not have a role of `button` assigned or a keyboard event handler to allow keyboard-only users to activate the element with the space bar.

This change adds a role of `button` to the link and create an event handler to allow a user to activate the `button` with the space bar.

It also fixes a couple of issues with the similar event handler for `start` buttons, 
- an error is firing an error on all pages where there is no `start` button. Fix this by adding a check for `null`s
- the default space bar behaviour of scrolling is firing when a user uses the keyboard to activate the button, which looks a bit strange. Add a `preventDefault` to stop this happening

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
