### PR TITLE
Ap 1807 applicant email

### DIFF
--- a/app/mailers/concerns/notify_template_methods.rb
+++ b/app/mailers/concerns/notify_template_methods.rb
@@ -15,4 +15,8 @@ module NotifyTemplateMethods
   def safe_nil(value)
     value || ''
   end
+
+  def url_expiry_date
+    (Date.today + 7.days).strftime('%d %B %Y')
+  end
 end

--- a/app/mailers/concerns/notify_template_methods.rb
+++ b/app/mailers/concerns/notify_template_methods.rb
@@ -17,6 +17,6 @@ module NotifyTemplateMethods
   end
 
   def url_expiry_date
-    (Date.today + 7.days).strftime('%d %B %Y')
+    (Date.today + 7.days).strftime('%-d %B %Y')
   end
 end

--- a/app/mailers/notify_mailer.rb
+++ b/app/mailers/notify_mailer.rb
@@ -16,10 +16,4 @@ class NotifyMailer < BaseApplyMailer
     )
     mail(to: email)
   end
-
-  private
-
-  def url_expiry_date
-    (Date.today + 7.days).strftime('%d %B %Y')
-  end
 end

--- a/app/mailers/notify_mailer.rb
+++ b/app/mailers/notify_mailer.rb
@@ -11,8 +11,15 @@ class NotifyMailer < BaseApplyMailer
       application_url: application_url,
       client_name: client_name,
       provider_firm: provider_firm,
-      ref_number: app_id
+      ref_number: app_id,
+      expiry_date: url_expiry_date
     )
     mail(to: email)
+  end
+
+  private
+
+  def url_expiry_date
+    (Date.today + 7.days).strftime('%d %B %Y')
   end
 end

--- a/app/mailers/resend_link_request_mailer.rb
+++ b/app/mailers/resend_link_request_mailer.rb
@@ -9,8 +9,15 @@ class ResendLinkRequestMailer < BaseApplyMailer
     set_personalisation(
       application_url: application_url,
       client_name: client_name,
-      ref_number: app_id
+      ref_number: app_id,
+      expiry_date: url_expiry_date
     )
     mail(to: email)
+  end
+
+  private
+
+  def url_expiry_date
+    (Date.today + 7.days).strftime('%d %B %Y')
   end
 end

--- a/app/mailers/resend_link_request_mailer.rb
+++ b/app/mailers/resend_link_request_mailer.rb
@@ -14,10 +14,4 @@ class ResendLinkRequestMailer < BaseApplyMailer
     )
     mail(to: email)
   end
-
-  private
-
-  def url_expiry_date
-    (Date.today + 7.days).strftime('%d %B %Y')
-  end
 end

--- a/app/mailers/submit_citizen_financial_reminder_mailer.rb
+++ b/app/mailers/submit_citizen_financial_reminder_mailer.rb
@@ -18,10 +18,4 @@ class SubmitCitizenFinancialReminderMailer < BaseApplyMailer
     )
     mail(to: email)
   end
-
-  private
-
-  def url_expiry_date
-    (Date.today + 7.days).strftime('%d %B %Y')
-  end
 end

--- a/app/mailers/submit_citizen_financial_reminder_mailer.rb
+++ b/app/mailers/submit_citizen_financial_reminder_mailer.rb
@@ -7,7 +7,7 @@ class SubmitCitizenFinancialReminderMailer < BaseApplyMailer
     scheduled_mailing.legal_aid_application.provider_step == 'check_provider_answers'
   end
 
