### PR TITLE
AP-2056 Remove selected proceeding types from search list

### DIFF
--- a/app/controllers/providers/proceedings_types_controller.rb
+++ b/app/controllers/providers/proceedings_types_controller.rb
@@ -5,6 +5,7 @@ module Providers
     # GET /provider/applications/:legal_aid_application_id/proceedings_types
     def index
       proceeding_types
+      @selectable_proceeding_types = @proceeding_types - legal_aid_application.proceeding_types
     end
 
     # POST /provider/applications/:legal_aid_application_id/proceedings_types

--- a/app/controllers/providers/proceedings_types_controller.rb
+++ b/app/controllers/providers/proceedings_types_controller.rb
@@ -5,7 +5,6 @@ module Providers
     # GET /provider/applications/:legal_aid_application_id/proceedings_types
     def index
       proceeding_types
-      @selectable_proceeding_types = @proceeding_types - legal_aid_application.proceeding_types
     end
 
     # POST /provider/applications/:legal_aid_application_id/proceedings_types

--- a/app/controllers/v1/proceeding_types_controller.rb
+++ b/app/controllers/v1/proceeding_types_controller.rb
@@ -3,11 +3,17 @@ module V1
     def index
       if params.key?(:search_term)
         search_term = params[:search_term]
-        results = ProceedingTypeFullTextSearch.call(search_term)
+        results = ProceedingTypeFullTextSearch.call(search_term, source_url)
         render json: results.to_json
       else
         render json: ProceedingType.all
       end
+    end
+
+    private
+
+    def source_url
+      params[:sourceUrl]
     end
   end
 end

--- a/app/services/proceeding_type_full_text_search.rb
+++ b/app/services/proceeding_type_full_text_search.rb
@@ -1,42 +1,79 @@
+# This class is responsible for searching the proceeding types table for matching terms.
+#
+# It uses Postresql's Full Text Search (see https://www.postgresql.org/docs/9.5/textsearch-intro.html)
+#
+# Results are currently retuned by ranked by relevance, i.e. search terms which appear in
+# the additional_search_terms field are ranked higher than those in meaning which in turn are
+# ranked higher that those in description.  This is controlled by the ProceedingType.refresh_textsearchable
+# method.
+#
 class ProceedingTypeFullTextSearch
   Result = Struct.new(:meaning, :code, :description, :category_law, :matter)
 
-  SEARCH_FIELDS = %i[
-    meaning
-    description
-    ccms_category_law
-    ccms_matter
-    additional_search_terms
-  ].freeze
-
-  def self.call(search_terms)
-    new(search_terms).call
+  def self.call(search_terms, source_url)
+    new(search_terms, source_url).call
   end
 
-  def initialize(search_terms)
-    @ts_queries = search_terms.downcase.split.map { |val| "%#{val}%" }
+  def initialize(search_terms, source_url)
+    @source_url = source_url
+    @ts_query = ts_query_transform(search_terms)
   end
 
   def call
-    result_set = ProceedingType.where(fields_contain_substr_query, *substr_query_args).order(:meaning).limit(8)
-    result_set.map { |row| instantiate_result(row) }
+    matching_results.delete_if { |result| result.code.in?(already_selected_codes) }
   end
 
   private
+
+  def already_selected_codes
+    @already_selected_codes ||= legal_aid_application.proceeding_types.pluck(:code)
+  end
+
+  def legal_aid_application
+    @legal_aid_application ||= application_from_source_url
+  end
+
+  def application_from_source_url
+    laa_id = URI(@source_url).path.sub('/providers/applications/', '').sub('/proceedings_types', '')
+    LegalAidApplication.find(laa_id)
+  end
+
+  def matching_results
+    result_set = ProceedingType.connection.exec_query(query_string,
+                                                      '-- PROCEEDING TYPE FULL TEXT SEARCH ---',
+                                                      [[nil, @ts_query]],
+                                                      prepare: true)
+    result_set.map { |row| instantiate_result(row) }
+  end
 
   def instantiate_result(row)
     Result.new(row['meaning'].strip, row['code'], row['description'].strip, row['ccms_category_law'].strip, row['ccms_matter'])
   end
 
-  def fields_contain_substr_query
-    SEARCH_FIELDS.each_with_object('') do |field, str|
-      str << "lower(#{field}) ILIKE ALL ( array[?] )"
-      str << ' OR ' unless field == SEARCH_FIELDS.last
-      str
-    end
+  def ts_query_transform(search_terms)
+    # transform the query into a form suitable for postgres to_tsquery function that matches
+    # on partial words
+    #
+    # "An owl & a pussycat went to sea" => "An:* & owl:* & a:* & pussycat:* & went:* & to:* & sea:*"
+    #
+    words = search_terms.split(/\s/).map { |w| "#{w}:*" }
+    words.join(' & ').gsub('& & &', '&')
   end
 
