### PR TITLE
AP-1768 BugFix No method error

### DIFF
--- a/app/mailers/submit_application_reminder_mailer.rb
+++ b/app/mailers/submit_application_reminder_mailer.rb
@@ -18,7 +18,7 @@ class SubmitApplicationReminderMailer < BaseApplyMailer
       ref_number: application['application_ref'],
       client_name: application.applicant.full_name,
       delegated_functions_date: application['used_delegated_functions_on']&.strftime('%d %B %Y'),
-      deadline_date: application['substantive_application_deadline_on'].strftime('%d %B %Y')
+      deadline_date: application['substantive_application_deadline_on']&.strftime('%d %B %Y')
     )
     mail to: to
   end

--- a/app/mailers/submit_application_reminder_mailer.rb
+++ b/app/mailers/submit_application_reminder_mailer.rb
@@ -17,7 +17,7 @@ class SubmitApplicationReminderMailer < BaseApplyMailer
       provider_name: name,
       ref_number: application['application_ref'],
       client_name: application.applicant.full_name,
-      delegated_functions_date: application['used_delegated_functions_on'].strftime('%d %B %Y'),
+      delegated_functions_date: application['used_delegated_functions_on']&.strftime('%d %B %Y'),
       deadline_date: application['substantive_application_deadline_on'].strftime('%d %B %Y')
     )
     mail to: to


### PR DESCRIPTION
## AP-1768 BugFix No method error

When sending an email to the provider called SubmitApplicationReminder it fails because it is missing the delegated functions date.

[Link to story](https://dsdmoj.atlassian.net/browse/AP-XXX)

- Add safe operator for when delegated function date is nil. This resolves an error, preventing a sentry error being sent whilst the sidekiq job restarts.

- Add a safe operator into the SubmitApplicationReminderMailer for substantive_application_deadline_on because there was an error that had no used_delegated_functions_on which could also mean it'll have no substantive_application_deadline_on


## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
