### PR TITLE
AP1-1767 Remove html attribute pattern to prevent html form validation

### DIFF
--- a/app/views/shared/forms/_date_part_input_fields.html.erb
+++ b/app/views/shared/forms/_date_part_input_fields.html.erb
@@ -8,6 +8,6 @@
 <div class="govuk-date-input__item">
   <div class="govuk-form-group">
     <%= form.label field_name, class: ['govuk-date-input__label govuk-label'], for: input_id %>
-    <%= form.text_field field_name, id: input_id, class: ["govuk-input govuk-date-input__input govuk-input--width-#{width} #{field_error_class}"], pattern: "[0-9]*", inputmode: "numeric" %>
+    <%= form.text_field field_name, id: input_id, class: ["govuk-input govuk-date-input__input govuk-input--width-#{width} #{field_error_class}"], inputmode: "numeric" %>
   </div>
 </div>


### PR DESCRIPTION
## AP1-1767 Remove html attribute pattern to prevent html form validation

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1767)

Remove html attribute pattern to prevent html form validation because we use our form object to validate not the html as it was not showing gds style errors.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
