### PR TITLE
Ap 1789 portal auth error

### DIFF
--- a/app/controllers/saml_sessions_controller.rb
+++ b/app/controllers/saml_sessions_controller.rb
@@ -5,7 +5,6 @@
 #
 class SamlSessionsController < Devise::SamlSessionsController
   before_action :update_locale
-  after_action :update_provider_details, only: :create, if: -> { response.successful? }
 
   def destroy
     session['signed_out'] = true
@@ -19,10 +18,9 @@ class SamlSessionsController < Devise::SamlSessionsController
   end
 
   def create
-    # Calls the create method in devise
     super
-  rescue StandardError => e
-    # redirects to access denied as providers_invalid_login_path expects there to be a provider.
+    update_provider_details
+  rescue StandardError
     redirect_to error_path(:access_denied)
   end
 

--- a/app/controllers/saml_sessions_controller.rb
+++ b/app/controllers/saml_sessions_controller.rb
@@ -5,7 +5,7 @@
 #
 class SamlSessionsController < Devise::SamlSessionsController
   before_action :update_locale
-  after_action :update_provider_details, only: :create
+  after_action :update_provider_details, only: :create, if: -> { response.successful? }
 
   def destroy
     session['signed_out'] = true
@@ -16,6 +16,14 @@ class SamlSessionsController < Devise::SamlSessionsController
     else
       redirect_to new_feedback_path
     end
+  end
+
+  def create
+    # Calls the create method in devise
+    super
+  rescue StandardError => e
+    # redirects to access denied as providers_invalid_login_path expects there to be a provider.
+    redirect_to error_path(:access_denied)
   end
 
   def after_sign_in_path_for(_provider)

--- a/spec/requests/saml_sessions_spec.rb
+++ b/spec/requests/saml_sessions_spec.rb
@@ -204,6 +204,16 @@ RSpec.describe 'SamlSessionsController', type: :request do
     end
   end
 
+  describe 'Login failed at LAA Portal' do
+    subject { post provider_session_path }
+    before { allow_any_instance_of(Devise::SessionsController).to receive(:create).and_raise(StandardError) }
+
+    it 'redirects to access denied' do
+      subject
+      expect(response).to redirect_to(error_path(:access_denied))
+    end
+  end
+
   def raw_details_response
     {
       providerFirmId: 22_381,


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1789)

When a CCMS user without Apply permissions tries to login they get an error due to a malformed SAML response from the portal. 

This change will capture the error and redirect the user to the access denied page

The `/invalid_login` page would appear to be the more appropriate page to redirect the user to, but this currently requires the user to have an account created for them when the login failed, however due to the SAML response this doesnt happen.





## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
