### PR TITLE
bugfix: true layer transactions failing

### DIFF
--- a/app/services/true_layer/importers/import_accounts_service.rb
+++ b/app/services/true_layer/importers/import_accounts_service.rb
@@ -25,7 +25,7 @@ module TrueLayer
           account.bank_transactions.clear
         end
         bank_provider.bank_accounts.clear
-        ActiveRecord::Base.logger.silence do
+        ActiveSupport::Logger.logger.silence do
           bank_provider.bank_accounts.create!(mapped_resources)
         end
       end

--- a/app/services/true_layer/importers/import_provider_service.rb
+++ b/app/services/true_layer/importers/import_provider_service.rb
@@ -26,7 +26,7 @@ module TrueLayer
         bank_provider = applicant.bank_providers.find_or_create_by!(
           true_layer_provider_id: provider[:provider][:provider_id]
         )
-        ActiveRecord::Base.logger.silence do
+        ActiveSupport::Logger.logger.silence do
           bank_provider.update!(mapped_resource)
         end
         bank_provider

--- a/app/services/true_layer/importers/import_transactions_service.rb
+++ b/app/services/true_layer/importers/import_transactions_service.rb
@@ -15,7 +15,7 @@ module TrueLayer
           errors.add(:import_transactions, true_layer_error)
         else
           bank_account.bank_transactions.clear
-          ActiveRecord::Base.logger.silence do
+          ActiveSupport::Logger.logger.silence do
             bank_account.bank_transactions.create!(mapped_resources)
           end
         end


### PR DESCRIPTION
## What

retrieving bank transactions from true layer is causing sidekiq to get stuck. This changes the logger to ActiveSupport instead of ActiverRecord


## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
