### PR TITLE
Ap 1876 report formatting

### DIFF
--- a/app/views/layouts/pdf.html.erb
+++ b/app/views/layouts/pdf.html.erb
@@ -2,8 +2,9 @@
 <html lang="en" class="govuk-template">
   <head>
     <meta charset="utf-8">
-    <%= wicked_pdf_stylesheet_link_tag 'application' %>
-    <%= wicked_pdf_stylesheet_link_tag 'pdf' %>
+    <%= stylesheet_pack_tag 'styles', media: 'all' %>
+    <%#= wicked_pdf_stylesheet_link_tag 'application' %>
+    <%#= wicked_pdf_stylesheet_link_tag 'pdf' %>
     <%= render 'layouts/govuk_base64_fonts.html' %>
   </head>
 

--- a/app/views/layouts/pdf.html.erb
+++ b/app/views/layouts/pdf.html.erb
@@ -3,8 +3,7 @@
   <head>
     <meta charset="utf-8">
     <%= stylesheet_pack_tag 'styles', media: 'all' %>
-    <%#= wicked_pdf_stylesheet_link_tag 'application' %>
-    <%#= wicked_pdf_stylesheet_link_tag 'pdf' %>
+    <%= wicked_pdf_stylesheet_pack_tag 'styles' %>
     <%= render 'layouts/govuk_base64_fonts.html' %>
   </head>
 

--- a/app/views/layouts/pdf.html.erb
+++ b/app/views/layouts/pdf.html.erb
@@ -2,7 +2,6 @@
 <html lang="en" class="govuk-template">
   <head>
     <meta charset="utf-8">
-    <%= stylesheet_pack_tag 'styles', media: 'all' %>
     <%= wicked_pdf_stylesheet_pack_tag 'styles' %>
     <%= render 'layouts/govuk_base64_fonts.html' %>
   </head>

--- a/spec/cassettes/stylesheets.yml
+++ b/spec/cassettes/stylesheets.yml
@@ -1,0 +1,71 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://www.example.com/packs-test/css/styles-497d061b.css
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - www.example.com
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Via:
+      - 1.1 WFRW001
+      Connection:
+      - Keep-Alive
+      Proxy-Connection:
+      - Keep-Alive
+      Content-Length:
+      - '1256'
+      Age:
+      - '1'
+      Expires:
+      - Fri, 04 Dec 2020 12:24:41 GMT
+      Date:
+      - Fri, 27 Nov 2020 12:24:41 GMT
+      Content-Type:
+      - text/html; charset=UTF-8
+      Server:
+      - ECS (dcb/7FA4)
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - max-age=604800
+      Last-Modified:
+      - Fri, 27 Nov 2020 12:24:40 GMT
+      Vary:
+      - Accept-Encoding
+      X-Cache:
+      - 404-HIT
+    body:
+      encoding: UTF-8
+      string: "<!doctype html>\n<html>\n<head>\n    <title>Example Domain</title>\n\n
+        \   <meta charset=\"utf-8\" />\n    <meta http-equiv=\"Content-type\" content=\"text/html;
+        charset=utf-8\" />\n    <meta name=\"viewport\" content=\"width=device-width,
+        initial-scale=1\" />\n    <style type=\"text/css\">\n    body {\n        background-color:
+        #f0f0f2;\n        margin: 0;\n        padding: 0;\n        font-family: -apple-system,
+        system-ui, BlinkMacSystemFont, \"Segoe UI\", \"Open Sans\", \"Helvetica Neue\",
+        Helvetica, Arial, sans-serif;\n        \n    }\n    div {\n        width:
+        600px;\n        margin: 5em auto;\n        padding: 2em;\n        background-color:
+        #fdfdff;\n        border-radius: 0.5em;\n        box-shadow: 2px 3px 7px 2px
+        rgba(0,0,0,0.02);\n    }\n    a:link, a:visited {\n        color: #38488f;\n
+        \       text-decoration: none;\n    }\n    @media (max-width: 700px) {\n        div
+        {\n            margin: 0 auto;\n            width: auto;\n        }\n    }\n
+        \   </style>    \n</head>\n\n<body>\n<div>\n    <h1>Example Domain</h1>\n
+        \   <p>This domain is for use in illustrative examples in documents. You may
+        use this\n    domain in literature without prior coordination or asking for
+        permission.</p>\n    <p><a href=\"https://www.iana.org/domains/example\">More
+        information...</a></p>\n</div>\n</body>\n</html>\n"
+  recorded_at: Fri, 27 Nov 2020 12:24:41 GMT
+recorded_with: VCR 6.0.0