-  def substr_query_args
-    Array.new(SEARCH_FIELDS.count, @ts_queries)
+  def query_string
+    <<~END_OF_QUERY
+      SELECT id,#{' '}
+        meaning,
+        code,
+        description,
+        ccms_category_law,
+        ccms_matter,
+        ts_rank(textsearchable, query) AS rank
+      FROM proceeding_types, to_tsquery($1) AS query
+      WHERE query @@ textsearchable
+      ORDER BY rank DESC
+      LIMIT 10;
+
+    END_OF_QUERY
   end
 end

--- a/app/views/providers/proceedings_types/index.html.erb
+++ b/app/views/providers/proceedings_types/index.html.erb
@@ -44,7 +44,7 @@
     <div class="govuk-grid-row govuk-!-margin-top-0">
       <div id="proceeding-list" class="govuk-grid-column-full govuk-list govuk-!-margin-bottom-0">
         <%= render partial: 'shared/forms/proceedings_types/proceeding_type_form',
-                   collection: @selectable_proceeding_types,
+                   collection: @proceeding_types,
                    as: :proceeding_type,
                    locals: {
                      model: nil,

--- a/app/views/providers/proceedings_types/index.html.erb
+++ b/app/views/providers/proceedings_types/index.html.erb
@@ -43,7 +43,13 @@
     local: true) do |form| %>
     <div class="govuk-grid-row govuk-!-margin-top-0">
       <div id="proceeding-list" class="govuk-grid-column-full govuk-list govuk-!-margin-bottom-0">
-        <%= render partial: 'shared/forms/proceedings_types/proceeding_type_form', collection: @proceeding_types, as: :proceeding_type, locals: { model: nil, form: form } %>
+        <%= render partial: 'shared/forms/proceedings_types/proceeding_type_form',
+                   collection: @selectable_proceeding_types,
+                   as: :proceeding_type,
+                   locals: {
+                     model: nil,
+                     form: form
+                   } %>
       </div>
       <div class="govuk-grid-row no-proceeding-items" style="display: none;">
         <div class="govuk-grid-column-two-thirds">

--- a/app/webpack/src/modules/proceedings.js
+++ b/app/webpack/src/modules/proceedings.js
@@ -5,7 +5,8 @@ let typingTimer; // timer identifier
 let ariaText;
 
 async function searchResults (searchTerm) {
-  const url = '/v1/proceeding_types?search_term=' + searchTerm;
+  var currentUrl = window.location.href
+  const url = '/v1/proceeding_types?search_term=' + searchTerm + '&sourceUrl=' + currentUrl;
   const response = await axios.get(url);
   return response.data;
 }

--- a/features/providers/civil_application_journey.feature
+++ b/features/providers/civil_application_journey.feature
@@ -102,6 +102,10 @@ Feature: Civil application journeys
     Then I choose 'Yes'
     Then I click 'Save and continue'
     Then I should be on a page showing 'Search for legal proceedings'
+    Then I search for proceeding 'non'
+    Then proceeding suggestions has results
+    Then I should be on a page showing 'Harassment - injunction'
+    And I should be on a page not showing 'Non-molestation order'
     Then I search for proceeding 'Occupation order'
     Then proceeding suggestions has results
     Then I choose a 'Occupation order' radio button

--- a/features/support/steps_helper.rb
+++ b/features/support/steps_helper.rb
@@ -3,7 +3,7 @@ Then('I should be on a page showing {string}') do |title|
 end
 
 Then('I should be on a page showing {string} with a date of {int} days ago') do |title, num_days|
-  expect(page).to have_content("#{title} #{num_days.days.ago.strftime('%d %B %Y')}")
+  expect(page).to have_content("#{title} #{num_days.days.ago.strftime('%-d %B %Y')}")
 end
 
 Then('I should be on the {string} page showing {string}') do |view_name, title|

--- a/spec/javascript/modules/proceedings.spec.js
+++ b/spec/javascript/modules/proceedings.spec.js
@@ -23,7 +23,7 @@ describe('ProceedingsTypes.searchResults', () => {
   })
 
   it('polls the correct endpoint', done => {
-    let endpoint = '/v1/proceeding_types?search_term=' + searchTerm;
+    let endpoint = '/v1/proceeding_types?search_term=' + searchTerm + '&sourceUrl=http://localhost/';
     expect(axios.get.mock.calls).toEqual([[endpoint]]);
     done();
   })

--- a/spec/requests/proceeding_types/index_proceeding_types_spec.rb
+++ b/spec/requests/proceeding_types/index_proceeding_types_spec.rb
@@ -18,28 +18,27 @@ RSpec.describe V1::ProceedingTypesController, type: :request do
     end
 
     context 'when there are proceeding types' do
