### PR TITLE
AP-1811 Give non-passported role automatically to all further new providers

### DIFF
--- a/app/services/provider_details_creator.rb
+++ b/app/services/provider_details_creator.rb
@@ -36,7 +36,6 @@ class ProviderDetailsCreator
       firm.update!(name: firm_name)
       firm.offices << offices
     end
-    # TODO: For the timebeing, we add passported permissions to every new firm, but this may change in the future.
     current_firm.permissions << @passported_permission unless current_firm.permissions.include?(@passported_permission)
     current_firm.permissions << @non_passported_permission unless current_firm.permissions.include?(@non_passported_permission)
     current_firm

--- a/app/services/provider_details_creator.rb
+++ b/app/services/provider_details_creator.rb
@@ -8,6 +8,7 @@ class ProviderDetailsCreator
   def initialize(provider)
     @provider = provider
     @passported_permission = Permission.find_by(role: 'application.passported.*')
+    @non_passported_permission = Permission.find_by(role: 'application.non_passported.*')
   end
 
   def call
@@ -37,6 +38,7 @@ class ProviderDetailsCreator
     end
     # TODO: For the timebeing, we add passported permissions to every new firm, but this may change in the future.
     current_firm.permissions << @passported_permission unless current_firm.permissions.include?(@passported_permission)
+    current_firm.permissions << @non_passported_permission unless current_firm.permissions.include?(@non_passported_permission)
     current_firm
   end
 

--- a/db/seeds/test_provider_populator.rb
+++ b/db/seeds/test_provider_populator.rb
@@ -39,18 +39,11 @@ class TestProviderPopulator
     passported_permission = Permission.find_by(role: 'application.passported.*')
     non_passported_permission = Permission.find_by(role: 'application.non_passported.*')
     Firm.all.each do |firm|
-      unless firm.permissions.map(&:role).include?('application.passported.*')
-        firm.permissions << passported_permission
-        firm.save!
-      end
-    end
+      next if firm.permissions.map(&:role).include?('application.passported.*')
 
-    %w[test1 sr MARTIN.RONAN@DAVIDGRAY.CO.UK BENREID].each do |firm_name|
-      firm = Provider.find_by(username: firm_name).firm
-      unless firm.permissions.map(&:role).include?('application.non_passported.*')
-        firm.permissions << non_passported_permission
-        firm.save!
-      end
+      firm.permissions << passported_permission
+      firm.permissions << non_passported_permission
+      firm.save!
     end
   end
 

--- a/db/seeds/test_provider_populator.rb
+++ b/db/seeds/test_provider_populator.rb
@@ -39,10 +39,8 @@ class TestProviderPopulator
     passported_permission = Permission.find_by(role: 'application.passported.*')
     non_passported_permission = Permission.find_by(role: 'application.non_passported.*')
     Firm.all.each do |firm|
-      next if firm.permissions.map(&:role).include?('application.passported.*')
-
-      firm.permissions << passported_permission
-      firm.permissions << non_passported_permission
+      firm.permissions << passported_permission unless firm.permissions.map(&:role).include?('application.passported.*')
+      firm.permissions << non_passported_permission unless firm.permissions.map(&:role).include?('application.non_passported.*')
       firm.save!
     end
   end

--- a/spec/requests/saml_sessions_spec.rb
+++ b/spec/requests/saml_sessions_spec.rb
@@ -57,6 +57,7 @@ RSpec.describe 'SamlSessionsController', type: :request do
 
     before do
       create :permission, :passported
+      create :permission, :non_passported
       allow_any_instance_of(Warden::Proxy).to receive(:authenticate!).and_return(provider)
       stub_request(:get, provider_details_api_url).to_return(body: provider_details_api_reponse, status: status)
     end

--- a/spec/services/provider_details_creator_spec.rb
+++ b/spec/services/provider_details_creator_spec.rb
@@ -55,6 +55,11 @@ RSpec.describe ProviderDetailsCreator do
       expect(firm.name).to eq(ccms_firm.name)
     end
 
+    it 'adds non passported permission to the firm' do
+      expect { subject }.to change { Firm.count }.by(1)
+      expect(firm.permissions.map(&:role)).to match_array(['application.passported.*', 'application.non_passported.*'])
+    end
+
     it 'creates the right offices' do
       expect { subject }.to change { Office.count }.by(2)
       expect(firm.offices.count).to eq(2)


### PR DESCRIPTION
**What**

[Link to story](https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=233&projectKey=AP&modal=detail&selectedIssue=AP-1811&assignee=5f968777632c6200712e443f)

All new firms added automatically are able to submit a non-passported application in provider details creator.

**Checklist**

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
