### PR TITLE
AP-1970: Parse CFE V3 response and add relevant tests for it

### DIFF
--- a/app/models/cfe/v3/result.rb
+++ b/app/models/cfe/v3/result.rb
@@ -1,0 +1,242 @@
+module CFE
+  module V3
+    class Result < CFE::BaseResult # rubocop:disable Metrics/ClassLength
+      def assessment_result
+        return nil if result_hash[:assessment].nil?
+
+        result_hash[:assessment][:assessment_result]
+      end
+
+      def capital_assessment_result
+        capital[:assessment_result]
+      end
+
+      def capital_contribution_required?
+        capital_assessment_result == 'contribution_required'
+      end
+
+      def capital_contribution
+        capital[:capital_contribution].to_d
+      end
+
+      def income_assessment_result
+        disposable_income[:assessment_result]
+      end
+
+      def income_contribution_required?
+        income_assessment_result == 'contribution_required'
+      end
+
+      def income_contribution
+        disposable_income[:income_contribution].to_d
+      end
+
+      def capital
+        result_hash[:assessment][:capital]
+      end
+
+      def gross_income
+        result_hash[:assessment][:gross_income]
+      end
+
+      def total_disposable_income_assessed
+        disposable_income[:total_disposable_income]
+      end
+
+      def total_gross_income_assessed
+        gross_income[:summary][:total_gross_income]
+      end
+
+      def gross_income_upper_threshold
+        gross_income[:summary][:upper_threshold]
+      end
+
+      def disposable_income
+        result_hash[:assessment][:disposable_income]
+      end
+
+      def disposable_income_lower_threshold
+        disposable_income[:lower_threshold]
+      end
+
+      def disposable_income_upper_threshold
+        disposable_income[:upper_threshold]
+      end
+
+      def vehicles
+        capital[:capital_items][:vehicles]
+      end
+
+      def remarks
+        Remarks.new(result_hash[:assessment][:remarks])
+      end
+
+      ################################################################
+      #                                                              #
+      #  INCOME VALUES                                               #
+      #                                                              #
+      ################################################################
+
+      def mortgage_per_month
+        disposable_income[:gross_housing_costs].to_d
+      end
+
+      def total_gross_income
+        gross_income[:summary][:total_gross_income].to_d
+      end
+
+      def maintenance_per_month
+        disposable_income[:maintenance_allowance].to_d
+      end
+
+      ################################################################
+      #                                                              #
+      #  CAPITAL ITEMS                                               #
+      #                                                              #
+      ################################################################
+
+      def non_liquid_capital_items
+        capital[:capital_items][:non_liquid].sort_by { |item| item[:description] }
+      end
+
+      def liquid_capital_items
+        capital[:capital_items][:liquid].sort_by { |item| item[:description] }
+      end
+
+      def total_property
+        capital[:total_property].to_d
+      end
+
+      def total_capital
+        capital[:total_capital]
+      end
+
+      def property
+        capital[:capital_items][:properties]
+      end
+
+      def main_home
+        property[:main_home]
+      end
+
+      def additional_properties
+        property[:additional_properties]
+      end
+
+      ################################################################
+      #                                                              #
+      #  VEHICLE                                                     #
+      #                                                              #
+      ################################################################
+
+      def vehicle
+        vehicles.first
+      end
+
+      def vehicles?
+        vehicles.any?
+      end
+
+      def vehicle_value
+        vehicle[:value].to_d
+      end
+
+      def total_vehicles
+        capital[:total_vehicle].to_d
+      end
+
+      ################################################################
+      #                                                              #
+      #  MONTHLY INCOME EQUIVALENTS                                  #
+      #                                                              #
+      ################################################################
+
+      def monthly_state_benefits
+        gross_income[:state_benefits][:monthly_equivalents].first[:all_sources].to_d
+      end
+
+      def mei_friends_or_family
+        monthly_income_equivalents[:friends_or_family].to_d
+      end
+
+      def mei_maintenance_in
+        monthly_income_equivalents[:maintenance_in].to_d
+      end
+
+      def mei_property_or_lodger
+        monthly_income_equivalents[:property_or_lodger].to_d
+      end
+
+      def mei_student_loan
+        gross_income[:irregular_income][:monthly_equivalents][:student_loan].to_d
+      end
+
+      def mei_pension
+        monthly_income_equivalents[:pension].to_d
+      end
+
+      def total_monthly_income
+        mei_pension + mei_student_loan + mei_property_or_lodger + mei_maintenance_in + mei_friends_or_family + monthly_state_benefits
+      end
+
+      ################################################################
+      #                                                              #
+      #  MONTHLY_OUTGOING_EQUIVALENTS                                #
+      #                                                              #
+      ################################################################
+
+      def moe_housing
+        monthly_outgoing_equivalents[:rent_or_mortgage].to_d.abs
+      end
+
+      def moe_childcare
+        monthly_outgoing_equivalents[:child_care].to_d.abs
+      end
+
+      def moe_maintenance_out
+        monthly_outgoing_equivalents[:maintenance_out].to_d.abs
+      end
+
+      def moe_legal_aid
+        monthly_outgoing_equivalents[:legal_aid].to_d.abs
+      end
+
+      def total_monthly_outgoings
+        moe_housing + moe_childcare + moe_maintenance_out + moe_legal_aid
+      end
+
+      ################################################################
+      #                                                              #
+      #  DEDUCTIONS                                                  #
+      #                                                              #
+      ################################################################
+
+      def dependants_allowance
+        deductions[:dependants_allowance].to_d
+      end
+
+      def disregarded_state_benefits
+        deductions[:disregarded_state_benefits].to_d
+      end
+
+      def total_deductions
+        dependants_allowance + disregarded_state_benefits
+      end
+
+      private
+
+      def monthly_income_equivalents
+        gross_income[:other_income][:monthly_equivalents][:all_sources]
+      end
+
+      def monthly_outgoing_equivalents
+        disposable_income[:monthly_equivalents][:all_sources]
+      end
+
+      def deductions
+        # stub out zero values if not found until CFE is updated
+        disposable_income[:deductions] || { dependants_allowance: '0.0', disregarded_state_benefits: '0.0' }
+      end
+    end
+  end
+end

--- a/app/services/cfe/obtain_assessment_result_service.rb
+++ b/app/services/cfe/obtain_assessment_result_service.rb
@@ -43,11 +43,24 @@ module CFE
     end
 
     def write_cfe_result
+      Setting.allow_cash_payment? ? result_v3 : result_v2
+    end
+
+    def result_v2
       CFE::V2::Result.create!(
         legal_aid_application_id: legal_aid_application.id,
         submission_id: @submission.id,
         result: @response.body,
         type: 'CFE::V2::Result'
+      )
+    end
+
+    def result_v3
+      CFE::V3::Result.create!(
+        legal_aid_application_id: legal_aid_application.id,
+        submission_id: @submission.id,
+        result: @response.body,
+        type: 'CFE::V3::Result'
       )
     end
   end

--- a/spec/factories/cfe_results.rb
+++ b/spec/factories/cfe_results.rb
@@ -56,4 +56,62 @@ FactoryBot.define do
       result { CFEResults::V2::MockResults.unknown.to_json }
     end
   end
+
+  factory :cfe_v3_result, class: CFE::V3::Result do
+    submission { create :cfe_submission }
+    legal_aid_application { submission.legal_aid_application }
+    result { CFEResults::V3::MockResults.eligible.to_json }
+
+    trait :eligible do
+      result { CFEResults::V3::MockResults.eligible.to_json }
+    end
+
+    trait :not_eligible do
+      result { CFEResults::V3::MockResults.not_eligible.to_json }
+    end
+
+    trait :no_capital do
+      result { CFEResults::V3::MockResults.no_capital.to_json }
+    end
+
+    trait :with_capital_contribution_required do
+      result { CFEResults::V3::MockResults.with_capital_contribution_required.to_json }
+    end
+
+    trait :with_income_contribution_required do
+      result { CFEResults::V3::MockResults.with_income_contribution_required.to_json }
+    end
+
+    trait :with_capital_and_income_contributions_required do
+      result { CFEResults::V3::MockResults.with_capital_and_income_contributions_required.to_json }
+    end
+
+    trait :no_additional_properties do
+      result { CFEResults::V3::MockResults.no_additional_properties.to_json }
+    end
+
+    trait :with_additional_properties do
+      result { CFEResults::V3::MockResults.with_additional_properties.to_json }
+    end
+
+    trait :no_vehicles do
+      result { CFEResults::V3::MockResults.no_vehicles.to_json }
+    end
+
+    trait :with_maintenance_received do
+      result { CFEResults::V3::MockResults.with_maintenance_received.to_json }
+    end
+
+    trait :with_student_finance_received do
+      result { CFEResults::V3::MockResults.with_student_finance_received.to_json }
+    end
+
+    trait :with_no_mortgage_costs do
+      result { CFEResults::V3::MockResults.with_no_mortgage_costs.to_json }
+    end
+
+    trait :with_unknown_result do
+      result { CFEResults::V3::MockResults.unknown.to_json }
+    end
+  end
 end

