### PR TITLE
AP-2044: Fix bug to ensure the student loan record for an application…

### DIFF
--- a/app/controllers/citizens/student_finances/annual_amounts_controller.rb
+++ b/app/controllers/citizens/student_finances/annual_amounts_controller.rb
@@ -20,7 +20,7 @@ module Citizens
       private
 
       def irregular_income
-        @irregular_income ||= IrregularIncome.new
+        legal_aid_application.irregular_incomes.find_by(income_type: 'student_loan')
       end
 
       def form_params

--- a/app/forms/legal_aid_applications/student_finance_form.rb
+++ b/app/forms/legal_aid_applications/student_finance_form.rb
@@ -8,6 +8,8 @@ module LegalAidApplications
 
     validate :student_finance_presence
 
+    private
+
     def student_finance_presence
       return if draft? || student_finance.present?
 

--- a/spec/requests/citizens/student_finance/annual_amounts_spec.rb
+++ b/spec/requests/citizens/student_finance/annual_amounts_spec.rb
@@ -28,9 +28,7 @@ RSpec.describe 'annual_amounts', type: :request do
     end
 
     context 'adds an amount' do
-      before do
-        get citizens_legal_aid_application_path(legal_aid_application.generate_secure_id)
-      end
+      before { get citizens_legal_aid_application_path(legal_aid_application.generate_secure_id) }
       let(:amount) { 2345 }
 
       it 'displays the outgoing types page' do
@@ -44,6 +42,19 @@ RSpec.describe 'annual_amounts', type: :request do
         expect(irregular_income.amount).to eq 2345
         expect(irregular_income.frequency).to eq 'annual'
         expect(irregular_income.income_type).to eq 'student_loan'
+      end
+
+      describe 'update record' do
+        before { patch citizens_student_finances_annual_amount_path, params: params }
+
+        context 'update amount' do
+          let(:amount) { 5000 }
+          it 'updates the same record without creating a new one' do
+            expect { patch citizens_student_finances_annual_amount_path, params: params }.to change { IrregularIncome.count }.by(0)
+            irregular_income = legal_aid_application.irregular_incomes.first
+            expect(irregular_income.amount).to eq 5000
+          end
+        end
       end
     end
 


### PR DESCRIPTION
… is updated and not duplicated


## What

[AP-2044](https://dsdmoj.atlassian.net/browse/AP-2044)

Multiple student loan records are created if you go back and enter/correct the student loan amount. This causes a failure when these are then sent to CFE. This fixes it.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
