### PR TITLE
Ap-1698: radio button accessibility

### DIFF
--- a/app/lib/govuk_elements_form_builder/form_builder.rb
+++ b/app/lib/govuk_elements_form_builder/form_builder.rb
@@ -10,6 +10,12 @@ module GovukElementsFormBuilder
     delegate :content_tag, to: :@template
     delegate :errors, to: :@object
 
+    def yes_no_radio_button_array
+      [
+        { value: :yes, label: I18n.t('generic.yes') },
+        { value: :no,  label: I18n.t('generic.no') }
+      ]
+    end
     # Usage:
     # <%= form.govuk_text_field :name %>
     # <%= form.govuk_text_area :statement %>
@@ -103,7 +109,7 @@ module GovukElementsFormBuilder
     # e.g., <%= form.govuk_collection_radio_buttons(:gender, ['f', 'm'], inline: true) %>
     #
     # TODO: Refactor this method and remove the rubocop:disable
-    def govuk_collection_radio_buttons(attribute, collection, *args) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+    def govuk_collection_radio_buttons(attribute, collection, *args, &block) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
       options = args.extract_options!.symbolize_keys!
       value_attr, label_attr = extract_value_and_label_attributes(args)
 
@@ -113,6 +119,7 @@ module GovukElementsFormBuilder
           classes << (options[:inline] ? 'govuk-radios--inline' : 'govuk-!-padding-top-2')
           concat_tags(
             hint_and_error_tags(attribute, options),
+            content_tag(:div, &block),
             content_tag(:div, class: classes.join(' ')) do
               inputs = collection.map do |obj|
                 value = value_attr ? obj[value_attr] : obj
@@ -216,7 +223,8 @@ module GovukElementsFormBuilder
       htag = title.fetch(:htag, :h1)
       padding_below = title.fetch(:padding_below, nil)
       padding_class = " govuk-!-padding-bottom-#{padding_below}" if padding_below.present?
-      content_tag(:legend, class: "govuk-fieldset__legend govuk-fieldset__legend--#{size}#{padding_class}") do
+      hidden = ' govuk-visually-hidden' if title.fetch(:hidden, nil)
+      content_tag(:legend, class: "govuk-fieldset__legend govuk-fieldset__legend--#{size}#{padding_class}#{hidden}") do
         content_tag(htag, title[:text], class: 'govuk-fieldset__heading')
       end
     end

--- a/app/views/citizens/additional_accounts/index.html.erb
+++ b/app/views/citizens/additional_accounts/index.html.erb
@@ -6,15 +6,8 @@
             input: :additional_account
           ) do %>
 
-        <%
-          options = [
-            { value: :yes, label: t('generic.yes') },
-            { value: :no,  label: t('generic.no') }
-          ]
-        %>
-
         <%= form.govuk_collection_radio_buttons :additional_account,
-                                                options,
+                                                form.yes_no_radio_button_array,
                                                 :value,
                                                 :label,
                                                 error: @error,

--- a/app/views/citizens/additional_accounts/index.html.erb
+++ b/app/views/citizens/additional_accounts/index.html.erb
@@ -13,10 +13,12 @@
           ]
         %>
 
-        <%= govuk_fieldset_header(content_for(:page_title)) %>
-
-        <%= form.govuk_collection_radio_buttons :additional_account, options, :value, :label, error: @error %>
-
+        <%= form.govuk_collection_radio_buttons :additional_account,
+                                                options,
+                                                :value,
+                                                :label,
+                                                error: @error,
+                                                title: content_for(:page_title) %>
       <% end %>
 
       <%= next_action_buttons(form: form) %>

--- a/app/views/citizens/additional_accounts/new.html.erb
+++ b/app/views/citizens/additional_accounts/new.html.erb
@@ -13,10 +13,12 @@
         ]
       %>
 
-      <%= govuk_fieldset_header(content_for(:page_title)) %>
-
-      <%= form.govuk_collection_radio_buttons :has_online_accounts, options, :value, :label, error: @error %>
-
+      <%= form.govuk_collection_radio_buttons :has_online_accounts,
+                                              options,
+                                              :value,
+                                              :label,
+                                              error: @error,
+                                              title: content_for(:page_title) %>
     <% end %>
 
     <%= next_action_buttons(form: form) %>

--- a/app/views/citizens/additional_accounts/new.html.erb
+++ b/app/views/citizens/additional_accounts/new.html.erb
@@ -6,15 +6,8 @@
           input: :has_online_accounts
         ) do %>
 
-      <%
-        options = [
-          { value: :yes, label: t('generic.yes') },
-          { value: :no,  label: t('generic.no') }
-        ]
-      %>
-
       <%= form.govuk_collection_radio_buttons :has_online_accounts,
