### PR TITLE
BUGFIX - test savings account balance not current account balance

### DIFF
--- a/app/services/cfe/create_capitals_service.rb
+++ b/app/services/cfe/create_capitals_service.rb
@@ -63,7 +63,7 @@ module CFE
     end
 
     def savings_account_balance
-      return unless legal_aid_application.online_current_accounts_balance.present?
+      return unless legal_aid_application.online_savings_accounts_balance.present?
 
       {
         description: 'Online savings accounts',


### PR DESCRIPTION
## FIX LIVE BUG

The code was testing `current_account_balance` for nil in order to decide whether or not to include `savings_account_balance` in the CFE payload for capital.  It should of course be testing `savings_account_balance`.  This bug was causing savings account balance of nil to be sent to CFE which caused a validation error.




## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
