### PR TITLE
AP1622 Add accessible message for loading transactions page

### DIFF
--- a/app/views/citizens/accounts/gather.html.erb
+++ b/app/views/citizens/accounts/gather.html.erb
@@ -5,8 +5,9 @@
     </div>
   <% end %>
 <% else %>
+  <div id="status" class="govuk-visually-hidden" role="status" data-status="<%= t('.status_message') %>"><%= t('.status_message') %></div>
   <div class="worker-waiter" data-worker-id="<%= session[:worker_id] %>" align="center">
-    <%= image_tag('loading.gif',  alt:'Page Loading') %>
+    <%= image_tag('loading.gif',  alt: t('.page_loading')) %>
     <p class="govuk-body-l"><%= t '.retrieving_transactions' %></p>
   </div>
 <% end %>

--- a/config/locales/en/citizens.yml
+++ b/config/locales/en/citizens.yml
@@ -5,6 +5,8 @@ en:
       gather:
         retrieving_transactions: Retrieving bank transactions
         default_error: Sorry, we are experiencing technical difficulties. Please try again later.
+        status_message: Transactions are loading, you will be redirected once complete.
+        page_loading: Page Loading
       index:
         account_holder_address_heading: Account holder address
         account_holder_name_heading: Account holder name


### PR DESCRIPTION
AP1622 Add accessible message when page is loading to import bank transactions

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1622)

Update the page belonging to the gather route on the AccountsController page with an accessible message describing that 'Transactions are loading, you will be redirected once complete.'

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
