### PR TITLE
Allow microsoft word documents to be uploaded on the statement of case page

### DIFF
--- a/app/forms/statement_of_cases/statement_of_case_form.rb
+++ b/app/forms/statement_of_cases/statement_of_case_form.rb
@@ -11,7 +11,6 @@ module StatementOfCases
     ALLOWED_CONTENT_TYPES = %w[
       application/pdf
       application/msword
-      application/vnd.openxmlformats-officedocument.wordprocessingml.document
       application/vnd.oasis.opendocument.text
       text/rtf
       text/plain
@@ -22,6 +21,8 @@ module StatementOfCases
       image/bmp
       image/x-bitmap
     ].freeze
+
+    WORD_DOCUMENT = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'.freeze
 
     def self.max_file_size
       MAX_FILE_SIZE
@@ -88,6 +89,7 @@ module StatementOfCases
 
     def disallowed_content_type(original_file)
       return if MimeMagic.by_magic(original_file)&.type.in?(ALLOWED_CONTENT_TYPES)
+      return if original_file.content_type == WORD_DOCUMENT
 
       errors.add(:original_file, original_file_error_for(:content_type_invalid, file_name: @original_file_name))
     end

--- a/spec/requests/providers/statement_of_case_spec.rb
+++ b/spec/requests/providers/statement_of_case_spec.rb
@@ -93,6 +93,21 @@ RSpec.describe 'provider statement of case requests', type: :request do
         expect(response).to have_http_status(:ok)
       end
 
+      context 'word document' do
+        let(:original_file) { uploaded_file('spec/fixtures/files/documents/hello_world.docx', 'application/vnd.openxmlformats-officedocument.wordprocessingml.document') }
+        let(:button_clicked) { upload_button }
+
+        it 'updates the record' do
+          subject
+          expect(statement_of_case.original_attachments.first).to be_present
+        end
+
+        it 'returns http success' do
+          subject
+          expect(response).to have_http_status(:ok)
+        end
+      end
+
       context 'and there is an error' do
         let(:original_file) { uploaded_file('spec/fixtures/files/zip.zip', 'application/zip') }
 


### PR DESCRIPTION
## Allow microsoft word documents to be uploaded on the statement of case page

- Allow docx and doc file types


mimemagic gem returns content type application/zip for docx or doc type files and zip files are not allowed to be uploaded
https://github.com/minad/mimemagic#extra-magic-overlay

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
