### PR TITLE
AP-2020 Update other capital ccms attributes

### DIFF
--- a/ccms_integration/example_payloads/Dave_Fabby_CaseAddPayload.xml
+++ b/ccms_integration/example_payloads/Dave_Fabby_CaseAddPayload.xml
@@ -1253,6 +1253,12 @@
                                     <ns0:UserDefinedInd>true</ns0:UserDefinedInd>
                                  </ns0:Attribute>
                                  <ns0:Attribute>
+                                    <ns0:Attribute>GB_INPUT_B_17WP2_8A</ns0:Attribute>
+                                    <ns0:ResponseType>boolean</ns0:ResponseType>
+                                    <ns0:ResponseValue>false</ns0:ResponseValue>
+                                    <ns0:UserDefinedInd>true</ns0:UserDefinedInd>
+                                 </ns0:Attribute>
+                                 <ns0:Attribute>
                                     <ns0:Attribute>OUT_GB_INFER_C_28WP4_2A</ns0:Attribute>
                                     <ns0:ResponseType>currency</ns0:ResponseType>
                                     <ns0:ResponseValue>0.00</ns0:ResponseValue>

--- a/ccms_integration/example_payloads/NonPassportedFullMonty.csv
+++ b/ccms_integration/example_payloads/NonPassportedFullMonty.csv
@@ -305,6 +305,7 @@ MeansAssesments,global,GB_PROC_B_40WP3_57A,boolean,false
 MeansAssesments,global,GB_PROC_B_40WP3_45A,boolean,false
 MeansAssesments,global,OUT_GB_INPUT_C_20WP3_372A,currency,false
 MeansAssesments,global,GB_INPUT_B_17WP2_7A,boolean,true
+MeansAssesments,global,GB_INPUT_B_17WP2_8A,boolean,true
 MeansAssesments,global,GB_INPUT_T_6WP3_330A,text,true
 MeansAssesments,global,OUT_GB_INFER_C_28WP4_2A,currency,false
 MeansAssesments,global,GB_PROC_B_39WP3_32A,boolean,false
@@ -656,7 +657,6 @@ MeansAssesments,OTHER_CAPITAL,OTHCAPITAL_INPUT_B_17WP2_1A,boolean,true
 MeansAssesments,OTHER_CAPITAL,OTHCAPITAL_INPUT_B_17WP2_5A,boolean,true
 MeansAssesments,OTHER_CAPITAL,OTHCAPITAL_INPUT_B_17WP2_4A,boolean,true
 MeansAssesments,OTHER_CAPITAL,OTHCAPITAL_INPUT_B_17WP2_2A,boolean,true
-MeansAssesments,OTHER_CAPITAL,OTHCAPITAL_INPUT_C_17WP2_14A,currency,true
 MeansAssesments,WILL,WILL_INPUT_B_2WP2_24A,boolean,true
 MeansAssesments,WILL,WILL_INPUT_B_2WP2_26A,boolean,true
 MeansAssesments,WILL,WILL_INPUT_B_2WP2_27A,boolean,true

--- a/ccms_integration/example_payloads/NonPassportedFullMonty.xml
+++ b/ccms_integration/example_payloads/NonPassportedFullMonty.xml
@@ -2094,7 +2094,13 @@
                       <ns3:Attribute>
                         <ns3:Attribute>GB_INPUT_B_17WP2_7A</ns3:Attribute>
                         <ns3:ResponseType>boolean</ns3:ResponseType>
-                        <ns3:ResponseValue>true</ns3:ResponseValue>
+                        <ns3:ResponseValue>false</ns3:ResponseValue>
+                        <ns3:UserDefinedInd>true</ns3:UserDefinedInd>
+                      </ns3:Attribute>
+                      <ns3:Attribute>
+                        <ns3:Attribute>GB_INPUT_B_17WP2_8A</ns3:Attribute>
+                        <ns3:ResponseType>boolean</ns3:ResponseType>
+                        <ns3:ResponseValue>false</ns3:ResponseValue>
                         <ns3:UserDefinedInd>true</ns3:UserDefinedInd>
                       </ns3:Attribute>
                       <ns3:Attribute>
