### PR TITLE
Fix the rake task to migrate submitted_at attribute

### DIFF
--- a/lib/tasks/migrate_submitted_at.rake
+++ b/lib/tasks/migrate_submitted_at.rake
@@ -6,7 +6,8 @@ namespace :migrate_submitted_at do
     chances_of_successes = ProceedingMeritsTask::ChancesOfSuccess.where.not(submitted_at: nil)
 
     chances_of_successes.each do |cs|
-      laa = cs.legal_aid_application
+      laa_id = cs.legal_aid_application_id
+      laa = LegalAidApplication.find(laa_id)
       laa.merits_submitted_at = cs.submitted_at
 
       laa.save!


### PR DESCRIPTION
## Fix the rake task to migrate submitted_at to merits_submitted_at on the LegalAidApplication

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2227)

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