-  def notify_citizen(application_id, email, application_url, client_name)
+  def notify_citizen(application_id, email, application_url, client_name, url_expiry_date)
     application = LegalAidApplication.find(application_id)
     template_name :reminder_to_submit_financial_information_client
     set_personalisation(

--- a/app/mailers/submit_citizen_financial_reminder_mailer.rb
+++ b/app/mailers/submit_citizen_financial_reminder_mailer.rb
@@ -13,8 +13,15 @@ class SubmitCitizenFinancialReminderMailer < BaseApplyMailer
     set_personalisation(
       ref_number: application['application_ref'],
       client_name: client_name,
-      application_url: application_url
+      application_url: application_url,
+      expiry_date: url_expiry_date
     )
     mail(to: email)
+  end
+
+  private
+
+  def url_expiry_date
+    (Date.today + 7.days).strftime('%d %B %Y')
   end
 end

--- a/app/services/submit_citizen_reminder_service.rb
+++ b/app/services/submit_citizen_reminder_service.rb
@@ -26,7 +26,7 @@ class SubmitCitizenReminderService
       applicant.email,
       application_url,
       applicant.full_name,
-      expiry_date
+      url_expiry_date
     ]
   end
 
@@ -36,10 +36,6 @@ class SubmitCitizenReminderService
 
   def applicant
     @applicant ||= application&.applicant
-  end
-
-  def url_expiry_date
-    (Date.today + 7.days).strftime('%d %B %Y')
   end
 
   def secure_id

--- a/app/services/submit_citizen_reminder_service.rb
+++ b/app/services/submit_citizen_reminder_service.rb
@@ -25,7 +25,8 @@ class SubmitCitizenReminderService
       application.id,
       applicant.email,
       application_url,
-      applicant.full_name
+      applicant.full_name,
+      expiry_date
     ]
   end
 
@@ -35,6 +36,10 @@ class SubmitCitizenReminderService
 
   def applicant
     @applicant ||= application&.applicant
+  end
+
+  def url_expiry_date
+    (Date.today + 7.days).strftime('%d %B %Y')
   end
 
   def secure_id

--- a/app/services/submit_citizen_reminder_service.rb
+++ b/app/services/submit_citizen_reminder_service.rb
@@ -47,6 +47,10 @@ class SubmitCitizenReminderService
     tomorrow.to_time + 9.hours
   end
 
+  def url_expiry_date
+    (Date.today + 7.days).strftime('%-d %B %Y')
+  end
+
   def nine_am_deadline_day
     deadline = Date.today + 7.days
     deadline.to_time + 9.hours

--- a/config/govuk_notify_templates.yml
+++ b/config/govuk_notify_templates.yml
@@ -9,11 +9,11 @@
 # we default to 'integration' group.
 #
 development:
-  citizen_start_application: e747df7d-4842-4bca-88a6-4ad3ebd89994
+  citizen_start_application: 74d7825f-91e4-4311-98a4-36cb517c8359 # this needs to be changed back and original email template amended
   feedback_notification: 4d391bf7-4e5b-4f49-b586-b6bb8ad06a30
   new_link_request: a577582b-3e60-44a4-885c-d4b12bf23958
   submission_confirmation: ce2d89ee-1c10-404b-91cc-52068933ba7b
-  reminder_to_submit_an_application: c4ac858d-68ae-437b-9353-06e632cd88f2
+  reminder_to_submit_an_application: 43de80f4-6a15-4be9-8a29-b3682cea3eee  # this needs to be changed back and original email template amended
   client_completed_means: d04e64ae-0a66-4577-83d6-6ce9f7fa27b4
   reminder_to_submit_financial_information_client: e8052551-2afa-4b11-b3e3-578248d9b582
   reminder_to_submit_financial_information_provider: ec4f423d-498a-4828-ab66-c2453cb42ed3

--- a/config/govuk_notify_templates.yml
+++ b/config/govuk_notify_templates.yml
@@ -9,14 +9,14 @@
 # we default to 'integration' group.
 #
 development:
-  citizen_start_application: e747df7d-4842-4bca-88a6-4ad3ebd89994
+  citizen_start_application: e4c8be11-3c40-440d-91fc-9c35b0507de2
   feedback_notification: 4d391bf7-4e5b-4f49-b586-b6bb8ad06a30
   submission_confirmation: ce2d89ee-1c10-404b-91cc-52068933ba7b
   reminder_to_submit_an_application: c4ac858d-68ae-437b-9353-06e632cd88f2
   client_completed_means: d04e64ae-0a66-4577-83d6-6ce9f7fa27b4
