### PR TITLE
AP-2046Z Application/Scope Limitation migration scripts

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,6 +15,7 @@ AllCops:
   - 'ccms_integration/*'
   - 'tmp/**/*'
   - 'log/**/*'
+  - 'lib/tasks/helpers/scope_limitations_migrator.rb'
 
 Layout/LineLength:
   Max: 180

--- a/app/models/assigned_df_scope_limitation.rb
+++ b/app/models/assigned_df_scope_limitation.rb
@@ -1,0 +1,2 @@
+class AssignedDfScopeLimitation < ApplicationProceedingTypesScopeLimitation
+end

--- a/app/models/assigned_substantive_scope_limitation.rb
+++ b/app/models/assigned_substantive_scope_limitation.rb
@@ -1,0 +1,2 @@
+class AssignedSubstantiveScopeLimitation < ApplicationProceedingTypesScopeLimitation
+end

--- a/lib/tasks/helpers/scope_limitations_migrator.rb
+++ b/lib/tasks/helpers/scope_limitations_migrator.rb
@@ -1,0 +1,49 @@
+class ScopeLimitationsMigrator
+  def initialize
+    @verbose_log = []
+  end
+
+  def self.call
+    new.call
+  end
+
+  def call
+    LegalAidApplication.pluck(:id).each { |laa_id| process(laa_id) }
+    @verbose_log.each { |vl| puts vl }
+  end
+
+  private
+
+  def log(msg)
+    @verbose_log << msg
+  end
+
+  def process(laa_id)
+    laa = LegalAidApplication.find(laa_id)
+    log "Processing LegalAidApplication #{laa.id} - #{laa.application_ref}"
+    if laa.proceeding_types.empty?
+      log '  No proceeding types - no action taken'
+      return
+    end
+    migrate!(laa)
+  end
+
+  def migrate!(laa)
+    laa.application_proceeding_types.each { |apt| process_apt(laa, apt) }
+  end
+
+  def process_apt(laa, apt)
+    laa.application_scope_limitations.each do |asl|
+      log "  Processing ASL #{asl.id}"
+      klass = asl.substantive? ? AssignedSubstantiveScopeLimitation : AssignedDfScopeLimitation
+      existing_record = klass.find_by(application_proceeding_type_id: apt.id, scope_limitation_id: asl.scope_limitation_id)
+      if existing_record.nil?
+        rec = klass.create!(application_proceeding_type_id: apt.id, scope_limitation_id: asl.scope_limitation_id)
+        log "    Created #{klass} id: #{rec.id} apt_id: #{apt.id} sl_id: #{asl.scope_limitation_id} "
+      else
+        log "    >>>>>>>>>> #{klass} record already exists for apt_id #{apt.id} and sl_id #{asl.scope_limitation_id}"
+      end
+    end
+  end
+end
+# :nocov:

--- a/lib/tasks/scope_limitations_migrator.rake
+++ b/lib/tasks/scope_limitations_migrator.rake
@@ -1,0 +1,7 @@
+namespace :scopes do
+  desc 'Migrates scope limiations from being attached to application to beinga attached to application-proceeding type'
+  task migrate: :environment do
+    require Rails.root.join('lib/tasks/helpers/scope_limitations_migrator')
+    ScopeLimitationsMigrator.call
+  end
+end

--- a/spec/lib/migration_helpers/scope_limitations_migrator_spec.rb
+++ b/spec/lib/migration_helpers/scope_limitations_migrator_spec.rb
@@ -1,0 +1,66 @@
+require 'rails_helper'
+require Rails.root.join('lib/tasks/helpers/scope_limitations_migrator')
+
+RSpec.describe ScopeLimitationsMigrator do
+  before { populate_legal_framework }
+
+  let(:pt0220) { ProceedingType.find_by(code: 'PR0220') }
+  let(:pt0206) { ProceedingType.find_by(code: 'PR0206') }
+  let(:sl_subst_pt0220) { pt0220.default_substantive_scope_limitation }
+  let(:sl_subst_pt0206) { pt0206.default_substantive_scope_limitation }
+  let(:sl_df_pt0206) { pt0206.default_delegated_functions_scope_limitation }
+
+  let!(:laa_no_proceeding_type) { create :legal_aid_application }
+  let!(:laa_subst) do
+    laa = create :legal_aid_application
+    laa.proceeding_types << pt0220
+    laa.scope_limitations << sl_subst_pt0220
+    laa.save!
+    laa
+  end
+  let!(:laa_df) do
+    laa = create :legal_aid_application
+    laa.proceeding_types << pt0206
+    laa.scope_limitations << sl_subst_pt0206
+    laa.scope_limitations << sl_df_pt0206
+    laa.save!
+    laa
+  end
+
+  context 'when the migrator hasnt been run already' do
+    it 'has no assigned scope limitations' do
+      expect(laa_no_proceeding_type.proceeding_types).to be_empty
+      expect(laa_subst.application_proceeding_types.first.assigned_scope_limitations).to be_empty
+      expect(laa_df.application_proceeding_types.first.assigned_scope_limitations).to be_empty
+    end
+
+    it 'migrates the old schema to the new' do
+      expect { ScopeLimitationsMigrator.call }.to change { ApplicationProceedingTypesScopeLimitation.count }.by(3)
+      expect(laa_no_proceeding_type.application_proceeding_types).to be_empty
+      expect(laa_subst.application_proceeding_types.first.assigned_scope_limitations).to eq [sl_subst_pt0220]
+      expect(laa_df.application_proceeding_types.first.assigned_scope_limitations).to match_array [sl_subst_pt0206, sl_df_pt0206]
+    end
+
+    context 'application has duplicate scope limitations' do
+      before { laa_df.scope_limitations << sl_df_pt0206 }
+
+      it 'ignores the duplicate scope limtation' do
+        expect(laa_df.proceeding_types.size).to eq 1
+        expect(laa_df.scope_limitations.size).to eq 3
+        expect { ScopeLimitationsMigrator.call }.to change { ApplicationProceedingTypesScopeLimitation.count }.by(3)
+        expect(laa_df.application_proceeding_types.first.assigned_scope_limitations.size).to eq 2
+      end
+    end
+  end
+
+  context 'when the migrator has already been run once' do
+    before { ScopeLimitationsMigrator.call }
+
+    it 'does not add any new records' do
+      expect { ScopeLimitationsMigrator.call }.not_to change { ApplicationProceedingTypesScopeLimitation.count }
+      expect(laa_no_proceeding_type.application_proceeding_types).to be_empty
+      expect(laa_subst.application_proceeding_types.first.assigned_scope_limitations).to eq [sl_subst_pt0220]
+      expect(laa_df.application_proceeding_types.first.assigned_scope_limitations).to match_array [sl_subst_pt0206, sl_df_pt0206]
+    end
+  end
+end

--- a/spec/requests/admin/settings_spec.rb
+++ b/spec/requests/admin/settings_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Admin::SettingsController, type: :request do
   let(:admin_user) { create :admin_user }
 
   before do
+    Setting.delete_all
     sign_in admin_user
   end
 


### PR DESCRIPTION
## Application/Scope Limitation migration scripts

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2046)

This PR contains a migration script to convert the old application_scope_limitation records into application_proceeding_types_scope_limitation records.  This is non-destructive (i.e. it doesn't delete the original records) and does not install any code which relies on the new records.  It will allow us to ensure that the migration has gone smoothly on the live database before deploying any code which relies on it.  It is also idempotent, so can be run multiple times with no adverse effects.

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
