### PR TITLE
Reduce calls to Geckoboard

### DIFF
--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -47,7 +47,7 @@ class LegalAidApplication < ApplicationRecord # rubocop:disable Metrics/ClassLen
   after_save do
     ActiveSupport::Notifications.instrument 'dashboard.delegated_functions_used' if saved_change_to_used_delegated_functions?
     ActiveSupport::Notifications.instrument 'dashboard.declined_open_banking' if saved_change_to_open_banking_consent?
-    ActiveSupport::Notifications.instrument('dashboard.provider_updated', provider_id: provider.id) if proc { |laa| laa.state.eql?(:assessment_submitted) }
+    ActiveSupport::Notifications.instrument('dashboard.provider_updated', provider_id: provider.id) if proc { |laa| laa.state }.eql?(:assessment_submitted)
   end
 
   attr_reader :proceeding_type_codes


### PR DESCRIPTION
## What

We're seeing lots of Sentry alerts due to exceeding the number of permitted calls to Geckoboard. This seems to be linked (at least partially) to the `ProviderDataJob`, which is triggered by a save to the `LegalAidApplication model`. The call is guarded by an if statement that always resolves to true:

`if proc { |laa| laa.state.eql?(:assessment_submitted) }`

It returns the proc, which is truthy, so a Geckoboard request is sent every time an application is saved. This corrects it so that the request is only made when the application is submitted:

`if proc { |laa| laa.state }.eql?(:assessment_submitted)`

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
