### PR TITLE
AP-2036: Remove validation of no selected bank transactions and add c…

### DIFF
--- a/app/models/cfe/v3/result.rb
+++ b/app/models/cfe/v3/result.rb
@@ -152,7 +152,7 @@ module CFE
       ################################################################
 
       def monthly_state_benefits
-        gross_income[:state_benefits][:monthly_equivalents].first[:all_sources].to_d
+        gross_income[:state_benefits][:monthly_equivalents][:all_sources].to_d
       end
 
       def mei_friends_or_family

--- a/app/views/shared/check_answers/_bank_transaction_table.html.erb
+++ b/app/views/shared/check_answers/_bank_transaction_table.html.erb
@@ -9,7 +9,7 @@
          <%= t('.total', text: transaction_type.label_name) %>
        </td>
        <td class="govuk-table__cell govuk-table__cell--numeric">
-         <%= gds_number_to_currency @legal_aid_application.bank_transactions.amounts.fetch(transaction_type.id, 0) %>
+         <%= gds_number_to_currency @legal_aid_application.transactions_total_by_type(:bank, transaction_type.id) %>
        </td>
      </tr>
    <% end %>

--- a/app/views/shared/check_answers/_income_summary.html.erb
+++ b/app/views/shared/check_answers/_income_summary.html.erb
@@ -18,7 +18,7 @@
         <%= transaction_type.label_name %>
       </dt>
       <dd class="govuk-summary-list__value">
-        <%= number_to_currency @legal_aid_application.bank_transactions.amounts.fetch(transaction_type.id, 0).abs %>
+        <%= number_to_currency @legal_aid_application.transactions_total_by_category(transaction_type.id) %>
       </dd>
     </div>
     <% end %>

--- a/spec/factories/cfe_results/v3/mock_results.rb
+++ b/spec/factories/cfe_results/v3/mock_results.rb
@@ -31,15 +31,17 @@ module CFEResults
                 }
               },
               state_benefits: {
-                monthly_equivalents: [
-                  {
-                    name: 'manually_chosen',
-                    all_sources: '75.0',
-                    cash_transactions: '25.0',
-                    bank_transactions: '50.00',
-                    excluded_from_income_assessment: false
-                  }
-                ]
+                monthly_equivalents: {
+                  all_sources: '75.0',
+                  cash_transactions: '25.0',
+                  bank_transactions: [
+                    {
+                      name: 'manually_chosen',
+                      monthly_value: '50.00',
+                      excluded_from_income_assessment: false
+                    }
+                  ]
+                }
               },
               other_income: {
                 monthly_equivalents: {

--- a/spec/models/bank_transaction_spec.rb
+++ b/spec/models/bank_transaction_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe BankTransaction do
     end
 
     describe 'scope by parent_transaction_type' do
-      it 'groups the transactions keyed by parent transaction tyep' do
+      it 'groups the transactions keyed by parent transaction type' do
         trx_p1 = create :bank_transaction, :credit, transaction_type: pension
         trx_p2 = create :bank_transaction, :credit, transaction_type: pension
         trx_b1 = create :bank_transaction, :credit, transaction_type: benefits

--- a/spec/services/cfe/obtain_assessment_result_service_spec.rb
+++ b/spec/services/cfe/obtain_assessment_result_service_spec.rb
@@ -348,27 +348,39 @@ module CFE # rubocop:disable Metrics/ModuleLength
           upper_threshold: '999999999999.0',
           assessment_result: 'eligible'
         },
-        student_loan: {
-          monthly_equivalents: '1000.0'
+        irregular_income: {
+          monthly_equivalents: {
+            student_loan: '0.0'
+          }
+        },
+        state_benefits: {
+          monthly_equivalents: {
+            all_sources: '114.95',
+            cash_transactions: '100.0',
+            bank_transactions: [
+              {
+                name: 'manually_chosen',
+                monthly_value: '14.95',
+                excluded_from_income_assessment: false
+              }
+            ]
+          }
         },
         other_income: {
           monthly_equivalents: {
             bank_transactions: {
-              benefits: '34.65',
               friends_or_family: '36.67',
               maintenance_in: '10.0',
               property_or_lodger: '666.67',
               pension: '16.67'
             },
             cash_transactions: {
-              benefits: '100.0',
               friends_or_family: '200.0',
               maintenance_in: '300.0',
               property_or_lodger: '400.0',
               pension: '500.0'
             },
             all_sources: {
-              benefits: '134.65',
               friends_or_family: '236.67',
               maintenance_in: '310.0',
               property_or_lodger: '1066.67',


### PR DESCRIPTION
…ash amounts to the means summary totals if cash payments exist


## What

[AP-2036](https://dsdmoj.atlassian.net/browse/AP-2036)

Add monthly cash payments for each incoming/outgoing category total on the means summary CYA page. Also to allow the user to move on if cash payments have been entered for a particular category whilst no bank transactions have been selected.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