--- a/spec/factories/cfe_results/v3/mock_results.rb
+++ b/spec/factories/cfe_results/v3/mock_results.rb
@@ -1,0 +1,300 @@
+module CFEResults
+  module V3
+    class MockResults # rubocop:disable Metrics/ClassLength
+      def self.eligible # rubocop:disable Metrics/MethodLength
+        {
+          version: '3',
+          timestamp: '2020-01-28T16:37:07.921+00:00',
+          success: true,
+          assessment: {
+            id: '41188692-9fa1-488d-818f-67f8509ff21a',
+            client_reference_id: 'CLIENT-REF-0007',
+            submission_date: '2020-01-28',
+            matter_proceeding_type: 'domestic_abuse',
+            assessment_result: 'eligible',
+            applicant: {
+              date_of_birth: '1996-08-15',
+              involvement_type: 'applicant',
+              has_partner_opponent: false,
+              receives_qualifying_benefit: false,
+              self_employed: false
+            },
+            gross_income: {
+              summary: {
+                total_gross_income: '150.0',
+                upper_threshold: '999999999999.0',
+                assessment_result: 'eligible'
+              },
+              irregular_income: {
+                monthly_equivalents: {
+                  student_loan: '0.0'
+                }
+              },
+              state_benefits: {
+                monthly_equivalents: [
+                  {
+                    name: 'manually_chosen',
+                    all_sources: '75.0',
+                    cash_transactions: '25.0',
+                    bank_transactions: '50.00',
+                    excluded_from_income_assessment: false
+                  }
+                ]
+              },
+              other_income: {
+                monthly_equivalents: {
+                  bank_transactions: {
+                    friends_or_family: '40.0',
+                    maintenance_in: '40.0',
+                    property_or_lodger: '350.0',
+                    pension: '50.0'
+                  },
+                  cash_transactions: {
+                    friends_or_family: '10.59',
+                    maintenance_in: '14.17',
+                    property_or_lodger: '100.0',
+                    pension: '32.52'
+                  },
+                  all_sources: {
+                    friends_or_family: '50.59',
+                    maintenance_in: '54.17',
+                    property_or_lodger: '450.0',
+                    pension: '82.52'
+                  }
+                }
+              }
+            },
+            disposable_income: {
+              monthly_equivalents: {
+                bank_transactions: {
+                  child_care: '60.0',
+                  rent_or_mortgage: '100.0',
+                  maintenance_out: '40.0',
+                  legal_aid: '350.0'
+                },
+                cash_transactions: {
+                  child_care: '40.0',
+                  rent_or_mortgage: '25.0',
+                  maintenance_out: '10.0',
+                  legal_aid: '50.0'
+                },
+                all_sources: {
+                  child_care: '100.0',
+                  rent_or_mortgage: '125.0',
+                  maintenance_out: '50.0',
+                  legal_aid: '400.0'
+                }
+              },
+              childcare_allowance: '0.0',
+              deductions: {
+                dependants_allowance: '291.86',
+                disregarded_state_benefits: '1500.0'
+              },
+              dependant_allowance: '0.0',
+              maintenance_allowance: '0.0',
+              gross_housing_costs: '125.0',
+              housing_benefit: '0.0',
+              net_housing_costs: '125.0',
+              total_outgoings_and_allowances: '175.0',
+              total_disposable_income: '0.0',
+              lower_threshold: '315.0',
+              upper_threshold: '999999999999.0',
+              assessment_result: 'eligible',
+              income_contribution: '0.0'
+            },
+            capital: {
+              capital_items: {
+                liquid: [
+                  {
+                    description: 'Ab quasi autem rerum.',
+                    value: '6692.12'
+                  }
+                ],
+                non_liquid: [
+                  {
+                    description: 'Omnis sit et corrupti.',
+                    value: '3902.92'
+                  }
+                ],
+                vehicles: [
+                  {
+                    value: '1784.61',
+                    loan_amount_outstanding: '3225.77',
+                    date_of_purchase: '2014-07-01',
+                    in_regular_use: true,
+                    included_in_assessment: false,
+                    assessed_value: '0.0'
+                  }
+                ],
+                properties: {
+                  main_home: {
+                    value: '5985.82',
+                    'outstanding_ mortgage': '7201.44',
+                    percentage_owned: '1.87',
+                    main_home: true,
+                    shared_with_housing_assoc: false,
+                    transaction_allowance: '179.57',
+                    allowable_outstanding_mortgage: '7201.44',
+                    net_value: '-1395.19',
+                    net_equity: '-26.09',
+                    main_home_equity_disregard: '100000.0',
+                    assessed_equity: '0.0'
+                  },
+                  additional_properties: [
+                    {
+                      value: '0.0',
+                      outstanding_mortgage: '8202.39',
+                      percentage_owned: '8.33',
+                      main_home: false,
+                      shared_with_housing_assoc: true,
+                      transaction_allowance: '113.46',
+                      allowable_outstanding_mortgage: '8202.39',
+                      net_value: '-4533.94',
+                      net_equity: '-8000.82',
+                      main_home_equity_disregard: '0.0',
+                      assessed_equity: '0.0'
+                    }
+                  ]
+                }
+              },
+              total_liquid: '5649.13',
+              total_non_liquid: '3902.92',
+              total_vehicle: '0.0',
+              total_property: '1134.0',
+              total_mortgage_allowance: '100000.0',
+              total_capital: '9552.05',
+              pensioner_capital_disregard: '0.0',
+              assessed_capital: '9552.05',
+              lower_threshold: '3000.0',
+              upper_threshold: '999999999999.0',
+              assessment_result: 'eligible',
+              capital_contribution: '0.0'
+            },
+            remarks: {
+            }
+          }
+        }
+      end
+
+      def self.not_eligible
+        not_eligible_result = eligible
+        not_eligible_result[:assessment][:assessment_result] = 'not_eligible'
+        not_eligible_result[:assessment][:disposable_income][:assessment_result] = 'not_eligible'
+        not_eligible_result[:assessment][:capital][:assessment_result] = 'not_eligible'
+        not_eligible_result
+      end
+
+      def self.with_capital_contribution_required
+        result = eligible
+        result[:assessment][:assessment_result] = 'contribution_required'
+        new_capital_section = result[:assessment][:capital]
+        new_capital_section[:capital_contribution] = '465.66'
+        new_capital_section[:assessment_result] = 'contribution_required'
+        result[:assessment][:capital] = new_capital_section
+        result
+      end
+
+      def self.with_income_contribution_required
+        result = eligible
+        result[:assessment][:assessment_result] = 'contribution_required'
+        new_disposable_income = eligible[:assessment][:disposable_income]
+        new_disposable_income[:assessment_result] = 'contribution_required'
+        new_disposable_income[:income_contribution] = 366.82
+        result[:assessment][:disposable_income] = new_disposable_income
+        result
+      end
+
+      def self.with_capital_and_income_contributions_required # rubocop:disable Metrics/AbcSize
+        result = eligible
+        result[:assessment][:assessment_result] = 'contribution_required'
+
+        new_disposable_income = eligible[:assessment][:disposable_income]
+        new_disposable_income[:assessment_result] = 'contribution_required'
+        new_disposable_income[:income_contribution] = 366.82
+        result[:assessment][:disposable_income] = new_disposable_income
+
+        result[:assessment][:assessment_result] = 'contribution_required'
+        new_capital_section = result[:assessment][:capital]
+        new_capital_section[:capital_contribution] = '465.66'
+        new_capital_section[:assessment_result] = 'contribution_required'
+        result[:assessment][:capital] = new_capital_section
+
+        result
+      end
+
+      def self.no_additional_properties
+        result = eligible
+        result[:assessment][:capital][:capital_items][:properties][:additional_properties] = []
+        result
+      end
+
+      def self.no_vehicles
+        result = eligible
+        result[:assessment][:capital][:capital_items][:vehicles] = []
+        result
+      end
+
+      def self.with_no_mortgage_costs
+        result = eligible
+        result[:assessment][:disposable_income][:gross_housing_costs] = 0.0
+        result
+      end
+
+      def self.no_capital
+        result = eligible
+        new_capital_section = result[:assessment][:capital]
+        new_capital_section[:capital_items][:liquid] = []
+        new_capital_section[:capital_items][:non_liquid] = []
+        new_capital_section[:capital_items][:vehicles] = []
+        new_capital_section[:capital_items][:properties][:main_home] = {}
+        new_capital_section[:capital_items][:properties][:additional_properties] = {}
+        new_capital_section[:total_liquid] = '0.0'
+        new_capital_section[:total_non_liquid] = '0.0'
+        new_capital_section[:total_vehicle] = '0.0'
+        new_capital_section[:total_property] = '0.0'
+        new_capital_section[:total_capital] = '0.0'
+        result[:assessment][:capital] = new_capital_section
+        result
+      end
+
+      def self.with_additional_properties
+        result = eligible
+        property = {
+          value: '5781.91',
+          outstanding_mortgage: '10202.39',
+          percentage_owned: '8.33',
+          main_home: false,
+          shared_with_housing_assoc: true,
+          transaction_allowance: '113.46',
+          allowable_outstanding_mortgage: '8202.00',
+          net_value: '-4533.94',
+          net_equity: '-8000.82',
+          main_home_equity_disregard: '0.0',
+          assessed_equity: '125.33'
+        }
+        result[:assessment][:capital][:capital_items][:properties][:additional_properties] = [property]
+        result
+      end
+
+      def self.with_maintenance_received
+        result = eligible
+        result[:assessment][:disposable_income][:maintenance_allowance] = '150.00'
+        result
+      end
+
+      def self.with_student_finance_received
+        result = eligible
+        result[:assessment][:gross_income][:irregular_income][:monthly_equivalents][:student_loan] = '125.00'
+        result
+      end
+
+      def self.unknown
+        result = eligible
+        result[:assessment][:assessment_result] = 'unknown'
+        result[:assessment][:capital][:assessment_result] = 'unknown'
+        result[:assessment][:disposable_income][:assessment_result] = 'unknown'
+        result
+      end
+    end
+  end
+end

