### PR TITLE
AP-1269:View for submission data on admin pages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -196,7 +196,7 @@ jobs:
     - *save_js_packages_cache
     - run:
         name: Run integration tests
-        command: bundle exec cucumber --format junit --out /tmp/test-results/cucumber
+        command: bundle exec cucumber --format junit --out /tmp/test-results/cucumber --format pretty
     - store_artifacts:
         path: tmp/capybara
     - store_test_results:

--- a/app/assets/stylesheets/admin/submissions.scss
+++ b/app/assets/stylesheets/admin/submissions.scss
@@ -1,0 +1,28 @@
+dl.kvp{
+  width:100%;
+  overflow:hidden;
+  position: relative;
+  left: 1em;
+}
+
+dl.kvp dt {
+  font-weight:600;
+  float:left;
+  width:49%;
+  clear:both;
+  padding: 0 0 3px;
+  position:relative;
+}
+
+dl.kvp dd {
+  float:right;
+  width:51%;
+  padding: 0 0 3px;
+  margin-left:0;
+}
+
+dl.kvp dd {
+  *float:none;
+  *width:auto;
+  *margin-left:49%;
+}

--- a/app/controllers/admin/legal_aid_applications/submissions_controller.rb
+++ b/app/controllers/admin/legal_aid_applications/submissions_controller.rb
@@ -1,0 +1,12 @@
+module Admin
+  module LegalAidApplications
+    class SubmissionsController < ApplicationController
+      before_action :authenticate_admin_user!
+      layout 'admin'.freeze
+
+      def show
+        @legal_aid_application = LegalAidApplication.find(params[:id])
+      end
+    end
+  end
+end

--- a/app/helpers/hash_format_helper.rb
+++ b/app/helpers/hash_format_helper.rb
@@ -1,0 +1,38 @@
+module HashFormatHelper
+  # These methods add classes to the HTML structure
+  def format_hash(hash, html = '')
+    hash.each do |key, value|
+      next if value.blank?
+
+      if standard_type?(value) || value.is_a?(Hash)
+        html += build_dl(key, value)
+      else
+        Rails.logger.info "Unexpected value type of '#{value.class.name}' for key '#{standardize_key(key)}' in format_hash: #{value.inspect}"
+      end
+    end
+    html.html_safe
+  end
+
+  private
+
+  def build_dl(key, value)
+    content_tag(:dl, class: 'govuk-body kvp govuk-!-margin-bottom-0') do
+      dl_contents = ''
+      dl_contents << content_tag(:dt, standardize_key(key))
+      dl_contents << if standard_type?(value)
+                       content_tag(:dd, value.to_s.capitalize)
+                     else
+                       format_hash(value)
+                     end
+      dl_contents.html_safe
+    end
+  end
+
+  def standardize_key(key)
+    key.to_s.underscore.humanize.titleize
+  end
+
+  def standard_type?(value)
+    value.is_a?(String) || value.is_a?(Numeric) || value.is_a?(TrueClass) || value.is_a?(FalseClass)
+  end
+end

--- a/app/views/admin/legal_aid_applications/_legal_aid_applications.html.erb
+++ b/app/views/admin/legal_aid_applications/_legal_aid_applications.html.erb
@@ -22,7 +22,7 @@
             <td class="govuk-table__cell"><%= application.enum_t(:state) %></td>
             <td class="govuk-table__cell"><%= mail_to application.provider.email, application.provider.username %></td>
             <td class="govuk-table__cell">
-              <%= "Discarded by user on #{application.discarded_at.strftime('%d-%m-%Y')}" if application.discarded? %>
+              <%= t('.discarded', date: application.discarded_at.strftime('%d-%m-%Y')) if application.discarded? %>
               <%= button_to(
                 t('.delete'),
                 admin_legal_aid_application_path(application.id),
@@ -35,13 +35,9 @@
                 "data-delete-message": t('.warning.delete')
               ) if destroy_enabled? %>
              </td>
-            <td class="govuk-table__cell"><%= button_to(
-                                                'Test CCMS connectivity',
-                                                admin_ccms_connectivity_test_path(application.id),
-                                                method: :get,
-                                                class: 'govuk-button'
-                                              ) %>
-                                             </td>
+            <td class="govuk-table__cell">
+              <%= link_to t('.data_view'), admin_legal_aid_applications_submission_path(application), class: 'govuk-button govuk-!-margin-bottom-0' %>
+            </td>
           </tr>
         <% end %>
       </tbody>

