### PR TITLE
AP-1778 Add rememberable Devise module to Applicant

### DIFF
--- a/app/controllers/auth_controller.rb
+++ b/app/controllers/auth_controller.rb
@@ -1,4 +1,6 @@
 class AuthController < ApplicationController
+  include Devise::Controllers::Rememberable
+
   class AuthorizationError < StandardError; end
 
   def failure

--- a/app/controllers/citizens/banks_controller.rb
+++ b/app/controllers/citizens/banks_controller.rb
@@ -1,6 +1,10 @@
 module Citizens
   class BanksController < CitizenBaseController
-    def index; end
+    include Devise::Controllers::Rememberable
+
+    def index
+      remember_me(current_applicant)
+    end
 
     def create
       if params[:provider_id].present?

--- a/app/controllers/citizens/check_answers_controller.rb
+++ b/app/controllers/citizens/check_answers_controller.rb
@@ -9,6 +9,7 @@ module Citizens
       legal_aid_application.complete_non_passported_means! unless legal_aid_application.provider_assessing_means?
       ProviderEmailService.new(legal_aid_application).send_email
       CitizenCompleteMeansJob.perform_later(legal_aid_application.id)
+      current_applicant.forget_me!
       go_forward
     end
 

--- a/app/controllers/citizens/citizen_base_controller.rb
+++ b/app/controllers/citizens/citizen_base_controller.rb
@@ -1,12 +1,16 @@
 module Citizens
   class CitizenBaseController < FlowBaseController
     include ApplicationFromSession
-    before_action :authenticate_applicant!
+    before_action :authenticate_with_devise
     before_action :check_not_complete
     before_action :set_cache_buster
     around_action :switch_locale
 
     private
+
+    def authenticate_with_devise
+      authenticate_applicant!
+    end
 
     class << self
       attr_reader :view_when_complete

--- a/app/controllers/citizens/gather_transactions_controller.rb
+++ b/app/controllers/citizens/gather_transactions_controller.rb
@@ -20,6 +20,13 @@ module Citizens
 
     private
 
+    def authenticate_with_devise
+      restored_session = OauthSessionSaver.get(current_applicant.id)
+      restored_session.each { |k, v| session[k] = v }
+      OauthSessionSaver.destroy!(current_applicant.id)
+      authenticate_applicant!
+    end
+
     def worker_errors
       return [] unless worker && worker['errors'].present?
 

--- a/app/controllers/citizens/legal_aid_applications_controller.rb
+++ b/app/controllers/citizens/legal_aid_applications_controller.rb
@@ -1,6 +1,6 @@
 module Citizens
   class LegalAidApplicationsController < CitizenBaseController
-    before_action :authenticate_applicant!, only: :index
+    before_action :authenticate_with_devise, only: :index
 
     # User passes in the Secure Id at the start of the journey. If login succeeds, they
     # are redirected to index where the first page is displayed.
@@ -8,6 +8,7 @@ module Citizens
       session[:journey_type] = :citizens
       return expired if application_error == :expired
 
+      legal_aid_application.applicant.remember_me!
       legal_aid_application.applicant_enter_means!
       start_applicant_flow
     end
@@ -15,6 +16,10 @@ module Citizens
     def index; end
 
     private
+
+    def authenticate_with_devise!
+      authenticate_applicant!
+    end
 
     def expired
       redirect_to citizens_resend_link_request_path(params[:id])

--- a/app/controllers/citizens/legal_aid_applications_controller.rb
+++ b/app/controllers/citizens/legal_aid_applications_controller.rb
@@ -17,7 +17,7 @@ module Citizens
 
     private
 
-    def authenticate_with_devise!
+    def authenticate_with_devise
       authenticate_applicant!
     end
 

--- a/app/lib/omniauth/strategies/moj_oauth2.rb
+++ b/app/lib/omniauth/strategies/moj_oauth2.rb
@@ -71,7 +71,8 @@ module OmniAuth
         # where only the applicant_id will be available.
         #
         OauthSessionSaver.store(applicant_id, session)