--- a/spec/cassettes/stylesheets2.yml
+++ b/spec/cassettes/stylesheets2.yml
@@ -1,0 +1,71 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://example.org/packs-test/css/styles-497d061b.css
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - example.org
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Via:
+      - 1.1 WFRW001
+      Connection:
+      - Keep-Alive
+      Proxy-Connection:
+      - Keep-Alive
+      Content-Length:
+      - '1256'
+      Age:
+      - '1287'
+      Expires:
+      - Fri, 04 Dec 2020 12:46:07 GMT
+      Date:
+      - Fri, 27 Nov 2020 12:46:07 GMT
+      Content-Type:
+      - text/html; charset=UTF-8
+      Server:
+      - ECS (dcb/7FA4)
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - max-age=604800
+      Last-Modified:
+      - Fri, 27 Nov 2020 12:24:40 GMT
+      Vary:
+      - Accept-Encoding
+      X-Cache:
+      - 404-HIT
+    body:
+      encoding: UTF-8
+      string: "<!doctype html>\n<html>\n<head>\n    <title>Example Domain</title>\n\n
+        \   <meta charset=\"utf-8\" />\n    <meta http-equiv=\"Content-type\" content=\"text/html;
+        charset=utf-8\" />\n    <meta name=\"viewport\" content=\"width=device-width,
+        initial-scale=1\" />\n    <style type=\"text/css\">\n    body {\n        background-color:
+        #f0f0f2;\n        margin: 0;\n        padding: 0;\n        font-family: -apple-system,
+        system-ui, BlinkMacSystemFont, \"Segoe UI\", \"Open Sans\", \"Helvetica Neue\",
+        Helvetica, Arial, sans-serif;\n        \n    }\n    div {\n        width:
+        600px;\n        margin: 5em auto;\n        padding: 2em;\n        background-color:
+        #fdfdff;\n        border-radius: 0.5em;\n        box-shadow: 2px 3px 7px 2px
+        rgba(0,0,0,0.02);\n    }\n    a:link, a:visited {\n        color: #38488f;\n
+        \       text-decoration: none;\n    }\n    @media (max-width: 700px) {\n        div
+        {\n            margin: 0 auto;\n            width: auto;\n        }\n    }\n
+        \   </style>    \n</head>\n\n<body>\n<div>\n    <h1>Example Domain</h1>\n
+        \   <p>This domain is for use in illustrative examples in documents. You may
+        use this\n    domain in literature without prior coordination or asking for
+        permission.</p>\n    <p><a href=\"https://www.iana.org/domains/example\">More
+        information...</a></p>\n</div>\n</body>\n</html>\n"
+  recorded_at: Fri, 27 Nov 2020 12:46:07 GMT
+recorded_with: VCR 6.0.0

--- a/spec/requests/providers/means_reports_spec.rb
+++ b/spec/requests/providers/means_reports_spec.rb
@@ -12,6 +12,12 @@ RSpec.describe Providers::MeansReportsController, type: :request do
   describe 'GET /providers/applications/:legal_aid_application_id/means_report' do
     subject { get providers_legal_aid_application_means_report_path(legal_aid_application, debug: true) }
 
+    around do |example|
+      VCR.turn_off!
+      example.run
+      VCR.turn_on!
+    end
+
     before do
       login_provider
       before_subject

--- a/spec/requests/providers/means_reports_spec.rb
+++ b/spec/requests/providers/means_reports_spec.rb
@@ -10,7 +10,11 @@ RSpec.describe Providers::MeansReportsController, type: :request do
   let(:before_subject) { nil }
 
   describe 'GET /providers/applications/:legal_aid_application_id/means_report' do
-    subject { get providers_legal_aid_application_means_report_path(legal_aid_application, debug: true) }
+    subject do
+      VCR.use_cassette('stylesheets') do
+        get providers_legal_aid_application_means_report_path(legal_aid_application, debug: true)
+      end
+    end
 
     before do
       login_provider

