### PR TITLE
AP-2366: Update FeedbackMailer

### DIFF
--- a/app/mailers/feedback_mailer.rb
+++ b/app/mailers/feedback_mailer.rb
@@ -34,6 +34,7 @@ class FeedbackMailer < BaseApplyMailer
   end
 
   def application_status
+    return '' if @legal_aid_application.nil?
     return 'pre-dwp-check' if @legal_aid_application&.pre_dwp_check?
 
     @legal_aid_application&.passported? ? 'passported' : 'non-passported'

--- a/spec/mailers/feedback_mailer_spec.rb
+++ b/spec/mailers/feedback_mailer_spec.rb
@@ -4,7 +4,8 @@ RSpec.describe FeedbackMailer, type: :mailer do
   describe 'notify' do
     let(:feedback) { create :feedback }
     let(:application) { create :application }
-    let(:mail) { described_class.notify(feedback.id, application.id) }
+    let(:application_id) { application.id }
+    let(:mail) { described_class.notify(feedback.id, application_id) }
 
     it 'sends to correct address' do
       expect(mail.to).to eq([Rails.configuration.x.support_email_address])
@@ -40,6 +41,7 @@ RSpec.describe FeedbackMailer, type: :mailer do
             expect(mail.govuk_notify_personalisation[:application_status]).to eq 'passported'
           end
         end
+
         context 'non-passported' do
           before do
             allow_any_instance_of(LegalAidApplication).to receive(:pre_dwp_check?).and_return(false)
@@ -47,6 +49,13 @@ RSpec.describe FeedbackMailer, type: :mailer do
           end
           it 'has a status of passported' do
             expect(mail.govuk_notify_personalisation[:application_status]).to eq 'non-passported'
+          end
+        end
+
+        context 'when no legal_aid_application is present' do
+          let(:application_id) { nil }
+          it 'has an empty status' do
+            expect(mail.govuk_notify_personalisation[:application_status]).to eq ''
           end
         end
       end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2366)

Return an empty string when no legal_aid_application can be loaded, rather than
defaulting to `non-passported`

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
