### PR TITLE
AP-2082 DWP Override Blue Box

### DIFF
--- a/app/controllers/providers/check_benefits_controller.rb
+++ b/app/controllers/providers/check_benefits_controller.rb
@@ -10,6 +10,8 @@ module Providers
       return set_negative_result_and_go_forward if known_issue_prevents_benefit_check?
 
       check_benefits if legal_aid_application.benefit_check_result_needs_updating?
+
+      go_forward(true) if Setting.override_dwp_results? && legal_aid_application.non_passported?
     end
 
     def update

--- a/app/controllers/providers/confirm_dwp_non_passported_applications_controller.rb
+++ b/app/controllers/providers/confirm_dwp_non_passported_applications_controller.rb
@@ -3,6 +3,8 @@ module Providers
     def show; end
 
     def update
+      return continue_or_draft if draft_selected?
+
       if dwp_results_correct.present?
         go_forward(dwp_results_correct == 'true')
       else

--- a/app/controllers/providers/confirm_dwp_non_passported_applications_controller.rb
+++ b/app/controllers/providers/confirm_dwp_non_passported_applications_controller.rb
@@ -1,11 +1,20 @@
 module Providers
   class ConfirmDWPNonPassportedApplicationsController < ProviderBaseController
-    def show
-      render :show
-    end
+    def show; end
 
     def update
-      go_forward
+      if dwp_results_correct.present?
+        go_forward(dwp_results_correct == 'true')
+      else
+        @error = { 'confirm_dwp_non_passported_applications-error' => I18n.t('providers.confirm_dwp_non_passported_applications.show.error') }
+        render :show
+      end
+    end
+
+    private
+
+    def dwp_results_correct
+      @dwp_results_correct ||= params[:dwp_results_correct]
     end
   end
 end

--- a/app/services/flow/flows/provider_dwp_override.rb
+++ b/app/services/flow/flows/provider_dwp_override.rb
@@ -4,9 +4,18 @@ module Flow
       STEPS = {
         confirm_dwp_non_passported_applications: {
           path: ->(application) { urls.providers_legal_aid_application_confirm_dwp_non_passported_applications_path(application) },
-          forward: :check_benefits
-          # uncomment the below to redirect to next pages being developed and remove line 7
-          # forward: ->(_application, confirm_dwp_non_passported) { confirm_dwp_non_passported ? :check_benefits : :check_client_details }
+          forward: ->(application, confirm_dwp_non_passported) do
+            if confirm_dwp_non_passported
+              application.change_state_machine_type('NonPassportedStateMachine')
+              :applicant_employed
+            else
+              application.change_state_machine_type('PassportedStateMachine')
+              :check_client_details
+            end
+          end
+        },
+        check_client_details: {
+          path: ->(application) { urls.providers_legal_aid_application_check_client_details_path(application) }
         }
       }.freeze
     end

--- a/app/views/providers/confirm_dwp_non_passported_applications/show.html.erb
+++ b/app/views/providers/confirm_dwp_non_passported_applications/show.html.erb
@@ -1,11 +1,27 @@
-<%= page_template page_title: '', template: :basic do %>
-  <%= form_with(builder: GOVUKDesignSystemFormBuilder::FormBuilder,
-                url: providers_legal_aid_application_confirm_dwp_non_passported_applications_path, method: :patch, local: true) do |form| %>
+<%= render partial: 'shared/error' if @error %>
+<div class="interruption-panel">
+  <%= page_template(page_title: t('.tab_title'), column_width: :full, template: :basic) do %>
+    <%= form_with(
+          builder: GOVUKDesignSystemFormBuilder::FormBuilder,
+          model: @form,
+          url: providers_legal_aid_application_confirm_dwp_non_passported_applications_path,
+          method: :patch,
+          local: true
+        ) do |form| %>
 
-    <div class="govuk-!-padding-bottom-2"></div>
-    <%= next_action_buttons(
-          show_draft: local_assigns.key?(:show_draft) ? show_draft : false,
-          form: form
-        ) %>
+      <%= form.govuk_radio_buttons_fieldset(:dwp_results_correct, legend: {text: t('.title'), tag: 'h1', size: 'l'}) do %>
+        <%= form.govuk_radio_button(:dwp_results_correct, true, label: {text: t('generic.yes')} ) %>
+        <%= form.govuk_radio_button(:dwp_results_correct, false, label: {text:  t('.no')} ) %>
+      <% end %>
+
+      <div class="govuk-!-padding-bottom-4"></div>
+
+      <%= next_action_buttons_with_form(
+            url: providers_legal_aid_application_confirm_dwp_non_passported_applications_path,
+            method: :patch,
+            show_draft: true,
+            continue_button_text: t('generic.continue')
+          ) %>
+    <% end %>
   <% end %>
