### PR TITLE
AP-1957 delegated functions date confirmation page

### DIFF
--- a/app/controllers/providers/delegated_functions_dates_controller.rb
+++ b/app/controllers/providers/delegated_functions_dates_controller.rb
@@ -1,0 +1,46 @@
+module Providers
+  class DelegatedFunctionsDatesController < ProviderBaseController
+    include PreDWPCheckVisible
+
+    def show
+      @form = LegalAidApplications::UsedDelegatedFunctionsForm.new(model: legal_aid_application)
+    end
+
+    # def update
+    #   @form = LegalAidApplications::UsedDelegatedFunctionsForm.new(form_params)
+    #   if save_continue_or_draft_and_update_scope_limitations
+    #     submit_application_reminder
+    #   else
+    #     render :show
+    #   end
+    # end
+
+    # private
+
+    # def submit_application_reminder
+    #   return if legal_aid_application.awaiting_applicant?
+    #   return if legal_aid_application.applicant_entering_means?
+    #   return unless @form.model.used_delegated_functions?
+
+    #   SubmitApplicationReminderService.new(legal_aid_application).send_email
+    # end
+
+    # def save_continue_or_draft_and_update_scope_limitations
+    #   return false unless save_continue_or_draft(@form)
+
+    #   AddScopeLimitationService.call(legal_aid_application, :delegated) if @form.model.used_delegated_functions?
+    #   true
+    # end
+
+    # def form_params
+    #   merge_with_model(legal_aid_application) do
+    #     params.require(:legal_aid_application).permit(
+    #       :used_delegated_functions_year,
+    #       :used_delegated_functions_month,
+    #       :used_delegated_functions_day,
+    #       :used_delegated_functions
+    #     )
+    #   end
+    # end
+  end
+end

--- a/app/controllers/providers/delegated_functions_dates_controller.rb
+++ b/app/controllers/providers/delegated_functions_dates_controller.rb
@@ -3,6 +3,7 @@ module Providers
     include PreDWPCheckVisible
 
     def show
+      @used_delegated_functions_on = legal_aid_application.used_delegated_functions_on
       @form = LegalAidApplications::DelegatedFunctionsDateForm.new(model: legal_aid_application)
     end
 

--- a/app/controllers/providers/delegated_functions_dates_controller.rb
+++ b/app/controllers/providers/delegated_functions_dates_controller.rb
@@ -3,11 +3,11 @@ module Providers
     include PreDWPCheckVisible
 
     def show
-      @form = LegalAidApplications::ConfirmDelegatedFunctionsDateForm.new(model: legal_aid_application)
+      @form = LegalAidApplications::DelegatedFunctionsDateForm.new(model: legal_aid_application)
     end
 
     def update
-      @form = LegalAidApplications::ConfirmDelegatedFunctionsDateForm.new(form_params)
+      @form = LegalAidApplications::DelegatedFunctionsDateForm.new(form_params)
       if save_continue_or_draft(@form)
         submit_application_reminder
       else

--- a/app/controllers/providers/delegated_functions_dates_controller.rb
+++ b/app/controllers/providers/delegated_functions_dates_controller.rb
@@ -21,7 +21,6 @@ module Providers
     def submit_application_reminder
       return if legal_aid_application.awaiting_applicant?
       return if legal_aid_application.applicant_entering_means?
-      return unless @form.model.used_delegated_functions?
 
       SubmitApplicationReminderService.new(legal_aid_application).send_email
     end

--- a/app/controllers/providers/delegated_functions_dates_controller.rb
+++ b/app/controllers/providers/delegated_functions_dates_controller.rb
@@ -3,44 +3,37 @@ module Providers
     include PreDWPCheckVisible
 
     def show
-      @form = LegalAidApplications::UsedDelegatedFunctionsForm.new(model: legal_aid_application)
+      @form = LegalAidApplications::ConfirmDelegatedFunctionsDateForm.new(model: legal_aid_application)
     end
 
-    # def update
-    #   @form = LegalAidApplications::UsedDelegatedFunctionsForm.new(form_params)
-    #   if save_continue_or_draft_and_update_scope_limitations
-    #     submit_application_reminder
-    #   else
-    #     render :show
-    #   end
-    # end
+    def update
+      @form = LegalAidApplications::ConfirmDelegatedFunctionsDateForm.new(form_params)
+      if save_continue_or_draft(@form)
+        submit_application_reminder
+      else
+        render :show
+      end
+    end
 
-    # private
+    private
 
-    # def submit_application_reminder
-    #   return if legal_aid_application.awaiting_applicant?
-    #   return if legal_aid_application.applicant_entering_means?
-    #   return unless @form.model.used_delegated_functions?
+    def submit_application_reminder
+      return if legal_aid_application.awaiting_applicant?
+      return if legal_aid_application.applicant_entering_means?
+      return unless @form.model.used_delegated_functions?
 
-    #   SubmitApplicationReminderService.new(legal_aid_application).send_email
-    # end
+      SubmitApplicationReminderService.new(legal_aid_application).send_email
+    end
 
-    # def save_continue_or_draft_and_update_scope_limitations
-    #   return false unless save_continue_or_draft(@form)
-
-    #   AddScopeLimitationService.call(legal_aid_application, :delegated) if @form.model.used_delegated_functions?
-    #   true
-    # end
-
-    # def form_params
-    #   merge_with_model(legal_aid_application) do
-    #     params.require(:legal_aid_application).permit(
-    #       :used_delegated_functions_year,
-    #       :used_delegated_functions_month,
-    #       :used_delegated_functions_day,
-    #       :used_delegated_functions
-    #     )
-    #   end
-    # end
+    def form_params
+      merge_with_model(legal_aid_application) do
+        params.require(:legal_aid_application).permit(
+          :used_delegated_functions_year,
+          :used_delegated_functions_month,
+          :used_delegated_functions_day,
+          :confirm_delegated_functions_date
+        )
+      end
+    end
   end
 end

--- a/app/controllers/providers/used_delegated_functions_controller.rb
+++ b/app/controllers/providers/used_delegated_functions_controller.rb
@@ -14,14 +14,6 @@ module Providers
 
     private
 
