### PR TITLE
move the to_s to fix tests

### DIFF
--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -251,12 +251,12 @@ class LegalAidApplication < ApplicationRecord # rubocop:disable Metrics/ClassLen
 
   def online_savings_accounts_balance
     accounts = applicant.bank_accounts.reject { |c| c.account_type == 'TRANSACTION' }&.map(&:balance)
-    accounts.sum
+    accounts.sum.to_s
   end
 
   def online_current_accounts_balance
     accounts = applicant.bank_accounts.reject { |c| c.account_type == 'SAVINGS' }&.map(&:balance)
-    accounts.sum
+    accounts.sum.to_s
   end
 
   def other_assets?

--- a/spec/services/cfe/create_capitals_service_spec.rb
+++ b/spec/services/cfe/create_capitals_service_spec.rb
@@ -100,11 +100,11 @@ module CFE
           },
           {
             description: 'Current accounts',
-            value: application.online_current_accounts_balance.to_s
+            value: application.online_current_accounts_balance
           },
           {
             description: 'Savings accounts',
-            value: application.online_savings_accounts_balance.to_s
+            value: application.online_savings_accounts_balance
           }
         ],
         non_liquid_capital: [


### PR DESCRIPTION
## What

Bugfix

If only one type of account (current or savings) is created by the test, then the other account type had a value of 0.  Zero is handled as a number in the test whereas any positive or negative value is a string. The fix moves the creation of the string to the method on legal_aid_application instead of in the test.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
