### PR TITLE
AP-2329 Add CHILD_PARTIES_C attribute for each proceeding

### DIFF
--- a/app/models/proceeding_type.rb
+++ b/app/models/proceeding_type.rb
@@ -33,4 +33,8 @@ class ProceedingType < ApplicationRecord
   def domestic_abuse?
     ccms_matter == 'Domestic Abuse'
   end
+
+  def section8?
+    ccms_matter == 'Section 8 orders'
+  end
 end

--- a/config/ccms/attribute_block_configs/base.yml
+++ b/config/ccms/attribute_block_configs/base.yml
@@ -5124,8 +5124,8 @@ proceeding_merits:
     response_type: boolean
     user_defined: false
   CHILD_PARTIES_C:
-    generate_block?: false
-    value: false
+    generate_block?: true
+    value: '#proceeding_section8?'
     br100_meaning: 'LARCriteria: Falls Within The Child Parties LAR Criteria'
     response_type: boolean
     user_defined: true

--- a/spec/data/ccms/case_add_request.xml
+++ b/spec/data/ccms/case_add_request.xml
@@ -2239,6 +2239,12 @@
                             <ns0:UserDefinedInd>true</ns0:UserDefinedInd>
                           </ns0:Attribute>
                           <ns0:Attribute>
+                            <ns0:Attribute>CHILD_PARTIES_C</ns0:Attribute>
+                            <ns0:ResponseType>boolean</ns0:ResponseType>
+                            <ns0:ResponseValue>false</ns0:ResponseValue>
+                            <ns0:UserDefinedInd>true</ns0:UserDefinedInd>
+                          </ns0:Attribute>
+                          <ns0:Attribute>
                             <ns0:Attribute>NEW_OR_EXISTING</ns0:Attribute>
                             <ns0:ResponseType>text</ns0:ResponseType>
                             <ns0:ResponseValue>NEW</ns0:ResponseValue>

--- a/spec/data/ccms/mp_case_add_request.xml
+++ b/spec/data/ccms/mp_case_add_request.xml
@@ -2312,6 +2312,12 @@
                             <ns0:UserDefinedInd>true</ns0:UserDefinedInd>
                           </ns0:Attribute>
                           <ns0:Attribute>
+                            <ns0:Attribute>CHILD_PARTIES_C</ns0:Attribute>
+                            <ns0:ResponseType>boolean</ns0:ResponseType>
+                            <ns0:ResponseValue>false</ns0:ResponseValue>
+                            <ns0:UserDefinedInd>true</ns0:UserDefinedInd>
+                          </ns0:Attribute>
+                          <ns0:Attribute>
                             <ns0:Attribute>NEW_OR_EXISTING</ns0:Attribute>
                             <ns0:ResponseType>text</ns0:ResponseType>
                             <ns0:ResponseValue>NEW</ns0:ResponseValue>

--- a/spec/services/ccms/requestors/case_add_requestor_xml_blocks/passported_attributes_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_xml_blocks/passported_attributes_spec.rb
@@ -71,6 +71,24 @@ module CCMS
           end
         end
 
+        context 'CHILD_PARTIES_C' do
+          context 'section8 proceeding' do
+            before { allow_any_instance_of(ProceedingType).to receive(:section8?).and_return true }
+            it 'is true' do
+              block = XmlExtractor.call(xml, :proceeding_merits, 'CHILD_PARTIES_C')
+              expect(block).to have_boolean_response(true)
+            end
+          end
+
+          context 'domestic abuse proceeding' do
+            before { allow_any_instance_of(ProceedingType).to receive(:section8?).and_return false }
+            it 'is false' do
+              block = XmlExtractor.call(xml, :proceeding_merits, 'CHILD_PARTIES_C')
+              expect(block).to have_boolean_response(false)
+            end
+          end
+        end
+
         context 'PASSPORTED_NINO' do
           let(:applicant) { legal_aid_application.applicant }
           it 'generates PASSPORTED NINO in global merits' do

--- a/spec/services/legal_framework/proceeding_types_service_spec.rb
+++ b/spec/services/legal_framework/proceeding_types_service_spec.rb
@@ -45,7 +45,7 @@ module LegalFramework
 
             it 'adds another proceeding type' do
               subject.add(**params)
-              expect(legal_aid_application.proceeding_types).to match_array [proceeding_type, proceeding_type2]
+              expect(legal_aid_application.proceeding_types).to match_array([proceeding_type, proceeding_type2])
             end
           end
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2923)

This attribute was previously omitted.  Now it is included for every proceeding type, coded to true if the proceeding. is a section 8 proceeding, otherwise false.

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