-                                              options,
+                                              form.yes_no_radio_button_array,
                                               :value,
                                               :label,
                                               error: @error,

--- a/app/views/citizens/banks/index.html.erb
+++ b/app/views/citizens/banks/index.html.erb
@@ -4,11 +4,13 @@
 
   <%= form_with(local: true) do |form| %>
     <%= govuk_form_group(show_error_if: @error) do %>
-      <h1 class="govuk-heading-xl"><%= content_for(:page_title) %></h1>
-      <%= govuk_hint t('.hint') %>
-      <div class="govuk-radios bank-selection">
-        <%= render partial: 'bank', collection: TrueLayerBank.available_banks, locals: { form: form } %>
-      </div>
+      <fieldset class="govuk-fieldset">
+        <%= govuk_fieldset_header content_for(:page_title) %>
+        <%= govuk_hint t('.hint') %>
+        <div class="govuk-radios bank-selection">
+          <%= render partial: 'bank', collection: TrueLayerBank.available_banks, locals: { form: form } %>
+        </div>
+      </fieldset>
     <% end %>
 
     <h2 class="govuk-heading-m"><%= t('.what_happens_next') %></h2>

--- a/app/views/citizens/consents/show.html.erb
+++ b/app/views/citizens/consents/show.html.erb
@@ -39,16 +39,23 @@
         </div>
       </details>
 
-      <%= form.govuk_radio_button(
-            :open_banking_consent,
-            true,
-            label: t('generic.yes')
-          ) %>
-
-      <%= form.govuk_radio_button(
-            :open_banking_consent,
-            false,
-            label: t('generic.no')
+      <%
+        options = [
+            { value: :true, label: t('generic.yes') },
+            { value: :false,  label: t('generic.no') }
+        ]
+      %>
+      <%= form.govuk_collection_radio_buttons(
+              :open_banking_consent,
+              options,
+              :value,
+              :label,
+              error: @error,
+              title: {
+                  text: t('.title_html'),
+                  htag: :h2,
+                  hidden: true
+              }
           ) %>
     <% end %>
 

--- a/app/views/citizens/student_finances/show.html.erb
+++ b/app/views/citizens/student_finances/show.html.erb
@@ -9,10 +9,13 @@
       ]
     %>
 
