### PR TITLE
BugFix - Capture exceptions in DeliveryMan when mailers raise an error

### DIFF
--- a/app/services/govuk_emails/delivery_man.rb
+++ b/app/services/govuk_emails/delivery_man.rb
@@ -19,6 +19,8 @@ module GovukEmails
       return unless scheduled_mail.waiting? # in case another job has picked it up
 
       eligible_for_delivery? ? deliver_now : cancel!
+    rescue StandardError => e
+      Sentry.capture_exception(e)
     end
 
     private


### PR DESCRIPTION
## BugFix - Capture exceptions in DeliveryMan when mailers raise an error

Related to this sentry issue has been discarded because it can reoccur in staging and we're okay with that. Under Sentry staging, settings, inbound filters, discarded >
![image](https://user-images.githubusercontent.com/25043924/110805460-01ee9a00-8279-11eb-84ee-711bc649b224.png)


When the DeliveryMan calls `deliver_now!` on a mailer job but that mailer raises an error then we should capture the issue and send the exception to Sentry.

This will mean that the ScheduledMailingsDeliveryJob can continue to call the DeliveryMan for 'waiting' jobs / scheduled mailings.

Update tests

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
