### PR TITLE
AP-2066 Update content for identify types of income page

### DIFF
--- a/app/views/shared/forms/_types_of_income_form.html.erb
+++ b/app/views/shared/forms/_types_of_income_form.html.erb
@@ -12,7 +12,7 @@
         <% TransactionType.credits.not_children.each do |transaction_type| %>
           <%= form.govuk_check_box :transaction_type_ids, transaction_type.id, link_errors: true,
                                    label: {text: t("transaction_types.names.#{journey_type}.#{transaction_type.name}")},
-                                   hint: {text: t(".hints.#{transaction_type.name}", default: '')} %>
+                                   hint: {text: t(".hints.#{journey_type}.#{transaction_type.name}", default: '')} %>
         <% end %>
       </div>
       <%= form.govuk_radio_divider %>

--- a/config/locales/cy/shared.yml
+++ b/config/locales/cy/shared.yml
@@ -462,10 +462,16 @@ cy:
             kroW
       types_of_income_form:
         hints:
-          friends_or_family: ".sllib ro tner rof rebmem ylimaf a morf yenom ,elpmaxe
-            roF"
-          benefits: ".stiderc xat ro tifeneB dlihC ,elpmaxe roF"
-          pension: ".snoisnep lanosrep dna ecalpkrow ,etatS edulcnI"
+          citizens:
+            friends_or_family: ".stnemyap ffo-eno edulcni ton oD .stsoc gnivil htiw pleh ot yenom uoy sevig ylraluger evitaler ro dneirf a fi tceleS"
+            benefits: .stiderc xat ro tifeneB dlihC ,elpmaxe roF
+            maintenance_in: .ecnanetniam dlihc sedulcni sihT
+            pension: .snoisnep lanosrep dna ecalpkrow ,etatS edulcnI
+          providers:
+            friends_or_family: .sllib ro tner rof rebmem ylimaf a morf yenom ,elpmaxe roF
+            benefits: .stiderc xat ro tifeneB dlihC ,elpmaxe roF
+            maintenance_in: .ecnanetniam dlihc sedulcni sihT
+            pension: .snoisnep lanosrep dna ecalpkrow ,etatS edulcnI
         expanded_explanation:
           heading: "?siht deksa gnieb I ma yhW"
           list: |2-

--- a/config/locales/en/shared.yml
+++ b/config/locales/en/shared.yml
@@ -426,9 +426,16 @@ en:
             not_known: Work still needs to be done to determine the likelihood of success
       types_of_income_form:
         hints:
-          friends_or_family: For example, money from a family member for rent or bills.
-          benefits: For example, Child Benefit or tax credits.
-          pension: Include State, workplace and personal pensions.
+          citizens:
+            friends_or_family: "Select if a friend or relative regularly gives you money to help with living costs. Do not include one-off payments."
+            benefits: For example, Child Benefit or tax credits.
+            maintenance_in: This includes child maintenance.
+            pension: Include State, workplace and personal pensions.
+          providers:
+            friends_or_family: For example, money from a family member for rent or bills.
+            benefits: For example, Child Benefit or tax credits.
+            maintenance_in: This includes child maintenance.
+            pension: Include State, workplace and personal pensions.
         expanded_explanation:
           heading: Why am I being asked this?
           list: |


### PR DESCRIPTION
## AP-2066 Update content for identify types of income page

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2066)

- Update the content for **provider and citizen** side of identify types of income except the hint for friends_or_family which is only changed for the citizen side



## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
