### PR TITLE
AP-1751 Fix HTML injection

### DIFF
--- a/app/views/shared/check_answers/_merits.html.erb
+++ b/app/views/shared/check_answers/_merits.html.erb
@@ -39,7 +39,7 @@
           no_border: !respondent.understands_terms_of_court_order
         ) %>
   </dl>
-  <div class='govuk-body'><%= simple_format respondent.understands_terms_of_court_order_details %></div>
+  <div class='govuk-body'><%= respondent.understands_terms_of_court_order_details %></div>
 
   <%= render 'shared/check_answers/section_break' unless respondent.understands_terms_of_court_order %>
 
@@ -51,7 +51,7 @@
           no_border: !respondent.warning_letter_sent
         ) %>
   </dl>
-  <div class='govuk-body'><%= simple_format respondent.warning_letter_sent_details %></div>
+  <div class='govuk-body'><%= respondent.warning_letter_sent_details %></div>
 
   <%= render 'shared/check_answers/section_break' unless respondent.warning_letter_sent %>
 
@@ -63,7 +63,7 @@
           no_border: !respondent.police_notified
         ) %>
   </dl>
-  <div class='govuk-body'><%= simple_format respondent.police_notified_details %></div>
+  <div class='govuk-body'><%= respondent.police_notified_details %></div>
 
   <%= render 'shared/check_answers/section_break' unless respondent.police_notified %>
 
@@ -75,7 +75,7 @@
           no_border: respondent.bail_conditions_set
         ) %>
   </dl>
-  <div class='govuk-body'><%= simple_format respondent.bail_conditions_set_details %></div>
+  <div class='govuk-body'><%= respondent.bail_conditions_set_details %></div>
 
   <%= render 'shared/check_answers/section_break' if respondent.bail_conditions_set %>
 </section>
@@ -85,7 +85,7 @@
     <%= t '.case-details-heading' %>
   </h2>
 
-  <div class='govuk-body'><%= simple_format merits_assessment.details_of_proceedings_before_the_court %></div>
+  <div class='govuk-body'><%= merits_assessment.details_of_proceedings_before_the_court %></div>
 
   <dl class="govuk-summary-list govuk-!-margin-bottom-2 print-remove-border">
     <%= check_answer_link(
@@ -98,7 +98,7 @@
         ) %>
   </dl>
 
-  <div class="govuk-body"><%= simple_format statement_of_case.statement %></div>
+  <div class="govuk-body"><%= statement_of_case.statement %></div>
 
   <%= render 'shared/check_answers/section_break' if respondent.bail_conditions_set %>
 
@@ -124,5 +124,5 @@
         ) unless merits_assessment.success_likely? %>
   </dl>
 
-  <div class='govuk-body'><%= simple_format merits_assessment.success_prospect_details %></div>
+  <div class='govuk-body'><%= merits_assessment.success_prospect_details %></div>
 </section>

--- a/app/views/shared/check_answers/_merits.html.erb
+++ b/app/views/shared/check_answers/_merits.html.erb
@@ -60,12 +60,12 @@
           name: :police_notified,
           question: t('.items.police_notified'),
           answer: yes_no(respondent.police_notified),
-          no_border: !respondent.police_notified
+          no_border: true
         ) %>
   </dl>
   <div class='govuk-body'><%= respondent.police_notified_details %></div>
 
-  <%= render 'shared/check_answers/section_break' unless respondent.police_notified %>
+  <%= render 'shared/check_answers/section_break' %>
 
   <dl class="govuk-summary-list govuk-!-margin-bottom-2">
     <%= check_answer_no_link(

--- a/app/views/shared/check_answers/_restrictions.html.erb
+++ b/app/views/shared/check_answers/_restrictions.html.erb
@@ -12,8 +12,8 @@
 </dl>
 
 <% if @legal_aid_application.has_restrictions %>
-  <div class="govuk-body wrap-text govuk-!-margin-bottom-0">
-    <%= simple_format @legal_aid_application.restrictions_details %>
+  <div class="govuk-body wrap-text govuk-!-margin-bottom-4">
+    <%= @legal_aid_application.restrictions_details %>
   </div>
 
   <hr class="govuk-section-break govuk-section-break--visible govuk-!-width-full" style="width: 100%;">


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1751)

Fixes issue raised in Section 4.6 of the security testing report.

* Removes the use of `simple_format` to display user-entered text, which is causing HTML render instead of being escaped.
* Fixes a minor layout issue caused by the removal of `simple_format` from the `restrictions` partial.
* Fixes a pre-existing issue where a section break on the merits check your answers page is displayed incorrectly when 'Have the police been notified?' is answered 'Yes'

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
