### PR TITLE
CHange the image used for CLAMAV use the hmpps image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ executors:
           GITHUB_TEAM_NAME_SLUG: laa-apply-for-legal-aid
       - image: circleci/postgres:10.5
       - image: circleci/redis:5.0
-      - image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/laa-apply-for-legal-aid/clamav:1.0.2
+      - image: ghcr.io/ministryofjustice/hmpps-clamav:latest
 
 references:
   decrypt_secrets: &decrypt_secrets

--- a/helm_deploy/apply-for-legal-aid/templates/deployment_web.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/deployment_web.yaml
@@ -20,9 +20,9 @@ spec:
         release: {{ .Release.Name }}
     spec:
       containers:
-        # https://github.com/ministryofjustice/clamav
+        # https://github.com/ministryofjustice/hmpps-utility-container-images
         - name: clamav
-          image: '754256621582.dkr.ecr.eu-west-2.amazonaws.com/laa-apply-for-legal-aid/clamav:1.0.2'
+          image: ghcr.io/ministryofjustice/hmpps-clamav:latest
           imagePullPolicy: IfNotPresent
           ports:
             - name: clamav


### PR DESCRIPTION
## What
ClamAV has been causing some failures as our image is not up to date
Changes to our existing repo were not resulting in the newest image being tagged as latest
Change where we get the clamav docker image from - now using HMPPS one



## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