-        OauthSessionSaver.store(state, session)
+        OauthSessionSaver.store(auth_params[:state], session)
+
         Debug.record_request(session, auth_params, callback_url, browser_details)
         redirect client.auth_code.authorize_url({ redirect_uri: callback_url }.merge(auth_params))
       end

--- a/app/lib/omniauth/strategies/moj_oauth2.rb
+++ b/app/lib/omniauth/strategies/moj_oauth2.rb
@@ -59,8 +59,19 @@ module OmniAuth
         hash
       end
 
-      def request_phase
+      def request_phase # rubocop:disable Metrics/AbcSize
         auth_params = authorize_params
+        applicant_id = session['warden.user.applicant.key'].first.first
+
+        # We save the session in the redis database here in case the user backgrounds his browser on a mobile
+        # device while looking up the bank credentials, which would result in the session being destroyed.
+        #
+        # We save it under the applicant_id key AND the state key, because it will be required in two different places,
+        # the callback phase of this class, where only the state will be available, and the gather_transactions_controller
+        # where only the applicant_id will be available.
+        #
+        OauthSessionSaver.store(applicant_id, session)
+        OauthSessionSaver.store(state, session)
         Debug.record_request(session, auth_params, callback_url, browser_details)
         redirect client.auth_code.authorize_url({ redirect_uri: callback_url }.merge(auth_params))
       end
@@ -88,9 +99,15 @@ module OmniAuth
       end
 
       def callback_phase # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
-        Debug.record_callback(session, request.params, browser_details)
+        # we ALWAYS restore the session even if a perfectly good one exists because if we try to do it inside an
+        # if statement, then the path that doesn't restore the session will set it to nil.  Go figure!
+        #
+        restored_session = OauthSessionSaver.get(state)
+        restored_session.each { |k, v| session[k] = v }
+        OauthSessionSaver.destroy!(state)
 
         error = request.params['error_reason'] || request.params['error']
+
         if error
           Debug.record_error(session, request.params, '', browser_details)
           fail!(error, CallbackError.new(request.params['error'], request.params['error_description'] || request.params['error_reason'], request.params['error_uri']))
@@ -155,6 +172,10 @@ module OmniAuth
       end
 
       private
