### PR TITLE
AP-1804 Add MimeMagic gem to validate file types

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -98,6 +98,9 @@ gem 'blazer', '>= 2.2.6'
 # Manage security headers
 gem 'secure_headers'
 
+# Identify file types before uploads
+gem 'mimemagic'
+
 group :development, :test do
   gem 'awesome_print', '~> 1.8.0'
   gem 'byebug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -656,6 +656,7 @@ DEPENDENCIES
   libreconv
   listen (>= 3.0.5, < 3.4)
   loofah (>= 2.2.3)
+  mimemagic
   nesty
   nokogiri
   omniauth (>= 1.9.1)

--- a/app/forms/statement_of_cases/statement_of_case_form.rb
+++ b/app/forms/statement_of_cases/statement_of_case_form.rb
@@ -63,8 +63,8 @@ module StatementOfCases
       @original_file_name = original_file.original_filename
       scanner_down(original_file)
       malware_scan(original_file)
-      disallowed_content_type(original_file)
       file_empty(original_file)
+      disallowed_content_type(original_file)
       too_big(original_file)
       create_attachment(original_file) unless errors.present?
     end
@@ -87,7 +87,7 @@ module StatementOfCases
     end
 
     def disallowed_content_type(original_file)
-      return if original_file.content_type.in?(ALLOWED_CONTENT_TYPES)
+      return if MimeMagic.by_magic(original_file)&.type.in?(ALLOWED_CONTENT_TYPES)
 
       errors.add(:original_file, original_file_error_for(:content_type_invalid, file_name: @original_file_name))
     end

--- a/spec/requests/providers/statement_of_case_spec.rb
+++ b/spec/requests/providers/statement_of_case_spec.rb
@@ -187,6 +187,20 @@ RSpec.describe 'provider statement of case requests', type: :request do
           end
         end
 
+        context 'file is invalid mime type but has valid content_type' do
+          let(:original_file) { uploaded_file('spec/fixtures/files/zip.zip', 'application/zip') }
+          before do
+            allow(original_file).to receive(:content_type).and_return('application/pdf')
+          end
+
+          it 'does not save the object and raise an error' do
+            subject
+            error = I18n.t('activemodel.errors.models.statement_of_case.attributes.original_file.content_type_invalid', file_name: original_file.original_filename)
+            expect(response.body).to include(error)
+            expect(statement_of_case).to be_nil
+          end
+        end
+
         context 'file is too big' do
           before { allow(StatementOfCases::StatementOfCaseForm).to receive(:max_file_size).and_return(0) }
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1804)

There is a security vulnerability in the way we check for valid statement of case file types using the file's `content_type`, which can be forged in HTTP requests.

Instead we can use the `MimeMagic` gem, which is able to examine the content of the file itself in order to identify the type more accurately.  This was chosen over the similar `Ruby-FileMagic` gem as it's easier to implement and better maintained.

![ETCj](https://user-images.githubusercontent.com/28729201/99256398-40190700-280d-11eb-9808-a89458b8d650.gif)

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
