### PR TITLE
AP-1762: Accessibility updates

### DIFF
--- a/app/helpers/table_sort_helper.rb
+++ b/app/helpers/table_sort_helper.rb
@@ -57,27 +57,7 @@ module TableSortHelper
   #   where at: is the width below which the column will be combined (options are 470 and 555)
   #   and append: is the contented that will be appended to the main content when the columns are combined
   #
-  # TODO: Depending on outcome of second DAC review this version may be deprecatable
-  # it adds a lot of noise to the aria tags and the simple_sortable_th was designed to
-  # be more screen reader friendly. Apparently, this version gives _too much_ detail
-  # to the users!
-  # It was left in place in Oct 2020 because it is still in use on the transaction pages
-  # and we wanted feedback on the new version before replacing it everywhere
   def sort_column_th(type:, content:, combine_right: {}, currently_sorted: nil)
-    combine_right_at = combine_right[:at]
-    klasses = %w[govuk-table__header sort]
-    klasses += ['table-combine_right_if_narrow', "narrow_#{combine_right_at}"] if combine_right_at
-    klasses << 'govuk-table__header--numeric' if type == :numeric
-    klasses << "header-sort-#{currently_sorted}" if currently_sorted
-    content_tag(:th, class: klasses, scope: 'col', 'data-sort-type' => type) do
-      sort_span_by +
-        sort_span_content(content) +
-        sort_span_combine_right(combine_right) +
-        sort_span_sort_indicator(type, currently_sorted)
-    end
-  end
-
-  def simple_sortable_th(type:, content:, combine_right: {}, currently_sorted: nil)
     combine_right_at = combine_right[:at]
     classes = %w[govuk-table__header sort] # sort enables function and wrapping th content in 'sortable-column' span
     classes += ['table-combine_right_if_narrow', "narrow_#{combine_right_at}"] if combine_right_at
@@ -100,55 +80,9 @@ module TableSortHelper
     )
   end
 
-  def sort_span_by
-    content_tag :span, "#{t('sorting.sort_by')} ", class: 'govuk-visually-hidden'
-  end
-
-  def sort_span_content(content)
-    content_tag :span, content, class: 'aria-sort-description'
-  end
-
-  def sort_span_sort_indicator(type = nil, currently_sorted = nil)
-    content_tag(
-      :span,
-      sort_span_screen_reader_sort_indicator(type, currently_sorted),
-      class: 'sort-direction-indicator'
-    )
-  end
-
-  def sort_span_screen_reader_sort_indicator(type, currently_sorted)
-    screen_reader_hint = sort_hint(type: type, direction: currently_sorted)
-    content = screen_reader_hint && "(#{screen_reader_hint})".html_safe
-    content_tag(
-      :span,
-      content,
-      class: 'screen-reader-sort-indicator govuk-visually-hidden'
-    )
-  end
-
   def sort_span_combine_right(options = {})
     return '' if options.empty?
 
     content_tag :span, " #{options[:append]}", class: 'table-hidden_right_title'
-  end
-
-  def sort_hint(type: :numeric, direction: :desc)
-    return unless direction
-
-    labels = sort_hint_labels[type]
-    return I18n.t("sorted_#{direction}_html") unless labels
-
-    labels.reverse! if direction == :desc
-    labels.map! { |label| I18n.t("sorting.#{label}") }
-    from, to = labels
-    I18n.t('sorting.currently_sorted_html', from: from, to: to)
-  end
-
-  def sort_hint_labels
-    {
-      numeric: %i[smallest largest],
-      alphabetic: %i[a z],
-      date: %i[newest oldest]
-    }
   end
 end

