### PR TITLE
Ap 2353 remove unused content translations

### DIFF
--- a/config/locales/cy/citizens.yml
+++ b/config/locales/cy/citizens.yml
@@ -5,8 +5,6 @@ cy:
       index:
         retrieving_transactions: snoitcasnart knab gniveirteR
         failed_transactions_retrieval: snoitcasnart knab eveirter ot deliaF
-        default_error: ".retal niaga yrt esaelP .seitluciffid lacinhcet gnicneirepxe
-          era ew ,yrroS"
         page_loading: gnidaoL egaP
         heading_1: snoitcasnart knab ruoy derahs yllufsseccus ev'uoY
         intro_text: ".shtnom 3 tsap eht morf stnemetats knab ruoy dedaolnwod ev’eW"
@@ -48,46 +46,23 @@ cy:
       create:
         error: knab a tceleS
     cash_incomes:
-      checkbox:
-        info: ".snioc dna setonknab ekil yenom lacisyhp snaem hsaC"
-        none_selected: evoba eht fo enoN
       show:
         page_heading: hsac ni eviecer uoy stnemyap tceleS
       cash_income_form:
-        dates: "%{date}"
         info: ".snioc dna setonknab ekil yenom lacisyhp snaem hsaC"
         none_selected: evoba eht fo enoN
-      update:
-        none_selected: hsac ni stnemyap eseht eviecer uoy fi tceleS
     cash_outgoings:
-      checkbox:
-        info: ".snioc dna setonknab ekil yenom lacisyhp snaem hsaC"
-        none_selected: evoba eht fo enoN
       show:
         page_heading: hsac ni ekam uoy stnemyap tceleS
       cash_outgoings_form:
-        dates: "%{date}"
         info: ".snioc dna setonknab ekil yenom lacisyhp snaem hsaC"
         none_selected: evoba eht fo enoN
-      update:
-        none_selected: hsac ni stnemyap eseht eviecer uoy fi tceleS
     check_answers:
       cash_transactions:
         cash_transactions_credits_header: hsac ni eviecer uoy stnemyaP
         cash_transactions_debits_header: hsac ni ekam uoy stnemyaP
         none: enoN
       index:
-        assets:
-          heading: stessa rehto dna sgnivas ,ytreporP
-          other_assets: stessa rehtO
-          outstanding_mortgage: tnuoma egagtrom gnidnatstuO
-          own_home: denwo ytreporP
-          percentage_home: denwo egatnecreP
-          property_value: eulav ytreporP
-          restrictions: "?stessa ruoy tsniaga gniworrob ro gnilles morf uoy tneverp
-            taht snoitcirtser lagel yna ereht erA"
-          savings_and_investments: stnemtsevni dna sgnivaS
-          shared_ownership: esle enoyna htiw denwO
         h1-heading: noitamrofni timbus dna srewsna ruoy kcehC
         bank_accounts:
           heading: stnuocca knab ruoY
@@ -134,30 +109,9 @@ cy:
             AAL eht naht rehto enoyna htiw sliated ruoy erahs
             sliated ni-ngis gniknab enilno ruoy ees
             sliated tnuocca knab ruoy erots
-    declarations:
-      show:
-        page_heading: noitaralceD
-        submit_button: timbus dna eergA
-    dependants:
-      assets_values:
-        show:
-          page_heading: "?000,8£ naht erom htrow stessa evah %{name} seoD"
-      relationships:
-        show:
-          page_heading: "?%{name} ot pihsnoitaler ruoy si tahW"
-    has_dependants:
-      show:
-        page_heading: "?stnadneped yna evah uoy oD"
-        info: ".troppus laicnanif rof uoy no sdneped dna uoy htiw sevil ohw tluda
-          ro dlihc a eb dluoc tnadneped A"
-        extra_info: ".eno evah uoy fi rentrap ruoy edulcni ton oD"
     has_offline_accounts:
       new:
         error: enilno ssecca tonnac uoy stnuocca tnerruc evah uoy fi sey tceleS
-    has_other_dependants:
-      show:
-        heading: "?stnadneped rehto yna evah uoy oD"
-        error: stnadneped rehto evah uoy fi sey tceleS
     identify_types_of_incomes:
       show:
         page_heading: "?eviecer uoy od stnemyap gniwollof eht fo hcihW"