-<% end %>
+</div>

--- a/app/webpack/stylesheets/interruption-panel.scss
+++ b/app/webpack/stylesheets/interruption-panel.scss
@@ -2,12 +2,8 @@
   background-color:#1d70b8;
   padding:30px;
 
-  p,h1,h2,ul {
-    color: #fff;
-  }
-
-  a, a:link, a:visited {
-    color: #fff;
+  p,h1,h2,ul,label,a,a:link,a:visited {
+    color: govuk-colour("white");
   }
 
   h2 {
@@ -38,6 +34,12 @@
     }
   }
 
+  .govuk-radios__label::before,
+  & ::after {
+    color: govuk-colour("black");
+    border-color: govuk-colour("black");
+    background-color: govuk-colour("white");
+  }
 }
 @media (min-width: 769px) {
   .interruption-panel {

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -155,6 +155,12 @@ en:
             Universal Credit
         title_html: You need to use <abbr title='Client and Cost Management System'>CCMS</abbr> for this application
         we_checked: "We checked with the DWP and your client does not receive:"
+    confirm_dwp_non_passported_applications:
+      show:
+        error: Select yes if your client does not receive a passporting benefit.
+        'no': No, my client receives a passporting benefit
+        tab_title: DWP records show that your client does not receive a passporting benefit – is this correct?
+        title: DWP records show that your client does not receive a passporting benefit – is this correct?
     check_merits_answers:
       show:
         h1-heading: Check your answers and submit application

--- a/features/providers/civil_application_journey.feature
+++ b/features/providers/civil_application_journey.feature
@@ -886,3 +886,30 @@ Feature: Civil application journeys
     Then I choose 'No'
     Then I click 'Save and continue'
     Then I should be on a page showing "Does your client own a vehicle?"
+
+  @javascript @vcr
+  Scenario: When the DWP override is enabled, a positive benefit check result behaves as usual
+    Given the setting to allow DWP overrides is enabled
+    And I complete the passported journey as far as check your answers
+    When I click 'Save and continue'
+    Then I should be on a page showing 'receives benefits that qualify for legal aid'
+
+  @javascript @vcr
+  Scenario: When the DWP override is enabled, a negative benefit check allows the solicitor to continue without overriding the result
+    Given the setting to allow DWP overrides is enabled
+    And I complete the non-passported journey as far as check your answers
+    When I click 'Save and continue'
+    Then I should be on a page showing 'DWP records show that your client does not receive a passporting benefit – is this correct?'
+    Then I choose 'Yes'
+    And I click 'Continue'
+    Then I should be on a page showing 'Is your client employed?'
+
+  @javascript @vcr
+  Scenario: When the DWP override is enabled, a negative benefit check allows the solicitor to override the result
+    Given the setting to allow DWP overrides is enabled
+    And I complete the non-passported journey as far as check your answers
+    Then I click 'Save and continue'
+    Then I should be on a page showing 'DWP records show that your client does not receive a passporting benefit – is this correct?'
+    Then I choose 'No'
+    And I click 'Continue'
+    Then I should be on a page showing 'check_client_detail page under construction'

--- a/features/step_definitions/civil_journey_steps.rb
+++ b/features/step_definitions/civil_journey_steps.rb
@@ -96,6 +96,10 @@ Given('the setting to allow multiple proceedings is enabled') do
   Setting.setting.update!(allow_multiple_proceedings: true)
 end
 
+Given('the setting to allow DWP overrides is enabled') do
+  Setting.setting.update!(override_dwp_results: true)
+end
+
 Then('I choose a {string} radio button') do |radio_button_name|
   choose(radio_button_name, allow_label_click: true)
 end
@@ -412,6 +416,37 @@ Given('I complete the passported journey as far as check your answers') do
   @legal_aid_application = create(
     :legal_aid_application,
     :with_passported_state_machine,
+    :at_entering_applicant_details,
+    :with_substantive_scope_limitation,
+    applicant: applicant,
+    used_delegated_functions_on: 1.day.ago
+  )
+  login_as @legal_aid_application.provider
+  visit(providers_legal_aid_application_check_provider_answers_path(@legal_aid_application))
+  steps %(Then I should be on a page showing 'Check your answers')
+end
+
+Given('I complete the non-passported journey as far as check your answers') do
+  applicant = create(
+    :applicant,
+    first_name: 'Test',
+    last_name: 'Test',
+    national_insurance_number: 'JA123456A',
+    date_of_birth: '01-01-1970',
+    email: 'test@test.com'
+  )
+  create(
+    :address,
+    address_line_one: 'Transport For London',
+    address_line_two: '98 Petty France',
+    city: 'London',
+    postcode: 'SW1H 9EA',
+    lookup_used: true,
+    applicant: applicant
+  )
+  @legal_aid_application = create(
+    :legal_aid_application,
+    :with_non_passported_state_machine,
     :at_entering_applicant_details,
     :with_substantive_scope_limitation,
     applicant: applicant,

--- a/spec/requests/providers/check_benefits_spec.rb
+++ b/spec/requests/providers/check_benefits_spec.rb
@@ -92,6 +92,29 @@ RSpec.describe Providers::CheckBenefitsController, type: :request do
       before { subject }
       it_behaves_like 'a provider not authenticated'
     end
+
+    context 'when dwp override is enabled' do
+      before(:all) { Setting.setting.update!(override_dwp_results: true) }
+      after(:all) { Setting.setting.update!(override_dwp_results: false) }
+
+      before { subject }
+
+      context 'when the check benefit result is positive' do
+        let(:application) { create :legal_aid_application, :with_applicant, :with_positive_benefit_check_result, :at_checking_applicant_details }
+
+        it 'displays the passported result page' do
+          expect(response.body).to include 'receives benefits that qualify for legal aid'
+        end
+      end
+
+      context 'when the check benefit result is negative' do
+        let(:application) { create :legal_aid_application, :with_applicant, :with_negative_benefit_check_result, :at_checking_applicant_details }
+
+        it 'displays the confirm dwp non passported_applications page' do
+          expect(response).to redirect_to providers_legal_aid_application_confirm_dwp_non_passported_applications_path(application)
+        end
+      end
+    end
   end
 
   describe 'PATCH /providers/applications/:application_id/check_benefit' do

--- a/spec/requests/providers/check_provider_answers_spec.rb
+++ b/spec/requests/providers/check_provider_answers_spec.rb
@@ -219,8 +219,8 @@ RSpec.describe Providers::CheckProviderAnswersController, type: :request do
         end
 
         context 'non passported' do
-          it 'redirects to the confirm dwp non passported applications page' do
-            expect(response).to redirect_to(providers_legal_aid_application_confirm_dwp_non_passported_applications_path(application))
+          it 'redirects to the check benefits page' do
+            expect(response).to redirect_to(providers_legal_aid_application_check_benefits_path(application))
           end
         end
 

--- a/spec/requests/providers/confirm_dwp_non_passported_applications_spec.rb
+++ b/spec/requests/providers/confirm_dwp_non_passported_applications_spec.rb
@@ -41,17 +41,54 @@ RSpec.describe Providers::ConfirmDWPNonPassportedApplicationsController, type: :
   end
 
   describe 'PATCH /providers/applications/:legal_aid_application_id/confirm_dwp_non_passported_applications' do
-    subject { patch "/providers/applications/#{application_id}/confirm_dwp_non_passported_applications" }
+    let(:params) do
+      {
+        continue_button: 'Continue'
+      }
+    end
+
+    subject { patch "/providers/applications/#{application_id}/confirm_dwp_non_passported_applications", params: params }
 
     before do
       login_as application.provider
       subject
     end
 
-    context 'Continue' do
-      it 'continues to the client details page' do
-        subject
-        expect(response).to redirect_to(providers_legal_aid_application_check_benefits_path(application))
+    context 'the results are correct' do
+      let(:params) do
+        {
+          continue_button: 'Continue',
+          dwp_results_correct: 'true'
+        }
+      end
+      it 'displays the applicant_employed page' do
+        expect(response).to redirect_to providers_legal_aid_application_applicant_employed_index_path(application)
+      end
+
+      it 'uses the non-passported state machine' do
+        expect(application.state_machine_proxy.type).to eq 'NonPassportedStateMachine'
+      end
+    end
+
+    context 'the solicitor wants to override the results' do
+      let(:params) do
+        {
+          continue_button: 'Continue',
+          dwp_results_correct: 'false'
+        }
+      end
+      it 'displays the check_client_details page' do
+        expect(response).to redirect_to providers_legal_aid_application_check_client_details_path(application)
+      end
+
+      it 'uses the passported state machine' do
+        expect(application.state_machine_proxy.type).to eq 'NonPassportedStateMachine'
+      end
+    end
+
+    context 'the solicitor does not select a radio button' do
+      it 'displays an error' do
+        expect(response.body).to include(I18n.t('providers.confirm_dwp_non_passported_applications.show.error'))
       end
     end
   end

--- a/spec/requests/providers/confirm_dwp_non_passported_applications_spec.rb
+++ b/spec/requests/providers/confirm_dwp_non_passported_applications_spec.rb
@@ -41,54 +41,79 @@ RSpec.describe Providers::ConfirmDWPNonPassportedApplicationsController, type: :
   end
 
   describe 'PATCH /providers/applications/:legal_aid_application_id/confirm_dwp_non_passported_applications' do
-    let(:params) do
-      {
-        continue_button: 'Continue'
-      }
-    end
-
-    subject { patch "/providers/applications/#{application_id}/confirm_dwp_non_passported_applications", params: params }
-
-    before do
-      login_as application.provider
-      subject
-    end
-
-    context 'the results are correct' do
+    context 'submitting with Continue button' do
       let(:params) do
         {
-          continue_button: 'Continue',
-          dwp_results_correct: 'true'
+          continue_button: 'Continue'
         }
       end
-      it 'displays the applicant_employed page' do
-        expect(response).to redirect_to providers_legal_aid_application_applicant_employed_index_path(application)
+
+      subject { patch "/providers/applications/#{application_id}/confirm_dwp_non_passported_applications", params: params }
+
+      before do
+        login_as application.provider
+        subject
       end
 
-      it 'uses the non-passported state machine' do
-        expect(application.state_machine_proxy.type).to eq 'NonPassportedStateMachine'
+      context 'the results are correct' do
+        let(:params) do
+          {
+            continue_button: 'Continue',
+            dwp_results_correct: 'true'
+          }
+        end
+        it 'displays the applicant_employed page' do
+          expect(response).to redirect_to providers_legal_aid_application_applicant_employed_index_path(application)
+        end
+
+        it 'uses the non-passported state machine' do
+          expect(application.state_machine_proxy.type).to eq 'NonPassportedStateMachine'
+        end
+      end
+
+      context 'the solicitor wants to override the results' do
+        let(:params) do
+          {
+            continue_button: 'Continue',
+            dwp_results_correct: 'false'
+          }
+        end
+        it 'displays the check_client_details page' do
+          expect(response).to redirect_to providers_legal_aid_application_check_client_details_path(application)
+        end
+
+        it 'uses the passported state machine' do
+          expect(application.state_machine_proxy.type).to eq 'NonPassportedStateMachine'
+        end
+      end
+
+      context 'the solicitor does not select a radio button' do
+        it 'displays an error' do
+          expect(response.body).to include(I18n.t('providers.confirm_dwp_non_passported_applications.show.error'))
+        end
       end
     end
 
-    context 'the solicitor wants to override the results' do
+    context 'submitting with Save As Draft button' do
       let(:params) do
         {
-          continue_button: 'Continue',
-          dwp_results_correct: 'false'
+          draft_button: 'Save as draft'
         }
       end
-      it 'displays the check_client_details page' do
-        expect(response).to redirect_to providers_legal_aid_application_check_client_details_path(application)
+
+      subject { patch "/providers/applications/#{application_id}/confirm_dwp_non_passported_applications", params: params }
+
+      before do
+        login_as application.provider
+        subject
       end
 
-      it 'uses the passported state machine' do
-        expect(application.state_machine_proxy.type).to eq 'NonPassportedStateMachine'
+      it "redirects provider to provider's applications page" do
+        expect(response).to redirect_to(providers_legal_aid_applications_path)
       end
-    end
 
-    context 'the solicitor does not select a radio button' do
-      it 'displays an error' do
-        expect(response.body).to include(I18n.t('providers.confirm_dwp_non_passported_applications.show.error'))
+      it 'sets the application as draft' do
+        expect(application.reload).to be_draft
       end
     end
   end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2082)

Solicitors need to be able to override a DWP benefit check result. This commit adds an alternative results page so that after a negative result the solicitor is given the option of overriding it. For now this simply leads to a holding page.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
