### PR TITLE
AP-1784 record reason for transitioning to use_ccms

### DIFF
--- a/app/controllers/citizens/additional_accounts_controller.rb
+++ b/app/controllers/citizens/additional_accounts_controller.rb
@@ -41,7 +41,7 @@ module Citizens
 
     def offline_accounts_update
       legal_aid_application.update(has_offline_accounts: true)
-      legal_aid_application.use_ccms! unless legal_aid_application.use_ccms?
+      legal_aid_application.use_ccms!(:offline_accounts) unless legal_aid_application.use_ccms?
     end
 
     def error

--- a/app/controllers/citizens/consents_controller.rb
+++ b/app/controllers/citizens/consents_controller.rb
@@ -17,7 +17,7 @@ module Citizens
     private
 
     def change_application_state
-      legal_aid_application.use_ccms! if @form.open_banking_consent != 'true'
+      legal_aid_application.use_ccms!(:no_banking_consent) if @form.open_banking_consent != 'true'
     end
 
     def form_params

--- a/app/controllers/providers/applicant_employed_controller.rb
+++ b/app/controllers/providers/applicant_employed_controller.rb
@@ -1,6 +1,7 @@
 module Providers
   class ApplicantEmployedController < ProviderBaseController
     def index
+      @legal_aid_application.reset_from_use_ccms! if @legal_aid_application.use_ccms?
       @form = Applicants::EmployedForm.new(model: applicant)
     end
 

--- a/app/controllers/providers/check_benefits_controller.rb
+++ b/app/controllers/providers/check_benefits_controller.rb
@@ -27,7 +27,7 @@ module Providers
 
       return false if provider.non_passported_permissions? && Setting.allow_non_passported_route?
 
-      legal_aid_application.use_ccms! unless legal_aid_application.use_ccms?
+      legal_aid_application.use_ccms!(:non_passported) unless legal_aid_application.use_ccms?
       true
     end
 

--- a/app/controllers/providers/use_ccms_employed_controller.rb
+++ b/app/controllers/providers/use_ccms_employed_controller.rb
@@ -1,5 +1,7 @@
 module Providers
   class UseCcmsEmployedController < ProviderBaseController
-    def index; end
+    def index
+      @legal_aid_application.use_ccms!(:employed)
+    end
   end
 end

--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -96,6 +96,7 @@ class LegalAidApplication < ApplicationRecord # rubocop:disable Metrics/ClassLen
            :submitting_assessment?,
            :use_ccms?,
            :summary_state,
+           :ccms_reason,
            to: :state_machine_proxy
 
   scope :latest, -> { order(created_at: :desc) }

--- a/app/services/reports/mis/non_passported_application_csv_line.rb
+++ b/app/services/reports/mis/non_passported_application_csv_line.rb
@@ -10,6 +10,7 @@ module Reports
         %w[
           application_ref
           state
+          ccms_reason
           username
           provider_email
           created_at
@@ -28,6 +29,7 @@ module Reports
       def call
         @line << laa.application_ref
         @line << laa.state
+        @line << laa.ccms_reason
         @line << laa.provider.username
         @line << provider.email
         @line << laa.created_at.strftime('%Y-%m-%d %H:%M:%S')

--- a/app/services/reports/mis/non_passported_applications_report.rb
+++ b/app/services/reports/mis/non_passported_applications_report.rb
@@ -8,7 +8,7 @@ module Reports
       def run
         csv_string = CSV.generate do |csv|
           csv << NonPassportedApplicationCsvLine.header_row
-          legal_aid_applications.find_each(batch_size: 100) do |legal_aid_application|
+          legal_aid_applications.each do |legal_aid_application|
             csv << NonPassportedApplicationCsvLine.call(legal_aid_application)
           end
         end

--- a/app/services/reports/mis/non_passported_applications_report.rb
+++ b/app/services/reports/mis/non_passported_applications_report.rb
@@ -21,7 +21,6 @@ module Reports
         LegalAidApplication.joins(:state_machine)
                            .where(created_at: [START_DATE..END_TIME])
                            .where(state_machine_proxies: { type: 'NonPassportedStateMachine' })
-                           .where.not(state_machine_proxies: { aasm_state: EXCLUDED_STATES })
                            .order(:created_at)
       end
     end

--- a/db/migrate/20201105112815_add_reason_to_state_machine_proxies.rb
+++ b/db/migrate/20201105112815_add_reason_to_state_machine_proxies.rb
@@ -1,0 +1,6 @@
+class AddReasonToStateMachineProxies < ActiveRecord::Migration[6.0]
+  def up
+    add_column :state_machine_proxies, :ccms_reason, :string
+    execute "UPDATE state_machine_proxies SET ccms_reason = 'unknown' WHERE aasm_state = 'use_ccms'"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_02_133306) do
+ActiveRecord::Schema.define(version: 2020_11_05_112815) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -686,6 +686,7 @@ ActiveRecord::Schema.define(version: 2020_11_02_133306) do
     t.string "aasm_state"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "ccms_reason"
   end
 
   create_table "statement_of_cases", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/factories/legal_aid_applications.rb
