### PR TITLE
AP-1779 Add a route for HTTP response 308

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -6,4 +6,9 @@ class ErrorsController < ApplicationController
     update_locale
     redirect_to error_path(:page_not_found, default_url_options)
   end
+
+  def permanent_redirect
+    update_locale
+    redirect_to error_path(:page_redirected, default_url_options)
+  end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -9,6 +9,9 @@ Rails.application.configure do
   # Do not eager load code on boot.
   config.eager_load = false
 
+  # Custom error pages defined in routes config
+  config.exceptions_app = routes
+
   # Show full error reports.
   config.consider_all_requests_local = true
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -4,6 +4,9 @@ Rails.application.configure do
   # Code is not reloaded between requests.
   config.cache_classes = true
 
+  # Custom error pages defined in routes config
+  config.exceptions_app = routes
+
   # Eager load code on boot. This eager loads most of Rails and
   # your application in memory, allowing both threaded web servers
   # and those relying on copy on write to perform better.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -7,6 +7,9 @@ Rails.application.configure do
   # and recreated between test runs. Don't rely on the data there!
   config.cache_classes = true
 
+  # Custom error pages defined in routes config
+  config.exceptions_app = routes
+
   # Do not eager load code on boot. This avoids loading your whole application
   # just for the purpose of running a single test. If you are using a tool that
   # preloads Rails for running tests, you may have to set it to true.

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -19,6 +19,8 @@ en:
         page_title: Page not found
         web_address_incorrect: If you typed the web address, check it is correct.
         web_address_copied: If you pasted the web address, check you copied the entire address.
+      page_redirected:
+        page_title: You are being redirected
       access_denied:
         page_title: Access denied
         permission_text: The page is not currently accessible to you

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -230,6 +230,8 @@ Rails.application.routes.draw do
     end
   end
 
+  match '/308', to: 'errors#permanent_redirect', via: :all
+
   get '/.well-known/security.txt' => redirect('https://raw.githubusercontent.com/ministryofjustice/security-guidance/master/contact/vulnerability-disclosure-security.txt')
 
   # Catch all route that traps paths not defined above. Must be last route.


### PR DESCRIPTION
## AP-1779 Add a route for HTTP response 308

From the security report (section 4.12), it was identified that information disclosed within HTTP response headers reveal system details that could assist an attacker. 

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1779)

Add a route for the http response 308 to fix a security issue revealing server name
in the http response after curl-ing the website


## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
