### PR TITLE
AP-1976 fix silencing logs around certain functions

### DIFF
--- a/app/services/true_layer/importers/import_accounts_service.rb
+++ b/app/services/true_layer/importers/import_accounts_service.rb
@@ -25,7 +25,9 @@ module TrueLayer
           account.bank_transactions.clear
         end
         bank_provider.bank_accounts.clear
-        bank_provider.bank_accounts.create!(mapped_resources)
+        ActiveRecord::Base.logger.silence do
+          bank_provider.bank_accounts.create!(mapped_resources)
+        end
       end
 
       def mapped_resources

--- a/app/services/true_layer/importers/import_provider_service.rb
+++ b/app/services/true_layer/importers/import_provider_service.rb
@@ -26,7 +26,9 @@ module TrueLayer
         bank_provider = applicant.bank_providers.find_or_create_by!(
           true_layer_provider_id: provider[:provider][:provider_id]
         )
-        bank_provider.update!(mapped_resource)
+        ActiveRecord::Base.logger.silence do
+          bank_provider.update!(mapped_resource)
+        end
         bank_provider
       end
 

--- a/app/services/true_layer/importers/import_transactions_service.rb
+++ b/app/services/true_layer/importers/import_transactions_service.rb
@@ -15,7 +15,9 @@ module TrueLayer
           errors.add(:import_transactions, true_layer_error)
         else
           bank_account.bank_transactions.clear
-          bank_account.bank_transactions.create!(mapped_resources)
+          ActiveRecord::Base.logger.silence do
+            bank_account.bank_transactions.create!(mapped_resources)
+          end
         end
       end
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -63,7 +63,7 @@ Rails.application.configure do
   config.x.email_domain.suffix = '@test.test'
 
   unless ENV['RAILS_ENABLE_TEST_LOG']
-    config.logger = Logger.new(nil)
+    config.logger = ActiveSupport::Logger.new(nil)
     config.log_level = :fatal
   end
 


### PR DESCRIPTION
## AP-1976 fix silencing logs around certain functions

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1976)

- There's no need for the level of detail in the logs to see bank info so silence the logs around it.

- Silence logs around bank info.

- Update the test environment to use the defualt logger ActiveSupport::Logger as it includes the #silence method needed to carry out the above tests.


## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
