### PR TITLE
AP 2089 - DWP override prep

### DIFF
--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -21,7 +21,8 @@ module Admin
                                       :manually_review_all_cases,
                                       :allow_welsh_translation,
                                       :allow_cash_payment,
-                                      :allow_multiple_proceedings)
+                                      :allow_multiple_proceedings,
+                                      :override_dwp_results)
     end
 
     def setting

--- a/app/controllers/providers/check_client_details_controller.rb
+++ b/app/controllers/providers/check_client_details_controller.rb
@@ -1,0 +1,5 @@
+module Providers
+  class CheckClientDetailsController < ProviderBaseController
+    def show; end
+  end
+end

--- a/app/controllers/providers/evidence_of_benefits_controller.rb
+++ b/app/controllers/providers/evidence_of_benefits_controller.rb
@@ -1,0 +1,5 @@
+module Providers
+  class EvidenceOfBenefitsController < ProviderBaseController
+    def show; end
+  end
+end

--- a/app/controllers/providers/received_benefit_confirmations_controller.rb
+++ b/app/controllers/providers/received_benefit_confirmations_controller.rb
@@ -1,0 +1,5 @@
+module Providers
+  class ReceivedBenefitConfirmationsController < ProviderBaseController
+    def show; end
+  end
+end

--- a/app/forms/settings/setting_form.rb
+++ b/app/forms/settings/setting_form.rb
@@ -8,13 +8,15 @@ module Settings
                   :manually_review_all_cases,
                   :allow_welsh_translation,
                   :allow_cash_payment,
-                  :allow_multiple_proceedings
+                  :allow_multiple_proceedings,
+                  :override_dwp_results
 
     validates :mock_true_layer_data,
               :manually_review_all_cases,
               :allow_welsh_translation,
               :allow_cash_payment,
               :allow_multiple_proceedings,
+              :override_dwp_results,
               presence: true
   end
 end

--- a/app/models/dwp_override.rb
+++ b/app/models/dwp_override.rb
@@ -1,0 +1,2 @@
+class DWPOverride < ApplicationRecord
+end

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -23,6 +23,10 @@ class Setting < ApplicationRecord
     setting.allow_multiple_proceedings
   end
 
+  def self.override_dwp_results?
+    setting.override_dwp_results
+  end
+
   def self.setting
     Setting.first || Setting.create!
   end

--- a/app/views/admin/settings/show.html.erb
+++ b/app/views/admin/settings/show.html.erb
@@ -56,6 +56,16 @@
         title: { size: :m, text: t('.labels.allow_multiple_proceedings') }
     ) %>
 
+    <%= form.govuk_collection_radio_buttons(
+        :override_dwp_results,
+        form.yes_no_radio_button_array,
+        :value,
+        :label,
+        inline: true,
+        hint: t('.hints.override_dwp_results'),
+        title: { size: :m, text: t('.labels.override_dwp_results') }
+    ) %>
+
     <%= form.submit(t('generic.submit'), class: 'govuk-button form-button') %>
   <% end %>
 <% end %>

--- a/app/views/providers/check_client_details/show.html.erb
+++ b/app/views/providers/check_client_details/show.html.erb
@@ -1,0 +1,1 @@
+check_client_detail page under construction

--- a/app/views/providers/evidence_of_benefits/show.html.erb
+++ b/app/views/providers/evidence_of_benefits/show.html.erb
@@ -1,0 +1,1 @@
+evidence_of_benefit page under construction

--- a/app/views/providers/received_benefit_confirmations/show.html.erb
+++ b/app/views/providers/received_benefit_confirmations/show.html.erb
@@ -1,0 +1,1 @@
+received_benefit_confirmation page under construction

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -36,6 +36,7 @@ en:
           allow_welsh_translation: Allow Welsh translation
           allow_cash_payment: Allow Cash Payments to be submitted
           allow_multiple_proceedings: Allow multiple proceedings
+          override_dwp_results: Allow DWP results to be overriden
         hints:
           mock_true_layer_data: Select Yes and TrueLayer data will be replaced by mock data from %{bank_transaction_filename}
           manually_review_all_cases: |
@@ -44,6 +45,7 @@ en:
           allow_welsh_translation: Select Yes to translate the service into Welsh
           allow_cash_payment: Select Yes to include the cash payment process in the user journey
           allow_multiple_proceedings: Select Yes to allow solicitors to select multiple proceeding types
+          override_dwp_results: Select Yes to allow solicitors to override results from benefit checker
     submitted_applications_reports:
       show:
         heading_1: Submitted Applications

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -63,3 +63,5 @@ en:
           <<: *true_false
         allow_multiple_proceedings:
           <<: *true_false
