### PR TITLE
Fix: Speed up rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,6 +10,8 @@ AllCops:
   - 'vendor/**/*'
   - 'node_modules/**/*'
   - 'ccms_integration/*'
+  - 'tmp/**/*'
+  - 'log/**/*'
 
 Layout/LineLength:
   Max: 180


### PR DESCRIPTION
## What

As time passes and the log and tmp folders increase in size
rubocop initialisation slows down because it pre-scans all
files

By ignoring them it speeds up considerably

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
