### PR TITLE
AP-2006: Turn off prepared cache statements to avoid cached DB querie…

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -3,6 +3,7 @@ default: &default
   encoding: unicode
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 25 } %>
   timeout: 5000
+  prepared_statements: false
 
 development:
   <<: *default


### PR DESCRIPTION
…s causing Sentry errors when the DB schema updates


## What

[AP-2006](https://dsdmoj.atlassian.net/browse/AP-2006)

Turned off prepare cache statements. 
Architectural log published in Confluence here https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/2993225825/Architectural+Log

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
