### PR TITLE
AP-2021 Changed the citizen flow to redirect correctly

### DIFF
--- a/app/services/flow/flows/citizen_capital.rb
+++ b/app/services/flow/flows/citizen_capital.rb
@@ -11,7 +11,13 @@ module Flow
               :student_finances
             end
           end,
-          check_answers: :check_answers
+          check_answers: ->(application) do
+            if Setting.allow_cash_payment? && application.transaction_types.credits.any?
+              :cash_incomes
+            else
+              :check_answers
+            end
+          end
         },
         cash_incomes: {
           path: ->(_) { urls.citizens_cash_income_path(locale: I18n.locale) },

--- a/features/citizens/citizens.feature
+++ b/features/citizens/citizens.feature
@@ -138,16 +138,23 @@ Feature: Citizen journey
 
   @javascript
   Scenario: I want to change income types via the check your answers page
+    Given the setting to allow cash payments is enabled
     Given I have completed an application
     And I complete the citizen journey as far as check your answers
     Then I should be on a page showing 'Check your answers'
     Then I should be on a page showing 'Benefits'
     And I click Check Your Answers Change link for 'incomings'
     Then I should be on a page showing 'Which of the following payments do you receive?'
-    Then I select 'Financial help from friends or family'
+    Then I select 'Maintenance payments'
+    And I click 'Save and continue'
+    Then I should be on the 'cash_income' page showing 'Select payments you receive in cash'
+    Then I select 'Maintenance payments'
+    Then I enter maintenance_in1 '100'
+    Then I enter maintenance_in2 '100'
+    Then I enter maintenance_in3 '100'
     Then I click 'Save and continue'
     Then I should be on a page showing 'Check your answers'
-    Then I should be on a page showing 'Financial help from friends or family Yes'
+    Then I should be on a page showing 'Maintenance payments Yes'
 
   @javascript
   Scenario: I want to add another bank account via the check your answers page

--- a/spec/requests/citizens/identify_types_of_incomes_spec.rb
+++ b/spec/requests/citizens/identify_types_of_incomes_spec.rb
@@ -165,5 +165,30 @@ RSpec.describe Citizens::IdentifyTypesOfIncomesController, type: :request do
         expect { subject }.not_to change { legal_aid_application.transaction_types.count }
       end
     end
+
+    context 'When checking citizen answers' do
+      before do
+        get citizens_legal_aid_application_path(legal_aid_application.generate_secure_id)
+        legal_aid_application.check_citizen_answers!
+        patch citizens_identify_types_of_income_path, params: params
+      end
+
+      context 'change to none selected' do
+        let(:params) { { legal_aid_application: { none_selected: 'true' } } }
+
+        it 'should redirect to the check answers page' do
+          expect(response).to redirect_to(citizens_check_answers_path)
+        end
+      end
+
+      context 'when a different income is selected' do
+        let(:params) { { legal_aid_application: { none_selected: 'false' } } }
+
+        it 'should redirect to the cash income step if allow_cash_payment set to true' do
+          allow(Setting).to receive(:allow_cash_payment?).and_return(true)
+          expect(subject).to redirect_to(citizens_cash_income_path)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2021)

Flow now runs correctly: User selects change link on CYA page to return to 'which payments do you receive' then directs to cash_income page before going back to CYA page. I have also added these steps to the relevant feature test.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
