### PR TITLE
AP-1625 More descriptive links for screenreaders

### DIFF
--- a/app/helpers/accessible_link_helper.rb
+++ b/app/helpers/accessible_link_helper.rb
@@ -1,0 +1,7 @@
+module AccessibleLinkHelper
+  def link_to_with_hidden_suffix(path:, text:, suffix:, klass: nil)
+    link_to(path, class: klass) do
+      "#{text}<span class='govuk-visually-hidden'> #{suffix}</span>".html_safe
+    end
+  end
+end

--- a/app/views/providers/about_the_financial_assessments/show.html.erb
+++ b/app/views/providers/about_the_financial_assessments/show.html.erb
@@ -21,7 +21,12 @@
           <%= @applicant.email %>
         </dt>
         <dd class="govuk-summary-list__actions">
-          <%= link_to(t('generic.change'), providers_legal_aid_application_email_address_path(anchor: :email), class: 'govuk-link change-link') %>
+          <%= link_to_with_hidden_suffix(
+                text: t('generic.change'),
+                path: providers_legal_aid_application_email_address_path(anchor: :email),
+                klass: 'govuk-link change-link',
+                suffix: 'email address'
+              ) %>
         </dd>
       </div>
     </dl>

--- a/app/views/providers/address_selections/show.html.erb
+++ b/app/views/providers/address_selections/show.html.erb
@@ -18,10 +18,11 @@
         <%= t('generic.address.postcode') %>
         <p class='govuk-body govuk-!-font-weight-bold' role='alert'>
           <%= @form.postcode.insert(-4, " ") %>
-          <%= link_to(
-                t('generic.change'),
-                providers_legal_aid_application_address_lookup_path(@legal_aid_application),
-                class: 'govuk-body change-link change-postcode-link'
+          <%= link_to_with_hidden_suffix(
+                text: t('generic.change'),
+                path: providers_legal_aid_application_address_lookup_path(@legal_aid_application),
+                klass: 'govuk-body change-link change-postcode-link',
+                suffix: 'postcode'
               ) %>
         </p>
       </p>

--- a/app/views/providers/bank_transactions/_list_selected.html.erb
+++ b/app/views/providers/bank_transactions/_list_selected.html.erb
@@ -21,13 +21,14 @@
         </td>
         <td class="govuk-table__cell">
           <%= button_to(
-                t('.remove_link'),
                 remove_transaction_type_providers_legal_aid_application_bank_transaction_path(@legal_aid_application, bank_transaction),
                 method: :patch,
                 class: 'button-as-link',
                 form_class: 'remote-remove-transaction',
                 remote: true
-              ) %>
+              ) do %>
+                <%= t('.remove_link') %><span class="govuk-visually-hidden"> <%= bank_transaction.description %> <%= value_with_currency_unit(bank_transaction.amount, bank_transaction.currency) %></span>
+              <% end %>
         </td>
       </tr>
     <% end %>

--- a/app/views/providers/has_other_dependants/show.html.erb
+++ b/app/views/providers/has_other_dependants/show.html.erb
@@ -21,7 +21,13 @@
         <dl class="govuk-summary-list__row" id="dependant_<%= dependant.number %>">
           <dt class="govuk-summary-list__value"><%= dependant.name %></dt>
           <dt class="govuk-summary-list__actions">
-            <a class="govuk-link" href="<%= providers_legal_aid_application_dependant_path(@legal_aid_application, dependant) %>"><%= t('.change') %><span class="govuk-visually-hidden"> name</span></a></dt>
+            <%= link_to_with_hidden_suffix(
+                  path: providers_legal_aid_application_dependant_path(@legal_aid_application, dependant),
+                  klass: 'govuk-link change-link',
+                  text: t('generic.change'),
+                  suffix: dependant.name
+                ) %>
+          </dt>
           <dt class="govuk-summary-list__actions">
             <dd class="govuk-summary-list__actions">
               <%= button_to(

--- a/app/views/providers/has_other_dependants/show.html.erb
+++ b/app/views/providers/has_other_dependants/show.html.erb
@@ -31,11 +31,12 @@
           <dt class="govuk-summary-list__actions">
             <dd class="govuk-summary-list__actions">
               <%= button_to(
-                t('.remove'),
                 providers_legal_aid_application_remove_dependant_path(@legal_aid_application, dependant),
                 method: :get,
                 class: 'button-as-link'
-              ) %>
+              ) do %>
+                <%= t('.remove') %><span class="govuk-visually-hidden"> <%= dependant.name %></span>
+              <% end %>
             </dd>
           </dt>
         </dl>

