### PR TITLE
Fix: Allow transition from paused to assessment_submitted

### DIFF
--- a/app/models/concerns/base_state_machine.rb
+++ b/app/models/concerns/base_state_machine.rb
@@ -142,7 +142,7 @@ class BaseStateMachine < ApplicationRecord  # rubocop:disable Metrics/ClassLengt
     end
 
     event :submitted_assessment do
-      transitions from: :submitting_assessment, to: :assessment_submitted
+      transitions from: %i[submission_paused submitting_assessment], to: :assessment_submitted
     end
 
     event :reset_from_use_ccms do


### PR DESCRIPTION
## What

After allowing the pausing of submissions this prevented the state changing after a manual start of the job

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase master`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
