### PR TITLE
AP-1572 Opponent page large gap between heading and first question

### DIFF
--- a/app/views/providers/respondents/show.html.erb
+++ b/app/views/providers/respondents/show.html.erb
@@ -9,8 +9,6 @@
         local: true
       ) do |form| %>
 
-    <div class="govuk-!-padding-bottom-7"></div>
-
     <%
       questions = %i[understands_terms_of_court_order warning_letter_sent].map do |attr|
         OpenStruct.new(


### PR DESCRIPTION
**What**

[Link to story](https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=233&projectKey=AP&modal=detail&selectedIssue=AP-1572&assignee=5f968777632c6200712e443f)

Fixed the respondent page where there was a large gap between heading and first question 'Does the opponent have the mental capacity...' .

**Checklist**

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
