### PR TITLE
Change text of provider declaration to include benefits fraud

### DIFF
--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -218,7 +218,7 @@ en:
           they may have to repay the legal costs if they keep or gain property or money at the end of the case (the 'statutory charge')
           the information they’ve given is complete and correct
           they’ll report any changes to their financial situation immediately
-        sign_app_text: 'If your client gives wrong or incomplete information, or they do not report changes, they may:'
+        sign_app_text: 'If your client gives wrong or incomplete information, does not report changes, or is found to have committed benefit fraud, they may:'
         warning:
           list: |
             be prosecuted


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=233&modal=detail&selectedIssue=AP-1397)

Updated the declaration text in the providers.yml file to include mention of benefits fraud, so that providers are aware of the consequences of their client committing benefits fraud. 

Note: The shared.yml file which contains the text for the application_declaration already includes content regarding benefits fraud, so I did not update this. 

## Checklist

Before you ask people to review this PR:

- [X] Tests and rubocop should be passing: `bundle exec rake`
- [X] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [X] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [X] The PR description should say what you changed and why, with a link to the JIRA story.
- [X] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [X] You should have checked that the commit messages say why the change was made.
