### PR TITLE
AP-2290 Assign first domestic abuse proceeding as lead

### DIFF
--- a/app/controllers/providers/has_other_proceedings_controller.rb
+++ b/app/controllers/providers/has_other_proceedings_controller.rb
@@ -50,17 +50,6 @@ module Providers
       legal_aid_application.save!
     end
 
-    def domestic_abuse_selected?
-      proceeding_types.any? { |type| type.ccms_matter == 'Domestic Abuse' }
-    end
-
-    def set_new_lead_proceeding
-      new_lead = ApplicationProceedingType.where(lead_proceeding: false).find_by(legal_aid_application_id: legal_aid_application.id)
-      new_lead.lead_proceeding = true
-      new_lead.save!
-      LeadProceedingAssignmentService.call(legal_aid_application)
-    end
-
     def form_params
       params[:action] == 'destroy' ? destroy_form_params : update_form_params
     end

--- a/app/controllers/providers/has_other_proceedings_controller.rb
+++ b/app/controllers/providers/has_other_proceedings_controller.rb
@@ -3,21 +3,21 @@ module Providers
     def show
       return go_forward unless Setting.allow_multiple_proceedings?
 
-      form
+      @form = LegalAidApplications::HasOtherProceedingsForm.new(model: legal_aid_application)
       proceeding_types
     end
 
     def update
-      return continue_or_draft if draft_selected?
+      @form = LegalAidApplications::HasOtherProceedingsForm.new(form_params)
+      @form.draft! if params[:draft_button]
+      if @form.save
+        LeadProceedingAssignmentService.call(legal_aid_application)
+        return continue_or_draft if draft_selected?
 
-      if go_forward?
-        return redirect_to providers_legal_aid_application_proceedings_types_path if legal_aid_application.checking_answers?
-
-        return go_forward(form.has_other_proceeding?)
+        go_forward(@form.has_other_proceeding?)
+      else
+        render :show
       end
-      form.errors.add(:has_other_proceeding, I18n.t('providers.has_other_proceedings.show.must_add_domestic_abuse')) unless domestic_abuse_selected?
-
-      render :show
     end
 
     def destroy
@@ -26,34 +26,14 @@ module Providers
 
       return redirect_to providers_legal_aid_application_proceedings_types_path if proceeding_types.empty?
 
-      form
+      @form = LegalAidApplications::HasOtherProceedingsForm.new(model: legal_aid_application)
       render :show
     end
 
     private
 
-    def go_forward?
-      # go forward if the form is valid AND either there is a dom ab proceeding, or they have selected True to add another proceeding
-      form.valid? && (form.has_other_proceeding? || domestic_abuse_selected?)
-    end
-
-    def form
-      @form ||= BinaryChoiceForm.call(
-        journey: :provider,
-        radio_buttons_input_name: :has_other_proceeding,
-        form_params: update_form_params
-      )
-    end
-
     def proceeding_types
       @proceeding_types ||= legal_aid_application.proceeding_types
-    end
-
-    def application_proceeding_type
-      ApplicationProceedingType.find_by(
-        legal_aid_application_id: legal_aid_application.id,
-        proceeding_type_id: proceeding_type.id
-      )
     end
 
     def proceeding_type
@@ -61,9 +41,8 @@ module Providers
     end
 
     def remove_proceeding
-      set_new_lead_proceeding if application_proceeding_type.lead_proceeding? && proceeding_types.count > 1
-
       LegalFramework::RemoveProceedingTypeService.call(legal_aid_application, proceeding_type)
+      LeadProceedingAssignmentService.call(legal_aid_application)
     end
 
     def remove_laspo_response
@@ -79,6 +58,7 @@ module Providers
       new_lead = ApplicationProceedingType.where(lead_proceeding: false).find_by(legal_aid_application_id: legal_aid_application.id)
       new_lead.lead_proceeding = true
       new_lead.save!
+      LeadProceedingAssignmentService.call(legal_aid_application)
     end
 
     def form_params
@@ -90,9 +70,11 @@ module Providers
     end
 
     def update_form_params
-      return {} unless params[:binary_choice_form]
+      merge_with_model(legal_aid_application) do
+        return {} unless params[:legal_aid_application]
 
-      params.require(:binary_choice_form).permit(:has_other_proceeding)
+        params.require(:legal_aid_application).permit(:has_other_proceeding)
+      end
     end
   end
 end

--- a/app/forms/base_form.rb
+++ b/app/forms/base_form.rb
@@ -69,6 +69,8 @@ module BaseForm
     def save
       return false unless valid?
 
+      return true if assignable_attributes.empty?
+
       model.attributes = clean_attributes(assignable_attributes)
       model.save(validate: false)
     end

--- a/app/forms/legal_aid_applications/has_other_proceedings_form.rb
+++ b/app/forms/legal_aid_applications/has_other_proceedings_form.rb
@@ -1,0 +1,45 @@
+module LegalAidApplications
+  class HasOtherProceedingsForm
+    include BaseForm
+
+    form_for LegalAidApplication
+
+    attr_accessor :has_other_proceeding
+
+    validate :radio_button_selected?
+
+    validate :at_least_one_domestic_abuse
+
+    delegate :proceeding_types, to: :model
+
+    def draft!
+      @draft = true
+    end
+
+    def radio_button_selected?
+      return if draft?
+
+      errors.add(:has_other_proceeding, I18n.t('providers.has_other_proceedings.show.error')) if @has_other_proceeding.blank?
+    end
+
+    def at_least_one_domestic_abuse
+      return if draft? || has_other_proceeding == 'true'
+
+      return if proceeding_types_include_domestic_abuse?
+
+      errors.add(:base, I18n.t('providers.has_other_proceedings.show.must_add_domestic_abuse'))
+    end
+
+    def exclude_from_model
+      [:has_other_proceeding]
+    end
+
+    def proceeding_types_include_domestic_abuse?
+      proceeding_types.map(&:domestic_abuse?).include?(true)
+    end
+
+    def has_other_proceeding? # rubocop:disable Naming/PredicateName
+      @has_other_proceeding == 'true'
+    end
+  end
+end

--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -133,16 +133,21 @@ class LegalAidApplication < ApplicationRecord
     _prefix: true
   )
 
-  # convenience method to return the lead proceeding type.  For now, that is the ONLY
-  # proceeding type until such time as we have multiple proceeding types per applications,
-  # at which time this method should be changed to determine which is the lead one and return that.
-  #
   def lead_proceeding_type
     ProceedingType.find(lead_application_proceeding_type.proceeding_type_id)
   end
 
   def lead_application_proceeding_type
     application_proceeding_types.find_by(lead_proceeding: true)
+  end
+
+  def find_or_create_lead_proceeding_type
+    apt = lead_application_proceeding_type
+    if apt.nil?
+      apt = application_proceeding_types.detect(&:domestic_abuse?)
+      apt.update!(lead_proceeding: true)
+    end
+    apt.proceeding_type
   end
 
   def application_proceedings_by_name

--- a/app/models/proceeding_type.rb
+++ b/app/models/proceeding_type.rb
@@ -29,4 +29,8 @@ class ProceedingType < ApplicationRecord
 
     connection.execute(query)
   end
+
+  def domestic_abuse?
+    ccms_matter == 'Domestic Abuse'
+  end
 end

--- a/app/services/lead_proceeding_assignment_service.rb
+++ b/app/services/lead_proceeding_assignment_service.rb
@@ -1,0 +1,29 @@
+# assigns the first domestic abuse proceeding type as lead if one isn't assigned already
+# not an error condition if there are no domestic abuse proceedings.
+#
+class LeadProceedingAssignmentService
+  def self.call(legal_aid_application)
+    new(legal_aid_application).call
+  end
+
+  def initialize(legal_aid_application)
+    @legal_aid_application = legal_aid_application.reload
+  end
+
+  def call
+    return if @legal_aid_application.application_proceeding_types.empty?
+
+    lead = @legal_aid_application.application_proceeding_types.find_by(lead_proceeding: true)
+    assign_new_lead if lead.nil?
+  end
+
+  private
+
+  def assign_new_lead
+    pt = @legal_aid_application.proceeding_types.detect(&:domestic_abuse?)
+    return if pt.nil?
+
+    apt = @legal_aid_application.application_proceeding_types.find_by(proceeding_type_id: pt.id)
+    apt.update!(lead_proceeding: true)
+  end
+end