--- a/app/views/admin/legal_aid_applications/submissions/show.html.erb
+++ b/app/views/admin/legal_aid_applications/submissions/show.html.erb
@@ -1,0 +1,66 @@
+<%= back_link() %>
+<div class='govuk-body'>
+  <h1 class="govuk-heading-l">Legal Aid Application</h1>
+  <dl class="govuk-body kvp">
+    <dt>Reference</dt>
+    <dd><%= @legal_aid_application.application_ref %></dd>
+    <dt>State</dt>
+    <dd><%= @legal_aid_application.state %></dd>
+  </dl>
+
+  <% if @legal_aid_application.cfe_submissions.present? %>
+    <% @legal_aid_application.cfe_submissions.each do |cfe_submission| %>
+      <h2 class="govuk-heading-m">CFE Submission (<%= cfe_submission.id %>)</h2>
+      <dl class="govuk-body kvp">
+        <dt>State</dt>
+        <dd><%= cfe_submission.aasm_state %></dd>
+        <dt>assessment_id</dt>
+        <dd><%= cfe_submission.assessment_id %></dd>
+        <dt>error message</dt>
+        <dd><%= cfe_submission.error_message ||= 'N/A' %></dd>
+      </dl>
+      <details>
+        <summary class="govuk-heading-m govuk-details__summary">CFE result</summary>
+        <section>
+          <%= format_hash(JSON.parse(cfe_submission.result.result)) %>
+        </section>
+      </details>
+    <% end %>
+  <% end %>
+</div>
+<div class="govuk-body">
+  <% if @legal_aid_application.ccms_submission.present? %>
+    <h2 class="govuk-heading-m">CCMS Submission (<%= @legal_aid_application.ccms_submission.id %>)</h2>
+    <section>
+      <dl class="govuk-body kvp">
+        <dt>State</dt>
+        <dd><%= @legal_aid_application.ccms_submission.aasm_state %></dd>
+        <dt>Case CCMS reference</dt>
+        <dd><%= @legal_aid_application.ccms_submission.case_ccms_reference %></dd>
+        <dt>Applicant CCMS reference</dt>
+        <dd><%= @legal_aid_application.ccms_submission.applicant_ccms_reference %></dd>
+        <dt>Applicant poll count</dt>
+        <dd><%= @legal_aid_application.ccms_submission.applicant_poll_count ||= 'N/A' %></dd>
+        <dt>Case poll count</dt>
+        <dd><%= @legal_aid_application.ccms_submission.case_poll_count ||= 'N/A' %></dd>
+      </dl>
+    </section>
+    <% if @legal_aid_application.ccms_submission.submission_history.present? %>
+      <h2 class="govuk-heading-m">CCMS Submission histories</h2>
+        <dl class="govuk-body kvp">
+          <% @legal_aid_application.ccms_submission.submission_history.order(:created_at).each do |submission_history| %>
+            <dt>Created <%= submission_history.created_at.strftime('%d %B %Y at %H:%M:%S') %></dt>
+            <dd><%= submission_history.id %></dd>
+            <dt>From state</dt>
+            <dd><%= submission_history.from_state %></dd>
+            <dt>To state</dt>
+            <dd><%= submission_history.to_state %></dd>
+            <dt>Success</dt>
+            <dd><%= submission_history.success %></dd>
+            <dt class="govuk-!-margin-bottom-5">Details</dt>
+            <dd><%= submission_history.details %></dd>
+        <% end %>
+        </dl>
+      <% end %>
+    <% end %>
+</div>

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -23,6 +23,8 @@ en:
         latest_applications: Latest Legal Aid Applications
         status: Status
         provider_username: Provider's username
+        discarded: Discarded by user on %{date}
+        data_view: Submission details
     settings:
       show:
         heading_1: Settings

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,6 +51,9 @@ Rails.application.routes.draw do
 
   namespace :admin do
     root to: 'legal_aid_applications#index'
+    namespace :legal_aid_applications do
+      resources :submissions, only: [:show]
+    end
     resources :legal_aid_applications, only: %i[index destroy] do
       post :create_test_applications, on: :collection
       delete :destroy_all, on: :collection

