### PR TITLE
Fix flaky postcode test

### DIFF
--- a/features/cassettes/Civil_application_journeys/Completes_the_application_using_manual_address.yml
+++ b/features/cassettes/Civil_application_journeys/Completes_the_application_using_manual_address.yml
@@ -2,13 +2,13 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?key=<ORDNANACE_SURVEY_API_KEY>&lr=EN&postcode=SW1H9AJ
+    uri: https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?key=<ORDNANACE_SURVEY_API_KEY>&lr=EN&postcode=XX11XX
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - Faraday v1.0.0
+      - Faraday v1.0.1
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -19,7 +19,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 29 May 2020 14:11:26 GMT
+      - Fri, 25 Sep 2020 13:26:11 GMT
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -27,7 +27,7 @@ http_interactions:
       Connection:
       - keep-alive
       Tx-Id:
-      - 1590761486854:854
+      - 1601040371064:64
       Status:
       - success
     body:
@@ -35,19 +35,19 @@ http_interactions:
       string: |-
         {
           "header" : {
-            "uri" : "https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?lr=EN&postcode=SW1H9AJ",
-            "query" : "postcode=SW1H9AJ",
+            "uri" : "https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?lr=EN&postcode=XX11XX",
+            "query" : "postcode=XX11XX",
             "offset" : 0,
             "totalresults" : 0,
             "format" : "JSON",
             "dataset" : "DPA",
             "lr" : "EN",
             "maxresults" : 100,
-            "epoch" : "75",
+            "epoch" : "78",
             "output_srs" : "EPSG:27700"
           }
         }
-  recorded_at: Fri, 29 May 2020 14:11:26 GMT
+  recorded_at: Fri, 25 Sep 2020 13:26:11 GMT
 - request:
     method: post
     uri: https://benefitchecker.stg.legalservices.gov.uk/lsx/lsc-services/benefitChecker?wsdl
@@ -55,7 +55,7 @@ http_interactions:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:wsdl="https://lsc.gov.uk/benefitchecker/service/1.0/API_1.0_Check"
-        xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Body><wsdl:check><clientReference>1f6f2607-1ba4-4b16-a96f-2b80f851a7c1</clientReference><nino>CB987654A</nino><surname>USER</surname><dateOfBirth>19990403</dateOfBirth><dateOfAward>20200529</dateOfAward><lscServiceName><BC_LSC_SERVICE_NAME></lscServiceName><clientOrgId><BC_CLIENT_ORG_ID></clientOrgId><clientUserId><BC_CLIENT_USER_ID></clientUserId></wsdl:check></env:Body></env:Envelope>
+        xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Body><wsdl:check><clientReference>02413302-abba-4f6b-a802-73b163c7bead</clientReference><nino>CB987654A</nino><surname>USER</surname><dateOfBirth>19990403</dateOfBirth><dateOfAward>20200925</dateOfAward><lscServiceName><BC_LSC_SERVICE_NAME></lscServiceName><clientOrgId><BC_CLIENT_ORG_ID></clientOrgId><clientUserId><BC_CLIENT_USER_ID></clientUserId></wsdl:check></env:Body></env:Envelope>
     headers:
       Soapaction:
       - '"check"'
@@ -75,7 +75,7 @@ http_interactions:
       message: ''
     headers:
       Date:
-      - Fri, 29 May 2020 14:11:28 GMT
+      - Fri, 25 Sep 2020 13:26:12 GMT
       Content-Type:
       - text/xml;charset=utf-8
       Transfer-Encoding:
@@ -83,7 +83,7 @@ http_interactions:
       Connection:
       - keep-alive
       X-Amzn-Trace-Id:
-      - Root=1-5ed11810-6bdaf9a4726cb8a4213e8198;
+      - Root=1-5f6deff4-106b0e0074e2068017013680;
       Vary:
       - Accept-Encoding
     body:
