### PR TITLE
BugFix: Flickering Multiple DF dates

### DIFF
--- a/spec/requests/providers/used_multiple_delegated_functions_spec.rb
+++ b/spec/requests/providers/used_multiple_delegated_functions_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe Providers::UsedMultipleDelegatedFunctionsController, type: :reque
     end
 
     it 'updates the application proceeding types delegated functions dates' do
-      application_proceeding_types.each_with_index do |apt, i|
+      application_proceeding_types.order(used_delegated_functions_on: :desc).each_with_index do |apt, i|
         expect(apt.used_delegated_functions_reported_on).to eq(today)
         expect(apt.used_delegated_functions_on).to eq(used_delegated_functions_on - i.days)
       end
@@ -226,7 +226,7 @@ RSpec.describe Providers::UsedMultipleDelegatedFunctionsController, type: :reque
 
       context 'with first application proceeding type' do
         it 'updates the application proceeding types delegated functions dates' do
-          apt = application_proceeding_types.first
+          apt = application_proceeding_types.order(used_delegated_functions_on: :desc).first
           expect(apt.used_delegated_functions_reported_on).to eq(today)
           expect(apt.used_delegated_functions_on).to eq(used_delegated_functions_on)
         end
@@ -234,7 +234,7 @@ RSpec.describe Providers::UsedMultipleDelegatedFunctionsController, type: :reque
 
       context 'with second application proceeding type' do
         it 'updates the application proceeding types delegated functions dates' do
-          apt = application_proceeding_types.last
+          apt = application_proceeding_types.order(used_delegated_functions_on: :desc).last
           expect(apt.used_delegated_functions_reported_on).to eq(today)
           expect(apt.used_delegated_functions_on).to eq(used_delegated_functions_on - 1.day)
         end

--- a/spec/requests/providers/used_multiple_delegated_functions_spec.rb
+++ b/spec/requests/providers/used_multiple_delegated_functions_spec.rb
@@ -55,9 +55,7 @@ RSpec.describe Providers::UsedMultipleDelegatedFunctionsController, type: :reque
     let!(:legal_aid_application) do
       create :legal_aid_application,
              :with_proceeding_types,
-             # :with_delegated_functions,
              proceeding_types_count: 2
-      # delegated_functions_date: used_delegated_functions_on
     end
     let(:today) { Time.zone.today }
     let(:used_delegated_functions_on) { rand(19).days.ago.to_date }


### PR DESCRIPTION
## What

Ensure the application proceeding types are always sorted
in the order expected by the each_with_index blocks

The params are sent to the controller in the sequence a->b
but sometimes are created as b->a this caused the sequence
of date - i.days to be in the wrong order

This aims to make the tests idempotent

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
