### PR TITLE
fix formatting of header-value displays

### DIFF
--- a/app/views/citizens/means_test_results/show.html.erb
+++ b/app/views/citizens/means_test_results/show.html.erb
@@ -5,15 +5,15 @@
     </h1>
     <div class="govuk-panel__body">
       <dl class="govuk-list inline-list">
-        <dt><%= t('.name') %>:</dt>
-        <dd>
-          <strong><%= @applicant.full_name %></strong>
-        </dd>
+        <dt>
+          <strong><%= t('.name') %>:</strong>
+        </dt>
+        <dd><%= @applicant.full_name %></dd>
 
-        <dt><%= t('.reference_number') %>:</dt>
-        <dd>
-          <strong><%= @legal_aid_application.application_ref %></strong>
-        </dd>
+        <dt>
+          <strong><%= t('.reference_number') %>:</strong>
+        </dt>
+        <dd><%= @legal_aid_application.application_ref %></dd>
       </dl>
     </div>
   </div>

--- a/app/views/providers/delete/show.html.erb
+++ b/app/views/providers/delete/show.html.erb
@@ -1,7 +1,17 @@
 <h1 class="govuk-heading-xl"><%= t('.page_title') %></h1>
-<p class="govuk-body">
-  <%= t('.applicant') %>: <strong><%= @legal_aid_application.applicant.full_name %></strong><br>
-  <%= t('.reference') %>: <strong><%= @legal_aid_application.application_ref %></strong></p>
+<div class="govuk-panel__body">
+  <dl class="govuk-list inline-list">
+    <dt>
+      <strong><%= t('.applicant') %>:</strong>
+    </dt>
+    <dd><%= @legal_aid_application.applicant.full_name %></dd>
+
+    <dt>
+      <strong><%= t('.reference') %>:</strong>
+    </dt>
+    <dd><%= @legal_aid_application.application_ref %></dd>
+  </dl>
+</div>
 
 <div class="govuk-warning-text">
   <span class="govuk-warning-text__icon" aria-hidden="true">!</span>

--- a/app/views/providers/submitted_applications/show.html.erb
+++ b/app/views/providers/submitted_applications/show.html.erb
@@ -1,20 +1,20 @@
 <%= page_template page_title: t('.heading'), back_link: :none do %>
   <div class="print-header-wrapper">
     <dl class="govuk-list inline-list print-header">
-      <dt><%= t('.client_name') %>:</dt>
-      <dd>
-        <strong><%= @legal_aid_application.applicant_full_name %></strong>
-      </dd>
+      <dt>
+        <strong><%= t('.client_name') %>:</strong>
+      </dt>
+      <dd><%= @legal_aid_application.applicant_full_name %></dd>
 
-      <dt><%= t('.case_reference_html') %>:</dt>
-      <dd>
-        <strong><%= @legal_aid_application.application_ref %></strong>
-      </dd>
+      <dt>
+        <strong><%= t('.case_reference_html') %>:</strong>
+      </dt>
+      <dd><%= @legal_aid_application.application_ref %></dd>
 
-      <dt><%= t('.ccms_reference_html') %>:</dt>
-      <dd>
-        <strong><%= @legal_aid_application.case_ccms_reference %></strong>
-      </dd>
+      <dt>
+        <strong><%= t('.ccms_reference_html') %>:</strong>
+      </dt>
+      <dd><%= @legal_aid_application.case_ccms_reference %></dd>
 
     </dl>
   </div>

--- a/spec/requests/providers/delete_controller_spec.rb
+++ b/spec/requests/providers/delete_controller_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Providers::DeleteController, type: :request do
       end
 
       it 'displays the application data' do
-        expect(unescaped_response_body).to include("LAA reference: <strong>#{legal_aid_application.application_ref}</strong>")
+        expect(unescaped_response_body).to include(legal_aid_application.application_ref)
       end
     end
   end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1581)

Fixed the formatting of some header-value pairs to match formatting everywhere else. The header should have emphasis while the value does not. 

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