+
+      def state
+        request.params['state']
+      end
 
       def browser_details
         browser = Browser.new(

--- a/app/lib/omniauth/strategies/true_layer.rb
+++ b/app/lib/omniauth/strategies/true_layer.rb
@@ -8,7 +8,10 @@ require_relative 'moj_oauth2'
 
 module OmniAuth
   module Strategies
-    # TODO: revert back to TrueLayer < OmniAuth::Strategies::OAuth2 once True layer debugging removed
+    # This class is a copy of OmniAuth::Strategies::OAuth2, with extra code to write debugging records (which can
+    # eventually be removed), and to save and re-instate the session in redis to cater for users with mobile devices
+    # who exit the browser to look for banking credentials, thus destroying the session
+    #
     class TrueLayer < OmniAuth::Strategies::MojOAuth2
       option :name, :true_layer
 

--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -2,7 +2,7 @@ require 'uri'
 require 'omniauth'
 
 class Applicant < ApplicationRecord
-  devise
+  devise :rememberable
 
   NINO_REGEXP = /^[A-CEGHJ-PR-TW-Z]{1}[A-CEGHJ-NPR-TW-Z]{1}[0-9]{6}[A-DFM]{1}$/.freeze
 

--- a/app/services/oauth_session_saver.rb
+++ b/app/services/oauth_session_saver.rb
@@ -1,0 +1,36 @@
+class OauthSessionSaver
+  TIME_TO_LIVE_IN_SECONDS = 600
+
+  def self.store(key, session)
+    new.store(key, session)
+  end
+
+  def self.get(key)
+    new.get(key)
+  end
+
+  def self.destroy!(key)
+    new.destroy!(key)
+  end
+
+  def initialize
+    @redis = Redis.new(url: Rails.configuration.x.redis.oauth_session_url)
+  end
+
+  def store(key, session)
+    return unless session.key?('omniauth.state')
+
+    @redis.set(key, session.to_json, ex: TIME_TO_LIVE_IN_SECONDS)
+  end
+
+  def get(key)
+    json = @redis.get(key)
+    return {} if json.nil?
+
+    JSON.parse(json)
+  end
+
+  def destroy!(key)
+    @redis.del(key)
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -115,6 +115,7 @@ module LaaApplyForLegalAid
 
     config.x.redis.base_url = ENV['REDIS_HOST'].present? && ENV['REDIS_PASSWORD'].present? ? "rediss://:#{ENV['REDIS_PASSWORD']}@#{ENV['REDIS_HOST']}:6379" : 'redis://localhost:6379' # rubocop:disable Layout/LineLength, Lint/RequireParentheses
     config.x.redis.page_history_url = "#{config.x.redis.base_url}/1"
+    config.x.redis.oauth_session_url = "#{config.x.redis.base_url}/2"
 
     # automatically include locale in the query string when generating urls with url_helpers
     Rails.application.routes.default_url_options[:locale] = I18n.locale

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -152,7 +152,7 @@ Devise.setup do |config|
 
   # ==> Configuration for :rememberable
   # The time the user will be remembered without asking for credentials again.
-  # config.remember_for = 2.weeks
+  config.remember_for = 4.hours
 
   # Invalidates all the remember me tokens when the user signs out.
   config.expire_all_remember_me_on_sign_out = true
@@ -162,7 +162,7 @@ Devise.setup do |config|
 
   # Options to be passed to the created cookie. For instance, you can set
   # secure: true in order to force SSL only cookies.
-  # config.rememberable_options = {}
+  config.rememberable_options = { secure: Rails.env.production? }
 
   # ==> Configuration for :validatable
   # Range for password length.

--- a/db/migrate/20201023142248_add_rememberable_to_applicant.rb
+++ b/db/migrate/20201023142248_add_rememberable_to_applicant.rb
@@ -1,0 +1,6 @@
+class AddRememberableToApplicant < ActiveRecord::Migration[6.0]
+  def change
+    add_column :applicants, :remember_created_at, :datetime
+    add_column :applicants, :remember_token, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -597,7 +597,6 @@ ActiveRecord::Schema.define(version: 2020_11_02_133306) do
     t.string "email"
     t.boolean "portal_enabled", default: true
     t.integer "contact_id"
-    t.string "invalid_login_details"
     t.index ["firm_id"], name: "index_providers_on_firm_id"
     t.index ["selected_office_id"], name: "index_providers_on_selected_office_id"
     t.index ["type"], name: "index_providers_on_type"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -93,6 +93,7 @@ ActiveRecord::Schema.define(version: 2020_11_02_133306) do
     t.string "true_layer_secure_data_id"
     t.datetime "remember_created_at"
     t.boolean "employed"
+    t.string "remember_token"
     t.index ["confirmation_token"], name: "index_applicants_on_confirmation_token", unique: true
     t.index ["email"], name: "index_applicants_on_email"
     t.index ["unlock_token"], name: "index_applicants_on_unlock_token", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -92,8 +92,8 @@ ActiveRecord::Schema.define(version: 2020_11_02_133306) do
     t.datetime "locked_at"
     t.string "true_layer_secure_data_id"
     t.datetime "remember_created_at"
-    t.boolean "employed"
     t.string "remember_token"
+    t.boolean "employed"
     t.index ["confirmation_token"], name: "index_applicants_on_confirmation_token", unique: true
     t.index ["email"], name: "index_applicants_on_email"
     t.index ["unlock_token"], name: "index_applicants_on_unlock_token", unique: true
@@ -597,6 +597,7 @@ ActiveRecord::Schema.define(version: 2020_11_02_133306) do
     t.string "email"
     t.boolean "portal_enabled", default: true
     t.integer "contact_id"
+    t.string "invalid_login_details"
     t.index ["firm_id"], name: "index_providers_on_firm_id"
     t.index ["selected_office_id"], name: "index_providers_on_selected_office_id"
     t.index ["type"], name: "index_providers_on_type"

--- a/spec/lib/omniauth/strategies/moj_oauth2_spec.rb
+++ b/spec/lib/omniauth/strategies/moj_oauth2_spec.rb
@@ -1,0 +1,73 @@
+require 'rails_helper'
+require Rails.root.join('app', 'lib', 'omniauth', 'strategies', 'moj_oauth2')
+
+module OmniAuth
+  module Strategies
+    RSpec.describe  MojOAuth2 do
+      let(:mock_rack_app) { double Rack::Pjax }
+      let(:applicant_id) { '50b98c1b-cf5d-428e-b32c-d20e9d1184dd' }
+      let(:omniauth_state) { '6ab2a928a9ac79ff38ad32f73c47db3fce9a0a8f5d069a76' }
+      let(:strategy) { described_class.new(mock_rack_app, {} ) }
+      let(:session) { example_session }
+      let(:client_id) { 'my_client_id' }
+      let(:client_secret) { 'my_client_secret' }
+      let(:client) { ::OAuth2::Client.new(client_id, client_secret, {}) }
+
+      context 'request_phase' do
+        before do
+          allow(strategy).to receive(:session).and_return(example_session)
+          allow(strategy).to receive(:authorize_params).and_return(example_auth_params)
+          allow(strategy).to receive(:callback_url).and_return('http://dummy_callback')
+          allow(strategy).to receive(:browser_details).and_return('Dummy browser details')
+
+        end
+
+        it 'saves the session with the applicant_id and omniauth state' do
+          expect(OauthSessionSaver).to receive(:store).with(applicant_id, session)
+          expect(OauthSessionSaver).to receive(:store).with(omniauth_state, session)
+          strategy.request_phase
+        end
+
+        it 'writes a Debug record' do
+          expect(Debug).to receive(:record_request).with(example_session,
+                                                         example_auth_params,
+                                                         'http://dummy_callback',
+                                                         'Dummy browser details')
+          strategy.request_phase
+        end
+      end
+
+      context 'callback phase' do
+
+      end
+
+
+
+      def example_session
+        HashWithIndifferentAccess.new(
+          {
+            'session_id' => 'c38047b5f6a12c9de1540621ac8dc7d3',
+            'current_application_id' => '583496de-f14e-46b5-bbff-8f95b4d6af22',
+            'page_history_id' => 'c121c57a-2802-4793-b700-af30b212d63b',
+            'warden.user.applicant.key' => [[applicant_id], nil],
+            '_csrf_token' => 'bHisWZcUID4DqymnSBSyJ31OghMf8cop4Aw/9RJ3T9c=',
+            'provider_id' => 'mock',
+            'omniauth.state' => omniauth_state
+          })
+      end
+
+      def example_auth_params
+        HashWithIndifferentAccess.new(
+          {
+            'state' => omniauth_state,
+            'scope' => 'info accounts balance transactions',
+            'enable_mock'=>true,
+            'provider_id' => 'mock',
+            'consent_id' => 'applyforlegalaidtest-uxqw',
+            'tracking_id' => '9829f7c1-e8c4-4334-8f39-ff48e024ea62'
+          })
+      end
+    end
+  end
+end
+

--- a/spec/lib/omniauth/strategies/moj_oauth2_spec.rb
+++ b/spec/lib/omniauth/strategies/moj_oauth2_spec.rb
@@ -19,7 +19,6 @@ module OmniAuth
           allow(strategy).to receive(:authorize_params).and_return(example_auth_params)
           allow(strategy).to receive(:callback_url).and_return('http://dummy_callback')
           allow(strategy).to receive(:browser_details).and_return('Dummy browser details')
-
         end
 
         it 'saves the session with the applicant_id and omniauth state' do
@@ -37,11 +36,22 @@ module OmniAuth
         end
       end
 
-      context 'callback phase' do
-
-      end
-
-
+      # context 'callback phase' do
+      #   let(:mock_request) { double 'request', params: example_request_params, scheme: 'http', url: 'my_url' }
+      #   let(:my_access_token) { OpenStruct.new(expired?: false) }
+      #
+      #   before do
+      #     allow(strategy).to receive(:request).and_return(mock_request)
+      #     allow(strategy).to receive(:session).and_return(example_session)
+      #     allow(strategy).to receive(:build_access_token).and_return(my_access_token)
+      #   end
+      #
+      #   it 'does' do
+      #     expect(OauthSessionSaver).to receive(:get).with(omniauth_state).and_return(example_session)
+      #     strategy.callback_phase
+      #   end
+      #
+      # end
 
       def example_session
         HashWithIndifferentAccess.new(
@@ -65,6 +75,13 @@ module OmniAuth
             'provider_id' => 'mock',
             'consent_id' => 'applyforlegalaidtest-uxqw',
             'tracking_id' => '9829f7c1-e8c4-4334-8f39-ff48e024ea62'
+          })
+      end
+
+      def example_request_params
+        HashWithIndifferentAccess.new(
+          {
+            state: omniauth_state
           })
       end
     end

