### PR TITLE
AP 2084 DWP Confirm Benefits Received

### DIFF
--- a/app/controllers/providers/check_provider_answers_controller.rb
+++ b/app/controllers/providers/check_provider_answers_controller.rb
@@ -15,7 +15,6 @@ module Providers
     end
 
     def continue
-      legal_aid_application.applicant_details_checked! unless draft_selected?
       continue_or_draft
     end
 

--- a/app/controllers/providers/confirm_dwp_non_passported_applications_controller.rb
+++ b/app/controllers/providers/confirm_dwp_non_passported_applications_controller.rb
@@ -6,7 +6,8 @@ module Providers
       return continue_or_draft if draft_selected?
 
       if dwp_results_correct.present?
-        go_forward(dwp_results_correct == 'true')
+        details_checked! if correct_dwp_result? && !details_checked?
+        go_forward(correct_dwp_result?)
       else
         @error = { 'confirm_dwp_non_passported_applications-error' => I18n.t('providers.confirm_dwp_non_passported_applications.show.error') }
         render :show
@@ -14,6 +15,18 @@ module Providers
     end
 
     private
+
+    def details_checked!
+      legal_aid_application.applicant_details_checked!
+    end
+
+    def details_checked?
+      legal_aid_application.applicant_details_checked?
+    end
+
+    def correct_dwp_result?
+      dwp_results_correct == 'true'
+    end
 
     def dwp_results_correct
       @dwp_results_correct ||= params[:dwp_results_correct]

--- a/app/controllers/providers/received_benefit_confirmations_controller.rb
+++ b/app/controllers/providers/received_benefit_confirmations_controller.rb
@@ -10,13 +10,27 @@ module Providers
       @form = Providers::ReceivedBenefitConfirmationForm.new(form_params)
 
       if @form.valid?
-        go_forward(form_params[:passporting_benefit] != 'none_selected')
+        benefit? ? @form.save : dwp_override.destroy!
+        details_checked! unless details_checked?
+        go_forward(benefit?)
       else
         render :show
       end
     end
 
     private
+
+    def benefit?
+      form_params[:passporting_benefit] != 'none_selected'
+    end
+
+    def details_checked!
+      legal_aid_application.applicant_details_checked!
+    end
+
+    def details_checked?
+      legal_aid_application.applicant_details_checked?
+    end
 
     def form_params
       merge_with_model(dwp_override) do

--- a/app/controllers/providers/received_benefit_confirmations_controller.rb
+++ b/app/controllers/providers/received_benefit_confirmations_controller.rb
@@ -1,5 +1,31 @@
 module Providers
   class ReceivedBenefitConfirmationsController < ProviderBaseController
-    def show; end
+    def show
+      @form = Providers::ReceivedBenefitConfirmationForm.new(model: dwp_override)
+    end
+
+    def update
+      return continue_or_draft if draft_selected?
+
+      @form = Providers::ReceivedBenefitConfirmationForm.new(form_params)
+
+      if @form.valid?
+        go_forward(form_params[:passporting_benefit] != 'none_selected')
+      else
+        render :show
+      end
+    end
+
+    private
+
+    def form_params
+      merge_with_model(dwp_override) do
+        params.require(:dwp_override).permit(:passporting_benefit)
+      end
+    end
+
+    def dwp_override
+      @dwp_override ||= legal_aid_application.dwp_override || legal_aid_application.create_dwp_override!
+    end
   end
 end

--- a/app/forms/providers/received_benefit_confirmation_form.rb
+++ b/app/forms/providers/received_benefit_confirmation_form.rb
@@ -1,0 +1,19 @@
+module Providers
+  class ReceivedBenefitConfirmationForm
+    include BaseForm
+
+    form_for DWPOverride
+
+    SINGLE_VALUE_ATTRIBUTES = %i[
+      universal_credit
+      guarantee_credit_element_of_pension_credit
+      income_based_job_seekers_allowance
+      income_related_employment_and_support_allowance
+      income_support
+    ].freeze
+
+    attr_accessor :passporting_benefit
+
+    validates :passporting_benefit, presence: true, unless: :draft?
+  end
+end

--- a/app/models/dwp_override.rb
+++ b/app/models/dwp_override.rb
@@ -1,2 +1,3 @@
 class DWPOverride < ApplicationRecord
+  belongs_to :legal_aid_application
 end

--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -31,6 +31,7 @@ class LegalAidApplication < ApplicationRecord
   has_one :ccms_submission, -> { order(created_at: :desc) }, class_name: 'CCMS::Submission', inverse_of: :legal_aid_application, dependent: :destroy
   has_one :vehicle, dependent: :destroy
   has_one :policy_disregards, dependent: :destroy
+  has_one :dwp_override, dependent: :destroy
 
   # The relationship below needs to be removed in ap-2047
   has_many :application_scope_limitations, dependent: :destroy

