### PR TITLE
Remove save as draft button from applicant screen

### DIFF
--- a/app/views/citizens/student_finances/show.html.erb
+++ b/app/views/citizens/student_finances/show.html.erb
@@ -17,9 +17,6 @@
                                             hint: t('.hint'),
                                             title: content_for(:page_title) %>
 
-    <%= next_action_buttons(
-            show_draft: true,
-            form: form
-        ) %>
+    <%= next_action_buttons(form: form) %>
   <% end %>
 <% end %>


### PR DESCRIPTION
## What

[AP-1776](https://dsdmoj.atlassian.net/browse/AP-1776)

The Student Finance view on the applicant journey contains a 'Save and come back later' button. This save-as-draft functionality is not available to applicants, only solicitors, so this commit removes the button from the view.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
