### PR TITLE
AP-1968: Update styling and read_only values for the means report

### DIFF
--- a/app/helpers/check_answers_helper.rb
+++ b/app/helpers/check_answers_helper.rb
@@ -3,7 +3,7 @@ module CheckAnswersHelper
   #     <dl class="govuk-summary-list govuk-!-margin-bottom-9">
   #       <%= check_answer_link ..... %>
   #     </dl>
-  def check_answer_link(question:, answer:, name:, url: nil, read_only: false, align_right: false, no_border: false) # rubocop:disable Metrics/ParameterLists
+  def check_answer_link(question:, answer:, name:, url: nil, read_only: false, no_border: false) # rubocop:disable Metrics/ParameterLists
     render(
       'shared/check_answers/item',
       name: name,
@@ -11,17 +11,17 @@ module CheckAnswersHelper
       question: question,
       answer: answer,
       read_only: url.nil? ? true : read_only,
-      no_border: no_border,
-      align_right: align_right
+      no_border: no_border
     )
   end
 
-  def check_answer_no_link(question:, answer:, name:, no_border: false)
+  def check_answer_no_link(question:, answer:, name:, no_border: false, read_only: false)
     render(
       'shared/check_answers/no_link_item',
       name: name,
       question: question,
       answer: answer,
+      read_only: read_only,
       no_border: no_border
     )
   end

--- a/app/views/layouts/pdf.html.erb
+++ b/app/views/layouts/pdf.html.erb
@@ -6,7 +6,7 @@
     <%= render 'layouts/govuk_base64_fonts' %>
   </head>
 
-  <body class="govuk-template__body ">
+  <body class="govuk-template__body pdf">
     <div class="govuk-width-container">
       <main class="govuk-main-wrapper " id="main-content" role="main">
         <%= yield %>

--- a/app/views/providers/means_reports/show.html.erb
+++ b/app/views/providers/means_reports/show.html.erb
@@ -20,7 +20,7 @@
           name: :receives_benefit,
           question: t('.question_receives_benefit'),
           answer: yes_no(@legal_aid_application.applicant_receives_benefit?),
-          align_right: true
+          read_only: true
         ) %>
   </dl>
 
@@ -76,7 +76,7 @@
   <% if @legal_aid_application.passported? && @cfe_result.capital_contribution_required? %>
     <section class="print-no-break">
       <h2 class="govuk-heading-l"><%= t('.caseworker-review-section-heading') %></h2>
-      <%= render partial: 'caseworker_review', locals: {remarks: @cfe_result.remarks } %>
+      <%= render partial: 'caseworker_review', locals: { remarks: @cfe_result.remarks } %>
     </section>
   <% end %>
 <% end %>

--- a/app/views/shared/check_answers/_capital_result.html.erb
+++ b/app/views/shared/check_answers/_capital_result.html.erb
@@ -5,32 +5,28 @@
           name: :total_capital_assessed,
           question: t('.total'),
           answer: gds_number_to_currency(@legal_aid_application.cfe_result.total_capital),
-          read_only: read_only,
-          align_right: read_only
+          read_only: read_only
         ) %>
 
     <%= check_answer_link(
           name: :capital_lower_limit,
           question: t('.lower_limit_label'),
           answer: gds_number_to_currency(Rails.configuration.x.capital_result.lower_limit),
-          read_only: read_only,
-          align_right: read_only
+          read_only: read_only
         ) %>
 
     <%= check_answer_link(
           name: :capital_upper_limit,
           question: t('.upper_limit_label'),
           answer: gds_number_to_currency(Rails.configuration.x.capital_result.upper_limit),
-          read_only: read_only,
-          align_right: read_only
+          read_only: read_only
         ) %>
 
     <%= check_answer_link(
           name: :capital_contribution,
           question: t('.contribution'),
           answer: gds_number_to_currency(@legal_aid_application.cfe_result.capital_contribution),
-          read_only: read_only,
-          align_right: read_only
+          read_only: read_only
         ) %>
   </dl>
 </section>

