### PR TITLE
bug-fix: Flicking feature

### DIFF
--- a/features/step_definitions/civil_journey_steps.rb
+++ b/features/step_definitions/civil_journey_steps.rb
@@ -389,15 +389,13 @@ Given('I complete the journey as far as check your answers') do
     lookup_used: true,
     applicant: applicant
   )
-  proceeding_type = ProceedingType.all.first
   @legal_aid_application = create(
     :legal_aid_application,
     :at_entering_applicant_details,
+    :with_proceeding_types,
     applicant: applicant,
-    proceeding_types: [proceeding_type],
     used_delegated_functions_on: 1.day.ago
   )
-  add_scope_limitations(@legal_aid_application, proceeding_type)
 
   login_as @legal_aid_application.provider
   visit(providers_legal_aid_application_check_provider_answers_path(@legal_aid_application))
@@ -610,6 +608,7 @@ Then(/^the results section is empty$/) do
 end
 
 Then(/^proceeding suggestions has results$/) do
+  wait_for_ajax
   expect(page).to have_css('#proceeding-list > .proceeding-item')
 end
 

--- a/features/step_definitions/civil_journey_steps.rb
+++ b/features/step_definitions/civil_journey_steps.rb
@@ -582,7 +582,6 @@ Then('I visit received benefit confirmation page') do
 end
 
 And('I search for proceeding {string}') do |proceeding_search|
-  pp @legal_aid_application&.proceeding_types&.pluck(:ccms_code, :meaning) if @legal_aid_application&.proceeding_types
   fill_in('proceeding-search-input', with: proceeding_search)
   wait_for_ajax
 end
@@ -654,9 +653,7 @@ Then('the answer for {string} should be {string}') do |field_name, answer|
 end
 
 Then('I select a proceeding type and continue') do
-  button = find('#proceeding-list').first(:button, 'Select and continue')
-  pp button
-  button.click
+  find('#proceeding-list').first(:button, 'Select and continue').click
 end
 
 Then('I select proceeding type {int}') do |index|


### PR DESCRIPTION
## What

Update the creation of the application to ensure the searched for value is
_never_ the proceeding type used in the creation by the factory

Sometimes the ProceedingType.all.first would return the 'non-mol' proceeding type thus rendering the subsequent search invalid
The creation of the PT and SL were very old and seem to have been replaced by this trait so I'd thought I'd try it 🤷‍♂️ 

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
