### PR TITLE
Ap 2046y include type in unique index

### DIFF
--- a/db/migrate/20210226133024_add_type_to_application_proceeding_types_scope_limitations.rb
+++ b/db/migrate/20210226133024_add_type_to_application_proceeding_types_scope_limitations.rb
@@ -1,0 +1,5 @@
+class AddTypeToApplicationProceedingTypesScopeLimitations < ActiveRecord::Migration[6.1]
+  def change
+    add_column :application_proceeding_types_scope_limitations, :type, :string
+  end
+end

--- a/db/migrate/20210309195130_add_unique_idex_to_application_proceeding_types_scope_limitations.rb
+++ b/db/migrate/20210309195130_add_unique_idex_to_application_proceeding_types_scope_limitations.rb
@@ -1,0 +1,16 @@
+class AddUniqueIdexToApplicationProceedingTypesScopeLimitations < ActiveRecord::Migration[6.1]
+  def up
+    remove_index :application_proceeding_types_scope_limitations, name: :index_application_proceeding_scope_limitation
+    add_index :application_proceeding_types_scope_limitations,
+              %i[application_proceeding_type_id scope_limitation_id],
+              name: :index_application_proceeding_scope_limitation,
+              unique: true
+  end
+
+  def down
+    remove_index :application_proceeding_types_scope_limitations, name: :index_application_proceeding_scope_limitation
+    add_index :application_proceeding_types_scope_limitations,
+              %i[application_proceeding_type_id scope_limitation_id],
+              name: :index_application_proceeding_scope_limitation
+  end
+end

--- a/db/migrate/20210315164353_add_type_to_unique_index.rb
+++ b/db/migrate/20210315164353_add_type_to_unique_index.rb
@@ -1,0 +1,17 @@
+class AddTypeToUniqueIndex < ActiveRecord::Migration[6.1]
+  def up
+    remove_index :application_proceeding_types_scope_limitations, name: :index_application_proceeding_scope_limitation
+    add_index :application_proceeding_types_scope_limitations,
+              %i[type application_proceeding_type_id scope_limitation_id],
+              name: :index_application_proceeding_scope_limitation,
+              unique: true
+  end
+
+  def down
+    remove_index :application_proceeding_types_scope_limitations, name: :index_application_proceeding_scope_limitation
+    add_index :application_proceeding_types_scope_limitations,
+              %i[application_proceeding_type_id scope_limitation_id],
+              name: :index_application_proceeding_scope_limitation,
+              unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_09_195130) do
+ActiveRecord::Schema.define(version: 2021_03_15_164353) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -122,8 +122,9 @@ ActiveRecord::Schema.define(version: 2021_03_09_195130) do
     t.uuid "scope_limitation_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["application_proceeding_type_id", "scope_limitation_id"], name: "index_application_proceeding_scope_limitation", unique: true
+    t.string "type"
     t.index ["scope_limitation_id", "application_proceeding_type_id"], name: "index_scope_limitation_application_proceeding"
+    t.index ["type", "application_proceeding_type_id", "scope_limitation_id"], name: "index_application_proceeding_scope_limitation", unique: true
   end
 
   create_table "application_scope_limitations", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_05_145638) do
+ActiveRecord::Schema.define(version: 2021_03_09_195130) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -122,7 +122,7 @@ ActiveRecord::Schema.define(version: 2021_03_05_145638) do
     t.uuid "scope_limitation_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["application_proceeding_type_id", "scope_limitation_id"], name: "index_application_proceeding_scope_limitation"
+    t.index ["application_proceeding_type_id", "scope_limitation_id"], name: "index_application_proceeding_scope_limitation", unique: true
     t.index ["scope_limitation_id", "application_proceeding_type_id"], name: "index_scope_limitation_application_proceeding"
   end
 


### PR DESCRIPTION
## Include type in the unique index on application_proceeding_types_scope_limitations table

Running the AP-2046Z migration failed on UAT master because of a unique index violation.  This is because the substantive and delegated functions scope limitations for some proceeding types are the same, meaning that when you add delegated functions it tries to add an `AssignedDfScopeLimtiation` record with the same `application_proceeding_type_id` and `scope_limtiation_id` as an existing `AssignedSubstantiveScopeLimitation` record.  Making the index unique on `type`, `application_proceeding_type_id` and `scope_limitation_id` gives us what we need.

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