@@ -201,10 +155,6 @@ cy:
           dekcehc ev'ew ecno dia lagel rof yfilauq uoy fi mrifnoc ll'eW"
         feedback_prefix: kcabdeef eviG
         feedback_suffix: ".ecivres siht evorpmi su pleh ot "
-    other_assets:
-      show:
-        h1-heading: "?evah uoy od stessa fo sepyt hcihW"
-        none_selected: eseht fo enoN
     resend_link_requests:
       show:
         page_title: deripxe sah knil sihT
@@ -214,33 +164,6 @@ cy:
         check_inbox: ".xobni liame ruoy kcehC"
         valid_until: ".snosaer ytiruces rof syad 7 rof evitca niamer ylno lliw knil
           wen ruoY"
-    restrictions:
-      show:
-        h1-heading: "?stessa ruoy tsniaga gniworrob ro gnilles morf uoy tneverp taht
-          snoitcirtser lagel yna ereht erA"
-        restrictions_details: yhw dna ,tsniaga worrob ro lles tonnac uoy stessa hcihw
-          su lleT
-        for_example: ":elpmaxe roF"
-        examples:
-          list: |2-
-
-            sgnideecorp lagel rehto ni etupsid fo tcejbus eht era stessa ruoy
-            dessessoper neeb sah emoh ruoy
-            tpurknab er'uoy
-    savings_and_investments:
-      accounts_summary:
-        col_account_number: rebmun tnuoccA
-        col_amount: tnuomA
-        col_sort_code: edoc troS
-        col_type: epyT
-        intro_text: ":stnuocca enilno gniwollof eht evah uoy su dlot ydaerla evah
-          uoY"
-      show:
-        h1-heading: "?evah uoy od stnemtsevni ro sgnivas fo sepyt tahW"
-        none_selected: eseht fo enoN
-    shared_ownerships:
-      show:
-        heading_1: "?esle enoyna htiw emoh ruoy nwo uoy oD"
     student_finances:
       show:
         field_set_header: "?ecnanif tneduts teg uoy oD"

--- a/config/locales/cy/shared.yml
+++ b/config/locales/cy/shared.yml
@@ -3,7 +3,6 @@ cy:
   shared:
     partials:
       revealing_checkbox:
-        dates: "%{date_end} ot %{date_start}"
         citizens:
           cash_incomes:
             hint: ".enon deviecer uoy fi 0 retne ro ,htnom hcae ni deviecer uoy tnuoma
@@ -146,7 +145,6 @@ cy:
         assets:
           other_assets: "?evah tneilc ruoy seod stessa fo sepyt hcihW"
           policy_disregards: seitirahc ro emehcs morf stnemyaP
-          restrictions: "?ylppa snoitcirtser yna oD"
           savings_and_investments: "?evah tneilc ruoy seod stnemtsevni ro sgnivas
             fo sepyt hcihW"
           savings_account: tnuocca sgnivaS
@@ -159,10 +157,6 @@ cy:
           percentage_home: "?nwo yllagel tneilc ruoy seod emoh rieht fo erahs % tahW"
           property_value: "?htrow emoh s'tneilc ruoy si hcum woH"
           shared_ownership: "?esle enoyna htiw emoh rieht nwo tneilc ruoy seoD"
-        submit:
-          heading: sliated ruoy timbuS
-          text: ".tcerroc era gnidivorp era uoy sliated eht ,egdelwonk ruoy fo tseb
-            eht ot ,taht gnimrifnoc era uoy noitacilppa siht gnittimbus yB"
       bank_transaction_table:
         total: latot %{text}
       capital_result:
@@ -179,15 +173,6 @@ cy:
         first_name: eman tsriF
         last_name: eman tsaL
         nino: rebmun ecnarusnI lanoitaN
-      income_details:
-        income:
-          benefits: stifeneB
-          family_help: ylimaf ro sdneirf morf pleh laicnaniF
-          maintenance_in: stnemyap ecnanetniaM
-          property_or_lodger: regdol ro ytreporp morf emocnI
-          student_loan: tnarg ro naol tnedutS
-          pension: noisneP
-          total_income: emocni latoT
       income_result:
         total_disposable_income: dessessa emocni elbasopsid latoT
         total_gross_income: dessessa emocni ssorg latoT
