### PR TITLE
Add extra state transition to fix production errors

### DIFF
--- a/app/models/concerns/base_state_machine.rb
+++ b/app/models/concerns/base_state_machine.rb
@@ -45,6 +45,7 @@ class BaseStateMachine < ApplicationRecord  # rubocop:disable Metrics/ClassLengt
         checking_applicant_details
         provider_confirming_applicant_eligibility
         use_ccms
+        delegated_functions_used
       ],
                   to: :applicant_details_checked,
                   after: proc { |legal_aid_application| CleanupCapitalAttributes.call(legal_aid_application) }


### PR DESCRIPTION
## What

We're seeing production errors due to a valid state transition.

It's possible for a provider to process a non-passported case that uses delegated functions, get to the `non_passported_client_instructions` screen, then hit back twice.

This currently throws the error `Event 'applicant_details_checked' cannot transition from 'delegated_functions_used'`.

This change adds the `delegated_functions_used` state to the `applicant_details_checked` event so that this is allowed.


## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
