### PR TITLE
AP-1636 updated content on means calculation result eligibility page

### DIFF
--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -66,7 +66,7 @@ en:
         heading: '%{name} could be eligible for legal aid'
         details:
           - Based on their financial situation, your client may not have to pay towards legal aid.
-          - You still need to provide details of the case before we can grant legal aid.
+          - You still need to provide details of the case before we can decide if they’re eligible.
       not_eligible:
         heading: '%{name} is unlikely to get legal aid'
         detail: This is because they have too much disposable capital.
@@ -74,7 +74,7 @@ en:
         heading: '%{name} may need to pay towards legal aid'
         details:
           - 'We’ve calculated that your client should pay %{amount} from their disposable capital.'
-          - 'You still need to provide details of the case before we can grant legal aid.'
+          - 'You still need to provide details of the case before we can decide if they’re eligible.'
       manual_check_required:
         heading: We need to check if %{name} should pay towards legal aid
         details:
@@ -97,7 +97,7 @@ en:
         heading: '%{name} could be eligible for legal aid'
         details:
           - Based on their financial situation, your client may not have to pay towards legal aid.
-          - You still need to provide details of the case before we can grant legal aid.
+          - You still need to provide details of the case before we can decide if they’re eligible.
       not_eligible:
         heading: '%{name} is unlikely to get legal aid'
         detail: 'This is because they have too much disposable capital.'
@@ -105,11 +105,11 @@ en:
         heading: '%{name} may need to pay towards legal aid'
         details:
           - 'We’ve calculated that your client should pay %{amount} from their disposable capital.'
-          - 'You still need to provide details of the case before we can grant legal aid.'
+          - 'You still need to provide details of the case before we can decide if they’re eligible.'
       capital_and_income_contribution_required:
         heading: '%{name} may need to pay towards legal aid'
         line_1: "We've calculated that your client should pay:"
-        line_2: You still need to provide details of the case before we can grant legal aid.
+        line_2: You still need to provide details of the case before we can decide if they’re eligible.
         details:
           - '%{income_contribution} from their disposable income'
           - '%{capital_contribution} from their disposable capital'
@@ -117,7 +117,7 @@ en:
         heading: '%{name} may need to pay towards legal aid'
         details:
           - "We’ve calculated that your client should pay %{amount} from their disposable income."
-          - 'You still need to provide details of the case before we can grant legal aid.'
+          - 'You still need to provide details of the case before we can decide if they’re eligible.'
       manual_check_required:
         heading: We need to check if %{name} should pay towards legal aid
         details:
@@ -466,7 +466,7 @@ en:
             income from a property or lodger
             pension payments
         is_this_correct: Is this correct?
-        student_finance: 
+        student_finance:
           heading: Student finance
           info: Your client also told us they'll get %{student_finance} in student finance this academic year.
         error: Select yes if your client does not receive these payments


### PR DESCRIPTION
*What*

[Link to story](https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=233&projectKey=AP&modal=detail&selectedIssue=AP-1636&assignee=5f968777632c6200712e443f)

The following content is potentially misleading as it sounds like getting legal aid is a formality once the case details are entered:
You still have to provide details of the case before we can grant legal aid.

Change it to:
You still need to provide details of the case before we can decide if they’re eligible.

All 6 instances of this page should be updated.

*Checklist*

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
