### PR TITLE
AP-1817 checkbox bugfix

### DIFF
--- a/app/webpack/src/checkbox_control.js
+++ b/app/webpack/src/checkbox_control.js
@@ -32,7 +32,7 @@ $(function() {
       if (this.checked) {
         control.prop("checked", true ).val(true)
       } else {
-        control.prop("checked", false ).val(false)
+        control.prop("checked", false ).val('')
       }
 
       checkboxes.each(function(index) {

--- a/app/webpack/src/checkbox_control.js
+++ b/app/webpack/src/checkbox_control.js
@@ -28,6 +28,7 @@ $(function() {
     */
     control.change( function() {
       const controlChecked = this.checked
+      control.prop("unchecked", true ).val(true)
 
       checkboxes.each(function(index) {
         const checkbox = $(this)

--- a/app/webpack/src/checkbox_control.js
+++ b/app/webpack/src/checkbox_control.js
@@ -28,7 +28,12 @@ $(function() {
     */
     control.change( function() {
       const controlChecked = this.checked
-      control.prop("unchecked", true ).val(true)
+
+      if (this.checked) {
+        control.prop("checked", true ).val(true)
+      } else {
+        control.prop("checked", false ).val(false)
+      }
 
       checkboxes.each(function(index) {
         const checkbox = $(this)


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1817)

Add some javascript that sets the value to true when the None of these checkbox is selected and sets it to false when it is deselected by clicking any of the other options.

The value for None of these is still set as default true on page load.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
