### PR TITLE
Record CFE API interaction

### DIFF
--- a/db/sample_data/bank_transactions_3.csv
+++ b/db/sample_data/bank_transactions_3.csv
@@ -1,0 +1,3 @@
+date,description,amount_out,amount_in
+06/11/2020,DWP AA123456A JSA,,148.70
+23/10/2020,DWP AA123456A JSA,,43.49

--- a/db/sample_data/bank_transactions_3.csv
+++ b/db/sample_data/bank_transactions_3.csv
@@ -1,3 +1,0 @@
-date,description,amount_out,amount_in
-06/11/2020,DWP AA123456A JSA,,148.70
-23/10/2020,DWP AA123456A JSA,,43.49

--- a/lib/tasks/cfe_printer.rake
+++ b/lib/tasks/cfe_printer.rake
@@ -1,7 +1,23 @@
 namespace :cfe do
   desc 'display transactions sent to cfe for an application: rake cfe:display[L-ABC-123]'
-  task :display, [:case_ref] => :environment do |_task, args|
+  task :display, [:application_ref] => :environment do |_task, args|
+    if args[:application_ref].nil?
+      puts "**** Missing application reference ****"
+      puts "Specify application reference as follows: rake cfe:display[L-ABC-123]'"
+      exit(1)
+    end
     require_relative 'helpers/cfe_api_displayer'
-    CfeApiDisplayer.new(args[:case_ref]).run
+    CfeApiDisplayer.new(args[:application_ref]).run
+  end
+  
+  desc 'record cfe conversation as yaml so that it can be played back: rake cfe:record_payloads[L-ABC-123]'
+  task :record_payloads, [:application_ref] => :environment do |_task, args|
+    if args[:application_ref].nil?
+      puts "**** Missing application reference ****"
+      puts "Specify application reference as follows: rake cfe:display[L-ABC-123]'"
+      exit(1)
+    end
+    require_relative 'helpers/cfe_payload_recorder'
+    CfePayloadRecorder.call(args[:application_ref])
   end
 end

--- a/lib/tasks/cfe_printer.rake
+++ b/lib/tasks/cfe_printer.rake
@@ -1,19 +1,19 @@
 namespace :cfe do
   desc 'display transactions sent to cfe for an application: rake cfe:display[L-ABC-123]'
-    task :display, [:application_ref] => :environment do |_task, args|
+  task :display, [:application_ref] => :environment do |_task, args|
     if args[:application_ref].nil?
-      puts "**** Missing application reference ****"
+      puts '**** Missing application reference ****'
       puts "Specify application reference as follows: rake cfe:display[L-ABC-123]'"
       exit(1)
     end
     require_relative 'helpers/cfe_api_displayer'
     CfeApiDisplayer.new(args[:application_ref]).run
   end
-  
+
   desc 'record cfe conversation as yaml so that it can be played back: rake cfe:record_payloads[L-ABC-123]'
   task :record_payloads, [:application_ref] => :environment do |_task, args|
     if args[:application_ref].nil?
-      puts "**** Missing application reference ****"
+      puts '**** Missing application reference ****'
       puts "Specify application reference as follows: rake cfe:display[L-ABC-123]'"
       exit(1)
     end

--- a/lib/tasks/cfe_printer.rake
+++ b/lib/tasks/cfe_printer.rake
@@ -1,6 +1,6 @@
 namespace :cfe do
   desc 'display transactions sent to cfe for an application: rake cfe:display[L-ABC-123]'
-  task :display, [:application_ref] => :environment do |_task, args|
+    task :display, [:application_ref] => :environment do |_task, args|
     if args[:application_ref].nil?
       puts "**** Missing application reference ****"
       puts "Specify application reference as follows: rake cfe:display[L-ABC-123]'"

--- a/lib/tasks/helpers/cfe_payload_recorder.rb
+++ b/lib/tasks/helpers/cfe_payload_recorder.rb
@@ -1,0 +1,36 @@
+class CfePayloadRecorder
+
+  def self.call(application_ref)
+    new(application_ref).call
+  end
+
+  def initialize(application_ref)
+    @legal_aid_application = LegalAidApplication.find_by(application_ref: application_ref)
+    raise ArgumentError.new('No such application') if @legal_aid_application.nil?
+    @recording = []
+  end
+
+  def call
+    submission = @legal_aid_application.most_recent_cfe_submission
+    submission.submission_histories.each do |history|
+      record_history(history)
+    end
+    puts "# CFE API calls for applicaiton #{@legal_aid_application.application_ref}"
+    puts @recording.to_yaml
+  end
+
+  private
+
+  def record_history(history)
+    hash = {}
+    hash[:method] = history.http_method
+    hash[:path] = extract_uri_path(history.url)
+    hash[:payload] = history.request_payload
+    @recording << hash
+  end
+
+  def extract_uri_path(url)
+    uri = URI(url)
+    uri.path
+  end
+end

--- a/lib/tasks/helpers/cfe_payload_recorder.rb
+++ b/lib/tasks/helpers/cfe_payload_recorder.rb
@@ -15,7 +15,11 @@ class CfePayloadRecorder
     submission.submission_histories.each do |history|
       record_history(history)
     end
+    puts '#'
     puts "# CFE API calls for applicaiton #{@legal_aid_application.application_ref}"
+    puts '# Copy and paste this output in to tmp/api_replay.yml in the CFE repo, and '
+    puts '# replay the API interaction with the rake task rake replay'
+    puts '#'
     puts @recording.to_yaml
   end
 

--- a/lib/tasks/helpers/cfe_payload_recorder.rb
+++ b/lib/tasks/helpers/cfe_payload_recorder.rb
@@ -1,12 +1,12 @@
 class CfePayloadRecorder
-
   def self.call(application_ref)
     new(application_ref).call
   end
 
   def initialize(application_ref)
     @legal_aid_application = LegalAidApplication.find_by(application_ref: application_ref)
-    raise ArgumentError.new('No such application') if @legal_aid_application.nil?
+    raise ArgumentError, 'No such application' if @legal_aid_application.nil?
+
     @recording = []
   end
 

--- a/lib/tasks/helpers/cfe_payload_recorder.rb
+++ b/lib/tasks/helpers/cfe_payload_recorder.rb
@@ -15,11 +15,11 @@ class CfePayloadRecorder
     submission.submission_histories.each do |history|
       record_history(history)
     end
-    puts '#'
-    puts "# CFE API calls for applicaiton #{@legal_aid_application.application_ref}"
-    puts '# Copy and paste this output in to tmp/api_replay.yml in the CFE repo, and '
-    puts '# replay the API interaction with the rake task rake replay'
-    puts '#'
+    puts '#'.yellow
+    puts "# CFE API calls for application #{@legal_aid_application.application_ref}".yellow
+    puts '# Copy and paste this output in to tmp/api_replay.yml in the CFE repo, and '.yellow
+    puts '# replay the API interaction with the rake task rake replay'.yellow
+    puts '#'.yellow
     puts @recording.to_yaml
   end
 


### PR DESCRIPTION
## Record CFE API interaction

Sometimes it is necessary to replay what apply sent to CFE in order to debug something in CFE.  This PR introduces that ability with a rake task that will read the CFE::SubmissionHistory records for an application, and output the details as YAML which can then be replayed locally to CFE with the `rake replay` task in the CFE repo.

### Usage

  `rake cfe:record_payloads[L-A12-B34]`

This will print out YAML which can be copied and pasted into the `tmp/api_replay.yml` file in the CFE project ready for the `rake replay` task.


## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
