### PR TITLE
AP-1680 Update readme and add user for portal login

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,37 @@ the `update_details` method on the current_provider (a Provider object supplied 
 a background job to query the 
 provider details API and updates any details that have changed on the provider record.
 
+
+### Signing out of the application
+
+When using the mock-saml in development or on UAT, sign out works in the way you'd expect: Clicking signout takes you
+to a page confirming your're signed out, and going to the start url will redirect you to the sign-in page.
+
+When using the portal for authentication, (on staging or live, or if configured as described below, on localhost), the
+sign out link takes you to a feedback page, but doesn't really sign you out.  This is an side effect of using the 
+portal Single Sign On system. You're not signed out until you tell the portal you've signed out, and when you do that, 
+you are signed out of all other applications at the same time. (Behind the scenes, the Devise `authenticate_provider!` 
+method contacts the portal to see if your signed in, and if so, repopulates the session with the required data).
+
+You can sign out of the portal by going to https://portal.stg.legalservices.gov.uk/oam/server/logout
+
+### How to set up localhost to use the portal
+
+Setting up localhost to use the portal staging environment for signing in rather than the mock is fairly straightforward:
+
+* change the values of the following environment variables in your .env file to the same values as in the Staging environment:
+    * LAA_PORTAL_MOCK_SAML=false
+    * LAA_PORTAL_IDP_CERT=<value from staging>
+    * LAA_PORTAL_IDP_SLO_TARGET_URL=https://portal.stg.legalservices.gov.uk/oam/server/logout
+    * LAA_PORTAL_SECRET_KEY=<value from staging>
+    * LAA_PORTAL_IDP_SSO_TARGET_URL=https://portal.stg.legalservices.gov.uk/oamfed/idp/samlv20
+    * LAA_PORTAL_CERTIFICATE=<value from staging>
+    * LAA_PORTAL_IDP_CERT_FINGERPRINT_ALGORITHM=<idp-cert-fingerprint-alg-goes-here>
+    
+  Note that the value for LAA_PORTAL_IDP_CERT_FINGERPRINT_ALGORITHM is <idp-cert-fingerprint-alg-goes-here> and not replaced with anything else.
+  
+* Use the BENREID credientials from staging to log in (This use is set up as part of the `db:seed` rake task)
+
 ### Benefits checker
 
 To mock the benefits check in development and testing add the following environment

--- a/db/seeds/test_provider_populator.rb
+++ b/db/seeds/test_provider_populator.rb
@@ -8,7 +8,8 @@ class TestProviderPopulator
     'Firm1 & Co.' => [805, %w[1F805I:12 2F805I:13 3F805I:14 4F805I:15]],
     'Firm2 & Co.' => [806, %w[2F805I:16 3F805I:17 4F805I:18]],
     'Richards & Co.' => [555, %w[1S555R:19 2S555R:20]],
-    'David Gray LLP' => [19_148, ['0B721W:137570']]
+    'David Gray LLP' => [19_148, ['0B721W:137570']],
+    'Test firm for portal login' => [807, %w[9F805X:21 3X805Z:22]]
   }.freeze
 
   TEST_PROVIDERS = {
@@ -21,7 +22,8 @@ class TestProviderPopulator
     'firm1-user2' => ['Firm1 & Co.', 'firm1-user2@example.com', 106, 591],
     'firm2-user1' => ['Firm2 & Co.', 'firm2-user1@example.com', 107, 592],
     'sr' => ['Richards & Co.', 'stephen.richards@digital.justice.gov.uk', 108, 593],
-    'MARTIN.RONAN@DAVIDGRAY.CO.UK' => ['David Gray LLP', 'martin.ronan@example.com', 494_000, 5027]
+    'MARTIN.RONAN@DAVIDGRAY.CO.UK' => ['David Gray LLP', 'martin.ronan@example.com', 494_000, 5027],
+    'BENREID' => ['Test firm for portal login', 'benreid@talbotssolicitors.co.uk', 107, 592]
   }.freeze
 
   def run


### PR DESCRIPTION
## What

This PR does three things: 
- Adds a section to the README explaining the difference of behaviour between signing out when using the LAA Portal for authentication, and signing out when using mock saml.
- Adds a section to the README explaining how to configure localhost to use the LAA Portal staging environment for authentication
- Adds a user BENREID to the seed data which can be used to sign on to the LAA Staging Portal

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1680)

Describe what you did and why.

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