+        override_dwp_results:
+          <<: *true_false

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -236,6 +236,9 @@ Rails.application.routes.draw do
       resource :merits_report, only: :show
       resource :means_report, only: :show
       resource :non_passported_client_instructions, only: :show
+      resource :check_client_details, only: :show
+      resource :received_benefit_confirmation, only: :show
+      resource :evidence_of_benefit, only: :show
     end
   end
 

--- a/db/migrate/20210305123318_add_dwp_override_flag_to_settings.rb
+++ b/db/migrate/20210305123318_add_dwp_override_flag_to_settings.rb
@@ -1,0 +1,5 @@
+class AddDWPOverrideFlagToSettings < ActiveRecord::Migration[6.1]
+  def change
+    add_column :settings, :override_dwp_results, :boolean, null: false, default: false
+  end
+end

--- a/db/migrate/20210305145638_create_dwp_overrides.rb
+++ b/db/migrate/20210305145638_create_dwp_overrides.rb
@@ -1,0 +1,11 @@
+class CreateDWPOverrides < ActiveRecord::Migration[6.1]
+  def change
+    create_table :dwp_overrides, id: :uuid do |t|
+      t.belongs_to :legal_aid_application, foreign_key: true, null: false, type: :uuid
+      t.text :passporting_benefit
+      t.boolean :evidence_available
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_05_123318) do
+ActiveRecord::Schema.define(version: 2021_03_05_145638) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -337,6 +337,15 @@ ActiveRecord::Schema.define(version: 2021_03_05_123318) do
     t.boolean "has_assets_more_than_threshold"
     t.decimal "assets_value"
     t.index ["legal_aid_application_id"], name: "index_dependants_on_legal_aid_application_id"
+  end
+
+  create_table "dwp_overrides", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "legal_aid_application_id", null: false
+    t.text "passporting_benefit"
+    t.boolean "evidence_available"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["legal_aid_application_id"], name: "index_dwp_overrides_on_legal_aid_application_id"
   end
 
   create_table "feedbacks", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -725,6 +734,7 @@ ActiveRecord::Schema.define(version: 2021_03_05_123318) do
   add_foreign_key "ccms_submissions", "legal_aid_applications", on_delete: :cascade
   add_foreign_key "cfe_submissions", "legal_aid_applications"
   add_foreign_key "dependants", "legal_aid_applications"
+  add_foreign_key "dwp_overrides", "legal_aid_applications"
   add_foreign_key "legal_aid_applications", "applicants"
   add_foreign_key "legal_aid_applications", "offices"
   add_foreign_key "legal_aid_applications", "providers"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_23_134124) do
+ActiveRecord::Schema.define(version: 2021_03_05_123318) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -657,6 +657,7 @@ ActiveRecord::Schema.define(version: 2021_02_23_134124) do
     t.boolean "allow_welsh_translation", default: false, null: false
     t.boolean "allow_cash_payment", default: false, null: false
     t.boolean "allow_multiple_proceedings", default: false, null: false
+    t.boolean "override_dwp_results", default: false, null: false
   end
 
   create_table "state_machine_proxies", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/lib/tasks/setup_db_for_testing.rake
+++ b/lib/tasks/setup_db_for_testing.rake
@@ -7,7 +7,8 @@ namespace :settings do
                     manually_review_all_cases: false,
                     allow_welsh_translation: false,
                     allow_cash_payment: false,
-                    allow_multiple_proceedings: false)
+                    allow_multiple_proceedings: false,
+                    override_dwp_results: false)
 
     pp Setting.first
   end

--- a/spec/models/setting_spec.rb
+++ b/spec/models/setting_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Setting do
         expect(rec.allow_welsh_translation?).to be false
         expect(rec.allow_cash_payment?).to be false
         expect(rec.allow_multiple_proceedings?).to be false
+        expect(rec.override_dwp_results?).to be false
         expect(rec.bank_transaction_filename).to eq 'db/sample_data/bank_transactions.csv'
       end
     end
@@ -24,6 +25,7 @@ RSpec.describe Setting do
           allow_welsh_translation: false,
           allow_cash_payment: false,
           allow_multiple_proceedings: false,
+          override_dwp_results: false,
           bank_transaction_filename: 'my_special_file.csv'
         )
       end
@@ -35,6 +37,7 @@ RSpec.describe Setting do
         expect(rec.allow_welsh_translation?).to be false
         expect(rec.allow_cash_payment?).to be false
         expect(rec.allow_multiple_proceedings?).to be false
+        expect(rec.override_dwp_results?).to be false
         expect(rec.bank_transaction_filename).to eq 'my_special_file.csv'
       end
     end
