### PR TITLE
AP-1545 Record providers email and page on feedback

### DIFF
--- a/app/controllers/concerns/backable.rb
+++ b/app/controllers/concerns/backable.rb
@@ -1,6 +1,6 @@
 module Backable
   extend ActiveSupport::Concern
-  HISTORY_SIZE = 20
+  HISTORY_SIZE = 10
 
   class_methods do
     def skip_back_history_actions

--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -28,7 +28,7 @@ class FeedbackController < ApplicationController
   private
 
   def print_session
-    puts ">>>>>>>>>>>> SESSION #{__FILE__}:#{__LINE__} <<<<<<<<<<<<".yellow
+    puts ">>>>>>>>>>>> SESSION #{__FILE__}:#{__LINE__} <<<<<<<<<<<<"
     puts session.to_h.inspect
   end
 
@@ -87,7 +87,7 @@ class FeedbackController < ApplicationController
   helper_method :back_path, :back_button, :success_message
 
   def update_return_path
-    puts ">>>>>>>>>>>> updating return path #{__FILE__}:#{__LINE__} <<<<<<<<<<<<".yellow
+    puts ">>>>>>>>>>>> updating return path #{__FILE__}:#{__LINE__} <<<<<<<<<<<<"
     puts request.referrer
     return if request.referer&.include?(feedback_index_path)
 

--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -26,7 +26,7 @@ class FeedbackController < ApplicationController
   end
 
   private
-  
+
   def print_session
     puts ">>>>>>>>>>>> SESSION #{__FILE__}:#{__LINE__} <<<<<<<<<<<<".yellow
     puts session.to_h.inspect

--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -29,7 +29,7 @@ class FeedbackController < ApplicationController
 
   def print_session
     puts ">>>>>>>>>>>> SESSION #{__FILE__}:#{__LINE__} <<<<<<<<<<<<"
-    puts session.to_h.inspect
+    Raven.capture_message("FeedbackController#new SESSION: #{session.to_h.inspect}")
   end
 
   def provider_email
@@ -88,6 +88,7 @@ class FeedbackController < ApplicationController
 
   def update_return_path
     puts ">>>>>>>>>>>> updating return path #{__FILE__}:#{__LINE__} <<<<<<<<<<<<"
+    Raven.capture_message("FeedbackController#new update return path: #{request.referrer}")
     puts request.referrer
     return if request.referer&.include?(feedback_index_path)
 

--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -1,5 +1,5 @@
 class FeedbackController < ApplicationController
-  before_action :print_session, :update_return_path
+  before_action :update_return_path
 
   def new
     @journey = source
@@ -26,11 +26,6 @@ class FeedbackController < ApplicationController
   end
 
   private
-
-  def print_session
-    puts ">>>>>>>>>>>> SESSION #{__FILE__}:#{__LINE__} <<<<<<<<<<<<"
-    Raven.capture_message("FeedbackController#new SESSION: #{session.to_h.inspect}")
-  end
 
   def provider_email
     if params[:signed_out_provider_id].present?
@@ -87,9 +82,6 @@ class FeedbackController < ApplicationController
   helper_method :back_path, :back_button, :success_message
 
   def update_return_path
-    puts ">>>>>>>>>>>> updating return path #{__FILE__}:#{__LINE__} <<<<<<<<<<<<"
-    Raven.capture_message("FeedbackController#new update return path: #{request.referrer}")
-    puts request.referrer
     return if request.referer&.include?(feedback_index_path)
 
     session[:feedback_return_path] = request.referer

--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -1,5 +1,5 @@
 class FeedbackController < ApplicationController
-  before_action :update_return_path
+  before_action :print_session, :update_return_path
 
   def new
     @journey = source
@@ -26,6 +26,11 @@ class FeedbackController < ApplicationController
   end
 
   private
