### PR TITLE
BugFix: Address flickering tests

### DIFF
--- a/spec/requests/providers/applicant_bank_accounts_spec.rb
+++ b/spec/requests/providers/applicant_bank_accounts_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe Providers::ApplicantBankAccountsController, type: :request do
           let(:offline_savings_accounts) { rand(1...1_000_000.0).round(2) }
 
           it 'updates the savings amount' do
-            expect(legal_aid_application.reload.savings_amount.offline_savings_accounts).to eq(offline_savings_accounts)
+            expect(legal_aid_application.reload.savings_amount.offline_savings_accounts).to eq(BigDecimal(offline_savings_accounts, offline_savings_accounts.to_s.length - 1))
           end
 
           it 'redirects to the savings and investments page' do


### PR DESCRIPTION
## What

There are some issues with BigDecimal, see their issues page and
this seems to be a new occurence.  An issue has been raised on
their repo https://github.com/ruby/bigdecimal/issues/194 but
this seems to work on the previously flickering values

It forces the value into a big decimal while setting the
precision manually based on the string length of the
random value generated, minus the decimal place separator

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
