### PR TITLE
AP-1626: Update result details header

### DIFF
--- a/app/views/providers/capital_income_assessment_results/_result_details.html.erb
+++ b/app/views/providers/capital_income_assessment_results/_result_details.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-details govuk-!-margin-top-6" data-module="govuk-details">
-    <h1 class="govuk-heading-m">
+    <h2 class="govuk-heading-m">
       <%= t('.client_eligibility_calculation') %>
-    </h1>
+    </h2>
 
   <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-breakdown">
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1626)

This was being called as a partial from capital_assessment_results
and capital_income_assessment_results.  In both cases it was being
called below the blue panel that already contained an H1.

Therefore downgrading this to an H2 should have no effect on the
display for users and will improve experince for screenreader
users

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
