### PR TITLE
BUGFIX: update pundit

### DIFF
--- a/app/policies/legal_aid_application_policy.rb
+++ b/app/policies/legal_aid_application_policy.rb
@@ -58,6 +58,6 @@ class LegalAidApplicationPolicy < ApplicationPolicy
 
     return true if @controller.respond_to?(:pre_dwp_check?) && @controller.pre_dwp_check? == true
 
-    record.passported? ? provider.passported_permissions? : provider.non_passported_permissions?
+    record.state_machine_proxy.is_a?(PassportedStateMachine) ? provider.passported_permissions? : provider.non_passported_permissions?
   end
 end

--- a/spec/policies/legal_aid_application_policy_spec.rb
+++ b/spec/policies/legal_aid_application_policy_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe LegalAidApplicationPolicy do
     end
 
     context 'application is non-passported' do
-      let(:legal_aid_application) { create(:legal_aid_application, :with_negative_benefit_check_result, provider: provider) }
+      let(:legal_aid_application) { create(:legal_aid_application, :with_negative_benefit_check_result, :with_non_passported_state_machine, provider: provider) }
       let(:authorization_context) { AuthorizationContext.new(provider, post_dwp_check_controller) }
       context 'provider has non-passported rights' do
         let(:provider) { create :provider, :with_non_passported_permissions }


### PR DESCRIPTION
## What

When attempting to delete an old claim a user was shown an authoriasation error

Because it was an old claim, it had been marked as `use_ccms` because the benefit
check failed.  This also meant that the application failed the `passported?` check
and theerfore the provider needed non-passported permissions to delete the claim.

This checks the state_machine_proxy and returns the correct permissions. It may
be worth nothing that this is a bit of a stricking plaster fix and that other
legacy claims may be in non-passported states due to the migration and that we
should endeavour to assess the liklihood of this recurring.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