--- a/spec/factories/legal_aid_applications.rb
+++ b/spec/factories/legal_aid_applications.rb
@@ -627,6 +627,13 @@ FactoryBot.define do
       end
     end
 
+    trait :with_cfe_v3_result do
+      after :create do |application|
+        cfe_submission = create :cfe_submission, legal_aid_application: application
+        create :cfe_v3_result, submission: cfe_submission
+      end
+    end
+
     trait :with_means_report do
       with_cfe_v2_result
       after :create do |application|

--- a/spec/factory_specs/cfe_result_factory_spec.rb
+++ b/spec/factory_specs/cfe_result_factory_spec.rb
@@ -1,269 +1,541 @@
 require 'rails_helper'
 
-RSpec.describe 'cfe_v2_result factory' do
+RSpec.describe 'cfe_result factory' do
   let(:assessment) { cfe_result.result_hash[:assessment] }
   let(:applicant) { assessment[:applicant] }
   let(:gross_income) { assessment[:gross_income] }
   let(:disposable_income) { assessment[:disposable_income] }
   let(:capital) { assessment[:capital] }
 
-  RSpec.shared_examples 'has the correct structure' do
-    it 'has the required top level keys' do
-      expect(cfe_result.result_hash.keys).to match_array %i[version timestamp success assessment]
-    end
+  context 'v2' do
+    RSpec.shared_examples 'has the correct structure for v2' do
+      it 'has the required top level keys' do
+        expect(cfe_result.result_hash.keys).to match_array %i[version timestamp success assessment]
+      end
 
-    it 'has required keys in assessment' do
-      expect(assessment.keys).to match_array %i[id
-                                                client_reference_id
-                                                submission_date
-                                                matter_proceeding_type
-                                                assessment_result
-                                                applicant
-                                                gross_income
-                                                disposable_income
-                                                capital
-                                                remarks]
-    end
-
-    it 'has required keys in applicant' do
-      expect(applicant.keys).to match_array %i[date_of_birth
-                                               involvement_type
-                                               has_partner_opponent
-                                               receives_qualifying_benefit
-                                               self_employed]
-    end
-
-    it 'has required keys in gross income' do
-      expect(gross_income.keys).to match_array %i[monthly_student_loan
-                                                  monthly_other_income
-                                                  monthly_state_benefits
-                                                  monthly_income_equivalents
-                                                  monthly_outgoing_equivalents
-                                                  total_gross_income
-                                                  upper_threshold
+      it 'has required keys in assessment' do
+        expect(assessment.keys).to match_array %i[id
+                                                  client_reference_id
+                                                  submission_date
+                                                  matter_proceeding_type
                                                   assessment_result
-                                                  state_benefits
-                                                  other_income]
+                                                  applicant
+                                                  gross_income
+                                                  disposable_income
+                                                  capital
+                                                  remarks]
+      end
+
+      it 'has required keys in applicant' do
+        expect(applicant.keys).to match_array %i[date_of_birth
+                                                 involvement_type
+                                                 has_partner_opponent
+                                                 receives_qualifying_benefit
+                                                 self_employed]
+      end
+
+      it 'has required keys in gross income' do
+        expect(gross_income.keys).to match_array %i[monthly_student_loan
+                                                    monthly_other_income
+                                                    monthly_state_benefits
+                                                    monthly_income_equivalents
+                                                    monthly_outgoing_equivalents
+                                                    total_gross_income
+                                                    upper_threshold
+                                                    assessment_result
+                                                    state_benefits
+                                                    other_income]
+      end
+
+      it 'has required keys in disposable income' do
+        expect(disposable_income.keys).to match_array %i[outgoings
+                                                         deductions
+                                                         childcare_allowance
+                                                         dependant_allowance
+                                                         maintenance_allowance
+                                                         gross_housing_costs
+                                                         housing_benefit
+                                                         net_housing_costs
+                                                         total_outgoings_and_allowances
+                                                         total_disposable_income
+                                                         lower_threshold
+                                                         upper_threshold
+                                                         assessment_result
+                                                         income_contribution]
+      end
+
+      it 'has the right keys in capital' do
+        expect(capital.keys).to match_array %i[capital_items
+                                               total_liquid
+                                               total_non_liquid
+                                               total_vehicle
+                                               total_property
+                                               total_mortgage_allowance
+                                               total_capital
+                                               pensioner_capital_disregard
+                                               assessed_capital
+                                               lower_threshold
+                                               upper_threshold
+                                               assessment_result
+                                               capital_contribution]
+      end
     end
 
-    it 'has required keys in disposable income' do
-      expect(disposable_income.keys).to match_array %i[outgoings
-                                                       deductions
-                                                       childcare_allowance
-                                                       dependant_allowance
-                                                       maintenance_allowance
-                                                       gross_housing_costs
-                                                       housing_benefit
-                                                       net_housing_costs
-                                                       total_outgoings_and_allowances
-                                                       total_disposable_income
-                                                       lower_threshold
-                                                       upper_threshold
-                                                       assessment_result
-                                                       income_contribution]
+    describe 'with no traits' do
+      let(:cfe_result) { create :cfe_v2_result }
+
+      include_examples 'has the correct structure for v2'
+
+      it 'has no contributions' do
+        expect(cfe_result.assessment_result).to eq 'eligible'
+        expect(cfe_result.capital_assessment_result).to eq 'eligible'
+        expect(cfe_result.income_assessment_result).to eq 'eligible'
+        expect(cfe_result.capital_contribution).to be_zero
+        expect(cfe_result.income_contribution).to be_zero
+      end
     end
 
