### PR TITLE
AP-1695 Provide back to application link for citizens feedback form

### DIFF
--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -73,7 +73,13 @@ class FeedbackController < ApplicationController
   end
 
   def success_message
+    return {} if citizen_journey?
+
     provider_signed_in? ? {} : I18n.t('feedback.new.signed_out')
+  end
+
+  def citizen_journey?
+    citizen_path_regex.match? session[:feedback_return_path]
   end
 
   def back_button
@@ -94,5 +100,9 @@ class FeedbackController < ApplicationController
     return :citizen if %r{/citizens/}.match?(path)
 
     :unknown
+  end
+
+  def citizen_path_regex
+    @citizen_path_regex ||= Regexp.new(/\/citizens\//)
   end
 end

--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -11,6 +11,7 @@ class FeedbackController < ApplicationController
     @feedback = Feedback.new(feedback_params)
     @feedback.originating_page = originating_page
     @feedback.email = provider_email
+    @display_close_tab_msg = params[:signed_out_provider_id].present?
 
     # must use bang version `deliver_later!` or failures won't be retried by sidekiq
     if @feedback.save

--- a/app/controllers/saml_sessions_controller.rb
+++ b/app/controllers/saml_sessions_controller.rb
@@ -11,7 +11,8 @@ class SamlSessionsController < Devise::SamlSessionsController
     session['feedback_return_path'] = destroy_provider_session_path
     sign_out current_provider
     if IdPSettingsAdapter.mock_saml?
-      redirect_to providers_root_url
+      # redirect_to providers_root_url
+      redirect_to new_feedback_path
     else
       redirect_to new_feedback_path
     end

--- a/app/controllers/saml_sessions_controller.rb
+++ b/app/controllers/saml_sessions_controller.rb
@@ -11,8 +11,7 @@ class SamlSessionsController < Devise::SamlSessionsController
     session['feedback_return_path'] = destroy_provider_session_path
     sign_out current_provider
     if IdPSettingsAdapter.mock_saml?
-      # redirect_to providers_root_url
-      redirect_to new_feedback_path
+      redirect_to providers_root_url
     else
       redirect_to new_feedback_path
     end

--- a/app/mailers/feedback_mailer.rb
+++ b/app/mailers/feedback_mailer.rb
@@ -21,7 +21,7 @@ class FeedbackMailer < BaseApplyMailer
       difficulty: safe_nil(feedback.difficulty),
       improvement_suggestion: safe_nil(feedback.improvement_suggestion),
       originating_page: safe_nil(feedback.originating_page),
-      provider_email: safe_nil(feedback.email)
+      provider_email: provider_email_phrase(feedback)
     )
   end
 
@@ -31,5 +31,11 @@ class FeedbackMailer < BaseApplyMailer
 
   def yes_or_no(feedback)
     feedback['done_all_needed'] == true ? 'Yes' : 'No'
+  end
+
+  def provider_email_phrase(feedback)
+    return '' if feedback.email.nil?
+
+    "from #{feedback.email}"
   end
 end

--- a/app/views/feedback/show.html.erb
+++ b/app/views/feedback/show.html.erb
@@ -1,9 +1,5 @@
 <%= page_template page_title: t('.title'), back_link: back_button do %>
-  <% if back_button == :none %>
-    <p><%= t('.close_tab') %></p>
-  <% else %>
-    <p class="govuk-body">
-      <%= link_to t('.link'), back_path, class: 'govuk-link govuk-link--no-visited-state' %>
-    </p>
-  <% end %>
+  <p class="govuk-body">
+    <%= link_to t('.link'), back_path, class: 'govuk-link govuk-link--no-visited-state' %>
+  </p>
 <% end %>

--- a/app/views/feedback/show.html.erb
+++ b/app/views/feedback/show.html.erb
@@ -1,5 +1,9 @@
 <%= page_template page_title: t('.title'), back_link: back_button do %>
-  <p class="govuk-body">
-    <%= link_to t('.link'), back_path, class: 'govuk-link govuk-link--no-visited-state' %>
-  </p>
+  <% if @display_close_tab_msg %>
+    <p><%= t('.close_tab') %></p>
+  <% else %>
+    <p class="govuk-body">
+      <%= link_to t('.link'), back_path, class: 'govuk-link govuk-link--no-visited-state' %>
+    </p>
+  <% end %>
 <% end %>

--- a/spec/factories/feedbacks.rb
+++ b/spec/factories/feedbacks.rb
@@ -8,6 +8,8 @@ FactoryBot.define do
     browser { %w[IE Chrome Safari Firefox Opera].sample }
     browser_version { Faker::App.semantic_version }
     source { %w[Provider Citizen Unknown].sample }
+    originating_page { 'http://localhost:3000/applications' }
+    email { 'me@example.com' }
 
     trait :with_timestamps do
       created_at { Faker::Time.backward }

--- a/spec/requests/feedbacks_spec.rb
+++ b/spec/requests/feedbacks_spec.rb
@@ -170,19 +170,5 @@ RSpec.describe 'FeedbacksController', type: :request do
     it 'displays a message' do
       expect(unescaped_response_body).to match(I18n.t('feedback.show.title'))
     end
-
-    context 'provider signed out' do
-      let(:provider) { create :provider }
-
-      before do
-        sign_in provider
-        delete destroy_provider_session_path
-        get feedback_path(feedback)
-      end
-
-      it 'displays close tab message' do
-        expect(unescaped_response_body).to match(I18n.t('.feedback.show.close_tab'))
-      end
-    end
   end
 end


### PR DESCRIPTION
## Provide back to application link on citizens' feedback page

Prior to this PR, when a citizen clicked the feedback link, there was no way to get back to the application after the feedback had been submitted.  We now use the same mechanism as for providers.  There is no feedback link for providers that are filling in feedback after having signed out.

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1695)

Describe what you did and why.

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
