### PR TITLE
AdminPage: Return result for empty cfe submission result

### DIFF
--- a/app/views/admin/legal_aid_applications/submissions/show.html.erb
+++ b/app/views/admin/legal_aid_applications/submissions/show.html.erb
@@ -1,3 +1,7 @@
+<%
+  empty_cfe_result = {result: 'nil'}
+%>
+
 <%= back_link() %>
 <div class='govuk-body'>
   <h1 class="govuk-heading-l">Legal Aid Application</h1>
@@ -36,7 +40,7 @@
           CFE result
         </summary>
         <section>
-          <%= format_hash(JSON.parse(cfe_submission.result.result)) %>
+          <%= format_hash(JSON.parse(cfe_submission.result&.result || empty_cfe_result)) %>
         </section>
       </details>
     <% end %>

--- a/spec/helpers/hash_format_helper_spec.rb
+++ b/spec/helpers/hash_format_helper_spec.rb
@@ -15,6 +15,13 @@ RSpec.describe HashFormatHelper, type: :helper do
       it { is_expected.to eql expected_response }
     end
 
+    context 'hash has key but no value' do
+      let(:source) { { result: nil } }
+      it 'returns empty string' do
+        expect(subject).to eq ''
+      end
+    end
+
     context 'when passed invalid data' do
       before do
         allow(Rails.logger).to receive(:info).at_least(:once)


### PR DESCRIPTION
## Fix bug ActionView::Template::Error when displaying empty CFE::Submission result on admin page

Fix bug ActionView::Template::Error undefined method `result' for nil:NilClass
in sentry [here](https://sentry.io/organizations/ministryofjustice/issues/2134505463/?project=5416054&query=is%3Aunresolved)

- Do this by returning result: 'nil' to signifiy an empty cfe_result as opposed to an empty string

- Test the format helper to show that a hash with an empty value returns an empty string ''

- result: 'nil' passed to format_helper will show Result: Nil for every nil cfe_result instead of using {result: nil} which would return an empty string and not displayed.


## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
