### PR TITLE
AP-1941 Add date_submitted to non-passported csv

### DIFF
--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -349,6 +349,10 @@ class LegalAidApplication < ApplicationRecord
     super
   end
 
+  def ccms_submission_date
+    association(:ccms_submission).load_target&.created_at
+  end
+
   def state
     state_machine_proxy.aasm_state
   end

--- a/app/services/reports/mis/non_passported_application_csv_line.rb
+++ b/app/services/reports/mis/non_passported_application_csv_line.rb
@@ -14,6 +14,7 @@ module Reports
           username
           provider_email
           created_at
+          date_submitted
           applicant_name
           deleted
         ]
@@ -35,6 +36,7 @@ module Reports
         @line << laa.provider.username
         @line << provider.email
         @line << laa.created_at.strftime('%Y-%m-%d %H:%M:%S')
+        @line << laa.ccms_submission_date&.strftime('%Y-%m-%d %H:%M:%S')
         @line << laa.applicant.full_name
         @line << deleted?(laa)
         sanitise

--- a/spec/services/reports/mis/non_passported_application_csv_line_spec.rb
+++ b/spec/services/reports/mis/non_passported_application_csv_line_spec.rb
@@ -14,6 +14,7 @@ module Reports
             username
             provider_email
             created_at
+            date_submitted
             applicant_name
             deleted
           ]
@@ -24,15 +25,15 @@ module Reports
       end
 
       describe '.call' do
-        let(:application) { create :legal_aid_application, :with_applicant }
+        let(:application) { create :legal_aid_application, :with_applicant, :at_assessment_submitted }
         let(:provider) { application.provider }
         let(:applicant) { application.applicant }
         let(:time) { Time.new(2020, 9, 20, 2, 3, 44) }
 
         subject { described_class.call(application) }
 
-        it 'returns an array of eight fields' do
-          expect(subject.size).to eq 8
+        it 'returns an array of nine fields' do
+          expect(subject.size).to eq 9
         end
 
         context 'undiscarded application' do
@@ -45,8 +46,9 @@ module Reports
               expect(fields[3]).to eq provider.username
               expect(fields[4]).to eq provider.email
               expect(fields[5]).to match DATE_TIME_REGEX
-              expect(fields[6]).to eq applicant.full_name
-              expect(fields[7]).to eq ''
+              expect(fields[6]).to match DATE_TIME_REGEX
+              expect(fields[7]).to eq applicant.full_name
+              expect(fields[8]).to eq ''
             end
           end
         end
@@ -62,8 +64,9 @@ module Reports
               expect(fields[3]).to eq provider.username
               expect(fields[4]).to eq provider.email
               expect(fields[5]).to match DATE_TIME_REGEX
-              expect(fields[6]).to eq applicant.full_name
-              expect(fields[7]).to eq 'Y'
+              expect(fields[6]).to match DATE_TIME_REGEX
+              expect(fields[7]).to eq applicant.full_name
+              expect(fields[8]).to eq 'Y'
             end
           end
         end

--- a/spec/services/reports/mis/non_passported_applications_report_spec.rb
+++ b/spec/services/reports/mis/non_passported_applications_report_spec.rb
@@ -8,6 +8,7 @@ module Reports
         travel_to(8.minutes.ago) { create_non_passported_application }
         travel_to(6.minutes.ago) { create_non_passported_application_use_ccms }
         travel_to(4.minutes.ago) { create_passported_application }
+        travel_to(2.minutes.ago) { create_submitted_application }
       end
 
       after do
@@ -22,19 +23,21 @@ module Reports
         let(:applicant) { application.applicant }
         let(:email) { application.provider.email }
         let(:created_at) { application.created_at.strftime('%Y-%m-%d %H:%M:%S') }
+        let(:submission_date) { LegalAidApplication.find_by(application_ref: 'L-SUBMITTED').ccms_submission_date.strftime('%Y-%m-%d %H:%M:%S') }
         let(:lines) { subject.split("\n") }
 
-        it 'three lines of data' do
-          expect(lines.size).to eq 3
+        it 'four lines of data' do
+          expect(lines.size).to eq 4
         end
 
         it 'returns a header line as the first line' do
-          expect(lines.first).to eq 'application_ref,state,ccms_reason,username,provider_email,created_at,applicant_name,deleted'
+          expect(lines.first).to eq 'application_ref,state,ccms_reason,username,provider_email,created_at,date_submitted,applicant_name,deleted'
         end
 
-        it 'returns data for the only non-passorted application after Sep 21st as second line' do
-          expect(lines[1]).to eq %(L-ATE,checking_citizen_answers,,#{username},#{email},#{created_at},#{applicant.full_name},"")
+        it 'returns data for all non-passorted applications after Sep 21st' do
+          expect(lines[1]).to eq %(L-ATE,checking_citizen_answers,,#{username},#{email},#{created_at},,#{applicant.full_name},"")
           expect(lines[2]).to match(/^L-USE-CCMS,use_ccms,employed,/)
+          expect(lines[3]).to match(/^L-SUBMITTED,assessment_submitted,.*#{submission_date},.*$/)
         end
       end
 
@@ -73,6 +76,15 @@ module Reports
                :with_passported_state_machine,
                :with_positive_benefit_check_result,
                application_ref: 'L-PASS'
+      end
+
+      def create_submitted_application
+        create :legal_aid_application,
+               :with_applicant,
+               :with_negative_benefit_check_result,
+               :with_non_passported_state_machine,
+               :at_assessment_submitted,
+               application_ref: 'L-SUBMITTED'
       end
     end
   end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1941)

Populates the date the application was submitted to CCMS on the non-passported application report.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