-    # def submit_application_reminder
-    #   return if legal_aid_application.awaiting_applicant?
-    #   return if legal_aid_application.applicant_entering_means?
-    #   return unless @form.model.used_delegated_functions?
-
-    #   SubmitApplicationReminderService.new(legal_aid_application).send_email
-    # end
-
     def save_continue_or_draft_and_update_scope_limitations
       return false unless save_continue_or_draft(@form)
 

--- a/app/controllers/providers/used_delegated_functions_controller.rb
+++ b/app/controllers/providers/used_delegated_functions_controller.rb
@@ -8,22 +8,19 @@ module Providers
 
     def update
       @form = LegalAidApplications::UsedDelegatedFunctionsForm.new(form_params)
-      if save_continue_or_draft_and_update_scope_limitations
-        submit_application_reminder
-      else
-        render :show
-      end
+
+      render :show unless save_continue_or_draft_and_update_scope_limitations
     end
 
     private
 
-    def submit_application_reminder
-      return if legal_aid_application.awaiting_applicant?
-      return if legal_aid_application.applicant_entering_means?
-      return unless @form.model.used_delegated_functions?
+    # def submit_application_reminder
+    #   return if legal_aid_application.awaiting_applicant?
+    #   return if legal_aid_application.applicant_entering_means?
+    #   return unless @form.model.used_delegated_functions?
 
-      SubmitApplicationReminderService.new(legal_aid_application).send_email
-    end
+    #   SubmitApplicationReminderService.new(legal_aid_application).send_email
+    # end
 
     def save_continue_or_draft_and_update_scope_limitations
       return false unless save_continue_or_draft(@form)

--- a/app/forms/legal_aid_applications/confirm_delegated_functions_date_form.rb
+++ b/app/forms/legal_aid_applications/confirm_delegated_functions_date_form.rb
@@ -1,0 +1,99 @@
+module LegalAidApplications
+  class ConfirmDelegatedFunctionsDateForm
+    include BaseForm
+    form_for LegalAidApplication
+
+    attr_accessor :used_delegated_functions_year, :used_delegated_functions_month,
+                  :used_delegated_functions_day, :confirm_delegated_functions_date
+    attr_writer :used_delegated_functions_on
+
+    validates :confirm_delegated_functions_date, presence: { unless: :draft? }
+    validates :used_delegated_functions_on, presence: { unless: :date_not_required? }
+    validates :used_delegated_functions_on, date: { not_in_the_future: true }, allow_nil: true
+    validate :date_in_range
+    validates :used_delegated_functions_reported_on, presence: { unless: :date_not_required? }
+
+    after_validation :update_substantive_application_deadline
+
+    def initialize(*args)
+      super
+      attributes[:used_delegated_functions_reported_on] = used_delegated_functions_reported_on
+      set_instance_variables_for_attributes_if_not_set_but_in_model(
+        attrs: date_fields.fields,
+        model_attributes: date_fields.model_attributes
+      )
+    end
+
+    # Note that this method is first called by `validates`.
+    # Without that validation, the functionality in this method will not be called before save
+    def used_delegated_functions_on
+      return model.used_delegated_functions_on unless confirm_delegated_functions_date_selected?
+      return @used_delegated_functions_on if @used_delegated_functions_on.present?
+      return if date_fields.blank?
+      return :invalid if date_fields.partially_complete? || date_fields.form_date_invalid?
+
+      @used_delegated_functions_on = attributes[:used_delegated_functions_on] = date_fields.form_date
+    end
+
+    def used_delegated_functions_reported_on
+      @used_delegated_functions_reported_on = confirm_delegated_functions_date_selected? ? Date.today : nil
+    end
+
+    private
+
+    def date_in_range
+      return if date_not_required? || !datetime?(used_delegated_functions_on)
+      return true if Time.zone.parse(used_delegated_functions_on.to_s) >= Date.current.ago(12.months)
+
+      add_date_in_range_error
+    end
+
+    def datetime?(value)
+      value.methods.include? :strftime
+    end
+
+    def add_date_in_range_error
+      translation_path = 'activemodel.errors.models.legal_aid_application.attributes.used_delegated_functions_on.date_not_in_range'
+      errors.add(:confirm_delegated_functions_date, I18n.t(translation_path, months: Time.zone.now.ago(12.months).strftime('%d %m %Y')))
+    end
+
+    def date_not_required?
+      !confirm_delegated_functions_date_selected? || draft_and_not_partially_complete_date?
+    end
+
+    def confirm_delegated_functions_date_selected?
+      ActiveModel::Type::Boolean.new.cast(confirm_delegated_functions_date)
+    end
+
+    def exclude_from_model
+      date_fields.fields << :confirm_delegated_functions_date
+    end
+
+    def draft_and_not_partially_complete_date?
+      draft? && !date_fields.partially_complete?
+    end
+
+    def delete_existing_date
+      model.used_delegated_functions_on = nil
+    end
+
+    def date_fields
+      @date_fields ||= DateFieldBuilder.new(
+        form: self,
+        model: model,
+        method: :used_delegated_functions_on,
+        prefix: :used_delegated_functions_
+      )
+    end
+
+    def substantive_application_deadline
+      return unless used_delegated_functions_on && used_delegated_functions_on != :invalid
+
+      SubstantiveApplicationDeadlineCalculator.call self
+    end
+
+    def update_substantive_application_deadline
+      model.substantive_application_deadline_on = substantive_application_deadline
+    end
+  end
+end

--- a/app/forms/legal_aid_applications/delegated_functions_date_form.rb
+++ b/app/forms/legal_aid_applications/delegated_functions_date_form.rb
@@ -36,7 +36,7 @@ module LegalAidApplications
     end
 
     def used_delegated_functions_reported_on
-      @used_delegated_functions_reported_on = confirm_delegated_functions_date_selected? ? Date.today : nil
+      @used_delegated_functions_reported_on = confirm_delegated_functions_date_selected? ? nil : Date.today
     end
 
     private

--- a/app/forms/legal_aid_applications/delegated_functions_date_form.rb
+++ b/app/forms/legal_aid_applications/delegated_functions_date_form.rb
@@ -1,5 +1,5 @@
 module LegalAidApplications
-  class ConfirmDelegatedFunctionsDateForm
+  class DelegatedFunctionsDateForm
     include BaseForm
     form_for LegalAidApplication
 
@@ -27,7 +27,7 @@ module LegalAidApplications
     # Note that this method is first called by `validates`.
     # Without that validation, the functionality in this method will not be called before save
     def used_delegated_functions_on
