### PR TITLE
AP-2321 Show uploaded files names on check answers page

### DIFF
--- a/app/forms/providers/gateway_evidence_form.rb
+++ b/app/forms/providers/gateway_evidence_form.rb
@@ -118,7 +118,8 @@ module Providers
     end
 
     def create_attachment(original_file)
-      model.legal_aid_application.attachments.create document: original_file, attachment_type: 'gateway_evidence', attachment_name: sequenced_attachment_name
+      model.legal_aid_application.attachments.create document: original_file, attachment_type: 'gateway_evidence', original_filename: @original_file.original_filename,
+                                                     attachment_name: sequenced_attachment_name
     end
 
     def sequenced_attachment_name

--- a/app/forms/statement_of_cases/statement_of_case_form.rb
+++ b/app/forms/statement_of_cases/statement_of_case_form.rb
@@ -29,7 +29,7 @@ module StatementOfCases
     end
 
     def exclude_from_model
-      %i[upload_button_pressed original_file]
+      %i[upload_button_pressed original_file original_filename]
     end
 
     validate :statement_present_or_file_uploaded

--- a/app/helpers/attachments_helper.rb
+++ b/app/helpers/attachments_helper.rb
@@ -1,0 +1,9 @@
+module AttachmentsHelper
+  def attachments_with_size(attachments)
+    return [] unless attachments
+
+    attachments&.map do |at|
+      at.original_filename + " (#{number_to_human_size(at.document.blob.byte_size)})"
+    end
+  end
+end

--- a/app/views/providers/check_merits_answers/show.html.erb
+++ b/app/views/providers/check_merits_answers/show.html.erb
@@ -7,10 +7,9 @@
         "shared/check_answers/#{Setting.allow_multiple_proceedings? ? 'merits': 'merits_orig'}",
         incident: @legal_aid_application.latest_incident,
         statement_of_case: @legal_aid_application.statement_of_case,
-        gateway_evidence: @legal_aid_application&.gateway_evidence,
         opponent: @legal_aid_application.opponent,
         chances_of_success: @application_proceeding_type.chances_of_success,
-        gateway_evidence: @legal_aid_application.gateway_evidence,
+        gateway_evidence: @legal_aid_application&.gateway_evidence,
         read_only: false
       ) %>
 

--- a/app/views/providers/check_merits_answers/show.html.erb
+++ b/app/views/providers/check_merits_answers/show.html.erb
@@ -7,6 +7,7 @@
         "shared/check_answers/#{Setting.allow_multiple_proceedings? ? 'merits': 'merits_orig'}",
         incident: @legal_aid_application.latest_incident,
         statement_of_case: @legal_aid_application.statement_of_case,
+        gateway_evidence: @legal_aid_application&.gateway_evidence,
         opponent: @legal_aid_application.opponent,
         chances_of_success: @application_proceeding_type.chances_of_success,
         gateway_evidence: @legal_aid_application.gateway_evidence,

--- a/app/views/providers/gateway_evidences/show.html.erb
+++ b/app/views/providers/gateway_evidences/show.html.erb
@@ -57,7 +57,7 @@
           local: true
       ) do |form| %>
 
-    <%= form.govuk_radio_divider %>
+    <div class="govuk-!-padding-bottom-6"></div>
 
     <%= next_action_buttons(show_draft: true, form: form) %>
   <% end %>

--- a/app/views/providers/submitted_applications/show.html.erb
+++ b/app/views/providers/submitted_applications/show.html.erb
@@ -129,6 +129,7 @@
         "shared/check_answers/#{Setting.allow_multiple_proceedings? ? :merits: :merits_orig}",
         incident: @legal_aid_application.latest_incident,
         statement_of_case: @legal_aid_application.statement_of_case,
+        gateway_evidence: @legal_aid_application&.gateway_evidence,
         opponent: @legal_aid_application.opponent,
         chances_of_success: @application_proceeding_type.chances_of_success,
         application_proceeding_type: @legal_aid_application.lead_application_proceeding_type,

--- a/app/views/shared/check_answers/_item.html.erb
+++ b/app/views/shared/check_answers/_item.html.erb
@@ -5,11 +5,25 @@
 
 <div class="govuk-summary-list__row <%= no_border %> normal-word-break" id="app-check-your-answers__<%= name %>">
   <dt class="govuk-summary-list__key govuk-!-width-one-half">
-    <%= question %>
+    <h2 class="govuk-heading-m"><%= question %></h2>
   </dt>
   <!--  in-line styling due to issues around pdf generation in our production envs -->
   <dd class="govuk-summary-list__value"<% if read_only %> style="text-align: right;"<% end %>>
