### PR TITLE
AP-1268 Rescue uncaught errors during CCMS submission

### DIFF
--- a/app/services/ccms/submitters/add_applicant_service.rb
+++ b/app/services/ccms/submitters/add_applicant_service.rb
@@ -9,7 +9,7 @@ module CCMS
         else
           handle_unsuccessful_response(xml_request, response)
         end
-      rescue CCMSError => e
+      rescue *CCMS_SUBMISSION_ERRORS => e
         handle_exception(e, xml_request)
       end
 

--- a/app/services/ccms/submitters/add_case_service.rb
+++ b/app/services/ccms/submitters/add_case_service.rb
@@ -14,7 +14,7 @@ module CCMS
         else
           handle_unsuccessful_response(xml_request, response)
         end
-      rescue StandardError => e
+      rescue *CCMS_SUBMISSION_ERRORS => e
         handle_exception(e, xml_request)
       end
 

--- a/app/services/ccms/submitters/base_submission_service.rb
+++ b/app/services/ccms/submitters/base_submission_service.rb
@@ -3,6 +3,12 @@ module CCMS
     class BaseSubmissionService
       attr_accessor :submission
 
+      CCMS_SUBMISSION_ERRORS = [
+        CCMSError,
+        Savon::Error,
+        StandardError
+      ].freeze
+
       def initialize(submission)
         @submission = submission
       end

--- a/app/services/ccms/submitters/base_submission_service.rb
+++ b/app/services/ccms/submitters/base_submission_service.rb
@@ -5,6 +5,8 @@ module CCMS
 
       CCMS_SUBMISSION_ERRORS = [
         CCMSError,
+        Savon::HTTPError,
+        Savon::SOAPFault,
         Savon::Error,
         StandardError
       ].freeze

--- a/app/services/ccms/submitters/check_applicant_status_service.rb
+++ b/app/services/ccms/submitters/check_applicant_status_service.rb
@@ -8,7 +8,7 @@ module CCMS
         response = applicant_add_status_requestor.call
         parser = CCMS::Parsers::ApplicantAddStatusResponseParser.new(tx_id, response)
         process_response(parser)
-      rescue CCMSError => e
+      rescue *CCMS_SUBMISSION_ERRORS => e
         handle_exception(e, xml_request)
       end
 

--- a/app/services/ccms/submitters/check_case_status_service.rb
+++ b/app/services/ccms/submitters/check_case_status_service.rb
@@ -7,7 +7,7 @@ module CCMS
         submission.save!
         parser = CCMS::Parsers::CaseAddStatusResponseParser.new(tx_id, response)
         process_response(parser)
-      rescue CCMSError => e
+      rescue *CCMS_SUBMISSION_ERRORS => e
         handle_exception(e, xml_request)
       end
 

--- a/app/services/ccms/submitters/obtain_applicant_reference_service.rb
+++ b/app/services/ccms/submitters/obtain_applicant_reference_service.rb
@@ -5,7 +5,7 @@ module CCMS
         tx_id = applicant_search_requestor.transaction_request_id
         parser = CCMS::Parsers::ApplicantSearchResponseParser.new(tx_id, response)
         process_records(parser)
-      rescue CCMSError => e
+      rescue *CCMS_SUBMISSION_ERRORS => e
         handle_exception(e, xml_request)
       end
 

--- a/app/services/ccms/submitters/obtain_case_reference_service.rb
+++ b/app/services/ccms/submitters/obtain_case_reference_service.rb
@@ -5,7 +5,7 @@ module CCMS
         submission.case_ccms_reference = reference_id
         submission.save!
         create_history(:initialised, submission.aasm_state, xml_request, response) if submission.obtain_case_ref!
-      rescue CCMSError => e
+      rescue *CCMS_SUBMISSION_ERRORS => e
         handle_exception(e, xml_request)
       end
 

