### PR TITLE
Remove newline from anonymised name

### DIFF
--- a/db/anonymise/rules.rb
+++ b/db/anonymise/rules.rb
@@ -119,12 +119,11 @@ NINO_REGEXP = /^[A-CEGHJ-PR-TW-Z]{1}[A-CEGHJ-NPR-TW-Z]{1}[0-9]{6}[A-DFM]{1}$/.fr
   legal_framework_submissions: {},
   offices_providers: {},
   opponents: {
-    full_name: -> { "#{Faker::Name.name}\n" },
+    full_name: -> { Faker::Name.name },
     understands_terms_of_court_order_details: -> { Faker::Lorem.sentence },
     warning_letter_sent_details: -> { Faker::Lorem.sentence },
     police_notified_details: -> { Faker::Lorem.sentence },
-    bail_conditions_set_details: -> { Faker::Lorem.sentence },
-    ccms_opponent_id: -> { Faker::Base.regexify(/^[0-9]{8}$/) }
+    bail_conditions_set_details: -> { Faker::Lorem.sentence }
   },
   other_assets_declarations: {},
   permissions: {},


### PR DESCRIPTION
## Anewline was being inserted into the anonymised name on the opponents table which was causing the restore to fail.

[Link to story](https://dsdmoj.atlassian.net/browse/AP-XXX)

Describe what you did and why.

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