-    <%= answer.present? ? answer : '-' %>
+    <% if answer.present? %>
+      <% if answer.kind_of?(Array) %>
+        <ul class="govuk-list">
+          <% answer.each do |ans| %>
+            <li>
+              <%= ans %>
+            </li>
+          <% end %>
+        </ul>
+      <% else %>
+        <%= answer %>
+      <% end %>
+    <% else %>
+      -
+    <% end %>
   </dd>
   <% unless read_only %>
     <dd class="govuk-summary-list__actions">

--- a/app/views/shared/check_answers/_item.html.erb
+++ b/app/views/shared/check_answers/_item.html.erb
@@ -1,6 +1,6 @@
 <%
   read_only = local_assigns[:read_only] ? read_only : false
-  no_border = no_border ? 'govuk-summary-list--no-border' : ''
+  no_border = no_border ? 'govuk-summary-list__row--no-border' : ''
 %>
 
 <div class="govuk-summary-list__row <%= no_border %> normal-word-break" id="app-check-your-answers__<%= name %>">

--- a/app/views/shared/check_answers/_item.html.erb
+++ b/app/views/shared/check_answers/_item.html.erb
@@ -5,7 +5,7 @@
 
 <div class="govuk-summary-list__row <%= no_border %> normal-word-break" id="app-check-your-answers__<%= name %>">
   <dt class="govuk-summary-list__key govuk-!-width-one-half">
-    <h2 class="govuk-heading-m"><%= question %></h2>
+    <%= question %>
   </dt>
   <!--  in-line styling due to issues around pdf generation in our production envs -->
   <dd class="govuk-summary-list__value"<% if read_only %> style="text-align: right;"<% end %>>

--- a/app/views/shared/check_answers/_merits.html.erb
+++ b/app/views/shared/check_answers/_merits.html.erb
@@ -101,11 +101,13 @@
 </section>
 <div class="govuk-!-padding-bottom-6"></div>
 <section class="print-no-break">
-  <%= check_answer_change_link(
+  <%= check_answer_link(
         name: :statement_of_case,
         url: providers_legal_aid_application_statement_of_case_path(@legal_aid_application),
+        answer: attachments_with_size(statement_of_case&.original_attachments),
         question: t('.statement-of-case-heading'),
-        read_only: read_only
+        read_only: read_only,
+        no_border: true
       ) %>
   <div class="govuk-body"><%= statement_of_case&.statement %></div>
   <%= render 'shared/check_answers/section_break' if statement_of_case&.statement %>
@@ -146,7 +148,7 @@
         name: :gateway_evidence,
         url: providers_legal_aid_application_gateway_evidence_path(@legal_aid_application),
         question: t('.items.gateway_evidence'),
-        answer: nil,
+        answer: attachments_with_size(gateway_evidence&.original_attachments),
         read_only: read_only
       ) %>
   </dl>

--- a/app/views/shared/check_answers/_merits.html.erb
+++ b/app/views/shared/check_answers/_merits.html.erb
@@ -101,14 +101,16 @@
 </section>
 <div class="govuk-!-padding-bottom-6"></div>
 <section class="print-no-break">
-  <%= check_answer_link(
-        name: :statement_of_case,
-        url: providers_legal_aid_application_statement_of_case_path(@legal_aid_application),
-        answer: attachments_with_size(statement_of_case&.original_attachments),
-        question: t('.statement-of-case-heading'),
-        read_only: read_only,
-        no_border: true
-      ) %>
+  <dl class="govuk-summary-list govuk-!-margin-bottom-2 print-remove-border">
+    <%= check_answer_link(
+          name: :statement_of_case,
+          url: providers_legal_aid_application_statement_of_case_path(@legal_aid_application),
+          answer: attachments_with_size(statement_of_case&.original_attachments),
+          question: t('.statement-of-case-heading'),
+          read_only: read_only,
+          no_border: true
+        ) %>
+  </dl>
   <div class="govuk-body"><%= statement_of_case&.statement %></div>
   <%= render 'shared/check_answers/section_break' if statement_of_case&.statement %>
 </section>

--- a/app/views/shared/check_answers/_merits_orig.html.erb
+++ b/app/views/shared/check_answers/_merits_orig.html.erb
@@ -108,13 +108,14 @@
           name: :statement_of_case,
           url: providers_legal_aid_application_statement_of_case_path(@legal_aid_application),
           question: t('.items.statement_of_case'),
-          answer: nil,
+          answer: attachments_with_size(statement_of_case&.original_attachments),
           read_only: read_only,
