### PR TITLE
Fix: rename variables inline with new rubocop

### DIFF
--- a/spec/factories/cash_transactions.rb
+++ b/spec/factories/cash_transactions.rb
@@ -4,15 +4,15 @@ FactoryBot.define do
     transaction_type
     amount { Faker::Number.decimal(l_digits: 3, r_digits: 2) }
 
-    trait :credit_month_1 do
+    trait :credit_month1 do
       transaction_date { Date.today.at_beginning_of_month - 1.months }
     end
 
-    trait :credit_month_2 do
+    trait :credit_month2 do
       transaction_date { Date.today.at_beginning_of_month - 2.months }
     end
 
-    trait :credit_month_3 do
+    trait :credit_month3 do
       transaction_date { Date.today.at_beginning_of_month - 3.months }
     end
   end

--- a/spec/models/aggregated_cash_income_spec.rb
+++ b/spec/models/aggregated_cash_income_spec.rb
@@ -38,12 +38,12 @@ RSpec.describe AggregatedCashIncome, type: :model do
     end
 
     context 'cash income transaction records exist' do
-      let(:pension1) { create :cash_transaction, :credit_month_1, legal_aid_application: application, transaction_type: pension }
-      let(:pension2) { create :cash_transaction, :credit_month_2, legal_aid_application: application, transaction_type: pension }
-      let(:pension3) { create :cash_transaction, :credit_month_3, legal_aid_application: application, transaction_type: pension }
-      let(:maintenance_in1) { create :cash_transaction, :credit_month_1, legal_aid_application: application, transaction_type: maintenance_in }
-      let(:maintenance_in2) { create :cash_transaction, :credit_month_2, legal_aid_application: application, transaction_type: maintenance_in }
-      let(:maintenance_in3) { create :cash_transaction, :credit_month_3, legal_aid_application: application, transaction_type: maintenance_in }
+      let(:pension1) { create :cash_transaction, :credit_month1, legal_aid_application: application, transaction_type: pension }
+      let(:pension2) { create :cash_transaction, :credit_month2, legal_aid_application: application, transaction_type: pension }
+      let(:pension3) { create :cash_transaction, :credit_month3, legal_aid_application: application, transaction_type: pension }
+      let(:maintenance_in1) { create :cash_transaction, :credit_month1, legal_aid_application: application, transaction_type: maintenance_in }
+      let(:maintenance_in2) { create :cash_transaction, :credit_month2, legal_aid_application: application, transaction_type: maintenance_in }
+      let(:maintenance_in3) { create :cash_transaction, :credit_month3, legal_aid_application: application, transaction_type: maintenance_in }
 
       before do
         pension1


### PR DESCRIPTION
## What

Update variables created between rubocop update PR being created and merged to master

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
