### PR TITLE
Ap 2367 implement cost override

### DIFF
--- a/app/controllers/providers/limitations_controller.rb
+++ b/app/controllers/providers/limitations_controller.rb
@@ -9,7 +9,7 @@ module Providers
     end
 
     def update
-      if Setting.allow_multiple_proceedings? && @legal_aid_application.used_delegated_functions?
+      if @legal_aid_application.used_delegated_functions?
         clear_limit_and_reason
         @form = LegalAidApplications::EmergencyCostOverrideForm.new(form_params)
         render :show unless save_continue_or_draft(@form)

--- a/app/views/providers/check_provider_answers/_shared.html.erb
+++ b/app/views/providers/check_provider_answers/_shared.html.erb
@@ -60,20 +60,18 @@
           legal_aid_application: @legal_aid_application
       ) %>
 
-  <% if Setting.allow_multiple_proceedings? %>
-    <% if @legal_aid_application.used_delegated_functions? %>
-      <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-          <h2 class="govuk-heading-m"><%= t '.emergency_cost_limit' %></h2>
-        </div>
-        <div class="govuk-grid-column-one-third">
-          <p><%= link_to_accessible t('.change'), providers_legal_aid_application_limitations_path(@legal_aid_application), class: 'govuk-link govuk-link-right' %></p>
-        </div>
+  <% if @legal_aid_application.used_delegated_functions? %>
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <h2 class="govuk-heading-m"><%= t '.emergency_cost_limit' %></h2>
       </div>
-      <%= render(
-            'shared/check_answers/emergency_costs',
-            legal_aid_application: @legal_aid_application,
-            read_only: @read_only
-          ) %>
-    <% end %>
+      <div class="govuk-grid-column-one-third">
+        <p><%= link_to_accessible t('.change'), providers_legal_aid_application_limitations_path(@legal_aid_application), class: 'govuk-link govuk-link-right' %></p>
+      </div>
+    </div>
+    <%= render(
+          'shared/check_answers/emergency_costs',
+          legal_aid_application: @legal_aid_application,
+          read_only: @read_only
+        ) %>
   <% end %>

--- a/app/views/providers/limitations/_legacy_proceeding_types.html.erb
+++ b/app/views/providers/limitations/_legacy_proceeding_types.html.erb
@@ -1,3 +1,8 @@
+<%= form_with(model: @form,
+              url: providers_legal_aid_application_limitations_path(@legal_aid_application),
+              method: :patch,
+              local: true) do |form| %>
+
 <%= page_template(page_title: t('.h1-heading')) do %>
 
   <h2 class="govuk-heading-m">
@@ -34,6 +39,27 @@
   <p><strong><%= t('.allowable_work') %></strong><%= application_proceeding_type.substantive_scope_limitation.description %></p>
   </p>
 
+  <p class="govuk-body">
+  <p><%= t('.default_limit_is') %> <strong><%= gds_number_to_currency(@legal_aid_application.default_delegated_functions_cost_limitation,  precision: 0) %></strong></p>
+  <%= form.govuk_radio_buttons_fieldset(:emergency_cost_override,
+                                        legend: { size: 's', tag: 'h2', text: t('.cost_override_question') }) do %>
+    <%= form.govuk_radio_button(:emergency_cost_override, true, link_errors: true, label: {text: t('generic.yes')} ) do %>
+      <%= form.govuk_text_field(
+            :emergency_cost_requested,
+            label: {text: t('.enter_cost_limit')},
+            value: number_to_currency_or_original_string(@form.emergency_cost_requested),
+            prefix_text: t('currency.gbp'),
+            width: 'one-third',
+            ) %>
+
+      <%= form.govuk_text_area(
+            :emergency_cost_reasons,
+            label: {text: t('.enter_cost_reasons')}
+          ) %>
+    <% end %>
+    <%= form.govuk_radio_button(:emergency_cost_override, false, label: {text:  t('generic.no')}) %>
+  <% end %>
+
   <div class="govuk-!-padding-bottom-6"></div>
 
   <%= next_action_buttons_with_form(
@@ -42,4 +68,5 @@
         show_draft: true
       ) %>
 
+<% end %>
 <% end %>

--- a/app/views/providers/limitations/_legacy_proceeding_types.html.erb
+++ b/app/views/providers/limitations/_legacy_proceeding_types.html.erb
@@ -3,8 +3,8 @@
               method: :patch,
               local: true) do |form| %>
 