--- a/app/views/shared/check_answers/_income_result.html.erb
+++ b/app/views/shared/check_answers/_income_result.html.erb
@@ -5,48 +5,42 @@
             name: :total_gross_income_assessed,
             question: t('.total_gross_income'),
             answer: gds_number_to_currency(@legal_aid_application.cfe_result.total_gross_income_assessed),
-            read_only: read_only,
-            align_right: read_only
+            read_only: read_only
         ) %>
 
     <%= check_answer_link(
             name: :total_disposable_income_assessed,
             question: t('.total_disposable_income'),
             answer: gds_number_to_currency(@legal_aid_application.cfe_result.total_disposable_income_assessed),
-            read_only: read_only,
-            align_right: read_only
+            read_only: read_only
         ) %>
 
     <%= check_answer_link(
             name: :gross_income_limit,
             question: t('.gross_income_limit'),
             answer: number_to_currency_or_na(@legal_aid_application.cfe_result.gross_income_upper_threshold),
-            read_only: read_only,
-            align_right: read_only
+            read_only: read_only
         ) %>
 
     <%= check_answer_link(
             name: :disposable_income_lower_limit,
             question: t('.disposable_income_lower_limit'),
             answer: gds_number_to_currency(@legal_aid_application.cfe_result.disposable_income_lower_threshold),
-            read_only: read_only,
-            align_right: read_only
+            read_only: read_only
         ) %>
 
     <%= check_answer_link(
             name: :disposable_income_upper_limit_limit,
             question: t('.disposable_income_upper_limit'),
             answer: number_to_currency_or_na(@legal_aid_application.cfe_result.disposable_income_upper_threshold),
-            read_only: read_only,
-            align_right: read_only
+            read_only: read_only
         ) %>
 
     <%= check_answer_link(
             name: :disposable_income_contribution,
             question: t('.disposable_income_contribution'),
             answer: gds_number_to_currency(@legal_aid_application.cfe_result.income_contribution),
-            read_only: read_only,
-            align_right: read_only
+            read_only: read_only
         ) %>
   </dl>
 </section>

--- a/app/views/shared/check_answers/_item.html.erb
+++ b/app/views/shared/check_answers/_item.html.erb
@@ -7,7 +7,8 @@
   <dt class="govuk-summary-list__key govuk-!-width-one-half">
     <%= question %>
   </dt>
-  <dd class="govuk-summary-list__value">
+  <!--  in-line styling due to issues around pdf generation in our production envs -->
+  <dd class="govuk-summary-list__value"<% if read_only %> style="text-align: right;"<% end %>>
     <%= answer.present? ? answer : '-' %>
   </dd>
   <% unless read_only %>

--- a/app/views/shared/check_answers/_merits.html.erb
+++ b/app/views/shared/check_answers/_merits.html.erb
@@ -10,13 +10,15 @@
     <%= check_answer_no_link(
           name: :notification_of_latest_incident,
           question: t('.items.notification_of_latest_incident'),
-          answer: incident&.told_on
+          answer: incident&.told_on,
+          read_only: read_only
         ) %>
 
     <%= check_answer_no_link(
           name: :date_of_latest_incident,
           question: t('.items.date_of_latest_incident'),
-          answer: incident&.occurred_on
+          answer: incident&.occurred_on,
+          read_only: read_only
         ) %>
   </dl>
 
@@ -36,7 +38,8 @@
     <%= check_answer_no_link(
           name: :respondent_name,
           question: t('.items.respondent_name'),
-          answer: respondent.full_name
+          answer: respondent.full_name,
+          read_only: read_only
         ) %>
   </dl>
 </section>
@@ -56,7 +59,8 @@
           name: :understands_terms_of_court_order,
           question: t('.items.understands_terms_of_court_order'),
           answer: yes_no(respondent.understands_terms_of_court_order),
-          no_border: !respondent.understands_terms_of_court_order
+          no_border: !respondent.understands_terms_of_court_order,
+          read_only: read_only
         ) %>
   </dl>
   <div class='govuk-body'><%= respondent.understands_terms_of_court_order_details %></div>
