### PR TITLE
AP-1727 Add application detail to Feedback email

### DIFF
--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -4,18 +4,16 @@ class FeedbackController < ApplicationController
   def new
     @journey = source
     @feedback = Feedback.new
-    @signed_out_provider_id = session.delete('signed_out_provider_id')
+    @signed_out = session.delete('signed_out')
+    @application_id = application_id
   end
 
   def create
-    @feedback = Feedback.new(feedback_params)
-    @feedback.originating_page = originating_page
-    @feedback.email = provider_email
-    @display_close_tab_msg = params[:signed_out_provider_id].present?
-
+    initialize_feedback
+    @display_close_tab_msg = params['signed_out'].present?
     # must use bang version `deliver_later!` or failures won't be retried by sidekiq
     if @feedback.save
-      FeedbackMailer.notify(@feedback).deliver_later!
+      FeedbackMailer.notify(@feedback, application_id).deliver_later!
       render :show
     else
       render :new
@@ -28,31 +26,40 @@ class FeedbackController < ApplicationController
 
   private
 
+  def initialize_feedback
+    @feedback = Feedback.new(feedback_params)
+    @feedback.originating_page = originating_page
+    @feedback.email = provider_email
+  end
+
   def provider_email
-    if params[:signed_out_provider_id].present?
-      signed_out_provider_email
-    else
-      signed_in_provider_email
+    # citizen side won't have access to current_provider but can get provider_email via current_application_id
+    provider&.email || current_provider&.email
+  end
+
+  def provider
+    LegalAidApplication.find_by_id(application_id)&.provider
+  end
+
+  def application_id
+    return params['application_id'] if params['application_id']
+    return session['current_application_id'] if source == :citizen
+
+    application_id_from_page_history || nil
+  end
+
+  def application_id_from_page_history
+    page_history_service = PageHistoryService.new(page_history_id: session[:page_history_id])
+    page_history = JSON.parse(page_history_service.read)
+    previous_page = page_history[-2]
+
+    previous_page&.split('/')&.each_with_index do |section, i|
+      return previous_page.split('/')[i + 1] if ['applications'].include?(section)
     end
   end
 
-  def signed_out_provider_email
-    provider_id = params[:signed_out_provider_id]
-    Provider.find(provider_id).email
-  end
-
-  def signed_in_provider_email
-    provider_struct = session['warden.user.provider.key']
-    return nil unless provider_struct
-
-    provider_id = provider_struct.first&.first
-    return nil unless provider_id
-
-    Provider.find(provider_id).email
-  end
-
   def originating_page
-    params[:signed_out_provider_id].present? ? destroy_provider_session_path : session['feedback_return_path']
+    params['signed_out'].present? ? destroy_provider_session_path : URI(session['feedback_return_path']).path.split('/').last
   end
 
   def feedback_params
@@ -62,10 +69,21 @@ class FeedbackController < ApplicationController
   end
 
   def browser_meta_data
-    { source: source,
+    { source: user,
       os: browser.platform.name,
       browser: browser.name,
       browser_version: browser.full_version }
+  end
+
+  def user
+    case source
+    when :citizen
+      'Applicant'
+    when :provider
+      'Provider'
+    else
+      'Unknown'
+    end
   end
 
   def back_path

--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -5,7 +5,6 @@ class FeedbackController < ApplicationController
     @journey = source
     @feedback = Feedback.new
     @signed_out = session.delete('signed_out')
-    @application_id = application_id
   end
 
   def create
@@ -42,7 +41,6 @@ class FeedbackController < ApplicationController
   end
 
   def application_id
-    return params['application_id'] if params['application_id']
     return session['current_application_id'] if source == :citizen
 
     application_id_from_page_history || nil

--- a/app/controllers/saml_sessions_controller.rb
+++ b/app/controllers/saml_sessions_controller.rb
@@ -7,7 +7,7 @@ class SamlSessionsController < Devise::SamlSessionsController
   after_action :update_provider_details, only: :create
 
   def destroy
-    session['signed_out_provider_id'] = current_provider.id
+    session['signed_out'] = true
     session['feedback_return_path'] = destroy_provider_session_path
     sign_out current_provider
     if IdPSettingsAdapter.mock_saml?

--- a/app/mailers/feedback_mailer.rb
+++ b/app/mailers/feedback_mailer.rb
@@ -4,25 +4,39 @@ class FeedbackMailer < BaseApplyMailer
   require_relative 'concerns/notify_template_methods'
   include NotifyTemplateMethods
 
-  def notify(feedback, to = support_email_address)
+  def notify(feedback, legal_aid_application_id, to = support_email_address)
     template_name :feedback_notification
+    legal_aid_application(legal_aid_application_id)
     personalise feedback
     mail to: to
   end
 
   private
 
-  def personalise(feedback)
+  def personalise(feedback) # rubocop:disable Metrics/AbcSize
     set_personalisation(
       created_at: feedback.created_at&.to_time.to_s(:rfc822),
       user_data: user_data(feedback),
+      user_type: feedback.source,
       done_all_needed: yes_or_no(feedback),
       satisfaction: safe_nil(feedback.satisfaction),
       difficulty: safe_nil(feedback.difficulty),
       improvement_suggestion: safe_nil(feedback.improvement_suggestion),
       originating_page: safe_nil(feedback.originating_page),
-      provider_email: provider_email_phrase(feedback)
+      provider_email: provider_email_phrase(feedback),
+      application_reference: @legal_aid_application&.application_ref || '',
+      application_status: application_status || ''
     )
+  end
+
+  def application_status
+    return 'pre-dwp-check' if @legal_aid_application&.pre_dwp_check?
+
+    @legal_aid_application&.passported? ? 'passported' : 'non-passported'
+  end
+
+  def legal_aid_application(legal_aid_application_id)
+    @legal_aid_application ||= LegalAidApplication.find_by_id(legal_aid_application_id)
   end
 
   def user_data(feedback)

--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -150,6 +150,10 @@ class LegalAidApplication < ApplicationRecord # rubocop:disable Metrics/ClassLen
     applicant.bank_transactions.where(happened_at: from..to)
   end
 
+  def pre_dwp_check?
+    BaseStateMachine.aasm.states.map(&:name).include? state.to_sym
+  end
+
   def income_types?
     transaction_types.credits.any?
   end

--- a/app/views/feedback/new.html.erb
+++ b/app/views/feedback/new.html.erb
@@ -43,7 +43,8 @@
             class: 'govuk-!-width-full'
         ) %>
 
