### PR TITLE
AP-1678 Test for missing Welsh translations

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -47,7 +47,7 @@ Rails.application.configure do
   config.active_record.verbose_query_logs = true
 
   # Raises error for missing translations
-  # config.action_view.raise_on_missing_translations = true
+  config.action_view.raise_on_missing_translations = true
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -47,7 +47,8 @@ Rails.application.configure do
   config.x.laa_portal.idp_cert_fingerprint_algorithm = 'http://www.w3.org/2000/09/xmldsig#sha'
 
   # Raises error for missing translations
-  # config.action_view.raise_on_missing_translations = true
+  config.action_view.raise_on_missing_translations = true
+
   Rails.application.routes.default_url_options[:host] = 'www.example.com'
 
   config.active_storage.service = :test

--- a/config/locales/cy/generic.yml
+++ b/config/locales/cy/generic.yml
@@ -6,13 +6,17 @@ cy:
     continue: eunitnoC
     cy: Cymraeg
     en: English
+    en-GB: English # Needed for testing as en-GB is used by Faker
     errors:
       problem_text: melborp a si erehT
+    menu: uneM
     'no': 'oN'
     or: ro
     remove: evomeR
     save_and_continue: eunitnoc dna evaS
+    save_and_come_back_later: etal kcab emoc dna evaS
     select_all_that_apply: ylppa taht lla tceleS
     send: dneS
     start_now: won tratS
+    toggle_navigation: noitagivaN leveL poT edih ro wohS
     'yes': seY

--- a/config/locales/en/generic.yml
+++ b/config/locales/en/generic.yml
@@ -16,6 +16,7 @@ en:
     destroy: Destroy
     edit: Edit
     en: English
+    en-GB: English # Needed for testing as en-GB is used by Faker
     enter_text: Enter text
     errors:
       problem_text: There is a problem

--- a/config/locales/en/transaction_types.yml
+++ b/config/locales/en/transaction_types.yml
@@ -31,6 +31,7 @@ en:
     table_label:
       benefits: Benefits
       child_care: Childcare
+      excluded_benefits: Disregarded benefits
       friends_or_family: Financial help
       legal_aid: Legal aid
       maintenance_in: Maintenance

