### PR TITLE
update spelling of Ordnance Survey 

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,6 +1,6 @@
 SENTRY_DSN=https://Add-the-sentry-dsn-here@sentry.io
 GOVUK_NOTIFY_API_KEY=<govuk-notify-api-key-goes-here>
-ORDNANACE_SURVEY_API_KEY=<ordnanace-survey-api-key-goes-here>
+ORDNANCE_SURVEY_API_KEY=<ordnanace-survey-api-key-goes-here>
 DB_HOST=
 DB_USER=
 BC_LSC_SERVICE_NAME=<benefit_checker_service_name>

--- a/app/services/address_lookup_service.rb
+++ b/app/services/address_lookup_service.rb
@@ -17,7 +17,7 @@ class AddressLookupService
 
   def query_params
     {
-      key: ENV['ORDNANACE_SURVEY_API_KEY'],
+      key: ENV['ORDNANCE_SURVEY_API_KEY'],
       postcode: postcode,
       lr: 'EN'
     }

--- a/helm_deploy/apply-for-legal-aid/templates/_envs.tpl
+++ b/helm_deploy/apply-for-legal-aid/templates/_envs.tpl
@@ -61,7 +61,7 @@ env:
       secretKeyRef:
         name: {{ template "apply-for-legal-aid.fullname" . }}
         key: govukNotifyEnv
-  - name: ORDNANACE_SURVEY_API_KEY
+  - name: ORDNANCE_SURVEY_API_KEY
     valueFrom:
       secretKeyRef:
         name: {{ template "apply-for-legal-aid.fullname" . }}

--- a/spec/services/address_lookup_service_spec.rb
+++ b/spec/services/address_lookup_service_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe AddressLookupService do
 
   let(:query_params) do
     {
-      key: ENV['ORDNANACE_SURVEY_API_KEY'],
+      key: ENV['ORDNANCE_SURVEY_API_KEY'],
       postcode: postcode,
       lr: 'EN'
     }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -47,7 +47,7 @@ VCR.configure do |vcr_config|
   vcr_config.configure_rspec_metadata!
   vcr_config.debug_logger = $stdout if vcr_debug
   vcr_config.filter_sensitive_data('<GOVUK_NOTIFY_API_KEY>') { ENV['GOVUK_NOTIFY_API_KEY'] }
-  vcr_config.filter_sensitive_data('<ORDNANACE_SURVEY_API_KEY>') { ENV['ORDNANACE_SURVEY_API_KEY'] }
+  vcr_config.filter_sensitive_data('<ORDNANCE_SURVEY_API_KEY>') { ENV['ORDNANCE_SURVEY_API_KEY'] }
   vcr_config.filter_sensitive_data('<BC_LSC_SERVICE_NAME>') { ENV['BC_LSC_SERVICE_NAME'] }
   vcr_config.filter_sensitive_data('<BC_CLIENT_ORG_ID>') { ENV['BC_CLIENT_ORG_ID'] }
   vcr_config.filter_sensitive_data('<BC_CLIENT_USER_ID>') { ENV['BC_CLIENT_USER_ID'] }


### PR DESCRIPTION
I noticed while troubleshooting Eloise's setup that the spelling of ordnance is incorrect. It caused an issue as we were checking the environment variables and it was returning `nil` when manually typed in. 

This will require devs to update their local `.env` file manually with the corrected spelling.

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