--- a/app/services/legal_framework/proceeding_types_service.rb
+++ b/app/services/legal_framework/proceeding_types_service.rb
@@ -10,6 +10,7 @@ module LegalFramework
       ActiveRecord::Base.transaction do
         @legal_aid_application.reset_proceeding_types! unless Setting.allow_multiple_proceedings? # This will probably change when multiple proceeding types implemented!
         @legal_aid_application.proceeding_types << proceeding_type(proceeding_type_id)
+        LeadProceedingAssignmentService.call(@legal_aid_application)
         AddAssignedScopeLimitationService.call(@legal_aid_application, proceeding_type_id, scope_type)
       end
     end

--- a/config/locales/en/activerecord.yml
+++ b/config/locales/en/activerecord.yml
@@ -19,6 +19,10 @@ en:
               invalid: address is not in the right format
             national_insurance_number:
               invalid: is not in the right format
+        application_proceeding_type:
+          attributes:
+            lead_proceeding:
+              multiple: Only one application proceeding type can be nominated as lead proceeding
         benefit_type:
           attributes:
             label:

--- a/features/step_definitions/civil_journey_steps.rb
+++ b/features/step_definitions/civil_journey_steps.rb
@@ -531,8 +531,9 @@ Given('I complete the application and view the check your answers page') do
     :legal_aid_application,
     :with_non_passported_state_machine,
     :applicant_entering_means,
+    :with_proceeding_types,
     applicant: applicant,
-    proceeding_types: [proceeding_type]
+    explicit_proceeding_types: [proceeding_type]
   )
   add_scope_limitations(@legal_aid_application, proceeding_type)
 

--- a/spec/factories/legal_aid_applications.rb
+++ b/spec/factories/legal_aid_applications.rb
@@ -208,7 +208,9 @@ FactoryBot.define do
     # :with_proceeding_types trait
     # ============================
     # takes optional arguments
-    #  - proceeding_type count, (1 is assumed if absent) - will generate random proceeding types.
+    #  - set_lead_proceeding - (true or false - true is assumed) - will set the first domestic abuse
+    #    proceeding as the lead proceeding
+    #  - proceeding_types_count, (1 is assumed if absent) - will generate random proceeding types.
     #    OR
     #  - explicit_proceeding_types (an array of proceeding types to attach to the application).  The ProceedingType
     #                              records must already have default substantive and df scope limitations (i.e. if
@@ -230,10 +232,12 @@ FactoryBot.define do
     # and create an ApplicationProceedingTypesScopeLimitation record for the delegated function default
     # scope limitation
     #
+    #
     trait :with_proceeding_types do
       transient do
         proceeding_types_count { 1 }
         explicit_proceeding_types { [] }
+        assign_lead_proceeding { true }
       end
 
       after(:create) do |application, evaluator|
@@ -250,6 +254,13 @@ FactoryBot.define do
         proceeding_types.each do |pt|
           apt = create :application_proceeding_type, legal_aid_application: application, proceeding_type: pt
           apt.substantive_scope_limitation = pt.default_substantive_scope_limitation
+        end
+
+        if evaluator.assign_lead_proceeding == true
+          da_pt = application.proceeding_types.detect(&:domestic_abuse?)
+          raise 'At least one domestic abuse proceeding type must be added before you can use the :with_lead_proceeding_type trait' if da_pt.nil?
+
+          application.application_proceeding_types.find_by(proceeding_type_id: da_pt.id).update!(lead_proceeding: true)
         end
         application.reload
       end
@@ -282,6 +293,21 @@ FactoryBot.define do
         application.application_proceeding_types.each do |app_proc_type|
           create(:chances_of_success, :with_optional_text, application_proceeding_type: app_proc_type)
           create(:attempts_to_settles, application_proceeding_type: app_proc_type)
+        end
+      end
+    end
+
+    # this trait will mark the first domestic abuse proceeding type for the application as the lead proceeding, unless one already exists
+    # the application proceeding types must have been set up before calling this trait.  Only needed for deprecated traits, not for :with_proceeding_types
+    #
+    trait :with_lead_proceeding_type do
+      after(:create) do |application|
+        if application.application_proceeding_types.detect(&:lead_proceeding).nil?
+          da_pt = application.proceeding_types.detect(&:domestic_abuse?)
+          raise 'At least one domestic abuse proceeding type must be added before you can use the :with_lead_proceeding_type trait' if da_pt.nil?
+
+          application.application_proceeding_types.find_by(proceeding_type_id: da_pt.id).update!(lead_proceeding: true)
+          application.reload
         end
       end
     end
@@ -618,9 +644,6 @@ FactoryBot.define do
     trait :at_assessment_submitted do
       with_everything_and_address
       with_positive_benefit_check_result
-      with_substantive_scope_limitation
-      with_delegated_functions_scope_limitation
-      with_delegated_functions
       with_cfe_v3_result
       with_means_report
       with_merits_report
@@ -636,9 +659,6 @@ FactoryBot.define do
     trait :at_submitting_assessment do
       with_everything_and_address
       with_positive_benefit_check_result
-      with_substantive_scope_limitation
-      with_delegated_functions_scope_limitation
-      with_delegated_functions
       with_cfe_v3_result
       with_means_report
       with_merits_report
@@ -767,7 +787,7 @@ FactoryBot.define do
           application.proceeding_types << create(:proceeding_type, :with_real_data)
           application.proceeding_types << create(:proceeding_type, :as_occupation_order)
         end
