### PR TITLE
AP-2045: Update ManualReviewDeterminer to flag submissions as needing…

### DIFF
--- a/app/services/ccms/attribute_value_generator.rb
+++ b/app/services/ccms/attribute_value_generator.rb
@@ -73,7 +73,6 @@ module CCMS
              :used_delegated_functions?, to: :legal_aid_application
 
     def initialize(submission)
-      @submission = submission
       @legal_aid_application = submission.legal_aid_application
     end
 
@@ -102,23 +101,23 @@ module CCMS
     end
 
     def submission_case_ccms_reference(_options)
-      @legal_aid_application.case_ccms_reference
+      legal_aid_application.case_ccms_reference
     end
 
     def used_delegated_functions_on(_options)
-      @legal_aid_application.used_delegated_functions_on.strftime('%d-%m-%Y')
+      legal_aid_application.used_delegated_functions_on.strftime('%d-%m-%Y')
     end
 
     def app_amendment_type(_options)
-      @legal_aid_application.used_delegated_functions? ? 'SUBDP' : 'SUB'
+      legal_aid_application.used_delegated_functions? ? 'SUBDP' : 'SUB'
     end
 
     def provider_firm_id(_options)
-      @legal_aid_application.provider.firm.ccms_id
+      legal_aid_application.provider.firm.ccms_id
     end
 
     def provider_email(_options)
-      @legal_aid_application.provider.email
+      legal_aid_application.provider.email
     end
 
     def applicant_national_insurance_number(_options)
@@ -169,7 +168,7 @@ module CCMS
     end
 
     def applicant_shares_ownership_of_second_home?(options)
-      applicant_owns_additional_property?(options) && @legal_aid_application.other_assets_declaration.second_home_percentage != 100
+      applicant_owns_additional_property?(options) && legal_aid_application.other_assets_declaration.second_home_percentage != 100
     end
 
     def applicant_has_trusts_bonds_or_stocks?(_options)
@@ -201,11 +200,11 @@ module CCMS
     end
 
     def lead_proceeding_type_default_level_of_service(_options)
-      @legal_aid_application.lead_proceeding_type.default_level_of_service.service_level_number
+      legal_aid_application.lead_proceeding_type.default_level_of_service.service_level_number
     end
 
     def lead_proceeding_type_default_level_of_service_name(_options)
-      @legal_aid_application.lead_proceeding_type.default_level_of_service.name
+      legal_aid_application.lead_proceeding_type.default_level_of_service.name
     end
 
     def applicant_postcode(_options)
@@ -233,43 +232,43 @@ module CCMS
     end
 
     def application_substantive?(_options)
-      !@legal_aid_application.used_delegated_functions?
+      !legal_aid_application.used_delegated_functions?
     end
 
     def proceeding_proceeding_application_type(_options)
-      @legal_aid_application.used_delegated_functions? ? 'Both' : 'Substantive'
+      legal_aid_application.used_delegated_functions? ? 'Both' : 'Substantive'
     end
 
     def no_warning_letter_sent?(_options)
-      !@legal_aid_application.respondent.warning_letter_sent
+      !legal_aid_application.respondent.warning_letter_sent
     end
 
     def applicant_owns_main_home?(_options)
-      !@legal_aid_application.own_home_no?
+      !legal_aid_application.own_home_no?
     end
 
     def applicant_shares_ownership_main_home?(_options)
-      (not_zero? @legal_aid_application.percentage_home) && @legal_aid_application.percentage_home < 100
+      (not_zero? legal_aid_application.percentage_home) && legal_aid_application.percentage_home < 100
     end
 
     def applicant_owns_percentage_main_home(_options)
-      @legal_aid_application.percentage_home
+      legal_aid_application.percentage_home
     end
 
     def third_party_owns_percentage_main_home(_options)
-      100 - @legal_aid_application.percentage_home
+      100 - legal_aid_application.percentage_home
     end
 
     def applicant_property_value(_options)
-      @legal_aid_application.property_value
+      legal_aid_application.property_value
     end
 
     def outstanding_mortgage?(_options)
-      !@legal_aid_application&.own_home_no? && @legal_aid_application&.own_home_mortgage? && @legal_aid_application&.outstanding_mortgage_amount
+      !legal_aid_application&.own_home_no? && legal_aid_application&.own_home_mortgage? && legal_aid_application&.outstanding_mortgage_amount
     end
 
     def outstanding_mortgage_amount(_options)
