### PR TITLE
add pre-commit gem 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -119,6 +119,7 @@ group :development do
   gem 'guard-rubocop'
   gem 'listen', '>= 3.0.5', '< 3.4'
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
+  gem 'pre-commit', require: false
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -393,6 +393,9 @@ GEM
     parser (2.7.2.0)
       ast (~> 2.4.1)
     pg (1.2.3)
+    pluginator (1.5.0)
+    pre-commit (0.39.0)
+      pluginator (~> 1.5)
     prometheus_exporter (0.4.17)
     protobuf-cucumber (3.10.8)
       activesupport (>= 3.2)
@@ -676,6 +679,7 @@ DEPENDENCIES
   omniauth-rails_csrf_protection (~> 0.1, >= 0.1.2)
   pagy
   pg
+  pre-commit
   prometheus_exporter
   pry-byebug
   puma (~> 5.1)

--- a/README.md
+++ b/README.md
@@ -76,6 +76,15 @@ This can be a bit tricky, so follow these steps:
 You should now check by looking at the file either in your editor or on the command line to ensure the
 file you've just added is in fact encrypted.
 
+### Pre-commit hooks 
+
+The pre-commit gem allows you to add git hooks which run linting automatically when making a commit.
+
+Checks are configured for the whole repo in `/config/pre-commit.yml`. 
+
+To install the pre-commit hooks locally, run the command `pre-commit install`. If you don't want the hooks then just don't run this command. 
+
+To bypass the checks once they're installed, add the -n flag when committing: `git commit -n` 
 
 ### Malware check of uploaded files
 

--- a/config/pre_commit.yml
+++ b/config/pre_commit.yml
@@ -1,0 +1,5 @@
+---
+:checks_add:
+- :rubocop
+:warnings_add:
+- :jshint


### PR DESCRIPTION
## Add pre-commit gem and config file 

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1886)

Add pre-commit gem and yaml file for configuring checks. 

Added rubocop to checks and jshint to warning. Erb_lint is not supported by this gem.

To install the pre-commit hooks locally, run the command `pre-commit install`. If you don't want the hooks then just don't run this command. 

To bypass the checks once they're installed, add the -n flag when committing i.e. `git commit -n' 

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
