### PR TITLE
AP-1614: sorting table accessibility update

### DIFF
--- a/app/helpers/table_sort_helper.rb
+++ b/app/helpers/table_sort_helper.rb
@@ -57,6 +57,12 @@ module TableSortHelper
   #   where at: is the width below which the column will be combined (options are 470 and 555)
   #   and append: is the contented that will be appended to the main content when the columns are combined
   #
+  # TODO: Depending on outcome of second DAC review this version may be deprecatable
+  # it adds a lot of noise to the aria tags and the simple_sortable_th was designed to
+  # be more screen reader friendly. Apparently, this version gives _too much_ detail
+  # to the users!
+  # It was left in place in Oct 2020 because it is still in use on the transaction pages
+  # and we wanted feedback on the new version before replacing it everywhere
   def sort_column_th(type:, content:, combine_right: {}, currently_sorted: nil)
     combine_right_at = combine_right[:at]
     klasses = %w[govuk-table__header sort]
@@ -69,6 +75,29 @@ module TableSortHelper
         sort_span_combine_right(combine_right) +
         sort_span_sort_indicator(type, currently_sorted)
     end
+  end
+
+  def simple_sortable_th(type:, content:, combine_right: {}, currently_sorted: nil)
+    combine_right_at = combine_right[:at]
+    classes = %w[govuk-table__header sort] # sort enables function and wrapping th content in 'sortable-column' span
+    classes += ['table-combine_right_if_narrow', "narrow_#{combine_right_at}"] if combine_right_at
+    classes << 'govuk-table__header--numeric' if type == :numeric
+    classes << "header-sort-#{currently_sorted}" if currently_sorted
+
+    content_tag(:th, role: 'columnheader', scope: 'col', class: classes) do
+      content_tag(:span, class: 'aria-sort-description') { content } +
+        sort_span_combine_right(combine_right) +
+        content_tag(:span, ', button', class: 'govuk-visually-hidden') +
+        simple_span_sort_indicator
+    end
+  end
+
+  def simple_span_sort_indicator
+    content_tag(
+      :span,
+      '',
+      class: 'sort-direction-indicator'
+    )
   end
 
   def sort_span_by

--- a/app/javascript/src/table-sort.js
+++ b/app/javascript/src/table-sort.js
@@ -3,23 +3,22 @@ $(document).ready(function() {
     let table;
     const endText = {
       asc: {
-        date: 'from <em>oldest</em> to <em>newest</em>',
-        numeric: 'from <em>smallest</em> to <em>largest</em>',
-        alphabetic: 'from <em>A.</em> to <em>Zed</em>',
-        undefined: 'in <em>ascending</em> order' //for when the data-sort-type is not set
+        date: 'from Oldest to Newest',
+        numeric: 'from Smallest to Largest',
+        alphabetic: 'from A. to Zed',
+        undefined: 'in ascending order' //for when the data-sort-type is not set
       },
       desc: {
-        date: 'from <em>newest</em> to <em>oldest</em>',
-        numeric: 'from <em>largest</em> to <em>smallest</em>',
-        alphabetic: 'from <em>Zed</em> to <em>A</em>',
-        undefined: 'in <em>descending</em> order' //for when the data-sort-type is not set
+        date: 'from Newest to Oldest',
+        numeric: 'from Largest to Smallest',
+        alphabetic: 'from Zed to A',
+        undefined: 'in descending order' //for when the data-sort-type is not set
       }
     }
 
     $('th.sort')
       .addClass("js-sortable")  //this class used to style as links, if JS not enabled, titles won't look clickable.
       .attr('tabindex', 0)
-      .wrapInner('<span class="sortable-column" title="sort this column"/>')
       .each(function(index) {
         const th = $(this),
           thIndex = $(this).index('th');
@@ -27,9 +26,12 @@ $(document).ready(function() {
 
         th.click(() => {
           table = th.parents('table');
-          th.parent().children().removeClass('header-sort-asc header-sort-desc')
+          th.parent().children().removeClass('header-sort-asc header-sort-desc');
+          th.parent().children().removeAttr('aria-sort');
           let sortDirection = inverse ? 'desc' : 'asc';
+          let verboseSortDirection = inverse ? 'descending' : 'ascending';
           th.addClass('header-sort-' + sortDirection);
+          th[0].setAttribute('aria-sort', verboseSortDirection);
           table.find('td').filter(function() {
             return $(this).index() === thIndex;
           }).sortElements((a, b) => (

--- a/app/views/providers/legal_aid_applications/_legal_aid_applications.html.erb
+++ b/app/views/providers/legal_aid_applications/_legal_aid_applications.html.erb
@@ -1,14 +1,15 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <table class="govuk-table sortable table-merge_columns">
+      <caption class="govuk-visually-hidden"><%= t('.table_description') %></caption>
       <thead class="govuk-table__head">
         <tr class="govuk-table__row">
-          <%= sort_column_th type: :alphabetic, content: t('.applicant_name'),   currently_sorted: @initial_sort[:applicant_name] %>
-          <%= sort_column_th type: :date,       content: t('.created_at'),       currently_sorted: @initial_sort[:created_at],       combine_right: { at: 555, append: t('.col_and_ref') } %>
-          <%= sort_column_th type: :alphabetic, content: t('.application_ref_html'),  currently_sorted: @initial_sort[:applicant_ref] %>
+          <%= simple_sortable_th type: :alphabetic, content: t('.applicant_name'), currently_sorted: @initial_sort[:applicant_name] %>
+          <%= simple_sortable_th type: :date, content: t('.created_at'), currently_sorted: @initial_sort[:created_at], combine_right: { at: 555, append: t('.col_and_ref') } %>
+          <%= simple_sortable_th type: :alphabetic, content: t('.application_ref_html'), currently_sorted: @initial_sort[:applicant_ref] %>
           <th class="nullcell" aria-hidden="true"></th>
-          <%= sort_column_th type: :alphabetic, content: t('.certificate_type'), currently_sorted: @initial_sort[:certificate_type], combine_right: { at: 555, append: t('.col_and_state') } %>
-          <%= sort_column_th type: :alphabetic, content: t('.status'),           currently_sorted: @initial_sort[:status] %>
+          <%= simple_sortable_th type: :alphabetic, content: t('.certificate_type'), currently_sorted: @initial_sort[:certificate_type], combine_right: { at: 555, append: t('.col_and_state') } %>
+          <%= simple_sortable_th type: :alphabetic, content: t('.status'), currently_sorted: @initial_sort[:status] %>
         </tr>
       </thead>
       <tbody class="govuk-table__body">
@@ -57,3 +58,5 @@
     <% end %>
   </div>
 </div>
+
+<div id="screen-reader-messages" class="govuk-visually-hidden" aria-live="polite" role='region'></div>

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -362,6 +362,7 @@ en:
         empty_result: Application cannot be found
         search_button: Search
       legal_aid_applications:
+        table_description: 'Applications table. Sortable by Name, Start date, LAA reference, Certificate type and Status.'
         applicant_name: Name
         application_ref_html: <abbr title='Legal Aid Agency'>LAA</abbr> reference
         created_at: Start date


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1614)

Following the DAC report, changes were requested to the screen-reader functionality of the applications table
This PR attempts to follow the recommendations by simplifying the prompts and matches the handling as used on their example

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