-      let!(:proceeding_types) do
-        [
-          create(:proceeding_type,
-                 :with_real_data,
-                 code: 'PH0001',
-                 ccms_category_law: 'Family',
-                 ccms_matter: 'Public Law - Family',
-                 ccms_matter_code: 'KPBLB',
-                 meaning: 'Application for a care order',
-                 description: 'to be represented on an application for a care order.',
-                 additional_search_terms: ''),
-          create(:proceeding_type,
-                 :with_real_data,
-                 code: 'PH0002',
-                 ccms_code: 'PBM24',
-                 ccms_category_law: 'Other',
-                 ccms_matter: 'Public Law - Other',
-                 ccms_matter_code: 'APBLB',
-                 meaning: 'Not an application for a care order',
-                 description: 'Not to be represented on an application for a care order.',
-                 additional_search_terms: 'injunction')
-        ]
+      before do
+        create(:proceeding_type,
+               :with_real_data,
+               code: 'PH0001',
+               ccms_category_law: 'Family',
+               ccms_matter: 'Public Law - Family',
+               ccms_matter_code: 'KPBLB',
+               meaning: 'Application for a care order',
+               description: 'to be represented on an application for a care order.',
+               additional_search_terms: '')
+        create(:proceeding_type,
+               :with_real_data,
+               code: 'PH0002',
+               ccms_code: 'PBM24',
+               ccms_category_law: 'Other',
+               ccms_matter: 'Public Law - Other',
+               ccms_matter_code: 'APBLB',
+               meaning: 'Not an application for a care order',
+               description: 'Not to be represented on an application for a care order.',
+               additional_search_terms: 'injunction')
+        ProceedingType.refresh_textsearchable
       end
 
       context 'no search term is given' do
@@ -77,8 +76,10 @@ RSpec.describe V1::ProceedingTypesController, type: :request do
 
       context 'a search term is given and there are results' do
         search_term = 'injunction'
+        let(:legal_aid_application) { create :legal_aid_application }
+        let(:source_url) { providers_legal_aid_application_proceedings_types_path(legal_aid_application) }
         let(:get_request) do
-          -> { get "/v1/proceeding_types?search_term=#{search_term}" }
+          -> { get "/v1/proceeding_types?search_term=#{search_term}&sourceUrl=#{source_url}" }
         end
 
         it 'returns a successful response with just the proceeding types matching the search term' do

--- a/spec/services/proceeding_type_full_text_search_spec.rb
+++ b/spec/services/proceeding_type_full_text_search_spec.rb
@@ -11,8 +11,11 @@ RSpec.describe ProceedingTypeFullTextSearch do
     ProceedingType.delete_all
   end
 
+  let(:legal_aid_application) { create :legal_aid_application }
+  let(:source_url) { Rails.application.routes.url_helpers.providers_legal_aid_application_proceedings_types_path(legal_aid_application) }
+
   describe '.call' do
-    subject { described_class.call(search_term) }
+    subject { described_class.call(search_term, source_url) }
 
     context 'searching for a non-existent term' do
       let(:search_term) { 'animals' }
@@ -22,48 +25,127 @@ RSpec.describe ProceedingTypeFullTextSearch do
       end
     end
 
-    context 'searching for a term that only exists on one record' do
-      let(:search_term) { 'mutilation' }
+    context 'when application has no proceeding types already selected' do
+      context 'searching for a term that only exists on one record' do
+        let(:search_term) { 'mutilation' }
 
-      it 'returns one result row' do
-        result_set = subject
-        expect(result_set.size).to eq 1
+        it 'returns one result row' do
+          result_set = subject
+          expect(result_set.size).to eq 1
+        end
+
+        it 'returns an instance of Result' do
+          result = subject.first
+          expect(result).to be_an_instance_of(ProceedingTypeFullTextSearch::Result)
+        end
+
+        it 'returns FGM Protection order' do
+          result = subject.first
+          expect(result.meaning).to eq 'FGM Protection Order'
+          expect(result.description).to eq 'To be represented on an application for a Female Genital Mutilation Protection Order under the Female Genital Mutilation Act.'
+        end
       end
 
-      it 'returns an instance of Result' do
-        result = subject.first
-        expect(result).to be_an_instance_of(ProceedingTypeFullTextSearch::Result)
+      context 'searching for a term which occures in more than one proceeding' do
+        let(:search_term) { 'molestation' }
+
+        it 'returns two results' do
+          result_set = subject
+          expect(result_set.size).to eq 2
+        end
+
+        it 'returns the one with the search ter in additional search terms first' do
+          result_set = subject
+          expect(result_set.map(&:meaning)).to eq ['Harassment - injunction', 'Non-molestation order']
+        end
       end
 
