### PR TITLE
AP-1954 Remove account holder duplication

### DIFF
--- a/app/models/bank_account.rb
+++ b/app/models/bank_account.rb
@@ -12,8 +12,8 @@ class BankAccount < ApplicationRecord
     ACCOUNT_TYPE_LABELS.fetch(account_type, account_type)
   end
 
-  def holders
-    'ClientSole' # TODO: CCMS placeholder
+  def holder_type
+    'Client Sole' # TODO: CCMS placeholder
   end
 
   def display_name

--- a/app/services/ccms/attribute_value_generator.rb
+++ b/app/services/ccms/attribute_value_generator.rb
@@ -97,8 +97,8 @@ module CCMS
       options[:bank_acct].bank_provider.name
     end
 
-    def bank_account_holders(_options)
-      'Client Sole' # TODO: CCMS placeholder
+    def bank_account_holder_type(options)
+      options[:bank_acct].holder_type
     end
 
     def submission_case_ccms_reference(_options)

--- a/config/ccms/attribute_block_configs/base.yml
+++ b/config/ccms/attribute_block_configs/base.yml
@@ -11,7 +11,7 @@ bank_acct:
     response_type: text
     user_defined: true
   BANKACC_INPUT_T_7WP2_6A:
-    value: "#bank_account_holders"
+    value: "#bank_account_holder_type"
     br100_meaning: 'Bank accounts: Account holders'
     response_type: text
     user_defined: true

--- a/config/ccms/attribute_block_configs/non_passported.yml
+++ b/config/ccms/attribute_block_configs/non_passported.yml
@@ -183,7 +183,7 @@ bank_acct:
     response_type: text
     generate_block?: true
   BANKACC_INPUT_T_7WP2_6A:
-    value: Client Sole
+    value: "#bank_account_holder_type"
     br100_meaning: 'Bank accounts: Account holders'
     user_defined: true
     response_type: text

--- a/spec/fixtures/files/ccms_keys/standard_ccms_keys.yml
+++ b/spec/fixtures/files/ccms_keys/standard_ccms_keys.yml
@@ -11,7 +11,7 @@ bank_acct:
     :response_type: text
     :user_defined: true
   HOLDERS:
-    :value: "#bank_account_holders"
+    :value: "#bank_account_holder_type"
     :br100_meaning: 'Bank accounts: Account holders'
     :response_type: text
     :user_defined: true

--- a/spec/fixtures/files/ccms_keys/standard_ccms_keys.yml
+++ b/spec/fixtures/files/ccms_keys/standard_ccms_keys.yml
@@ -16,7 +16,7 @@ bank_acct:
     :response_type: text
     :user_defined: true
   BANK_NAME:
-    :value: Mock Bank
+    :value: '#bank_name'
     :br100_meaning: 'Bank accounts: Name of bank'
     :response_type: text
     :user_defined: true

--- a/spec/models/bank_account_spec.rb
+++ b/spec/models/bank_account_spec.rb
@@ -18,10 +18,10 @@ RSpec.describe BankAccount, type: :model do
     end
   end
 
-  describe '#holders' do
+  describe '#holder_type' do
     it 'returns the correct account holder' do
       bank_account = create :bank_account
-      expect(bank_account.holders).to eq 'ClientSole'
+      expect(bank_account.holder_type).to eq 'Client Sole'
     end
   end
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1954)

Raised during work on [AP-1859](https://dsdmoj.atlassian.net/browse/AP-1859)

Bank account holder information is hardcoded for CCMS attributes in several places. Tidy this up by reducing this to a single coding in the `BankAccount` model and let all other places reference that. This will make further analysis of the other CCMS attributes easier.

Also:

* Fixes an error in the `BankAccount` model where `ClientSole` should be `Client Sole`.
* Renames the `bank_account_holders` method to `bank_account_holder_type` to remove possible confusion with the `BankAccountHolder` model used elsewhere.
* Changes a hardcoded CCMS bank name attribute from `Mock Bank` to use the actual bank name.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
