### PR TITLE
BugFix - Create admin report when none exists

### DIFF
--- a/app/controllers/admin/reports_controller.rb
+++ b/app/controllers/admin/reports_controller.rb
@@ -21,7 +21,8 @@ module Admin
       expires_now
       respond_to do |format|
         format.csv do
-          send_data submitted_applications_report, filename: "submitted_applications_#{timestamp}.csv", content_type: 'text/csv'
+          data = submitted_applications_report || Reports::MIS::ApplicationDetailsReport.new.run
+          send_data data, filename: "submitted_applications_#{timestamp}.csv", content_type: 'text/csv'
         end
       end
     end
@@ -30,7 +31,8 @@ module Admin
       expires_now
       respond_to do |format|
         format.csv do
-          send_data non_passported_applications_report, filename: "non_passported_#{timestamp}.csv", type: :csv, content_type: 'text/csv'
+          data = non_passported_applications_report || Reports::MIS::NonPassportedApplicationsReport.new.run
+          send_data data, filename: "non_passported_#{timestamp}.csv", type: :csv, content_type: 'text/csv'
         end
       end
     end
@@ -42,11 +44,15 @@ module Admin
     private
 
     def submitted_applications_report
+      return unless admin_report
+
       attachment = admin_report.submitted_applications.attachment
       attachment.blob.download
     end
 
     def non_passported_applications_report
+      return unless admin_report
+
       attachment = admin_report.non_passported_applications.attachment
       attachment.blob.download
     end


### PR DESCRIPTION
## BugFix - Create admin report when none exists

Create an admin report synchronously on initial admin report setup, when there is no admin report at all. This creates them before the cronjob which executes at 8pm.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
