### PR TITLE
BUGFIX: error on legal_aid_application_spec.rb:278

### DIFF
--- a/spec/factories/transaction_types.rb
+++ b/spec/factories/transaction_types.rb
@@ -16,9 +16,11 @@ FactoryBot.define do
     operation { TransactionType::NAMES.keys.sample }
 
     trait :debit do
+      name { TransactionType::NAMES[:debit].sample }
       operation { :debit }
     end
     trait :credit do
+      TransactionType::NAMES[:credit].sample
       operation { :credit }
     end
 


### PR DESCRIPTION
## What

Having a debit name with a credit type may have caused issues

This was caused by the transaction type factory picking a random
value using TransactionType::NAMES.values.flatten.sample

Because it was randomised within the factory, re-running rspec with
the same seed would not provide the same type on a subsequent run!

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