-      @legal_aid_application.outstanding_mortgage_amount
+      legal_aid_application.outstanding_mortgage_amount
     end
 
     def applicant_has_vehicle?(_options)
@@ -312,7 +311,7 @@ module CCMS
     end
 
     def benefit_check_passed?(_options)
-      @legal_aid_application.benefit_check_result.result == 'Yes'
+      legal_aid_application.benefit_check_result.result == 'Yes'
     end
 
     def proceeding_cost_limitation(_options)
@@ -324,11 +323,11 @@ module CCMS
     private
 
     def applicant
-      @applicant ||= @legal_aid_application.applicant
+      @applicant ||= legal_aid_application.applicant
     end
 
     def lead_proceeding_type
-      @lead_proceeding_type ||= @legal_aid_application.lead_proceeding_type
+      @lead_proceeding_type ||= legal_aid_application.lead_proceeding_type
     end
 
     def standardly_named_method?(method)
@@ -336,19 +335,19 @@ module CCMS
     end
 
     def savings
-      @savings ||= @legal_aid_application.savings_amount
+      @savings ||= legal_aid_application.savings_amount
     end
 
     def other_assets
-      @other_assets ||= @legal_aid_application.other_assets_declaration
+      @other_assets ||= legal_aid_application.other_assets_declaration
     end
 
     def cfe_result
-      @cfe_result ||= @legal_aid_application.cfe_result
+      @cfe_result ||= legal_aid_application.cfe_result
     end
 
     def scope_limitations
-      @scope_limitations ||= @legal_aid_application.scope_limitations
+      @scope_limitations ||= legal_aid_application.scope_limitations
     end
 
     def proceeding_limitation_desc(_options)
@@ -366,7 +365,7 @@ module CCMS
     def call_standard_method(method, options) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity
       case method
       when APPLICATION_REGEX
-        @legal_aid_application.__send__(Regexp.last_match(1))
+        legal_aid_application.__send__(Regexp.last_match(1))
       when APPLICANT_REGEX
         applicant.__send__(Regexp.last_match(1))
       when APPLICATION_PROCEEDING_TYPE_REGEX
@@ -380,21 +379,21 @@ module CCMS
       when PROCEEDING_REGEX
         options[:proceeding].__send__(Regexp.last_match(1))
       when INCOME_TYPE_REGEX
-        @legal_aid_application.transaction_types.for_income_type?(Regexp.last_match(1).chomp('?'))
+        legal_aid_application.transaction_types.for_income_type?(Regexp.last_match(1).chomp('?'))
       when OPPONENT
         options[:opponent].__send__(Regexp.last_match(1))
       when OUTGOING
-        @legal_aid_application.transaction_types.for_outgoing_type?(Regexp.last_match(1).chomp('?'))
+        legal_aid_application.transaction_types.for_outgoing_type?(Regexp.last_match(1).chomp('?'))
       when RESPONDENT
         options[:respondent].__send__(Regexp.last_match(1))
       when MERITS_ASSESSMENT
         options[:merits_assessment].__send__(Regexp.last_match(1))
       when SAVINGS_AMOUNT
-        @legal_aid_application.savings_amount.__send__(Regexp.last_match(1))
+        legal_aid_application.savings_amount.__send__(Regexp.last_match(1))
       when OTHER_ASSETS_DECLARATION
-        @legal_aid_application.other_assets_declaration.__send__(Regexp.last_match(1))
+        legal_aid_application.other_assets_declaration.__send__(Regexp.last_match(1))
       when LEAD_PROCEEDING_TYPE
-        @legal_aid_application.lead_proceeding_type.__send__(Regexp.last_match(1))
+        legal_aid_application.lead_proceeding_type.__send__(Regexp.last_match(1))
       end
     end
 
@@ -407,7 +406,7 @@ module CCMS
     end
 
     def manual_case_review_required?
-      ManualReviewDeterminer.call(@legal_aid_application)
+      ManualReviewDeterminer.call(legal_aid_application)
     end
   end
 end

--- a/app/services/ccms/manual_review_determiner.rb
+++ b/app/services/ccms/manual_review_determiner.rb
@@ -26,11 +26,17 @@ module CCMS
     end
 
     def call
-      return true if Setting.manually_review_all_cases? && non_passported?
+      needs_review?
+    end
 
-      return true if capital_contribution_required? && has_restrictions?
+    private
 
-      false
+    def needs_review?
+      manually_review_all_non_passported? || capital_contribution_required? || has_restrictions?
+    end
+
+    def manually_review_all_non_passported?
+      Setting.manually_review_all_cases? && non_passported?
     end
   end
 end

