### PR TITLE
BugFix Separate flickering test for multiple used delegated functions

### DIFF
--- a/spec/requests/providers/used_multiple_delegated_functions_spec.rb
+++ b/spec/requests/providers/used_multiple_delegated_functions_spec.rb
@@ -226,10 +226,19 @@ RSpec.describe Providers::UsedMultipleDelegatedFunctionsController, type: :reque
         expect(response).to redirect_to(providers_legal_aid_applications_path)
       end
 
-      it 'updates the application proceeding types delegated functions dates' do
-        application_proceeding_types.each_with_index do |type, i|
-          expect(type.used_delegated_functions_reported_on).to eq(today)
-          expect(type.used_delegated_functions_on).to eq(used_delegated_functions_on - i.day)
+      context 'with first application proceeding type' do
+        it 'updates the application proceeding types delegated functions dates' do
+          apt = application_proceeding_types.first
+          expect(apt.used_delegated_functions_reported_on).to eq(today)
+          expect(apt.used_delegated_functions_on).to eq(used_delegated_functions_on)
+        end
+      end
+
+      context 'with second application proceeding type' do
+        it 'updates the application proceeding types delegated functions dates' do
+          apt = application_proceeding_types.last
+          expect(apt.used_delegated_functions_reported_on).to eq(today)
+          expect(apt.used_delegated_functions_on).to eq(used_delegated_functions_on - 1.day)
         end
       end
 


### PR DESCRIPTION
## BugFix Separate flickering test for multiple used delegated functions

- Seperate out a test block for multiple used delegated functions as this is a flickering test.

- This will enable us to narrow down the cause of the flickering test if it happens again.

- An assumption could be the application proceeding types are returning in different order because of the factory. Another assumption is that it's to do with timezones. Just an assumption.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
