### PR TITLE
AP-1255 Copy change and error message position change

### DIFF
--- a/app/forms/statement_of_cases/statement_of_case_form.rb
+++ b/app/forms/statement_of_cases/statement_of_case_form.rb
@@ -32,7 +32,7 @@ module StatementOfCases
       %i[upload_button_pressed original_file]
     end
 
-    validates :statement, presence: true, unless: :file_present_or_draft?
+    validate :statement_present_or_file_uploaded
     validate :file_uploaded?
     validate :original_file_valid
 
@@ -47,6 +47,12 @@ module StatementOfCases
     end
 
     private
+
+    def statement_present_or_file_uploaded
+      return if file_present_or_draft?
+
+      @errors.add(:original_file, :blank) if statement.blank?
+    end
 
     def attachments_made?
       model.legal_aid_application.attachments.present?

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -388,8 +388,7 @@ en:
               file_virus: The selected file contains a virus
               system_down: There was a problem uploading your file - try again
               no_file_chosen: You must choose at least one file
-            statement:
-              blank: Either attach a file or enter text
+              blank: Attach a file or enter text
         vehicle:
           attributes:
             estimated_value:

--- a/spec/requests/providers/statement_of_case_spec.rb
+++ b/spec/requests/providers/statement_of_case_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe 'provider statement of case requests', type: :request do
 
           it 'returns error message' do
             subject
-            error = I18n.t('activemodel.errors.models.statement_of_case.attributes.original_file.no_file_chosen')
+            error = I18n.t('activemodel.errors.models.statement_of_case.attributes.original_file.blank')
             expect(response.body).to include(error)
           end
         end
@@ -169,7 +169,7 @@ RSpec.describe 'provider statement of case requests', type: :request do
           it 'fails' do
             subject
             expect(response.body).to include('There is a problem')
-            expect(response.body).to include(I18n.t('activemodel.errors.models.statement_of_case.attributes.statement.blank'))
+            expect(response.body).to include(I18n.t('activemodel.errors.models.statement_of_case.attributes.original_file.blank'))
           end
         end
 
@@ -255,7 +255,7 @@ RSpec.describe 'provider statement of case requests', type: :request do
 
           it 'displays error' do
             subject
-            expect(response.body).to match 'id="statement-error"'
+            expect(response.body).to match 'id="original_file-error"'
           end
 
           context 'file contains a malware' do


### PR DESCRIPTION
## Error message change

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1255)

- Change wording of error message if no file is uploaded and no text entered
- Change position of error message to above file (this is done by assigning the error to the `original_file` attribute)

<img width="1050" alt="Screenshot 2020-11-23 at 16 42 45" src="https://user-images.githubusercontent.com/115617/99989963-29ddee80-2dab-11eb-897f-e85d52f16a0c.png">


## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
