### PR TITLE
BUGFIX - Don't send details for current account to CFE when nil

### DIFF
--- a/app/services/cfe/create_capitals_service.rb
+++ b/app/services/cfe/create_capitals_service.rb
@@ -81,6 +81,8 @@ module CFE
       items = []
       field_names_and_descriptions.each do |field_name, field_description|
         value = model.__send__(field_name)
+        next if value.nil?
+
         items << description_and_value(field_description, value) if not_nil_or_zero?(value)
       end
       items


### PR DESCRIPTION
## DOn't send current account details to CFE when nil

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1993)

CFE is failing if on the non-passported journey the provider says yes to "Does your client have any savings account your client cannot access on-line".  

This is because in the non-passported journey, we only ask for savings account, not current account, so that field remains nil.  This value of nil was being sent to CFE, which rejected it as invalid.

The solution is not to send details of any field which is nil.


## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
