### PR TITLE
AP-1665 Set default responsibility for firms

### DIFF
--- a/app/models/firm.rb
+++ b/app/models/firm.rb
@@ -6,6 +6,10 @@ class Firm < ApplicationRecord
   has_many :actor_permissions, as: :permittable
   has_many :permissions, through: :actor_permissions
 
+  before_create do
+    self.permission_ids = [passported_permission_id]
+  end
+
   after_create do
     ActiveSupport::Notifications.instrument 'dashboard.firm_created'
   end
@@ -16,5 +20,9 @@ class Firm < ApplicationRecord
     else
       all
     end
+  end
+
+  def passported_permission_id
+    Permission.find_by(role: 'application.passported.*')&.id
   end
 end

--- a/spec/models/firm_spec.rb
+++ b/spec/models/firm_spec.rb
@@ -5,8 +5,15 @@ RSpec.describe 'Firm' do
 
   describe '#permissions' do
     context 'when there are no permissions' do
-      it 'returns an empty collection' do
-        expect(firm.permissions).to be_empty
+      let!(:default_permission) { create :permission }
+      let(:firm_with_no_permission) { create :firm }
+
+      before do
+        allow_any_instance_of(Firm).to receive(:passported_permission_id).and_return(default_permission.id)
+      end
+
+      it 'has a default permission' do
+        expect(firm_with_no_permission.permissions).to eq [default_permission]
       end
     end
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1665)

Adds the passported responsibility to all new firms automatically so that providers can use the system without any further admin interaction.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
