### PR TITLE
BugFix application reminder no delegated functions & transition error

### DIFF
--- a/app/mailers/submit_application_reminder_mailer.rb
+++ b/app/mailers/submit_application_reminder_mailer.rb
@@ -16,7 +16,7 @@ class SubmitApplicationReminderMailer < BaseApplyMailer
       provider_name: name,
       ref_number: application['application_ref'],
       client_name: application.applicant.full_name,
-      delegated_functions_date: application['used_delegated_functions_on'].strftime('%-d %B %Y'),
+      delegated_functions_date: application['used_delegated_functions_on']&.strftime('%-d %B %Y'),
       deadline_date: application['substantive_application_deadline_on'].strftime('%-d %B %Y')
     )
     mail to: to

--- a/app/models/concerns/base_state_machine.rb
+++ b/app/models/concerns/base_state_machine.rb
@@ -65,6 +65,7 @@ class BaseStateMachine < ApplicationRecord  # rubocop:disable Metrics/ClassLengt
         provider_entering_means
         applicant_details_checked
         delegated_functions_used
+        checking_applicant_details
         provider_confirming_applicant_eligibility
       ],
                   to: :delegated_functions_used

--- a/spec/requests/admin/settings_spec.rb
+++ b/spec/requests/admin/settings_spec.rb
@@ -45,6 +45,8 @@ RSpec.describe Admin::SettingsController, type: :request do
 
     subject { patch admin_settings_path, params: params }
 
+    after { Setting.delete_all }
+
     it 'change settings values' do
       subject
       expect(setting.mock_true_layer_data?).to eq(true)


### PR DESCRIPTION
## Bug fix application reminder no delegated functions and transition error


- Fix AASM::InvalidTransition error for https://sentry.io/organizations/ministryofjustice/issues/2274131373/?project=5416054&referrer=slack . This allows used delegated functions to be changed and the provider to continue with the application.

- Also, fix submit application reminder mailer issue when there is no used delegated functions. https://sentry.io/organizations/ministryofjustice/issues/2267314506/?project=5416053&referrer=slack

- Fix failing Admin Settings test

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