--- a/features/cassettes/Citizen_journey_in_Welsh/Follow_citizen_journey_from_Accounts_page.yml
+++ b/features/cassettes/Citizen_journey_in_Welsh/Follow_citizen_journey_from_Accounts_page.yml
@@ -1,0 +1,137 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://auth.truelayer.com/api/providers/oauth/openbanking
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - auth.truelayer.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 18 Nov 2020 09:27:17 GMT
+      Referrer-Policy:
+      - no-referrer
+      Server:
+      - envoy
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Envoy-Upstream-Service-Time:
+      - '54'
+      X-Frame-Options:
+      - deny
+      X-Request-Id:
+      - cfa70687-16e3-4894-bc1b-b917c0e90f83
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '1307'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"provider_id":"ob-hsbc","display_name":"HSBC","country":"uk","logo_url":"https://truelayer-provider-assets.s3.amazonaws.com/global/logos/hsbc.svg","scopes":["info","accounts","balance","transactions","cards","direct_debits","offline_access"]},{"provider_id":"ob-ptsb","display_name":"PTSB","country":"ie","logo_url":"https://truelayer-provider-assets.s3.amazonaws.com/ie/logos/ptsb.svg","scopes":["accounts","balance","transactions","cards","direct_debits","standing_orders","offline_access"]},{"provider_id":"ob-revolut-ie","display_name":"Revolut
+        Ireland","country":"ie","logo_url":"https://truelayer-provider-assets.s3.amazonaws.com/global/logos/revolut.svg","scopes":["info","accounts","balance","transactions","direct_debits","standing_orders","offline_access"]},{"provider_id":"ob-revolut","display_name":"Revolut","country":"uk","logo_url":"https://truelayer-provider-assets.s3.amazonaws.com/global/logos/revolut.svg","scopes":["info","accounts","balance","transactions","direct_debits","standing_orders","offline_access"]},{"provider_id":"ob-tesco","display_name":"Tesco
+        Bank","country":"uk","logo_url":"https://truelayer-provider-assets.s3.amazonaws.com/uk/logos/tesco.svg","scopes":["info","accounts","balance","transactions","cards","direct_debits","standing_orders","offline_access"]},{"provider_id":"ob-rbs","display_name":"Royal
+        Bank of Scotland","country":"uk","logo_url":"https://truelayer-provider-assets.s3.amazonaws.com/global/logos/rbs.svg","scopes":["info","accounts","balance","transactions","cards","direct_debits","standing_orders","offline_access"]},{"provider_id":"ob-ms","display_name":"M&S
+        Bank","country":"uk","logo_url":"https://truelayer-provider-assets.s3.amazonaws.com/uk/logos/ms.svg","scopes":["info","accounts","balance","transactions","cards","offline_access"]},{"provider_id":"ob-barclays-business","display_name":"Barclays
+        Business","country":"uk","logo_url":"https://truelayer-provider-assets.s3.amazonaws.com/global/logos/barclays.svg","scopes":["info","accounts","balance","transactions","cards","direct_debits","standing_orders","offline_access"]},{"provider_id":"ob-revolut-it","display_name":"Revolut
+        Italy","country":"it","logo_url":"https://truelayer-provider-assets.s3.amazonaws.com/global/logos/revolut.svg","scopes":["info","accounts","balance","transactions","direct_debits","standing_orders","offline_access"]},{"provider_id":"ob-capital-one","display_name":"Capital
+        One","country":"uk","logo_url":"https://truelayer-provider-assets.s3.amazonaws.com/global/logos/capital-one.svg","scopes":["info","balance","transactions","cards","offline_access"]},{"provider_id":"ob-transferwise-fr","display_name":"Transferwise
+        France","country":"fr","logo_url":"https://truelayer-provider-assets.s3.amazonaws.com/global/logos/transferwise.svg","scopes":["accounts","balance","transactions","offline_access"]},{"provider_id":"ob-first-direct","display_name":"first
+        direct","country":"uk","logo_url":"https://truelayer-provider-assets.s3.amazonaws.com/uk/logos/first-direct.svg","scopes":["info","accounts","balance","transactions","cards","offline_access"]},{"provider_id":"ob-transferwise-es","display_name":"Transferwise
+        Spain","country":"es","logo_url":"https://truelayer-provider-assets.s3.amazonaws.com/global/logos/transferwise.svg","scopes":["accounts","balance","transactions","offline_access"]},{"provider_id":"ob-transferwise-ie","display_name":"Transferwise
+        Ireland","country":"ie","logo_url":"https://truelayer-provider-assets.s3.amazonaws.com/global/logos/transferwise.svg","scopes":["accounts","balance","transactions","offline_access"]},{"provider_id":"ob-aib","display_name":"AIB","country":"ie","logo_url":"https://truelayer-provider-assets.s3.amazonaws.com/global/logos/aib.svg","scopes":["accounts","balance","transactions","cards","direct_debits","standing_orders","offline_access"]},{"provider_id":"ob-tide","display_name":"Tide","country":"uk","logo_url":"https://truelayer-provider-assets.s3.amazonaws.com/uk/logos/tide.svg","scopes":["info","accounts","balance","transactions","direct_debits","standing_orders","offline_access"]},{"provider_id":"ob-yorkshire-building-society","display_name":"Yorkshire
+        Building Society","country":"uk","logo_url":"https://truelayer-provider-assets.s3.amazonaws.com/uk/logos/yorkshire-building-society.svg","scopes":["info","accounts","balance","transactions","standing_orders","offline_access"]},{"provider_id":"ob-tsb","display_name":"TSB","country":"uk","logo_url":"https://truelayer-provider-assets.s3.amazonaws.com/uk/logos/tsb.svg","scopes":["info","accounts","balance","transactions","cards","direct_debits","standing_orders","offline_access"]},{"provider_id":"ob-mbna","display_name":"MBNA","country":"uk","logo_url":"https://truelayer-provider-assets.s3.amazonaws.com/uk/logos/mbna.svg","scopes":["balance","transactions","cards","offline_access"]},{"provider_id":"ob-barclays","display_name":"Barclays","country":"uk","logo_url":"https://truelayer-provider-assets.s3.amazonaws.com/global/logos/barclays.svg","scopes":["info","accounts","balance","transactions","cards","direct_debits","standing_orders","offline_access"]},{"provider_id":"ob-chelsea-building-society","display_name":"Chelsea
+        Building Society","country":"uk","logo_url":"https://truelayer-provider-assets.s3.amazonaws.com/uk/logos/chelsea-building-society.svg","scopes":["info","accounts","balance","transactions","standing_orders","offline_access"]},{"provider_id":"ob-revolut-es","display_name":"Revolut
+        Spain","country":"es","logo_url":"https://truelayer-provider-assets.s3.amazonaws.com/global/logos/revolut.svg","scopes":["info","accounts","balance","transactions","direct_debits","standing_orders","offline_access"]},{"provider_id":"ob-ulster-ie","display_name":"Ulster
+        Bank ROI","country":"ie","logo_url":"https://truelayer-provider-assets.s3.amazonaws.com/global/logos/ulster.svg","scopes":["info","accounts","balance","transactions","cards","direct_debits","standing_orders","offline_access"]},{"provider_id":"ob-lloyds","display_name":"Lloyds","country":"uk","logo_url":"https://truelayer-provider-assets.s3.amazonaws.com/global/logos/lloyds.svg","scopes":["info","accounts","balance","transactions","cards","direct_debits","standing_orders","offline_access"]},{"provider_id":"ob-natwest","display_name":"NatWest","country":"uk","logo_url":"https://truelayer-provider-assets.s3.amazonaws.com/global/logos/natwest.svg","scopes":["info","accounts","balance","transactions","cards","direct_debits","standing_orders","offline_access"]},{"provider_id":"ob-transferwise-it","display_name":"Transferwise
+        Italy","country":"it","logo_url":"https://truelayer-provider-assets.s3.amazonaws.com/global/logos/transferwise.svg","scopes":["accounts","balance","transactions","offline_access"]},{"provider_id":"ob-halifax","display_name":"Halifax","country":"uk","logo_url":"https://truelayer-provider-assets.s3.amazonaws.com/uk/logos/halifax.svg","scopes":["info","accounts","balance","transactions","cards","direct_debits","standing_orders","offline_access"]},{"provider_id":"ob-ulster","display_name":"Ulster
+        Bank","country":"uk","logo_url":"https://truelayer-provider-assets.s3.amazonaws.com/global/logos/ulster.svg","scopes":["info","accounts","balance","transactions","cards","direct_debits","standing_orders","offline_access"]},{"provider_id":"ob-hsbc-business","display_name":"HSBC
+        Business","country":"uk","logo_url":"https://truelayer-provider-assets.s3.amazonaws.com/global/logos/hsbc.svg","scopes":["accounts","balance","transactions","cards","direct_debits","offline_access"]},{"provider_id":"ob-transferwise-de","display_name":"Transferwise
+        Germany","country":"de","logo_url":"https://truelayer-provider-assets.s3.amazonaws.com/global/logos/transferwise.svg","scopes":["accounts","balance","transactions","offline_access"]},{"provider_id":"ob-lloyds-business","display_name":"Lloyds
+        Business","country":"uk","logo_url":"https://truelayer-provider-assets.s3.amazonaws.com/global/logos/lloyds.svg","scopes":["info","accounts","balance","transactions","cards","direct_debits","standing_orders","offline_access"]},{"provider_id":"ob-monzo","display_name":"Monzo","country":"uk","logo_url":"https://truelayer-provider-assets.s3.amazonaws.com/global/logos/monzo.svg","scopes":["info","accounts","balance","transactions","direct_debits","standing_orders","offline_access"]},{"provider_id":"ob-barclaycard","display_name":"Barclaycard","country":"uk","logo_url":"https://truelayer-provider-assets.s3.amazonaws.com/global/logos/barclaycard.svg","scopes":["balance","transactions","cards","offline_access"]},{"provider_id":"ob-virgin-money","display_name":"Virgin
+        Money","country":"uk","logo_url":"https://truelayer-provider-assets.s3.amazonaws.com/uk/logos/virgin-money.svg","scopes":["info","accounts","balance","transactions","cards","direct_debits","standing_orders","offline_access"]},{"provider_id":"ob-revolut-fr","display_name":"Revolut
+        France","country":"fr","logo_url":"https://truelayer-provider-assets.s3.amazonaws.com/global/logos/revolut.svg","scopes":["info","accounts","balance","transactions","direct_debits","standing_orders","offline_access"]},{"provider_id":"ob-transferwise","display_name":"Transferwise","country":"uk","logo_url":"https://truelayer-provider-assets.s3.amazonaws.com/global/logos/transferwise.svg","scopes":["accounts","balance","transactions","offline_access"]},{"provider_id":"ob-nationwide","display_name":"Nationwide","country":"uk","logo_url":"https://truelayer-provider-assets.s3.amazonaws.com/uk/logos/nationwide.svg","scopes":["info","accounts","balance","transactions","cards","direct_debits","standing_orders","offline_access"]},{"provider_id":"ob-bos","display_name":"Bank
+        of Scotland","country":"uk","logo_url":"https://truelayer-provider-assets.s3.amazonaws.com/uk/logos/bos.svg","scopes":["info","accounts","balance","transactions","cards","direct_debits","standing_orders","offline_access"]},{"provider_id":"ob-boi-ie","display_name":"Bank
+        of Ireland","country":"ie","logo_url":"https://truelayer-provider-assets.s3.amazonaws.com/global/logos/boi.svg","scopes":["accounts","balance","transactions","cards","direct_debits","standing_orders","offline_access"]},{"provider_id":"ob-revolut-de","display_name":"Revolut
+        Germany","country":"de","logo_url":"https://truelayer-provider-assets.s3.amazonaws.com/global/logos/revolut.svg","scopes":["info","accounts","balance","transactions","direct_debits","standing_orders","offline_access"]},{"provider_id":"ob-danske","display_name":"Danske
+        Bank","country":"uk","logo_url":"https://truelayer-provider-assets.s3.amazonaws.com/global/logos/danske.svg","scopes":["info","accounts","balance","transactions","offline_access"]},{"provider_id":"ob-santander","display_name":"Santander","country":"uk","logo_url":"https://truelayer-provider-assets.s3.amazonaws.com/global/logos/santander.svg","scopes":["info","accounts","balance","transactions","cards","direct_debits","standing_orders","offline_access"]}]'
+  recorded_at: Wed, 18 Nov 2020 09:27:17 GMT
+- request:
+    method: get
+    uri: https://auth.truelayer.com/api/providers/oauth
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - auth.truelayer.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 18 Nov 2020 09:27:17 GMT
+      Referrer-Policy:
+      - no-referrer
+      Server:
+      - envoy
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Envoy-Upstream-Service-Time:
+      - '74'
+      X-Frame-Options:
+      - deny
+      X-Request-Id:
+      - 3146dfcd-caf2-4338-bb47-d06a6155e82a
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '220'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"provider_id":"oauth-starling","display_name":"Starling","country":"uk","logo_url":"https://truelayer-provider-assets.s3.amazonaws.com/global/logos/starling.svg","scopes":["info","accounts","balance","transactions","offline_access"]},{"provider_id":"oauth-amex","display_name":"Amex","country":"uk","logo_url":"https://truelayer-provider-assets.s3.amazonaws.com/global/logos/amex.svg","scopes":["info","balance","transactions","cards","offline_access"]}]'
+  recorded_at: Wed, 18 Nov 2020 09:27:17 GMT
+recorded_with: VCR 6.0.0

