### PR TITLE
AP-2349 Add extra logic around task completion for chances of success

### DIFF
--- a/app/controllers/providers/proceeding_merits_task/chances_of_success_controller.rb
+++ b/app/controllers/providers/proceeding_merits_task/chances_of_success_controller.rb
@@ -12,6 +12,10 @@ module Providers
 
       private
 
+      def task_list_should_update?
+        application_has_task_list? && !draft_selected? && @form.valid? && @form.success_likely.eql?('true')
+      end
+
       def legal_aid_application
         @legal_aid_application ||= application_proceeding_type.legal_aid_application
       end

--- a/spec/requests/providers/proceeding_merits_task/chances_of_success_spec.rb
+++ b/spec/requests/providers/proceeding_merits_task/chances_of_success_spec.rb
@@ -101,6 +101,12 @@ module Providers
             expect { subject }.not_to change { chances_of_success.reload.success_prospect_details }
           end
 
+          it 'does not set the task to complete' do
+            subject
+            serialized_merits_task_list = legal_aid_application.legal_framework_merits_task_list.reload.serialized_data
+            expect(serialized_merits_task_list).to_not match(/name: :chances_of_success\n\s+dependencies: \*\d\n\s+state: :complete/)
+          end
+
           it 'redirects to next page' do
             subject
             expect(response).to redirect_to(providers_merits_task_list_success_prospects_path(application_proceeding_type))


### PR DESCRIPTION
## AP-2349 Add extra logic around task completion for chances of success

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2349)

Don't update the merits task list status of chances of success to complete if the success_likely is false.

Co-authored: colinbruce 
## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
