### PR TITLE
AP-1790 Ensure state change to use_ccms

### DIFF
--- a/app/controllers/admin/admin_base_controller.rb
+++ b/app/controllers/admin/admin_base_controller.rb
@@ -1,6 +1,6 @@
 module Admin
   class AdminBaseController < ApplicationController
-    before_action :check_vpn_ipaddr, :authenticate_admin_user!
+    before_action :check_vpn_ipaddr, :authenticate_admin_user!, :set_cache_buster
     layout 'admin'.freeze
 
     protected
@@ -16,6 +16,14 @@ module Admin
     def ip_addr_authorised?(string_ipaddr)
       ip_checker = AuthorizedIpRanges.new
       ip_checker.authorized?(string_ipaddr)
+    end
+
+    private
+
+    def set_cache_buster
+      response.headers['Cache-Control'] = 'no-cache, no-store, max-age=0, must-revalidate'
+      response.headers['Pragma'] = 'no-cache'
+      response.headers['Expires'] = 'Fri, 01 Jan 1990 00:00:00 GMT'
     end
   end
 end

--- a/app/controllers/admin/reports_controller.rb
+++ b/app/controllers/admin/reports_controller.rb
@@ -22,7 +22,8 @@ module Admin
     def download_submitted
       respond_to do |format|
         format.csv do
-          send_data Reports::MIS::ApplicationDetailsReport.new.run
+          data = Reports::MIS::ApplicationDetailsReport.new.run
+          send_data data, filename: "submitted_applications_#{timestamp}.csv", content_type: 'text/csv'
         end
       end
     end
@@ -30,9 +31,14 @@ module Admin
     def download_non_passported
       respond_to do |format|
         format.csv do
-          send_data Reports::MIS::NonPassportedApplicationsReport.new.run
+          data = Reports::MIS::NonPassportedApplicationsReport.new.run
+          send_data data, filename: "non_passported_#{timestamp}.csv", content_type: 'text/csv'
         end
       end
+    end
+
+    def timestamp
+      Time.now.strftime('%FT%T')
     end
   end
 end

--- a/app/controllers/citizens/additional_accounts_controller.rb
+++ b/app/controllers/citizens/additional_accounts_controller.rb
@@ -2,6 +2,7 @@ module Citizens
   class AdditionalAccountsController < CitizenBaseController
     def index
       legal_aid_application.update!(has_offline_accounts: nil)
+      legal_aid_application.reset_to_applicant_entering_means! if legal_aid_application.use_ccms?
       legal_aid_application.applicant_enter_means! unless legal_aid_application.applicant_entering_means?
     end
 
@@ -17,7 +18,9 @@ module Citizens
       end
     end
 
-    def new; end
+    def new
+      legal_aid_application.reset_to_applicant_entering_means! if legal_aid_application.use_ccms?
+    end
 
     def update
       case params[:has_online_accounts]

--- a/app/controllers/citizens/consents_controller.rb
+++ b/app/controllers/citizens/consents_controller.rb
@@ -1,6 +1,7 @@
 module Citizens
   class ConsentsController < CitizenBaseController
     def show
+      @legal_aid_application.reset_to_applicant_entering_means! if @legal_aid_application.use_ccms?
       @form = Applicants::OpenBankingConsentForm.new(model: legal_aid_application)
     end
 
@@ -17,7 +18,7 @@ module Citizens
     private
 
     def change_application_state
-      legal_aid_application.use_ccms!(:no_banking_consent) if @form.open_banking_consent != 'true'
+      legal_aid_application.use_ccms!(:no_applicant_consent) if @form.open_banking_consent != 'true'
     end
 
     def form_params

--- a/app/controllers/providers/use_ccms_controller.rb
+++ b/app/controllers/providers/use_ccms_controller.rb
@@ -1,5 +1,18 @@
 module Providers
   class UseCCMSController < ProviderBaseController
-    def show; end
+    def show
+      @legal_aid_application.use_ccms!(use_ccms_reason)
+    end
+
+    private
+
+    def use_ccms_reason
+      case request.referer
+      when providers_legal_aid_application_open_banking_consents_url(@legal_aid_application)
+        :no_online_banking
+      else
+        :unknown
+      end
+    end
   end
 end

--- a/app/models/concerns/base_state_machine.rb
+++ b/app/models/concerns/base_state_machine.rb
@@ -5,7 +5,8 @@ class BaseStateMachine < ApplicationRecord  # rubocop:disable Metrics/ClassLengt
 
   VALID_CCMS_REASONS = %i[
     employed
-    no_banking_consent
+    no_online_banking
+    no_applicant_consent
     non_passported
     offline_accounts
     unknown

--- a/app/models/concerns/non_passported_state_machine.rb
+++ b/app/models/concerns/non_passported_state_machine.rb
@@ -54,6 +54,11 @@ class NonPassportedStateMachine < BaseStateMachine # rubocop:disable Metrics/Cla
       ],
                   to: :checking_non_passported_means
     end
