### PR TITLE
AP-2068 Update hint text on Identify Types of Outgoing page

### DIFF
--- a/app/views/shared/forms/_types_of_outgoings_form.html.erb
+++ b/app/views/shared/forms/_types_of_outgoings_form.html.erb
@@ -11,7 +11,8 @@
       <div class="deselect-group govuk-!-padding-bottom-1" data-deselect-ctrl="#legal-aid-application-none-selected-true-field">
         <% TransactionType.debits.each do |transaction_type| %>
           <%= form.govuk_check_box :transaction_type_ids, transaction_type.id, link_errors: true,
-                                   label: {text: t("transaction_types.names.#{journey_type}.#{transaction_type.name}")} %>
+                                   label: {text: t("transaction_types.names.#{journey_type}.#{transaction_type.name}")},
+                                   hint: {text: t(".hints.#{transaction_type.name}", default: '')} %>
         <% end %>
       </div>
       <%= form.govuk_radio_divider %>

--- a/config/locales/en/shared.yml
+++ b/config/locales/en/shared.yml
@@ -426,6 +426,10 @@ en:
             Your solicitor will look at your bank statements and put your transactions into the categories you select.
             We need this information to check if you qualify financially for legal aid.
       types_of_outgoings_form:
+        hints:
+          rent_or_mortgage: For example, rent, mortgage or board and lodging.
+          child_care: For example, to a childminder, nanny or nursery.
+          maintenance_out: This includes child maintenance.
         expanded_explanation:
           heading: Why am I being asked this?
           list: |

--- a/features/support/steps_helper.rb
+++ b/features/support/steps_helper.rb
@@ -3,7 +3,7 @@ Then('I should be on a page showing {string}') do |title|
 end
 
 Then('I should be on a page showing {string} with a date of {int} days ago') do |title, num_days|
-  expect(page).to have_content("#{title} #{num_days.days.ago.strftime('%d %B %Y')}")
+  expect(page).to have_content("#{title} #{num_days.days.ago.strftime('%-d %B %Y')}")
 end
 
 Then('I should be on the {string} page showing {string}') do |view_name, title|


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2068)

Update content
1. Update ‘rent or mortgage’ hint text to read:
For example, rent, mortgage or board and lodging.

2. Update ‘childcare costs’ hint text to read:
For example, to a childminder, nanny or nursery.

3. Update ‘maintenance payments' hint text to read:
This includes child maintenance.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