-<%= page_template(page_title: t('.h1-heading')) do %>
-
+<%= page_template page_title: t('.h1-heading'), template: :basic, form: form do %>
+  <h1 class="govuk-heading-xl"><%= t('.h1-heading') %></h1>
   <h2 class="govuk-heading-m">
     <%= t('.proceedings_heading') %>
   </h2>

--- a/app/views/shared/check_answers/_emergency_costs.html.erb
+++ b/app/views/shared/check_answers/_emergency_costs.html.erb
@@ -4,14 +4,16 @@
         question: t('.request_higher_limit'),
         answer: yes_no(@legal_aid_application.emergency_cost_override)
       ) %>
-  <%= check_answer_no_link(
-        name: :emergency_cost_requested,
-        question: t(".new_cost_limit"),
-        answer: gds_number_to_currency(@legal_aid_application.emergency_cost_requested,  precision: 0)
-      ) %>
-  <%= check_answer_no_link(
-        name: :emergency_cost_reasons,
-        question: t(".new_limit_reasons"),
-        answer: @legal_aid_application.emergency_cost_reasons
-      ) %>
+  <% if @legal_aid_application.emergency_cost_override %>
+    <%= check_answer_no_link(
+          name: :emergency_cost_requested,
+          question: t(".new_cost_limit"),
+          answer: gds_number_to_currency(@legal_aid_application.emergency_cost_requested,  precision: 0)
+        ) %>
+    <%= check_answer_no_link(
+          name: :emergency_cost_reasons,
+          question: t(".new_limit_reasons"),
+          answer: @legal_aid_application.emergency_cost_reasons
+        ) %>
+  <% end %>
 </dl>

--- a/app/views/shared/check_answers/_merits.html.erb
+++ b/app/views/shared/check_answers/_merits.html.erb
@@ -222,25 +222,27 @@
               ) %>
         </dl>
 
-        <dl class="govuk-summary-list govuk-!-margin-bottom-2">
-          <%= check_answer_link(
-                name: :emergency_cost_requested,
-                url: providers_legal_aid_application_limitations_path(@legal_aid_application),
-                question: t('.items.cost_override_question'),
-                answer: gds_number_to_currency(@legal_aid_application.emergency_cost_requested,  precision: 0),
-                read_only: true
-              ) %>
-        </dl>
+        <% if @legal_aid_application.emergency_cost_override %>
+          <dl class="govuk-summary-list govuk-!-margin-bottom-2">
+            <%= check_answer_link(
+                  name: :emergency_cost_requested,
+                  url: providers_legal_aid_application_limitations_path(@legal_aid_application),
+                  question: t('.items.cost_override_question'),
+                  answer: gds_number_to_currency(@legal_aid_application.emergency_cost_requested,  precision: 0),
+                  read_only: true
+                ) %>
+          </dl>
 
-        <dl class="govuk-summary-list govuk-!-margin-bottom-2">
-          <%= check_answer_link(
-                name: :emergency_cost_requested,
-                url: providers_legal_aid_application_limitations_path(@legal_aid_application),
-                question: t('.items.enter_cost_reasons'),
-                answer: @legal_aid_application.emergency_cost_reasons,
-                read_only: true
-              ) %>
-        </dl>
+          <dl class="govuk-summary-list govuk-!-margin-bottom-2">
+            <%= check_answer_link(
+                  name: :emergency_cost_requested,
+                  url: providers_legal_aid_application_limitations_path(@legal_aid_application),
+                  question: t('.items.enter_cost_reasons'),
+                  answer: @legal_aid_application.emergency_cost_reasons,
+                  read_only: true
+                ) %>
+          </dl>
       <% end %>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/views/shared/check_answers/_merits.html.erb
+++ b/app/views/shared/check_answers/_merits.html.erb
@@ -206,5 +206,41 @@
             ) %>
       </dl>
     </section>
