### PR TITLE
BUGFIX -remove DateTime zone methods from Circle CI housekeeping scripts

### DIFF
--- a/bin/delete_ecr_images
+++ b/bin/delete_ecr_images
@@ -12,8 +12,8 @@ images = JSON.parse(json_output)['imageDetails']
 
 images_to_delete = []
 images.each do |i|
-  date_pushed = DateTime.strptime(i['imagePushedAt'].to_s, '%s').in_time_zone
-  age_in_days = (DateTime.current - date_pushed).to_i
+  date_pushed = DateTime.strptime(i['imagePushedAt'].to_s, '%s')
+  age_in_days = (DateTime.now - date_pushed).to_i
   images_to_delete << i if age_in_days > delete_if_older_than
 end
 


### PR DESCRIPTION
## remove DateTime zone methods from Circle CI housekeeping scripts

The circle ci scripts had recently been amended to use `DateTime#in_time_zone` and `Date.current`.  These are rails extensions to Ruby and not available to Circle Ci when it is runing these scripts.  Have removed them


## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
