### PR TITLE
Helper method to compare HTML in Rspec

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -111,3 +111,11 @@ def set_session(vars = {}) # rubocop:disable Naming/AccessorMethodName
     expect(session[var]).to be_present
   end
 end
+
+# encodes strings to HTML so that comparisons like "O'Keefe & Sons" don't fail
+# for some reason, most entities are translated to their named equivalent, e.g. &amp;
+# but apostrophes are translated to decimal equivalent, '&#39;'
+#
+def html_compare(string)
+  HTMLEntities.new.encode(string).gsub('&apos;', '&#39;')
+end

--- a/spec/requests/citizens/check_answers_spec.rb
+++ b/spec/requests/citizens/check_answers_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe 'check your answers requests', type: :request do
 
     it 'displays the name of the firm' do
       subject
-      expect(response.body).to include(html_encode(firm.name))
+      expect(response.body).to include(html_compare(firm.name))
     end
 
     context 'firms with special characters in the name' do

--- a/spec/requests/citizens/check_answers_spec.rb
+++ b/spec/requests/citizens/check_answers_spec.rb
@@ -60,7 +60,15 @@ RSpec.describe 'check your answers requests', type: :request do
 
     it 'displays the name of the firm' do
       subject
-      expect(response.body).to include(HTMLEntities.new.encode(firm.name))
+      expect(response.body).to include(html_encode(firm.name))
+    end
+
+    context 'firms with special characters in the name' do
+      let(:firm) { create :firm, name: %q(O'Keefe & Sons - "Pay less with  <The master builders>!") }
+      it 'finds the firm even though it has special characters' do
+        subject
+        expect(response.body).to include(html_compare(firm.name))
+      end
     end
   end
 


### PR DESCRIPTION
## Helper method to compare HTML in Rspec

Rspec occasionally fails if Faker generates a firm name (or person's name) with an apostrophe.
the line

   `expect(response.body).to include(firm.name)`

will fail if the firm name is "O'Keefe & Sons" because the response body contains the special 
characters apostrophe and ampersand encoded into HTML entities.  

In a further little twist sent just to torment us, it encodes most special characters as the named enitity, e.g. the ampersand as `&amp;` but the apostrophe as a decimal entity `&#39;` rather than the more usual  `&apos;`.

This PR adds a method `html_compare` to `rails_helper.rb` which can be used to overcome that, and so the line above can be written

   `expect(response.body).to include(html_compare(firm.name))`

and always pass no matter what Faker throws at it.



Describe what you did and why.

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