--- a/features/admin/application_list.feature
+++ b/features/admin/application_list.feature
@@ -1,0 +1,9 @@
+Feature: Admin application functions
+
+  @javascript
+  Scenario: I can view the ccms data from a submitted application
+    Given an application has been submitted
+    When I am logged in as an admin
+    And I click link 'Submission details'
+    Then I should see 'Legal Aid Application'
+    And I should see 'CCMS Submission'

--- a/features/step_definitions/admin_steps.rb
+++ b/features/step_definitions/admin_steps.rb
@@ -1,0 +1,27 @@
+Given(/^I am logged in as an admin$/) do
+  OmniAuth.config.test_mode = true
+  admin_user = create(:admin_user, username: 'apply_maintenance')
+  OmniAuth.config.add_mock(
+    :google_oauth2,
+    info: { email: admin_user.email },
+    origin: admin_settings_url
+  )
+  get admin_user_google_oauth2_omniauth_callback_path
+  follow_redirect!
+  visit admin_legal_aid_applications_path
+  click_link 'Log in via google'
+end
+
+Given('an application has been submitted') do
+  @legal_aid_application = create(
+    :application,
+    :with_everything,
+    :with_passported_state_machine,
+    :initiated,
+    provider: create(:provider)
+  )
+end
+
+Given(/^I visit the admin applications page$/) do
+  visit admin_legal_aid_applications_path
+end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -136,6 +136,10 @@ World(FactoryBot::Syntax::Methods)
 World(Warden::Test::Helpers)
 
 After do |scenario|
+  # reset oauth mocks
+  OmniAuth.config.mock_auth[:google_oauth2] = nil
+  OmniAuth.config.test_mode = false
+
   if scenario.failed?
     name = scenario.location.file.gsub('features/', '').gsub(%r{/\.|/}, '-')
     screenshot_image(name)

--- a/spec/helpers/hash_format_helper_spec.rb
+++ b/spec/helpers/hash_format_helper_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe HashFormatHelper, type: :helper do
+  let(:source) { { key: 'value', sub_hash: { sub_key: 'sub_value' } } }
+  let(:expected_response) do
+    '<dl class="govuk-body kvp govuk-!-margin-bottom-0"><dt>Key</dt><dd>Value</dd></dl>' \
+    '<dl class="govuk-body kvp govuk-!-margin-bottom-0"><dt>Sub Hash</dt>'\
+    '<dl class="govuk-body kvp govuk-!-margin-bottom-0"><dt>Sub Key</dt><dd>Sub_value</dd></dl></dl>'
+  end
+
+  describe '#format_hash' do
+    subject { format_hash(source) }
+
+    context 'when passed a hash' do
+      it { is_expected.to eql expected_response }
+    end
+
+    context 'when passed invalid data' do
+      before do
+        allow(Rails.logger).to receive(:info).at_least(:once)
+        subject
+      end
+
+      let(:source) { { key: ['value', 'value 2'] } }
+      let(:expected_response) { "Unexpected value type of 'Array' for key 'Key' in format_hash: [\"value\", \"value 2\"]" }
+
+      it 'logs error messages' do
+        expect(Rails.logger).to have_received(:info).with(expected_response).once
+      end
+    end
+  end
+end

--- a/spec/requests/admin/legal_aid_applications/submissions_controller_spec.rb
+++ b/spec/requests/admin/legal_aid_applications/submissions_controller_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe Admin::LegalAidApplications::SubmissionsController, type: :request do
+  let(:admin_user) { create :admin_user }
+  let(:legal_aid_application) { create(:legal_aid_application, :with_everything) }
+
+  before { sign_in admin_user }
+
+  describe 'GET show' do
+    subject { get admin_legal_aid_applications_submission_path(legal_aid_application) }
+
+    it 'renders successfully' do
+      subject
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'displays correct application' do
+      subject
+      expect(response.body).to include(legal_aid_application.application_ref)
+    end
+  end
+end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1269)

Add an additional controller/view to display data from the CFE and CCMS submissions
This will allow admin users to view this data without relying on Devs manually extracting and parsing data

I have included the CFE result behind a collapsible details section so that it can be readers choice and they don't have to scroll past it to get to the CCMS submission data
![image](https://user-images.githubusercontent.com/6757677/99252939-b7e43300-2807-11eb-86e1-117ff975108a.png)
There should be a subsequent ticket to add the Submission History XML request and response

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