+++ b/spec/factories/legal_aid_applications.rb
@@ -168,6 +168,12 @@ FactoryBot.define do
       end
     end
 
+    trait :use_ccms_employed do
+      before(:create) do |application|
+        application.state_machine_proxy.update(aasm_state: :use_ccms, ccms_reason: :employed)
+      end
+    end
+
     #############################################################################
 
     trait :with_irregular_income do

--- a/spec/factories/legal_aid_applications.rb
+++ b/spec/factories/legal_aid_applications.rb
@@ -67,6 +67,7 @@ FactoryBot.define do
 
     trait :applicant_entering_means do
       before(:create) do |application|
+        application.change_state_machine_type('NonPassportedStateMachine')
         application.state_machine_proxy.update(aasm_state: :applicant_entering_means)
       end
     end
@@ -163,7 +164,7 @@ FactoryBot.define do
 
     trait :use_ccms do
       before(:create) do |application|
-        application.state_machine_proxy.update(aasm_state: :use_ccms)
+        application.state_machine_proxy.update(aasm_state: :use_ccms, ccms_reason: :unknown)
       end
     end
 
@@ -408,7 +409,7 @@ FactoryBot.define do
 
     trait :at_use_ccms do
       before(:create) do |application|
-        application.state_machine_proxy.update(aasm_state: :use_ccms)
+        application.state_machine_proxy.update(aasm_state: :use_ccms, ccms_reason: :unknown)
       end
 
       provider_step { :use_ccms }
@@ -448,6 +449,7 @@ FactoryBot.define do
       with_proceeding_types
 
       before(:create) do |application|
+        application.change_state_machine_type('NonPassportedStateMachine')
         application.state_machine_proxy.update(aasm_state: :client_completed_means)
       end
 

--- a/spec/requests/admin/reports_spec.rb
+++ b/spec/requests/admin/reports_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Admin::ReportsController, type: :request do
 
     it 'sends the data' do
       subject
-      expect(response.body).to match(/^application_ref,state,username,provider_email,created_at/)
+      expect(response.body).to match(/^application_ref,state,ccms_reason,username,provider_email,created_at/)
     end
   end
 end

--- a/spec/requests/citizens/additional_accounts_spec.rb
+++ b/spec/requests/citizens/additional_accounts_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'citizen additional accounts request test', type: :request do
   context 'when an applicant revisits the page to change their answer' do
     before do
       application.update!(has_offline_accounts: true)
-      application.use_ccms!
+      application.use_ccms!(:offline_accounts)
     end
 
     it 'checks that offline account is reset to nil' do

--- a/spec/requests/providers/applicant_employed_spec.rb
+++ b/spec/requests/providers/applicant_employed_spec.rb
@@ -22,6 +22,14 @@ RSpec.describe Providers::ApplicantEmployedController, type: :request do
 
       it_behaves_like 'a provider not authenticated'
     end
+
+    context 'when the application is in use_ccms state' do
+      let(:legal_aid_application) { create :legal_aid_application, :use_ccms_employed, applicant: applicant }
+      it 'sets the state back to applicant details checked and removes the reason' do
+        expect(legal_aid_application.reload.state).to eq 'applicant_details_checked'
+        expect(legal_aid_application.ccms_reason).to be_nil
+      end
+    end
   end
 
   describe 'PATCH /providers/applications/:legal_aid_application_id/applicant_employed' do

--- a/spec/requests/providers/use_ccms_employed_spec.rb
+++ b/spec/requests/providers/use_ccms_employed_spec.rb
@@ -23,8 +23,12 @@ RSpec.describe Providers::UseCcmsEmployedController, type: :request do
       end
 
       it 'shows text to use CCMS' do
