### PR TITLE
AP-1799 Use update! in factories

### DIFF
--- a/app/services/test_application_creation_service.rb
+++ b/app/services/test_application_creation_service.rb
@@ -4,10 +4,13 @@ class TestApplicationCreationService
     at_checking_applicant_details
     at_checking_passported_answers
     at_applicant_details_checked
-    awaiting_applicant
-    applicant_entering_means
     provider_entering_merits
     at_checking_merits_answers
+  ].freeze
+
+  NON_PASSPORTED_TEST_TRAITS = %i[
+    awaiting_applicant
+    applicant_entering_means
   ].freeze
 
   def self.call
@@ -17,7 +20,11 @@ class TestApplicationCreationService
   def call
     providers.each do |provider|
       APPLICATION_TEST_TRAITS.each do |trait|
-        create_test_application(provider, trait)
+        create_passported_application(provider, trait)
+      end
+
+      NON_PASSPORTED_TEST_TRAITS.each do |trait|
+        create_non_passported_application(provider, trait)
       end
     end
   end
@@ -28,9 +35,20 @@ class TestApplicationCreationService
     Provider.all
   end
 
-  def create_test_application(provider, trait)
+  def create_passported_application(provider, trait)
     FactoryBot.create(
       :application,
+      :with_passported_state_machine,
+      :with_applicant,
+      trait,
+      provider: provider
+    )
+  end
+
+  def create_non_passported_application(provider, trait)
+    FactoryBot.create(
+      :application,
+      :with_non_passported_state_machine,
       :with_applicant,
       trait,
       provider: provider

--- a/spec/factories/legal_aid_applications.rb
+++ b/spec/factories/legal_aid_applications.rb
@@ -43,134 +43,133 @@ FactoryBot.define do
 
     trait :initiated do
       before(:create) do |application|
-        application.state_machine_proxy.update(aasm_state: :initiated)
+        application.state_machine_proxy.update!(aasm_state: :initiated)
       end
     end
 
     trait :analysing_bank_transactions do
       before(:create) do |application|
-        application.state_machine_proxy.update(aasm_state: :analysing_bank_transactions)
+        application.state_machine_proxy.update!(aasm_state: :analysing_bank_transactions)
       end
     end
 
     trait :awaiting_applicant do
       before(:create) do |application|
-        application.state_machine_proxy.update(aasm_state: :awaiting_applicant)
+        application.state_machine_proxy.update!(aasm_state: :awaiting_applicant)
       end
     end
 
     trait :applicant_details_checked do
       before(:create) do |application|
-        application.state_machine_proxy.update(aasm_state: :applicant_details_checked)
+        application.state_machine_proxy.update!(aasm_state: :applicant_details_checked)
       end
     end
 
     trait :applicant_entering_means do
       before(:create) do |application|
-        application.change_state_machine_type('NonPassportedStateMachine')
-        application.state_machine_proxy.update(aasm_state: :applicant_entering_means)
+        application.state_machine_proxy.update!(aasm_state: :applicant_entering_means)
       end
     end
 
     trait :assessment_submitted do
       before(:create) do |application|
-        application.state_machine_proxy.update(aasm_state: :assessment_submitted)
+        application.state_machine_proxy.update!(aasm_state: :assessment_submitted)
       end
     end
 
     trait :awaiting_applicant do
       before(:create) do |application|
-        application.state_machine_proxy.update(aasm_state: :awaiting_applicant)
+        application.state_machine_proxy.update!(aasm_state: :awaiting_applicant)
       end
     end
 
     trait :checking_applicant_details do
       before(:create) do |application|
-        application.state_machine_proxy.update(aasm_state: :checking_applicant_details)
+        application.state_machine_proxy.update!(aasm_state: :checking_applicant_details)
       end
     end
 
     trait :checking_citizen_answers do
       before(:create) do |application|
-        application.state_machine_proxy.update(aasm_state: :checking_citizen_answers)
+        application.state_machine_proxy.update!(aasm_state: :checking_citizen_answers)
       end
     end
 
     trait :checking_merits_answers do
       before(:create) do |application|
-        application.state_machine_proxy.update(aasm_state: :checking_merits_answers)
+        application.state_machine_proxy.update!(aasm_state: :checking_merits_answers)
       end
     end
 
     trait :checking_non_passported_means do
       before(:create) do |application|
-        application.state_machine_proxy.update(aasm_state: :checking_non_passported_means)
+        application.state_machine_proxy.update!(aasm_state: :checking_non_passported_means)
       end
     end
 
     trait :checking_passported_answers do
       before(:create) do |application|
-        application.state_machine_proxy.update(aasm_state: :checking_passported_answers)
+        application.state_machine_proxy.update!(aasm_state: :checking_passported_answers)
       end
     end
 
     trait :delegated_functions_used do
       before(:create) do |application|
-        application.state_machine_proxy.update(aasm_state: :delegated_functions_used)
+        application.state_machine_proxy.update!(aasm_state: :delegated_functions_used)
       end
     end
 
     trait :entering_applicant_details do
       before(:create) do |application|
-        application.state_machine_proxy.update(aasm_state: :entering_applicant_details)
+        application.state_machine_proxy.update!(aasm_state: :entering_applicant_details)
       end
     end
 
     trait :generating_reports do
       before(:create) do |application|
-        application.state_machine_proxy.update(aasm_state: :generating_reports)
+        application.state_machine_proxy.update!(aasm_state: :generating_reports)
       end
     end
 
     trait :provider_assessing_means do
       before(:create) do |application|
-        application.state_machine_proxy.update(aasm_state: :provider_assessing_means)
+        application.state_machine_proxy.update!(aasm_state: :provider_assessing_means)
       end
     end
 
     trait :provider_confirming_applicant_eligibility do
       before(:create) do |application|
-        application.state_machine_proxy.update(aasm_state: :provider_confirming_applicant_eligibility)
+        application.state_machine_proxy.update!(aasm_state: :provider_confirming_applicant_eligibility)
       end
     end
 
     trait :provider_entering_means do
       before(:create) do |application|
-        application.state_machine_proxy.update(aasm_state: :provider_entering_means)
+        application.state_machine_proxy.update!(aasm_state: :provider_entering_means)
       end
     end
 
     trait :provider_entering_merits do
       before(:create) do |application|
-        application.state_machine_proxy.update(aasm_state: :provider_entering_merits)
+        application.state_machine_proxy.update!(aasm_state: :provider_entering_merits)
       end
     end
 
     trait :submitting_assessment do
       before(:create) do |application|
-        application.state_machine_proxy.update(aasm_state: :submitting_assessment)
+        application.state_machine_proxy.update!(aasm_state: :submitting_assessment)
       end
     end
 
     trait :use_ccms do
       before(:create) do |application|
-        application.state_machine_proxy.update(aasm_state: :use_ccms, ccms_reason: :unknown)
+        application.state_machine_proxy.update!(aasm_state: :use_ccms, ccms_reason: :unknown)
       end
     end
 
     trait :use_ccms_employed do
       before(:create) do |application|
-        application.state_machine_proxy.update(aasm_state: :use_ccms, ccms_reason: :employed)
+        application.state_machine_proxy.update!(aasm_state: :use_ccms, ccms_reason: :employed)
       end
     end
 
@@ -185,7 +184,7 @@ FactoryBot.define do
 
     trait :submitted_to_ccms do
       before(:create) do |application|
-        application.state_machine_proxy.update(aasm_state: %i[assessment_submitted generating_reports submitting_assessment].sample)
+        application.state_machine_proxy.update!(aasm_state: %i[assessment_submitted generating_reports submitting_assessment].sample)
       end
     end
 
@@ -324,6 +323,7 @@ FactoryBot.define do
 
     trait :with_everything do
       with_applicant
+      with_non_passported_state_machine
       applicant_entering_means
       with_savings_amount
       with_other_assets_declaration
@@ -347,6 +347,7 @@ FactoryBot.define do
 
     trait :with_everything_and_address do
       with_applicant_and_address
+      with_non_passported_state_machine
       applicant_entering_means
       with_savings_amount
       with_other_assets_declaration
@@ -399,7 +400,7 @@ FactoryBot.define do
 
     trait :at_initiated do
       before(:create) do |application|
-        application.state_machine_proxy.update(aasm_state: :initiated)
+        application.state_machine_proxy.update!(aasm_state: :initiated)
       end
 
       provider_step { :applicants }
@@ -407,7 +408,7 @@ FactoryBot.define do
 
     trait :at_entering_applicant_details do
       before(:create) do |application|
-        application.state_machine_proxy.update(aasm_state: :entering_applicant_details)
+        application.state_machine_proxy.update!(aasm_state: :entering_applicant_details)
       end
 
       provider_step { :applicants }
@@ -415,7 +416,7 @@ FactoryBot.define do
 
     trait :at_use_ccms do
       before(:create) do |application|
-        application.state_machine_proxy.update(aasm_state: :use_ccms, ccms_reason: :unknown)
+        application.state_machine_proxy.update!(aasm_state: :use_ccms, ccms_reason: :unknown)
       end
 
       provider_step { :use_ccms }
@@ -425,7 +426,7 @@ FactoryBot.define do
       with_proceeding_types
 
       before(:create) do |application|
-        application.state_machine_proxy.update(aasm_state: :checking_applicant_details)
+        application.state_machine_proxy.update!(aasm_state: :checking_applicant_details)
       end
 
       provider_step { :check_provider_answers }
@@ -435,7 +436,7 @@ FactoryBot.define do
       with_proceeding_types
 
       before(:create) do |application|
-        application.state_machine_proxy.update(aasm_state: :checking_passported_answers)
+        application.state_machine_proxy.update!(aasm_state: :checking_passported_answers)
       end
 
       provider_step { :check_passported_answers }
@@ -445,7 +446,7 @@ FactoryBot.define do
       with_proceeding_types
 
       before(:create) do |application|
-        application.state_machine_proxy.update(aasm_state: :applicant_details_checked)
+        application.state_machine_proxy.update!(aasm_state: :applicant_details_checked)
       end
 
       provider_step { :check_benefits }
@@ -455,8 +456,7 @@ FactoryBot.define do
       with_proceeding_types
 
       before(:create) do |application|
-        application.change_state_machine_type('NonPassportedStateMachine')
-        application.state_machine_proxy.update(aasm_state: :client_completed_means)
+        application.state_machine_proxy.update!(aasm_state: :checking_citizen_answers)
       end
 
       provider_step { :client_completed_means }
@@ -466,7 +466,7 @@ FactoryBot.define do
       with_proceeding_types
 
       before(:create) do |application|
-        application.state_machine_proxy.update(aasm_state: :provider_assessing_means)
+        application.state_machine_proxy.update!(aasm_state: :provider_assessing_means)
       end
 
       provider_step { :check_provider_answers }
@@ -478,7 +478,7 @@ FactoryBot.define do
       with_merits_statement_of_case
 
       before(:create) do |application|
-        application.state_machine_proxy.update(aasm_state: :checking_merits_answers)
+        application.state_machine_proxy.update!(aasm_state: :checking_merits_answers)
       end
 
       provider_step { :check_merits_answers }
@@ -496,7 +496,7 @@ FactoryBot.define do
       with_ccms_submission
 
       after(:create) do |application|
-        application.state_machine_proxy.update(aasm_state: :assessment_submitted)
+        application.state_machine_proxy.update!(aasm_state: :assessment_submitted)
       end
 
       provider_step { :end_of_application }
@@ -514,7 +514,7 @@ FactoryBot.define do
       with_ccms_submission
 
       before(:create) do |application|
-        application.state_machine_proxy.update(aasm_state: :submitting_assessment)
+        application.state_machine_proxy.update!(aasm_state: :submitting_assessment)
       end
 
       provider_step { :end_of_application }

--- a/spec/mailers/submit_provider_financial_reminder_mailer_spec.rb
+++ b/spec/mailers/submit_provider_financial_reminder_mailer_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe SubmitProviderFinancialReminderMailer, type: :mailer do
   describe '.eligible_for_delivery?' do
     let(:scheduled_mailing) { create :scheduled_mailing, legal_aid_application: application }
     context 'it is eligible' do
-      let(:application) { create :legal_aid_application, :at_client_completed_means }
+      let(:application) { create :legal_aid_application, :with_non_passported_state_machine, :at_client_completed_means }
       it 'returns true' do
         expect(described_class.eligible_for_delivery?(scheduled_mailing)).to be true
       end

--- a/spec/models/legal_aid_application_spec.rb
+++ b/spec/models/legal_aid_application_spec.rb
@@ -104,12 +104,14 @@ RSpec.describe LegalAidApplication, type: :model do
     end
 
     context 'in non passported state' do
+      let!(:legal_aid_application) { create :legal_aid_application, :with_non_passported_state_machine, :with_applicant, state }
       let(:state) { :checking_non_passported_means }
 
       it 'is false' do
         expect(legal_aid_application.pre_dwp_check?).to eq false
       end
     end
+
     context 'in passported state' do
       let(:state) { :checking_passported_answers }
 

--- a/spec/requests/admin/legal_aid_applications_spec.rb
+++ b/spec/requests/admin/legal_aid_applications_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Admin::LegalAidApplicationsController, type: :request do
   let(:count) { 3 }
-  let!(:legal_aid_applications) { create_list :legal_aid_application, count, :with_applicant }
+  let!(:legal_aid_applications) { create_list :legal_aid_application, count, :with_applicant, :with_non_passported_state_machine }
   let(:admin_user) { create :admin_user }
   let(:params) { {} }
 
@@ -80,7 +80,7 @@ RSpec.describe Admin::LegalAidApplicationsController, type: :request do
     let(:count) { 1 }
 
     it 'creates test legal_aid_applications' do
-      number_new = TestApplicationCreationService::APPLICATION_TEST_TRAITS.size
+      number_new = TestApplicationCreationService::APPLICATION_TEST_TRAITS.size + TestApplicationCreationService::NON_PASSPORTED_TEST_TRAITS.size
       expect { subject }.to change { LegalAidApplication.count }.by(number_new)
     end
 

--- a/spec/requests/providers/restrictions_spec.rb
+++ b/spec/requests/providers/restrictions_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe 'provider restrictions request', type: :request do
         end
 
         context 'provider on passported route' do
-          let(:application) { create :legal_aid_application, :with_applicant, :passported, :with_passported_state_machine, :provider_assessing_means }
+          let(:application) { create :legal_aid_application, :with_applicant, :passported, :with_passported_state_machine, :checking_passported_answers }
           it 'redirects to check passported answers' do
             expect(response).to redirect_to(providers_legal_aid_application_check_passported_answers_path(application))
           end

--- a/spec/services/reports/mis/non_passported_applications_report_spec.rb
+++ b/spec/services/reports/mis/non_passported_applications_report_spec.rb
@@ -29,7 +29,7 @@ module Reports
         end
 
         it 'returns data for the only non-passorted application after Sep 21st as second line' do
-          expect(lines[1]).to eq %(L-ATE,initiated,,#{username},#{email},#{created_at},#{applicant.full_name},"")
+          expect(lines[1]).to eq %(L-ATE,checking_citizen_answers,,#{username},#{email},#{created_at},#{applicant.full_name},"")
           expect(lines[2]).to match(/^L-USE-CCMS,use_ccms,employed,/)
         end
       end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1799)

Fix `state_machine` traits in the `legal_aid_applications` factory so that they use `update!` instead of `update`. This has surfaced some failing tests which are also fixed here.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
