### PR TITLE
Fix statement of case uploading by moving delete buttons outside of f…

### DIFF
--- a/app/views/providers/statement_of_cases/show.html.erb
+++ b/app/views/providers/statement_of_cases/show.html.erb
@@ -23,57 +23,57 @@
 
     <%= form.govuk_fieldset legend: {text: page_title, tag: 'h1', size: 'xl'} do %>
 
-    <p class="govuk-body"><%= t('generic.tell_us') %></p>
-    <ul class="govuk-list govuk-list--bullet govuk-!-padding-bottom-2">
-      <% (1..5).each do |bullet_number| %>
-        <li><%= t(".bullet-#{bullet_number}") %></li>
+      <p class="govuk-body"><%= t('generic.tell_us') %></p>
+      <ul class="govuk-list govuk-list--bullet govuk-!-padding-bottom-2">
+        <% (1..5).each do |bullet_number| %>
+          <li><%= t(".bullet-#{bullet_number}") %></li>
+        <% end %>
+      </ul>
+
+      <div class="govuk-warning-text">
+        <span class="govuk-warning-text__icon govuk_two_line_warning" aria-hidden="true">!</span>
+        <strong class="govuk-warning-text__text">
+          <span class="govuk-warning-text__assistive"><%= t('.warning_text') %></span>
+          <%= t('.warning_text') %>
+        </strong>
+      </div>
+
+      <%= form.govuk_file_field :original_file, label: {text: t('generic.upload_file'), size: 'm'},
+                                hint: {text: t('.size_hint')} %>
+      <%= form.submit(
+              t('generic.upload'),
+              id: 'upload',
+              name: 'upload_button',
+              class: 'govuk-button form-button'
+          ) %>
+
+      <% #  Customised accessibility alerts within this span below %>
+      <% if @successfully_deleted %>
+        <span role="alert" class="govuk-visually-hidden"><%= @successfully_deleted %></span>
       <% end %>
-    </ul>
-
-    <div class="govuk-warning-text">
-      <span class="govuk-warning-text__icon govuk_two_line_warning" aria-hidden="true">!</span>
-      <strong class="govuk-warning-text__text">
-        <span class="govuk-warning-text__assistive"><%= t('.warning_text') %></span>
-        <%= t('.warning_text') %>
-      </strong>
-    </div>
-
-    <%= form.govuk_file_field :original_file, label: {text: t('generic.upload_file'), size: 'm'},
-                              hint: {text: t('.size_hint')} %>
-    <%= form.submit(
-            t('generic.upload'),
-            id: 'upload',
-            name: 'upload_button',
-            class: 'govuk-button form-button'
-        ) %>
-
-    <% #  Customised accessibility alerts within this span below %>
-    <% if @successfully_deleted %>
-      <span role="alert" class="govuk-visually-hidden"><%= @successfully_deleted %></span>
+      <% if @error_message || @successful_upload %>
+        <span role="alert" class="govuk-visually-hidden"><%= @successful_upload %><%= @error_message %></span>
+      <% end %>
     <% end %>
-    <% if @error_message || @successful_upload %>
-      <span role="alert" class="govuk-visually-hidden"><%= @successful_upload %><%= @error_message %></span>
-    <% end %>
+  <% end %>
 
-    <div id="uploaded-files-table-container">
-      <%= render partial: 'uploaded_files', locals: { attachments: @form.model.original_attachments } %>
-    </div>
-    <% end %>
+  <div id="uploaded-files-table-container">
+    <%= render partial: 'uploaded_files', locals: { attachments: @form.model.original_attachments } %>
+  </div>
 
-    <%= form_with(
-          builder: GOVUKDesignSystemFormBuilder::FormBuilder,
-          model: @form,
-          url: providers_legal_aid_application_statement_of_case_path,
-          method: :patch,
-          local: true
-      ) do |form| %>
+  <%= form_with(
+        builder: GOVUKDesignSystemFormBuilder::FormBuilder,
+        model: @form,
+        url: providers_legal_aid_application_statement_of_case_path,
+        method: :patch,
+        local: true
+    ) do |form| %>
 
-      <%= form.govuk_radio_divider %>
+    <%= form.govuk_radio_divider %>
 
-      <%= form.govuk_text_area :statement, label: {text: t('generic.enter_text')}, rows: 15 %>
+    <%= form.govuk_text_area :statement, label: {text: t('generic.enter_text')}, rows: 15 %>
 
-      <%= next_action_buttons(show_draft: true, form: form) %>
-    <% end %>
+    <%= next_action_buttons(show_draft: true, form: form) %>
   <% end %>
 <% end %>
 


### PR DESCRIPTION
…orm builder group


## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2144)

Statement of cases attachments are all deleted when a 2nd upload is made. This is because the delete buttons were contained within the formbuilder and overrided the patch action with a delete one instead. By moving the delete attachments outside of the formbuilder group this fixes the issue.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