-          no_border: statement_of_case&.statement.present?
+          no_border: statement_of_case&.statement.present? || !statement_of_case&.original_attachments.present?
         ) %>
   </dl>
 
   <div class="govuk-body"><%= statement_of_case&.statement %></div>
+  <%= render 'shared/check_answers/section_break' if statement_of_case&.statement.present? %>
 
   <dl class="govuk-summary-list govuk-!-margin-bottom-2">
     <%= check_answer_link(

--- a/app/views/shared/check_answers/_no_link_item.html.erb
+++ b/app/views/shared/check_answers/_no_link_item.html.erb
@@ -7,6 +7,20 @@
   </dt>
   <!--  in-line styling due to issues around pdf generation in our production envs -->
   <dd class="govuk-summary-list__value"<% if read_only %> style="text-align: right;"<% end %>>
-    <%= answer.present? ? answer : '-' %>
+    <% if answer.present? %>
+      <% if answer.kind_of?(Array) %>
+        <ul class="govuk-list">
+          <% answer.each do |ans| %>
+            <li>
+              <%= ans %>
+            </li>
+          <% end %>
+        </ul>
+      <% else %>
+        <%= answer %>
+      <% end %>
+    <% else %>
+      -
+    <% end %>
   </dd>
 </div>

--- a/db/migrate/20210621100811_add_original_filename_to_attachments.rb
+++ b/db/migrate/20210621100811_add_original_filename_to_attachments.rb
@@ -1,0 +1,5 @@
+class AddOriginalFilenameToAttachments < ActiveRecord::Migration[6.1]
+  def change
+    add_column :attachments, :original_filename, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -151,6 +151,8 @@ ActiveRecord::Schema.define(version: 2021_06_24_130422) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "attachment_name"
+    t.text "original_filename"
+    t.decimal "size", precision: 10, scale: 2
   end
 
   create_table "attempts_to_settles", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/features/providers/civil_application_journey.feature
+++ b/features/providers/civil_application_journey.feature
@@ -755,6 +755,7 @@ Feature: Civil application journeys
     Then I enter the application merits task statement of case statement field 'This is some test data for the statement of case'
     Then I click 'Save and continue'
     Then I should be on a page showing "Check your answers"
+    Then I should be on a page showing "hello_world.pdf (15.7 KB)"
     And the answer for 'Statement of case' should be 'This is some test data for the statement of case'
     And I should be on a page showing "Confirm the following"
     Then I click link "Back"

--- a/features/providers/multi_proceedings.feature
+++ b/features/providers/multi_proceedings.feature
@@ -38,6 +38,15 @@ Feature: Merits task list
     When I click 'Save and continue'
     Then I should be on the 'check_provider_answers' page showing 'Check your answers'
 
+
+  @javascript @vcr
+  Scenario: When the flag is enabled
+    Given the feature flag for allow_multiple_proceedings is enabled
+    Given I complete the multiple proceedings journey as far as check passported answers
+    Then I should be on a page showing "Fake gateway evidence file (15.7 KB)"
+    Then I should be on a page showing "Fake file name 1 (15.7 KB)"
+    Then I should be on a page showing "Statement of case text entered here"
+
   @javascript @vcr
   Scenario: When the flag is disabled
     Given the feature flag for allow_multiple_proceedings is disabled

--- a/features/step_definitions/civil_journey_steps.rb
+++ b/features/step_definitions/civil_journey_steps.rb
@@ -467,6 +467,26 @@ Given('I complete the passported journey as far as check your answers') do
   steps %(Then I should be on a page showing 'Check your answers')
 end
 
+Given('I complete the multiple proceedings journey as far as check passported answers') do
+  @legal_aid_application = create(
+    :application,
+    :with_applicant,
+    :with_proceeding_types,
+    :with_non_passported_state_machine,
+    :provider_entering_merits,
+    :with_transaction_period,
+    :with_attached_statement_of_case,
+    :with_chances_of_success,
+    :with_gateway_evidence,
+    :with_policy_disregards,
+    :with_benefits_transactions
+  )
+  login_as @legal_aid_application.provider
+  visit(providers_legal_aid_application_check_merits_answers_path(@legal_aid_application))
+
+  steps %(Then I should be on a page showing 'Check your answers')
+end
+
 Given('I complete the non-passported journey as far as check your answers') do
   applicant = create(
     :applicant,

--- a/spec/factories/gateway_evidences.rb
+++ b/spec/factories/gateway_evidences.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     trait :with_original_file_attached do
       after :create do |ge|
         attachment = ge.legal_aid_application.attachments.create!(attachment_type: 'gateway_evidence',
-                                                                  attachment_name: 'gateway_evidence')
+                                                                  attachment_name: 'gateway_evidence', original_filename: 'Fake gateway evidence file')
 
         filepath = Rails.root.join('spec/fixtures/files/documents/hello_world.pdf')
         attachment.document.attach(io: File.open(filepath), filename: 'hello_world.pdf', content_type: 'application/pdf')

--- a/spec/factories/legal_aid_applications.rb
+++ b/spec/factories/legal_aid_applications.rb
@@ -446,6 +446,18 @@ FactoryBot.define do
       end
     end
 
+    trait :with_attached_statement_of_case do
+      after(:create) do |application|
+        create(:statement_of_case, :with_original_file_attached, legal_aid_application: application)
+      end
+    end
+
+    trait :with_gateway_evidence do
+      after(:create) do |application|
+        create(:gateway_evidence, :with_original_file_attached, legal_aid_application: application)
+      end
+    end
+
     trait :with_opponent do
       opponent { build :opponent }
     end

--- a/spec/factories/statement_of_cases.rb
+++ b/spec/factories/statement_of_cases.rb
@@ -9,9 +9,11 @@ FactoryBot.define do
     end
 
     trait :with_original_file_attached do
+      statement { 'Statement of case text entered here' }
+
       after :create do |soc|
         attachment = soc.legal_aid_application.attachments.create!(attachment_type: 'statement_of_case',
-                                                                   attachment_name: 'statement_of_case')
+                                                                   attachment_name: 'statement_of_case', original_filename: 'Fake file name 1')
 
         filepath = Rails.root.join('spec/fixtures/files/documents/hello_world.pdf')
         attachment.document.attach(io: File.open(filepath), filename: 'hello_world.pdf', content_type: 'application/pdf')

