### PR TITLE
tech-debt: update circle flow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -418,6 +418,7 @@ workflows:
       - deploy_staging:
           requires:
             # - webhint_reports
+            - integration_tests
             - unit_tests
             - build_and_push
       - hold_production_notification:


### PR DESCRIPTION
## What

In some of the work to ignore webhint and turn uat deploys
off and on again some of the jobs got orphaned.

It was possible for the cucumber tests to fail and still push to live
It is still possible for master uat deploy to fail but as the helm
work is progressing I will leave that one for now!

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
