### PR TITLE
Ap 2398 back link dwp override

### DIFF
--- a/app/controllers/providers/confirm_dwp_non_passported_applications_controller.rb
+++ b/app/controllers/providers/confirm_dwp_non_passported_applications_controller.rb
@@ -1,6 +1,7 @@
 module Providers
   class ConfirmDWPNonPassportedApplicationsController < ProviderBaseController
     def show
+      delete_check_benefits_from_history
       form
     end
 
@@ -37,6 +38,14 @@ module Providers
       return {} unless params[:binary_choice_form]
 
       params.require(:binary_choice_form).permit(:correct_dwp_result)
+    end
+
+    def delete_check_benefits_from_history
+      return if page_history.empty?
+
+      temp_page_history = page_history
+      temp_page_history.delete_if { |path| path.include?('check_benefits') }
+      page_history_service.write(temp_page_history)
     end
   end
 end

--- a/features/providers/pathways_from_check_your_answers.feature
+++ b/features/providers/pathways_from_check_your_answers.feature
@@ -125,3 +125,12 @@ Feature: Pathways from check your answers
     And I should be on a page showing 'Child arrangements order (contact)'
     And I should be on a page showing 'LASPO'
     And the answer for 'in scope of laspo' should be 'Yes'
+
+  @javascript @vcr
+  Scenario: I click the back button on the DWP override page
+    Given I complete the non-passported journey as far as check your answers
+    And the setting to allow DWP overrides is enabled
+    When I click 'Save and continue'
+    Then I should be on a page showing 'DWP records show that your client does not receive a passporting benefit – is this correct?'
+    When I click link 'Back'
+    Then I should be on a page showing 'Check your answers'

--- a/spec/requests/providers/confirm_dwp_non_passported_applications_spec.rb
+++ b/spec/requests/providers/confirm_dwp_non_passported_applications_spec.rb
@@ -22,6 +22,22 @@ RSpec.describe Providers::ConfirmDWPNonPassportedApplicationsController, type: :
         expect(response).to be_successful
       end
     end
+
+    describe 'back link' do
+      let(:page1) { providers_legal_aid_application_check_provider_answers_path(application) }
+      let(:page2) { providers_legal_aid_application_check_benefits_path(application) }
+
+      before do
+        login_as application.provider
+        get page1
+        get page2
+        subject
+      end
+
+      it 'points to check youe answers page' do
+        expect(response.body).to have_back_link("#{page1}&back=true")
+      end
+    end
   end
 
   describe 'PATCH /providers/applications/:legal_aid_application_id/confirm_dwp_non_passported_applications' do


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2398)

Remove check_benefits from page history, so that back button on DWP override page links to check_provider_answers page.

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
