### PR TITLE
BugFix Fix broken rake task to pluck id for applications

### DIFF
--- a/lib/tasks/move_delegated_functions_data.rake
+++ b/lib/tasks/move_delegated_functions_data.rake
@@ -5,7 +5,7 @@ namespace :move_delegated_functions_data do
     # if delegated functions exist on the legal aid application
     # then move the values for used_delegated_functions_on AND used_delegated_functions_reported_on
     # to their respective fields on application_proceeding_types
-    application_ids = LegalAidApplication.where.not(used_delegated_functions_on: nil).pluck_id
+    application_ids = LegalAidApplication.where.not(used_delegated_functions_on: nil).pluck(:id)
 
     application_ids.each do |ap_id|
       application = LegalAidApplication.find(ap_id)


### PR DESCRIPTION
## BugFix Fix broken rake task to pluck id for applications


This fixes the broken rake task with no method pluck_id when it should be pluck(:id)

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
