### PR TITLE
Enable cucumber to cope with Faker names with apostrophes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -101,6 +101,7 @@ group :development, :test do
   gem 'dotenv-rails', '>= 2.7.5'
   gem 'erb_lint', require: false
   gem 'i18n-tasks', '>= 0.9.31'
+  gem 'htmlentities'
   gem 'json_expressions'
   gem 'nokogiri'
   gem 'pry-byebug'

--- a/Gemfile
+++ b/Gemfile
@@ -100,8 +100,8 @@ group :development, :test do
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
   gem 'dotenv-rails', '>= 2.7.5'
   gem 'erb_lint', require: false
-  gem 'i18n-tasks', '>= 0.9.31'
   gem 'htmlentities'
+  gem 'i18n-tasks', '>= 0.9.31'
   gem 'json_expressions'
   gem 'nokogiri'
   gem 'pry-byebug'
@@ -111,7 +111,7 @@ group :development, :test do
 
   # Available in dev env for generators
   gem 'rspec-rails', '~> 4.0', '>= 4.0.1'
-end
+end 
 
 group :development do
   gem 'better_errors', '>= 2.7.1'

--- a/Gemfile
+++ b/Gemfile
@@ -111,7 +111,7 @@ group :development, :test do
 
   # Available in dev env for generators
   gem 'rspec-rails', '~> 4.0', '>= 4.0.1'
-end 
+end
 
 group :development do
   gem 'better_errors', '>= 2.7.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -266,6 +266,7 @@ GEM
     hashie (4.1.0)
     highline (2.0.3)
     html_tokenizer (0.0.7)
+    htmlentities (4.3.4)
     http_parser.rb (0.6.0)
     httpi (2.4.4)
       rack
@@ -626,6 +627,7 @@ DEPENDENCIES
   guard-livereload
   guard-rspec
   guard-rubocop
+  htmlentities
   i18n-tasks (>= 0.9.31)
   json_expressions
   jwt

--- a/features/step_definitions/civil_journey_steps.rb
+++ b/features/step_definitions/civil_journey_steps.rb
@@ -70,7 +70,7 @@ Given('I previously created a passported application with no assets and left on 
 end
 
 Given(/^I view the previously created application$/) do
-  find(:xpath, "//tr[contains(.,'#{@legal_aid_application.application_ref}')]/td[1]/a[contains(.,'#{@legal_aid_application.applicant.full_name}')]").click
+  find(:xpath, "//tr[contains(.,'#{@legal_aid_application.application_ref}')]/td[1]/a[contains(.,'#{HTMLEntities.new.encode(@legal_aid_application.applicant.full_name)}')]").click
 end
 
 Then(/^I should not see the previously created application$/) do


### PR DESCRIPTION
## Enable cucumber to cope with Faker names with apostrophes

Occasionally, feature tests fail because Faker has generated names like O'Keefe which then cause the cukes to fail because it's trying to find `O'Keefe` on the page, and it is rendered as `O&apos;Keefe`. This fixes that issue (in at least one place - there may be more).

Describe what you did and why.

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
