### PR TITLE
AP-1735 Record TrueLayer requests and callbacks

### DIFF
--- a/app/lib/omniauth/strategies/moj_oauth2.rb
+++ b/app/lib/omniauth/strategies/moj_oauth2.rb
@@ -5,6 +5,7 @@ require 'socket'       # for SocketError
 require 'timeout'      # for Timeout::Error
 
 # rubocop:disable Lint/MissingSuper
+# :nocov:
 
 module OmniAuth
   module Strategies
@@ -173,5 +174,5 @@ module OmniAuth
 end
 
 OmniAuth.config.add_camelization 'oauth2', 'OAuth2'
-
+# :nocov:
 # rubocop:enable Lint/MissingSuper

--- a/app/lib/omniauth/strategies/moj_oauth2.rb
+++ b/app/lib/omniauth/strategies/moj_oauth2.rb
@@ -1,8 +1,10 @@
-require "oauth2"
-require "omniauth"
-require "securerandom"
-require "socket"       # for SocketError
-require "timeout"      # for Timeout::Error
+require 'oauth2'
+require 'omniauth'
+require 'securerandom'
+require 'socket'       # for SocketError
+require 'timeout'      # for Timeout::Error
+
+# rubocop:disable Lint/MissingSuper
 
 module OmniAuth
   module Strategies
@@ -11,7 +13,7 @@ module OmniAuth
     # You must generally register your application with the provider and
     # utilize an application id and secret in order to authenticate using
     # OAuth 2.0.
-    class MojOAuth2
+    class MojOAuth2 # rubocop:disable Metrics/ClassLength
       include OmniAuth::Strategy
 
       def self.inherited(subclass)
@@ -32,13 +34,13 @@ module OmniAuth
       option :pkce, false
       option :pkce_verifier, nil
       option :pkce_options, {
-        :code_challenge => proc { |verifier|
+        code_challenge: proc { |verifier|
           Base64.urlsafe_encode64(
             Digest::SHA2.digest(verifier),
-            :padding => false,
-            )
+            padding: false
+          )
         },
-        :code_challenge_method => "S256",
+        code_challenge_method: 'S256'
       }
 
       attr_accessor :access_token
@@ -48,18 +50,18 @@ module OmniAuth
       end
 
       credentials do
-        hash = {"token" => access_token.token}
-        hash["refresh_token"] = access_token.refresh_token if access_token.expires? && access_token.refresh_token
-        hash["expires_at"] = access_token.expires_at if access_token.expires?
-        hash["expires"] = access_token.expires?
+        hash = { 'token' => access_token.token }
+        hash['refresh_token'] = access_token.refresh_token if access_token.expires? && access_token.refresh_token
+        hash['expires_at'] = access_token.expires_at if access_token.expires?
+        hash['expires'] = access_token.expires?
         hash
       end
 
       def request_phase
         auth_params = authorize_params
-        rec = Debug.record_request(session, auth_params, callback_url)
+        Debug.record_request(session, auth_params, callback_url)
 
-        redirect client.auth_code.authorize_url({:redirect_uri => callback_url}.merge(auth_params))
+        redirect client.auth_code.authorize_url({ redirect_uri: callback_url }.merge(auth_params))
       end
 
       def authorize_params # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
@@ -67,33 +69,33 @@ module OmniAuth
 
         if OmniAuth.config.test_mode
           @env ||= {}
-          @env["rack.session"] ||= {}
+          @env['rack.session'] ||= {}
         end
 
         params = options.authorize_params
-                   .merge(options_for("authorize"))
-                   .merge(pkce_authorize_params)
+                        .merge(options_for('authorize'))
+                        .merge(pkce_authorize_params)
 
-        session["omniauth.pkce.verifier"] = options.pkce_verifier if options.pkce
-        session["omniauth.state"] = params[:state]
+        session['omniauth.pkce.verifier'] = options.pkce_verifier if options.pkce
+        session['omniauth.state'] = params[:state]
 
         params
       end
 
       def token_params
-        options.token_params.merge(options_for("token")).merge(pkce_token_params)
+        options.token_params.merge(options_for('token')).merge(pkce_token_params)
       end
 
       def callback_phase # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
-        rec = Debug.record_callback(session, request.params)
+        Debug.record_callback(session, request.params)
 
-        error = request.params["error_reason"] || request.params["error"]
+        error = request.params['error_reason'] || request.params['error']
         if error
           Debug.error(session, request.params, '')
