### PR TITLE
AP-2172 Add used_delegated_functions columns and rake task

### DIFF
--- a/app/models/application_proceeding_type.rb
+++ b/app/models/application_proceeding_type.rb
@@ -54,6 +54,10 @@ class ApplicationProceedingType < ApplicationRecord
     "P_#{proceeding_case_id}"
   end
 
+  def used_delegated_functions?
+    used_delegated_functions_on.present?
+  end
+
   private
 
   def highest_proceeding_case_id

--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -199,13 +199,12 @@ class LegalAidApplication < ApplicationRecord
     #  loop through the collection to see if at least one APT for the legal aid application has a value in used_delegated_functions_on
     # this should break the loop when it finds a delegated_functon_date
     # we dont care about how many just if one exists
-    # returns nil which is falsey if nothing is found
     #
     # currently this is always false in tests as the factories aRE NOT SET UP TO STorE THIS INFORMATION
 
     # first_df_date = apts.map(&:used_delegated_functions_on).find(&:present?)
 
-    first_df_date = application_proceeding_types.find do |apt|
+    false unless application_proceeding_types.find do |apt|
       break apt.used_delegated_functions_on if apt.used_delegated_functions_on.present?
     end
   end

--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -196,16 +196,10 @@ class LegalAidApplication < ApplicationRecord
   end
 
   def used_delegated_functions?
-    #  loop through the collection to see if at least one APT for the legal aid application has a value in used_delegated_functions_on
-    # this should break the loop when it finds a delegated_functon_date
-    # we dont care about how many just if one exists
-    #
-    # currently this is always false in tests as the factories aRE NOT SET UP TO STorE THIS INFORMATION
-
-    # first_df_date = apts.map(&:used_delegated_functions_on).find(&:present?)
-
-    false unless application_proceeding_types.find do |apt|
-      break apt.used_delegated_functions_on if apt.used_delegated_functions_on.present?
+    if Setting.allow_multiple_proceedings?
+      application_proceeding_types.map(&:used_delegated_functions?).include?(true)
+    else
+      attributes['used_delegated_functions']
     end
   end
 

--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -195,6 +195,21 @@ class LegalAidApplication < ApplicationRecord
     )
   end
 
+  def used_delegated_functions?
+    #  loop through the collection to see if at least one APT for the legal aid application has a value in used_delegated_functions_on
+    # this should break the loop when it finds a delegated_functon_date
+    # we dont care about how many just if one exists
+    # returns nil which is falsey if nothing is found
+    #
+    # currently this is always false in tests as the factories aRE NOT SET UP TO STorE THIS INFORMATION
+
+    # first_df_date = apts.map(&:used_delegated_functions_on).find(&:present?)
+
+    first_df_date = application_proceeding_types.find do |apt|
+      break apt.used_delegated_functions_on if apt.used_delegated_functions_on.present?
+    end
+  end
+
   def parent_transaction_types
     ids = transaction_types.map(&:parent_or_self).map(&:id)
     TransactionType.where(id: ids)

--- a/db/migrate/20210408162032_add_delegated_functions_date_to_application_proceeding_types.rb
+++ b/db/migrate/20210408162032_add_delegated_functions_date_to_application_proceeding_types.rb
@@ -1,0 +1,6 @@
+class AddDelegatedFunctionsDateToApplicationProceedingTypes < ActiveRecord::Migration[6.1]
+  def change
+    add_column :application_proceeding_types, :used_delegated_functions_on, :date
+    add_column :application_proceeding_types, :used_delegated_functions_reported_on, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_07_120727) do
+ActiveRecord::Schema.define(version: 2021_04_08_162032) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -113,6 +113,8 @@ ActiveRecord::Schema.define(version: 2021_04_07_120727) do
     t.datetime "updated_at", null: false
     t.integer "proceeding_case_id"
     t.boolean "lead_proceeding", default: false, null: false
+    t.date "used_delegated_functions_on"
+    t.date "used_delegated_functions_reported_on"
     t.index ["legal_aid_application_id"], name: "index_application_proceeding_types_on_legal_aid_application_id"
     t.index ["proceeding_case_id"], name: "index_application_proceeding_types_on_proceeding_case_id", unique: true
     t.index ["proceeding_type_id"], name: "index_application_proceeding_types_on_proceeding_type_id"