--- a/spec/data/ccms/case_add_request.xml
+++ b/spec/data/ccms/case_add_request.xml
@@ -270,7 +270,7 @@
                           <ns0:Attribute>
                             <ns0:Attribute>APPLY_CASE_MEANS_REVIEW</ns0:Attribute>
                             <ns0:ResponseType>boolean</ns0:ResponseType>
-                            <ns0:ResponseValue>true</ns0:ResponseValue>
+                            <ns0:ResponseValue>false</ns0:ResponseValue>
                             <ns0:UserDefinedInd>false</ns0:UserDefinedInd>
                           </ns0:Attribute>
                           <ns0:Attribute>
@@ -1392,7 +1392,7 @@
                           <ns0:Attribute>
                             <ns0:Attribute>APPLY_CASE_MEANS_REVIEW</ns0:Attribute>
                             <ns0:ResponseType>boolean</ns0:ResponseType>
-                            <ns0:ResponseValue>true</ns0:ResponseValue>
+                            <ns0:ResponseValue>false</ns0:ResponseValue>
                             <ns0:UserDefinedInd>false</ns0:UserDefinedInd>
                           </ns0:Attribute>
                           <ns0:Attribute>

--- a/spec/requests/providers/capital_assessment_results_spec.rb
+++ b/spec/requests/providers/capital_assessment_results_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe Providers::CapitalAssessmentResultsController, type: :request do
         subject
       end
 
-      context 'no policy disregards' do
+      context 'with policy disregards' do
         let(:add_policy_disregards?) { true }
         context 'eligible' do
           let(:cfe_result) { create :cfe_v2_result, :eligible }
@@ -118,7 +118,7 @@ RSpec.describe Providers::CapitalAssessmentResultsController, type: :request do
           end
 
           it 'displays the correct result' do
-            expect(unescaped_response_body).to include(I18n.t('eligible.heading', name: applicant_name, scope: locale_scope))
+            expect(unescaped_response_body).to include(I18n.t('manual_check_disregards.heading', name: applicant_name, scope: locale_scope))
           end
         end
 
@@ -135,7 +135,7 @@ RSpec.describe Providers::CapitalAssessmentResultsController, type: :request do
         end
       end
 
-      context 'with policy disregards' do
+      context 'with no policy disregards' do
         context 'eligible' do
           let(:cfe_result) { create :cfe_v2_result, :eligible }
           it 'returns http success' do
@@ -143,7 +143,7 @@ RSpec.describe Providers::CapitalAssessmentResultsController, type: :request do
           end
 
           it 'displays the correct result' do
-            expect(unescaped_response_body).to include(I18n.t('eligible.heading', name: applicant_name, scope: locale_scope))
+            expect(unescaped_response_body).to include(I18n.t('manual_check_required.heading', name: applicant_name, scope: locale_scope))
           end
         end
 

--- a/spec/requests/providers/capital_income_assessment_results_spec.rb
+++ b/spec/requests/providers/capital_income_assessment_results_spec.rb
@@ -170,7 +170,7 @@ RSpec.describe Providers::CapitalIncomeAssessmentResultsController, type: :reque
           end
 
           it 'displays the correct result' do
-            expect(unescaped_response_body).to include(I18n.t('eligible.heading', name: applicant_name, scope: locale_scope))
+            expect(unescaped_response_body).to include(I18n.t('manual_check_required.heading', name: applicant_name, scope: locale_scope))
           end
         end
 
@@ -193,8 +193,8 @@ RSpec.describe Providers::CapitalIncomeAssessmentResultsController, type: :reque
             expect(response).to have_http_status(:ok)
           end
 
-          it 'does not displays manual check required' do
-            expect(unescaped_response_body).not_to include(I18n.t('manual_check_required.heading', name: applicant_name, scope: locale_scope))
+          it 'displays manual check required' do
+            expect(unescaped_response_body).to include(I18n.t('manual_check_required.heading', name: applicant_name, scope: locale_scope))
           end
         end
 
@@ -221,7 +221,7 @@ RSpec.describe Providers::CapitalIncomeAssessmentResultsController, type: :reque
           end
 
           it 'displays the correct result' do
-            expect(unescaped_response_body).to include(I18n.t('eligible.heading', name: applicant_name, scope: locale_scope))
+            expect(unescaped_response_body).to include(I18n.t('manual_check_disregards.heading', name: applicant_name, scope: locale_scope))
           end
         end
 

