### PR TITLE
AP-2298 display all labels

### DIFF
--- a/app/helpers/capital_helper.rb
+++ b/app/helpers/capital_helper.rb
@@ -20,15 +20,12 @@ module CapitalHelper
     return nil if items.blank?
 
     {
-      items: items,
-      total_value: items.sum(&:amount)
+      items: items
     }
   end
 
   def capital_amount_items(items, locale_namespace, percentage_values)
     items&.map do |attribute, amount|
-      next unless amount
-
       type = percentage_values.include?(attribute.to_sym) ? :percentage : :currency
 
       OpenStruct.new(
@@ -41,7 +38,9 @@ module CapitalHelper
   end
 
   def capital_amount_text(amount, type)
-    if type == :percentage
+    if amount.nil?
+      'No'
+    elsif type == :percentage
       number_to_percentage(amount, precision: 2)
     else
       gds_number_to_currency(amount)

--- a/app/helpers/capital_helper.rb
+++ b/app/helpers/capital_helper.rb
@@ -1,6 +1,7 @@
 module CapitalHelper
   def capital_amounts_list(capital, locale_namespace:, percentage_values: [])
     attributes = capital_amount_attributes(capital)
+    attributes = combine_second_home_attributes(attributes)
     build_asset_list(attributes, locale_namespace, percentage_values)
   end
 
@@ -22,6 +23,15 @@ module CapitalHelper
     {
       items: items
     }
+  end
+
+  def combine_second_home_attributes(items)
+    second_home_attributes = items.select { |attr_name, _| attr_name.include?('second_home') }
+    if second_home_attributes.all? { |_, value| value.nil? }
+      items.except!(*second_home_attributes.keys)
+      items[:second_home] = nil
+    end
+    items
   end
 
   def capital_amount_items(items, locale_namespace, percentage_values)

--- a/app/helpers/capital_helper.rb
+++ b/app/helpers/capital_helper.rb
@@ -40,6 +40,7 @@ module CapitalHelper
 
       OpenStruct.new(
         label: t("#{locale_namespace}#{attribute}"),
+        name: attribute.to_s.delete_prefix('check_box_'),
         amount: amount,
         type: type,
         amount_text: capital_amount_text(amount, type)

--- a/app/helpers/capital_helper.rb
+++ b/app/helpers/capital_helper.rb
@@ -26,6 +26,8 @@ module CapitalHelper
   end
 
   def combine_second_home_attributes(items)
+    return nil if items.blank?
+
     second_home_attributes = items.select { |attr_name, _| attr_name.include?('second_home') }
     if second_home_attributes.all? { |_, value| value.nil? }
       items.except!(*second_home_attributes.keys)

--- a/app/helpers/policy_disregards_helper.rb
+++ b/app/helpers/policy_disregards_helper.rb
@@ -11,10 +11,13 @@ module PolicyDisregardsHelper
     london_emergencies_trust
   ].freeze
 
-  def policy_disregards_hash(policy_disregards)
+  def policy_disregards_list(policy_disregards)
     items = policy_disregards_as_array(policy_disregards)
     items&.compact!
-    return nil if items.blank?
+
+    items.map do |item|
+      item.amount_text ||= 'No'
+    end
 
     {
       items: items
@@ -23,7 +26,7 @@ module PolicyDisregardsHelper
 
   def policy_disregards_as_array(policy_disregards)
     ATTRIBUTES&.map do |attribute|
-      send(attribute, policy_disregards) if policy_disregards.send("#{attribute}?")
+      send(attribute, policy_disregards)
     end
   end
 

--- a/app/views/shared/check_answers/_assets.html.erb
+++ b/app/views/shared/check_answers/_assets.html.erb
@@ -74,7 +74,7 @@
           name: :policy_disregards,
           url: check_answer_url_for(journey_type, :policy_disregards, @legal_aid_application),
           question: t('.assets.policy_disregards'),
-          answer_hash: policy_disregards_hash(@legal_aid_application.policy_disregards),
+          answer_hash: policy_disregards_list(@legal_aid_application.policy_disregards),
           read_only: read_only
         ) %>
   <% end %>

--- a/app/views/shared/check_answers/_dependants.html.erb
+++ b/app/views/shared/check_answers/_dependants.html.erb
@@ -11,7 +11,7 @@
 <% if @legal_aid_application.dependants %>
   <% @legal_aid_application.dependants.each_with_index do |dependant, index| %>
     <%= check_answer_one_change_link(
-      name: "dependants",
+      name: "dependants_#{index + 1}",
       url: providers_legal_aid_application_dependant_path(@legal_aid_application, dependant),
       question: "Dependant #{index + 1}: #{dependant.name}",
       answer_hash: dependant_hash(dependant),

--- a/app/views/shared/check_answers/_dependants.html.erb
+++ b/app/views/shared/check_answers/_dependants.html.erb
@@ -11,7 +11,7 @@
 <% if @legal_aid_application.dependants %>
   <% @legal_aid_application.dependants.each_with_index do |dependant, index| %>
     <%= check_answer_one_change_link(
-      name: "dependants_#{index + 1}",
+      name: "dependants",
       url: providers_legal_aid_application_dependant_path(@legal_aid_application, dependant),
       question: "Dependant #{index + 1}: #{dependant.name}",
       answer_hash: dependant_hash(dependant),

--- a/app/views/shared/check_answers/_no_link_item.html.erb
+++ b/app/views/shared/check_answers/_no_link_item.html.erb
@@ -2,7 +2,7 @@
   no_border = no_border ? 'govuk-summary-list--no-border' : ''
 %>
 <div class="govuk-summary-list__row <%= no_border %> normal-word-break" id="app-check-your-answers__<%= name %>">
-  <dt class="govuk-summary-list__key">
+  <dt class="govuk-summary-list__key govuk-!-width-one-half">
     <%= question %>
   </dt>
   <!--  in-line styling due to issues around pdf generation in our production envs -->

--- a/app/views/shared/check_answers/_one_link_section.html.erb
+++ b/app/views/shared/check_answers/_one_link_section.html.erb
@@ -13,12 +13,12 @@
   <% end %>
 </div>
 
-<dl class="govuk-summary-list govuk-!-margin-bottom-9">
+<dl class="govuk-summary-list govuk-!-margin-bottom-9" id="app-check-your-answers__<%= name %>_items">
   <% if answer_hash.present? %>
 
-      <% answer_hash&.fetch(:items, [])&.each_with_index do |item| %>
+      <% answer_hash&.fetch(:items, [])&.each_with_index do |item, index| %>
         <%= check_answer_no_link(
-              name: item.name || name,
+              name: item.name || "#{name}_#{index}",
               question: item.label,
               answer: safe_yes_or_no(item.amount_text),
               read_only: read_only

--- a/app/views/shared/check_answers/_one_link_section.html.erb
+++ b/app/views/shared/check_answers/_one_link_section.html.erb
@@ -16,9 +16,9 @@
 <dl class="govuk-summary-list govuk-!-margin-bottom-9">
   <% if answer_hash.present? %>
 
-      <% answer_hash&.fetch(:items, [])&.each_with_index do |item, index| %>
+      <% answer_hash&.fetch(:items, [])&.each_with_index do |item| %>
         <%= check_answer_no_link(
-              name: "#{name}_#{index}",
+              name: item.name || name,
               question: item.label,
               answer: safe_yes_or_no(item.amount_text),
               read_only: read_only

--- a/config/locales/en/shared.yml
+++ b/config/locales/en/shared.yml
@@ -404,6 +404,7 @@ en:
               check_box_second_home_mortgage: Second property or holiday home outstanding mortgage amount
               check_box_second_home_percentage: Second property or holiday home percentage owned
               check_box_second_home_value: Second property or holiday home estimated value
+              check_box_second_home: Second property or holiday home
               check_box_timeshare_property_value: Timeshare property
               check_box_trust_value: Interest in a trust
               valuable_items_value: Enter the estimated value

--- a/features/providers/check_your_answers.feature
+++ b/features/providers/check_your_answers.feature
@@ -102,7 +102,7 @@ Feature: Checking answers backwards and forwards
     Then I select 'None of these'
     Then I click 'Save and continue'
     Then I am on the check your answers page for other assets
-    And the answer for 'Bank Accounts' should be 'None declared'
+    And the answer for all 'Bank accounts' categories should be 'No'
 
   @javascript
   Scenario: I am able to go back and change Savings and Investments and be taken back to the check your answers page for other assets
@@ -133,7 +133,7 @@ Feature: Checking answers backwards and forwards
     Then I select 'None of these'
     Then I click 'Save and continue'
     Then I am on the check your answers page for other assets
-    And the answer for 'Savings and investments' should be 'None declared'
+    And the answer for all 'Savings and investments' categories should be 'No'
 
   @javascript
   Scenario: I am able to go back and change Other Assets and be taken to the restrictions page
@@ -163,7 +163,7 @@ Feature: Checking answers backwards and forwards
     Then I select 'None of these'
     Then I click 'Save and continue'
     Then I am on the check your answers page for other assets
-    And the answer for 'Other assets' should be 'None declared'
+    And the answer for all 'Other assets' categories should be 'No'
 
   @javascript
   Scenario: I am able to go back and select multiple disregards then come straight back to the check your answers page
@@ -177,6 +177,7 @@ Feature: Checking answers backwards and forwards
     And I select 'Vaccine Damage Payments Scheme'
     Then I click 'Save and continue'
     Then I am on the check your answers page for policy disregards
+    And the answer for 'policy disregards' should be 'England Infected Blood Support Scheme'
     And the answer for 'policy disregards' should be 'Vaccine Damage Payments Scheme'
 
     @javascript

--- a/features/providers/civil_application_journey.feature
+++ b/features/providers/civil_application_journey.feature
@@ -899,7 +899,7 @@ Feature: Civil application journeys
     Then I select 'None of these'
     Then I click 'Save and continue'
     Then I should be on a page showing "Check your answers"
-    And the answer for 'policy disregards' should be 'None declared'
+    And the answer for all 'policy disregards' categories should be 'No'
     Then I click Check Your Answers Change link for 'policy disregards'
     And I deselect 'None of these'
     Then I click 'Save and continue'

--- a/features/providers/complete_and_check_means_answers.feature
+++ b/features/providers/complete_and_check_means_answers.feature
@@ -193,15 +193,14 @@ Feature: Completing and checking means answers backwards and forwards
   Scenario: I go back and change the answer to second home from the means summary page
     Given I am checking the applicant's means answers
     Then I should be on a page showing 'Which types of assets does your client have?'
-    And the answer for 'Second home' should be 'No'
-    And I should not see 'Second property or holiday home outstanding mortgage amount'
+    And I should be on a page showing 'Second property or holiday home estimated value'
     Then I click Check Your Answers Change link for 'other assets'
     And I should be on a page showing 'Which types of assets does your client have?'
     And I should be on a page showing 'Select all that apply'
-    Then I select 'Second property or holiday home'
-    And I fill 'Enter estimated value' with '200000'
-    And I fill 'Enter outstanding mortgage amount' with '100000'
-    And I fill 'Enter percentage share you legally own' with '50'
+    Then I deselect 'Second property or holiday home'
+    Then I click 'Save and continue'
     Then I click 'Save and continue'
     Then I should be on the 'means_summary' page showing 'Check your answers'
-    And the answer for 'Second property value' should be '£200000'
+    And the answer for 'Second home' should be 'No'
+    And I should not see 'Second property or holiday home estimated value'
+

--- a/features/providers/complete_and_check_means_answers.feature
+++ b/features/providers/complete_and_check_means_answers.feature
@@ -188,3 +188,20 @@ Feature: Completing and checking means answers backwards and forwards
     Then I should be on the 'means_summary' page showing 'Check your answers'
     And the answer for 'has offline savings' should be 'No'
     And I should not see 'Amount in offline savings accounts'
+
+  @javascript
+  Scenario: I go back and change the answer to second home from the means summary page
+    Given I am checking the applicant's means answers
+    Then I should be on a page showing 'Which types of assets does your client have?'
+    And the answer for 'Second home' should be 'No'
+    And I should not see 'Second property or holiday home outstanding mortgage amount'
+    Then I click Check Your Answers Change link for 'other assets'
+    And I should be on a page showing 'Which types of assets does your client have?'
+    And I should be on a page showing 'Select all that apply'
+    Then I select 'Second property or holiday home'
+    And I fill 'Enter estimated value' with '200000'
+    And I fill 'Enter outstanding mortgage amount' with '100000'
+    And I fill 'Enter percentage share you legally own' with '50'
+    Then I click 'Save and continue'
+    Then I should be on the 'means_summary' page showing 'Check your answers'
+    And the answer for 'Second property value' should be '£200000'

--- a/features/step_definitions/civil_journey_steps.rb
+++ b/features/step_definitions/civil_journey_steps.rb
@@ -729,6 +729,16 @@ Then('the answer for {string} should be {string}') do |field_name, answer|
   expect(page).to have_content(answer)
 end
 
+Then('the answer for all {string} categories should be {string}') do |field_name, expected_answer|
+  field_name.downcase!
+  field_name.gsub!(/\s+/, '_')
+  wrong_answer = expected_answer == 'No' ? 'Yes' : 'No'
+  within "#app-check-your-answers__#{field_name}_items" do # search within the section to check that all answers are yes/no
+    expect(page).to have_text(expected_answer)
+    expect(page).to_not have_text(wrong_answer)
+  end
+end
+
 Then('I select a proceeding type and continue') do
   find('#proceeding-list').first(:button, 'Select and continue').click
 end

--- a/spec/helpers/policy_disregards_helper_spec.rb
+++ b/spec/helpers/policy_disregards_helper_spec.rb
@@ -8,25 +8,41 @@ RSpec.describe PolicyDisregardsHelper, type: :helper do
     context 'no disregards selected' do
       let(:policy_disregards) { create :policy_disregards, none_selected: true }
 
-      it 'returns nil' do
-        expect(policy_disregards_list(policy_disregards)).to be_nil
+      it 'does not return nil' do
+        expect(policy_disregards_list(policy_disregards)).to_not be_nil
+      end
+
+      it 'returns the correct hash' do
+        expect(policy_disregards_list(policy_disregards)).to eq(expected_result_none_selected)
       end
     end
 
     context 'disregards selected' do
       let(:policy_disregards) { create :policy_disregards, none_selected: false, england_infected_blood_support: true }
 
-      it 'returns a hash of the selected disregards' do
+      it 'returns the correct hash' do
         expect(policy_disregards_list(policy_disregards)).to eq(expected_result)
       end
+    end
 
-      def expected_result
-        {
-          items: [
-            OpenStruct.new(label: 'England Infected Blood Support Scheme', amount_text: true)
-          ]
-        }
-      end
+    def expected_result_none_selected
+      {
+        items: [
+          OpenStruct.new(label: 'England Infected Blood Support Scheme', amount_text: 'No'),
+          OpenStruct.new(label: 'Vaccine Damage Payments Scheme', amount_text: 'No'),
+          OpenStruct.new(label: 'Variant Creutzfeldt-Jakob disease (vCJD) Trust', amount_text: 'No'),
+          OpenStruct.new(label: 'Criminal Injuries Compensation Scheme', amount_text: 'No'),
+          OpenStruct.new(label: 'National Emergencies Trust (NET)', amount_text: 'No'),
+          OpenStruct.new(label: 'We Love Manchester Emergency Fund', amount_text: 'No'),
+          OpenStruct.new(label: 'The London Emergencies Trust', amount_text: 'No')
+        ]
+      }
+    end
+
+    def expected_result
+      {
+        items: [OpenStruct.new(label: 'England Infected Blood Support Scheme', amount_text: true)] + expected_result_none_selected[:items][1..]
+      }
     end
   end
 end

--- a/spec/helpers/policy_disregards_helper_spec.rb
+++ b/spec/helpers/policy_disregards_helper_spec.rb
@@ -4,12 +4,12 @@ RSpec.describe PolicyDisregardsHelper, type: :helper do
   include ApplicationHelper
 
   describe '#policy_disregards_hash' do
-    let(:result) { policy_disregards_hash(policy_disregards) }
+    let(:result) { policy_disregards_list(policy_disregards) }
     context 'no disregards selected' do
       let(:policy_disregards) { create :policy_disregards, none_selected: true }
 
       it 'returns nil' do
-        expect(policy_disregards_hash(policy_disregards)).to be_nil
+        expect(policy_disregards_list(policy_disregards)).to be_nil
       end
     end
 
@@ -17,7 +17,7 @@ RSpec.describe PolicyDisregardsHelper, type: :helper do
       let(:policy_disregards) { create :policy_disregards, none_selected: false, england_infected_blood_support: true }
 
       it 'returns a hash of the selected disregards' do
-        expect(policy_disregards_hash(policy_disregards)).to eq(expected_result)
+        expect(policy_disregards_list(policy_disregards)).to eq(expected_result)
       end
 
       def expected_result

--- a/spec/requests/providers/check_passported_answers_spec.rb
+++ b/spec/requests/providers/check_passported_answers_spec.rb
@@ -61,10 +61,10 @@ RSpec.describe 'check passported answers requests', type: :request do
         expect(response.body).to include(I18n.t('shared.check_answers.vehicles.providers.used_regularly'))
       end
 
-      it 'displays None Declared in the policy disregards section' do
+      it 'displays no categories selected in the policy disregards section' do
         parsed_response = Nokogiri::HTML(response.body)
         node = parsed_response.css('#app-check-your-answers__policy_disregards_header + .govuk-summary-list')
-        expect(node.text).to include(I18n.t('.generic.none_declared'))
+        expect(node.text).not_to include(I18n.t('.generic.yes'))
       end
 
       context 'applicant does not have any savings' do
@@ -76,8 +76,10 @@ RSpec.describe 'check passported answers requests', type: :request do
                  :with_passported_state_machine,
                  :provider_entering_means
         end
-        it 'displays that no savings have been declared' do
-          expect(response.body).to include(I18n.t('.generic.none_declared'))
+        it 'displays no categories selected in the savings and investments section' do
+          parsed_response = Nokogiri::HTML(response.body)
+          node = parsed_response.css('#app-check-your-answers__savings_and_investments_items')
+          expect(node.text).not_to include(I18n.t('.generic.yes'))
         end
       end
 
@@ -91,7 +93,9 @@ RSpec.describe 'check passported answers requests', type: :request do
                  :provider_entering_means
         end
         it 'displays that no other assets have been declared' do
-          expect(response.body).to include(I18n.t('.generic.none_declared'))
+          parsed_response = Nokogiri::HTML(response.body)
+          node = parsed_response.css('#app-check-your-answers__other_assets_items')
+          expect(node.text).not_to include(I18n.t('.generic.yes'))
         end
       end
 
@@ -105,7 +109,9 @@ RSpec.describe 'check passported answers requests', type: :request do
                  has_restrictions: false
         end
         it 'displays that no capital restrictions have been declared' do
-          expect(response.body).to include(I18n.t('.generic.no'))
+          parsed_response = Nokogiri::HTML(response.body)
+          node = parsed_response.css('#app-check-your-answers__restrictions')
+          expect(node.text).to include(I18n.t('.generic.no'))
         end
       end
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2298)

Updated capital helper methods to return a full list of items for savings and investments and other assets so that all labels can be displayed on the check your answers page, so that providers can check if they've missed something. 
Same for policy disregards.
Updated summary list styling on this page to make it consistent. 
Updated tests, added new feature test and step which checks the answers for all items of a CYA section e.g. savings and investments

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
