### PR TITLE
FLICKERING-TESTS: ensure saml setting

### DIFF
--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -74,6 +74,7 @@ RSpec.describe Provider, type: :model do
 
   describe '#cms_apply_role?' do
     let(:provider) { create :provider, roles: roles }
+    before { allow(Rails.configuration.x.laa_portal).to receive(:mock_saml).and_return(false) }
 
     context 'ccms_apply_role_present' do
       let(:roles) { 'EMI,PUI_XXCCMS_BILL_PREPARATION,ZZZ,CCMS_Apply' }

--- a/spec/requests/saml_sessions_spec.rb
+++ b/spec/requests/saml_sessions_spec.rb
@@ -43,6 +43,7 @@ RSpec.describe 'SamlSessionsController', type: :request do
       before do
         allow(Rails.configuration.x.laa_portal).to receive(:mock_saml).and_return('true')
       end
+      after { allow(Rails.configuration.x.laa_portal).to receive(:mock_saml).and_return('false') }
 
       it 'redirects to providers root' do
         subject

--- a/spec/requests/saml_sessions_spec.rb
+++ b/spec/requests/saml_sessions_spec.rb
@@ -92,6 +92,7 @@ RSpec.describe 'SamlSessionsController', type: :request do
           let(:api_response) { raw_details_response }
           let(:status) { 200 }
           let(:provider) { create :provider, :created_by_devise, :without_ccms_apply_role, username: username }
+          before { allow(Rails.configuration.x.laa_portal).to receive(:mock_saml).and_return(false) }
 
           it 'does not call the ProviderDetailsCreator' do
             expect(ProviderDetailsCreator).not_to receive(:call)

--- a/spec/services/provider_after_login_service_spec.rb
+++ b/spec/services/provider_after_login_service_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe ProviderAfterLoginService do
   describe '.call' do
     context 'provider does not have CCMS_Apply role' do
       let(:provider) { create :provider, :created_by_devise, :without_ccms_apply_role }
+      before { allow(Rails.configuration.x.laa_portal).to receive(:mock_saml).and_return(false) }
+
       it 'updates the provider invalid login details' do
         subject
         expect(provider.invalid_login_details).to eq 'role'


### PR DESCRIPTION
## What

running `rspec --seed 63916` would trigger a set of failing tests

Sometimes the mock_saml is turned on or off for a specific test
If it set and a following test needs it in the other value it
needs to be turned back to false

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