-    <%= govuk_fieldset_header(content_for(:page_title)) %>
-    <%= govuk_hint t('.hint') %>
-
-    <%= form.govuk_collection_radio_buttons :student_finance, options, :value, :label, error: @error %>
+    <%= form.govuk_collection_radio_buttons :student_finance,
+                                            options,
+                                            :value,
+                                            :label,
+                                            error: @error,
+                                            hint: t('.hint'),
+                                            title: content_for(:page_title) %>
 
     <%= next_action_buttons(
             show_draft: true,

--- a/app/views/providers/applicant_bank_accounts/show.html.erb
+++ b/app/views/providers/applicant_bank_accounts/show.html.erb
@@ -55,34 +55,18 @@
     </div>
 
     <div class="govuk-!-padding-bottom-4"></div>
-    <%= govuk_form_group(
-            show_error_if: @error,
-            input: :offline_savings_account
-        ) do %>
 
-      <h2 class="govuk-heading-l"><%= t('.offline_savings_accounts') %></h2>
-
-      <p class="govuk-hint"><%= t('.hints.offline_savings_accounts') %></p>
-
-      <%= govuk_error_message(@error&.values&.first) %>
-
-      <div class="govuk-radios govuk-radios--conditional govuk-!-padding-top-2" data-module="govuk-radios">
-        <%= form.govuk_radio_button(
-                :offline_savings_account,
-                'yes',
-                label: t('generic.yes'),
-                error: @error&.values&.first,
-                checked: @legal_aid_application&.savings_amount&.offline_savings_accounts.present?
-            ) %>
-
-        <%= form.govuk_radio_button(
-                :offline_savings_account,
-                'no',
-                error: @error&.values&.first,
-                label: t('generic.no')
-            ) %>
-      </div>
-  <% end %>
+    <%= form.govuk_collection_radio_buttons :offline_savings_account,
+                                            form.yes_no_radio_button_array,
+                                            :value,
+                                            :label,
+                                            error: @error&.values&.first,
+                                            hint: t('.hints.offline_savings_accounts'),
+                                            title: {
+                                              text: t('.offline_savings_accounts'),
+                                              htag: 'h2',
+                                              size: :l
+                                            } %>
 
     <%= next_action_buttons(
             show_draft: true,

--- a/app/views/providers/confirm_offices/show.html.erb
+++ b/app/views/providers/confirm_offices/show.html.erb
@@ -22,7 +22,10 @@
 
       <%= form.govuk_collection_radio_buttons(
             :correct,
-            form.yes_no_radio_button_array,
+            [
+              { value: :yes, label: t('generic.yes') },
+              { value: :no,  label: t('.no_another_office') }
+            ],
             :value,
             :label,
             error: @error,

--- a/app/views/providers/confirm_offices/show.html.erb
+++ b/app/views/providers/confirm_offices/show.html.erb
@@ -19,15 +19,10 @@
     <%= govuk_form_group(
           show_error_if: @error,
         ) do %>
-      <%
-        options = [
-          { value: :yes, label: t('generic.yes') },
-          { value: :no,  label: t('.no_another_office') }
-        ]
-      %>
+
       <%= form.govuk_collection_radio_buttons(
             :correct,
-            options,
+            form.yes_no_radio_button_array,
             :value,
             :label,
             error: @error,

--- a/app/views/providers/dependants/_form.html.erb
+++ b/app/views/providers/dependants/_form.html.erb
@@ -13,23 +13,25 @@
     <%= date_input_fields prefix: :dob, field_name: :date_of_birth, form: form %>
 
     <%= govuk_form_group(input: :relationship, show_error_if: @form.errors.messages[:relationship].any?) do %>
-      <div id='relationship'></div>
-      <%= govuk_fieldset_header(size: 'm') { t('.relationship') } %>
-      <%= govuk_error_message(form.object.errors[:relationship].first) %>
+      <fieldset class="govuk-fieldset">
+        <div id='relationship'></div>
+        <%= govuk_fieldset_header(size: 'm') { t('.relationship') } %>
+        <%= govuk_error_message(form.object.errors[:relationship].first) %>
 
-      <div class="govuk-!-padding-bottom-3"></div>
-
-      <% Dependant.relationships.keys.each do |relationship_type| %>
         <div class="govuk-!-padding-bottom-3"></div>
 
-        <%= form.govuk_radio_button(
-                :relationship,
-                relationship_type,
-                label: t(".option.#{relationship_type}"),
-                hint: t(".option.hint.#{relationship_type}"),
-                checked: @form.relationship.to_s == relationship_type.to_s
-            ) %>
-      <% end %>
+        <% Dependant.relationships.keys.each do |relationship_type| %>
+          <div class="govuk-!-padding-bottom-3"></div>
+
+          <%= form.govuk_radio_button(
+                  :relationship,
+                  relationship_type,
+                  label: t(".option.#{relationship_type}"),
+                  hint: t(".option.hint.#{relationship_type}"),
+                  checked: @form.relationship.to_s == relationship_type.to_s
+              ) %>
+        <% end %>
+      </fieldset>
     <% end %>
     <%
       options = [
@@ -47,12 +49,13 @@
         ) %>
 
     <%= govuk_form_group show_error_if: @form.errors.messages[:has_income].present? do %>
-      <div id='has_income'></div>
-      <%= govuk_fieldset_header(size: 'm') { t('.has_income.question') } %>
-      <%= govuk_hint t('.has_income.hint') %>
-      <%= govuk_error_message(form.object.errors[:has_income].first) %>
+      <fieldset class="govuk-fieldset">
+        <div id='has_income'></div>
+        <%= govuk_fieldset_header(size: 'm') { t('.has_income.question') } %>
+        <%= govuk_hint t('.has_income.hint') %>
+        <%= govuk_error_message(form.object.errors[:has_income].first) %>
 
-      <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios">
+        <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios">
         <%= form.govuk_radio_button(
                 :has_income,
                 true,
@@ -76,18 +79,20 @@
                 label: t('generic.no')
             ) %>
       </div>
+      </fieldset>
     <% end %>
 
     <%= govuk_form_group show_error_if: @form.errors[:has_assets_more_than_threshold].present? do %>
-      <div id='has_assets_more_than_threshold'></div>
-      <%= govuk_fieldset_header(size: 'm') { t('.has_assets_more_than_threshold.question') } %>
-      <%= govuk_error_message(form.object.errors[:has_assets_more_than_threshold].first) %>
+      <fieldset class="govuk-fieldset">
+        <div id='has_assets_more_than_threshold'></div>
+        <%= govuk_fieldset_header(size: 'm') { t('.has_assets_more_than_threshold.question') } %>
+        <%= govuk_error_message(form.object.errors[:has_assets_more_than_threshold].first) %>
 
-      <%= govuk_hint t('.has_assets_more_than_threshold.hint') %>
+        <%= govuk_hint t('.has_assets_more_than_threshold.hint') %>
 
-      <div class="govuk-!-padding-bottom-2"></div>
+        <div class="govuk-!-padding-bottom-2"></div>
 
-      <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios">
+        <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios">
         <%= form.govuk_radio_button(
                 :has_assets_more_than_threshold,
                 true,
@@ -113,7 +118,7 @@
                 checked: @form.has_assets_more_than_threshold == false
             ) %>
       </div>
-
+      </fieldset>
     <% end %>
 
     <div class="govuk-!-padding-bottom-2"></div>

--- a/app/views/providers/has_dependants/show.html.erb
+++ b/app/views/providers/has_dependants/show.html.erb
@@ -6,38 +6,42 @@
           local: true
       ) do |form| %>
 
-    <%= govuk_form_group show_error_if: @form.errors.present? do %>
-      <%= govuk_fieldset_header page_title %>
+    <%= govuk_form_group(
+            show_error_if: @form.errors.present?,
+            input: :has_dependants
+        ) do %>
+      <%
+        options = [
+            { value: :true, label: t('generic.yes') },
+            { value: :false,  label: t('generic.no') }
+        ]
+      %>
 
-      <div class="govuk-!-padding-bottom-4"></div>
+      <%= form.govuk_collection_radio_buttons :has_dependants,
+                                              options,
+                                              :value,
+                                              :label,
+                                              error: @error,
+                                              title: {
+                                                  text: t('.page_title'),
+                                                  padding_below: 4
+                                              } do %>
+          <p class="govuk-body">
+            <%= t('.info') %>
+          </p>
 
-      <p class="govuk-body">
-        <%= t('.info') %>
-      </p>
+          <ul class="govuk-list govuk-list--bullet">
+            <% t('.list').each_line do |item| %>
+              <li><%= item %></li>
+            <% end %>
+          </ul>
 
-      <ul class="govuk-list govuk-list--bullet">
-        <% t('.list').each_line do |item| %>
-          <li><%= item %></li>
-        <% end %>
-      </ul>
-
-      <div class="govuk-inset-text">
-        <p class="govuk-body">
-          <%= t('.extra_info') %>
-        </p>
-      </div>
-
-      <%= form.govuk_radio_button(
-              :has_dependants,
-              true,
-              label: t('generic.yes')
-          ) %>
-
-      <%= form.govuk_radio_button(
-              :has_dependants,
-              false,
-              label: t('generic.no')
-          ) %>
+          <div class="govuk-inset-text">
+            <p class="govuk-body">
+              <%= t('.extra_info') %>
+            </p>
+          </div>
+      <% end %>
 
     <% end %>
 

--- a/app/views/providers/has_other_dependants/show.html.erb
+++ b/app/views/providers/has_other_dependants/show.html.erb
@@ -51,14 +51,7 @@
             input: :other_dependant
         ) do %>
 
-      <%
-        options = [
-            { value: :yes, label: t('generic.yes') },
-            { value: :no,  label: t('generic.no') }
-        ]
-      %>
-
-      <%= form.govuk_collection_radio_buttons :other_dependant, options, :value, :label, error: @error&.values&.first, title: content_for(:page_title) %>
+      <%= form.govuk_collection_radio_buttons :other_dependant, form.yes_no_radio_button_array, :value, :label, error: @error&.values&.first, title: content_for(:page_title) %>
 
     <% end %>
 

--- a/app/views/providers/no_income_summaries/show.html.erb
+++ b/app/views/providers/no_income_summaries/show.html.erb
@@ -21,42 +21,43 @@
           method: :patch,
           local: true
       ) do |form| %>
+    <fieldset class="govuk-fieldset">
+      <%= govuk_fieldset_header t('.page_heading') %>
 
-    <%= govuk_fieldset_header t('.page_heading') %>
+      <p class="gov-body"><%= t('.subheading.text') %></p>
+      <%= list_from_translation_path('.no_income_summaries.show.subheading') %>
 
-    <p class="gov-body"><%= t('.subheading.text') %></p>
-    <%= list_from_translation_path('.no_income_summaries.show.subheading') %>
+      <h2 class="govuk-heading-l"><%= t('.is_this_correct') %></h2>
 
-    <h2 class="govuk-heading-l"><%= t('.is_this_correct') %></h2>
+      <%= govuk_form_group(
+              show_error_if: @error,
+              input: :confirm_no_income
+          ) do %>
 
-    <%= govuk_form_group(
-            show_error_if: @error,
-            input: :confirm_no_income
-        ) do %>
+        <%= govuk_error_message(@error&.values&.first, id: 'confirm_no_income-error') %>
 
-      <%= govuk_error_message(@error&.values&.first) %>
+        <div class="govuk-radios govuk-radios--conditional govuk-!-padding-top-2" data-module="govuk-radios">
+          <%= form.govuk_radio_button(
+                  :confirm_no_income,
+                  'yes',
+                  label: t('generic.yes'),
+                  error: @error&.values&.first
+              ) %>
 
-      <div class="govuk-radios govuk-radios--conditional govuk-!-padding-top-2" data-module="govuk-radios">
-        <%= form.govuk_radio_button(
-                :confirm_no_income,
-                'yes',
-                label: t('generic.yes'),
-                error: @error&.values&.first
-            ) %>
+          <%= form.govuk_radio_button(
+                  :confirm_no_income,
+                  'no',
+                  label: t('generic.no'),
+                  error: @error&.values&.first
+              ) %>
+        </div>
+      <% end %>
 
-        <%= form.govuk_radio_button(
-                :confirm_no_income,
-                'no',
-                label: t('generic.no'),
-                error: @error&.values&.first
-            ) %>
-      </div>
-    <% end %>
+      <%= next_action_buttons_with_form(
+              url: providers_legal_aid_application_no_income_summary_path,
+              show_draft: true
+          ) %>
 
-    <%= next_action_buttons_with_form(
-            url: providers_legal_aid_application_no_income_summary_path,
-            show_draft: true
-        ) %>
-
+    </fieldset>
   <% end %>
 <% end %>

--- a/app/views/providers/no_outgoings_summaries/show.html.erb
+++ b/app/views/providers/no_outgoings_summaries/show.html.erb
@@ -21,42 +21,43 @@
           method: :patch,
           local: true
       ) do |form| %>
