### PR TITLE
Tech-Debt: Update omni-auth

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ gem 'bootsnap', '>= 1.1.0', require: false
 # Authentication
 gem 'devise', '>= 4.7.1' # User authentication
 gem 'devise_saml_authenticatable', '>= 1.6.2'
-gem 'omniauth', '>= 1.9.1'
+gem 'omniauth', '>= 2'
 gem 'omniauth-google-oauth2', '>= 0.8.0'
 gem 'omniauth-oauth2', '>= 1.6.0' # Provide Oauth2 strategy framework
 gem 'omniauth-rails_csrf_protection', '~> 0.1', '>= 0.1.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -376,9 +376,10 @@ GEM
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
-    omniauth (1.9.1)
+    omniauth (2.0.0)
       hashie (>= 3.4.6)
       rack (>= 1.6.2, < 3)
+      rack-protection
     omniauth-google-oauth2 (0.8.1)
       jwt (>= 2.0)
       oauth2 (~> 1.1)
@@ -427,6 +428,8 @@ GEM
     rack-pjax (1.1.0)
       nokogiri (~> 1.5)
       rack (>= 1.1)
+    rack-protection (2.1.0)
+      rack
     rack-proxy (0.6.5)
       rack
     rack-test (1.1.0)
@@ -682,7 +685,7 @@ DEPENDENCIES
   mimemagic
   nesty
   nokogiri
-  omniauth (>= 1.9.1)
+  omniauth (>= 2)
   omniauth-google-oauth2 (>= 0.8.0)
   omniauth-oauth2 (>= 1.6.0)
   omniauth-rails_csrf_protection (~> 0.1, >= 0.1.2)


### PR DESCRIPTION
## What

OmniAuth has updated to 2.0 which should remove the CVE-2015-9284 warning by relying on POST for auth
Our service uses POST so it did not affect us, but this should reduce the noise whenever you push code from the commandline!

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
