### PR TITLE
AP-1623 add the proceeding meaning to aria label

### DIFF
--- a/app/views/shared/forms/proceedings_types/_proceeding_type_form.html.erb
+++ b/app/views/shared/forms/proceedings_types/_proceeding_type_form.html.erb
@@ -15,7 +15,8 @@
           ),
           method: :patch,
           tabindex: '-1',
-          class: 'govuk-button proceeding-link govuk-!-margin-top-4'
+          class: 'govuk-button proceeding-link govuk-!-margin-top-4',
+          "aria-label"=>"Select and continue #{proceeding_type.meaning}"
         ) %>
   </div>
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1623)

As per the comment on the Jira ticket, this adds an aria-label with the select and continue text and also the name of the proceeding. So a screen reader will read out e.g. "Select and continue Forced marriage protection order"

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
