### PR TITLE
AP-2359: Reduce Dashboard::UpdaterJob calls to geckoboard

### DIFF
--- a/app/services/dashboard_event_handler.rb
+++ b/app/services/dashboard_event_handler.rb
@@ -46,8 +46,8 @@ class DashboardEventHandler
   end
 
   def ccms_submission_saved
-    Dashboard::UpdaterJob.perform_later('Applications') if payload[:state] == 'failed'
-    Dashboard::UpdaterJob.set(wait: 1.minute).perform_later('PendingCCMSSubmissions') unless payload[:state].in?(%w[failed completed])
+    Dashboard::UpdaterJob.perform_later('Applications') if payload[:state].in?(%w[failed completed])
+    Dashboard::UpdaterJob.set(wait: 1.minute).perform_later('PendingCCMSSubmissions') if payload[:state].in?(%w[initialised failed completed])
   end
 
   def declined_open_banking

--- a/spec/services/dashboard_event_handler_spec.rb
+++ b/spec/services/dashboard_event_handler_spec.rb
@@ -55,6 +55,17 @@ RSpec.describe DashboardEventHandler do
     before { ActiveJob::Base.queue_adapter = :test }
 
     after { ActiveJob::Base.queue_adapter = :sidekiq }
+    context 'saved with state initialised' do
+      let(:state) { 'initialised' }
+
+      it 'does not fire the Applications job' do
+        expect { subject }.to have_enqueued_job(Dashboard::UpdaterJob).with('Applications').at_most(1).times
+      end
+
+      it 'fires PendingCCMSSubmissions job' do
+        expect { subject }.to have_enqueued_job(Dashboard::UpdaterJob).with('PendingCCMSSubmissions').once
+      end
+    end
 
     context 'saved with state failed' do
       let(:state) { 'failed' }
@@ -63,20 +74,20 @@ RSpec.describe DashboardEventHandler do
         expect { subject }.to have_enqueued_job(Dashboard::UpdaterJob).with('Applications').at_least(1).times
       end
 
-      it 'does not fire a PendingCCMSSubmissions job' do
-        expect { subject }.to_not have_enqueued_job(Dashboard::UpdaterJob).with('PendingCCMSSubmissions')
+      it 'fires PendingCCMSSubmissions job' do
+        expect { subject }.to have_enqueued_job(Dashboard::UpdaterJob).with('PendingCCMSSubmissions').once
       end
     end
 
     context 'saved with_state completed' do
       let(:state) { 'completed' }
 
-      it 'does not fire the Applications job' do
+      it 'fires the Applications job' do
         expect { subject }.to have_enqueued_job(Dashboard::UpdaterJob).with('Applications').at_least(1).times
       end
 
-      it 'does not fire a PendingCCMSSubmissions job' do
-        expect { subject }.to_not have_enqueued_job(Dashboard::UpdaterJob).with('PendingCCMSSubmissions')
+      it 'fires the PendingCCMSSubmissions job' do
+        expect { subject }.to have_enqueued_job(Dashboard::UpdaterJob).with('PendingCCMSSubmissions').once
       end
     end
   end

--- a/spec/services/dashboard_event_handler_spec.rb
+++ b/spec/services/dashboard_event_handler_spec.rb
@@ -55,10 +55,12 @@ RSpec.describe DashboardEventHandler do
     before { ActiveJob::Base.queue_adapter = :test }
 
     after { ActiveJob::Base.queue_adapter = :sidekiq }
+
     context 'saved with state initialised' do
       let(:state) { 'initialised' }
 
-      it 'does not fire the Applications job' do
+      it 'does not fire additional Application jobs' do
+        # one is fired from creating the LegalAidApplication required by the ccms_submission factory
         expect { subject }.to have_enqueued_job(Dashboard::UpdaterJob).with('Applications').at_most(1).times
       end
 
@@ -88,6 +90,19 @@ RSpec.describe DashboardEventHandler do
 
       it 'fires the PendingCCMSSubmissions job' do
         expect { subject }.to have_enqueued_job(Dashboard::UpdaterJob).with('PendingCCMSSubmissions').once
+      end
+    end
+
+    context 'saved with document_ids_obtained' do
+      let(:state) { 'document_ids_obtained' }
+
+      it 'does not fire additional Application jobs' do
+        # one is fired from creating the LegalAidApplication required by the ccms_submission factory
+        expect { subject }.to have_enqueued_job(Dashboard::UpdaterJob).with('Applications').at_most(1).times
+      end
+
+      it 'does not fire a PendingCCMSSubmissions job' do
+        expect { subject }.to_not have_enqueued_job(Dashboard::UpdaterJob).with('PendingCCMSSubmissions')
       end
     end
   end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2359)

Previously we would update geckoboard after each step of the CCMS `dance`
That could mean 20-30 calls in a few seconds and would occasionally trip
the geckoboard rate limits

This PR attempts to reduce that noise bu sending a ccms_submission_saved job
when a CCMS submission is initialised and then updating again when it concludes
either completed or failed.  It also updates the Applications call to send
whether the job completes successfully or not.  This should clear the
CCMS error widget when manually pushing a CCMS job though

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
