### PR TITLE
ap-2043 add quote marks for proper separation

### DIFF
--- a/app/views/providers/income_summary/_income_type_item.html.erb
+++ b/app/views/providers/income_summary/_income_type_item.html.erb
@@ -24,7 +24,7 @@
       </span>
     <% end %>
     <% if error_message %>
-      <span id=<%= "error-#{name}" %>class="govuk-error-message"><%= error_message %></span>
+      <span id='<%= "error-#{name}" %>' class="govuk-error-message"><%= error_message %></span>
     <% end %>
   </h2>
   <%= content_tag(:div, class: 'app-task-list__items', id: "list-item-#{name}") do %>

--- a/app/views/providers/outgoings_summary/_outgoing_type_item.html.erb
+++ b/app/views/providers/outgoings_summary/_outgoing_type_item.html.erb
@@ -18,7 +18,7 @@
       </span>
     <% end %>
     <% if error_message %>
-      <span id=<%= "error-#{name}" %>class="govuk-error-message"><%= error_message %></span>
+      <span id='<%= "error-#{name}" %>' class="govuk-error-message"><%= error_message %></span>
     <% end %>
   </h2>
   <%= content_tag(:div, class: 'app-task-list__items', id: "list-item-#{name}") do %>


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2043)

added a space and single quote marks to separate out the error name and class, erblint was failing when just a space was added to fix this, which is probably how it got introduced in the first place.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
