### PR TITLE
AP-2330 Add PASSPORTED_NINO attribute to passported payloads

### DIFF
--- a/config/ccms/attribute_block_configs/base.yml
+++ b/config/ccms/attribute_block_configs/base.yml
@@ -2428,6 +2428,12 @@ global_means:
     br100_meaning: 'Int.Result: Client Land- Value of equity'
     response_type: currency
     user_defined: false
+  PASSPORTED_NINO:
+    user_defined: true
+    br100_meaning: "Passported: The Receipient's NINO"
+    response_type: text
+    generate_block?: true
+    value: '#applicant_national_insurance_number'
   APPLICATION_FROM_APPLY:
     :value: true
     :br100_meaning: 'The application has been made through the Apply service'

--- a/config/ccms/attribute_block_configs/non_passported.yml
+++ b/config/ccms/attribute_block_configs/non_passported.yml
@@ -831,8 +831,8 @@ global_means:
     user_defined: true
     br100_meaning: "Passported: The Receipient's NINO"
     response_type: text
-    generate_block?: true
-    value: '#applicant_national_insurance_number'
+    generate_block?: false
+    value: ''
   PROSPECTS_OF_SUCCESS:
     user_defined: false
     br100_meaning: "The proceeding's prospect of success"

--- a/config/ccms/attribute_block_configs/non_passported.yml
+++ b/config/ccms/attribute_block_configs/non_passported.yml
@@ -827,12 +827,19 @@ global_means:
     response_type: number
     generate_block?: '#applicant_shares_ownership_main_home?'
     value: '#third_party_owns_percentage_main_home'
+  PASSPORTED_NINO:
+    user_defined: true
+    br100_meaning: "Passported: The Receipient's NINO"
+    response_type: text
+    generate_block?: true
+    value: '#applicant_national_insurance_number'
   PROSPECTS_OF_SUCCESS:
     user_defined: false
     br100_meaning: "The proceeding's prospect of success"
     response_type: text
     generate_block?: true
     value: '#ccms_code_prospects_of_success'
+
 global_merits:
   APP_CARE_SUPERVISION:
     generate_block?: true

--- a/spec/data/ccms/case_add_request.xml
+++ b/spec/data/ccms/case_add_request.xml
@@ -1354,6 +1354,12 @@
                             <ns0:UserDefinedInd>true</ns0:UserDefinedInd>
                           </ns0:Attribute>
                           <ns0:Attribute>
+                            <ns0:Attribute>PASSPORTED_NINO</ns0:Attribute>
+                            <ns0:ResponseType>text</ns0:ResponseType>
+                            <ns0:ResponseValue>EG587804M</ns0:ResponseValue>
+                            <ns0:UserDefinedInd>true</ns0:UserDefinedInd>
+                          </ns0:Attribute>
+                          <ns0:Attribute>
                             <ns0:Attribute>APPLICATION_FROM_APPLY</ns0:Attribute>
                             <ns0:ResponseType>boolean</ns0:ResponseType>
                             <ns0:ResponseValue>true</ns0:ResponseValue>

--- a/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_variable_attributes_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_variable_attributes_spec.rb
@@ -397,10 +397,9 @@ module CCMS
         end
 
         context 'PASSPORTED_NINO' do
-          it 'generates PASSPORTED NINO in global merits' do
+          it 'does not generate the block' do
             block = XmlExtractor.call(xml, :global_means, 'PASSPORTED_NINO')
-            expect(block).to have_text_response applicant.national_insurance_number
-            expect(block).to be_user_defined
+            expect(block).not_to be_present
           end
         end
 

--- a/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_variable_attributes_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_variable_attributes_spec.rb
@@ -396,6 +396,14 @@ module CCMS
           end
         end
 
+        context 'PASSPORTED_NINO' do
+          it 'generates PASSPORTED NINO in global merits' do
+            block = XmlExtractor.call(xml, :global_means, 'PASSPORTED_NINO')
+            expect(block).to have_text_response applicant.national_insurance_number
+            expect(block).to be_user_defined
+          end
+        end
+
         context 'GB_INPUT_B_9WP3_353A' do
           context 'applicant has a student loan/grant' do
             let(:student_loan_income) { create :transaction_type, :credit, name: 'student_loan' }

--- a/spec/services/ccms/requestors/case_add_requestor_xml_blocks/passported_attributes_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_xml_blocks/passported_attributes_spec.rb
@@ -1855,6 +1855,7 @@ module CCMS
           [:global_means, 'OUT_GB_INPUT_C_20WP3_379A'],
           [:global_means, 'OUT_GB_PROC_C_34WP3_12A'],
           [:global_means, 'OUT_INCOME_CONT'],
+          [:global_means, 'PASSPORTED_NINO'],
           [:global_means, 'PROVIDER_CASE_REFERENCE'],
           [:global_means, 'PUI_CLIENT_INCOME_CONT'],
           [:global_means, 'RB_VERSION_DATE_MEANS'],

--- a/spec/services/ccms/requestors/case_add_requestor_xml_blocks/passported_attributes_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_xml_blocks/passported_attributes_spec.rb
@@ -71,6 +71,16 @@ module CCMS
           end
         end
 
+
+        context 'PASSPORTED_NINO' do
+          let(:applicant) { legal_aid_application.applicant }
+          it 'generates PASSPORTED NINO in global merits' do
+            block = XmlExtractor.call(xml, :global_means, 'PASSPORTED_NINO')
+            expect(block).to have_text_response applicant.national_insurance_number
+            expect(block).to be_user_defined
+          end
+        end
+
         context 'CLIENT_ELIGIBILITY and PUI_CLIENT_ELIGIBILITY' do
           context 'eligible' do
             let!(:cfe_result) { create :cfe_v3_result, submission: cfe_submission }

--- a/spec/services/ccms/requestors/case_add_requestor_xml_blocks/passported_attributes_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_xml_blocks/passported_attributes_spec.rb
@@ -71,7 +71,6 @@ module CCMS
           end
         end
 
-
         context 'PASSPORTED_NINO' do
           let(:applicant) { legal_aid_application.applicant }
           it 'generates PASSPORTED NINO in global merits' do
@@ -1865,7 +1864,6 @@ module CCMS
           [:global_means, 'OUT_GB_INPUT_C_20WP3_379A'],
           [:global_means, 'OUT_GB_PROC_C_34WP3_12A'],
           [:global_means, 'OUT_INCOME_CONT'],
-          [:global_means, 'PASSPORTED_NINO'],
           [:global_means, 'PROVIDER_CASE_REFERENCE'],
           [:global_means, 'PUI_CLIENT_INCOME_CONT'],
           [:global_means, 'RB_VERSION_DATE_MEANS'],


### PR DESCRIPTION
## Added PASSPORTED_NINO attribute to CCMS payload for passported applications

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2330)

- Added block to `config/ccms/attribute_block_configs/non_passported.yml` to generate value
- Added test to ensure it was generated for non-passported applications
- Added test to ensure it was omitted for passported applications

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
