### PR TITLE
Add a hold_uat manual approval to circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -334,9 +334,13 @@ workflows:
       - build_and_push:
           requires:
           - lint_checks
+      - hold_uat:
+          type: approval
+          requires:
+            - build_and_push
       - deploy_uat:
           requires:
-          - build_and_push
+            - hold_uat
       - unit_tests:
           requires:
           - lint_checks


### PR DESCRIPTION
## Add a hold_uat manual approval to circleci


Add a hold_uat manual approval to circleci

This will mean deployments to uat are made when needed as opposed to automatically and thus reducing our kubernetes pods/deployments. This will also reduce ingress limit reached issues e.g.
```
Quata-exceeded 
Namespace xyz-xyz-uat is using 91% of its pods quota
```

Consequently, Dependabot will not be deployed to UAT until  it's neccessary and other git branches.

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
