### PR TITLE
AP-2042 Trap ActiveRecord errors and prevent job from failing

### DIFF
--- a/app/models/sent_email.rb
+++ b/app/models/sent_email.rb
@@ -2,6 +2,5 @@ class SentEmail < ApplicationRecord
   validates :mailer,
             :mail_method,
             :govuk_message_id,
-            :addressee,
             :sent_at, presence: true
 end

--- a/app/services/govuk_emails/email_monitor.rb
+++ b/app/services/govuk_emails/email_monitor.rb
@@ -96,7 +96,9 @@ module GovukEmails
     end
 
     def update_sent_email_with_exception
-      sent_email = SentEmail.find_by!(govuk_message_id: govuk_message_id)
+      sent_email = SentEmail.find_by(govuk_message_id: govuk_message_id)
+      return unless sent_email # cater for cases where the sent email couldnt be created in the first place
+
       sent_email.update(status: 'Notifications::Client::NotFoundError', status_checked_at: Time.zone.now)
     end
 

--- a/app/services/govuk_emails/email_monitor.rb
+++ b/app/services/govuk_emails/email_monitor.rb
@@ -84,10 +84,14 @@ module GovukEmails
                         sent_at: Time.zone.now,
                         status: 'created',
                         status_checked_at: nil)
+    rescue StandardError => e
+      Raven.capture_message("Unable to write SentEmail record: #{e.class} #{e.message} Params: #{@email_args.inspect}")
     end
 
     def update_sent_email
       sent_email = SentEmail.find_by!(govuk_message_id: govuk_message_id)
+      return unless sent_email # cater for cases where the sent email couldnt be created in the first place
+
       sent_email.update(status: email.status, status_checked_at: Time.zone.now)
     end
 


### PR DESCRIPTION
## Prevent duplicate emails from being sent after ActiveRecord error

The SentEmail.create! was failing with a validation error  (not all emails have an email address amongst the parameters) and this was causing the job to fail, and be retried by sidekiq after having sent the mail, resulting in duplicate mails.

This solves the problem by:
 - removing the validates presence of addressee
 - trapping errors, reporting them to Sentry, and allowing the job to continue

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2042)

Describe what you did and why.

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
