### PR TITLE
AP-1988: Fix redirect from check provider answers page to forward to …

### DIFF
--- a/app/controllers/providers/check_provider_answers_controller.rb
+++ b/app/controllers/providers/check_provider_answers_controller.rb
@@ -3,7 +3,7 @@ module Providers
     include PreDWPCheckVisible
 
     def index
-      return redirect_to_means_summary if legal_aid_application.provider_assessing_means?
+      return redirect_to_client_completed_means if legal_aid_application.provider_assessing_means?
 
       set_variables
       legal_aid_application.check_applicant_details! unless status_change_not_required?
@@ -29,8 +29,8 @@ module Providers
 
     # This handles the situation where a provider is viewing providers/applications and a citizens completes their
     # journey - causing the link to the application to be out of step with the provider step.
-    def redirect_to_means_summary
-      redirect_to providers_legal_aid_application_means_summary_path(legal_aid_application)
+    def redirect_to_client_completed_means
+      redirect_to providers_legal_aid_application_client_completed_means_path(legal_aid_application)
     end
 
     def status_change_not_required?

--- a/spec/requests/providers/check_provider_answers_spec.rb
+++ b/spec/requests/providers/check_provider_answers_spec.rb
@@ -152,8 +152,8 @@ RSpec.describe Providers::CheckProviderAnswersController, type: :request do
 
       context 'when client has completed their journey' do
         let(:application) { create(:legal_aid_application, :with_proceeding_types, :with_applicant_and_address, :with_non_passported_state_machine, :provider_assessing_means) }
-        it 'redirects to means summary' do
-          expect(response).to redirect_to(providers_legal_aid_application_means_summary_path(application))
+        it 'redirects to client completed means page' do
+          expect(response).to redirect_to(providers_legal_aid_application_client_completed_means_path(application))
         end
       end
     end


### PR DESCRIPTION
…client completed means page


## What

[AP-1988](https://dsdmoj.atlassian.net/browse/AP-1988)

Bug fix redirect from check provider answers page to forward to client completed means page

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
