### PR TITLE
AP-1752 add secure ssl config option

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,0 +1,3 @@
+# config/initializers/session_store.rb
+# set secure: true, optionally only do this for certain Rails environments (e.g., Staging / Production
+Rails.application.config.session_store :cookie_store, key: '_laa_apply_for_legal_aid_session', secure: Rails.env.production? ? true : false


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1752)

Add `session_store` to initializers to allow secure_cookies to be set
This uses the Rails.env.production? test, which sets it to `true` for UAT, STAGING and PRODUCTION.
For local development mode it is therefore `false`

The HostEnv variable `app/models/host_env.rb` we use elsewhere is unsuitable as this value is not known at the point the docker image is built which causes it to fail.

An alternative option is to add in a new environment variable to only have secure_cookies in production however I am not sure of the value of that as we run all 3 environments in production mode and use HTTPS in all of them.

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