-    <%= hidden_field_tag 'signed_out_provider_id', @signed_out_provider_id %>
+    <%= hidden_field_tag 'signed_out', @signed_out %>
+    <%= hidden_field_tag 'application_id', @application_id %>
 
     <%= form.submit t('generic.send'), class: 'govuk-button' %>
 

--- a/config/govuk_notify_templates.yml
+++ b/config/govuk_notify_templates.yml
@@ -10,7 +10,7 @@
 #
 development:
   citizen_start_application: e747df7d-4842-4bca-88a6-4ad3ebd89994
-  feedback_notification: 9aa7c2d5-f7ee-405c-9ec4-c0fcee149572
+  feedback_notification: 4d391bf7-4e5b-4f49-b586-b6bb8ad06a30
   new_link_request: a577582b-3e60-44a4-885c-d4b12bf23958
   submission_confirmation: ce2d89ee-1c10-404b-91cc-52068933ba7b
   reminder_to_submit_an_application: c4ac858d-68ae-437b-9353-06e632cd88f2
@@ -21,7 +21,7 @@ development:
 
 production:
   citizen_start_application: 7e5fb1a7-4b78-4a95-917e-c0bcb78a5fcc
-  feedback_notification: d8b0be70-c70c-436d-83f1-3db9f272e29d
+  feedback_notification: fd050a04-54d2-4736-bb6c-66431c7d9e41
   new_link_request: 3cc3be57-e072-4095-9caa-c0cd52193405
   submission_confirmation: 5472b10b-bc11-432a-a18d-9f20de5b2854
   reminder_to_submit_an_application: 96e58b6c-83e2-4ae8-be67-028803e98398

--- a/spec/mailers/feedback_mailer_spec.rb
+++ b/spec/mailers/feedback_mailer_spec.rb
@@ -3,7 +3,8 @@ require 'rails_helper'
 RSpec.describe FeedbackMailer, type: :mailer do
   describe 'notify' do
     let(:feedback) { create :feedback }
-    let(:mail) { described_class.notify(feedback) }
+    let(:application) { create :application }
+    let(:mail) { described_class.notify(feedback, application.id) }
 
     it 'uses GovukNotifyMailerJob' do
       expect(described_class.delivery_job).to eq(GovukNotifyMailerJob)

--- a/spec/models/legal_aid_application_spec.rb
+++ b/spec/models/legal_aid_application_spec.rb
@@ -93,6 +93,32 @@ RSpec.describe LegalAidApplication, type: :model do
     end
   end
 
+  describe '#pre_dwp_check?' do
+    let(:state) { :initiated }
+    let!(:legal_aid_application) { create :legal_aid_application, :with_applicant, state }
+
+    context 'in pre-dwp-check state' do
+      it 'is true' do
+        expect(legal_aid_application.pre_dwp_check?).to eq true
+      end
+    end
+
+    context 'in non passported state' do
+      let(:state) { :checking_non_passported_means }
+
+      it 'is false' do
+        expect(legal_aid_application.pre_dwp_check?).to eq false
+      end
+    end
+    context 'in passported state' do
+      let(:state) { :checking_passported_answers }
+
+      it 'is false' do
+        expect(legal_aid_application.pre_dwp_check?).to eq false
+      end
+    end
+  end
+
   describe 'benefit_check_result_needs_updating?' do
     let!(:legal_aid_application) { create :legal_aid_application, :with_applicant, :at_entering_applicant_details }
     let(:applicant) { legal_aid_application.applicant }

--- a/spec/requests/saml_sessions_spec.rb
+++ b/spec/requests/saml_sessions_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'SamlSessionsController', type: :request do
 
     it 'records id of logged out provider in session' do
       subject
-      expect(session['signed_out_provider_id']).to eq provider.id
+      expect(session['signed_out']).to eq true
     end
 
     it 'records the signout page as the feedback return path' do


### PR DESCRIPTION
## AP-1727 Add application detail to Feedback email

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1727)

- Update feedback process to include legal aid application infromation: application_ref, state, user_type (citizen / provider).

- Give the application_id to the feedback mailer to gather application information for the email.


#### When the provider clicks on feedback/signout when on an application then:
-  Use the PageHistoryService / page_history to get the application id

#### When the provider clicks on feedback/signout on index page or non appliction page then:
- Add provider email from :current_provider 
- Application information is left empty on the feedback mailer

#### When the citizen clicks on feedback then:
- Use the existing session['current_application_id'] to get the provider email
- Pass the session['current_application_id'] as a param to the feedback mailer

--- 
- Update tests

- Test when a provider clicks feedback whilst not on an application e.g. on the index page / application dashboard

## Citizen feedback email

![image](https://user-images.githubusercontent.com/25043924/96258212-8df2e300-0fb3-11eb-9cbe-7eb070892d75.png)

## Provider feedback email

![image](https://user-images.githubusercontent.com/25043924/96258424-eaee9900-0fb3-11eb-83be-0f6bd9973158.png)

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
