### PR TITLE
AP-1907 Fix unknown ccms reason

### DIFF
--- a/app/controllers/providers/use_ccms_controller.rb
+++ b/app/controllers/providers/use_ccms_controller.rb
@@ -1,7 +1,7 @@
 module Providers
   class UseCCMSController < ProviderBaseController
     def show
-      @legal_aid_application.use_ccms!(use_ccms_reason)
+      @legal_aid_application.use_ccms!(use_ccms_reason) unless @legal_aid_application.use_ccms?
     end
 
     private
@@ -11,8 +11,6 @@ module Providers
       when providers_legal_aid_application_open_banking_consents_url(@legal_aid_application)
         :no_online_banking
       else
-        # debug logging to see where these 'unknown' ccms_reasons area coming from
-        Raven.capture_message "Setting unknown CCMS reason, referer: #{request.referer}, not #{providers_legal_aid_application_open_banking_consents_url(@legal_aid_application)}"
         :unknown
       end
     end

--- a/app/models/concerns/base_state_machine.rb
+++ b/app/models/concerns/base_state_machine.rb
@@ -83,9 +83,6 @@ class BaseStateMachine < ApplicationRecord  # rubocop:disable Metrics/ClassLengt
                   after: proc { |reason|
                     raise 'Invalid ccms_reason' unless reason.in?(VALID_CCMS_REASONS)
 
-                    # logging to find out where unknonw ccms reasons are coming from
-                    Raven.capture_message "UNKNOWN CCMS REASON\n#{caller}" if reason.to_sym == :unknown
-
                     update!(ccms_reason: reason)
                   }
     end


### PR DESCRIPTION

## Fix bug: ccms reason set to unknown

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1907)

The `Providers::UseCCMSController` sets the state to `use_ccms` and the `ccms_reason` to a value depending on what page the request came from.  This does not work well if an application is already in `use_ccms` state, and it is viewed from the applications list page.  This bug is fixed by not calling '#use_ccms!' if the state is already `use_ccms`

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
