### PR TITLE
BUGFIX: wrap timecop in do block

### DIFF
--- a/spec/services/reports/mis/non_passported_application_csv_line_spec.rb
+++ b/spec/services/reports/mis/non_passported_application_csv_line_spec.rb
@@ -32,13 +32,14 @@ module Reports
         end
 
         it 'returns an array with the expected values' do
-          Timecop.freeze(time)
-          fields = subject
-          expect(fields[0]).to eq application.application_ref
-          expect(fields[1]).to eq application.state
-          expect(fields[2]).to eq provider.username
-          expect(fields[3]).to eq provider.email
-          expect(fields[4]).to match DATE_TIME_REGEX
+          Timecop.freeze(time) do
+            fields = subject
+            expect(fields[0]).to eq application.application_ref
+            expect(fields[1]).to eq application.state
+            expect(fields[2]).to eq provider.username
+            expect(fields[3]).to eq provider.email
+            expect(fields[4]).to match DATE_TIME_REGEX
+          end
         end
       end
     end


### PR DESCRIPTION
## What

This was causing the tests in `non_passported_applications_report_spec.rb` to fail because it was locking the date before the cut off for the new report.  

Turning it into a block means that Timecop resets the date at the end.

Maybe we should look at implementing safe_mode? https://github.com/travisjeffery/timecop#timecopsafe_mode

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