@@ -4264,12 +4270,6 @@
                         <ns3:Attribute>OTHCAPITAL_INPUT_B_17WP2_2A</ns3:Attribute>
                         <ns3:ResponseType>boolean</ns3:ResponseType>
                         <ns3:ResponseValue>false</ns3:ResponseValue>
-                        <ns3:UserDefinedInd>true</ns3:UserDefinedInd>
-                      </ns3:Attribute>
-                      <ns3:Attribute>
-                        <ns3:Attribute>OTHCAPITAL_INPUT_C_17WP2_14A</ns3:Attribute>
-                        <ns3:ResponseType>currency</ns3:ResponseType>
-                        <ns3:ResponseValue>200.00</ns3:ResponseValue>
                         <ns3:UserDefinedInd>true</ns3:UserDefinedInd>
                       </ns3:Attribute>
                     </ns3:Attributes>

--- a/ccms_integration/example_payloads/PassportedSingleProceedingNonMol.xml
+++ b/ccms_integration/example_payloads/PassportedSingleProceedingNonMol.xml
@@ -1151,6 +1151,12 @@
                                     <ns1:UserDefinedInd>true</ns1:UserDefinedInd>
                                  </ns1:Attribute>
                                  <ns1:Attribute>
+                                    <ns1:Attribute>GB_INPUT_B_17WP2_8A</ns1:Attribute>
+                                    <ns1:ResponseType>boolean</ns1:ResponseType>
+                                    <ns1:ResponseValue>false</ns1:ResponseValue>
+                                    <ns1:UserDefinedInd>true</ns1:UserDefinedInd>
+                                 </ns1:Attribute>
+                                 <ns1:Attribute>
                                     <ns1:Attribute>OUT_GB_INFER_C_26WP2_105A</ns1:Attribute>
                                     <ns1:ResponseType>currency</ns1:ResponseType>
                                     <ns1:ResponseValue>0.00</ns1:ResponseValue>

--- a/ccms_integration/example_payloads/PassportedSingleProceedingNonMolDelegated.xml
+++ b/ccms_integration/example_payloads/PassportedSingleProceedingNonMolDelegated.xml
@@ -1151,6 +1151,12 @@
                                     <ns1:UserDefinedInd>true</ns1:UserDefinedInd>
                                  </ns1:Attribute>
                                  <ns1:Attribute>
+                                    <ns1:Attribute>GB_INPUT_B_17WP2_8A</ns1:Attribute>
+                                    <ns1:ResponseType>boolean</ns1:ResponseType>
+                                    <ns1:ResponseValue>false</ns1:ResponseValue>
+                                    <ns1:UserDefinedInd>true</ns1:UserDefinedInd>
+                                 </ns1:Attribute>
+                                 <ns1:Attribute>
                                     <ns1:Attribute>OUT_GB_INFER_C_26WP2_105A</ns1:Attribute>
                                     <ns1:ResponseType>currency</ns1:ResponseType>
                                     <ns1:ResponseValue>0.00</ns1:ResponseValue>

--- a/config/ccms/attribute_block_configs/base.yml
+++ b/config/ccms/attribute_block_configs/base.yml
@@ -902,6 +902,11 @@ global_means:
     br100_meaning: 'Other capital: The client has other capital?'
     response_type: boolean
     user_defined: true
+  GB_INPUT_B_17WP2_8A:
+    value: false
+    br100_meaning: 'Other capital: '
+    response_type: boolean
+    user_defined: true
   OUT_GB_INFER_C_28WP4_2A:
     generate_block?: false
     value: 0.0