--- a/app/views/providers/income_summary/_income_type_item.html.erb
+++ b/app/views/providers/income_summary/_income_type_item.html.erb
@@ -1,8 +1,9 @@
 <%
-  transaction_link = link_to(
-    link_text,
-    providers_legal_aid_application_incoming_transactions_path(transaction_type: name),
-    class: 'govuk-body transaction-type-link'
+  transaction_link = link_to_with_hidden_suffix(
+    path: providers_legal_aid_application_incoming_transactions_path(transaction_type: name),
+    klass: 'govuk-body transaction-type-link',
+    text: link_text,
+    suffix: "for #{t "transaction_types.names.providers.#{name}"}"
   )
   form_group_error_class = error.present? ? 'govuk-form-group--error' : ''
   error_message = error.present? ? error.first : ''

--- a/app/views/providers/outgoings_summary/_outgoing_type_item.html.erb
+++ b/app/views/providers/outgoings_summary/_outgoing_type_item.html.erb
@@ -1,8 +1,9 @@
 <%
-  transaction_link = link_to(
-    link_text,
-    providers_legal_aid_application_outgoing_transactions_path(transaction_type: name),
-    class: 'govuk-body transaction-type-link'
+  transaction_link = link_to_with_hidden_suffix(
+    text: link_text,
+    path: providers_legal_aid_application_outgoing_transactions_path(transaction_type: name),
+    klass: 'govuk-body transaction-type-link',
+    suffix: "for #{t "transaction_types.names.providers.#{name}"}"
   )
   form_group_error_class = error.present? ? 'govuk-form-group--error' : ''
   error_message = error.present? ? error.first : ''

--- a/app/views/shared/check_answers/_item.html.erb
+++ b/app/views/shared/check_answers/_item.html.erb
@@ -14,9 +14,7 @@
   <% unless read_only && align_right %>
     <dd class="govuk-summary-list__actions">
       <% unless read_only %>
-        <%= link_to(url, class: 'govuk-link change-link') do %>
-          <%= t('generic.change') %><span class="govuk-visually-hidden"> <%= question %></span>
-        <% end %>
+        <%= link_to_with_hidden_suffix(path: url, klass: 'govuk-link change-link', text: t('generic.change'), suffix: question) %>
       <% end %>
     </dd>
   <% end %>

--- a/app/views/shared/check_answers/_one_change_link_long_answers_section.erb
+++ b/app/views/shared/check_answers/_one_change_link_long_answers_section.erb
@@ -5,9 +5,7 @@
   <% if answer_hash.present? && !read_only %>
     <div class="govuk-grid-column-one-third govuk-summary-list--no-border align-text-right">
       <p>
-        <%= link_to(url, class: 'govuk-link') do %>
-          <%= t('generic.change') %><span class="govuk-visually-hidden"><%= question %></span>
-        <% end %>
+        <%= link_to_with_hidden_suffix(path: url, klass: 'govuk-link change-link', text: t('generic.change'), suffix: question) %>
       </p>
     </div>
   <% end %>

--- a/app/views/shared/check_answers/_one_link_section.html.erb
+++ b/app/views/shared/check_answers/_one_link_section.html.erb
@@ -7,9 +7,7 @@
   <% if answer_hash.present? && !read_only %>
     <div class="govuk-grid-column-one-third govuk-summary-list--no-border align-text-right">
       <p>
-        <%= link_to(url, class: 'govuk-link') do %>
-          <%= t('generic.change') %><span class="govuk-visually-hidden"><%= question %></span>
-        <% end %>
+        <%= link_to_with_hidden_suffix(path: url, klass: 'govuk-link change-link', text: t('generic.change'), suffix: question) %>
       </p>
     </div>
   <% end %>

--- a/app/views/shared/check_answers/_only_link_section.html.erb
+++ b/app/views/shared/check_answers/_only_link_section.html.erb
@@ -5,10 +5,7 @@
   <% unless read_only %>
       <div class="govuk-grid-column-one-third govuk-summary-list--no-border align-text-right">
         <p>
-          <%= link_to(url, class: 'govuk-link change-link') do %>
-            <%= t('generic.change') %>
-            <span class="govuk-visually-hidden"><%= question %></span>
-          <% end %>
+          <%= link_to_with_hidden_suffix(path: url, klass: 'govuk-link change-link', text: t('generic.change'), suffix: question) %>
         </p>
       </div>
   <% end %>

--- a/app/views/shared/forms/proceedings_types/_proceeding_type.html.erb
+++ b/app/views/shared/forms/proceedings_types/_proceeding_type.html.erb
@@ -7,11 +7,11 @@
   </div>
   <div class="govuk-grid-column-one-third control-column">
     <p class="govuk-body govuk-!-margin-bottom-1 govuk-!-margin-top-4">
-      <%= link_to(
-            I18n.t('.link_title', scope: translation_path),
-            providers_legal_aid_application_proceedings_types_path(
-              legal_aid_application_id: @legal_aid_application
-            )
+      <%= link_to_with_hidden_suffix(
+            text: t('generic.change'),
+            path: providers_legal_aid_application_proceedings_types_path(legal_aid_application_id: @legal_aid_application),
+            klass: 'govuk-link change-link',
+            suffix: 'proceeding'
           ) %>
     </p>
   </div>

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -376,7 +376,6 @@ en:
       show:
         h1-heading: What you're applying for
         h2-heading: Proceeding
-        link_title: Change
         if_delegated_used: Covered under an emergency certificate
         form_of_service: "Form of service: "
         form_of_service_type: Full representation

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -727,7 +727,6 @@ en:
       show:
         page_title: Does your client have any other dependants?
         existing: "You have added %{count}"
-        change: Change
         remove: Remove
         warning:
           delete: Are you sure you want to delete this dependant?

--- a/spec/helpers/accessible_link_helper.rb
+++ b/spec/helpers/accessible_link_helper.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe AccessibleLinkHelper, type: :helper do
+  describe '#link_to_with_hidden_suffix' do
+    let(:path) { 'test_path' }
+    let(:klass) { 'test-class' }
+    let(:visible_text) { 'visible link text' }
+    let(:hidden_text) { 'hidden link text' }
+
+    it 'returns the html for a link partly hidden from screen readers' do
+      link = link_to_with_hidden_suffix(path: path, klass: klass, text: visible_text, suffix: hidden_text)
+      expect(link).to eq "<a class=\"test-class\" href=\"test_path\">visible link text<span class='govuk-visually-hidden'> hidden link text</span></a>"
+    end
+
+    context 'with no class provided' do
+      it 'returns the html for a link partly hidden from screen readers' do
+        link = link_to_with_hidden_suffix(path: path, text: visible_text, suffix: hidden_text)
+        expect(link).to eq "<a href=\"test_path\">visible link text<span class='govuk-visually-hidden'> hidden link text</span></a>"
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1625)

There are a number of links in the application where the intent is clear for a sighted user but not obvious for a screenreader user, especially when multiple links exist on a page. This change adds a helper method to create links with text that is partially hidden using a `govuk-visually-hidden` span.

This allows us to keep to our current design but also add extra context for screenreader users - for example a link can be displayed as 'Change' but read out as 'Change postcode'.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