--- a/app/javascript/src/details-polyfill.js
+++ b/app/javascript/src/details-polyfill.js
@@ -1,0 +1,240 @@
+// <details> polyfill
+// http://caniuse.com/#feat=details
+
+// FF Support for HTML5's <details> and <summary>
+// https://bugzilla.mozilla.org/show_bug.cgi?id=591737
+
+// http://www.sitepoint.com/fixing-the-details-element/
+
+;(function (global) {
+    'use strict'
+
+    var GOVUK = global.GOVUK || {}
+
+    GOVUK.details = {
+        NATIVE_DETAILS: typeof document.createElement('details').open === 'boolean',
+        KEY_ENTER: 13,
+        KEY_SPACE: 32,
+
+        // Create a started flag so we can prevent the initialisation
+        // function firing from both DOMContentLoaded and window.onload
+        started: false,
+
+        // Add event construct for modern browsers or IE
+        // which fires the callback with a pre-converted target reference
+        addEvent: function (node, type, callback) {
+            if (node.addEventListener) {
+                node.addEventListener(type, function (e) {
+                    callback(e, e.target)
+                }, false)
+            } else if (node.attachEvent) {
+                node.attachEvent('on' + type, function (e) {
+                    callback(e, e.srcElement)
+                })
+            }
+        },
+
+        removeEvent: function (node, type) {
+            if (node.removeEventListener) {
+                node.removeEventListener(type, function (e) {
+                }, false)
+            } else if (node.detachEvent) {
+                node.detachEvent('on' + type, function (e) {
+                })
+            }
+        },
+
+        // Cross-browser character code / key pressed
+        charCode: function (e) {
+            return (typeof e.which === 'number') ? e.which : e.keyCode
+        },
+
+        // Cross-browser preventing default action
+        preventDefault: function (e) {
+            if (e.preventDefault) {
+                e.preventDefault()
+            } else {
+                e.returnValue = false
+            }
+        },
+
+        // Handle cross-modal click events
+        addClickEvent: function (node, callback) {
+            GOVUK.details.addEvent(node, 'keypress', function (e, target) {
+                // When the key gets pressed - check if it is enter or space
+                if (GOVUK.details.charCode(e) === GOVUK.details.KEY_ENTER || GOVUK.details.charCode(e) === GOVUK.details.KEY_SPACE) {
+                    if (target.nodeName.toLowerCase() === 'summary') {
+                        // Prevent space from scrolling the page
+                        // and enter from submitting a form
+                        GOVUK.details.preventDefault(e)
+                        // Click to let the click event do all the necessary action
+                        if (target.click) {
+                            target.click()
+                        } else {
+                            // except Safari 5.1 and under don't support .click() here
+                            callback(e, target)
+                        }
+                    }
+                }
+            })
+
+            // Prevent keyup to prevent clicking twice in Firefox when using space key
+            GOVUK.details.addEvent(node, 'keyup', function (e, target) {
+                if (GOVUK.details.charCode(e) === GOVUK.details.KEY_SPACE) {
+                    if (target.nodeName === 'SUMMARY') {
+                        GOVUK.details.preventDefault(e)
+                    }
+                }
+            })
+
+            GOVUK.details.addEvent(node, 'click', function (e, target) {
+                callback(e, target)
+            })
+        },
+
+        // Get the nearest ancestor element of a node that matches a given tag name
+        getAncestor: function (node, match) {
+            do {
+                if (!node || node.nodeName.toLowerCase() === match) {
+                    break
+                }
+                node = node.parentNode
+            } while (node)
+
+            return node
+        },
+
+        // Initialisation function
+        addDetailsPolyfill: function (list, container) {
+            container = container || document.body
+            // If this has already happened, just return
+            // else set the flag so it doesn't happen again
+            if (GOVUK.details.started) {
+                return
+            }
+            GOVUK.details.started = true
+            // Get the collection of details elements, but if that's empty
+            // then we don't need to bother with the rest of the scripting
+            if ((list = container.getElementsByTagName('details')).length === 0) {
+                return
+            }
+            // else iterate through them to apply their initial state
+            var n = list.length
+            var i = 0
+            for (i; i < n; i++) {
+                var details = list[i]
+
+                // Save shortcuts to the inner summary and content elements
+                details.__summary = details.getElementsByTagName('summary').item(0)
+                details.__content = details.getElementsByTagName('div').item(0)
+
+                if (!details.__summary || !details.__content) {
+                    return
+                }
+                // If the content doesn't have an ID, assign it one now
+                // which we'll need for the summary's aria-controls assignment
+                if (!details.__content.id) {
+                    details.__content.id = 'details-content-' + i
+                }
+
+                // Add ARIA role="group" to details
+                details.setAttribute('role', 'group')
+
+                // Add role=button to summary
+                details.__summary.setAttribute('role', 'button')
+
+                // Add aria-controls
+                details.__summary.setAttribute('aria-controls', details.__content.id)
+
+                // Set tabIndex so the summary is keyboard accessible for non-native elements
+                // http://www.saliences.com/browserBugs/tabIndex.html
+                if (!GOVUK.details.NATIVE_DETAILS) {
+                    details.__summary.tabIndex = 0
+                }
+
+                // Detect initial open state
+                var openAttr = details.getAttribute('open') !== null
+                if (openAttr === true) {
+                    details.__summary.setAttribute('aria-expanded', 'true')
+                    details.__content.setAttribute('aria-hidden', 'false')
+                } else {
+                    details.__summary.setAttribute('aria-expanded', 'false')
+                    details.__content.setAttribute('aria-hidden', 'true')
+                    if (!GOVUK.details.NATIVE_DETAILS) {
+                        details.__content.style.display = 'none'
+                    }
+                }
+
+                // Create a circular reference from the summary back to its
+                // parent details element, for convenience in the click handler
+                details.__summary.__details = details
+
+                // If this is not a native implementation, create an arrow
+                // inside the summary
+                if (!GOVUK.details.NATIVE_DETAILS) {
+                    var twisty = document.createElement('i')
+
+                    if (openAttr === true) {
+                        twisty.className = 'arrow arrow-open'
+                        twisty.appendChild(document.createTextNode('\u25bc'))
+                    } else {
+                        twisty.className = 'arrow arrow-closed'
+                        twisty.appendChild(document.createTextNode('\u25ba'))
+                    }
+
+                    details.__summary.__twisty = details.__summary.insertBefore(twisty, details.__summary.firstChild)
+                    details.__summary.__twisty.setAttribute('aria-hidden', 'true')
+                }
+            }
+
+            // Bind a click event to handle summary elements
+            GOVUK.details.addClickEvent(container, function (e, summary) {
+                if (!(summary = GOVUK.details.getAncestor(summary, 'summary'))) {
+                    return true
+                }
+                return GOVUK.details.statechange(summary)
+            })
+        },
+
+        // Define a statechange function that updates aria-expanded and style.display
+        // Also update the arrow position
+        statechange: function (summary) {
+            var expanded = summary.__details.__summary.getAttribute('aria-expanded') === 'true'
+            var hidden = summary.__details.__content.getAttribute('aria-hidden') === 'true'
+
+            summary.__details.__summary.setAttribute('aria-expanded', (expanded ? 'false' : 'true'))
+            summary.__details.__content.setAttribute('aria-hidden', (hidden ? 'false' : 'true'))
+
+            if (!GOVUK.details.NATIVE_DETAILS) {
+                summary.__details.__content.style.display = (expanded ? 'none' : '')
+
+                var hasOpenAttr = summary.__details.getAttribute('open') !== null
+                if (!hasOpenAttr) {
+                    summary.__details.setAttribute('open', 'open')
+                } else {
+                    summary.__details.removeAttribute('open')
+                }
+            }
+
+            if (summary.__twisty) {
+                summary.__twisty.firstChild.nodeValue = (expanded ? '\u25ba' : '\u25bc')
+                summary.__twisty.setAttribute('class', (expanded ? 'arrow arrow-closed' : 'arrow arrow-open'))
+            }
+
+            return true
+        },
+
+        destroy: function (node) {
+            GOVUK.details.removeEvent(node, 'click')
+        },
+
+        // Bind two load events for modern and older browsers
+        // If the first one fires it will set a flag to block the second one
+        // but if it's not supported then the second one will fire
+        init: function ($container) {
+            GOVUK.details.addEvent(document, 'DOMContentLoaded', GOVUK.details.addDetailsPolyfill)
+            GOVUK.details.addEvent(window, 'load', GOVUK.details.addDetailsPolyfill)
+        }
+    }
+    global.GOVUK = GOVUK
+})(window)

