### PR TITLE
AP-2087 Require Caseworker review if DWP result has been overridden

### DIFF
--- a/app/controllers/providers/means_reports_controller.rb
+++ b/app/controllers/providers/means_reports_controller.rb
@@ -4,6 +4,7 @@ module Providers
 
     def show
       @cfe_result = @legal_aid_application.cfe_result
+      @manual_review_determiner = CCMS::ManualReviewDeterminer.new(@legal_aid_application)
       render pdf: 'Means report',
              layout: 'pdf',
              show_as_html: params.key?(:debug)

--- a/app/models/cfe/base_result.rb
+++ b/app/models/cfe/base_result.rb
@@ -142,7 +142,7 @@ module CFE
     private
 
     def manual_check_required?
-      CCMS::ManualReviewDeterminer.call(legal_aid_application)
+      CCMS::ManualReviewDeterminer.new(legal_aid_application).manual_review_required?
     end
 
     def determine_type_of_contribution

--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -229,6 +229,8 @@ class LegalAidApplication < ApplicationRecord
   end
 
   def applicant_receives_benefit?
+    return true if dwp_override
+
     benefit_check_result&.positive? || false
   end
 

--- a/app/services/ccms/attribute_value_generator.rb
+++ b/app/services/ccms/attribute_value_generator.rb
@@ -406,7 +406,7 @@ module CCMS
     end
 
     def manual_case_review_required?
-      ManualReviewDeterminer.call(legal_aid_application)
+      ManualReviewDeterminer.new(legal_aid_application).manual_review_required?
     end
   end
 end

--- a/app/services/ccms/manual_review_determiner.rb
+++ b/app/services/ccms/manual_review_determiner.rb
@@ -23,9 +23,10 @@ module CCMS
     end
 
     def manual_review_required?
-      return true if dwp_override
-
-      manually_review_all_non_passported? || capital_contribution_required? || has_restrictions?
+      dwp_override.present? ||
+        manually_review_all_non_passported? ||
+        capital_contribution_required? ||
+        has_restrictions?
     end
 
     def review_reasons

--- a/app/services/ccms/manual_review_determiner.rb
+++ b/app/services/ccms/manual_review_determiner.rb
@@ -10,29 +10,44 @@ module CCMS
     attr_reader :legal_aid_application
 
     delegate :cfe_result,
+             :dwp_override,
              :passported?,
              :non_passported?,
              :has_restrictions?, to: :legal_aid_application
 
     delegate :capital_contribution_required?, to: :cfe_result
 
-    def self.call(legal_aid_application)
-      new(legal_aid_application).call
-    end
-
     def initialize(legal_aid_application)
       @legal_aid_application = legal_aid_application
       raise 'Unable to determine whether Manual review is required before means assessment' if legal_aid_application.cfe_result.nil?
     end
 
-    def call
-      needs_review?
+    def manual_review_required?
+      return true if dwp_override
+
+      manually_review_all_non_passported? || capital_contribution_required? || has_restrictions?
+    end
+
+    def review_reasons
+      cfe_review_reasons + application_review_reasons
+    end
+
+    def review_categories_by_reason
+      cfe_result.remarks.review_categories_by_reason
     end
 
     private
 
-    def needs_review?
-      manually_review_all_non_passported? || capital_contribution_required? || has_restrictions?
+    def cfe_result
+      @cfe_result ||= @legal_aid_application.cfe_result
+    end
+
+    def cfe_review_reasons
+      cfe_result.remarks.review_reasons
+    end
+
+    def application_review_reasons
+      dwp_override ? [:dwp_override] : []
     end
 
     def manually_review_all_non_passported?

--- a/app/services/reports/means_report_creator.rb
+++ b/app/services/reports/means_report_creator.rb
@@ -25,7 +25,8 @@ module Reports
         layout: 'pdf',
         locals: {
           :@legal_aid_application => legal_aid_application,
-          :@cfe_result => legal_aid_application.cfe_result
+          :@cfe_result => legal_aid_application.cfe_result,
+          :@manual_review_determiner => CCMS::ManualReviewDeterminer.new(legal_aid_application)
         }
       )
     end

