### PR TITLE
Tech-debt: Update fake saml logon

### DIFF
--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -18,10 +18,10 @@ class SamlIdpController < SamlIdp::IdpController
   def idp_authenticate(email, password)
     return unless config.password == password
 
-    user = config.users.find { |u| u[:email] == email }
+    user = Provider.find_by(email: email)
     return unless user
 
-    Provider.find_by(username: user.username)
+    user
   end
 
   def idp_make_saml_response(provider, email)


### PR DESCRIPTION
## What
Previously it looked at the values in mock_saml.rb
Which was fine as that was how we seeded the database

Now we can restore an anonymised DB from a remote service
the canonical email addresses will be in the DB.

This change leaves the values in mock_saml for seeding UAT
and local databases but now looks for email addresses in
the Providers table while still using the default mock_saml
password

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
