### PR TITLE
remove old command flags

### DIFF
--- a/bin/delete_uat_release
+++ b/bin/delete_uat_release
@@ -20,7 +20,7 @@ then
   if [[ $UAT_RELEASES == *"$UAT_RELEASE"* ]]
   then
     echo "Deleting UAT release $UAT_RELEASE"
-    helm delete $UAT_RELEASE --namespace=${KUBE_ENV_UAT_NAMESPACE} --purge
+    helm delete $UAT_RELEASE --namespace=${KUBE_ENV_UAT_NAMESPACE}
   else
     echo "UAT release $UAT_RELEASE was not found"
   fi

--- a/bin/uat_deploy
+++ b/bin/uat_deploy
@@ -9,7 +9,7 @@ deploy() {
   echo "Deploying CIRCLE_SHA1: $CIRCLE_SHA1 under release name: '$RELEASE_NAME'..."
 
   helm upgrade $RELEASE_NAME ./helm_deploy/apply-for-legal-aid/. \
-                --install --force --wait \
+                --install --wait \
                 --namespace=${KUBE_ENV_UAT_NAMESPACE} \
                 --values ./helm_deploy/apply-for-legal-aid/values-uat.yaml \
                 --set deploy.host="$RELEASE_HOST" \


### PR DESCRIPTION
Forgot to remove the `--force` flag from the ap-1515 PR and also the `--purge` flag



Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
