### PR TITLE
AP-1739 Route all non-passported applications for caseworker review

### DIFF
--- a/app/services/ccms/manual_review_determiner.rb
+++ b/app/services/ccms/manual_review_determiner.rb
@@ -26,7 +26,7 @@ module CCMS
     end
 
     def call
-      return true if Setting.manually_review_all_cases?
+      return true if Setting.manually_review_all_cases? && non_passported?
 
       return true if capital_contribution_required? && has_restrictions?
 

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -29,11 +29,13 @@ en:
         labels:
           mock_true_layer_data: Mock TrueLayer Data
           allow_non_passported_route: Allow non-passported route
-          manually_review_all_cases: Manually review all applications
+          manually_review_all_cases: Manually review all non-passported applications
         hints:
           mock_true_layer_data: Select Yes and TrueLayer data will be replaced by mock data from %{bank_transaction_filename}
           allow_non_passported_route: Select Yes to allow non-passported route
-          manually_review_all_cases: Select Yes to route all applications to caseworker for review, No to have just those marked for manual review routed to caseworkers
+          manually_review_all_cases: |
+            All applications with capital contributions AND restrictions on assets will be routed to caseworker for review.
+            Select Yes to additionally route all non-passported applications to casewoker for review.
     submitted_applications_reports:
       show:
         heading_1: Submitted Applications

--- a/spec/services/ccms/manual_review_determiner_spec.rb
+++ b/spec/services/ccms/manual_review_determiner_spec.rb
@@ -22,6 +22,15 @@ module CCMS
           let(:legal_aid_application) { create :legal_aid_application, :with_positive_benefit_check_result }
           let!(:cfe_result) { create :cfe_v2_result, submission: cfe_submission }
 
+          it 'returns false' do
+            expect(subject).to be false
+          end
+        end
+
+        context 'non-passported, no contrib, no restrictions' do
+          let(:legal_aid_application) { create :legal_aid_application, :with_negative_benefit_check_result }
+          let!(:cfe_result) { create :cfe_v2_result, submission: cfe_submission }
+
           it 'returns true' do
             expect(subject).to be true
           end


### PR DESCRIPTION
## Route all non-passported applications for caseworker review

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1739)

- changed conditons for flagging in `CCMS::ManualReviewDeterminer`
- updated label and hint text of setting

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
