### PR TITLE
AP-1670: Update Feedback Mailer to get correct translations for Notify feedback personalisations

### DIFF
--- a/app/mailers/feedback_mailer.rb
+++ b/app/mailers/feedback_mailer.rb
@@ -19,14 +19,18 @@ class FeedbackMailer < BaseApplyMailer
       user_data: user_data(feedback),
       user_type: feedback.source,
       done_all_needed: yes_or_no(feedback),
-      satisfaction: safe_nil(feedback.satisfaction),
-      difficulty: safe_nil(feedback.difficulty),
+      satisfaction: safe_nil(get_translation('satisfaction', feedback.satisfaction)),
+      difficulty: safe_nil(get_translation('difficulty', feedback.difficulty)),
       improvement_suggestion: safe_nil(feedback.improvement_suggestion),
       originating_page: safe_nil(feedback.originating_page),
       provider_email: provider_email_phrase(feedback),
       application_reference: @legal_aid_application&.application_ref || '',
       application_status: application_status || ''
     )
+  end
+
+  def get_translation(type, key)
+    t "model_enum_translations.feedback.#{type}.#{key}"
   end
 
   def application_status


### PR DESCRIPTION

## What

[AP-1670](https://dsdmoj.atlassian.net/browse/AP-1670)

Update feedback mailer to use actual translations rather than input keys for feedback emails.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