@@ -204,9 +189,6 @@ cy:
         opponent-heading: sliated tnenoppO
         latest-incident-heading: sliated tnedicni tsetaL
         items:
-          client_declaration: noitaralced tneilC
-          client_declaration_answer: deerga & daeR
-          proceedings_currently_before_court: truoc erofeb yltnerruc sgnideecorP
           prospects_of_success: "?retteb ro %05 emoctuo lufsseccus a fo ecnahc eht
             sI"
           success_prospect: "?emoctuo lufsseccus a fo ecnahc eht si tahW"
@@ -219,20 +201,17 @@ cy:
           notification_of_latest_incident: "?tnedicni esuba citsemod tsetal eht tuoba
             uoy tcatnoc tneilc ruoy did nehW"
           date_of_latest_incident: "?rucco tnedicni eht did nehW"
-          details_of_latest_incident: "?tnedicni eht gnirud deneppah tahW"
       no_link_cash_transaction_item:
         no_transactions: 'oN'
         html:
           no_transactions: 'oN'
       proceedings_details:
         section_proceeding:
-          heading: dia lagel fo epocS
           client_involvement_type: epyt tnemevlovni tneilC
           client_involvement_type_applicant: tnacilppA
           proceeding: "?rof dia lagel tnaw tneilc ruoy seod tahW"
       delegated_functions:
         section_delegated:
-          heading: snoitcnuf detageleD
           used_delegated_functions: "?snoitcnuf detageled desu uoy evaH"
           used_delegated_functions_on: snoitcnuf detageled desu uoy etaD
       emergency_limitations:
@@ -248,7 +227,6 @@ cy:
           heading: stessa ruoy no snoitcirtseR
           question: "?stessa ruoy tsniaga gniworrob ro gnilles morf uoy tneverp taht
             snoitcirtser lagel yna ereht erA"
-          details: snoitcirtser fo sliateD
         providers:
           heading: stessa s'tneilc ruoy no snoitcirtseR
           question: "?stessa rieht tsniaga gniworrob ro gnilles morf tneilc ruoy tneverp
@@ -266,30 +244,8 @@ cy:
         told_on_label: "?tnedicni esuba citsemod tsetal eht tuoba uoy tcatnoc tneilc
           ruoy did nehW"
         told_on_hint: .9102 3 13 elpmaxe roF
-        purchased_on_hint: '.0891 3 13 ,elpmaxe roF'
         used_delegated_functions_on_label: snoitcnuf detageled desu uoy etaD
         used_delegated_functions_on_hint: ".%{options} ,elpmaxe roF"
-      dependants:
-        assets_value:
-          example: ".serahs ro sgnivas hsac ,ytreporp ,elpmaxe roF"
-          enter_assets_value: eulav tessa latot eht retnE
-        details:
-          add_dependant_later: ".retal stnadneped erom dda nac uoY"
-          you_already_told_about: ":tuoba su dlot ydaerla ev'uoY"
-          dependant_list_item: "%{date_of_birth} nrob ,%{name}"
-        relationship:
-          option:
-            child_relative: evitaler dlihc a er'yehT
-            adult_relative: evitaler tluda na er'yehT
-            hint:
-              child_relative: ".wehpen ro ecein ,dlihcdnarg ,dlihc ruoy ,elpmaxe roF"
-              adult_relative: ".elcnu ro tnua ,tnerapdnarg ,tnerap a ,elpmaxe roF"
-        monthly_incomes:
-          hint: ".tnarg ro naol tneduts ro ,pihsecitnerppa ,boj a morf yenom ,elpmaxe
-            roF"
-          enter_monthly_income: htnom hcae teg yeht tnuoma eht retnE
-      savings_and_investments_form:
-        none_selected: eseht fo enoN
       policy_disregards:
         form:
           providers:
@@ -316,57 +272,6 @@ cy:
               income_support: troppuS emocnI
       revealing_checkbox:
         attribute:
