### PR TITLE
AP-2393 Ensure Proceedings are displayed in a consistent order

### DIFF
--- a/app/services/legal_framework/merits_tasks_retriever_service.rb
+++ b/app/services/legal_framework/merits_tasks_retriever_service.rb
@@ -16,7 +16,7 @@ module LegalFramework
     private
 
     def proceeding_types_codes
-      legal_aid_application.proceeding_types.map(&:ccms_code)
+      legal_aid_application.application_proceeding_types.map{ |apt| apt.proceeding_type.ccms_code }
     end
   end
 end

--- a/app/services/legal_framework/merits_tasks_retriever_service.rb
+++ b/app/services/legal_framework/merits_tasks_retriever_service.rb
@@ -16,7 +16,7 @@ module LegalFramework
     private
 
     def proceeding_types_codes
-      legal_aid_application.application_proceeding_types.map{ |apt| apt.proceeding_type.ccms_code }
+      legal_aid_application.application_proceeding_types.map { |apt| apt.proceeding_type.ccms_code }
     end
   end
 end

--- a/app/views/providers/has_other_proceedings/show.html.erb
+++ b/app/views/providers/has_other_proceedings/show.html.erb
@@ -7,16 +7,16 @@
     <% if @legal_aid_application.proceeding_types.any? %>
       <h1 class="govuk-heading-xl"><%= t('.existing', count: "#{pluralize(@legal_aid_application.proceeding_types.count, 'proceeding')}") %></h1>
       <div class="govuk-summary-list">
-        <% @legal_aid_application.proceeding_types.order(:created_at).each do |type| %>
-          <dl class="govuk-summary-list__row" id="proceeding_type_<%= type.code %>">
-            <dt class="govuk-summary-list__value"><%= type.meaning %></dt>
+        <% @legal_aid_application.application_proceeding_types.order(:created_at).each do |apt| %>
+          <dl class="govuk-summary-list__row" id="proceeding_type_<%= apt.proceeding_type.code %>">
+            <dt class="govuk-summary-list__value"><%= apt.proceeding_type.meaning %></dt>
             <dd class="govuk-summary-list__actions">
               <%= link_to_accessible(
                     t('.remove'),
-                    providers_legal_aid_application_has_other_proceedings_path(@legal_aid_application, id: type.code),
+                    providers_legal_aid_application_has_other_proceedings_path(@legal_aid_application, id: apt.proceeding_type.code),
                     class: 'govuk-link change-link',
                     method: :delete,
-                    suffix: type.meaning
+                    suffix: apt.proceeding_type.meaning
                   ) %>
             </dd>
           </dl>


### PR DESCRIPTION
## Ensure Proceedings are displayed in a consistent order

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2393)

In all places in the Apply service, proceedings are displayed in the order they were added to the application.

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