--- a/spec/services/ccms/manual_review_determiner_spec.rb
+++ b/spec/services/ccms/manual_review_determiner_spec.rb
@@ -8,108 +8,190 @@ module CCMS
     subject { described_class.call(legal_aid_application) }
 
     describe '.call' do
-      context 'assessment not yet carried out on legal aid application' do
-        let(:legal_aid_application) { create :legal_aid_application }
-        it 'raises an error' do
-          expect { subject }.to raise_error RuntimeError, 'Unable to determine whether Manual review is required before means assessment'
-        end
-      end
-
-      context 'manual review setting true' do
-        before { setting.update! manually_review_all_cases: true }
-
-        context 'passported, no contrib, no_restrictions' do
-          let(:legal_aid_application) { create :legal_aid_application, :with_positive_benefit_check_result }
-          let!(:cfe_result) { create :cfe_v2_result, submission: cfe_submission }
-
-          it 'returns false' do
-            expect(subject).to be false
+      context 'cfe result v2' do
+        context 'assessment not yet carried out on legal aid application' do
+          let(:legal_aid_application) { create :legal_aid_application }
+          it 'raises an error' do
+            expect { subject }.to raise_error RuntimeError, 'Unable to determine whether Manual review is required before means assessment'
           end
         end
 
-        context 'non-passported, no contrib, no restrictions' do
-          let(:legal_aid_application) { create :legal_aid_application, :with_negative_benefit_check_result }
-          let!(:cfe_result) { create :cfe_v2_result, submission: cfe_submission }
+        context 'manual review setting true' do
+          before { setting.update! manually_review_all_cases: true }
 
-          it 'returns true' do
-            expect(subject).to be true
-          end
-        end
-      end
+          context 'passported, no contrib, no_restrictions' do
+            let(:legal_aid_application) { create :legal_aid_application, :with_positive_benefit_check_result }
+            let!(:cfe_result) { create :cfe_v2_result, submission: cfe_submission }
 
-      context 'manual review setting false' do
-        before { setting.update! manually_review_all_cases: false }
-
-        context 'passported' do
-          let(:legal_aid_application) { create :legal_aid_application, :with_positive_benefit_check_result, has_restrictions: false }
-
-          context 'contribution' do
-            let!(:cfe_result) { create :cfe_v2_result, :with_capital_contribution_required, submission: cfe_submission }
-
-            context 'no restrictions' do
-              it 'returns false' do
-                expect(subject).to be false
-              end
+            it 'returns false' do
+              expect(subject).to be false
             end
+          end
 
-            context 'restrictions' do
-              before { legal_aid_application.update! has_restrictions: true }
+          context 'non-passported, no contrib' do
+            let(:legal_aid_application) { create :legal_aid_application, :with_negative_benefit_check_result }
+            let!(:cfe_result) { create :cfe_v2_result, submission: cfe_submission }
+
+            it 'returns true' do
+              expect(subject).to be true
+            end
+          end
+        end
+
+        context 'manual review setting false' do
+          before { setting.update! manually_review_all_cases: false }
+
+          context 'passported' do
+            let(:legal_aid_application) { create :legal_aid_application, :with_positive_benefit_check_result, has_restrictions: true }
+
+            context 'contribution' do
+              let!(:cfe_result) { create :cfe_v2_result, :with_capital_contribution_required, submission: cfe_submission }
+
               it 'returns true' do
                 expect(subject).to be true
               end
             end
+
+            context 'no contribution' do
+              let!(:cfe_result) { create :cfe_v2_result, submission: cfe_submission }
+
+              context 'restrictions' do
+                it 'returns false' do
+                  expect(subject).to be true
+                end
+              end
+
+              context 'no restrictions' do
+                before { legal_aid_application.update! has_restrictions: false }
+
+                it 'returns false' do
+                  expect(subject).to be false
+                end
+              end
+            end
           end
 
-          context 'no contribution' do
-            let!(:cfe_result) { create :cfe_v2_result, submission: cfe_submission }
+          context 'non-passported' do
+            let(:legal_aid_application) { create :legal_aid_application, :with_negative_benefit_check_result, has_restrictions: true }
 
-            context 'no restrictions' do
-              it 'returns false' do
-                expect(subject).to be false
-              end
-            end
+            context 'contribution' do
+              let!(:cfe_result) { create :cfe_v2_result, :with_capital_contribution_required, submission: cfe_submission }
 