--- a/app/services/flow/flows/provider_dwp_override.rb
+++ b/app/services/flow/flows/provider_dwp_override.rb
@@ -16,13 +16,19 @@ module Flow
         },
         check_client_details: {
           path: ->(application) { urls.providers_legal_aid_application_check_client_details_path(application) },
-          forward: ->(application, correct_details) do
-            if correct_details
+          forward: ->(_application, correct_details) { correct_details ? :received_benefit_confirmations : :applicant_details }
+        },
+        received_benefit_confirmations: {
+          path: ->(application) { urls.providers_legal_aid_application_received_benefit_confirmation_path(application) },
+          forward: ->(application, has_benefit) do
+            if has_benefit
               # this needs to be moved to the last step in the override flow
               # and replaced here with the next :confirm_benefits steps
+              application.change_state_machine_type('PassportedStateMachine')
               application.used_delegated_functions? ? :substantive_applications : :capital_introductions
             else
-              :applicant_details
+              application.change_state_machine_type('NonPassportedStateMachine')
+              :applicant_employed
             end
           end
         }

--- a/app/views/providers/received_benefit_confirmations/show.html.erb
+++ b/app/views/providers/received_benefit_confirmations/show.html.erb
@@ -1,1 +1,8 @@
-received_benefit_confirmation page under construction
+ <%= page_template page_title: t('.h1-heading'), template: :basic, show_errors_for: @form do %>
+    <%= render partial: '/shared/forms/received_benefit_confirmation/form',
+               locals: {
+                 model: @form,
+                 show_draft: true,
+                 url: providers_legal_aid_application_received_benefit_confirmation_path(@legal_aid_application)
+               } %>
+ <% end %>

--- a/app/views/shared/forms/received_benefit_confirmation/_form.html.erb
+++ b/app/views/shared/forms/received_benefit_confirmation/_form.html.erb
@@ -1,0 +1,22 @@
+<%= form_with(builder: GOVUKDesignSystemFormBuilder::FormBuilder, model: model, url: url, method: :patch, local: true) do |form| %>
+  <%
+    options = []
+    Providers::ReceivedBenefitConfirmationForm::SINGLE_VALUE_ATTRIBUTES.each do |benefit|
+      options << OpenStruct.new(value: benefit, label: t(".providers.received_benefit_confirmations.#{benefit}"))
+    end
+  %>
+
+  <%= form.govuk_collection_radio_buttons(:passporting_benefit, options, :value, :label,
+                                          legend: {size: 'xl', tag: 'h1', text: content_for(:page_title)}) %>
+
+    <%= form.govuk_radio_divider %>
+    <%= form.govuk_radio_button(:passporting_benefit, :none_selected, label: {text:  t('generic.none_selected')}) %>
+
+  <div class="govuk-!-padding-bottom-3"></div>
+
+  <%= next_action_buttons(
+        show_draft: local_assigns.key?(:show_draft) ? show_draft : false,
+        form: form
+      ) %>
+
+<% end %>

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -166,6 +166,10 @@ en:
               not_a_number: Value must be an amount of money, like 1,000
               too_many_decimals: Value must not include more than 2 decimal numbers
               less_than_threshold: Select no if they have assets worth less than £8,000
+        dwp_override:
+          attributes:
+            passporting_benefit:
+              blank: Select if your client has received any of these benefits
         incident:
           attributes:
             told_on:

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -584,6 +584,9 @@ en:
         page_title: Your profile
         role: Permission
         username: Username
+    received_benefit_confirmations:
+      show:
+        h1-heading: Which passporting benefit does your client receive?
     respondents:
       show:
         h1-heading: Opponent details

--- a/config/locales/en/shared.yml
+++ b/config/locales/en/shared.yml
@@ -314,6 +314,15 @@ en:
               national_emergencies_trust: National Emergencies Trust (NET)
               we_love_manchester_emergency_fund: We Love Manchester Emergency Fund
               london_emergencies_trust: The London Emergencies Trust
+      received_benefit_confirmation:
+        form:
+          providers:
+            received_benefit_confirmations:
+              universal_credit: Universal Credit
+              guarantee_credit_element_of_pension_credit: Guarantee Credit element of Pension Credit
+              income_based_job_seekers_allowance: Income-based Jobseeker’s Allowance (JSA)
+              income_related_employment_and_support_allowance: Income-related Employment and Support Allowance (ESA)
+              income_support: Income Support
       revealing_checkbox:
         attribute:
           citizens:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -238,7 +238,7 @@ Rails.application.routes.draw do
       resource :non_passported_client_instructions, only: :show
       resource :confirm_dwp_non_passported_applications, only: %i[show update]
       resource :check_client_details, only: %i[show update]
-      resource :received_benefit_confirmation, only: :show
+      resource :received_benefit_confirmation, only: %i[show update]
       resource :evidence_of_benefit, only: :show
     end
   end