-  reminder_to_submit_financial_information_client: e8052551-2afa-4b11-b3e3-578248d9b582
+  reminder_to_submit_financial_information_client: de564311-231d-4081-98d5-95770bff94a3
   reminder_to_submit_financial_information_provider: ec4f423d-498a-4828-ab66-c2453cb42ed3
-  new_link_to_client: 5708ec04-c789-4f7e-8a15-ad7dd3f4f336
+  new_link_to_client: 325849a2-4c38-4579-a517-4d2a1e465ba0
 
 production:
   citizen_start_application: 7e5fb1a7-4b78-4a95-917e-c0bcb78a5fcc

--- a/config/govuk_notify_templates.yml
+++ b/config/govuk_notify_templates.yml
@@ -9,11 +9,10 @@
 # we default to 'integration' group.
 #
 development:
-  citizen_start_application: 74d7825f-91e4-4311-98a4-36cb517c8359 # this needs to be changed back and original email template amended
+  citizen_start_application: e747df7d-4842-4bca-88a6-4ad3ebd89994
   feedback_notification: 4d391bf7-4e5b-4f49-b586-b6bb8ad06a30
-  new_link_request: 8d93ef3b-a744-4c88-87c8-a6f326886c12 # a577582b-3e60-44a4-885c-d4b12bf23958 this needs to be changed back and original email template amended
   submission_confirmation: ce2d89ee-1c10-404b-91cc-52068933ba7b
-  reminder_to_submit_an_application: 43de80f4-6a15-4be9-8a29-b3682cea3eee  # this needs to be changed back and original email template amended
+  reminder_to_submit_an_application: c4ac858d-68ae-437b-9353-06e632cd88f2
   client_completed_means: d04e64ae-0a66-4577-83d6-6ce9f7fa27b4
   reminder_to_submit_financial_information_client: e8052551-2afa-4b11-b3e3-578248d9b582
   reminder_to_submit_financial_information_provider: ec4f423d-498a-4828-ab66-c2453cb42ed3
@@ -22,7 +21,6 @@ development:
 production:
   citizen_start_application: 7e5fb1a7-4b78-4a95-917e-c0bcb78a5fcc
   feedback_notification: fd050a04-54d2-4736-bb6c-66431c7d9e41
-  new_link_request: 3cc3be57-e072-4095-9caa-c0cd52193405
   submission_confirmation: 5472b10b-bc11-432a-a18d-9f20de5b2854
   reminder_to_submit_an_application: 96e58b6c-83e2-4ae8-be67-028803e98398
   client_completed_means: b343446d-b487-4f8b-9673-2aaf21ea10a1

--- a/config/govuk_notify_templates.yml
+++ b/config/govuk_notify_templates.yml
@@ -11,7 +11,7 @@
 development:
   citizen_start_application: 74d7825f-91e4-4311-98a4-36cb517c8359 # this needs to be changed back and original email template amended
   feedback_notification: 4d391bf7-4e5b-4f49-b586-b6bb8ad06a30
-  new_link_request: a577582b-3e60-44a4-885c-d4b12bf23958
+  new_link_request: 8d93ef3b-a744-4c88-87c8-a6f326886c12 # a577582b-3e60-44a4-885c-d4b12bf23958 this needs to be changed back and original email template amended
   submission_confirmation: ce2d89ee-1c10-404b-91cc-52068933ba7b
   reminder_to_submit_an_application: 43de80f4-6a15-4be9-8a29-b3682cea3eee  # this needs to be changed back and original email template amended
   client_completed_means: d04e64ae-0a66-4577-83d6-6ce9f7fa27b4

--- a/config/govuk_notify_templates.yml
+++ b/config/govuk_notify_templates.yml
@@ -19,11 +19,11 @@ development:
   new_link_to_client: 325849a2-4c38-4579-a517-4d2a1e465ba0
 
 production:
