### PR TITLE
Bug-fix: Address flickering test

### DIFF
--- a/spec/requests/providers/application_merits_task/remove_involved_child_spec.rb
+++ b/spec/requests/providers/application_merits_task/remove_involved_child_spec.rb
@@ -15,7 +15,7 @@ module Providers
 
         it 'displays the childs details' do
           subject
-          expect(response.body).to include(child2.full_name)
+          expect(response.body).to include(html_compare(child2.full_name))
         end
       end
 


### PR DESCRIPTION
## What

One of the new tests did not ensure the name was escaped
this adds the helper that ensures the name is checked
properly

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
