### PR TITLE
Ap 1701 savings account bugfix

### DIFF
--- a/app/helpers/capital_helper.rb
+++ b/app/helpers/capital_helper.rb
@@ -1,11 +1,6 @@
 module CapitalHelper
   def capital_amounts_list(capital, locale_namespace:, percentage_values: [])
-    items = if @legal_aid_application.passported?
-              capital_amount_items(capital, locale_namespace, percentage_values)
-            else
-              non_passported_capital_amount_items(capital, locale_namespace, percentage_values)
-            end
-
+    items = capital_amount_items(capital, locale_namespace, percentage_values)
     items&.compact!
     return nil unless items.present?
 
@@ -16,22 +11,7 @@ module CapitalHelper
   end
 
   def capital_amount_items(capital, locale_namespace, percentage_values)
-    capital&.amount_attributes&.map do |attribute, amount|
-      next unless amount
-
-      type = percentage_values.include?(attribute.to_sym) ? :percentage : :currency
-
-      OpenStruct.new(
-        label: t("#{locale_namespace}#{attribute}"),
-        amount: amount,
-        type: type,
-        amount_text: capital_amount_text(amount, type)
-      )
-    end
-  end
-
-  def non_passported_capital_amount_items(capital, locale_namespace, percentage_values)
-    capital&.amount_attributes&.reject { |c| c == 'offline_savings_accounts' }&.map do |attribute, amount|
+    capital_amount_attributes(capital)&.map do |attribute, amount|
       next unless amount
 
       type = percentage_values.include?(attribute.to_sym) ? :percentage : :currency
@@ -51,5 +31,11 @@ module CapitalHelper
     else
       number_to_currency(amount)
     end
+  end
+
+  def capital_amount_attributes(capital)
+    return capital&.amount_attributes if @legal_aid_application.passported?
+
+    capital&.amount_attributes&.reject { |c| c == 'offline_savings_accounts' }
   end
 end

--- a/app/helpers/liquid_capital_items_helper.rb
+++ b/app/helpers/liquid_capital_items_helper.rb
@@ -1,0 +1,13 @@
+module LiquidCapitalItemsHelper
+  def capital_items_to_display?(legal_aid_application, item)
+    return false if legal_aid_application.passported? && ['Online current accounts', 'Online savings accounts'].include?(item[:description])
+
+    true
+  end
+
+  def item_description(legal_aid_application, item)
+    return 'Savings accounts your client cannot access online' if item[:description].eql?('Savings accounts') && legal_aid_application.non_passported?
+
+    item[:description]
+  end
+end

