### PR TITLE
AP-1991 Shift the citizen completed means mailer to a later stage

### DIFF
--- a/app/controllers/citizens/check_answers_controller.rb
+++ b/app/controllers/citizens/check_answers_controller.rb
@@ -27,7 +27,6 @@ module Citizens
     end
 
     def send_emails
-      ProviderEmailService.new(legal_aid_application).send_email
       CitizenCompletionEmailService.new(legal_aid_application).send_email
     end
   end

--- a/app/jobs/bank_transactions_analyser_job.rb
+++ b/app/jobs/bank_transactions_analyser_job.rb
@@ -2,5 +2,6 @@ class BankTransactionsAnalyserJob < ActiveJob::Base
   def perform(legal_aid_application)
     StateBenefitAnalyserService.call(legal_aid_application)
     legal_aid_application.complete_bank_transaction_analysis!
+    ProviderEmailService.new(legal_aid_application).send_email if legal_aid_application.provider_assessing_means?
   end
 end

--- a/spec/jobs/bank_transactions_analyser_job_spec.rb
+++ b/spec/jobs/bank_transactions_analyser_job_spec.rb
@@ -2,6 +2,13 @@ require 'rails_helper'
 
 RSpec.describe BankTransactionsAnalyserJob, type: :job do
   let(:legal_aid_application) { create :legal_aid_application, :with_non_passported_state_machine, :analysing_bank_transactions }
+  let(:provider_email_service) { double(ProviderEmailService, send_email: true) }
+
+  before do
+    allow(StateBenefitAnalyserService).to receive(:call).with(legal_aid_application)
+    allow(ProviderEmailService).to receive(:new).with(legal_aid_application).and_return(provider_email_service)
+  end
+
   subject { described_class.perform_now(legal_aid_application) }
 
   describe '#perform' do
@@ -14,6 +21,25 @@ RSpec.describe BankTransactionsAnalyserJob, type: :job do
       allow(StateBenefitAnalyserService).to receive(:call).with(legal_aid_application)
       subject
       expect(legal_aid_application.reload.state).to eq('provider_assessing_means')
+    end
+
+    context 'transactions analysis' do
+      context 'pending' do
+        before do
+          allow_any_instance_of(NonPassportedStateMachine).to receive(:aasm_state).and_return('analysing_bank_transactions')
+        end
+
+        it 'does not call ProviderEmailService' do
+          expect(provider_email_service).not_to receive(:send_email)
+          subject
+        end
+      end
+      context 'complete' do
+        it 'calls ProviderEmailService' do
+          expect(provider_email_service).to receive(:send_email)
+          subject
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Shift the citizen completed means mailer to a later stage

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1991)

We send the citizen completed means to the provider before the appliction has completed submission as in completed the bank transaction analyser job

This means the provider won't think to continue on with an application with the wrong state


## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
