### PR TITLE
Remove webhint from Rake

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,5 +7,5 @@ Rails.application.load_tasks
 
 unless Rails.env.production?
   task(:default).clear
-  task default: %i[rubocop erblint javascript_tests spec webhint:generate_reports]
+  task default: %i[rubocop erblint javascript_tests spec cucumber]
 end


### PR DESCRIPTION
## What

Webhint runs as part of the `rake` test suite. It usually fails. We've removed it from the CircleCI pipeline so it also makes sense to also remove it here, replacing it with `cucumber` so that the feature tests still run.

Webhint can still be run locally by running `rake webhint:generate_reports`.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
