### PR TITLE
AP-1996 show checkbox errors on revealed fields

### DIFF
--- a/app/views/providers/other_assets/_second_home_conditional_checkbox.html.erb
+++ b/app/views/providers/other_assets/_second_home_conditional_checkbox.html.erb
@@ -1,7 +1,7 @@
 <%
   check_box_attribute = 'check_box_second_home'
   hint = I18n.t("helpers.hint.#{check_box_attribute}", default: nil)
-  @form.__send__("#{check_box_attribute}=", model.any_second_home_value_present?)
+  @form.__send__("#{check_box_attribute}=", model.send(check_box_attribute).present? || model.any_second_home_value_present?)
 %>
 
 <%= form.govuk_check_box check_box_attribute, true, multiple: false, link_errors: true,

--- a/app/views/shared/forms/revealing_checkbox/_attribute.html.erb
+++ b/app/views/shared/forms/revealing_checkbox/_attribute.html.erb
@@ -3,7 +3,7 @@
   hint = controller_t "hint.#{check_box_attribute}", default: ''
   revealing_hint = controller_t "hint.revealing_#{check_box_attribute}", default: ''
   value = model.send(attribute)
-  @form.__send__("#{check_box_attribute}=", value.present?)
+  @form.__send__("#{check_box_attribute}=", model.send(check_box_attribute).present? || value.present?)
 %>
 <%= form.govuk_check_box check_box_attribute, true, multiple: false, link_errors: true,
                          label: {text: controller_t(check_box_attribute)},


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1996)

Fixed so that fields are expanded to show errors on the conditionally revealed fields 

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
