### PR TITLE
AP-1938: admin search

### DIFF
--- a/app/controllers/admin/legal_aid_applications_controller.rb
+++ b/app/controllers/admin/legal_aid_applications_controller.rb
@@ -12,6 +12,19 @@ module Admin
       )
     end
 
+    def search
+      if search_params.present?
+        @pagy, @applications = pagy(
+          search_application_results,
+          items: params.fetch(:page_size, DEFAULT_PAGE_SIZE),
+          size: [1, 1, 1, 1]
+        )
+      elsif search_params.nil?
+        @error = t('.error')
+      end
+      render :index
+    end
+
     def create_test_applications
       TestApplicationCreationService.call
       redirect_to action: :index
@@ -45,8 +58,26 @@ module Admin
 
     private
 
+    def search_application_results
+      search_applications
+        .where(application_ref: search_params)
+        .or(search_applications.where(id: search_params))
+        .or(search_applications.where("first_name || ' ' || last_name ILIKE '%#{search_params}%'"))
+        .or(search_applications.where("case_ccms_reference = '#{search_params}'"))
+    end
+
+    def search_applications
+      @search_applications ||= LegalAidApplication.left_outer_joins(:ccms_submission).joins(:applicant)
+    end
+
     def legal_aid_application
       @legal_aid_application ||= LegalAidApplication.find(params[:id])
+    end
+
+    def search_params
+      params.require(:search)
+    rescue ActionController::ParameterMissing
+      nil
     end
   end
 end

--- a/app/views/admin/legal_aid_applications/index.html.erb
+++ b/app/views/admin/legal_aid_applications/index.html.erb
@@ -3,6 +3,7 @@
       column_width: :full,
       back_link: :none
     ) do %>
+  <%= render partial: 'shared/error' if @error %>
 
   <div id="confirm-delete" class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary" data-cancel-text="<%= t('.cancel_delete') %>" hidden>
     <h2 class="govuk-error-summary__title" id="error-summary-title">
@@ -41,6 +42,18 @@
         "data-application-id": 'destroy_all',
         "data-delete-message": t('.warning.delete_all')
       ) if @applications.present? && destroy_enabled? %>
+<% end %>
+
+<%= form_with(
+      url: admin_application_search_path,
+      method: :post,
+      local: true
+    ) do |form| %>
+
+  <%= govuk_form_group(show_error_if: @error)  do %>
+    <%= form.govuk_text_field :search, class: 'govuk-input--width-20', value: params['search'] || '' %>
+    <%= form.submit(t('generic.search'), class: 'govuk-button form-button', name: 'search_button') %>
+  <% end %>
 <% end %>
 
 <% if @applications.present? %>

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -25,6 +25,8 @@ en:
         provider_username: Provider's username
         discarded: Discarded by user on %{date}
         data_view: Submission details
+      search:
+        error: Please enter a search criteria
     settings:
       show:
         heading_1: Settings

--- a/config/locales/en/generic.yml
+++ b/config/locales/en/generic.yml
@@ -42,6 +42,7 @@ en:
     start: Start
     start_now: Start now
     new_app: Make a new application
+    search: Search
     submit: Submit
     submit_and_continue: Submit and continue
     tell_us: Your statement must include

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -7,6 +7,7 @@ en:
     accessibility:
       error: "Error:"
     hint:
+      search: You can search by Application Reference, ccms_reference, client's name or application_id
       additional_account: Share details of any accounts you have with another bank or building society
       address_lookup:
         postcode: This must be a valid UK postcode
@@ -21,6 +22,7 @@ en:
         own_vehicle: This includes cars, vans and motorcycles
       student_finance: This includes any type of student loan, grant or bursary.
     label:
+      search: 'Application search:'
       applicant:
         employed:
           <<: *true_false

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,6 +50,7 @@ Rails.application.routes.draw do
 
   namespace :admin do
     root to: 'legal_aid_applications#index'