--- a/app/services/ccms/submitters/obtain_document_id_service.rb
+++ b/app/services/ccms/submitters/obtain_document_id_service.rb
@@ -10,7 +10,7 @@ module CCMS
         raise CCMSError, "Failed to obtain document ids for: #{failed_requesting_ids}" if failed_requesting_ids.present?
 
         submission.obtain_document_ids!
-      rescue CCMSError => e
+      rescue *CCMS_SUBMISSION_ERRORS => e
         handle_exception(e, nil)
       end
 
@@ -47,7 +47,7 @@ module CCMS
         response = update_document_and_return_response(document, document_id_requestor)
         document.save!
         create_history('applicant_ref_obtained', 'document_ids_obtained', document_id_requestor.formatted_xml, response) if submission.save!
-      rescue CCMSError => e
+      rescue *CCMS_SUBMISSION_ERRORS => e
         document.status = :failed
         document.save!
         create_ccms_failure_history('applicant_ref_obtained', e, document_id_requestor.formatted_xml)

--- a/app/services/ccms/submitters/upload_documents_service.rb
+++ b/app/services/ccms/submitters/upload_documents_service.rb
@@ -9,7 +9,7 @@ module CCMS
         raise CCMSError, "The following documents failed to upload: #{failed_upload_ids}" if failed_upload_ids.present?
 
         create_history('case_created', submission.aasm_state, nil, nil) if submission.complete!
-      rescue CCMSError => e
+      rescue *CCMS_SUBMISSION_ERRORS => e
         handle_exception(e, nil)
       end
 
@@ -25,7 +25,7 @@ module CCMS
         submission_document.save!
         submission.save!
         create_history('case_created', submission_document.status, document_upload_requestor.formatted_xml, response)
-      rescue CCMSError => e
+      rescue *CCMS_SUBMISSION_ERRORS => e
         submission_document.status = :failed
         submission.save!
         create_ccms_failure_history('case_created', e, document_upload_requestor.formatted_xml)

--- a/spec/services/ccms/submitters/add_applicant_service_spec.rb
+++ b/spec/services/ccms/submitters/add_applicant_service_spec.rb
@@ -71,10 +71,10 @@ module CCMS
 
       context 'operation in error' do
         context 'error when adding an applicant' do
-          let(:error) { [CCMS::CCMSError, Savon::Error, StandardError].sample }
+          let(:error) { [CCMS::CCMSError, Savon::Error, StandardError] }
 
           before do
-            expect_any_instance_of(CCMS::Requestors::ApplicantAddRequestor).to receive(:call).and_raise(error, 'oops')
+            expect_any_instance_of(CCMS::Requestors::ApplicantAddRequestor).to receive(:call).and_raise(error.sample, 'oops')
           end
 
           it 'puts it into failed state' do

--- a/spec/services/ccms/submitters/add_applicant_service_spec.rb
+++ b/spec/services/ccms/submitters/add_applicant_service_spec.rb
@@ -71,8 +71,10 @@ module CCMS
 
       context 'operation in error' do
         context 'error when adding an applicant' do
+          let(:error) { [CCMS::CCMSError, Savon::Error, StandardError].sample }
+
           before do
-            expect_any_instance_of(CCMS::Requestors::ApplicantAddRequestor).to receive(:call).and_raise(CCMS::CCMSError, 'oops')
+            expect_any_instance_of(CCMS::Requestors::ApplicantAddRequestor).to receive(:call).and_raise(error, 'oops')
           end
 
           it 'puts it into failed state' do
@@ -85,7 +87,7 @@ module CCMS
             expect(history.from_state).to eq 'case_ref_obtained'
             expect(history.to_state).to eq 'failed'
             expect(history.success).to be false
