### PR TITLE
AP-1725 left align content

### DIFF
--- a/app/views/shared/check_answers/_client_details.html.erb
+++ b/app/views/shared/check_answers/_client_details.html.erb
@@ -5,7 +5,7 @@
         question: t('.first_name'),
         answer: applicant.first_name,
         read_only: read_only,
-        align_right: read_only
+        align_right: false
       ) if :first_name.in?(attributes) %>
 
   <%= check_answer_link(
@@ -14,7 +14,7 @@
         question: t('.last_name'),
         answer: applicant.last_name,
         read_only: read_only,
-        align_right: read_only
+        align_right: false
       ) if :last_name.in?(attributes) %>
 
   <%= check_answer_link(
@@ -23,14 +23,14 @@
         question: t('.dob'),
         answer: applicant.date_of_birth,
         read_only: read_only,
-        align_right: read_only
+        align_right: false
       ) if :date_of_birth.in?(attributes) %>
 
   <%= check_answer_link(
         name: :age,
         question: t('.age_question'),
         answer: t('.age', years: applicant.age),
-        align_right: true
+        align_right: false
       ) if :age.in?(attributes) %>
 
   <%= check_answer_link(
@@ -39,7 +39,7 @@
         question: t('.nino'),
         answer: applicant.national_insurance_number,
         read_only: read_only,
-        align_right: read_only
+        align_right: false
       ) if :national_insurance_number.in?(attributes) %>
 
   <%= check_answer_link(
@@ -48,7 +48,7 @@
         question: t('.email'),
         answer: applicant.email,
         read_only: read_only,
-        align_right: read_only
+        align_right: false
       ) if :email.in?(attributes) %>
 
   <%= check_answer_link(
@@ -57,6 +57,6 @@
         question: t('.address'),
         answer: address_with_line_breaks(address),
         read_only: read_only,
-        align_right: read_only
+        align_right: false
       ) if :address.in?(attributes) %>
 </dl>

--- a/app/views/shared/check_answers/_no_link_item.html.erb
+++ b/app/views/shared/check_answers/_no_link_item.html.erb
@@ -1,5 +1,5 @@
 <%
-  align_right = local_assigns[:align_right] ? align_right : false,
+  align_right = local_assigns[:align_right] ? align_right : false
   no_border = no_border ? 'govuk-summary-list--no-border' : ''
 %>
 <div class="govuk-summary-list__row <%= no_border %> normal-word-break" id="app-check-your-answers__<%= name %>">


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1725)

Removed an errant comma which was breaking the `align_right` variable and returning `true` instead of `false` on `app/views/shared/check_answers/_no_link_item.html.erb`

Changed the align_right status to `false` for client details as there does not appear to be any page where these need to be aligned right.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
