### PR TITLE
AP-2024 error now works when police_notified is blank

### DIFF
--- a/app/forms/respondents/respondent_form.rb
+++ b/app/forms/respondents/respondent_form.rb
@@ -50,7 +50,7 @@ module Respondents
     def police_notified_presence
       return if police_notified.blank?
 
-      value = __send__("police_notified_details_#{police_notified}".to_sym)
+      value = __send__("police_notified_details_#{police_notified}")
       return if value.present? || draft?
 
       translation_path = "activemodel.errors.models.respondent.attributes.police_notified_details_#{police_notified}.blank"
@@ -60,7 +60,7 @@ module Respondents
     def interpolate_police_notified_details
       return unless [true, false, 'true', 'false'].include?(police_notified)
 
-      value = __send__("police_notified_details_#{police_notified}".to_sym)
+      value = __send__("police_notified_details_#{police_notified}")
       @police_notified_details = value&.empty? ? nil : value
       attributes['police_notified_details'] = @police_notified_details
     end
@@ -76,7 +76,7 @@ module Respondents
 
     def clear_details
       %i[understands_terms_of_court_order warning_letter_sent].each do |attr|
-        details = "#{attr}_details".to_sym
+        details = "#{attr}_details"
         attr_value = __send__(attr)
         __send__(details)&.clear if attr_value.to_s == 'true'
       end

--- a/app/forms/respondents/respondent_form.rb
+++ b/app/forms/respondents/respondent_form.rb
@@ -30,11 +30,7 @@ module Respondents
     )
 
     validates :police_notified, presence: true, unless: :draft?
-    validates(
-      :police_notified_details,
-      presence: true,
-      if: proc { |form| !form.draft? && (%w[true false].include? form.police_notified.to_s) }
-    )
+    validate :police_notified_presence
 
     validates :bail_conditions_set, presence: true, unless: :draft?
     validates(
@@ -50,6 +46,16 @@ module Respondents
     end
 
     private
+
+    def police_notified_presence
+      return if police_notified.blank?
+
+      value = __send__("police_notified_details_#{police_notified}".to_sym)
+      return if value.present? || draft?
+
+      translation_path = "activemodel.errors.models.respondent.attributes.police_notified_details_#{police_notified}.blank"
+      errors.add("police_notified_details_#{police_notified}".to_sym, I18n.t(translation_path))
+    end
 
     def interpolate_police_notified_details
       return unless [true, false, 'true', 'false'].include?(police_notified)

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -342,14 +342,18 @@ en:
               blank: Select yes if a warning letter has been sent to the opponent
             police_notified:
               blank: Select yes if the police have been notified
+            police_notified_details:
+              blank: Select yes if the police have been notified
             bail_conditions_set:
               blank: Select yes if bail conditions have been set
             understands_terms_of_court_order_details:
               blank: Tell us why you think the court would enforce a breach of an order
             warning_letter_sent_details:
               blank: Tell us why a warning letter has not been sent
-            police_notified_details:
+            police_notified_details_true:
               blank: Tell us what action the police have taken
+            police_notified_details_false:
+              blank: Tell us why the police have not been notified
             bail_conditions_set_details:
               blank: Give details of the bail conditions
         savings_amount:

--- a/spec/forms/respondents/respondent_form_spec.rb
+++ b/spec/forms/respondents/respondent_form_spec.rb
@@ -152,7 +152,7 @@ RSpec.describe Respondents::RespondentForm, type: :form do
       it 'generates errors' do
         expect(subject.errors[:understands_terms_of_court_order_details].join).to eq(I18n.t('understands_terms_of_court_order_details.blank', scope: i18n_scope))
         expect(subject.errors[:warning_letter_sent_details].join).to eq(I18n.t('warning_letter_sent_details.blank', scope: i18n_scope))
-        expect(subject.errors[:police_notified_details].join).to eq(I18n.t('police_notified_details.blank', scope: i18n_scope))
+        expect(subject.errors[:police_notified_details_true].join).to eq(I18n.t('activemodel.errors.models.respondent.attributes.police_notified_details_true.blank'))
         expect(subject.errors[:bail_conditions_set_details].join).to eq(I18n.t('bail_conditions_set_details.blank', scope: i18n_scope))
       end
 
@@ -161,7 +161,7 @@ RSpec.describe Respondents::RespondentForm, type: :form do
           %i[
             understands_terms_of_court_order_details
             warning_letter_sent_details
-            police_notified_details
+            police_notified_details_true
             bail_conditions_set_details
           ]
         )
@@ -212,7 +212,7 @@ RSpec.describe Respondents::RespondentForm, type: :form do
           police_notified: 'false',
           understands_terms_of_court_order_details: '',
           warning_letter_sent_details: '',
-          police_notified_details: '',
+          police_notified_details_false: '',
           bail_conditions_set_details: ''
         }
       end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2024)

Form validation added to handle true or false selection. Translations also added.

When nothing selected OR text box is blank, the error is now correctly displayed at the top & at the relevant question level, ie the question is highlighted in red with an appropriate error message.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