--- a/app/views/providers/means_reports/_caseworker_review.html.erb
+++ b/app/views/providers/means_reports/_caseworker_review.html.erb
@@ -6,25 +6,25 @@
         <%= t(".required") %>
       </dt>
       <dd class="<%= "govuk-summary-list__value align-text-right" %>">
-        <%= yes_no(remarks.caseworker_review_required?) %>
+        <%= yes_no(manual_review_determiner.manual_review_required?) %>
       </dd>
     </div>
 
-    <% if remarks.caseworker_review_required? %>
+    <% if manual_review_determiner.manual_review_required? %>
 
       <div class="<%= "govuk-summary-list__row  normal-word-break govuk-summary-list__row--no-border" %>" id="<%= "means-merits-report__caseworker-review-required" %>">
         <dt class="<%= "govuk-summary-list__key govuk-!-width-one-half" %>">
           <%= t(".reasons") %>
         </dt>
         <dd class="<%= "govuk-summary-list__value align-text-right" %>">
-          <% remarks.review_reasons.each do |reason| %>
+          <% manual_review_determiner.review_reasons.each do |reason| %>
             <%= t(".reason.#{reason}") %>
             <br>
           <% end %>
         </dd>
       </div>
 
-      <% remarks.review_categories_by_reason&.each do |reason, categories| %>
+      <% manual_review_determiner.review_categories_by_reason&.each do |reason, categories| %>
         <div class="<%= "govuk-summary-list__row  normal-word-break govuk-summary-list__row--no-border" %>" id="<%= "means-merits-report__caseworker-review-required" %>">
           <dt class="<%= "govuk-summary-list__key govuk-!-width-one-half" %>">
             <%= t(".category-#{reason}") %>

--- a/app/views/providers/means_reports/show.html.erb
+++ b/app/views/providers/means_reports/show.html.erb
@@ -56,7 +56,7 @@
 
     <section class="print-no-break">
       <h2 class="govuk-heading-l"><%= t('.caseworker-review-section-heading') %></h2>
-      <%= render partial: 'caseworker_review', locals: {remarks: @cfe_result.remarks } %>
+      <%= render partial: 'caseworker_review', locals: {manual_review_determiner: @manual_review_determiner } %>
     </section>
 
   <% end %>
@@ -73,10 +73,10 @@
 
   <%= render 'shared/check_answers/assets', read_only: true %>
 
-  <% if @legal_aid_application.passported? && @cfe_result.capital_contribution_required? %>
+  <% if @legal_aid_application.passported? && @manual_review_determiner.manual_review_required? %>
     <section class="print-no-break">
       <h2 class="govuk-heading-l"><%= t('.caseworker-review-section-heading') %></h2>
-      <%= render partial: 'caseworker_review', locals: { remarks: @cfe_result.remarks } %>
+      <%= render partial: 'caseworker_review', locals: { manual_review_determiner: @manual_review_determiner } %>
     </section>
   <% end %>
 <% end %>

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -440,6 +440,7 @@ en:
           residual_balance: Capital Contribution - Residual Balance Check
           policy_disregards: Discretionary disregards selected
           multi_benefit: Multiple benefits in single bank transaction
+          dwp_override: Provider disagrees with DWP result
       show:
         heading: Means report
         caseworker-review-section-heading: Caseworker Review

--- a/db/migrate/20210309111908_add_unique_index_to_dwp_overrides.rb
+++ b/db/migrate/20210309111908_add_unique_index_to_dwp_overrides.rb
@@ -1,0 +1,6 @@
+class AddUniqueIndexToDWPOverrides < ActiveRecord::Migration[6.1]
+  def change
+    remove_index :dwp_overrides, name: :index_dwp_overrides_on_legal_aid_application_id
+    add_index :dwp_overrides, :legal_aid_application_id, unique: true
+  end
+end

--- a/db/migrate/20210309111908_add_unique_index_to_dwp_overrides.rb
+++ b/db/migrate/20210309111908_add_unique_index_to_dwp_overrides.rb
@@ -1,6 +1,11 @@
 class AddUniqueIndexToDWPOverrides < ActiveRecord::Migration[6.1]
-  def change
+  def up
     remove_index :dwp_overrides, name: :index_dwp_overrides_on_legal_aid_application_id
     add_index :dwp_overrides, :legal_aid_application_id, unique: true
