### PR TITLE
AP-1708: proceeding type accessibility update

### DIFF
--- a/app/helpers/flow_helper.rb
+++ b/app/helpers/flow_helper.rb
@@ -2,6 +2,7 @@ module FlowHelper
   def next_action_buttons_with_form(
     url:,
     method: :post,
+    show_continue: true,
     show_draft: false,
     continue_button_text: t('generic.save_and_continue'),
     draft_button_text: t('generic.save_and_come_back_later')
@@ -9,6 +10,7 @@ module FlowHelper
 
     form_with(model: nil, url: url, method: method, local: true) do |form|
       next_action_buttons(
+        show_continue: show_continue,
         show_draft: show_draft,
         form: form,
         continue_button_text: continue_button_text,
@@ -20,6 +22,7 @@ module FlowHelper
   def next_action_buttons(
     form:,
     continue_id: :continue,
+    show_continue: true,
     show_draft: false,
     continue_button_text: t('generic.save_and_continue'),
     draft_button_text: t('generic.save_and_come_back_later')
@@ -29,6 +32,7 @@ module FlowHelper
       'shared/forms/next_action_buttons',
       continue_id: continue_id,
       form: form,
+      show_continue: show_continue,
       show_draft: show_draft,
       continue_button_text: continue_button_text,
       draft_button_text: draft_button_text

--- a/app/views/providers/proceedings_types/index.html.erb
+++ b/app/views/providers/proceedings_types/index.html.erb
@@ -14,6 +14,7 @@
       <%= t '.heading_2' %>
       <span class="govuk-hint govuk-!-margin-top-0">
         <%= t '.search_help_example' %>
+        <span class="govuk-visually-hidden">, results will automatically return</span>
       </span>
     </label>
   </h2>

--- a/app/views/providers/proceedings_types/index.html.erb
+++ b/app/views/providers/proceedings_types/index.html.erb
@@ -14,7 +14,6 @@
       <%= t '.heading_2' %>
       <span class="govuk-hint govuk-!-margin-top-0">
         <%= t '.search_help_example' %>
-        <span class="govuk-visually-hidden" id="proceedingTypes" role="alert" aria-live="assertive" data-message="<%= t '.accessibility_message' %>"></span>
       </span>
     </label>
   </h2>
@@ -22,7 +21,7 @@
   <div class="govuk-grid-row search-field govuk-!-margin-top-0">
     <div class="govuk-grid-column-two-thirds govuk-!-margin-top-0">
       <%= govuk_error_message(error_message) %>
-      <input class="govuk-input <%= input_error_class %>" id="proceeding-search-input" name="proceeding-search-input" type="text" aria-label="<%= t '.accessibility_message_safari_browser' %>">
+      <input class="govuk-input <%= input_error_class %>" id="proceeding-search-input" name="proceeding-search-input" type="text">
     </div>
 
     <div class="govuk-grid-column-one-third govuk-!-margin-top-2 clear-search">
@@ -42,11 +41,14 @@
   </div>
 </div>
 
+<div id="screen-reader-messages" class="govuk-visually-hidden" aria-live="polite" aria-atomic='true' role='region'></div>
+
 <div class="govuk-grid-row govuk-!-margin-top-5">
   <div class="govuk-grid-column-two-thirds">
     <%= next_action_buttons_with_form(
           url: providers_legal_aid_application_proceedings_types_path,
-          show_draft: true
+          show_draft: true,
+          show_continue: false
         ) %>
   </div>
 </div>

--- a/app/views/shared/forms/_next_action_buttons.html.erb
+++ b/app/views/shared/forms/_next_action_buttons.html.erb
@@ -1,11 +1,12 @@
-<%= form.submit(
+<% if show_continue %>
+  <%= form.submit(
       continue_button_text,
       id: continue_id,
       name: 'continue_button',
       class: 'govuk-button form-button',
       data: { module: 'govuk-button' }
     ) %>
-
+<% end %>
 <% if show_draft %>
   <%= form.submit(
         draft_button_text,

--- a/app/views/shared/forms/proceedings_types/_proceeding_type_form.html.erb
+++ b/app/views/shared/forms/proceedings_types/_proceeding_type_form.html.erb
@@ -1,5 +1,5 @@
 <li id="<%= proceeding_type.code %>" class="govuk-grid-row proceeding-item govuk-!-margin-bottom-0" tabindex="0">
-  <div class="govuk-grid-column-two-thirds text-column">
+  <div class="govuk-grid-column-two-thirds text-column" aria-hidden="true">
     <h3 class="govuk-body govuk-!-margin-bottom-1 govuk-!-margin-top-4"><%= proceeding_type.meaning %></h3>
     <span class="govuk-caption-m">
       <%= proceeding_type.ccms_category_law %> &gt; <%= proceeding_type.ccms_matter %>
@@ -16,7 +16,7 @@
           method: :patch,
           tabindex: '-1',
           class: 'govuk-button proceeding-link govuk-!-margin-top-4',
-          "aria-label"=>"Select and continue #{proceeding_type.meaning}"
+          "aria-label"=>"Select #{proceeding_type.meaning.gsub(/[^0-9a-z ]/i, '')} and continue"
         ) %>
   </div>
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1708)

In searching for ways of improving the accessibility of the proceeding type page I reviewed the DAC report and aria handling. 
I have refined the aria tags to provide a (hopefully) simpler screenreader flow.

The proposed accessible drop-down doesn't allow the large volume of data we currently require to display but it might be worth adding another ticket to see if it would improve the address drop-down handling?

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