--- a/spec/lib/omniauth/strategies/moj_oauth2_spec.rb
+++ b/spec/lib/omniauth/strategies/moj_oauth2_spec.rb
@@ -3,11 +3,11 @@ require Rails.root.join('app', 'lib', 'omniauth', 'strategies', 'moj_oauth2')
 
 module OmniAuth
   module Strategies
-    RSpec.describe  MojOAuth2 do
+    RSpec.describe MojOAuth2 do
       let(:mock_rack_app) { double Rack::Pjax, call: nil }
       let(:applicant_id) { '50b98c1b-cf5d-428e-b32c-d20e9d1184dd' }
       let(:omniauth_state) { '6ab2a928a9ac79ff38ad32f73c47db3fce9a0a8f5d069a76' }
-      let(:strategy) { described_class.new(mock_rack_app, {} ) }
+      let(:strategy) { described_class.new(mock_rack_app, {}) }
       let(:session) { example_session }
       let(:client_id) { 'my_client_id' }
       let(:client_secret) { 'my_client_secret' }
@@ -56,7 +56,6 @@ module OmniAuth
           expect(OauthSessionSaver).to receive(:destroy!).with(omniauth_state)
           strategy.callback_phase
         end
-
       end
 
       def example_session
@@ -69,7 +68,8 @@ module OmniAuth
             '_csrf_token' => 'bHisWZcUID4DqymnSBSyJ31OghMf8cop4Aw/9RJ3T9c=',
             'provider_id' => 'mock',
             'omniauth.state' => omniauth_state