--- a/features/providers/civil_application_journey.feature
+++ b/features/providers/civil_application_journey.feature
@@ -919,4 +919,11 @@ Feature: Civil application journeys
     When I click link "Back"
     Then I choose 'These details are correct'
     And I click 'Save and continue'
+    Then I should be on a page showing 'Which passporting benefit does your client receive?'
+    Then I choose 'None of these'
+    And I click 'Save and continue'
+    Then I should be on a page showing 'Is your client employed?'
+    When I click link "Back"
+    Then I choose 'Universal Credit'
+    And I click 'Save and continue'
     Then I should be on a page showing "Before you continue"

--- a/spec/requests/providers/check_client_details_spec.rb
+++ b/spec/requests/providers/check_client_details_spec.rb
@@ -50,23 +50,8 @@ RSpec.describe Providers::CheckClientDetailsController, type: :request do
     context 'correct client details' do
       let(:params) { { providers_check_client_details_form: { check_client_details: 'true' } } }
 
-      context 'delegated functions' do
-        let(:application) do
-          create :legal_aid_application,
-                 :with_proceeding_types,
-                 :with_applicant_and_address,
-                 used_delegated_functions: true
-        end
-
-        it 'continue to the substantive applications page' do
-          expect(response).to redirect_to(providers_legal_aid_application_substantive_application_path(application))
-        end
-      end
-
-      context 'no delegated functions' do
-        it 'continue to the capital introductions page' do
-          expect(response).to redirect_to(providers_legal_aid_application_capital_introduction_path(application))
-        end
+      it 'continue to the received benefit confirmations page' do
+        expect(response).to redirect_to(providers_legal_aid_application_received_benefit_confirmation_path(application))
       end
     end
 

--- a/spec/requests/providers/check_provider_answers_spec.rb
+++ b/spec/requests/providers/check_provider_answers_spec.rb
@@ -202,16 +202,6 @@ RSpec.describe Providers::CheckProviderAnswersController, type: :request do
         expect(response).to redirect_to(providers_legal_aid_application_check_benefits_path(application))
       end
 
-      it 'changes the state to "applicant_details_checked"' do
-        subject
-        expect(application.reload.applicant_details_checked?).to be_truthy
-      end
-
-      it 'syncs the application' do
-        expect(CleanupCapitalAttributes).to receive(:call).with(application)
-        subject
-      end
-
       context 'allow dwp override' do
         before do
           allow(Setting).to receive(:override_dwp_results?).and_return(true)

--- a/spec/requests/providers/received_benefit_confirmations_spec.rb
+++ b/spec/requests/providers/received_benefit_confirmations_spec.rb
@@ -23,7 +23,55 @@ RSpec.describe Providers::ReceivedBenefitConfirmationsController, type: :request
       end
 
       it 'displays the correct page' do
-        expect(unescaped_response_body).to include('received_benefit_confirmation page under construction')
+        expect(unescaped_response_body).to include('Which passporting benefit does your client receive?')
+      end
+    end
+  end
+
+  describe 'PATCH /providers/applications/:legal_aid_application_id/received_benefit_confirmation' do
+    subject { patch "/providers/applications/#{application_id}/received_benefit_confirmation", params: params }
+    let(:params) { { dwp_override: { passporting_benefit: nil } } }
+
+    before do
+      login_as application.provider
+      subject
+    end
+
+    context 'validation error' do
+      it 'displays error if nothing selected' do
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include('Select if your client has received any of these benefits')
+      end
+    end
+
+    context 'benefit selected' do
+      let(:params) { { dwp_override: { passporting_benefit: :universal_credit } } }
+
+      context 'delegated functions' do
+        let(:application) do
+          create :legal_aid_application,
+                 :with_proceeding_types,
+                 :with_applicant_and_address,
+                 used_delegated_functions: true
+        end
+
+        it 'continue to the substantive applications page' do
+          expect(response).to redirect_to(providers_legal_aid_application_substantive_application_path(application))
+        end
+      end
+
+      context 'no delegated functions' do
+        it 'continue to the capital introductions page' do
+          expect(response).to redirect_to(providers_legal_aid_application_capital_introduction_path(application))
+        end
+      end
+    end
+
+    context 'none of these selected' do
+      let(:params) { { dwp_override: { passporting_benefit: :none_selected } } }
+
+      it 'continue to the applicant details page' do
+        expect(response).to redirect_to(providers_legal_aid_application_applicant_employed_index_path(application))
       end
     end
   end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2084)

Page to confirm which benefit is received if client details are correct. 
Provider can only select 1 option.
If the provider selects one of the 5 state benefit options it should continue to new page AP-2085.
Provider receives an error if no option is selected and tries to continue with the journey. 
If the provider selects ‘None of the above’ continue to normal non-passported journey.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
