### PR TITLE
Ap-2146 update heading sizes and hierarchy on 'add another' pages

### DIFF
--- a/app/views/providers/application_merits_task/has_other_involved_children/show.html.erb
+++ b/app/views/providers/application_merits_task/has_other_involved_children/show.html.erb
@@ -9,7 +9,7 @@
                     form: form do %>
 
     <% if @legal_aid_application.involved_children.count > 0 %>
-    <%= govuk_fieldset_header(size: 'l') { t('.existing', count: "#{pluralize(@legal_aid_application.involved_children.count, 'child')}")} %>
+    <h1 class="govuk-heading-xl"><%= t('.existing', count: "#{pluralize(@legal_aid_application.involved_children.count, 'child')}") %></h1>
     <div class="govuk-summary-list">
       <table class="govuk-table">
         <thead class="govuk-table__head">
@@ -45,7 +45,7 @@
                                             yes_no_options,
                                             :value,
                                             :label,
-                                            legend: {text: t(".add_another"), size: 'l', tag: 'h1'} %>
+                                            legend: {text: t(".add_another"), size: 'l', tag: 'h2'} %>
 
       <%= next_action_buttons(form: form) %>
   <% end %>

--- a/app/views/providers/has_other_dependants/show.html.erb
+++ b/app/views/providers/has_other_dependants/show.html.erb
@@ -8,7 +8,7 @@
   <%= page_template page_title: t('.page_title'), form: form, template: :basic do %>
 
   <% if @legal_aid_application.has_dependants? %>
-    <%= govuk_fieldset_header(size: 'm') { t('.existing', count: "#{pluralize(@legal_aid_application.dependants.count, 'dependant')}")} %>
+    <h1 class="govuk-heading-xl"><%= t('.existing', count: "#{pluralize(@legal_aid_application.dependants.count, 'dependant')}") %></h1>
     <div class="govuk-summary-list">
       <% @legal_aid_application.dependants.order(:created_at, :number).each do |dependant| %>
         <dl class="govuk-summary-list__row" id="dependant_<%= dependant.number %>">
@@ -40,7 +40,7 @@
                                           yes_no_options,
                                           :value,
                                           :label,
-                                          legend: {text: content_for(:page_title), size: 'xl', tag: 'h1'} %>
+                                          legend: {text: content_for(:page_title), size: 'l', tag: 'h2'} %>
 
   <%= next_action_buttons(form: form) %>
   <% end %>

--- a/app/views/providers/has_other_proceedings/show.html.erb
+++ b/app/views/providers/has_other_proceedings/show.html.erb
@@ -5,7 +5,7 @@
   <%= page_template page_title: t('.page_title'), template: :basic, form: form do %>
 
     <% if @legal_aid_application.proceeding_types.any? %>
-      <%= govuk_fieldset_header(size: 'm') { t('.existing', count: "#{pluralize(@legal_aid_application.proceeding_types.count, 'proceeding')}")} %>
+      <h1 class="govuk-heading-xl"><%= t('.existing', count: "#{pluralize(@legal_aid_application.proceeding_types.count, 'proceeding')}") %></h1>
       <div class="govuk-summary-list">
         <% @legal_aid_application.proceeding_types.order(:created_at).each do |type| %>
           <dl class="govuk-summary-list__row" id="proceeding_type_<%= type.code %>">
@@ -25,7 +25,7 @@
     <% end %>
 
     <%= form.govuk_collection_radio_buttons :has_other_proceeding, yes_no_options, :value, :label,
-                                            legend: {text: content_for(:page_title), tag: 'h1', size: 'xl'} %>
+                                            legend: {text: content_for(:page_title), tag: 'h2', size: 'l'} %>
 
     <%= next_action_buttons(
             form: form,


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2146)

Made the first heading h1 and size xl, and the second heading h2 and size l - this is to have a consistent heading hierarchy and page flow

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