--- a/app/views/providers/legal_aid_applications/_legal_aid_applications.html.erb
+++ b/app/views/providers/legal_aid_applications/_legal_aid_applications.html.erb
@@ -4,12 +4,12 @@
       <caption class="govuk-visually-hidden"><%= t('.table_description') %></caption>
       <thead class="govuk-table__head">
         <tr class="govuk-table__row">
-          <%= simple_sortable_th type: :alphabetic, content: t('.applicant_name'), currently_sorted: @initial_sort[:applicant_name] %>
-          <%= simple_sortable_th type: :date, content: t('.created_at'), currently_sorted: @initial_sort[:created_at], combine_right: { at: 555, append: t('.col_and_ref') } %>
-          <%= simple_sortable_th type: :alphabetic, content: t('.application_ref_html'), currently_sorted: @initial_sort[:applicant_ref] %>
+          <%= sort_column_th type: :alphabetic, content: t('.applicant_name'), currently_sorted: @initial_sort[:applicant_name] %>
+          <%= sort_column_th type: :date, content: t('.created_at'), currently_sorted: @initial_sort[:created_at], combine_right: { at: 555, append: t('.col_and_ref') } %>
+          <%= sort_column_th type: :alphabetic, content: t('.application_ref_html'), currently_sorted: @initial_sort[:applicant_ref] %>
           <th class="nullcell" aria-hidden="true"></th>
