### PR TITLE
Bugfix: Webpacker pdf report display

### DIFF
--- a/app/controllers/admin/legal_aid_applications/submissions_controller.rb
+++ b/app/controllers/admin/legal_aid_applications/submissions_controller.rb
@@ -53,6 +53,7 @@ module Admin
                   filename: filename(attribute, params[:id])
       end
 
+      # :nocov:
       def download_report(attribute)
         report = legal_aid_application.send("#{attribute}_report")
         send_data report.document.download,
@@ -60,6 +61,7 @@ module Admin
                   type: 'application/pdf',
                   filename: report.attachment_name
       end
+      # :nocov:
     end
   end
 end

--- a/app/controllers/admin/legal_aid_applications/submissions_controller.rb
+++ b/app/controllers/admin/legal_aid_applications/submissions_controller.rb
@@ -6,7 +6,7 @@ module Admin
       layout 'admin'.freeze
 
       def show
-        @legal_aid_application = LegalAidApplication.find(params[:id])
+        legal_aid_application
       end
 
       def download_xml_response
@@ -17,7 +17,19 @@ module Admin
         download_data :request
       end
 
+      def download_means_report
+        download_report :means
+      end
+
+      def download_merits_report
+        download_report :merits
+      end
+
       private
+
+      def legal_aid_application
+        @legal_aid_application ||= LegalAidApplication.find(params[:id])
+      end
 
       def filename(type, id)
         "submission_history_#{id}_#{type}.xml"
@@ -39,6 +51,14 @@ module Admin
                   status: 200,
                   type: 'text/xml',
                   filename: filename(attribute, params[:id])
+      end
+
+      def download_report(attribute)
+        report = legal_aid_application.send("#{attribute}_report")
+        send_data report.document.download,
+                  status: 200,
+                  type: 'application/pdf',
+                  filename: report.attachment_name
       end
     end
   end

--- a/app/views/admin/legal_aid_applications/submissions/show.html.erb
+++ b/app/views/admin/legal_aid_applications/submissions/show.html.erb
@@ -7,7 +7,17 @@
     <dt>State</dt>
     <dd><%= @legal_aid_application.state %></dd>
   </dl>
-
+  <h2 class="govuk-heading-m">Reports</h2>
+  <dl class="govuk-body kvp">
+    <% if @legal_aid_application.means_report %>
+      <dt>Means report</dt>
+      <dd><%= link_to('Download means report', download_means_report_admin_legal_aid_applications_submission_path(@legal_aid_application)) %></dd>
+    <% end %>
+    <% if @legal_aid_application.merits_report %>
+      <dt>Merits report</dt>
+      <dd><%= link_to('Download merits report', download_merits_report_admin_legal_aid_applications_submission_path(@legal_aid_application)) %>
+    <% end %>
+  </dl>
   <% if @legal_aid_application.cfe_submissions.present? %>
     <% @legal_aid_application.cfe_submissions.each do |cfe_submission| %>
       <h2 class="govuk-heading-m">CFE Submission (<%= cfe_submission.id %>)</h2>

--- a/app/views/layouts/pdf.html.erb
+++ b/app/views/layouts/pdf.html.erb
@@ -2,7 +2,7 @@
 <html lang="en" class="govuk-template">
   <head>
     <meta charset="utf-8">
-    <%= wicked_pdf_stylesheet_pack_tag 'styles' %>
+    <%= stylesheet_pack_tag 'styles' %>
     <%= render 'layouts/govuk_base64_fonts.html' %>
   </head>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,6 +55,8 @@ Rails.application.routes.draw do
         member do
           get 'download_xml_response'
           get 'download_xml_request'
+          get 'download_means_report'
+          get 'download_merits_report'
         end
       end
     end

--- a/features/admin/application_list.feature
+++ b/features/admin/application_list.feature
@@ -7,3 +7,6 @@ Feature: Admin application functions
     And I click link 'Submission details'
     Then I should see 'Legal Aid Application'
     And I should see 'CCMS Submission'
+    And I should see 'Download means report'
+    And I should see 'Download merits report'
+    # test clicking the links with caution... it will download a file to your machine on each run

--- a/features/step_definitions/admin_steps.rb
+++ b/features/step_definitions/admin_steps.rb
@@ -15,9 +15,7 @@ end
 Given('an application has been submitted') do
   @legal_aid_application = create(
     :application,
-    :with_everything,
-    :with_passported_state_machine,
-    :initiated,
+    :at_assessment_submitted,
     provider: create(:provider)
   )
 end

--- a/spec/requests/admin/legal_aid_applications/submissions_controller_spec.rb
+++ b/spec/requests/admin/legal_aid_applications/submissions_controller_spec.rb
@@ -51,6 +51,26 @@ RSpec.describe Admin::LegalAidApplications::SubmissionsController, type: :reques
         subject
       end
     end
+
+    context 'pdf' do
+      describe 'GET download_means_report' do
+        subject { get download_means_report_admin_legal_aid_applications_submission_path(legal_aid_application, format: :pdf) }
+
+        it 'downloads the file' do
+          expect_any_instance_of(described_class).to receive(:download_report).with(:means)
+          subject
+        end
+      end
+
+      describe 'GET download_merits_report' do
+        subject { get download_merits_report_admin_legal_aid_applications_submission_path(legal_aid_application, format: :pdf) }
+
+        it 'downloads the file' do
+          expect_any_instance_of(described_class).to receive(:download_report).with(:merits)
+          subject
+        end
+      end
+    end
   end
 
   describe 'nil value' do


### PR DESCRIPTION
## What

Add method of opening generated reports from submission page
This is to help us debug issues where documents generated and sent to CCMS do not match the /means_report view

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