-          })
+          }
+        )
       end
 
       def example_auth_params
@@ -77,27 +77,29 @@ module OmniAuth
           {
             'state' => omniauth_state,
             'scope' => 'info accounts balance transactions',
-            'enable_mock'=>true,
+            'enable_mock' => true,
             'provider_id' => 'mock',
             'consent_id' => 'applyforlegalaidtest-uxqw',
             'tracking_id' => '9829f7c1-e8c4-4334-8f39-ff48e024ea62'
-          })
+          }
+        )
       end
 
       def example_request_params
         HashWithIndifferentAccess.new(
           {
             state: omniauth_state
-          })
+          }
+        )
       end
 
       def example_environment
         HashWithIndifferentAccess.new(
           {
             'omniauth.auth' => {}
-          })
+          }
+        )
       end
     end
   end
 end
-

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -69,6 +69,7 @@ RSpec.configure do |config|
   config.include XMLBlockMatchers
   config.before(:suite) do
     Faker::Config.locale = 'en-GB'
+    DatabaseCleaner.clean_with :truncation
   end
 
   # Add support for Devise authentication helpers

--- a/spec/services/oauth_session_saver_spec.rb
+++ b/spec/services/oauth_session_saver_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.describe OauthSessionSaver do
+  let(:session) do
+    {
+      'session_id' => 'c38047b5f6a12c9de1540621ac8dc7d3',
+      'current_application_id' => '583496de-f14e-46b5-bbff-8f95b4d6af22',
+      'page_history_id' => 'c121c57a-2802-4793-b700-af30b212d63b',
+      'warden.user.applicant.key' => [['50b98c1b-cf5d-428e-b32c-d20e9d1184dd'], nil],
+      '_csrf_token' => 'bHisWZcUID4DqymnSBSyJ31OghMf8cop4Aw/9RJ3T9c=',
+      'provider_id' => 'mock',
+      'omniauth.state' => '6ab2a928a9ac79ff38ad32f73c47db3fce9a0a8f5d069a76'
+    }
+  end
+  let(:key) { SecureRandom.uuid }
+  let(:redis) { Redis.new(url: Rails.configuration.x.redis.oauth_session_url) }
+
+  describe '.store' do
+    it 'stores the session in the redis database as JSON' do
+      OauthSessionSaver.store(key, session)
+      stored_session = redis.get(key)
+      expect(stored_session).to eq session.to_json
+    end
+
+    it 'remaining time-to-live is less than the services TTL value' do
+      OauthSessionSaver.store(key, session)
+      expect(redis.ttl(key) <= OauthSessionSaver::TIME_TO_LIVE_IN_SECONDS).to be true
+    end
+  end
+
+  describe '.get' do
+    context 'a record with the key exists' do
+      before { redis.set(key, session.to_json) }
+      it 'returns the reconstituted session hash' do
+        expect(OauthSessionSaver.get(key)).to eq session
+      end
+    end
+
+    context 'no such record exists' do
+      it 'returns empty array' do
+        expect(OauthSessionSaver.get(SecureRandom.uuid)).to eq({})
+      end
+    end
+  end
+
+  describe '.destroy!' do
+    before { redis.set(key, session.to_json) }
+    it 'deletes the record from the redis database' do
+      OauthSessionSaver.destroy!(key)
+      expect(redis.get(key)).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
## Allow for session being deleted when collecting bank transactions

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1778)

