### PR TITLE
Remove redis initializer to prevent deprecation warning being displayed

### DIFF
--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,5 +1,0 @@
-# Prevents error messages in sidekiq in dev boxes.
-# should be removed once sidekiq uses #exists?
-#
-# TODO remove when sidekiq updated
-Redis.exists_returns_integer = false


### PR DESCRIPTION
## What

Changes to the redis gem were causing deprecation warnings to be constantly displayed by sidekiq. We added a redis initializer to suppress those warnings.

The issue with redis has subsequently been [fixed](https://github.com/resque/redis-namespace/pull/171) however our initializer is now causing the deprecation warning to be displayed when running eg rspec or cucumber from the command line:

![image](https://user-images.githubusercontent.com/28729201/99565175-4355f380-29c3-11eb-859a-2fad71458d81.png)

Removing the initializer prevents the deprecation warning from being displayed on the command line and does not reintroduce the warning to sidekiq.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
