### PR TITLE
Ap 2249 update the admin reports

### DIFF
--- a/app/services/reports/mis/application_detail_csv_line.rb
+++ b/app/services/reports/mis/application_detail_csv_line.rb
@@ -5,7 +5,8 @@ module Reports
 
       attr_reader :laa
 
-      delegate :benefit_check_result,
+      delegate :applicant_receives_benefit?,
+               :dwp_override,
                :ccms_submission,
                :created_at,
                :lead_application_proceeding_type,
@@ -74,7 +75,8 @@ module Reports
           'CCMS reference number',
           'Matter type',
           'Proceeding type selected',
-          'DWP check result',
+          'Case Type',
+          'DWP Overridden',
           'Delegated functions used',
           'Delegated functions date',
           'Delegated functions reported',
@@ -148,7 +150,8 @@ module Reports
         provider_firm_details
         application_details
         proceeding_details
-        dwp_check_result
+        passported_check_result
+        dwp_overridden
         delegated_functions
         main_home_details
         vehicle_details
@@ -177,8 +180,12 @@ module Reports
         @line << proceeding_types.map(&:meaning).sort.join(', ')
       end
 
-      def dwp_check_result
-        @line << benefit_check_result.result == 'Yes' ? 'Passported' : 'Non-passported'
+      def passported_check_result
+        @line << (applicant_receives_benefit? ? 'Passported' : 'Non-passported')
+      end
+
+      def dwp_overridden
+        @line << (dwp_override ? 'TRUE' : 'FALSE')
       end
 
       def delegated_functions

--- a/app/services/reports/mis/application_detail_csv_line.rb
+++ b/app/services/reports/mis/application_detail_csv_line.rb
@@ -5,8 +5,7 @@ module Reports
 
       attr_reader :laa
 
-      delegate :application_ref,
-               :benefit_check_result,
+      delegate :benefit_check_result,
                :ccms_submission,
                :created_at,
                :lead_application_proceeding_type,
@@ -72,7 +71,6 @@ module Reports
           'Firm name',
           'User name',
           'Office ID',
-          'Apply reference number',
           'CCMS reference number',
           'Matter type',
           'Proceeding type selected',
@@ -171,7 +169,6 @@ module Reports
       end
 
       def application_details
-        @line << application_ref
         @line << case_ccms_reference
       end
 

--- a/app/services/reports/mis/application_detail_csv_line.rb
+++ b/app/services/reports/mis/application_detail_csv_line.rb
@@ -6,9 +6,9 @@ module Reports
       attr_reader :laa
 
       delegate :applicant_receives_benefit?,
-               :dwp_override,
                :ccms_submission,
                :created_at,
+               :dwp_override,
                :lead_application_proceeding_type,
                :office,
                :other_assets_declaration,
@@ -181,7 +181,7 @@ module Reports
       end
 
       def passported_check_result
-        @line << (applicant_receives_benefit? ? 'Passported' : 'Non-passported')
+        @line << (applicant_receives_benefit? ? 'Passported' : 'Non-Passported')
       end
 
       def dwp_overridden