-            context 'restrictions' do
-              before { legal_aid_application.update! has_restrictions: true }
-              it 'returns false' do
-                expect(subject).to be false
-              end
-            end
-          end
-        end
-
-        context 'non-passported' do
-          let(:legal_aid_application) { create :legal_aid_application, :with_negative_benefit_check_result, has_restrictions: false }
-
-          context 'contribution' do
-            let!(:cfe_result) { create :cfe_v2_result, :with_capital_contribution_required, submission: cfe_submission }
-
-            context 'no restrictions' do
-              it 'returns false' do
-                expect(subject).to be false
-              end
-            end
-            context 'restrictions' do
-              before { legal_aid_application.update! has_restrictions: true }
               it 'returns true' do
                 expect(subject).to be true
               end
             end
+
+            context 'no contribution' do
+              let!(:cfe_result) { create :cfe_v2_result, submission: cfe_submission }
+
+              context 'restrictions' do
+                it 'returns false' do
+                  expect(subject).to be true
+                end
+              end
+
+              context 'no restrictions' do
+                before { legal_aid_application.update! has_restrictions: false }
+
+                it 'returns false' do
+                  expect(subject).to be false
+                end
+              end
+            end
+          end
+        end
+      end
+
+      context 'cfe result v3' do
+        context 'assessment not yet carried out on legal aid application' do
+          let(:legal_aid_application) { create :legal_aid_application }
+          it 'raises an error' do
+            expect { subject }.to raise_error RuntimeError, 'Unable to determine whether Manual review is required before means assessment'
+          end
+        end
+
+        context 'manual review setting true' do
+          before { setting.update! manually_review_all_cases: true }
+
+          context 'passported, no contrib, no_restrictions' do
+            let(:legal_aid_application) { create :legal_aid_application, :with_positive_benefit_check_result }
+            let!(:cfe_result) { create :cfe_v3_result, submission: cfe_submission }
+
+            it 'returns false' do
+              expect(subject).to be false
+            end
           end
 
-          context 'no contribution' do
-            let!(:cfe_result) { create :cfe_v2_result, submission: cfe_submission }
+          context 'non-passported, no contrib' do
+            let(:legal_aid_application) { create :legal_aid_application, :with_negative_benefit_check_result }
+            let!(:cfe_result) { create :cfe_v3_result, submission: cfe_submission }
 
-            context 'no restrictions' do
-              it 'returns false' do
-                expect(subject).to be false
+            it 'returns true' do
+              expect(subject).to be true
+            end
+          end
+        end
+
+        context 'manual review setting false' do
+          before { setting.update! manually_review_all_cases: false }
+
+          context 'passported' do
+            let(:legal_aid_application) { create :legal_aid_application, :with_positive_benefit_check_result, has_restrictions: true }
+
+            context 'contribution' do
+              let!(:cfe_result) { create :cfe_v3_result, :with_capital_contribution_required, submission: cfe_submission }
+
+              it 'returns true' do
+                expect(subject).to be true
               end
             end
 
-            context 'restrictions' do
-              before { legal_aid_application.update! has_restrictions: true }
-              it 'returns false' do
-                expect(subject).to be false
+            context 'no contribution' do
+              let!(:cfe_result) { create :cfe_v3_result, submission: cfe_submission }
+
+              context 'restrictions' do
+                it 'returns false' do
+                  expect(subject).to be true
+                end
+              end
+
+              context 'no restrictions' do
+                before { legal_aid_application.update! has_restrictions: false }
+
+                it 'returns false' do
+                  expect(subject).to be false
+                end
+              end
+            end
+          end
+
+          context 'non-passported' do
+            let(:legal_aid_application) { create :legal_aid_application, :with_negative_benefit_check_result, has_restrictions: true }
+
+            context 'contribution' do
+              let!(:cfe_result) { create :cfe_v3_result, :with_capital_contribution_required, submission: cfe_submission }
+
+              it 'returns true' do
+                expect(subject).to be true
+              end
+            end
+
+            context 'no contribution' do
+              let!(:cfe_result) { create :cfe_v3_result, submission: cfe_submission }
+
+              context 'restrictions' do
+                it 'returns false' do
+                  expect(subject).to be true
+                end
+              end
+
+              context 'no restrictions' do
+                before { legal_aid_application.update! has_restrictions: false }
+
+                it 'returns false' do
+                  expect(subject).to be false
+                end
               end
             end
           end


### PR DESCRIPTION
… a review even if there are restrictions


## What

[AP-2045](https://dsdmoj.atlassian.net/browse/AP-2045)

Removed a check on restrictions when flagging if a passported application needs a manual review

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
