### PR TITLE
AP-1934 Show savings account as "none declared" on caseworker means report

### DIFF
--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -276,12 +276,12 @@ class LegalAidApplication < ApplicationRecord
 
   def online_savings_accounts_balance
     accounts = applicant.bank_accounts.reject { |c| c.account_type == 'TRANSACTION' }&.map(&:balance)
-    accounts.sum.to_s
+    accounts.present? ? accounts.sum.to_s : nil
   end
 
   def online_current_accounts_balance
     accounts = applicant.bank_accounts.reject { |c| c.account_type == 'SAVINGS' }&.map(&:balance)
-    accounts.sum.to_s
+    accounts.present? ? accounts.sum.to_s : nil
   end
 
   def other_assets?

--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -280,7 +280,7 @@ class LegalAidApplication < ApplicationRecord
   end
 
   def online_current_accounts_balance
-    accounts = applicant.bank_accounts.reject { |c| c.account_type == 'SAVINGS' }&.map(&:balance)
+    accounts = applicant.bank_accounts.select { |c| c.account_type == 'TRANSACTION' }&.map(&:balance)
     accounts.present? ? accounts.sum.to_s : nil
   end
 

--- a/app/views/shared/check_answers/_assets.html.erb
+++ b/app/views/shared/check_answers/_assets.html.erb
@@ -2,7 +2,7 @@
   read_only = false unless local_assigns.key?(:read_only)
   online_savings_accounts = @legal_aid_application.online_savings_accounts_balance
   online_current_accounts = @legal_aid_application.online_current_accounts_balance
-  %>
+%>
 <section class="print-no-break">
   <%= render 'shared/check_answers/property', read_only: read_only %>
 </section>

--- a/app/views/shared/check_answers/_assets.html.erb
+++ b/app/views/shared/check_answers/_assets.html.erb
@@ -1,4 +1,8 @@
-<% read_only = false unless local_assigns.key?(:read_only) %>
+<%
+  read_only = false unless local_assigns.key?(:read_only)
+  online_savings_accounts = @legal_aid_application.online_savings_accounts_balance
+  online_current_accounts = @legal_aid_application.online_current_accounts_balance
+  %>
 <section class="print-no-break">
   <%= render 'shared/check_answers/property', read_only: read_only %>
 </section>
@@ -48,17 +52,16 @@
               name: :online_current_accounts,
               url: check_answer_url_for(journey_type, :applicant_bank_accounts, @legal_aid_application),
               question: t('.assets.current_account'),
-              answer: gds_number_to_currency(@legal_aid_application.online_current_accounts_balance),
+              answer: online_current_accounts ? gds_number_to_currency(online_current_accounts) : t('generic.none_declared'),
               read_only: read_only,
           ) %>
-
-    <%= check_answer_link(
-            name: :online_savings_accounts,
-            url: check_answer_url_for(journey_type, :applicant_bank_accounts, @legal_aid_application),
-            question: t('.assets.savings_account'),
-            answer: gds_number_to_currency(@legal_aid_application.online_savings_accounts_balance),
-            read_only: read_only,
-        ) %>
+        <%= check_answer_link(
+              name: :online_savings_accounts,
+              url: check_answer_url_for(journey_type, :applicant_bank_accounts, @legal_aid_application),
+              question: t('.assets.savings_account'),
+              answer: online_savings_accounts ? gds_number_to_currency(online_savings_accounts) : t('generic.none_declared'),
+              read_only: read_only,
+          ) %>
     </dl>
 
   <% end %>

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -416,6 +416,7 @@ en:
           unknown_frequency: Frequency unknown
           residual_balance: Capital Contribution - Residual Balance Check
           policy_disregards: Discretionary disregards selected
+          multi_benefit: Multiple benefits in single bank transaction
       show:
         heading: Means report
         caseworker-review-section-heading: Caseworker Review


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1934)

Under "which types of savings and investments does your client have?", if there is no Savings (or Current) Account uploaded, this will show 'None Declared'. If it is uploaded with a balance of 0, this will still show as £0.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