+  
+  def print_session
+    puts ">>>>>>>>>>>> SESSION #{__FILE__}:#{__LINE__} <<<<<<<<<<<<".yellow
+    puts session.to_h.inspect
+  end
 
   def provider_email
     if params[:signed_out_provider_id].present?
@@ -82,6 +87,8 @@ class FeedbackController < ApplicationController
   helper_method :back_path, :back_button, :success_message
 
   def update_return_path
+    puts ">>>>>>>>>>>> updating return path #{__FILE__}:#{__LINE__} <<<<<<<<<<<<".yellow
+    puts request.referrer
     return if request.referer&.include?(feedback_index_path)
 
     session[:feedback_return_path] = request.referer

--- a/app/controllers/saml_sessions_controller.rb
+++ b/app/controllers/saml_sessions_controller.rb
@@ -7,6 +7,8 @@ class SamlSessionsController < Devise::SamlSessionsController
   after_action :update_provider_details, only: :create
 
   def destroy
+    session['signed_out_provider_id'] = current_provider.id
+    session['feedback_return_path'] = destroy_provider_session_path
     sign_out current_provider
     if IdPSettingsAdapter.mock_saml?
       redirect_to providers_root_url

--- a/app/controllers/test/sessions_controller.rb
+++ b/app/controllers/test/sessions_controller.rb
@@ -1,4 +1,9 @@
 module Test
+  # This controller is used purely for setting session variables for RSpec request spec.
+  # Use with the #set_session method defined in spec/rails_helper.rb
+  #
+  # The test_session_path route is defined in test environment only
+  #
   class SessionsController < ApplicationController
     def create
       json_vars = params.permit(:session_vars)

--- a/app/controllers/test/sessions_controller.rb
+++ b/app/controllers/test/sessions_controller.rb
@@ -1,0 +1,12 @@
+module Test
+  class SessionsController < ApplicationController
+    def create
+      json_vars = params.permit(:session_vars)
+      vars = JSON.parse(json_vars[:session_vars])
+      vars.each do |var, value|
+        session[var] = value
+      end
+      head :created
+    end
+  end
+end

--- a/app/mailers/concerns/notify_template_methods.rb
+++ b/app/mailers/concerns/notify_template_methods.rb
@@ -11,4 +11,8 @@ module NotifyTemplateMethods
   def support_email_address
     Rails.configuration.x.support_email_address
   end
+
+  def safe_nil(value)
+    value || ''
+  end
 end

--- a/app/mailers/feedback_mailer.rb
+++ b/app/mailers/feedback_mailer.rb
@@ -6,14 +6,16 @@ class FeedbackMailer < BaseApplyMailer
 
   def notify(feedback, to = support_email_address)
     template_name :feedback_notification
+    personalise feedback
+    mail to: to
+  end
 
+  private
+
+  def personalise(feedback)
     set_personalisation(
       created_at: feedback.created_at&.to_time&.to_s(:rfc822),
-      user_data: [
-        feedback.os,
-        "#{feedback.browser} #{feedback.browser_version}",
-        feedback.source
-      ].join(' - '),
+      user_data: user_data(feedback),
       done_all_needed: yes_or_no(feedback),
       satisfaction: safe_nil(feedback.satisfaction),
       difficulty: safe_nil(feedback.difficulty),
@@ -21,10 +23,11 @@ class FeedbackMailer < BaseApplyMailer
       originating_page: safe_nil(feedback.originating_page),
       provider_email: safe_nil(feedback.email)
     )
-    mail to: to
   end
 
-  private
+  def user_data(feedback)
+    "#{feedback.os} :: #{feedback.browser} #{feedback.browser_version} :: #{feedback.source}"
+  end
 
   def yes_or_no(feedback)
     feedback['done_all_needed'] == true ? 'Yes' : 'No'

--- a/app/mailers/feedback_mailer.rb
+++ b/app/mailers/feedback_mailer.rb
@@ -6,17 +6,20 @@ class FeedbackMailer < BaseApplyMailer
 
   def notify(feedback, to = support_email_address)
     template_name :feedback_notification