--- a/lib/tasks/move_delegated_functions_data.rake
+++ b/lib/tasks/move_delegated_functions_data.rake
@@ -1,0 +1,10 @@
+namespace :move_delegated_functions_data do
+  desc 'Sets the lead_proceeding value to TRUE for all existing cases'
+
+  task update_application_proceeding_type_table: :environment do
+    # if delegated functions exist on the legal aid application
+    # then move the values for used_delegated_functions_on AND used_delegated_functions_reported_on
+    # to their respective fields on application_proceeding_types
+
+  end
+end

--- a/lib/tasks/move_delegated_functions_data.rake
+++ b/lib/tasks/move_delegated_functions_data.rake
@@ -5,6 +5,5 @@ namespace :move_delegated_functions_data do
     # if delegated functions exist on the legal aid application
     # then move the values for used_delegated_functions_on AND used_delegated_functions_reported_on
     # to their respective fields on application_proceeding_types
-
   end
 end

--- a/lib/tasks/move_delegated_functions_data.rake
+++ b/lib/tasks/move_delegated_functions_data.rake
@@ -1,9 +1,21 @@
 namespace :move_delegated_functions_data do
-  desc 'Sets the lead_proceeding value to TRUE for all existing cases'
+  desc 'Copies over used delegated functions data from legal aid application to application proceeding type'
 
   task update_application_proceeding_type_table: :environment do
     # if delegated functions exist on the legal aid application
     # then move the values for used_delegated_functions_on AND used_delegated_functions_reported_on
     # to their respective fields on application_proceeding_types
+    application_ids = LegalAidApplication.where.not(used_delegated_functions_on: nil).pluck_id
+
+    application_ids.each do |ap_id|
+      application = LegalAidApplication.find(ap_id)
+
+      application.application_proceeding_types.each do |apt|
+        apt.used_delegated_functions_on = application.used_delegated_functions_on
+        apt.used_delegated_functions_reported_on = application.used_delegated_functions_reported_on
+
+        apt.save!
+      end
+    end
   end
 end

--- a/spec/models/application_proceeding_type_spec.rb
+++ b/spec/models/application_proceeding_type_spec.rb
@@ -49,6 +49,34 @@ RSpec.describe ApplicationProceedingType do
     end
   end
 
+  describe '#used_delegated_functions?' do
+    let(:application) { create :legal_aid_application }
+
+    before do
+      create :application_proceeding_type, legal_aid_application: application, used_delegated_functions_on: nil
+      create :application_proceeding_type, legal_aid_application: application, used_delegated_functions_on: df_date
+      Setting.setting.update(allow_multiple_proceedings: true)
+    end
+
+    context 'delegated functions used' do
+      let(:df_date) { Time.current }
+
+      it 'returns true' do
+        application_proceeding_type = application.application_proceeding_types.first
+        expect(application_proceeding_type.used_delegated_functions?).to be true
+      end
+    end
+
+    context 'delegated functions not used' do
+      let(:df_date) { nil }
+
+      it 'returns false' do
+        application_proceeding_type = application.application_proceeding_types.first
+        expect(application_proceeding_type.used_delegated_functions?).to be false
+      end
+    end
+  end
+
   describe 'assigned_scope_limitations' do
     let(:application) { create :legal_aid_application }
     let(:proceeding_type) { ProceedingType.first }

--- a/spec/models/application_proceeding_type_spec.rb
+++ b/spec/models/application_proceeding_type_spec.rb
@@ -51,16 +51,14 @@ RSpec.describe ApplicationProceedingType do
 
   describe '#used_delegated_functions?' do
     let(:application) { create :legal_aid_application }
+    let!(:application_proceeding_type) { create :application_proceeding_type, legal_aid_application: application, used_delegated_functions_on: df_date }
+    let(:df_date) { Time.current }
 
     before do
-      create :application_proceeding_type, legal_aid_application: application, used_delegated_functions_on: nil
-      create :application_proceeding_type, legal_aid_application: application, used_delegated_functions_on: df_date
       Setting.setting.update(allow_multiple_proceedings: true)
     end
 
     context 'delegated functions used' do
-      let(:df_date) { Time.current }
-
       it 'returns true' do
         application_proceeding_type = application.application_proceeding_types.first
         expect(application_proceeding_type.used_delegated_functions?).to be true

--- a/spec/models/legal_aid_application_spec.rb
+++ b/spec/models/legal_aid_application_spec.rb
@@ -592,6 +592,54 @@ RSpec.describe LegalAidApplication, type: :model do
     end
   end
 
