### PR TITLE
Ap 1960 specify a lead proceeding

### DIFF
--- a/app/models/application_proceeding_type.rb
+++ b/app/models/application_proceeding_type.rb
@@ -23,6 +23,7 @@ class ApplicationProceedingType < ApplicationRecord
 
   before_create do
     self.proceeding_case_id = highest_proceeding_case_id + 1 if proceeding_case_id.blank?
+    self.lead_proceeding = true if proceedings.empty?
   end
 
   def add_default_substantive_scope_limitation
@@ -46,5 +47,9 @@ class ApplicationProceedingType < ApplicationRecord
   def highest_proceeding_case_id
     rec = self.class.order(proceeding_case_id: :desc).first
     rec.nil? || rec.proceeding_case_id.nil? ? FIRST_PROCEEDING_CASE_ID : rec.proceeding_case_id
+  end
+
+  def proceedings
+    ApplicationProceedingType.where(legal_aid_application_id: legal_aid_application.id)
   end
 end

--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -134,7 +134,8 @@ class LegalAidApplication < ApplicationRecord
   # at which time this method should be changed to determine which is the lead one and return that.
   #
   def lead_proceeding_type
-    proceeding_types.first
+    lead = application_proceeding_types.find_by(lead_proceeding: true)
+    ProceedingType.find(lead.proceeding_type_id)
   end
 
   def cfe_result

--- a/app/services/ccms/requestors/case_add_requestor.rb
+++ b/app/services/ccms/requestors/case_add_requestor.rb
@@ -187,7 +187,7 @@ module CCMS
         xml.__send__('ns2:Proceeding') do
           xml.__send__('ns2:ProceedingCaseID', application_proceeding_type.proceeding_case_p_num)
           xml.__send__('ns2:Status', 'Draft')
-          xml.__send__('ns2:LeadProceedingIndicator', true)
+          xml.__send__('ns2:LeadProceedingIndicator', application_proceeding_type.lead_proceeding)
           xml.__send__('ns2:ProceedingDetails') { generate_proceeding_type(xml, application_proceeding_type) }
         end
       end

--- a/db/migrate/20210324140533_add_lead_type_to_application_proc_types.rb
+++ b/db/migrate/20210324140533_add_lead_type_to_application_proc_types.rb
@@ -1,0 +1,5 @@
+class AddLeadTypeToApplicationProcTypes < ActiveRecord::Migration[6.1]
+  def change
+    add_column :application_proceeding_types, :lead_proceeding, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_23_153440) do
+ActiveRecord::Schema.define(version: 2021_03_24_140533) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -112,6 +112,7 @@ ActiveRecord::Schema.define(version: 2021_03_23_153440) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "proceeding_case_id"
+    t.boolean "lead_proceeding", default: false, null: false
     t.index ["legal_aid_application_id"], name: "index_application_proceeding_types_on_legal_aid_application_id"
     t.index ["proceeding_case_id"], name: "index_application_proceeding_types_on_proceeding_case_id", unique: true
     t.index ["proceeding_type_id"], name: "index_application_proceeding_types_on_proceeding_type_id"

