### PR TITLE
Fix delegated functions date format in cucumber

### DIFF
--- a/features/support/steps_helper.rb
+++ b/features/support/steps_helper.rb
@@ -3,7 +3,7 @@ Then('I should be on a page showing {string}') do |title|
 end
 
 Then('I should be on a page showing {string} with a date of {int} days ago') do |title, num_days|
-  expect(page).to have_content("#{title} #{num_days.days.ago.strftime('%d %B %Y')}")
+  expect(page).to have_content("#{title} #{num_days.days.ago.strftime('%-d %B %Y')}")
 end
 
 Then('I should be on the {string} page showing {string}') do |view_name, title|


### PR DESCRIPTION
## What

Feature tests are failing because they expect the delegated function used on date to have a leading zero. This date is not displayed with a leading zero in the app. We've only just reached a date when this becomes a problems, so this hasn't been an issue up until now.

Thi fixes the expected date format to strip the zero.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
