### PR TITLE
AP-2306: Remove deprecation warnings

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,5 +1,7 @@
-require Rails.root.join 'app/lib/omni_auth/omni_auth_true_layer'
-require Rails.root.join 'app/controllers/applicants/omniauth_callbacks_controller.rb'
+Rails.application.reloader.to_prepare do
+  require Rails.root.join 'app/lib/omni_auth/omni_auth_true_layer'
+  require Rails.root.join 'app/controllers/applicants/omniauth_callbacks_controller.rb'
+end
 
 OmniAuth.config.allowed_request_methods = %i[post get]
 OmniAuth.config.logger = Rails.logger


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2306)

Update the OmniAuth initializer
Requiring a controller in an initializer reloads all helpers and
this was causing the deprecation warning.  Wrapping the requires in
the suggested `Rails.application.reloader.to_prepare do` block seems
to have quieted the warning when running server and console locally

Testing on UAT to ensure there are no issues with production
style execution

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