-          citizens:
-            other_assets:
-              check_box_valuable_items_value: erom ro 005£ htrow smeti elbaulav ynA
-              check_box_land_value: dnaL
-              check_box_inherited_assets_value: deid sah ohw nosrep a fo etatse eht
-                morf stessa ro yenoM
-              check_box_money_owed_value: egagtrom etavirp a morf gnidulcni ,uoy ot
-                dewo yenoM
-              check_box_second_home_mortgage: tnuoma egagtrom gnidnatstuo emoh yadiloh
-                ro ytreporp dnoceS
-              check_box_second_home_percentage: denwo egatnecrep emoh yadiloh ro ytreporp
-                dnoceS
-              check_box_second_home_value: eulav detamitse emoh yadiloh ro ytreporp
-                dnoceS
-              check_box_timeshare_property_value: ytreporp erahsemiT
-              check_box_trust_value: tsurt a ni tseretnI
-              valuable_items_value: stsoc elas yna sunim ,eulav latot detamitse retnE
-              land_value: eulav detamitse retnE
-              inherited_assets_value: eulav latot detamitse retnE
-              money_owed_value: dewo tnuoma detamitse retnE
-              timeshare_property_value: stsoc elas dna naol yna sunim ,eulav retnE
-              trust_value: eulav latot detamitse retnE
-              hint:
-                check_box_valuable_items_value: krow rof desu sloot ro gnihtolc ,erutinruf
-                  ,sgnir tnemegagne ro gniddew edulcni ton od – seuqitna ro tra ,yrellewej
-                  ,elpmaxe roF
-            savings_and_investments:
-              cash: tnuoma latot eht retnE
-              check_box_cash: tnuocca knab a ni ton yenoM
-              check_box_life_assurance_endowment_policy: egagtrom a ot deknil ton
-                seicilop tnemwodne dna ecnarussa efiL
-              check_box_national_savings: sdnoB muimerP dna setacifitreC sgnivaS lanoitaN
-              check_box_other_person_account: tnuocca knab s'nosrep rehtona ot sseccA
-              check_box_peps_unit_trusts_capital_bonds_gov_stocks: skcots tnemnrevog
-                dna sdnob latipac ,stsurt tinu ,sPEP
-              check_box_plc_shares: ")ynapmoc detimil cilbup( CLP a ni serahS"
-              hint:
-                revealing_check_box_offline_current_accounts: latot eht retne neht
-                  ,meht dda ,htnom tsal tnuocca hcae morf ecnalab tsewol eht ekat
-                  ,stnuocca elpitlum evah uoy fI
-                check_box_cash: .emoh ta tpek hsac ,elpmaxe roF
-                check_box_life_assurance_endowment_policy: htaed no tuo yap ylno taht
-                  seicilop edulcni ton oD
-                check_box_other_person_account: tnuocca s'dlihc a no yrotangis a era
-                  uoy ,elpmaxe roF
-              life_assurance_endowment_policy: nwo uoy lla fo eulav latot eht retnE
-              national_savings: nwo uoy lla fo eulav latot eht retnE
-              other_person_account: stnuocca lla ni latot detamitse eht retnE
-              peps_unit_trusts_capital_bonds_gov_stocks: nwo uoy lla fo eulav latot
-                eht retnE
-              plc_shares: nwo uoy lla fo eulav latot eht retnE
           providers:
             other_assets:
               check_box_valuable_items_value: erom ro 005£ htrow smeti elbaulav ynA
@@ -477,11 +382,8 @@ cy:
       property: ytreporP
       value: eulaV
       outstanding_mortgage: egagtrom gnidnatstuO
-      mortgage_deduction: noitcuded egagtroM
       disregards: snoitcuded dna sdragersiD
       assessment_amount: noitaluclac ni dedulcni tnuomA
-      main_home_disregard: dragersid emoh niaM
-      main_home: emoh niaM
       additional_property: ytreporp lanoitiddA
     vehicle_results:
       vehicles: selciheV

--- a/config/locales/en/citizens.yml
+++ b/config/locales/en/citizens.yml
@@ -5,7 +5,6 @@ en:
       index:
         retrieving_transactions: Retrieving bank transactions
         failed_transactions_retrieval: Failed to retrieve bank transactions
