### PR TITLE
AP-1990 remove jQuery from checkbox_control.js

### DIFF
--- a/app/views/providers/other_assets/_form.html.erb
+++ b/app/views/providers/other_assets/_form.html.erb
@@ -1,9 +1,8 @@
 <%= form_with(builder: GOVUKDesignSystemFormBuilder::FormBuilder, model: model, url: url, method: :patch, local: true) do |form| %>
 
-    <%= form.govuk_fieldset legend: {size: 'xl', tag: 'h1', text: page_title}, described_by: 'select-all-that-apply-hint' do %>
-
-    <span id="select-all-that-apply-hint" class="govuk-hint"><%= t('generic.select_all_that_apply') %></span>
-
+    <%= form.govuk_check_boxes_fieldset :other_assets,
+                                        legend: { text: page_title, size: "xl", tag: 'h1'},
+                                        hint: { text: t('generic.select_all_that_apply')} do %>
     <div class="govuk-checkboxes" data-module="govuk-checkboxes">
       <div class="deselect-group" data-deselect-ctrl="#other-assets-declaration-none-selected-true-field">
       <%= render partial: '/shared/forms/revealing_checkbox/attribute',

--- a/app/views/providers/other_assets/_form.html.erb
+++ b/app/views/providers/other_assets/_form.html.erb
@@ -5,7 +5,7 @@
     <span id="select-all-that-apply-hint" class="govuk-hint"><%= t('generic.select_all_that_apply') %></span>
 
     <div class="govuk-checkboxes" data-module="govuk-checkboxes">
-      <div class="deselect-group" data-deselect-ctrl="#other_assets_declaration_none_selected">
+      <div class="deselect-group" data-deselect-ctrl="#other-assets-declaration-none-selected-true-field">
       <%= render partial: '/shared/forms/revealing_checkbox/attribute',
                  collection: Citizens::OtherAssetsForm::VALUABLE_ITEMS_VALUE_ATTRIBUTE,
                  locals: { model: model, form: form } %>

--- a/app/views/providers/other_assets/_form.html.erb
+++ b/app/views/providers/other_assets/_form.html.erb
@@ -5,7 +5,7 @@
     <span id="select-all-that-apply-hint" class="govuk-hint"><%= t('generic.select_all_that_apply') %></span>
 
     <div class="govuk-checkboxes" data-module="govuk-checkboxes">
-      <div class="deselect-group" data-deselect-ctrl="[name='other_assets_declaration[none_selected]']">
+      <div class="deselect-group" data-deselect-ctrl="#other_assets_declaration_none_selected">
       <%= render partial: '/shared/forms/revealing_checkbox/attribute',
                  collection: Citizens::OtherAssetsForm::VALUABLE_ITEMS_VALUE_ATTRIBUTE,
                  locals: { model: model, form: form } %>

--- a/app/views/shared/forms/_offline_accounts_form.html.erb
+++ b/app/views/shared/forms/_offline_accounts_form.html.erb
@@ -11,14 +11,14 @@
                                    legend: { text: page_title, size: "xl" },
                                    hint: { text: t('generic.select_all_that_apply')} do %>
     <div class="govuk-checkboxes" data-module="govuk-checkboxes">
-      <div class="deselect-group" data-deselect-ctrl="#savings_amount_no_account_selected">
+      <div class="deselect-group" data-deselect-ctrl="#savings-amount-no-account-selected-true-field">
         <%= render partial: 'shared/forms/revealing_checkbox/attribute',
                    collection: attributes,
                    locals: { model: @form, form: form } %>
       </div>
     </div>
     <%= form.govuk_radio_divider %>
-    <%= form.govuk_check_box :no_account_selected, true, multiple: false, label: {text: no_account_selected} %>
+    <%= form.govuk_check_box :no_account_selected, true, '', multiple: false, label: {text: no_account_selected} %>
 
   <% end %>
 

--- a/app/views/shared/forms/_offline_accounts_form.html.erb
+++ b/app/views/shared/forms/_offline_accounts_form.html.erb
@@ -8,7 +8,7 @@
         local: true) do |form| %>
 
   <%= form.govuk_check_boxes_fieldset :savings_amount,
-                                   legend: { text: page_title, size: "xl" },
+                                   legend: { text: page_title, size: "xl", tag: 'h1'},
                                    hint: { text: t('generic.select_all_that_apply')} do %>
     <div class="govuk-checkboxes" data-module="govuk-checkboxes">
       <div class="deselect-group" data-deselect-ctrl="#savings-amount-no-account-selected-true-field">

--- a/app/views/shared/forms/_offline_accounts_form.html.erb
+++ b/app/views/shared/forms/_offline_accounts_form.html.erb
@@ -11,7 +11,7 @@
                                    legend: { text: page_title, size: "xl" },
                                    hint: { text: t('generic.select_all_that_apply')} do %>
     <div class="govuk-checkboxes" data-module="govuk-checkboxes">
