### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ In some cases a deployed branch will not be merged with `master` in which case t
 helm list --namespace=laa-apply-for-legalaid-uat --namespace=laa-apply-for-legalaid-uat --debug --all
 
 # delete a specific release
-helm delete <name-of-the-release> --namespace=laa-apply-for-legalaid-uat --purge
+helm delete --namespace=laa-apply-for-legalaid-uat <name-of-the-release>
 ```
 
 ## Dev: running locally


### PR DESCRIPTION
## What

Following the Helm3 update the --purge flag is no longer required
I also shifted the name placeholder to the end of the line, it still
works and makes it easier to cut and paste the instruction

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
