### PR TITLE
AP-2258 Add modsecurity to our ingress

### DIFF
--- a/helm_deploy/apply-for-legal-aid/templates/ingress.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/ingress.yaml
@@ -10,6 +10,11 @@ metadata:
     chart: {{ template "apply-for-legal-aid.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    kubernetes.io/ingress.class: "modsec01"
+    nginx.ingress.kubernetes.io/enable-modsecurity: "true"
+    nginx.ingress.kubernetes.io/modsecurity-snippet: |
+      SecRuleEngine On
 {{- with .Values.ingress.annotations }}
   annotations:
 {{ toYaml . | indent 4 }}


### PR DESCRIPTION
## AP-2258 Add modsecurity to our ingress

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2258)

- Add modescurity rule to our ingress.

We have ingress configured in our config files and not in cloud platform.

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
