### PR TITLE
Fix: Change pause_submission event handling

### DIFF
--- a/app/controllers/providers/check_merits_answers_controller.rb
+++ b/app/controllers/providers/check_merits_answers_controller.rb
@@ -8,7 +8,7 @@ module Providers
 
     def continue
       unless draft_selected?
-        legal_aid_application.generate_reports! if legal_aid_application.may_generate_reports?
+        legal_aid_application.generate_reports!
         legal_aid_application.merits_complete!
       end
       continue_or_draft

--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -93,7 +93,6 @@ class LegalAidApplication < ApplicationRecord
            :checking_passported_answers?,
            :entering_applicant_details?,
            :generating_reports?,
-           :may_generate_reports?,
            :provider_assessing_means?,
            :provider_checking_or_checked_citizens_means_answers?,
            :provider_entering_means?,

--- a/spec/models/legal_aid_application_spec.rb
+++ b/spec/models/legal_aid_application_spec.rb
@@ -827,6 +827,7 @@ RSpec.describe LegalAidApplication, type: :model do
   describe '#submitted_assessment' do
     let(:legal_aid_application) { create :legal_aid_application, :with_applicant, :checking_merits_answers }
     let(:feedback_url) { 'http://test/feedback/new' }
+    before { allow(Rails.configuration.x.ccms_soa).to receive(:submit_applications_to_ccms).and_return(true) }
 
     it 'schedules a PostSubmissionProcessingJob ' do
       expect(PostSubmissionProcessingJob).to receive(:perform_later).with(

--- a/spec/requests/providers/check_merits_answers_spec.rb
+++ b/spec/requests/providers/check_merits_answers_spec.rb
@@ -157,9 +157,27 @@ RSpec.describe 'check merits answers requests', type: :request do
         expect(application.reload.summary_state).to eq :submitted
       end
 
-      it 'transitions to generating_reports state' do
-        subject
-        expect(application.reload).to be_generating_reports
+      context 'when the Setting.enable_ccms_submission?' do
+        before { allow(EnableCCMSSubmission).to receive(:call).and_return(allow_ccms_submission) }
+
+        context 'is turned on' do
+          let(:allow_ccms_submission) { true }
+
+          it 'transitions to generating_reports state' do
+            subject
+            expect(application.reload).to be_generating_reports
+            # expect(application.reload.state).to eq 'generating_reports'
+          end
+        end
+
+        context 'is turned off' do
+          let(:allow_ccms_submission) { false }
+
+          it 'transitions to submission_paused state' do
+            subject
+            expect(application.reload.state).to eq 'submission_paused'
+          end
+        end
       end
 
       context 'Form submitted using Save as draft button' do

--- a/spec/requests/providers/check_merits_answers_spec.rb
+++ b/spec/requests/providers/check_merits_answers_spec.rb
@@ -125,6 +125,8 @@ RSpec.describe 'check merits answers requests', type: :request do
     subject do
       patch "/providers/applications/#{application.id}/check_merits_answers/continue", params: params
     end
+    before { allow(EnableCCMSSubmission).to receive(:call).and_return(allow_ccms_submission) }
+    let(:allow_ccms_submission) { true }
 
     context 'logged in as an authenticated provider' do
       before do
@@ -158,11 +160,7 @@ RSpec.describe 'check merits answers requests', type: :request do
       end
 
       context 'when the Setting.enable_ccms_submission?' do
-        before { allow(EnableCCMSSubmission).to receive(:call).and_return(allow_ccms_submission) }
-
         context 'is turned on' do
-          let(:allow_ccms_submission) { true }
-
           it 'transitions to generating_reports state' do
             subject
             expect(application.reload).to be_generating_reports

--- a/spec/services/reports/reports_creator_spec.rb
+++ b/spec/services/reports/reports_creator_spec.rb
@@ -12,23 +12,7 @@ RSpec.describe Reports::ReportsCreator do
 
   subject { described_class.call(legal_aid_application) }
 
-  before { allow(EnableCCMSSubmission).to receive(:call).and_return(allow_ccms_submission) }
-  let(:allow_ccms_submission) { true }
-
   describe '.call' do
-    context 'when the Setting.enable_ccms_submission? is turned off' do
-      let(:allow_ccms_submission) { false }
-
-      it 'updates the state to submission_paused' do
-        expect(Reports::MeritsReportCreator).to receive(:call).with(legal_aid_application)
-        expect(Reports::MeansReportCreator).to receive(:call).with(legal_aid_application)
-        expect(Reports::BankTransactions::BankTransactionReportCreator).to_not receive(:call).with(legal_aid_application)
-        subject
-        legal_aid_application.reload
-        expect(legal_aid_application.state).to eq('submission_paused')
-      end
-    end
-
     it 'creates reports and update state' do
       expect(Reports::MeritsReportCreator).to receive(:call).with(legal_aid_application)
       expect(Reports::MeansReportCreator).to receive(:call).with(legal_aid_application)


### PR DESCRIPTION
## What

This was originally implemented at haste due to the
short notice of CCMS shutdown.  It was not clear
when developing at pace that the first call to the
CCMS APIs were made in the ReportsCreatorWorker.

Therefore when we 'paused' teh submissions the reports
creator was failing to create the documents as there
was no way to fulfill the `ensure_case_ccms_reference_exists`
by requesting a `case_ccms_reference`

This PR moves the pause step forward to after check_merits
and removes the check on whether the step should run in the
controller

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase master`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
