### PR TITLE
AP-2372: BugFix for DF and DWP override routing issue

### DIFF
--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -260,7 +260,7 @@ class LegalAidApplication < ApplicationRecord
   end
 
   def applicant_receives_benefit?
-    return true if dwp_override
+    return true if dwp_override&.has_evidence_of_benefit?
 
     benefit_check_result&.positive? || false
   end

--- a/spec/factories/dwp_overrides.rb
+++ b/spec/factories/dwp_overrides.rb
@@ -4,5 +4,13 @@ FactoryBot.define do
 
     passporting_benefit { 'universal_credit' }
     has_evidence_of_benefit { nil }
+
+    trait :with_no_evidence do
+      has_evidence_of_benefit { false }
+    end
+
+    trait :with_evidence do
+      has_evidence_of_benefit { true }
+    end
   end
 end

--- a/spec/models/legal_aid_application_spec.rb
+++ b/spec/models/legal_aid_application_spec.rb
@@ -810,13 +810,28 @@ RSpec.describe LegalAidApplication, type: :model do
         end
 
         context 'DWP Override' do
-          before { create :dwp_override, legal_aid_application: legal_aid_application }
-          it 'returns true' do
-            expect(legal_aid_application.applicant_receives_benefit?).to be true
+          context 'when the provider selects yes for evidence' do
+            before { create :dwp_override, :with_evidence, legal_aid_application: legal_aid_application }
+
+            it 'returns true' do
+              expect(legal_aid_application.applicant_receives_benefit?).to be true
+            end
+
+            it 'returns false for the alias non_passported' do
+              expect(legal_aid_application.non_passported?).to be false
+            end
           end
 
-          it 'returns false for the alias non_passported' do
-            expect(legal_aid_application.non_passported?).to be false
+          context 'when the provider selects no for evidence' do
+            before { create :dwp_override, :with_no_evidence, legal_aid_application: legal_aid_application }
+
+            it 'returns false' do
+              expect(legal_aid_application.applicant_receives_benefit?).to be false
+            end
+
+            it 'returns true for the alias non_passported' do
+              expect(legal_aid_application.non_passported?).to be true
+            end
           end
         end
       end
@@ -830,7 +845,7 @@ RSpec.describe LegalAidApplication, type: :model do
         end
 
         context 'DWP Override' do
-          before { create :dwp_override, legal_aid_application: legal_aid_application }
+          before { create :dwp_override, :with_evidence, legal_aid_application: legal_aid_application }
           it 'returns true' do
             expect(legal_aid_application.applicant_receives_benefit?).to be true
           end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2372)

Extended the substantive_applications_spec tests to ensure the correct routing when a provider overrides the DWP result
but does not have evidence of the benefit received
Updated the applicant_receives_benefit method of LegalAidApplication to only return true if the provider has selected yes to having evidence of the benefit


## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
