### PR TITLE
Ccms report generator

### DIFF
--- a/app/controllers/admin/reports_controller.rb
+++ b/app/controllers/admin/reports_controller.rb
@@ -5,18 +5,16 @@ module Admin
     DEFAULT_PAGE_SIZE = 10
 
     def index
-      @reports = {
-        csv_download: {
-          report_title: 'Download CSV of all submitted applications',
-          path: :admin_reports_submitted_csv_path,
-          path_text: 'Download CSV'
-        },
-        non_passported_applications: {
-          report_title: 'Non passported applications',
-          path: :admin_reports_non_passported_csv_path,
-          path_text: 'Download CSV'
-        }
-      }
+      reports
+    end
+
+    def create
+      reports
+      if reports_types_creator.valid?
+        download_custom_report
+      else
+        render :index
+      end
     end
 
     def download_submitted
@@ -31,9 +29,9 @@ module Admin
 
     def download_non_passported
       expires_now
-      data = Reports::MIS::NonPassportedApplicationsReport.new.run
       respond_to do |format|
         format.csv do
+          data = Reports::MIS::NonPassportedApplicationsReport.new.run
           send_data data, filename: "non_passported_#{timestamp}.csv", type: :csv, content_type: 'text/csv'
         end
       end
@@ -41,6 +39,37 @@ module Admin
 
     def timestamp
       Time.current.strftime('%FT%T')
+    end
+
+    private
+
+    def download_custom_report
+      expires_now
+      data = reports_types_creator.generate_csv
+      send_data data, filename: "custom_apply_ccms_report_#{timestamp}.csv", type: :csv, content_type: 'text/csv'
+    end
+
+    def reports_types_creator
+      @reports_types_creator ||= Reports::ReportsTypesCreator.call(form_params)
+    end
+
+    def reports
+      @reports ||= {
+        csv_download: {
+          report_title: 'Download CSV of all submitted applications',
+          path: :admin_reports_submitted_csv_path,
+          path_text: 'Download CSV'
+        },
+        non_passported_applications: {
+          report_title: 'Non passported applications',
+          path: :admin_reports_non_passported_csv_path,
+          path_text: 'Download CSV'
+        }
+      }
+    end
+
+    def form_params
+      convert_date_params(params[:reports_reports_types_creator] || params)
     end
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,4 +21,9 @@ class ApplicationController < ActionController::Base
   def update_locale
     I18n.locale = params[:locale] || I18n.default_locale
   end
+
+  def convert_date_params(params)
+    # gsub finds ([digit]i) and replaces with _[digit]i
+    params.transform_keys! { |key| key.gsub(/\((\di)\)/, '_\\1') }
+  end
 end

--- a/app/controllers/providers/provider_base_controller.rb
+++ b/app/controllers/providers/provider_base_controller.rb
@@ -6,10 +6,5 @@ module Providers
     include ApplicationDependable
     include Draftable
     include Authorizable
-
-    def convert_date_params(params)
-      # gsub finds ([digit]i) and replaces with _[digit]i
-      params.transform_keys! { |key| key.gsub(/\((\di)\)/, '_\\1') }
-    end
   end
 end

