### PR TITLE
TECH-DEBT: remove webhint from Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -372,9 +372,9 @@ workflows:
       - integration_tests:
           requires:
           - lint_checks
-      - webhint_reports:
-          requires:
-          - integration_tests
+      # - webhint_reports:
+      #    requires:
+      #    - integration_tests
 
   merge_pr:
     jobs:
@@ -397,12 +397,12 @@ workflows:
       - integration_tests:
           requires:
             - lint_checks
-      - webhint_reports:
-          requires:
-            - integration_tests
+      # - webhint_reports:
+      #     requires:
+      #       - integration_tests
       - deploy_staging:
           requires:
-            - webhint_reports
+            # - webhint_reports
             - unit_tests
             - build_and_push
       - hold_production_notification:


### PR DESCRIPTION
## What

Due to issues with yarn and upgrades to ruby/yarn packages/circle docker images we are removing webhint from the circle process

This is intended to be a short term removal until we have time/skills on the team to address the webhint/yarn config and either
a) fix the current implmentation, or;
b) replace it with an alternative automated accessibility scanner

[Spike to investigate re-implementation](https://dsdmoj.atlassian.net/browse/AP-1710)

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, ~with a link to the JIRA story.~
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