+    <fieldset class="govuk-fieldset">
+      <%= govuk_fieldset_header t('.page_heading') %>
 
-    <%= govuk_fieldset_header t('.page_heading') %>
+      <p class="gov-body"><%= t('.subheading.text') %></p>
+      <%= list_from_translation_path('.no_outgoings_summaries.show.subheading') %>
 
-    <p class="gov-body"><%= t('.subheading.text') %></p>
-    <%= list_from_translation_path('.no_outgoings_summaries.show.subheading') %>
+      <h2 class="govuk-heading-l"><%= t('.is_this_correct') %></h2>
 
-    <h2 class="govuk-heading-l"><%= t('.is_this_correct') %></h2>
+      <%= govuk_form_group(
+              show_error_if: @error,
+              input: :confirm_no_income
+          ) do %>
 
-    <%= govuk_form_group(
-            show_error_if: @error,
-            input: :confirm_no_income
-        ) do %>
+        <%= govuk_error_message(@error&.values&.first, id: 'confirm_no_outgoings-error') %>
 
-      <%= govuk_error_message(@error&.values&.first) %>
+        <div class="govuk-radios govuk-radios--conditional govuk-!-padding-top-2" data-module="govuk-radios">
+          <%= form.govuk_radio_button(
+                  :confirm_no_outgoings,
+                  'yes',
+                  label: t('generic.yes'),
+                  error: @error&.values&.first
+              ) %>
 