-          fail!(error, CallbackError.new(request.params["error"], request.params["error_description"] || request.params["error_reason"], request.params["error_uri"]))
-        elsif !options.provider_ignores_state && (request.params["state"].to_s.empty? || request.params["state"] != session.delete("omniauth.state"))
+          fail!(error, CallbackError.new(request.params['error'], request.params['error_description'] || request.params['error_reason'], request.params['error_uri']))
+        elsif !options.provider_ignores_state && (request.params['state'].to_s.empty? || request.params['state'] != session.delete('omniauth.state'))
           Debug.error(session, request.params, 'CSRF detected')
-          fail!(:csrf_detected, CallbackError.new(:csrf_detected, "CSRF detected"))
+          fail!(:csrf_detected, CallbackError.new(:csrf_detected, 'CSRF detected'))
         else
           self.access_token = build_access_token
           self.access_token = access_token.refresh! if access_token.expired?
@@ -116,21 +118,21 @@ module OmniAuth
 
         # NOTE: see https://tools.ietf.org/html/rfc7636#appendix-A
         {
-          :code_challenge => options.pkce_options[:code_challenge]
-                               .call(options.pkce_verifier),
-          :code_challenge_method => options.pkce_options[:code_challenge_method],
+          code_challenge: options.pkce_options[:code_challenge]
+                                 .call(options.pkce_verifier),
+          code_challenge_method: options.pkce_options[:code_challenge_method]
         }
       end
 
       def pkce_token_params
         return {} unless options.pkce
 
-        {:code_verifier => session.delete("omniauth.pkce.verifier")}
+        { code_verifier: session.delete('omniauth.pkce.verifier') }
       end
 
       def build_access_token
-        verifier = request.params["code"]
-        client.auth_code.get_token(verifier, {:redirect_uri => callback_url}.merge(token_params.to_hash(:symbolize_keys => true)), deep_symbolize(options.auth_token_params))
+        verifier = request.params['code']
+        client.auth_code.get_token(verifier, { redirect_uri: callback_url }.merge(token_params.to_hash(symbolize_keys: true)), deep_symbolize(options.auth_token_params))
       end
 
       def deep_symbolize(options)
@@ -139,7 +141,7 @@ module OmniAuth
         end
       end
 
-      def options_for(option)
+      def options_for(option) # rubocop:disable Metrics/AbcSize
         hash = {}
         options.send(:"#{option}_options").select { |key| options[key] }.each do |key|
           hash[key.to_sym] = if options[key].respond_to?(:call)
@@ -163,11 +165,13 @@ module OmniAuth
         end
 
         def message
-          [error, error_reason, error_uri].compact.join(" | ")
+          [error, error_reason, error_uri].compact.join(' | ')
         end
       end
     end
   end
 end
 
-OmniAuth.config.add_camelization "oauth2", "OAuth2"
+OmniAuth.config.add_camelization 'oauth2', 'OAuth2'
+
+# rubocop:enable Lint/MissingSuper

