### PR TITLE
BugFix Add the jquery back to the worker waiter

### DIFF
--- a/app/webpack/src/worker_waiter.js
+++ b/app/webpack/src/worker_waiter.js
@@ -1,49 +1,50 @@
-const axios = require('axios');
+const $ = require('jquery')
+const axios = require('axios')
 
 async function checkWorkerStatus() {
-  const worker_id = document.querySelector(".worker-waiter").getAttribute('data-worker-id');
-  const response = await axios.get(`/v1/workers/${worker_id}`);
-  return response.data;
+  const worker_id = $(".worker-waiter").data('worker-id')
+  const response = await axios.get(`/v1/workers/${worker_id}`)
+  return response.data
 }
 
 function waitForWorker() {
-  if (!document.querySelectorAll('.worker-waiter').length) {
-    return;
+  if (!$('.worker-waiter').length) {
+    return
   }
 
   checkWorkerStatus().then(data => {
-      // delay next action by 1 second e.g. calling api again
-      return new Promise(resolve => setTimeout(() => resolve(data), 1000));
-    }).then((data) => workerResponse(data, waitForWorker)).catch(() =>{
-      window.location.reload();
-    });
+    // delay next action by 1 second e.g. calling api again
+    return new Promise(resolve => setTimeout(() => resolve(data), 1000));
+  }).then((data) => workerResponse(data, waitForWorker)).catch(() => {
+    window.location.reload()
+  })
 }
 
 function workerResponse(data, waitForWorker) {
-  const working_statuses = ['queued', 'working'];
+  const working_statuses = ['queued', 'working']
   if (data && working_statuses.includes(data.status)) {
-    waitForWorker();
+    waitForWorker()
   } else {
-    window.location.reload();
+    window.location.reload()
   }
 }
 
 function accessibilityAlert() {
   setTimeout(() => {
-    let accessibilityMessage = document.querySelector('#accessibilityMessageUpdate');
-    if (accessibilityMessage !== undefined) {
-      accessibilityMessage.innerHTML = accessibilityMessage.dataset.message;
+    let accessibilityMessage = document.querySelector('#accessibilityMessageUpdate')
+    if (accessibilityMessage != undefined) {
+      accessibilityMessage.innerHTML = accessibilityMessage.dataset.message
     }
-  }, 5000);
+  }, 5000)
 }
 
 export {
   waitForWorker,
   checkWorkerStatus,
   workerResponse
-};
+}
 
 if (process.env.NODE_ENV !== 'test') {
-  waitForWorker();
-  accessibilityAlert();
+  $(waitForWorker)
+  $(accessibilityAlert)
 }


### PR DESCRIPTION
## BugFix revert jquery removal on worker waiter javascript

This is because there is a live bug as the worker waiter javascript does not make any network calls to the
worker waiter controller in the backend and thus causing this page to hang.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
