### PR TITLE
BugFix Remove active support and sidekiq logger from sentry

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -9,6 +9,10 @@ if %w[production].include?(Rails.env) && ENV['SENTRY_DSN'].present?
     filter = ActiveSupport::ParameterFilter.new(Rails.application.config.filter_parameters.map(&:to_s))
 
     config.before_send = ->(event, _hint) {
+      event.extra[:sidekiq][:job]['args'].first['arguments'] = [] if event.extra.dig(:sidekiq, :job, 'args')
+
+      event.extra[:sidekiq][:jobstr] = {} if event.extra.dig(:sidekiq, :jobstr)
+
       event.request.data = filter.filter(event.request&.data || []) if event.request&.data
 
       event

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -5,7 +5,6 @@ require 'sentry-sidekiq'
 if %w[production].include?(Rails.env) && ENV['SENTRY_DSN'].present?
   Sentry.init do |config|
     config.dsn = ENV['SENTRY_DSN']
-    config.breadcrumbs_logger = %i[active_support_logger sentry_logger]
 
     filter = ActiveSupport::ParameterFilter.new(Rails.application.config.filter_parameters.map(&:to_s))
 


### PR DESCRIPTION
## Remove activesupport and sidekiq breadcrumb logger from sentry

This stops any pii leaking into sentry as the logs are shown in the breadcrumbs.


Reimplement sidekiq before_send sanitisation of arguments to stop PII in sentry.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
