### PR TITLE
BugFix: Address BigDecimal rounding issues

### DIFF
--- a/spec/requests/providers/applicant_bank_accounts_spec.rb
+++ b/spec/requests/providers/applicant_bank_accounts_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe Providers::ApplicantBankAccountsController, type: :request do
           let(:offline_savings_accounts) { rand(1...1_000_000.0).round(2) }
 
           it 'updates the savings amount' do
-            expect(legal_aid_application.reload.savings_amount.offline_savings_accounts).to eq(BigDecimal(offline_savings_accounts, offline_savings_accounts.to_s.length - 1))
+            expect(legal_aid_application.reload.savings_amount.offline_savings_accounts).to eq(BigDecimal(offline_savings_accounts.to_s))
           end
 
           it 'redirects to the savings and investments page' do

--- a/spec/services/true_layer/bank_data_import_service_spec.rb
+++ b/spec/services/true_layer/bank_data_import_service_spec.rb
@@ -41,8 +41,8 @@ RSpec.describe TrueLayer::BankDataImportService do
 
     it 'imports the account balances' do
       subject
-      mock_account_balances = mock_data[:accounts].map { |a| a[:balance][:current].to_s }.sort
-      account_balances = bank_provider.bank_accounts.map { |a| a.balance.to_s }.sort
+      mock_account_balances = mock_data[:accounts].map { |a| BigDecimal(a[:balance][:current].to_s).to_s }.sort
+      account_balances = bank_provider.bank_accounts.map { |a| BigDecimal(a.balance.to_s).to_s }.sort
       expect(account_balances).to eq(mock_account_balances)
     end
 


### PR DESCRIPTION
## What

There was another flicker when the truelayer MOCK_DATA generated
a value of `823332.18`, the test found `823332.1800000001`
previous experience shows this would have been fine at
`823332.19`

This solution converts the float to a string and passes it to
BigDecimal.  Passing the float directly requires the precision
to be sent, which requires converting to a string!

I've backported this solution to a previous bugfix as it's easier
to read and means the code is more consistent

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
