### PR TITLE
AP-2360 Remove trailing whitespaces for Applicant and Dependant

### DIFF
--- a/app/forms/applicants/basic_details_form.rb
+++ b/app/forms/applicants/basic_details_form.rb
@@ -12,7 +12,9 @@ module Applicants
 
     before_validation :normalise_national_insurance_number
 
-    before_validation :squish_whitespaces
+    before_validation do
+      squish_whitespaces(:first_name, :last_name)
+    end
 
     # Note order of validation here determines order they appear on page
     # So validations for each field need to be in order, and presence validations
@@ -39,12 +41,6 @@ module Applicants
         attrs: dob_date_fields.fields,
         model_attributes: dob_date_fields.model_attributes
       )
-    end
-
-    def squish_whitespaces
-      attributes.each do |k, v|
-        attributes[k] = v.squish if v.respond_to?(:squish)
-      end
     end
 
     def date_of_birth

--- a/app/forms/applicants/basic_details_form.rb
+++ b/app/forms/applicants/basic_details_form.rb
@@ -12,6 +12,8 @@ module Applicants
 
     before_validation :normalise_national_insurance_number
 
+    before_validation :squish_whitespaces
+
     # Note order of validation here determines order they appear on page
     # So validations for each field need to be in order, and presence validations
     # split so that they occur in the right order.
@@ -37,6 +39,12 @@ module Applicants
         attrs: dob_date_fields.fields,
         model_attributes: dob_date_fields.model_attributes
       )
+    end
+
+    def squish_whitespaces
+      attributes.each do |k, v|
+        attributes[k] = v.squish if v.respond_to?(:squish)
+      end
     end
 
     def date_of_birth

--- a/app/forms/base_form.rb
+++ b/app/forms/base_form.rb
@@ -93,6 +93,12 @@ module BaseForm
       @attributes ||= {}
     end
 
+    def squish_whitespaces(*attribute_names)
+      attribute_names.each do |attr_name|
+        attributes[attr_name.to_s]&.squish!
+      end
+    end
+
     def save_as_draft
       @draft = true
       set_blanks_to_nil

--- a/app/forms/legal_aid_applications/dependant_form.rb
+++ b/app/forms/legal_aid_applications/dependant_form.rb
@@ -17,7 +17,9 @@ module LegalAidApplications
     attr_accessor(*ATTRIBUTES)
     attr_writer :date_of_birth
 
-    before_validation :squish_whitespaces
+    before_validation do
+      squish_whitespaces(:name)
+    end
 
     validates :name, presence: true
     validates :date_of_birth, presence: true
@@ -66,12 +68,6 @@ module LegalAidApplications
 
     def attributes_to_clean
       %i[monthly_income assets_value]
-    end
-
-    def squish_whitespaces
-      attributes.each do |k, v|
-        attributes[k] = v.squish if v.respond_to?(:squish)
-      end
     end
 
     # Note that this method is first called by `validates`.

--- a/app/forms/legal_aid_applications/dependant_form.rb
+++ b/app/forms/legal_aid_applications/dependant_form.rb
@@ -17,6 +17,8 @@ module LegalAidApplications
     attr_accessor(*ATTRIBUTES)
     attr_writer :date_of_birth
 