-  citizen_start_application: 7e5fb1a7-4b78-4a95-917e-c0bcb78a5fcc
+  citizen_start_application: 1ad50d58-ab76-4583-8c31-258d7c8304a4
   feedback_notification: fd050a04-54d2-4736-bb6c-66431c7d9e41
   submission_confirmation: 5472b10b-bc11-432a-a18d-9f20de5b2854
   reminder_to_submit_an_application: 96e58b6c-83e2-4ae8-be67-028803e98398
   client_completed_means: b343446d-b487-4f8b-9673-2aaf21ea10a1
-  reminder_to_submit_financial_information_client: 2a07ae35-670a-4753-a7cf-58843068b659
+  reminder_to_submit_financial_information_client: ea0b7443-7200-4abf-8ba8-de0462f9a7b5
   reminder_to_submit_financial_information_provider: 9843f667-8b11-41c0-9c11-622fffc686ec
-  new_link_to_client: b59f52f3-ad0b-45ed-9b2a-a33686f4278a
+  new_link_to_client: 1f360188-7046-4eb2-9c03-a8253bf663c1

--- a/spec/mailers/notify_mailer_spec.rb
+++ b/spec/mailers/notify_mailer_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe NotifyMailer, type: :mailer do
         client_name: client_name,
         provider_firm: provider_firm,
         ref_number: app_id,
-        expiry_date: (Date.today + 7.days).strftime('%d %B %Y')
+        expiry_date: (Date.today + 7.days).strftime('%-d %B %Y')
       )
     end
   end

--- a/spec/mailers/notify_mailer_spec.rb
+++ b/spec/mailers/notify_mailer_spec.rb
@@ -32,7 +32,8 @@ RSpec.describe NotifyMailer, type: :mailer do
         application_url: application_url,
         client_name: client_name,
         provider_firm: provider_firm,
-        ref_number: app_id
+        ref_number: app_id,
+        expiry_date: (Date.today + 7.days).strftime('%d %B %Y')
       )
     end
   end

--- a/spec/mailers/submit_application_reminder_mailer_spec.rb
+++ b/spec/mailers/submit_application_reminder_mailer_spec.rb
@@ -17,8 +17,7 @@ RSpec.describe SubmitApplicationReminderMailer, type: :mailer do
     end
 
     it 'sets the correct template' do
-      # expect(mail.govuk_notify_template).to eq('c4ac858d-68ae-437b-9353-06e632cd88f2')
-      expect(mail.govuk_notify_template).to eq('43de80f4-6a15-4be9-8a29-b3682cea3eee')  # this needs to be changed back and original email template amended
+      expect(mail.govuk_notify_template).to eq('c4ac858d-68ae-437b-9353-06e632cd88f2')
     end
 
     it 'has the right personalisation' do

--- a/spec/mailers/submit_application_reminder_mailer_spec.rb
+++ b/spec/mailers/submit_application_reminder_mailer_spec.rb
@@ -17,7 +17,8 @@ RSpec.describe SubmitApplicationReminderMailer, type: :mailer do
     end
 
     it 'sets the correct template' do
-      expect(mail.govuk_notify_template).to eq('c4ac858d-68ae-437b-9353-06e632cd88f2')
+      # expect(mail.govuk_notify_template).to eq('c4ac858d-68ae-437b-9353-06e632cd88f2')
+      expect(mail.govuk_notify_template).to eq('43de80f4-6a15-4be9-8a29-b3682cea3eee')  # this needs to be changed back and original email template amended
     end
 
     it 'has the right personalisation' do

--- a/spec/mailers/submit_citizen_financial_reminder_mailer_spec.rb
+++ b/spec/mailers/submit_citizen_financial_reminder_mailer_spec.rb
@@ -25,7 +25,8 @@ RSpec.describe SubmitCitizenFinancialReminderMailer, type: :mailer do
       expect(mail.govuk_notify_personalisation).to eq(
         ref_number: application.application_ref,
         client_name: application.applicant.full_name,
-        application_url: application_url
+        application_url: application_url,
+        expiry_date: (Date.today + 7.days).strftime('%d %B %Y')
       )
     end
   end

