### PR TITLE
Update formbuilder in proceedings types forms

### DIFF
--- a/app/controllers/providers/has_other_proceedings_controller.rb
+++ b/app/controllers/providers/has_other_proceedings_controller.rb
@@ -3,16 +3,17 @@ module Providers
     def show
       return go_forward unless Setting.allow_multiple_proceedings?
 
+      @form = Providers::HasOtherProceedingsForm.new
       proceeding_types
     end
 
     def update
       return continue_or_draft if draft_selected?
 
-      if params[:has_other_proceeding].in?(%w[true false])
-        go_forward(params[:has_other_proceeding] == 'true')
+      @form = Providers::HasOtherProceedingsForm.new(form_params)
+      if @form.valid?
+        go_forward(form_params[:has_other_proceedings] == 'true')
       else
-        @error = { 'has_other_proceeding-error' => I18n.t('providers.has_other_proceedings.show.error') }
         render :show
       end
     end
@@ -34,7 +35,7 @@ module Providers
     end
 
     def proceeding_type_id
-      proceeding_types.find_by(code: form_params)&.id
+      proceeding_types.find_by(code: params.require(:id))&.id
     end
 
     def proceeding_type
@@ -53,7 +54,7 @@ module Providers
     end
 
     def form_params
-      params.require(:id)
+      params.require(:providers_has_other_proceedings_form).permit(:has_other_proceedings)
     end
   end
 end

--- a/app/controllers/providers/has_other_proceedings_controller.rb
+++ b/app/controllers/providers/has_other_proceedings_controller.rb
@@ -24,6 +24,7 @@ module Providers
       if proceeding_types.empty?
         redirect_to providers_legal_aid_application_proceedings_types_path
       else
+        @form = Providers::HasOtherProceedingsForm.new
         render :show
       end
     end

--- a/app/forms/providers/has_other_proceedings_form.rb
+++ b/app/forms/providers/has_other_proceedings_form.rb
@@ -1,0 +1,17 @@
+module Providers
+  class HasOtherProceedingsForm
+    include ActiveModel::Model
+
+    attr_accessor :has_other_proceedings
+
+    validate :other_proceedings_present?
+
+    def other_proceedings_present?
+      errors.add :has_other_proceedings, error_message if has_other_proceedings.blank?
+    end
+
+    def error_message
+      I18n.t('providers.has_other_proceedings.show.error')
+    end
+  end
+end

--- a/app/views/providers/has_other_proceedings/show.html.erb
+++ b/app/views/providers/has_other_proceedings/show.html.erb
@@ -1,7 +1,5 @@
 <%= page_template page_title: t('.page_title'), template: :basic do %>
 
-  <%= render partial: 'shared/error' if @error %>
-
   <% if @legal_aid_application.proceeding_types.any? %>
     <%= govuk_fieldset_header(size: 'm') { t('.existing', count: "#{pluralize(@legal_aid_application.proceeding_types.count, 'proceeding')}")} %>
     <div class="govuk-summary-list">
@@ -22,16 +20,14 @@
     </div>
   <% end %>
 
-  <%= form_with(url: providers_legal_aid_application_has_other_proceedings_path, method: :patch, local: true) do |form| %>
+  <%= form_with(builder: GOVUKDesignSystemFormBuilder::FormBuilder,
+                model: @form,
+                url: providers_legal_aid_application_has_other_proceedings_path,
+                method: :patch,
+                local: true) do |form| %>
 
-    <%= govuk_form_group(
-            show_error_if: @error,
-            input: :has_other_proceeding
-        ) do %>
-
-      <%= form.govuk_collection_radio_buttons :has_other_proceeding, form.yes_no_radio_button_array, :value, :label, error: @error&.values&.first, title: content_for(:page_title) %>
-
-    <% end %>
+      <%= form.govuk_collection_radio_buttons :has_other_proceedings, yes_no_options, :value, :label,
+                                              legend: {text: content_for(:page_title), tag: 'h1', size: 'xl'} %>
 
     <%= next_action_buttons(
             form: form,

--- a/app/views/providers/proceedings_types/index.html.erb
+++ b/app/views/providers/proceedings_types/index.html.erb
@@ -37,6 +37,7 @@
 
 <% if Setting.allow_multiple_proceedings? %>
   <%= form_with(
+    builder: GOVUKDesignSystemFormBuilder::FormBuilder,
     model: nil,
     url: providers_legal_aid_application_proceedings_types_path,
     local: true) do |form| %>

--- a/app/views/shared/forms/proceedings_types/_proceeding_type_form.html.erb
+++ b/app/views/shared/forms/proceedings_types/_proceeding_type_form.html.erb
@@ -1,8 +1,8 @@
 <div id="<%= proceeding_type.code %>" class="govuk-grid-row proceeding-item govuk-!-margin-bottom-0" tabindex="0">
-    <%= form.govuk_radio_button(
-        :id,
-        proceeding_type.id,
-        label: proceeding_type.meaning,
-        hint: "#{proceeding_type.ccms_category_law} (#{proceeding_type.ccms_matter})"
-    ) %>
+  <%= form.govuk_radio_button(
+          :id,
+          proceeding_type.id,
+          label: {text: proceeding_type.meaning},
+          hint: {text: "#{proceeding_type.ccms_category_law} (#{proceeding_type.ccms_matter})"}
+      ) %>
 </div>

--- a/spec/requests/providers/has_other_proceedings_controller_spec.rb
+++ b/spec/requests/providers/has_other_proceedings_controller_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Providers::HasOtherProceedingsController, type: :request do
     end
 
     context 'choose yes' do
-      let(:params) { { has_other_proceeding: 'true' } }
+      let(:params) { { providers_has_other_proceedings_form: { has_other_proceedings: 'true' } } }
 
       it 'redirects to the page to add another proceeding type' do
         expect(response).to redirect_to(providers_legal_aid_application_proceedings_types_path(legal_aid_application))
@@ -53,7 +53,7 @@ RSpec.describe Providers::HasOtherProceedingsController, type: :request do
     end
 
     context 'choose no' do
-      let(:params) { { has_other_proceeding: 'false' } }
+      let(:params) { { providers_has_other_proceedings_form: { has_other_proceedings: 'false' } } }
 
       it 'redirects to the delegated functions page' do
         expect(response).to redirect_to(providers_legal_aid_application_used_delegated_functions_path(legal_aid_application))
@@ -61,7 +61,7 @@ RSpec.describe Providers::HasOtherProceedingsController, type: :request do
     end
 
     context 'choose nothing' do
-      let(:params) { nil }
+      let(:params) { { providers_has_other_proceedings_form: { has_other_proceedings: nil } } }
 
       it 'stays on the page if there is a validation error' do
         expect(response).to have_http_status(:ok)


### PR DESCRIPTION
## Add new formbuilder to proceedings types pages

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1981)

Updated proceedings types page and has other proceedings page to use new formbuilder

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
