### PR TITLE
AP-1624 Fix inaccurate heading structure

### DIFF
--- a/app/views/providers/income_summary/_add_other_income.html.erb
+++ b/app/views/providers/income_summary/_add_other_income.html.erb
@@ -1,5 +1,5 @@
 <li>
-  <h2 class="app-task-list__section">
+  <div class="app-task-list__section">
     <span class="app-task-list__section-number">
       <%= image_tag('plus_icon.svg', alt: '') %>
     </span>
@@ -8,5 +8,5 @@
           providers_legal_aid_application_identify_types_of_income_path(@legal_aid_application),
           class: 'govuk-body'
         ) %>
-  </h2>
+  </div>
 </li>

--- a/app/views/providers/outgoings_summary/_add_other_outgoings.erb
+++ b/app/views/providers/outgoings_summary/_add_other_outgoings.erb
@@ -1,8 +1,8 @@
 <li>
-  <h2 class="app-task-list__section">
+  <div class="app-task-list__section">
     <span class="app-task-list__section-number">
       <%= image_tag('plus_icon.svg', alt: '') %>
     </span>
     <%= link_to t('.add_other_outgoings'), providers_legal_aid_application_identify_types_of_outgoing_path(@legal_aid_application), class: 'govuk-body' %>
-  </h2>
+  </div>
 </li>


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1624)

The `income_summary` and `outgoings_summary` pages contain a link and an image inside an `h2` tag. This is confusing for screenreader users.

This changes the `h2` tag to a `div`, as recommended by DAC.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