--- a/spec/requests/providers/means_reports_spec.rb
+++ b/spec/requests/providers/means_reports_spec.rb
@@ -12,12 +12,6 @@ RSpec.describe Providers::MeansReportsController, type: :request do
   describe 'GET /providers/applications/:legal_aid_application_id/means_report' do
     subject { get providers_legal_aid_application_means_report_path(legal_aid_application, debug: true) }
 
-    around do |example|
-      VCR.turn_off!
-      example.run
-      VCR.turn_on!
-    end
-
     before do
       login_provider
       before_subject

--- a/spec/requests/providers/means_reports_spec.rb
+++ b/spec/requests/providers/means_reports_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Providers::MeansReportsController, type: :request do
   describe 'GET /providers/applications/:legal_aid_application_id/means_report' do
     subject do
       # dont' match on path - webpacker keeps changing the second part of the path
-      VCR.use_cassette('stylesheets', match_requests_on: [:method, :host, :headers]) do
+      VCR.use_cassette('stylesheets', match_requests_on: %i[method host headers]) do
         get providers_legal_aid_application_means_report_path(legal_aid_application, debug: true)
       end
     end

--- a/spec/requests/providers/means_reports_spec.rb
+++ b/spec/requests/providers/means_reports_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe Providers::MeansReportsController, type: :request do
 
   describe 'GET /providers/applications/:legal_aid_application_id/means_report' do
     subject do
-      VCR.use_cassette('stylesheets') do
+      # dont' match on path - webpacker keeps changing the second part of the path
+      VCR.use_cassette('stylesheets', match_requests_on: [:method, :host, :headers]) do
         get providers_legal_aid_application_means_report_path(legal_aid_application, debug: true)
       end
     end

--- a/spec/requests/providers/merits_reports_spec.rb
+++ b/spec/requests/providers/merits_reports_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe Providers::MeritsReportsController, type: :request do
 
   describe 'GET /providers/applications/:legal_aid_application_id/merits_report' do
     subject do
-      VCR.use_cassette('stylesheets') do
+      # dont' match on path - webpacker keeps changing the second part of the path
+      VCR.use_cassette('stylesheets', match_requests_on: [:method, :host, :headers]) do
         get providers_legal_aid_application_merits_report_path(legal_aid_application, debug: true)
       end
     end

--- a/spec/requests/providers/merits_reports_spec.rb
+++ b/spec/requests/providers/merits_reports_spec.rb
@@ -7,7 +7,11 @@ RSpec.describe Providers::MeritsReportsController, type: :request do
   let(:before_subject) { nil }
 
   describe 'GET /providers/applications/:legal_aid_application_id/merits_report' do
-    subject { get providers_legal_aid_application_merits_report_path(legal_aid_application, debug: true) }
+    subject do
+      VCR.use_cassette('stylesheets') do
+        get providers_legal_aid_application_merits_report_path(legal_aid_application, debug: true)
+      end
+    end
 
     before do
       login_provider

--- a/spec/requests/providers/merits_reports_spec.rb
+++ b/spec/requests/providers/merits_reports_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Providers::MeritsReportsController, type: :request do
   describe 'GET /providers/applications/:legal_aid_application_id/merits_report' do
     subject do
       # dont' match on path - webpacker keeps changing the second part of the path
-      VCR.use_cassette('stylesheets', match_requests_on: [:method, :host, :headers]) do
+      VCR.use_cassette('stylesheets', match_requests_on: %i[method host headers]) do
         get providers_legal_aid_application_merits_report_path(legal_aid_application, debug: true)
       end
     end

--- a/spec/requests/providers/merits_reports_spec.rb
+++ b/spec/requests/providers/merits_reports_spec.rb
@@ -9,12 +9,6 @@ RSpec.describe Providers::MeritsReportsController, type: :request do
   describe 'GET /providers/applications/:legal_aid_application_id/merits_report' do
     subject { get providers_legal_aid_application_merits_report_path(legal_aid_application, debug: true) }
 
-    around do |example|
-      VCR.turn_off!
-      example.run
-      VCR.turn_on!
-    end
-
     before do
       login_provider
       before_subject

--- a/spec/requests/providers/merits_reports_spec.rb
+++ b/spec/requests/providers/merits_reports_spec.rb
@@ -9,6 +9,12 @@ RSpec.describe Providers::MeritsReportsController, type: :request do
   describe 'GET /providers/applications/:legal_aid_application_id/merits_report' do
     subject { get providers_legal_aid_application_merits_report_path(legal_aid_application, debug: true) }
 