+
+    event :reset_to_applicant_entering_means do
+      transitions from: :use_ccms, to: :applicant_entering_means,
+                  after: proc { update!(ccms_reason: nil) }
+    end
   end
 
   def checking_passported_answers?

--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -75,6 +75,7 @@ class LegalAidApplication < ApplicationRecord
            :provider_used_delegated_functions!,
            :reset!,
            :reset_from_use_ccms!,
+           :reset_to_applicant_entering_means!,
            :submitted_assessment!,
            :use_ccms!,
            :applicant_details_checked?,

--- a/app/services/reports/mis/non_passported_applications_report.rb
+++ b/app/services/reports/mis/non_passported_applications_report.rb
@@ -1,7 +1,6 @@
 module Reports
   module MIS
     class NonPassportedApplicationsReport
-      EXCLUDED_STATES = %w[use_ccms].freeze
       START_DATE = Time.new(2020, 9, 21, 0, 0, 0)
       END_TIME = Date.today.end_of_day
 

--- a/spec/factories/legal_aid_applications.rb
+++ b/spec/factories/legal_aid_applications.rb
@@ -173,6 +173,12 @@ FactoryBot.define do
       end
     end
 
+    trait :use_ccms_no_banking_consent do
+      before(:create) do |application|
+        application.state_machine_proxy.update!(aasm_state: :use_ccms, ccms_reason: :no_banking_consent)
+      end
+    end
+
     #############################################################################
 
     trait :with_irregular_income do

--- a/spec/requests/citizens/additional_accounts_spec.rb
+++ b/spec/requests/citizens/additional_accounts_spec.rb
@@ -16,6 +16,24 @@ RSpec.describe 'citizen additional accounts request test', type: :request do
     end
   end
 
+  context 'when application is in use_ccms state' do
+    it 'has reset the state and ccms_reason' do
+      application.use_ccms!(:no_online_banking)
+      get citizens_additional_accounts_path
+      expect(application.reload.state).to eq 'applicant_entering_means'
+      expect(application.ccms_reason).to be_nil
+    end
+  end
+
+  describe 'GET /citizens/additional_accounts/new' do
+    before { application.use_ccms!(:no_online_banking) }
+    it 'has reset the state and ccms_reason' do
+      get new_citizens_additional_account_path(application)
+      expect(application.reload.state).to eq 'applicant_entering_means'
+      expect(application.ccms_reason).to be_nil
+    end
+  end
+
   context 'when an applicant revisits the page to change their answer' do
     before do
       application.update!(has_offline_accounts: true)

--- a/spec/requests/providers/use_ccms_spec.rb
+++ b/spec/requests/providers/use_ccms_spec.rb
@@ -26,6 +26,35 @@ RSpec.describe Providers::UseCCMSController, type: :request do
         subject
         expect(response.body).to include(I18n.t('providers.use_ccms.show.title_html'))
       end
+
+      it 'sets the state to use_ccms' do
+        subject
+        expect(legal_aid_application.reload.state).to eq 'use_ccms'
+      end
+    end
+
+    describe 'ccms_reason' do
+      before do
+        login_as provider
+        allow_any_instance_of(ActionDispatch::Request).to receive(:referer).and_return(referer)
+      end
+
+      context 'when referrer is open_banking_consents page' do
+        let(:referer) { providers_legal_aid_application_open_banking_consents_url(legal_aid_application) }
+
+        it 'sets the ccms reason to :no_provider_consent' do
+          get providers_legal_aid_application_use_ccms_path(legal_aid_application)
+          expect(legal_aid_application.reload.ccms_reason).to eq 'no_online_banking'
+        end
+      end
+
+      context 'when referrer is another unknown page' do
+        let(:referer) { 'http://www.example.com/providers' }
+        it 'sets the ccms reason to :unknown' do
+          get providers_legal_aid_application_use_ccms_path(legal_aid_application)
+          expect(legal_aid_application.reload.ccms_reason).to eq 'unknown'
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Ensure state change to use_ccms

Users were being told to use CCMS but the applications weren't in all cases being switched to `use_ccms` state with an appropriate reason.  This PR rectifies that.

It also ensures that the admin reports are not cached so that a fresh copy is sent every time.

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1790)

Describe what you did and why.

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