-      <div class="govuk-radios govuk-radios--conditional govuk-!-padding-top-2" data-module="govuk-radios">
-        <%= form.govuk_radio_button(
-                :confirm_no_outgoings,
-                'yes',
-                label: t('generic.yes'),
-                error: @error&.values&.first
-            ) %>
+          <%= form.govuk_radio_button(
+                  :confirm_no_outgoings,
+                  'no',
+                  label: t('generic.no'),
+                  error: @error&.values&.first
+              ) %>
+        </div>
+      <% end %>
 
-        <%= form.govuk_radio_button(
-                :confirm_no_outgoings,
-                'no',
-                label: t('generic.no'),
-                error: @error&.values&.first
-            ) %>
-      </div>
-    <% end %>
+      <%= next_action_buttons_with_form(
+              url: providers_legal_aid_application_no_outgoings_summary_path,
+              show_draft: true
+          ) %>
 
-    <%= next_action_buttons_with_form(
-            url: providers_legal_aid_application_no_outgoings_summary_path,
-            show_draft: true
-        ) %>
-
+    </fieldset>
   <% end %>
 <% end %>

--- a/app/views/providers/remove_dependant/show.html.erb
+++ b/app/views/providers/remove_dependant/show.html.erb
@@ -20,14 +20,7 @@
             input: :remove_dependant
         ) do %>
 
