### PR TITLE
AP-1773: update benefit selection

### DIFF
--- a/app/controllers/providers/transactions_controller.rb
+++ b/app/controllers/providers/transactions_controller.rb
@@ -24,7 +24,7 @@ module Providers
       new_values = { transaction_type_id: transaction_type.id }
       new_values[:meta_data] = manually_chosen_metadata(transaction_type)
       bank_transactions
-        .where(id: selected_transaction_ids)
+        .where(id: selected_transaction_ids, meta_data: nil)
         .update_all(new_values)
     end
 

--- a/app/controllers/providers/transactions_controller.rb
+++ b/app/controllers/providers/transactions_controller.rb
@@ -9,16 +9,11 @@ module Providers
     end
 
     def update
-      reset_selection
       set_selection
       continue_or_draft
     end
 
     private
-
-    def reset_selection
-      bank_transactions.where(transaction_type_id: transaction_type.id).update_all(transaction_type_id: nil)
-    end
 
     def set_selection
       new_values = { transaction_type_id: transaction_type.id }

--- a/app/views/providers/transactions/show.html.erb
+++ b/app/views/providers/transactions/show.html.erb
@@ -71,7 +71,7 @@
         <%= form.collection_check_boxes :transaction_ids, @bank_transactions, :id, :description do |builder| %>
           <tr class="govuk-table__row">
             <td class="govuk-table__cell tick-box-cell">
-              <% if builder.object.transaction_type_id == nil || builder.object.transaction_type_id == @transaction_type.id %>
+              <% if builder.object.transaction_type_id == nil %>
                 <div class="govuk-checkboxes__item">
                   <% checked = builder.object.transaction_type_id == @transaction_type.id %>
                   <%= builder.check_box(class: 'govuk-checkboxes__input', checked: checked, 'aria-labelledby' => 'Date-' + builder.object.id + ' Description-' + builder.object.id + ' Amount-' + builder.object.id) %>

--- a/features/step_definitions/civil_journey_steps.rb
+++ b/features/step_definitions/civil_journey_steps.rb
@@ -194,7 +194,7 @@ Given('I start the merits application with student finance') do
     :provider_assessing_means,
     :with_irregular_income,
     :with_transaction_period,
-    :with_benefits_transactions
+    :with_uncategorised_credit_transactions
   )
 
   login_as @legal_aid_application.provider

--- a/spec/requests/providers/transactions_spec.rb
+++ b/spec/requests/providers/transactions_spec.rb
@@ -167,6 +167,25 @@ RSpec.describe Providers::TransactionsController, type: :request do
         end
       end
 
+      context 'when there are identified benefits' do
+        let!(:benefits_transaction_type) { create :transaction_type, :benefits }
+        let!(:selected_transactions) { [bank_transaction_B, bank_transaction_other_applicant, benefit_bank_transaction, child_benefit_bank_transaction] }
+        let!(:benefit_bank_transaction) { create :bank_transaction, :benefits, bank_account: bank_account, meta_data: nil }
+        let!(:child_benefit_bank_transaction) do
+          create :bank_transaction, :benefits, bank_account: bank_account, meta_data: { code: 'CHB', label: 'child_benefit', name: 'Child Benefit' }
+        end
+        let(:params) do
+          {
+            transaction_type: benefits_transaction_type.name,
+            transaction_ids: selected_transactions.pluck(:id)
+          }
+        end
+
+        it 'does not change the meta data for the pre-analysed data' do
+          expect { subject }.not_to change { child_benefit_bank_transaction.reload.meta_data }
+        end
+      end
+
       context 'when being set to friends_or_family' do
         let!(:friends_or_family_transaction_type) { create :transaction_type, :friends_or_family }
         let!(:selected_transactions) { [bank_transaction_B, bank_transaction_other_applicant, friends_or_family_bank_transaction] }

--- a/spec/requests/providers/transactions_spec.rb
+++ b/spec/requests/providers/transactions_spec.rb
@@ -111,10 +111,6 @@ RSpec.describe Providers::TransactionsController, type: :request do
   end
 
   shared_examples_for 'PATCH #providers/transactions' do
-    it 'unselect the previously selected' do
-      expect { subject }.to change { bank_transaction_A.reload.transaction_type }.to(nil)
-    end
-
     it 'saves the selected transactions' do
       expect { subject }.to change { bank_transaction_B.reload.transaction_type }.from(nil).to(transaction_type)
     end

--- a/spec/requests/providers/transactions_spec.rb
+++ b/spec/requests/providers/transactions_spec.rb
@@ -55,12 +55,6 @@ RSpec.describe Providers::TransactionsController, type: :request do
         expect(unescaped_response_body).to include(expected_amount)
       end
 
-      it 'shows selected transactions' do
-        subject
-        checkbox = parsed_response_body.at_css("[value='#{bank_transaction_selected.id}']")
-        expect(checkbox[:checked]).to eq('checked')
-      end
-
       it 'does not show transactions that do not match the operation on the transaction type' do
         subject
         expect(unescaped_response_body).not_to include(bank_transaction_not_matching.description)


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1773)

Update the transaction handling.  
Previously transactions that had been identified as benefits would be displayed, ticked, on the add new transactions page. If a user submitted the page (regardless of adding new ticked rows) all rows would identified as `manually_chosen`.

This affected the data sent to CFE.

This removes previously ticked rows.  The main screen says 
![image](https://user-images.githubusercontent.com/6757677/96571965-32cb3400-12c4-11eb-85ec-ada651fcc28c.png)

So I have taken this to mean that the `remove` link is the sole way of de-selecting a line-item.  Now a provider can only tick new rows on the incoming_transactions page
![image](https://user-images.githubusercontent.com/6757677/96572145-63ab6900-12c4-11eb-8e68-3aeb0705d2cc.png)



## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