--- a/spec/helpers/attachments_helper_spec.rb
+++ b/spec/helpers/attachments_helper_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe AttachmentsHelper, type: :helper do
+  let(:application) { create :legal_aid_application }
+
+  describe '#attachments_with_size' do
+    context 'with attachments' do
+      let!(:statement_of_case) { create :statement_of_case, :with_original_file_attached, legal_aid_application: application }
+      let(:attachments) { statement_of_case.original_attachments }
+
+      it 'returns array of file names with their file size' do
+        expect(attachments_with_size(attachments)).to eq ['Fake file name 1 (15.7 KB)']
+      end
+    end
+
+    context 'without attachments' do
+      let(:attachments) { nil }
+
+      it 'returns empty array' do
+        expect(attachments_with_size(attachments)).to eq []
+      end
+    end
+  end
+end

--- a/spec/requests/providers/application_merits_task/statement_of_case_spec.rb
+++ b/spec/requests/providers/application_merits_task/statement_of_case_spec.rb
@@ -147,6 +147,12 @@ module Providers
               expect(statement_of_case.original_attachments.first).to be_present
             end
 
+            it 'stores the original filename' do
+              subject
+              attachment = statement_of_case.original_attachments.first
+              expect(attachment.original_filename).to eq 'hello_world.docx'
+            end
+
             it 'has the relevant content type' do
               subject
               document = statement_of_case.original_attachments.first.document

--- a/spec/requests/providers/gateway_evidence_spec.rb
+++ b/spec/requests/providers/gateway_evidence_spec.rb
@@ -54,6 +54,12 @@ module Providers
         expect(gateway_evidence.original_attachments.first).to be_present
       end
 
+      it 'stores the original filename' do
+        subject
+        attachment = gateway_evidence.original_attachments.first
+        expect(attachment.original_filename).to eq 'hello_world.pdf'
+      end
+
       it 'redirects to the next page' do
         subject
         expect(response).to redirect_to providers_legal_aid_application_check_merits_answers_path(legal_aid_application)


### PR DESCRIPTION
## AP-2321 Show uploaded files names on check answers page

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2321)

- Add migration to create a new column original_filename for Attachment to store the files original names.

- Show the uploaded files names on the check answers page. This includes statement of case and gateway evidence.


- Create a helper to return file names concatenated with their file size. 
- Test this helper


**Also**:
```
Update html class '.govuk-summary-list--no-border' to class '.govuk-summary-list__row--no-border'

This is done for row by row basis. This is because it was not working when printing the check merits answers
page. The browser print page/popup would still show the border. Now with the __row--no-border it no longer shows as expected.
This is because the class was being added to a summary list row and thus required a row by row basis to remove the
border e.g.  'govuk-summary-list__row--no-border'
```

**EDIT:**

Fix sentry bug which could be the cause of UAT issues atm
```
ArgumentError Sidekiq/PdfConverterWorker
'gateway_evidence_1_pdf' is not a valid attachment_type
```
## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
