### PR TITLE
AP-1888 Display error summaries on additional accounts screens

### DIFF
--- a/app/controllers/citizens/additional_accounts_controller.rb
+++ b/app/controllers/citizens/additional_accounts_controller.rb
@@ -13,7 +13,7 @@ module Citizens
       when 'false'
         go_forward
       else
-        error 'index'
+        error('additional_account', 'index')
         render :index
       end
     end
@@ -31,7 +31,7 @@ module Citizens
         offline_accounts_update
         go_forward
       else
-        error 'new'
+        error('has_online_accounts', 'new')
         render :new
       end
     end
@@ -47,8 +47,8 @@ module Citizens
       legal_aid_application.use_ccms!(:offline_accounts) unless legal_aid_application.use_ccms?
     end
 
-    def error(type)
-      @error = I18n.t("citizens.additional_accounts.#{type}.error")
+    def error(id, action)
+      @error = { "#{id}-error": I18n.t("citizens.additional_accounts.#{action}.error") }
     end
   end
 end

--- a/app/forms/applicants/open_banking_consent_form.rb
+++ b/app/forms/applicants/open_banking_consent_form.rb
@@ -13,7 +13,7 @@ module Applicants
     def open_banking_consent_presence
       return if open_banking_consent.present?
 
-      errors.add(:open_banking_consent, I18n.t('activemodel.errors.models.legal_aid_application.attributes.open_banking_consents.citizens.blank_html'))
+      errors.add(:open_banking_consent, I18n.t('activemodel.errors.models.legal_aid_application.attributes.open_banking_consents.citizens.blank_html').html_safe)
     end
   end
 end

--- a/app/views/citizens/additional_accounts/_error.html.erb
+++ b/app/views/citizens/additional_accounts/_error.html.erb
@@ -1,0 +1,12 @@
+<div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
+  <h2 class="govuk-error-summary__title" id="error-summary-title">
+    <%= t('generic.errors.problem_text') %>
+  </h2>
+  <div class="govuk-error-summary__body">
+    <ul class="govuk-list govuk-error-summary__list">
+      <li>
+        <%= link_to @error.values.first, "##{@error.keys.first}" %>
+      </li>
+    </ul>
+  </div>
+</div>

--- a/app/views/citizens/additional_accounts/index.html.erb
+++ b/app/views/citizens/additional_accounts/index.html.erb
@@ -1,6 +1,8 @@
   <%= page_template page_title: t('.field_set_header'), template: :basic do %>
     <%= form_with(model: @form, url: citizens_additional_accounts_path, method: :post, local: true) do |form| %>
 
+      <%= render partial: 'error' if @error %>
+
       <%= govuk_form_group(
             show_error_if: @error,
             input: :additional_account
@@ -10,7 +12,7 @@
                                                 form.yes_no_radio_button_array,
                                                 :value,
                                                 :label,
-                                                error: @error,
+                                                error: @error&.values&.first,
                                                 title: content_for(:page_title) %>
       <% end %>
 

--- a/app/views/citizens/additional_accounts/new.html.erb
+++ b/app/views/citizens/additional_accounts/new.html.erb
@@ -1,6 +1,8 @@
 <%= page_template page_title: t('.field_set_header'), template: :basic do %>
   <%= form_with(model: @form, url: citizens_additional_account_path(id: :update), method: :patch, local: true) do |form| %>
 
+    <%= render partial: 'error' if @error %>
+
     <%= govuk_form_group(
           show_error_if: @error,
           input: :has_offline_accounts
@@ -11,7 +13,7 @@
                                               :value,
                                               :label,
                                               hint: t('.hint'),
-                                              error: @error,
+                                              error: @error&.values&.first,
                                               title: content_for(:page_title) %>
     <% end %>
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1888)

* Add a partial to display error summaries on the `/additional_accounts` screens [1]
* Add a better-worded error for `/additional_accounts/new` 
* Fix the issue where html was being displayed in the error summary

[1] we're using this pattern in a number of places - there are at least eight other versions of the errors partial knocking about 🤦 I'm going to create a separate ticket to look at refactoring that to remove the duplication.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
