### PR TITLE
Add DB anonymisation rule

### DIFF
--- a/db/anonymise/rules.rb
+++ b/db/anonymise/rules.rb
@@ -123,7 +123,8 @@ NINO_REGEXP = /^[A-CEGHJ-PR-TW-Z]{1}[A-CEGHJ-NPR-TW-Z]{1}[0-9]{6}[A-DFM]{1}$/.fr
     understands_terms_of_court_order_details: -> { Faker::Lorem.sentence },
     warning_letter_sent_details: -> { Faker::Lorem.sentence },
     police_notified_details: -> { Faker::Lorem.sentence },
-    bail_conditions_set_details: -> { Faker::Lorem.sentence }
+    bail_conditions_set_details: -> { Faker::Lorem.sentence },
+    ccms_opponent_id: -> { Faker::Base.regexify(/^[0-9]{8}$/) }
   },
   other_assets_declarations: {},
   permissions: {},


### PR DESCRIPTION
## Add Anonymiusation rule

The restore of the anonymised database dump of production is not working, and failing with this error:


`psql:./tmp/production.anon.sql:261403: ERROR:  missing data for column "ccms_opponent_id"`

`CONTEXT:  COPY opponents, line 1: "841cbaf4-0bdd-4bd1-bda3-934b36983fe5	9437bcfb-2e7a-4590-8e8f-9edf80a0fcd9`

The `ccms_opponent_id` column is all nil in the live database - that shouldn't be a problem, but when restoring it seems to expect a value.  This PR is to put in a fake number so that there is data there.


[Link to story](https://dsdmoj.atlassian.net/browse/AP-XXX)

Describe what you did and why.

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
