### PR TITLE
AP 2104 dwp error styling

### DIFF
--- a/app/views/providers/confirm_dwp_non_passported_applications/show.html.erb
+++ b/app/views/providers/confirm_dwp_non_passported_applications/show.html.erb
@@ -11,13 +11,12 @@
           local: true
         ) do |form| %>
 
-      <div class=<%="#{error_class}"%>>
+      <div class="<%= "#{error_class}" %>">
         <%= form.govuk_radio_buttons_fieldset(:dwp_results_correct, legend: {text: t('.title'), tag: 'h1', size: 'l'} ) do %>
           <%= form.govuk_radio_button(:dwp_results_correct, true, label: {text: t('generic.yes')} ) %>
           <%= form.govuk_radio_button(:dwp_results_correct, false, label: {text:  t('.no')} ) %>
         <% end %>
       </div>
-
 
       <% if @error %>
         <%= link_to_accessible @error.values.first, "#dwp-results-correct-true-field", class: 'govuk-heading-s' %>

--- a/app/views/providers/confirm_dwp_non_passported_applications/show.html.erb
+++ b/app/views/providers/confirm_dwp_non_passported_applications/show.html.erb
@@ -1,6 +1,8 @@
-<%= render partial: 'shared/error' if @error %>
+<% error_class = @error ? 'alternative-error-style' : '' %>
+
 <div class="interruption-panel">
   <%= page_template(page_title: t('.tab_title'), column_width: :full, template: :basic) do %>
+
     <%= form_with(
           builder: GOVUKDesignSystemFormBuilder::FormBuilder,
           model: @form,
@@ -9,9 +11,16 @@
           local: true
         ) do |form| %>
 
-      <%= form.govuk_radio_buttons_fieldset(:dwp_results_correct, legend: {text: t('.title'), tag: 'h1', size: 'l'}) do %>
-        <%= form.govuk_radio_button(:dwp_results_correct, true, label: {text: t('generic.yes')} ) %>
-        <%= form.govuk_radio_button(:dwp_results_correct, false, label: {text:  t('.no')} ) %>
+      <div class=<%="#{error_class}"%>>
+        <%= form.govuk_radio_buttons_fieldset(:dwp_results_correct, legend: {text: t('.title'), tag: 'h1', size: 'l'} ) do %>
+          <%= form.govuk_radio_button(:dwp_results_correct, true, label: {text: t('generic.yes')} ) %>
+          <%= form.govuk_radio_button(:dwp_results_correct, false, label: {text:  t('.no')} ) %>
+        <% end %>
+      </div>
+
+
+      <% if @error %>
+        <%= link_to_accessible @error.values.first, "#dwp-results-correct-true-field", class: 'govuk-heading-s' %>
       <% end %>
 
       <div class="govuk-!-padding-bottom-4"></div>

--- a/app/webpack/stylesheets/alternative-error-style.scss
+++ b/app/webpack/stylesheets/alternative-error-style.scss
@@ -1,0 +1,4 @@
+.alternative-error-style {
+  border-left: 5px solid white;
+  padding-left: 15px;
+}

--- a/app/webpack/stylesheets/application.scss
+++ b/app/webpack/stylesheets/application.scss
@@ -8,6 +8,7 @@
 
 @import 'admin';
 @import 'bank-selection';
+@import 'alternative-error-style';
 @import 'check-your-answers';
 @import 'govuk-currency-input';
 @import 'govuk-mods';


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2104)

Remove existing error styling (summary at top of page)
Add error message in white below the field and make it link to the first radio button.
Add styling to add error bar to left hand side and make it white

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
