### PR TITLE
Tech debt:remove mimemagic

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -92,9 +92,6 @@ gem 'rails_admin', '~> 2.1'
 # Manage security headers
 gem 'secure_headers'
 
-# Identify file types before uploads
-gem 'mimemagic'
-
 # DFE formbuilder
 gem 'govuk_design_system_formbuilder'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -362,9 +362,6 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2020.1104)
-    mimemagic (0.3.9)
-      nokogiri (~> 1)
-      rake
     mini_mime (1.0.3)
     mini_portile2 (2.5.0)
     minitest (5.14.4)
@@ -716,7 +713,6 @@ DEPENDENCIES
   libreconv
   listen (>= 3.0.5, < 3.6)
   loofah (>= 2.2.3)
-  mimemagic
   nesty
   nokogiri
   omniauth (>= 2.0.0)

--- a/app/forms/statement_of_cases/statement_of_case_form.rb
+++ b/app/forms/statement_of_cases/statement_of_case_form.rb
@@ -94,7 +94,7 @@ module StatementOfCases
     end
 
     def disallowed_content_type(original_file)
-      return if MimeMagic.by_magic(original_file)&.type.in?(ALLOWED_CONTENT_TYPES)
+      return if Marcel::Magic.by_magic(original_file)&.type.in?(ALLOWED_CONTENT_TYPES)
       return if original_file.content_type == WORD_DOCUMENT
 
       errors.add(:original_file, original_file_error_for(:content_type_invalid, file_name: @original_file_name))


### PR DESCRIPTION
## What

After the issues with MimeMagic, the Rails core team moved to an updated version of Marcel that changed it's mime data source and removed any reference to mimemagic

We used a specific call to mime magic to determine the Statement of Case upload, so I have replaced that with a call to the equivalent Marcel call and then removed the mimemagic gem entirely

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