-      <%
-        options = [
-            { value: :yes, label: t('generic.yes') },
-            { value: :no,  label: t('generic.no') }
-        ]
-      %>
-
-      <%= form.govuk_collection_radio_buttons :remove_dependant, options, :value, :label, error: @error&.values&.first, title: content_for(:page_title) %>
+      <%= form.govuk_collection_radio_buttons :remove_dependant, form.yes_no_radio_button_array, :value, :label, error: @error&.values&.first, title: content_for(:page_title) %>
 
     <% end %>
 

--- a/app/views/providers/restrictions/_form.html.erb
+++ b/app/views/providers/restrictions/_form.html.erb
@@ -1,32 +1,34 @@
 <%= form_with(model: model, url: url, method: :patch, local: true) do |form| %>
   <%= govuk_form_group show_error_if: @form.errors.present? do %>
-    <%= govuk_fieldset_header page_title, size: 'l', padding_below: 4 %>
+    <fieldset class="govuk-fieldset">
+      <%= govuk_fieldset_header page_title, size: 'l', padding_below: 4 %>
 
-    <p class="govuk-body"><%= for_example %></p>
-    <%= list_from_translation_path ".restrictions.show.examples" %>
-    <div class="govuk-!-padding-bottom-4"></div>
+      <p class="govuk-body"><%= for_example %></p>
+      <%= list_from_translation_path ".restrictions.show.examples" %>
+      <div class="govuk-!-padding-bottom-4"></div>
 
-    <%= govuk_error_message(@form.errors[:has_restrictions].first) %>
-    <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios">
-      <%= form.govuk_radio_button(
-        :has_restrictions,
-        true,
-        label: t('generic.yes'),
-        checked: @form.has_restrictions.to_s == 'true',
-        'data-aria-controls' => 'conditional-true') %>
+      <%= govuk_error_message(@form.errors[:has_restrictions].first) %>
+      <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios">
+        <%= form.govuk_radio_button(
+          :has_restrictions,
+          true,
+          label: t('generic.yes'),
+          checked: @form.has_restrictions.to_s == 'true',
+          'data-aria-controls' => 'conditional-true') %>
 
-      <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-true">
-        <%= govuk_error_message(@form.errors[:restrictions_details].first) %>
-        <%= form.govuk_text_area :restrictions_details, rows: 5, label: details %>
+        <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-true">
+          <%= govuk_error_message(@form.errors[:restrictions_details].first) %>
+          <%= form.govuk_text_area :restrictions_details, rows: 5, label: details %>
+        </div>
+
+        <%= form.govuk_radio_button(
+          :has_restrictions,
+          false,
+          label: t('generic.no'),
+          checked: @form.has_restrictions.to_s == 'false'
+        ) %>
       </div>
-
-      <%= form.govuk_radio_button(
-        :has_restrictions,
-        false,
-        label: t('generic.no'),
-        checked: @form.has_restrictions.to_s == 'false'
-      ) %>
-    </div>
+    </fieldset>
   <% end %>
 
   <%= next_action_buttons(

--- a/app/views/providers/select_offices/show.html.erb
+++ b/app/views/providers/select_offices/show.html.erb
@@ -1,12 +1,13 @@
 <%= page_template page_title: t('.h1-heading', firm: firm.name), template: :basic do %>
   <%= form_with(model: @form, url: providers_select_office_path, method: :patch, local: true) do |form| %>
-    <fieldset class="govuk-fieldset">
-      <%= govuk_fieldset_header(content_for(:page_title), padding_below: 6) %>
-
-      <%= form.govuk_collection_radio_buttons(:selected_office_id, @form.model.offices, :id, :code) %>
-    </fieldset>
-
-    <div class="govuk-!-padding-bottom-2"></div>
+    <%= form.govuk_collection_radio_buttons(:selected_office_id,
+                                            @form.model.offices,
+                                            :id,
+                                            :code,
+                                            title: {
+                                                text: content_for(:page_title),
+                                                padding_below: 6
+                                            }) %>
 
     <%= next_action_buttons(form: form) %>
   <% end %>

--- a/app/views/providers/used_delegated_functions/show.html.erb
+++ b/app/views/providers/used_delegated_functions/show.html.erb
@@ -8,28 +8,30 @@
       ) do |form| %>
 
     <%= govuk_form_group show_error_if: @form.errors.present? do %>
-      <%= govuk_fieldset_header page_title %>
+      <fieldset class="govuk-fieldset">
+        <%= govuk_fieldset_header page_title %>
 
-      <%= render 'shared/show_errors' %>
+        <%= render 'shared/show_errors' %>
 