+
+      <% if read_only %>
+        <h2 class="govuk-heading-m">
+          <%= t '.cost-override-heading' %>
+        </h2>
+
+        <dl class="govuk-summary-list govuk-!-margin-bottom-2">
+          <%= check_answer_link(
+                name: :emergency_cost_override,
+                url: providers_legal_aid_application_limitations_path(@legal_aid_application),
+                question: t('.items.override_requested'),
+                answer: yes_no(@legal_aid_application.emergency_cost_override),
+                read_only: true
+              ) %>
+        </dl>
+
+        <dl class="govuk-summary-list govuk-!-margin-bottom-2">
+          <%= check_answer_link(
+                name: :emergency_cost_requested,
+                url: providers_legal_aid_application_limitations_path(@legal_aid_application),
+                question: t('.items.cost_override_question'),
+                answer: gds_number_to_currency(@legal_aid_application.emergency_cost_requested,  precision: 0),
+                read_only: true
+              ) %>
+        </dl>
+
+        <dl class="govuk-summary-list govuk-!-margin-bottom-2">
+          <%= check_answer_link(
+                name: :emergency_cost_requested,
+                url: providers_legal_aid_application_limitations_path(@legal_aid_application),
+                question: t('.items.enter_cost_reasons'),
+                answer: @legal_aid_application.emergency_cost_reasons,
+                read_only: true
+              ) %>
+        </dl>
+      <% end %>
   <% end %>
 <% end %>

--- a/app/views/shared/check_answers/_merits_orig.html.erb
+++ b/app/views/shared/check_answers/_merits_orig.html.erb
@@ -119,7 +119,6 @@
 
   <dl class="govuk-summary-list govuk-!-margin-bottom-2">
 