-    it 'has the right keys in capital' do
-      expect(capital.keys).to match_array %i[capital_items
-                                             total_liquid
-                                             total_non_liquid
-                                             total_vehicle
-                                             total_property
-                                             total_mortgage_allowance
-                                             total_capital
-                                             pensioner_capital_disregard
-                                             assessed_capital
-                                             lower_threshold
-                                             upper_threshold
-                                             assessment_result
-                                             capital_contribution]
+    describe 'trait :eligible' do
+      let(:cfe_result) { create :cfe_v2_result, :eligible }
+
+      include_examples 'has the correct structure for v2'
+
+      it 'has no contributions' do
+        expect(cfe_result.assessment_result).to eq 'eligible'
+        expect(cfe_result.capital_assessment_result).to eq 'eligible'
+        expect(cfe_result.income_assessment_result).to eq 'eligible'
+        expect(cfe_result.capital_contribution).to be_zero
+        expect(cfe_result.income_contribution).to be_zero
+      end
+    end
+
+    describe 'trait :not_eligible' do
+      let(:cfe_result) { create :cfe_v2_result, :not_eligible }
+
+      include_examples 'has the correct structure for v2'
+
+      it 'is not eligible with no contributions' do
+        expect(cfe_result.assessment_result).to eq 'not_eligible'
+        expect(cfe_result.capital_assessment_result).to eq 'not_eligible'
+        expect(cfe_result.income_assessment_result).to eq 'not_eligible'
+        expect(cfe_result.capital_contribution).to be_zero
+        expect(cfe_result.income_contribution).to be_zero
+      end
+    end
+
+    describe 'no capital' do
+      let(:cfe_result) { create :cfe_v2_result, :no_capital }
+
+      include_examples 'has the correct structure for v2'
+
+      it 'all capital items are zero' do
+        expect(cfe_result.assessment_result).to eq 'eligible'
+        expect(cfe_result.capital_assessment_result).to eq 'eligible'
+        expect(cfe_result.income_assessment_result).to eq 'eligible'
+        expect(cfe_result.capital_contribution).to be_zero
+        expect(cfe_result.income_contribution).to be_zero
+      end
+    end
+
+    describe 'trait :with_capital_contribution_required' do
+      let(:cfe_result) { create :cfe_v2_result, :with_capital_contribution_required }
+
+      include_examples 'has the correct structure for v2'
+
+      it 'is eligible with a contribution' do
+        expect(cfe_result.assessment_result).to eq 'contribution_required'
+        expect(cfe_result.capital_assessment_result).to eq 'contribution_required'
+        expect(cfe_result.income_assessment_result).to eq 'eligible'
+        expect(cfe_result.capital_contribution).not_to be_zero
+        expect(cfe_result.income_contribution).to be_zero
+      end
+    end
+
+    describe 'trait :no_additional_properties' do
+      let(:cfe_result) { create :cfe_v2_result, :no_additional_properties }
+
+      include_examples 'has the correct structure for v2'
+
+      it 'is eligible' do
+        expect(cfe_result.assessment_result).to eq 'eligible'
+        expect(cfe_result.capital_assessment_result).to eq 'eligible'
+        expect(cfe_result.income_assessment_result).to eq 'eligible'
+        expect(cfe_result.capital_contribution).to be_zero
+        expect(cfe_result.income_contribution).to be_zero
+      end
+
+      it 'has no additional properties' do
+        expect(cfe_result.additional_properties).to be_empty
+      end
+    end
+
+    describe 'trait :with_additional_properties' do
+      let(:cfe_result) { create :cfe_v2_result, :with_additional_properties }
+
+      include_examples 'has the correct structure for v2'
+
+      it 'is eligible' do
+        expect(cfe_result.assessment_result).to eq 'eligible'
+        expect(cfe_result.capital_assessment_result).to eq 'eligible'
+        expect(cfe_result.income_assessment_result).to eq 'eligible'
+        expect(cfe_result.capital_contribution).to be_zero
+        expect(cfe_result.income_contribution).to be_zero
+      end
+
+      it 'has additional properties' do
+        expect(cfe_result.additional_properties).not_to be_empty
+      end
+    end
+
+    describe 'trait :no_vehicles' do
+      let(:cfe_result) { create :cfe_v2_result, :no_vehicles }
+
+      include_examples 'has the correct structure for v2'
+
+      it 'is eligible' do
+        expect(cfe_result.assessment_result).to eq 'eligible'
+        expect(cfe_result.capital_assessment_result).to eq 'eligible'
+        expect(cfe_result.income_assessment_result).to eq 'eligible'
+        expect(cfe_result.capital_contribution).to be_zero
+        expect(cfe_result.income_contribution).to be_zero
+      end
+
+      it 'has no vehicles' do
+        expect(cfe_result.vehicles).to be_empty
+      end
+    end
+
+    describe 'trait: with_maintenance_received' do
+      let(:cfe_result) { create :cfe_v2_result, :with_maintenance_received }
+
+      include_examples 'has the correct structure for v2'
+
+      it 'is eligible' do
+        expect(cfe_result.assessment_result).to eq 'eligible'
+        expect(cfe_result.capital_assessment_result).to eq 'eligible'
+        expect(cfe_result.income_assessment_result).to eq 'eligible'
+        expect(cfe_result.capital_contribution).to be_zero
+        expect(cfe_result.income_contribution).to be_zero
+      end
+
+      it 'has maintenance' do
+        expect(cfe_result.maintenance_costs).not_to be_empty
+      end
+    end
+
+    describe 'trait :no_mortgage_costs' do
+      let(:cfe_result) { create :cfe_v2_result, :with_no_mortgage_costs }
+
+      include_examples 'has the correct structure for v2'
+
+      it 'is eligible' do
+        expect(cfe_result.assessment_result).to eq 'eligible'
+        expect(cfe_result.capital_assessment_result).to eq 'eligible'
+        expect(cfe_result.income_assessment_result).to eq 'eligible'
+        expect(cfe_result.capital_contribution).to be_zero
+        expect(cfe_result.income_contribution).to be_zero
+      end
+
+      it 'has no_mortgage_costs' do
+        expect(cfe_result.mortgage_per_month).to be_zero
+      end
+    end
+
+    describe 'trait :with_income_contribution_required' do
+      let(:cfe_result) { create :cfe_v2_result, :with_income_contribution_required }
+
+      include_examples 'has the correct structure for v2'
+
+      it 'requires a contribution' do
+        expect(cfe_result.assessment_result).to eq 'contribution_required'
+        expect(cfe_result.capital_assessment_result).to eq 'eligible'
+        expect(cfe_result.income_assessment_result).to eq 'contribution_required'
+        expect(cfe_result.capital_contribution).to be_zero
+        expect(cfe_result.income_contribution).not_to be_zero
+      end
+    end
+
+    describe 'trait :with_capital_and_income_contributions_required' do
+      let(:cfe_result) { create :cfe_v2_result, :with_capital_and_income_contributions_required }
+
+      include_examples 'has the correct structure for v2'
+      it 'reuqires both contributions' do
+        expect(cfe_result.assessment_result).to eq 'contribution_required'
+        expect(cfe_result.capital_assessment_result).to eq 'contribution_required'
+        expect(cfe_result.income_assessment_result).to eq 'contribution_required'
+        expect(cfe_result.capital_contribution).not_to be_zero
+        expect(cfe_result.income_contribution).not_to be_zero
+      end
     end
   end
 
-  describe 'with no traits' do
-    let(:cfe_result) { create :cfe_v2_result }
+  context 'v3' do
+    RSpec.shared_examples 'has the correct structure for v3' do
+      it 'has the required top level keys' do
+        expect(cfe_result.result_hash.keys).to match_array %i[version timestamp success assessment]
+      end
 
-    include_examples 'has the correct structure'
+      it 'has required keys in assessment' do
+        expect(assessment.keys).to match_array %i[id
+                                                  client_reference_id
+                                                  submission_date
+                                                  matter_proceeding_type
+                                                  assessment_result
+                                                  applicant
+                                                  gross_income
+                                                  disposable_income
+                                                  capital
+                                                  remarks]
+      end
 
-    it 'has no contributions' do
-      expect(cfe_result.assessment_result).to eq 'eligible'
-      expect(cfe_result.capital_assessment_result).to eq 'eligible'
-      expect(cfe_result.income_assessment_result).to eq 'eligible'
-      expect(cfe_result.capital_contribution).to be_zero
-      expect(cfe_result.income_contribution).to be_zero
-    end
-  end
+      it 'has required keys in applicant' do
+        expect(applicant.keys).to match_array %i[date_of_birth
+                                                 involvement_type
+                                                 has_partner_opponent
+                                                 receives_qualifying_benefit
+                                                 self_employed]
+      end
 
-  describe 'trait :eligible' do
-    let(:cfe_result) { create :cfe_v2_result, :eligible }
+      it 'has required keys in gross income' do
+        expect(gross_income.keys).to match_array %i[summary
+                                                    irregular_income
+                                                    state_benefits
+                                                    other_income]
+      end
 
-    include_examples 'has the correct structure'
+      it 'has required keys in gross income summary' do
+        expect(gross_income[:summary].keys).to match_array %i[total_gross_income
+                                                              upper_threshold
+                                                              assessment_result]
+      end
 
-    it 'has no contributions' do
-      expect(cfe_result.assessment_result).to eq 'eligible'
-      expect(cfe_result.capital_assessment_result).to eq 'eligible'
-      expect(cfe_result.income_assessment_result).to eq 'eligible'
-      expect(cfe_result.capital_contribution).to be_zero
-      expect(cfe_result.income_contribution).to be_zero
-    end
-  end
+      it 'has required keys in gross income other income monthly equivalents' do
+        expect(gross_income[:other_income][:monthly_equivalents].keys).to match_array %i[cash_transactions
+                                                                                         bank_transactions
+                                                                                         all_sources]
+      end
 
-  describe 'trait :not_eligible' do
-    let(:cfe_result) { create :cfe_v2_result, :not_eligible }
+      it 'has required keys in disposable income monthly equivalents' do
+        expect(disposable_income[:monthly_equivalents].keys).to match_array %i[cash_transactions
+                                                                               bank_transactions
+                                                                               all_sources]
+      end
 
-    include_examples 'has the correct structure'
+      it 'has required keys in disposable income' do
+        expect(disposable_income.keys).to match_array %i[monthly_equivalents
+                                                         deductions
+                                                         childcare_allowance
+                                                         dependant_allowance
+                                                         maintenance_allowance
+                                                         gross_housing_costs
+                                                         housing_benefit
+                                                         net_housing_costs
+                                                         total_outgoings_and_allowances
+                                                         total_disposable_income
+                                                         lower_threshold
+                                                         upper_threshold
+                                                         assessment_result
+                                                         income_contribution]
+      end
 