--- a/app/lib/omniauth/strategies/moj_oauth2.rb
+++ b/app/lib/omniauth/strategies/moj_oauth2.rb
@@ -1,0 +1,173 @@
+require "oauth2"
+require "omniauth"
+require "securerandom"
+require "socket"       # for SocketError
+require "timeout"      # for Timeout::Error
+
+module OmniAuth
+  module Strategies
+    # Authentication strategy for connecting with APIs constructed using
+    # the [OAuth 2.0 Specification](http://tools.ietf.org/html/draft-ietf-oauth-v2-10).
+    # You must generally register your application with the provider and
+    # utilize an application id and secret in order to authenticate using
+    # OAuth 2.0.
+    class MojOAuth2
+      include OmniAuth::Strategy
+
+      def self.inherited(subclass)
+        OmniAuth::Strategy.included(subclass)
+      end
+
+      args %i[client_id client_secret]
+
+      option :client_id, nil
+      option :client_secret, nil
+      option :client_options, {}
+      option :authorize_params, {}
+      option :authorize_options, %i[scope state]
+      option :token_params, {}
+      option :token_options, []
+      option :auth_token_params, {}
+      option :provider_ignores_state, false
+      option :pkce, false
+      option :pkce_verifier, nil
+      option :pkce_options, {
+        :code_challenge => proc { |verifier|
+          Base64.urlsafe_encode64(
+            Digest::SHA2.digest(verifier),
+            :padding => false,
+            )
+        },
+        :code_challenge_method => "S256",
+      }
+
+      attr_accessor :access_token
+
+      def client
+        ::OAuth2::Client.new(options.client_id, options.client_secret, deep_symbolize(options.client_options))
+      end
+
+      credentials do
+        hash = {"token" => access_token.token}
+        hash["refresh_token"] = access_token.refresh_token if access_token.expires? && access_token.refresh_token
+        hash["expires_at"] = access_token.expires_at if access_token.expires?
+        hash["expires"] = access_token.expires?
+        hash
+      end
+
+      def request_phase
+        auth_params = authorize_params
+        rec = Debug.record_request(session, auth_params, callback_url)
+
+        redirect client.auth_code.authorize_url({:redirect_uri => callback_url}.merge(auth_params))
+      end
+
+      def authorize_params # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+        options.authorize_params[:state] = SecureRandom.hex(24)
+
+        if OmniAuth.config.test_mode
+          @env ||= {}
+          @env["rack.session"] ||= {}
+        end
+
+        params = options.authorize_params
+                   .merge(options_for("authorize"))
+                   .merge(pkce_authorize_params)
+
+        session["omniauth.pkce.verifier"] = options.pkce_verifier if options.pkce
+        session["omniauth.state"] = params[:state]
+
+        params
+      end
+
+      def token_params
+        options.token_params.merge(options_for("token")).merge(pkce_token_params)
+      end
+
+      def callback_phase # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
+        rec = Debug.record_callback(session, request.params)
+
+        error = request.params["error_reason"] || request.params["error"]
+        if error
+          Debug.error(session, request.params, '')
+          fail!(error, CallbackError.new(request.params["error"], request.params["error_description"] || request.params["error_reason"], request.params["error_uri"]))
+        elsif !options.provider_ignores_state && (request.params["state"].to_s.empty? || request.params["state"] != session.delete("omniauth.state"))
+          Debug.error(session, request.params, 'CSRF detected')
+          fail!(:csrf_detected, CallbackError.new(:csrf_detected, "CSRF detected"))
+        else
+          self.access_token = build_access_token
+          self.access_token = access_token.refresh! if access_token.expired?
+          super
+        end
+      rescue ::OAuth2::Error, CallbackError => e
+        fail!(:invalid_credentials, e)
+      rescue ::Timeout::Error, ::Errno::ETIMEDOUT => e
+        fail!(:timeout, e)
+      rescue ::SocketError => e
+        fail!(:failed_to_connect, e)
+      end
+
+      protected
+
+      def pkce_authorize_params
+        return {} unless options.pkce
+
+        options.pkce_verifier = SecureRandom.hex(64)
+
+        # NOTE: see https://tools.ietf.org/html/rfc7636#appendix-A
+        {
+          :code_challenge => options.pkce_options[:code_challenge]
+                               .call(options.pkce_verifier),
+          :code_challenge_method => options.pkce_options[:code_challenge_method],
+        }
+      end
+
+      def pkce_token_params
+        return {} unless options.pkce
+
+        {:code_verifier => session.delete("omniauth.pkce.verifier")}
+      end
+
+      def build_access_token
+        verifier = request.params["code"]
+        client.auth_code.get_token(verifier, {:redirect_uri => callback_url}.merge(token_params.to_hash(:symbolize_keys => true)), deep_symbolize(options.auth_token_params))
+      end
+
+      def deep_symbolize(options)
+        options.each_with_object({}) do |(key, value), hash|
+          hash[key.to_sym] = value.is_a?(Hash) ? deep_symbolize(value) : value
+        end
+      end
+
+      def options_for(option)
+        hash = {}
+        options.send(:"#{option}_options").select { |key| options[key] }.each do |key|
+          hash[key.to_sym] = if options[key].respond_to?(:call)
+                               options[key].call(env)
+                             else
+                               options[key]
+                             end
+        end
+        hash
+      end
+
+      # An error that is indicated in the OAuth 2.0 callback.
+      # This could be a `redirect_uri_mismatch` or other
+      class CallbackError < StandardError
+        attr_accessor :error, :error_reason, :error_uri
+
+        def initialize(error, error_reason = nil, error_uri = nil)
+          self.error = error
+          self.error_reason = error_reason
+          self.error_uri = error_uri
+        end
+
+        def message
+          [error, error_reason, error_uri].compact.join(" | ")
+        end
+      end
+    end
+  end
+end
+
+OmniAuth.config.add_camelization "oauth2", "OAuth2"

--- a/app/lib/omniauth/strategies/true_layer.rb
+++ b/app/lib/omniauth/strategies/true_layer.rb
@@ -3,9 +3,12 @@
 # Note that you need to restart the server to apply changes to this file.
 require 'omniauth-oauth2'
 
