### PR TITLE
AP-1909 Remove better_errors gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -112,8 +112,6 @@ group :development, :test do
 end
 
 group :development do
-  gem 'better_errors', '>= 2.7.1'
-  gem 'binding_of_caller'
   gem 'guard-cucumber'
   gem 'guard-livereload'
   gem 'guard-rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,10 +121,6 @@ GEM
       ice_nine (~> 0.11.0)
       thread_safe (~> 0.3, >= 0.3.1)
     bcrypt (3.1.16)
-    better_errors (2.9.1)
-      coderay (>= 1.0.0)
-      erubi (>= 1.0.0)
-      rack (>= 0.9.0)
     better_html (1.0.15)
       actionview (>= 4.0)
       activesupport (>= 4.0)
@@ -133,8 +129,6 @@ GEM
       html_tokenizer (~> 0.0.6)
       parser (>= 2.4)
       smart_properties
-    binding_of_caller (0.8.0)
-      debug_inspector (>= 0.0.1)
     bootsnap (1.5.1)
       msgpack (~> 1.0)
     browser (5.1.0)
@@ -200,7 +194,6 @@ GEM
       cucumber-cucumber-expressions (~> 10.3, >= 10.3.0)
       cucumber-messages (~> 13.0, >= 13.0.1)
     database_cleaner (1.8.5)
-    debug_inspector (0.0.3)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
     devise (4.7.3)
@@ -638,8 +631,6 @@ DEPENDENCIES
   awesome_print (~> 1.8.0)
   aws-sdk-s3
   axe-core-cucumber
-  better_errors (>= 2.7.1)
-  binding_of_caller
   bootsnap (>= 1.1.0)
   browser
   business


### PR DESCRIPTION
## AP-1909 Remove better_errors gem

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1909)

This is because it is disllowed by our csp policy. I've left a git issue in their repo better_errors/issues/496#issue-762183543

- Remove better_errors and its required binding_of_caller gem.



## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