-        default_error: Sorry, we are experiencing technical difficulties. Please try again later.
         page_loading: Page Loading
         heading_1: "You've successfully shared your bank transactions"
         intro_text: We’ve downloaded your bank statements from the past 3 months.
@@ -42,46 +41,23 @@ en:
       create:
         error: Select a bank
     cash_incomes:
-      checkbox:
-        info: Cash means physical money like banknotes and coins.
-        none_selected: None of the above
       show:
         page_heading: Select payments you receive in cash
       cash_income_form:
-        dates: "%{date}"
         info: Cash means physical money like banknotes and coins.
         none_selected: None of the above
-      update:
-        none_selected: Select if you receive these payments in cash
     cash_outgoings:
-      checkbox:
-        info: Cash means physical money like banknotes and coins.
-        none_selected: None of the above
       show:
         page_heading: Select payments you make in cash
       cash_outgoings_form:
-        dates: "%{date}"
         info: Cash means physical money like banknotes and coins.
         none_selected: None of the above
-      update:
-        none_selected: Select if you receive these payments in cash
-
     check_answers:
       cash_transactions:
         cash_transactions_credits_header: Payments you receive in cash
         cash_transactions_debits_header: Payments you make in cash
         none: None
       index:
-        assets:
-          heading: Property, savings and other assets
-          other_assets: Other assets
-          outstanding_mortgage: Outstanding mortgage amount
-          own_home: Property owned
-          percentage_home: Percentage owned
-          property_value: Property value
-          restrictions: Are there any legal restrictions that prevent you from selling or borrowing against your assets?
-          savings_and_investments: Savings and investments
-          shared_ownership: Owned with anyone else
         h1-heading: Check your answers and submit information
         bank_accounts:
           heading: Your bank accounts
@@ -123,29 +99,9 @@ en:
             see your online banking sign-in details
             share your details with anyone other than the LAA
             have any ongoing access to your bank account details
-    declarations:
-      show:
-        page_heading: Declaration
-        submit_button: Agree and submit
-    dependants:
-      assets_values:
-        show:
-          page_heading: "Does %{name} have assets worth more than £8,000?"
-      relationships:
-        show:
-          page_heading: "What is your relationship to %{name}?"
-    has_dependants:
-      show:
-        page_heading: Do you have any dependants?
-        info: A dependant could be a child or adult who lives with you and depends on you for financial support.
-        extra_info: Do not include your partner if you have one.
     has_offline_accounts:
       new:
         error: Select yes if you have current accounts you cannot access online
-    has_other_dependants:
-      show:
-        heading: Do you have any other dependants?
-        error: Select yes if you have other dependants
     identify_types_of_incomes:
       show:
         page_heading: Which of the following payments do you receive?
@@ -180,10 +136,6 @@ en:
         what-happens-next:  We'll confirm if you qualify for legal aid once we've checked your financial situation and the details of your case.
         feedback_prefix: 'Give feedback'
         feedback_suffix: ' to help us improve this service.'
-    other_assets:
-      show:
-        h1-heading: Which types of assets do you have?
-        none_selected: None of these
     resend_link_requests:
       show:
         page_title: This link has expired
@@ -192,29 +144,6 @@ en:
         page_title: We've sent you a new link
         check_inbox: Check your email inbox.
         valid_until: Your new link will only remain active for 7 days for security reasons.
-    restrictions:
-      show:
-        h1-heading: Are there any legal restrictions that prevent you from selling or borrowing against your assets?
-        restrictions_details: Tell us which assets you cannot sell or borrow against, and why
-        for_example: "For example:"
-        examples:
-          list: |
-            you're bankrupt
-            your home has been repossessed
-            your assets are the subject of dispute in other legal proceedings
-    savings_and_investments:
-      accounts_summary:
-        col_account_number: Account number
-        col_amount: Amount
-        col_sort_code: Sort code
-        col_type: Type
-        intro_text: 'You have already told us you have the following online accounts:'
-      show:
-        h1-heading: What types of savings or investments do you have?
-        none_selected: None of these
-    shared_ownerships:
-      show:
-        heading_1: Do you own your home with anyone else?
     student_finances:
       show:
         field_set_header: Do you get student finance?

