### PR TITLE
AP-1878 update styling to match GDS

### DIFF
--- a/app/mailers/submit_application_reminder_mailer.rb
+++ b/app/mailers/submit_application_reminder_mailer.rb
@@ -17,8 +17,8 @@ class SubmitApplicationReminderMailer < BaseApplyMailer
       provider_name: name,
       ref_number: application['application_ref'],
       client_name: application.applicant.full_name,
-      delegated_functions_date: application['used_delegated_functions_on'].strftime('%d %B %Y'),
-      deadline_date: application['substantive_application_deadline_on'].strftime('%d %B %Y')
+      delegated_functions_date: application['used_delegated_functions_on'].strftime('%-d %B %Y'),
+      deadline_date: application['substantive_application_deadline_on'].strftime('%-d %B %Y')
     )
     mail to: to
   end

--- a/spec/mailers/submit_application_reminder_mailer_spec.rb
+++ b/spec/mailers/submit_application_reminder_mailer_spec.rb
@@ -26,8 +26,8 @@ RSpec.describe SubmitApplicationReminderMailer, type: :mailer do
         provider_name: provider_name,
         ref_number: application.application_ref,
         client_name: application.applicant.full_name,
-        delegated_functions_date: application.used_delegated_functions_on.strftime('%d %B %Y'),
-        deadline_date: application.substantive_application_deadline_on.strftime('%d %B %Y')
+        delegated_functions_date: application.used_delegated_functions_on.strftime('%-d %B %Y'),
+        deadline_date: application.substantive_application_deadline_on.strftime('%-d %B %Y')
       )
     end
   end

--- a/spec/services/submit_application_reminder_service_spec.rb
+++ b/spec/services/submit_application_reminder_service_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe SubmitApplicationReminderService, :vcr do
           provider_name: provider.name,
           ref_number: application.application_ref,
           client_name: application.applicant.full_name,
-          delegated_functions_date: application.used_delegated_functions_on.strftime('%d %B %Y'),
-          deadline_date: application.substantive_application_deadline_on.strftime('%d %B %Y')
+          delegated_functions_date: application.used_delegated_functions_on.strftime('%-d %B %Y'),
+          deadline_date: application.substantive_application_deadline_on.strftime('%-d %B %Y')
         )
       end
     end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1878)

Change formatting of the dates we include in the substantive reminder email to exclude any preceding zeros in the day field on date, to be inline with GDS guidelines https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style


## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
