### PR TITLE
BUGFIX: error on legal_aid_application_spec.rb:278

### DIFF
--- a/spec/models/legal_aid_application_spec.rb
+++ b/spec/models/legal_aid_application_spec.rb
@@ -274,7 +274,7 @@ RSpec.describe LegalAidApplication, type: :model do
 
       context 'outgoing transactions' do
         let!(:bank_transaction) { create :bank_transaction, :debit, transaction_type: nil, bank_account: bank_account }
-        let!(:transaction_type) { create :transaction_type, :debit }
+        let!(:transaction_type) { create :transaction_type, :debit, :friends_or_family }
         it 'returns true' do
           expect(legal_aid_application.uncategorised_transactions?(:debit)).to eq true
         end


### PR DESCRIPTION
## What

This was caused by the transaction type factory picking a value from
TransactionType::NAMES.values.flatten.sample

When this was excluded_benefits the handling was just different
enough to cause the test to fail.  Because it was randomised within
the factory re-running rspec with the same seed would not provide the
same type on a subsequent run!

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