--- a/app/services/reports/mis/non_passported_application_csv_line.rb
+++ b/app/services/reports/mis/non_passported_application_csv_line.rb
@@ -8,7 +8,6 @@ module Reports
 
       def self.header_row
         %w[
-          application_ref
           state
           ccms_reason
           username
@@ -30,7 +29,6 @@ module Reports
       end
 
       def call
-        @line << laa.application_ref
         @line << laa.state
         @line << laa.ccms_reason
         @line << laa.provider.username

--- a/spec/requests/admin/reports_spec.rb
+++ b/spec/requests/admin/reports_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Admin::ReportsController, type: :request do
 
     it 'sends the data' do
       subject
-      expect(response.body).to match(/^Firm name,User name,Office ID,Apply reference number,/)
+      expect(response.body).to match(/^Firm name,User name,Office ID,/)
     end
   end
 
@@ -59,7 +59,7 @@ RSpec.describe Admin::ReportsController, type: :request do
 
     it 'sends the data' do
       subject
-      expect(response.body).to match(/^application_ref,state,ccms_reason,username,provider_email,created_at/)
+      expect(response.body).to match(/^state,ccms_reason,username,provider_email,created_at/)
     end
   end
 
@@ -106,7 +106,7 @@ RSpec.describe Admin::ReportsController, type: :request do
         before { subject }
 
         it 'sends csv response data' do
-          expect(response.body).to include('application_ref,case_ccms_reference,COUNTRY,APPLY_CASE_MEANS_REVIEW')
+          expect(response.body).to include('case_ccms_reference,COUNTRY,APPLY_CASE_MEANS_REVIEW')
         end
       end
     end

--- a/spec/services/reports/mis/application_detail_csv_line_spec.rb
+++ b/spec/services/reports/mis/application_detail_csv_line_spec.rb
@@ -112,6 +112,7 @@ module Reports
       let(:outstanding_mortgage) { 397_822 }
       let(:percentage_home) { 50 }
       let(:benefit_check_result_text) { 'Yes' }
+      let(:dwp_overridden) { 'FALSE' }
       let(:current_acct_val) { 25.44 }
       let(:savings_acct_val) { 266.10 }
       let(:cash_val) { 17 }

--- a/spec/services/reports/mis/application_detail_csv_line_spec.rb
+++ b/spec/services/reports/mis/application_detail_csv_line_spec.rb
@@ -5,7 +5,6 @@ module Reports
     RSpec.describe ApplicationDetailCsvLine do
       let(:legal_aid_application) do
         create :application,
-               application_ref: 'L-X99-ZZZ',
                applicant: applicant,
                own_home: own_home_status,
                property_value: property_value,
@@ -160,7 +159,6 @@ module Reports
             expect(value_for('Firm name')).to eq 'Legal beagles'
             expect(value_for('User name')).to eq 'psr001'
             expect(value_for('Office ID')).to eq '1T823E'
-            expect(value_for('Apply reference number')).to eq 'L-X99-ZZZ'
             expect(value_for('CCMS reference number')).to eq '42226668880'
             expect(value_for('Matter type')).to eq 'Matter type'
             expect(value_for('Proceeding type selected')).to eq 'Proceeding type meaning'

--- a/spec/services/reports/mis/application_detail_csv_line_spec.rb
+++ b/spec/services/reports/mis/application_detail_csv_line_spec.rb
@@ -161,9 +161,10 @@ module Reports
             expect(value_for('User name')).to eq 'psr001'
             expect(value_for('Office ID')).to eq '1T823E'
             expect(value_for('CCMS reference number')).to eq '42226668880'
+            expect(value_for('DWP Overridden')).to eq 'FALSE'
             expect(value_for('Matter type')).to eq 'Matter type'
             expect(value_for('Proceeding type selected')).to eq 'Proceeding type meaning'
-            expect(value_for('DWP check result')).to eq 'Yes'
+            expect(value_for('Case Type')).to eq 'Passported'
             expect(value_for('Delegated functions used')).to eq 'Yes'
             expect(value_for('Delegated functions date')).to eq '2020-01-01'
             expect(value_for('Delegated functions reported')).to eq '2020-02-21'
@@ -171,8 +172,8 @@ module Reports
 
           context 'DWP check result negative' do
             let(:benefit_check_result_text) { 'No' }
-            it 'generates no' do
-              expect(value_for('DWP check result')).to eq 'No'
+            it 'generates Non-Passported' do
+              expect(value_for('Case Type')).to eq 'Non-Passported'
             end
           end
 

--- a/spec/services/reports/mis/non_passported_application_csv_line_spec.rb
+++ b/spec/services/reports/mis/non_passported_application_csv_line_spec.rb
@@ -8,7 +8,6 @@ module Reports
       describe '.header_row' do
         let(:expected_header_row) do
           %w[
-            application_ref
             state
             ccms_reason
             username
@@ -33,22 +32,21 @@ module Reports
         subject { described_class.call(application) }
 
         it 'returns an array of nine fields' do
-          expect(subject.size).to eq 9
+          expect(subject.size).to eq 8
         end
 
         context 'undiscarded application' do
           it 'returns an array with the expected values' do
             travel_to(time) do
               fields = subject
-              expect(fields[0]).to eq application.application_ref
-              expect(fields[1]).to eq application.state
-              expect(fields[2]).to eq application.ccms_reason
-              expect(fields[3]).to eq provider.username
-              expect(fields[4]).to eq provider.email
+              expect(fields[0]).to eq application.state
+              expect(fields[1]).to eq application.ccms_reason
+              expect(fields[2]).to eq provider.username
+              expect(fields[3]).to eq provider.email
+              expect(fields[4]).to match DATE_TIME_REGEX
               expect(fields[5]).to match DATE_TIME_REGEX
-              expect(fields[6]).to match DATE_TIME_REGEX
-              expect(fields[7]).to eq applicant.full_name
-              expect(fields[8]).to eq ''
+              expect(fields[6]).to eq applicant.full_name
+              expect(fields[7]).to eq ''
             end
           end
         end
@@ -58,15 +56,14 @@ module Reports
           it 'returns an array with the expected values' do
             travel_to(time) do
               fields = subject
-              expect(fields[0]).to eq application.application_ref
-              expect(fields[1]).to eq application.state
-              expect(fields[2]).to eq application.ccms_reason
-              expect(fields[3]).to eq provider.username
-              expect(fields[4]).to eq provider.email
+              expect(fields[0]).to eq application.state
+              expect(fields[1]).to eq application.ccms_reason
+              expect(fields[2]).to eq provider.username
+              expect(fields[3]).to eq provider.email
+              expect(fields[4]).to match DATE_TIME_REGEX
               expect(fields[5]).to match DATE_TIME_REGEX
-              expect(fields[6]).to match DATE_TIME_REGEX
-              expect(fields[7]).to eq applicant.full_name
-              expect(fields[8]).to eq 'Y'
+              expect(fields[6]).to eq applicant.full_name
+              expect(fields[7]).to eq 'Y'
             end
           end
         end
@@ -74,7 +71,7 @@ module Reports
         context 'data begins with a vulnerable character' do
           before { provider.email = '=malicious_code' }
           it 'returns the escaped text' do
-            expect(subject[4]).to eq "'=malicious_code"
+            expect(subject[3]).to eq "'=malicious_code"
           end
         end
       end

--- a/spec/services/reports/mis/non_passported_applications_report_spec.rb
+++ b/spec/services/reports/mis/non_passported_applications_report_spec.rb
@@ -31,13 +31,13 @@ module Reports
         end
 
         it 'returns a header line as the first line' do
-          expect(lines.first).to eq 'application_ref,state,ccms_reason,username,provider_email,created_at,date_submitted,applicant_name,deleted'
+          expect(lines.first).to eq 'state,ccms_reason,username,provider_email,created_at,date_submitted,applicant_name,deleted'
         end
 
         it 'returns data for all non-passorted applications after Sep 21st' do
-          expect(lines[1]).to eq %(L-ATE,checking_citizen_answers,,#{username},#{email},#{created_at},,#{applicant.full_name},"")
-          expect(lines[2]).to match(/^L-USE-CCMS,use_ccms,employed,/)
-          expect(lines[3]).to match(/^L-SUBMITTED,assessment_submitted,.*#{submission_date},.*$/)
+          expect(lines[1]).to eq %(checking_citizen_answers,,#{username},#{email},#{created_at},,#{applicant.full_name},"")
+          expect(lines[2]).to match(/^use_ccms,employed,/)
+          expect(lines[3]).to match(/^assessment_submitted,.*#{submission_date},.*$/)
         end
       end
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2249)

Change the way we report passported/non-passported cases on the admin report
Add in the dwp_override column and result
Remove the Apply application_ref

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
