### PR TITLE
AP-1852 add feature flag for cash payments

### DIFF
--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -19,7 +19,8 @@ module Admin
     def form_params
       params.require(:setting).permit(:mock_true_layer_data,
                                       :manually_review_all_cases,
-                                      :allow_welsh_translation)
+                                      :allow_welsh_translation,
+                                      :allow_cash_payment)
     end
 
     def setting

--- a/app/forms/settings/setting_form.rb
+++ b/app/forms/settings/setting_form.rb
@@ -6,11 +6,13 @@ module Settings
 
     attr_accessor :mock_true_layer_data,
                   :manually_review_all_cases,
-                  :allow_welsh_translation
+                  :allow_welsh_translation,
+                  :allow_cash_payment
 
     validates :mock_true_layer_data,
               :manually_review_all_cases,
               :allow_welsh_translation,
+              :allow_cash_payment,
               presence: true
   end
 end

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -15,6 +15,10 @@ class Setting < ApplicationRecord
     setting.allow_welsh_translation
   end
 
+  def self.allow_cash_payment?
+    setting.allow_cash_payment
+  end
+
   def self.setting
     Setting.first || Setting.create!
   end

--- a/app/views/admin/settings/show.html.erb
+++ b/app/views/admin/settings/show.html.erb
@@ -36,6 +36,16 @@
       title: { size: :m, text: t('.labels.allow_welsh_translation') }
     ) %>
 
+    <%= form.govuk_collection_radio_buttons(
+        :allow_cash_payment,
+        form.yes_no_radio_button_array,
+        :value,
+        :label,
+        inline: true,
+        hint: t('.hints.allow_cash_payment'),
+        title: { size: :m, text: t('.labels.allow_cash_payment') }
+    ) %>
+
     <%= form.submit(t('generic.submit'), class: 'govuk-button form-button') %>
   <% end %>
 <% end %>

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -32,12 +32,14 @@ en:
           mock_true_layer_data: Mock TrueLayer Data
           manually_review_all_cases: Manually review all non-passported applications
           allow_welsh_translation: Allow Welsh translation
+          allow_cash_payment: Allow Cash Payments to be submitted
         hints:
           mock_true_layer_data: Select Yes and TrueLayer data will be replaced by mock data from %{bank_transaction_filename}
           manually_review_all_cases: |
             All applications with capital contributions AND restrictions on assets will be routed to caseworker for review.
             Select Yes to additionally route all non-passported applications to caseworker for review.
           allow_welsh_translation: Select Yes to translate the service into Welsh
+          allow_cash_payment: Select Yes to include the cash payment process in the user journey
     submitted_applications_reports:
       show:
         heading_1: Submitted Applications

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -64,3 +64,5 @@ en:
           <<: *true_false
         allow_welsh_translation:
           <<: *true_false
+        allow_cash_payment:
+          <<: *true_false

--- a/db/migrate/20201210161115_add_cash_payment_flag_to_settings.rb
+++ b/db/migrate/20201210161115_add_cash_payment_flag_to_settings.rb
@@ -1,0 +1,5 @@
+class AddCashPaymentFlagToSettings < ActiveRecord::Migration[6.0]
+  def change
+    add_column :settings, :allow_cash_payment, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_30_151951) do
+ActiveRecord::Schema.define(version: 2020_12_10_161115) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -608,6 +608,7 @@ ActiveRecord::Schema.define(version: 2020_11_30_151951) do
     t.boolean "manually_review_all_cases", default: true
     t.string "bank_transaction_filename", default: "db/sample_data/bank_transactions.csv"
     t.boolean "allow_welsh_translation", default: false, null: false
+    t.boolean "allow_cash_payment", default: false, null: false
   end
 
   create_table "state_machine_proxies", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/lib/tasks/setup_db_for_testing.rake
+++ b/lib/tasks/setup_db_for_testing.rake
@@ -5,7 +5,8 @@ namespace :settings do
     setting.update!(mock_true_layer_data: true,
                     bank_transaction_filename: 'db/sample_data/bank_transactions_2.csv',
                     manually_review_all_cases: false,
-                    allow_welsh_translation: false)
+                    allow_welsh_translation: false,
+                    allow_cash_payment: false)
 
     pp Setting.first
   end

--- a/spec/models/setting_spec.rb
+++ b/spec/models/setting_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Setting do
         expect(rec.mock_true_layer_data?).to be false
         expect(rec.manually_review_all_cases?).to be true
         expect(rec.allow_welsh_translation?).to be false
+        expect(rec.allow_cash_payment?).to be false
         expect(rec.bank_transaction_filename).to eq 'db/sample_data/bank_transactions.csv'
       end
     end
@@ -20,6 +21,7 @@ RSpec.describe Setting do
           mock_true_layer_data: true,
           manually_review_all_cases: false,
           allow_welsh_translation: false,
+          allow_cash_payment: false,
           bank_transaction_filename: 'my_special_file.csv'
         )
       end
@@ -29,6 +31,7 @@ RSpec.describe Setting do
         expect(rec.mock_true_layer_data?).to be true
         expect(rec.manually_review_all_cases?).to be false
         expect(rec.allow_welsh_translation?).to be false
+        expect(rec.allow_cash_payment?).to be false
         expect(rec.bank_transaction_filename).to eq 'my_special_file.csv'
       end
     end
@@ -41,6 +44,7 @@ RSpec.describe Setting do
       expect(Setting.mock_true_layer_data?).to be false
       expect(Setting.manually_review_all_cases?).to be true
       expect(Setting.allow_welsh_translation?).to be false
+      expect(Setting.allow_cash_payment?).to be false
       expect(Setting.bank_transaction_filename).to eq 'db/sample_data/bank_transactions.csv'
     end
   end

--- a/spec/requests/admin/settings_spec.rb
+++ b/spec/requests/admin/settings_spec.rb
@@ -35,7 +35,8 @@ RSpec.describe Admin::SettingsController, type: :request do
       {
         setting: {
           mock_true_layer_data: 'true',
-          allow_welsh_translation: 'true'
+          allow_welsh_translation: 'true',
+          allow_cash_payment: 'true'
         }
       }
     end
@@ -47,6 +48,7 @@ RSpec.describe Admin::SettingsController, type: :request do
       subject
       expect(Setting.mock_true_layer_data?).to eq(true)
       expect(Setting.allow_welsh_translation?).to eq(true)
+      expect(Setting.allow_cash_payment?).to eq(true)
     end
 
     it 'create settings if they do not exist' do


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1852)

Add a new feature flag to the `/admin/settings` page which will hide/show access to the cash payments part of the Apply journey.

The new setting is called `:allow_cash_payment`

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
