### PR TITLE
BugFix reverse rubocop fix for bin/bundle file 

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -59,6 +59,10 @@ Metrics/ModuleLength:
 Metrics/ParameterLists:
   Max: 7
 
+Rails/Present:
+  Exclude:
+  - 'bin/bundle'
+
 Style/BlockDelimiters:
   EnforcedStyle: braces_for_chaining
 

--- a/bin/bundle
+++ b/bin/bundle
@@ -42,7 +42,7 @@ m = Module.new do
 
   def gemfile
     gemfile = ENV['BUNDLE_GEMFILE']
-    return gemfile if gemfile.present?
+    return gemfile if gemfile && !gemfile.empty?
 
     File.expand_path('../Gemfile', __dir__)
   end


### PR DESCRIPTION
## BugFix reverse rubocop fix for bin/bundle file 

[Link to story](https://dsdmoj.atlassian.net/browse/AP-XXX)

This is because #present? is not a ruby method and this file is not a rails file.


## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