@@ -68,7 +72,8 @@
           name: :warning_letter_sent,
           question: t('.items.warning_letter_sent'),
           answer: yes_no(respondent.warning_letter_sent),
-          no_border: !respondent.warning_letter_sent
+          no_border: !respondent.warning_letter_sent,
+          read_only: read_only
         ) %>
   </dl>
   <div class='govuk-body'><%= respondent.warning_letter_sent_details %></div>
@@ -80,7 +85,8 @@
           name: :police_notified,
           question: t('.items.police_notified'),
           answer: yes_no(respondent.police_notified),
-          no_border: true
+          no_border: true,
+          read_only: read_only
         ) %>
   </dl>
   <div class='govuk-body'><%= respondent.police_notified_details %></div>
@@ -92,7 +98,8 @@
           name: :bail_conditions_set,
           question: t('.items.bail_conditions_set'),
           answer: yes_no(respondent.bail_conditions_set),
-          no_border: respondent.bail_conditions_set
+          no_border: respondent.bail_conditions_set,
+          read_only: read_only
         ) %>
   </dl>
   <div class='govuk-body'><%= respondent.bail_conditions_set_details %></div>
@@ -126,8 +133,7 @@
           url: providers_legal_aid_application_success_likely_index_path(@legal_aid_application),
           question: t('.items.prospects_of_success'),
           answer: yes_no(merits_assessment.success_likely),
-          read_only: read_only,
-          align_right: read_only
+          read_only: read_only
         ) %>
   </dl>
 
@@ -137,8 +143,7 @@
           url: providers_legal_aid_application_success_likely_index_path(@legal_aid_application),
           question: t('.items.success_prospect'),
           answer: t("shared.forms.success_prospect.#{merits_assessment.success_prospect}"),
-          read_only: read_only,
-          align_right: read_only
+          read_only: read_only
         ) unless merits_assessment.success_likely? %>
   </dl>
 

--- a/app/views/shared/check_answers/_no_link_item.html.erb
+++ b/app/views/shared/check_answers/_no_link_item.html.erb
@@ -5,7 +5,8 @@
   <dt class="govuk-summary-list__key">
     <%= question %>
   </dt>
-  <dd class="govuk-summary-list__value">
+  <!--  in-line styling due to issues around pdf generation in our production envs -->
+  <dd class="govuk-summary-list__value"<% if read_only %> style="text-align: right;"<% end %>>
     <%= answer.present? ? answer : '-' %>
   </dd>
 </div>

--- a/app/views/shared/check_answers/_one_link_section.html.erb
+++ b/app/views/shared/check_answers/_one_link_section.html.erb
@@ -20,7 +20,8 @@
         <%= check_answer_no_link(
               name: "#{name}_#{index}",
               question: item.label,
-              answer: safe_yes_or_no(item.amount_text)
+              answer: safe_yes_or_no(item.amount_text),
+              read_only: read_only
             ) %>
       <% end %>
 

--- a/app/views/shared/check_answers/_property.html.erb
+++ b/app/views/shared/check_answers/_property.html.erb
@@ -5,8 +5,7 @@
           url: check_answer_url_for(journey_type, :own_homes, @legal_aid_application),
           question: t('shared.check_answers.assets.property.own_home'),
           answer: @legal_aid_application.own_home.blank? ? '' : t("shared.forms.own_home_form.#{@legal_aid_application.own_home}"),
