### PR TITLE
Bug-fix: Webpacker pdf fix

### DIFF
--- a/app/helpers/pdf_helper.rb
+++ b/app/helpers/pdf_helper.rb
@@ -1,0 +1,6 @@
+module PdfHelper
+  def apply_webpacker_stylesheet_pack_tag(source)
+    file = Webpacker.manifest.lookup!(source, type: 'css')
+    "<style type='text/css' media='all'>#{read_asset(file)}</style>".html_safe
+  end
+end

--- a/app/views/admin/legal_aid_applications/submissions/show.html.erb
+++ b/app/views/admin/legal_aid_applications/submissions/show.html.erb
@@ -9,11 +9,11 @@
   </dl>
   <h2 class="govuk-heading-m">Reports</h2>
   <dl class="govuk-body kvp">
-    <% if @legal_aid_application.means_report %>
+    <% if @legal_aid_application&.means_report&.document.present? %>
       <dt>Means report</dt>
       <dd><%= link_to('Download means report', download_means_report_admin_legal_aid_applications_submission_path(@legal_aid_application)) %></dd>
     <% end %>
-    <% if @legal_aid_application.merits_report %>
+    <% if @legal_aid_application&.merits_report&.document.present? %>
       <dt>Merits report</dt>
       <dd><%= link_to('Download merits report', download_merits_report_admin_legal_aid_applications_submission_path(@legal_aid_application)) %>
     <% end %>

--- a/app/views/layouts/pdf.html.erb
+++ b/app/views/layouts/pdf.html.erb
@@ -2,7 +2,7 @@
 <html lang="en" class="govuk-template">
   <head>
     <meta charset="utf-8">
-    <%= stylesheet_pack_tag 'styles' %>
+    <%= apply_webpacker_stylesheet_pack_tag('styles') %>
     <%= render 'layouts/govuk_base64_fonts.html' %>
   </head>
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1876)

This requires a new helper method.  

Basically, the wicked helpers are very limited in usefulness and restrictive in how they function/expect your service to function.
Therefore I reverse-engineered what their helper does and wrapped dit in out own helper that reads the CSS from the webpack object (regardless of it's compiled name) and exports it as an on-page stylesheet tag

I also added a fix to only show download links on the admin pages if the report has a document (and can therefore be downloaded)

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
