### PR TITLE
AP-1967: Initial fix for mean summary CYA page for non passported jou…

### DIFF
--- a/app/views/shared/check_answers/_assets.html.erb
+++ b/app/views/shared/check_answers/_assets.html.erb
@@ -9,30 +9,75 @@
 <section class="print-no-break">
   <%= render 'shared/check_answers/vehicles', read_only: read_only %>
 
-  <% if @legal_aid_application.non_passported? &&  @legal_aid_application.offline_savings? %>
-    <h2 class="govuk-heading-m"><%= t('.assets.offline_accounts') %></h2>
-    <dl class="govuk-summary-list govuk-!-margin-bottom-9">
+  <% if @legal_aid_application.non_passported? %>
+    <% if read_only %>
+      <h2 class="govuk-heading-m"><%= t('.assets.bank_accounts') %></h2>
+      <dl class="govuk-summary-list govuk-!-margin-bottom-9">
 
-      <%= check_answer_link(
-              name: :offline_accounts,
+        <%= check_answer_link(
+              name: :online_current_accounts,
               url: check_answer_url_for(journey_type, :applicant_bank_accounts, @legal_aid_application),
+              question: t('.assets.current_account'),
+              answer: online_current_accounts ? gds_number_to_currency(online_current_accounts) : t('generic.none_declared'),
+              read_only: read_only,
+            ) %>
+        <%= check_answer_link(
+              name: :online_savings_accounts,
+              url: check_answer_url_for(journey_type, :applicant_bank_accounts, @legal_aid_application),
+              question: t('.assets.savings_account'),
+              answer: online_savings_accounts ? gds_number_to_currency(online_savings_accounts) : t('generic.none_declared'),
+              read_only: read_only,
+            ) %>
+      </dl>
+    <% end %>
+
+    <div class="govuk-grid-row" id="app-check-your-answers__has_offline_savings_account_header">
+      <div class="govuk-grid-column-two-thirds">
+        <h2 class="govuk-heading-m"><%= t('.assets.has_offline_savings_account') %></h2>
+      </div>
+    </div>
+
+    <dl class="govuk-summary-list govuk-!-margin-bottom-9">
+    <%= check_answer_link(
+          name: :has_offline_savings_account,
+          url: check_answer_url_for(journey_type, :applicant_bank_accounts, @legal_aid_application),
+          question: t('.assets.has_offline_savings_account'),
+          answer: yes_no(@legal_aid_application.offline_savings?),
+          read_only: read_only,
+        ) %>
+    </dl>
+
+    <% if @legal_aid_application.offline_savings? %>
+      <div class="govuk-grid-row" id="app-check-your-answers__offline_savings_account_header">
+        <div class="govuk-grid-column-two-thirds">
+          <h2 class="govuk-heading-m"><%= t('.assets.offline_savings') %></h2>
+        </div>
+      </div>
+
+      <dl class="govuk-summary-list govuk-!-margin-bottom-9">
+        <%= check_answer_link(
+              name: :offline_savings_accounts,
+              url: check_answer_url_for(journey_type, :offline_savings_accounts, @legal_aid_application),
               question: t('.assets.offline_savings'),
               answer: gds_number_to_currency(@legal_aid_application.offline_savings_value),
               read_only: read_only,
-          ) %>
-    </dl>
-  <% end %>
+            ) %>
+      </dl>
+    <% end %>
+  <% else %>
 
-  <%= check_answer_one_change_link(
-        name: :bank_accounts,
-        url: check_answer_url_for(journey_type, :offline_accounts, @legal_aid_application),
-        question: t('.assets.bank_accounts'),
-        answer_hash: capital_accounts_list(
-          @legal_aid_application.savings_amount,
-          locale_namespace: "shared.forms.revealing_checkbox.attribute.#{journey_type}.savings_and_investments.check_box_"
-        ),
-        read_only: read_only
-      ) %>
+    <%= check_answer_one_change_link(
+          name: :bank_accounts,
+          url: check_answer_url_for(journey_type, :offline_accounts, @legal_aid_application),
+          question: t('.assets.bank_accounts'),
+          answer_hash: capital_accounts_list(
+            @legal_aid_application.savings_amount,
+            locale_namespace: "shared.forms.revealing_checkbox.attribute.#{journey_type}.savings_and_investments.check_box_"
+          ),
+          read_only: read_only
+        ) %>
+
+  <% end %>
 
   <%= check_answer_one_change_link(
         name: :savings_and_investments,
@@ -45,26 +90,6 @@
         read_only: read_only
       ) %>
 
