### PR TITLE
BugFix File uploads / Attachment creation errors for multiple attachments

### DIFF
--- a/app/services/pdf_converter.rb
+++ b/app/services/pdf_converter.rb
@@ -19,7 +19,7 @@ class PdfConverter
       pdf_filename = "#{File.basename(@original_attachment.attachment_name, '.*')}.pdf"
       pdf_attachment = Attachment.create!(
         legal_aid_application_id: @original_attachment.legal_aid_application_id,
-        attachment_type: "#{File.basename(@original_attachment.attachment_name, '.*')}_pdf",
+        attachment_type: "#{File.basename(@original_attachment.attachment_type, '.*')}_pdf",
         attachment_name: pdf_filename
       )
       pdf_attachment.document.attach(

--- a/spec/services/pdf_converter_spec.rb
+++ b/spec/services/pdf_converter_spec.rb
@@ -43,6 +43,25 @@ RSpec.describe PdfConverter do
           attachment = statement_of_case.original_attachments.first
           expect(attachment.pdf_attachment_id).to eq pdf_attachment.id
         end
+
+        context 'when there are multiple uploaded files' do
+          let(:attachment) { statement_of_case.legal_aid_application.attachments.create!(attachment_type: 'statement_of_case', attachment_name: 'statement_of_case_2') }
+
+          it 'converts the file to pdf' do
+            expect(Libreconv).to receive(:convert)
+            expect { subject }.to change { ActiveStorage::Attachment.count }.by(1)
+            pdf_attachment = statement_of_case.pdf_attachments.first
+            expect(pdf_attachment.attachment_name).to eq 'statement_of_case_2.pdf'
+            expect(pdf_attachment.attachment_type).to eq 'statement_of_case_pdf'
+          end
+
+          it 'relates the pdf record to the original file' do
+            subject
+            pdf_attachment = statement_of_case.pdf_attachments.first
+            attachment = statement_of_case.original_attachments.first
+            expect(attachment.pdf_attachment_id).to eq pdf_attachment.id
+          end
+        end
       end
     end
   end
@@ -85,6 +104,25 @@ RSpec.describe PdfConverter do
           pdf_attachment = gateway_evidence.pdf_attachments.first
           attachment = gateway_evidence.original_attachments.first
           expect(attachment.pdf_attachment_id).to eq pdf_attachment.id
+        end
+
+        context 'when there are multiple uploaded files' do
+          let(:attachment) { gateway_evidence.legal_aid_application.attachments.create!(attachment_type: 'gateway_evidence', attachment_name: 'gateway_evidence_2') }
+
+          it 'converts the file to pdf' do
+            expect(Libreconv).to receive(:convert)
+            expect { subject }.to change { ActiveStorage::Attachment.count }.by(1)
+            pdf_attachment = gateway_evidence.pdf_attachments.first
+            expect(pdf_attachment.attachment_name).to eq 'gateway_evidence_2.pdf'
+            expect(pdf_attachment.attachment_type).to eq 'gateway_evidence_pdf'
+          end
+
+          it 'relates the pdf record to the original file' do
+            subject
+            pdf_attachment = gateway_evidence.pdf_attachments.first
+            attachment = gateway_evidence.original_attachments.first
+            expect(attachment.pdf_attachment_id).to eq pdf_attachment.id
+          end
         end
       end
     end


### PR DESCRIPTION
## BugFix Attachment creation errors for PDFConvertor


[Link to story](https://dsdmoj.atlassian.net/browse/AP-2379)

**Error in sentry:**

```
ArgumentError Sidekiq/PdfConverterWorker
'statement_of_case_3_pdf' is not a valid attachment_type
```
If say a statement of case was uploaded 3 times then the attachment_name will increment to statement_of_case_3
which is fine. However, this multi-file upload triggers the error below:

The problem is in the PDFConvertor worker placing the wrong value in attachment_type for the Attachment model.
Attachment#attachment_type is an enum and e.g. 'statement_of_case_3' is not matching with 'statement_of_case_pdf' in the model.

- The solution is to get the type value from the #attachment_type method instead of the #attachment_name



**### This fixes the bug but does not fix existing failed PDFConvertor workers in all environments.**





.
## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
