### PR TITLE
AP-1672 Add fake Welsh translations

### DIFF
--- a/config/locales/cy/activemodel.yml
+++ b/config/locales/cy/activemodel.yml
@@ -1,0 +1,21 @@
+---
+cy:
+  accessibility:
+    problem_text: melborp a si erehT
+  activemodel:
+    errors:
+      models:
+        irregular_income:
+          attributes:
+            amount:
+              blank: raey cimedaca siht teg ll’uoy ecnanif tneduts fo tnuoma latoteht retnE
+              too_many_decimals: 000,01 ekil ,yenom fo tnuoma na eb tsum tnuoma naol tnedutS
+              not_a_number: 000,01 ekil ,yenom fo tnuoma na eb tsum tnuoma naol tnedutS
+        legal_aid_application:
+          attributes:
+            open_banking_consents:
+              citizens:
+                blank_html: ">rbba/<AAL>'ycnegA diA lageL'=eltit rbba< eht htiw noitamrofni
+                  tnuocca knab ruoy erahs ot eerga uoy fi sey tceleS"
+            student_finance:
+              blank: ecnanif tneduts teg uoy fi sey tceleS

--- a/config/locales/cy/activerecord.yml
+++ b/config/locales/cy/activerecord.yml
@@ -1,0 +1,13 @@
+---
+cy:
+  activerecord:
+    errors:
+      models:
+        feedback:
+          attributes:
+            satisfaction:
+              blank: ecivres eht htiw erew uoy deifsitas woh tceleS
+            difficulty:
+              blank: ecivres wen eht gnisu dia lagel rof ylppa ot saw ti tluciffid ro ysae woh tceleS
+            done_all_needed:
+              inclusion: yadot dedeen uoy tahw od ot elba uoy erew uoy fi sey tceleS

