### PR TITLE
AP-1648 Add CCMS applicant if no applicant ref returned

### DIFF
--- a/app/services/ccms/submitters/obtain_applicant_reference_service.rb
+++ b/app/services/ccms/submitters/obtain_applicant_reference_service.rb
@@ -20,11 +20,12 @@ module CCMS
       end
 
       def process_records(parser) # rubocop:disable Metrics/AbcSize
-        if parser.record_count.to_i.zero?
+        applicant_ccms_reference = parser.applicant_ccms_reference
+        if applicant_ccms_reference.nil?
           create_history(:case_ref_obtained, submission.aasm_state, xml_request, response)
           CCMS::Submitters::AddApplicantService.new(submission).call
         else
-          submission.applicant_ccms_reference = parser.applicant_ccms_reference
+          submission.applicant_ccms_reference = applicant_ccms_reference
           submission.save!
           create_history(:case_ref_obtained, submission.aasm_state, xml_request, response) if submission.obtain_applicant_ref!
         end

--- a/spec/data/ccms/applicant_search_response_results_no_details.xml
+++ b/spec/data/ccms/applicant_search_response_results_no_details.xml
@@ -1,0 +1,28 @@
+<env:Envelope xmlns:env="http://schemas.xmlsoap.org/soap/envelope/" xmlns:wsa="http://www.w3.org/2005/08/addressing">
+  <env:Header>
+    <wsa:MessageID>urn:663B18706B5211E99F6F058281F6012C</wsa:MessageID>
+    <wsa:ReplyTo>
+      <wsa:Address>http://www.w3.org/2005/08/addressing/anonymous</wsa:Address>
+    </wsa:ReplyTo>
+  </env:Header>
+  <env:Body>
+    <ClientInqRS xmlns:msg="http://legalservices.gov.uk/CCMS/ClientManagement/Client/1.0/ClientBIM" xmlns="http://legalservices.gov.uk/CCMS/ClientManagement/Client/1.0/ClientBIM" xmlns:wsa="http://www.w3.org/2005/08/addressing">
+      <header:HeaderRS xmlns:header="http://legalservices.gov.uk/Enterprise/Common/1.0/Header">
+        <header:TransactionID>20190301030405123456</header:TransactionID>
+        <header:RequestDetails>
+          <header:TransactionRequestID>20190301030405123456</header:TransactionRequestID>
+          <header:Language>ENG</header:Language>
+          <header:UserLoginID>my_login</header:UserLoginID>
+          <header:UserRole>my_role</header:UserRole>
+        </header:RequestDetails>
+        <header:Status>
+          <header:Status>Success</header:Status>
+          <header:StatusFreeText>End of Get Party details process.</header:StatusFreeText>
+        </header:Status>
+      </header:HeaderRS>
+      <msg:RecordCount>
+        <common:RecordsFetched xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">1</common:RecordsFetched>
+      </msg:RecordCount>
+    </ClientInqRS>
+  </env:Body>
+</env:Envelope>


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1648)

A recent production incident highlighted that it's possible for an applicant to exist in the CCMS database but be disabled, in which case a non-zero `record_count` is returned to Apply but no `ClientReferenceNumber` is included. This causes failures later in the submission process

This PR changes that functionality so that in this situation Apply makes a call to CCMS to create a new applicant.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
