### PR TITLE
AP-1610: Update confirm_office view

### DIFF
--- a/app/lib/govuk_elements_form_builder/form_builder.rb
+++ b/app/lib/govuk_elements_form_builder/form_builder.rb
@@ -214,7 +214,9 @@ module GovukElementsFormBuilder
       title = text_hash(title)
       size = title.fetch(:size, 'xl')
       htag = title.fetch(:htag, :h1)
-      content_tag(:legend, class: "govuk-fieldset__legend govuk-fieldset__legend--#{size}") do
+      padding_below = title.fetch(:padding_below, nil)
+      padding_class = " govuk-!-padding-bottom-#{padding_below}" if padding_below.present?
+      content_tag(:legend, class: "govuk-fieldset__legend govuk-fieldset__legend--#{size}#{padding_class}") do
         content_tag(htag, title[:text], class: 'govuk-fieldset__heading')
       end
     end

--- a/app/views/providers/confirm_offices/show.html.erb
+++ b/app/views/providers/confirm_offices/show.html.erb
@@ -1,4 +1,4 @@
-<%= page_template page_title: t('.h1-heading', firm: firm.name), template: :basic do %>
+<%= page_template page_title: t('.h1-heading', office_code: current_provider.selected_office.code), template: :basic do %>
   <%= form_with(url: providers_confirm_office_path, method: :patch, local: true) do |form| %>
 
     <% if @error %>
@@ -19,24 +19,24 @@
     <%= govuk_form_group(
           show_error_if: @error,
         ) do %>
-
-      <%= govuk_fieldset_header(content_for(:page_title)) %>
-
-      <div class="govuk-!-padding-bottom-6"></div>
-      <p class="govuk-body">
-        <strong><%= t('.account_number') %></strong> <%= current_provider.selected_office.code %>
-      </p>
-
-      <div class="govuk-!-padding-bottom-2"></div>
-      <h2 class="govuk-heading-m"><%= t('.is_this_correct') %></h2>
-
       <%
         options = [
           { value: :yes, label: t('generic.yes') },
           { value: :no,  label: t('.no_another_office') }
         ]
       %>
-      <%= form.govuk_collection_radio_buttons :correct, options, :value, :label, error: @error %>
+      <%= form.govuk_collection_radio_buttons(
+            :correct,
+            options,
+            :value,
+            :label,
+            error: @error,
+            title: {
+                      text: t('.h1-heading', office_code: current_provider.selected_office.code),
+                      htag: :h1,
+                      padding_below: 6
+            }
+          ) %>
 
     <% end %>
 

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -274,11 +274,9 @@ en:
           - property, savings and other assets
     confirm_offices:
       show:
-        h1-heading: Confirm the account number of the office handling this application
+        h1-heading: Is %{office_code} your office account number?
         error: Select yes if this is the account number of the office handling this application
         no_another_office: No, another office is handling this application
-        account_number: 'Legal Aid Agency account number: '
-        is_this_correct: Is this correct?
     date_client_told_incidents:
       show:
         h1-heading: Latest incident details

--- a/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
+++ b/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
@@ -134,6 +134,21 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
         expect(subject).to eq expected_html
       end
     end
+
+    context 'passing in a title hash with padding' do
+      let(:params) do
+        {
+          text: 'My text',
+          size: :m,
+          htag: :h2,
+          padding_below: 6
+        }
+      end
+      it 'returns html with medium size' do
+        expected_html = '<legend class="govuk-fieldset__legend govuk-fieldset__legend--m govuk-!-padding-bottom-6"><h2 class="govuk-fieldset__heading">My text</h2></legend>'
+        expect(subject).to eq expected_html
+      end
+    end
   end
 
   describe 'govuk_text_field' do


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1610)

Move the text inside an HTML block in providers.yml
This allows the view to call a single block and assign
it to the legend inside the govuk_collection_radio_buttons
helper

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
