### PR TITLE
Bugfix: test that falls over if proc types in wrong order

### DIFF
--- a/spec/services/legal_framework/proceeding_types_service_spec.rb
+++ b/spec/services/legal_framework/proceeding_types_service_spec.rb
@@ -45,7 +45,7 @@ module LegalFramework
 
             it 'adds another proceeding type' do
               subject.add(**params)
-              expect(legal_aid_application.proceeding_types).to eq([proceeding_type, proceeding_type2])
+              expect(legal_aid_application.proceeding_types).to match_array [proceeding_type, proceeding_type2]
             end
           end
 


### PR DESCRIPTION
## What

Fix a test that occasionally fails when the proceedings are in a different order


## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