-            expect(history.details).to match(/CCMS::CCMSError/)
+            expect(history.details).to match(/#{error}/)
             expect(history.details).to match(/oops/)
             expect(history.request).to be_soap_envelope_with(
               command: 'ns2:ClientAddRQ',

--- a/spec/services/ccms/submitters/add_case_service_spec.rb
+++ b/spec/services/ccms/submitters/add_case_service_spec.rb
@@ -104,10 +104,10 @@ module CCMS
 
       context 'operation in error' do
         context 'error when adding a case' do
-          let(:error) { [CCMS::CCMSError, Savon::Error, StandardError].sample }
+          let(:error) { [CCMS::CCMSError, Savon::Error, StandardError] }
 
           before do
-            expect_any_instance_of(CCMS::Requestors::CaseAddRequestor).to receive(:call).and_raise(error, 'oops')
+            expect_any_instance_of(CCMS::Requestors::CaseAddRequestor).to receive(:call).and_raise(error.sample, 'oops')
           end
 
           it 'puts it into failed state' do

--- a/spec/services/ccms/submitters/add_case_service_spec.rb
+++ b/spec/services/ccms/submitters/add_case_service_spec.rb
@@ -104,8 +104,10 @@ module CCMS
 
       context 'operation in error' do
         context 'error when adding a case' do
+          let(:error) { [CCMS::CCMSError, Savon::Error, StandardError].sample }
+
           before do
-            expect_any_instance_of(CCMS::Requestors::CaseAddRequestor).to receive(:call).and_raise(CCMS::CCMSError, 'oops')
+            expect_any_instance_of(CCMS::Requestors::CaseAddRequestor).to receive(:call).and_raise(error, 'oops')
           end
 
           it 'puts it into failed state' do
@@ -118,7 +120,7 @@ module CCMS
             expect(history.from_state).to eq 'applicant_ref_obtained'
             expect(history.to_state).to eq 'failed'
             expect(history.success).to be false
-            expect(history.details).to match(/CCMS::CCMSError/)
+            expect(history.details).to match(/#{error}/)
             expect(history.details).to match(/oops/)
             expect(history.request).to be_soap_envelope_with(
               command: 'ns4:CaseAddRQ',

--- a/spec/services/ccms/submitters/check_applicant_status_service_spec.rb
+++ b/spec/services/ccms/submitters/check_applicant_status_service_spec.rb
@@ -125,8 +125,10 @@ module CCMS
         end
 
         context 'operation unsuccessful' do
+          let(:error) { [CCMS::CCMSError, Savon::Error, StandardError].sample }
+
           before do
-            expect_any_instance_of(CCMS::Requestors::ApplicantAddStatusRequestor).to receive(:call).and_raise(CCMSError, 'oops')
+            expect_any_instance_of(CCMS::Requestors::ApplicantAddStatusRequestor).to receive(:call).and_raise(error, 'oops')
           end
 
           it 'increments the poll count' do
@@ -142,7 +144,7 @@ module CCMS
             expect(history.from_state).to eq 'applicant_submitted'
             expect(history.to_state).to eq 'failed'
             expect(history.success).to be false
-            expect(history.details).to match(/CCMS::CCMSError/)
+            expect(history.details).to match(/#{error}/)
             expect(history.details).to match(/oops/)
             expect(history.request).to be_soap_envelope_with(
               command: 'ns2:ClientAddUpdtStatusRQ',

--- a/spec/services/ccms/submitters/check_applicant_status_service_spec.rb
+++ b/spec/services/ccms/submitters/check_applicant_status_service_spec.rb
@@ -125,10 +125,10 @@ module CCMS
         end
 
         context 'operation unsuccessful' do
-          let(:error) { [CCMS::CCMSError, Savon::Error, StandardError].sample }
+          let(:error) { [CCMS::CCMSError, Savon::Error, StandardError] }
 
           before do
-            expect_any_instance_of(CCMS::Requestors::ApplicantAddStatusRequestor).to receive(:call).and_raise(error, 'oops')
+            expect_any_instance_of(CCMS::Requestors::ApplicantAddStatusRequestor).to receive(:call).and_raise(error.sample, 'oops')
           end
 
           it 'increments the poll count' do

--- a/spec/services/ccms/submitters/check_case_status_service_spec.rb
+++ b/spec/services/ccms/submitters/check_case_status_service_spec.rb
@@ -130,11 +130,11 @@ RSpec.describe CCMS::Submitters::CheckCaseStatusService do
 
     context 'operation unsuccessful' do
       let(:transaction_request_id_in_example_response) { '20190301030405123456' }
-      let(:error) { [CCMS::CCMSError, Savon::Error, StandardError].sample }
+      let(:error) { [CCMS::CCMSError, Savon::Error, StandardError] }
 
       before do
         allow(case_add_status_requestor).to receive(:formatted_xml).and_return(case_add_status_request)
-        expect(case_add_status_requestor).to receive(:call).and_raise(error, 'oops')
+        expect(case_add_status_requestor).to receive(:call).and_raise(error.sample, 'oops')
         expect(case_add_status_requestor).to receive(:transaction_request_id).and_return(transaction_request_id_in_example_response)
       end
 

--- a/spec/services/ccms/submitters/check_case_status_service_spec.rb
+++ b/spec/services/ccms/submitters/check_case_status_service_spec.rb
@@ -130,10 +130,11 @@ RSpec.describe CCMS::Submitters::CheckCaseStatusService do
 
     context 'operation unsuccessful' do
       let(:transaction_request_id_in_example_response) { '20190301030405123456' }
+      let(:error) { [CCMS::CCMSError, Savon::Error, StandardError].sample }
 
       before do
         allow(case_add_status_requestor).to receive(:formatted_xml).and_return(case_add_status_request)
-        expect(case_add_status_requestor).to receive(:call).and_raise(CCMS::CCMSError, 'oops')
+        expect(case_add_status_requestor).to receive(:call).and_raise(error, 'oops')
         expect(case_add_status_requestor).to receive(:transaction_request_id).and_return(transaction_request_id_in_example_response)
       end
 
@@ -152,7 +153,7 @@ RSpec.describe CCMS::Submitters::CheckCaseStatusService do
         expect(history.request).to eq case_add_status_request
         expect(history.request).to_not be_nil
         expect(history.success).to be false
-        expect(history.details).to match(/CCMS::CCMSError/)
+        expect(history.details).to match(/#{error}/)
         expect(history.details).to match(/oops/)
       end
 

--- a/spec/services/ccms/submitters/obtain_applicant_reference_service_spec.rb
+++ b/spec/services/ccms/submitters/obtain_applicant_reference_service_spec.rb
@@ -123,10 +123,10 @@ module CCMS
 
       context 'operation in error' do
         context 'error when searching for applicant' do
-          let(:error) { [CCMS::CCMSError, Savon::Error, StandardError].sample }
+          let(:error) { [CCMS::CCMSError, Savon::Error, StandardError] }
 
           before do
-            expect_any_instance_of(CCMS::Requestors::ApplicantSearchRequestor).to receive(:call).and_raise(error, 'oops')
+            expect_any_instance_of(CCMS::Requestors::ApplicantSearchRequestor).to receive(:call).and_raise(error.sample, 'oops')
           end
 
           it 'puts it into failed state' do

--- a/spec/services/ccms/submitters/obtain_applicant_reference_service_spec.rb
+++ b/spec/services/ccms/submitters/obtain_applicant_reference_service_spec.rb
@@ -123,8 +123,10 @@ module CCMS
 
       context 'operation in error' do
         context 'error when searching for applicant' do
+          let(:error) { [CCMS::CCMSError, Savon::Error, StandardError].sample }
+
           before do
-            expect_any_instance_of(CCMS::Requestors::ApplicantSearchRequestor).to receive(:call).and_raise(CCMS::CCMSError, 'oops')
+            expect_any_instance_of(CCMS::Requestors::ApplicantSearchRequestor).to receive(:call).and_raise(error, 'oops')
           end
 
           it 'puts it into failed state' do
@@ -137,7 +139,7 @@ module CCMS
             expect(latest_history.from_state).to eq 'case_ref_obtained'
             expect(latest_history.to_state).to eq 'failed'
             expect(latest_history.success).to be false
-            expect(latest_history.details).to match(/CCMS::CCMSError/)
+            expect(latest_history.details).to match(/#{error}/)
             expect(latest_history.details).to match(/oops/)
             expect(latest_history.request).to be_soap_envelope_with(
               command: 'ns2:ClientInqRQ',

--- a/spec/services/ccms/submitters/obtain_case_reference_service_spec.rb
+++ b/spec/services/ccms/submitters/obtain_case_reference_service_spec.rb
@@ -59,10 +59,10 @@ module CCMS
       end
 
       context 'operation in error' do
-        let(:error) { [CCMS::CCMSError, Savon::Error, StandardError].sample }
+        let(:error) { [CCMS::CCMSError, Savon::Error, StandardError] }
 
         before do
-          expect_any_instance_of(CCMS::Requestors::ReferenceDataRequestor).to receive(:call).and_raise(error, 'oops')
+          expect_any_instance_of(CCMS::Requestors::ReferenceDataRequestor).to receive(:call).and_raise(error.sample, 'oops')
         end
 
         it 'puts it into failed state' do

--- a/spec/services/ccms/submitters/obtain_case_reference_service_spec.rb
+++ b/spec/services/ccms/submitters/obtain_case_reference_service_spec.rb
@@ -59,8 +59,10 @@ module CCMS
       end
 
       context 'operation in error' do
+        let(:error) { [CCMS::CCMSError, Savon::Error, StandardError].sample }
+
         before do
-          expect_any_instance_of(CCMS::Requestors::ReferenceDataRequestor).to receive(:call).and_raise(CCMS::CCMSError, 'oops')
+          expect_any_instance_of(CCMS::Requestors::ReferenceDataRequestor).to receive(:call).and_raise(error, 'oops')
         end
 
         it 'puts it into failed state' do
@@ -73,7 +75,7 @@ module CCMS
           expect(history.from_state).to eq 'initialised'
           expect(history.to_state).to eq 'failed'
           expect(history.success).to be false
-          expect(history.details).to match(/CCMS::CCMSError/)
+          expect(history.details).to match(/#{error}/)
           expect(history.details).to match(/oops/)
           expect(history.request).to be_soap_envelope_with(
             command: 'ns2:ReferenceDataInqRQ',

--- a/spec/services/ccms/submitters/obtain_document_id_service_spec.rb
+++ b/spec/services/ccms/submitters/obtain_document_id_service_spec.rb
@@ -119,9 +119,11 @@ module CCMS
         # the microsecond :(
         context 'when populating documents' do
           let!(:statement_of_case) { create :statement_of_case, :with_original_and_pdf_files_attached, legal_aid_application: legal_aid_application }
+          let(:error) { [CCMS::CCMSError, Savon::Error, StandardError].sample }
+
           before do
             allow_any_instance_of(CCMS::Requestors::DocumentIdRequestor).to receive(:transaction_request_id).and_return('20190301030405123456')
-            expect_any_instance_of(CCMS::Requestors::DocumentIdRequestor).to receive(:call).and_raise(CCMSError, 'Failed to obtain document ids for')
+            expect_any_instance_of(CCMS::Requestors::DocumentIdRequestor).to receive(:call).and_raise(error, 'Failed to obtain document ids for')
           end
 
           it 'changes the submission state to failed' do
@@ -133,7 +135,7 @@ module CCMS
             expect(history.from_state).to eq 'applicant_ref_obtained' # this is failing gets case_submitted
             expect(history.to_state).to eq 'failed'
             expect(history.success).to be false
-            expect(history.details).to match(/CCMS::CCMSError/)
+            expect(history.details).to match(/#{error}/)
             expect(history.details).to match(/Failed to obtain document ids for/)
             expect(history.request).to be_nil
             expect(history.response).to be_nil

--- a/spec/services/ccms/submitters/obtain_document_id_service_spec.rb
+++ b/spec/services/ccms/submitters/obtain_document_id_service_spec.rb
@@ -119,11 +119,11 @@ module CCMS
         # the microsecond :(
         context 'when populating documents' do
           let!(:statement_of_case) { create :statement_of_case, :with_original_and_pdf_files_attached, legal_aid_application: legal_aid_application }
-          let(:error) { [CCMS::CCMSError, Savon::Error, StandardError].sample }
+          let(:error) { [CCMS::CCMSError, Savon::Error, StandardError] }
 
           before do
             allow_any_instance_of(CCMS::Requestors::DocumentIdRequestor).to receive(:transaction_request_id).and_return('20190301030405123456')
-            expect_any_instance_of(CCMS::Requestors::DocumentIdRequestor).to receive(:call).and_raise(error, 'Failed to obtain document ids for')
+            expect_any_instance_of(CCMS::Requestors::DocumentIdRequestor).to receive(:call).and_raise(error.sample, 'Failed to obtain document ids for')
           end
 
           it 'changes the submission state to failed' do

--- a/spec/services/ccms/submitters/upload_documents_service_spec.rb
+++ b/spec/services/ccms/submitters/upload_documents_service_spec.rb
@@ -96,11 +96,11 @@ RSpec.describe CCMS::Submitters::UploadDocumentsService do
 
   context 'operation unsuccessful' do
     let(:history) { histories.where(request: nil, response: nil, to_state: 'failed').last }
-    let(:error) { [CCMS::CCMSError, Savon::Error, StandardError].sample }
+    let(:error) { [CCMS::CCMSError, Savon::Error, StandardError] }
 
     context 'operation fails due to an exception' do
       before do
-        allow(document_upload_requestor).to receive(:call).and_raise(error, 'failed to upload')
+        allow(document_upload_requestor).to receive(:call).and_raise(error.sample, 'failed to upload')
       end
 
       it 'changes the submission state to failed' do

--- a/spec/services/ccms/submitters/upload_documents_service_spec.rb
+++ b/spec/services/ccms/submitters/upload_documents_service_spec.rb
@@ -96,9 +96,11 @@ RSpec.describe CCMS::Submitters::UploadDocumentsService do
 
   context 'operation unsuccessful' do
     let(:history) { histories.where(request: nil, response: nil, to_state: 'failed').last }
+    let(:error) { [CCMS::CCMSError, Savon::Error, StandardError].sample }
+
     context 'operation fails due to an exception' do
       before do
-        allow(document_upload_requestor).to receive(:call).and_raise(CCMS::CCMSError, 'failed to upload')
+        allow(document_upload_requestor).to receive(:call).and_raise(error, 'failed to upload')
       end
 
       it 'changes the submission state to failed' do
@@ -119,7 +121,7 @@ RSpec.describe CCMS::Submitters::UploadDocumentsService do
         expect(first_history.from_state).to eq 'case_created'
         expect(first_history.to_state).to eq 'failed'
         expect(first_history.success).to be false
-        expect(first_history.details).to match(/CCMS::CCMSError/)
+        expect(first_history.details).to match(/#{error}/)
         expect(first_history.details).to match(/failed to upload/)
       end
 


### PR DESCRIPTION
## AP-1268 Rescue uncaught errors during CCMS submission

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1268)

Added StandardError, Savon::Error, Savon::HTTPError and Savon::SOAPFault to the rescue clause when submitting a request to ccms. This is in order to then update the submission history table with the errors that weren't being caught before.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
