### PR TITLE
rake task has been run so remove it

### DIFF
--- a/lib/tasks/set_lead_proceeding.rake
+++ b/lib/tasks/set_lead_proceeding.rake
@@ -1,9 +1,0 @@
-namespace :update_lead_proceeding do
-  desc 'Sets the lead_proceeding value to TRUE for all existing cases'
-
-  task set_value_to_true: :environment do
-    ApplicationProceedingType.all.each do |t|
-      t.update(lead_proceeding: true)
-    end
-  end
-end


### PR DESCRIPTION
## What

This rake task was part of ap-1960 to set lead_proceeding for an application.
The rake task has been run to set all existing `application_proceeding_type.lead_proceeding` to TRUE
The rake task is no longer required.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
