### PR TITLE
AP-2073 Fix spacing issue on income and outgoings summary pages

### DIFF
--- a/app/views/providers/income_summary/index.html.erb
+++ b/app/views/providers/income_summary/index.html.erb
@@ -52,6 +52,8 @@
 
   <% end %>
 
+  <div class="govuk-!-padding-bottom-6"></div>
+
   <%= next_action_buttons_with_form(
         url: providers_legal_aid_application_income_summary_index_path,
         show_draft: true

--- a/app/views/providers/outgoings_summary/index.html.erb
+++ b/app/views/providers/outgoings_summary/index.html.erb
@@ -45,6 +45,8 @@
     <%= render partial: 'shared/cash_transactions' %>
   <% end %>
 
+  <div class="govuk-!-padding-bottom-6"></div>
+
   <%= next_action_buttons_with_form(
         url: providers_legal_aid_application_outgoings_summary_index_path,
         show_draft: true


### PR DESCRIPTION
## Fix spacing issue on income and outgoings summary pages

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2073)

Add spacing above button of padding size 6

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