@@ -91,8 +91,8 @@ http_interactions:
       string: <?xml version="1.0" encoding="UTF-8"?><soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
         xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><soapenv:Body><benefitCheckerResponse
         xmlns="https://lsc.gov.uk/benefitchecker/service/1.0/API_1.0_Check"><ns1:originalClientRef
-        xmlns:ns1="http://lsc.gov.uk/benefitchecker/data/1.0">1f6f2607-1ba4-4b16-a96f-2b80f851a7c1</ns1:originalClientRef><ns2:benefitCheckerStatus
+        xmlns:ns1="http://lsc.gov.uk/benefitchecker/data/1.0">02413302-abba-4f6b-a802-73b163c7bead</ns1:originalClientRef><ns2:benefitCheckerStatus
         xmlns:ns2="http://lsc.gov.uk/benefitchecker/data/1.0">Undetermined</ns2:benefitCheckerStatus><ns3:confirmationRef
-        xmlns:ns3="http://lsc.gov.uk/benefitchecker/data/1.0">T1590761488143</ns3:confirmationRef></benefitCheckerResponse></soapenv:Body></soapenv:Envelope>
-  recorded_at: Fri, 29 May 2020 14:11:28 GMT
+        xmlns:ns3="http://lsc.gov.uk/benefitchecker/data/1.0">T1601040372617</ns3:confirmationRef></benefitCheckerResponse></soapenv:Body></soapenv:Envelope>
+  recorded_at: Fri, 25 Sep 2020 13:26:12 GMT
 recorded_with: VCR 6.0.0

--- a/features/cassettes/Civil_application_journeys/I_want_to_change_address_manually_from_the_check_your_answers_page.yml
+++ b/features/cassettes/Civil_application_journeys/I_want_to_change_address_manually_from_the_check_your_answers_page.yml
@@ -2,13 +2,13 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?key=<ORDNANACE_SURVEY_API_KEY>&lr=EN&postcode=SW1H9AJ
+    uri: https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?key=<ORDNANACE_SURVEY_API_KEY>&lr=EN&postcode=XX11XX
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - Faraday v1.0.0
+      - Faraday v1.0.1
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -19,7 +19,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 29 May 2020 14:11:42 GMT
+      - Fri, 25 Sep 2020 13:27:48 GMT
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -27,7 +27,7 @@ http_interactions:
       Connection:
       - keep-alive
       Tx-Id:
-      - 1590761502962:962
+      - 1601040468717:717
       Status:
       - success
     body:
@@ -35,17 +35,17 @@ http_interactions:
       string: |-
         {
           "header" : {
-            "uri" : "https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?lr=EN&postcode=SW1H9AJ",
-            "query" : "postcode=SW1H9AJ",
+            "uri" : "https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?lr=EN&postcode=XX11XX",
+            "query" : "postcode=XX11XX",
             "offset" : 0,
             "totalresults" : 0,
             "format" : "JSON",
             "dataset" : "DPA",
             "lr" : "EN",
             "maxresults" : 100,
-            "epoch" : "75",
+            "epoch" : "78",
             "output_srs" : "EPSG:27700"
           }
         }
-  recorded_at: Fri, 29 May 2020 14:11:42 GMT
+  recorded_at: Fri, 25 Sep 2020 13:27:48 GMT
 recorded_with: VCR 6.0.0

--- a/features/providers/civil_application_journey.feature
+++ b/features/providers/civil_application_journey.feature
@@ -163,11 +163,11 @@ Feature: Civil application journeys
     Then I enter national insurance number 'CB987654A'
     Then I click 'Save and continue'
     Then I am on the postcode entry page
-    Then I enter a postcode 'SW1H 9AJ'
+    Then I enter a postcode 'XX1 1XX'
     Then I click find address
-    Then I enter address line one '102 Petty France'
-    Then I enter city 'London'
-    Then I enter postcode 'SW1H 9AJ'
+    Then I enter address line one 'Fake Road'
+    Then I enter city 'Fake City'
+    Then I enter postcode 'XX1 1XX'
     Then I click 'Save and continue'
     Then I search for proceeding 'Non-molestation order'
     Then proceeding suggestions has results
