### PR TITLE
AP-1726 Standardise usage of radio buttons

### DIFF
--- a/app/controllers/citizens/additional_accounts_controller.rb
+++ b/app/controllers/citizens/additional_accounts_controller.rb
@@ -8,9 +8,9 @@ module Citizens
 
     def create
       case params[:additional_account]
-      when 'yes'
+      when 'true'
         redirect_to new_citizens_additional_account_path
-      when 'no'
+      when 'false'
         go_forward
       else
         error
@@ -24,10 +24,10 @@ module Citizens
 
     def update
       case params[:has_online_accounts]
-      when 'yes'
+      when 'true'
         online_accounts_update
         redirect_to citizens_banks_path
-      when 'no'
+      when 'false'
         offline_accounts_update
         go_forward
       else
@@ -39,7 +39,7 @@ module Citizens
     private
 
     def online_accounts_update
-      legal_aid_application.update(has_offline_accounts: false)
+      legal_aid_application.update!(has_offline_accounts: false)
     end
 
     def offline_accounts_update

--- a/app/controllers/providers/applicant_bank_accounts_controller.rb
+++ b/app/controllers/providers/applicant_bank_accounts_controller.rb
@@ -5,9 +5,9 @@ module Providers
     end
 
     def update
-      if params[:offline_savings_account].in?(%w[yes no])
-        go_forward(params[:offline_savings_account] == 'yes')
-        reset_account_balance if params[:offline_savings_account] == 'no'
+      if params[:offline_savings_account].in?(%w[true false])
+        go_forward(params[:offline_savings_account] == 'true')
+        reset_account_balance if params[:offline_savings_account] == 'false'
       else
         @error = { 'offline_savings_account-error' => I18n.t('providers.applicant_bank_accounts.show.error') }
         applicant_accounts

--- a/app/controllers/providers/confirm_offices_controller.rb
+++ b/app/controllers/providers/confirm_offices_controller.rb
@@ -11,9 +11,9 @@ module Providers
 
     def update
       case params[:correct]
-      when 'yes'
+      when 'true'
         redirect_to providers_legal_aid_applications_path
-      when 'no'
+      when 'false'
         current_provider.update!(selected_office: nil)
         redirect_to providers_select_office_path
       else

--- a/app/controllers/providers/has_other_dependants_controller.rb
+++ b/app/controllers/providers/has_other_dependants_controller.rb
@@ -3,8 +3,8 @@ module Providers
     def show; end
 
     def update
-      if params[:other_dependant].in?(%w[yes no])
-        go_forward(params[:other_dependant] == 'yes')
+      if params[:other_dependant].in?(%w[true false])
+        go_forward(params[:other_dependant] == 'true')
       else
         @error = { 'other_dependant-error' => I18n.t('providers.has_other_dependants.show.error') }
         render :show

--- a/app/controllers/providers/no_income_summaries_controller.rb
+++ b/app/controllers/providers/no_income_summaries_controller.rb
@@ -5,8 +5,8 @@ module Providers
     end
 
     def update
-      if params[:confirm_no_income].in?(%w[yes no])
-        go_forward(params[:confirm_no_income] == 'yes')
+      if params[:confirm_no_income].in?(%w[true false])
+        go_forward(params[:confirm_no_income] == 'true')
       else
         @error = { 'confirm_no_income-error' => I18n.t('providers.no_income_summaries.show.error') }
         render :show

--- a/app/controllers/providers/no_outgoings_summaries_controller.rb
+++ b/app/controllers/providers/no_outgoings_summaries_controller.rb
@@ -3,8 +3,8 @@ module Providers
     def show; end
 
     def update
-      if params[:confirm_no_outgoings].in?(%w[yes no])
-        go_forward(params[:confirm_no_outgoings] == 'yes')
+      if params[:confirm_no_outgoings].in?(%w[true false])
+        go_forward(params[:confirm_no_outgoings] == 'true')
       else
         @error = { 'confirm_no_outgoings-error' => I18n.t('providers.no_outgoings_summaries.show.error') }
         render :show

--- a/app/controllers/providers/remove_dependant_controller.rb
+++ b/app/controllers/providers/remove_dependant_controller.rb
@@ -5,8 +5,8 @@ module Providers
     end
 
     def update