-      return model.used_delegated_functions_on unless confirm_delegated_functions_date_selected?
+      return model.used_delegated_functions_on if confirm_delegated_functions_date_selected?
       return @used_delegated_functions_on if @used_delegated_functions_on.present?
       return if date_fields.blank?
       return :invalid if date_fields.partially_complete? || date_fields.form_date_invalid?
@@ -58,7 +58,7 @@ module LegalAidApplications
     end
 
     def date_not_required?
-      !confirm_delegated_functions_date_selected? || draft_and_not_partially_complete_date?
+      confirm_delegated_functions_date_selected? || draft_and_not_partially_complete_date?
     end
 
     def confirm_delegated_functions_date_selected?

--- a/app/forms/legal_aid_applications/delegated_functions_date_form.rb
+++ b/app/forms/legal_aid_applications/delegated_functions_date_form.rb
@@ -73,10 +73,6 @@ module LegalAidApplications
       draft? && !date_fields.partially_complete?
     end
 
-    def delete_existing_date
-      model.used_delegated_functions_on = nil
-    end
-
     def date_fields
       @date_fields ||= DateFieldBuilder.new(
         form: self,

--- a/app/forms/legal_aid_applications/delegated_functions_date_form.rb
+++ b/app/forms/legal_aid_applications/delegated_functions_date_form.rb
@@ -36,7 +36,7 @@ module LegalAidApplications
     end
 
     def used_delegated_functions_reported_on
-      @used_delegated_functions_reported_on = confirm_delegated_functions_date_selected? ? nil : Date.today
+      @used_delegated_functions_reported_on = confirm_delegated_functions_date_selected? ? nil : Time.zone.today
     end
 
     private

--- a/app/services/flow/flows/provider_start.rb
+++ b/app/services/flow/flows/provider_start.rb
@@ -47,6 +47,10 @@ module Flow
         },
         used_delegated_functions: {
           path: ->(application) { urls.providers_legal_aid_application_used_delegated_functions_path(application) },
+          forward: :delegated_functions_date
+        },
+        delegated_functions_date: {
+          path: ->(application) { urls.providers_legal_aid_application_delegated_functions_date_path(application) },
           forward: :limitations
         },
         limitations: {

--- a/app/services/flow/flows/provider_start.rb
+++ b/app/services/flow/flows/provider_start.rb
@@ -47,9 +47,11 @@ module Flow
         },
         used_delegated_functions: {
           path: ->(application) { urls.providers_legal_aid_application_used_delegated_functions_path(application) },
-          forward: :delegated_functions_date
+          forward: ->(application) do
+            application.used_delegated_functions? ? :delegated_functions_dates : :limitations
+          end
         },