-      <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios">
-        <%= form.govuk_radio_button(
-              :used_delegated_functions,
-              true,
-              label: t('generic.yes'),
-              'data-aria-controls' => 'conditional-true'
-            ) %>
+        <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios">
+          <%= form.govuk_radio_button(
+                :used_delegated_functions,
+                true,
+                label: t('generic.yes'),
+                'data-aria-controls' => 'conditional-true'
+              ) %>
 
-        <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-true">
-          <%= date_input_fields prefix: :used_delegated_functions, field_name: :used_delegated_functions_on, form: form %>
+          <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-true">
+            <%= date_input_fields prefix: :used_delegated_functions, field_name: :used_delegated_functions_on, form: form %>
+          </div>
+
+          <%= form.govuk_radio_button(
+                :used_delegated_functions,
+                false,
+                label: t('generic.no')
+              ) %>
         </div>
-
-        <%= form.govuk_radio_button(
-              :used_delegated_functions,
-              false,
-              label: t('generic.no')
-            ) %>
-      </div>
+      </fieldset>
 
     <% end %>
 

--- a/app/views/shared/forms/_open_banking_consents.html.erb
+++ b/app/views/shared/forms/_open_banking_consents.html.erb
@@ -6,37 +6,37 @@
       ) do |form| %>
 
     <%= govuk_form_group(input: :provider_received_citizen_consent, show_error_if: @form.errors.present?) do %>
-      <%= govuk_fieldset_header page_title %>
+      <fieldset class="govuk-fieldset">
+        <%= govuk_fieldset_header page_title, padding_below: 4 %>
 
-      <div class="govuk-!-padding-bottom-4"></div>
+        <p class="govuk-body">
+          <%= info %>
+        </p>
 
-      <p class="govuk-body">
-        <%= info %>
-      </p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li><%= t('providers.open_banking_consents.show.list_1') %></li>
+          <li><%= t('providers.open_banking_consents.show.list_2_html') %></li>
+          <li><%= t('providers.open_banking_consents.show.list_3') %></li>
+        </ul>
 
-      <ul class="govuk-list govuk-list--bullet">
-        <li><%= t('providers.open_banking_consents.show.list_1') %></li>
-        <li><%= t('providers.open_banking_consents.show.list_2_html') %></li>
-        <li><%= t('providers.open_banking_consents.show.list_3') %></li>
-      </ul>
+        <%= form.govuk_radio_button(
+                :provider_received_citizen_consent,
+                true,
+                label: t('providers.open_banking_consents.show.radio_yes')
+            ) %>
 
-      <%= form.govuk_radio_button(
-              :provider_received_citizen_consent,
-              true,
-              label: t('providers.open_banking_consents.show.radio_yes')
-          ) %>
+        <%= form.govuk_radio_button(
+                :provider_received_citizen_consent,
+                false,
+                label: t('providers.open_banking_consents.show.radio_no')
+            ) %>
 
-      <%= form.govuk_radio_button(
-              :provider_received_citizen_consent,
-              false,
-              label: t('providers.open_banking_consents.show.radio_no')
-          ) %>
+        <div class="govuk-!-padding-bottom-5"></div>
 
-      <div class="govuk-!-padding-bottom-5"></div>
-
-      <%= next_action_buttons(
-          show_draft: local_assigns.key?(:show_draft) ? show_draft : false,
-          form: form
-      ) %>
+        <%= next_action_buttons(
+            show_draft: local_assigns.key?(:show_draft) ? show_draft : false,
+            form: form
+        ) %>
+      </fieldset>
     <% end %>
   <% end %>

--- a/app/views/shared/forms/_success_prospect_form.html.erb
+++ b/app/views/shared/forms/_success_prospect_form.html.erb
@@ -9,23 +9,25 @@
   <% input_error_class = error ? 'govuk-input--error' : '' %>
 
   <%= govuk_form_group(input: :success_prospect, show_error_if: @form.errors.any?) do %>
-    <%= govuk_fieldset_header(content_for(:page_title)) %>
-    <%= govuk_error_message(form.object.errors[:client_received_legal_help].first) %>
-    <%= content_tag(:span, error, class: 'govuk-error-message', id: 'success_prospect') if error %>
+    <fieldset class="govuk-fieldset">
+      <%= govuk_fieldset_header(content_for(:page_title)) %>
+      <%= govuk_error_message(form.object.errors[:client_received_legal_help].first) %>
+      <%= content_tag(:span, error, class: 'govuk-error-message', id: 'success_prospect') if error %>
 
