### PR TITLE
Identify renamed tables in migration_hook

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -361,7 +361,7 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2020.1104)
-    mimemagic (0.3.5)
+    mimemagic (0.3.6)
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
     minitest (5.14.4)

--- a/scripts/migration_hook.rb
+++ b/scripts/migration_hook.rb
@@ -7,20 +7,29 @@ def tables_in_schema
 end
 
 def tables_in_rules
-  @rules.keys
+  @rules.keys.map(&:to_s)
 end
 
 puts "tables in schema: #{tables_in_schema.count}"
 puts "tables with rules: #{tables_in_rules.count}"
 
+def rules_without_tables
+  tables_in_rules - tables_in_schema
+end
+
+def tables_without_rules
+  tables_in_schema - tables_in_rules
+end
+
 exit_status = 0
-if tables_in_rules.count > tables_in_schema.count
-  diff = tables_in_rules.reject { |x| tables_in_schema.include?(x.to_s) }
-  puts "Rules exist for non-existent tables: #{diff.join(', ')}"
+
+if rules_without_tables.any?
+  puts "Rules exist for non-existent tables: #{rules_without_tables.join(', ')}"
   exit_status = 1
-elsif tables_in_schema.count > tables_in_rules.count
-  diff = tables_in_schema.reject { |x| tables_in_rules.include?(x.to_sym) }
-  puts "Tables missing from rules: #{diff.join(', ')}"
+end
+
+if tables_without_rules.any?
+  puts "Tables missing from rules: #{tables_without_rules.join(', ')}"
   exit_status = 1
 end
 


### PR DESCRIPTION
## What

The `migration_hook` script used by the 'Check anonymise rules' GitHub action does not identify cases where a table has been renamed. It only alerts if there is a difference in the number of tables between the rules file and the schema.

This change amends the script to identify any difference in table names by finding the difference between the two arrays and failing with an appropriate message.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
