### PR TITLE
AP-1973 Convert substantive form to use new formbuilder

### DIFF
--- a/app/views/providers/substantive_applications/show.html.erb
+++ b/app/views/providers/substantive_applications/show.html.erb
@@ -1,42 +1,27 @@
 <%= page_template page_title: t('.heading'), template: :basic do %>
 
   <%= form_with(
+        builder: GOVUKDesignSystemFormBuilder::FormBuilder,
         model: @form,
         url: providers_legal_aid_application_substantive_application_path,
         method: :patch,
         local: true
       ) do |form| %>
 
-    <%= govuk_form_group show_error_if: @form.errors.present? do %>
-      <fieldset class="govuk-fieldset">
-        <%= govuk_fieldset_header page_title %>
-        <p class="govuk-body govuk-!-padding-top-6 govuk-!-padding-bottom-4">
-          <%= t('.information_on_next_actions') %>
+    <%= form.govuk_radio_buttons_fieldset(:substantive_application,
+                                            legend: { size: 'xl', tag: 'h1', text: page_title}) do %>
+
+      <p class="govuk-body govuk-body govuk-!-padding-top-6 govuk-!-padding-bottom-4">
+        <%= t '.information_on_next_actions' %>
+      </p>
+
+      <%= form.govuk_radio_button :substantive_application, true, label: { text: t('generic.yes') } %>
+
+      <%= form.govuk_radio_button :substantive_application, false, label: { text: t('.no_start_later') } do %>
+        <p class="govuk-body">
+          <%= t('.must_submit_by', deadline: @form.substantive_application_deadline_on) %>
         </p>
-
-        <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios">
-
-          <%= govuk_error_message(form.object.errors[:substantive_application].first) %>
-
-          <%= form.govuk_radio_button(
-                :substantive_application,
-                true,
-                label: t('generic.yes')
-              ) %>
-
-          <%= form.govuk_radio_button(
-                :substantive_application,
-                false,
-                label: t('.no_start_later'),
-                'data-aria-controls' => 'substantive-deadline'
-              ) %>
-          <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="substantive-deadline">
-            <p class="govuk-body">
-              <%= t('.must_submit_by', deadline: @form.substantive_application_deadline_on) %>
-            </p>
-          </div>
-        </div>
-      </fieldset>
+      <% end %>
     <% end %>
 
     <div class="govuk-!-padding-bottom-4"></div>


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1973)

Refactor `/app/views/providers/substantive_applications/show.html.erb` to use the new formbuilder.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
