### PR TITLE
AP-2204 fix bug where df date_reported_on was not being stored for cases where df date was over a month old

### DIFF
--- a/app/controllers/providers/used_delegated_functions_controller.rb
+++ b/app/controllers/providers/used_delegated_functions_controller.rb
@@ -52,9 +52,7 @@ module Providers
     end
 
     def update_scope_limitations
-      # update_substantive_application_deadline
       earliest_delegated_functions_date ? add_delegated_scope_limitations : remove_delegated_scope_limitations
-      # submit_application_reminder if !draft_selected? && earliest_delegated_functions_date && earliest_delegated_functions_date > Date.current - 1.month
     end
 
     def add_delegated_scope_limitations

--- a/app/forms/legal_aid_applications/confirm_delegated_functions_date_form.rb
+++ b/app/forms/legal_aid_applications/confirm_delegated_functions_date_form.rb
@@ -68,7 +68,7 @@ module LegalAidApplications
 
         proceeding.application_proceeding_type.update(
           used_delegated_functions_on: delegated_functions_date,
-          used_delegated_functions_reported_on: delegated_functions_reported_date(delegated_functions_date)
+          used_delegated_functions_reported_on: Time.zone.today
         )
       end
     end
@@ -88,14 +88,6 @@ module LegalAidApplications
         prefix: :"#{name}_used_delegated_functions_on_",
         suffix: :gov_uk
       )
-    end
-
-    def delegated_functions_reported_date(date)
-      Time.zone.today unless date.nil? || date_over_a_month_ago?(date)
-    end
-
-    def date_over_a_month_ago?(date)
-      date.before?(Time.zone.today - 1.month + 1.day)
     end
 
     def draft_nothing_selected?

--- a/app/forms/legal_aid_applications/used_multiple_delegated_functions_form.rb
+++ b/app/forms/legal_aid_applications/used_multiple_delegated_functions_form.rb
@@ -97,10 +97,6 @@ module LegalAidApplications
       Time.zone.today unless date.nil?
     end
 
-    # def date_over_a_month_ago?(date)
-    #   date.before?(Time.zone.today - 1.month + 1.day)
-    # end
-
     def checkbox_for?(category)
       __send__(category) == 'true'
     end

--- a/spec/forms/legal_aid_applications/confirm_delegated_functions_date_form_spec.rb
+++ b/spec/forms/legal_aid_applications/confirm_delegated_functions_date_form_spec.rb
@@ -36,9 +36,9 @@ RSpec.describe LegalAidApplications::ConfirmDelegatedFunctionsDateForm, type: :f
         expect(subject).to be_valid
       end
 
-      it 'updates the application types with no reported on date' do
+      it 'updates the application types reported on date to Today' do
         application_proceeding_types.each_with_index do |type, i|
-          expect(type.used_delegated_functions_reported_on).to be_nil
+          expect(type.used_delegated_functions_reported_on).to eq Time.zone.today
           expect(type.used_delegated_functions_on).to eq(used_delegated_functions_on - i.day)
         end
       end

--- a/spec/forms/legal_aid_applications/used_multiple_delegated_functions_form_spec.rb
+++ b/spec/forms/legal_aid_applications/used_multiple_delegated_functions_form_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe LegalAidApplications::UsedMultipleDelegatedFunctionsForm, type: :
       application_proceeding_types.reload
     end
 
-    context 'two of the thee proceeding types have delegated functions' do
+    context 'two of the three proceeding types have delegated functions' do
       it 'updates each application proceeding type' do
         expect(application_proceeding_types.map(&:used_delegated_functions_on)).to match_array([nil, used_delegated_functions_on, used_delegated_functions_on])
         expect(application_proceeding_types.map(&:used_delegated_functions_reported_on)).to match_array([nil, used_delegated_functions_reported_on,


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2204)

removed commented out code that was no longer needed
revised a test that was checking something incorrectly
Set reported_on_date value in the form instead of calling a method on the model
Updated multiple DF form to no longer leave the value nil if the date is over a month ago

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