--- a/app/services/cfe/create_capitals_service.rb
+++ b/app/services/cfe/create_capitals_service.rb
@@ -10,8 +10,8 @@ module CFE
     }.freeze
 
     SAVINGS_AMOUNT_FIELDS = {
-      offline_current_accounts: 'Current accounts your client cannot access online',
-      offline_savings_accounts: 'Savings accounts your client cannot access online',
+      offline_current_accounts: 'Current accounts',
+      offline_savings_accounts: 'Savings accounts',
       cash: 'Money not in a bank account',
       other_person_account: "Access to another person's bank account",
       national_savings: 'ISAs, National Savings Certificates and Premium Bonds',
@@ -57,7 +57,7 @@ module CFE
       return unless legal_aid_application.online_current_accounts_balance.present?
 
       {
-        description: 'Current accounts',
+        description: 'Online Current accounts',
         value: legal_aid_application.online_current_accounts_balance
       }
     end
@@ -66,7 +66,7 @@ module CFE
       return unless legal_aid_application.online_current_accounts_balance.present?
 
       {
-        description: 'Savings accounts',
+        description: 'Online Savings accounts',
         value: legal_aid_application.online_savings_accounts_balance
       }
     end

--- a/app/services/cfe/create_capitals_service.rb
+++ b/app/services/cfe/create_capitals_service.rb
@@ -57,7 +57,7 @@ module CFE
       return unless legal_aid_application.online_current_accounts_balance.present?
 
       {
-        description: 'Online Current accounts',
+        description: 'Online current accounts',
         value: legal_aid_application.online_current_accounts_balance
       }
     end
@@ -66,7 +66,7 @@ module CFE
       return unless legal_aid_application.online_current_accounts_balance.present?
 
       {
-        description: 'Online Savings accounts',
+        description: 'Online savings accounts',
         value: legal_aid_application.online_savings_accounts_balance
       }
     end

--- a/app/views/shared/_savings_and_investments.html.erb
+++ b/app/views/shared/_savings_and_investments.html.erb
@@ -4,7 +4,7 @@
       <h2 class="govuk-heading-m"><%= t('.savings_and_investments') %></h2>
       <table class="govuk-table">
         <tbody>
-        <% @cfe_result.liquid_capital_items.reject {|i| i[:description] == 'Online Savings accounts' || i[:description] == 'Online Current accounts' }&.map do |item| %>
+        <% @cfe_result.liquid_capital_items.reject {|i| i[:description] == 'Online savings accounts' || i[:description] == 'Online current accounts' }&.map do |item| %>
           <%= render partial: 'shared/results_detail_row', locals: { caption: item[:description], value: number_to_currency(item[:value]) } %>
         <% end %>
         <%= render partial: 'shared/results_total_row', locals: { caption: t('.assessed_amount'), value: number_to_currency(@cfe_result.total_savings) } %>
@@ -16,7 +16,8 @@
       <h2 class="govuk-heading-m"><%= t('.savings_and_investments') %></h2>
       <table class="govuk-table">
         <tbody>
-        <% @cfe_result.liquid_capital_items.each do |item| %>
+        <% @cfe_result.liquid_capital_items.map! do |item| %>
+        <% item[:description] = 'Savings accounts your client cannot access online' if item[:description] == 'Savings accounts' %>
           <%= render partial: 'shared/results_detail_row', locals: { caption: item[:description], value: number_to_currency(item[:value]) } %>
         <% end %>
         <%= render partial: 'shared/results_total_row', locals: { caption: t('.assessed_amount'), value: number_to_currency(@cfe_result.total_savings) } %>

--- a/app/views/shared/_savings_and_investments.html.erb
+++ b/app/views/shared/_savings_and_investments.html.erb
@@ -1,13 +1,27 @@
 <% if @cfe_result.liquid_capital_items.any? %>
-  <div class="govuk-accordion__section-content">
-    <h2 class="govuk-heading-m"><%= t('.savings_and_investments') %></h2>
-    <table class="govuk-table">
-      <tbody>
+  <% if @legal_aid_application.passported? %>
+    <div class="govuk-accordion__section-content">
+      <h2 class="govuk-heading-m"><%= t('.savings_and_investments') %></h2>
+      <table class="govuk-table">
+        <tbody>
+        <% @cfe_result.liquid_capital_items.reject {|i| i[:description] == 'Online Savings accounts' || i[:description] == 'Online Current accounts' }&.map do |item| %>
+          <%= render partial: 'shared/results_detail_row', locals: { caption: item[:description], value: number_to_currency(item[:value]) } %>
+        <% end %>
+        <%= render partial: 'shared/results_total_row', locals: { caption: t('.assessed_amount'), value: number_to_currency(@cfe_result.total_savings) } %>
+        </tbody>
+      </table>
+    </div>
+  <% else %>
+    <div class="govuk-accordion__section-content">
+      <h2 class="govuk-heading-m"><%= t('.savings_and_investments') %></h2>
+      <table class="govuk-table">
+        <tbody>
         <% @cfe_result.liquid_capital_items.each do |item| %>
           <%= render partial: 'shared/results_detail_row', locals: { caption: item[:description], value: number_to_currency(item[:value]) } %>
         <% end %>
         <%= render partial: 'shared/results_total_row', locals: { caption: t('.assessed_amount'), value: number_to_currency(@cfe_result.total_savings) } %>
-      </tbody>
-    </table>
-  </div>
+        </tbody>
+      </table>
+    </div>
+  <% end %>
 <% end %>

--- a/app/views/shared/_savings_and_investments.html.erb
+++ b/app/views/shared/_savings_and_investments.html.erb
@@ -1,28 +1,15 @@
 <% if @cfe_result.liquid_capital_items.any? %>
-  <% if @legal_aid_application.passported? %>
-    <div class="govuk-accordion__section-content">
-      <h2 class="govuk-heading-m"><%= t('.savings_and_investments') %></h2>
-      <table class="govuk-table">
-        <tbody>
-        <% @cfe_result.liquid_capital_items.reject {|i| i[:description] == 'Online savings accounts' || i[:description] == 'Online current accounts' }&.map do |item| %>
-          <%= render partial: 'shared/results_detail_row', locals: { caption: item[:description], value: number_to_currency(item[:value]) } %>
+  <div class="govuk-accordion__section-content">
+    <h2 class="govuk-heading-m"><%= t('.savings_and_investments') %></h2>
+    <table class="govuk-table">
+      <tbody>
+        <% @cfe_result.liquid_capital_items.each do |item| %>
+          <% if capital_items_to_display?(@legal_aid_application, item) %>
+            <%= render partial: 'shared/results_detail_row', locals: {caption:  item_description(@legal_aid_application, item), value: number_to_currency(item[:value]) } %>
+          <% end %>
         <% end %>
-        <%= render partial: 'shared/results_total_row', locals: { caption: t('.assessed_amount'), value: number_to_currency(@cfe_result.total_savings) } %>
-        </tbody>
-      </table>
-    </div>
-  <% else %>
-    <div class="govuk-accordion__section-content">
-      <h2 class="govuk-heading-m"><%= t('.savings_and_investments') %></h2>
-      <table class="govuk-table">
-        <tbody>
-        <% @cfe_result.liquid_capital_items.map! do |item| %>
-        <% item[:description] = 'Savings accounts your client cannot access online' if item[:description] == 'Savings accounts' %>
-          <%= render partial: 'shared/results_detail_row', locals: { caption: item[:description], value: number_to_currency(item[:value]) } %>
-        <% end %>
-        <%= render partial: 'shared/results_total_row', locals: { caption: t('.assessed_amount'), value: number_to_currency(@cfe_result.total_savings) } %>
-        </tbody>
-      </table>
-    </div>
-  <% end %>
+      <%= render partial: 'shared/results_total_row', locals: { caption: t('.assessed_amount'), value: number_to_currency(@cfe_result.total_savings) } %>
+      </tbody>
+    </table>
+  </div>
 <% end %>

--- a/app/views/shared/check_answers/_assets.html.erb
+++ b/app/views/shared/check_answers/_assets.html.erb
@@ -94,7 +94,7 @@
         read_only: read_only
       ) if @legal_aid_application.savings_amount? %>
 
