### PR TITLE
AP-1808 Allow destroying application to destroy the applicant it belongs to

### DIFF
--- a/app/controllers/admin/legal_aid_applications_controller.rb
+++ b/app/controllers/admin/legal_aid_applications_controller.rb
@@ -21,14 +21,12 @@ module Admin
       raise 'Legal Aid Application Destroy All action disabled' unless destroy_enabled?
 
       LegalAidApplication.destroy_all
-      Applicant.destroy_all
       redirect_to action: :index
     end
 
     def destroy
       raise 'Legal Aid Application Destroy action disabled' unless destroy_enabled?
 
-      legal_aid_application.applicant&.destroy
       legal_aid_application.destroy
       redirect_to action: :index
     end

--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -10,7 +10,7 @@ class LegalAidApplication < ApplicationRecord # rubocop:disable Metrics/ClassLen
   WORKING_DAYS_TO_COMPLETE_SUBSTANTIVE_APPLICATION = 20
   CCMS_SUBMITTED_STATES = %w[generating_reports submitting_assessment assessment_submitted].freeze
 
-  belongs_to :applicant, optional: true
+  belongs_to :applicant, optional: true, dependent: :destroy
   belongs_to :provider, optional: false
   belongs_to :office, optional: true
   has_many :application_proceeding_types, dependent: :destroy

--- a/spec/factories/legal_aid_applications.rb
+++ b/spec/factories/legal_aid_applications.rb
@@ -520,6 +520,23 @@ FactoryBot.define do
       provider_step { :end_of_application }
     end
 
+    trait :with_bank_transactions do
+      after :create do |application|
+        bank_provider = create :bank_provider, applicant: application.applicant
+        bank_account = create :bank_account, bank_provider: bank_provider
+        create :bank_account_holder, bank_provider: bank_provider
+        create :bank_error, applicant: application.applicant
+        [90, 60, 30].each do |count|
+          create :bank_transaction,
+                 :benefits,
+                 happened_at: count.days.ago,
+                 bank_account: bank_account,
+                 operation: 'credit',
+                 meta_data: { code: 'CHB', label: 'child_benefit', name: 'Child Benefit' }
+        end
+      end
+    end
+
     trait :with_benefits_transactions do
       after :create do |application|
         bank_provider = create :bank_provider, applicant: application.applicant

--- a/spec/models/legal_aid_application_spec.rb
+++ b/spec/models/legal_aid_application_spec.rb
@@ -433,7 +433,7 @@ RSpec.describe LegalAidApplication, type: :model do
   # that then become redundant.
   describe '.destroy_all' do
     let!(:legal_aid_application) do
-      create :legal_aid_application, :with_everything, :with_proceeding_types, :with_negative_benefit_check_result
+      create :legal_aid_application, :with_everything, :with_proceeding_types, :with_negative_benefit_check_result, :with_bank_transactions
     end
 
     before do
@@ -451,6 +451,11 @@ RSpec.describe LegalAidApplication, type: :model do
       expect(MeritsAssessment.count).not_to be_zero
       expect(StatementOfCase.count).not_to be_zero
       expect(Applicant.count).not_to be_zero
+      expect(BankAccount.count).not_to be_zero
+      expect(BankTransaction.count).not_to be_zero
+      expect(BankProvider.count).not_to be_zero
+      expect(BankAccountHolder.count).not_to be_zero
+      expect(BankError.count).not_to be_zero
       expect(LegalAidApplicationTransactionType.count).not_to be_zero
       expect { subject }.to change { described_class.count }.to(0)
       expect(ApplicationProceedingType.count).to be_zero
@@ -460,6 +465,11 @@ RSpec.describe LegalAidApplication, type: :model do
       expect(MeritsAssessment.count).to be_zero
       expect(StatementOfCase.count).to be_zero
       expect(Applicant.count).to be_zero
+      expect(BankAccount.count).to be_zero
+      expect(BankTransaction.count).to be_zero
+      expect(BankProvider.count).to be_zero
+      expect(BankAccountHolder.count).to be_zero
+      expect(BankError.count).to be_zero
       expect(LegalAidApplicationTransactionType.count).to be_zero
     end
 

--- a/spec/models/legal_aid_application_spec.rb
+++ b/spec/models/legal_aid_application_spec.rb
@@ -450,6 +450,7 @@ RSpec.describe LegalAidApplication, type: :model do
       expect(SavingsAmount.count).not_to be_zero
       expect(MeritsAssessment.count).not_to be_zero
       expect(StatementOfCase.count).not_to be_zero
+      expect(Applicant.count).not_to be_zero
       expect(LegalAidApplicationTransactionType.count).not_to be_zero
       expect { subject }.to change { described_class.count }.to(0)
       expect(ApplicationProceedingType.count).to be_zero
@@ -458,15 +459,14 @@ RSpec.describe LegalAidApplication, type: :model do
       expect(SavingsAmount.count).to be_zero
       expect(MeritsAssessment.count).to be_zero
       expect(StatementOfCase.count).to be_zero
+      expect(Applicant.count).to be_zero
       expect(LegalAidApplicationTransactionType.count).to be_zero
     end
 
     it 'leaves object it should not affect' do
-      expect(Applicant.count).not_to be_zero
       expect(ProceedingType.count).not_to be_zero
       expect(TransactionType.count).not_to be_zero
       subject
-      expect(Applicant.count).not_to be_zero
       expect(ProceedingType.count).not_to be_zero
       expect(TransactionType.count).not_to be_zero
     end


### PR DESCRIPTION
## AP-1808 Allow destroying application to destroy the applicant it belongs to

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1808)

- Allow the deletion of the applicant when its application is deleted. This deletes it's bank transaction data, too.

- Remove deletion of applicant in admin controller as deleting the application deletes the applicant now

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