--- a/features/citizens/citizens_welsh.feature
+++ b/features/citizens/citizens_welsh.feature
@@ -1,0 +1,97 @@
+Feature: Citizen journey in Welsh
+
+  @javascript
+  Scenario: Start citizen journey until TrueLayer Auth
+    Given An application has been created
+    And a "true layer bank" exists in the database
+    Then I visit the start of the financial assessment in Welsh
+    Then I should be on a page showing 'noitacilppa dia lagel ruoY'
+    Then I click link 'tratS'
+    Then I should be on a page showing "?>rbba/'ycnegA diA lageL'=eltit rbba< eht htiw noitamrofni tnuocca knab ruoy erahs ot eerga uoy oD"
+    Then I choose 'seY'
+    Then I click 'eunitnoC'
+    Then I should be on a page showing 'knab ruoy tceleS'
+    Then I should be on a page showing ".sknab tnereffid htiw stnuocca evah uoy fi retal erom tceles ot elba eb ll'uoY .emit a ta knab eno tceleS"
+    Then I click link 'kcaB'
+    Then I should be on a page showing "?>rbba/'ycnegA diA lageL'=eltit rbba< eht htiw noitamrofni tnuocca knab ruoy erahs ot eerga uoy oD"
+    Then I choose 'oN'
+    Then I click 'eunitnoC'
+    Then I should be on a page showing 'noitacilppa ruoy eunitnoc ot roticilos ruoy tcatnoC'
+    Then I click link 'kcaB'
+    Then I should be on a page showing "?>rbba/'ycnegA diA lageL'=eltit rbba< eht htiw noitamrofni tnuocca knab ruoy erahs ot eerga uoy oD"
+    Then I choose 'seY'
+    Then I click 'eunitnoC'
+    Then I choose 'HSBC'
+    Then I click 'eunitnoC'
+    Then I am directed to TrueLayer
+
+  @javascript @vcr
+  Scenario: Follow citizen journey from Accounts page
+    Given An application has been created
+    Then I visit the start of the financial assessment in Welsh
+    Then I visit the accounts page
+    Then I click link 'Cymraeg'
+    Then I click link 'eunitnoC'
+    Then I should be on a page showing '?sknab rehto htiw stnuocca evah uoy oD'
+    Then I choose 'seY'
+    Then I click 'eunitnoc dna evaS'
+    Then I should be on a page showing '?sknab rehto htiw stnuocca ruoy ot ssecca enilno evah uoy oD'
+    Then I choose 'oN'
+    Then I click 'eunitnoc dna evaS'
+    Then I should be on a page showing 'roticilos ruoy tcatnoC'
+    Then I click link 'kcaB'
+    Then I should be on a page showing 'ssecca enilno evah uoy oD'
+    Then I choose 'seY'
+    Then I click 'eunitnoc dna evaS'
+    Then I should be on a page showing 'knab ruoy tceleS'
+    Then I click link 'kcaB'
+    Then I click link 'kcaB'
+    Then I should be on a page showing '?sknab rehto htiw stnuocca evah uoy oD'
+    Then I choose 'oN'
+    Then I click 'eunitnoc dna evaS'
+    Then I should be on a page showing 'eviecer uoy od stnemyap gniwollof eht fo hcihW'
+    And I select 'eseht fo enoN'
+    Then I click 'eunitnoc dna evaS'
+    Then I should be on the 'student_finance' page showing '?ecnanif tneduts teg uoy oD'
+    When I choose 'seY'
+    And I click 'eunitnoc dna evaS'
+    Then I should be on the 'annual_amount' page showing '?raey cimedaca siht teg uoy lliw ecnanif tneduts hcum woH'
+    When I enter amount '5000'
+    And I click 'eunitnoc dna evaS'
+    Then I should be on a page showing '?ekam uoy od stnemyap gniwollof eht fo hcihW'
+    Then I select 'egagtrom ro tneR'
+    Then I click 'eunitnoc dna evaS'
+    Then I should be on a page showing 'srewsna ruoy kcehC'
+    Then I should be on a page showing 'gniwollof eht mrifnoC'
+    Then I click 'timbus dna eergA'
+    Then I should be on a page showing "noitamrofni laicnanif ruoy derahs ev'uoY"
+    Then I click the browser back button
+    Then I should be on a page showing "tnemssessa laicnanif ruoy detelpmoc ydaerla ev'uoY"
+
+  @javascript @vcr
+  Scenario: View privacy policy
+    Given An application has been created
+    Then I visit the start of the financial assessment in Welsh
+    Then I click link 'ycilop ycavirP'
+    Then I should be on a page showing 'atad ruoy deen ew yhW'
+
+  @javascript @vcr
+  Scenario: View contact information
+    Given An application has been created
+    Then I visit the start of the financial assessment in Welsh
+    Then I click link 'tcatnoC'
+    Then I should be on a page showing 'su tcatnoC'
+
+  @javascript @vcr
+  Scenario: View accessibility statement
+    Given An application has been created
+    Then I visit the start of the financial assessment in Welsh
+    Then I click link 'tnemetats ytilibisseccA'
+    Then I should be on a page showing 'ecivres siht gnisU'
+
+  @javascript @vcr
+  Scenario: Visit the feedback page
+    Given An application has been created
+    Then I visit the start of the financial assessment in Welsh
+    Then I click link 'kcabdeeF'
+    Then I should be on a page showing '?ecivres siht esu ot ti saw tluciffid ro ysae woH'

