### PR TITLE
AP-1702 Add dynamic content to NoIncomeSummaries page

### DIFF
--- a/app/controllers/providers/no_income_summaries_controller.rb
+++ b/app/controllers/providers/no_income_summaries_controller.rb
@@ -1,6 +1,8 @@
 module Providers
   class NoIncomeSummariesController < ProviderBaseController
-    def show; end
+    def show
+      @student_finance = legal_aid_application.value_of_student_finance
+    end
 
     def update
       if params[:confirm_no_income].in?(%w[yes no])

--- a/app/views/providers/no_income_summaries/show.html.erb
+++ b/app/views/providers/no_income_summaries/show.html.erb
@@ -53,6 +53,12 @@
         </div>
       <% end %>
 
+    <% if @student_finance %>
+      <h2 class="govuk-heading-l"><%= t('.student_finance.heading') %></h2>
+
+      <p><%= t('.student_finance.info', student_finance: value_with_currency_unit(@student_finance, t('currency.gbp'))) %></p>
+    <% end %>
+
       <%= next_action_buttons_with_form(
               url: providers_legal_aid_application_no_income_summary_path,
               show_draft: true

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -466,6 +466,9 @@ en:
             income from a property or lodger
             pension payments
         is_this_correct: Is this correct?
+        student_finance: 
+          heading: Student finance
+          info: Your client also told us they'll get %{student_finance} in student finance this academic year.
         error: Select yes if your client does not receive these payments
     no_outgoings_summaries:
       show:

--- a/features/providers/non_passported_journey.feature
+++ b/features/providers/non_passported_journey.feature
@@ -5,6 +5,7 @@ Feature: Non-passported applicant journeys
     Then I should be on the 'client_completed_means' page showing 'Continue your application'
     Then I click 'Continue'
     Then I should be on a page showing "Your client's income"
+    And I should not see 'Student finance'
     Then I choose "Yes"
     Then I click 'Save and continue'
     Then I should be on the 'has_dependants' page showing "Does your client have any dependants?"
@@ -298,6 +299,7 @@ Feature: Non-passported applicant journeys
     Then I should be on the 'client_completed_means' page showing 'Continue your application'
     When I click 'Continue'
     Then I should be on a page showing "Your client's income"
+    Then I should be on a page showing "Student finance"
     Then I choose "No"
     And I click 'Save and continue'
     Then I should be on the 'identify_types_of_income' page showing "Which types of income does your client receive?"


### PR DESCRIPTION
AP-1702 Add dynamic content to NoIncomeSummaries page

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1702)


- Add student finance content to the NoIncomeSummaries page when there are no other incomes but there is student finance.

- Add testing


## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