-          read_only: read_only,
-          align_right: read_only
+          read_only: read_only
           ) %>
 
   <%= check_answer_link(
@@ -14,8 +13,7 @@
           url: check_answer_url_for(journey_type, :property_values, @legal_aid_application),
           question: t('shared.check_answers.assets.property.property_value'),
           answer: gds_number_to_currency(@legal_aid_application.property_value),
-          read_only: read_only,
-          align_right: read_only
+          read_only: read_only
           ) if @legal_aid_application.own_home? %>
 
   <%= check_answer_link(
@@ -23,8 +21,7 @@
           url: check_answer_url_for(journey_type, :outstanding_mortgages, @legal_aid_application),
           question: t('shared.check_answers.assets.property.outstanding_mortgage'),
           answer: gds_number_to_currency(@legal_aid_application.outstanding_mortgage_amount),
-          read_only: read_only,
-          align_right: read_only
+          read_only: read_only
           ) if @legal_aid_application.own_home_mortgage? %>
 
   <%= check_answer_link(
@@ -32,8 +29,7 @@
           url: check_answer_url_for(journey_type, :shared_ownerships, @legal_aid_application),
           question: t('shared.check_answers.assets.property.shared_ownership'),
           answer: @legal_aid_application.shared_ownership.blank? ? '' : t("shared.forms.shared_ownership_form.#{@legal_aid_application.shared_ownership}"),
-          read_only: read_only,
-          align_right: read_only
+          read_only: read_only
           ) if @legal_aid_application.own_home? %>
 
   <%= check_answer_link(
@@ -41,8 +37,7 @@
           url: check_answer_url_for(journey_type, :percentage_homes, @legal_aid_application),
           question: t('shared.check_answers.assets.property.percentage_home'),
           answer: number_to_percentage(@legal_aid_application.percentage_home, precision: 2),
-          read_only: read_only,
-          align_right: read_only
+          read_only: read_only
           ) if @legal_aid_application.shared_ownership? && @legal_aid_application.own_home? %>
 
 </dl>

--- a/app/views/shared/check_answers/_restrictions.html.erb
+++ b/app/views/shared/check_answers/_restrictions.html.erb
@@ -6,7 +6,7 @@
         question: t(".#{journey_type}.question"),
         answer: yes_no(@legal_aid_application.has_restrictions),
         no_border: @legal_aid_application.has_restrictions?,
-        read_only: read_only,
+        read_only: read_only
       ) %>
 
 </dl>

--- a/app/webpack/stylesheets/check-your-answers.scss
+++ b/app/webpack/stylesheets/check-your-answers.scss
@@ -4,6 +4,11 @@
 $govuk-fonts-path: "~govuk-frontend/govuk/assets/fonts/";
 
 // Recommended - Use these styles for the check your answers pattern
+
+.pdf {
+  text-rendering: geometricPrecision;
+}
+
 .app-check-your-answers {
   @include govuk-font(19);
   @include govuk-responsive-margin(3, "bottom");
@@ -12,12 +17,6 @@ $govuk-fonts-path: "~govuk-frontend/govuk/assets/fonts/";
 
   .govuk-grid-row div:first-child {
     font-weight: bold;
-  }
-
-  .align_right {
-    @include govuk-media-query($from: desktop) {
-      text-align: right;
-    }
   }
 }
 .app-check-your-answers {
@@ -28,12 +27,6 @@ $govuk-fonts-path: "~govuk-frontend/govuk/assets/fonts/";
 
   .govuk-grid-row div:first-child {
     font-weight: bold;
-  }
-
-  .align_right {
-    @include govuk-media-query($from: desktop) {
-      text-align: right;
-    }
   }
 }
 
@@ -54,13 +47,6 @@ $govuk-fonts-path: "~govuk-frontend/govuk/assets/fonts/";
 
   .govuk-grid-row div:last-child {
     width: 25%;
-  }
-
-  .align_right {
-    @include govuk-media-query($from: desktop) {
-      width: 100%;
-      text-align: right;
-    }
   }
 }
 
@@ -103,7 +89,9 @@ $govuk-fonts-path: "~govuk-frontend/govuk/assets/fonts/";
 }
 
 .align-text-right {
-  text-align: right;
+  @include govuk-media-query($from: desktop) {
+    text-align: right;
+  }
 }
 
 strong.app-tag--capitalize {


### PR DESCRIPTION
## What

[AP-1968](https://dsdmoj.atlassian.net/browse/AP-1968)

Refactored the align right styling as even though it was being set it appears it wasn't being used when an html file was set to read_only for the reports generation. Also wickedpdf sets out it's own formatting when creating a pdf which supersedes class name styling so by setting text-precision this assists with the rendering process to ensure there is whitespace between question/answers in the means (and other) reports. 

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
