### PR TITLE
Update the long_date form for i18n localisation

### DIFF
--- a/config/locales/cy/dates.yml
+++ b/config/locales/cy/dates.yml
@@ -4,7 +4,7 @@ cy:
     formats:
       default: "%Y-%m-%d"
       short_date: "%-d %b %Y"
-      long_date: "%B %d, %Y"
+      long_date: "%-d %B %Y"
       month_name: "%B"
     abbr_month_names:
       -

--- a/config/locales/en/dates.yml
+++ b/config/locales/en/dates.yml
@@ -4,7 +4,7 @@ en:
     formats:
       default: "%Y-%m-%d"
       short_date: "%-d %b %Y"
-      long_date: "%B %d, %Y"
+      long_date: "%-d %B %Y"
       month_name: "%B"
     abbr_month_names:
       -

--- a/spec/helpers/transaction_period_helper_spec.rb
+++ b/spec/helpers/transaction_period_helper_spec.rb
@@ -5,13 +5,13 @@ RSpec.describe TransactionPeriodHelper, type: :helper do
 
   describe '#date_from(application)' do
     it 'returns a valid date' do
-      expect(helper.date_from(application)).to eq 'October 21, 2020'
+      expect(helper.date_from(application)).to eq '21 October 2020'
     end
   end
 
   describe '#date_to(application)' do
     it 'returns a valid date' do
-      expect(helper.date_to(application)).to eq 'January 21, 2021'
+      expect(helper.date_to(application)).to eq '21 January 2021'
     end
   end
 end


### PR DESCRIPTION
## Update the long_date form for i18n localisation

- This puts the long date as e.g. 21 October 2020
rather than October 21, 2020

It is used in the transactions_helper. Above the transactions table we have 21 October 2020 to 21 January 2021

- Update the tests


## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