--- a/config/locales/cy/citizens.yml
+++ b/config/locales/cy/citizens.yml
@@ -1,0 +1,136 @@
+---
+cy:
+  citizens:
+    gather_transactions:
+      index:
+        retrieving_transactions: snoitcasnart knab gniveirteR
+        failed_transactions_retrieval: snoitcasnart knab eveirter ot deliaF
+        default_error: ".retal niaga yrt esaelP .seitluciffid lacinhcet gnicneirepxe era ew ,yrroS"
+        page_loading: gnidaoL egaP
+        heading_1: snoitcasnart knab ruoy derahs yllufsseccus ev'uoY
+        intro_text: ".shtnom 3 tsap eht morf stnemetats knab ruoy dedaolnwod ev’eW"
+        balance_text: ".noitautis laicnanif ruoy dnatsrednu su pleh ot seirogetac otni snoitcasnart ruoy tup ot roticilos ruoy ksa ll’eW"
+      display_error:
+        bank_selection_link: niaga yrT
+    accounts:
+      index:
+        account_holder_address_heading: sserdda redloh tnuoccA
+        account_holder_name_heading: eman redloh tnuoccA
+        account_number_heading: rebmuN tnuoccA
+        balance_heading: ecnalaB
+        sort_code_heading: edoC troS
+        type_heading: epyT
+        your_accounts: stnuocca knab ruoY
+        link_other_account: tnuocca knab rehtona ddA
+    additional_accounts:
+      index:
+        field_set_header: "?sknab rehto htiw stnuocca evah uoy oD"
+      new:
+        field_set_header: "?sknab rehto htiw stnuocca ruoy ot ssecca enilno evah uoy oD"
+      error: sknab rehto htiw stnuocca evah uoy fi sey tceleS
+    banks:
+      index:
+        title: knab ruoy tceleS
+        what_happens_next: txen sneppah tahW
+        connect: ".AAL eht htiw noitamrofni tnuocca knab ruoy erahs nac uoy os reyaLeurT gnisu knab ruoy ot uoy tcennoc ll'eW"
+        hint: ".sknab tnereffid htiw stnuocca evah uoy fi retal erom tceles ot elba eb ll'uoY .emit a ta knab eno tceleS"
+      create:
+        error: knab a tceleS
+    check_answers:
+      index:
+        assets:
+          heading: stessa rehto dna sgnivas ,ytreporP
+          other_assets: stessa rehtO
+          outstanding_mortgage: tnuoma egagtrom gnidnatstuO
+          own_home: denwo ytreporP
+          percentage_home: denwo egatnecreP
+          property_value: eulav ytreporP
+          restrictions: "?stessa ruoy tsniaga gniworrob ro gnilles morf uoy tneverp taht snoitcirtser lagel yna ereht erA"
+          savings_and_investments: stnemtsevni dna sgnivaS
+          shared_ownership: esle enoyna htiw denwO
+        h1-heading: noitamrofni timbus dna srewsna ruoy kcehC
+        bank-heading: stnuocca knab ruoY
+        link_other_account: tnuocca knab rehtona ddA
+        payments_receive_heading: eviecer uoy stnemyaP
+        payments_make_heading: ekam uoy stnemyaP
+        submit_button: timbus dna eergA
+        income_outgoings: sgniogtuo dna emocni ruoY
+      student_finance:
+        student_finance: ecnanif tnedutS
+        do_you_get: "?ecnanif tneduts teg uoy oD"
+        how_much: "?raey cimedaca siht teg uoy lliw ecnanif tneduts hcum woH"
+    contact_providers:
+      show:
+        title: noitacilppa ruoy eunitnoc ot roticilos ruoy tcatnoC
+        they_will_check: ".secnanif ruoy tuoba gniksa yb dia lagel rof yfilauq uoy rehtehw kcehc lliw yehT"
+    consents:
+      show:
+        title_html: "?>rbba/<AAL>'ycnegA diA lageL'=eltit rbba< eht htiw noitamrofni tnuocca knab ruoy erahs ot eerga uoy oD"
+        inset_text: ".esle gnihtyna rof ti esu ton od eW .noitacilppa dia lagel ruoy troppus ot noitamrofni laicnanif ruoy esu ylno eW"
+        summary_heading: "?ees ot elba eb AAL eht lliw noitamrofni tahW"
+        summary_heading_html: "?ees ot elba eb >rbba/<AAL>'ycnegA diA lageL'=eltit rbba< eht lliw noitamrofni tahW"
+        able_to_see:
+          heading: ":ruoy ees ot elba eb ll'eW"
+          list: |
+            sredro gnidnats dna stibeD tceriD
+            secnalab tnuocca
+            sliated noitcasnart dna stnemetats knab
+            sliated tnuocca
+        unable_to_see:
+          heading: ":ton lliw eW"
+          list: |
+            tnuocca knab ruoy ot ssecca gniogno yna evah
+            drowssap dna emanresu gniknab enilno ruoy evas
+    declarations:
+      show:
+        page_heading: noitaralceD
+        submit_button: timbus dna eergA
+    identify_types_of_incomes:
+      show:
+        page_heading: "?eviecer uoy od stnemyap gniwollof eht fo hcihW"
+      update:
+        none_selected: emocni fo sepyt yna eviecer uoy fi tceleS
+    identify_types_of_outgoings:
+      show:
+        page_heading: "?ekam uoy od stnemyap gniwollof eht fo hcihW"
+      update:
+        none_selected: stnemyap raluger yna ekam uoy fi tceleS
+    legal_aid_applications:
+      index:
+        case_reference: ":ecnerefer esaC"
+        heading_1: noitacilppa dia lagel ruoY
+        how_we_do_this_heading: siht od ew woH
+        how_we_do_this_body_1: ".gniknab enilno ruoy ot uoy tcennoc ot ecivres ytrap-driht eruces a sesu )AAL( ycnegA diA lageL ehT"
+        how_we_do_this_body_2: ".stnuocca knab ruoy ot ssecca emit-eno reyaLeurT evig ot deksa eb ll'uoy ,gniknab enilno ot ni dengis ev'uoy ecnO"
+        how_we_do_this_body_3: ".AAL eht htiw ti erahs dna noitamrofni tnuocca knab ruoy ssecca yliraropmet lliw reyaLeurT ,eerga uoy fI"
+        how_we_do_this_body_4: ".dia lagel rof yllaicnanif yfilauq uoy fi kcehc meht pleh ot roticilos ruoy htiw shtnom 3 tsap eht morf stnemetats knab ruoy erahs neht eW"
+        name: ":emaN"
+        online_banking_details: ".sliated ni ngis gniknab enilno ruoY"
+        what_you_will_need: deen ll'uoy tahW
+        we_need_to_check: ".dia lagel rof yllaicnanif yfilauq uoy fi kcehc ot deen eW"
+        your_solicitor: ":roticilos ruoY"
+    means_test_results:
+      show:
+        page-heading: txen sneppah tahW
+        completed_financial_assessment: noitamrofni laicnanif ruoy derahs ev'uoY
+        name: emaN
+        reference_number: rebmun ecnerefeR
+        solicitors-actions: ".noitacilppa ruoy etelpmoc meht pleh ot dedivorp uoy noitamrofni eht esu lliw roticilos ruoY"
+        what-happens-next: ".esac ruoy fo sliated eht dna noitautis laicnanif ruoy dekcehc ev'ew ecno dia lagel rof yfilauq uoy fi mrifnoc ll'eW"
+        feedback_link_html: .ecivres siht evorpmi su pleh ot >a/<kcabdeef eviG>"knil_kuvog"=ssalc"}lru{%"=ferh a<
+    resend_link_requests:
+      show:
+        page_title: deripxe sah knil sihT
+        new_link_request: knil wen a tseuqeR
+      update:
+        page_title: knil wen a uoy tnes ev'eW
+        check_inbox: ".xobni liame ruoy kcehC"
+        valid_until: ".snosaer ytiruces rof syad 7 rof evitca niamer ylno lliw knil wen ruoY"
+    student_finances:
+      show:
+        field_set_header: "?ecnanif tneduts teg uoy oD"
+        hint: ".yrasrub ro tnarg ,naol tneduts fo epyt yna sedulcni sihT"
+      annual_amounts:
+        show:
+          field_set_header: "?raey cimedaca siht teg uoy lliw ecnanif tneduts hcum woH"
+          hint: ".rettel tnemeltitne ecnanif tneduts ruoy kcehC"