@@ -49,6 +52,7 @@ RSpec.describe Setting do
       expect(Setting.allow_welsh_translation?).to be false
       expect(Setting.allow_cash_payment?).to be false
       expect(Setting.allow_multiple_proceedings?).to be false
+      expect(Setting.override_dwp_results?).to be false
       expect(Setting.bank_transaction_filename).to eq 'db/sample_data/bank_transactions.csv'
     end
   end

--- a/spec/requests/admin/settings_spec.rb
+++ b/spec/requests/admin/settings_spec.rb
@@ -37,7 +37,8 @@ RSpec.describe Admin::SettingsController, type: :request do
           mock_true_layer_data: 'true',
           allow_welsh_translation: 'true',
           allow_cash_payment: 'true',
-          allow_multiple_proceedings: 'true'
+          allow_multiple_proceedings: 'true',
+          override_dwp_results: 'true'
         }
       }
     end
@@ -51,6 +52,7 @@ RSpec.describe Admin::SettingsController, type: :request do
       expect(setting.allow_welsh_translation?).to eq(true)
       expect(setting.allow_cash_payment?).to eq(true)
       expect(setting.allow_multiple_proceedings?).to eq(true)
+      expect(setting.override_dwp_results?).to eq(true)
     end
 
     it 'create settings if they do not exist' do

--- a/spec/requests/providers/check_client_details_spec.rb
+++ b/spec/requests/providers/check_client_details_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe Providers::CheckClientDetailsController, type: :request do
+  let(:application) { create(:legal_aid_application, :with_proceeding_types, :with_applicant_and_address) }
+  let(:application_id) { application.id }
+
+  describe 'GET /providers/applications/:legal_aid_application_id/check_client_details' do
+    subject { get "/providers/applications/#{application_id}/check_client_details" }
+
+    context 'when the provider is not authenticated' do
+      before { subject }
+      it_behaves_like 'a provider not authenticated'
+    end
+
+    context 'when the provider is authenticated' do
+      before do
+        login_as application.provider
+        subject
+      end
+
+      it 'returns success' do
+        expect(response).to be_successful
+      end
+
+      it 'displays the correct page' do
+        expect(unescaped_response_body).to include('check_client_detail page under construction')
+      end
+    end
+  end
+end

--- a/spec/requests/providers/evidence_of_benefits_spec.rb
+++ b/spec/requests/providers/evidence_of_benefits_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe Providers::EvidenceOfBenefitsController, type: :request do
+  let(:application) { create(:legal_aid_application, :with_proceeding_types, :with_applicant_and_address) }
+  let(:application_id) { application.id }
+
+  describe 'GET /providers/applications/:legal_aid_application_id/evidence_of_benefit' do
+    subject { get "/providers/applications/#{application_id}/evidence_of_benefit" }
+
+    context 'when the provider is not authenticated' do
+      before { subject }
+      it_behaves_like 'a provider not authenticated'
+    end
+
+    context 'when the provider is authenticated' do
+      before do
+        login_as application.provider
+        subject
+      end
+
+      it 'returns success' do
+        expect(response).to be_successful
+      end
+
+      it 'displays the correct page' do
+        expect(unescaped_response_body).to include('evidence_of_benefit page under construction')
+      end
+    end
+  end
+end

--- a/spec/requests/providers/received_benefit_confirmations_spec.rb
+++ b/spec/requests/providers/received_benefit_confirmations_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe Providers::ReceivedBenefitConfirmationsController, type: :request do
+  let(:application) { create(:legal_aid_application, :with_proceeding_types, :with_applicant_and_address) }
+  let(:application_id) { application.id }
+
+  describe 'GET /providers/applications/:legal_aid_application_id/received_benefit_confirmation' do
+    subject { get "/providers/applications/#{application_id}/received_benefit_confirmation" }
+
+    context 'when the provider is not authenticated' do
+      before { subject }
+      it_behaves_like 'a provider not authenticated'
+    end
+
+    context 'when the provider is authenticated' do
+      before do
+        login_as application.provider
+        subject
+      end
+
+      it 'returns success' do
+        expect(response).to be_successful
+      end
+
+      it 'displays the correct page' do
+        expect(unescaped_response_body).to include('received_benefit_confirmation page under construction')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2089)

- Add DWP override feature flag
- Add DWPOverride model and database table
- Add routes, controllers and views for three new pages: `check_client_details`, `received_benefit_confirmation` and `evidence_of_benefit`. None of these pages are currently wired into any flows.

NB: `received_benefit_confirmation` is different to the `confirm_benefit_received` requested on the ticket, as it leads to a controller called `ConfirmBenefitReceivedsController` which is really ugly. Happy to rename it if required.
 
## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
