### PR TITLE
AP-2289 duplicate DF dates on application_proceeding_type

### DIFF
--- a/app/controllers/providers/limitations_controller.rb
+++ b/app/controllers/providers/limitations_controller.rb
@@ -3,11 +3,26 @@ module Providers
     include PreDWPCheckVisible
 
     def show
+      update_df_dates
       legal_aid_application.enter_applicant_details! unless legal_aid_application.entering_applicant_details?
     end
 
     def update
       continue_or_draft
+    end
+
+    private
+
+    # This is a little hack to ensure that df dates are copied to the application proceeding type
+    # in the lead-up to switching over to multiple proceedings.  It's done here so that it's after
+    # all the checks that are carried out on older df dates
+
+    # TODO: remove once multiple proceedings has been implemented
+
+    def update_df_dates
+      apt = legal_aid_application.application_proceeding_types.first
+      apt.update!(used_delegated_functions_on: legal_aid_application.used_delegated_functions_on,
+                  used_delegated_functions_reported_on: legal_aid_application.used_delegated_functions_reported_on)
     end
   end
 end

--- a/app/controllers/providers/limitations_controller.rb
+++ b/app/controllers/providers/limitations_controller.rb
@@ -20,6 +20,8 @@ module Providers
     # TODO: remove once multiple proceedings has been implemented
 
     def update_df_dates
+      return if Setting.allow_multiple_proceedings?
+
       apt = legal_aid_application.application_proceeding_types.first
       apt.update!(used_delegated_functions_on: legal_aid_application.used_delegated_functions_on,
                   used_delegated_functions_reported_on: legal_aid_application.used_delegated_functions_reported_on)


### PR DESCRIPTION
## Duplciate DF dates on Application Proceeding Type record

This is just in prepareation for the switch to multiple proceedings - we need all new applications to start recording their DF dates on the application proceeding type record AS WELL AS the legal aid application, so that the DF dates refactoring in AP-2234 will work. 

There is already a rake task to copy over the data for older applications.

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2289)

Describe what you did and why.

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
