### PR TITLE
AP-2344 Include gateway evidence documents to ccms upload

### DIFF
--- a/app/services/ccms/requestors/document_id_requestor.rb
+++ b/app/services/ccms/requestors/document_id_requestor.rb
@@ -42,8 +42,11 @@ module CCMS
       end
 
       def document_type(xml)
-        if @document_type.eql?('bank_transaction_report')
+        case @document_type
+        when 'bank_transaction_report'
           xml.__send__('ns4:DocumentType', 'BSTMT')
+        when 'gateway_evidence_pdf'
+          xml.__send__('ns4:DocumentType', 'STATE')
         else
           xml.__send__('ns4:DocumentType', 'ADMIN1')
         end

--- a/app/services/ccms/requestors/document_upload_requestor.rb
+++ b/app/services/ccms/requestors/document_upload_requestor.rb
@@ -51,9 +51,13 @@ module CCMS
       end
 
       def document_type(xml)
-        if @document_type.eql?('bank_transaction_report')
+        case @document_type
+        when 'bank_transaction_report'
           xml.__send__('ns4:DocumentType', 'BSTMT')
           xml.__send__('ns4:FileExtension', 'csv')
+        when 'gateway_evidence_pdf'
+          xml.__send__('ns4:DocumentType', 'STATE')
+          xml.__send__('ns4:FileExtension', 'pdf')
         else
           xml.__send__('ns4:DocumentType', 'ADMIN1')
           xml.__send__('ns4:FileExtension', 'pdf')

--- a/app/services/ccms/submitters/obtain_document_id_service.rb
+++ b/app/services/ccms/submitters/obtain_document_id_service.rb
@@ -1,6 +1,8 @@
 module CCMS
   module Submitters
     class ObtainDocumentIdService < BaseSubmissionService
+      NON_PDF_VERSION_ATTACHMENTS = %w[statement_of_case gateway_evidence].freeze
+
       def call
         return unless populate_documents
 
@@ -18,7 +20,8 @@ module CCMS
 
       def pdf_attachments
         # Ignore the original document and use the pdf attachment it was converted to
-        @pdf_attachments ||= attachments.reject { |a| a.attachment_type == 'statement_of_case' }
+
+        @pdf_attachments ||= attachments.reject { |a| NON_PDF_VERSION_ATTACHMENTS.include? a.attachment_type }
       end
 
       def attachments

--- a/spec/services/ccms/requestors/document_upload_requestor_spec.rb
+++ b/spec/services/ccms/requestors/document_upload_requestor_spec.rb
@@ -27,6 +27,24 @@ module CCMS
           end
         end
 
+        context 'when sent a gateway evidence document' do
+          let(:requestor) { described_class.new(case_ccms_reference, document_id, document_encoded_base64, 'my_login', 'gateway_evidence_pdf') }
+
+          include_context 'ccms soa configuration'
+
+          it 'generates the expected XML' do
+            allow(requestor).to receive(:transaction_request_id).and_return(expected_tx_id)
+            expect(requestor.formatted_xml).to be_soap_envelope_with(
+              command: 'ns2:DocumentUploadRQ',
+              transaction_id: expected_tx_id,
+              matching: %w[
+                <ns4:DocumentType>STATE</ns4:DocumentType>
+                <ns4:FileExtension>pdf</ns4:FileExtension>
+              ]
+            )
+          end
+        end
+
         context 'when sent a bank_transaction_report' do
           let(:requestor) { described_class.new(case_ccms_reference, document_id, document_encoded_base64, 'my_login', 'bank_transaction_report') }
 

--- a/spec/services/ccms/submitters/obtain_document_id_service_spec.rb
+++ b/spec/services/ccms/submitters/obtain_document_id_service_spec.rb
@@ -103,11 +103,13 @@ module CCMS
               )
             end
 
-            it 'creates three documents as ADMIN1 and one as BSTMT' do
+            it 'creates three documents as ADMIN1, one as STATE and one as BSTMT' do
               subject.call
               admin1_documents = SubmissionHistory.where(submission_id: submission.id).map(&:request).map { |x| x.scan(/ADMIN1/) }.flatten.count
+              state_documents = SubmissionHistory.where(submission_id: submission.id).map(&:request).map { |x| x.scan(/STATE/) }.flatten.count
               bstmt_documents = SubmissionHistory.where(submission_id: submission.id).map(&:request).map { |x| x.scan(/BSTMT/) }.flatten.count
-              expect(admin1_documents).to eq 4
+              expect(admin1_documents).to eq 3
+              expect(state_documents).to eq 1
               expect(bstmt_documents).to eq 1
             end
 

--- a/spec/services/ccms/submitters/obtain_document_id_service_spec.rb
+++ b/spec/services/ccms/submitters/obtain_document_id_service_spec.rb
@@ -49,11 +49,18 @@ module CCMS
             create :attachment, :means_report, legal_aid_application: legal_aid_application
             create :attachment, :bank_transaction_report, legal_aid_application: legal_aid_application
             create :statement_of_case, :with_original_and_pdf_files_attached, legal_aid_application: legal_aid_application
+            create :gateway_evidence, :with_original_and_pdf_files_attached, legal_aid_application: legal_aid_application
           end
 
-          it 'populates the documents array with statement_of_case, means_report and merits_report' do
+          it 'populates the documents array with statement_of_case, gateway_evidence, means_report and merits_report' do
             subject.call
-            expect(submission.submission_documents.count).to eq 4
+            expect(submission.submission_documents.count).to eq 5
+          end
+
+          it 'populates document array with gateway_evidence' do
+            subject.call
+            gateway_evidence_submission = submission.submission_documents.select { |a| a.document_type == 'gateway_evidence_pdf' }
+            expect(gateway_evidence_submission.count).to eq 1
           end
 
           context 'when requesting document_ids' do
@@ -76,7 +83,7 @@ module CCMS
             end
 
             it 'writes a history record for each document' do
-              expect { subject.call }.to change { SubmissionHistory.count }.by(4)
+              expect { subject.call }.to change { SubmissionHistory.count }.by(5)
             end
 
             it 'updates the history records' do
@@ -100,7 +107,7 @@ module CCMS
               subject.call
               admin1_documents = SubmissionHistory.where(submission_id: submission.id).map(&:request).map { |x| x.scan(/ADMIN1/) }.flatten.count
               bstmt_documents = SubmissionHistory.where(submission_id: submission.id).map(&:request).map { |x| x.scan(/BSTMT/) }.flatten.count
-              expect(admin1_documents).to eq 3
+              expect(admin1_documents).to eq 4
               expect(bstmt_documents).to eq 1
             end
 


### PR DESCRIPTION
## AP-2344 Include gateway evidence documents to ccms upload

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2344)

- Add gateway evidence document attachments to the ccms document upload process

- Test the above.

### Question for reviewer:

We thoroughly test with a statement of case attachment. Do you think these tests should be duplicated for gateway evidence? The document upload process focuses on documents attached to the application and not what type specifically.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
