### PR TITLE
ap-2038 remove sign in link from citizen views

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -18,12 +18,15 @@
     </div>
     <div class="govuk-header__content">
       <%= home_link %>
-      <div class="no-print">
-        <%= menu_button if user_header_link %>
-        <nav>
-          <%= user_header_link %>
-        </nav>
-      </div>
+      <% unless current_journey == :citizens %>
+        <div class="no-print">
+          <%= menu_button if user_header_link %>
+          <%= current_journey %>
+          <nav>
+            <%= user_header_link %>
+          </nav>
+        </div>
+      <% end %>
     </div>
   </div>
 </header>

--- a/features/citizens/citizens.feature
+++ b/features/citizens/citizens.feature
@@ -28,6 +28,7 @@ Feature: Citizen journey
   Scenario: View privacy policy
     Given An application has been created
     Then I visit the start of the financial assessment
+    Then I should not see 'Sign In'
     Then I click link "Privacy policy"
     Then I should be on a page showing "Why we need your data"
     Then I should be on a page showing "Your rights"


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2038)

Use a conditional check to hide the sign in link in the header on the citizen journey but still have it visible for admin and provider journeys.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