-        delegated_functions_date: {
+        delegated_functions_dates: {
           path: ->(application) { urls.providers_legal_aid_application_delegated_functions_date_path(application) },
           forward: :limitations
         },

--- a/app/services/flow/flows/provider_start.rb
+++ b/app/services/flow/flows/provider_start.rb
@@ -48,7 +48,7 @@ module Flow
         used_delegated_functions: {
           path: ->(application) { urls.providers_legal_aid_application_used_delegated_functions_path(application) },
           forward: ->(application) do
-            application.used_delegated_functions_on&.between?(12.months.ago, 1.months.ago) ? :delegated_functions_dates : :limitations
+            application.used_delegated_functions_on&.between?(12.months.ago, 1.month.ago) ? :delegated_functions_dates : :limitations
           end
         },
         delegated_functions_dates: {

--- a/app/services/flow/flows/provider_start.rb
+++ b/app/services/flow/flows/provider_start.rb
@@ -48,7 +48,7 @@ module Flow
         used_delegated_functions: {
           path: ->(application) { urls.providers_legal_aid_application_used_delegated_functions_path(application) },
           forward: ->(application) do
-            application.used_delegated_functions? ? :delegated_functions_dates : :limitations
+            application.used_delegated_functions_on&.between?(12.months.ago, 1.months.ago) ? :delegated_functions_dates : :limitations
           end
         },
         delegated_functions_dates: {

--- a/app/views/providers/delegated_functions_dates/show.html.erb
+++ b/app/views/providers/delegated_functions_dates/show.html.erb
@@ -2,7 +2,7 @@
 
   <%= form_with(
         model: @form,
-        url: providers_legal_aid_application_used_delegated_functions_path,
+        url: providers_legal_aid_application_delegated_functions_date_path,
         method: :patch,
         local: true
       ) do |form| %>
@@ -15,13 +15,13 @@
 
         <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios">
           <%= form.govuk_radio_button(
-                :used_delegated_functions,
+                :confirm_delegated_functions_date,
                 false,
                 label: t('.correct_date')
               ) %>
 
           <%= form.govuk_radio_button(
-                :used_delegated_functions,
+                :confirm_delegated_functions_date,
                 true,
                 label: t('.different_date'),
                 'data-aria-controls' => 'conditional-true'

--- a/app/views/providers/delegated_functions_dates/show.html.erb
+++ b/app/views/providers/delegated_functions_dates/show.html.erb
@@ -1,0 +1,42 @@
+<%= page_template page_title: t('.heading', date: @used_delegated_functions_on), template: :basic do %>
+
+  <%= form_with(
+        model: @form,
+        url: providers_legal_aid_application_used_delegated_functions_path,
+        method: :patch,
+        local: true
+      ) do |form| %>
+
+    <%= govuk_form_group show_error_if: @form.errors.present? do %>
+      <fieldset class="govuk-fieldset">
+        <%= govuk_fieldset_header page_title %>
+
+        <%= render 'shared/show_errors' %>
+
+        <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios">
+          <%= form.govuk_radio_button(
+                :used_delegated_functions,
+                false,
+                label: t('.correct_date')
+              ) %>
+
+          <%= form.govuk_radio_button(
+                :used_delegated_functions,
+                true,
+                label: t('.different_date'),
+                'data-aria-controls' => 'conditional-true'
+              ) %>
+
+          <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-true">
+            <%= date_input_fields prefix: :used_delegated_functions, field_name: :used_delegated_functions_on, form: form, options: number_of_days_ago(5) %>
+          </div>
+        </div>
+      </fieldset>
+
+    <% end %>
+
+    <div class="govuk-!-padding-bottom-4"></div>
+
+    <%= next_action_buttons(show_draft: true, form: form) %>
+  <% end %>
+<% end %>

--- a/app/views/providers/delegated_functions_dates/show.html.erb
+++ b/app/views/providers/delegated_functions_dates/show.html.erb
@@ -16,13 +16,13 @@
         <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios">
           <%= form.govuk_radio_button(
                 :confirm_delegated_functions_date,
-                false,
+                true,
                 label: t('.correct_date')
               ) %>
 
           <%= form.govuk_radio_button(
                 :confirm_delegated_functions_date,
-                true,
+                false,
                 label: t('.different_date'),
                 'data-aria-controls' => 'conditional-true'
               ) %>

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -187,6 +187,8 @@ en:
               not_a_number: *student_error
         legal_aid_application:
           attributes:
+            confirm_delegated_functions_date:
+              blank: Confirm the date you used delegated functions
             has_dependants:
               blank: Select yes if your client has any dependants
             has_restrictions:

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -728,6 +728,11 @@ en:
     used_delegated_functions:
       show:
         heading: Have you used delegated functions?
+    delegated_functions_dates:
+      show:
+        heading: "Confirm you used delegated functions on %{date}"
+        correct_date: This date is correct
+        different_date: I used delegated functions on a different date
     vehicles:
       show:
         heading: Does your client own a vehicle?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -226,6 +226,7 @@ Rails.application.routes.draw do
       end
       resource :means_summary, only: %i[show update]
       resource :used_delegated_functions, only: %i[show update]
+      resource :delegated_functions_date, only: %i[show update]
       resource :use_ccms, only: %i[show]
       resources :use_ccms_employed, only: %i[index]
       resource :substantive_application, only: %i[show update]

--- a/features/providers/civil_application_journey.feature
+++ b/features/providers/civil_application_journey.feature
@@ -237,13 +237,19 @@ Feature: Civil application journeys
     Then I choose 'Yes'
     Then I enter the 'used delegated functions on' date of 2 days ago
     Then I click 'Save and continue'
+    Then I should be on a page showing "Confirm you used delegated functions on" with a date of 2 days ago
+    Then I choose "This date is correct"
+    Then I click 'Save and continue'
     Then I should be on a page showing "What you're applying for"
+    Then I click link "Back"
+    Then I should be on a page showing "Confirm you used delegated functions on" with a date of 2 days ago
+    Then I choose "I used delegated functions on a different date"
+    Then I enter the 'used delegated functions' date of 3 days ago
+    Then I click 'Save and continue'
+    Then I should be on a page showing "What you're applying for"
+    Then I click 'Save and continue'
     Then I should be on a page showing "Covered under an emergency certificate"
     Then I should be on a page showing "Covered under a substantive certificate"
-    Then I click 'Save and continue'
-    Then I should be on a page showing 'Check your answers'
-    Then I should be on a page showing 'Covered under an emergency certificate'
-    Then I should be on a page showing 'Covered under a substantive certificate'
     Then I click 'Save and continue'
     Then I should be on a page showing 'receives benefits that qualify for legal aid'
 

--- a/features/providers/civil_application_journey.feature
+++ b/features/providers/civil_application_journey.feature
@@ -235,14 +235,14 @@ Feature: Civil application journeys
     Then I select a proceeding type and continue
     Then I should be on a page showing 'Have you used delegated functions?'
     Then I choose 'Yes'
-    Then I enter the 'used delegated functions on' date of 2 days ago
+    Then I enter the 'used delegated functions on' date of 35 days ago
     Then I click 'Save and continue'
-    Then I should be on a page showing "Confirm you used delegated functions on" with a date of 2 days ago
+    Then I should be on a page showing "Confirm you used delegated functions on" with a date of 35 days ago
     Then I choose "This date is correct"
     Then I click 'Save and continue'
     Then I should be on a page showing "What you're applying for"
     Then I click link "Back"
-    Then I should be on a page showing "Confirm you used delegated functions on" with a date of 2 days ago
+    Then I should be on a page showing "Confirm you used delegated functions on" with a date of 35 days ago
     Then I choose "I used delegated functions on a different date"
     Then I enter the 'used delegated functions' date of 3 days ago
     Then I click 'Save and continue'

--- a/features/support/steps_helper.rb
+++ b/features/support/steps_helper.rb
@@ -2,6 +2,10 @@ Then('I should be on a page showing {string}') do |title|
   expect(page).to have_content(title)
 end
 
+Then('I should be on a page showing {string} with a date of 2 days ago') do |title|
+  expect(page).to have_content("#{title} #{2.days.ago.strftime('%d %B %Y')}")
+end
+
 Then('I should be on the {string} page showing {string}') do |view_name, title|
   expect(page.current_path).to end_with(view_name)
   expect(page).to have_content(title)

--- a/spec/forms/legal_aid_applications/delegated_functions_date_form_spec.rb
+++ b/spec/forms/legal_aid_applications/delegated_functions_date_form_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe LegalAidApplications::DelegatedFunctionsDateForm, type: :form, vcr: { cassette_name: 'gov_uk_bank_holiday_api' } do
   let(:legal_aid_application) { create :legal_aid_application, used_delegated_functions_on: '12/12/2020' }
   let(:confirm_delegated_functions_date) { true }
-  let(:used_delegated_functions_reported_on) { Date.today }
+  let(:used_delegated_functions_reported_on) { Time.zone.today }
   let(:used_delegated_functions_on) { rand(20).days.ago.to_date }
   let(:day) { used_delegated_functions_on.day }
   let(:month) { used_delegated_functions_on.month }
@@ -85,7 +85,7 @@ RSpec.describe LegalAidApplications::DelegatedFunctionsDateForm, type: :form, vc
       end
 
       context 'when occurred on is in future' do
-        let(:used_delegated_functions_on) { 1.days.from_now.to_date }
+        let(:used_delegated_functions_on) { 1.day.from_now.to_date }
         let(:error_locale) { 'used_delegated_functions_on.date_is_in_the_future' }
 
         it 'is invalid' do
@@ -174,7 +174,7 @@ RSpec.describe LegalAidApplications::DelegatedFunctionsDateForm, type: :form, vc
       end
 
       context 'when occurred on is in future' do
-        let(:used_delegated_functions_on) { 1.days.from_now.to_date }
+        let(:used_delegated_functions_on) { 1.day.from_now.to_date }
         let(:error_locale) { 'used_delegated_functions_on.date_is_in_the_future' }
 
         it 'is invalid' do

--- a/spec/forms/legal_aid_applications/delegated_functions_date_form_spec.rb
+++ b/spec/forms/legal_aid_applications/delegated_functions_date_form_spec.rb
@@ -79,7 +79,8 @@ RSpec.describe LegalAidApplications::DelegatedFunctionsDateForm, type: :form, vc
 
         it 'generates the expected error message' do
           expect(message).not_to match(/^translation missing:/)
-          expect(subject.errors[:confirm_delegated_functions_date].join).to match(I18n.t(error_locale, scope: i18n_scope, months: Time.zone.now.ago(12.months).strftime('%d %m %Y')))
+          expect(subject.errors[:confirm_delegated_functions_date].join).to match(I18n.t(error_locale, scope: i18n_scope,
+                                                                                                       months: Time.zone.now.ago(12.months).strftime('%d %m %Y')))
         end
       end
 
@@ -137,7 +138,6 @@ RSpec.describe LegalAidApplications::DelegatedFunctionsDateForm, type: :form, vc
         end
       end
     end
-
 
     describe '#save_as_draft' do
       let(:confirm_delegated_functions_date) { false }

--- a/spec/forms/legal_aid_applications/delegated_functions_date_form_spec.rb
+++ b/spec/forms/legal_aid_applications/delegated_functions_date_form_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+RSpec.describe LegalAidApplications::DelegatedFunctionsDateForm, type: :form, vcr: { cassette_name: 'gov_uk_bank_holiday_api' } do
+  let(:legal_aid_application) { create :legal_aid_application, used_delegated_functions_on: '12/12/2020' }
+  let(:confirm_delegated_functions_date) { true }
+  let(:used_delegated_functions_reported_on) { Date.today }
+  let(:used_delegated_functions_on) { rand(20).days.ago.to_date }
+  let(:day) { used_delegated_functions_on.day }
+  let(:month) { used_delegated_functions_on.month }
+  let(:year) { used_delegated_functions_on.year }
+  let(:i18n_scope) { 'activemodel.errors.models.legal_aid_application.attributes' }
+  let(:error_locale) { :defined_in_spec }
+  let(:message) { I18n.t(error_locale, scope: i18n_scope) }
+
+  let(:params) do
+    {
+      used_delegated_functions_day: day.to_s,
+      used_delegated_functions_month: month.to_s,
+      used_delegated_functions_year: year.to_s,
+      confirm_delegated_functions_date: :confirm_delegated_functions_date.to_s
+    }
+  end
+
+  subject { described_class.new(params.merge(model: legal_aid_application)) }
+
+  describe '#save' do
+    before do
+      subject.save
+      legal_aid_application.reload
+    end
+
+    it 'does not update the application' do
+      expect(legal_aid_application.used_delegated_functions_on).to eq(Date.parse('12/12/2020'))
+    end
+
+    context 'confirm_delegated_functions_date is false' do
+      let(:confirm_delegated_functions_date) { false }
+
+      it 'updates the application' do
+        expect(legal_aid_application.used_delegated_functions_reported_on).to eq(used_delegated_functions_reported_on)
+        expect(legal_aid_application.used_delegated_functions_on).to eq(used_delegated_functions_on)
+        # expect { subject.save }.to change { legal_aid_application }
+      end
+    end
+  end
+end

--- a/spec/forms/legal_aid_applications/delegated_functions_date_form_spec.rb
+++ b/spec/forms/legal_aid_applications/delegated_functions_date_form_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe LegalAidApplications::DelegatedFunctionsDateForm, type: :form, vc
       used_delegated_functions_day: day.to_s,
       used_delegated_functions_month: month.to_s,
       used_delegated_functions_year: year.to_s,
-      confirm_delegated_functions_date: :confirm_delegated_functions_date.to_s
+      confirm_delegated_functions_date: confirm_delegated_functions_date.to_s
     }
   end
 
@@ -36,10 +36,169 @@ RSpec.describe LegalAidApplications::DelegatedFunctionsDateForm, type: :form, vc
     context 'confirm_delegated_functions_date is false' do
       let(:confirm_delegated_functions_date) { false }
 
-      it 'updates the application' do
-        expect(legal_aid_application.used_delegated_functions_reported_on).to eq(used_delegated_functions_reported_on)
+      context 'edited used delegated functions date' do
+        it 'updates the application' do
+          expect(legal_aid_application.used_delegated_functions_reported_on).to eq(used_delegated_functions_reported_on)
+          expect(legal_aid_application.used_delegated_functions_on).to eq(used_delegated_functions_on)
+        end
+
+        context 'date is exactly 12 months ago' do
+          let(:used_delegated_functions_on) { 12.months.ago }
+
+          it 'is valid' do
+            expect(subject).to be_valid
+          end
+
+          it 'updates the application' do
+            expect(legal_aid_application.used_delegated_functions_on).to eq(used_delegated_functions_on.to_date)
+          end
+        end
+      end
+
+      context 'when date is invalid' do
+        let(:month) { 15 }
+        let(:error_locale) { 'used_delegated_functions_on.date_not_valid' }
+
+        it 'is invalid' do
+          expect(subject).to be_invalid
+        end
+
+        it 'generates the expected error message' do
+          expect(message).not_to match(/^translation missing:/)
+          expect(subject.errors[:used_delegated_functions_on].join).to match(message)
+        end
+      end
+
+      context 'date is older than 12 months ago' do
+        let(:used_delegated_functions_on) { 13.months.ago }
+        let(:error_locale) { 'used_delegated_functions_on.date_not_in_range' }
+
+        it 'is invalid' do
+          expect(subject).to be_invalid
+        end
+
+        it 'generates the expected error message' do
+          expect(message).not_to match(/^translation missing:/)
+          expect(subject.errors[:confirm_delegated_functions_date].join).to match(I18n.t(error_locale, scope: i18n_scope, months: Time.zone.now.ago(12.months).strftime('%d %m %Y')))
+        end
+      end
+
+      context 'when occurred on is in future' do
+        let(:used_delegated_functions_on) { 1.days.from_now.to_date }
+        let(:error_locale) { 'used_delegated_functions_on.date_is_in_the_future' }
+
+        it 'is invalid' do
+          expect(subject).to be_invalid
+        end
+
+        it 'generates the expected error message' do
+          expect(message).not_to match(/^translation missing:/)
+          expect(subject.errors[:used_delegated_functions_on].join).to match(message)
+        end
+      end
+
+      context 'changed the delegated functions date' do
+        let(:legal_aid_application) { create :legal_aid_application, used_delegated_functions_on: rand(20).days.ago.to_date }
+        context 'edited date is blank' do
+          let(:day) { nil }
+          let(:month) { nil }
+          let(:year) { nil }
+          let(:error_locale) { 'used_delegated_functions_on.blank' }
+
+          it 'is invalid' do
+            expect(subject).to be_invalid
+          end
+
+          it 'generates the expected error message' do
+            expect(message).not_to match(/^translation missing:/)
+            expect(subject.errors[:used_delegated_functions_on].join).to match(message)
+          end
+        end
+      end
+
+      context 'with a partial date' do
+        let(:error_locale) { 'used_delegated_functions_on.date_not_valid' }
+        let(:params) do
+          {
+            used_delegated_functions_year: year.to_s,
+            used_delegated_functions_month: '',
+            used_delegated_functions_day: day.to_s,
+            confirm_delegated_functions_date: confirm_delegated_functions_date
+          }
+        end
+
+        it 'is invalid' do
+          expect(subject).to be_invalid
+        end
+
+        it 'generates the expected error message' do
+          expect(message).not_to match(/^translation missing:/)
+          expect(subject.errors[:used_delegated_functions_on].join).to match(message)
+        end
+      end
+    end
+
+
+    describe '#save_as_draft' do
+      let(:confirm_delegated_functions_date) { false }
+
+      before do
+        subject.save_as_draft
+        legal_aid_application.reload
+      end
+
+      it 'updates the legal_aid_application' do
         expect(legal_aid_application.used_delegated_functions_on).to eq(used_delegated_functions_on)
-        # expect { subject.save }.to change { legal_aid_application }
+      end
+
+      context 'when occurred on is invalid' do
+        let(:month) { 15 }
+        let(:error_locale) { 'used_delegated_functions_on.date_not_valid' }
+
+        it 'is invalid' do
+          expect(subject).to be_invalid
+        end
+
+        it 'generates the expected error message' do
+          expect(message).not_to match(/^translation missing:/)
+          expect(subject.errors[:used_delegated_functions_on].join).to match(message)
+        end
+      end
+
+      context 'when occurred on is in future' do
+        let(:used_delegated_functions_on) { 1.days.from_now.to_date }
+        let(:error_locale) { 'used_delegated_functions_on.date_is_in_the_future' }
+
+        it 'is invalid' do
+          expect(subject).to be_invalid
+        end
+
+        it 'generates the expected error message' do
+          expect(message).not_to match(/^translation missing:/)
+          expect(subject.errors[:used_delegated_functions_on].join).to match(message)
+        end
+      end
+
+      context 'without date' do
+        let(:params) { {} }
+        let(:legal_aid_application) { create :legal_aid_application, used_delegated_functions_on: nil }
+
+        it 'is valid' do
+          expect(subject).to be_valid
+        end
+      end
+
+      context 'confirmed the delegated functions date' do
+        let(:confirm_delegated_functions_date) { true }
+
+        before do
+          subject.save_as_draft
+          legal_aid_application.reload
+        end
+
+        it 'does not update the application' do
+          expect(legal_aid_application.used_delegated_functions_on).to eq(Date.parse('12/12/2020'))
+        end
       end
     end
   end

--- a/spec/forms/legal_aid_applications/delegated_functions_date_form_spec.rb
+++ b/spec/forms/legal_aid_applications/delegated_functions_date_form_spec.rb
@@ -139,6 +139,14 @@ RSpec.describe LegalAidApplications::DelegatedFunctionsDateForm, type: :form, vc
       end
     end
 
+    context 'confirm_delegated_functions_date is nil' do
+      let(:confirm_delegated_functions_date) { nil }
+
+      it 'generates the expected error message' do
+        expect(subject.errors[:confirm_delegated_functions_date].join).to match(I18n.t('.confirm_delegated_functions_date.blank', scope: i18n_scope))
+      end
+    end
+
     describe '#save_as_draft' do
       let(:confirm_delegated_functions_date) { false }
 

--- a/spec/requests/providers/delegated_functions_date_spec.rb
+++ b/spec/requests/providers/delegated_functions_date_spec.rb
@@ -54,6 +54,10 @@ RSpec.describe Providers::DelegatedFunctionsDatesController, type: :request, vcr
       expect(response).to redirect_to(providers_legal_aid_application_limitations_path(legal_aid_application))
     end
 
+    it 'sends an email reminder' do
+      expect(SubmitApplicationReminderService).to have_received(:new).with(legal_aid_application)
+    end
+
     context 'when not authenticated' do
       let(:login_provider) { nil }
       it_behaves_like 'a provider not authenticated'
@@ -126,6 +130,10 @@ RSpec.describe Providers::DelegatedFunctionsDatesController, type: :request, vcr
         it 'displays error' do
           expect(response.body).to include('govuk-error-summary')
           expect(response.body).to include(I18n.t('activemodel.errors.models.legal_aid_application.attributes.used_delegated_functions_on.blank'))
+        end
+
+        it 'sends an email reminder' do
+          expect(SubmitApplicationReminderService).not_to have_received(:new).with(legal_aid_application)
         end
       end
     end

--- a/spec/requests/providers/delegated_functions_date_spec.rb
+++ b/spec/requests/providers/delegated_functions_date_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+RSpec.describe Providers::DelegatedFunctionsDatesController, type: :request do
+  let(:legal_aid_application) { create :legal_aid_application }
+  let(:login_provider) { login_as legal_aid_application.provider }
+
+  before do
+    login_provider
+    subject
+  end
+
+  describe 'GET /providers/applications/:legal_aid_application_id/delegated_functions_date' do
+    subject do
+      get providers_legal_aid_application_delegated_functions_date_path(legal_aid_application)
+    end
+
+    it 'renders successfully' do
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end

--- a/spec/requests/providers/delegated_functions_date_spec.rb
+++ b/spec/requests/providers/delegated_functions_date_spec.rb
@@ -49,9 +49,11 @@ RSpec.describe Providers::DelegatedFunctionsDatesController, type: :request do
     end
 
     it 'redirects to the limitations page' do
+      # fill
     end
 
     context 'confirm_delegated_functions_date false' do
+      # fill
     end
   end
 end

--- a/spec/requests/providers/delegated_functions_date_spec.rb
+++ b/spec/requests/providers/delegated_functions_date_spec.rb
@@ -17,4 +17,41 @@ RSpec.describe Providers::DelegatedFunctionsDatesController, type: :request do
       expect(response).to have_http_status(:ok)
     end
   end
+
+  describe 'PATCH /providers/applications/:legal_aid_application_id/delegated_functions_date' do
+    let(:confirm_delegated_functions_date) { true }
+    let(:used_delegated_functions_on) { rand(20).days.ago.to_date }
+    let(:day) { used_delegated_functions_on.day }
+    let(:month) { used_delegated_functions_on.month }
+    let(:year) { used_delegated_functions_on.year }
+    let(:params) do
+      {
+        legal_aid_application: {
+          used_delegated_functions_day: day.to_s,
+          used_delegated_functions_month: month.to_s,
+          used_delegated_functions_year: year.to_s,
+          confirm_delegated_functions_date: confirm_delegated_functions_date.to_s
+        }
+      }
+    end
+    let(:button_clicked) { {} }
+
+    subject do
+      patch(
+        providers_legal_aid_application_delegated_functions_date_path(legal_aid_application),
+        params: params.merge(button_clicked)
+      )
+    end
+
+    it 'does not update the legal aid application' do
+      legal_aid_application.reload
+      expect(legal_aid_application.used_delegated_functions_on).to eq used_delegated_functions_on
+    end
+
+    it 'redirects to the limitations page' do
+    end
+
+    context 'confirm_delegated_functions_date false' do
+    end
+  end
 end

--- a/spec/requests/providers/delegated_functions_date_spec.rb
+++ b/spec/requests/providers/delegated_functions_date_spec.rb
@@ -1,7 +1,8 @@
 require 'rails_helper'
-RSpec.describe Providers::DelegatedFunctionsDatesController, type: :request do
-  let(:legal_aid_application) { create :legal_aid_application }
+RSpec.describe Providers::DelegatedFunctionsDatesController, type: :request, vcr: { cassette_name: 'gov_uk_bank_holiday_api' } do
+  let(:legal_aid_application) { create :legal_aid_application, used_delegated_functions_on: '12/12/2020' }
   let(:login_provider) { login_as legal_aid_application.provider }
+  let(:mocked_email_service) { instance_double(SubmitApplicationReminderService, send_email: {}) }
 
   before do
     login_provider
@@ -36,7 +37,8 @@ RSpec.describe Providers::DelegatedFunctionsDatesController, type: :request do
     end
     let(:button_clicked) { {} }
 
-    subject do
+    before do
+      allow(SubmitApplicationReminderService).to receive(:new).with(legal_aid_application).and_return(mocked_email_service)
       patch(
         providers_legal_aid_application_delegated_functions_date_path(legal_aid_application),
         params: params.merge(button_clicked)
@@ -45,15 +47,142 @@ RSpec.describe Providers::DelegatedFunctionsDatesController, type: :request do
 
     it 'does not update the legal aid application' do
       legal_aid_application.reload
-      expect(legal_aid_application.used_delegated_functions_on).to eq used_delegated_functions_on
+      expect(legal_aid_application.used_delegated_functions_on).to eq Date.parse('12/12/2020')
     end
 
     it 'redirects to the limitations page' do
-      # fill
+      expect(response).to redirect_to(providers_legal_aid_application_limitations_path(legal_aid_application))
     end
 
-    context 'confirm_delegated_functions_date false' do
-      # fill
+    context 'when not authenticated' do
+      let(:login_provider) { nil }
+      it_behaves_like 'a provider not authenticated'
+    end
+
+    context 'edited the delegated functions date' do
+      let(:confirm_delegated_functions_date) { false }
+
+      context 'when date incomplete' do
+        let(:month) { '' }
+
+        it 'renders show' do
+          expect(response).to have_http_status(:ok)
+        end
+
+        it 'displays error' do
+          expect(response.body).to include('govuk-error-summary')
+          expect(response.body).to include(I18n.t('activemodel.errors.models.legal_aid_application.attributes.used_delegated_functions_on.date_not_valid'))
+        end
+      end
+
+      context 'date is not in range' do
+        let(:year) { 2018 }
+        let(:month) { 10 }
+        let(:day) { 1 }
+
+        it 'renders show' do
+          expect(response).to have_http_status(:ok)
+        end
+
+        it 'displays error' do
+          hint_text_date = Time.zone.now.ago(12.months).strftime('%d %m %Y')
+
+          subject
+          translation_path = 'activemodel.errors.models.legal_aid_application.attributes.used_delegated_functions_on.date_not_in_range'
+          expect(response.body).to include(I18n.t(translation_path, months: hint_text_date))
+        end
+      end
+
+      context 'when date contains alpha characters' do
+        let(:params) do
+          {
+            legal_aid_application: {
+              used_delegated_functions_day: day.to_s,
+              used_delegated_functions_month: '5s',
+              used_delegated_functions_year: year.to_s,
+              confirm_delegated_functions_date: confirm_delegated_functions_date.to_s
+            }
+          }
+        end
+        it 'renders show' do
+          expect(response).to have_http_status(:ok)
+        end
+
+        it 'displays error' do
+          expect(response.body).to include('govuk-error-summary')
+          expect(response.body).to include(I18n.t('activemodel.errors.models.legal_aid_application.attributes.used_delegated_functions_on.date_not_valid'))
+        end
+      end
+
+      context 'when date not entered' do
+        let(:day) { '' }
+        let(:month) { '' }
+        let(:year) { '' }
+
+        it 'renders show' do
+          expect(response).to have_http_status(:ok)
+        end
+
+        it 'displays error' do
+          expect(response.body).to include('govuk-error-summary')
+          expect(response.body).to include(I18n.t('activemodel.errors.models.legal_aid_application.attributes.used_delegated_functions_on.blank'))
+        end
+      end
+    end
+
+    context 'Form submitted using Save as draft button' do
+      let(:confirm_delegated_functions_date) { false }
+      let(:button_clicked) { { draft_button: 'Save as draft' } }
+
+      it "redirects provider to provider's applications page" do
+        expect(response).to redirect_to(providers_legal_aid_applications_path)
+      end
+
+      it 'updates the application' do
+        legal_aid_application.reload
+        expect(legal_aid_application.used_delegated_functions_on).to eq used_delegated_functions_on
+      end
+
+      context 'when date incomplete' do
+        let(:month) { '' }
+
+        it 'renders show' do
+          expect(response).to have_http_status(:ok)
+        end
+
+        it 'displays error' do
+          expect(response.body).to include('govuk-error-summary')
+          expect(response.body).to include(I18n.t('activemodel.errors.models.legal_aid_application.attributes.used_delegated_functions_on.date_not_valid'))
+        end
+      end
+
+      context 'when date not entered' do
+        let(:day) { '' }
+        let(:month) { '' }
+        let(:year) { '' }
+
+        it "redirects provider to provider's applications page" do
+          expect(response).to redirect_to(providers_legal_aid_applications_path)
+        end
+
+        it 'does not update the application' do
+          legal_aid_application.reload
+          expect(legal_aid_application.used_delegated_functions_on).to eq(Date.parse('12/12/2020'))
+        end
+      end
+
+      context 'confirmed the delegated functions date and nothing is changed' do
+        let(:confirm_delegated_functions_date) { true }
+
+        it 'does not update the legal aid application' do
+          legal_aid_application.reload
+          expect(legal_aid_application.used_delegated_functions_on).to eq Date.parse('12/12/2020')
+        end
+
+        it "redirects provider to provider's applications page" do
+          expect(response).to redirect_to(providers_legal_aid_applications_path)
+        end
+      end
     end
   end
 end

--- a/spec/requests/providers/used_delegated_functions_spec.rb
+++ b/spec/requests/providers/used_delegated_functions_spec.rb
@@ -88,8 +88,16 @@ RSpec.describe Providers::UsedDelegatedFunctionsController, type: :request, vcr:
       expect(legal_aid_application.used_delegated_functions).to eq(used_delegated_functions)
     end
 
-    it 'redirects to the delegated_functions_date page' do
-      expect(response).to redirect_to(providers_legal_aid_application_delegated_functions_date_path(legal_aid_application))
+    it 'redirects to the limitations page' do
+      expect(response).to redirect_to(providers_legal_aid_application_limitations_path(legal_aid_application))
+    end
+
+    context 'used delegated functions date is between 1 month and 12 months ago' do
+      let(:used_delegated_functions_on) { rand(35..365).days.ago.to_date }
+
+      it 'redirects to the delegated_functions_date page' do
+        expect(response).to redirect_to(providers_legal_aid_application_delegated_functions_date_path(legal_aid_application))
+      end
     end
 
     context 'when not authenticated' do

--- a/spec/requests/providers/used_delegated_functions_spec.rb
+++ b/spec/requests/providers/used_delegated_functions_spec.rb
@@ -90,8 +90,8 @@ RSpec.describe Providers::UsedDelegatedFunctionsController, type: :request, vcr:
       expect(legal_aid_application.used_delegated_functions).to eq(used_delegated_functions)
     end
 
-    it 'redirects to the limitations page' do
-      expect(response).to redirect_to(providers_legal_aid_application_limitations_path(legal_aid_application))
+    it 'redirects to the delegated_functions_date page' do
+      expect(response).to redirect_to(providers_legal_aid_application_delegated_functions_date_path(legal_aid_application))
     end
 
     context 'when not authenticated' do

--- a/spec/requests/providers/used_delegated_functions_spec.rb
+++ b/spec/requests/providers/used_delegated_functions_spec.rb
@@ -2,7 +2,6 @@ require 'rails_helper'
 RSpec.describe Providers::UsedDelegatedFunctionsController, type: :request, vcr: { cassette_name: 'gov_uk_bank_holiday_api' } do
   let(:legal_aid_application) { create :legal_aid_application }
   let(:login_provider) { login_as legal_aid_application.provider }
-  let(:mocked_email_service) { instance_double(SubmitApplicationReminderService, send_email: {}) }
 
   before do
     login_provider
@@ -77,7 +76,6 @@ RSpec.describe Providers::UsedDelegatedFunctionsController, type: :request, vcr:
     let(:button_clicked) { {} }
 
     before do
-      allow(SubmitApplicationReminderService).to receive(:new).with(legal_aid_application).and_return(mocked_email_service)
       patch(
         providers_legal_aid_application_used_delegated_functions_path(legal_aid_application),
         params: params.merge(button_clicked)

--- a/spec/requests/providers/used_delegated_functions_spec.rb
+++ b/spec/requests/providers/used_delegated_functions_spec.rb
@@ -176,7 +176,7 @@ RSpec.describe Providers::UsedDelegatedFunctionsController, type: :request, vcr:
         expect(legal_aid_application.scope_limitations).to eq [default_substantive_scope_limitation]
       end
 
-      it 'redirects to the online banking page' do
+      it 'redirects to the limitations page' do
         expect(response).to redirect_to(providers_legal_aid_application_limitations_path(legal_aid_application))
       end
 

--- a/spec/requests/providers/used_delegated_functions_spec.rb
+++ b/spec/requests/providers/used_delegated_functions_spec.rb
@@ -177,10 +177,6 @@ RSpec.describe Providers::UsedDelegatedFunctionsController, type: :request, vcr:
       it 'redirects to the limitations page' do
         expect(response).to redirect_to(providers_legal_aid_application_limitations_path(legal_aid_application))
       end
-
-      it 'does not send a reminder email' do
-        expect(SubmitApplicationReminderService).not_to have_received(:new).with(legal_aid_application)
-      end
     end
 
     context 'Form submitted using Save as draft button' do


### PR DESCRIPTION
## AP-1957 delegated functions date confirmation page

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1957)

- Add a new page to confirm the delegated functions date

- Duplicate the used delegated functions form with some changes for the new page. This is because the used delegated functions form is already complicated enough and reusing it will make it more so, thus it seems better to have duplication.

- Add requests tests and form tests

- Update the  feature tests

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
