### PR TITLE
AP-1620 Make table header contrast accessible

### DIFF
--- a/app/assets/stylesheets/table-sort.scss
+++ b/app/assets/stylesheets/table-sort.scss
@@ -1,3 +1,5 @@
+@import "govuk-frontend/govuk/settings/all";
+
 .sort.js-sortable, th.select-all, th.clear-all {
   color:#0b0c0c;
   cursor:pointer;
@@ -13,7 +15,7 @@
     background-color:#c8cacb;
   }
   &:focus {
-    outline: 3px solid #ffdd00;
+    box-shadow: 0 0 0 $govuk-focus-width $govuk-focus-text-colour, 0 0 0 $govuk-focus-width*2 $govuk-focus-colour;
     outline-offset: 0;
     z-index: 100;
   }


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1620)

Table headers on `/applications`, `/incoming_transactions` and `/outgoing_transactions` do not have GOVUK compliant contrast when they have focus.

This change adds formatting using CSS so that the cell is correctly highlighted with both a black border and a yellow border.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
