### PR TITLE
ap-1875 display the student loan value

### DIFF
--- a/app/models/cfe/v2/result.rb
+++ b/app/models/cfe/v2/result.rb
@@ -194,7 +194,7 @@ module CFE
       end
 
       def mei_student_loan
-        monthly_income_equivalents[:student_loan].to_d
+        gross_income[:monthly_student_loan].to_d
       end
 
       def mei_pension

--- a/spec/factories/cfe_results.rb
+++ b/spec/factories/cfe_results.rb
@@ -44,6 +44,10 @@ FactoryBot.define do
       result { CFEResults::V2::MockResults.with_maintenance_received.to_json }
     end
 
+    trait :with_student_finance_received do
+      result { CFEResults::V2::MockResults.with_student_finance_received.to_json }
+    end
+
     trait :with_no_mortgage_costs do
       result { CFEResults::V2::MockResults.with_no_mortgage_costs.to_json }
     end

--- a/spec/factories/cfe_results/v2/mock_results.rb
+++ b/spec/factories/cfe_results/v2/mock_results.rb
@@ -20,6 +20,7 @@ module CFEResults
               self_employed: false
             },
             gross_income: {
+              monthly_student_loan: '0.0',
               monthly_other_income: '75.0',
               monthly_state_benefits: '75.0',
               total_gross_income: '150.0',
@@ -30,7 +31,6 @@ module CFEResults
                   friends_or_family: '50.59',
                   maintenance_in: '54.17',
                   property_or_lodger: '450.0',
-                  student_loan: '230.09',
                   pension: '82.52'
                 },
               monthly_outgoing_equivalents:
@@ -321,6 +321,12 @@ module CFEResults
       def self.with_maintenance_received
         result = eligible
         result[:assessment][:disposable_income][:maintenance_allowance] = '150.00'
+        result
+      end
+
+      def self.with_student_finance_received
+        result = eligible
+        result[:assessment][:gross_income][:monthly_student_loan] = '125.00'
         result
       end
 

--- a/spec/factory_specs/cfe_result_factory_spec.rb
+++ b/spec/factory_specs/cfe_result_factory_spec.rb
@@ -34,7 +34,8 @@ RSpec.describe 'cfe_v2_result factory' do
     end
 
     it 'has required keys in gross income' do
-      expect(gross_income.keys).to match_array %i[monthly_other_income
+      expect(gross_income.keys).to match_array %i[monthly_student_loan
+                                                  monthly_other_income
                                                   monthly_state_benefits
                                                   monthly_income_equivalents
                                                   monthly_outgoing_equivalents

--- a/spec/models/cfe/v2/result_spec.rb
+++ b/spec/models/cfe/v2/result_spec.rb
@@ -10,6 +10,7 @@ module CFE
       let(:additional_property) { create :cfe_v2_result, :with_additional_properties }
       let(:no_vehicles) { create :cfe_v2_result, :no_vehicles }
       let(:with_maintenance) { create :cfe_v2_result, :with_maintenance_received }
+      let(:with_student_finance) { create :cfe_v2_result, :with_student_finance_received }
       let(:no_mortgage) { create :cfe_v2_result, :with_no_mortgage_costs }
       let(:legal_aid_application) { create :legal_aid_application, :with_restrictions, :with_cfe_v2_result }
       let(:contribution_and_restriction_result) { create :cfe_v2_result, :with_capital_contribution_required, submission: cfe_submission }
@@ -413,6 +414,18 @@ module CFE
 
         context 'when maintenance is not received' do
           subject(:maintenance_per_month) { eligible_result.maintenance_per_month }
+          it { is_expected.to eq 0.00 }
+        end
+      end
+
+      describe 'mei_student_loan' do
+        context 'when student_loan is received' do
+          subject(:mei_student_loan) { with_student_finance.mei_student_loan }
+          it { is_expected.to eq 125.00 }
+        end
+
+        context 'when student_loan is not received' do
+          subject(:mei_student_loan) { eligible_result.mei_student_loan }
           it { is_expected.to eq 0.00 }
         end
       end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1875)

We are no longer using the monthly_equivalent calculator to calculate the student loan value. Student loan is now under irregular income instead of other_income and the annual sum is divided by 12. 

Changed `mei_student_loan` to take the value from cfe_result.gross_income[:monthly_student_loan] This ensures that wherever `mei_student_loan` is used (particularly to display results) we now access the correct value.

The `monthly_student_loan` value is already being included in the calculations for total monthly/disposable income etc. So the totals and calculations are all still correct it is only on pages where we breakdown by income type that the values are not being displayed.


## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
