### PR TITLE
AP-1724 add tracking _id for true layer journey

### DIFF
--- a/app/lib/omniauth/strategies/true_layer.rb
+++ b/app/lib/omniauth/strategies/true_layer.rb
@@ -22,6 +22,7 @@ module OmniAuth
 
         extra_params[:provider_id] = session[:provider_id] if session[:provider_id].present?
         extra_params[:consent_id] = consent_id if consent_id
+        extra_params[:tracking_id] = session[:current_application_id]
 
         super.merge(extra_params)
       end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1723)

Add a tracking_id to the auth request sent to TrueLayer that allows us to track an individuals session with true layer

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
