### PR TITLE
AP-1629 Use correct input type on date fields

### DIFF
--- a/app/views/shared/forms/_date_part_input_fields.html.erb
+++ b/app/views/shared/forms/_date_part_input_fields.html.erb
@@ -8,6 +8,6 @@
 <div class="govuk-date-input__item">
   <div class="govuk-form-group">
     <%= form.label field_name, class: ['govuk-date-input__label govuk-label'], for: input_id %>
-    <%= form.text_field field_name, id: input_id, class: ["govuk-input govuk-date-input__input govuk-input--width-#{width} #{field_error_class}"] %>
+    <%= form.text_field field_name, id: input_id, class: ["govuk-input govuk-date-input__input govuk-input--width-#{width} #{field_error_class}"], pattern: "[0-9]*", inputmode: "numeric" %>
   </div>
 </div>


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1629)

The input type for the date field is set as 'text'. This means mobile users may have to switch to a numeric keypad to enter values.

Add `inputmode="numeric" pattern="[0-9]*"` to the date input form so that this is fixed for all date fields. When a mobile user enters data their keyboard will default to a numeric keypad.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