-
     <%= check_answer_link(
           name: :success_likely,
           url: providers_merits_task_list_chances_of_success_index_path(@application_proceeding_type),
@@ -141,23 +140,39 @@
 
   <div class='govuk-body'><%= chances_of_success.success_prospect_details %></div>
 
-  <dl class="govuk-summary-list govuk-!-margin-bottom-2">
-    <%= check_answer_link(
-          name: :emergency_cost_requested,
-          url: providers_legal_aid_application_limitations_path(@legal_aid_application),
-          question: t('.items.cost_override_question'),
-          answer: @legal_aid_application.emergency_cost_requested,
-          read_only: read_only
-        ) %>
-  </dl>
+  <% if read_only %>
+    <h2 class="govuk-heading-m">
+      <%= t '.cost-override-heading' %>
+    </h2>
 
-  <dl class="govuk-summary-list govuk-!-margin-bottom-2">
-  <%= check_answer_link(
-        name: :emergency_cost_requested,
-        url: providers_legal_aid_application_limitations_path(@legal_aid_application),
-        question: t('.items.enter_cost_reasons'),
-        answer: @legal_aid_application.emergency_cost_reasons,
-        read_only: read_only
-      ) %>
-  </dl>
+    <dl class="govuk-summary-list govuk-!-margin-bottom-2">
+      <%= check_answer_link(
+            name: :emergency_cost_override,
+            url: providers_legal_aid_application_limitations_path(@legal_aid_application),
+            question: t('.items.override_requested'),
+            answer: yes_no(@legal_aid_application.emergency_cost_override),
+            read_only: true
+          ) %>
+    </dl>
+
+    <dl class="govuk-summary-list govuk-!-margin-bottom-2">
+      <%= check_answer_link(
+            name: :emergency_cost_requested,
+            url: providers_legal_aid_application_limitations_path(@legal_aid_application),
+            question: t('.items.cost_override_question'),
+            answer: gds_number_to_currency(@legal_aid_application.emergency_cost_requested,  precision: 0),
+            read_only: true
+          ) %>
+    </dl>
+
+    <dl class="govuk-summary-list govuk-!-margin-bottom-2">
+    <%= check_answer_link(
+          name: :emergency_cost_reasons,
+          url: providers_legal_aid_application_limitations_path(@legal_aid_application),
+          question: t('.items.enter_cost_reasons'),
+          answer: @legal_aid_application.emergency_cost_reasons,
+          read_only: true
+        ) %>
+    </dl>
+  <% end %>
 </section>

--- a/app/views/shared/check_answers/_merits_orig.html.erb
+++ b/app/views/shared/check_answers/_merits_orig.html.erb
@@ -118,6 +118,8 @@
   <%= render 'shared/check_answers/section_break' if statement_of_case&.statement.present? %>
 
   <dl class="govuk-summary-list govuk-!-margin-bottom-2">
+
+
     <%= check_answer_link(
           name: :success_likely,
           url: providers_merits_task_list_chances_of_success_index_path(@application_proceeding_type),
@@ -138,4 +140,24 @@
   </dl>
 
   <div class='govuk-body'><%= chances_of_success.success_prospect_details %></div>
+
+  <dl class="govuk-summary-list govuk-!-margin-bottom-2">
+    <%= check_answer_link(
+          name: :emergency_cost_requested,
+          url: providers_legal_aid_application_limitations_path(@legal_aid_application),
+          question: t('.items.cost_override_question'),
+          answer: @legal_aid_application.emergency_cost_requested,
+          read_only: read_only
+        ) %>
+  </dl>
+
+  <dl class="govuk-summary-list govuk-!-margin-bottom-2">
+  <%= check_answer_link(
+        name: :emergency_cost_requested,
+        url: providers_legal_aid_application_limitations_path(@legal_aid_application),
+        question: t('.items.enter_cost_reasons'),
+        answer: @legal_aid_application.emergency_cost_reasons,
+        read_only: read_only
+      ) %>
+  </dl>
 </section>

--- a/config/locales/en/shared.yml
+++ b/config/locales/en/shared.yml
@@ -219,6 +219,8 @@ en:
         items:
           client_declaration: Client declaration
           client_declaration_answer: Read & agreed
+          cost_override_question: Do you want to request a higher cost limit?
+          enter_cost_reasons: Tell us why you need a higher cost limit
           proceedings_currently_before_court: Proceedings currently before court
           prospects_of_success: Is the chance of a successful outcome 50% or better?
           success_prospect: What is the chance of a successful outcome?

--- a/config/locales/en/shared.yml
+++ b/config/locales/en/shared.yml
@@ -210,6 +210,7 @@ en:
       merits: &merits
         complete-application-heading: Complete the application
         complete-application-text: By submitting this application you are confirming that, to the best of your knowledge, the details you are providing are correct.
+        cost-override-heading: Emergency cost override
         case-details-heading: Case details
         involved-children-heading: Children involved in this application
         opponent-heading: Opponent details
@@ -219,8 +220,9 @@ en:
         items:
           client_declaration: Client declaration
           client_declaration_answer: Read & agreed
-          cost_override_question: Do you want to request a higher cost limit?
-          enter_cost_reasons: Tell us why you need a higher cost limit
+          override_requested: Do you want to request a higher cost limit?
+          cost_override_question: What is the new requested emergency cost limit?
+          enter_cost_reasons: Tell us why you need a higher cost limit.
           proceedings_currently_before_court: Proceedings currently before court
           prospects_of_success: Is the chance of a successful outcome 50% or better?
           success_prospect: What is the chance of a successful outcome?

--- a/features/providers/civil_application_journey.feature
+++ b/features/providers/civil_application_journey.feature
@@ -285,6 +285,9 @@ Feature: Civil application journeys
     Then I click 'Save and continue'
     Then I should be on a page showing "Covered under an emergency certificate"
     Then I should be on a page showing "Covered under a substantive certificate"
+    When I choose 'Yes'
+    And I enter a emergency cost requested '5000'
+    And I enter legal aid application emergency cost reasons field 'This is why I require extra funding'
     Then I click 'Save and continue'
     Then I should be on a page showing 'receives benefits that qualify for legal aid'
 

--- a/spec/requests/providers/limitations_spec.rb
+++ b/spec/requests/providers/limitations_spec.rb
@@ -39,6 +39,16 @@ RSpec.describe Providers::LimitationsController, type: :request do
       it 'does not have a details section' do
         expect(parsed_response_body.css('details')).to be_empty
       end
+
+      context 'when delegated functions have been used' do
+        let(:legal_aid_application) { create :legal_aid_application, :with_proceeding_types, :with_delegated_functions }
+        let(:proceeding_type) { legal_aid_application.proceeding_types.first }
+        let(:provider) { legal_aid_application.provider }
+
+        it 'shows the correct text' do
+          expect(unescaped_response_body).to include(I18n.t('providers.limitations.legacy_proceeding_types.cost_override_question'))
+        end
+      end
     end
 
     context 'when the multiple proceedings flag is on' do


### PR DESCRIPTION
## What
Remove the settings flag from the cost override feature so it is accessible to any user who use delegated functions
Update limitations/legacy_proceeding_types to show the new form and display errors correctly
Update check_provider_answers so the new section is shown if DF have been used and the chnage link works to allow users to change the information
Update merits page to show the new emergency cost override details only on merits reports and not on the merits_assessment page (it cannot be changed from here due to a state change)

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2367)

Describe what you did and why.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
