### PR TITLE
AP-2004 Remove back link from Application Created page

### DIFF
--- a/app/views/providers/application_confirmations/show.html.erb
+++ b/app/views/providers/application_confirmations/show.html.erb
@@ -11,7 +11,7 @@
   </div>
 <% end %>
 
-<%= page_template page_title: nil do %>
+<%= page_template page_title: nil, back_link: :none do %>
 
   <p class="govuk-body"><%= t '.sent_email_text', email: @legal_aid_application.applicant.email %></p>
   <h2 class="govuk-heading-m"><%= t '.happen_next_heading' %></h2>


### PR DESCRIPTION
## Remove back link from Application Created page

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2004)

Remove back link from page that is displayed after a provider and clicked the button to send the applicant an email with a link to complete the appplication.

Previously, clicking the back link would have redisplayed the "Give your client temporary access to the system page" enabling the provider to send another email, which would have been confusing.
Clicking the back link again would have caused a transition error because the case is already in "awaiting applicant" state.

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