--- a/app/services/reports/reports_types_creator.rb
+++ b/app/services/reports/reports_types_creator.rb
@@ -1,0 +1,170 @@
+module Reports
+  class ReportsTypesCreator # rubocop:disable Metrics/ClassLength
+    include ActiveModel::Model
+
+    def self.call(params)
+      new(params).call
+    end
+
+    attr_reader :application_type,
+                :submitted_to_ccms,
+                :capital_assessment_result,
+                :records_to,
+                :records_from,
+                :payload_attrs
+
+    validate :validate_required
+
+    def initialize(params)
+      @application_type = params[:application_type]
+      @submitted_to_ccms = params[:submitted_to_ccms]
+      @capital_assessment_result = params[:capital_assessment_result]
+      @payload_attrs = params[:payload_attrs]
+      @records_from = process_date(params, :records_from) || Date.parse('2019-12-01')
+      @records_to = process_date(params, :records_to) || Date.current
+    end
+
+    def call
+      search_applications if valid?
+      self
+    end
+
+    def generate_csv
+      CSV.generate do |csv|
+        if @results.present?
+          csv << %w[application_ref case_ccms_reference] + default_opts[:payload_attrs]
+          @results.each do |row|
+            csv << row.map { |v| "\"#{v}\"" }
+          end
+        end
+      end
+    end
+
+    private
+
+    def default_opts
+      @default_opts ||= {
+        passported: application_type != 'A' && application_type,
+        submitted_to_ccms: submitted_to_ccms == 'true',
+        assessment_result: capital_assessment_result.last != '' && capital_assessment_result,
+        payload_attrs: separate_attrs(payload_attrs)
+      }
+    end
+
+    def validate_required
+      errors.add(:application_type, I18n.t('activemodel.errors.models.reports.application_type')) if application_type.empty?
+      errors.add(:submitted_to_ccms, I18n.t('activemodel.errors.models.reports.submitted_to_ccms')) if submitted_to_ccms.empty?
+    end
+
+    def separate_attrs(str)
+      return [] if !str || str.strip.empty?
+
+      str.split(/\r\n|,|\s/).reject(&:empty?).map(&:upcase)
+    end
+
+    def process_date(params, date_type)
+      date_params = params.select { |key, _value| key.to_s.include? date_type.to_s }
+      return if date_params.values.first.empty?
+
+      Date.parse("#{date_params[:"#{date_type}_1i"]}-#{date_params[:"#{date_type}_2i"]}-#{date_params[:"#{date_type}_3i"]}")
+    end
+
+    def find_application_ids
+      # get application ids with a benefit check result within time range
+      laa_ids = BenefitCheckResult
+                .where('created_at >= ?', "#{records_from.strftime('%Y-%m-%d')} 00:00:00.000000")
+                .where('created_at <= ?', "#{records_to.strftime('%Y-%m-%d')} 23:59:59.999999")
+
+      # distinguish whether a passported or non-passported application
+      if default_opts[:passported]
+        laa_ids = laa_ids.where(result: default_opts[:passported] == 'P' ? 'Yes' : 'No')
+      end
+
+      # then get ids
+      laa_ids.pluck(:legal_aid_application_id)
+    end
+
+    def find_latest_application(id:)
+      CFE::BaseResult.where(legal_aid_application_id: id).order('created_at DESC').first
+    end
+
+    def filter_by_assessment_result(ids)
+      return ids unless default_opts[:assessment_result]
+
+      new_ids = []
+      # get the latest CFE result (in case of multiple attempts/corrections) for an application
+      # using the base class; this is to accommodate for different CFE result versions
+      ids.each do |id|
+        record = find_latest_application(id: id)
+        next unless record
+
+        hash = JSON.parse record.result
+        # get either V1 or V2 CFE assessment result
+        result = hash['assessment_result'] || hash.dig('assessment', 'capital', 'assessment_result')
+        new_ids << id if default_opts[:assessment_result].include? result
+      end
+
+      new_ids
+    end
+
+    def ccms_submission(id)
+      if default_opts[:submitted_to_ccms]
+        CCMS::Submission.find_by(legal_aid_application_id: id, aasm_state: 'completed')
+      else
+        CCMS::Submission.find_by(legal_aid_application_id: id)
+      end
+    end
+
+    def extract_attributes_from_history(hist)
+      Nokogiri::XML(hist.request).remove_namespaces!.xpath('//Attributes//Attribute//Attribute')
+    end
+
+    def siblings_response_value(siblings)
+      siblings.detect { |s| s.name == 'ResponseValue' }.text
+    end
+
+    def process_payload_attrs(result, laa_ref, ccms_hist) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+      return result unless default_opts[:payload_attrs].any? && ccms_hist
+
+      xml_key_values = []
+      attrs = extract_attributes_from_history(ccms_hist)
+
+      default_opts[:payload_attrs].each do |payload_attr|
+        dups = []
+        case_review_attrs = attrs.select { |a| a.text == payload_attr }
+
+        case_review_attrs.each do |attr|
+          next if dups.include? laa_ref
+
+          dups << laa_ref
+          siblings = attr.parent.children
+          xml_key_values << siblings_response_value(siblings)
+        end
+      end
+
+      result + xml_key_values
+    end
+
+    def process_result(laa_ref, ccms_ref, ccms_hist)
+      result = [laa_ref]
+      result << ccms_ref if ccms_ref
+      application_ccms_history = ccms_hist&.find_by(to_state: 'case_submitted')
+
+      @results << process_payload_attrs(result, laa_ref, application_ccms_history)
+    end
+
+    def search_applications
+      @results = []
+      application_ids = filter_by_assessment_result(find_application_ids)
+
+      application_ids.each do |id|
+        ccms = ccms_submission(id)
+        ccms_ref = ccms&.case_ccms_reference
+        laa = LegalAidApplication.find_by(id: id)
+        ccms_hist = laa&.ccms_submission&.submission_history
+
+        process_result(laa.application_ref, ccms_ref, ccms_hist) unless default_opts[:submitted_to_ccms] && !ccms
+      end
+    end
+  end
+end

--- a/app/views/admin/reports/index.html.erb
+++ b/app/views/admin/reports/index.html.erb
@@ -4,24 +4,73 @@
   back_link: :none
   ) do %>
 
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
-      <table class="govuk-table">
-        <thead class="govuk-table__head">
-        <tr class="govuk-table__row">
-          <th class="govuk-table__header" scope="col"><%= 'Report name' %></th>
-          <th class="govuk-table__header" scope="col"><%= 'Action' %></th>
-        </tr>
-        </thead>
-        <tbody class="govuk-table__body">
-        <% @reports.each do |_key, report| %>
+  <%= form_with(
+        builder: GOVUKDesignSystemFormBuilder::FormBuilder,
+        model: @reports_types_creator,
+        url: admin_reports_path,
+        method: :post,
+        local: true
+      ) do |form| %>
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-full">
+        <table class="govuk-table">
+          <thead class="govuk-table__head">
           <tr class="govuk-table__row">
