### PR TITLE
Reduce log pollution in the testing environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,12 @@ Staging and UAT environments.
   - [Staging](https://mojdt.slack.com/messages/GGWMW7M0F)
   - [Production](https://mojdt.slack.com/messages/GGWE9V9BP)
 
+## Logging
+
+To enable full logs in the test environment, `ENV['RAILS_ENABLE_TEST_LOG']` must return "true". 
+
+`ENV['RAILS_ENABLE_TEST_LOG']` defaults to nil (falsey) in order to reduce log pollution during testing.
+
 ## Notifications - GOV.UK Notify
 
 [GOV.UK Notify](https://www.notifications.service.gov.uk/ "GOV.UK Notify") is a government service that allows teams across government to send emails, text messages and sometimes paper at a considerably lower cost than standard providers.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -62,6 +62,11 @@ Rails.application.configure do
 
   config.x.email_domain.suffix = '@test.test'
 
+  unless ENV['RAILS_ENABLE_TEST_LOG']
+    config.logger = Logger.new(nil)
+    config.log_level = :fatal
+  end
+
   # Dummy url for provider details api
   config.x.provider_details.url = 'http://dummy-provider-details-api/'
 


### PR DESCRIPTION
## Reduce log pollution in the testing environment

- Set the log_level to fatal which logs when something happens that causes the application to crash. This reduces log pollution and speeds up testing.

- Create an environment variable ENV['RAILS_ENABLE_TEST_LOG'] to allow default logging in the test environment e.g.
`RAILS_ENABLE_TEST_LOG=1 rspec ./spec`

- Update readme

resources: https://jtway.co/speed-up-your-rails-test-suite-by-6-in-1-line-13fedb869ec4


## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
