### PR TITLE
Convert jQuery in table-select-all.js to javascript 

### DIFF
--- a/app/webpack/src/table-select-all.js
+++ b/app/webpack/src/table-select-all.js
@@ -1,6 +1,5 @@
 document.addEventListener('DOMContentLoaded', event => {
   const clearAllElems = document.querySelector('.select-clear-all');
-  const selectTable = clearAllElems.closest('table');
 
   function resetSelectClearLink(table) {
     const link = table.querySelector('.select-clear-all');
@@ -27,8 +26,8 @@ document.addEventListener('DOMContentLoaded', event => {
   }
 
   if (clearAllElems) {
+    const table = clearAllElems.closest('table');
     clearAllElems.addEventListener("click", function() {
-      const table = selectTable;
       if (this.classList.contains('clear-all')) {
         let checkboxes = document.querySelectorAll('input:checked');
         checkboxes.forEach(function(box) {
@@ -56,7 +55,6 @@ document.addEventListener('DOMContentLoaded', event => {
       }
     });
 
-    const table = selectTable;
     const input = table.querySelector("input");
     input.addEventListener("click", function() {
       resetSelectClearLink(table);

--- a/app/webpack/src/table-select-all.js
+++ b/app/webpack/src/table-select-all.js
@@ -1,16 +1,19 @@
 document.addEventListener('DOMContentLoaded', event => {
-  if (document.querySelector('.select-clear-all')) {
+  var clearAllElems = document.querySelector('.select-clear-all')
+  var selectTable = clearAllElems.parentNode.parentNode.parentNode
+
+  if (clearAllElems) {
     function resetSelectClearLink(table) {
       const link = table.querySelector('.select-clear-all');
       link.setAttribute('tabindex', 0);
       link.classList.remove('select-all', 'clear-all');
 
       if (table.querySelector('input:checked')) {
-        link.classList.add('clear-all')
+        link.classList.add('clear-all');
         link.textContent = link.getAttribute('data-copy-clear');
       }
       else {
-        link.classList.add('select-all')
+        link.classList.add('select-all');
         link.textContent = link.getAttribute('data-copy-select');
       }
     }
@@ -24,27 +27,27 @@ document.addEventListener('DOMContentLoaded', event => {
       }
     }
 
-    document.querySelector('.select-clear-all').addEventListener("click", function() {
-      const table = document.querySelector('table');
-      if(this.classList.contains('clear-all')) {
-        let checkboxes = document.querySelectorAll('input:checked')
+    clearAllElems.addEventListener("click", function() {
+      const table = selectTable;
+      if (this.classList.contains('clear-all')) {
+        let checkboxes = document.querySelectorAll('input:checked');
         checkboxes.forEach(function(box) {
-          box.checked = false
+          box.checked = false;
         })
         document.querySelector("#screen-reader-messages").textContent = "All transactions deselected.";  //this adds a message to the message div which is read out by the screen reader
       } else if (this.classList.contains('select-all')) {
-        let checkboxes = table.querySelectorAll('input:not(:checked)')
+        let checkboxes = table.querySelectorAll('input:not(:checked)');
         checkboxes.forEach(function(box) {
-          box.checked = true
+          box.checked = true;
         })
         document.querySelector("#screen-reader-messages").textContent = "All transactions selected.";
       }
-      resetSelectClearLink(table)
+      resetSelectClearLink(table);
       return false;
     });
 
     // TODO: test this
-    document.querySelector('.select-clear-all').addEventListener('keypress', function(ev) {
+    clearAllElems.addEventListener('keypress', function(ev) {
       const returnKeyCode = 13;
       const spaceBarCode = 32;
       if (ev.which === returnKeyCode || ev.which === spaceBarCode) { //on space or return
@@ -53,11 +56,11 @@ document.addEventListener('DOMContentLoaded', event => {
       }
     });
 
-    const table = document.querySelector('table')
+    const table = selectTable
     const input = table.querySelector("input")
     input.addEventListener("click", function() {
       resetSelectClearLink(table);
-      setCategory(table.querySelector('tr'))
+      setCategory(table.querySelector('tr'));
     });
 
     resetSelectClearLink(table)

--- a/app/webpack/src/table-select-all.js
+++ b/app/webpack/src/table-select-all.js
@@ -1,54 +1,65 @@
-$(document).ready(function() {
-  if ($('.select-clear-all').length) {
+document.addEventListener('DOMContentLoaded', event => {
+  if (document.querySelector('.select-clear-all')) {
     function resetSelectClearLink(table) {
-      const link = table.find('.select-clear-all');
-      link.attr('tabindex', 0);
-      link.removeClass('select-all clear-all');
+      const link = table.querySelector('.select-clear-all');
+      link.setAttribute('tabindex', 0);
+      link.classList.remove('select-all', 'clear-all');
 
-      if (table.find('input:checked').length) {
-        link.addClass('clear-all').text(link.data('copy-clear'));
+      if (table.querySelector('input:checked')) {
+        link.classList.add('clear-all')
+        link.textContent = link.getAttribute('data-copy-clear');
       }
       else {
-        link.addClass('select-all').text(link.data('copy-select'));
+        link.classList.add('select-all')
+        link.textContent = link.getAttribute('data-copy-select');
       }
     }
 
     function setCategory(row) {
-      let vacantItem = row.find(".table-category-vacant");
-      if (row.find('input:checked').length) {
-        vacantItem.addClass("table-category-preview");
+      let vacantItem = row.querySelector(".table-category-vacant");
+      if (row.querySelector('input:checked')) {
+        vacantItem.classList.add("table-category-preview");
       } else {
-        vacantItem.removeClass("table-category-preview");
+        vacantItem.classList.remove("table-category-preview");
       }
     }
 
-    $('.select-clear-all').click(function() {
-      const table = $(this).parents('table');
-      if($(this).hasClass('clear-all')) {
-        $("#screen-reader-messages").text("All transactions deselected.");  //this adds a message to the message div which is read out by the screen reader
-        table.find('input:checked').prop('checked', false);
-      } else if ($(this).hasClass('select-all')) {
-        table.find('input:not(:checked)').prop('checked', true);
-        $("#screen-reader-messages").text("All transactions selected."); 
+    document.querySelector('.select-clear-all').addEventListener("click", function() {
+      const table = document.querySelector('table');
+      if(this.classList.contains('clear-all')) {
+        let checkboxes = document.querySelectorAll('input:checked')
+        checkboxes.forEach(function(box) {
+          box.checked = false
+        })
+        document.querySelector("#screen-reader-messages").textContent = "All transactions deselected.";  //this adds a message to the message div which is read out by the screen reader
+      } else if (this.classList.contains('select-all')) {
+        let checkboxes = table.querySelectorAll('input:not(:checked)')
+        checkboxes.forEach(function(box) {
+          box.checked = true
+        })
+        document.querySelector("#screen-reader-messages").textContent = "All transactions selected.";
       }
-      resetSelectClearLink($(this).parents('table'))
+      resetSelectClearLink(table)
       return false;
     });
 
-    $('.select-clear-all').keypress(function(ev) {
+    // TODO: test this
+    document.querySelector('.select-clear-all').addEventListener('keypress', function(ev) {
       const returnKeyCode = 13;
       const spaceBarCode = 32;
-      if (ev.which==returnKeyCode || ev.which==spaceBarCode) { //on space or return
-        $(this).click(); //mimic a click
+      if (ev.which === returnKeyCode || ev.which === spaceBarCode) { //on space or return
+        this.click(); //mimic a click
         return false;
       }
     });
 
-    $('table').find("input").click(function() {
-      resetSelectClearLink($(this).parents('table'));
-      setCategory($(this).parents('tr'))
+    const table = document.querySelector('table')
+    const input = table.querySelector("input")
+    input.addEventListener("click", function() {
+      resetSelectClearLink(table);
+      setCategory(table.querySelector('tr'))
     });
 
-    resetSelectClearLink($('.select-clear-all').parents('table'))
+    resetSelectClearLink(table)
   }
 });

--- a/app/webpack/src/table-select-all.js
+++ b/app/webpack/src/table-select-all.js
@@ -1,45 +1,45 @@
 document.addEventListener('DOMContentLoaded', event => {
-  var clearAllElems = document.querySelector('.select-clear-all')
-  var selectTable = clearAllElems.parentNode.parentNode.parentNode
+  const clearAllElems = document.querySelector('.select-clear-all');
+  const selectTable = clearAllElems.closest('table');
+
+  function resetSelectClearLink(table) {
+    const link = table.querySelector('.select-clear-all');
+    link.setAttribute('tabindex', 0);
+    link.classList.remove('select-all', 'clear-all');
+
+    if (table.querySelector('input:checked')) {
+      link.classList.add('clear-all');
+      link.textContent = link.getAttribute('data-copy-clear');
+    }
+    else {
+      link.classList.add('select-all');
+      link.textContent = link.getAttribute('data-copy-select');
+    }
+  }
+
+  function setCategory(row) {
+    let vacantItem = row.querySelector(".table-category-vacant");
+    if (row.querySelector('input:checked')) {
+      vacantItem.classList.add("table-category-preview");
+    } else {
+      vacantItem.classList.remove("table-category-preview");
+    }
+  }
 
   if (clearAllElems) {
-    function resetSelectClearLink(table) {
-      const link = table.querySelector('.select-clear-all');
-      link.setAttribute('tabindex', 0);
-      link.classList.remove('select-all', 'clear-all');
-
-      if (table.querySelector('input:checked')) {
-        link.classList.add('clear-all');
-        link.textContent = link.getAttribute('data-copy-clear');
-      }
-      else {
-        link.classList.add('select-all');
-        link.textContent = link.getAttribute('data-copy-select');
-      }
-    }
-
-    function setCategory(row) {
-      let vacantItem = row.querySelector(".table-category-vacant");
-      if (row.querySelector('input:checked')) {
-        vacantItem.classList.add("table-category-preview");
-      } else {
-        vacantItem.classList.remove("table-category-preview");
-      }
-    }
-
     clearAllElems.addEventListener("click", function() {
       const table = selectTable;
       if (this.classList.contains('clear-all')) {
         let checkboxes = document.querySelectorAll('input:checked');
         checkboxes.forEach(function(box) {
           box.checked = false;
-        })
+        });
         document.querySelector("#screen-reader-messages").textContent = "All transactions deselected.";  //this adds a message to the message div which is read out by the screen reader
       } else if (this.classList.contains('select-all')) {
         let checkboxes = table.querySelectorAll('input:not(:checked)');
         checkboxes.forEach(function(box) {
           box.checked = true;
-        })
+        });
         document.querySelector("#screen-reader-messages").textContent = "All transactions selected.";
       }
       resetSelectClearLink(table);
@@ -56,13 +56,13 @@ document.addEventListener('DOMContentLoaded', event => {
       }
     });
 
-    const table = selectTable
-    const input = table.querySelector("input")
+    const table = selectTable;
+    const input = table.querySelector("input");
     input.addEventListener("click", function() {
       resetSelectClearLink(table);
       setCategory(table.querySelector('tr'));
     });
 
-    resetSelectClearLink(table)
+    resetSelectClearLink(table);
   }
 });


### PR DESCRIPTION
## Convert jQuery in table-select-all.js to javascript

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1833)

Converted the jQuery code that allows a user to select all/clear all in a table to vanilla javascript. This makes the select all functionality accessible to users who are using non-jQuery-supporting browsers/technology. 

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