+  describe '#used_delegated_functions?' do
+    context 'not allowed multiple proceedings' do
+      before { Setting.setting.update(allow_multiple_proceedings: false) }
+
+      context 'delegated functions used' do
+        let(:legal_aid_application) { create :legal_aid_application, used_delegated_functions: true, used_delegated_functions_on: Time.current }
+
+        it 'returns true' do
+          expect(legal_aid_application.used_delegated_functions?).to be true
+        end
+      end
+
+      context 'delegated functions not used' do
+        let(:legal_aid_application) { create :legal_aid_application, used_delegated_functions: false, used_delegated_functions_on: nil }
+
+        it 'returns false' do
+          expect(legal_aid_application.used_delegated_functions?).to be false
+        end
+      end
+    end
+
+    context 'allow_multiple_proceedings' do
+      let(:legal_aid_application) { create :legal_aid_application }
+
+      before do
+        create :application_proceeding_type, legal_aid_application: legal_aid_application, used_delegated_functions_on: nil
+        create :application_proceeding_type, legal_aid_application: legal_aid_application, used_delegated_functions_on: df_date
+        Setting.setting.update(allow_multiple_proceedings: true)
+      end
+
+      context 'delegated functions used' do
+        let(:df_date) { Time.current }
+
+        it 'returns true' do
+          expect(legal_aid_application.used_delegated_functions?).to be true
+        end
+      end
+
+      context 'delegated functions not used' do
+        let(:df_date) { nil }
+
+        it 'returns false' do
+          expect(legal_aid_application.used_delegated_functions?).to be false
+        end
+      end
+    end
+  end
+
   describe 'default_cost_limitations' do
     let(:proceeding_type) do
       create :proceeding_type,

--- a/spec/requests/providers/means_summaries_spec.rb
+++ b/spec/requests/providers/means_summaries_spec.rb
@@ -131,8 +131,6 @@ RSpec.describe Providers::MeansSummariesController, type: :request do
         let(:cfe_result) { false }
 
         it 'redirects to the problem page' do
-          pp 2_222_222
-          pp legal_aid_application.used_delegated_functions?
           expect(response).to redirect_to(problem_index_path)
         end
       end

--- a/spec/requests/providers/means_summaries_spec.rb
+++ b/spec/requests/providers/means_summaries_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe Providers::MeansSummariesController, type: :request do
         let(:cfe_result) { false }
 
         it 'redirects to the problem page' do
-          pp 2222222
+          pp 2_222_222
           pp legal_aid_application.used_delegated_functions?
           expect(response).to redirect_to(problem_index_path)
         end

--- a/spec/requests/providers/means_summaries_spec.rb
+++ b/spec/requests/providers/means_summaries_spec.rb
@@ -9,12 +9,19 @@ RSpec.describe Providers::MeansSummariesController, type: :request do
   let(:bank_account) { create :bank_account, bank_provider: bank_provider }
   let(:vehicle) { create :vehicle, :populated }
   let(:own_vehicle) { true }
+  let(:proceeding_type) { create :proceeding_type, :with_real_data }
+  let(:scope_limitation) { create :scope_limitation, code: 'AA001', description: 'Temporibus illum modi. Enim exercitationem nemo. In ut quia.' }
+  let(:sl2) { create :scope_limitation }
   let(:legal_aid_application) do
     create :legal_aid_application,
            :with_negative_benefit_check_result,
            :with_non_passported_state_machine,
            :provider_assessing_means,
            :with_policy_disregards,
+           :with_proceeding_type_and_scope_limitations,
+           this_proceeding_type: proceeding_type,
+           substantive_scope_limitation: scope_limitation,
+           df_scope_limitation: sl2,
            vehicle: vehicle,
            own_vehicle: own_vehicle,
            applicant: applicant,
@@ -124,6 +131,8 @@ RSpec.describe Providers::MeansSummariesController, type: :request do
         let(:cfe_result) { false }
 
         it 'redirects to the problem page' do
+          pp 2222222
+          pp legal_aid_application.used_delegated_functions?
           expect(response).to redirect_to(problem_index_path)
         end
       end


### PR DESCRIPTION
## AP-2172 Add used_delegated_functions columns and rake task

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2172)

- Add two columns to the application proceeding types table: **used_delegated_functions_on** and **used_delegated_functions_reported_on**

- Add a rake task to migrate used delegated functions values from the legal aid applications to the application proceeding types table

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
