### PR TITLE
formbuilder: date of birth updates

### DIFF
--- a/app/forms/applicants/basic_details_form.rb
+++ b/app/forms/applicants/basic_details_form.rb
@@ -3,7 +3,7 @@ module Applicants
     include BaseForm
 
     ATTRIBUTES = %i[first_name last_name national_insurance_number
-                    dob_1i dob_2i dob_3i].freeze
+                    date_of_birth_1i date_of_birth_2i date_of_birth_3i].freeze
 
     form_for Applicant
 
@@ -67,7 +67,7 @@ module Applicants
         form: self,
         model: model,
         method: :date_of_birth,
-        prefix: :dob_,
+        prefix: :date_of_birth_,
         suffix: :gov_uk
       )
     end

--- a/app/forms/concerns/date_field_builder.rb
+++ b/app/forms/concerns/date_field_builder.rb
@@ -59,7 +59,7 @@ class DateFieldBuilder
   def model_attributes
     return unless model_date.present?
 
-    fields.each_with_object({}) { |part, hash| hash[parts_hash[part]] = model_date.__send__(part) }
+    DATE_PARTS.each_with_object({}) { |part, hash| hash[parts_hash[part]] = model_date.__send__(part) }
   end
 
   def model_date

--- a/app/views/shared/forms/_applicant_form.html.erb
+++ b/app/views/shared/forms/_applicant_form.html.erb
@@ -20,8 +20,7 @@
     </fieldset>
 
     <div class="govuk-!-padding-bottom-4"></div>
-
-    <%= form.govuk_date_field :dob, legend: { text: t("shared.forms.date_input_fields.date_of_birth_label") },
+    <%= form.govuk_date_field :date_of_birth, legend: { text: t("shared.forms.date_input_fields.date_of_birth_label") },
                               hint: { text: t("shared.forms.date_input_fields.date_of_birth_hint")} %>
 
     <div class="govuk-!-padding-bottom-6"></div>

--- a/spec/forms/applicants/basic_details_form_spec.rb
+++ b/spec/forms/applicants/basic_details_form_spec.rb
@@ -143,9 +143,9 @@ RSpec.describe Applicants::BasicDetailsForm, type: :form do
           first_name: attributes[:first_name],
           last_name: attributes[:last_name],
           national_insurance_number: attributes[:national_insurance_number],
-          dob_year: attributes[:date_of_birth].year.to_s,
-          dob_month: attributes[:date_of_birth].month.to_s,
-          dob_day: attributes[:date_of_birth].day.to_s,
+          date_of_birth_1i: attributes[:date_of_birth].year.to_s,
+          date_of_birth_2i: attributes[:date_of_birth].month.to_s,
+          date_of_birth_3i: attributes[:date_of_birth].day.to_s,
           model: applicant
         }
       end
@@ -166,9 +166,9 @@ RSpec.describe Applicants::BasicDetailsForm, type: :form do
           first_name: attributes[:first_name],
           last_name: attributes[:last_name],
           national_insurance_number: attributes[:national_insurance_number],
-          dob_year: '10',
-          dob_month: '21',
-          dob_day: '44',
+          date_of_birth_1i: '10',
+          date_of_birth_2i: '21',
+          date_of_birth_3i: '44',
           model: applicant
         }
       end
@@ -275,8 +275,8 @@ RSpec.describe Applicants::BasicDetailsForm, type: :form do
           first_name: attributes[:first_name],
           last_name: attributes[:last_name],
           national_insurance_number: attributes[:national_insurance_number],
-          dob_month: '10',
-          dob_day: '4',
+          date_of_birth_2i: '10',
+          date_of_birth_3i: '4',
           model: applicant
         }
       end
@@ -313,9 +313,9 @@ RSpec.describe Applicants::BasicDetailsForm, type: :form do
       end
 
       it 'populates dob fields from model' do
-        expect(subject.dob_year).to eq(applicant.date_of_birth.year)
-        expect(subject.dob_month).to eq(applicant.date_of_birth.month)
-        expect(subject.dob_day).to eq(applicant.date_of_birth.day)
+        expect(subject.date_of_birth_1i).to eq(applicant.date_of_birth.year)
+        expect(subject.date_of_birth_2i).to eq(applicant.date_of_birth.month)
+        expect(subject.date_of_birth_3i).to eq(applicant.date_of_birth.day)
       end
     end
   end


### PR DESCRIPTION
## What

* revert the fields to DATE_PARTS : this was actually okay as-was and did not need to be updated
* Update the basic_details_form  - The conversion between date_of_birth and dob was causing issues
    date_of_birth would load and render on the view but not save
    dob would save but would not load when the form was rendered

    Removing the conversion makes the field names longer but allows rendering _and_ saving!

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
