### PR TITLE
BugFix - Revert the data scrubbing for sentry config

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -10,10 +10,6 @@ if %w[production].include?(Rails.env) && ENV['SENTRY_DSN'].present?
     filter = ActiveSupport::ParameterFilter.new(Rails.application.config.filter_parameters.map(&:to_s))
 
     config.before_send = ->(event, _hint) {
-      event.extra[:sidekiq][:job]['args'].first['arguments'] = [] if event.extra.dig(:sidekiq, :job, 'args')
-
-      event.extra[:sidekiq][:jobstr] = {} if event.extra.dig(:sidekiq, :jobstr)
-
       event.request.data = filter.filter(event.request&.data || []) if event.request&.data
 
       event


### PR DESCRIPTION
## BugFix - Revert the data scrubbing for sentry config

This is because it is being used by the email monitor and caused a addressee can't be blank error in sentry


## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