--- a/config/ccms/attribute_block_configs/non_passported.yml
+++ b/config/ccms/attribute_block_configs/non_passported.yml
@@ -1597,19 +1597,18 @@ other_capital:
     response_type: boolean
     user_defined: true
     generate_block?: true
-  OTHCAPITAL_INPUT_C_17WP2_14A:
-    value: '0'
-    br100_meaning: 'Other capital: The value'
-    user_defined: true
-    response_type: currency
-    generate_block?: true
   OTHCAPITAL_INPUT_T_17WP2_13A:
     value: "."
     br100_meaning: 'Other capital: What it is'
     user_defined: true
     response_type: text
     generate_block?: true
-
+  OTHCAPITAL_INPUT_C_17WP2_14A:
+    value: '0'
+    br100_meaning: 'Other capital: The value'
+    user_defined: true
+    response_type: currency
+    generate_block?: false
 other_savings:
   OTHERSAVING_INPUT_B_10WP2_14A:
     value: false

--- a/spec/data/ccms/case_add_request.xml
+++ b/spec/data/ccms/case_add_request.xml
@@ -646,6 +646,12 @@
                             <ns0:UserDefinedInd>true</ns0:UserDefinedInd>
                           </ns0:Attribute>
                           <ns0:Attribute>
+                            <ns0:Attribute>GB_INPUT_B_17WP2_8A</ns0:Attribute>
+                            <ns0:ResponseType>boolean</ns0:ResponseType>
+                            <ns0:ResponseValue>false</ns0:ResponseValue>
+                            <ns0:UserDefinedInd>true</ns0:UserDefinedInd>
+                          </ns0:Attribute>
+                          <ns0:Attribute>
                             <ns0:Attribute>GB_PROC_B_39WP3_32A</ns0:Attribute>
                             <ns0:ResponseType>boolean</ns0:ResponseType>
                             <ns0:ResponseValue>false</ns0:ResponseValue>

--- a/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_additional_property_attributes_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_additional_property_attributes_spec.rb
@@ -110,7 +110,6 @@ module CCMS
             ['main_third', 'MAINTHIRD_INPUT_T_3WP2_12A', 'text', true, '.'],
             ['main_third', 'MAINTHIRD_INPUT_T_3WP2_13A', 'text', true, 'Other'],
             ['money_due', 'MONEYDUE_INPUT_T_15WP2_13A', 'text', true, 'debtor'],
-            ['other_capital', 'OTHCAPITAL_INPUT_C_17WP2_14A', 'currency', true, '0'],
             ['other_capital', 'OTHCAPITAL_INPUT_T_17WP2_13A', 'text', true, '.'],
             ['other_savings', 'OTHERSAVING_INPUT_C_10WP2_11A', 'currency', true, '0'],
             ['other_savings', 'OTHERSAVING_INPUT_T_10WP2_18A', 'text', true, '0'],

--- a/spec/services/ccms/requestors/case_add_requestor_xml_blocks/passported_attributes_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_xml_blocks/passported_attributes_spec.rb
@@ -2084,6 +2084,7 @@ module CCMS
           [:global_means, 'GB_INFER_B_1WP1_1A'],
           [:global_means, 'GB_INPUT_B_14WP2_7A'],
           [:global_means, 'GB_INPUT_B_17WP2_7A'],
+          [:global_means, 'GB_INPUT_B_17WP2_8A'],
           [:global_means, 'GB_INPUT_B_18WP2_2A'],
           [:global_means, 'GB_INPUT_B_18WP2_4A'],
           [:global_means, 'GB_INPUT_B_1WP1_2A'],


### PR DESCRIPTION
## AP-2020 Update other capital ccms attributes

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2020)

- Hardcode GB_INPUT_B_17WP2_7A to false 
- Add new attribute GB_INPUT_B_17WP2_8A with hardcode value of false
- remove ccms attribute OTHCAPITAL_INPUT_C_17WP2_14A

- Update tests

left to do:
- [ ] find meaning of GB_INPUT_B_17WP2_8A and add to attribute block config

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