-  <% if read_only &&  @legal_aid_application.non_passported? %>
-    <dl class="govuk-summary-list govuk-!-margin-bottom-9">
-
-      <%= check_answer_link(
-              name: :online_current_accounts,
-              url: check_answer_url_for(journey_type, :applicant_bank_accounts, @legal_aid_application),
-              question: t('.assets.current_account'),
-              answer: online_current_accounts ? gds_number_to_currency(online_current_accounts) : t('generic.none_declared'),
-              read_only: read_only,
-          ) %>
-        <%= check_answer_link(
-              name: :online_savings_accounts,
-              url: check_answer_url_for(journey_type, :applicant_bank_accounts, @legal_aid_application),
-              question: t('.assets.savings_account'),
-              answer: online_savings_accounts ? gds_number_to_currency(online_savings_accounts) : t('generic.none_declared'),
-              read_only: read_only,
-          ) %>
-    </dl>
-
-  <% end %>
   <%= check_answer_one_change_link(
         name: :other_assets,
         url: check_answer_url_for(journey_type, :other_assets, @legal_aid_application),

--- a/config/locales/en/shared.yml
+++ b/config/locales/en/shared.yml
@@ -112,6 +112,7 @@ en:
     check_answers:
       assets:
         assets:
+          has_offline_savings_account: Does your client have any savings accounts they cannot access online?
           property-heading: Property
           offline_accounts: Your client's bank accounts
           offline_savings: Savings accounts your client cannot access online

--- a/spec/factories/legal_aid_applications.rb
+++ b/spec/factories/legal_aid_applications.rb
@@ -32,6 +32,7 @@ FactoryBot.define do
         state_machine = FactoryBot.build(:non_passported_state_machine, legal_aid_application: application)
         application.update!(state_machine: state_machine)
       end
+      non_passported
     end
 
     trait :with_passported_state_machine do
@@ -39,6 +40,7 @@ FactoryBot.define do
         state_machine = FactoryBot.build(:passported_state_machine, legal_aid_application: application)
         application.update!(state_machine: state_machine)
       end
+      passported
     end
 
     trait :initiated do

--- a/spec/requests/providers/substantive_applications_spec.rb
+++ b/spec/requests/providers/substantive_applications_spec.rb
@@ -1,7 +1,8 @@
 require 'rails_helper'
 RSpec.describe Providers::UsedDelegatedFunctionsController, type: :request, vcr: { cassette_name: 'gov_uk_bank_holiday_api' } do
+  let(:state) { :with_passported_state_machine }
   let(:legal_aid_application) do
-    create :legal_aid_application, :with_passported_state_machine, :applicant_details_checked, used_delegated_functions_on: 1.day.ago, applicant: applicant
+    create :legal_aid_application, state, :applicant_details_checked, used_delegated_functions_on: 1.day.ago, applicant: applicant
   end
 
   let(:applicant) { create :applicant, :not_employed }
@@ -29,6 +30,7 @@ RSpec.describe Providers::UsedDelegatedFunctionsController, type: :request, vcr:
   end
 
   describe 'PATCH /providers/applications/:legal_aid_application_id/substantive_application' do
+    let(:state) { :with_non_passported_state_machine }
     let(:substantive_application) { true }
     let(:params) do
       {

--- a/spec/services/reports/reports_creator_spec.rb
+++ b/spec/services/reports/reports_creator_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Reports::ReportsCreator do
-  let(:legal_aid_application) { create :legal_aid_application, :with_proceeding_types, :with_positive_benefit_check_result, :with_everything, :generating_reports }
+  let(:legal_aid_application) { create :legal_aid_application, :with_proceeding_types, :with_everything, :with_passported_state_machine, :generating_reports }
 
   subject { described_class.call(legal_aid_application) }
 


### PR DESCRIPTION
…rneys


## What

[AP-1967](https://dsdmoj.atlassian.net/browse/AP-1967)

Updated the means summary CYA page to ensure offline bank accounts is revealed for the passported journey only and to reveal the 'Do you have any offline savings' question so the user can change their answer. I've initially put in more hardcoded html for the headers but if there is a better way using the check_answer_link erb partials then please let me know, it was to ensure the styling was consistent. I wasn't splitting hairs on it too much as it might be this page is updated when the new formbuilder is implemented anyway.

Also, it appears the factory traits that generate an application with a passported or non_passported state do not update the benefit_check_result which ensures `legal_aid_application.non_passported?` is set to the right thing. For now, the simplest fix I could find was to include the `passported` and `non_passported` traits with the `:with_passported_state_machine` and `:with_non_passported_state_machine` traits respectively. This actually flagged a couple of tests which hadn't been setup properly which were only passing because the bug with `non_passported?`. Whether or not there is a better solution or this is fine for now, please let me know.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
