### PR TITLE
hide delete button for submitted applications

### DIFF
--- a/app/views/providers/legal_aid_applications/_legal_aid_applications.html.erb
+++ b/app/views/providers/legal_aid_applications/_legal_aid_applications.html.erb
@@ -48,12 +48,14 @@
               <%= gov_uk_tag text: application.enum_t(:summary_state), type: application.summary_state %>
             <% end %>
             <td>
+              <% unless application.summary_state == :submitted %>
               <%= link_to_with_hidden_suffix(
-                      text: t('.delete'),
-                      path: providers_legal_aid_application_delete_path(application),
-                      klass: 'govuk-button govuk-button--secondary govuk-!-margin-bottom-0',
-                      suffix: t('.delete_suffix', reference: application.application_ref, applicant: application.applicant_full_name)
+                  text: t('.delete'),
+                  path: providers_legal_aid_application_delete_path(application),
+                  klass: 'govuk-button govuk-button--secondary govuk-!-margin-bottom-0',
+                  suffix: t('.delete_suffix', reference: application.application_ref, applicant: application.applicant_full_name)
                   ) %>
+              <% end %>
             </td>
           </tr>
         <% end %>

--- a/features/providers/deleting_applications.feature
+++ b/features/providers/deleting_applications.feature
@@ -1,8 +1,8 @@
 Feature: Deleting applications
 
   @javascript
-  Scenario: I can delete a previously created application
-    Given I have previously created multiple applications
+  Scenario: I can delete a previously created application which has not yet been submitted
+    Given I have created but not submitted an application
     When I visit the applications page
     And I click delete for the previously created application
     Then I should be on the '/delete' page showing 'Are you sure you want to delete this application?'
@@ -11,3 +11,9 @@ Feature: Deleting applications
     And I should not see the previously created application
     When I click the browser back button
     Then I should be on a page showing 'Your applications'
+
+  @javascript
+  Scenario: I cannot delete a previously created application which has been submitted
+    Given I have created and submitted an application
+    When I visit the applications page
+    Then I should not see 'Delete'

--- a/features/step_definitions/civil_journey_steps.rb
+++ b/features/step_definitions/civil_journey_steps.rb
@@ -43,6 +43,28 @@ Given('I have previously created multiple applications') do
   login_as @legal_aid_application.provider
 end
 
+Given('I have created and submitted an application') do
+  @legal_aid_application = create(
+    :application,
+    :with_everything,
+    :with_passported_state_machine,
+    :initiated,
+    provider: create(:provider)
+  )
+  login_as @legal_aid_application.provider
+end
+
+Given('I have created but not submitted an application') do
+  @legal_aid_application = create(
+    :application,
+    :with_applicant,
+    :draft,
+    :initiated,
+    provider: create(:provider)
+  )
+  login_as @legal_aid_application.provider
+end
+
 Given('I previously created a passported application and left on the {string} page') do |provider_step|
   @legal_aid_application = create(
     :application,


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1802)

On the applications list page for a provider, hide the delete button for applications with status 'submitted', since these cannot be deleted. Update the cucumber test feature 'delete_applications'.

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
