### PR TITLE
Ap 2063 duplicate entity id

### DIFF
--- a/config/ccms/means_entity_configs/non_passported.yml
+++ b/config/ccms/means_entity_configs/non_passported.yml
@@ -90,7 +90,7 @@
 
 - method: :generate_entity
   entity_name: OTHERSAVING
-  instance_label: the timeshare
+  instance_label: the other saving1
   yaml_section: :other_savings
 
 - predicate: :vehicles_present?


### PR DESCRIPTION
## What

[AP-2063](https://dsdmoj.atlassian.net/browse/AP-2063)

Duplicate entity ids are happening due to the fact the OTHERSAVING attribute is using the wrong instance label. By correcting it to what we have in our example xml payload this should avoid duplicates and fix this issue.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