-      <div class="deselect-group" data-deselect-ctrl="[name='savings_amount[no_account_selected]']">
+      <div class="deselect-group" data-deselect-ctrl="#savings_amount_no_account_selected">
         <%= render partial: 'shared/forms/revealing_checkbox/attribute',
                    collection: attributes,
                    locals: { model: @form, form: form } %>

--- a/app/views/shared/forms/_savings_and_investments_form.html.erb
+++ b/app/views/shared/forms/_savings_and_investments_form.html.erb
@@ -3,7 +3,7 @@
 <%= form_with(builder: GOVUKDesignSystemFormBuilder::FormBuilder, model: @form, url: form_path, method: :patch, local: true) do |form| %>
 
   <%= form.govuk_check_boxes_fieldset :bank_accounts,
-                                      legend: { text: page_title, size: "xl" },
+                                      legend: { text: page_title, size: "xl", tag: 'h1'},
                                       hint: { text: t('generic.select_all_that_apply')} do %>
     <div class="govuk-checkboxes" data-module="govuk-checkboxes">
       <div class="deselect-group" data-deselect-ctrl="#savings-amount-none-selected-true-field">

--- a/app/views/shared/forms/_savings_and_investments_form.html.erb
+++ b/app/views/shared/forms/_savings_and_investments_form.html.erb
@@ -2,31 +2,18 @@
 
 <%= form_with(builder: GOVUKDesignSystemFormBuilder::FormBuilder, model: @form, url: form_path, method: :patch, local: true) do |form| %>
 
-  <%= govuk_form_group show_error_if: @form.errors.present? do %>
-    <fieldset class="govuk-fieldset" aria-describedby="select-all-that-apply-hint">
-      <%= govuk_fieldset_header page_title %>
-      <span id="select-all-that-apply-hint" class="govuk-hint"><%= t('generic.select_all_that_apply') %></span>
-
-      <%= render 'shared/show_errors' unless @form.any_checkbox_checked? %>
-
-      <div class="govuk-checkboxes" data-module="govuk-checkboxes">
-        <div class="deselect-group" data-deselect-ctrl="#savings_amount_none_selected">
-          <%= render partial: 'shared/forms/revealing_checkbox/attribute',
-                     collection: attributes,
-                     locals: { model: @form, form: form } %>
-        </div>
+  <%= form.govuk_check_boxes_fieldset :bank_accounts,
+                                      legend: { text: page_title, size: "xl" },
+                                      hint: { text: t('generic.select_all_that_apply')} do %>
+    <div class="govuk-checkboxes" data-module="govuk-checkboxes">
+      <div class="deselect-group" data-deselect-ctrl="#savings-amount-none-selected-true-field">
+        <%= render partial: 'shared/forms/revealing_checkbox/attribute',
+                   collection: attributes,
+                   locals: { model: @form, form: form } %>
       </div>