+  end
+
+  def down
+    remove_index :dwp_overrides, name: :index_dwp_overrides_on_legal_aid_application_id
+    add_index :dwp_overrides, :legal_aid_application_id
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -346,7 +346,7 @@ ActiveRecord::Schema.define(version: 2021_03_15_164353) do
     t.boolean "evidence_available"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["legal_aid_application_id"], name: "index_dwp_overrides_on_legal_aid_application_id"
+    t.index ["legal_aid_application_id"], name: "index_dwp_overrides_on_legal_aid_application_id", unique: true
   end
 
   create_table "feedbacks", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/factories/dwp_overrides.rb
+++ b/spec/factories/dwp_overrides.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :dwp_override do
+    legal_aid_application
+    passporting_benefit { 'Universal Credit' }
+    evidence_available { true }
+
+    trait 'no evidence_available' do
+      evidence_available { false }
+    end
+  end
+end

--- a/spec/models/cfe/v3/result_spec.rb
+++ b/spec/models/cfe/v3/result_spec.rb
@@ -15,6 +15,7 @@ module CFE
       let(:legal_aid_application) { create :legal_aid_application, :with_restrictions, :with_cfe_v3_result }
       let(:contribution_and_restriction_result) { create :cfe_v3_result, :with_capital_contribution_required, submission: cfe_submission }
       let(:cfe_submission) { create :cfe_submission, legal_aid_application: legal_aid_application }
+      let(:manual_review_determiner) { CCMS::ManualReviewDeterminer.new(application) }
 
       describe '#overview' do
         subject { cfe_result.overview }
@@ -22,7 +23,7 @@ module CFE
         let(:application) { cfe_result.legal_aid_application }
 
         context 'manual check not required' do
-          before { allow(CCMS::ManualReviewDeterminer).to receive(:call).with(application).and_return(false) }
+          before { allow(manual_review_determiner).to receive(:manual_review_required?).and_return(false) }
 
           context 'eligible' do
             let(:cfe_result) { create :cfe_v3_result, :eligible }
@@ -61,7 +62,7 @@ module CFE
         end
 
         context 'manual check IS required and restrictions do not exist' do
-          before { allow(CCMS::ManualReviewDeterminer).to receive(:call).with(application).and_return(true) }
+          before { allow(manual_review_determiner).to receive(:manual_review_required?).and_return(true) }
 
           context 'eligible' do
             let(:cfe_result) { create :cfe_v3_result, :eligible }
@@ -101,7 +102,7 @@ module CFE
 
         context 'manual check IS required and restrictions exist' do
           before do
-            allow(CCMS::ManualReviewDeterminer).to receive(:call).with(application).and_return(true)
+            allow(manual_review_determiner).to receive(:manual_review_required?).and_return(true)
             application.has_restrictions = true
           end
 

--- a/spec/models/legal_aid_application_spec.rb
+++ b/spec/models/legal_aid_application_spec.rb
@@ -648,30 +648,61 @@ RSpec.describe LegalAidApplication, type: :model do
     context 'benefit_check_result exists?' do
       context 'passported' do
         before { create :benefit_check_result, :positive, legal_aid_application: legal_aid_application }
-        it 'returns true' do
-          expect(legal_aid_application.applicant_receives_benefit?).to be true
+        context 'No DWP Override' do
+          it 'returns true' do
+            expect(legal_aid_application.applicant_receives_benefit?).to be true
+          end
+
+          it 'returns true for the aliased method #passported?' do
+            expect(legal_aid_application.passported?).to be true
+          end
         end
 
-        it 'returns true for the aliased method #passported?' do
-          expect(legal_aid_application.passported?).to be true
+        context 'DWP override' do
+          before { create :dwp_override, legal_aid_application: legal_aid_application }
+          it 'returns true' do
+            expect(legal_aid_application.applicant_receives_benefit?).to be true
+          end
         end
       end
 
       context 'not passported' do
         before { create :benefit_check_result, legal_aid_application: legal_aid_application }
