### PR TITLE
AP-2111 Use transaction_period as basis for cash payment months

### DIFF
--- a/app/models/base_aggregated_cash_transaction.rb
+++ b/app/models/base_aggregated_cash_transaction.rb
@@ -181,7 +181,7 @@ class BaseAggregatedCashTransaction # rubocop:disable Metrics/ClassLength
   end
 
   def calculated_date(month_number)
-    Time.zone.today.at_beginning_of_month - month_number.months
+    __send__("month#{month_number}".to_sym)
   end
 
   def checkbox_for(category)

--- a/app/models/base_aggregated_cash_transaction.rb
+++ b/app/models/base_aggregated_cash_transaction.rb
@@ -16,9 +16,10 @@ class BaseAggregatedCashTransaction # rubocop:disable Metrics/ClassLength
 
   attr_accessor :month1, :month2, :month3
 
-  def initialize
+  def initialize(legal_aid_application_id:)
     super
-    @month1 = Time.zone.today.beginning_of_month - 1.month
+    legal_aid_application = LegalAidApplication.find(legal_aid_application_id)
+    @month1 = legal_aid_application.calculation_date.beginning_of_month - 1.month
     @month2 = month1 - 1.month
     @month3 = month2 - 1.month
   end
@@ -52,7 +53,7 @@ class BaseAggregatedCashTransaction # rubocop:disable Metrics/ClassLength
 
     def find_by(legal_aid_application_id:)
       transactions = find_transactions(legal_aid_application_id)
-      model = new
+      model = new(legal_aid_application_id: legal_aid_application_id)
       model.none_selected = true
       transactions.each { |trx| populate_attribute(model, trx) }
       model

--- a/app/webpack/src/modules/proceedings.js
+++ b/app/webpack/src/modules/proceedings.js
@@ -9,6 +9,7 @@ let typingTimer,
   previousSearchTerm = null,
   containSimilarWords = false;
 
+
 async function searchResults (searchTerm) {
   const currentUrl = window.location.href;
   const url = `/v1/proceeding_types?search_term=${searchTerm}&sourceUrl=${currentUrl}`;

--- a/spec/models/aggregated_cash_income_spec.rb
+++ b/spec/models/aggregated_cash_income_spec.rb
@@ -422,7 +422,7 @@ RSpec.describe AggregatedCashIncome, type: :model do
           expect { subject }.to change { CashTransaction.count }.by(0)
         end
 
-        it 'updates the three previous months according to current date' do
+        it 'updates the three previous months according to application calculation date date' do
           subject
 
           categories.each do |category|
@@ -430,7 +430,7 @@ RSpec.describe AggregatedCashIncome, type: :model do
 
             transactions.each_with_index do |transaction, i|
               date = transaction.transaction_date
-              historical_date = Time.zone.today.at_beginning_of_month - (i + 1).months
+              historical_date = application.calculation_date.at_beginning_of_month - (i + 1).months
               expect(date).to eq historical_date
             end
           end

--- a/spec/models/aggregated_cash_outgoings_spec.rb
+++ b/spec/models/aggregated_cash_outgoings_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe AggregatedCashOutgoings, type: :model do
-  let(:aco) { described_class.new }
+  let(:aco) { described_class.new(legal_aid_application_id: application.id) }
   let(:application) { create :legal_aid_application }
   let(:categories) { %i[rent_or_mortgage maintenance_out] }
   let!(:rent_or_mortgage) { create :transaction_type, :rent_or_mortgage }
@@ -16,6 +16,8 @@ RSpec.describe AggregatedCashOutgoings, type: :model do
   let(:month1_name) { month1_tx_date.strftime('%B') }
   let(:month2_name) { month2_tx_date.strftime('%B') }
   let(:month3_name) { month3_tx_date.strftime('%B') }
+
+  before { application.set_transaction_period }
 
   describe '#find_by' do
     context 'no cash income transaction records' do

--- a/spec/models/aggregated_cash_outgoings_spec.rb
+++ b/spec/models/aggregated_cash_outgoings_spec.rb
@@ -375,7 +375,7 @@ RSpec.describe AggregatedCashOutgoings, type: :model do
           expect { subject }.to change { CashTransaction.count }.by(0)
         end
 
-        it 'updates the three previous months according to current date' do
+        it 'updates the three previous months according to applicaiton calculation date' do
           subject
 
           categories.each do |category|
@@ -383,7 +383,7 @@ RSpec.describe AggregatedCashOutgoings, type: :model do
 
             transactions.each_with_index do |transaction, i|
               date = transaction.transaction_date
-              historical_date = Time.zone.today.at_beginning_of_month - (i + 1).months
+              historical_date = application.calculation_date.at_beginning_of_month - (i + 1).months
               expect(date).to eq historical_date
             end
           end

--- a/spec/requests/citizens/cash_incomes_spec.rb
+++ b/spec/requests/citizens/cash_incomes_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe Citizens::CashIncomesController, type: :request do
   let!(:maintenance_in) { create :transaction_type, :maintenance_in }
   let(:next_flow_step) { flow_forward_path }
 
+  before { legal_aid_application.set_transaction_period }
+
   describe 'GET /citizens/cash_income' do
     before do
       get citizens_legal_aid_application_path(legal_aid_application.generate_secure_id)

--- a/spec/requests/citizens/cash_outgoings_spec.rb
+++ b/spec/requests/citizens/cash_outgoings_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe Citizens::CashOutgoingsController, type: :request do
   let!(:maintenance_out) { create :transaction_type, :maintenance_out }
   let(:next_flow_step) { flow_forward_path }
 
+  before { legal_aid_application.set_transaction_period }
+
   describe 'GET /citizens/cash_outgoings' do
     before do
       get citizens_legal_aid_application_path(legal_aid_application.generate_secure_id)


### PR DESCRIPTION
## Use transaction_period as basis for cash payment months

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2111)

CFE expects the cash payment dates to be the three months prior to the calculation date, which is either today or the delegated functions date if that has been used.

This PR changes the AggregatedCashIncome model to use the calculation date, rather than today's date.

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
