### PR TITLE
Bug-fix: Geckoboard fix

### DIFF
--- a/app/models/dashboard/single_object/applicant_email.rb
+++ b/app/models/dashboard/single_object/applicant_email.rb
@@ -9,7 +9,7 @@ module Dashboard
       end
 
       def run
-        @dataset = @client.datasets.find_or_create(dataset_name, dataset_definition)
+        @dataset = @client.datasets.find_or_create(dataset_name, **dataset_definition)
         @dataset.post(build_row, delete_by: :timestamp)
         log_data_message
       end

--- a/app/models/dashboard/single_object/feedback.rb
+++ b/app/models/dashboard/single_object/feedback.rb
@@ -17,7 +17,7 @@ module Dashboard
       end
 
       def run
-        @dataset = @client.datasets.find_or_create(dataset_name, dataset_definition)
+        @dataset = @client.datasets.find_or_create(dataset_name, **dataset_definition)
         @dataset.post(build_row, delete_by: :timestamp)
         log_data_message
       end

--- a/app/models/dashboard/single_object/provider_data.rb
+++ b/app/models/dashboard/single_object/provider_data.rb
@@ -9,7 +9,7 @@ module Dashboard
       end
 
       def run
-        @dataset = @client.datasets.find_or_create(dataset_name, dataset_definition)
+        @dataset = @client.datasets.find_or_create(dataset_name, **dataset_definition)
         @dataset.post(build_row, delete_by: :timestamp)
         log_data_message
       end

--- a/app/models/dashboard/widget.rb
+++ b/app/models/dashboard/widget.rb
@@ -8,7 +8,7 @@ module Dashboard
     end
 
     def run
-      @dataset = @client.datasets.find_or_create(dataset_name, @widget_klass.dataset_definition)
+      @dataset = @client.datasets.find_or_create(dataset_name, **@widget_klass.dataset_definition)
       @dataset.put(data)
       log_data_message
     end

--- a/app/models/dashboard/widget_data_providers/applications.rb
+++ b/app/models/dashboard/widget_data_providers/applications.rb
@@ -4,14 +4,14 @@ module Dashboard
       def self.dataset_definition
         {
           fields: [
-            Geckoboard::DateField.new(:date, name: 'Date').to_hash,
-            Geckoboard::NumberField.new(:started_apps, name: 'Started applications').to_hash,
-            Geckoboard::NumberField.new(:submitted_apps, name: 'Submitted applications').to_hash,
-            Geckoboard::NumberField.new(:submitted_passported_apps, name: 'Submitted passported applications').to_hash,
-            Geckoboard::NumberField.new(:submitted_nonpassported_apps, name: 'Submitted nonpassported applications').to_hash,
-            Geckoboard::NumberField.new(:total_submitted_apps, name: 'Total submitted applications').to_hash,
-            Geckoboard::NumberField.new(:failed_apps, name: 'Failed applications').to_hash,
-            Geckoboard::NumberField.new(:delegated_func_apps, name: 'Delegated function applications').to_hash
+            Geckoboard::DateField.new(:date, name: 'Date'),
+            Geckoboard::NumberField.new(:started_apps, name: 'Started applications'),
+            Geckoboard::NumberField.new(:submitted_apps, name: 'Submitted applications'),
+            Geckoboard::NumberField.new(:submitted_passported_apps, name: 'Submitted passported applications'),
+            Geckoboard::NumberField.new(:submitted_nonpassported_apps, name: 'Submitted nonpassported applications'),
+            Geckoboard::NumberField.new(:total_submitted_apps, name: 'Total submitted applications'),
+            Geckoboard::NumberField.new(:failed_apps, name: 'Failed applications'),
+            Geckoboard::NumberField.new(:delegated_func_apps, name: 'Delegated function applications')
           ],
           unique_by: [:date]
         }

--- a/app/models/dashboard/widget_data_providers/number_provider_firms.rb
+++ b/app/models/dashboard/widget_data_providers/number_provider_firms.rb
@@ -6,7 +6,7 @@ module Dashboard
       def self.dataset_definition
         {
           fields: [
-            Geckoboard::NumberField.new(:number, name: 'Firms').to_hash
+            Geckoboard::NumberField.new(:number, name: 'Firms')
           ]
         }
       end

--- a/app/models/dashboard/widget_data_providers/pending_ccms_submissions.rb
+++ b/app/models/dashboard/widget_data_providers/pending_ccms_submissions.rb
@@ -5,7 +5,7 @@ module Dashboard
       def self.dataset_definition
         {
           fields: [
-            Geckoboard::NumberField.new(:number, name: 'Pending CCMS Submissions').to_hash
+            Geckoboard::NumberField.new(:number, name: 'Pending CCMS Submissions')
           ]
         }
       end

--- a/app/models/dashboard/widget_data_providers/percentage_declined_open_banking.rb
+++ b/app/models/dashboard/widget_data_providers/percentage_declined_open_banking.rb
@@ -6,7 +6,7 @@ module Dashboard
       def self.dataset_definition
         {
           fields: [
-            Geckoboard::NumberField.new(:declined_open_banking, name: 'Percentage that declined open banking consent').to_hash
+            Geckoboard::NumberField.new(:declined_open_banking, name: 'Percentage that declined open banking consent')
           ]
         }
       end


### PR DESCRIPTION
## What

Bug-Fix: Geckoboard …

Add double-splat to the dataset_definition calls, these
all the hashes in the methods to be flattened and passed
to the find_or_create method of the geckoboard datasets
class
Remove the `to_hash` from the Geckoboard fields, the
double_splat fix makes these superfluous

## Checklist

Before you ask people to review this PR:

- [x] Tests and rubocop should be passing: `bundle exec rake`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [x] The PR description should say what you changed and why, with a link to the JIRA story.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
