### PR TITLE
AP-1595 Enable ActiveStorage sidekiq queue

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -3,3 +3,5 @@
   - default
   - mailers
   - sidekiq_alive
+  - active_storage_analysis
+  - active_storage_purge

--- a/spec/services/metrics/sidekiq_queue_sizes_spec.rb
+++ b/spec/services/metrics/sidekiq_queue_sizes_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Metrics::SidekiqQueueSizes do
   describe '#call' do
-    let(:queues) { %w[default mailers sidekiq_alive] }
+    let(:queues) { %w[default mailers sidekiq_alive active_storage_analysis active_storage_purge] }
     let(:prometheus_client) { spy(PrometheusExporter::Client) }
     let(:collector_type) { PrometheusCollectors::SidekiqQueueCollector::COLLECTOR_TYPE }
     subject { described_class.call(prometheus_client) }


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1595)

ActiveStorage is enqueing `active_storage_analysis` and `active_storage_purge ` jobs which are never being processed because sidekiq does not know about the queues. There are currently ~6000 analysis and ~60 purge jobs queued in production. This change adds queue details to `config/sidekiq.yml` so that those jobs will be processed.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
