### PR TITLE
AP-1741 Manually approve deployments to master UAT

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -351,6 +351,13 @@ jobs:
       - hold-notification:
           message: "$CIRCLE_USERNAME has a pending production approval for $CIRCLE_BRANCH"
 
+  hold_master_uat_notification:
+    executor: notification-executor
+    steps:
+      - hold-notification:
+          message: "$CIRCLE_USERNAME - ONLY APPROVE IF THIS CODE WAS NEEDED FOR PEN TESTING\n There is a pending MASTER UAT approval for $CIRCLE_BRANCH"
+
+
 workflows:
   version: 2
   open_pr:
@@ -384,12 +391,19 @@ workflows:
       - build_and_push:
           requires:
           - lint_checks
+      - hold_master_uat_notification:
+          requires:
+            - lint_checks
+      - hold_master_uat_approval:
+          type: approval
+          requires:
+            - hold_master_uat_notification
       - deploy_master_uat:
           requires:
-            - build_and_push
+            - hold_master_uat_notification
       - delete_uat_branch:
           requires:
-            - deploy_master_uat
+            - lint_checks
       - unit_tests:
           requires:
             - lint_checks

--- a/app/mailers/feedback_mailer.rb
+++ b/app/mailers/feedback_mailer.rb
@@ -34,6 +34,9 @@ class FeedbackMailer < BaseApplyMailer
   end
 
   def provider_email_phrase(feedback)
+    puts ">>>>>>>>>>>>  #{__FILE__}:#{__LINE__} <<<<<<<<<<<<".yellow
+    ap feedback
+    puts ">>>>>>>>>>>>  #{__FILE__}:#{__LINE__} <<<<<<<<<<<<".yellow
     return '' if feedback.email.nil?
 
     "from #{feedback.email}"

--- a/app/mailers/feedback_mailer.rb
+++ b/app/mailers/feedback_mailer.rb
@@ -34,9 +34,6 @@ class FeedbackMailer < BaseApplyMailer
   end
 
   def provider_email_phrase(feedback)
-    puts ">>>>>>>>>>>>  #{__FILE__}:#{__LINE__} <<<<<<<<<<<<".yellow
-    ap feedback
-    puts ">>>>>>>>>>>>  #{__FILE__}:#{__LINE__} <<<<<<<<<<<<".yellow
     return '' if feedback.email.nil?
 
     "from #{feedback.email}"


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1741)

DAC are using master UAT for accessibility testing.  We don't want to deploy to that environment automatically while that is going on.

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
