### PR TITLE
AP-2007 Hide logging mailer arguments for security

### DIFF
--- a/app/jobs/govuk_notify_mailer_job.rb
+++ b/app/jobs/govuk_notify_mailer_job.rb
@@ -1,4 +1,6 @@
 class GovukNotifyMailerJob < ActionMailer::MailDeliveryJob
+  self.log_arguments = false
+
   def perform(mailer, mail_method, delivery_method, args:)
     email_args, govuk_message_id = extract_govuk_message_id(args)
     GovukEmails::EmailMonitor.call(


### PR DESCRIPTION
## AP-2007 Hide logging mailer arguments for security

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2007)

Hide logging mailer arguments for security. This means information about the applicant or provider is kept hidden from logs.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