-      if params[:remove_dependant].in?(%w[yes no])
-        dependant&.destroy! if params[:remove_dependant] == 'yes'
+      if params[:remove_dependant].in?(%w[true false])
+        dependant&.destroy! if params[:remove_dependant] == 'true'
         go_forward
       else
         @error = { 'remove_dependants-error' => I18n.t('providers.remove_dependant.show.error') }

--- a/app/lib/govuk_elements_form_builder/form_builder.rb
+++ b/app/lib/govuk_elements_form_builder/form_builder.rb
@@ -12,8 +12,8 @@ module GovukElementsFormBuilder
 
     def yes_no_radio_button_array
       [
-        { value: :yes, label: I18n.t('generic.yes') },
-        { value: :no,  label: I18n.t('generic.no') }
+        { value: true, label: I18n.t('generic.yes') },
+        { value: false, label: I18n.t('generic.no') }
       ]
     end
     # Usage:

--- a/app/views/admin/settings/show.html.erb
+++ b/app/views/admin/settings/show.html.erb
@@ -8,7 +8,9 @@
 
     <%= form.govuk_collection_radio_buttons(
           :mock_true_layer_data,
-          [true, false],
+          form.yes_no_radio_button_array,
+          :value,
+          :label,
           inline: true,
           hint: t('.hints.mock_true_layer_data', bank_transaction_filename: Setting.bank_transaction_filename),
           title: { size: :m, text: t('.labels.mock_true_layer_data') }
@@ -16,7 +18,9 @@
 
     <%= form.govuk_collection_radio_buttons(
       :manually_review_all_cases,
-      [true, false],
+      form.yes_no_radio_button_array,
+      :value,
+      :label,
       inline: true,
       hint: t('.hints.manually_review_all_cases'),
       title: { size: :m, text: t('.labels.manually_review_all_cases') }
@@ -24,7 +28,9 @@
 
     <%= form.govuk_collection_radio_buttons(
       :allow_welsh_translation,
-      [true, false],
+      form.yes_no_radio_button_array,
+      :value,
+      :label,
       inline: true,
       hint: t('.hints.allow_welsh_translation'),
       title: { size: :m, text: t('.labels.allow_welsh_translation') }

--- a/app/views/citizens/consents/show.html.erb
+++ b/app/views/citizens/consents/show.html.erb
@@ -39,15 +39,9 @@
         </div>
       </details>
 
-      <%
-        options = [
-            { value: :true, label: t('generic.yes') },
-            { value: :false,  label: t('generic.no') }
-        ]
-      %>
       <%= form.govuk_collection_radio_buttons(
               :open_banking_consent,
-              options,
+              form.yes_no_radio_button_array,
               :value,
               :label,
               error: @error,

--- a/app/views/citizens/student_finances/show.html.erb
+++ b/app/views/citizens/student_finances/show.html.erb
@@ -2,15 +2,8 @@
 
   <%= form_with(model: @form, url: citizens_student_finance_path, method: :patch, local: true) do |form| %>
 
-    <%
-      options = [
-          { value: :true, label: t('generic.yes') },
-          { value: :false,  label: t('generic.no') }
-      ]
-    %>
-
     <%= form.govuk_collection_radio_buttons :student_finance,
-                                            options,
+                                            form.yes_no_radio_button_array,
                                             :value,
                                             :label,
                                             error: @error,

--- a/app/views/providers/applicant_employed/index.html.erb
+++ b/app/views/providers/applicant_employed/index.html.erb
@@ -14,7 +14,9 @@
 
     <%= form.govuk_collection_radio_buttons(
           :employed,
-          [true, false],
+          form.yes_no_radio_button_array,
+          :value,
+          :label,
           hint: t('.hint'),
           title: content_for(:page_title)
         ) %>

--- a/app/views/providers/confirm_offices/show.html.erb
+++ b/app/views/providers/confirm_offices/show.html.erb
@@ -19,23 +19,22 @@
     <%= govuk_form_group(
           show_error_if: @error,
         ) do %>
+      <fieldset class="govuk-fieldset">
+        <%= govuk_fieldset_header page_title, padding_below: 4 %>
 
-      <%= form.govuk_collection_radio_buttons(
-            :correct,
-            [
-              { value: :yes, label: t('generic.yes') },
-              { value: :no,  label: t('.no_another_office') }
-            ],
-            :value,
-            :label,
-            error: @error,
-            title: {
-                      text: t('.h1-heading', office_code: current_provider.selected_office.code),
-                      htag: :h1,
-                      padding_below: 6
-            }
-          ) %>
+        <%= form.govuk_radio_button(
+                :correct,
+                true,
+                label: t('generic.yes')
+            ) %>
 
+        <%= form.govuk_radio_button(
+                :correct,
+                false,
+                label: t('.no_another_office')
+            ) %>
+      </fieldset>
+ <div class="govuk-!-padding-bottom-2"></div>
     <% end %>
 
     <%= next_action_buttons(form: form) %>

--- a/app/views/providers/dependants/_form.html.erb
+++ b/app/views/providers/dependants/_form.html.erb
@@ -33,16 +33,10 @@
         <% end %>
       </fieldset>
     <% end %>
-    <%
-      options = [
-          { value: true, label: t('generic.yes') },
-          { value: false, label: t('generic.no') }
-      ]
-    %>
 
     <%= form.govuk_collection_radio_buttons(
             :in_full_time_education,
-            options,
+            form.yes_no_radio_button_array,
             :value,
             :label,
             title:  { text: t('.in_full_time_education'), size: :m, htag: :h2 }

--- a/app/views/providers/has_dependants/show.html.erb
+++ b/app/views/providers/has_dependants/show.html.erb
@@ -10,15 +10,9 @@
             show_error_if: @form.errors.present?,
             input: :has_dependants
         ) do %>
-      <%
-        options = [
-            { value: :true, label: t('generic.yes') },
-            { value: :false,  label: t('generic.no') }
-        ]
-      %>
 
       <%= form.govuk_collection_radio_buttons :has_dependants,
-                                              options,
+                                              form.yes_no_radio_button_array,
                                               :value,
                                               :label,
                                               error: @error,

--- a/app/views/providers/no_income_summaries/show.html.erb
+++ b/app/views/providers/no_income_summaries/show.html.erb
@@ -39,14 +39,14 @@
         <div class="govuk-radios govuk-radios--conditional govuk-!-padding-top-2" data-module="govuk-radios">
           <%= form.govuk_radio_button(
                   :confirm_no_income,
-                  'yes',
+                  true,
                   label: t('generic.yes'),
                   error: @error&.values&.first
               ) %>
 
           <%= form.govuk_radio_button(
                   :confirm_no_income,
-                  'no',
+                  false,
                   label: t('generic.no'),
                   error: @error&.values&.first
               ) %>

--- a/app/views/providers/no_income_summaries/show.html.erb
+++ b/app/views/providers/no_income_summaries/show.html.erb
@@ -37,19 +37,11 @@
         <%= govuk_error_message(@error&.values&.first, id: 'confirm_no_income-error') %>
 
         <div class="govuk-radios govuk-radios--conditional govuk-!-padding-top-2" data-module="govuk-radios">
-          <%= form.govuk_radio_button(
-                  :confirm_no_income,
-                  true,
-                  label: t('generic.yes'),
-                  error: @error&.values&.first
-              ) %>
-
-          <%= form.govuk_radio_button(
-                  :confirm_no_income,
-                  false,
-                  label: t('generic.no'),
-                  error: @error&.values&.first
-              ) %>
+          <%= form.govuk_collection_radio_buttons :confirm_no_income,
+                                                  form.yes_no_radio_button_array,
+                                                  :value,
+                                                  :label,
+                                                  error: @error %>
         </div>
       <% end %>
 

--- a/app/views/providers/no_income_summaries/show.html.erb
+++ b/app/views/providers/no_income_summaries/show.html.erb
@@ -37,11 +37,19 @@
         <%= govuk_error_message(@error&.values&.first, id: 'confirm_no_income-error') %>
 
         <div class="govuk-radios govuk-radios--conditional govuk-!-padding-top-2" data-module="govuk-radios">
-          <%= form.govuk_collection_radio_buttons :confirm_no_income,
-                                                  form.yes_no_radio_button_array,
-                                                  :value,
-                                                  :label,
-                                                  error: @error %>
+          <%= form.govuk_radio_button(
+                  :confirm_no_income,
+                  true,
+                  label: t('generic.yes'),
+                  error: @error&.values&.first
+              ) %>
+
+          <%= form.govuk_radio_button(
+                  :confirm_no_income,
+                  false,
+                  label: t('generic.no'),
+                  error: @error&.values&.first
+              ) %>
         </div>
       <% end %>
 

--- a/app/views/providers/no_outgoings_summaries/show.html.erb
+++ b/app/views/providers/no_outgoings_summaries/show.html.erb
@@ -36,12 +36,20 @@
 
         <%= govuk_error_message(@error&.values&.first, id: 'confirm_no_outgoings-error') %>
 
-        <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios">
-          <%= form.govuk_collection_radio_buttons :confirm_no_outgoings,
-                                                  form.yes_no_radio_button_array,
-                                                  :value,
-                                                  :label,
-                                                  error: @error %>
+        <div class="govuk-radios govuk-radios--conditional govuk-!-padding-top-2" data-module="govuk-radios">
+          <%= form.govuk_radio_button(
+                  :confirm_no_outgoings,
+                  true,
+                  label: t('generic.yes'),
+                  error: @error&.values&.first
+              ) %>
+
+          <%= form.govuk_radio_button(
+                  :confirm_no_outgoings,
+                  false,
+                  label: t('generic.no'),
+                  error: @error&.values&.first
+              ) %>
         </div>
       <% end %>
 

--- a/app/views/providers/no_outgoings_summaries/show.html.erb
+++ b/app/views/providers/no_outgoings_summaries/show.html.erb
@@ -36,20 +36,12 @@
 
         <%= govuk_error_message(@error&.values&.first, id: 'confirm_no_outgoings-error') %>
 
-        <div class="govuk-radios govuk-radios--conditional govuk-!-padding-top-2" data-module="govuk-radios">
-          <%= form.govuk_radio_button(
-                  :confirm_no_outgoings,
-                  'yes',
-                  label: t('generic.yes'),
-                  error: @error&.values&.first
-              ) %>
-
-          <%= form.govuk_radio_button(
-                  :confirm_no_outgoings,
-                  'no',
-                  label: t('generic.no'),
-                  error: @error&.values&.first
-              ) %>
+        <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios">
+          <%= form.govuk_collection_radio_buttons :confirm_no_outgoings,
+                                                  form.yes_no_radio_button_array,
+                                                  :value,
+                                                  :label,
+                                                  error: @error %>
         </div>
       <% end %>
 

--- a/app/views/providers/respondents/_respondent_detail.html.erb
+++ b/app/views/providers/respondents/_respondent_detail.html.erb
@@ -7,7 +7,9 @@
   <div id="<%= question.attribute %>" class="govuk-radios govuk-radios--conditional" data-module="govuk-radios">
       <%= form.govuk_collection_radio_buttons(
             question.attribute,
-            [true, false],
+            form.yes_no_radio_button_array,
+            :value,
+            :label,
             inline: true,
             title: { size: :m, text: question.title, htag: :h2 },
             input_attributes: question.show_details_when ? { question.show_details_when.to_s => { 'data-aria-controls' => conditional_id } } : nil

--- a/app/views/providers/success_likely/index.html.erb
+++ b/app/views/providers/success_likely/index.html.erb
@@ -12,7 +12,9 @@
 
     <%= form.govuk_collection_radio_buttons(
           :success_likely,
-          [true, false],
+          form.yes_no_radio_button_array,
+          :value,
+          :label,
           title: content_for(:page_title)
         ) %>
 

--- a/app/views/shared/forms/vehicles/_ages.html.erb
+++ b/app/views/shared/forms/vehicles/_ages.html.erb
@@ -7,11 +7,8 @@
   <%= govuk_form_group show_error_if: @form.errors.present? do %>
     <%= form.govuk_collection_radio_buttons(
           :more_than_three_years_old,
-          [
-            { code: 'true', label: t('generic.yes') },
-            { code: 'false', label: t('generic.no') }
-          ],
-          :code,
+          form.yes_no_radio_button_array,
+          :value,
           :label,
           title: page_title
         ) %>

--- a/app/views/shared/forms/vehicles/_own_vehicle.html.erb
+++ b/app/views/shared/forms/vehicles/_own_vehicle.html.erb
@@ -2,7 +2,9 @@
 
   <%= form.govuk_collection_radio_buttons(
         :own_vehicle,
-        [true, false],
+        form.yes_no_radio_button_array,
+        :value,
+        :label,
         title: content_for(:page_title)
       ) %>
 

--- a/app/views/shared/forms/vehicles/_regular_use.html.erb
+++ b/app/views/shared/forms/vehicles/_regular_use.html.erb
@@ -7,11 +7,8 @@
   <%= govuk_form_group show_error_if: @form.errors.present? do %>
     <%= form.govuk_collection_radio_buttons(
           :used_regularly,
-          [
-            { code: 'true', label: t('generic.yes') },
-            { code: 'false', label: t('generic.no') }
-          ],
-          :code,
+          form.yes_no_radio_button_array,
+          :value,
           :label,
           title: page_title,
           hint: t('.include_partner_use')

--- a/spec/requests/citizens/additional_accounts_spec.rb
+++ b/spec/requests/citizens/additional_accounts_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe 'citizen additional accounts request test', type: :request do
     end
 
     context 'with Yes submitted' do
-      let(:params) { { additional_account: 'yes' } }
+      let(:params) { { additional_account: 'true' } }
 
       it 'redirects to new action' do
         expect(response).to redirect_to(new_citizens_additional_account_path)
@@ -69,7 +69,7 @@ RSpec.describe 'citizen additional accounts request test', type: :request do
     end
 
     context 'with No submitted' do
-      let(:params) { { additional_account: 'no' } }
+      let(:params) { { additional_account: 'false' } }
 
       it 'redirects to /citizens/identify_types_of_income(.:format)' do
         expect(response).to redirect_to(citizens_identify_types_of_income_path)
@@ -106,7 +106,7 @@ RSpec.describe 'citizen additional accounts request test', type: :request do
     end
 
     context 'with Yes submitted' do
-      let(:params) { { has_online_accounts: 'yes' } }
+      let(:params) { { has_online_accounts: 'true' } }
 
       it 'redirects to select another bank' do
         expect(response).to redirect_to(citizens_banks_path)
@@ -118,7 +118,7 @@ RSpec.describe 'citizen additional accounts request test', type: :request do
     end
 
     context 'with No submitted' do
-      let(:params) { { has_online_accounts: 'no' } }
+      let(:params) { { has_online_accounts: 'false' } }
 
       it 'redirects to contact provider path' do
         expect(response).to redirect_to(citizens_contact_provider_path)

--- a/spec/requests/providers/applicant_bank_accounts_spec.rb
+++ b/spec/requests/providers/applicant_bank_accounts_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Providers::ApplicantBankAccountsController, type: :request do
   end
 
   describe 'PATCH /providers/applications/:legal_aid_application_id/does-client-use-online-banking' do
-    let(:offline_savings_account) { 'yes' }
+    let(:offline_savings_account) { 'true' }
     let(:submit_button) { {} }
     let(:params) do
       {
@@ -75,7 +75,7 @@ RSpec.describe Providers::ApplicantBankAccountsController, type: :request do
       end
 
       context 'The NO option is chosen' do
-        let(:offline_savings_account) { 'no' }
+        let(:offline_savings_account) { 'false' }
 
         it 'redirects to the savings and investments page' do
           expect(response).to redirect_to(providers_legal_aid_application_savings_and_investment_path(legal_aid_application))

--- a/spec/requests/providers/confirm_offices_spec.rb
+++ b/spec/requests/providers/confirm_offices_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe 'provider confirm office', type: :request do
 
   describe 'PATCH providers/confirm_office' do
     subject { patch providers_confirm_office_path, params: params }
-    let(:params) { { correct: 'yes' } }
+    let(:params) { { correct: 'true' } }
 
     context 'when the provider is authenticated' do
       before do
@@ -81,7 +81,7 @@ RSpec.describe 'provider confirm office', type: :request do
       end
 
       context 'no is selected' do
-        let(:params) { { correct: 'no' } }
+        let(:params) { { correct: 'false' } }
 
         it 'redirects to the office select page' do
           expect(response).to redirect_to providers_select_office_path

--- a/spec/requests/providers/has_other_dependants_controller_spec.rb
+++ b/spec/requests/providers/has_other_dependants_controller_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Providers::HasOtherDependantsController, type: :request do
     subject { patch providers_legal_aid_application_has_other_dependants_path(legal_aid_application), params: params }
 
     context 'choose yes' do
-      let(:other_dependant) { 'yes' }
+      let(:other_dependant) { 'true' }
 
       it 'redirects to the page to add another dependant' do
         expect(response).to redirect_to(new_providers_legal_aid_application_dependant_path(legal_aid_application))
@@ -35,7 +35,7 @@ RSpec.describe Providers::HasOtherDependantsController, type: :request do
     end
 
     context 'choose no' do
-      let(:other_dependant) { 'no' }
+      let(:other_dependant) { 'false' }
 
       it 'redirects to the outgoings summary page' do
         expect(response).to redirect_to(providers_legal_aid_application_no_outgoings_summary_path(legal_aid_application))

--- a/spec/requests/providers/no_income_summaries_spec.rb
+++ b/spec/requests/providers/no_income_summaries_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Providers::NoIncomeSummariesController, type: :request do
   end
 
   describe 'PATCH /providers/applications/:legal_aid_application_id/no_income_summary' do
-    let(:confirm_no_income) { 'yes' }
+    let(:confirm_no_income) { 'true' }
     let(:submit_button) { {} }
     let(:params) do
       {
@@ -65,7 +65,7 @@ RSpec.describe Providers::NoIncomeSummariesController, type: :request do
       end
 
       context 'The NO option is chosen' do
-        let(:confirm_no_income) { 'no' }
+        let(:confirm_no_income) { 'false' }
 
         it 'redirects to the identify income types page' do
           expect(response).to redirect_to(providers_legal_aid_application_identify_types_of_income_path(legal_aid_application))

--- a/spec/requests/providers/no_outgoings_summaries_spec.rb
+++ b/spec/requests/providers/no_outgoings_summaries_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Providers::NoOutgoingsSummariesController, type: :request do
   end
 
   describe 'PATCH /providers/applications/:legal_aid_application_id/no_outgoings_summary' do
-    let(:confirm_no_outgoings) { 'yes' }
+    let(:confirm_no_outgoings) { 'true' }
     let(:submit_button) { {} }
     let(:params) do
       {
@@ -65,7 +65,7 @@ RSpec.describe Providers::NoOutgoingsSummariesController, type: :request do
       end
 
       context 'The NO option is chosen' do
-        let(:confirm_no_outgoings) { 'no' }
+        let(:confirm_no_outgoings) { 'false' }
 
         it 'redirects to the identify outgoings types page' do
           expect(response).to redirect_to(providers_legal_aid_application_identify_types_of_outgoing_path(legal_aid_application))

--- a/spec/requests/providers/remove_dependant_controller_spec.rb
+++ b/spec/requests/providers/remove_dependant_controller_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Providers::RemoveDependantController, type: :request do
     subject { patch providers_legal_aid_application_remove_dependant_path(legal_aid_application, dependant), params: params }
 
     context 'choose yes' do
-      let(:remove_dependant) { 'yes' }
+      let(:remove_dependant) { 'true' }
 
       it 'redirects to the has other dependants page' do
         expect(response).to redirect_to(providers_legal_aid_application_has_other_dependants_path(legal_aid_application))
@@ -42,7 +42,7 @@ RSpec.describe Providers::RemoveDependantController, type: :request do
     end
 
     context 'choose no' do
-      let(:remove_dependant) { 'no' }
+      let(:remove_dependant) { 'false' }
 
       it 'redirects to the has other dependants page' do
         expect(response).to redirect_to(providers_legal_aid_application_has_other_dependants_path(legal_aid_application))


### PR DESCRIPTION
## AP-1726 Standardise usage of radio buttons

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1726)

- Update form builder method #yes_no_radio_button_array to use the value true or false as true or false has been used in many more places as the radio button value than yes or no.
- Update relevant controllers to expect true or false instead of yes or no

- Update views to pass in (form.yes_no_radio_button_array, :value, :label,...) to the form.govuk_collection_radio_buttons method

- Update tests

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
