### PR TITLE
AP-1917: Identify non live feedback

### DIFF
--- a/app/mailers/feedback_mailer.rb
+++ b/app/mailers/feedback_mailer.rb
@@ -25,7 +25,8 @@ class FeedbackMailer < BaseApplyMailer
       originating_page: safe_nil(feedback.originating_page),
       provider_email: provider_email_phrase(feedback),
       application_reference: @legal_aid_application&.application_ref || '',
-      application_status: application_status || ''
+      application_status: application_status || '',
+      non_live_env: non_live_environment?
     )
   end
 
@@ -49,6 +50,10 @@ class FeedbackMailer < BaseApplyMailer
 
   def yes_or_no(feedback)
     feedback['done_all_needed'] == true ? 'Yes' : 'No'
+  end
+
+  def non_live_environment?
+    %w[staging uat localhost].any? { |env| Rails.configuration.x.application.host.include?(env) } ? '- non-live' : ''
   end
 
   def provider_email_phrase(feedback)

--- a/app/mailers/feedback_mailer.rb
+++ b/app/mailers/feedback_mailer.rb
@@ -26,7 +26,7 @@ class FeedbackMailer < BaseApplyMailer
       provider_email: provider_email_phrase(feedback),
       application_reference: @legal_aid_application&.application_ref || '',
       application_status: application_status || '',
-      non_live_env: non_live_environment?
+      non_live_env: non_live_environment? ? '- non-live' : ''
     )
   end
 
@@ -53,7 +53,7 @@ class FeedbackMailer < BaseApplyMailer
   end
 
   def non_live_environment?
-    %w[staging uat localhost].any? { |env| Rails.configuration.x.application.host.include?(env) } ? '- non-live' : ''
+    %w[staging uat localhost].any? { |env| Rails.configuration.x.application.host.include?(env) }
   end
 
   def provider_email_phrase(feedback)

--- a/config/govuk_notify_templates.yml
+++ b/config/govuk_notify_templates.yml
@@ -1,5 +1,5 @@
 citizen_start_application: 1ad50d58-ab76-4583-8c31-258d7c8304a4
-feedback_notification: fd050a04-54d2-4736-bb6c-66431c7d9e41
+feedback_notification: abb5932d-24a3-49fe-a103-907d367dd75f
 submission_confirmation: 5472b10b-bc11-432a-a18d-9f20de5b2854
 reminder_to_submit_an_application: 96e58b6c-83e2-4ae8-be67-028803e98398
 client_completed_means: b343446d-b487-4f8b-9673-2aaf21ea10a1


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1917)

Created a new version of the feedback template on Notify, that adds a `non_live_env` suffix to the subject line
Added a helper method to the feedback_mailer that checks for uat, staging, or localhost in the current host URL and sends ' -non live' to the template
If none of those are found, it will send an empty string ('') as notify does not handle nil gracefully!

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
