### PR TITLE
AP-1857 Add pry-rescue gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -123,6 +123,8 @@ group :development do
   gem 'guard-rspec'
   gem 'guard-rubocop'
   gem 'listen', '>= 3.0.5', '< 3.5'
+  gem 'pry-rescue'
+  gem 'pry-stack_explorer'
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,6 +129,8 @@ GEM
       html_tokenizer (~> 0.0.6)
       parser (>= 2.4)
       smart_properties
+    binding_of_caller (1.0.0)
+      debug_inspector (>= 0.0.1)
     bootsnap (1.5.1)
       msgpack (~> 1.0)
     browser (5.2.0)
@@ -194,6 +196,7 @@ GEM
       cucumber-cucumber-expressions (~> 10.3, >= 10.3.0)
       cucumber-messages (~> 13.0, >= 13.0.1)
     database_cleaner (1.8.5)
+    debug_inspector (1.0.0)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
     devise (4.7.3)
@@ -300,6 +303,7 @@ GEM
       terminal-table (>= 1.5.1)
     ice_nine (0.11.2)
     iniparse (1.5.0)
+    interception (0.5)
     jmespath (1.4.0)
     jquery-rails (4.4.0)
       rails-dom-testing (>= 1, < 3)
@@ -405,6 +409,12 @@ GEM
     pry-byebug (3.9.0)
       byebug (~> 11.0)
       pry (~> 0.13.0)
+    pry-rescue (1.5.2)
+      interception (>= 0.5)
+      pry (>= 0.12.0)
+    pry-stack_explorer (0.6.0)
+      binding_of_caller (~> 1.0)
+      pry (~> 0.13)
     public_suffix (4.0.6)
     puma (5.1.1)
       nio4r (~> 2.0)
@@ -679,6 +689,8 @@ DEPENDENCIES
   pg
   prometheus_exporter
   pry-byebug
+  pry-rescue
+  pry-stack_explorer
   puma (~> 5.1)
   pundit
   rails (~> 6.0.3)

--- a/README.md
+++ b/README.md
@@ -209,6 +209,14 @@ When changes to test files are made it will run the tests in that file
 When changes are made to objects it will attempt to pattern match the appropriate tests and run them, e.g. changes to `app/models/applicant.rb` will run `spec/models/applicant_sepc.rb`
 Ensuring your test files match the folder structure and naming convention will help guard monitor your file changes
 
+#### pry-rescue
+
+The repo also includes `pry-rescue`, a gem to allow faster debugging. Running
+```
+bundle exec rescue rspec
+```
+will cause any failing tests or unhandled exceptions to automatically open a `pry` prompt for immediate investigation.
+
 ## Deployment
 
 The deployment is triggered on all builds in [CircleCI](https://circleci.com/gh/ministryofjustice/laa-apply-for-legal-aid) but requires approval to the desired environment.

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,6 +7,7 @@ abort('The Rails environment is running in production mode!') if Rails.env.produ
 require 'rspec/rails'
 require 'json_expressions/rspec'
 require 'awesome_print'
+require 'pry-rescue/rspec' if Rails.env.development?
 
 # Add additional requires below this line. Rails is not loaded until this point!
 Dir[Rails.root.join('spec/support/**/*.rb')].sort.each { |f| require f }


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1857)

Add `pry-rescue` and `pry-stack_explorer` gems so that rspec tests are halted to allow investigation when a failure occurs.

This does not happen automatically when running `bundle exec rspec`. A developer needs to run `bundle exec rescue rspec` for this to take affect; the readme has been updated to reflect this. A further ticket will be added to spike an investigation into automatically running `pry-rescue` as part of the standard rspec test suite.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
