### PR TITLE
AP-1781 BugFix for flow on delete path

### DIFF
--- a/app/services/flow/flows/provider_start.rb
+++ b/app/services/flow/flows/provider_start.rb
@@ -108,6 +108,9 @@ module Flow
         use_ccms: {
           path: ->(application) { urls.providers_legal_aid_application_use_ccms_path(application) }
         },
+        delete: {
+          path: ->(application) { urls.providers_legal_aid_application_delete_path(application) }
+        },
         use_ccms_employed: {
           path: ->(application) { urls.providers_legal_aid_application_use_ccms_employed_index_path(application) }
         },

--- a/spec/services/flow/base_flow_service_spec.rb
+++ b/spec/services/flow/base_flow_service_spec.rb
@@ -118,6 +118,14 @@ RSpec.describe Flow::BaseFlowService do
           end
         end
       end
+
+      context 'path for step is not defined' do
+        let(:path) { nil }
+
+        it 'raises an error' do
+          expect { subject.current_path }.to raise_error(/not defined/)
+        end
+      end
     end
 
     describe '#forward_path' do


### PR DESCRIPTION
## AP-1781 BugFix for flow on delete path

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1781)

Add a FlowStep for the delete page to prevent the below error:

```
Flow::FlowError
:path of step :delete is not defined
```

The error occurred when clicking on the delete page as it was not a part of the flow and had no path for step :delete

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
