### PR TITLE
AP-1874 format sort code as plain text

### DIFF
--- a/app/presenters/bank_transaction_presenter.rb
+++ b/app/presenters/bank_transaction_presenter.rb
@@ -98,7 +98,8 @@ class BankTransactionPresenter
   end
 
   def transaction_account_sort_code
-    %(="#{account_for_transaction.sort_code}")
+    # add tab to end of sort code to prevent bug in Excel interpreting it as a date
+    "#{account_for_transaction.sort_code}\t"
   end
 
   def transaction_account_number

--- a/app/presenters/bank_transaction_presenter.rb
+++ b/app/presenters/bank_transaction_presenter.rb
@@ -98,7 +98,7 @@ class BankTransactionPresenter
   end
 
   def transaction_account_sort_code
-    "'#{account_for_transaction.sort_code}"
+    %(="#{account_for_transaction.sort_code}")
   end
 
   def transaction_account_number

--- a/app/presenters/bank_transaction_presenter.rb
+++ b/app/presenters/bank_transaction_presenter.rb
@@ -98,7 +98,7 @@ class BankTransactionPresenter
   end
 
   def transaction_account_sort_code
-    account_for_transaction.sort_code
+    "'#{account_for_transaction.sort_code}"
   end
 
   def transaction_account_number

--- a/spec/presenters/bank_transaction_presenter_spec.rb
+++ b/spec/presenters/bank_transaction_presenter_spec.rb
@@ -127,14 +127,12 @@ RSpec.describe BankTransactionPresenter do
 
     describe 'account_name' do
       subject(:account_name) { presenter.build_transaction_hash[:account_name] }
-
       it { is_expected.to eq account.bank_and_account_name }
     end
 
     describe 'account_sort_code' do
       subject(:account_sort_code) { presenter.build_transaction_hash[:account_sort_code] }
-
-      it { is_expected.to eq "=\"#{account.sort_code}\"" }
+      it { is_expected.to eq "#{account.sort_code}\t" }
     end
 
     describe 'account_number' do

--- a/spec/presenters/bank_transaction_presenter_spec.rb
+++ b/spec/presenters/bank_transaction_presenter_spec.rb
@@ -134,7 +134,7 @@ RSpec.describe BankTransactionPresenter do
     describe 'account_sort_code' do
       subject(:account_sort_code) { presenter.build_transaction_hash[:account_sort_code] }
 
-      it { is_expected.to eq "'#{account.sort_code}" }
+      it { is_expected.to eq "=\"#{account.sort_code}\"" }
     end
 
     describe 'account_number' do

--- a/spec/presenters/bank_transaction_presenter_spec.rb
+++ b/spec/presenters/bank_transaction_presenter_spec.rb
@@ -134,7 +134,7 @@ RSpec.describe BankTransactionPresenter do
     describe 'account_sort_code' do
       subject(:account_sort_code) { presenter.build_transaction_hash[:account_sort_code] }
 
-      it { is_expected.to eq account.sort_code }
+      it { is_expected.to eq "'#{account.sort_code}" }
     end
 
     describe 'account_number' do


### PR DESCRIPTION
## Format sort code as plain text

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1874)

On the bank transactions CSV file, some sort codes were being interpreted by Excel as dates and displayed wrongly.  This PR forces them to be interpreted as plain text by preceeding them with a single quote

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
