### PR TITLE
AP-2273 cash transactions none of the above

### DIFF
--- a/app/controllers/citizens/cash_incomes_controller.rb
+++ b/app/controllers/citizens/cash_incomes_controller.rb
@@ -6,6 +6,7 @@ module Citizens
 
     def update
       if aggregated_cash_income.update(form_params)
+        update_no_cash_income(form_params)
         go_forward
       else
         render :show
@@ -26,6 +27,11 @@ module Citizens
                  legal_aid_application_id: legal_aid_application[:id],
                  none_selected: params[:aggregated_cash_income][:none_selected]
                })
+    end
+
+    def update_no_cash_income(params)
+      val = params.permit(:none_selected)[:none_selected] == 'true'
+      legal_aid_application.update!(no_cash_income: val)
     end
   end
 end

--- a/app/controllers/citizens/cash_outgoings_controller.rb
+++ b/app/controllers/citizens/cash_outgoings_controller.rb
@@ -6,6 +6,7 @@ module Citizens
 
     def update
       if aggregated_cash_outgoings.update(form_params)
+        update_no_cash_outgoings(form_params)
         go_forward
       else
         render :show
@@ -26,6 +27,11 @@ module Citizens
                  legal_aid_application_id: legal_aid_application[:id],
                  none_selected: params[:aggregated_cash_outgoings][:none_selected]
                })
+    end
+
+    def update_no_cash_outgoings(params)
+      val = params.permit(:none_selected)[:none_selected] == 'true'
+      legal_aid_application.update!(no_cash_outgoings: val)
     end
   end
 end

--- a/app/models/cash_transaction.rb
+++ b/app/models/cash_transaction.rb
@@ -1,5 +1,5 @@
 class CashTransaction < ApplicationRecord
-  # The CashTranscation records the monthly amount paid or received by an applicant in cash for a particular month
+  # The CashTransaction records the monthly amount paid or received by an applicant in cash for a particular month
   # for a particular TransactionType.  These records always come in threes, representing each of the last three months
   # before an application was made.  The transaction date is set to the first of the month.
 

--- a/app/views/citizens/cash_incomes/_cash_income_form.html.erb
+++ b/app/views/citizens/cash_incomes/_cash_income_form.html.erb
@@ -24,7 +24,7 @@
       </div>
 
       <%= form.govuk_radio_divider %>
-      <%= form.govuk_check_box :none_selected, true, '', multiple: false, label: {text: t('.none_selected')} %>
+      <%= form.govuk_check_box :none_selected, true, '', multiple: false, label: {text: t('.none_selected')}, checked: @legal_aid_application.no_cash_income? %>
     <% end %>
 
     <%= next_action_buttons(

--- a/app/views/citizens/cash_outgoings/_cash_outgoings_form.html.erb
+++ b/app/views/citizens/cash_outgoings/_cash_outgoings_form.html.erb
@@ -25,8 +25,7 @@
       </div>
 
     <%= form.govuk_radio_divider %>
-    <%= form.govuk_check_box :none_selected, true, '', multiple: false,
-                             label: {text: t('.none_selected')} %>
+    <%= form.govuk_check_box :none_selected, true, '', multiple: false, label: {text: t('.none_selected')}, checked: @legal_aid_application.no_cash_outgoings? %>
   <% end %>
 
   <%= next_action_buttons(

--- a/app/views/shared/forms/_types_of_outgoings_form.html.erb
+++ b/app/views/shared/forms/_types_of_outgoings_form.html.erb
@@ -17,8 +17,7 @@
         <% end %>
       </div>
       <%= form.govuk_radio_divider %>
-      <%= form.govuk_check_box :none_selected, true, '', link_errors: true, multiple: false,
-                               label: {text: t('generic.none_selected')} %>
+      <%= form.govuk_check_box :none_selected, true, '', multiple: false, label: {text: t('generic.none_selected')} %>
     <% end %>
 
     <% if journey == :citizen %>

--- a/db/migrate/20210712112003_add_no_cash_income_and_outgoings.rb
+++ b/db/migrate/20210712112003_add_no_cash_income_and_outgoings.rb
@@ -1,0 +1,6 @@
+class AddNoCashIncomeAndOutgoings < ActiveRecord::Migration[6.1]
+  def change
+    add_column :legal_aid_applications, :no_cash_income, :boolean
+    add_column :legal_aid_applications, :no_cash_outgoings, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_24_130422) do
+ActiveRecord::Schema.define(version: 2021_07_12_112003) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -492,6 +492,8 @@ ActiveRecord::Schema.define(version: 2021_06_24_130422) do
     t.boolean "emergency_cost_override"
     t.decimal "emergency_cost_requested"
     t.string "emergency_cost_reasons"
+    t.boolean "no_cash_income"
+    t.boolean "no_cash_outgoings"
     t.index ["applicant_id"], name: "index_legal_aid_applications_on_applicant_id"
     t.index ["application_ref"], name: "index_legal_aid_applications_on_application_ref", unique: true
     t.index ["discarded_at"], name: "index_legal_aid_applications_on_discarded_at"

--- a/spec/requests/citizens/cash_incomes_spec.rb
+++ b/spec/requests/citizens/cash_incomes_spec.rb
@@ -33,6 +33,10 @@ RSpec.describe Citizens::CashIncomesController, type: :request do
         it 'redirects to new action' do
           expect(response).to redirect_to(next_flow_step)
         end
+
+        it 'updates the model attribute for no cash income to false' do
+          expect(legal_aid_application.reload.no_cash_income).to be(false)
+        end
       end
 
       context 'none of the above' do
@@ -40,6 +44,10 @@ RSpec.describe Citizens::CashIncomesController, type: :request do
 
         it 'redirects to new action' do
           expect(response).to redirect_to(next_flow_step)
+        end
+
+        it 'updates the model attribute for no cash income to true' do
+          expect(legal_aid_application.reload.no_cash_income).to eq(true)
         end
       end
     end
@@ -94,7 +102,8 @@ RSpec.describe Citizens::CashIncomesController, type: :request do
           check_box_benefits: 'true',
           benefits1: '1',
           benefits2: '2',
-          benefits3: '3'
+          benefits3: '3',
+          none_selected: ''
         }
       }
     end

--- a/spec/requests/citizens/cash_outgoings_spec.rb
+++ b/spec/requests/citizens/cash_outgoings_spec.rb
@@ -33,6 +33,10 @@ RSpec.describe Citizens::CashOutgoingsController, type: :request do
         it 'redirects to new action' do
           expect(response).to redirect_to(next_flow_step)
         end
+
+        it 'updates the model attribute for no cash outgoings to false' do
+          expect(legal_aid_application.reload.no_cash_outgoings).to be(false)
+        end
       end
 
       context 'none of the above' do
@@ -40,6 +44,10 @@ RSpec.describe Citizens::CashOutgoingsController, type: :request do
 
         it 'redirects to new action' do
           expect(response).to redirect_to(next_flow_step)
+        end
+
+        it 'updates the model attribute for no cash outgoings to true' do
+          expect(legal_aid_application.reload.no_cash_outgoings).to eq(true)
         end
       end
     end
@@ -94,7 +102,8 @@ RSpec.describe Citizens::CashOutgoingsController, type: :request do
           check_box_child_care: 'true',
           child_care1: '1',
           child_care2: '2',
-          child_care3: '3'
+          child_care3: '3',
+          none_selected: ''
         }
       }
     end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2273)

Added attributes to LegalAidApplication to record when no cash income/outgoings have been selected
This is so we can display 'None of the above' as checked when a user returns to the page via the back button or from the CYA page

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