--- a/config/locales/en/shared.yml
+++ b/config/locales/en/shared.yml
@@ -3,7 +3,6 @@ en:
   shared:
     partials:
       revealing_checkbox:
-        dates:  "%{date_start} to %{date_end}"
         citizens:
           cash_incomes:
             hint: Enter the total cash amount you received in each month, or enter 0 if you received none.
@@ -152,7 +151,6 @@ en:
         assets:
           other_assets: Which types of assets does your client have?
           policy_disregards: Payments from scheme or charities
-          restrictions: Do any restrictions apply?
           savings_and_investments: Which types of savings or investments does your client have?
           savings_account: Savings account
           current_account: Current account
@@ -164,9 +162,6 @@ en:
           percentage_home: What % share of their home does your client legally own?
           property_value: How much is your client's home worth?
           shared_ownership: Does your client own their home with anyone else?
-        submit:
-          heading: Submit your details
-          text: By submitting this application you are confirming that, to the best of your knowledge, the details you are providing are correct.
       offline_savings_accounts:
         heading: Bank accounts
         offline_savings_accounts: Has savings accounts they cannot access online
@@ -191,15 +186,6 @@ en:
         request_higher_limit: Do you want to request a higher cost limit?
         new_cost_limit: New emergency cost limit
         new_limit_reasons: Why you need a higher cost limit
-      income_details:
-        income:
-          benefits: Benefits
-          family_help: Financial help from friends or family
-          maintenance_in: Maintenance payments
-          property_or_lodger: Income from property or lodger
-          student_loan: Student loan or grant
-          pension: Pension
-          total_income: Total income
       income_result:
         total_disposable_income: Total disposable income assessed
         total_gross_income: Total gross income assessed
@@ -218,12 +204,9 @@ en:
         statement-of-case-heading: Statement of case
         gateway-evidence-heading: Supporting evidence
         items:
-          client_declaration: Client declaration
-          client_declaration_answer: Read & agreed
           override_requested: Do you want to request a higher cost limit?
           cost_override_question: What is the new requested emergency cost limit?
           enter_cost_reasons: Tell us why you need a higher cost limit.
-          proceedings_currently_before_court: Proceedings currently before court
           prospects_of_success: Is the chance of a successful outcome 50% or better?
           success_prospect: What is the chance of a successful outcome?
           statement_of_case: Provide a statement of case
@@ -237,7 +220,6 @@ en:
           bail_conditions_set: Have bail conditions been set?
           notification_of_latest_incident: When did your client contact you about the latest domestic abuse incident?
           date_of_latest_incident: When did the incident occur?
-          details_of_latest_incident: What happened during the incident?
           gateway_evidence: Upload supporting evidence
       merits_orig: # TODO: Delete when Multi-proceeding flag is removed
         <<: *merits
@@ -248,7 +230,6 @@ en:
       proceedings_details:
         proceeding: Proceeding
         section_proceeding:
-          heading: Scope of legal aid
           client_involvement_type: Client involvement type
           client_involvement_type_applicant: Applicant
           proceeding: What does your client want legal aid for?
@@ -258,7 +239,6 @@ en:
       delegated_functions:
         not_used: Not used
         section_delegated:
-          heading: Delegated functions
           used_delegated_functions: Have you used delegated functions?
           used_delegated_functions_on: Date you used delegated functions
       emergency_limitations:
@@ -273,7 +253,6 @@ en:
         citizens:
           heading: Restrictions on your assets
           question: Are there any legal restrictions that prevent you from selling or borrowing against your assets?
-          details: Details of restrictions
         providers:
           heading: Restrictions on your client's assets
           question: Is your client prohibited from selling or borrowing against their assets? 
@@ -297,7 +276,6 @@ en:
         occurred_on_label: When did the incident occur?
         told_on_label: When did your client contact you about the latest domestic abuse incident?
         told_on_hint: For example 31 3 2019.
-        purchased_on_hint: For example, 31 3 1980.
         used_delegated_functions_on_label: Date you used delegated functions
         used_delegated_functions_on_hint: "For example, %{options}."
       dependants:
