### PR TITLE
BugFix Allow for existing attachments with no original filenames

### DIFF
--- a/app/helpers/attachments_helper.rb
+++ b/app/helpers/attachments_helper.rb
@@ -3,7 +3,7 @@ module AttachmentsHelper
     return [] unless attachments
 
     attachments&.map do |at|
-      at.original_filename + " (#{number_to_human_size(at.document.blob.byte_size)})"
+      (at.original_filename || at.attachment_type) + " (#{number_to_human_size(at.document.blob.byte_size)})"
     end
   end
 end

--- a/spec/helpers/attachments_helper_spec.rb
+++ b/spec/helpers/attachments_helper_spec.rb
@@ -20,5 +20,15 @@ RSpec.describe AttachmentsHelper, type: :helper do
         expect(attachments_with_size(attachments)).to eq []
       end
     end
+
+    context 'without original_filename' do
+      let(:attachment1) { create :attachment, original_filename: nil }
+      let(:attachment2) { create :attachment, original_filename: 'fake name' }
+      let(:attachments) { [attachment1, attachment2] }
+
+      it 'returns attachment_type name in its place' do
+        expect(attachments_with_size(attachments)).to match_array ['statement_of_case (15.7 KB)', 'fake name (15.7 KB)']
+      end
+    end
   end
 end


### PR DESCRIPTION
## BugFix Allow for existing attachments with no original filenames

Some attachments in our current database do not have original_filename values in their Attachment records.
This caused a bug because the attachment helper used on the check merits answers page was expecting something.

Use the attachment_type as the default name for the file when no original_filename exists.

This should not be required going forward because all attachments will now have original_filenames attached.

Related ticket https://github.com/ministryofjustice/laa-apply-for-legal-aid/pull/2651
## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
