### PR TITLE
AP-2267 BugFix - Update predwp check to be more accurate

### DIFF
--- a/app/models/concerns/base_state_machine.rb
+++ b/app/models/concerns/base_state_machine.rb
@@ -12,6 +12,12 @@ class BaseStateMachine < ApplicationRecord  # rubocop:disable Metrics/ClassLengt
     unknown
   ].freeze
 
+  PRE_DWP_STATES = %i[
+    initiated
+    entering_applicant_details
+    checking_applicant_details
+  ].freeze
+
   include AASM
 
   aasm do # rubocop:disable Metrics/BlockLength

--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -185,7 +185,7 @@ class LegalAidApplication < ApplicationRecord
   end
 
   def pre_dwp_check?
-    BaseStateMachine.aasm.states.map(&:name).include? state.to_sym
+    BaseStateMachine::PRE_DWP_STATES.include? state.to_sym
   end
 
   def income_types?

--- a/spec/mailers/feedback_mailer_spec.rb
+++ b/spec/mailers/feedback_mailer_spec.rb
@@ -23,6 +23,14 @@ RSpec.describe FeedbackMailer, type: :mailer do
           end
         end
 
+        context 'when application state is not a pre_dwp_check state' do
+          let(:application) { create :application, :assessment_submitted }
+
+          it 'does not have a status of pre dwp check' do
+            expect(mail.govuk_notify_personalisation[:application_status]).not_to eq 'pre-dwp-check'
+          end
+        end
+
         context 'passported' do
           before do
             allow_any_instance_of(LegalAidApplication).to receive(:pre_dwp_check?).and_return(false)


### PR DESCRIPTION
## AP-2267 BUGFIX Update predwp check to be more accurate

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2267)

Update the base state machine to define the states that occur before the dwp check.

Update the LegalAidApplication model to use the above states to check if a legal aid application is in the pre_dwp_check state.

Test the above.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
