### PR TITLE
Bug-fix: update flickering test

### DIFF
--- a/spec/models/application_proceeding_type_spec.rb
+++ b/spec/models/application_proceeding_type_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe ApplicationProceedingType do
         before { application_proceeding_type.add_default_substantive_scope_limitation }
 
         it 'ignores the duplicate request' do
-          expect(application_proceeding_type.assigned_scope_limitations).to eq [default_scope_limitation, default_df_scope_limitation]
+          expect(application_proceeding_type.assigned_scope_limitations).to match_array [default_scope_limitation, default_df_scope_limitation]
         end
       end
 


### PR DESCRIPTION
## What

Update the test to reduce the flickering, it was using an equality matcher
on an array.  Sometimes the objects are back to front and therefore not
equal.  Using match_array ensures that the two values are present
regardless of the sequence

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