+
     set_personalisation(
-      created_at: feedback['created_at']&.to_time&.to_s(:rfc822),
+      created_at: feedback.created_at&.to_time&.to_s(:rfc822),
       user_data: [
-        feedback['os'],
-        "#{feedback['browser']} #{feedback['browser_version']}",
-        feedback['source']
+        feedback.os,
+        "#{feedback.browser} #{feedback.browser_version}",
+        feedback.source
       ].join(' - '),
       done_all_needed: yes_or_no(feedback),
-      satisfaction: (feedback['satisfaction'] || ''),
-      difficulty: (feedback['difficulty'] || ''),
-      improvement_suggestion: (feedback['improvement_suggestion'] || '')
+      satisfaction: safe_nil(feedback.satisfaction),
+      difficulty: safe_nil(feedback.difficulty),
+      improvement_suggestion: safe_nil(feedback.improvement_suggestion),
+      originating_page: safe_nil(feedback.originating_page),
+      provider_email: safe_nil(feedback.email)
     )
     mail to: to
   end

--- a/app/views/feedback/new.html.erb
+++ b/app/views/feedback/new.html.erb
@@ -1,6 +1,6 @@
 <%= page_template page_title: t('.title'), show_errors_for: @feedback, back_link: back_button, success_message: success_message do %>
   <%= form_for(@feedback, url: feedback_index_path) do |form| %>
-
+    <% applicant_email_hint = @journey == :citizen ? t('.applicant_email_hint') : '' %>
     <%= form.govuk_collection_radio_buttons(
             :done_all_needed,
             [true, false],
@@ -38,9 +38,13 @@
             label: {
               size: :m
             },
+            hint: applicant_email_hint,
             rows: 4,
             class: 'govuk-!-width-full'
         ) %>
+
+    <%= hidden_field_tag 'signed_out_provider_id', @signed_out_provider_id %>
+
     <%= form.submit t('generic.send'), class: 'govuk-button' %>
 
   <% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -53,6 +53,7 @@ module LaaApplyForLegalAid
       env: ENV.fetch('GOVUK_NOTIFY_ENV', 'development')
     ).symbolize_keys
     config.x.support_email_address = 'apply-for-legal-aid@digital.justice.gov.uk'.freeze
+
     config.x.smoke_test_email_address = 'simulate-delivered@notifications.service.gov.uk'.freeze
     config.x.govuk_notify_api_key = ENV['GOVUK_NOTIFY_API_KEY']
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -52,8 +52,8 @@ module LaaApplyForLegalAid
       :govuk_notify_templates,
       env: ENV.fetch('GOVUK_NOTIFY_ENV', 'development')
     ).symbolize_keys
-    config.x.support_email_address = 'apply-for-legal-aid@digital.justice.gov.uk'.freeze
 
+    config.x.support_email_address = 'apply-for-legal-aid@digital.justice.gov.uk'.freeze
     config.x.smoke_test_email_address = 'simulate-delivered@notifications.service.gov.uk'.freeze
     config.x.govuk_notify_api_key = ENV['GOVUK_NOTIFY_API_KEY']
 

--- a/config/govuk_notify_templates.yml
+++ b/config/govuk_notify_templates.yml
@@ -10,7 +10,7 @@
 #
 development:
   citizen_start_application: 570e1b9d-6238-45fd-b75c-96f2f39db8e9
-  feedback_notification: ac458f81-b7dd-4b2c-944c-3f17d2f2392c
+  feedback_notification: 9aa7c2d5-f7ee-405c-9ec4-c0fcee149572
   new_link_request: a577582b-3e60-44a4-885c-d4b12bf23958
   submission_confirmation: ce2d89ee-1c10-404b-91cc-52068933ba7b
   reminder_to_submit_an_application: c4ac858d-68ae-437b-9353-06e632cd88f2