-            <td class="govuk-table__cell case-full-name"><%= report[:report_title] %></td>
-            <td class="govuk-table__cell"><%= link_to_accessible(report[:path_text], __send__(report[:path], format: :csv)) %></td>
+            <th class="govuk-table__header" scope="col">Report name</th>
+            <th class="govuk-table__header" scope="col">Action</th>
           </tr>
-        <% end %>
-        </tbody>
-      </table>
+          </thead>
+          <tbody class="govuk-table__body">
+          <% @reports.each do |_key, report| %>
+            <tr class="govuk-table__row">
+              <td class="govuk-table__cell case-full-name"><%= report[:report_title] %></td>
+              <td class="govuk-table__cell"><%= link_to_accessible(report[:path_text], __send__(report[:path], format: :csv)) %></td>
+            </tr>
+          <% end %>
+          </tbody>
+        </table>
+      </div>
     </div>
-  </div>
+
+    <%= form.govuk_collection_radio_buttons :application_type,
+                                            [OpenStruct.new(value: 'A', label: t("admin.reports.application_type.all")),
+                                             OpenStruct.new(value: 'P', label: t("admin.reports.application_type.passported")),
+                                             OpenStruct.new(value: 'NP', label: t("admin.reports.application_type.non_passported"))],
+                                            :value,
+                                            :label,
+                                            inline: true,
+                                            hint: { text: '' },
+                                            legend: { text: t("admin.reports.application_type.heading"), tag: 'h1', size: 'm' } %>
+
+    <%= form.govuk_collection_radio_buttons :submitted_to_ccms,
+                                            yes_no_options,
+                                            :value,
+                                            :label,
+                                            inline: true,
+                                            hint: { text: '' },
+                                            legend: { text: t("admin.reports.submitted_to_ccms.heading"), tag: 'h1', size: 'm' } %>
+
+    <%= form.govuk_collection_check_boxes :capital_assessment_result,
+                                          [OpenStruct.new(id: 'pending', name: t("admin.reports.capital_assessment_result.pending")),
+                                          OpenStruct.new(id: 'eligible', name: t("admin.reports.capital_assessment_result.eligible")),
+                                          OpenStruct.new(id: 'ineligible', name: t("admin.reports.capital_assessment_result.not_eligible")),
+                                          OpenStruct.new(id: 'contribution_required', name: t("admin.reports.capital_assessment_result.contribution_required"))],
+                                          :id,
+                                          :name,
+                                          hint: { text: '(Optional)' },
+                                          legend: { text: t("admin.reports.capital_assessment_result.heading")} %>
+
+    <%= form.govuk_date_field :records_from, legend: { text: t("admin.reports.date_input_fields.records_from.heading") },
+                              hint: { text: t("admin.reports.date_input_fields.records_from.hint")} %>
+
+    <%= form.govuk_date_field :records_to, legend: { text: t("admin.reports.date_input_fields.records_to.heading") },
+                              hint: { text: t("admin.reports.date_input_fields.records_to.hint")} %>
+
+    <%= form.govuk_fieldset legend: {size: 'm', tag: 'h1', text: 'Collate XML Payload Attributes'} do %>
+      <%= form.govuk_text_area :payload_attrs, label: {text: '(Optional)'}, hint: {text: 'Separate attribute names with a comma, space or newline'}, rows: 15 %>
+    <% end %>
+
+    <input type="submit" name="commit" value="Submit" class="govuk-button form-button">
+  <% end %>
 <% end %>

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -335,6 +335,9 @@ en:
               blank: Select an account number
             username:
               already_exists: There is already a user with that username