-    it 'is not eligible with no contributions' do
-      expect(cfe_result.assessment_result).to eq 'not_eligible'
-      expect(cfe_result.capital_assessment_result).to eq 'not_eligible'
-      expect(cfe_result.income_assessment_result).to eq 'not_eligible'
-      expect(cfe_result.capital_contribution).to be_zero
-      expect(cfe_result.income_contribution).to be_zero
-    end
-  end
-
-  describe 'no capital' do
-    let(:cfe_result) { create :cfe_v2_result, :no_capital }
-
-    include_examples 'has the correct structure'
-
-    it 'all capital items are zero' do
-      expect(cfe_result.assessment_result).to eq 'eligible'
-      expect(cfe_result.capital_assessment_result).to eq 'eligible'
-      expect(cfe_result.income_assessment_result).to eq 'eligible'
-      expect(cfe_result.capital_contribution).to be_zero
-      expect(cfe_result.income_contribution).to be_zero
-    end
-  end
-
-  describe 'trait :with_capital_contribution_required' do
-    let(:cfe_result) { create :cfe_v2_result, :with_capital_contribution_required }
-
-    include_examples 'has the correct structure'
-
-    it 'is eligible with a contribution' do
-      expect(cfe_result.assessment_result).to eq 'contribution_required'
-      expect(cfe_result.capital_assessment_result).to eq 'contribution_required'
-      expect(cfe_result.income_assessment_result).to eq 'eligible'
-      expect(cfe_result.capital_contribution).not_to be_zero
-      expect(cfe_result.income_contribution).to be_zero
-    end
-  end
-
-  describe 'trait :no_additional_properties' do
-    let(:cfe_result) { create :cfe_v2_result, :no_additional_properties }
-
-    include_examples 'has the correct structure'
-
-    it 'is eligible' do
-      expect(cfe_result.assessment_result).to eq 'eligible'
-      expect(cfe_result.capital_assessment_result).to eq 'eligible'
-      expect(cfe_result.income_assessment_result).to eq 'eligible'
-      expect(cfe_result.capital_contribution).to be_zero
-      expect(cfe_result.income_contribution).to be_zero
-    end
-
-    it 'has no additional properties' do
-      expect(cfe_result.additional_properties).to be_empty
-    end
-  end
-
-  describe 'trait :with_additional_properties' do
-    let(:cfe_result) { create :cfe_v2_result, :with_additional_properties }
-
-    include_examples 'has the correct structure'
-
-    it 'is eligible' do
-      expect(cfe_result.assessment_result).to eq 'eligible'
-      expect(cfe_result.capital_assessment_result).to eq 'eligible'
-      expect(cfe_result.income_assessment_result).to eq 'eligible'
-      expect(cfe_result.capital_contribution).to be_zero
-      expect(cfe_result.income_contribution).to be_zero
+      it 'has the right keys in capital' do
+        expect(capital.keys).to match_array %i[capital_items
+                                               total_liquid
+                                               total_non_liquid
+                                               total_vehicle
+                                               total_property
+                                               total_mortgage_allowance
+                                               total_capital
+                                               pensioner_capital_disregard
+                                               assessed_capital
+                                               lower_threshold
+                                               upper_threshold
+                                               assessment_result
+                                               capital_contribution]
+      end
     end
 
-    it 'has additional properties' do
-      expect(cfe_result.additional_properties).not_to be_empty
-    end
-  end
+    describe 'with no traits' do
+      let(:cfe_result) { create :cfe_v3_result }
 
-  describe 'trait :no_vehicles' do
-    let(:cfe_result) { create :cfe_v2_result, :no_vehicles }
+      include_examples 'has the correct structure for v3'
 
-    include_examples 'has the correct structure'
-
-    it 'is eligible' do
-      expect(cfe_result.assessment_result).to eq 'eligible'
-      expect(cfe_result.capital_assessment_result).to eq 'eligible'
-      expect(cfe_result.income_assessment_result).to eq 'eligible'
-      expect(cfe_result.capital_contribution).to be_zero
-      expect(cfe_result.income_contribution).to be_zero
+      it 'has no contributions' do
+        expect(cfe_result.assessment_result).to eq 'eligible'
+        expect(cfe_result.capital_assessment_result).to eq 'eligible'
+        expect(cfe_result.income_assessment_result).to eq 'eligible'
+        expect(cfe_result.capital_contribution).to be_zero
+        expect(cfe_result.income_contribution).to be_zero
+      end
     end
 
-    it 'has no vehicles' do
-      expect(cfe_result.vehicles).to be_empty
-    end
-  end
+    describe 'trait :eligible' do
+      let(:cfe_result) { create :cfe_v3_result, :eligible }
 
-  describe 'trait: with_maintenance_received' do
-    let(:cfe_result) { create :cfe_v2_result, :with_maintenance_received }
+      include_examples 'has the correct structure for v3'
 
-    include_examples 'has the correct structure'
-
-    it 'is eligible' do
-      expect(cfe_result.assessment_result).to eq 'eligible'
-      expect(cfe_result.capital_assessment_result).to eq 'eligible'
-      expect(cfe_result.income_assessment_result).to eq 'eligible'
-      expect(cfe_result.capital_contribution).to be_zero
-      expect(cfe_result.income_contribution).to be_zero
+      it 'has no contributions' do
+        expect(cfe_result.assessment_result).to eq 'eligible'
+        expect(cfe_result.capital_assessment_result).to eq 'eligible'
+        expect(cfe_result.income_assessment_result).to eq 'eligible'
+        expect(cfe_result.capital_contribution).to be_zero
+        expect(cfe_result.income_contribution).to be_zero
+      end
     end
 
-    it 'has maintenance' do
-      expect(cfe_result.maintenance_costs).not_to be_empty
-    end
-  end
+    describe 'trait :not_eligible' do
+      let(:cfe_result) { create :cfe_v3_result, :not_eligible }
 
-  describe 'trait :no_mortgage_costs' do
-    let(:cfe_result) { create :cfe_v2_result, :with_no_mortgage_costs }
+      include_examples 'has the correct structure for v3'
 
-    include_examples 'has the correct structure'
-
-    it 'is eligible' do
-      expect(cfe_result.assessment_result).to eq 'eligible'
-      expect(cfe_result.capital_assessment_result).to eq 'eligible'
-      expect(cfe_result.income_assessment_result).to eq 'eligible'
-      expect(cfe_result.capital_contribution).to be_zero
-      expect(cfe_result.income_contribution).to be_zero
+      it 'is not eligible with no contributions' do
+        expect(cfe_result.assessment_result).to eq 'not_eligible'
+        expect(cfe_result.capital_assessment_result).to eq 'not_eligible'
+        expect(cfe_result.income_assessment_result).to eq 'not_eligible'
+        expect(cfe_result.capital_contribution).to be_zero
+        expect(cfe_result.income_contribution).to be_zero
+      end
     end
 
-    it 'has no_mortgage_costs' do
-      expect(cfe_result.mortgage_per_month).to be_zero
+    describe 'no capital' do
+      let(:cfe_result) { create :cfe_v3_result, :no_capital }
+
+      include_examples 'has the correct structure for v3'
+
+      it 'all capital items are zero' do
+        expect(cfe_result.assessment_result).to eq 'eligible'
+        expect(cfe_result.capital_assessment_result).to eq 'eligible'
+        expect(cfe_result.income_assessment_result).to eq 'eligible'
+        expect(cfe_result.capital_contribution).to be_zero
+        expect(cfe_result.income_contribution).to be_zero
+      end
     end
-  end
 
-  describe 'trait :with_income_contribution_required' do
-    let(:cfe_result) { create :cfe_v2_result, :with_income_contribution_required }
+    describe 'trait :with_capital_contribution_required' do
+      let(:cfe_result) { create :cfe_v3_result, :with_capital_contribution_required }
 
-    include_examples 'has the correct structure'
+      include_examples 'has the correct structure for v3'
 
-    it 'requires a contribution' do
-      expect(cfe_result.assessment_result).to eq 'contribution_required'
-      expect(cfe_result.capital_assessment_result).to eq 'eligible'
-      expect(cfe_result.income_assessment_result).to eq 'contribution_required'
-      expect(cfe_result.capital_contribution).to be_zero
-      expect(cfe_result.income_contribution).not_to be_zero
+      it 'is eligible with a contribution' do
+        expect(cfe_result.assessment_result).to eq 'contribution_required'
+        expect(cfe_result.capital_assessment_result).to eq 'contribution_required'
+        expect(cfe_result.income_assessment_result).to eq 'eligible'
+        expect(cfe_result.capital_contribution).not_to be_zero
+        expect(cfe_result.income_contribution).to be_zero
+      end
     end
-  end
 
-  describe 'trait :with_capital_and_income_contributions_required' do
-    let(:cfe_result) { create :cfe_v2_result, :with_capital_and_income_contributions_required }
+    describe 'trait :no_additional_properties' do
+      let(:cfe_result) { create :cfe_v3_result, :no_additional_properties }
 