+    post 'search', to: 'legal_aid_applications#search', as: 'application_search'
     namespace :legal_aid_applications do
       resources :submissions, only: [:show] do
         member do

--- a/features/admin/application_list.feature
+++ b/features/admin/application_list.feature
@@ -10,3 +10,31 @@ Feature: Admin application functions
     And I should see 'Download means report'
     And I should see 'Download merits report'
     # test clicking the links with caution... it will download a file to your machine on each run
+
+  @javascript
+  Scenario: I can search for specific applications
+    Given multiple applications have been submitted
+    When I am logged in as an admin
+    Then I should see 'Application search:'
+    And I should not see the first application
+    When I click 'Search'
+    # without entering a value
+    Then I should see 'There is a problem'
+    And I should see 'Please enter a search criteria'
+    When I search for the first application_ref
+    And I click 'Search'
+    Then I should see the first application
+    And I should see 'Showing 1 of 1 result'
+    When I search for the second applications client
+    And I click 'Search'
+    Then I should see the second application
+    And I should see 'Showing 1 of 1 result'
+    When I search for the third case_ccms_reference
+    And I click 'Search'
+    Then I should see the third application
+    And I should see 'Showing 1 of 1 result'
+    When I search for the fourth id
+    And I click 'Search'
+    Then I should see the fourth application
+    And I should see 'Showing 1 of 1 result'
+

--- a/features/step_definitions/admin_steps.rb
+++ b/features/step_definitions/admin_steps.rb
@@ -20,6 +20,39 @@ Given('an application has been submitted') do
   )
 end
 
+Given('multiple applications have been submitted') do
+  create_list(
+    :application,
+    15,
+    :at_assessment_submitted,
+    :with_applicant,
+    provider: create(:provider)
+  )
+  # create :application,
+  #        :with_applicant,
+  #        provider: create(:provider)
+  # binding.pry unless Applicant.count > 0
+end
+
 Given(/^I visit the admin applications page$/) do
   visit admin_legal_aid_applications_path
+end
+
+Then(/^I should (see|not see) the (\S*) application$/) do |visibility, number|
+  first_ref = LegalAidApplication.order(:created_at).send(number).application_ref
+  if visibility == 'see'
+    expect(page).to have_content(first_ref)
+  else
+    expect(page).not_to have_content(first_ref)
+  end
+end
+
+When(/^I search for the (\S*) (\S*)$/) do |number, field|
+  value = LegalAidApplication.order(:created_at).send(number).send(field)
+  fill_in('search', with: value)
+end
+
+When(/^I search for the (\S*) applications client$/) do |number|
+  name = LegalAidApplication.order(:created_at).send(number).applicant.full_name
+  fill_in('search', with: name)
 end

--- a/spec/requests/admin/legal_aid_applications_controller_spec.rb
+++ b/spec/requests/admin/legal_aid_applications_controller_spec.rb
@@ -75,6 +75,25 @@ RSpec.describe Admin::LegalAidApplicationsController, type: :request do
     end
   end
 
+  describe 'POST /admin/search' do
+    subject { post admin_application_search_path(params) }
+    let(:params) { nil }
+    before { subject }
+
+    context 'when the params are empty' do
+      it { expect(response.body).to include('Please enter a search criteria') }
+    end
+
+    context 'when the params match an application' do
+      let(:params) { { search: legal_aid_applications.first.id } }
+
+      it 'shows the matching application' do
+        expect(response.body).to include(legal_aid_applications.first.application_ref)
+        expect(response.body).to include('Showing 1 of 1 result')
+      end
+    end
+  end
+
   describe 'POST /admin/legal_aid_applications/create_test_applications' do
     subject { post create_test_applications_admin_legal_aid_applications_path }
     let(:count) { 1 }


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1938)

Added a search form to the Admin/application list page
This allows admin users to search for Client (case insensitive name matches anywhere e.g. `th` would match `Theon Grayjoy` and `Sarah Smith`), ccms_reference, and application id or reference (exact matches only)
An error message is displayed if an admin hits search with no criteria

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
