### PR TITLE
AP-1582 Valuable items content and validation

### DIFF
--- a/app/forms/citizens/other_assets_form.rb
+++ b/app/forms/citizens/other_assets_form.rb
@@ -22,13 +22,16 @@ module Citizens
 
     OTHER_CHECKBOXES = %i[check_box_second_home check_box_valuable_items_value none_selected].freeze
 
+    INDIVIDUALLY_VALIDATED = %i[second_home_percentage valuable_items_value].freeze
+
     ALL_ATTRIBUTES = (SECOND_HOME_ATTRIBUTES + SINGLE_VALUE_ATTRIBUTES + VALUABLE_ITEMS_VALUE_ATTRIBUTE).freeze
 
     CHECK_BOXES_ATTRIBUTES = (SINGLE_VALUE_ATTRIBUTES.map { |attribute| "check_box_#{attribute}".to_sym } + OTHER_CHECKBOXES).freeze
 
     validates(:second_home_percentage, numericality: { greater_than_or_equal_to: 0 }, allow_blank: true)
+    validates(:valuable_items_value, currency: { greater_than_or_equal_to: 500 }, allow_blank: true)
     validates(*SECOND_HOME_ATTRIBUTES, presence: true, if: proc { |form| form.check_box_second_home.present? })
-    validates(*ALL_ATTRIBUTES - [:second_home_percentage], allow_blank: true, currency: { greater_than_or_equal_to: 0 })
+    validates(*ALL_ATTRIBUTES - INDIVIDUALLY_VALIDATED, allow_blank: true, currency: { greater_than_or_equal_to: 0 })
     validates(*VALUABLE_ITEMS_VALUE_ATTRIBUTE, presence: true, if: proc { |form| form.__send__(:check_box_valuable_items_value).present? })
 
     SINGLE_VALUE_ATTRIBUTES.each do |attribute|

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -51,7 +51,7 @@ en:
         used_delegated_functions_year: Year
       statement_of_case:
         file_uploaded: "You have uploaded %{file_name}"
-        file_deleted: "You have deleted %{file_name}"  
+        file_deleted: "You have deleted %{file_name}"
       vehicle:
         purchased_on_day: Day
         purchased_on_month: Month
@@ -251,7 +251,7 @@ en:
           attributes:
             valuable_items_value:
               blank: Enter the estimated total value of valuable items
-              greater_than_or_equal_to: Estimated valuable item value must be 0 or more
+              greater_than_or_equal_to: Estimated value must be £500 or more
               not_a_number: Estimated valuable items value must be an amount of money, like 60,000
               too_many_decimals: Estimated valuable items value must not include more than 2 decimal numbers
             land_value:

--- a/config/locales/en/shared.yml
+++ b/config/locales/en/shared.yml
@@ -221,7 +221,7 @@ en:
         attribute:
           citizens:
             other_assets:
-              check_box_valuable_items_value: Any valuable items worth more than £500
+              check_box_valuable_items_value: Any valuable items worth £500 or more
               check_box_land_value: Land
               check_box_inherited_assets_value: Money or assets from the estate of a person who has died
               check_box_money_owed_value: Money owed to you, including from a private mortgage
@@ -258,7 +258,7 @@ en:
               plc_shares: Enter the total value of all you own
           providers:
             other_assets:
-              check_box_valuable_items_value: Any valuable items worth more than £500
+              check_box_valuable_items_value: Any valuable items worth £500 or more
               check_box_land_value: Land
               check_box_inherited_assets_value: Money or assets from the estate of a person who has died
               check_box_money_owed_value: Money owed to them, including from a private mortgage
@@ -267,7 +267,7 @@ en:
               check_box_second_home_value: Second property or holiday home estimated value
               check_box_timeshare_property_value: Timeshare property
               check_box_trust_value: Interest in a trust
-              valuable_items_value: Enter estimated total value, minus any sale costs
+              valuable_items_value: Enter the estimated value
               land_value: Enter estimated value
               inherited_assets_value: Enter estimated total value
               money_owed_value: Enter estimated amount owed

--- a/spec/forms/citizens/other_assets_form_spec.rb
+++ b/spec/forms/citizens/other_assets_form_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe Citizens::OtherAssetsForm do
         check_box_land_value: 'true',
         land_value: '1,234.55',
         check_box_valuable_items_value: 'true',
-        valuable_items_value: '566.0',
+        valuable_items_value: valuable_items_value,
         check_box_inherited_assets_value: 'true',
         inherited_assets_value: '3,500',
         check_box_money_owed_value: 'true',
@@ -109,6 +109,7 @@ RSpec.describe Citizens::OtherAssetsForm do
         trust_value: '3,560,622.77',
         none_selected: '' }
     end
+    let(:valuable_items_value) { '566.0' }
 
     describe 'instantiation' do
       context 'from an existing record' do
@@ -131,6 +132,19 @@ RSpec.describe Citizens::OtherAssetsForm do
 
               it 'is valid' do
                 expect(form).to be_valid
+              end
+            end
+          end
+
+          context 'invalid form params' do
+            let(:submitted_params) { params }
+
+            describe 'when valuable_items_value is below threshold' do
+              let(:valuable_items_value) { '499.0' }
+
+              it 'is invalid' do
+                expect(form).to be_invalid
+                expect(form.errors[:valuable_items_value]).to eq [translation_for(:valuable_items_value, 'greater_than_or_equal_to')]
               end
             end
           end


### PR DESCRIPTION
*What*
[Link to story](https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=233&projectKey=AP&modal=detail&selectedIssue=AP-1582&assignee=5f968777632c6200712e443f)

Description
1/ Change check box text from ‘Any valuable items worth over £500’ to ‘Any valuable items worth £500 or more’.
Reason: our current text does not allow for items worth exactly £500.

2/ Change hint text from ‘Enter the estimated value, minus any sale costs’ to ‘Enter the estimated value’.
Reason: spoke to Dave about this and he agreed that asking for the estimated value is sufficient here, without the added burden of the provider or client having to guess or find out ‘sale costs’.

3/ Validation and Error message if value less than £500 entered:
Estimated value must be £500 or more

User Story
As a provider,
I want to understand what I am being asked for my client’s valuable items and I want to be told if there is an error if I have put an amount that is less than £500
so that I can be as accurate as possible with the means assessment

*Checklist*

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
