### PR TITLE
AP-1797 strip leading and trailing spaces from email address

### DIFF
--- a/app/forms/applicants/email_form.rb
+++ b/app/forms/applicants/email_form.rb
@@ -6,7 +6,13 @@ module Applicants
 
     attr_accessor :email
 
+    before_validation :strip_email
+
     validates :email, format: { with: URI::MailTo::EMAIL_REGEXP }, allow_blank: true
     validates :email, presence: true
+
+    def strip_email
+      email.strip!
+    end
   end
 end

--- a/spec/forms/applicants/email_form_spec.rb
+++ b/spec/forms/applicants/email_form_spec.rb
@@ -41,5 +41,14 @@ RSpec.describe Applicants::EmailForm, type: :form do
         expect(subject.errors[:email]).to be_present
       end
     end
+
+    context 'stripping whitespace' do
+      let(:fake_email_address) { Faker::Internet.safe_email }
+      let(:email) { "  #{fake_email_address}  " }
+      it 'updates the applicant email with the email address without whitespece' do
+        subject.save
+        expect(applicant.reload.email).to eq fake_email_address
+      end
+    end
   end
 end


### PR DESCRIPTION
## strip leading and trailing spaces from email address

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1797)

Call `#strip!` on email address in EmailForm before validation

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
