### PR TITLE
AP-1745 Error handling when Clamav is down or raises an error

### DIFF
--- a/app/forms/statement_of_cases/statement_of_case_form.rb
+++ b/app/forms/statement_of_cases/statement_of_case_form.rb
@@ -61,6 +61,7 @@ module StatementOfCases
       return if original_file.nil?
 
       @original_file_name = original_file.original_filename
+      scanner_down(original_file)
       malware_scan(original_file)
       disallowed_content_type(original_file)
       file_empty(original_file)
@@ -89,6 +90,12 @@ module StatementOfCases
       return if original_file.content_type.in?(ALLOWED_CONTENT_TYPES)
 
       errors.add(:original_file, original_file_error_for(:content_type_invalid, file_name: @original_file_name))
+    end
+
+    def scanner_down(original_file)
+      return if malware_scan_result(original_file).scanner_working
+
+      errors.add(:original_file, original_file_error_for(:system_down, file_name: @original_file_name))
     end
 
     def malware_scan(original_file)

--- a/app/services/malware_scanner.rb
+++ b/app/services/malware_scanner.rb
@@ -1,6 +1,4 @@
 class MalwareScanner
-  ClamdscanError = Class.new(StandardError)
-
   def self.call(**args)
     new(**args).call
   end
@@ -20,6 +18,7 @@ class MalwareScanner
       uploader: uploader,
       virus_found: virus_found?,
       scan_result: scan_result.result,
+      scanner_working: scanner_down?,
       file_details: file_details
     )
 
@@ -36,12 +35,16 @@ class MalwareScanner
     @virus_found ||= !scan_result.status.success?
   end
 
+  def scanner_down?
+    scan_result.status.exitstatus != 2
+  end
+
   def scan_result
     @scan_result ||= begin
       stdout, stderr, status = Open3.capture3(*(command + [file_path.to_s]))
       result = stdout.strip
 
-      raise ClamdscanError, (stderr.presence || stdout) if status.exitstatus == 2
+      Raven.capture_message("ClamdscanError, #{stderr.presence || stdout}") if status.exitstatus == 2
 
       OpenStruct.new(
         result: result,

--- a/app/services/malware_scanner.rb
+++ b/app/services/malware_scanner.rb
@@ -18,7 +18,7 @@ class MalwareScanner
       uploader: uploader,
       virus_found: virus_found?,
       scan_result: scan_result.result,
-      scanner_working: scanner_down?,
+      scanner_working: scanner_working?,
       file_details: file_details
     )
 
@@ -35,8 +35,11 @@ class MalwareScanner
     @virus_found ||= !scan_result.status.success?
   end
 
-  def scanner_down?
-    scan_result.status.exitstatus != 2
+  def scanner_working?
+    return true unless scan_result.status.exitstatus == 2
+
+    Raven.capture_message("ClamdscanError, #{scan_result.error.presence || scan_result.result}")
+    false
   end
 
   def scan_result
@@ -44,11 +47,10 @@ class MalwareScanner
       stdout, stderr, status = Open3.capture3(*(command + [file_path.to_s]))
       result = stdout.strip
 
-      Raven.capture_message("ClamdscanError, #{stderr.presence || stdout}") if status.exitstatus == 2
-
       OpenStruct.new(
         result: result,
-        status: status
+        status: status,
+        error: stderr
       )
     end
   end

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -388,6 +388,7 @@ en:
               file_empty: The selected file is empty
               file_too_big: The selected file must be smaller than %{size}MB
               file_virus: The selected file contains a virus
+              system_down: There was a problem uploading your file - try again
               no_file_chosen: You must choose at least one file
             statement:
               blank: Either attach a file or enter text

--- a/db/migrate/20201022121901_add_status_to_malware_scan_results.rb
+++ b/db/migrate/20201022121901_add_status_to_malware_scan_results.rb
@@ -1,0 +1,5 @@
+class AddStatusToMalwareScanResults < ActiveRecord::Migration[6.0]
+  def change
+    add_column :malware_scan_results, :scanner_working, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -469,6 +469,7 @@ ActiveRecord::Schema.define(version: 2020_11_02_133306) do
     t.json "file_details"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "scanner_working"
     t.index ["uploader_type", "uploader_id"], name: "index_malware_scan_results_on_uploader_type_and_uploader_id"
   end
 

--- a/spec/requests/providers/statement_of_case_spec.rb
+++ b/spec/requests/providers/statement_of_case_spec.rb
@@ -122,6 +122,18 @@ RSpec.describe 'provider statement of case requests', type: :request do
           end
         end
       end
+
+      context 'virus scanner is down' do
+        before do
+          allow_any_instance_of(MalwareScanResult).to receive(:scanner_working).with(any_args).and_return(false)
+        end
+
+        it 'returns error message' do
+          subject
+          error = I18n.t('activemodel.errors.models.statement_of_case.attributes.original_file.system_down')
+          expect(response.body).to include(error)
+        end
+      end
     end
 
     context 'Continue button pressed' do

--- a/spec/services/malware_scanner_spec.rb
+++ b/spec/services/malware_scanner_spec.rb
@@ -51,20 +51,17 @@ RSpec.describe MalwareScanner do
       end
     end
 
-    context 'command fails' do
-      let(:file_path) { Rails.root.join("spec/fixtures/files/#{SecureRandom.hex}") }
-
-      it 'raises an error' do
-        expect { subject }.to raise_error(described_class::ClamdscanError)
-      end
-    end
-
-    context 'command returns an error' do
-      let(:scan_result) { ["failed: No such file or directory. ERROR\n", '', double('process_status', exitstatus: 2)] }
+    context 'scanner down' do
+      let(:scan_result) { ["failed: No such file or directory. ERROR\n", '', double('process_status', exitstatus: 2, success?: false)] }
       before { allow(Open3).to receive(:capture3).and_return(scan_result) }
 
-      it 'raises an error' do
-        expect { subject }.to raise_error(described_class::ClamdscanError)
+      it 'returns false' do
+        expect(subject.scanner_working).to eq false
+      end
+
+      it 'notifies sentry' do
+        expect(Raven).to receive(:capture_message).with(/ClamdscanError, failed: No such file or directory. ERROR/)
+        subject
       end
     end
 


### PR DESCRIPTION
## AP-1745 Error handling when Clamav is down or raises an error

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1745)

- Add an error message when the clamadscan is down.
- Replace the raising of error :ClamdscanError with a raven capture message
- Update tests

This is a temporary fix until we turn this malware scanning into a worker/job that can be retried automatically.


## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
