### PR TITLE
Repair Delegated Function dates

### DIFF
--- a/bin/df_dates_updater.rb
+++ b/bin/df_dates_updater.rb
@@ -1,5 +1,4 @@
 class DFDatesUpdater
-
   def run
     apts = ApplicationProceedingType.where(used_delegated_functions_on: nil)
     apts.each { |apt| process_apt(apt) }
@@ -19,7 +18,9 @@ class DFDatesUpdater
     reminder_mail = ScheduledMailing.where(mailer_klass: 'SubmitApplicationReminderMailer', legal_aid_application_id: laa.id).first
     reported_date = reminder_mail&.created_at || df_date
     apt.update!(used_delegated_functions_on: df_date, used_delegated_functions_reported_on: reported_date)
+    # rubocop:disable Layout/LineLength
     puts "Legal Aid Application id: #{laa.id}  deadline: #{laa.substantive_application_deadline_on.strftime('%F')} DF dates updated to: #{df_date.strftime('%F')} (used), #{reported_date.strftime('%F')} (reported)"
+    # rubocop:enable Layout/LineLength
   end
 end
 

--- a/bin/df_dates_updater.rb
+++ b/bin/df_dates_updater.rb
@@ -1,18 +1,26 @@
 class DFDatesUpdater
+
   def run
-    laa_ids = LegalAidApplication.where.not(substantive_application_deadline_on: nil).pluck(:id)
-    laa_ids.each do |laa_id|
-      laa = LegalAidApplication.find laa_id
-      df_date = WorkingDayCalculator.call(working_days: -20, from: laa.substantive_application_deadline_on)
-      reminder_mail = ScheduledMailing.where(mailer_klass: 'SubmitApplicationReminderMailer', legal_aid_application_id: laa_id).first
-      reported_date = reminder_mail&.created_at || df_date
-      laa.application_proceeding_types.each do |apt|
-        apt.update!(used_delegated_functions_on: df_date, used_delegated_functions_reported_on: reported_date)
-      end
-      puts "Legal Aid Application id: #{laa_id}  deadline: #{laa.substantive_application_deadline_on.strftime('%F')} DF dates updated to: #{df_date.strftime('%F')} (used), #{reported_date.strftime('%F')} (reported)"
-    end
+    apts = ApplicationProceedingType.where(used_delegated_functions_on: nil)
+    apts.each { |apt| process_apt(apt) }
+  end
+
+  private
+
+  def process_apt(apt)
+    laa = apt.legal_aid_application
+    return if laa.substantive_application_deadline_on.nil?
+
+    update_apt(apt, laa)
+  end
+
+  def update_apt(apt, laa)
+    df_date = WorkingDayCalculator.call(working_days: -20, from: laa.substantive_application_deadline_on)
+    reminder_mail = ScheduledMailing.where(mailer_klass: 'SubmitApplicationReminderMailer', legal_aid_application_id: laa.id).first
+    reported_date = reminder_mail&.created_at || df_date
+    apt.update!(used_delegated_functions_on: df_date, used_delegated_functions_reported_on: reported_date)
+    puts "Legal Aid Application id: #{laa.id}  deadline: #{laa.substantive_application_deadline_on.strftime('%F')} DF dates updated to: #{df_date.strftime('%F')} (used), #{reported_date.strftime('%F')} (reported)"
   end
 end
-
 
 DFDatesUpdater.new.run

--- a/bin/df_dates_updater.rb
+++ b/bin/df_dates_updater.rb
@@ -1,0 +1,18 @@
+class DFDatesUpdater
+  def run
+    laa_ids = LegalAidApplication.where.not(substantive_application_deadline_on: nil).pluck(:id)
+    laa_ids.each do |laa_id|
+      laa = LegalAidApplication.find laa_id
+      df_date = WorkingDayCalculator.call(working_days: -20, from: laa.substantive_application_deadline_on)
+      reminder_mail = ScheduledMailing.where(mailer_klass: 'SubmitApplicationReminderMailer', legal_aid_application_id: laa_id).first
+      reported_date = reminder_mail&.created_at || df_date
+      laa.application_proceeding_types.each do |apt|
+        apt.update!(used_delegated_functions_on: df_date, used_delegated_functions_reported_on: reported_date)
+      end
+      puts "Legal Aid Application id: #{laa_id}  deadline: #{laa.substantive_application_deadline_on.strftime('%F')} DF dates updated to: #{df_date.strftime('%F')} (used), #{reported_date.strftime('%F')} (reported)"
+    end
+  end
+end
+
+
+DFDatesUpdater.new.run


### PR DESCRIPTION
## Script to repair DF dates

In the migration to use delegated function dates on the `application_proceeding_type`, the rake task to copy the dates from the `legal_aid_application` to the `application_proceeding_type` was not run before deleting those columns from the legal_aid_applications table (it had been run earlier, but application had been created since then).

This script finds all the application proceeding types without delegated function dates, and checks the legal aid application record to see if there is a value in the `substantive_application_deadline_on` (which means delegated functions have been used).  If there is, it updates the application proceeding type with a date 20 working days before the deadline, and uses the reminder mail's created_at date as the DF reporting date.

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
