### PR TITLE
AP-1955 Reduce size of statement of case uploads

### DIFF
--- a/app/forms/statement_of_cases/statement_of_case_form.rb
+++ b/app/forms/statement_of_cases/statement_of_case_form.rb
@@ -6,7 +6,7 @@ module StatementOfCases
 
     attr_accessor :statement, :original_file, :provider_uploader, :upload_button_pressed
 
-    MAX_FILE_SIZE = 8.megabytes
+    MAX_FILE_SIZE = 7.megabytes
 
     ALLOWED_CONTENT_TYPES = %w[
       application/pdf

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -635,7 +635,7 @@ en:
         bullet-4: why the proceedings are necessary
         bullet-5: if anyone else might be able to fund the case
         h1-heading: Provide a statement of case
-        size_hint: The maximum file size is 8MB. You can attach more than one file.
+        size_hint: The maximum file size is 7MB. You can attach more than one file.
         warning: Warning
         warning_text: You must provide a complete statement now. You will not be able to upload a statement later.
       uploaded_files:


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1955)

Users are currently able to upload statement of case files up to 8mb in size. This can cause issues after base64 encoding - there is a 10mb limit on the AWS gateway, and encoded files can exceed that limit.

This amends the `StatementOfCase` model to reduce the permitted file size to 7mb, which is hopefully low enough to prevent the 10mb limit being hit.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
