### PR TITLE
Fix Rake Job for cleaning whitespaces 

### DIFF
--- a/lib/tasks/clean_whitespaces.rake
+++ b/lib/tasks/clean_whitespaces.rake
@@ -2,16 +2,16 @@ namespace :clean_whitespaces do
   desc 'Clean/Squish whitespaces from Applicants, Dependants and Opponents'
   task clean: :environment do
     Applicant.find_each do |applicant|
-      applicant.first_name = applicant.first_name.squish
-      applicant.last_name = applicant.last_name.squish
+      applicant.first_name = applicant.first_name&.squish
+      applicant.last_name = applicant.last_name&.squish
       applicant.save!
     end
     Dependant.find_each do |dependant|
-      dependant.name = dependant.first_name.squish
+      dependant.name = dependant.name&.squish
       dependant.save!
     end
     ApplicationMeritsTask::Opponent.find_each do |opponent|
-      opponent.full_name = opponent.full_name.squish
+      opponent.full_name = opponent.full_name&.squish
       opponent.save!
     end
   end


### PR DESCRIPTION
## Fix Rake Job for cleaning whitespaces 

[Link to story](https://dsdmoj.atlassian.net/browse/AP-XXX)

Don't squish whitespaces when nil attributes. In particular the Applicant, which can exist at bare minimum with no details.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