-    <div class="govuk-radios govuk-radios--conditional govuk-!-padding-top-2" data-module="govuk-radios">
-      <%= render partial: 'shared/forms/success_prospect/success_prospect_item',
-                 collection: MeritsAssessment.prospects_unlikely_to_succeed, as: :prospect,
-                 locals: { form: form,
-                           group_error_class: group_error_class,
-                           input_error_class: input_error_class } %>
+      <div class="govuk-radios govuk-radios--conditional govuk-!-padding-top-2" data-module="govuk-radios">
+        <%= render partial: 'shared/forms/success_prospect/success_prospect_item',
+                   collection: MeritsAssessment.prospects_unlikely_to_succeed, as: :prospect,
+                   locals: { form: form,
+                             group_error_class: group_error_class,
+                             input_error_class: input_error_class } %>
 
-    </div>
-    <div id="success-prospect-text-area">
-      <%= form.govuk_text_area :success_prospect_details,
-                               rows: 5,
-                               value: @form.success_prospect_details %>
-    </div>
+      </div>
+      <div id="success-prospect-text-area">
+        <%= form.govuk_text_area :success_prospect_details,
+                                 rows: 5,
+                                 value: @form.success_prospect_details %>
+      </div>
+    </fieldset>
   <% end %>
   <%= next_action_buttons(show_draft: true, form: form) %>
 <% end %>

--- a/app/views/shared/forms/vehicles/_remaining_payment.html.erb
+++ b/app/views/shared/forms/vehicles/_remaining_payment.html.erb
@@ -6,39 +6,40 @@
     ) do |form| %>
 
   <%= govuk_form_group show_error_if: @form.errors.present? do %>
-    <%= govuk_fieldset_header page_title %>
+    <fieldset class="govuk-fieldset">
+      <%= govuk_fieldset_header page_title %>
 
-    <%= govuk_hint t('.detail_of_payments_to_include') %>
+      <%= govuk_hint t('.detail_of_payments_to_include') %>
 
-      <%= render 'shared/show_errors' %>
+        <%= render 'shared/show_errors' %>
 
-    <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios">
-      <%= form.govuk_radio_button(
-            :payments_remain,
-            true,
-            label: t('generic.yes'),
-            'data-aria-controls' => 'conditional-true',
-            checked: @form.payments_remain? || @form.model.payment_remaining?
-          ) %>
+      <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios">
+        <%= form.govuk_radio_button(
+              :payments_remain,
+              true,
+              label: t('generic.yes'),
+              'data-aria-controls' => 'conditional-true',
+              checked: @form.payments_remain? || @form.model.payment_remaining?
+            ) %>
 
-      <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-true">
-        <%= form.govuk_text_field(
-              :payment_remaining,
-              label: t('.enter_amount_left_to_pay'),
-              value: number_to_currency_or_original_string(@form.payment_remaining),
-              input_prefix: t('currency.gbp'),
-              class: 'govuk-!-width-one-third'
+        <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-true">
+          <%= form.govuk_text_field(
+                :payment_remaining,
+                label: t('.enter_amount_left_to_pay'),
+                value: number_to_currency_or_original_string(@form.payment_remaining),
+                input_prefix: t('currency.gbp'),
+                class: 'govuk-!-width-one-third'
+              ) %>
+        </div>
+
+        <%= form.govuk_radio_button(
+              :payments_remain,
+              false,
+              label: t('generic.no'),
+              checked: @form.model.payment_remaining&.zero? && !@form.payments_remain?
             ) %>
       </div>
-
-      <%= form.govuk_radio_button(
-            :payments_remain,
-            false,
-            label: t('generic.no'),
-            checked: @form.model.payment_remaining&.zero? && !@form.payments_remain?
-          ) %>
-    </div>
-
+    </fieldset>
   <% end %>
   <div class="govuk-!-padding-bottom-4"></div>
   <%= next_action_buttons(


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1698)

Work through the application and ensure that all forms with radio buttons are accessible in-line with DAC recommendations

I have extended the formbuilder to:
* allow hidden legend This can be used on pages where a simple h1 radio button is not enough
* Allow passing a block to the method which allows wrapping help text inside a form  group without writing them manually each time
* Add yes/no button array to reduce repetition in views

Ensured the radio buttons in use have a correctly structured fieldset and legend. This was done by either
a) adding a fieldset tag around a complex radio button collection; or
b) switching to use the govuk_collection_radio_buttons helper method where possible

## Follow-up jira tickets to write
- [x] [Assess and rationalise similar patterns](https://dsdmoj.atlassian.net/browse/AP-1726)
- [x] [Investigate and implement the DFE-Digital govuk_design_system_formbuilder](https://dsdmoj.atlassian.net/browse/AP-1728)

These fall outside the scope of this accessibility ticket but will definitely reduce the cognitive load and technical debt for future devs

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
