### PR TITLE
AP-1810 Enable non passported permissions all providers

### DIFF
--- a/lib/tasks/helpers/permissions_updater.rb
+++ b/lib/tasks/helpers/permissions_updater.rb
@@ -1,0 +1,18 @@
+class PermissionsUpdater
+  def initialize
+    @passported = Permission.find_by(role: 'application.passported.*')
+    @non_passported = Permission.find_by(role: 'application.non_passported.*')
+  end
+
+  def run
+    Firm.all.each { |firm| update_permissions(firm) }
+  end
+
+  private
+
+  def update_permissions(firm)
+    firm.permissions << @passported unless firm.permissions.include?(@passported)
+    firm.permissions << @non_passported unless firm.permissions.include?(@non_passported)
+    firm.save!
+  end
+end

--- a/lib/tasks/permissions_updater.rake
+++ b/lib/tasks/permissions_updater.rake
@@ -1,0 +1,6 @@
+namespace :temp do
+  task permissions: :environment do
+    require Rails.root.join('lib/tasks/helpers/permissions_updater')
+    PermissionsUpdater.new.run
+  end
+end

--- a/spec/lib/task_helpers/permissions_updater_spec.rb
+++ b/spec/lib/task_helpers/permissions_updater_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+require Rails.root.join('lib/tasks/helpers/permissions_updater')
+
+RSpec.describe PermissionsUpdater do
+  let!(:firm_both) { create :firm, :with_passported_and_non_passported_permissions }
+  let!(:firm_non_passported) { create :firm, :with_non_passported_permissions }
+  let!(:firm_passported) { create :firm, :with_passported_permissions }
+  let!(:firm_none) { create :firm, :with_no_permissions }
+
+  it 'adds non_passported permissions' do
+    PermissionsUpdater.new.run
+    expect(firm_both.reload.permissions.map(&:role)).to match_array(['application.passported.*', 'application.non_passported.*'])
+    expect(firm_non_passported.reload.permissions.map(&:role)).to match_array(['application.passported.*', 'application.non_passported.*'])
+    expect(firm_passported.reload.permissions.map(&:role)).to match_array(['application.passported.*', 'application.non_passported.*'])
+    expect(firm_none.reload.permissions.map(&:role)).to match_array(['application.passported.*', 'application.non_passported.*'])
+  end
+end


### PR DESCRIPTION
**What**

[Link to story](https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=233&projectKey=AP&modal=detail&selectedIssue=AP-1810&assignee=5f968777632c6200712e443f)

Enabled non-passported permissions for all providers.

**Checklist**

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