--- a/config/locales/cy/contacts.yml
+++ b/config/locales/cy/contacts.yml
@@ -1,0 +1,12 @@
+---
+cy:
+  contacts:
+    show:
+      h1-heading: su tcatnoC
+      case_enquiries:
+        heading: seiriuqne esaC
+        phone_number: 053 4418 3020 :enohpeleT
+      technical_support:
+        heading: troppus lacinhceT
+        email_text: ":liamE"
+        email_address: ku.vog.ecitsuj.latigid@dia-lagel-rof-ylppa

--- a/config/locales/cy/currency.yml
+++ b/config/locales/cy/currency.yml
@@ -1,0 +1,6 @@
+---
+cy:
+  currency:
+    eur: "€"
+    gbp: "£" # Also the default for `number_to_currency` as set via "en.number.currency.format.unit"
+    usd: "$"

--- a/config/locales/cy/errors.yml
+++ b/config/locales/cy/errors.yml
@@ -1,0 +1,29 @@
+---
+cy:
+  errors:
+    title_prefix: rorrE
+    messages:
+      already_confirmed: ni gningis yrt esaelp ,demrifnoc ydaerla saw
+      confirmation_period_expired: eno wen a tseuqer esaelp ,}doirep{% nihtiw demrifnoc eb ot sdeen
+      expired: eno wen a tseuqer esaelp ,deripxe sah
+      not_found: dnuof ton
+      not_locked: dekcol ton saw
+      not_saved:
+        one: ":devas gnieb morf }ecruoser{% siht detibihorp rorre 1"
+        other: ":devas gnieb morf }ecruoser{% siht detibihorp srorre }tnuoc{%"
+    show:
+      assessment_already_completed:
+        page_title: tnemssessa laicnanif ruoy detelpmoc ydaerla ev'uoY
+        contact_provider: ".sutats noitacilppa ruoy kcehc ot roticilos ruoy htiw kaepS"
+      page_not_found:
+        page_title: dnuof ton egaP
+        web_address_incorrect: ".tcerroc si ti kcehc ,sserdda bew eht depyt uoy fI"
+        web_address_copied: ".sserdda eritne eht deipoc uoy kcehc ,sserdda bew eht detsap uoy fI"
+      access_denied:
+        page_title: deined sseccA
+        permission_text: uoy ot elbissecca yltnerruc ton si egap ehT
+  problem:
+    index:
+      title: ecivres eht htiw melborp a si ereht ,yrroS
+      try_later: ".retal niaga yrT"
+      answers_saved: ".srewsna ruoy devas eW"

--- a/config/locales/cy/feedback.yml
+++ b/config/locales/cy/feedback.yml
@@ -1,0 +1,14 @@
+---
+cy:
+  feedback:
+    new:
+      applicant_email_hint: esnopser a ekil d'uoy fi sserdda liame ruoy edivorp esaelP
+      difficulty: "?ecivres siht esu ot ti saw tluciffid ro ysae woH"
+      done_all_needed: "?yadot dedeen uoy tahw od ot elba uoy ereW"
+      satisfaction: "?ecivres siht htiw uoy erew deifsitas woh ,llarevO"
+      signed_out: tuo dengis era uoY
+      title: ecivres siht evorpmi su pleH
+    show:
+      close_tab: ".egap ro bat siht esolc nac uoY"
+      link: noitacilppa ruoy ot kcaB
+      title: kcabdeef ruoy rof uoy knahT

--- a/config/locales/cy/generic.yml
+++ b/config/locales/cy/generic.yml
@@ -1,0 +1,16 @@
+---
+cy:
+  generic:
+    back: kcaB
+    change: egnahC
+    continue: eunitnoC
+    errors:
+      problem_text: melborp a si erehT
+    'no': 'oN'
+    or: ro
+    remove: evomeR
+    save_and_continue: eunitnoc dna evaS
+    select_all_that_apply: ylppa taht lla tceleS
+    send: dneS
+    start_now: won tratS
+    'yes': seY

--- a/config/locales/cy/helpers.yml
+++ b/config/locales/cy/helpers.yml
@@ -1,0 +1,17 @@
+---
+cy:
+  true_false:
+    'false': 'oN'
+    'true': seY
+  helpers:
+    accessibility:
+      error: ":rorrE"
+    hint:
+      additional_account: yteicos gnidliub ro knab rehtona htiw evah uoy stnuocca yna fo sliated erahS
+      student_finance: ".yrasrub ro tnarg ,naol tneduts fo epyt yna sedulcni sihT"
+    label:
+      feedback:
+        done_all_needed:
+          'false': 'oN'
+          'true': seY
+        improvement_suggestion: "?ecivres eht evorpmi dluoc ew woh no snoitseggus ro kcabdeef rehto yna evah uoy oD"

--- a/config/locales/cy/layouts.yml
+++ b/config/locales/cy/layouts.yml
@@ -1,0 +1,20 @@
+---
+cy:
+  layouts:
+    application:
+      footer:
+        contact: tcatnoC
+        cookies: seikooC
+        copyright: thgirypoc nworC
+        digital_services_html: secivreS latigiD >rbba/<JOM>'ecitsuJ fo yrtsiniM'=eltit rbba<
+        feedback: kcabdeeF
+        open_gov_link_text: 0.3v ecneciL tnemnrevoG nepO
+        privacy_policy: ycilop ycavirP
+        span_text_1: eht rednu elbaliava si tnetnoc llA
+        span_text_2: detats esiwrehto erehw tpecxe
+        support: skniL troppuS
+        terms: snoitidnoc dna smreT
+      header:
+        gov_uk_link_title: egapemoh KU.VOG eht ot oG
+        title: dia lagel rof ylppA
+    login: nI ngiS

--- a/config/locales/cy/model_enum_translations.yml
+++ b/config/locales/cy/model_enum_translations.yml
@@ -1,0 +1,16 @@
+---
+cy:
+  model_enum_translations:
+    feedback:
+      satisfaction:
+        dissatisfied: deifsitassiD
+        neither_dissatisfied_nor_satisfied: deifsitassid ron deifsitas rehtieN
+        satisfied: deifsitaS
+        very_dissatisfied: deifsitassid yreV
+        very_satisfied: deifsitas yreV
+      difficulty:
+        very_difficult: tluciffid yreV
+        difficult: tluciffiD
+        neither_difficult_nor_easy: tluciffid ron ysae rehtieN
+        easy: ysaE
+        very_easy: ysae yreV

--- a/config/locales/cy/privacy_policy.yml
+++ b/config/locales/cy/privacy_policy.yml
@@ -1,0 +1,109 @@
+---
+cy:
+  privacy_policy:
+    index:
+      h1-heading: ycilop ycavirP
+      what_we_collect:
+        header: tcelloc ew atad tahW
+        data_we_collect: ":sedulcni uoy morf tcelloc ew atad ehT"
+        list:
+          item_1: rebmun ecnarusnI lanoitaN dna sliated tcatnoc ,htrib fo etad ,sserdda ,eman ruoy ekil sliated lanosrep
+          item_2: dia lagel rof yfilauq uoy fi kcehc ot noitamrofni laicnanif
+          item_3_html: desu uoy >a/<resworb bew>'sresworb/pleh/ku.vog.www//:sptth'=ferh a< fo noisrev hcihw fo sliated dna ,sserdda >rbba/<)PI(>'locotorP tenretnI'=eltit rbba< locotorP tenretnI ruoy
+          item_4_html: seuqinhcet gniggat egap dna >a/<seikooc>"seikooc/pleh/ku.vog.www//:sptth"=ferh a< gnisu ,etis eht esu uoy woh no noitamrofni
+          item_5: evael uoy kcabdeef yna
+      google_analytics:
+        why: ".ecivres eht esu uoy woh tuoba noitamrofni tcelloc ot erawtfos scitylanA elgooG esu eW"
+        list_heading: ":tuoba noitamrofni serots scitylanA elgooG"
+        list: |
+          ecivres eht gnisu er’uoy elihw no kcilc uoy tahw
+          ecivres eht ot tog uoy woh
+          egap hcae no dneps uoy gnol woh
+          tisiv uoy segap eht
+        security_information: ".era uoy ohw yfitnedi ot desu eb tonnac noitamrofni siht os )sserdda ro eman ruoy elpmaxe rof( scitylanA elgooG hguorht noitamrofni lanosrep ruoy erots ro tcelloc ton od eW"
+      why_we_need_your_data:
+        header: atad ruoy deen ew yhW
+        list_heading: ":ot atad tcelloc eW"
+        list: |
+          etarucca dna tcerroc era ekam ew snoisiced eht taht erusne ot stidua tuo yrrac
+          erutidnepxe cilbup yfitsuj
+          duarf ro emirc tceted ro tneverp
+          ecivres eht evorpmi dna rotinom su pleh
+          ecivres eht tuoba scitsitats rehtag
+          sresu sti fo sdeen eht steem ecivres eht erus ekam
+          dia lagel rof yfilauq uoy rehtehw tuo krow
+        legal_basis_html: .>a/<2102 tcA sredneffO fo tnemhsinuP dna gnicnetneS ,diA lageL>"detcane/stnetnoc/01/2102/agpku/ku.vog.noitalsigel.www//:ptth"=ferh a< eht ni deniatnoc srewop eht fo tluser eht si atad lanosrep ruoy gnissecorp rof sisab lagel ehT
+      what_we_do_with_your_data:
+        header: atad ruoy htiw od ew tahW
+        what: ".noitacilppa dia lagel ruoy etelpmoc nac yeht os roticilos ruoy htiw atad lanosrep ruoy erahs ll’eW"
+        we_may:
+          list_heading: ":htiw atad ruoy erahs osla yam eW"
+          list: |
+            redivorp gnitsoh ruo elpmaxe rof ,sreilppus ygolonhcet ruo
+            seicnega noitcelloc tbed dna ecnerefer tiderc sa hcus snoitasinagro cilbup-non
+            seidob cilbup dna seicnega ,stnemtraped tnemnrevog rehto
+        we_will_not:
+          list_heading: ":ton lliw eW"
+          list: |
+            sesoprup gnitekram rof seitrap driht htiw atad ruoy erahs
+            seitrap driht ot atad ruoy tner ro lles
+        we_will: ".emirc rehto ro duarf tneverp ot ro ,redro truoc yb ,elpmaxe rof – ot su seriuqer wal eht fi atad ruoy erahs lliw eW"
+      where_your_data_is_processed_and_stored:
+        header: derots dna dessecorp si atad ruoy erehW
+        info_1: ".derots s’ti nehw dna dessecorp s’ti elihw htob ,segats lla ta elbissop sa efas sa si atad ruoy taht erus ekam ot smetsys ruo nur dna dliub ,ngised eW"
+        info_2_html: .uoy yfitnedi yllanosrep ot desu eb tonnac siht tub ,>rbba/<AEE>'aerA cimonocE naeporuE'=eltit rbba< eht edistuo derrefsnart eb yam atad scitylanA elgooG .>rbba/<)AEE(>'aerA cimonocE naeporuE'=eltit rbba< >a/<aerA cimonocE naeporuE>"aee-ue/ku.vog.www//:sptth"=ferh a< eht ni derots si atad lanosrep llA
+      security:
+        header: eruces ti peek dna atad ruoy tcetorp ew woH
+        info_1: ".noitpyrcne fo slevel gniyrav gnisu atad ruoy tcetorp ew ,elpmaxe rof – atad ruoy fo erusolcsid ro ssecca desirohtuanu tneverp ot sessecorp dna smetsys pu tes evah eW .eruces atad ruoy peek ot nac ew taht lla gniod ot dettimmoc era eW"
+        info_2: ".eruces flaheb ruo no ssecorp yeht atad lanosrep lla peek htiw laed ew taht seitrap driht yna taht erus ekam osla eW"
+      data_retention_period:
+        header: atad ruoy peek ew gnol woH
+        list_heading: ":sa gnol sa rof atad lanosrep ruoy niater ylno lliw eW"
+        list: |
+          ot su seriuqer wal eht
+          tnemucod siht ni tuo tes sesoprup eht rof dedeen si ti
+        info_html: .reciffO noitcetorP ataD ruo morf ypoc a tseuqer ro ,>a/<atad gniniater no ycilop ruo>"fdp.9102-tsugua-sdrr-aal/035428/elif/atad_tnemhcatta/sdaolpu/metsys/sdaolpu/tnemnrevog/ku.vog.ecivres.gnihsilbup.stessa//:sptth"=ferh a< weiV
+      rights:
+        header: sthgir ruoY
+        list_heading: ":tseuqer ot thgir eht evah uoY"
+        list: |
+          atad lanosrep ruoy eteled ro esu ,tcelloc ot ffats tcurtsni ew woh no noitamrofni
+          snoitasinagro rehto htiw evah ew stnemeerga gnirahs-atad yna fo ypoc a
+          ti rof noitacifitsuj a regnol on si ereht fi desare si atad lanosrep ruoy taht
+          detcerroc si atad lanosrep ruoy ni etaruccani gnihtyna taht
+          )'tseuqer ssecca tcejbus' a( atad lanosrep taht fo ypoc a
+          dessecorp si atad lanosrep ruoy woh tuoba noitamrofni
+        info_html: ".reciffO noitcetorP ataD >rbba/<)JOM(>'ecitsuJ fo yrtsiniM'=eltit rbba< ecitsuJ fo yrtsiniM eht tcatnoc ,stseuqer eseht fo yna evah uoy fI"
+        data_protection_office_contact_details:
+          title: reciffO noitcetorP ataD ehT
+          email_address_html: '>a/<ku.vog.ecitsuj@ecnailpmoc.atad>"ku.gro.oci@krowesac:otliam"=ferh a<'
+          address:
+            line_1: ecitsuJ fo yrtsiniM
+            line_2: ecnarF ytteP 201
+            line_3: nodnoL
+            post_code: JA9 H1WS
+      contact_or_complaint:
+        header: tnialpmoc a ekam ro su tcatnoC
+        data_protection_office:
+          list_heading_html: ":uoy fi reciffO noitcetorP ataD >rbba/<JOM>'ecitsuJ fo yrtsiniM'=eltit rbba< eht tcatnoC"
+          list: |
+            ro desusim neeb sah atad lanosrep ruoy taht kniht
+            eciton ycavirp siht ni gnihtyna tuoba noitseuq a evah
+          contact_details:
+            email_address_html: '>a/<ku.gro.oci@krowesac>"ku.gro.oci@krowesac:otliam"=ferh a<'
+            telephone: 3111 321 3030 :enohpeleT
+            text_phone: '068545 52610 :enohptxeT'
+            call_hours: mp03:4 ot ma9 ,yadirF ot yadnoM
+            call_costs_html: '>a/<segrahc llac tuoba tuo dniF>"segrahc-llac/ku.vog.www//:sptth"=ferh a<'
+        commissioner_office:
+          list_heading_html: ":)>rbba/<OCI>'eciffO s'renoissimmoC noitamrofnI'=eltit rbba<( eciffO s'renoissimmoC noitamrofnI eht tcatnoC"
+          list: |
+            noitcetorp atad tuoba ecivda tnednepedni rof
+            tnialpmoc a ekam ot
+          address:
+            title: eciffO s'renoissimmoC noitamrofnI
+            line_1: esuoH effilcyW
+            line_2: enaL retaW
+            line_3: wolsmliW
+            line_4: erihsehC
+            post_code: FA5 9KS

--- a/config/locales/cy/shared.yml
+++ b/config/locales/cy/shared.yml
@@ -1,0 +1,39 @@
+---
+cy:
+  shared:
+    applicant_declaration:
+      confirm_following: gniwollof eht mrifnoC
+      submission_list_summary: taht eerga uoY
+      submission_list: |
+        yletaidemmi noitautis laicnanif ruoy ot segnahc yna troper ll'uoy
+        tcerroc dna etelpmoc si nevig ev'uoy noitamrofni eht
+        )'egrahc yrotutats' eht sa nwonk( esac ruoy fo dne eht ta yenom ro ytreporp niag ro peek uoy fi stsoc lagel eht yaper ot evah yam uoy
+        dia lagel ruoy sdrawot yap ot evah yam uoy
+        seicnega ecnerefer tiderc dna knab ruoy htiw sliated ruoy kcehc nac ew
+        smotsuC dna euneveR MH dna snoisneP dna kroW rof tnemtrapeD eht ekil stnemtraped tnemnrevog rehto htiw noitamrofni ruoy erahs nac ew
+        uoy tneserper ot }mrif{% detcurtsni ev'uoy
+      warning_list_summary: yam uoy ,duarf tifeneb dettimmoc evah ot dnuof era ro ,segnahc troper ton od ,noitamrofni etelpmocni ro gnorw evig uoy fI
+      warning_list: |
+        stsoc eht kcab yap ot evah dna deppots dia lagel ruoy evah
+        ytlanep laicnanif a yap ot deen
+        detucesorp eb
+    forms:
+      identify_types_of_outgoings_form:
+        none_selected: eseht fo enoN
+        expanded_explanation:
+          heading: "?siht deksa gnieb I ma yhW"
+          list: |
+            .dia lagel rof yllaicnanif yfilauq uoy fi kcehc ot noitamrofni siht deen eW
+            .tceles uoy seirogetac eht otni snoitcasnart ruoy tup dna stnemetats knab ruoy ta kool lliw roticilos ruoY
+      types_of_income_form:
+        financial_help_examples: ".sllib ro tner rof rebmem ylimaf a morf yenom ,elpmaxe roF"
+        benefits_examples: ".stiderc xat ro tifeneB dlihC ,elpmaxe roF"
+        pension_examples: ".snoisnep lanosrep dna ecalpkrow ,etatS edulcnI"
+        none_selected: eseht fo enoN
+        expanded_explanation:
+          heading: "?siht deksa gnieb I ma yhW"
+          list: |
+            .dia lagel rof yllaicnanif yfilauq uoy fi kcehc ot noitamrofni siht deen eW
+            .tceles uoy seirogetac eht otni snoitcasnart ruoy tup dna stnemetats knab ruoy ta kool lliw roticilos ruoY
+    page-title:
+      suffix: dia lagel rof ylppA

--- a/config/locales/cy/transaction_types.yml
+++ b/config/locales/cy/transaction_types.yml
@@ -1,0 +1,17 @@
+---
+cy:
+  transaction_types:
+    names:
+      citizens:
+        benefits: stifeneB
+        child_care: stsoc eracdlihC
+        excluded_benefits: stifeneb dedragersiD
+        friends_or_family: ylimaf ro sdneirf morf pleh laicnaniF
+        legal_aid: esac lanimirc a ni dia lagel sdrawot stnemyaP
+        maintenance_in: stnemyap ecnanetniaM
+        maintenance_out: rentrap-xe na ro nerdlihc rof stnemyap ecnanetniaM
+        pension: noisneP
+        property_or_lodger: regdol ro ytreporp a morf emocnI
+        rent_or_mortgage: stnemyap egagtrom ro tneR
+        salary: segaw ro yralaS
+        student_loan: tnarg ro naol tnedutS

--- a/config/locales/cy/true_layer_errors.yml
+++ b/config/locales/cy/true_layer_errors.yml
@@ -1,0 +1,20 @@
+---
+cy:
+  true_layer_errors:
+    headings:
+      provider_error: won thgir knab ruoy ot tcennoc tonnac eW
+      account_permanently_locked: tnuocca ruoy ssecca tonnac eW
+      account_temporarily_locked: won thgir tnuocca ruoy ssecca tonnac eW
+      internal_server_error: ecivres eht htiw melborp a si ereht ,yrroS
+      user_input_required: knab ruoy htiw ytitnedi ruoy yfirev ot deen uoY
+      wrong_credentials: drowssap dna emanresu tcerroc eht retne ton did uoY
+      unknown: derrucco sah rorre nwonknu nA
+    detail:
+      provider_error: ''
+      account_permanently_locked: ".tnuocca ruoy htiw melborp a s’ereht fi ees ot knab ruoy tcatnoC"
+      account_temporarily_locked: ''
+      internal_server_error: ''
+      user_input_required: ''
+      wrong_credentials: ''
+      unknown: ".retal niaga yrt esaelP  .ti no gnikrow era dna ,detrela neeb evah eW  .derrucco sah rorre nwonknu nA"
+    close_tab: ".egap ro bat siht esolc nac uoY"

--- a/lib/tasks/cy.rake
+++ b/lib/tasks/cy.rake
@@ -1,0 +1,5 @@
+desc 'Duplicate the en locales to cy and reverse all strings'
+task cy: :environment do
+  require_relative 'helpers/cy_helper'
+  CyHelper.new.run
+end

--- a/lib/tasks/helpers/cy_helper.rb
+++ b/lib/tasks/helpers/cy_helper.rb
@@ -1,0 +1,51 @@
+class CyHelper
+  def initialize
+    @cy_dir = Rails.root.join('config/locales/cy')
+    @en_dir = Rails.root.join('config/locales/en')
+  end
+
+  def run
+    initialize_cy_dir
+    copy_en_to_cy
+    translation_files.each { |f| reverse_strings(f) }
+  end
+
+  private
+
+  def initialize_cy_dir
+    delete_cy_dir if File.exist?(@cy_dir)
+  end
+
+  def delete_cy_dir
+    puts 'deleting cy dir'
+    system "rm -rf #{@cy_dir}"
+  end
+
+  def copy_en_to_cy
+    puts 'copying en locale to cy'
+    system "mkdir #{@cy_dir}"
+    system "cp #{@en_dir}/* #{@cy_dir}/"
+  end
+
+  def translation_files
+    Dir["#{@cy_dir}/*.yml"].sort
+  end
+
+  def reverse_strings(filename)
+    puts "Reversing #{filename}"
+    hash = YAML.load_file(filename)
+    hash['cy'] = hash['en']
+    hash.delete('en')
+    hash['cy'].each_key { |k| reverse_key(k, hash['cy']) }
+    File.open(filename, 'w') { |f| f.puts(YAML.dump(hash)) }
+  end
+
+  def reverse_key(key, hash)
+    case hash[key]
+    when String then hash[key] = hash[key].reverse
+    when Hash then hash[key].each_key do |k|
+                     reverse_key(k, hash[key])
+                   end
+    end
+  end
+end

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -3,10 +3,26 @@ require 'rails_helper'
 
 RSpec.describe 'I18n' do
   let(:i18n) { I18n::Tasks::BaseTask.new }
-  let(:missing_keys) { i18n.missing_keys }
+  let(:missing_keys) { i18n.missing_keys[locale] || I18n::Tasks::Data::Tree::Siblings.new }
 
-  it 'does not have missing keys' do
-    expect(missing_keys).to be_empty,
-                            "Missing #{missing_keys.leaves.count} i18n keys, run `i18n-tasks missing' to show them"
+  context 'English' do
+    let(:locale) { 'en' }
+    it 'does not have missing keys' do
+      expect(missing_keys).to be_empty,
+                              "Missing #{missing_keys.leaves.count} i18n keys, run `i18n-tasks missing' to show them"
+    end
+  end
+
+  context 'Welsh' do
+    let(:locale) { 'cy' }
+    it 'does not have missing keys for the applicant journey' do
+      missing_applicant_keys = []
+      missing_keys.leaves.each do |leaf|
+        missing_applicant_keys << leaf if leaf.data[:occurrences]&.first&.path&.include? '/citizen'
+      end
+
+      expect(missing_applicant_keys).to be_empty,
+                                        "Missing #{missing_applicant_keys.count} i18n keys, run `i18n-tasks missing' to show them"
+    end
   end
 end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1672)

Copies all translations for the applicant journey the `/cy` locale and converts them to fake-Welsh (by reversing each string) for use in developing the Welsh language version of the applicant journey.

* This only applies to text that appears on the current applicant journey - any translations for providers or for parts of the applicant journey that are no longer visible to applicants (eg dependants, vehicles, capital and equity) have not been included.

* Behaviour of `spec/i18n_spec.rb` has been changed - it now tests for all translations in the English locale but only translations on pages on the applicant journey for the Welsh locale.

* Rake task to generate fake-Welsh versions of all translation files is included for future use.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
