### PR TITLE
BUGFIX NightlyJob, undo timezone adherence for cleaning ecr images

### DIFF
--- a/bin/delete_ecr_images
+++ b/bin/delete_ecr_images
@@ -12,8 +12,8 @@ images = JSON.parse(json_output)['imageDetails']
 
 images_to_delete = []
 images.each do |i|
-  date_pushed = DateTime.strptime(i['imagePushedAt'].to_s, '%s').in_time_zone
-  age_in_days = (DateTime.current - date_pushed).to_i
+  date_pushed = DateTime.strptime(i['imagePushedAt'].to_s, '%s')
+  age_in_days = (DateTime.now - date_pushed).to_i
   images_to_delete << i if age_in_days > delete_if_older_than
 end
 


### PR DESCRIPTION
## Undo timezone adherence for cleaning ecr images

This is because #in_time_zone and #current aren't methods of DateTime object. Also, this ruby file is not requiring **ActiveSupport** and all of it's date / time / timezone **extensions** including #in_time_zone and #current

This fixes the issue:
```bash
./bin/delete_ecr_images:15:in `block in <main>': undefined method `in_time_zone' for #<DateTime:0x0000560e3caf61a8> (NoMethodError)
```

The ruby core Time class is not extended by the rails ActiveSupport::TimeZone which has the benefits of Time.**current** etc.
Therefore #in_time_zone is not extended onto Date objects (DateTime).

As this is a nightly job, I don't believe it's neccessary to require 'activesupport/all' here and i don't think timezones will be an issue on this job.

**Resource**:

https://stackoverflow.com/questions/35057864/undefined-method-zone-for-timeclass-after-requiring-active-support-time-with

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
