### PR TITLE
AP-2023 BugFix Restrictions page error not appearing correctly

### DIFF
--- a/app/views/providers/restrictions/show.html.erb
+++ b/app/views/providers/restrictions/show.html.erb
@@ -1,7 +1,7 @@
 <%= page_template page_title: t('.h1-heading'), template: :basic do %>
   <%= render partial: 'form',
              locals: {
-               model: @legal_aid_application,
+               model: @form,
                show_draft: true,
                url: providers_legal_aid_application_restrictions_path(@legal_aid_application),
                for_example: t('.for_example'),


### PR DESCRIPTION
## AP-2023 BugFix Restrictions page error not appearing correctly

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2023)

Use form instance instead of legal aid application . This fixes the issue with assigning errors correctly

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