-          <%= simple_sortable_th type: :alphabetic, content: t('.certificate_type'), currently_sorted: @initial_sort[:certificate_type], combine_right: { at: 555, append: t('.col_and_state') } %>
-          <%= simple_sortable_th type: :alphabetic, content: t('.status'), currently_sorted: @initial_sort[:status] %>
+          <%= sort_column_th type: :alphabetic, content: t('.certificate_type'), currently_sorted: @initial_sort[:certificate_type], combine_right: { at: 555, append: t('.col_and_state') } %>
+          <%= sort_column_th type: :alphabetic, content: t('.status'), currently_sorted: @initial_sort[:status] %>
           <th class='govuk-table__header clear-all' scope='col'>Action</th>
         </tr>
       </thead>

--- a/app/views/providers/proceedings_types/index.html.erb
+++ b/app/views/providers/proceedings_types/index.html.erb
@@ -42,7 +42,7 @@
   </div>
 </div>
 
-<div id="screen-reader-messages" class="govuk-visually-hidden" aria-live="polite" aria-atomic='true' role='region'></div>
+<div id="screen-reader-messages" class="govuk-visually-hidden" aria-live="polite" aria-atomic='true' role='alert'></div>
 
 <div class="govuk-grid-row govuk-!-margin-top-5">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/providers/substantive_applications/show.html.erb
+++ b/app/views/providers/substantive_applications/show.html.erb
@@ -8,34 +8,35 @@
       ) do |form| %>
 
     <%= govuk_form_group show_error_if: @form.errors.present? do %>
-      <%= govuk_fieldset_header page_title %>
-      <p class="govuk-body govuk-!-padding-top-6 govuk-!-padding-bottom-4">
-        <%= t('.information_on_next_actions') %>
-      </p>
+      <fieldset class="govuk-fieldset">
+        <%= govuk_fieldset_header page_title %>
+        <p class="govuk-body govuk-!-padding-top-6 govuk-!-padding-bottom-4">
+          <%= t('.information_on_next_actions') %>
+        </p>
 
-      <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios">
+        <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios">
 
-        <%= govuk_error_message(form.object.errors[:substantive_application].first) %>
+          <%= govuk_error_message(form.object.errors[:substantive_application].first) %>
 
-        <%= form.govuk_radio_button(
-              :substantive_application,
-              true,
-              label: t('generic.yes')
-            ) %>
+          <%= form.govuk_radio_button(
+                :substantive_application,
+                true,
+                label: t('generic.yes')
+              ) %>
 
