### PR TITLE
BUGFIX Use DateTime instead of Time class for strptime method

### DIFF
--- a/bin/delete_ecr_images
+++ b/bin/delete_ecr_images
@@ -12,7 +12,7 @@ images = JSON.parse(json_output)['imageDetails']
 
 images_to_delete = []
 images.each do |i|
-  date_pushed = Time.strptime(i['imagePushedAt'].to_s, '%s').in_time_zone
+  date_pushed = DateTime.strptime(i['imagePushedAt'].to_s, '%s').in_time_zone
   age_in_days = (DateTime.current - date_pushed).to_i
   images_to_delete << i if age_in_days > delete_if_older_than
 end


### PR DESCRIPTION
## BUGFIX Use DateTime instead of Time class for strptime method


- Use DateTime instead of Time class for strptime method. This is because it raises a bug in circleci:

```bash
./bin/delete_ecr_images:15:in `block in <main>': undefined method `strptime' for Time:Class (NoMethodError)
```

This is because we require 'date' in the delete_ecr_images file. Instead of requiring 'time' and using Time objects etc. I changed the code to use DateTime. This uses .in_time_zone and DateTime.current to meet TimeZone standardisations requirements.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
