### PR TITLE
Fix page history when gathering bank transactions

### DIFF
--- a/spec/requests/citizens/gather_transactions_spec.rb
+++ b/spec/requests/citizens/gather_transactions_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe 'citizen accounts request', type: :request do
   let!(:applicant_bank_account) do
     create(:bank_account, bank_provider_id: applicant_bank_provider.id, currency: 'GBP')
   end
+  let(:page_history_service) { PageHistoryService.new(page_history_id: session['page_history_id']) }
 
   describe 'GET /citizens/gather_transactions' do
     subject { get citizens_gather_transactions_path }
@@ -36,7 +37,7 @@ RSpec.describe 'citizen accounts request', type: :request do
     end
 
     it 'does not add its url to history' do
-      expect(session[:page_history]).not_to include(citizens_gather_transactions_path)
+      expect(page_history_service.read).to eq nil
     end
   end
 
@@ -56,8 +57,8 @@ RSpec.describe 'citizen accounts request', type: :request do
       expect(unescaped_response_body).to include(I18n.t('citizens.gather_transactions.index.heading_1'))
     end
 
-    it 'has reset the session and has no page history' do
-      expect(session.keys).not_to include(:page_history)
+    it 'has reset the page history' do
+      expect(page_history_service.read).to eq nil
     end
 
     context 'background worker is still working' do


### PR DESCRIPTION
## What

`spec/requests/citizens/gather_transactions_spec.rb` was added using the old method of storing page histories in the session. This changes two tests to use the `PageHistoryService`.


## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