+        reports:
+          application_type: Select if you want to search all cases or a particular type
+          submitted_to_ccms: Select if you want to search cases submitted to CCMS only
         respondent:
           attributes:
             full_name:

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -75,6 +75,27 @@ en:
     reports:
       index:
         heading_1: 'Admin reports and downloads'
+      date_input_fields:
+        records_from:
+          heading: Select records from
+          hint: (Optional) Default, 1 12 2019 - from month service went live
+        records_to:
+          heading: Select records to
+          hint: (Optional) Default, Todays's Date
+      submitted_to_ccms:
+        heading: Cases Successfully Submitted to CCMS Only
+      capital_assessment_result:
+        heading: Capital Assessment Result
+        none: 'None'
+        pending: 'Pending'
+        eligible: 'Eligible'
+        not_eligible: 'Not Eligible'
+        contribution_required: 'Contribution Required'
+      application_type:
+        heading: Application Type
+        all: 'All'
+        passported: 'Passported'
+        non_passported: 'Non-Passported'
     roles:
       index:
         heading_1: Search for the Provider firm name

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -69,7 +69,11 @@ Rails.application.routes.draw do
     resource :submitted_applications_report, only: %i[show]
     resource :feedback, controller: :feedback, only: %i[show]
     resources :ccms_connectivity_tests, only: [:show]
-    resources :reports, only: [:index]
+    resources :reports, only: %i[index create] do
+      member do
+        get 'download_custom_report'
+      end
+    end
     get 'user_dashboard', to: 'user_dashboard#index', as: 'user_dashboard'
     resources :roles, only: %i[index create update]
     namespace :roles do

--- a/spec/factories/ccms_submission_histories.rb
+++ b/spec/factories/ccms_submission_histories.rb
@@ -15,38 +15,7 @@ FactoryBot.define do
     end
 
     trait :with_xml do
-      request do
-        '<?xml version="1.0" encoding="UTF-8"?>
-      <soap:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns2="http://legalservices.gov.uk/CCMS/Common/ReferenceData/1.0/ReferenceDataBIM"
-      xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd" xmlns:ns3="http://legalservices.gov.uk/Enterprise/Common/1.0/Header"
-      xmlns:ns4="http://legalservices.gov.uk/Enterprise/Common/1.0/Common" xmlns:ns5="http://legalservices.gov.uk/CCMS/Common/ReferenceData/1.0/ReferenceDataBIO">
-        <soap:Header>
-          <ns1:Security>
-            <ns1:UsernameToken>
-              <ns1:Username/>
-              <ns1:Password Type=""></ns1:Password>
-            </ns1:UsernameToken>
-          </ns1:Security>
-        </soap:Header>
-        <soap:Body>
-          <ns2:ReferenceDataInqRQ>
-            <ns3:HeaderRQ>
-              <ns3:TransactionRequestID>202011191634055689868875843</ns3:TransactionRequestID>
-              <ns3:Language>ENG</ns3:Language>
-              <ns3:UserLoginID>MARTIN.RONAN@DAVIDGRAY.CO.UK</ns3:UserLoginID>
-              <ns3:UserRole/>
-            </ns3:HeaderRQ>
-            <ns2:SearchCriteria>
-              <ns5:ContextKey>CaseReferenceNumber</ns5:ContextKey>
-              <ns5:SearchKey>
-                <ns5:Key>CaseReferenceNumber</ns5:Key>
-              </ns5:SearchKey>
-            </ns2:SearchCriteria>
-          </ns2:ReferenceDataInqRQ>
-        </soap:Body>
-      </soap:Envelope>
-      '
-      end
+      request { File.open(Rails.root.join('ccms_integration/example_payloads/NonPassportedFullMonty.xml')) { |f| Nokogiri::XML(f).remove_namespaces! } }
       response do
         '<?xml version="1.0" encoding="UTF-8"?>
       <soap:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns2="http://legalservices.gov.uk/CCMS/Common/ReferenceData/1.0/ReferenceDataBIM"