-  <% if read_only %>
+  <% if read_only &&  @legal_aid_application.non_passported? %>
     <dl class="govuk-summary-list govuk-!-margin-bottom-9">
 
       <%= check_answer_link(

--- a/app/views/shared/check_answers/_one_link_section.html.erb
+++ b/app/views/shared/check_answers/_one_link_section.html.erb
@@ -29,7 +29,8 @@
           name: name,
           url: url,
           question: question,
-          answer: t('generic.none_declared')
+          answer: t('generic.none_declared'),
+          read_only: read_only
         ) %>
   <% end %>
 </dl>

--- a/spec/requests/providers/means_reports_spec.rb
+++ b/spec/requests/providers/means_reports_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Providers::MeansReportsController, type: :request do
   include ActionView::Helpers::NumberHelper
 
-  let(:legal_aid_application) { create :legal_aid_application, :with_proceeding_types, :with_everything, :with_cfe_v2_result, :assessment_submitted }
+  let(:legal_aid_application) { create :legal_aid_application, :with_proceeding_types, :with_everything, :with_cfe_v2_result, :passported, :assessment_submitted }
   let(:login_provider) { login_as legal_aid_application.provider }
   let!(:submission) { create :submission, legal_aid_application: legal_aid_application }
   let(:cfe_result) { legal_aid_application.cfe_result }

--- a/spec/services/cfe/create_capitals_service_spec.rb
+++ b/spec/services/cfe/create_capitals_service_spec.rb
@@ -101,11 +101,11 @@ module CFE
             value: savings_amount.national_savings.to_s
           },
           {
-            description: 'Online Current accounts',
+            description: 'Online current accounts',
             value: application.online_current_accounts_balance
           },
           {
-            description: 'Online Savings accounts',
+            description: 'Online savings accounts',
             value: application.online_savings_accounts_balance
           }
         ],

--- a/spec/services/cfe/create_capitals_service_spec.rb
+++ b/spec/services/cfe/create_capitals_service_spec.rb
@@ -81,11 +81,11 @@ module CFE
       {
         bank_accounts: [
           {
-            description: 'Current accounts your client cannot access online',
+            description: 'Current accounts',
             value: savings_amount.offline_current_accounts.to_s
           },
           {
-            description: 'Savings accounts your client cannot access online',
+            description: 'Savings accounts',
             value: savings_amount.offline_savings_accounts.to_s
           },
           {
@@ -101,11 +101,11 @@ module CFE
             value: savings_amount.national_savings.to_s
           },
           {
-            description: 'Current accounts',
+            description: 'Online Current accounts',
             value: application.online_current_accounts_balance
           },
           {
-            description: 'Savings accounts',
+            description: 'Online Savings accounts',
             value: application.online_savings_accounts_balance
           }
         ],


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1701)

Added a new method to `CapitalHelper` to display `passported` or `non-pasported` differently due to how we handle bank balances.

Renamed the `offline_current/savings_accounts` and also the TrueLayer obtained accounts.

I need to confirm with Dave about the preferred naming of these on the `means_report` and `capital_assessment_result` pages

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