-    include_examples 'has the correct structure'
-    it 'reuqires both contributions' do
-      expect(cfe_result.assessment_result).to eq 'contribution_required'
-      expect(cfe_result.capital_assessment_result).to eq 'contribution_required'
-      expect(cfe_result.income_assessment_result).to eq 'contribution_required'
-      expect(cfe_result.capital_contribution).not_to be_zero
-      expect(cfe_result.income_contribution).not_to be_zero
+      include_examples 'has the correct structure for v3'
+
+      it 'is eligible' do
+        expect(cfe_result.assessment_result).to eq 'eligible'
+        expect(cfe_result.capital_assessment_result).to eq 'eligible'
+        expect(cfe_result.income_assessment_result).to eq 'eligible'
+        expect(cfe_result.capital_contribution).to be_zero
+        expect(cfe_result.income_contribution).to be_zero
+      end
+
+      it 'has no additional properties' do
+        expect(cfe_result.additional_properties).to be_empty
+      end
+    end
+
+    describe 'trait :with_additional_properties' do
+      let(:cfe_result) { create :cfe_v3_result, :with_additional_properties }
+
+      include_examples 'has the correct structure for v3'
+
+      it 'is eligible' do
+        expect(cfe_result.assessment_result).to eq 'eligible'
+        expect(cfe_result.capital_assessment_result).to eq 'eligible'
+        expect(cfe_result.income_assessment_result).to eq 'eligible'
+        expect(cfe_result.capital_contribution).to be_zero
+        expect(cfe_result.income_contribution).to be_zero
+      end
+
+      it 'has additional properties' do
+        expect(cfe_result.additional_properties).not_to be_empty
+      end
+    end
+
+    describe 'trait :no_vehicles' do
+      let(:cfe_result) { create :cfe_v3_result, :no_vehicles }
+
+      include_examples 'has the correct structure for v3'
+
+      it 'is eligible' do
+        expect(cfe_result.assessment_result).to eq 'eligible'
+        expect(cfe_result.capital_assessment_result).to eq 'eligible'
+        expect(cfe_result.income_assessment_result).to eq 'eligible'
+        expect(cfe_result.capital_contribution).to be_zero
+        expect(cfe_result.income_contribution).to be_zero
+      end
+
+      it 'has no vehicles' do
+        expect(cfe_result.vehicles).to be_empty
+      end
+    end
+
+    describe 'trait: with_maintenance_received' do
+      let(:cfe_result) { create :cfe_v3_result, :with_maintenance_received }
+
+      include_examples 'has the correct structure for v3'
+
+      it 'is eligible' do
+        expect(cfe_result.assessment_result).to eq 'eligible'
+        expect(cfe_result.capital_assessment_result).to eq 'eligible'
+        expect(cfe_result.income_assessment_result).to eq 'eligible'
+        expect(cfe_result.capital_contribution).to be_zero
+        expect(cfe_result.income_contribution).to be_zero
+      end
+    end
+
+    describe 'trait :no_mortgage_costs' do
+      let(:cfe_result) { create :cfe_v3_result, :with_no_mortgage_costs }
+
+      include_examples 'has the correct structure for v3'
+
+      it 'is eligible' do
+        expect(cfe_result.assessment_result).to eq 'eligible'
+        expect(cfe_result.capital_assessment_result).to eq 'eligible'
+        expect(cfe_result.income_assessment_result).to eq 'eligible'
+        expect(cfe_result.capital_contribution).to be_zero
+        expect(cfe_result.income_contribution).to be_zero
+      end
+
+      it 'has no_mortgage_costs' do
+        expect(cfe_result.mortgage_per_month).to be_zero
+      end
+    end
+
+    describe 'trait :with_income_contribution_required' do
+      let(:cfe_result) { create :cfe_v3_result, :with_income_contribution_required }
+
+      include_examples 'has the correct structure for v3'
+
+      it 'requires a contribution' do
+        expect(cfe_result.assessment_result).to eq 'contribution_required'
+        expect(cfe_result.capital_assessment_result).to eq 'eligible'
+        expect(cfe_result.income_assessment_result).to eq 'contribution_required'
+        expect(cfe_result.capital_contribution).to be_zero
+        expect(cfe_result.income_contribution).not_to be_zero
+      end
+    end
+
+    describe 'trait :with_capital_and_income_contributions_required' do
+      let(:cfe_result) { create :cfe_v3_result, :with_capital_and_income_contributions_required }
+
+      include_examples 'has the correct structure for v3'
+      it 'reuqires both contributions' do
+        expect(cfe_result.assessment_result).to eq 'contribution_required'
+        expect(cfe_result.capital_assessment_result).to eq 'contribution_required'
+        expect(cfe_result.income_assessment_result).to eq 'contribution_required'
+        expect(cfe_result.capital_contribution).not_to be_zero
+        expect(cfe_result.income_contribution).not_to be_zero
+      end
     end
   end
 end