+# remove this once special true layer debugging removed
+require_relative 'moj_oauth2'
+
 module OmniAuth
   module Strategies
-    class TrueLayer < OmniAuth::Strategies::OAuth2
+    class TrueLayer < OmniAuth::Strategies::MojOAuth2 # TODO revert back to TrueLayer < OmniAuth::Strategies::OAuth2 once True layer debugging removed
       option :name, :true_layer
 
       option :client_options,

--- a/app/lib/omniauth/strategies/true_layer.rb
+++ b/app/lib/omniauth/strategies/true_layer.rb
@@ -8,7 +8,8 @@ require_relative 'moj_oauth2'
 
 module OmniAuth
   module Strategies
-    class TrueLayer < OmniAuth::Strategies::MojOAuth2 # TODO revert back to TrueLayer < OmniAuth::Strategies::OAuth2 once True layer debugging removed
+    # TODO: revert back to TrueLayer < OmniAuth::Strategies::OAuth2 once True layer debugging removed
+    class TrueLayer < OmniAuth::Strategies::MojOAuth2
       option :name, :true_layer
 
       option :client_options,

--- a/app/models/debug.rb
+++ b/app/models/debug.rb
@@ -1,6 +1,5 @@
 class Debug < ApplicationRecord
-
-
+  # :nocov:
   def self.record_request(session, auth_params, callback_url)
     create!(
       debug_type: 'request',
@@ -11,7 +10,6 @@ class Debug < ApplicationRecord
       callback_url: callback_url
     )
   end
-
 
   def self.record_callback(session, callback_params)
     create!(
@@ -33,5 +31,5 @@ class Debug < ApplicationRecord
       error_details: details
     )
   end
-
+  # :nocov:
 end

--- a/app/models/debug.rb
+++ b/app/models/debug.rb
@@ -1,0 +1,37 @@
+class Debug < ApplicationRecord
+
+
+  def self.record_request(session, auth_params, callback_url)
+    create!(
+      debug_type: 'request',
+      legal_aid_application_id: session[:current_application_id],
+      session_id: session[:session_id],
+      session: session.to_h.to_json,
+      auth_params: auth_params.to_json,
+      callback_url: callback_url
+    )
+  end
+
+
+  def self.record_callback(session, callback_params)
+    create!(
+      debug_type: 'callback',
+      legal_aid_application_id: session[:current_application_id],
+      session_id: session[:session_id],
+      session: session.to_h.to_json,
+      callback_params: callback_params.to_json
+    )
+  end
+
+  def self.record_error(session, params, details)
+    create!(
+      debug_type: 'error',
+      legal_aid_application_id: session[:current_application_id],
+      session_id: session[:session_id],
+      session: session.to_h.to_json,
+      callback_params: params.to_json,
+      error_details: details
+    )
+  end
+
+end

--- a/db/migrate/20201005152150_create_debugs_table.rb
+++ b/db/migrate/20201005152150_create_debugs_table.rb
@@ -1,0 +1,16 @@
+class CreateDebugsTable < ActiveRecord::Migration[6.0]
+  def change
+    create_table :debugs, id: :uuid do |t|
+      t.string :debug_type
+      t.string :legal_aid_application_id
+      t.string :session_id
+      t.text :session
+      t.string :auth_params
+      t.string :callback_params
+      t.string :callback_url
+      t.string :error_details
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_21_143900) do
+ActiveRecord::Schema.define(version: 2020_10_05_152150) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -331,6 +331,19 @@ ActiveRecord::Schema.define(version: 2020_09_21_143900) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["legal_aid_application_id"], name: "index_cfe_submissions_on_legal_aid_application_id"
+  end
+
+  create_table "debugs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "debug_type"
+    t.string "legal_aid_application_id"
+    t.string "session_id"
+    t.text "session"
+    t.string "auth_params"
+    t.string "callback_params"
+    t.string "callback_url"
+    t.string "error_details"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "dependants", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1735)

- Copied the class `Omniauth::Strategies::Oauth2` from the `omniauth-oauth2` gem into the Apply project and renamed it `Omniauth::Strategies:MojOauth2`
- Changed `Omniauth::Strategies::TrueLayer` in our app to derive from `Omniauth::Strategies:MojOauth2` instead of `Omniauth::Strategies::Oauth2`
- Created a `debugs` table to hold debug info
- modified `Omniauth::Strategies:MojOauth2` to write debug info to the debugs table when making a true layer request, when processing a true layer callback, and when there is a CSRF error

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
