### PR TITLE
AP-2331 Non-passported dependant child attributes in CCMS payload

### DIFF
--- a/app/models/dependant.rb
+++ b/app/models/dependant.rb
@@ -3,6 +3,8 @@ class Dependant < ApplicationRecord
 
   belongs_to :legal_aid_application
 
+  scope :child_relative, -> { where(relationship: 'child_relative') }
+
   DEFAULT_VALUES = {
     in_full_time_education: false,
     relationship: 'child_relative',

--- a/app/models/dependant.rb
+++ b/app/models/dependant.rb
@@ -30,7 +30,15 @@ class Dependant < ApplicationRecord
   end
 
   def eighteen_or_less?
-    age < 19
+    age <= 19
+  end
+
+  def fifteen_or_less?
+    age <= 15
+  end
+
+  def sixteen_or_over?
+    age >= 16
   end
 
   def as_json

--- a/app/models/dependant.rb
+++ b/app/models/dependant.rb
@@ -30,15 +30,15 @@ class Dependant < ApplicationRecord
   end
 
   def eighteen_or_less?
-    age <= 19
+    age < 19
   end
 
   def fifteen_or_less?
-    age <= 15
+    age < 16
   end
 
   def sixteen_or_over?
-    age >= 16
+    age > 15
   end
 
   def as_json

--- a/app/services/ccms/attribute_value_generator.rb
+++ b/app/services/ccms/attribute_value_generator.rb
@@ -28,6 +28,7 @@ module CCMS
                                 |bank_account
                                 |lead_proceeding_type
                                 |chances_of_success
+                                |dependant
                                 |opponent
                                 |other_assets_declaration
                                 |other_party
@@ -45,6 +46,7 @@ module CCMS
     BANK_REGEX = /^bank_account_(\S+)$/.freeze
     LEAD_PROCEEDING_TYPE = /^lead_proceeding_type_(\S+)$/.freeze
     CHANCES_OF_SUCCESS = /^chances_of_success_(\S+)$/.freeze
+    DEPENDANT_REGEX = /^dependant_(\S+)$/.freeze
     OPPONENT = /^opponent_(\S+)$/.freeze
     OTHER_ASSETS_DECLARATION = /^other_assets_declaration_(\S+)$/.freeze
     OTHER_PARTY = /^other_party_(\S+)$/.freeze
@@ -373,6 +375,8 @@ module CCMS
         options[:bank_acct].__send__(Regexp.last_match(1))
       when CHANCES_OF_SUCCESS
         options[:chances_of_success].__send__(Regexp.last_match(1))
+      when DEPENDANT_REGEX
+        options[:dependant].__send__(Regexp.last_match(1))
       when VEHICLE_REGEX
         options[:vehicle].__send__(Regexp.last_match(1))
       when WAGE_SLIP_REGEX

--- a/app/services/ccms/requestors/case_add_requestor.rb
+++ b/app/services/ccms/requestors/case_add_requestor.rb
@@ -393,7 +393,7 @@ module CCMS
         @legal_aid_application.dependants.child_relative.each_with_index { |dependant, index| generate_client_residing_person_instance(xml, dependant, index) }
       end
 
-      def generate_client_residing_person_instance(xml, dependant, index)
+      def generate_client_residing_person_instance(xml, _dependant, index)
         xml.__send__('ns0:Instances') do
           xml.__send__('ns0:InstanceLabel', "the client's residing person#{index + 1}")
           xml.__send__('ns0:Attributes') { EntityAttributesGenerator.call(self, xml, :client_residing_person) }

--- a/app/services/ccms/requestors/case_add_requestor.rb
+++ b/app/services/ccms/requestors/case_add_requestor.rb
@@ -393,10 +393,10 @@ module CCMS
         @legal_aid_application.dependants.child_relative.each_with_index { |dependant, index| generate_client_residing_person_instance(xml, dependant, index) }
       end
 
-      def generate_client_residing_person_instance(xml, _dependant, index)
+      def generate_client_residing_person_instance(xml, dependant, index)
         xml.__send__('ns0:Instances') do
           xml.__send__('ns0:InstanceLabel', "the client's residing person#{index + 1}")
-          xml.__send__('ns0:Attributes') { EntityAttributesGenerator.call(self, xml, :client_residing_person) }
+          xml.__send__('ns0:Attributes') { EntityAttributesGenerator.call(self, xml, :client_residing_person, dependant: dependant) }
         end
       end
 

--- a/app/services/ccms/requestors/case_add_requestor.rb
+++ b/app/services/ccms/requestors/case_add_requestor.rb
@@ -387,6 +387,19 @@ module CCMS
         end
       end
 
+      def generate_client_residing_person_entity(xml, sequence_no, _config)
+        xml.__send__('ns0:SequenceNumber', sequence_no)
+        xml.__send__('ns0:EntityName', 'CLIENT_RESIDING_PERSON')
+        @legal_aid_application.dependants.child_relative.each_with_index { |dependant, index| generate_client_residing_person_instance(xml, dependant, index) }
+      end
+
+      def generate_client_residing_person_instance(xml, dependant, index)
+        xml.__send__('ns0:Instances') do
+          xml.__send__('ns0:InstanceLabel', "the client's residing person#{index + 1}")
+          xml.__send__('ns0:Attributes') { EntityAttributesGenerator.call(self, xml, :client_residing_person) }
+        end
+      end
+
       def generate_opponent_other_parties(xml, sequence_no)
         xml.__send__('ns0:SequenceNumber', sequence_no)
         xml.__send__('ns0:EntityName', 'OPPONENT_OTHER_PARTIES')

--- a/app/services/ccms/requestors/non_passported_case_add_requestor.rb
+++ b/app/services/ccms/requestors/non_passported_case_add_requestor.rb
@@ -24,6 +24,10 @@ module CCMS
         not_nil_or_zero? @legal_aid_application.savings_amount.national_savings
       end
 
+      def dependant_children?
+        @legal_aid_application.dependants.child_relative.any?
+      end
+
       def capital_share_present?
         not_nil_or_zero? @legal_aid_application.savings_amount.plc_shares
       end

--- a/config/ccms/attribute_block_configs/non_passported.yml
+++ b/config/ccms/attribute_block_configs/non_passported.yml
@@ -1551,6 +1551,25 @@ client_residing_person:
     user_defined: false
     response_type: boolean
     value: false
+  CLI_RES_PER_INPUT_B_12WP3_21A:
+    generate_block: true
+    br100_meaning: "Dependant: Relationship is child aged 15 and under"
+    user_defined: false
+    response_type: boolean
+    value: '#dependant_fifteen_or_less?'
+  CLI_RES_PER_INPUT_B_12WP3_23A:
+    generate_block: true
+    br100_meaning: "Person Residing: The child receives their own income?"
+    user_defined: true
+    response_type: boolean
+    value: '#dependant_has_income?'
+  CLI_RES_PER_INPUT_B_12WP3_24A:
+    generate_block: true
+    br100_meaning: "Dependant: Relationship is child aged 16 and over"
+    user_defined: false
+    response_type: boolean
+    value: '#dependant_sixteen_or_over?'
+
 
 national_savings:
   CLINATIONAL_INPUT_B_9WP2_10A:

--- a/config/ccms/attribute_block_configs/non_passported.yml
+++ b/config/ccms/attribute_block_configs/non_passported.yml
@@ -1544,6 +1544,14 @@ money_due:
     response_type: text
     generate_block?: true
 
+client_residing_person:
+  CLI_RES_PER_INPUT_B_12WP3_20A:
+    generate_block: true
+    br100_meaning: "Dependant: relationship is a foster child"
+    user_defined: false
+    response_type: boolean
+    value: false
+
 national_savings:
   CLINATIONAL_INPUT_B_9WP2_10A:
     generate_block?: true

--- a/config/ccms/means_entity_configs/non_passported.yml
+++ b/config/ccms/means_entity_configs/non_passported.yml
@@ -1,4 +1,9 @@
 ---
+- predicate: :dependant_children?
+  method: :generate_client_residing_person_entity
+  entity_name: CLIENT_RESIDING_PERSON
+  yaml_section: :client_residing_person
+
 - predicate: :national_savings_present?
   method: :generate_entity
   entity_name: CLINATIONAL

--- a/spec/factories/dependants.rb
+++ b/spec/factories/dependants.rb
@@ -26,7 +26,7 @@ FactoryBot.define do
       relationship { 'child_relative' }
     end
 
-    trait :child16_to_18 do
+    trait :child16_to18 do
       date_of_birth { Faker::Date.birthday(min_age: 16, max_age: 18) }
       relationship { 'child_relative' }
     end

--- a/spec/factories/dependants.rb
+++ b/spec/factories/dependants.rb
@@ -13,10 +13,12 @@ FactoryBot.define do
 
     trait :over18 do
       date_of_birth { Faker::Date.birthday(min_age: 19, max_age: 65) }
+      relationship { 'adult_relative' }
     end
 
     trait :under18 do
       date_of_birth { Faker::Date.birthday(min_age: 1, max_age: 17) }
+      relationship { 'child_relative' }
     end
   end
 end

--- a/spec/factories/dependants.rb
+++ b/spec/factories/dependants.rb
@@ -20,5 +20,14 @@ FactoryBot.define do
       date_of_birth { Faker::Date.birthday(min_age: 1, max_age: 17) }
       relationship { 'child_relative' }
     end
+
+    trait :under15 do
+      date_of_birth { Faker::Date.birthday(min_age: 1, max_age: 14) }
+      relationship { 'child_relative' }
+    end
+
+    trait :child15_to_18 do
+      date_of_birth { Faker::Date.birthday(min_age: 16, max_age: 17) }
+    end
   end
 end

--- a/spec/factories/dependants.rb
+++ b/spec/factories/dependants.rb
@@ -26,8 +26,9 @@ FactoryBot.define do
       relationship { 'child_relative' }
     end
 
-    trait :child15_to_18 do
-      date_of_birth { Faker::Date.birthday(min_age: 16, max_age: 17) }
+    trait :child16_to_18 do
+      date_of_birth { Faker::Date.birthday(min_age: 16, max_age: 18) }
+      relationship { 'child_relative' }
     end
   end
 end

--- a/spec/factories/legal_aid_applications.rb
+++ b/spec/factories/legal_aid_applications.rb
@@ -358,11 +358,11 @@ FactoryBot.define do
 
     trait :with_dependant do
       transient do
-        dependants_count { 1 }
+        dependant_count { 1 }
       end
 
       after(:create) do |application, evaluator|
-        application.dependants = evaluator.dependants.presence || create_list(:dependant, 1)
+        application.dependants = evaluator.dependants.presence || create_list(:dependant, evaluator.dependant_count)
         application.save
       end
     end

--- a/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_dependant_child_attributes_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_dependant_child_attributes_spec.rb
@@ -40,8 +40,7 @@ module CCMS
 
           context 'with dependant children' do
             let!(:younger_child) { create :dependant, :under15, legal_aid_application: legal_aid_application, number: 1, has_income: false }
-            let!(:older_child) { create :dependant, :child16_to_18, legal_aid_application: legal_aid_application, number: 2, has_income: true }
-
+            let!(:older_child) { create :dependant, :child16_to18, legal_aid_application: legal_aid_application, number: 2, has_income: true }
 
             context 'variable attributes' do
               context 'attribute CLI_RES_PER_INPUT_B_12WP3_21A - Dependant: Relationship is child aged 15 and under' do
@@ -148,7 +147,6 @@ module CCMS
           end
         end
 
-
         context 'passported' do
           let(:legal_aid_application) do
             create :legal_aid_application,
@@ -170,6 +168,5 @@ module CCMS
         end
       end
     end
-
   end
 end

--- a/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_dependant_child_attributes_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_dependant_child_attributes_spec.rb
@@ -1,0 +1,79 @@
+require 'rails_helper'
+
+module CCMS
+  module Requestors # rubocop:disable Metrics/ModuleLength
+    RSpec.describe NonPassportedCaseAddRequestor do
+      context 'XML request' do
+        let(:expected_tx_id) { '201904011604570390059770666' }
+        let(:firm) { create :firm, name: 'Firm1' }
+        let(:office) { create :office, firm: firm }
+        let(:savings_amount) { legal_aid_application.savings_amount }
+        let(:other_assets_decl) { legal_aid_application.other_assets_declaration }
+        let(:provider) do
+          create :provider,
+                 firm: firm,
+                 selected_office: office,
+                 username: 4_953_649
+        end
+
+        let(:legal_aid_application) do
+          create :legal_aid_application,
+                 :with_everything,
+                 :with_applicant_and_address,
+                 :with_negative_benefit_check_result,
+                 :with_proceeding_types,
+                 :with_chances_of_success,
+                 populate_vehicle: true,
+                 with_bank_accounts: 2,
+                 provider: provider,
+                 office: office
+        end
+
+        let!(:child_dependants) { create_list :dependant, 2, :under18, legal_aid_application: legal_aid_application }
+        let!(:adult_dependants) { create_list :dependant, 2, :over18, legal_aid_application: legal_aid_application }
+
+
+        let(:ccms_reference) { '300000054005' }
+        let(:submission) { create :submission, :case_ref_obtained, legal_aid_application: legal_aid_application, case_ccms_reference: ccms_reference }
+        let(:cfe_submission) { create :cfe_submission, legal_aid_application: legal_aid_application }
+        let!(:cfe_result) { create :cfe_v3_result, submission: cfe_submission }
+        let(:requestor) { described_class.new(submission, {}) }
+        let(:xml) { requestor.formatted_xml }
+
+        it 'generates the expected block for each of the hard coded attrs' do
+          puts ">>>>>>>>>>>>  #{__FILE__}:#{__LINE__} <<<<<<<<<<<<".yellow
+          puts xml
+          puts ">>>>>>>>>>>>  #{__FILE__}:#{__LINE__} <<<<<<<<<<<<".yellow
+          hard_coded_attrs.each do |attr|
+            entity, attr_name, type, user_defined, value = attr
+            block = XmlExtractor.call(xml, entity.to_sym, attr_name)
+            case type
+            when 'number'
+              expect(block).to have_number_response value.to_i
+            when 'text'
+              expect(block).to have_text_response value
+            when 'currency'
+              expect(block).to have_currency_response value
+            when 'date'
+              expect(block).to have_date_response value
+            else raise 'Unexpected type'
+            end
+
+            case user_defined
+            when true
+              expect(block).to be_user_defined
+            else
+              expect(block).not_to be_user_defined
+            end
+          end
+        end
+
+        def hard_coded_attrs
+          [
+            ['client_residing_person', 'CLI_RES_PER_INPUT_B_12WP3_20A', 'boolean', false, false]
+          ]
+        end
+      end
+    end
+  end
+end

--- a/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_dependant_child_attributes_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_dependant_child_attributes_spec.rb
@@ -16,22 +16,7 @@ module CCMS
                  username: 4_953_649
         end
 
-        let(:legal_aid_application) do
-          create :legal_aid_application,
-                 :with_everything,
-                 :with_applicant_and_address,
-                 :with_negative_benefit_check_result,
-                 :with_proceeding_types,
-                 :with_chances_of_success,
-                 populate_vehicle: true,
-                 with_bank_accounts: 2,
-                 provider: provider,
-                 office: office
-        end
-
-
-        let!(:adult_dependants) { create_list :dependant, 2, :over18, legal_aid_application: legal_aid_application }
-
+        let!(:adult_dependant) { create :dependant, :over18, legal_aid_application: legal_aid_application, number: 3 }
         let(:ccms_reference) { '300000054005' }
         let(:submission) { create :submission, :case_ref_obtained, legal_aid_application: legal_aid_application, case_ccms_reference: ccms_reference }
         let(:cfe_submission) { create :cfe_submission, legal_aid_application: legal_aid_application }
@@ -39,69 +24,152 @@ module CCMS
         let(:requestor) { described_class.new(submission, {}) }
         let(:xml) { requestor.formatted_xml }
 
-        context 'with dependant children' do
-          let!(:child_dependants) { create_list :dependant, 2, :under18, legal_aid_application: legal_aid_application }
+        context 'non-passported' do
+          let(:legal_aid_application) do
+            create :legal_aid_application,
+                   :with_everything,
+                   :with_applicant_and_address,
+                   :with_negative_benefit_check_result,
+                   :with_proceeding_types,
+                   :with_chances_of_success,
+                   populate_vehicle: true,
+                   with_bank_accounts: 2,
+                   provider: provider,
+                   office: office
+          end
 
-          context 'hard coded attributes' do
-            let(:hard_coded_attrs) do
-              [
-                # key for XmlExtractor xpath, attribute name, response type, user_defined?, expected_value
-                ['client_residing_person', 'CLI_RES_PER_INPUT_B_12WP3_20A', 'boolean', false, false]
-              ]
-            end
+          context 'with dependant children' do
+            let!(:younger_child) { create :dependant, :under15, legal_aid_application: legal_aid_application, number: 1, has_income: false }
+            let!(:older_child) { create :dependant, :child16_to_18, legal_aid_application: legal_aid_application, number: 2, has_income: true }
 
-            it 'generates a CLIENT RESIDING PERSON ENTITY' do
-              entity = XmlExtractor.call(xml, :client_residing_person_entity)
-              expect(entity).to be_present
-            end
 
-            it 'generates the an attribute block for each dependant child' do
-              hard_coded_attrs.each do |attr|
-                entity, attr_name, _type, _user_defined, _value = attr
-                blocks = XmlExtractor.call(xml, entity.to_sym, attr_name)
-                expect(blocks.size).to eq 2
+            context 'variable attributes' do
+              context 'attribute CLI_RES_PER_INPUT_B_12WP3_21A - Dependant: Relationship is child aged 15 and under' do
+                let(:blocks) { XmlExtractor.call(xml, :client_residing_person, 'CLI_RES_PER_INPUT_B_12WP3_21A') }
+
+                it 'is true for the younger child' do
+                  block = blocks.first
+                  expect(block).to have_boolean_response true
+                end
+
+                it 'is false for the older child' do
+                  block = blocks.last
+                  expect(block).to have_boolean_response false
+                end
+              end
+
+              context 'attribute CLI_RES_PER_INPUT_B_12WP3_23A - Person Residing: The child receives their own income?' do
+                let(:blocks) { XmlExtractor.call(xml, :client_residing_person, 'CLI_RES_PER_INPUT_B_12WP3_23A') }
+
+                it 'is false for the younger child without income' do
+                  block = blocks.first
+                  expect(block).to have_boolean_response false
+                end
+
+                it 'is true for the older child with income' do
+                  block = blocks.last
+                  expect(block).to have_boolean_response true
+                end
+              end
+
+              context 'attribute CLI_RES_PER_INPUT_B_12WP3_24A - Dependant: Relationship is child aged 16 and over' do
+                let(:blocks) { XmlExtractor.call(xml, :client_residing_person, 'CLI_RES_PER_INPUT_B_12WP3_24A') }
+
+                it 'is false for the younger child' do
+                  block = blocks.first
+                  expect(block).to have_boolean_response false
+                end
+
+                it 'is true for the older child' do
+                  block = blocks.last
+                  expect(block).to have_boolean_response true
+                end
               end
             end
 
-            it 'generates the expected block for each of the hard coded attrs' do
-              hard_coded_attrs.each do |attr|
-                entity, attr_name, type, user_defined, value = attr
-                blocks = XmlExtractor.call(xml, entity.to_sym, attr_name)
+            context 'hard coded attributes' do
+              let(:hard_coded_attrs) do
+                [
+                  # key for XmlExtractor xpath, attribute name, response type, user_defined?, expected_value
+                  ['client_residing_person', 'CLI_RES_PER_INPUT_B_12WP3_20A', 'boolean', false, false]
+                ]
+              end
 
-                blocks.each do |block|
-                  case type
-                  when 'number'
-                    expect(block).to have_number_response value.to_i
-                  when 'text'
-                    expect(block).to have_text_response value
-                  when 'currency'
-                    expect(block).to have_currency_response value
-                  when 'date'
-                    expect(block).to have_date_response value
-                  when 'boolean'
-                    expect(block).to have_boolean_response value
-                  else raise 'Unexpected type'
-                  end
+              it 'generates a CLIENT RESIDING PERSON ENTITY' do
+                entity = XmlExtractor.call(xml, :client_residing_person_entity)
+                expect(entity).to be_present
+              end
 
-                  case user_defined
-                  when true
-                    expect(block).to be_user_defined
-                  else
-                    expect(block).not_to be_user_defined
+              it 'generates the an attribute block for each dependant child' do
+                hard_coded_attrs.each do |attr|
+                  entity, attr_name, _type, _user_defined, _value = attr
+                  blocks = XmlExtractor.call(xml, entity.to_sym, attr_name)
+                  expect(blocks.size).to eq 2
+                end
+              end
+
+              it 'generates the expected block for each of the hard coded attrs' do
+                hard_coded_attrs.each do |attr|
+                  entity, attr_name, type, user_defined, value = attr
+                  blocks = XmlExtractor.call(xml, entity.to_sym, attr_name)
+
+                  blocks.each do |block|
+                    case type
+                    when 'number'
+                      expect(block).to have_number_response value.to_i
+                    when 'text'
+                      expect(block).to have_text_response value
+                    when 'currency'
+                      expect(block).to have_currency_response value
+                    when 'date'
+                      expect(block).to have_date_response value
+                    when 'boolean'
+                      expect(block).to have_boolean_response value
+                    else raise 'Unexpected type'
+                    end
+
+                    case user_defined
+                    when true
+                      expect(block).to be_user_defined
+                    else
+                      expect(block).not_to be_user_defined
+                    end
                   end
                 end
               end
             end
           end
+
+          context 'without dependant children' do
+            it 'does not generate a client residing person entity' do
+              entity = XmlExtractor.call(xml, :client_residing_person_entity)
+              expect(entity).to be_empty
+            end
+          end
         end
 
-        context 'without dependant children' do
-          it 'does not generate a client residing person entiry' do
+
+        context 'passported' do
+          let(:legal_aid_application) do
+            create :legal_aid_application,
+                   :with_everything,
+                   :with_applicant_and_address,
+                   :with_positive_benefit_check_result,
+                   :with_proceeding_types,
+                   :with_chances_of_success,
+                   populate_vehicle: true,
+                   with_bank_accounts: 2,
+                   provider: provider,
+                   office: office
+          end
+
+          it 'does not generate a client residing person entity' do
             entity = XmlExtractor.call(xml, :client_residing_person_entity)
             expect(entity).to be_empty
           end
         end
       end
     end
+
   end
 end

--- a/spec/support/xml_extractor.rb
+++ b/spec/support/xml_extractor.rb
@@ -9,6 +9,7 @@ class XmlExtractor
     cli_capital: %(//MeansAssesments//AssesmentDetails//Entity[EntityName = "CLICAPITAL"]//Attributes/Attribute),
     cli_premium: %(//MeansAssesments//AssesmentDetails//Entity[EntityName = "CLIPREMIUM"]//Attributes/Attribute),
     cli_stock: %(//MeansAssesments//AssesmentDetails//Entity[EntityName = "CLISTOCK"]//Attributes/Attribute),
+    client_residing_person: %(//MeansAssesments//AssesmentDetails//Entity[EntityName = "CLIENT_RESIDING_PERSON"]//Attributes/Attribute),
     devolved_powers_date: %(/Envelope/Body/CaseAddRQ/Case/CaseDetails/ApplicationDetails/DevolvedPowersDate),
     employment_entity: %(/Envelope/Body/CaseAddRQ/Case/CaseDetails/ApplicationDetails/MeansAssesments/AssesmentResults/AssesmentDetails/AssessmentScreens/Entity[EntityName = "EMPLOYMENT_CLIENT"]),
     family_statement: %(/Envelope/Body/CaseAddRQ/Case/CaseDetails/ApplicationDetails/MeritsAssesments/AssesmentResults/AssesmentDetails/AssessmentScreens/Entity[EntityName = "FAMILY_STATEMENT"]//Attributes/Attribute),

--- a/spec/support/xml_extractor.rb
+++ b/spec/support/xml_extractor.rb
@@ -10,6 +10,7 @@ class XmlExtractor
     cli_premium: %(//MeansAssesments//AssesmentDetails//Entity[EntityName = "CLIPREMIUM"]//Attributes/Attribute),
     cli_stock: %(//MeansAssesments//AssesmentDetails//Entity[EntityName = "CLISTOCK"]//Attributes/Attribute),
     client_residing_person: %(//MeansAssesments//AssesmentDetails//Entity[EntityName = "CLIENT_RESIDING_PERSON"]//Attributes/Attribute),
+    client_residing_person_entity: %(//MeansAssesments//AssesmentDetails//Entity[EntityName = "CLIENT_RESIDING_PERSON"]),
     devolved_powers_date: %(/Envelope/Body/CaseAddRQ/Case/CaseDetails/ApplicationDetails/DevolvedPowersDate),
     employment_entity: %(/Envelope/Body/CaseAddRQ/Case/CaseDetails/ApplicationDetails/MeansAssesments/AssesmentResults/AssesmentDetails/AssessmentScreens/Entity[EntityName = "EMPLOYMENT_CLIENT"]),
     family_statement: %(/Envelope/Body/CaseAddRQ/Case/CaseDetails/ApplicationDetails/MeritsAssesments/AssesmentResults/AssesmentDetails/AssessmentScreens/Entity[EntityName = "FAMILY_STATEMENT"]//Attributes/Attribute),


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2331)

- Added code to generate the `CLIENT_RESIDING_PERSON` entity if there are any dependant children
- Added code to generate and test the following attributes for *each* child dependant within that entity for non-passported applications
  - `CLI_RES_PER_INPUT_B_12WP3_20A`
  - `CLI_RES_PER_INPUT_B_12WP3_21A`
  - `CLI_RES_PER_INPUT_B_12WP3_23A`
  - `CLI_RES_PER_INPUT_B_12WP3_24A`


## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