@@ -353,11 +353,11 @@ Feature: Civil application journeys
     Given I complete the journey as far as check your answers
     And I click Check Your Answers Change link for 'Address'
     Then I am on the postcode entry page
-    Then I enter a postcode 'SW1H 9AJ'
+    Then I enter a postcode 'XX1 1XX'
     Then I click find address
-    Then I enter address line one '102 Petty France'
-    Then I enter city 'London'
-    Then I enter postcode 'SW1H 9AJ'
+    Then I enter address line one 'Fake Road'
+    Then I enter city 'Fake City'
+    Then I enter postcode 'XX1 1XX'
     Then I click 'Save and continue'
     Then I should be on a page showing 'Check your answers'
 

--- a/spec/cassettes/Providers_AddressSelectionsController/GET_/providers/applications/_legal_aid_application_id/address_selections/edit/when_the_provider_is_authenticated/a_postcode_has_been_entered_before/but_the_lookup_does_not_return_any_valid_results/renders_the_manual_address_selection_page.yml
+++ b/spec/cassettes/Providers_AddressSelectionsController/GET_/providers/applications/_legal_aid_application_id/address_selections/edit/when_the_provider_is_authenticated/a_postcode_has_been_entered_before/but_the_lookup_does_not_return_any_valid_results/renders_the_manual_address_selection_page.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?key=<ORDNANACE_SURVEY_API_KEY>&lr=EN&postcode=SW1H9AJ
+    uri: https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?key=<ORDNANACE_SURVEY_API_KEY>&lr=EN&postcode=XX11XX
     body:
       encoding: US-ASCII
       string: ''
@@ -19,7 +19,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 18 Aug 2020 10:29:00 GMT
+      - Fri, 25 Sep 2020 13:12:42 GMT
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -27,7 +27,7 @@ http_interactions:
       Connection:
       - keep-alive
       Tx-Id:
-      - 1597746540868:868
+      - 1601039562327:327
       Status:
       - success
     body:
@@ -35,17 +35,17 @@ http_interactions:
       string: |-
         {
           "header" : {
-            "uri" : "https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?lr=EN&postcode=SW1H9AJ",
-            "query" : "postcode=SW1H9AJ",
+            "uri" : "https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?lr=EN&postcode=XX11XX",
+            "query" : "postcode=XX11XX",
             "offset" : 0,
             "totalresults" : 0,
             "format" : "JSON",
             "dataset" : "DPA",
             "lr" : "EN",
             "maxresults" : 100,
-            "epoch" : "77",
+            "epoch" : "78",
             "output_srs" : "EPSG:27700"
           }
         }
-  recorded_at: Tue, 18 Aug 2020 10:29:00 GMT
+  recorded_at: Fri, 25 Sep 2020 13:12:42 GMT
 recorded_with: VCR 6.0.0

--- a/spec/requests/providers/address_selections_spec.rb
+++ b/spec/requests/providers/address_selections_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Providers::AddressSelectionsController, type: :request do
         end
 
         context 'but the lookup does not return any valid results' do
-          let(:postcode) { 'SW1H 9AJ' } # NOTE: test account does not return any results for this postcode
+          let(:postcode) { 'XX1 1XX' }
           let(:form_heading) { "Enter your client's correspondence address" }
           let(:error_message) { 'We could not find any addresses for that postcode. Enter the address manually.' }
 


### PR DESCRIPTION
## What

The OS postcode checker previously didn't return any addresses for `SW1H 9AJ`, so that postcode is used in tests for non-existent addresses. However 102 Petty France is now (correctly) returned for that postcode. This will cause tests to fail next time VCR cassettes are recorded.

This changes `SW1H 9AJ` to `XX1X 1XX` (which is vaild postcode that is unlikely to have any addresses associated with it the near future) in one spec and two feature tests, and re-records the cassettes.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
