### PR TITLE
Fix: Flickering search feature

### DIFF
--- a/features/step_definitions/civil_journey_steps.rb
+++ b/features/step_definitions/civil_journey_steps.rb
@@ -379,7 +379,7 @@ Given('I complete the journey as far as check your answers') do
     lookup_used: true,
     applicant: applicant
   )
-  proceeding_type = ProceedingType.all.sample
+  proceeding_type = ProceedingType.all.first
   @legal_aid_application = create(
     :legal_aid_application,
     :at_entering_applicant_details,


### PR DESCRIPTION
## What 

The setup for the test chose a random proceeding_type
Now we remove the current proceeding type from the
search results this would occasionally fail

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