-        <%= form.govuk_radio_button(
-              :substantive_application,
-              false,
-              label: t('.no_start_later'),
-              'data-aria-controls' => 'substantive-deadline'
-            ) %>
-        <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="substantive-deadline">
-          <p class="govuk-body">
-            <%= t('.must_submit_by', deadline: @form.substantive_application_deadline_on) %>
-          </p>
+          <%= form.govuk_radio_button(
+                :substantive_application,
+                false,
+                label: t('.no_start_later'),
+                'data-aria-controls' => 'substantive-deadline'
+              ) %>
+          <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="substantive-deadline">
+            <p class="govuk-body">
+              <%= t('.must_submit_by', deadline: @form.substantive_application_deadline_on) %>
+            </p>
+          </div>
         </div>
-      </div>
-
+      </fieldset>
     <% end %>
 
     <div class="govuk-!-padding-bottom-4"></div>

--- a/app/views/providers/transactions/show.html.erb
+++ b/app/views/providers/transactions/show.html.erb
@@ -33,7 +33,8 @@
     <div id="screen-reader-messages" class="govuk-visually-hidden" role="alert" aria-live="assertive"></div>
     <table class="govuk-table sortable table-merge_columns">
       <caption class="govuk-table__caption">
-        <%= content_tag(:h2, t('date.date_period', from: date_from, to: date_to), class: 'govuk-heading-s') if @bank_transactions.any? %>
+        <%= content_tag(:span, t('.table_description', from: date_from, to: date_to), class: 'govuk-visually-hidden') if @bank_transactions.any? %>
+        <%= content_tag(:h2, t('date.date_period', from: date_from, to: date_to), aria: { hidden: 'true'}, class: 'govuk-heading-s') if @bank_transactions.any? %>
       </caption>
       <thead class="govuk-table__head">
         <tr class="govuk-table__row">

--- a/app/views/shared/forms/_shared_ownership_form.html.erb
+++ b/app/views/shared/forms/_shared_ownership_form.html.erb
@@ -7,18 +7,19 @@
   <% input_error_class = error ? 'govuk-input--error' : '' %>
 
   <%= govuk_form_group show_error_if: error do %>
-    <%= govuk_fieldset_header page_title %>
+    <fieldset class="govuk-fieldset">
+      <%= govuk_fieldset_header page_title %>
 
-    <%= content_tag(:span, error, class: 'govuk-error-message', id: 'shared_ownership') if error %>
+      <%= content_tag(:span, error, class: 'govuk-error-message', id: 'shared_ownership') if error %>
 
-    <div class="govuk-radios govuk-!-padding-top-2">
-      <%= render partial: 'shared/forms/shared_ownership_form/shared_ownership_item',
-                 collection: LegalAidApplication::SHARED_OWNERSHIP_REASONS, as: :reason,
-                 locals: { form: form,
-                           input_error_class: input_error_class } %>
+      <div class="govuk-radios govuk-!-padding-top-2">
+        <%= render partial: 'shared/forms/shared_ownership_form/shared_ownership_item',
+                   collection: LegalAidApplication::SHARED_OWNERSHIP_REASONS, as: :reason,
+                   locals: { form: form,
+                             input_error_class: input_error_class } %>
 
-    </div>
-
+      </div>
+    </fieldset>
   <% end %>
 
   <%= next_action_buttons(

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -697,6 +697,7 @@ en:
         carer_disability: Carer and disability benefits
         low_income: Low income benefits
       show:
+        table_description: 'Transactions table "%{from} to %{to}". Sortable by Date, Description, Amount and Category.'
         col_category: Category
         col_and_category: and category
         col_amount: Amount


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1727)

Following the DAC re-review, the following changes were required.
1. Form Controls - Grouped (A)
"do you want to make a substantive application now?"
"does your client own their home with anyone else?"
These views were missing fieldsets that enclosed the radio buttons

2. Sortable table (A)
The initial issue has been fixed and has been approved by DAC as a workable solution. It now needs to be applied to the transaction tables in the service:

3. Status message (AA)
The issue  with he proceeding type view has been initially resolved but have resulted in a new issue:
The alert is not being read out to JAWS users when browsing in Internet Explorer. The role has changed from Alert to Region which will prevent the live region from being read correctly. Change the role back to ‘alert’ or ‘status’  

This PR addresses the points raised

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