--- a/features/step_definitions/citizens_steps.rb
+++ b/features/step_definitions/citizens_steps.rb
@@ -20,6 +20,12 @@ Then('I visit the start of the financial assessment') do
   visit citizens_legal_aid_application_path(secure_id)
 end
 
+Then('I visit the start of the financial assessment in Welsh') do
+  Setting.setting.update!(allow_welsh_translation: true)
+  visit citizens_legal_aid_application_path(secure_id)
+  click_link('Cymraeg')
+end
+
 Then('I visit the first question about dependants') do
   visit citizens_legal_aid_application_path(secure_id)
   visit citizens_has_dependants_path

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -15,10 +15,11 @@ RSpec.describe 'I18n' do
 
   context 'Welsh' do
     let(:locale) { 'cy' }
+    let(:welsh_paths) { ['/accessibility_statement', '/citizen', '/contact', '/error', '/feedback', '/privacy_policy'] }
     it 'does not have missing keys for the applicant journey' do
       missing_applicant_keys = []
       missing_keys.leaves.each do |leaf|
-        missing_applicant_keys << leaf if leaf.data[:occurrences]&.first&.path&.include? '/citizen'
+        missing_applicant_keys << leaf if welsh_paths.any? { |path| leaf.data[:occurrences]&.first&.path&.include? "views#{path}" }
       end
 
       expect(missing_applicant_keys).to be_empty,


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1678)

In order to thoroughly test for missing Welsh translations on the applicant journey, this PR:
 
* expands the existing `spec/i18n_spec.rb` test (which previously only tested for missing Welsh translations on the `/citizens` path) to also test for missing Welsh translations on `/accessibility_statement`, `/contact`, `/error`, `/feedback`, and `/privacy_policy`.
* sets `config.action_view.raise_on_missing_translations` to true in `development` and `test` environments so that missing translations are surfaced as exceptions instead of falling back on default values (and fixes some missing translations identified as a result 😬).
* adds new feature tests to visit all pages on the citizen journey in Welsh - combined with the above change this will ensure that any missing translations cause a failure 


## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
