### PR TITLE
AP-1748 Sanitise CSV files

### DIFF
--- a/app/services/reports/mis/application_detail_csv_line.rb
+++ b/app/services/reports/mis/application_detail_csv_line.rb
@@ -1,6 +1,8 @@
 module Reports
   module MIS
     class ApplicationDetailCsvLine
+      include Sanitisable
+
       attr_reader :laa
 
       delegate :application_ref,
@@ -156,7 +158,7 @@ module Reports
         restrictions
         respondent_details
         merits
-        @line
+        sanitise
       end
 
       private

--- a/app/services/reports/mis/non_passported_application_csv_line.rb
+++ b/app/services/reports/mis/non_passported_application_csv_line.rb
@@ -1,6 +1,7 @@
 module Reports
   module MIS
     class NonPassportedApplicationCsvLine
+      include Sanitisable
       attr_reader :laa
 
       delegate :provider, to: :laa
@@ -30,6 +31,7 @@ module Reports
         @line << laa.provider.username
         @line << provider.email
         @line << laa.created_at.strftime('%Y-%m-%d %H:%M:%S')
+        sanitise
       end
     end
   end

--- a/app/services/reports/mis/sanitisable.rb
+++ b/app/services/reports/mis/sanitisable.rb
@@ -1,0 +1,25 @@
+module Reports
+  module MIS
+    module Sanitisable
+      def sanitise
+        @line.map { |field| sanitise_field(field) }
+      end
+
+      def sanitise_field(field)
+        field.nil? || field.is_a?(Numeric) ? field : prefix_if_necessary(field)
+      end
+
+      def prefix_if_necessary(field)
+        starts_with_special_character?(field.to_s) ? prefix(field.to_s) : field
+      end
+
+      def starts_with_special_character?(str)
+        %w[= + - @ %].include?(str.first)
+      end
+
+      def prefix(field)
+        "'#{field}"
+      end
+    end
+  end
+end

--- a/spec/services/reports/mis/application_detail_csv_line_spec.rb
+++ b/spec/services/reports/mis/application_detail_csv_line_spec.rb
@@ -411,6 +411,13 @@ module Reports
               expect(value_for('Bail details')).to eq respondent.bail_conditions_set_details
             end
           end
+
+          context 'data begins with a vulnerable character' do
+            before { firm.name = '=malicious_code' }
+            it 'returns the escaped text' do
+              expect(value_for('Firm name')).to eq "'=malicious_code"
+            end
+          end
         end
       end
 

--- a/spec/services/reports/mis/non_passported_application_csv_line_spec.rb
+++ b/spec/services/reports/mis/non_passported_application_csv_line_spec.rb
@@ -41,6 +41,13 @@ module Reports
             expect(fields[4]).to match DATE_TIME_REGEX
           end
         end
+
+        context 'data begins with a vulnerable character' do
+          before { provider.email = '=malicious_code' }
+          it 'returns the escaped text' do
+            expect(subject[3]).to eq "'=malicious_code"
+          end
+        end
       end
     end
   end

--- a/spec/services/reports/mis/sanitisable_spec.rb
+++ b/spec/services/reports/mis/sanitisable_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+module Reports
+  module MIS
+    class TestCsvLine
+      include Sanitisable
+
+      def initialize
+        @line = ['+field_1', '-field_2', '=field_3', '@field_4', '%field_5']
+      end
+    end
+
+    RSpec.describe Sanitisable do
+      describe 'sanitise' do
+        let(:test_line) { TestCsvLine.new }
+        let(:sanitised_line) { ["'+field_1", "'-field_2", "'=field_3", "'@field_4", "'%field_5"] }
+
+        it 'escapes all fields that begin with vulnerable characters' do
+          expect(test_line.sanitise).to eq(sanitised_line)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1748)

CSV files produced by Apply are vulnerable to csv injection exploits. This adds a mixin to provide functionality to sanitise the data by prefixing an apostrophe to any fields that begin with an exploitable character (+, -, =, @ or %).

This has been added to the `ApplicationDetailCsvLine` and `NonPassportedApplicationCsvLine` classes to sanitise both reports (the non-passported application report doesn't contain any user-entered data so is not particularly vulnerable but has been included for consistency).

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