--- a/features/step_definitions/civil_journey_steps.rb
+++ b/features/step_definitions/civil_journey_steps.rb
@@ -82,6 +82,7 @@ Given('I previously created a passported application with no assets and left on 
     :application,
     :with_applicant,
     :without_own_home,
+    :with_proceeding_types,
     :with_no_other_assets,
     :with_policy_disregards,
     :with_passported_state_machine,

--- a/lib/tasks/set_lead_proceeding.rake
+++ b/lib/tasks/set_lead_proceeding.rake
@@ -1,0 +1,9 @@
+namespace :update_lead_proceeding do
+  desc 'Sets the lead_proceeding value to TRUE for all existing cases'
+
+  task set_value_to_true: :environment do
+    ApplicationProceedingType.all.each do |t|
+      t.update(lead_proceeding: true)
+    end
+  end
+end

--- a/spec/models/application_proceeding_type_spec.rb
+++ b/spec/models/application_proceeding_type_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe ApplicationProceedingType do
   describe '#proceeding_case_id' do
     let(:legal_aid_application) { create :legal_aid_application }
     let(:proceeding_type) { create :proceeding_type }
+    let(:proceeding_type2) { create :proceeding_type }
 
     context 'empty_database' do
       it 'creates record with first proceeding case id' do
@@ -12,6 +13,7 @@ RSpec.describe ApplicationProceedingType do
         legal_aid_application.save!
         application_proceeding_type = legal_aid_application.application_proceeding_types.first
         expect(application_proceeding_type.proceeding_case_id > 55_000_000).to be true
+        expect(application_proceeding_type.lead_proceeding).to be true
       end
     end
 
@@ -24,6 +26,16 @@ RSpec.describe ApplicationProceedingType do
         legal_aid_application.save!
         application_proceeding_type = legal_aid_application.application_proceeding_types.first
         expect(application_proceeding_type.proceeding_case_id).to eq highest_proceeding_case_id + 1
+      end
+
+      it 'creates record with multiple proceedings and assigns the first one as lead_proceeding' do
+        legal_aid_application.proceeding_types << proceeding_type
+        legal_aid_application.proceeding_types << proceeding_type2
+        legal_aid_application.save!
+        first_proceeding_type = legal_aid_application.application_proceeding_types.order(proceeding_case_id: :asc).first
+        expect(first_proceeding_type.lead_proceeding).to be true
+        second_proceeding_type = legal_aid_application.application_proceeding_types.order(proceeding_case_id: :asc).last
+        expect(second_proceeding_type.lead_proceeding).to be false
       end
     end
   end

--- a/spec/requests/providers/check_passported_answers_spec.rb
+++ b/spec/requests/providers/check_passported_answers_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe 'check passported answers requests', type: :request do
     let!(:application) do
       create :legal_aid_application,
              :with_everything,
+             :with_proceeding_types,
              :with_passported_state_machine,
              :provider_entering_means,
              vehicle: vehicle,
@@ -66,28 +67,35 @@ RSpec.describe 'check passported answers requests', type: :request do
       end
 
       context 'applicant does not have any savings' do
-        let(:application) { create :legal_aid_application, :with_everything, :with_no_savings, :with_passported_state_machine, :provider_entering_means }
+        let(:application) { create :legal_aid_application, :with_everything, :with_proceeding_types, :with_no_savings, :with_passported_state_machine, :provider_entering_means }
         it 'displays that no savings have been declared' do
           expect(response.body).to include(I18n.t('.generic.none_declared'))
         end
       end
 
       context 'applicant does not have any other assets' do
-        let(:application) { create :legal_aid_application, :with_everything, :with_no_other_assets, :with_passported_state_machine, :provider_entering_means }
+        let(:application) do
+          create :legal_aid_application, :with_everything, :with_proceeding_types, :with_no_other_assets, :with_passported_state_machine, :provider_entering_means
+        end
         it 'displays that no other assets have been declared' do
           expect(response.body).to include(I18n.t('.generic.none_declared'))
         end
       end
 
       context 'applicant does not have any capital restrictions' do
-        let(:application) { create :legal_aid_application, :with_everything, :with_passported_state_machine, :provider_entering_means, has_restrictions: false }
+        let(:application) do
+          create :legal_aid_application, :with_everything, :with_proceeding_types, :with_passported_state_machine, :provider_entering_means, has_restrictions: false
+        end
         it 'displays that no capital restrictions have been declared' do
           expect(response.body).to include(I18n.t('.generic.no'))
         end
       end
 
       context 'applicant does not have any capital' do
-        let(:application) { create :legal_aid_application, :with_applicant, :with_policy_disregards, :without_own_home, :with_passported_state_machine, :provider_entering_means }
+        let(:application) do
+          create :legal_aid_application, :with_applicant, :with_proceeding_types, :with_policy_disregards, :without_own_home, :with_passported_state_machine,
+                 :provider_entering_means
+        end
         it 'does not display capital restrictions' do
           expect(response.body).not_to include('restrictions')
         end
@@ -125,7 +133,7 @@ RSpec.describe 'check passported answers requests', type: :request do
       end
 
       context 'applicant does not own home' do
-        let(:application) { create :legal_aid_application, :with_everything, :without_own_home, :with_passported_state_machine, :provider_entering_means }
+        let(:application) { create :legal_aid_application, :with_everything, :with_proceeding_types, :without_own_home, :with_passported_state_machine, :provider_entering_means }
         it 'does not display property value' do
           expect(response.body).not_to include(gds_number_to_currency(application.property_value, unit: '£'))
           expect(response.body).not_to include('Property value')
@@ -138,7 +146,9 @@ RSpec.describe 'check passported answers requests', type: :request do
       end
 
       context 'applicant owns home without mortgage' do
-        let(:application) { create :legal_aid_application, :with_everything, :with_own_home_owned_outright, :with_passported_state_machine, :provider_entering_means }
+        let(:application) do
+          create :legal_aid_application, :with_everything, :with_proceeding_types, :with_own_home_owned_outright, :with_passported_state_machine, :provider_entering_means
+        end
         it 'does not display property value' do
           expect(response.body).not_to include(gds_number_to_currency(application.outstanding_mortgage_amount, unit: '£'))
           expect(response.body).not_to include('Outstanding mortgage')
@@ -149,6 +159,7 @@ RSpec.describe 'check passported answers requests', type: :request do
         let!(:application) do
           create :legal_aid_application,
                  :with_everything,
+                 :with_proceeding_types,
                  :with_passported_state_machine,
                  :provider_entering_means,
                  :with_populated_policy_disregards,
@@ -166,6 +177,7 @@ RSpec.describe 'check passported answers requests', type: :request do
           create :legal_aid_application,
                  :with_everything,
                  :with_no_other_assets,
+                 :with_proceeding_types,
                  :with_home_sole_owner,
                  :with_passported_state_machine,
                  :provider_entering_means
@@ -275,7 +287,7 @@ RSpec.describe 'check passported answers requests', type: :request do
     end
 
     context 'logged in as an authenticated provider' do
-      let(:application) { create :legal_aid_application, :with_everything, :with_passported_state_machine, :provider_entering_means }
+      let(:application) { create :legal_aid_application, :with_everything, :with_proceeding_types, :with_passported_state_machine, :provider_entering_means }
 
       before do
         login_as application.provider

--- a/spec/requests/providers/has_other_proceedings_controller_spec.rb
+++ b/spec/requests/providers/has_other_proceedings_controller_spec.rb
@@ -88,6 +88,16 @@ RSpec.describe Providers::HasOtherProceedingsController, type: :request do
         subject
         expect(response.body).to include('You have added 1 proceeding')
       end
+
+      context 'delete lead proceeding' do
+        let(:params) { { id: legal_aid_application.proceeding_types.first.code } }
+        subject { delete providers_legal_aid_application_has_other_proceedings_path(legal_aid_application), params: params }
+
+        it 'sets a new lead proceeding when the original one is deleted' do
+          subject
+          expect(legal_aid_application.application_proceeding_types[0].lead_proceeding).to eq true
+        end
+      end
     end
 
     context 'remove all proceedings' do


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-1960)

Add a method to check if a proceeding type is the first to be assigned to an application, if it is, a new attribute lead_proceeding, is set to TRUE. All subsequent proceedings on the same application have this value set as FALSE.

Why? Apply does not actually care about a lead proceeding, it is a CCMS requirement. As such the first proceeding added is as good as any. However when we make subsequent proceeding types dependant on the first one then the first proceeding entered becomes important to Apply so the assigning it as lead_proceeeding seems like the best choice.

The ticket specifies it should be a domestic abuse type, but as all our proceedings are Domestic Abuse there is no need to do extra work to determine this is the case. Also once we had non Domestic Abuse cases we would need to revisit this.

The rake task:
When the lead_proceeding attribute is created it is set as default false, this means that on all existing records the setting is FALSE. As these are all single proceeding type cases these should be set to TRUE. The rake task changes all existing proc_types to be lead proc types.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
