### PR TITLE
Tech-debt/Flickering tests

### DIFF
--- a/spec/forms/legal_aid_applications/used_multiple_delegated_functions_form_spec.rb
+++ b/spec/forms/legal_aid_applications/used_multiple_delegated_functions_form_spec.rb
@@ -51,6 +51,13 @@ RSpec.describe LegalAidApplications::UsedMultipleDelegatedFunctionsForm, type: :
       end
 
       it 'updates the application types with no reported on date' do
+        expect(application_proceeding_types.all.pluck(:used_delegated_functions_on)).to match_array [today - 12.months, today - 12.months + 1.day]
+        expect(application_proceeding_types.all.pluck(:used_delegated_functions_reported_on)).to match_array [nil, nil]
+
+        # TODO: replace the below with the above if the below still flickers
+        # also, check that this has value... used_delegated_functions_reported_on should always have a value
+        # if the used_delegated_functions_on has one
+
         application_proceeding_types.each_with_index do |type, i|
           expect(type.used_delegated_functions_reported_on).to be_nil
           expect(type.used_delegated_functions_on).to eq(used_delegated_functions_on - i.day)

--- a/spec/requests/providers/proceeding_merits_task/involved_children_spec.rb
+++ b/spec/requests/providers/proceeding_merits_task/involved_children_spec.rb
@@ -27,7 +27,7 @@ module Providers
           end
 
           it 'lists all involved children\'s names in the application' do
-            expect(involved_children_names.all? { |name| response.body.include? name }).to be true
+            expect(involved_children_names.all? { |name| response.body.include? html_compare(name) }).to be true
           end
         end
       end


### PR DESCRIPTION
## What

* Ensure the InvolvedChildrenController name is escaped with by the html_compare method
* added additional debugging tests to the used_multiple_delegated_functions_form_spec if the new ones pass and the original ones fail then we can delete the original ones, or delete the new ones if they are impractical 🤷‍♂️ 

Since adding the debug step I cannot make the test flicker, so I've left it in place to see if it will fail longer term

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
