### PR TITLE
add new retry for curl:

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,11 @@ RUN apk --no-cache add --virtual build-dependencies \
 #  # Install kubectl
 # RUN curl -LO /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl
 RUN echo $KUBECTL_VERSION
-RUN curl -Lo /usr/local/bin/kubectl --retry 3 --retry-delay 3 https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl
+RUN curl -Lo /usr/local/bin/kubectl \
+        --retry 3 \
+        --retry-delay 3 \
+        --retry-connrefused \
+        https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl
 
 # Ensure everything is executable
 RUN chmod +x /usr/local/bin/*


### PR DESCRIPTION
## What

We have had a few [circle failures like these](https://app.circleci.com/pipelines/github/ministryofjustice/laa-apply-for-legal-aid/6061/workflows/ed269959-f68f-47a9-9355-dbfac998f189/jobs/42462) today. This is caused by the `curl` command (used to install `kubectl`) in the docker file, failing.

The actual error is 

` OpenSSL SSL_read: SSL_ERROR_SYSCALL, errno 104`

Which seems to just be caused by an intermittent network issue, so it is difficult to replicate. The output at the moment does not give any indication that the retries are occurring.

I have added the flag `--retry-connrefused `to see if this can help with these errors. This flag may give us another opportunity at retrying the connection/`curl` command before it fails.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