--- a/spec/models/cfe/v3/result_spec.rb
+++ b/spec/models/cfe/v3/result_spec.rb
@@ -1,0 +1,516 @@
+require 'rails_helper'
+
+module CFE
+  module V3
+    RSpec.describe Result, type: :model do
+      let(:eligible_result) { create :cfe_v3_result }
+      let(:not_eligible_result) { create :cfe_v3_result, :not_eligible }
+      let(:contribution_required_result) { create :cfe_v3_result, :with_capital_contribution_required }
+      let(:no_additional_properties) { create :cfe_v3_result, :no_additional_properties }
+      let(:additional_property) { create :cfe_v3_result, :with_additional_properties }
+      let(:no_vehicles) { create :cfe_v3_result, :no_vehicles }
+      let(:with_maintenance) { create :cfe_v3_result, :with_maintenance_received }
+      let(:with_student_finance) { create :cfe_v3_result, :with_student_finance_received }
+      let(:no_mortgage) { create :cfe_v3_result, :with_no_mortgage_costs }
+      let(:legal_aid_application) { create :legal_aid_application, :with_restrictions, :with_cfe_v3_result }
+      let(:contribution_and_restriction_result) { create :cfe_v3_result, :with_capital_contribution_required, submission: cfe_submission }
+      let(:cfe_submission) { create :cfe_submission, legal_aid_application: legal_aid_application }
+
+      describe '#overview' do
+        subject { cfe_result.overview }
+
+        let(:application) { cfe_result.legal_aid_application }
+
+        context 'manual check not required' do
+          before { allow(CCMS::ManualReviewDeterminer).to receive(:call).with(application).and_return(false) }
+
+          context 'eligible' do
+            let(:cfe_result) { create :cfe_v3_result, :eligible }
+            it 'returns eligible' do
+              expect(subject).to eq 'eligible'
+            end
+          end
+
+          context 'not_eligible' do
+            let(:cfe_result) { create :cfe_v3_result, :not_eligible }
+            it 'returns not_eligible' do
+              expect(subject).to eq 'not_eligible'
+            end
+          end
+
+          context 'capital_contribution_required' do
+            let(:cfe_result) { create :cfe_v3_result, :with_capital_contribution_required }
+            it 'returns capital_contribution_required' do
+              expect(subject).to eq 'capital_contribution_required'
+            end
+          end
+
+          context 'income_contribution_required' do
+            let(:cfe_result) { create :cfe_v3_result, :with_income_contribution_required }
+            it 'returns income_contribution_required' do
+              expect(subject).to eq 'income_contribution_required'
+            end
+          end
+
+          context 'capital_and_income_contribution_required' do
+            let(:cfe_result) { create :cfe_v3_result, :with_capital_and_income_contributions_required }
+            it 'returns capital_and_income_contribution_required' do
+              expect(subject).to eq 'capital_and_income_contribution_required'
+            end
+          end
+        end
+
+        context 'manual check IS required and restrictions do not exist' do
+          before { allow(CCMS::ManualReviewDeterminer).to receive(:call).with(application).and_return(true) }
+
+          context 'eligible' do
+            let(:cfe_result) { create :cfe_v3_result, :eligible }
+            it 'returns eligible' do
+              expect(subject).to eq 'eligible'
+            end
+          end
+
+          context 'not_eligible' do
+            let(:cfe_result) { create :cfe_v3_result, :not_eligible }
+            it 'returns not_eligible' do
+              expect(subject).to eq 'not_eligible'
+            end
+          end
+
+          context 'capital_contribution_required' do
+            let(:cfe_result) { create :cfe_v3_result, :with_capital_contribution_required }
+            it 'returns capital_contribution_required' do
+              expect(subject).to eq 'capital_contribution_required'
+            end
+          end
+
+          context 'income_contribution_required' do
+            let(:cfe_result) { create :cfe_v3_result, :with_income_contribution_required }
+            it 'returns income_contribution_required' do
+              expect(subject).to eq 'income_contribution_required'
+            end
+          end
+
+          context 'capital_and_income_contribution_required' do
+            let(:cfe_result) { create :cfe_v3_result, :with_capital_and_income_contributions_required }
+            it 'returns capital_and_income_contribution_required' do
+              expect(subject).to eq 'capital_and_income_contribution_required'
+            end
+          end
+        end
+
+        context 'manual check IS required and restrictions exist' do
+          before do
+            allow(CCMS::ManualReviewDeterminer).to receive(:call).with(application).and_return(true)
+            application.has_restrictions = true
+          end
+
+          context 'eligible' do
+            let(:cfe_result) { create :cfe_v3_result, :eligible }
+            it 'returns manual_check_required' do
+              expect(subject).to eq 'manual_check_required'
+            end
+          end
+
+          context 'not_eligible' do
+            let(:cfe_result) { create :cfe_v3_result, :not_eligible }
+            it 'returns manual_check_required' do
+              expect(subject).to eq 'manual_check_required'
+            end
+          end
+
+          context 'capital_contribution_required' do
+            let(:cfe_result) { create :cfe_v3_result, :with_capital_contribution_required }
+            it 'returns manual_check_required' do
+              expect(subject).to eq 'manual_check_required'
+            end
+          end
+
+          context 'income_contribution_required' do
+            let(:cfe_result) { create :cfe_v3_result, :with_income_contribution_required }
+            it 'returns manual_check_required' do
+              expect(subject).to eq 'manual_check_required'
+            end
+          end
+
+          context 'capital_and_income_contribution_required' do
+            let(:cfe_result) { create :cfe_v3_result, :with_capital_and_income_contributions_required }
+            it 'returns manual_check_required' do
+              expect(subject).to eq 'manual_check_required'
+            end
+          end
+        end
+      end
+
+      describe '#assessment_result' do
+        context 'eligible' do
+          it 'returns eligible' do
+            expect(eligible_result.assessment_result).to eq 'eligible'
+          end
+        end
+
+        context 'not_eligible' do
+          it 'returns not_eligible' do
+            expect(not_eligible_result.assessment_result).to eq 'not_eligible'
+          end
+        end
+
+        context 'contribution_required' do
+          it 'returns contribution_required' do
+            expect(contribution_required_result.assessment_result).to eq 'contribution_required'
+          end
+        end
+      end
+
+      describe '#capital_contribution' do
+        it 'returns the value of the capital contribution' do
+          expect(contribution_required_result.capital_contribution).to eq 465.66
+        end
+      end
+
+      describe 'eligible?' do
+        context 'returns true' do
+          it 'returns boolean response for eligible' do
+            expect(eligible_result.eligible?).to be true
+          end
+        end
+
+        context 'returns false' do
+          it 'returns false response for eligible' do
+            expect(not_eligible_result.eligible?).to be false
+          end
+        end
+      end
+
+      describe 'capital_contribution_required?' do
+        context 'contribution not required ' do
+          it 'returns false for capital_contribution_required' do
+            expect(eligible_result.capital_contribution_required?).to be false
+          end
+        end
+
+        context 'contribution is required ' do
+          it 'returns true for capital_contribution_required' do
+            expect(contribution_required_result.capital_contribution_required?).to be true
+          end
+        end
+      end
+
+      ################################################################
+      #  CAPITAL ITEMS                                               #
+      ################################################################
+
+      #  Are the next 2 tests testing the correct thing? Currently checks that an array contains items, what if there are no items?
+      describe 'non_liquid_capital_items' do
+        it 'returns the description and value for first item in non liquid items array' do
+          expect(eligible_result.non_liquid_capital_items.first[:description]).to be_a String
+          expect(eligible_result.non_liquid_capital_items.first[:value].to_d).to eq 3902.92
+        end
+      end
+
+      describe 'liquid_capital_items' do
+        it 'returns the description and value for first item in liquid items array' do
+          expect(eligible_result.liquid_capital_items.first[:description]).to be_a String
+          expect(eligible_result.liquid_capital_items.first[:value].to_d).to eq 6692.12
+        end
+      end
+
+      describe 'total_property' do
+        it 'returns the assessed value for total property' do
+          expect(eligible_result.total_property).to eq 1134.00
+        end
+      end
+
+      describe 'total_capital' do
+        it 'returns the assessed value for total capital' do
+          expect(eligible_result.total_capital).to eq '9552.05'
+        end
+      end
+
+      describe 'total_savings' do
+        it 'returns the assessed value for liquid assets' do
+          expect(eligible_result.total_savings).to eq 5649.13
+        end
+      end
+
+      describe 'total_other_assets' do
+        it 'returns the assessed value for non liquid assets' do
+          expect(eligible_result.total_other_assets).to eq 3902.92
+        end
+      end
+
+      ################################################################
+      # VEHICLES                                                     #
+      ################################################################
+
+      describe 'vehicle' do
+        it 'returns a vehicle' do
+          expect(eligible_result.vehicle).to be_kind_of(Hash)
+          expect(eligible_result.vehicle[:value].to_d).to eq 1784.61
+        end
+      end
+
+      describe 'vehicles?' do
+        context 'vehicle(s) exist' do
+          it 'returns a boolean response if vehicles exist' do
+            expect(eligible_result.vehicles?).to be true
+          end
+
+          context 'vehicles dont exist'
+          it 'returns a boolean response if vehicles exist' do
+            expect(no_vehicles.vehicles?).to be false
+          end
+        end
+      end
+
+      describe 'vehicle_value' do
+        it 'returns the assessed value for applicants vehicle' do
+          expect(eligible_result.vehicle_value).to eq 1784.61
+        end
+      end
+
+      describe 'vehicle_loan_amount_outstanding' do
+        it 'returns the loan value outstanding on applicants vehicle' do
+          expect(eligible_result.vehicle_loan_amount_outstanding).to eq 3225.77
+        end
+      end
+
+      describe 'vehicle_disregard' do
+        it 'returns the vehicle disregard for applicants vehicle ' do
+          expect(eligible_result.vehicle_disregard).to eq 1784.61
+        end
+      end
+
+      describe 'vehicle_assessed_amount' do
+        it 'returns the assessed value for the applicants vehicle' do
+          expect(eligible_result.vehicle_assessed_amount).to eq 0.0
+        end
+      end
+
+      describe 'total_vehicles' do
+        it 'returns the assessed value for all applicants vehicle(s)' do
+          expect(eligible_result.total_vehicles).to eq 0.0
+        end
+      end
+
+      ################################################################
+      #  ADDITIONAL PROPERTY                                         #
+      ################################################################
+
+      describe '#additional_property?' do
+        context 'present' do
+          it 'returns true' do
+            expect(additional_property.additional_property?).to be true
+          end
+        end
+
+        context 'not present' do
+          it 'returns false' do
+            expect(no_additional_properties.additional_property?).to be false
+          end
+        end
+
+        context 'present but zero' do
+          it 'returns false' do
+            expect(eligible_result.additional_property?).to be false
+          end
+        end
+      end
+
+      describe 'additional_property_value' do
+        it 'returns the value of the first additional property' do
+          expect(additional_property.additional_property_value).to eq 5_781.91
+        end
+      end
+
+      describe 'additional_property_transaction_allowance' do
+        it 'returns the transaction allowance for the first additional property' do
+          expect(additional_property.additional_property_transaction_allowance).to eq(-113.46)
+        end
+      end
+
+      describe 'additional_property_mortgage' do
+        it 'returns the mortgage for the first additional property' do
+          expect(additional_property.additional_property_mortgage).to eq(-8202.00)
+        end
+      end
+
+      describe 'additional_property_assessed_equity' do
+        it 'returns the assessed equity for the first additional property' do
+          expect(additional_property.additional_property_assessed_equity).to eq 125.33
+        end
+      end
+
+      ################################################################
+      #  MAIN HOME                                                   #
+      ################################################################
+
+      describe 'main_home_value' do
+        it 'returns the assessed value for the main home' do
+          expect(eligible_result.main_home_value).to eq 5985.82
+        end
+      end
+
+      describe 'main_home_outstanding_mortgage' do
+        it 'returns the assessed value for the main home' do
+          expect(eligible_result.main_home_outstanding_mortgage).to eq(-7201.44)
+        end
+      end
+
+      describe 'main_home_transaction_allowance' do
+        it 'returns the assessed value for the main home' do
+          expect(eligible_result.main_home_transaction_allowance).to eq(-179.57)
+        end
+      end
+
+      describe 'main_home_equity_disregard' do
+        it 'returns the assessed value for the main home' do
+          expect(eligible_result.main_home_equity_disregard).to eq(-100_000.0)
+        end
+      end
+
+      describe 'main_home_assessed_equity' do
+        it 'returns the assessed value for the main home' do
+          expect(eligible_result.main_home_assessed_equity).to eq 0.0
+        end
+      end
+
+      ################################################################
+      #  DISPOSABLE INCOME                                           #
+      ################################################################
+
+      describe 'maintenance_per_month' do
+        context 'when maintenance is received' do
+          subject(:maintenance_per_month) { with_maintenance.maintenance_per_month }
+          it { is_expected.to eq 150.00 }
+        end
+
+        context 'when maintenance is not received' do
+          subject(:maintenance_per_month) { eligible_result.maintenance_per_month }
+          it { is_expected.to eq 0.00 }
+        end
+      end
+
+      describe 'mei_student_loan' do
+        context 'when student_loan is received' do
+          subject(:mei_student_loan) { with_student_finance.mei_student_loan }
+          it { is_expected.to eq 125.00 }
+        end
+
+        context 'when student_loan is not received' do
+          subject(:mei_student_loan) { eligible_result.mei_student_loan }
+          it { is_expected.to eq 0.00 }
+        end
+      end
+
+      ################################################################
+      #  THRESHOLDS                                                  #
+      ################################################################
+
+      describe 'gross_income_upper_threshold' do
+        it 'returns the gross income upper threshold' do
+          expect(eligible_result.gross_income_upper_threshold).to eq '999999999999.0'
+        end
+      end
+
+      describe 'disposable_income_upper_threshold' do
+        it 'returns the disposable income upper threshold' do
+          expect(eligible_result.disposable_income_upper_threshold).to eq '999999999999.0'
+        end
+      end
+
+      describe 'disposable_income_lower_threshold' do
+        it 'returns the disposable income lower threshold' do
+          expect(eligible_result.disposable_income_lower_threshold).to eq '315.0'
+        end
+      end
+
+      ################################################################
+      #  TOTALS                                                      #
+      ################################################################
+
+      describe 'mortgage per month' do
+        context 'when mortgage is paid' do
+          it 'returns the value of mortgage per month' do
+            expect(eligible_result.mortgage_per_month).to eq 125.0
+          end
+        end
+
+        context 'when no mortgage is paid' do
+          it 'returns the value of mortgage per month' do
+            expect(no_mortgage.mortgage_per_month).to eq 0.0
+          end
+        end
+      end
+
+      describe 'pensioner_capital_disregard' do
+        it 'returns the total pension disregard' do
+          expect(eligible_result.pensioner_capital_disregard).to eq 0.0
+        end
+      end
+
+      describe 'total_capital_before_pensioner_disregard' do
+        it 'returns total capital before pension disregard' do
+          expect(eligible_result.total_capital_before_pensioner_disregard).to eq 10_686.05
+        end
+      end
+
+      describe 'total_disposable_capital' do
+        it 'returns total disposable capital' do
+          expect(eligible_result.total_disposable_capital).to eq 10_686.05
+        end
+      end
+
+      describe 'total_monthly_income' do
+        it 'returns total monthly income' do
+          expect(eligible_result.total_monthly_income).to eq 712.28
+        end
+      end
+
+      describe 'total_monthly_outgoings' do
+        it 'returns total monthly outgoings' do
+          expect(eligible_result.total_monthly_outgoings).to eq 675.0
+        end
+      end
+
+      describe 'total_gross_income' do
+        it 'returns total gross income' do
+          expect(eligible_result.total_gross_income).to eq 150.0
+        end
+      end
+
+      describe 'total_disposable_income_assessed' do
+        it 'returns total disposable income assessed' do
+          expect(eligible_result.total_disposable_income_assessed).to eq '0.0'
+        end
+      end
+
+      describe 'total_gross_income_assessed' do
+        it 'returns total gross income assessed' do
+          expect(eligible_result.total_gross_income_assessed).to eq '150.0'
+        end
+      end
+
+      describe 'total_deductions' do
+        it 'returns total deductions' do
+          expect(eligible_result.total_deductions).to eq 1791.86
+        end
+      end
+
+      ################################################################
+      #  REMARKS                                                     #
+      ################################################################
+
+      describe 'remarks' do
+        it 'returns a CFE::Remarks object' do
+          expect(eligible_result.remarks).to be_instance_of(CFE::Remarks)
+        end
+
+        it 'instantiates the Remarks class with the remarks part of the hash' do
+          expect(CFE::Remarks).to receive(:new).with({})
+          eligible_result.remarks
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/providers/means_reports_spec.rb
+++ b/spec/requests/providers/means_reports_spec.rb
@@ -23,32 +23,81 @@ RSpec.describe Providers::MeansReportsController, type: :request do
       subject
     end
 
