### PR TITLE
AP-2328 Add new ccms attribute to check passported or not

### DIFF
--- a/config/ccms/attribute_block_configs/base.yml
+++ b/config/ccms/attribute_block_configs/base.yml
@@ -2456,6 +2456,12 @@ global_merits:
     br100_meaning: The Application Includes Immigration Proceedings
     response_type: boolean
     user_defined: false
+  GB_INFER_T_6WP1_66A:
+    generate_block?: true
+    value: 'CLIENT'
+    br100_meaning: "Passported: The person who receives passported benefit?"
+    response_type: text
+    user_defined: false
   COPY_SEPARATE_STATEMENT:
     value: false
     br100_meaning: The provider has a copy of separate statement

--- a/config/ccms/attribute_block_configs/non_passported.yml
+++ b/config/ccms/attribute_block_configs/non_passported.yml
@@ -973,6 +973,9 @@ global_merits:
   FIRST_TIER_TRIBUNAL_TAXATION:
     generate_block?: true
     value: false
+  GB_INFER_T_6WP1_66A:
+    generate_block?: false
+    value: ''
   HIGH_COURT:
     generate_block?: true
     value: false

--- a/spec/data/ccms/case_add_request.xml
+++ b/spec/data/ccms/case_add_request.xml
@@ -1402,6 +1402,12 @@
                             <ns0:UserDefinedInd>false</ns0:UserDefinedInd>
                           </ns0:Attribute>
                           <ns0:Attribute>
+                            <ns0:Attribute>GB_INFER_T_6WP1_66A</ns0:Attribute>
+                            <ns0:ResponseType>text</ns0:ResponseType>
+                            <ns0:ResponseValue>CLIENT</ns0:ResponseValue>
+                            <ns0:UserDefinedInd>false</ns0:UserDefinedInd>
+                          </ns0:Attribute>
+                          <ns0:Attribute>
                             <ns0:Attribute>COPY_SEPARATE_STATEMENT</ns0:Attribute>
                             <ns0:ResponseType>boolean</ns0:ResponseType>
                             <ns0:ResponseValue>false</ns0:ResponseValue>

--- a/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_attributes_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_attributes_spec.rb
@@ -499,6 +499,13 @@ module CCMS
           end
         end
 
+        context 'GB_INFER_T_6WP1_66A' do
+          it 'is omitted' do
+            block = XmlExtractor.call(xml, :global_merits, 'GB_INFER_T_6WP1_66A')
+            expect(block).not_to be_present
+          end
+        end
+
         context 'Proceeding Matter Type Descriptions' do
           let(:attrs) do
             %w[

--- a/spec/services/ccms/requestors/case_add_requestor_xml_blocks/passported_attributes_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_xml_blocks/passported_attributes_spec.rb
@@ -80,6 +80,14 @@ module CCMS
           end
         end
 
+        context 'GB_INFER_T_6WP1_66A' do
+          it 'generates GB_INFER_T_6WP1_66A in global merits' do
+            block = XmlExtractor.call(xml, :global_merits, 'GB_INFER_T_6WP1_66A')
+            expect(block).to have_text_response 'CLIENT'
+            expect(block).not_to be_user_defined
+          end
+        end
+
         context 'CLIENT_ELIGIBILITY and PUI_CLIENT_ELIGIBILITY' do
           context 'eligible' do
             let!(:cfe_result) { create :cfe_v3_result, submission: cfe_submission }


### PR DESCRIPTION
[Link to story](https://dsdmoj.atlassian.net/browse/AP-2328)


- Add attribute GB_INFER_T_6WP1_66A to the ccms payload for passported and omit for non-passported applications

- Test the above

Co-authored-by: willc-work

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