-
-      <div class="govuk-radios__divider tickbox_divider"><%= or_break %></div>
-
-      <div class="govuk-checkboxes">
-        <div class="govuk-checkboxes__item">
-          <%= form.check_box :none_selected, { class: 'govuk-checkboxes__input' }, true, '' %>
-          <%= form.label :none_selected, none_selected, class: 'govuk-label govuk-checkboxes__label' %>
-        </div>
-      </div>
-
-    </fieldset>
+    </div>
+    <%= form.govuk_radio_divider %>
+    <%= form.govuk_check_box :none_selected, true, '', multiple: false, label: {text: none_selected} %>
   <% end %>
 
   <%= next_action_buttons(

--- a/app/views/shared/forms/_savings_and_investments_form.html.erb
+++ b/app/views/shared/forms/_savings_and_investments_form.html.erb
@@ -10,7 +10,7 @@
       <%= render 'shared/show_errors' unless @form.any_checkbox_checked? %>
 
       <div class="govuk-checkboxes" data-module="govuk-checkboxes">
-        <div class="deselect-group" data-deselect-ctrl="[name='savings_amount[none_selected]']">
+        <div class="deselect-group" data-deselect-ctrl="#savings_amount_none_selected">
           <%= render partial: 'shared/forms/revealing_checkbox/attribute',
                      collection: attributes,
                      locals: { model: @form, form: form } %>

--- a/app/views/shared/forms/policy_disregards/_form.html.erb
+++ b/app/views/shared/forms/policy_disregards/_form.html.erb
@@ -8,7 +8,7 @@
       <%= render 'shared/show_errors' %>
 
       <div class="govuk-checkboxes" data-module="govuk-checkboxes">
-        <div class="deselect-group" data-deselect-ctrl="[name='policy_disregards[none_selected]']">
+        <div class="deselect-group" data-deselect-ctrl="#policy_disregards_none_selected">
           <% Providers::PolicyDisregardsForm::SINGLE_VALUE_ATTRIBUTES.each do |checkbox| %>
             <div class="govuk-checkboxes__item">
               <%= form.check_box checkbox, { class: 'govuk-checkboxes__input' }, true, '' %>

--- a/app/webpack/src/checkbox_control.js
+++ b/app/webpack/src/checkbox_control.js
@@ -1,4 +1,4 @@
-$(function() {
+document.addEventListener('DOMContentLoaded', event => {
   /*
     Usage:
       Required: A group of checkboxes,
@@ -7,15 +7,16 @@ $(function() {
       Enclose the checkbox group with a div of class "deselect-group"
         and set it's "data-deselect-ctrl" to the jquery identifier for the control checkbox
   */
-  $('.deselect-group').each(function() {
-    const container = $(this)
-    const control = $(container.data('deselect-ctrl'))
-    const checkboxMemory = []
-    const checkboxes = container.find("input:checkbox")
-    const hiddenFieldMemory = []
-    const hideableFields = container.find('.govuk-checkboxes__conditional')
 
-    if(!control.length) return
+  document.querySelectorAll('.deselect-group').forEach((container) => {
+
+    let control = document.querySelector(container.getAttribute('data-deselect-ctrl'));
+
+    let checkboxMemory = [];
+    let checkboxes = container.querySelectorAll('input[type=checkbox]');
+
+    let hiddenFieldMemory = [];
+    let hideableFields = container.querySelectorAll('.govuk-checkboxes__conditional');
 
     /*
       Monitor changes of the control
@@ -26,34 +27,35 @@ $(function() {
       If deselected:
         Set each checkbox based on its remembered state
     */
-    control.change( function() {
-      const controlChecked = this.checked
+
+    control.addEventListener("change", function() {
+      let controlChecked = this.checked;
 
       if (this.checked) {
-        control.prop("checked", true ).val(true)
+        control.checked = true;
+        control.value = true;
       } else {
-        control.prop("checked", false ).val('')
+        control.checked = false;
+        control.value = '';
       }
 
-      checkboxes.each(function(index) {
-        const checkbox = $(this)
+      checkboxes.forEach((checkbox, index) => {
         if(controlChecked) {
-          checkboxMemory[index] = this.checked
-          checkbox.prop("checked", false)
+          checkboxMemory[index] = checkbox.checked;
+          checkbox.checked = false;
         } else {
-          checkbox.prop("checked", checkboxMemory[index])
+          checkbox.checked = checkboxMemory[index];
         }
       })
 
-      hideableFields.each(function (index) {
-        const hideableField = $(this)
+      hideableFields.forEach((hideableField, index) => {
         if (controlChecked) {
-          if (!hideableField.hasClass('govuk-checkboxes__conditional--hidden')) {
-            hideableField.addClass('govuk-checkboxes__conditional--hidden')
-            hiddenFieldMemory[index] = true
+          if (!hideableField.classList.contains('govuk-checkboxes__conditional--hidden')) {
+            hideableField.classList.add('govuk-checkboxes__conditional--hidden');
+            hiddenFieldMemory[index] = true;
           }
         } else if (hiddenFieldMemory[index]){
-            hideableField.removeClass('govuk-checkboxes__conditional--hidden')
+            hideableField.classList.remove('govuk-checkboxes__conditional--hidden');
         }
       })
     })
@@ -62,8 +64,13 @@ $(function() {
       Monitor changes to the checkboxes within the container.
       If one is selected, deselect the control.
     */
-    checkboxes.change( function() {
-      if(this.checked) { control.prop("checked", false ).val(false) }
+    checkboxes.forEach((checkbox) => {
+      checkbox.addEventListener("change", function() {
+        if(checkbox.checked) {
+          control.checked = false;
+          control.value = '';
+        }
+      })
     })
   })
 })

--- a/features/providers/civil_application_journey.feature
+++ b/features/providers/civil_application_journey.feature
@@ -846,6 +846,19 @@ Feature: Civil application journeys
     Then I should be on the "other_assets" page showing "Select if your client has any of these types of assets"
     Then I select "None of these"
     Then I click "Save and continue"
+    Then I should be on a page showing "Check your answers"
+    And I click Check Your Answers Change link for 'policy disregards'
+    Then I should be on a page showing 'schemes or charities'
+    Then I select 'None of these'
+    Then I click 'Save and continue'
+    Then I should be on a page showing "Check your answers"
+    And the answer for 'policy disregards' should be 'None declared'
+    Then I click Check Your Answers Change link for 'policy disregards'
+    And I deselect 'None of these'
+    Then I click 'Save and continue'
+    Then I should be on the 'policy_disregards' page showing 'Select if your client has received any of these payments'
+    Then I select "None of these"
+    Then I click "Save and continue"
 
   @javascript @vcr
   Scenario: I want to change client details after a failed benefit check


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1990)

- Removed jQuery from checkbox_control.js
- Changed the data-deselect-ctrl attribute in some forms so the 'none_selected' checkbox is always selected by id and not name attribute
- Added the policy disregards page to the 'changing checkbox answers via back button' cucumber test

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