--- a/spec/factories/ccms_submissions.rb
+++ b/spec/factories/ccms_submissions.rb
@@ -66,5 +66,16 @@ FactoryBot.define do
         create(:ccms_submission_document, submission: submission)
       end
     end
+
+    trait :case_completed do
+      case_ccms_reference { Faker::Number.number(digits: 12) }
+      applicant_ccms_reference { Faker::Number.number(digits: 8) }
+      aasm_state { 'completed' }
+
+      after(:create) do |submission|
+        create(:ccms_submission_history, :with_xml, to_state: 'case_submitted', submission: submission)
+        create(:ccms_submission_document, submission: submission)
+      end
+    end
   end
 end

--- a/spec/factories/legal_aid_applications.rb
+++ b/spec/factories/legal_aid_applications.rb
@@ -653,6 +653,12 @@ FactoryBot.define do
       end
     end
 
+    trait :with_ccms_submission_completed do
+      after :create do |application|
+        create :ccms_submission, :case_created, :case_completed, legal_aid_application: application
+      end
+    end
+
     trait :discarded do
       discarded_at { Time.current - 5.minutes }
     end

--- a/spec/services/reports/reports_types_creator_spec.rb
+++ b/spec/services/reports/reports_types_creator_spec.rb
@@ -1,0 +1,202 @@
+require 'rails_helper'
+
+RSpec.describe Reports::ReportsTypesCreator do
+  let(:firm) { create :firm }
+  let(:provider) { create :provider, firm: firm }
+  let!(:application_non_passported) do
+    create :legal_aid_application,
+           :with_everything,
+           :with_proceeding_types,
+           :at_assessment_submitted,
+           :with_negative_benefit_check_result,
+           :with_ccms_submission_completed,
+           provider: provider
+  end
+  let!(:application_passported) do
+    create :legal_aid_application,
+           :with_everything,
+           :with_proceeding_types,
+           :at_assessment_submitted,
+           :with_positive_benefit_check_result,
+           provider: provider
+  end
+
+  let(:report) { Reports::ReportsTypesCreator.call(params) }
+
+  describe 'all application types' do
+    context 'matching application' do
+      let(:params) do
+        {
+          application_type: 'A',
+          submitted_to_ccms: 'false',
+          capital_assessment_result: ['eligible'],
+          records_from_3i: '',
+          records_from_2i: '',
+          records_from_1i: '',
+          records_to_3i: '',
+          records_to_2i: '',
+          records_to_1i: '',
+          payload_attrs: "country\r\nAPPLY_CASE_MEANS_REVIEW"
+        }
+      end
+
+      context 'generated csv' do
+        let(:today) { Date.current }
+        let(:yesterday) { today - 1.day }
+        let(:two_days_ago) { today - 2.days }
+
+        before do
+          @table = CSV.parse(report.generate_csv, headers: true)
+        end
+
+        it 'has the correct headers' do
+          expect(@table.headers).to eql(%w[application_ref case_ccms_reference COUNTRY APPLY_CASE_MEANS_REVIEW])
+        end
+
+        it 'has the correct application reference' do
+          expect(@table.first['application_ref']).to include(application_non_passported.application_ref)
+        end
+
+        it 'has the correct case ccms reference' do
+          ccms_record = CCMS::Submission.find_by(legal_aid_application_id: application_non_passported.id)
+          expect(@table.first['case_ccms_reference']).to include(ccms_record.case_ccms_reference)
+        end
+
+        context 'in date range' do
+          let(:params) do
+            {
+              application_type: 'A',
+              submitted_to_ccms: 'false',
+              capital_assessment_result: ['eligible'],
+              records_from_3i: two_days_ago.year.to_s,
+              records_from_2i: two_days_ago.month.to_s,
+              records_from_1i: two_days_ago.day.to_s,
+              records_to_3i: today.year.to_s,
+              records_to_2i: today.month.to_s,
+              records_to_1i: today.day.to_s,
+              payload_attrs: "country\r\nAPPLY_CASE_MEANS_REVIEW"
+            }
+          end
+
+          it 'has both records' do
+            expect(@table.count).to eql(2)
+          end
+        end
+
+        context 'outside date range' do
+          let(:params) do
+            {
+              application_type: 'A',
+              submitted_to_ccms: 'false',
+              capital_assessment_result: ['eligible'],
+              records_from_3i: two_days_ago.year.to_s,
+              records_from_2i: two_days_ago.month.to_s,
+              records_from_1i: two_days_ago.day.to_s,
+              records_to_3i: yesterday.year.to_s,
+              records_to_2i: yesterday.month.to_s,
+              records_to_1i: yesterday.day.to_s,
+              payload_attrs: "country\r\nAPPLY_CASE_MEANS_REVIEW"
+            }
+          end
+
+          it 'has no records' do
+            expect(@table).to be_empty
+          end
+        end
+
+        context 'passported only' do
+          let(:params) do
+            {
+              application_type: 'P',
+              submitted_to_ccms: 'false',
+              capital_assessment_result: ['eligible'],
+              records_from_3i: '',
+              records_from_2i: '',
+              records_from_1i: '',
+              records_to_3i: '',
+              records_to_2i: '',
+              records_to_1i: '',
+              payload_attrs: "country\r\nAPPLY_CASE_MEANS_REVIEW"
+            }
+          end
+
+          it 'has one passported record' do
+            expect(@table.count).to eql(1)
+            expect(@table.first['application_ref']).to include(application_passported.application_ref)
+          end
+        end
+
+        context 'non passported only' do
+          let(:params) do
+            {
+              application_type: 'NP',
+              submitted_to_ccms: 'false',
+              capital_assessment_result: ['eligible'],
+              records_from_3i: '',
+              records_from_2i: '',
+              records_from_1i: '',
+              records_to_3i: '',
+              records_to_2i: '',
+              records_to_1i: '',
+              payload_attrs: "country\r\nAPPLY_CASE_MEANS_REVIEW"
+            }
+          end
+
+          it 'has one passported record' do
+            expect(@table.count).to eql(1)
+            expect(@table.first['application_ref']).to include(application_non_passported.application_ref)
+          end
+        end
+
+        context 'submitted to ccms' do
+          let(:params) do
+            {
+              application_type: 'A',
+              submitted_to_ccms: 'true',
+              capital_assessment_result: ['eligible'],
+              records_from_3i: '',
+              records_from_2i: '',
+              records_from_1i: '',
+              records_to_3i: '',
+              records_to_2i: '',
+              records_to_1i: '',
+              payload_attrs: "country\r\nAPPLY_CASE_MEANS_REVIEW"
+            }
+          end
+
+          it 'collects records successfully sent to ccms only' do
+            expect(@table.count).to eql(1)
+            expect(@table.first['application_ref']).to include(application_non_passported.application_ref)
+          end
+
+          it 'extracts XML attributes listed by the user' do
+            expect(@table.first['COUNTRY']).to include('GBR')
+            expect(@table.first['APPLY_CASE_MEANS_REVIEW']).to include('false')
+          end
+        end
+      end
+    end
+
+    context 'no matches' do
+      let(:params) do
+        {
+          application_type: 'A',
+          submitted_to_ccms: 'false',
+          capital_assessment_result: ['pending'],
+          records_from_3i: '',
+          records_from_2i: '',
+          records_from_1i: '',
+          records_to_3i: '',
+          records_to_2i: '',
+          records_to_1i: '',
+          payload_attrs: "country\r\nAPPLY_CASE_MEANS_REVIEW"
+        }
+      end
+
+      it 'does not generate a csv report' do
+        table = CSV.parse(report.generate_csv, headers: true)
+        expect(table).to be_empty
+      end
+    end
+  end
+end

--- a/spec/services/true_layer/bank_data_import_service_spec.rb
+++ b/spec/services/true_layer/bank_data_import_service_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe TrueLayer::BankDataImportService do
   let(:applicant) { legal_aid_application.applicant }
 
   before do
+    Setting.delete_all
     applicant.store_true_layer_token(token: token, expires: token_expires_at)
   end
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-XXX)

Using L&D time to generate a CCMS report with xml payload details based on options in the Admin reports UI.
Feel free to pull this down and test, though tricky without real submissions to CCMS.

In this PR I've extended factories to accommodate successfully submitted cases to CCMS in the CCMS Submission and CCMS Submission History tables. With that, I've then got a custom report generator that uses a UI to capture what a user would like to find in terms of Apply/CCMS cases, whether they are passported or not, date ranges, capital assessment result and also to extract XML attribute values into a CSV file.

<img width="452" alt="Screenshot 2021-03-17 at 19 23 04" src="https://user-images.githubusercontent.com/17381167/111526084-34573600-8756-11eb-9f15-7f55b3000e49.png">

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
