### PR TITLE
Remove timecop gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -140,7 +140,6 @@ group :test do
   gem 'shoulda-matchers', '~> 4.4'
   gem 'simplecov', require: false
   gem 'simplecov-rcov'
-  gem 'timecop'
   gem 'vcr'
   gem 'webdrivers', '~> 4.4'
   gem 'webmock'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -576,7 +576,6 @@ GEM
     thor (1.0.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
-    timecop (0.9.2)
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
     tzinfo-data (1.2020.4)
@@ -694,7 +693,6 @@ DEPENDENCIES
   spring-watcher-listen (~> 2.0.0)
   sprockets (~> 3.7.2)
   sprockets-es6 (>= 0.9.2)
-  timecop
   tzinfo-data
   vcr
   webdack-uuid_migration (~> 1.3.0)

--- a/spec/helpers/time_helper_spec.rb
+++ b/spec/helpers/time_helper_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe TimeHelper, type: :helper do
 
     before do
       new_time = Time.local(2020, 10, 1, 1, 0, 0)
-      Timecop.freeze(new_time)
+      travel_to(new_time)
     end
     it 'returns a valid date' do
       expect(helper.number_of_days_ago(days)).to eq '29 09 2020'

--- a/spec/models/scheduled_mailing_spec.rb
+++ b/spec/models/scheduled_mailing_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe ScheduledMailing do
     context 'mailer class does not override #eligible_for_delivery?' do
       let(:scheduled_mail) { create :scheduled_mailing, :due, :always_eligible_for_delivery }
       it 'delivers the mail' do
-        Timecop.freeze(now) do
+        travel_to(now) do
           expect(ResendLinkRequestMailer)
             .to receive(:notify)
             .with(scheduled_mail.legal_aid_application_id, 'Bob Marley', 'bob@wailing.jm')
@@ -47,7 +47,7 @@ RSpec.describe ScheduledMailing do
         let(:legal_aid_application) { create :legal_aid_application, :at_checking_applicant_details }
 
         it 'delivers the mail' do
-          Timecop.freeze(now) do
+          travel_to(now) do
             expect(SubmitApplicationReminderMailer)
               .to receive(:notify_provider)
               .with(scheduled_mail.legal_aid_application_id, 'Bob Marley', 'bob@wailing.jm')
@@ -68,7 +68,7 @@ RSpec.describe ScheduledMailing do
         end
 
         it 'cancels the mail' do
-          Timecop.freeze(now) do
+          travel_to(now) do
             scheduled_mail.deliver!
             expect(scheduled_mail.reload.cancelled_at.to_s).to eq now.to_s
           end
@@ -96,7 +96,7 @@ RSpec.describe ScheduledMailing do
     let(:now) { Time.zone.now }
 
     it 'updates the record as cancelled' do
-      Timecop.freeze(now) do
+      travel_to(now) do
         scheduled_mail.cancel!
         expect(scheduled_mail.reload.cancelled_at.to_s).to eq now.to_s
       end

--- a/spec/services/ccms/requestors/applicant_add_requestor_spec.rb
+++ b/spec/services/ccms/requestors/applicant_add_requestor_spec.rb
@@ -4,7 +4,7 @@ module CCMS
   module Requestors
     RSpec.describe ApplicantAddRequestor do
       let(:expected_xml) { ccms_data_from_file 'applicant_add_request.xml' }
-      let(:expected_tx_id) { '20190101121530123456' }
+      let(:expected_tx_id) { '20190101121530000000' }
 
       let(:address) do
         create(:address,
@@ -41,7 +41,7 @@ module CCMS
       end
       describe '#transaction_request_id' do
         it 'returns the id based on current time' do
-          Timecop.freeze(2019, 1, 1, 12, 15, 30.123456) do
+          travel_to Time.local(2019, 1, 1, 12, 15, 30) do
             expect(requestor.transaction_request_id).to start_with expected_tx_id
           end
         end

--- a/spec/services/ccms/requestors/applicant_add_status_requestor_spec.rb
+++ b/spec/services/ccms/requestors/applicant_add_status_requestor_spec.rb
@@ -4,7 +4,7 @@ module CCMS
   module Requestors
     RSpec.describe ApplicantAddStatusRequestor do
       let(:expected_xml) { ccms_data_from_file 'applicant_add_status_request.xml' }
-      let(:expected_tx_id) { '20190101121530123456' }
+      let(:expected_tx_id) { '20190101121530000000' }
       let(:requestor) { described_class.new(expected_tx_id, 'my_login') }
 
       describe 'XML request' do
@@ -24,7 +24,7 @@ module CCMS
 
       describe '#transaction_request_id' do
         it 'returns the id based on current time' do
-          Timecop.freeze(2019, 1, 1, 12, 15, 30.123456) do
+          travel_to Time.local(2019, 1, 1, 12, 15, 30) do
             expect(requestor.transaction_request_id).to start_with expected_tx_id
           end
         end

--- a/spec/services/ccms/requestors/applicant_search_requestor_spec.rb
+++ b/spec/services/ccms/requestors/applicant_search_requestor_spec.rb
@@ -4,7 +4,7 @@ module CCMS
   module Requestors
     RSpec.describe ApplicantSearchRequestor do
       let(:expected_xml) { ccms_data_from_file 'applicant_search_request.xml' }
-      let(:expected_tx_id) { '20190101121530123456' }
+      let(:expected_tx_id) { '20190101121530000000' }
       let(:applicant) do
         create(:applicant,
                first_name: 'lenovo',
@@ -32,7 +32,7 @@ module CCMS
 
       describe '#transaction_request_id' do
         it 'returns the id based on current time' do
-          Timecop.freeze(2019, 1, 1, 12, 15, 30.123456) do
+          travel_to Time.local(2019, 1, 1, 12, 15, 30) do
             expect(requestor.transaction_request_id).to start_with expected_tx_id
           end
         end

--- a/spec/services/ccms/requestors/case_add_requestor_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_spec.rb
@@ -25,7 +25,7 @@ module CCMS
         let(:expected_xml) { requestor.__send__(:request_xml) }
 
         before do
-          Timecop.freeze
+          freeze_time
           expect(requestor).to receive(:soap_client).and_return(soap_client_double)
         end
 

--- a/spec/services/ccms/requestors/case_add_status_requestor_spec.rb
+++ b/spec/services/ccms/requestors/case_add_status_requestor_spec.rb
@@ -4,7 +4,7 @@ module CCMS
   module Requestors
     RSpec.describe CaseAddStatusRequestor do
       let(:expected_xml) { ccms_data_from_file 'case_add_status_request.xml' }
-      let(:expected_tx_id) { '20190101121530123456' }
+      let(:expected_tx_id) { '20190101121530000000' }
       let(:requestor) { described_class.new(expected_tx_id, 'my_login') }
 
       describe 'XML request' do
@@ -21,7 +21,7 @@ module CCMS
 
       describe '#transaction_request_id' do
         it 'returns the id based on current time' do
-          Timecop.freeze(2019, 1, 1, 12, 15, 30.123456) do
+          travel_to Time.local(2019, 1, 1, 12, 15, 30) do
             expect(requestor.transaction_request_id).to start_with expected_tx_id
           end
         end

--- a/spec/services/ccms/requestors/document_id_requestor_spec.rb
+++ b/spec/services/ccms/requestors/document_id_requestor_spec.rb
@@ -4,7 +4,7 @@ module CCMS
   module Requestors
     RSpec.describe DocumentIdRequestor do
       let(:expected_xml) { ccms_data_from_file 'document_id_request.xml' }
-      let(:expected_tx_id) { '20190101121530123456' }
+      let(:expected_tx_id) { '20190101121530000000' }
       let(:case_ccms_reference) { '1234567890' }
       let(:requestor) { described_class.new(case_ccms_reference, 'my_login', type) }
       let(:type) { 'means_report' }
@@ -47,7 +47,7 @@ module CCMS
 
       describe '#transaction_request_id' do
         it 'returns the id based on current time' do
-          Timecop.freeze(2019, 1, 1, 12, 15, 30.123456) do
+          travel_to Time.local(2019, 1, 1, 12, 15, 30) do
             expect(requestor.transaction_request_id).to start_with expected_tx_id
           end
         end

--- a/spec/services/ccms/requestors/document_upload_requestor_spec.rb
+++ b/spec/services/ccms/requestors/document_upload_requestor_spec.rb
@@ -4,7 +4,7 @@ module CCMS
   module Requestors
     RSpec.describe DocumentUploadRequestor do
       let(:expected_xml) { ccms_data_from_file 'document_upload_request.xml' }
-      let(:expected_tx_id) { '20190101121530123456' }
+      let(:expected_tx_id) { '20190101121530000000' }
       let(:case_ccms_reference) { '1234567890' }
       let(:document_id) { '4420073' }
       let(:document_encoded_base64) { 'JVBERi0xLjUNCiW1tbW1DQoxIDAgb2JqDQo8PC9UeXBlL0NhdGFsb2cvUGFnZXMgMiA' }
@@ -48,7 +48,7 @@ module CCMS
 
       describe '#transaction_request_id' do
         it 'returns the id based on current time' do
-          Timecop.freeze(2019, 1, 1, 12, 15, 30.123456) do
+          travel_to Time.local(2019, 1, 1, 12, 15, 30) do
             expect(requestor.transaction_request_id).to start_with expected_tx_id
           end
         end

--- a/spec/services/ccms/requestors/reference_data_requestor_spec.rb
+++ b/spec/services/ccms/requestors/reference_data_requestor_spec.rb
@@ -4,7 +4,7 @@ module CCMS
   module Requestors
     RSpec.describe ReferenceDataRequestor do
       let(:expected_xml) { ccms_data_from_file 'reference_data_request.xml' }
-      let(:expected_tx_id) { '20190101121530123456' }
+      let(:expected_tx_id) { '20190101121530000000' }
       let(:requestor) { described_class.new('my_login') }
 
       describe 'XML request' do
@@ -24,7 +24,7 @@ module CCMS
 
       describe '#transaction_request_id' do
         it 'returns the id based on current time' do
-          Timecop.freeze(2019, 1, 1, 12, 15, 30.123456) do
+          travel_to Time.local(2019, 1, 1, 12, 15, 30) do
             expect(requestor.transaction_request_id).to start_with expected_tx_id
           end
         end
@@ -36,7 +36,7 @@ module CCMS
         let(:expected_xml) { requestor.__send__(:request_xml) }
 
         before do
-          Timecop.freeze
+          freeze_time
           expect(requestor).to receive(:soap_client).and_return(soap_client_double)
         end
 

--- a/spec/services/reports/mis/non_passported_application_csv_line_spec.rb
+++ b/spec/services/reports/mis/non_passported_application_csv_line_spec.rb
@@ -37,7 +37,7 @@ module Reports
 
         context 'undiscarded application' do
           it 'returns an array with the expected values' do
-            Timecop.freeze(time) do
+            travel_to(time) do
               fields = subject
               expect(fields[0]).to eq application.application_ref
               expect(fields[1]).to eq application.state
@@ -54,7 +54,7 @@ module Reports
         context 'discarded application' do
           before { application.discard! }
           it 'returns an array with the expected values' do
-            Timecop.freeze(time) do
+            travel_to(time) do
               fields = subject
               expect(fields[0]).to eq application.application_ref
               expect(fields[1]).to eq application.state

--- a/spec/services/reports/mis/non_passported_applications_report_spec.rb
+++ b/spec/services/reports/mis/non_passported_applications_report_spec.rb
@@ -5,9 +5,13 @@ module Reports
     RSpec.describe NonPassportedApplicationsReport do
       before do
         create_early_non_passported_application
-        Timecop.freeze(8.minutes.ago) { create_non_passported_application }
-        Timecop.freeze(6.minutes.ago) { create_non_passported_application_use_ccms }
-        Timecop.freeze(4.minutes.ago) { create_passported_application }
+        travel_to(8.minutes.ago) { create_non_passported_application }
+        travel_to(6.minutes.ago) { create_non_passported_application_use_ccms }
+        travel_to(4.minutes.ago) { create_passported_application }
+      end
+
+      after do
+        travel_back
       end
 
       subject { described_class.new.run }
@@ -35,7 +39,7 @@ module Reports
       end
 
       def create_early_non_passported_application
-        Timecop.freeze(Time.new(2020, 9, 1, 2, 3, 4)) do
+        travel_to(Time.local(2020, 9, 1, 2, 3, 4)) do
           create :legal_aid_application,
                  :with_applicant,
                  :with_negative_benefit_check_result,


### PR DESCRIPTION
## Remove timecop gem

Suggestion to remove timecop gem and replace it with rails [ActiveSupport::Testing::TimeHelpers ](https://api.rubyonrails.org/v5.2.4/classes/ActiveSupport/Testing/TimeHelpers.html)


Non blocker issue:

- The TimeHelper turns nanoseconds to 0 and this means tests for the #transaction_request_id will have 0 in place of the nanosecond making the test less accurate bot not wrong.
> Note that the usec for the time passed will be set to 0 to prevent rounding errors with external services, like MySQL (which will round instead of floor, leading to off-by-one-second errors).

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
