### PR TITLE
Tech debt/rubocop fix

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -99,12 +99,6 @@ Metrics/PerceivedComplexity:
   IgnoredMethods:
     - 'cli_arg_version' # from bin/bundle - auto generated method
 
-# TODO: Monitor this cop - when first added we got lots of
-# false positives e.g. with `steps %(...)` so it was
-# turned off, fixes may mean we can re-enable it
-Layout/LineEndStringConcatenationIndentation:
-  Enabled: false
-
 Naming/InclusiveLanguage:
   CheckComments: false
   CheckStrings: false

--- a/spec/helpers/hash_format_helper_spec.rb
+++ b/spec/helpers/hash_format_helper_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe HashFormatHelper, type: :helper do
   let(:source) { { key: 'value', sub_hash: { sub_key: 'sub_value' } } }
   let(:expected_response) do
     '<dl class="govuk-body kvp govuk-!-margin-bottom-0"><dt>Key</dt><dd>Value</dd></dl>' \
-    '<dl class="govuk-body kvp govuk-!-margin-bottom-0"><dt>Sub Hash</dt>'\
-    '<dl class="govuk-body kvp govuk-!-margin-bottom-0"><dt>Sub Key</dt><dd>Sub_value</dd></dl></dl>'
+      '<dl class="govuk-body kvp govuk-!-margin-bottom-0"><dt>Sub Hash</dt>'\
+      '<dl class="govuk-body kvp govuk-!-margin-bottom-0"><dt>Sub Key</dt><dd>Sub_value</dd></dl></dl>'
   end
 
   describe '#format_hash' do


### PR DESCRIPTION
## What

We had ignored the new `Layout/LineEndStringConcatenationIndentation` cop because of the number of false positives, these have been addressed in a subsequent update, so I've removed the override and fixed the remaining issue

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