We have seen instances of applicants using mobile phones having the session destroyed between making the call to true layer and receiving the call back, which in turn causes an Omniauth CSRF error.  We believe this behaviour is caused by the applicant switching to another app on their mobile phone to look up their credentials and then switching back to the browser to continue.  This has been observed to happen.

Adding the `rememberable` Devise module is not enough to cure this problem because at the start of the applicant journey, the magic link is decoded to provide a `legal_aid_application_id` which is stored in the session.  So even with the `rememberable` module enabled, the new session will not contain the legal_aid_application_id.

The solution is during the request phase of the call to TrueLayer, to store the session in the redis database twice - once with a key of the state variable, and once with the key of the `applicant id`.  The is because it is needed during the callback phase of Omniauth, which only knows about the state variable, and again by the `gather_transactions_controller` which only knows about the `applicant_id`.  The records are written to redis with an expiry time of 10 minutes, and are in any case deleted once they have been successfully retrieved.

- Added `rememberable` to the `Applicant` model and to the relevant contollers.
- Called 'remember_me` in the `BanksController` to instantiate the devise cookie 
- Called `forget_me` in the `CheckAnswersController` to invalidate the devise cookie
- Replaced the before_action `authenticate_applicant!` in the `CitizenBaseController` with the method `authenticate_with_devise` which just calls `authenticate_applicant!`.  This enables it to be overridden in the `GatherTransactionsContoller` that have to restore the session before authentication
- Created `OauthSessionSaver` service to handle storage, retrieval and deletion of session data in the redis database
- Call `OauthSessionSaver.store` to store the session in the request phase of the omniauth strategy
- Call `OauthSessionSaver.get` and `OauthSessionSaver.destroy` in the callback phase of omniauth strategy
- Call `OauthSessionSaver.get` and `OauthSessionSaver.destroy` in `GatherTransactionController`


## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