--- a/spec/mailers/submit_citizen_financial_reminder_mailer_spec.rb
+++ b/spec/mailers/submit_citizen_financial_reminder_mailer_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe SubmitCitizenFinancialReminderMailer, type: :mailer do
     end
 
     it 'sets the correct template' do
-      expect(mail.govuk_notify_template).to eq('e8052551-2afa-4b11-b3e3-578248d9b582')
+      expect(mail.govuk_notify_template).to eq('de564311-231d-4081-98d5-95770bff94a3')
     end
 
     it 'has the right personalisation' do

--- a/spec/mailers/submit_citizen_financial_reminder_mailer_spec.rb
+++ b/spec/mailers/submit_citizen_financial_reminder_mailer_spec.rb
@@ -5,9 +5,10 @@ RSpec.describe SubmitCitizenFinancialReminderMailer, type: :mailer do
   let(:email) { Faker::Internet.safe_email }
   let(:provider_name) { Faker::Name.name }
   let(:application_url) { 'http://test.com' }
+  let(:url_expiry_date) { (Date.today + 7.days).strftime('%-d %B %Y') }
 
   describe '#notify_citizen' do
-    let(:mail) { described_class.notify_citizen(application.id, email, application_url, application.applicant.full_name) }
+    let(:mail) { described_class.notify_citizen(application.id, email, application_url, application.applicant.full_name, url_expiry_date) }
 
     it 'sends an email to the correct address' do
       expect(mail.to).to eq([email])
@@ -26,7 +27,7 @@ RSpec.describe SubmitCitizenFinancialReminderMailer, type: :mailer do
         ref_number: application.application_ref,
         client_name: application.applicant.full_name,
         application_url: application_url,
-        expiry_date: (Date.today + 7.days).strftime('%d %B %Y')
+        expiry_date: (Date.today + 7.days).strftime('%-d %B %Y')
       )
     end
   end

--- a/spec/services/submit_citizen_reminder_service_spec.rb
+++ b/spec/services/submit_citizen_reminder_service_spec.rb
@@ -21,7 +21,8 @@ RSpec.describe SubmitCitizenReminderService, :vcr do
         expect(mail.govuk_notify_personalisation).to eq(
           application_url: application_url,
           ref_number: application.application_ref,
-          client_name: application.applicant.full_name
+          client_name: application.applicant.full_name,
+          expiry_date: (Date.today + 7.days).strftime('%d %B %Y')
         )
       end
     end

--- a/spec/services/submit_citizen_reminder_service_spec.rb
+++ b/spec/services/submit_citizen_reminder_service_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe SubmitCitizenReminderService, :vcr do
   let(:provider) { create :provider, email: simulated_email_address }
   let(:application) { create :application, :with_applicant, provider: provider }
   let(:application_url) { 'http://test.com' }
+  let(:url_expiry_date) { (Date.today + 7.days).strftime('%-d %B %Y') }
 
   subject { described_class.new(application) }
 
@@ -15,14 +16,14 @@ RSpec.describe SubmitCitizenReminderService, :vcr do
     end
 
     context 'sending the email' do
-      let(:mail) { SubmitCitizenFinancialReminderMailer.notify_citizen(application.id, simulated_email_address, application_url, application.applicant.full_name) }
+      let(:mail) { SubmitCitizenFinancialReminderMailer.notify_citizen(application.id, simulated_email_address, application_url, application.applicant.full_name, url_expiry_date) }
 
       it 'sends an email with the right parameters' do
         expect(mail.govuk_notify_personalisation).to eq(
           application_url: application_url,
           ref_number: application.application_ref,
           client_name: application.applicant.full_name,
-          expiry_date: (Date.today + 7.days).strftime('%d %B %Y')
+          expiry_date: url_expiry_date
         )
       end
     end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1807)

Added in new parameter for client emails to include the date on which the url expires. 

URL is set to expire 7 days from the date it is issued. Reminder emails have the date set on the day they are scheduled

For UAT testing this has 3 new notify templates. Once it has passed UAT these will need to be removed and the original templates updated to include the new wording and date. This will then need to be tested in staging before release to production.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
