### PR TITLE
REVERT: remove hold-uat step from circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -391,19 +391,21 @@ workflows:
       - build_and_push:
           requires:
           - lint_checks
-      - hold_master_uat_notification:
-          requires:
-            - lint_checks
-      - hold_master_uat_approval:
-          type: approval
-          requires:
-            - hold_master_uat_notification
+#      - hold_master_uat_notification:
+#          requires:
+#            - lint_checks
+#      - hold_master_uat_approval:
+#          type: approval
+#          requires:
+#            - hold_master_uat_notification
       - deploy_master_uat:
           requires:
-            - hold_master_uat_approval
+            - build_and_push
+#            - hold_master_uat_approval
       - delete_uat_branch:
           requires:
-            - lint_checks
+#            - lint_checks
+            - build_and_push
       - unit_tests:
           requires:
             - lint_checks


### PR DESCRIPTION
## What

Revert the circle hold-uat changes.  There will be a third DAC review so only commented out for now

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
