### PR TITLE
AP-1668 List firm permissions

### DIFF
--- a/app/views/admin/firms/index.html.erb
+++ b/app/views/admin/firms/index.html.erb
@@ -9,20 +9,26 @@
     <table class="govuk-table">
       <thead class="govuk-table__head">
         <tr class="govuk-table__row">
-          <th class="govuk-table__header" scope="col"><%= t('.firm') %></th>
+          <th class="govuk-table__header govuk-!-width-one-quarter" scope="col"><%= t('.firm') %></th>
           <th class="govuk-table__header" scope="col"><%= t('.num_users') %></th>
+          <th class="govuk-table__header govuk-!-width-one-half" scope="col"><%= t('.permissions') %></th>
           <th class="govuk-table__header" scope="col"><%= t('.action') %></th>
         </tr>
       </thead>
 
       <tbody class="govuk-table__body">
-      <% @firms.each do |firm| %>
-        <tr class="govuk-table__row">
-          <td class="govuk-table__cell case-full-name"><%= firm.name %></td>
-          <td class="govuk-table__cell case-reference-number"><%= firm.providers.count %></td>
-          <td class="govuk-table__cell case-reference-number"><%= link_to t('.view_users'), admin_firm_providers_path(firm), id: "firm-#{firm.id}", method: :get %></td>
-        </tr>
-      <% end %>
+        <% @firms.each do |firm| %>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell"><%= firm.name %></td>
+            <td class="govuk-table__cell"><%= firm.providers.count %></td>
+            <td class="govuk-table__cell">
+              <% firm.permissions.each do |permission| %>
+                <li><%= permission.description %></li>
+              <% end %>
+            </td>
+            <td class="govuk-table__cell"><%= link_to t('.view_users'), admin_firm_providers_path(firm), id: "firm-#{firm.id}", method: :get %></td>
+          </tr>
+        <% end %>
       </tbody>
     </table>
   </div>

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -59,6 +59,7 @@ en:
         action: Action
         firm: Firm name
         num_users: Number of provider users
+        permissions: Permissions
         view_users: View provider users
     reports:
       index:

--- a/spec/factories/firms.rb
+++ b/spec/factories/firms.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   factory :firm do
     ccms_id { rand(1..1000) }
     name { Faker::Company.name }
+    with_passported_permissions
   end
 
   trait :with_passported_permissions do

--- a/spec/models/firm_spec.rb
+++ b/spec/models/firm_spec.rb
@@ -18,33 +18,29 @@ RSpec.describe 'Firm' do
     end
 
     context 'when there are permissions' do
+      let(:default_permission) { Permission.find_by(role: 'application.passported.*') }
       let!(:permission1) { create :permission }
       let!(:permission2) { create :permission }
 
-      context 'with just permission 2' do
-        before do
-          firm.permissions << permission2
-          firm.save!
-        end
-
-        it 'returns just the one permission' do
-          expect(firm.reload.permissions).to eq [permission2]
+      context 'with just the default permission' do
+        it 'returns the default permission' do
+          expect(firm.reload.permissions).to eq [default_permission]
         end
       end
 
-      context 'with both permissions' do
+      context 'with additional permissions added' do
         before do
           firm.permissions << permission2
           firm.permissions << permission1
           firm.save!
         end
 
-        it 'returns both permissions' do
-          expect(firm.reload.permissions).to match_array [permission2, permission1]
+        it 'returns the correct permissions' do
+          expect(firm.reload.permissions).to match_array [default_permission, permission2, permission1]
         end
 
         it 'returns all permissions' do
-          expect(firm.permissions.all).to match_array [permission2, permission1]
+          expect(firm.permissions.all).to match_array [default_permission, permission2, permission1]
         end
       end
     end

--- a/spec/requests/admin/firms_spec.rb
+++ b/spec/requests/admin/firms_spec.rb
@@ -3,9 +3,13 @@ require 'rails_helper'
 module Admin
   RSpec.describe FirmsController, type: :request do
     let(:admin_user) { create :admin_user }
+    let(:permission) { create :permission }
     let!(:firms) { create_list :firm, 3 }
 
-    before { sign_in admin_user }
+    before do
+      firms.first.update!({ permission_ids: [permission.id] })
+      sign_in admin_user
+    end
 
     describe 'GET admin/firms' do
       before { get admin_firms_path }
@@ -18,11 +22,16 @@ module Admin
         expect(response.body).to include('List of firms')
       end
 
-      it 'the name of every firm' do
+      it 'the displays the name of every firm' do
         response_body = CGI.unescapeHTML(response.body)
         expect(response_body).to include(firms[0].name)
         expect(response_body).to include(firms[1].name)
         expect(response_body).to include(firms[2].name)
+      end
+
+      it 'displays firm permissions' do
+        response_body = CGI.unescapeHTML(response.body)
+        expect(response_body).to include(permission.description)
       end
     end
   end

--- a/spec/requests/admin/firms_spec.rb
+++ b/spec/requests/admin/firms_spec.rb
@@ -3,13 +3,9 @@ require 'rails_helper'
 module Admin
   RSpec.describe FirmsController, type: :request do
     let(:admin_user) { create :admin_user }
-    let(:permission) { create :permission }
     let!(:firms) { create_list :firm, 3 }
 
-    before do
-      firms.first.update!({ permission_ids: [permission.id] })
-      sign_in admin_user
-    end
+    before { sign_in admin_user }
 
     describe 'GET admin/firms' do
       before { get admin_firms_path }
@@ -31,7 +27,7 @@ module Admin
 
       it 'displays firm permissions' do
         response_body = CGI.unescapeHTML(response.body)
-        expect(response_body).to include(permission.description)
+        expect(response_body).to include(firms.first.permissions.first.description)
       end
     end
   end

--- a/spec/requests/providers/check_benefits_spec.rb
+++ b/spec/requests/providers/check_benefits_spec.rb
@@ -253,6 +253,7 @@ RSpec.describe Providers::CheckBenefitsController, type: :request do
         Setting.setting.update!(allow_non_passported_route: perm.setting)
         allow(Rails.configuration.x).to receive(:allow_non_passported_route).and_return(perm.env)
         provider = create :provider, perm.provider_permissions
+        provider.firm.permissions = []
         application = create :application, :checking_applicant_details, applicant: applicant, provider: provider
         create :benefit_check_result, perm.benefit_check_result, legal_aid_application: application
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1668)

Amend the index view for /admin/firms to display which permissions a firm holds.

Also adjusts the table layout to account for the extra column and tidies up the existing code a little.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
