### PR TITLE
Capture exceptions during entity attributes generation

### DIFF
--- a/app/services/ccms/payload_generators/entity_attributes_generator.rb
+++ b/app/services/ccms/payload_generators/entity_attributes_generator.rb
@@ -68,6 +68,9 @@ module CCMS
         else
           raise CCMSError, "Submission #{submission.id} - Unknown response type in attributes config yaml file: #{config[:response_type]}"
         end
+      rescue StandardError => e
+        Raven.capture_message("EntityAttributesGenerator #{e.class}: #{e.message} with config.inspect values of: #{config.inspect}")
+        raise
       end
 
       def extract_raw_value(config)


### PR DESCRIPTION


## Capture exceptions during entity attributes generation

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1939)

During the ccms submission we generate entitiy attributes

- This change captures the error and sends a message to Sentry via Raven explaining the config. This allows for better debugging.

After rescuing the error , it reraises it. It'll be rescued again later. This rescue duplication is so that we can check
what the config looked like in the attribute generation.

- Test this


## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