-        pt = application.lead_proceeding_type
+        pt = application.find_or_create_lead_proceeding_type
         sl = create :scope_limitation, :substantive_default, joined_proceeding_type: pt
         apt = application.application_proceeding_types.find_by(proceeding_type_id: pt.id)
         AssignedSubstantiveScopeLimitation.create!(application_proceeding_type_id: apt.id,
@@ -785,11 +805,12 @@ FactoryBot.define do
       after(:create) do |application, _evaluator|
         if application.proceeding_types.empty?
           application.proceeding_types = create_list(:proceeding_type, 1)
-          pt = application.lead_proceeding_type
+          pt = application.find_or_create_lead_proceeding_type
           sl = create :scope_limitation, :substantive_default, joined_proceeding_type: pt
           apt = application.application_proceeding_types.find_by(proceeding_type_id: pt.id)
           AssignedSubstantiveScopeLimitation.create!(application_proceeding_type_id: apt.id,
                                                      scope_limitation_id: sl.id)
+          application.reload
         end
       end
     end
@@ -819,16 +840,16 @@ FactoryBot.define do
     #                                                                                                     #
     #######################################################################################################
     #
-    trait :with_delegated_functions_scope_limitation do
-      after(:create) do |application, evaluator|
-        application.proceeding_types = evaluator.proceeding_types.presence || create_list(:proceeding_type, 1)
-        pt = application.lead_proceeding_type
-        sl = create :scope_limitation, :delegated_functions_default, joined_proceeding_type: pt
-        apt = application.application_proceeding_types.find_by(proceeding_type_id: pt.id)
-        AssignedDfScopeLimitation.create!(application_proceeding_type_id: apt.id,
-                                          scope_limitation_id: sl.id)
-      end
-    end
+    # trait :with_delegated_functions_scope_limitation do
+    #   after(:create) do |application, evaluator|
+    #     application.proceeding_types = evaluator.proceeding_types.presence || create_list(:proceeding_type, 1)
+    #     pt = application.lead_proceeding_type
+    #     sl = create :scope_limitation, :delegated_functions_default, joined_proceeding_type: pt
+    #     apt = application.application_proceeding_types.find_by(proceeding_type_id: pt.id)
+    #     AssignedDfScopeLimitation.create!(application_proceeding_type_id: apt.id,
+    #                                       scope_limitation_id: sl.id)
+    #   end
+    # end
 
     #######################################################################################################
     #                                                                                                     #
@@ -853,6 +874,7 @@ FactoryBot.define do
         pt1.proceeding_type_scope_limitations << create(:proceeding_type_scope_limitation, :delegated_functions_default, scope_limitation: sl2) if sl2.present?
         application.proceeding_types << pt1
         apt = application.application_proceeding_types.first
+        apt.update!(lead_proceeding: true)
         AssignedSubstantiveScopeLimitation.create!(application_proceeding_type: apt, scope_limitation: sl1)
         AssignedDfScopeLimitation.create!(application_proceeding_type: apt, scope_limitation: sl2) if sl2.present?
       end

--- a/spec/factories/legal_aid_applications.rb
+++ b/spec/factories/legal_aid_applications.rb
@@ -841,23 +841,6 @@ FactoryBot.define do
 
     #######################################################################################################
     #                                                                                                     #
-    #     DEPRECATED - use :with_proceeding_types, :with_delegated_functions instead                      #
-    #                                                                                                     #
-    #######################################################################################################
-    #
-    # trait :with_delegated_functions_scope_limitation do
-    #   after(:create) do |application, evaluator|
-    #     application.proceeding_types = evaluator.proceeding_types.presence || create_list(:proceeding_type, 1)
-    #     pt = application.lead_proceeding_type
-    #     sl = create :scope_limitation, :delegated_functions_default, joined_proceeding_type: pt
-    #     apt = application.application_proceeding_types.find_by(proceeding_type_id: pt.id)
-    #     AssignedDfScopeLimitation.create!(application_proceeding_type_id: apt.id,
-    #                                       scope_limitation_id: sl.id)
-    #   end
-    # end
-
-    #######################################################################################################
-    #                                                                                                     #
     #     DEPRECATED - use :with_proceeding_types instead                                                 #
     #                                                                                                     #
     #######################################################################################################

--- a/spec/factories/legal_aid_applications.rb
+++ b/spec/factories/legal_aid_applications.rb
@@ -274,7 +274,12 @@ FactoryBot.define do
           application.proceeding_types << create(:proceeding_type, :with_real_data)
           application.proceeding_types << create(:proceeding_type, :as_section_8_child_residence)
         end
-        pt = application.lead_proceeding_type
+        lead_apt = application.application_proceeding_types.find_by(lead_proceeding: true)
+        if lead_apt.nil?
+          lead_apt = application.application_proceeding_types.detect { |apt| apt.proceeding_type.ccms_matter == 'Domestic Abuse' }
+          lead_apt.update!(lead_proceeding: true)
+        end
+        pt = lead_apt.proceeding_type
         sl = create :scope_limitation, :substantive_default, joined_proceeding_type: pt
         apt = application.application_proceeding_types.find_by(proceeding_type_id: pt.id)
         AssignedSubstantiveScopeLimitation.create!(application_proceeding_type_id: apt.id,

--- a/spec/factories/proceeding_types.rb
+++ b/spec/factories/proceeding_types.rb
@@ -9,7 +9,7 @@ FactoryBot.define do
     description { "Description-#{ccms_code}" }
     ccms_category_law { 'Category law' }
     ccms_category_law_code { 'Category law code' }
-    ccms_matter { 'Matter' }
+    ccms_matter { 'Domestic Abuse' }
     ccms_matter_code { 'Matter code' }
     default_service_level_id { create(:service_level).id }
     default_cost_limitation_delegated_functions { 1 }
@@ -86,6 +86,36 @@ FactoryBot.define do
         create(:scope_limitation, :substantive_default, joined_proceeding_type: proceeding_type)
         create(:scope_limitation, :delegated_functions_default, joined_proceeding_type: proceeding_type)
       end
+    end
+
+    trait :domestic_abuse do
+      sequence(:ccms_code) { |n| format('DA%<number>03d', number: n) }
+      ccms_matter { 'Domestic Abuse' }
+    end
+
+    trait :section8 do
+      sequence(:ccms_code) { |n| format('SE%<number>03d', number: n) }
+      ccms_matter { 'Section 8 orders' }
+    end
+
+    trait :da001 do
+      ccms_code { 'DA001' }
+      ccms_matter { 'Domestic Abuse' }
+    end
+
+    trait :da004 do
+      ccms_code { 'DA004' }
+      ccms_matter { 'Domestic Abuse' }
+    end
+
+    trait :se013 do
+      ccms_code { 'SE013' }
+      ccms_matter { 'Section 8 orders' }
+    end
+
+    trait :se014 do
+      ccms_code { 'SE014' }
+      ccms_matter { 'Section 8 orders' }
     end
   end
 end

--- a/spec/factory_specs/legal_aid_application_factory_spec.rb
+++ b/spec/factory_specs/legal_aid_application_factory_spec.rb
@@ -242,34 +242,6 @@ RSpec.describe 'LegalAidApplication factory' do
     end
   end
 
-  # describe ':with_delegated_functions_scope_limitation' do
-  #   let(:laa) { create :legal_aid_application, :with_delegated_functions_scope_limitation }
-  #
-  #   subject { laa }
-  #
-  #   it 'creates a proceeding type and adds it to the application' do
-  #     expect(ProceedingType.count).to eq 0
-  #     expect { subject }.to change { ProceedingType.count }.by(1)
-  #     expect(laa.lead_proceeding_type).to eq ProceedingType.first
-  #   end
-  #
-  #   it 'creates a default scope DF limitation and adds to the lead proceeding type' do
-  #     expect(ScopeLimitation.count).to eq 0
-  #     expect { subject }.to change { ScopeLimitation.count }.by(1)
-  #     expect(laa.lead_proceeding_type.eligible_scope_limitations).to eq [ScopeLimitation.first]
-  #     expect(laa.lead_proceeding_type.default_delegated_functions_scope_limitation).to eq ScopeLimitation.first
-  #   end
-  #
-  #   it 'assigns the scope limtiation to the lead proceeding type' do
-  #     expect { subject }.to change { ApplicationProceedingTypesScopeLimitation.count }.by(1)
-  #     lead_pt = laa.lead_proceeding_type
-  #     apt = laa.reload.application_proceeding_types.find_by(proceeding_type_id: lead_pt.id)
-  #     aptsl = ApplicationProceedingTypesScopeLimitation.find_by(application_proceeding_type_id: apt.id)
-  #     expect(aptsl).to be_instance_of(AssignedDfScopeLimitation)
-  #     expect(aptsl.scope_limitation_id).to eq ScopeLimitation.first.id
-  #   end
-  # end
-
   describe ':with_proceeding_type_and_scope_limitations' do
     let(:pt1) { create :proceeding_type }
     let(:sl1) { create :scope_limitation }

--- a/spec/factory_specs/legal_aid_application_factory_spec.rb
+++ b/spec/factory_specs/legal_aid_application_factory_spec.rb
@@ -242,33 +242,33 @@ RSpec.describe 'LegalAidApplication factory' do
     end
   end
 
-  describe ':with_delegated_functions_scope_limitation' do
-    let(:laa) { create :legal_aid_application, :with_delegated_functions_scope_limitation }
-
-    subject { laa }
-
-    it 'creates a proceeding type and adds it to the application' do
-      expect(ProceedingType.count).to eq 0
-      expect { subject }.to change { ProceedingType.count }.by(1)
-      expect(laa.lead_proceeding_type).to eq ProceedingType.first
-    end
-
-    it 'creates a default scope DF limitation and adds to the lead proceeding type' do
-      expect(ScopeLimitation.count).to eq 0
-      expect { subject }.to change { ScopeLimitation.count }.by(1)
-      expect(laa.lead_proceeding_type.eligible_scope_limitations).to eq [ScopeLimitation.first]
-      expect(laa.lead_proceeding_type.default_delegated_functions_scope_limitation).to eq ScopeLimitation.first
-    end
-
-    it 'assigns the scope limtiation to the lead proceeding type' do
-      expect { subject }.to change { ApplicationProceedingTypesScopeLimitation.count }.by(1)
-      lead_pt = laa.lead_proceeding_type
-      apt = laa.reload.application_proceeding_types.find_by(proceeding_type_id: lead_pt.id)
-      aptsl = ApplicationProceedingTypesScopeLimitation.find_by(application_proceeding_type_id: apt.id)
-      expect(aptsl).to be_instance_of(AssignedDfScopeLimitation)
-      expect(aptsl.scope_limitation_id).to eq ScopeLimitation.first.id
-    end
-  end
+  # describe ':with_delegated_functions_scope_limitation' do
+  #   let(:laa) { create :legal_aid_application, :with_delegated_functions_scope_limitation }
+  #
+  #   subject { laa }
+  #
+  #   it 'creates a proceeding type and adds it to the application' do
+  #     expect(ProceedingType.count).to eq 0
+  #     expect { subject }.to change { ProceedingType.count }.by(1)
+  #     expect(laa.lead_proceeding_type).to eq ProceedingType.first
+  #   end
+  #
+  #   it 'creates a default scope DF limitation and adds to the lead proceeding type' do
+  #     expect(ScopeLimitation.count).to eq 0
+  #     expect { subject }.to change { ScopeLimitation.count }.by(1)
+  #     expect(laa.lead_proceeding_type.eligible_scope_limitations).to eq [ScopeLimitation.first]
+  #     expect(laa.lead_proceeding_type.default_delegated_functions_scope_limitation).to eq ScopeLimitation.first
+  #   end
+  #
+  #   it 'assigns the scope limtiation to the lead proceeding type' do
+  #     expect { subject }.to change { ApplicationProceedingTypesScopeLimitation.count }.by(1)
+  #     lead_pt = laa.lead_proceeding_type
+  #     apt = laa.reload.application_proceeding_types.find_by(proceeding_type_id: lead_pt.id)
+  #     aptsl = ApplicationProceedingTypesScopeLimitation.find_by(application_proceeding_type_id: apt.id)
+  #     expect(aptsl).to be_instance_of(AssignedDfScopeLimitation)
+  #     expect(aptsl.scope_limitation_id).to eq ScopeLimitation.first.id
+  #   end
+  # end
 
   describe ':with_proceeding_type_and_scope_limitations' do
     let(:pt1) { create :proceeding_type }

--- a/spec/models/legal_aid_application_spec.rb
+++ b/spec/models/legal_aid_application_spec.rb
@@ -730,7 +730,6 @@ RSpec.describe LegalAidApplication, type: :model do
              default_cost_limitation_delegated_functions: 2_500
     end
     context 'substantive' do
-      # let(:application) { create :legal_aid_application, proceeding_types: [proceeding_type] }
       let(:application) { create :legal_aid_application, :with_proceeding_types, :with_delegated_functions, proceeding_types: [proceeding_type] }
       it 'returns the substantive cost limitation for the first proceeding type' do
         expect(application.default_cost_limitation).to eq 9_000

--- a/spec/models/legal_aid_application_spec.rb
+++ b/spec/models/legal_aid_application_spec.rb
@@ -730,14 +730,15 @@ RSpec.describe LegalAidApplication, type: :model do
              default_cost_limitation_delegated_functions: 2_500
     end
     context 'substantive' do
-      let(:application) { create :legal_aid_application, proceeding_types: [proceeding_type] }
+      # let(:application) { create :legal_aid_application, proceeding_types: [proceeding_type] }
+      let(:application) { create :legal_aid_application, :with_proceeding_types, :with_delegated_functions, proceeding_types: [proceeding_type] }
       it 'returns the substantive cost limitation for the first proceeding type' do
         expect(application.default_cost_limitation).to eq 9_000
       end
     end
 
     context 'delegated functions' do
-      let(:application) { create :legal_aid_application, :with_delegated_functions, proceeding_types: [proceeding_type] }
+      let(:application) { create :legal_aid_application, :with_proceeding_types, :with_delegated_functions, proceeding_types: [proceeding_type] }
       it 'returns the subtantive cost limitation for the first proceeding type' do
         expect(application.default_cost_limitation).to eq 9_000
       end

--- a/spec/models/proceeding_type_spec.rb
+++ b/spec/models/proceeding_type_spec.rb
@@ -44,4 +44,21 @@ RSpec.describe ProceedingType, type: :model do
       end
     end
   end
+
+  describe '#domestic_abuse?' do
+    let(:proceeding_type) { create :proceeding_type, ccms_matter: matter }
+    context 'domestic abuse' do
+      let(:matter) { 'Domestic Abuse' }
+      it 'returns true' do
+        expect(proceeding_type.domestic_abuse?).to be true
+      end
+    end
+
+    context 'something else' do
+      let(:matter) { 'Something Else' }
+      it 'returns false' do
+        expect(proceeding_type.domestic_abuse?).to be false
+      end
+    end
+  end
 end

--- a/spec/models/proceeding_type_spec.rb
+++ b/spec/models/proceeding_type_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe ProceedingType, type: :model do
       end
     end
 
-    context 'something else' do
+    context 'not domestic abuse' do
       let(:matter) { 'Something Else' }
       it 'returns false' do
         expect(proceeding_type.domestic_abuse?).to be false

--- a/spec/requests/providers/application_merits_task/has_other_involved_children_spec.rb
+++ b/spec/requests/providers/application_merits_task/has_other_involved_children_spec.rb
@@ -3,16 +3,13 @@ require 'rails_helper'
 module Providers
   module ApplicationMeritsTask
     RSpec.describe HasOtherInvolvedChildrenController, type: :request do
-      let(:application) { create :legal_aid_application, :with_multiple_proceeding_types_inc_section8 }
+      let(:pt_da) { create :proceeding_type, :with_real_data }
+      let(:pt_s8) { create :proceeding_type, :as_section_8_child_residence }
+      let(:application) { create :legal_aid_application, :with_proceeding_types, explicit_proceeding_types: [pt_da, pt_s8] }
       let(:provider) { application.provider }
       let(:child1) { create :involved_child, legal_aid_application: application }
       let(:smtl) { create :legal_framework_merits_task_list, legal_aid_application: application }
-      let(:application_proceeding_type) do
-        create :application_proceeding_type,
-               legal_aid_application: application,
-               proceeding_type: create(:proceeding_type, :as_section_8_child_residence)
-      end
-
+      let(:application_proceeding_type) { legal_aid_application.application_proceeding_types.detect { |apt| apt.proceeding_type_id == pt_s8.id } }
       before do
         allow(LegalFramework::MeritsTasksService).to receive(:call).with(application).and_return(smtl)
         login_as provider

--- a/spec/requests/providers/application_merits_task/opponents_spec.rb
+++ b/spec/requests/providers/application_merits_task/opponents_spec.rb
@@ -3,14 +3,12 @@ require 'rails_helper'
 module Providers
   module ApplicationMeritsTask
     RSpec.describe OpponentsController, type: :request do
-      let(:legal_aid_application) { create :legal_aid_application, :with_multiple_proceeding_types_inc_section8 }
+      let(:pt_da) { create :proceeding_type, :with_real_data }
+      let(:pt_s8) { create :proceeding_type, :as_section_8_child_residence }
+      let(:legal_aid_application) { create :legal_aid_application, :with_proceeding_types, explicit_proceeding_types: [pt_da, pt_s8] }
       let(:login_provider) { login_as legal_aid_application.provider }
       let(:smtl) { create :legal_framework_merits_task_list, legal_aid_application: legal_aid_application }
-      let(:application_proceeding_type) do
-        create :application_proceeding_type,
-               legal_aid_application: legal_aid_application,
-               proceeding_type: create(:proceeding_type, :as_section_8_child_residence)
-      end
+      let(:application_proceeding_type) { legal_aid_application.application_proceeding_types.detect { |apt| apt.proceeding_type_id == pt_s8.id } }
 
       describe 'GET /providers/applications/:legal_aid_application_id/opponent' do
         subject { get providers_legal_aid_application_opponent_path(legal_aid_application) }
@@ -32,7 +30,7 @@ module Providers
 
         context 'with an existing opponent' do
           let(:opponent) { create :opponent }
-          let(:legal_aid_application) { create :legal_aid_application, :with_multiple_proceeding_types_inc_section8, opponent: opponent }
+          let(:legal_aid_application) { create :legal_aid_application, :with_proceeding_types, explicit_proceeding_types: [pt_da, pt_s8], opponent: opponent }
 
           it 'renders successfully' do
             expect(response).to have_http_status(:ok)

--- a/spec/requests/providers/application_merits_task/statement_of_case_spec.rb
+++ b/spec/requests/providers/application_merits_task/statement_of_case_spec.rb
@@ -5,6 +5,7 @@ module Providers
   module ApplicationMeritsTask
     RSpec.describe StatementOfCasesController, type: :request do
       let(:legal_aid_application) { create :legal_aid_application, :with_multiple_proceeding_types_inc_section8 }
+      # let(:legal_aid_application) { create :legal_aid_application, :with_proceeding_types, :with_chances_of_success }
       let(:provider) { legal_aid_application.provider }
       let(:soc) { nil }
       let(:i18n_error_path) { 'activemodel.errors.models.application_merits_task/statement_of_case.attributes.original_file' }

--- a/spec/requests/providers/check_merits_answers_spec.rb
+++ b/spec/requests/providers/check_merits_answers_spec.rb
@@ -10,15 +10,9 @@ RSpec.describe 'check merits answers requests', type: :request do
     let(:application) do
       create :legal_aid_application,
              :with_everything,
-# <<<<<<< HEAD
              :with_multiple_proceeding_types_inc_section8,
              :with_involved_children,
              :provider_entering_merits
-# =======
-#              :with_proceeding_types,
-#              :with_chances_of_success,
-#              :checking_merits_answers
-# >>>>>>> cf7a3a666 (AP-2290 Make first domestic abuse proceeding lead)
     end
 
     subject { get "/providers/applications/#{application.id}/check_merits_answers" }

--- a/spec/requests/providers/check_merits_answers_spec.rb
+++ b/spec/requests/providers/check_merits_answers_spec.rb
@@ -10,9 +10,15 @@ RSpec.describe 'check merits answers requests', type: :request do
     let(:application) do
       create :legal_aid_application,
              :with_everything,
+# <<<<<<< HEAD
              :with_multiple_proceeding_types_inc_section8,
              :with_involved_children,
              :provider_entering_merits
+# =======
+#              :with_proceeding_types,
+#              :with_chances_of_success,
+#              :checking_merits_answers
+# >>>>>>> cf7a3a666 (AP-2290 Make first domestic abuse proceeding lead)
     end
 
     subject { get "/providers/applications/#{application.id}/check_merits_answers" }
@@ -187,7 +193,8 @@ RSpec.describe 'check merits answers requests', type: :request do
     let(:application) do
       create :legal_aid_application,
              :with_everything,
-             :with_application_proceeding_type,
+             :with_proceeding_types,
+             :with_chances_of_success,
              :checking_merits_answers
     end
 

--- a/spec/requests/providers/check_passported_answers_spec.rb
+++ b/spec/requests/providers/check_passported_answers_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe 'check passported answers requests', type: :request do
     context 'logged in as an authenticated provider' do
       before do
         login_as application.provider
+        application.reload
         subject
       end
 
@@ -67,7 +68,14 @@ RSpec.describe 'check passported answers requests', type: :request do
       end
 
       context 'applicant does not have any savings' do
-        let(:application) { create :legal_aid_application, :with_everything, :with_proceeding_types, :with_no_savings, :with_passported_state_machine, :provider_entering_means }
+        let(:application) do
+          create :legal_aid_application,
+                 :with_everything,
+                 :with_proceeding_types,
+                 :with_no_savings,
+                 :with_passported_state_machine,
+                 :provider_entering_means
+        end
         it 'displays that no savings have been declared' do
           expect(response.body).to include(I18n.t('.generic.none_declared'))
         end
@@ -75,7 +83,12 @@ RSpec.describe 'check passported answers requests', type: :request do
 
       context 'applicant does not have any other assets' do
         let(:application) do
-          create :legal_aid_application, :with_everything, :with_proceeding_types, :with_no_other_assets, :with_passported_state_machine, :provider_entering_means
+          create :legal_aid_application,
+                 :with_everything,
+                 :with_proceeding_types,
+                 :with_no_other_assets,
+                 :with_passported_state_machine,
+                 :provider_entering_means
         end
         it 'displays that no other assets have been declared' do
           expect(response.body).to include(I18n.t('.generic.none_declared'))
@@ -84,7 +97,12 @@ RSpec.describe 'check passported answers requests', type: :request do
 
       context 'applicant does not have any capital restrictions' do
         let(:application) do
-          create :legal_aid_application, :with_everything, :with_proceeding_types, :with_passported_state_machine, :provider_entering_means, has_restrictions: false
+          create :legal_aid_application,
+                 :with_everything,
+                 :with_proceeding_types,
+                 :with_passported_state_machine,
+                 :provider_entering_means,
+                 has_restrictions: false
         end
         it 'displays that no capital restrictions have been declared' do
           expect(response.body).to include(I18n.t('.generic.no'))
@@ -93,7 +111,12 @@ RSpec.describe 'check passported answers requests', type: :request do
 
       context 'applicant does not have any capital' do
         let(:application) do
-          create :legal_aid_application, :with_applicant, :with_proceeding_types, :with_policy_disregards, :without_own_home, :with_passported_state_machine,
+          create :legal_aid_application,
+                 :with_applicant,
+                 :with_proceeding_types,
+                 :with_policy_disregards,
+                 :without_own_home,
+                 :with_passported_state_machine,
                  :provider_entering_means
         end
         it 'does not display capital restrictions' do
@@ -133,7 +156,14 @@ RSpec.describe 'check passported answers requests', type: :request do
       end
 
       context 'applicant does not own home' do
-        let(:application) { create :legal_aid_application, :with_everything, :with_proceeding_types, :without_own_home, :with_passported_state_machine, :provider_entering_means }
+        let(:application) do
+          create :legal_aid_application,
+                 :with_everything,
+                 :with_proceeding_types,
+                 :without_own_home,
+                 :with_passported_state_machine,
+                 :provider_entering_means
+        end
         it 'does not display property value' do
           expect(response.body).not_to include(gds_number_to_currency(application.property_value, unit: '£'))
           expect(response.body).not_to include('Property value')
@@ -147,7 +177,12 @@ RSpec.describe 'check passported answers requests', type: :request do
 
       context 'applicant owns home without mortgage' do
         let(:application) do
-          create :legal_aid_application, :with_everything, :with_proceeding_types, :with_own_home_owned_outright, :with_passported_state_machine, :provider_entering_means
+          create :legal_aid_application,
+                 :with_everything,
+                 :with_proceeding_types,
+                 :with_own_home_owned_outright,
+                 :with_passported_state_machine,
+                 :provider_entering_means
         end
         it 'does not display property value' do
           expect(response.body).not_to include(gds_number_to_currency(application.outstanding_mortgage_amount, unit: '£'))
@@ -276,7 +311,8 @@ RSpec.describe 'check passported answers requests', type: :request do
       create :legal_aid_application,
              :with_everything,
              :with_passported_state_machine,
-             :checking_passported_answers
+             :checking_passported_answers,
+             :with_proceeding_types
     end
 
     subject { patch "/providers/applications/#{application.id}/check_passported_answers/reset" }
@@ -287,7 +323,13 @@ RSpec.describe 'check passported answers requests', type: :request do
     end
 
     context 'logged in as an authenticated provider' do
-      let(:application) { create :legal_aid_application, :with_everything, :with_proceeding_types, :with_passported_state_machine, :provider_entering_means }
+      let(:application) do
+        create :legal_aid_application,
+               :with_everything,
+               :with_proceeding_types,
+               :with_passported_state_machine,
+               :provider_entering_means
+      end
 
       before do
         login_as application.provider

--- a/spec/requests/providers/has_other_proceedings_controller_spec.rb
+++ b/spec/requests/providers/has_other_proceedings_controller_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe Providers::HasOtherProceedingsController, type: :request do
         let(:legal_aid_application) { create :legal_aid_application, :at_checking_applicant_details, :with_only_section8_proceeding_type }
 
         it 'redirects to the page to add another proceeding type' do
-          expect(response).to redirect_to(providers_legal_aid_application_proceedings_types_path(legal_aid_application))
+          expect(response.body).to include(I18n.t('providers.has_other_proceedings.show.must_add_domestic_abuse'))
         end
       end
     end

--- a/spec/requests/providers/has_other_proceedings_controller_spec.rb
+++ b/spec/requests/providers/has_other_proceedings_controller_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe Providers::HasOtherProceedingsController, type: :request do
   let(:provider) { legal_aid_application.provider }
   let(:next_flow_step) { flow_forward_path }
 
-
   before { login_as provider }
 
   describe 'GET /providers/:application_id/has_other_proceedings' do
@@ -85,7 +84,6 @@ RSpec.describe Providers::HasOtherProceedingsController, type: :request do
       end
     end
 
-
     context 'with only Section 8 proceedings selected' do
       let(:proceeding_type) { create :proceeding_type, code: 'SE003', ccms_matter: 'Section 8 orders' }
       let(:legal_aid_application) { create :legal_aid_application, :with_proceeding_types, assign_lead_proceeding: false, explicit_proceeding_types: [proceeding_type] }
@@ -99,7 +97,6 @@ RSpec.describe Providers::HasOtherProceedingsController, type: :request do
         end
       end
 
-
       context 'choose yes' do
         let(:params) { { legal_aid_application: { has_other_proceeding: 'true' } } }
 
@@ -108,7 +105,6 @@ RSpec.describe Providers::HasOtherProceedingsController, type: :request do
         end
       end
     end
-
 
     context 'with at least one domestic abuse and at least one section 8 proceeding' do
       let(:pt1) { create :proceeding_type, :as_occupation_order }

--- a/spec/requests/providers/has_other_proceedings_controller_spec.rb
+++ b/spec/requests/providers/has_other_proceedings_controller_spec.rb
@@ -76,9 +76,8 @@ RSpec.describe Providers::HasOtherProceedingsController, type: :request do
       end
     end
 
-
-      context 'choose nothing' do
-        let(:params) { { legal_aid_application: { has_other_proceeding: '' }, continue_button: 'Save and continue' } }
+    context 'choose nothing' do
+      let(:params) { { legal_aid_application: { has_other_proceeding: '' }, continue_button: 'Save and continue' } }
 
       it 'stays on the page if there is a validation error' do
         expect(response).to have_http_status(:ok)

--- a/spec/requests/providers/merits_reports_spec.rb
+++ b/spec/requests/providers/merits_reports_spec.rb
@@ -1,7 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe Providers::MeritsReportsController, type: :request do
-  let(:legal_aid_application) { create :legal_aid_application, :with_application_proceeding_type, :with_everything, :assessment_submitted }
+  let(:legal_aid_application) do
+    create :legal_aid_application,
+           :with_proceeding_types,
+           :with_everything,
+           :assessment_submitted,
+           :with_chances_of_success
+  end
   let(:login_provider) { login_as legal_aid_application.provider }
   let!(:submission) { create :submission, legal_aid_application: legal_aid_application }
   let(:before_subject) { nil }

--- a/spec/requests/providers/merits_task_lists_controller_spec.rb
+++ b/spec/requests/providers/merits_task_lists_controller_spec.rb
@@ -2,7 +2,14 @@ require 'rails_helper'
 
 RSpec.describe Providers::MeritsTaskListsController, type: :request do
   let(:login_provider) { login_as legal_aid_application.provider }
-  let(:legal_aid_application) { create :legal_aid_application, :with_multiple_proceeding_types_inc_section8 }
+  let(:pt_da) { create :proceeding_type, :with_real_data }
+  let(:pt_s8) { create :proceeding_type, :as_section_8_child_residence }
+  let(:legal_aid_application) do
+    create :legal_aid_application,
+           :with_proceeding_types,
+           explicit_proceeding_types: [pt_da, pt_s8]
+  end
+
   let(:proceeding_names) do
     legal_aid_application.application_proceeding_types.map do |type|
       ProceedingType.find(type.proceeding_type_id).meaning
@@ -11,6 +18,7 @@ RSpec.describe Providers::MeritsTaskListsController, type: :request do
   let(:task_list) { create :legal_framework_merits_task_list, legal_aid_application: legal_aid_application }
 
   before do
+    legal_aid_application
     allow(LegalFramework::MeritsTasksService).to receive(:call).with(legal_aid_application).and_return(task_list)
     login_provider
     subject

--- a/spec/requests/providers/proceeding_merits_task/attempts_to_settle_controller_spec.rb
+++ b/spec/requests/providers/proceeding_merits_task/attempts_to_settle_controller_spec.rb
@@ -1,7 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe Providers::ProceedingMeritsTask::AttemptsToSettleController, type: :request do
-  let(:legal_aid_application) { create(:legal_aid_application, :with_multiple_proceeding_types_inc_section8) }
+  let(:pt_da) { create :proceeding_type, :with_real_data }
+  let(:pt_s8) { create :proceeding_type, :as_section_8_child_residence }
+  let(:legal_aid_application) { create :legal_aid_application, :with_proceeding_types, explicit_proceeding_types: [pt_da, pt_s8] }
   let(:application_proceeding_type) { legal_aid_application.application_proceeding_types.find_by(proceeding_type_id: proceeding_type) }
   let(:proceeding_type) { ProceedingType.find_by(ccms_code: 'SE014') }
   let(:smtl) { create :legal_framework_merits_task_list, legal_aid_application: legal_aid_application }
@@ -62,7 +64,7 @@ RSpec.describe Providers::ProceedingMeritsTask::AttemptsToSettleController, type
         end
 
         context 'when the application is in draft' do
-          let(:legal_aid_application) { create(:legal_aid_application, :with_multiple_proceeding_types_inc_section8, :draft) }
+          let(:legal_aid_application) { create :legal_aid_application, :with_proceeding_types, :draft, explicit_proceeding_types: [pt_da, pt_s8] }
 
           it 'redirects provider back to the merits task list' do
             subject

--- a/spec/requests/providers/proceeding_merits_task/chances_of_success_spec.rb
+++ b/spec/requests/providers/proceeding_merits_task/chances_of_success_spec.rb
@@ -4,13 +4,12 @@ module Providers
   module ProceedingMeritsTask
     RSpec.describe ChancesOfSuccessController, type: :request do
       let(:chances_of_success) { create :chances_of_success, application_proceeding_type: application_proceeding_type }
-      let(:legal_aid_application) { create :legal_aid_application, :with_multiple_proceeding_types_inc_section8 }
       let(:smtl) { create :legal_framework_merits_task_list, legal_aid_application: legal_aid_application }
-      let(:application_proceeding_type) do
-        create :application_proceeding_type,
-               legal_aid_application: legal_aid_application,
-               proceeding_type: create(:proceeding_type, :as_section_8_child_residence)
-      end
+      let(:pt_da) { create :proceeding_type, :with_real_data }
+      let(:pt_s8) { create :proceeding_type, :as_section_8_child_residence }
+      let(:legal_aid_application) { create :legal_aid_application, :with_proceeding_types, explicit_proceeding_types: [pt_da, pt_s8] }
+
+      let(:application_proceeding_type) { legal_aid_application.application_proceeding_types.first }
       let(:login) { login_as legal_aid_application.provider }
 
       before do

--- a/spec/requests/providers/proceeding_merits_task/linked_children_spec.rb
+++ b/spec/requests/providers/proceeding_merits_task/linked_children_spec.rb
@@ -3,7 +3,9 @@ require 'rails_helper'
 module Providers
   module ProceedingMeritsTask
     RSpec.describe LinkedChildrenController, type: :request do
-      let!(:legal_aid_application) { create :legal_aid_application, :with_involved_children, :with_multiple_proceeding_types_inc_section8 }
+      let(:pt_da) { create :proceeding_type, :with_real_data }
+      let(:pt_s8) { create :proceeding_type, :as_section_8_child_residence }
+      let!(:legal_aid_application) { create :legal_aid_application, :with_proceeding_types, :with_involved_children, explicit_proceeding_types: [pt_da, pt_s8] }
       let(:involved_children_names) { legal_aid_application.involved_children.map(&:full_name) }
       let(:application_proceeding_type) { legal_aid_application.application_proceeding_types.find_by(proceeding_type_id: proceeding_type) }
       let(:proceeding_type) { ProceedingType.find_by(ccms_code: 'SE014') }

--- a/spec/requests/providers/proceedings_types_spec.rb
+++ b/spec/requests/providers/proceedings_types_spec.rb
@@ -153,8 +153,6 @@ RSpec.describe Providers::ProceedingsTypesController, type: :request do
 
           it 'displays errors' do
             subject
-            # puts ">>>>>> page output to >>>>> file://#{ENV['HOME']}/tmp/rspec.html"
-            # File.open("#{ENV['HOME']}/tmp/rspec.html", 'w') { |fp| fp.puts response.body }
             expect(response.body).to include('govuk-input--error')
             expect(response.body).to include('govuk-form-group--error')
           end

--- a/spec/requests/providers/proceedings_types_spec.rb
+++ b/spec/requests/providers/proceedings_types_spec.rb
@@ -143,6 +143,7 @@ RSpec.describe Providers::ProceedingsTypesController, type: :request do
 
           before do
             allow(LegalFramework::ProceedingTypesService).to receive(:new).with(legal_aid_application).and_return(proceeding_type_service)
+            allow(LeadProceedingAssignmentService).to receive(:call).with(legal_aid_application)
           end
 
           it 'renders index' do
@@ -152,6 +153,8 @@ RSpec.describe Providers::ProceedingsTypesController, type: :request do
 
           it 'displays errors' do
             subject
+            # puts ">>>>>> page output to >>>>> file://#{ENV['HOME']}/tmp/rspec.html"
+            # File.open("#{ENV['HOME']}/tmp/rspec.html", 'w') { |fp| fp.puts response.body }
             expect(response.body).to include('govuk-input--error')
             expect(response.body).to include('govuk-form-group--error')
           end

--- a/spec/requests/providers/submitted_applications_spec.rb
+++ b/spec/requests/providers/submitted_applications_spec.rb
@@ -4,8 +4,14 @@ RSpec.describe Providers::SubmittedApplicationsController, type: :request do
   let(:firm) { create :firm }
   let(:provider) { create :provider, firm: firm }
   let(:legal_aid_application) do
-    create :legal_aid_application, :with_everything, :with_application_proceeding_type, :assessment_submitted, provider: provider
+    create :legal_aid_application,
+           :with_everything,
+           :with_proceeding_types,
+           :with_chances_of_success,
+           :assessment_submitted,
+           provider: provider
   end
+
   let(:login) { login_as legal_aid_application.provider }
   let(:html) { Nokogiri::HTML(response.body) }
   let(:print_buttons) { html.xpath('//button[contains(text(), "Print application")]') }

--- a/spec/services/ccms/requestors/case_add_requestor_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_spec.rb
@@ -1,4 +1,3 @@
-# add_case_requestor_spec.rb
 require 'rails_helper'
 
 module CCMS

--- a/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_entities_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_entities_spec.rb
@@ -41,9 +41,6 @@ module CCMS
         let(:requestor) { described_class.new(submission, {}) }
         let(:xml) { requestor.formatted_xml }
         let(:success_prospect) { :likely }
-        # let!(:chances_of_success) do
-        #   create :chances_of_success, success_prospect: success_prospect, success_prospect_details: 'details', application_proceeding_type: application_proceeding_type
-        # end
 
         before do
           legal_aid_application.reload

--- a/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_entities_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_entities_spec.rb
@@ -22,6 +22,8 @@ module CCMS
                  :with_everything,
                  :with_applicant_and_address,
                  :with_negative_benefit_check_result,
+                 :with_proceeding_types,
+                 :with_chances_of_success,
                  populate_vehicle: true,
                  with_bank_accounts: 2,
                  provider: provider,
@@ -39,9 +41,9 @@ module CCMS
         let(:requestor) { described_class.new(submission, {}) }
         let(:xml) { requestor.formatted_xml }
         let(:success_prospect) { :likely }
-        let!(:chances_of_success) do
-          create :chances_of_success, success_prospect: success_prospect, success_prospect_details: 'details', application_proceeding_type: application_proceeding_type
-        end
+        # let!(:chances_of_success) do
+        #   create :chances_of_success, success_prospect: success_prospect, success_prospect_details: 'details', application_proceeding_type: application_proceeding_type
+        # end
 
         before do
           legal_aid_application.reload
@@ -164,6 +166,8 @@ module CCMS
                      :with_everything,
                      :with_applicant_and_address,
                      :with_positive_benefit_check_result,
+                     :with_proceeding_types,
+                     :with_chances_of_success,
                      vehicle: nil,
                      office: office
             end

--- a/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_variable_attributes_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_variable_attributes_spec.rb
@@ -21,6 +21,9 @@ module CCMS
                  :with_everything,
                  :with_applicant_and_address,
                  :with_negative_benefit_check_result,
+                 :with_proceeding_types,
+                 :with_chances_of_success,
+                 proceeding_types_count: 1,
                  populate_vehicle: true,
                  with_bank_accounts: 2,
                  provider: provider,
@@ -28,16 +31,18 @@ module CCMS
                  percentage_home: percentage_home
         end
 
-        let!(:application_proceeding_type) { create :application_proceeding_type, :with_proceeding_type_scope_limitations, legal_aid_application: legal_aid_application }
+        # let!(:application_proceeding_type) { create :application_proceeding_type, :with_proceeding_type_scope_limitations, legal_aid_application: legal_aid_application }
+        let(:application_proceeding_type) { legal_aid_application.application_proceeding_types.first }
         let(:ccms_reference) { '300000054005' }
         let(:submission) { create :submission, :case_ref_obtained, legal_aid_application: legal_aid_application, case_ccms_reference: ccms_reference }
         let(:cfe_submission) { create :cfe_submission, legal_aid_application: legal_aid_application }
         let!(:cfe_result) { create :cfe_v3_result, submission: cfe_submission }
         let(:requestor) { described_class.new(submission, {}) }
         let(:xml) { requestor.formatted_xml }
-        let!(:chances_of_success) do
-          create :chances_of_success, :with_optional_text, application_proceeding_type: application_proceeding_type
-        end
+        # let!(:chances_of_success) do
+        #   create :chances_of_success, :with_optional_text, application_proceeding_type: application_proceeding_type
+        # end
+        let(:chances_of_success) { application_proceeding_type.chances_of_success }
         let(:applicant) { legal_aid_application.applicant }
         let(:percentage_home) { rand(1...99.0).round(2) }
 
@@ -451,6 +456,9 @@ module CCMS
                    :with_everything,
                    :with_applicant_and_address,
                    :with_negative_benefit_check_result,
+                   :with_proceeding_types,
+                   :with_chances_of_success,
+                   proceeding_types_count: 1,
                    populate_vehicle: true,
                    with_bank_accounts: 2,
                    provider: provider,

--- a/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_variable_attributes_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_variable_attributes_spec.rb
@@ -31,7 +31,6 @@ module CCMS
                  percentage_home: percentage_home
         end
 
-        # let!(:application_proceeding_type) { create :application_proceeding_type, :with_proceeding_type_scope_limitations, legal_aid_application: legal_aid_application }
         let(:application_proceeding_type) { legal_aid_application.application_proceeding_types.first }
         let(:ccms_reference) { '300000054005' }
         let(:submission) { create :submission, :case_ref_obtained, legal_aid_application: legal_aid_application, case_ccms_reference: ccms_reference }
@@ -39,9 +38,6 @@ module CCMS
         let!(:cfe_result) { create :cfe_v3_result, submission: cfe_submission }
         let(:requestor) { described_class.new(submission, {}) }
         let(:xml) { requestor.formatted_xml }
-        # let!(:chances_of_success) do
-        #   create :chances_of_success, :with_optional_text, application_proceeding_type: application_proceeding_type
-        # end
         let(:chances_of_success) { application_proceeding_type.chances_of_success }
         let(:applicant) { legal_aid_application.applicant }
         let(:percentage_home) { rand(1...99.0).round(2) }

--- a/spec/services/lead_proceeding_assignment_service_spec.rb
+++ b/spec/services/lead_proceeding_assignment_service_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+RSpec.describe LeadProceedingAssignmentService do
+  let(:pt_da1) { create :proceeding_type, :domestic_abuse }
+  let(:pt_da2) { create :proceeding_type, :domestic_abuse }
+  let(:pt_s81) { create :proceeding_type, :section8 }
+  let(:pt_s82) { create :proceeding_type, :section8 }
+  let!(:laa) { create :legal_aid_application, :with_proceeding_types, assign_lead_proceeding: false, explicit_proceeding_types: explicit_proceeding_types }
+
+  subject { described_class.call(laa) }
+
+  context 'when a lead proceeding already exists' do
+    let(:explicit_proceeding_types) { [pt_s81, pt_s82, pt_da1, pt_da2] }
+    before { make_lead!(pt_da2) }
+
+    it 'changes nothing' do
+      subject
+      expect(apt_for(pt_s81).lead_proceeding?).to be false
+      expect(apt_for(pt_s82).lead_proceeding?).to be false
+      expect(apt_for(pt_da1).lead_proceeding?).to be false
+      expect(apt_for(pt_da2).lead_proceeding?).to be true
+    end
+  end
+
+  context 'when there are no lead proceedings' do
+    let(:explicit_proceeding_types) { [pt_s81, pt_s82, pt_da1] }
+
+    it 'sets the domestic abuse proceeding as lead' do
+      subject
+      expect(apt_for(pt_s81).lead_proceeding?).to be false
+      expect(apt_for(pt_s82).lead_proceeding?).to be false
+      expect(apt_for(pt_da1).lead_proceeding?).to be true
+    end
+  end
+
+  context 'when there are no domestic abuse proceedings' do
+    let(:explicit_proceeding_types) { [pt_s81, pt_s82] }
+
+    it 'changes nothing' do
+      expect(apt_for(pt_s81).lead_proceeding?).to be false
+      expect(apt_for(pt_s82).lead_proceeding?).to be false
+    end
+  end
+
+  def make_lead!(proceeding_type)
+    apt_for(proceeding_type).update!(lead_proceeding: true)
+  end
+
+  def apt_for(proceeding_type)
+    laa.application_proceeding_types.find_by(proceeding_type_id: proceeding_type.id)
+  end
+end

--- a/spec/services/reports/merits_report_creator_spec.rb
+++ b/spec/services/reports/merits_report_creator_spec.rb
@@ -1,7 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe Reports::MeritsReportCreator do
-  let(:legal_aid_application) { create :legal_aid_application, :with_application_proceeding_type, :with_everything, :generating_reports }
+  let(:legal_aid_application) do
+    create :legal_aid_application,
+           :with_application_proceeding_type,
+           :with_lead_proceeding_type,
+           :with_everything,
+           :generating_reports
+  end
 
   subject do
     # dont' match on path - webpacker keeps changing the second part of the path

--- a/spec/services/reports/mis/application_detail_csv_line_spec.rb
+++ b/spec/services/reports/mis/application_detail_csv_line_spec.rb
@@ -184,7 +184,7 @@ module Reports
             expect(value_for('CCMS reference number')).to eq '42226668880'
             expect(value_for('DWP Overridden')).to eq 'FALSE'
             expect(value_for('Case Type')).to eq 'Passported'
-            expect(value_for('Matter type')).to eq 'Matter'
+            expect(value_for('Matter type')).to eq 'Domestic Abuse'
             expect(value_for('Proceeding type selected')).to match(/^Meaning-DA\d{3,4}$/)
             expect(value_for('Delegated functions used')).to eq 'Yes'
             expect(value_for('Delegated functions date')).to eq '2020-01-01'

--- a/spec/services/reports/mis/application_details_report_spec.rb
+++ b/spec/services/reports/mis/application_details_report_spec.rb
@@ -3,12 +3,22 @@ require 'rails_helper'
 module Reports
   module MIS
     RSpec.describe ApplicationDetailsReport do
-      let!(:unsubmitted_applications) { create_list :legal_aid_application, 3, :with_application_proceeding_type, :with_passported_state_machine }
+      let!(:unsubmitted_applications) { create_list :legal_aid_application, 3, :with_proceeding_types, :with_passported_state_machine }
       let!(:submitted_applications) do
-        create_list :legal_aid_application, 3, :with_passported_state_machine, :with_application_proceeding_type, :at_assessment_submitted, :with_merits_submitted_at
+        create_list :legal_aid_application, 3,
+                    :with_passported_state_machine,
+                    :with_proceeding_types,
+                    :with_chances_of_success,
+                    :at_assessment_submitted,
+                    :with_merits_submitted_at
       end
       let!(:applications_being_submitted) do
-        create :legal_aid_application, :with_passported_state_machine, :with_application_proceeding_type, :at_submitting_assessment, :with_merits_submitted_at
+        create :legal_aid_application,
+               :with_passported_state_machine,
+               :with_proceeding_types,
+               :with_chances_of_success,
+               :at_submitting_assessment,
+               :with_merits_submitted_at
       end
       let(:report) { described_class.new }
 

--- a/spec/services/reports/mis/non_passported_application_csv_line_spec.rb
+++ b/spec/services/reports/mis/non_passported_application_csv_line_spec.rb
@@ -29,8 +29,6 @@ module Reports
         let(:applicant) { application.applicant }
         let(:time) { Time.zone.local(2020, 9, 20, 2, 3, 44) }
 
-        # before { LeadProceedingAssignmentService.call(application) }
-
         subject { described_class.call(application) }
 
         it 'returns an array of nine fields' do

--- a/spec/services/reports/mis/non_passported_application_csv_line_spec.rb
+++ b/spec/services/reports/mis/non_passported_application_csv_line_spec.rb
@@ -29,6 +29,8 @@ module Reports
         let(:applicant) { application.applicant }
         let(:time) { Time.zone.local(2020, 9, 20, 2, 3, 44) }
 
+        # before { LeadProceedingAssignmentService.call(application) }
+
         subject { described_class.call(application) }
 
         it 'returns an array of nine fields' do


### PR DESCRIPTION
## Assign first domestic abuse proceeding as lead

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2290)

Previously, there was an `before_save` hook on `ApplicationProceedingType` which set the record to be the lead proceeding if there wasn't one already (this was fine as only domestic abuse proceedings were used). This has been removed, and replaced with a new service to assign the first domestic abuse proceeding as lead (if there is one) and is called from the controller:

- Created a new `HasOtherProceedingsForm` which is used in place of the `BinaryChoiceForm`.  This is so that validation can be run to ensure that there is at least one Domestic Abuse proceeding if the choice is made not to add any more proceedings
- Created `LeadProceedingAssignmentService` which is called from the `HasOtherProceedingsController` to assign the lead proceeding if required
- Added a validation to `ApplicationProceedingType` to ensure that there was only ever one lead proceeding per application
- Changed the `:with_proceeding_types` trait on the `LegalAidApplications` factory to automatically assign the first domestic abuse proceeding type as lead, unless the  transient `assign_lead_proceeding` is set to false
- Refactored a lot of the tests to use the new `:with_proceeding_types` trait in order to correctly set up lead proceeding

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
