### PR TITLE
AP-2384 Allow for missing gateway evidence in merits report

### DIFF
--- a/app/views/providers/means_reports/show.html.erb
+++ b/app/views/providers/means_reports/show.html.erb
@@ -11,7 +11,7 @@
         read_only: true
       ) %>
 
-  <% if Setting.allow_multiple_proceedings? %>
+  <% if Setting.allow_multiple_proceedings? && @legal_aid_application.cfe_result&.version_4? %>
     <h2 class="govuk-heading-m"><%= t('.proceeding_eligibility') %></h2>
     <%= render 'shared/means_report/proceeding_eligibility', results: @legal_aid_application.cfe_result.results_by_proceeding_type %>
   <% end %>

--- a/app/views/providers/merits_reports/show.html.erb
+++ b/app/views/providers/merits_reports/show.html.erb
@@ -34,6 +34,7 @@
         statement_of_case: @legal_aid_application.statement_of_case,
         opponent: @legal_aid_application.opponent,
         chances_of_success: @application_proceeding_type.chances_of_success,
+        gateway_evidence: @legal_aid_application&.gateway_evidence,
         read_only: true
       ) %>
 <% end %>

--- a/app/views/shared/check_answers/_merits.html.erb
+++ b/app/views/shared/check_answers/_merits.html.erb
@@ -139,23 +139,26 @@
   </section>
 <% end %>
 
-<div class="govuk-!-padding-bottom-6"></div>
+<%# TODO: The gateway evidence may not exist for an application transitioning to MP feature %>
+<% if gateway_evidence %>
+  <div class="govuk-!-padding-bottom-6"></div>
 
-<section class="print-no-break">
-  <h2 class="govuk-heading-m">
-    <%= t '.gateway-evidence-heading' %>
-  </h2>
-  <dl class="govuk-summary-list govuk-!-margin-bottom-2 print-remove-border">
-  <%= check_answer_link(
-        name: :gateway_evidence,
-        url: providers_legal_aid_application_gateway_evidence_path(@legal_aid_application),
-        question: t('.items.gateway_evidence'),
-        answer: attachments_with_size(gateway_evidence&.original_attachments),
-        read_only: read_only
-      ) %>
-  </dl>
+  <section class="print-no-break">
+    <h2 class="govuk-heading-m">
+      <%= t '.gateway-evidence-heading' %>
+    </h2>
+    <dl class="govuk-summary-list govuk-!-margin-bottom-2 print-remove-border">
+    <%= check_answer_link(
+          name: :gateway_evidence,
+          url: providers_legal_aid_application_gateway_evidence_path(@legal_aid_application),
+          question: t('.items.gateway_evidence'),
+          answer: attachments_with_size(gateway_evidence&.original_attachments),
+          read_only: read_only
+        ) %>
+    </dl>
 
-</section>
+  </section>
+<% end %>
 
 <% @legal_aid_application.application_proceeding_types.each do |apt| %>
   <div class="govuk-!-padding-bottom-6"></div>

--- a/features/providers/multi_proceedings.feature
+++ b/features/providers/multi_proceedings.feature
@@ -42,7 +42,7 @@ Feature: Merits task list
   @javascript @vcr
   Scenario: When the flag is enabled
     Given the feature flag for allow_multiple_proceedings is enabled
-    Given I complete the multiple proceedings journey as far as check passported answers
+    Given I complete the multiple proceedings journey as far as check passported answers with multiple proceedings
     Then I should be on a page showing "Fake gateway evidence file (15.7 KB)"
     Then I should be on a page showing "Fake file name 1 (15.7 KB)"
     Then I should be on a page showing "Statement of case text entered here"

--- a/features/step_definitions/civil_journey_steps.rb
+++ b/features/step_definitions/civil_journey_steps.rb
@@ -485,7 +485,9 @@ Given('I complete the passported journey as far as check your answers') do
   steps %(Then I should be on a page showing 'Check your answers')
 end
 
-Given('I complete the multiple proceedings journey as far as check passported answers') do
+Given('I complete the multiple proceedings journey as far as check passported answers with multiple proceedings') do
+  proceeding_one = ProceedingType.find_by(code: 'PR0208')
+  proceeding_two = ProceedingType.find_by(code: 'PR0214')
   @legal_aid_application = create(
     :application,
     :with_applicant,
@@ -497,8 +499,10 @@ Given('I complete the multiple proceedings journey as far as check passported an
     :with_chances_of_success,
     :with_gateway_evidence,
     :with_policy_disregards,
-    :with_benefits_transactions
+    :with_benefits_transactions,
+    explicit_proceeding_types: [proceeding_one, proceeding_two]
   )
+
   login_as @legal_aid_application.provider
   visit(providers_legal_aid_application_check_merits_answers_path(@legal_aid_application))
 


### PR DESCRIPTION
## AP-2384 Allow for missing gateway evidence in merits report

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2384)

Allow for missing gateway evidence in merits report because applications that were created without a gateway evidence may fail to generate a merits report.
## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