-        subject
         expect(response.body).to include(I18n.t('providers.use_ccms_employed.index.title_html'))
+      end
+
+      it 'sets state to use_ccms and reason to employed' do
+        expect(legal_aid_application.reload.state).to eq 'use_ccms'
+        expect(legal_aid_application.ccms_reason).to eq 'employed'
       end
     end
   end

--- a/spec/services/reports/mis/non_passported_application_csv_line_spec.rb
+++ b/spec/services/reports/mis/non_passported_application_csv_line_spec.rb
@@ -10,6 +10,7 @@ module Reports
           %w[
             application_ref
             state
+            ccms_reason
             username
             provider_email
             created_at
@@ -28,7 +29,7 @@ module Reports
         subject { described_class.call(application) }
 
         it 'returns an array of five fields' do
-          expect(subject.size).to eq 5
+          expect(subject.size).to eq 6
         end
 
         it 'returns an array with the expected values' do
@@ -36,16 +37,17 @@ module Reports
             fields = subject
             expect(fields[0]).to eq application.application_ref
             expect(fields[1]).to eq application.state
-            expect(fields[2]).to eq provider.username
-            expect(fields[3]).to eq provider.email
-            expect(fields[4]).to match DATE_TIME_REGEX
+            expect(fields[2]).to eq application.ccms_reason
+            expect(fields[3]).to eq provider.username
+            expect(fields[4]).to eq provider.email
+            expect(fields[5]).to match DATE_TIME_REGEX
           end
         end
 
         context 'data begins with a vulnerable character' do
           before { provider.email = '=malicious_code' }
           it 'returns the escaped text' do
-            expect(subject[3]).to eq "'=malicious_code"
+            expect(subject[4]).to eq "'=malicious_code"
           end
         end
       end

--- a/spec/services/reports/mis/non_passported_applications_report_spec.rb
+++ b/spec/services/reports/mis/non_passported_applications_report_spec.rb
@@ -57,7 +57,6 @@ module Reports
                :with_non_passported_state_machine,
                :use_ccms_employed,
                application_ref: 'L-USE-CCMS'
-
       end
 
       def create_passported_application

--- a/spec/services/reports/mis/non_passported_applications_report_spec.rb
+++ b/spec/services/reports/mis/non_passported_applications_report_spec.rb
@@ -24,11 +24,11 @@ module Reports
         end
 
         it 'returns a header line as the first line' do
-          expect(lines.first).to eq 'application_ref,state,username,provider_email,created_at'
+          expect(lines.first).to eq 'application_ref,state,ccms_reason,username,provider_email,created_at'
         end
 
         it 'returns data for the only non-passorted application after Sep 21st as second line' do
-          expect(lines[1]).to eq "L-ATE,initiated,#{username},#{email},#{created_at}"
+          expect(lines[1]).to eq "L-ATE,initiated,,#{username},#{email},#{created_at}"
         end
       end
 

--- a/spec/services/reports/mis/non_passported_applications_report_spec.rb
+++ b/spec/services/reports/mis/non_passported_applications_report_spec.rb
@@ -4,10 +4,10 @@ module Reports
   module MIS
     RSpec.describe NonPassportedApplicationsReport do
       before do
-        Timecop.freeze(10.seconds.ago) { create_early_non_passported_application }
-        Timecop.freeze(8.seconds.ago) { create_non_passported_application }
-        Timecop.freeze(6.seconds.ago) { create_non_passported_application_use_ccms }
-        Timecop.freeze(4.seconds.ago) { create_passported_application }
+        create_early_non_passported_application
+        Timecop.freeze(8.minutes.ago) { create_non_passported_application }
+        Timecop.freeze(6.minutes.ago) { create_non_passported_application_use_ccms }
+        Timecop.freeze(4.minutes.ago) { create_passported_application }
       end
 
       subject { described_class.new.run }


### PR DESCRIPTION
## Record reason for transitioning to use_ccms state

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1784)

- Added `ccms_reason` column to `state_machine_proxies`, and set all existing records in state `use_ccms` to have a `ccms_reason` of `unknown`.
- Added an after block to the `use_ccms` event on the state machine to record reason
- Updated all calls to use_ccms! to provide a reason
- Added `ccms_reason` column to Non-Passported Applications Report
- Moved `base_state_machine.rb`, `non_passported_state_machine.rb` and `passported_state_machine.rb` from `models/concerns` to `models` where they belong

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