-      it 'returns FGM Protection order' do
-        result = subject.first
-        expect(result.meaning).to eq 'FGM Protection Order'
-        expect(result.description).to eq 'To be represented on an application for a Female Genital Mutilation Protection Order under the Female Genital Mutilation Act.'
+      context 'multiple term searches' do
+        let(:search_term) { 'protection order' }
+
+        it 'only returns results matching both terms' do
+          result_set = subject
+          expect(result_set.map(&:meaning)).to match_array(['FGM Protection Order',
+                                                            'Forced marriage protection order',
+                                                            'Variation or discharge under section 5 protection from harassment act 1997'])
+        end
       end
     end
 
-    context 'searching for a term which occures in more than one proceeding' do
-      let(:search_term) { 'molestation' }
-
-      it 'returns two results' do
-        result_set = subject
-        expect(result_set.size).to eq 2
+    context 'when application already has proceeding types selected' do
+      before do
+        # add Forced mariage protection order and Occupation order
+        legal_aid_application.proceeding_types << ProceedingType.find_by(code: 'PR0203')
+        legal_aid_application.proceeding_types << ProceedingType.find_by(code: 'PR0214')
       end
 
-      it 'returns the one with the search ter in additional search terms first' do
-        result_set = subject
-        expect(result_set.map(&:meaning)).to eq ['Harassment - injunction', 'Non-molestation order']
+      context 'searching for a term not on an already-selected proceeding' do
+        context 'searching for a term that only exists on one record' do
+          let(:search_term) { 'mutilation' }
+
+          it 'returns one result row' do
+            result_set = subject
+            expect(result_set.size).to eq 1
+          end
+
+          it 'returns an instance of Result' do
+            result = subject.first
+            expect(result).to be_an_instance_of(ProceedingTypeFullTextSearch::Result)
+          end
+
+          it 'returns FGM Protection order' do
+            result = subject.first
+            expect(result.meaning).to eq 'FGM Protection Order'
+            expect(result.description).to eq 'To be represented on an application for a Female Genital Mutilation Protection Order under the Female Genital Mutilation Act.'
+          end
+        end
+
+        context 'searching for a term which occures in more than one proceeding' do
+          let(:search_term) { 'molestation' }
+
+          it 'returns two results' do
+            result_set = subject
+            expect(result_set.size).to eq 2
+          end
+
+          it 'returns the one with the search ter in additional search terms first' do
+            result_set = subject
+            expect(result_set.map(&:meaning)).to eq ['Harassment - injunction', 'Non-molestation order']
+          end
+        end
+
+        context 'multiple term searches' do
+          let(:search_term) { 'har inj' } # harassment injuction
+
+          it 'only returns results matching both terms' do
+            result_set = subject
+            expect(result_set.map(&:meaning)).to match_array(['Non-molestation order', 'Harassment - injunction'])
+          end
+
+          it 'returns the item with the search terms in additional_search_terms first' do
+            result_set = subject
+            expect(result_set.first.meaning).to eq 'Non-molestation order'
+          end
+        end
       end
-    end
 
-    context 'multiple term searches' do
-      let(:search_term) { 'protection order' }
+      context 'searching for a term on a proceeding type that has already been selected' do
+        let(:search_term) { 'order' }
 
-      it 'only returns results matching both terms' do
-        result_set = subject
-        expect(result_set.map(&:meaning)).to eq ['FGM Protection Order',
-                                                 'Forced marriage protection order',
-                                                 'Variation or discharge under section 5 protection from harassment act 1997']
+        it 'does not include either of the proceeding types already on the application' do
+          meanings = subject.map(&:meaning)
+          expect(meanings).not_to include('Forced marriage protection order')
+          expect(meanings).not_to include('Occupation order')
+        end
+
+        it 'does include all the other matching proceeding types' do
+          meanings = subject.map(&:meaning)
+          expect(meanings).to match_array(['Non-molestation order',
+                                           'FGM Protection Order',
+                                           'Variation or discharge under section 5 protection from harassment act 1997',
+                                           'Inherent jurisdiction high court injunction',
+                                           'Extend, variation or discharge - Part IV'])
+        end
       end
     end
   end


### PR DESCRIPTION
## Remove selected proceeding types from search list

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2056)

In order to prevent a provider selecting the same proceeding type twice for an application, proceeding types already selected are removed from the proceeding type search results..

This is achieved by the javascript passing in the current page URL to the `V1::ProceedingTypesController` which in turn allows the `ProceedingTypeFullTextSearch` service to access the `LegalAidApplication` to get a list of `ProceedingTypes` that have already been added to the application and remove them from the search results.

This PR also re-enables Full Text searching, tweaked to allow search by partial words, and returns results ordered by relevance.  This can be changed to order them alphabetically if required.

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