@@ -331,15 +309,6 @@ en:
         mortgage: Yes, with a mortgage or loan
         'no': 'No'
         owned_outright: Yes, owned outright
-      percentage_home_form:
-        citizens:
-          percentage_homes:
-            hint:
-              percentage_home: Your name must be on the property deeds, lease, freehold or mortgage.
-            percentage_home: Enter the estimated percentage share you own
-        providers:
-          percentage_homes:
-            percentage_home: Your client's name must be on the property deeds, lease, freehold or mortgage
       policy_disregards:
         form:
           providers:
@@ -362,43 +331,6 @@ en:
               income_support: Income Support
       revealing_checkbox:
         attribute:
-          citizens:
-            other_assets:
-              check_box_valuable_items_value: Any valuable items worth £500 or more
-              check_box_land_value: Land
-              check_box_inherited_assets_value: Money or assets from the estate of a person who has died
-              check_box_money_owed_value: Money owed to you, including from a private mortgage
-              check_box_second_home_mortgage: Second property or holiday home outstanding mortgage amount
-              check_box_second_home_percentage: Second property or holiday home percentage owned
-              check_box_second_home_value: Second property or holiday home estimated value
-              check_box_timeshare_property_value: Timeshare property
-              check_box_trust_value: Interest in a trust
-              valuable_items_value: Enter estimated total value, minus any sale costs
-              land_value: Enter estimated value
-              inherited_assets_value: Enter estimated total value
-              money_owed_value: Enter estimated amount owed
-              timeshare_property_value: Enter value, minus any loan and sale costs
-              trust_value: Enter estimated total value
-              hint:
-                check_box_valuable_items_value: For example, jewellery, art or antiques – do not include wedding or engagement rings, furniture, clothing or tools used for work
-            savings_and_investments:
-              cash: Enter the total amount
-              check_box_cash: Money not in a bank account
-              check_box_life_assurance_endowment_policy: Life assurance and endowment policies not linked to a mortgage
-              check_box_national_savings: National Savings Certificates and Premium Bonds
-              check_box_other_person_account: Access to another person's bank account
-              check_box_peps_unit_trusts_capital_bonds_gov_stocks: PEPs, unit trusts, capital bonds and government stocks
-              check_box_plc_shares: Shares in a PLC (public limited company)
-              hint:
-                revealing_check_box_offline_current_accounts: If you have multiple accounts, take the lowest balance from each account last month, add them, then enter the total
-                check_box_cash: For example, cash kept at home
-                check_box_life_assurance_endowment_policy: Do not include policies that only pay out on death
-                check_box_other_person_account: For example, you are a signatory on a child's account
-              life_assurance_endowment_policy: Enter the total value of all you own
-              national_savings: Enter the total value of all you own
-              other_person_account: Enter the estimated total in all accounts
-              peps_unit_trusts_capital_bonds_gov_stocks: Enter the total value of all you own
-              plc_shares: Enter the total value of all you own
           providers:
             other_assets:
               check_box_valuable_items_value: Any valuable items worth £500 or more
@@ -498,11 +430,8 @@ en:
       property: Property
       value: Value
       outstanding_mortgage: Outstanding mortgage
-      mortgage_deduction: Mortgage deduction
       disregards: Disregards and deductions
       assessment_amount: Amount included in calculation
-      main_home_disregard: Main home disregard
-      main_home: Main home
       additional_property: Additional property
     vehicle_results:
       vehicles: Vehicles


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=233&modal=detail&selectedIssue=AP-2353)

- Ran i18n-tasks unused to identify (potentially) unused translations (this identified a lot of false positives).
- Ran bundle exec rake to identify any tests that have been broken by missing translations and replaced the missing translation.
- Tested the citizen journey and the provider journey manually for passported and non-passported claims and replaced any missing translations.
- I have attempted to check that none of the translations removed are used, but this could do with another pair of eyes and some manual testing.

## Checklist

Before you ask people to review this PR:

- [ ] Tests and rubocop should be passing: `bundle exec rake`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [ ] There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- [ ] The PR description should say what you changed and why, with a link to the JIRA story.
- [ ] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
