### PR TITLE
BugFix Local Dev environment logger issue when using silence method

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -47,7 +47,7 @@ Rails.application.configure do
   config.active_record.verbose_query_logs = true
 
   config.log_level = :info
-  config.logger = Logger.new($stdout)
+  config.logger = ActiveSupport::Logger.new($stdout)
 
   # Raises error for missing translations
   config.i18n.raise_on_missing_translations = true


### PR DESCRIPTION
## BugFix logger issue when using silence method

The silence method is used on the activesupport logger not the default rails logger.

This caused an issue locally around truelayer bank import data worker

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
