### PR TITLE
Downgrade rexml

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -111,6 +111,7 @@ group :development, :test do
   gem 'nokogiri'
   gem 'overcommit'
   gem 'pry-byebug'
+  gem 'rexml', '3.2.4'
   gem 'rspec_junit_formatter'
   gem 'rubocop', require: false
   gem 'rubocop-performance'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -506,7 +506,7 @@ GEM
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
-    rexml (3.2.5)
+    rexml (3.2.4)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
       rspec-expectations (~> 3.10.0)
@@ -735,6 +735,7 @@ DEPENDENCIES
   rails_admin (~> 2.1)
   redis-namespace
   regexp-examples
+  rexml (= 3.2.4)
   rspec-rails (~> 5.0)
   rspec_junit_formatter
   rubocop


### PR DESCRIPTION
## Downgrade REXML

The recent upgrade of REXML from 3.2.4 to 3.2.5 has affected our ability to login locally using mock saml.

Details:  The decoding of the saml signature gives the following error:

```
REXML::ParseException < RuntimeError
"Garbage component exists at the end: <]>: </p:Response[@ID=$id]/ds:Signature]>"
```

Have pinned the REXMl version to 3.2.4 in the Gemfile.



## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
