### PR TITLE
Remove full stop from 'Application created' page

### DIFF
--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -40,7 +40,7 @@ en:
         happen_next_heading: What happens next
         happen_next_text: You can continue your application once your client has shared their financial information.
         let_you_know_text: We'll let you know once they've done this.
-        sent_email_text:  "We've sent an email to %{email}."
+        sent_email_text:  "We've sent an email to %{email}"
         sub_title: Your case reference is
     bank_transactions:
       list_selected:
@@ -466,7 +466,7 @@ en:
             income from a property or lodger
             pension payments
         is_this_correct: Is this correct?
-        student_finance: 
+        student_finance:
           heading: Student finance
           info: Your client also told us they'll get %{student_finance} in student finance this academic year.
         error: Select yes if your client does not receive these payments


### PR DESCRIPTION
**What**

https://dsdmoj.atlassian.net/browse/AP-1439

Page:/providers/applications/[client id]/application_confirmation

Remove full stop from 'We've sent an email to [email address].' as it could be seen as a typo. 

**Checklist**

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
