### PR TITLE
Rake task to list cucumber steps

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -105,6 +105,7 @@ group :development, :test do
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
   gem 'dotenv-rails', '>= 2.7.5'
   gem 'erb_lint', '0.0.37', require: false
+  gem 'hirb'
   gem 'htmlentities'
   gem 'i18n-tasks', '>= 0.9.31'
   gem 'json_expressions'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -303,6 +303,7 @@ GEM
     hashdiff (1.0.1)
     hashie (4.1.0)
     highline (2.0.3)
+    hirb (0.7.3)
     html_tokenizer (0.0.7)
     htmlentities (4.3.4)
     http_parser.rb (0.6.0)
@@ -707,6 +708,7 @@ DEPENDENCIES
   guard-livereload
   guard-rspec
   guard-rubocop
+  hirb
   htmlentities
   i18n-tasks (>= 0.9.31)
   json_expressions

--- a/lib/tasks/cucumber_steps.rake
+++ b/lib/tasks/cucumber_steps.rake
@@ -1,0 +1,23 @@
+namespace :cucumber do
+  desc 'List all defined steps'
+  task :steps do
+    require 'hirb'
+    extend Hirb::Console
+    puts "CUCUMBER steps:"
+    puts ""
+    step_definition_dir = "features/step_definitions"
+
+    results = []
+    Dir.glob(File.join(step_definition_dir,'**/*.rb')).each do |step_file|
+      File.new(step_file).read.each_line.each_with_index do |line, number|
+        next unless line =~ /^\s*(Given|When|Then)\((.+)\)\s*do$/
+        name = $2.gsub('/', '').gsub('^', '').gsub('$', '').gsub("'", '')
+        results<< OpenStruct.new(stepname: name, location: "#{step_file}:#{number + 1}")
+      end
+    end
+
+    table results, :resize => false, :fields=>[:stepname, :location]
+    puts ""
+  end
+
+end

--- a/lib/tasks/cucumber_steps.rake
+++ b/lib/tasks/cucumber_steps.rake
@@ -1,23 +1,25 @@
+# rubocop:disable Rails/RakeEnvironment
 namespace :cucumber do
   desc 'List all defined steps'
   task :steps do
     require 'hirb'
     extend Hirb::Console
-    puts "CUCUMBER steps:"
-    puts ""
-    step_definition_dir = "features/step_definitions"
+    puts 'CUCUMBER steps:'
+    puts ''
+    step_definition_dir = 'features/step_definitions'
 
     results = []
-    Dir.glob(File.join(step_definition_dir,'**/*.rb')).each do |step_file|
+    Dir.glob(File.join(step_definition_dir, '**/*.rb')).each do |step_file|
       File.new(step_file).read.each_line.each_with_index do |line, number|
         next unless line =~ /^\s*(Given|When|Then)\((.+)\)\s*do$/
-        name = $2.gsub('/', '').gsub('^', '').gsub('$', '').gsub("'", '').gsub('"', '')
-        results<< OpenStruct.new(stepname: name, location: "#{step_file}:#{number + 1}")
+
+        name = Regexp.last_match(2).delete('/').delete('^').delete('$').delete("'").delete('"')
+        results << OpenStruct.new(stepname: name, location: "#{step_file}:#{number + 1}")
       end
     end
 
-    table results, :resize => false, :fields=>[:stepname, :location]
-    puts ""
+    table results, resize: false, fields: %i[stepname location]
+    puts ''
   end
-
 end
+# rubocop:enable Rails/RakeEnvironment

--- a/lib/tasks/cucumber_steps.rake
+++ b/lib/tasks/cucumber_steps.rake
@@ -11,7 +11,7 @@ namespace :cucumber do
     Dir.glob(File.join(step_definition_dir,'**/*.rb')).each do |step_file|
       File.new(step_file).read.each_line.each_with_index do |line, number|
         next unless line =~ /^\s*(Given|When|Then)\((.+)\)\s*do$/
-        name = $2.gsub('/', '').gsub('^', '').gsub('$', '').gsub("'", '')
+        name = $2.gsub('/', '').gsub('^', '').gsub('$', '').gsub("'", '').gsub('"', '')
         results<< OpenStruct.new(stepname: name, location: "#{step_file}:#{number + 1}")
       end
     end


