### PR TITLE
AP-1959 BUGFIX do not set provider step to delete

### DIFF
--- a/app/controllers/concerns/providers/application_dependable.rb
+++ b/app/controllers/concerns/providers/application_dependable.rb
@@ -26,7 +26,7 @@ module Providers
         return if self.class.legal_aid_application_not_required?
         return process_invalid_application unless legal_aid_application.present?
 
-        legal_aid_application.update!(provider_step: provider_step, provider_step_params: provider_step_params)
+        legal_aid_application.update!(provider_step: provider_step, provider_step_params: provider_step_params) unless provider_step == :delete
       end
 
       def process_invalid_application


### PR DESCRIPTION
## Do not set the provider_step to delete

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1959)

As part of the `Providers::ApplicationDependable` module, every controller set the `provider_step` field to the name of the controller.  This is to allow the application to be saved, and then picked up at the same place at a later date.

Unfortunately, this is also true for the DeleteController.  If the user accidentally hits the delete button, then backs out, the provider step remains set at delete.  This means that when they click on the application from the index page, it immediately asks them to confirm they want to delete the application (thank God!)

Solution: Don't set the provider step to `:delete`

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
