### PR TITLE
Ap 1886 add overcommit gem 

### DIFF
--- a/.overcommit.yml
+++ b/.overcommit.yml
@@ -1,0 +1,24 @@
+CommitMsg:
+  ALL:
+    requires_files: false
+    quiet: true
+
+  CapitalizedSubject:
+    enabled: false
+
+  SingleLineSubject:
+    enabled: false
+
+  TextWidth:
+    enabled: false
+
+  TrailingPeriod:
+    enabled: false
+
+PreCommit:
+  RuboCop:
+    enabled: true
+    command: ['bundle', 'exec', 'rubocop'] # Invoke within Bundler context
+  ErbLint:
+    enabled: true
+    command: ['erblint']

--- a/Gemfile
+++ b/Gemfile
@@ -101,6 +101,7 @@ group :development, :test do
   gem 'i18n-tasks', '>= 0.9.31'
   gem 'json_expressions'
   gem 'nokogiri'
+  gem 'overcommit'
   gem 'pry-byebug'
   gem 'rspec_junit_formatter'
   gem 'rubocop', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -305,6 +305,7 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       terminal-table (>= 1.5.1)
     ice_nine (0.11.2)
+    iniparse (1.5.0)
     jmespath (1.4.0)
     jquery-rails (4.4.0)
       rails-dom-testing (>= 1, < 3)
@@ -388,6 +389,9 @@ GEM
       actionpack (>= 4.2)
       omniauth (>= 1.3.1)
     orm_adapter (0.5.0)
+    overcommit (0.57.0)
+      childprocess (>= 0.6.3, < 5)
+      iniparse (~> 1.4)
     pagy (3.10.0)
     parallel (1.20.1)
     parser (2.7.2.0)
@@ -674,6 +678,7 @@ DEPENDENCIES
   omniauth-google-oauth2 (>= 0.8.0)
   omniauth-oauth2 (>= 1.6.0)
   omniauth-rails_csrf_protection (~> 0.1, >= 0.1.2)
+  overcommit
   pagy
   pg
   prometheus_exporter

--- a/README.md
+++ b/README.md
@@ -94,6 +94,20 @@ You may also need to run:
 sudo apt install clamdscan
 ```
 
+### Overcommit
+
+Overcommit is a gem which adds git pre-commit hooks to your project. Pre-commit hooks run various 
+lint checks before making a commit. Checks are configured on a project-wide basis in .overcommit.yml.
+
+To install the git hooks locally, you need to install the overcommit gem in your root Ruby environment (not your project environment):
+```
+sudo -i
+gem install overcommit
+``` 
+If you don't want the git hooks installed, just don't run the above commands.
+
+Once the hooks are installed, if you need to you can skip them with the `-n` flag: `git commit -n` 
+
 ### Run the application server
 
 ```


### PR DESCRIPTION
## Add overcommit gem to configure project-wide pre-commit hooks 

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1886)

Added the overcommit gem, which allows you to configure pre-commit hooks for the whole project. 
Added rubocop and erblint to pre-commit hooks. 
This is to try to prevent the issue of starting pipelines which fail on lint checks. 
Instructions to install locally are in the README. 

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
