### PR TITLE
AP1425 Suppress Sentry alerts for postcode not found

### DIFF
--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,12 +1,4 @@
 class Address < ApplicationRecord
-  # The REGEXP for the postcode validation is taken from this very detailed stack overflow answer:
-  # https://stackoverflow.com/questions/164979/uk-postcode-regex-comprehensive/51885364#51885364
-  # The second REGEXP from the answer section of that comment was used because as part
-  # of the validation process we are changing postcode to uppercase and removing spaces this allows
-  # for some simplification of the regular expression
-
-  POSTCODE_REGEXP = /\A([A-Z][A-HJ-Y]?[0-9][A-Z0-9]?[0-9][A-Z]{2}|GIR ?0A{2})\z/.freeze
-
   belongs_to :applicant
 
   validates :city, :postcode, presence: true

--- a/app/services/address_lookup_service.rb
+++ b/app/services/address_lookup_service.rb
@@ -2,7 +2,6 @@ class AddressLookupService
   prepend SimpleCommand
 
   ORDNANCE_SURVEY_URL = 'https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode'.freeze
-  POSTCODE_REGEXP = /\A([A-Z][A-HJ-Y]?[0-9][A-Z0-9]?[0-9][A-Z]{2}|GIR ?0A{2})\z/.freeze
 
   attr_reader :postcode
 

--- a/app/services/address_lookup_service.rb
+++ b/app/services/address_lookup_service.rb
@@ -2,6 +2,7 @@ class AddressLookupService
   prepend SimpleCommand
 
   ORDNANCE_SURVEY_URL = 'https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode'.freeze
+  POSTCODE_REGEXP = /\A([A-Z][A-HJ-Y]?[0-9][A-Z0-9]?[0-9][A-Z]{2}|GIR ?0A{2})\z/.freeze
 
   attr_reader :postcode
 
@@ -55,6 +56,6 @@ class AddressLookupService
 
   def record_error(state, error)
     errors.add(:lookup, state)
-    Raven.capture_exception(error)
+    Raven.capture_exception(error) unless POSTCODE_REGEXP.match?(@postcode) && state == :unsuccessful
   end
 end

--- a/config/initializers/settings.rb
+++ b/config/initializers/settings.rb
@@ -1,1 +1,7 @@
+# The REGEXP for the postcode validation is taken from this very detailed stack overflow answer:
+# https://stackoverflow.com/questions/164979/uk-postcode-regex-comprehensive/51885364#51885364
+# The second REGEXP from the answer section of that comment was used because as part
+# of the validation process we are changing postcode to uppercase and removing spaces this allows
+# for some simplification of the regular expression
+
 POSTCODE_REGEXP = /\A([A-Z][A-HJ-Y]?[0-9][A-Z0-9]?[0-9][A-Z]{2}|GIR ?0A{2})\z/.freeze

--- a/spec/services/address_lookup_service_spec.rb
+++ b/spec/services/address_lookup_service_spec.rb
@@ -70,6 +70,7 @@ RSpec.describe AddressLookupService do
           }
         }
       end
+      let(:postcode) { nil }
 
       before do
         stub_request(:get, api_request_uri)
@@ -92,6 +93,22 @@ RSpec.describe AddressLookupService do
     it 'captures error' do
       expect(Raven).to receive(:capture_exception).with(message_contains('Service unavailable'))
       service.__send__(:record_error, state, error)
+    end
+
+    context 'postocde is in a correct format' do
+      let(:state) { :unsuccessful }
+      let(:error) { StandardError.new 'Resource x does not exist' }
+      let(:postcode) { 'SW109LO' }
+
+      before do
+        stub_request(:get, api_request_uri)
+          .to_raise(Errno::ECONNREFUSED)
+      end
+
+      it 'does not capture error' do
+        expect(Raven).not_to receive(:capture_exception).with(message_contains('Resource x does not exist'))
+        service.call
+      end
     end
   end
 end


### PR DESCRIPTION
## AP1425 Suppress Sentry alerts for postcode not found

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1425)

- Don't send a sentry message if the user has typed a postcode with the correct format but was a mistype.
- test the changes

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
