### PR TITLE
Add rack-attack gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem 'loofah', '>= 2.2.3'
 gem 'pg'
 gem 'pg_dump_anonymize'
 gem 'puma', '~> 5.3'
+gem 'rack-attack' # prevent/reduce php phishing attacks
 gem 'rails', '~> 6.1.4'
 gem 'regexp-examples'
 gem 'savon', '~> 2.12.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -451,6 +451,8 @@ GEM
       activesupport (>= 3.0.0)
     racc (1.5.2)
     rack (2.2.3)
+    rack-attack (6.5.0)
+      rack (>= 1.0, < 3)
     rack-pjax (1.1.0)
       nokogiri (~> 1.5)
       rack (>= 1.1)
@@ -743,6 +745,7 @@ DEPENDENCIES
   pundit
   rails (~> 6.1.4)
   rails_admin (~> 2.1)
+  rack-attack
   redis-namespace
   regexp-examples
   rspec-rails (~> 5.0)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -91,6 +91,7 @@ Rails.application.configure do
 
   config.active_storage.service = :amazon
   config.x.application.host_url = "https://#{config.x.application.host}"
+  config.middleware.use Rack::Attack if %w[staging uat localhost].include?(config.x.application.host)
 
   # Verifies that versions and hashed value of the package contents in the project's package.json
   config.webpacker.check_yarn_integrity = false

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,0 +1,7 @@
+module Rack
+  class Attack
+    Rack::Attack.blocklist('bad-robots') do |req|
+      req.ip if /\S+\.php/.match?(req.path)
+    end
+  end
+end


### PR DESCRIPTION
## What

Taken from a [blog post](https://andycroll.com/ruby/ignore-php-bots-with-rack-attack/)
by brighton-ruby organiser, [Andy Croll](https://andycroll.com/)

The aim is to block the attempts at `hacking` exploits in our 'php'!
e.g. trying to post malicious data to `wp-content/plugins/wp-ticket/assets/ext/zebraform/process.php`

25 Jun 
* rebased on master, including updating the git-crypt keys
* also pushed up an untested, incomplete, first pass at configuring rack-attack on non-prod environments

That was as far as I got back in the day!

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