@@ -21,7 +21,7 @@ development:
 
 production:
   citizen_start_application: 66865f0d-6410-40e2-b862-98724eb6e33a
-  feedback_notification: 246379d9-14f5-470e-a8a4-31c4b61e64b2
+  feedback_notification: d8b0be70-c70c-436d-83f1-3db9f272e29d
   new_link_request: 3cc3be57-e072-4095-9caa-c0cd52193405
   submission_confirmation: 5472b10b-bc11-432a-a18d-9f20de5b2854
   reminder_to_submit_an_application: 96e58b6c-83e2-4ae8-be67-028803e98398

--- a/config/locales/en/feedback.yml
+++ b/config/locales/en/feedback.yml
@@ -2,6 +2,7 @@
 en:
   feedback:
     new:
+      applicant_email_hint: Please provide your email address if you'd like a response
       difficulty: How easy or difficult was it to use this service?
       done_all_needed: Were you able to do what you needed today?
       satisfaction: Overall, how satisfied were you with this service?

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -7,8 +7,8 @@ en:
     accessibility:
       error: "Error:"
     hint:
-      feedback:
-        improvement_suggestion: Please provide your email address if you'd like a response
+#      feedback:
+#        improvement_suggestion: Please provide your email address if you'd like a response
       additional_account: Share details of any accounts you have with another bank or building society
       address_lookup:
         postcode: This must be a valid UK postcode

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -7,8 +7,6 @@ en:
     accessibility:
       error: "Error:"
     hint:
-#      feedback:
-#        improvement_suggestion: Please provide your email address if you'd like a response
       additional_account: Share details of any accounts you have with another bank or building society
       address_lookup:
         postcode: This must be a valid UK postcode

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -218,6 +218,13 @@ Rails.application.routes.draw do
     end
   end
 
+  # dummy route to set session vars available in test environment only
+  if Rails.env.test?
+    namespace :test do
+      resource :session, only: %i[create]
+    end
+  end
+
   get '/.well-known/security.txt' => redirect('https://raw.githubusercontent.com/ministryofjustice/security-guidance/master/contact/vulnerability-disclosure-security.txt')
 
   # Catch all route that traps paths not defined above. Must be last route.

--- a/db/migrate/20200921143900_add_email_to_feedback.rb
+++ b/db/migrate/20200921143900_add_email_to_feedback.rb
@@ -1,0 +1,6 @@
+class AddEmailToFeedback < ActiveRecord::Migration[6.0]
+  def change
+    add_column :feedbacks, :email, :string
+    add_column :feedbacks, :originating_page, :string
+  end
+end

--- a/db/seeds/test_provider_populator.rb
+++ b/db/seeds/test_provider_populator.rb
@@ -23,7 +23,7 @@ class TestProviderPopulator
     'firm2-user1' => ['Firm2 & Co.', 'firm2-user1@example.com', 107, 592],
     'sr' => ['Richards & Co.', 'stephen.richards@digital.justice.gov.uk', 108, 593],
     'MARTIN.RONAN@DAVIDGRAY.CO.UK' => ['David Gray LLP', 'martin.ronan@example.com', 494_000, 5027],
-    'BENREID' => ['Test firm for portal login', 'benreid@talbotssolicitors.co.uk', 107, 592]
+    'BENREID' => ['Test firm for portal login', 'benreid@example.co.uk', 107, 592]
   }.freeze
 
   def run
@@ -45,7 +45,7 @@ class TestProviderPopulator
       end
     end
 
-    %w[test1 sr MARTIN.RONAN@DAVIDGRAY.CO.UK].each do |firm_name|
+    %w[test1 sr MARTIN.RONAN@DAVIDGRAY.CO.UK BENREID].each do |firm_name|
       firm = Provider.find_by(username: firm_name).firm
       unless firm.permissions.map(&:role).include?('application.non_passported.*')
         firm.permissions << non_passported_permission