-        it 'returns false' do
-          expect(legal_aid_application.applicant_receives_benefit?).to be false
+        context 'No DWP override' do
+          it 'returns false' do
+            expect(legal_aid_application.applicant_receives_benefit?).to be false
+          end
+
+          it 'returns true for the alias non_passported' do
+            expect(legal_aid_application.non_passported?).to be true
+          end
         end
 
-        it 'returns true for the alias non_passported' do
-          expect(legal_aid_application.non_passported?).to be true
+        context 'DWP Override' do
+          before { create :dwp_override, legal_aid_application: legal_aid_application }
+          it 'returns true' do
+            expect(legal_aid_application.applicant_receives_benefit?).to be true
+          end
+
+          it 'returns false for the alias non_passported' do
+            expect(legal_aid_application.non_passported?).to be false
+          end
         end
       end
 
       context 'undetermined' do
         before { create :benefit_check_result, :undetermined, legal_aid_application: legal_aid_application }
-        it 'returns false' do
-          expect(legal_aid_application.applicant_receives_benefit?).to be false
+        context 'No DWP Override' do
+          it 'returns false' do
+            expect(legal_aid_application.applicant_receives_benefit?).to be false
+          end
+        end
+
+        context 'DWP Override' do
+          before { create :dwp_override, legal_aid_application: legal_aid_application }
+          it 'returns true' do
+            expect(legal_aid_application.applicant_receives_benefit?).to be true
+          end
         end
       end
     end

--- a/spec/services/ccms/manual_review_determiner_spec.rb
+++ b/spec/services/ccms/manual_review_determiner_spec.rb
@@ -3,13 +3,14 @@ require 'rails_helper'
 module CCMS
   RSpec.describe ManualReviewDeterminer do
     let(:setting) { Setting.setting }
-    let(:cfe_submission) { create :cfe_submission, legal_aid_application: legal_aid_application }
+    let!(:cfe_submission) { create :cfe_submission, legal_aid_application: legal_aid_application }
+    let(:determiner) { described_class.new(legal_aid_application) }
+    let(:legal_aid_application) { create :legal_aid_application }
 
-    subject { described_class.call(legal_aid_application) }
+    describe '#manual_review_required?' do
+      subject { determiner.manual_review_required? }
 
-    describe '.call' do
       context 'assessment not yet carried out on legal aid application' do
-        let(:legal_aid_application) { create :legal_aid_application }
         it 'raises an error' do
           expect { subject }.to raise_error RuntimeError, 'Unable to determine whether Manual review is required before means assessment'
         end
@@ -18,86 +19,199 @@ module CCMS
       context 'manual review setting true' do
         before { setting.update! manually_review_all_cases: true }
 
-        context 'passported, no contrib, no_restrictions' do
-          let(:legal_aid_application) { create :legal_aid_application, :with_positive_benefit_check_result }
-          let!(:cfe_result) { create :cfe_v3_result, submission: cfe_submission }
+        context 'no DWP override' do
+          context 'passported, no contrib, no_restrictions' do
+            let(:legal_aid_application) { create :legal_aid_application, :with_positive_benefit_check_result }
+            let!(:cfe_result) { create :cfe_v3_result, submission: cfe_submission }
 
-          it 'returns false' do
-            expect(subject).to be false
+            it 'returns false' do
+              expect(subject).to be false
+            end
+          end
+
+          context 'non-passported, no contrib' do
+            let(:legal_aid_application) { create :legal_aid_application, :with_negative_benefit_check_result }
+            let!(:cfe_result) { create :cfe_v3_result, submission: cfe_submission }
+
+            it 'returns true' do
+              expect(subject).to be true
+            end
           end
         end
 
-        context 'non-passported, no contrib' do
-          let(:legal_aid_application) { create :legal_aid_application, :with_negative_benefit_check_result }
-          let!(:cfe_result) { create :cfe_v3_result, submission: cfe_submission }
+        context 'with DWP override' do
+          before { create :dwp_override, legal_aid_application: legal_aid_application }
 