### PR DESCRIPTION
## Rake task to list cucumber step definitiosn

  `rake cucumber:steps`

gives the following output:

```
CUCUMBER steps:

+----------------------------------------------------------------------------------------------+------------------------------------------------------+
| stepname                                                                                     | location                                             |
+----------------------------------------------------------------------------------------------+------------------------------------------------------+
| the page is accessible                                                                       | features/step_definitions/accessibility.rb:1         |
| I am logged in as a provider                                                                 | features/step_definitions/civil_journey_steps.rb:3   |
| I visit the application service                                                              | features/step_definitions/civil_journey_steps.rb:11  |
| I visit the select office page                                                               | features/step_definitions/civil_journey_steps.rb:15  |
| I visit the confirm office page                                                              | features/step_definitions/civil_journey_steps.rb:19  |
| I have an existing office                                                                    | features/step_definitions/civil_journey_steps.rb:23  |
| I visit the applications page                                                                | features/step_definitions/civil_journey_steps.rb:28  |
| I have previously created multiple applications                                              | features/step_definitions/civil_journey_steps.rb:32  |
| I have created and submitted an application                                                  | features/step_definitions/civil_journey_steps.rb:46  |
| I have created but not submitted an application                                              | features/step_definitions/civil_journey_steps.rb:57  |
| the setting to allow multiple proceedings is enabled                                         | features/step_definitions/civil_journey_steps.rb:96  |
| the setting to allow DWP overrides is enabled                                                | features/step_definitions/civil_journey_steps.rb:100 |
| I view the previously created application                                                    | features/step_definitions/civil_journey_steps.rb:108 |
| I should not see the previously created application                                          | features/step_definitions/civil_journey_steps.rb:112 |
| I click delete for the previously created application                                        | features/step_definitions/civil_journey_steps.rb:116 |
| I view the first application in the table                                                    | features/step_definitions/civil_journey_steps.rb:120 |
| I start the journey as far as the applicant page                                             | features/step_definitions/civil_journey_steps.rb:124 |
| I start a non-passported application                                                         | features/step_definitions/civil_journey_steps.rb:136 |
| I start a non-passported application after a failed benefit check                            | features/step_definitions/civil_journey_steps.rb:163 |
| I start the journey as far as the client completed means page                                | features/step_definitions/civil_journey_steps.rb:194 |
| I am checking the applicants means answers.                                                  | features/step_definitions/civil_journey_steps.rb:207 |
| I have completed the non-passported means assessment and start the merits assessment         | features/step_definitions/civil_journey_steps.rb:220 |
| I start the merits application                                                               | features/step_definitions/civil_journey_steps.rb:235 |
| I start the merits application with bank transactions with no transaction type category      | features/step_definitions/civil_journey_steps.rb:252 |
| I start the merits application with student finance                                          | features/step_definitions/civil_journey_steps.rb:271 |
| I start the application with a negative benefit check result                                 | features/step_definitions/civil_journey_steps.rb:292 |
| I start the application with a negative benefit check result and no used delegated functions | features/step_definitions/civil_journey_steps.rb:311 |
| I start the merits application and the applicant has uploaded transaction data               | features/step_definitions/civil_journey_steps.rb:330 |
| I start the journey as far as the start of the vehicle section                               | features/step_definitions/civil_journey_steps.rb:349 |
| I used delegated functions                                                                   | features/step_definitions/civil_journey_steps.rb:362 |
| I complete the journey as far as check your answers                                          | features/step_definitions/civil_journey_steps.rb:366 |
| I complete the passported journey as far as check your answers                               | features/step_definitions/civil_journey_steps.rb:398 |
| I complete the non-passported journey as far as check your answers                           | features/step_definitions/civil_journey_steps.rb:429 |
| I complete the passported journey as far as capital check your answers                       | features/step_definitions/civil_journey_steps.rb:460 |
| I complete the application and view the check your answers page                              | features/step_definitions/civil_journey_steps.rb:491 |
| The means questions have been answered by the applicant                                      | features/step_definitions/civil_journey_steps.rb:523 |
| I add the details for a child dependant                                                      | features/step_definitions/civil_journey_steps.rb:542 |
| Bank transactions exist                                                                      | features/step_definitions/civil_journey_steps.rb:553 |
| I visit received benefit confirmation page                                                   | features/step_definitions/civil_journey_steps.rb:573 |
| I click clear search                                                                         | features/step_definitions/civil_journey_steps.rb:590 |
| proceeding search field is empty                                                             | features/step_definitions/civil_journey_steps.rb:594 |
| the results section is empty                                                                 | features/step_definitions/civil_journey_steps.rb:598 |
| proceeding suggestions has results                                                           | features/step_definitions/civil_journey_steps.rb:602 |
| I select a proceeding type and continue                                                      | features/step_definitions/civil_journey_steps.rb:647 |
| I see the client details page                                                                | features/step_definitions/civil_journey_steps.rb:666 |
| I should be on the Applicant page                                                            | features/step_definitions/civil_journey_steps.rb:670 |
| I see a notice confirming an e-mail was sent to the citizen                                  | features/step_definitions/civil_journey_steps.rb:719 |
| I select the first checkbox                                                                  | features/step_definitions/civil_journey_steps.rb:735 |
| I select the second checkbox                                                                 | features/step_definitions/civil_journey_steps.rb:739 |
| I am on the postcode entry page                                                              | features/step_definitions/civil_journey_steps.rb:743 |
| I click find address                                                                         | features/step_definitions/civil_journey_steps.rb:747 |
| I am on the application confirmation page                                                    | features/step_definitions/civil_journey_steps.rb:755 |
| I am on the legal aid applications                                                           | features/step_definitions/civil_journey_steps.rb:759 |
| I am on the About the Financial Assessment page                                              | features/step_definitions/civil_journey_steps.rb:763 |
| I am on the check your answers page for other assets                                         | features/step_definitions/civil_journey_steps.rb:767 |
| I am on the check your answers page for policy disregards                                    | features/step_definitions/civil_journey_steps.rb:772 |
| I am on the read only version of the check your answers page                                 | features/step_definitions/civil_journey_steps.rb:777 |
| I click How we checked your clients benefits status                                          | features/step_definitions/civil_journey_steps.rb:782 |
| show me the page                                                                             | features/step_definitions/civil_journey_steps.rb:787 |
| wait a bit                                                                                   | features/step_definitions/civil_journey_steps.rb:791 |
| I click the browser back button                                                              | features/step_definitions/civil_journey_steps.rb:796 |
| I bind and pry                                                                               | features/step_definitions/debug_steps.rb:2           |
| I save and open page                                                                         | features/step_definitions/debug_steps.rb:6           |
| I save and open screenshot                                                                   | features/step_definitions/debug_steps.rb:11          |
| I am logged in as an admin                                                                   | features/step_definitions/admin_steps.rb:1           |
| an application has been submitted                                                            | features/step_definitions/admin_steps.rb:15          |
| multiple applications have been submitted                                                    | features/step_definitions/admin_steps.rb:23          |
| I visit the admin applications page                                                          | features/step_definitions/admin_steps.rb:37          |
| An application has been created                                                              | features/step_definitions/citizens_steps.rb:1        |
| I visit the start of the financial assessment                                                | features/step_definitions/citizens_steps.rb:19       |
| I visit the start of the financial assessment in Welsh                                       | features/step_definitions/citizens_steps.rb:23       |
| I visit the first question about dependants                                                  | features/step_definitions/citizens_steps.rb:29       |
| I visit the accounts page                                                                    | features/step_definitions/citizens_steps.rb:34       |
| I visit the gather transactions page                                                         | features/step_definitions/citizens_steps.rb:39       |
| I am directed to TrueLayer                                                                   | features/step_definitions/citizens_steps.rb:59       |
| I have completed an application                                                              | features/step_definitions/citizens_steps.rb:67       |
| I complete the citizen journey as far as check your answers                                  | features/step_definitions/citizens_steps.rb:82       |
| the application has a restriction                                                            | features/step_definitions/citizens_steps.rb:87       |
| I should have completed the dependants section of the journey                                | features/step_definitions/citizens_steps.rb:99       |
| skip.*this scenario                                                                          | features/step_definitions/skippy.rb:3                |
+----------------------------------------------------------------------------------------------+------------------------------------------------------+
80 rows in set
```


Describe what you did and why.

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
