### PR TITLE
Tech debt/fix chance of success routing flicker

### DIFF
--- a/spec/factories/legal_aid_applications.rb
+++ b/spec/factories/legal_aid_applications.rb
@@ -279,6 +279,7 @@ FactoryBot.define do
           lead_apt = application.application_proceeding_types.detect { |apt| apt.proceeding_type.ccms_matter == 'Domestic Abuse' }
           lead_apt.update!(lead_proceeding: true)
         end
+        application.update(provider_step_params: { merits_task_list_id: lead_apt.id })
         pt = lead_apt.proceeding_type
         sl = create :scope_limitation, :substantive_default, joined_proceeding_type: pt
         apt = application.application_proceeding_types.find_by(proceeding_type_id: pt.id)


### PR DESCRIPTION
## What

Trying to debug a solution to the `Providers::ProceedingMeritsTask::ChancesOfSuccessController` flicker that seems to occur more on Circle than local.

The flicker indicated that something was wrong in the `chances_of_success` routing in `provider_merits.rb` and, because this was a true flicker rather than a race condition, it couldn't be replicated.

Therefore I decided to update the factory trait used for the legal_aid_application to ensure the provider_step_params was populated with a merits_task_list_id that would enable the correct routing.

This has been run ~8 times on Circle and not failed once.

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
