### PR TITLE
AP-2067/2071 Content changes on cash_income and cash_outgoings screen

### DIFF
--- a/app/views/shared/partials/_revealing_checkbox.html.erb
+++ b/app/views/shared/partials/_revealing_checkbox.html.erb
@@ -11,7 +11,7 @@
 </div>
 
 <div class="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden" id="conditional_<%= name %>">
-  <span class="govuk-hint"><% t('.hint') %></span>
+  <span class="govuk-hint"><%= t('.hint') %></span>
 
   <% (1..number_of_fields).each do |number| %>
     <%= govuk_form_group show_error_if: model.errors.messages["#{name}#{number}".to_sym][0] do %>

--- a/app/views/shared/partials/_revealing_checkbox.html.erb
+++ b/app/views/shared/partials/_revealing_checkbox.html.erb
@@ -11,7 +11,7 @@
 </div>
 
 <div class="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden" id="conditional_<%= name %>">
-  <span class="govuk-hint"><%= t('.hint') %></span>
+  <span class="govuk-hint"><%= t(".#{journey_type}.#{controller_name}.hint") %></span>
 
   <% (1..number_of_fields).each do |number| %>
     <%= govuk_form_group show_error_if: model.errors.messages["#{name}#{number}".to_sym][0] do %>

--- a/config/locales/cy/shared.yml
+++ b/config/locales/cy/shared.yml
@@ -4,16 +4,16 @@ cy:
     partials:
       revealing_checkbox:
         dates: "%{date_end} ot %{date_start}"
-        hint: ".enon deviecer uoy fi 0 retne ro ,htnom radnelac hcae ni deviecer uoy
-          tnuoma hsac latot eht retnE"
         citizens:
           cash_incomes:
+            hint: ".enon deviecer uoy fi 0 retne ro ,htnom hcae deviecer uoy tnuoma hsac latot eht retnE"
             check_box_benefits: stifeneB
             check_box_friends_or_family: ylimaf ro sdneirf morf pleh laicnaniF
             check_box_maintenance_in: stnemyap ecnanetniaM
             check_box_property_or_lodger: regdol ro ytreporp a morf emocnI
             check_box_pension: noisneP
           cash_outgoings:
+            hint: ".enon diap uoy fi 0 retne ro ,htnom hcae diap uoy tnuoma hsac latot eht retnE"
             check_box_rent_or_mortgage: stnemyap gnisuoH
             check_box_child_care: stnemyap eracdlihC
             check_box_maintenance_out: stnemyap ecnanetniaM

--- a/config/locales/en/shared.yml
+++ b/config/locales/en/shared.yml
@@ -4,15 +4,16 @@ en:
     partials:
       revealing_checkbox:
         dates:  "%{date_start} to %{date_end}"
-        hint: Enter the total cash amount you received each month, or enter 0 if you received none.
         citizens:
           cash_incomes:
+            hint: Enter the total cash amount you received each month, or enter 0 if you received none.
             check_box_benefits: Benefits
             check_box_friends_or_family: Financial help from friends or family
             check_box_maintenance_in: Maintenance payments from a former partner
             check_box_property_or_lodger: Income from a property or lodger
             check_box_pension: Pension
           cash_outgoings:
+            hint: Enter the total cash amount you paid each month, or enter 0 if you paid none.
             check_box_rent_or_mortgage: Housing payments
             check_box_child_care: Childcare payments
             check_box_maintenance_out: Maintenance payments to a former partner

--- a/config/locales/en/shared.yml
+++ b/config/locales/en/shared.yml
@@ -4,12 +4,12 @@ en:
     partials:
       revealing_checkbox:
         dates:  "%{date_start} to %{date_end}"
-        hint: Enter the total cash amount you received in each calendar month, or enter 0 if you received none.
+        hint: Enter the total cash amount you received each month, or enter 0 if you received none.
         citizens:
           cash_incomes:
             check_box_benefits: Benefits
             check_box_friends_or_family: Financial help from friends or family
-            check_box_maintenance_in: Maintenance payments
+            check_box_maintenance_in: Maintenance payments from a former partner
             check_box_property_or_lodger: Income from a property or lodger
             check_box_pension: Pension
           cash_outgoings:

--- a/config/locales/en/shared.yml
+++ b/config/locales/en/shared.yml
@@ -15,8 +15,8 @@ en:
           cash_outgoings:
             check_box_rent_or_mortgage: Housing payments
             check_box_child_care: Childcare payments
-            check_box_maintenance_out: Maintenance payments
-            check_box_legal_aid: Legal aid payments
+            check_box_maintenance_out: Maintenance payments to a former partner
+            check_box_legal_aid: Payments towards legal aid in a criminal case
     applicant_declaration:
       confirm_following: Confirm the following
       submission_list_summary: You agree that


### PR DESCRIPTION
## What

[AP-2067](https://dsdmoj.atlassian.net/browse/AP-2067) & [AP-2071](https://dsdmoj.atlassian.net/browse/AP-2071)

Minor content changes on /citizens/cash_income and /citizens/cash_outgoings

- amend label on maintence and legal aid checkboxes
- fix bug preventing hints being displayed on checkboxes
- refactor hint functionality on `_revealing_checkbox` partial to allow different hints to be displayed for income and outgoings


## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
