### PR TITLE
AP-1568 Update NotifyMailer to include provider firm name

### DIFF
--- a/app/mailers/notify_mailer.rb
+++ b/app/mailers/notify_mailer.rb
@@ -5,11 +5,12 @@ class NotifyMailer < BaseApplyMailer
   require_relative 'concerns/notify_template_methods'
   include NotifyTemplateMethods
 
-  def citizen_start_email(app_id, email, application_url, client_name)
+  def citizen_start_email(app_id, email, application_url, client_name, provider_firm)
     template_name :citizen_start_application
     set_personalisation(
       application_url: application_url,
       client_name: client_name,
+      provider_firm: provider_firm,
       ref_number: app_id
     )
     mail(to: email)

--- a/app/services/citizen_email_service.rb
+++ b/app/services/citizen_email_service.rb
@@ -20,8 +20,13 @@ class CitizenEmailService
       application.application_ref,
       applicant.email_address,
       application_url,
-      applicant.full_name
+      applicant.full_name,
+      provider.firm.name
     ]
+  end
+
+  def provider
+    application&.provider
   end
 
   def application_url

--- a/config/govuk_notify_templates.yml
+++ b/config/govuk_notify_templates.yml
@@ -20,7 +20,7 @@ development:
   new_link_to_client: 5708ec04-c789-4f7e-8a15-ad7dd3f4f336
 
 production:
-  citizen_start_application: 66865f0d-6410-40e2-b862-98724eb6e33a
+  citizen_start_application: 7e5fb1a7-4b78-4a95-917e-c0bcb78a5fcc
   feedback_notification: d8b0be70-c70c-436d-83f1-3db9f272e29d
   new_link_request: 3cc3be57-e072-4095-9caa-c0cd52193405
   submission_confirmation: 5472b10b-bc11-432a-a18d-9f20de5b2854

--- a/config/govuk_notify_templates.yml
+++ b/config/govuk_notify_templates.yml
@@ -9,7 +9,7 @@
 # we default to 'integration' group.
 #
 development:
-  citizen_start_application: 570e1b9d-6238-45fd-b75c-96f2f39db8e9
+  citizen_start_application: e747df7d-4842-4bca-88a6-4ad3ebd89994
   feedback_notification: 9aa7c2d5-f7ee-405c-9ec4-c0fcee149572
   new_link_request: a577582b-3e60-44a4-885c-d4b12bf23958
   submission_confirmation: ce2d89ee-1c10-404b-91cc-52068933ba7b

--- a/spec/mailers/notify_mailer_spec.rb
+++ b/spec/mailers/notify_mailer_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe NotifyMailer, type: :mailer do
   let(:app_id) { SecureRandom.uuid }
   let(:email) { Faker::Internet.safe_email }
   let(:client_name) { Faker::Name.name }
+  let(:provider_firm) { Faker::Name.name }
   let(:application_url) { "/applications/#{app_id}/citizen/start" }
   let(:citizen_start_application_template) { Rails.configuration.govuk_notify_templates[:citizen_start_application] }
 
@@ -12,7 +13,7 @@ RSpec.describe NotifyMailer, type: :mailer do
   end
 
   describe '#citizen_start_email' do
-    let(:mail) { described_class.citizen_start_email(app_id, email, application_url, client_name) }
+    let(:mail) { described_class.citizen_start_email(app_id, email, application_url, client_name, provider_firm) }
 
     it 'sends an email to the correct address' do
       expect(mail.to).to eq([email])
@@ -30,6 +31,7 @@ RSpec.describe NotifyMailer, type: :mailer do
       expect(mail.govuk_notify_personalisation).to eq(
         application_url: application_url,
         client_name: client_name,
+        provider_firm: provider_firm,
         ref_number: app_id
       )
     end

--- a/spec/services/citizen_email_service_spec.rb
+++ b/spec/services/citizen_email_service_spec.rb
@@ -4,7 +4,9 @@ require 'sidekiq/testing'
 RSpec.describe CitizenEmailService do
   let(:smoke_test_email) { Rails.configuration.x.smoke_test_email_address }
   let(:applicant) { create(:applicant, first_name: 'John', last_name: 'Doe', email: smoke_test_email) }
-  let(:application) { create(:application, applicant: applicant) }
+  let(:firm) { create :firm }
+  let(:provider) { create :provider, firm: firm }
+  let(:application) { create(:application, applicant: applicant, provider: provider) }
   let(:secure_id) { SecureRandom.uuid }
   let(:citizen_url) { "http://www.example.com/citizens/legal_aid_applications/#{secure_id}" }
 
@@ -14,7 +16,7 @@ RSpec.describe CitizenEmailService do
     it 'sends an email' do
       message_delivery = instance_double(ActionMailer::MessageDelivery)
       expect(NotifyMailer).to receive(:citizen_start_email)
-        .with(application.application_ref, applicant.email, citizen_url, 'John Doe')
+        .with(application.application_ref, applicant.email, citizen_url, 'John Doe', provider.firm.name)
         .and_return(message_delivery)
       expect(message_delivery).to receive(:deliver_later!)
       expect(application).to receive(:generate_secure_id).and_return(secure_id)


### PR DESCRIPTION
## AP-1568 Update NotifyMailer to include provider firm name

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1568)

- Update NotifyMailer to include provider firm name

- Update tests


### Left to do

- [x] Include email into production notify template and add production GovUK Notify template

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
