### PR TITLE
AP-2033: Fix PDF generation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,11 +29,14 @@ RUN apk --no-cache add --virtual build-dependencies \
                   linux-headers \
                   clamav-daemon \
                   libreoffice \
+                  ttf-dejavu \
+                  ttf-droid \
+                  ttf-freefont \
+                  ttf-liberation \
                   ttf-ubuntu-font-family \
                   wkhtmltopdf \
                   bash \
  && pip3 install awscli
-
 #  # Install kubectl
 # RUN curl -LO /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl
 RUN echo $KUBECTL_VERSION

--- a/app/views/layouts/pdf.html.erb
+++ b/app/views/layouts/pdf.html.erb
@@ -6,7 +6,7 @@
     <%= render 'layouts/govuk_base64_fonts' %>
   </head>
 
-  <body class="govuk-template__body pdf">
+  <body class="govuk-template__body" style="padding-left: 3em; padding-top: 3em;">
     <div class="govuk-width-container">
       <main class="govuk-main-wrapper " id="main-content" role="main">
         <%= yield %>

--- a/app/webpack/stylesheets/check-your-answers.scss
+++ b/app/webpack/stylesheets/check-your-answers.scss
@@ -5,10 +5,6 @@ $govuk-fonts-path: "~govuk-frontend/govuk/assets/fonts/";
 
 // Recommended - Use these styles for the check your answers pattern
 
-.pdf {
-  text-rendering: geometricPrecision;
-}
-
 .app-check-your-answers {
   @include govuk-font(19);
   @include govuk-responsive-margin(3, "bottom");


### PR DESCRIPTION
## What

[AP-2033](https://dsdmoj.atlassian.net/browse/AP-2033)

Urgh! Where do I start. PDF generation locally was working whereas in our remote environments it was not. Wicked_PDF is a wrapper for wkhtmltopdf which, when running on our base Docker image which uses alpine, doesn't play nicely and ends up overriding any CSS (if it even exists) with its own defaults. The mostly successful solution to this issue was working out that our docker image needed additional base fonts installed to mitigate this behaviour when wkhtmltopdf runs on alpine. However even so, some in-line styling is needed as the Webkit Q rendering engine isn't perfect due to this. Also whatever we see generated by the html isn't what is going to be generated in the pdf. That is a misconception also noted by the open source community making this issue doubly irritating. Anyway, we've pretty much fixed it. 🙄 

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