-          it 'returns true' do
-            expect(subject).to be true
+          context 'passported, no contrib, no_restrictions' do
+            let(:legal_aid_application) { create :legal_aid_application, :with_positive_benefit_check_result }
+            let!(:cfe_result) { create :cfe_v3_result, submission: cfe_submission }
+
+            it 'returns true' do
+              expect(subject).to be true
+            end
+          end
+
+          context 'non-passported, no contrib' do
+            let(:legal_aid_application) { create :legal_aid_application, :with_negative_benefit_check_result }
+            let!(:cfe_result) { create :cfe_v3_result, submission: cfe_submission }
+
+            it 'returns true' do
+              expect(subject).to be true
+            end
           end
         end
       end
 
       context 'manual review setting false' do
         before { setting.update! manually_review_all_cases: false }
+        context 'no DWP override' do
+          context 'passported' do
+            let(:legal_aid_application) { create :legal_aid_application, :with_positive_benefit_check_result, has_restrictions: true }
 
-        context 'passported' do
-          let(:legal_aid_application) { create :legal_aid_application, :with_positive_benefit_check_result, has_restrictions: true }
+            context 'contribution' do
+              let!(:cfe_result) { create :cfe_v3_result, :with_capital_contribution_required, submission: cfe_submission }
 
-          context 'contribution' do
-            let!(:cfe_result) { create :cfe_v3_result, :with_capital_contribution_required, submission: cfe_submission }
-
-            it 'returns true' do
-              expect(subject).to be true
-            end
-          end
-
-          context 'no contribution' do
-            let!(:cfe_result) { create :cfe_v3_result, submission: cfe_submission }
-
-            context 'restrictions' do
-              it 'returns false' do
+              it 'returns true' do
                 expect(subject).to be true
               end
             end
 
-            context 'no restrictions' do
-              before { legal_aid_application.update! has_restrictions: false }
+            context 'no contribution' do
+              let!(:cfe_result) { create :cfe_v3_result, submission: cfe_submission }
 
-              it 'returns false' do
-                expect(subject).to be false
+              context 'restrictions' do
+                it 'returns false' do
+                  expect(subject).to be true
+                end
+              end
+
+              context 'no restrictions' do
+                before { legal_aid_application.update! has_restrictions: false }
+
+                it 'returns false' do
+                  expect(subject).to be false
+                end
+              end
+            end
+          end
+
+          context 'non-passported' do
+            let(:legal_aid_application) { create :legal_aid_application, :with_negative_benefit_check_result, has_restrictions: true }
+
+            context 'contribution' do
+              let!(:cfe_result) { create :cfe_v3_result, :with_capital_contribution_required, submission: cfe_submission }
+
+              it 'returns true' do
+                expect(subject).to be true
+              end
+            end
+
+            context 'no contribution' do
+              let!(:cfe_result) { create :cfe_v3_result, submission: cfe_submission }
+
+              context 'restrictions' do
+                it 'returns false' do
+                  expect(subject).to be true
+                end
+              end
+
+              context 'no restrictions' do
+                before { legal_aid_application.update! has_restrictions: false }
+
+                it 'returns false' do
+                  expect(subject).to be false
+                end
               end
             end
           end
         end
 
-        context 'non-passported' do
-          let(:legal_aid_application) { create :legal_aid_application, :with_negative_benefit_check_result, has_restrictions: true }
+        context 'with DWP override' do
+          before { create :dwp_override, legal_aid_application: legal_aid_application }
+          context 'passported' do
+            let(:legal_aid_application) { create :legal_aid_application, :with_positive_benefit_check_result, has_restrictions: true }
 
-          context 'contribution' do
-            let!(:cfe_result) { create :cfe_v3_result, :with_capital_contribution_required, submission: cfe_submission }
+            context 'contribution' do
+              let!(:cfe_result) { create :cfe_v3_result, :with_capital_contribution_required, submission: cfe_submission }
 
-            it 'returns true' do
-              expect(subject).to be true
-            end
-          end
-
-          context 'no contribution' do
-            let!(:cfe_result) { create :cfe_v3_result, submission: cfe_submission }
-
-            context 'restrictions' do
-              it 'returns false' do
+              it 'returns true' do
                 expect(subject).to be true
               end
             end
 
-            context 'no restrictions' do
-              before { legal_aid_application.update! has_restrictions: false }
+            context 'no contribution' do
+              let!(:cfe_result) { create :cfe_v3_result, submission: cfe_submission }
 
