### PR TITLE
AP-2150 Bugfix remove bank transaction on income summary page

### DIFF
--- a/app/controllers/providers/bank_transactions_controller.rb
+++ b/app/controllers/providers/bank_transactions_controller.rb
@@ -1,7 +1,7 @@
 module Providers
   class BankTransactionsController < ProviderBaseController
     def remove_transaction_type
-      bank_transaction.update!(transaction_type: nil)
+      bank_transaction.update!(transaction_type: nil, meta_data: nil)
       head :ok
     end
 

--- a/spec/requests/providers/bank_transactions_spec.rb
+++ b/spec/requests/providers/bank_transactions_spec.rb
@@ -37,6 +37,11 @@ RSpec.describe Providers::BankTransactionsController, type: :request do
     end
 
     it 'removes the meta data on the transaction' do
+      bank_transaction.update(meta_data: { code: 'XXXX',
+                                           label: 'manually_chosen',
+                                           name: 'Maintenance In',
+                                           category: 'Maintenance In',
+                                           selected_by: 'Provider' })
       expect { subject }.to change { bank_transaction.reload.meta_data }.to(nil)
     end
 

--- a/spec/requests/providers/bank_transactions_spec.rb
+++ b/spec/requests/providers/bank_transactions_spec.rb
@@ -36,6 +36,10 @@ RSpec.describe Providers::BankTransactionsController, type: :request do
       expect { subject }.to change { bank_transaction.reload.transaction_type }.to(nil)
     end
 
+    it 'removes the meta data on the transaction' do
+      expect { subject }.to change { bank_transaction.reload.meta_data }.to(nil)
+    end
+
     context 'bank_transaction does not belong to this application' do
       let(:bank_account) { create :bank_account }
 


### PR DESCRIPTION
## Bugfix

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2150)

Previously, when a bank transaction was removed from an income or outgoings category on the income summary page, it merely set the `transaction_type_id` field to nil, thereby removing the link with that transaction type.  however, it left the `meta_data` field intact which meant that the transaction could not be shown when assigned to another category.  This PR fixes that.

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
