### PR TITLE
remove manual settings for none_selected in cash transactions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -111,6 +111,7 @@ group :development, :test do
   gem 'nokogiri'
   gem 'overcommit'
   gem 'pry-byebug'
+  gem 'rexml', '3.2.4'
   gem 'rspec_junit_formatter'
   gem 'rubocop', require: false
   gem 'rubocop-performance'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -506,7 +506,7 @@ GEM
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
-    rexml (3.2.5)
+    rexml (3.2.4)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
       rspec-expectations (~> 3.10.0)
@@ -735,6 +735,7 @@ DEPENDENCIES
   rails_admin (~> 2.1)
   redis-namespace
   regexp-examples
+  rexml (= 3.2.4)
   rspec-rails (~> 5.0)
   rspec_junit_formatter
   rubocop

--- a/app/models/base_aggregated_cash_transaction.rb
+++ b/app/models/base_aggregated_cash_transaction.rb
@@ -48,13 +48,11 @@ class BaseAggregatedCashTransaction # rubocop:disable Metrics/ClassLength
       model.__send__(value_method, trx.amount)
       model.__send__(checkbox_method, 'true')
       model.__send__("month#{trx.month_number}=", trx.transaction_date)
-      model.none_selected = false
     end
 
     def find_by(legal_aid_application_id:)
       transactions = find_transactions(legal_aid_application_id)
       model = new(legal_aid_application_id: legal_aid_application_id)
-      model.none_selected = true
       transactions.each { |trx| populate_attribute(model, trx) }
       model
     end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2148)

We'd been manually setting none_selected for cash transactions in the `base_aggregated_cash_transaction.rb` file, under the methods find_by and populate_attributes. I have removed these references now so none_selected doesn't pre-populate. 

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