+    before_validation :squish_whitespaces
+
     validates :name, presence: true
     validates :date_of_birth, presence: true
     validates(
@@ -64,6 +66,12 @@ module LegalAidApplications
 
     def attributes_to_clean
       %i[monthly_income assets_value]
+    end
+
+    def squish_whitespaces
+      attributes.each do |k, v|
+        attributes[k] = v.squish if v.respond_to?(:squish)
+      end
     end
 
     # Note that this method is first called by `validates`.

--- a/app/forms/opponents/opponent_form.rb
+++ b/app/forms/opponents/opponent_form.rb
@@ -9,7 +9,7 @@ module Opponents
                   :police_notified, :police_notified_details, :police_notified_details_true, :police_notified_details_false,
                   :bail_conditions_set, :bail_conditions_set_details, :full_name
 
-    before_validation :clear_details, :clear_bail_details, :interpolate_police_notified_details
+    before_validation :clear_details, :clear_bail_details, :interpolate_police_notified_details, :squish_whitespaces
 
     def exclude_from_model
       %i[police_notified_details_true police_notified_details_false]
@@ -50,6 +50,12 @@ module Opponents
     end
 
     private
+
+    def squish_whitespaces
+      attributes.each do |k, v|
+        attributes[k] = v.squish if v.respond_to?(:squish)
+      end
+    end
 
     def police_notified_presence
       return if police_notified.blank?

--- a/app/forms/opponents/opponent_form.rb
+++ b/app/forms/opponents/opponent_form.rb
@@ -9,7 +9,11 @@ module Opponents
                   :police_notified, :police_notified_details, :police_notified_details_true, :police_notified_details_false,
                   :bail_conditions_set, :bail_conditions_set_details, :full_name
 
-    before_validation :clear_details, :clear_bail_details, :interpolate_police_notified_details, :squish_whitespaces
+    before_validation :clear_details, :clear_bail_details, :interpolate_police_notified_details
+
+    before_validation do
+      squish_whitespaces(:full_name)
+    end
 
     def exclude_from_model
       %i[police_notified_details_true police_notified_details_false]
@@ -50,12 +54,6 @@ module Opponents
     end
 
     private
-
-    def squish_whitespaces
-      attributes.each do |k, v|
-        attributes[k] = v.squish if v.respond_to?(:squish)
-      end
-    end
 
     def police_notified_presence
       return if police_notified.blank?

--- a/app/forms/providers/application_merits_task/involved_child_form.rb
+++ b/app/forms/providers/application_merits_task/involved_child_form.rb
@@ -15,7 +15,9 @@ module Providers
       attr_accessor(*ATTRIBUTES)
       attr_writer :date_of_birth
 
-      before_validation :squish_whitespaces
+      before_validation do
+        squish_whitespaces(:full_name)
+      end
 
       validates :full_name, presence: true, unless: :draft?
       validates :date_of_birth, presence: true, unless: :draft_and_not_partially_complete_date?
@@ -40,12 +42,6 @@ module Providers
       end
 
       private
-
-      def squish_whitespaces
-        attributes.each do |k, v|
-          attributes[k] = v.squish if v.respond_to?(:squish)
-        end
-      end
 
       def draft_and_not_partially_complete_date?
         draft? && !date_fields.partially_complete?

--- a/app/forms/providers/application_merits_task/involved_child_form.rb
+++ b/app/forms/providers/application_merits_task/involved_child_form.rb
@@ -15,6 +15,8 @@ module Providers
       attr_accessor(*ATTRIBUTES)
       attr_writer :date_of_birth
 
+      before_validation :squish_whitespaces
+
       validates :full_name, presence: true, unless: :draft?
       validates :date_of_birth, presence: true, unless: :draft_and_not_partially_complete_date?
       validates :date_of_birth, date: { not_in_the_future: true }, allow_nil: true
@@ -38,6 +40,12 @@ module Providers
       end
 
       private
+
+      def squish_whitespaces
+        attributes.each do |k, v|
+          attributes[k] = v.squish if v.respond_to?(:squish)
+        end
+      end
 
       def draft_and_not_partially_complete_date?
         draft? && !date_fields.partially_complete?

--- a/lib/tasks/clean_whitespaces.rake
+++ b/lib/tasks/clean_whitespaces.rake
@@ -1,0 +1,14 @@
+namespace :clean_whitespaces do
+  desc 'Clean/Squish whitespaces from Applicants and Dependants'
+  task clean: :environment do
+    Applicant.find_each do |applicant|
+      applicant.first_name = applicant.first_name.squish
+      applicant.last_name = applicant.last_name.squish
+      applicant.save!
+    end
+    Dependant.find_each do |dependant|
+      dependant.name = dependant.first_name.squish
+      dependant.save!
+    end
+  end
+end

--- a/lib/tasks/clean_whitespaces.rake
+++ b/lib/tasks/clean_whitespaces.rake
@@ -1,5 +1,5 @@
 namespace :clean_whitespaces do
-  desc 'Clean/Squish whitespaces from Applicants and Dependants'
+  desc 'Clean/Squish whitespaces from Applicants, Dependants and Opponents'
   task clean: :environment do
     Applicant.find_each do |applicant|
       applicant.first_name = applicant.first_name.squish
@@ -9,6 +9,10 @@ namespace :clean_whitespaces do
     Dependant.find_each do |dependant|
       dependant.name = dependant.first_name.squish
       dependant.save!
+    end
+    ApplicationMeritsTask::Opponent.find_each do |opponent|
+      opponent.full_name = opponent.full_name.squish
+      opponent.save!
     end
   end
 end

--- a/spec/requests/providers/applicant_details_spec.rb
+++ b/spec/requests/providers/applicant_details_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe Providers::ApplicantDetailsController, type: :request do
               applicant: {
                 first_name: '  John  ',
                 last_name: '   Doe',
-                national_insurance_number: '  AA 12 34 56 C  ',
+                national_insurance_number: 'AA 12 34 56 C',
                 'date_of_birth(1i)': '1999',
                 'date_of_birth(2i)': '07',
                 'date_of_birth(3i)': '11',
@@ -99,12 +99,13 @@ RSpec.describe Providers::ApplicantDetailsController, type: :request do
             }
           end
 
-          it 'strips and trims whitespaces from applicant details' do
-            subject
-            applicant = application.reload.applicant
-            expect(applicant.first_name).to eq 'John'
-            expect(applicant.last_name).to eq 'Doe'
-            expect(applicant.national_insurance_number).to eq 'AA123456C'
+          context 'when first name or last name has excess whitespaces' do
+            it 'strips and trims whitespaces from applicant details' do
+              subject
+              applicant = application.reload.applicant
+              expect(applicant.first_name).to eq 'John'
+              expect(applicant.last_name).to eq 'Doe'
+            end
           end
         end
 

--- a/spec/requests/providers/applicant_details_spec.rb
+++ b/spec/requests/providers/applicant_details_spec.rb
@@ -84,6 +84,30 @@ RSpec.describe Providers::ApplicantDetailsController, type: :request do
           expect(new_applicant).to be_instance_of(Applicant)
         end
 
+        context 'applicant details has trailing white spaces' do
+          let(:params) do
+            {
+              applicant: {
+                first_name: '  John  ',
+                last_name: '   Doe',
+                national_insurance_number: '  AA 12 34 56 C  ',
+                'date_of_birth(1i)': '1999',
+                'date_of_birth(2i)': '07',
+                'date_of_birth(3i)': '11',
+                email: Faker::Internet.safe_email
+              }
+            }
+          end
+
+          it 'strips and trims whitespaces from applicant details' do
+            subject
+            applicant = application.reload.applicant
+            expect(applicant.first_name).to eq 'John'
+            expect(applicant.last_name).to eq 'Doe'
+            expect(applicant.national_insurance_number).to eq 'AA123456C'
+          end
+        end
+
         context 'when the application is in draft' do
           let(:application) { create(:legal_aid_application, :draft) }
 

--- a/spec/requests/providers/application_merits_task/involved_children_spec.rb
+++ b/spec/requests/providers/application_merits_task/involved_children_spec.rb
@@ -84,6 +84,15 @@ module Providers
               subject
               expect(response).to redirect_to(providers_legal_aid_application_has_other_involved_children_path(application))
             end
+
+            context 'with trailing whitespaces' do
+              let(:new_full_name) { '  John    Doe  ' }
+
+              it 'removes excess whitespaces' do
+                subject
+                expect(child.reload.full_name).to eq 'John Doe'
+              end
+            end
           end
 
           context 'invalid params' do

--- a/spec/requests/providers/application_merits_task/opponents_spec.rb
+++ b/spec/requests/providers/application_merits_task/opponents_spec.rb
@@ -110,10 +110,18 @@ module Providers
           let(:full_name) { '   John   Doe  ' }
           let(:sample_opponent) { build :opponent, :police_notified_true, warning_letter_sent_details: '  extra    space  ' }
 
-          it 'removes excess whitespaces' do
-            subject
-            expect(opponent.reload.full_name).to eq 'John Doe'
-            expect(opponent.reload.warning_letter_sent_details).to eq 'extra space'
+          context 'fullname' do
+            it 'removes excess whitespaces' do
+              subject
+              expect(opponent.reload.full_name).to eq 'John Doe'
+            end
+          end
+
+          context 'when not a fullname attribute' do
+            it 'leaves the excess whitespaces' do
+              subject
+              expect(opponent.reload.warning_letter_sent_details).to eq '  extra    space  '
+            end
           end
         end
 

--- a/spec/requests/providers/application_merits_task/opponents_spec.rb
+++ b/spec/requests/providers/application_merits_task/opponents_spec.rb
@@ -48,10 +48,11 @@ module Providers
 
       describe 'PATCH /providers/applications/:legal_aid_application_id/opponent' do
         let(:sample_opponent) { build :opponent, :police_notified_true }
+        let(:full_name) { Faker::Name.name }
         let(:params) do
           {
             application_merits_task_opponent: {
-              full_name: Faker::Name.name,
+              full_name: full_name,
               understands_terms_of_court_order: sample_opponent.understands_terms_of_court_order.to_s,
               understands_terms_of_court_order_details: sample_opponent.understands_terms_of_court_order_details,
               warning_letter_sent: sample_opponent.warning_letter_sent.to_s,
@@ -103,6 +104,17 @@ module Providers
         it 'redirects to the next page' do
           subject
           expect(response).to redirect_to(flow_forward_path)
+        end
+
+        context 'when attributes have trailing whitespaces' do
+          let(:full_name) { '   John   Doe  ' }
+          let(:sample_opponent) { build :opponent, :police_notified_true, warning_letter_sent_details: '  extra    space  ' }
+
+          it 'removes excess whitespaces' do
+            subject
+            expect(opponent.reload.full_name).to eq 'John Doe'
+            expect(opponent.reload.warning_letter_sent_details).to eq 'extra space'
+          end
         end
 
         context 'when not authenticated' do

--- a/spec/requests/providers/dependants_controller_spec.rb
+++ b/spec/requests/providers/dependants_controller_spec.rb
@@ -79,6 +79,31 @@ RSpec.describe Providers::DependantsController, type: :request do
       end
     end
 
+    context 'when there are extra whitespaces in dependant name' do
+      let(:params) do
+        {
+          dependant: {
+            name: '   bob  john  ',
+            dob_day: 1,
+            dob_month: 1,
+            dob_year: 1990,
+            relationship: 'child_relative',
+            monthly_income: '',
+            has_income: 'false',
+            in_full_time_education: 'false',
+            has_assets_more_than_threshold: 'false',
+            assets_value: ''
+          }
+        }
+      end
+
+      it 'strips and trims whitespaces from dependant name' do
+        subject
+        dependant = legal_aid_application.reload.dependants.first
+        expect(dependant.name).to eq 'bob john'
+      end
+    end
+
     context 'when the parameters are invalid' do
       let(:params) do
         {


### PR DESCRIPTION
## AP-2360 Remove trailing whitespaces for Applicant and Dependant

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2360)

1. Squish/Remove trailing and duplicate whitespaces from attributes relating to Dependant, Applicant, InolvedChild and Opponent

2. Test the above

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