-    it 'renders successfully' do
-      expect(response).to have_http_status(:ok)
+    context 'assessment v2 response' do
+      it 'renders successfully' do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'displays the application ref number' do
+        expect(unescaped_response_body).to include(legal_aid_application.application_ref)
+      end
+
+      it 'displays the CCMS case reference' do
+        expect(unescaped_response_body).to include(submission.case_ccms_reference)
+      end
+
+      it 'displays the total capital assessed' do
+        expect(unescaped_response_body).to include(gds_number_to_currency(cfe_result.total_capital))
+      end
+
+      it 'displays the capital lower limit' do
+        expect(unescaped_response_body).to include('£3,000')
+      end
+
+      it 'displays the capital upper limit' do
+        expect(unescaped_response_body).to include('£8,000')
+      end
+
+      it 'displays the capital contribution' do
+        expect(unescaped_response_body).to include(gds_number_to_currency(cfe_result.capital_contribution))
+      end
     end
 
-    it 'displays the application ref number' do
-      expect(unescaped_response_body).to include(legal_aid_application.application_ref)
-    end
+    context 'assessment v3 response' do
+      let(:legal_aid_application) { create :legal_aid_application, :with_proceeding_types, :with_everything, :with_cfe_v3_result, :assessment_submitted }
 
-    it 'displays the CCMS case reference' do
-      expect(unescaped_response_body).to include(submission.case_ccms_reference)
-    end
+      it 'renders successfully' do
+        expect(response).to have_http_status(:ok)
+      end
 
-    it 'displays the total capital assessed' do
-      expect(unescaped_response_body).to include(gds_number_to_currency(cfe_result.total_capital))
-    end
+      it 'displays all sources for Benefits' do
+        expect(unescaped_response_body).to include('Benefits')
+        expect(unescaped_response_body).to include('£75')
+      end
 
-    it 'displays the capital lower limit' do
-      expect(unescaped_response_body).to include('£3,000')
-    end
+      it 'displays all sources for Housing Costs' do
+        expect(unescaped_response_body).to include('Housing costs')
+        expect(unescaped_response_body).to include('£125')
+      end
 
-    it 'displays the capital upper limit' do
-      expect(unescaped_response_body).to include('£8,000')
-    end
+      it 'displays student loan' do
+        expect(unescaped_response_body).to include('Student loan or grant')
+        expect(unescaped_response_body).to include('£0')
+      end
 
-    it 'displays the capital contribution' do
-      expect(unescaped_response_body).to include(gds_number_to_currency(cfe_result.capital_contribution))
+      it 'displays the application ref number' do
+        expect(unescaped_response_body).to include(legal_aid_application.application_ref)
+      end
+
+      it 'displays the CCMS case reference' do
+        expect(unescaped_response_body).to include(submission.case_ccms_reference)
+      end
+
+      it 'displays the total capital assessed' do
+        expect(unescaped_response_body).to include(gds_number_to_currency(cfe_result.total_capital))
+      end
+
+      it 'displays the capital lower limit' do
+        expect(unescaped_response_body).to include('£3,000')
+      end
+
+      it 'displays the capital upper limit' do
+        expect(unescaped_response_body).to include('£8,000')
+      end
+
+      it 'displays the capital contribution' do
+        expect(unescaped_response_body).to include(gds_number_to_currency(cfe_result.capital_contribution))
+      end
     end
 
     context 'when not authenticated' do

--- a/spec/services/reports/means_report_creator_spec.rb
+++ b/spec/services/reports/means_report_creator_spec.rb
@@ -11,18 +11,38 @@ RSpec.describe Reports::MeansReportCreator do
   end
 
   describe '.call' do
-    it 'attaches means_report.pdf to the application' do
-      expect_any_instance_of(CCMS::Requestors::ReferenceDataRequestor).to receive(:call)
-      expect(Providers::MeansReportsController.renderer).to receive(:render).and_call_original
-      subject
-      legal_aid_application.reload
-      expect(legal_aid_application.means_report.document.content_type).to eq('application/pdf')
-      expect(legal_aid_application.means_report.document.filename).to eq('means_report.pdf')
+    context 'assessment v2 response' do
+      it 'attaches means_report.pdf to the application' do
+        expect_any_instance_of(CCMS::Requestors::ReferenceDataRequestor).to receive(:call)
+        expect(Providers::MeansReportsController.renderer).to receive(:render).and_call_original
+        subject
+        legal_aid_application.reload
+        expect(legal_aid_application.means_report.document.content_type).to eq('application/pdf')
+        expect(legal_aid_application.means_report.document.filename).to eq('means_report.pdf')
+      end
+
+      it 'does not attach a report if one already exists' do
+        create :attachment, :means_report, legal_aid_application: legal_aid_application
+        expect { subject }.not_to change { Attachment.count }
+      end
     end
 
-    it 'does not attach a report if one already exists' do
-      create :attachment, :means_report, legal_aid_application: legal_aid_application
-      expect { subject }.not_to change { Attachment.count }
+    context 'assessment v3 response' do
+      let(:legal_aid_application) { create :legal_aid_application, :with_proceeding_types, :with_everything, :with_cfe_v3_result, :generating_reports }
+
+      it 'attaches means_report.pdf to the application' do
+        expect_any_instance_of(CCMS::Requestors::ReferenceDataRequestor).to receive(:call)
+        expect(Providers::MeansReportsController.renderer).to receive(:render).and_call_original
+        subject
+        legal_aid_application.reload
+        expect(legal_aid_application.means_report.document.content_type).to eq('application/pdf')
+        expect(legal_aid_application.means_report.document.filename).to eq('means_report.pdf')
+      end
+
+      it 'does not attach a report if one already exists' do
+        create :attachment, :means_report, legal_aid_application: legal_aid_application
+        expect { subject }.not_to change { Attachment.count }
+      end
     end
   end
 end


### PR DESCRIPTION
## What

[AP-1970](https://dsdmoj.atlassian.net/browse/AP-1970)

To complete the cash transactions work this PR parses the CFE V3 response when admin settings are set to include cash transactions. V3 CFE result factories and traits have been setup, separately to V2, with a view for the latter to be removed once this work is all live.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