-              it 'returns false' do
-                expect(subject).to be false
+              context 'restrictions' do
+                it 'returns false' do
+                  expect(subject).to be true
+                end
+              end
+
+              context 'no restrictions' do
+                before { legal_aid_application.update! has_restrictions: false }
+
+                it 'returns true' do
+                  expect(subject).to be true
+                end
               end
             end
           end
+
+          context 'non-passported' do
+            let(:legal_aid_application) { create :legal_aid_application, :with_negative_benefit_check_result, has_restrictions: true }
+
+            context 'contribution' do
+              let!(:cfe_result) { create :cfe_v3_result, :with_capital_contribution_required, submission: cfe_submission }
+
+              it 'returns true' do
+                expect(subject).to be true
+              end
+            end
+
+            context 'no contribution' do
+              let!(:cfe_result) { create :cfe_v3_result, submission: cfe_submission }
+
+              context 'restrictions' do
+                it 'returns false' do
+                  expect(subject).to be true
+                end
+              end
+
+              context 'no restrictions' do
+                before { legal_aid_application.update! has_restrictions: false }
+
+                it 'returns true' do
+                  legal_aid_application.reload
+                  expect(subject).to be true
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+
+    describe '#review_reasons' do
+      subject { determiner.review_reasons }
+
+      let(:cfe_result) { double 'CFE Result', remarks: cfe_remarks }
+      let(:cfe_remarks) { double 'CFE Remarks', review_reasons: review_reasons }
+      let(:review_reasons) { %i[unknown_frequency multi_benefit] }
+      let(:override_reaons) { %i[unknown_frequency multi_benefit dwp_override] }
+
+      before { allow_any_instance_of(cfe_submission.class).to receive(:result).and_return(cfe_result) }
+
+      context 'No DWP Override' do
+        it 'just takes the review reasons from the CFE result' do
+          expect(subject).to eq review_reasons
+        end
+      end
+
+      context 'With DWP override' do
+        before { create :dwp_override, legal_aid_application: legal_aid_application }
+        it 'adds the dwp review to the cfe result reasons' do
+          expect(subject).to eq override_reaons
         end
       end
     end

--- a/spec/services/ccms/requestors/case_add_requestor_xml_blocks/passported_attributes_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_xml_blocks/passported_attributes_spec.rb
@@ -1510,9 +1510,13 @@ module CCMS
 
         context 'APPLY_CASE_MEANS_REVIEW' do
           context 'in global means and global merits' do
+            let(:determiner) { double ManualReviewDeterminer }
+
+            before { allow(ManualReviewDeterminer).to receive(:new).and_return(determiner) }
+
             context 'Manual review required' do
               it 'set the attribute to false' do
-                allow(ManualReviewDeterminer).to receive(:call).with(legal_aid_application).times.and_return(true)
+                allow(determiner).to receive(:manual_review_required?).and_return(true)
                 block = XmlExtractor.call(xml, :global_means, 'APPLY_CASE_MEANS_REVIEW')
                 expect(block).to have_boolean_response false
                 block = XmlExtractor.call(xml, :global_merits, 'APPLY_CASE_MEANS_REVIEW')
@@ -1522,7 +1526,7 @@ module CCMS
 
             context 'Manual review not required' do
               it 'sets the attribute to true' do
-                allow(ManualReviewDeterminer).to receive(:call).with(legal_aid_application).times.and_return(false)
+                allow(determiner).to receive(:manual_review_required?).and_return(false)
                 block = XmlExtractor.call(xml, :global_means, 'APPLY_CASE_MEANS_REVIEW')
                 expect(block).to have_boolean_response true
                 block = XmlExtractor.call(xml, :global_merits, 'APPLY_CASE_MEANS_REVIEW')


### PR DESCRIPTION
## Require Caseworker review if DWP result has been overridden

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2087)

- Put the decision making for caseworker review in one place, `ManualReviewDeterminer` to be used both by Means Report Generator and CCMS payload 
- Update `ManualReviewDeterminer` to add in `:dwp_override` review reason if DWP result overridden
- Update `#applicant_receives_benefits?`, `#passported?` and `#non_passported?` to take DWP override into account
- Ensure only one DWPOverride record per 'LegalAidApplication`

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
