### PR TITLE
AP-1817 Bugfix income checkbox

### DIFF
--- a/app/javascript/src/checkbox_control.js
+++ b/app/javascript/src/checkbox_control.js
@@ -28,15 +28,7 @@ $(function() {
     */
     control.change( function() {
       const controlChecked = this.checked
-
-      // added the line below which updates the control checkbox value to 'true' if it is selected
-      // the problem is that now double clicking on the control box doesnt hide the check mark
-      // although the none_selected param is set to false
-      // clicking on anything in the select-group removes the checkmark
-
-      control.prop("checked", true ).val(true)
-
-
+      control.prop("unchecked", true ).val(true)
       checkboxes.each(function(index) {
         const checkbox = $(this)
         if(controlChecked) {

--- a/app/javascript/src/checkbox_control.js
+++ b/app/javascript/src/checkbox_control.js
@@ -29,6 +29,14 @@ $(function() {
     control.change( function() {
       const controlChecked = this.checked
 
+      // added the line below which updates the control checkbox value to 'true' if it is selected
+      // the problem is that now double clicking on the control box doesnt hide the check mark
+      // although the none_selected param is set to false
+      // clicking on anything in the select-group removes the checkmark
+
+      control.prop("checked", true ).val(true)
+
+
       checkboxes.each(function(index) {
         const checkbox = $(this)
         if(controlChecked) {


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1817)

Add some javascript that sets the value to true when the `None of these` checkbox is selected and sets it to `false` when it is deselected by clicking any of the other options.

The value for `None of these` is still set as default `true` on page load.
## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
