### PR TITLE
BUGFIX: remove names from cucumber step

### DIFF
--- a/features/step_definitions/civil_journey_steps.rb
+++ b/features/step_definitions/civil_journey_steps.rb
@@ -70,7 +70,7 @@ Given('I previously created a passported application with no assets and left on 
 end
 
 Given(/^I view the previously created application$/) do
-  find(:xpath, "//tr[contains(.,'#{@legal_aid_application.application_ref}')]/td[1]/a[contains(.,'#{@legal_aid_application.applicant.full_name}')]").click
+  find(:xpath, "//tr[contains(.,'#{@legal_aid_application.application_ref}')]/td[1]/a").click
 end
 
 Then(/^I should not see the previously created application$/) do


### PR DESCRIPTION
## What

When the delete function was added there were two anchor tags on the row
and this step was amended to look for the anchor tag containing the
applicants name.  This breaks when faker generates a name with an
apostrophe e.g. O`Malley.

This check has been removed and it now looks for the anchor tag in the
first cell of the row instead

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
