### PR TITLE
AP-2356: Always create task list

### DIFF
--- a/app/controllers/providers/capital_assessment_results_controller.rb
+++ b/app/controllers/providers/capital_assessment_results_controller.rb
@@ -9,6 +9,7 @@ module Providers
     end
 
     def update
+      LegalFramework::MeritsTasksService.call(legal_aid_application)
       continue_or_draft
     end
 

--- a/spec/requests/providers/capital_assessment_results_spec.rb
+++ b/spec/requests/providers/capital_assessment_results_spec.rb
@@ -184,6 +184,7 @@ RSpec.describe Providers::CapitalAssessmentResultsController, type: :request do
     context 'when the provider is authenticated' do
       before do
         allow(Setting).to receive(:allow_multiple_proceedings?).and_return(multi_proc_flag)
+        allow(LegalFramework::MeritsTasksService).to receive(:call).with(legal_aid_application).and_return(true)
         login_provider
         subject
       end
@@ -204,6 +205,11 @@ RSpec.describe Providers::CapitalAssessmentResultsController, type: :request do
           it 'redirects to start chances of success' do
             expect(subject).to redirect_to(providers_legal_aid_application_start_chances_of_success_path)
           end
+        end
+
+        it 'creates a task list' do
+          subject
+          expect(LegalFramework::MeritsTasksService).to have_received(:call).with(legal_aid_application)
         end
       end
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2356)

As part of the MP work the task list was being created on arriving at the task list controller, this creates it after the capital assessment page.  

This means it will be created for all applications regardless of the MP flag state and allows applications in progress to route back to the task list seamlessly
![mp-switch](https://user-images.githubusercontent.com/6757677/123054553-e0b35300-d3fc-11eb-8e42-d812639698f8.gif)

Tasks completed while the flag is false are still marked as complete as the code to mark tasks as complete checks for the existence before flagging and is not behind the flag

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
