### PR TITLE
AP-1756 Add gem to implement content-security-policy headers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -95,6 +95,9 @@ gem 'rails_admin', '~> 2.0', '>= 2.0.2'
 # Create reports with SQL queries
 gem 'blazer', '>= 2.2.6'
 
+# Manage security headers
+gem 'secure_headers'
+
 group :development, :test do
   gem 'awesome_print', '~> 1.8.0'
   gem 'byebug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -506,6 +506,7 @@ GEM
       nokogiri (>= 1.8.1)
       nori (~> 2.4)
       wasabi (~> 3.4)
+    secure_headers (6.3.1)
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
@@ -656,6 +657,7 @@ DEPENDENCIES
   ruby-saml-idp!
   sass-rails (~> 6.0, >= 6.0.0)
   savon (~> 2.12.1)
+  secure_headers
   selenium-webdriver
   sentry-raven
   shoulda-matchers (~> 4.4)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -79,7 +79,7 @@ module ApplicationHelper
   end
 
   def print_button(text)
-    content_tag :button, text, class: 'govuk-button no-print', type: 'button', onclick: 'window.print()'
+    content_tag :button, text, class: 'govuk-button no-print', id: 'print', type: 'button'
   end
 
   def start_button_label(button_text)

--- a/app/javascript/src/print_button.js
+++ b/app/javascript/src/print_button.js
@@ -1,0 +1,9 @@
+$(document).ready(function() {
+  const print_button = document.getElementById("print");
+
+  if (print_button != null) {
+    print_button.onclick = function() {
+      window.print();
+    };
+  }
+});

--- a/app/views/layouts/_google_tag_manager.html.erb
+++ b/app/views/layouts/_google_tag_manager.html.erb
@@ -1,5 +1,6 @@
-  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+<script nonce="<%= content_security_policy_script_nonce %>">(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
   new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
   j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-  })(window,document,'script','dataLayer', '<%= Rails.configuration.x.google_tag_manager_tracking_id %>');</script>
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;var n=d.querySelector('[nonce]');
+  n&&j.setAttribute('nonce',n.nonce||n.getAttribute('nonce'));f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer', "<%= Rails.configuration.x.google_tag_manager_tracking_id %>");</script>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -37,7 +37,7 @@
 
   <body class="govuk-template__body ">
     <%= render partial: 'layouts/google_tag_manager_no_script' if google_tag_present? %>
-    <script>
+    <script nonce="<%= content_security_policy_script_nonce %>">
       document.body.className = (
         (document.body.className)
           ? document.body.className + ' js-enabled'

--- a/app/views/providers/statement_of_cases/show.html.erb
+++ b/app/views/providers/statement_of_cases/show.html.erb
@@ -73,7 +73,7 @@
   <% end %>
 <% end %>
 
-<script>
+<script nonce="<%= content_security_policy_script_nonce %>">
   window.LAA_VARS = {
     images: {
       loading_small: <%= image_path('loading-small.gif').to_json.html_safe %>

--- a/app/views/saml_idp/idp/saml_post.html.erb
+++ b/app/views/saml_idp/idp/saml_post.html.erb
@@ -4,7 +4,7 @@
     <meta charset='utf-8'>
     <meta http-equiv='X-UA-Compatible' content='IE=edge,chrome=1'>
   </head>
-  <body onload="document.forms[0].submit();">
+  <body>
     <%= form_tag("#{Rails.configuration.x.application.host_url}/providers/saml/auth") do %>
       <%= hidden_field_tag('SAMLResponse', @saml_response) %>
       <%= hidden_field_tag('RelayState', params[:RelayState]) %>
@@ -12,3 +12,9 @@
     <% end %>
   </body>
 </html>
+
+<script nonce="<%= content_security_policy_script_nonce %>">
+  document.addEventListener('DOMContentLoaded', function() {
+    document.forms[0].submit();
+  });
+</script>

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -1,0 +1,13 @@
+SecureHeaders::Configuration.configure do |config|
+  # rubocop:disable Lint/PercentStringArray
+  config.csp = {
+    default_src: %w['self'],
+    img_src: %w['self' https://www.google-analytics.com www.googletagmanager.com
+                https://truelayer-client-logos.s3-eu-west-1.amazonaws.com https://truelayer-provider-assets.s3.amazonaws.com],
+    script_src: %w['self' nonce https://www.google-analytics.com https://www.googletagmanager.com],
+    style_src: %w['self' 'unsafe-inline'],
+    object_src: %w['none'],
+    connect_src: %w['self' https://www.google-analytics.com]
+  }
+  # rubocop:enable Lint/PercentStringArray
+end

--- a/spec/requests/providers/submitted_applications_spec.rb
+++ b/spec/requests/providers/submitted_applications_spec.rb
@@ -38,12 +38,6 @@ RSpec.describe Providers::SubmittedApplicationsController, type: :request do
       end
     end
 
-    it 'triggers window.print() when clicking the printing buttons' do
-      print_buttons.each do |print_button|
-        expect(print_button.attributes['onclick'].value).to eq('window.print()')
-      end
-    end
-
     it 'includes the name of the firm' do
       subject
       expect(unescaped_response_body).to include(firm.name)


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1756)

See 4.14 of the security testing report.

Adds the `secure_headers` gem and configures it to generate `content-security-policy` (CSP) headers. The recommendation was to add this header `Content-Security-Policy: script-src 'self'; object-src 'none'; require-trusted-types-for 'script';` however for various this reasons this does not completely suit our application and extra configuration is required:

* `script_src` - additionally allows scripts from https://www.google-analytics.com and https://www.googletagmanager.com in order for Google Analytics to continue to function
* `img_src` - additionally allows images from https://truelayer-client-logos.s3-eu-west-1.amazonaws.com and https://truelayer-provider-assets.s3.amazonaws.com to be loaded to allow bank logos to be displayed
* `style_src` - we have inline styling in several places. In order to allow this to behave correctly, I've allowed `unsafe-inline`. This seems to be a more accepted approach for styles than scripts
* `require-trusted-types-for`- this is described in [guidance](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy) as 'an experimental API that should not be used in production code' so I have omitted it.

We also have inline javascript in several places which will not work with CSP in place. I've added nonces to those scripts to allow them to continue to work. This wasn't possible in one place, so I have extracted the js used to print completed applications into its own file.

We might want to look at moving our inline javascript and styling to separate files at some point to allow us to tighten this up.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