--- a/features/providers/civil_application_journey.feature
+++ b/features/providers/civil_application_journey.feature
@@ -599,9 +599,11 @@ Feature: Civil application journeys
     Then I should be on a page showing "What is the outstanding mortgage on your client's home?"
     Then I click link "Back"
     Then I should be on a page showing "How much is your client's home worth?"
-    Then I click link "Back"
-    Then I should be on a page showing "Does your client own the home that they live in?"
-    Then I click 'Save and continue'
+    # The following back has been temporarily taken out of this cuke while the page history size setting is reduced to 10
+    #    Then I click link "Back"
+    #    Then I should be on a page showing "Does your client own the home that they live in?"
+    #    Then I click 'Save and continue'
+
     Then I click 'Save and continue'
     Then I click 'Save and continue'
     Then I click 'Save and continue'

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -96,3 +96,18 @@ end
 def uploaded_file(path, content_type = nil, binary: false)
   Rack::Test::UploadedFile.new(Rails.root.join(path), content_type, binary)
 end
+
+# method to enable session vars to be set in request spec.
+# uses the test_session_path route which is only available in test env.
+def set_session(vars = {})
+  return if vars.empty?
+
+  my_params = { session_vars: vars.to_json }
+
+  post test_session_path, params: my_params
+  expect(response).to have_http_status(:created)
+
+  vars.each_key do |var|
+    expect(session[var]).to be_present
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -99,7 +99,7 @@ end
 
 # method to enable session vars to be set in request spec.
 # uses the test_session_path route which is only available in test env.
-def set_session(vars = {})
+def set_session(vars = {}) # rubocop:disable Naming/AccessorMethodName
   return if vars.empty?
 
   my_params = { session_vars: vars.to_json }

--- a/spec/requests/saml_sessions_spec.rb
+++ b/spec/requests/saml_sessions_spec.rb
@@ -17,6 +17,16 @@ RSpec.describe 'SamlSessionsController', type: :request do
       expect(controller.current_provider).to be_nil
     end
 
+    it 'records id of logged out provider in session' do
+      subject
+      expect(session['signed_out_provider_id']).to eq provider.id
+    end
+
+    it 'records the signout page as the feedback return path' do
+      subject
+      expect(session['feedback_return_path']).to eq destroy_provider_session_path
+    end
+
     context 'no mock saml' do
       before do
         allow(Rails.configuration.x.laa_portal).to receive(:mock_saml).and_return('false')

--- a/spec/services/govuk_emails/email_monitor_spec.rb
+++ b/spec/services/govuk_emails/email_monitor_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe GovukEmails::EmailMonitor do
   let(:mailer) { 'FeedbackMailer' }
   let(:mail_method) { 'notify' }
   let(:delivery_method) { 'deliver_now!' }
-  let(:feedback_email_params) { { 'content' => Faker::Lorem.sentence } }
+  let(:feedback_email_params) { create :feedback }
   let(:to) { 'julien.sansot@digital.justice.gov.uk' }
   let(:email_args) { [feedback_email_params, to] }
   let(:message_status) { 'sending' }


### PR DESCRIPTION
## Record provider email and page on feedback

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1545)

- Added `originating_page` and `email` to `feedbacks` table
- On signing out, stored the provider id in the session as `signed_out_provider_id` to make it available to the Feedback controller
- in `FeedbackController#new` extracted the `signed_out_provider_id` from the session and submitted it as a hidden field
- in `FeedbackController#create` extracted got the provider id either from the hidden form param (if signed out) or the session and stored in the Feedack record
- stored the originating page  the Feedback record
- Duplicated the gov uk templates with two new variables: originating page and provider email
- updated the FeedbackMailer to use the new templates with the additional variables
- Wrote `Test::SessionsController` and associated `#set_session` method in `rails_helper.rb` to enable session variable to be set in RSpec request specs

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
