### PR TITLE
AP-1962 Remove overriden ccms_submission method

### DIFF
--- a/app/models/concerns/base_state_machine.rb
+++ b/app/models/concerns/base_state_machine.rb
@@ -119,7 +119,9 @@ class BaseStateMachine < ApplicationRecord  # rubocop:disable Metrics/ClassLengt
 
     event :generated_reports do
       transitions from: :generating_reports, to: :submitting_assessment,
-                  after: proc { |legal_aid_application| legal_aid_application.ccms_submission.process_async! if Rails.configuration.x.ccms_soa.submit_applications_to_ccms }
+                  after: proc { |legal_aid_application|
+                           legal_aid_application.find_or_create_ccms_submission.process_async! if Rails.configuration.x.ccms_soa.submit_applications_to_ccms
+                         }
     end
 
     event :submitted_assessment do

--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -348,9 +348,9 @@ class LegalAidApplication < ApplicationRecord
     lead_proceeding_type.default_cost_limitation_delegated_functions
   end
 
-  def ccms_submission
-    create_ccms_submission! unless super
-    super
+  def find_or_create_ccms_submission
+    create_ccms_submission! unless ccms_submission
+    ccms_submission
   end
 
   def ccms_submission_date

--- a/spec/models/legal_aid_application_spec.rb
+++ b/spec/models/legal_aid_application_spec.rb
@@ -691,7 +691,7 @@ RSpec.describe LegalAidApplication, type: :model do
     before { allow(Rails.configuration.x.ccms_soa).to receive(:submit_applications_to_ccms).and_return(submit_applications_to_ccms) }
 
     it 'starts the ccms submission process' do
-      expect(legal_aid_application.ccms_submission).to receive(:process_async!)
+      expect(legal_aid_application.find_or_create_ccms_submission).to receive(:process_async!)
       legal_aid_application.generated_reports!
     end
 
@@ -699,7 +699,7 @@ RSpec.describe LegalAidApplication, type: :model do
       let(:submit_applications_to_ccms) { false }
 
       it 'does not start the ccms submission process' do
-        expect(legal_aid_application.ccms_submission).not_to receive(:process_async!)
+        expect(legal_aid_application.find_or_create_ccms_submission).not_to receive(:process_async!)
         legal_aid_application.generated_reports!
       end
     end

--- a/spec/requests/admin/legal_aid_applications/submissions_controller_spec.rb
+++ b/spec/requests/admin/legal_aid_applications/submissions_controller_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Admin::LegalAidApplications::SubmissionsController, type: :request do
   let(:admin_user) { create :admin_user }
-  let(:legal_aid_application) { create(:legal_aid_application, :with_everything) }
+  let(:legal_aid_application) { create(:legal_aid_application, :with_everything, :with_ccms_submission) }
 
   before { sign_in admin_user }
 
@@ -17,6 +17,15 @@ RSpec.describe Admin::LegalAidApplications::SubmissionsController, type: :reques
     it 'displays correct application' do
       subject
       expect(response.body).to include(legal_aid_application.application_ref)
+    end
+
+    context 'when no ccms submission exists' do
+      let(:legal_aid_application) { create(:legal_aid_application, :with_everything) }
+
+      it 'does not display submission data' do
+        subject
+        expect(response.body).not_to include('CCMS Submission')
+      end
     end
   end
 

--- a/spec/requests/admin/submitted_applications_reports_spec.rb
+++ b/spec/requests/admin/submitted_applications_reports_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Admin::SubmittedApplicationsReportsController, type: :request do
   let(:count) { 3 }
-  let!(:legal_aid_applications) { create_list :legal_aid_application, count, :with_applicant, :submitted_to_ccms }
+  let!(:legal_aid_applications) { create_list :legal_aid_application, count, :with_applicant, :with_ccms_submission, :submitted_to_ccms }
   let!(:unsubmitted_application) { create :legal_aid_application, :with_applicant }
   let(:admin_user) { create :admin_user }
   let(:params) { {} }

--- a/spec/services/reports/reports_creator_spec.rb
+++ b/spec/services/reports/reports_creator_spec.rb
@@ -1,7 +1,14 @@
 require 'rails_helper'
 
 RSpec.describe Reports::ReportsCreator do
-  let(:legal_aid_application) { create :legal_aid_application, :with_proceeding_types, :with_everything, :with_passported_state_machine, :generating_reports }
+  let(:legal_aid_application) do
+    create :legal_aid_application,
+           :with_proceeding_types,
+           :with_ccms_submission,
+           :with_everything,
+           :with_passported_state_machine,
+           :generating_reports
+  end
 
   subject { described_class.call(legal_aid_application) }
 
@@ -20,6 +27,7 @@ RSpec.describe Reports::ReportsCreator do
         create :legal_aid_application,
                :with_proceeding_types,
                :with_everything,
+               :with_ccms_submission,
                :with_benefits_transactions,
                :with_uncategorised_credit_transactions,
                :generating_reports


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1962)

The legal_aid_application model overrides the default ccms_submission method, causing it to create a new submission when it is called (if one doesn't already exist)

- remove the method 
- fix some tests which break as a result

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
