### PR TITLE
AP-2138 Add AttemptsToSettle model

### DIFF
--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -23,6 +23,7 @@ class LegalAidApplication < ApplicationRecord
   has_one :statement_of_case, dependent: :destroy
   has_one :respondent, dependent: :destroy
   has_one :latest_incident, -> { order(occurred_on: :desc) }, class_name: :Incident, inverse_of: :legal_aid_application, dependent: :destroy
+  has_one :attempts_to_settles, class_name: 'ProceedingMeritsTask::AttemptsToSettle', dependent: :destroy
   has_many :legal_aid_application_transaction_types, dependent: :destroy
   has_many :transaction_types, through: :legal_aid_application_transaction_types
   has_many :cash_transactions, dependent: :destroy

--- a/app/models/proceeding_merits_task/attempts_to_settle.rb
+++ b/app/models/proceeding_merits_task/attempts_to_settle.rb
@@ -1,0 +1,5 @@
+module ProceedingMeritsTask
+  class AttemptsToSettle < ApplicationRecord
+    belongs_to :legal_aid_application
+  end
+end

--- a/db/anonymise/rules.rb
+++ b/db/anonymise/rules.rb
@@ -30,6 +30,9 @@ NINO_REGEXP = /^[A-CEGHJ-PR-TW-Z]{1}[A-CEGHJ-NPR-TW-Z]{1}[0-9]{6}[A-DFM]{1}$/.fr
   application_proceeding_types_scope_limitations: {},
   application_scope_limitations: {},
   attachments: {},
+  attempts_to_settles: {
+    attempts_made: -> { Faker::Lorem.sentence }
+  },
   bank_account_holders: {
     true_layer_response: nil,
     full_name: -> { Faker::Name.name },

--- a/db/migrate/20210319110509_create_attempts_to_settle.rb
+++ b/db/migrate/20210319110509_create_attempts_to_settle.rb
@@ -1,0 +1,9 @@
+class CreateAttemptsToSettle < ActiveRecord::Migration[6.1]
+  def change
+    create_table :attempts_to_settles, id: :uuid do |t|
+      t.belongs_to :legal_aid_application, foreign_key: true, null: false, type: :uuid
+      t.text :attempts_made
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_15_164353) do
+ActiveRecord::Schema.define(version: 2021_03_19_110509) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -143,6 +143,14 @@ ActiveRecord::Schema.define(version: 2021_03_15_164353) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "attachment_name"
+  end
+
+  create_table "attempts_to_settles", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "legal_aid_application_id", null: false
+    t.text "attempts_made"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["legal_aid_application_id"], name: "index_attempts_to_settles_on_legal_aid_application_id"
   end
 
   create_table "bank_account_holders", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -723,6 +731,7 @@ ActiveRecord::Schema.define(version: 2021_03_15_164353) do
   add_foreign_key "addresses", "applicants"
   add_foreign_key "application_proceeding_types", "legal_aid_applications"
   add_foreign_key "application_proceeding_types", "proceeding_types"
+  add_foreign_key "attempts_to_settles", "legal_aid_applications"
   add_foreign_key "bank_account_holders", "bank_providers"
   add_foreign_key "bank_accounts", "bank_providers"
   add_foreign_key "bank_errors", "applicants"


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2138)

Adds the `ProceedingMeritsTask::AttemptsToSettle` model and database table. The table contains only a text field and a foreign key to the `legal_aid_applications` table.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