+    around do |example|
+      VCR.turn_off!
+      example.run
+      VCR.turn_on!
+    end
+
     before do
       login_provider
       before_subject

--- a/spec/services/reports/means_report_creator_spec.rb
+++ b/spec/services/reports/means_report_creator_spec.rb
@@ -4,7 +4,8 @@ RSpec.describe Reports::MeansReportCreator do
   let(:legal_aid_application) { create :legal_aid_application, :with_proceeding_types, :with_everything, :with_cfe_v2_result, :generating_reports }
 
   subject do
-    VCR.use_cassette('stylesheets2') do
+    # dont' match on path - webpacker keeps changing the second part of the path
+    VCR.use_cassette('stylesheets2', match_requests_on: [:method, :host, :headers]) do
       described_class.call(legal_aid_application)
     end
   end

--- a/spec/services/reports/means_report_creator_spec.rb
+++ b/spec/services/reports/means_report_creator_spec.rb
@@ -3,7 +3,11 @@ require 'rails_helper'
 RSpec.describe Reports::MeansReportCreator do
   let(:legal_aid_application) { create :legal_aid_application, :with_proceeding_types, :with_everything, :with_cfe_v2_result, :generating_reports }
 
-  subject { described_class.call(legal_aid_application) }
+  subject do
+    VCR.use_cassette('stylesheets2') do
+      described_class.call(legal_aid_application)
+    end
+  end
 
   describe '.call' do
     it 'attaches means_report.pdf to the application' do

--- a/spec/services/reports/means_report_creator_spec.rb
+++ b/spec/services/reports/means_report_creator_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Reports::MeansReportCreator do
 
   subject do
     # dont' match on path - webpacker keeps changing the second part of the path
-    VCR.use_cassette('stylesheets2', match_requests_on: [:method, :host, :headers]) do
+    VCR.use_cassette('stylesheets2', match_requests_on: %i[method host headers]) do
       described_class.call(legal_aid_application)
     end
   end

--- a/spec/services/reports/merits_report_creator_spec.rb
+++ b/spec/services/reports/merits_report_creator_spec.rb
@@ -3,7 +3,12 @@ require 'rails_helper'
 RSpec.describe Reports::MeritsReportCreator do
   let(:legal_aid_application) { create :legal_aid_application, :with_proceeding_types, :with_everything, :generating_reports }
 
-  subject { described_class.call(legal_aid_application) }
+  subject do
+    VCR.use_cassette('stylesheets2') do
+      described_class.call(legal_aid_application)
+    end
+
+  end
 
   describe '.call' do
     it 'attaches merits_report.pdf to the application' do

--- a/spec/services/reports/merits_report_creator_spec.rb
+++ b/spec/services/reports/merits_report_creator_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Reports::MeritsReportCreator do
 
   subject do
     # dont' match on path - webpacker keeps changing the second part of the path
-    VCR.use_cassette('stylesheets2', match_requests_on: [:method, :host, :headers]) do
+    VCR.use_cassette('stylesheets2', match_requests_on: %i[method host headers]) do
       described_class.call(legal_aid_application)
     end
   end

--- a/spec/services/reports/merits_report_creator_spec.rb
+++ b/spec/services/reports/merits_report_creator_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe Reports::MeritsReportCreator do
     VCR.use_cassette('stylesheets2') do
       described_class.call(legal_aid_application)
     end
-
   end
 
   describe '.call' do

--- a/spec/services/reports/merits_report_creator_spec.rb
+++ b/spec/services/reports/merits_report_creator_spec.rb
@@ -4,7 +4,8 @@ RSpec.describe Reports::MeritsReportCreator do
   let(:legal_aid_application) { create :legal_aid_application, :with_proceeding_types, :with_everything, :generating_reports }
 
   subject do
-    VCR.use_cassette('stylesheets2') do
+    # dont' match on path - webpacker keeps changing the second part of the path
+    VCR.use_cassette('stylesheets2', match_requests_on: [:method, :host, :headers]) do
       described_class.call(legal_aid_application)
     end
   end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1876)

Changed the wicked_pdf pack tag to wicked_pdf link tag pointing to the compiled webpack stylesheets, so that the means report displays with the correct formatting. 

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
