### PR TITLE
AP-2276 Add migration to remove two columns from ChancesOfSuccess

### DIFF
--- a/db/migrate/20210602110352_remove_legal_aid_application_association_from_chances_of_success.rb
+++ b/db/migrate/20210602110352_remove_legal_aid_application_association_from_chances_of_success.rb
@@ -1,0 +1,11 @@
+class RemoveLegalAidApplicationAssociationFromChancesOfSuccess < ActiveRecord::Migration[6.1]
+  def up
+    change_table :chances_of_successes do |t|
+      t.remove_references :legal_aid_application
+    end
+  end
+
+  def down
+    add_reference :chances_of_successes, :legal_aid_application, foreign_key: true, null: true, type: :uuid
+  end
+end

--- a/db/migrate/20210602114709_remove_submitted_at_from_chances_of_success.rb
+++ b/db/migrate/20210602114709_remove_submitted_at_from_chances_of_success.rb
@@ -1,0 +1,5 @@
+class RemoveSubmittedAtFromChancesOfSuccess < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :chances_of_successes, :submitted_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_20_071320) do
+ActiveRecord::Schema.define(version: 2021_06_02_110352) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -322,7 +322,6 @@ ActiveRecord::Schema.define(version: 2021_05_20_071320) do
   end
 
   create_table "chances_of_successes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "legal_aid_application_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.text "application_purpose"
@@ -334,7 +333,6 @@ ActiveRecord::Schema.define(version: 2021_05_20_071320) do
     t.boolean "success_likely"
     t.uuid "application_proceeding_type_id", null: false
     t.index ["application_proceeding_type_id"], name: "index_chances_of_successes_on_application_proceeding_type_id"
-    t.index ["legal_aid_application_id"], name: "index_chances_of_successes_on_legal_aid_application_id"
   end
 
   create_table "debugs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -791,7 +789,6 @@ ActiveRecord::Schema.define(version: 2021_05_20_071320) do
   add_foreign_key "ccms_submissions", "legal_aid_applications", on_delete: :cascade
   add_foreign_key "cfe_submissions", "legal_aid_applications"
   add_foreign_key "chances_of_successes", "application_proceeding_types"
-  add_foreign_key "chances_of_successes", "legal_aid_applications", on_delete: :cascade
   add_foreign_key "dependants", "legal_aid_applications"
   add_foreign_key "dwp_overrides", "legal_aid_applications"
   add_foreign_key "involved_children", "legal_aid_applications"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_02_110352) do
+ActiveRecord::Schema.define(version: 2021_06_02_114709) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -329,7 +329,6 @@ ActiveRecord::Schema.define(version: 2021_06_02_110352) do
     t.text "details_of_proceedings_before_the_court"
     t.string "success_prospect"
     t.text "success_prospect_details"
-    t.datetime "submitted_at"
     t.boolean "success_likely"
     t.uuid "application_proceeding_type_id", null: false
     t.index ["application_proceeding_type_id"], name: "index_chances_of_successes_on_application_proceeding_type_id"


### PR DESCRIPTION
## Add migration to remove two columns from ChancesOfSuccess

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2276)

- Add migration to remove the legal aid application reference/association with chances of success because it is now associated through the application proceeding type

- Add migration to remove submitted_at from chances of success because it is now under the legal aid application under the name 'merits_submitted_at'

**Tested with:**
Production anonymised data
Rails console and checking if the data has properly been migrated previously from this  PR https://github.com/ministryofjustice/laa-apply-for-legal-aid/pull/2492
## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
