### PR TITLE
AP-2429: Reduce time spent running unit tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,6 @@ references:
         sudo apt-get update
         sudo apt-get install -y postgresql-client
         sudo apt-get install -y clamav-daemon
-        sudo apt-get install -y libreoffice
         sudo apt-get install -y wkhtmltopdf
         sudo apt-get install -y git-crypt
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,7 +140,6 @@ commands:
       - slack/approval:
           message: << parameters.message >>
           webhook: << parameters.webhook >>
-
 jobs:
   lint_checks:
     executor: linting-executor
@@ -180,6 +179,32 @@ jobs:
     - store_artifacts:
         path: ./coverage
 
+  full_unit_tests:
+    executor: test-executor
+    steps:
+    - checkout
+    - *install_packages_for_testing
+    - *decrypt_secrets
+    - *restore_gems_cache
+    - *install_gems
+    - *save_gems_cache
+    - *setup_database
+    - *restore_js_packages_cache
+    - *install_js_packages
+    - *save_js_packages_cache
+    - run:
+        environment:
+          INC_CCMS: true
+        name: Run ruby tests
+        command: bundle exec rspec --format progress --format RspecJunitFormatter -o /tmp/test-results/rspec/rspec.xml
+    - store_test_results:
+        path: /tmp/test-results/rspec
+    - store_artifacts:
+        path: ./coverage
+    - slack/status:
+        fail_only: true
+        success_message: ":yep: The full CCMS run was successful"
+        failure_message: ":nope: <!here> The full CCMS run has failed, run:\n INC_CCMS=true bundle exec rspec --tag ccms \n locally to trace and resolve the issue"
   integration_tests:
     executor: test-executor
     steps:
@@ -400,3 +425,13 @@ workflows:
             only: master
     jobs:
     - clean_up_ecr
+
+  full_ccms_unit_test_run:
+    triggers:
+    - schedule:
+        cron: "15 2 * * *"
+        filters:
+          branches:
+            only: master
+    jobs:
+    - full_unit_tests

--- a/.github/workflows/i18n_checks.yml
+++ b/.github/workflows/i18n_checks.yml
@@ -1,0 +1,49 @@
+name: Check I18n matches
+on:
+  schedule:
+    - cron:  '5 7 * * *'
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      PGHOST: localhost
+      PGUSER: postgres
+      RAILS_ENV: test
+      TZ: "Europe/London"
+    services:
+      postgres:
+        image: postgres:10.11
+        ports: ["5432:5432"]
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Ruby 2.7
+        uses: ruby/setup-ruby@v1
+      - uses: actions/cache@v2
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-
+      - name: Bundle install
+        run: |
+          gem install bundler
+          bundle config path vendor/bundle
+          bundle install --jobs 4 --retry 3
+      - name: Configure database
+        run: |
+          bin/rails db:create db:schema:load
+      - name: Run Tests
+        env:
+          NOCOVERAGE: true
+        run: |
+          bundle exec rspec --tag i18n
+      - name: Slack alert
+        id: slack
+        uses: slackapi/slack-github-action@v1.14.0
+        if: failure()
+        with:
+          channel-id: ${{ secrets.SLACK_CHANNEL }}
+          slack-message: ':alert: <!here> the daily Apply I18n checks have failed.  To reproduce locally, run `bundle exec rspec --tag i18n` and resolve the issues'
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -209,6 +209,21 @@ bin/rake
 VCR_RECORD_MODE=all bin/rake
 ```
 
+As of August 2021, rspec will ignore the CCMS tests. There are 600+ of them and they were taking >6 minutes to run.
+Removing them halved the time taken to run the entire test suite.  A full overnight run is now scheduled in CircleCI and, on failure, it will alert via the apply-dev channel in slack
+
+If you are working on the CCMS tests and need to run them locally, you can run the tests locally with
+```shell
+INC_CCMS=true bundle exec rspec
+```
+This will run the entire test suite and monitor code coverage.
+
+If you don't care about code coverage, you could run 
+```ruby
+bundle exec rspec --tag ccms
+```
+and it will only run the CCMS tests, but complain about coverage
+
 #### Guard
 
 The repo also includes a Guardfile, this can be run in a terminal window

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -1,7 +1,7 @@
 require 'i18n/tasks'
 require 'rails_helper'
 
-RSpec.describe 'I18n' do
+RSpec.describe 'I18n', :i18n do
   let(:i18n) { I18n::Tasks::BaseTask.new }
   let(:missing_keys) { i18n.missing_keys[locale] || I18n::Tasks::Data::Tree::Siblings.new }
 

--- a/spec/models/applicant_spec.rb
+++ b/spec/models/applicant_spec.rb
@@ -96,6 +96,10 @@ RSpec.describe Applicant, type: :model do
     it 'returns the age of the applicant' do
       expect(subject).to be_kind_of(Integer)
     end
+
+    it 'sets the child? value' do
+      expect(legal_aid_application.applicant.child?).to eq legal_aid_application.applicant.age < 16
+    end
   end
 
   describe '#receives_financial_support?' do

--- a/spec/models/application_merits_task/involved_child_spec.rb
+++ b/spec/models/application_merits_task/involved_child_spec.rb
@@ -2,6 +2,14 @@ require 'rails_helper'
 
 module ApplicationMeritsTask
   RSpec.describe InvolvedChild do
+    describe 'standard values' do
+      subject(:involved_child) { build :involved_child }
+
+      it { expect(involved_child.ccms_relationship_to_case).to eq 'CHILD' }
+      it { expect(involved_child.ccms_child?).to eq true }
+      it { expect(involved_child.ccms_opponent_relationship_to_case).to eq 'Child' }
+    end
+
     describe '#split_full_name' do
       let(:involved_child) { build :involved_child, full_name: full_name }
 

--- a/spec/models/application_merits_task/opponent_spec.rb
+++ b/spec/models/application_merits_task/opponent_spec.rb
@@ -2,6 +2,14 @@ require 'rails_helper'
 
 module ApplicationMeritsTask
   RSpec.describe Opponent do
+    describe 'standard values' do
+      subject(:opponent) { build :opponent }
+
+      it { expect(opponent.ccms_relationship_to_case).to eq 'OPP' }
+      it { expect(opponent.ccms_child?).to eq false }
+      it { expect(opponent.ccms_opponent_relationship_to_case).to eq 'Opponent' }
+    end
+
     describe 'CCMSOpponentIdGenerator concern' do
       let(:expected_id) { Faker::Number.number(digits: 8) }
 

--- a/spec/models/bank_account_spec.rb
+++ b/spec/models/bank_account_spec.rb
@@ -96,4 +96,11 @@ RSpec.describe BankAccount, type: :model do
       create :bank_transaction, bank_account: bank_account, happened_at: Date.current, running_balance: 415.26
     end
   end
+
+  describe 'standard values' do
+    subject(:bank_account) { create :bank_account }
+
+    it { expect(bank_account.has_wages?).to be false }
+    it { expect(bank_account.ccms_instance_name(1)).to eq 'the bank account1' }
+  end
 end

--- a/spec/models/dependant_spec.rb
+++ b/spec/models/dependant_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe Dependant, type: :model do
         expect(dependant.over_fifteen?).to eq(false)
       end
 
-      it 'returns true' do
+      it 'returns false' do
         expect(dependant.sixteen_or_over?).to eq(false)
       end
     end
@@ -98,7 +98,7 @@ RSpec.describe Dependant, type: :model do
         expect(dependant.over_fifteen?).to eq(false)
       end
 
-      it 'returns true' do
+      it 'returns false' do
         expect(dependant.sixteen_or_over?).to eq(false)
       end
     end

--- a/spec/models/dependant_spec.rb
+++ b/spec/models/dependant_spec.rb
@@ -73,6 +73,10 @@ RSpec.describe Dependant, type: :model do
       it 'returns false' do
         expect(dependant.over_fifteen?).to eq(false)
       end
+
+      it 'returns true' do
+        expect(dependant.sixteen_or_over?).to eq(false)
+      end
     end
 
     context 'more than 15 years old' do
@@ -81,6 +85,10 @@ RSpec.describe Dependant, type: :model do
       it 'returns true' do
         expect(dependant.over_fifteen?).to eq(true)
       end
+
+      it 'returns true' do
+        expect(dependant.sixteen_or_over?).to eq(true)
+      end
     end
 
     context '15 and a half years old' do
@@ -88,6 +96,10 @@ RSpec.describe Dependant, type: :model do
 
       it 'returns false' do
         expect(dependant.over_fifteen?).to eq(false)
+      end
+
+      it 'returns true' do
+        expect(dependant.sixteen_or_over?).to eq(false)
       end
     end
 
@@ -162,6 +174,31 @@ RSpec.describe Dependant, type: :model do
       it 'returns adult relative' do
         expect(dependant.ccms_relationship_to_client).to eq 'Child aged 16 and over'
       end
+    end
+  end
+
+  describe 'assets_over_threshold?' do
+    subject(:assets_over_threshold) { dependant.assets_over_threshold? }
+    let(:dependant) { create :dependant, legal_aid_application: legal_aid_application, assets_value: assets_value }
+
+    context 'when assets_value is nil' do
+      let(:assets_value) { nil }
+      it { is_expected.to be false }
+    end
+
+    context 'when assets_value is below threshold' do
+      let(:assets_value) { 7999.99 }
+      it { is_expected.to be false }
+    end
+
+    context 'when assets_value is on threshold' do
+      let(:assets_value) { 8000 }
+      it { is_expected.to be false }
+    end
+
+    context 'when assets_value is above threshold' do
+      let(:assets_value) { 8000.01 }
+      it { is_expected.to be true }
     end
   end
 end

--- a/spec/models/proceeding_type_spec.rb
+++ b/spec/models/proceeding_type_spec.rb
@@ -61,4 +61,21 @@ RSpec.describe ProceedingType, type: :model do
       end
     end
   end
+
+  describe '#section8?' do
+    let(:proceeding_type) { create :proceeding_type, ccms_matter: matter }
+    context 'section 8' do
+      let(:matter) { 'Section 8 orders' }
+      it 'returns true' do
+        expect(proceeding_type.section8?).to be true
+      end
+    end
+
+    context 'not section 8' do
+      let(:matter) { 'Domestic Abuse' }
+      it 'returns false' do
+        expect(proceeding_type.section8?).to be false
+      end
+    end
+  end
 end

--- a/spec/services/ccms/attribute_configuration_spec.rb
+++ b/spec/services/ccms/attribute_configuration_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 module CCMS
-  RSpec.describe AttributeConfiguration do
+  RSpec.describe AttributeConfiguration, :ccms do
     before do
       allow_any_instance_of(described_class).to receive(:configuration_files).and_return(mock_configuration)
     end

--- a/spec/services/ccms/attribute_value_generator_spec.rb
+++ b/spec/services/ccms/attribute_value_generator_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 module CCMS
-  RSpec.describe AttributeValueGenerator do
+  RSpec.describe AttributeValueGenerator, :ccms do
     let(:submission) { create :submission }
     let(:value_generator) { AttributeValueGenerator.new(submission) }
 

--- a/spec/services/ccms/case_add_requestor_factory_spec.rb
+++ b/spec/services/ccms/case_add_requestor_factory_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 module CCMS
-  RSpec.describe CaseAddRequestorFactory do
+  RSpec.describe CaseAddRequestorFactory, :ccms do
     let(:submission) { create :submission, legal_aid_application: legal_aid_application }
 
     context 'passported' do

--- a/spec/services/ccms/manual_review_determiner_spec.rb
+++ b/spec/services/ccms/manual_review_determiner_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 module CCMS
-  RSpec.describe ManualReviewDeterminer do
+  RSpec.describe ManualReviewDeterminer, :ccms do
     let(:setting) { Setting.setting }
     let!(:cfe_submission) { create :cfe_submission, legal_aid_application: legal_aid_application }
     let(:determiner) { described_class.new(legal_aid_application) }

--- a/spec/services/ccms/parsers/applicant_add_response_parser_spec.rb
+++ b/spec/services/ccms/parsers/applicant_add_response_parser_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 module CCMS
   module Parsers
-    RSpec.describe ApplicantAddResponseParser do
+    RSpec.describe ApplicantAddResponseParser, :ccms do
       let(:expected_tx_id) { '20190301030405123456' }
 
       context 'successful response' do

--- a/spec/services/ccms/parsers/applicant_add_status_response_parser_spec.rb
+++ b/spec/services/ccms/parsers/applicant_add_status_response_parser_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 module CCMS
   module Parsers
-    RSpec.describe ApplicantAddStatusResponseParser do
+    RSpec.describe ApplicantAddStatusResponseParser, :ccms do
       let(:response_xml) { ccms_data_from_file 'applicant_add_status_response.xml' }
       let(:expected_tx_id) { '20190301030405123456' }
       let(:expected_applicant_ccms_reference) { '20910584' }

--- a/spec/services/ccms/parsers/applicant_search_response_parser_spec.rb
+++ b/spec/services/ccms/parsers/applicant_search_response_parser_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 module CCMS
   module Parsers
-    RSpec.describe ApplicantSearchResponseParser do
+    RSpec.describe ApplicantSearchResponseParser, :ccms do
       describe 'parsing applicant search responses' do
         let(:no_results_response_xml) { ccms_data_from_file 'applicant_search_response_no_results.xml' }
         let(:one_result_response_xml) { ccms_data_from_file 'applicant_search_response_one_result.xml' }

--- a/spec/services/ccms/parsers/case_add_response_parser_spec.rb
+++ b/spec/services/ccms/parsers/case_add_response_parser_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 module CCMS
   module Parsers
-    RSpec.describe CaseAddResponseParser do
+    RSpec.describe CaseAddResponseParser, :ccms do
       let(:expected_tx_id) { '20190301030405123456' }
 
       context 'successful response' do

--- a/spec/services/ccms/parsers/case_add_status_response_parser_spec.rb
+++ b/spec/services/ccms/parsers/case_add_status_response_parser_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 module CCMS
   module Parsers
-    RSpec.describe CaseAddStatusResponseParser do
+    RSpec.describe CaseAddStatusResponseParser, :ccms do
       context 'successful response' do
         describe '#success?' do
           let(:expected_tx_id) { '20190301030405123456' }

--- a/spec/services/ccms/parsers/document_id_response_parser_spec.rb
+++ b/spec/services/ccms/parsers/document_id_response_parser_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 module CCMS
   module Parsers
-    RSpec.describe DocumentIdResponseParser do
+    RSpec.describe DocumentIdResponseParser, :ccms do
       let(:response_xml) { ccms_data_from_file 'document_id_response.xml' }
       let(:expected_tx_id) { '20190301030405123456' }
       let(:expected_document_id) { '4420073' }

--- a/spec/services/ccms/parsers/document_upload_response_parser_spec.rb
+++ b/spec/services/ccms/parsers/document_upload_response_parser_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 module CCMS
   module Parsers
-    RSpec.describe DocumentUploadResponseParser do
+    RSpec.describe DocumentUploadResponseParser, :ccms do
       describe '#success?' do
         let(:response_xml) { ccms_data_from_file 'document_upload_response.xml' }
         let(:expected_tx_id) { '20190301030405123456' }

--- a/spec/services/ccms/parsers/reference_data_response_parser_spec.rb
+++ b/spec/services/ccms/parsers/reference_data_response_parser_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 module CCMS
   module Parsers
-    RSpec.describe ReferenceDataResponseParser do
+    RSpec.describe ReferenceDataResponseParser, :ccms do
       let(:expected_tx_id) { '20190301030405123456' }
       let(:expected_reference_number) { '300000135140' }
 

--- a/spec/services/ccms/payload_generators/entity_attributes_generator_spec.rb
+++ b/spec/services/ccms/payload_generators/entity_attributes_generator_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 module CCMS
   module PayloadGenerators
-    RSpec.describe EntityAttributesGenerator do
+    RSpec.describe EntityAttributesGenerator, :ccms do
       let(:generator) { described_class.new(requestor, xml, entity_name, options) }
       let(:requestor) { double CCMS::Requestors::CaseAddRequestor, submission: submission, ccms_attribute_keys: yaml_keys }
       let(:submission) { double CCMS::Submission, id: '34343434', legal_aid_application: legal_aid_application }

--- a/spec/services/ccms/requestors/applicant_add_requestor_spec.rb
+++ b/spec/services/ccms/requestors/applicant_add_requestor_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 module CCMS
   module Requestors
-    RSpec.describe ApplicantAddRequestor do
+    RSpec.describe ApplicantAddRequestor, :ccms do
       let(:expected_xml) { ccms_data_from_file 'applicant_add_request.xml' }
       let(:expected_tx_id) { '20190101121530000000' }
 

--- a/spec/services/ccms/requestors/applicant_add_status_requestor_spec.rb
+++ b/spec/services/ccms/requestors/applicant_add_status_requestor_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 module CCMS
   module Requestors
-    RSpec.describe ApplicantAddStatusRequestor do
+    RSpec.describe ApplicantAddStatusRequestor, :ccms do
       let(:expected_xml) { ccms_data_from_file 'applicant_add_status_request.xml' }
       let(:expected_tx_id) { '20190101121530000000' }
       let(:requestor) { described_class.new(expected_tx_id, 'my_login') }

--- a/spec/services/ccms/requestors/applicant_search_requestor_spec.rb
+++ b/spec/services/ccms/requestors/applicant_search_requestor_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 module CCMS
   module Requestors
-    RSpec.describe ApplicantSearchRequestor do
+    RSpec.describe ApplicantSearchRequestor, :ccms do
       let(:expected_xml) { ccms_data_from_file 'applicant_search_request.xml' }
       let(:expected_tx_id) { '20190101121530000000' }
       let(:applicant) do

--- a/spec/services/ccms/requestors/case_add_requestor_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 module CCMS
   module Requestors
-    RSpec.describe CaseAddRequestor do
+    RSpec.describe CaseAddRequestor, :ccms do
       describe '#call' do
         let(:expected_tx_id) { '202011241154290000006983477' }
 

--- a/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_additional_property_attributes_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_additional_property_attributes_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 module CCMS
   module Requestors # rubocop:disable Metrics/ModuleLength
-    RSpec.describe NonPassportedCaseAddRequestor do
+    RSpec.describe NonPassportedCaseAddRequestor, :ccms do
       context 'XML request' do
         let(:expected_tx_id) { '201904011604570390059770666' }
         let(:firm) { create :firm, name: 'Firm1' }

--- a/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_attributes_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_attributes_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 module CCMS
   module Requestors # rubocop:disable Metrics/ModuleLength
-    RSpec.describe NonPassportedCaseAddRequestor do
+    RSpec.describe NonPassportedCaseAddRequestor, :ccms do
       context 'XML request' do
         let(:expected_tx_id) { '201904011604570390059770666' }
         let(:firm) { create :firm, name: 'Firm1' }

--- a/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_benefits_attrs_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_benefits_attrs_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 module CCMS
   module Requestors # rubocop:disable Metrics/ModuleLength
-    RSpec.describe NonPassportedCaseAddRequestor do
+    RSpec.describe NonPassportedCaseAddRequestor, :ccms do
       context 'XML request' do
         let(:expected_tx_id) { '201904011604570390059770666' }
         let(:proceeding_type) { legal_aid_application.application_proceeding_types.first.proceeding_type }

--- a/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_dependant_child_attributes_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_dependant_child_attributes_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 module CCMS
   module Requestors # rubocop:disable Metrics/ModuleLength
-    RSpec.describe NonPassportedCaseAddRequestor do
+    RSpec.describe NonPassportedCaseAddRequestor, :ccms do
       context 'XML request' do
         let(:expected_tx_id) { '201904011604570390059770666' }
         let(:firm) { create :firm, name: 'Firm1' }

--- a/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_entities_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_entities_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 module CCMS
   module Requestors # rubocop:disable Metrics/ModuleLength
-    RSpec.describe NonPassportedCaseAddRequestor do
+    RSpec.describe NonPassportedCaseAddRequestor, :ccms do
       context 'XML request' do
         let(:expected_tx_id) { '201904011604570390059770666' }
         let(:proceeding_type) { create :proceeding_type, :with_real_data }

--- a/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_variable_attributes_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_variable_attributes_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 module CCMS
   module Requestors # rubocop:disable Metrics/ModuleLength
-    RSpec.describe NonPassportedCaseAddRequestor do
+    RSpec.describe NonPassportedCaseAddRequestor, :ccms do
       context 'XML request' do
         let(:expected_tx_id) { '201904011604570390059770666' }
         let(:firm) { create :firm, name: 'Firm1' }

--- a/spec/services/ccms/requestors/case_add_requestor_xml_blocks/passported_attributes_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_xml_blocks/passported_attributes_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 module CCMS
   module Requestors # rubocop:disable Metrics/ModuleLength
-    RSpec.describe CaseAddRequestor do
+    RSpec.describe CaseAddRequestor, :ccms do
       context 'XML request' do
         let(:expected_tx_id) { '201904011604570390059770666' }
         let(:firm) { create :firm, name: 'Firm1' }

--- a/spec/services/ccms/requestors/case_add_status_requestor_spec.rb
+++ b/spec/services/ccms/requestors/case_add_status_requestor_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 module CCMS
   module Requestors
-    RSpec.describe CaseAddStatusRequestor do
+    RSpec.describe CaseAddStatusRequestor, :ccms do
       let(:expected_xml) { ccms_data_from_file 'case_add_status_request.xml' }
       let(:expected_tx_id) { '20190101121530000000' }
       let(:requestor) { described_class.new(expected_tx_id, 'my_login') }

--- a/spec/services/ccms/requestors/document_id_requestor_spec.rb
+++ b/spec/services/ccms/requestors/document_id_requestor_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 module CCMS
   module Requestors
-    RSpec.describe DocumentIdRequestor do
+    RSpec.describe DocumentIdRequestor, :ccms do
       let(:expected_xml) { ccms_data_from_file 'document_id_request.xml' }
       let(:expected_tx_id) { '20190101121530000000' }
       let(:case_ccms_reference) { '1234567890' }

--- a/spec/services/ccms/requestors/document_upload_requestor_spec.rb
+++ b/spec/services/ccms/requestors/document_upload_requestor_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 module CCMS
   module Requestors
-    RSpec.describe DocumentUploadRequestor do
+    RSpec.describe DocumentUploadRequestor, :ccms do
       let(:expected_xml) { ccms_data_from_file 'document_upload_request.xml' }
       let(:expected_tx_id) { '20190101121530000000' }
       let(:case_ccms_reference) { '1234567890' }

--- a/spec/services/ccms/requestors/reference_data_requestor_spec.rb
+++ b/spec/services/ccms/requestors/reference_data_requestor_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 module CCMS
   module Requestors
-    RSpec.describe ReferenceDataRequestor do
+    RSpec.describe ReferenceDataRequestor, :ccms do
       let(:expected_xml) { ccms_data_from_file 'reference_data_request.xml' }
       let(:expected_tx_id) { '20190101121530000000' }
       let(:requestor) { described_class.new('my_login') }

--- a/spec/services/ccms/submitters/add_applicant_service_spec.rb
+++ b/spec/services/ccms/submitters/add_applicant_service_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 module CCMS
   module Submitters # rubocop:disable Metrics/ModuleLength
-    RSpec.describe AddApplicantService do
+    RSpec.describe AddApplicantService, :ccms do
       let(:legal_aid_application) { create :legal_aid_application, :with_applicant_and_address }
       let(:applicant) { legal_aid_application.applicant }
       let(:address) { applicant.address }

--- a/spec/services/ccms/submitters/add_case_service_spec.rb
+++ b/spec/services/ccms/submitters/add_case_service_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 module CCMS
   module Submitters # rubocop:disable Metrics/ModuleLength
-    RSpec.describe AddCaseService do
+    RSpec.describe AddCaseService, :ccms do
       let(:legal_aid_application) do
         create :legal_aid_application,
                :with_proceeding_types,

--- a/spec/services/ccms/submitters/check_applicant_status_service_spec.rb
+++ b/spec/services/ccms/submitters/check_applicant_status_service_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 module CCMS
   module Submitters # rubocop:disable Metrics/ModuleLength
-    RSpec.describe CheckApplicantStatusService do
+    RSpec.describe CheckApplicantStatusService, :ccms do
       let(:submission) { create :submission, :applicant_submitted }
       let(:history) { SubmissionHistory.find_by(submission_id: submission.id) }
       let(:response_body) { ccms_data_from_file 'applicant_add_status_response.xml' }

--- a/spec/services/ccms/submitters/check_case_status_service_spec.rb
+++ b/spec/services/ccms/submitters/check_case_status_service_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe CCMS::Submitters::CheckCaseStatusService do
+RSpec.describe CCMS::Submitters::CheckCaseStatusService, :ccms do
   let(:submission) { create :submission, :case_submitted }
   let(:case_add_status_requestor) { double CCMS::Requestors::CaseAddStatusRequestor }
   let(:history) { CCMS::SubmissionHistory.find_by(submission_id: submission.id) }

--- a/spec/services/ccms/submitters/obtain_applicant_reference_service_spec.rb
+++ b/spec/services/ccms/submitters/obtain_applicant_reference_service_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 module CCMS
   module Submitters # rubocop:disable Metrics/ModuleLength
-    RSpec.describe ObtainApplicantReferenceService do
+    RSpec.describe ObtainApplicantReferenceService, :ccms do
       let(:legal_aid_application) { create :legal_aid_application, :with_proceeding_types, :with_everything_and_address, populate_vehicle: true }
       let(:applicant) { legal_aid_application.applicant }
       let(:submission) { create :submission, :case_ref_obtained, legal_aid_application: legal_aid_application }

--- a/spec/services/ccms/submitters/obtain_case_reference_service_spec.rb
+++ b/spec/services/ccms/submitters/obtain_case_reference_service_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 module CCMS
   module Submitters
-    RSpec.describe ObtainCaseReferenceService do
+    RSpec.describe ObtainCaseReferenceService, :ccms do
       let(:legal_aid_application) { create :legal_aid_application }
       let(:submission) { create :submission, legal_aid_application: legal_aid_application }
       let(:history) { SubmissionHistory.find_by(submission_id: submission.id) }

--- a/spec/services/ccms/submitters/obtain_document_id_service_spec.rb
+++ b/spec/services/ccms/submitters/obtain_document_id_service_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 module CCMS
   module Submitters # rubocop:disable Metrics/ModuleLength
-    RSpec.describe ObtainDocumentIdService do
+    RSpec.describe ObtainDocumentIdService, :ccms do
       let(:legal_aid_application) do
         create :legal_aid_application,
                :with_applicant,

--- a/spec/services/ccms/submitters/upload_documents_service_spec.rb
+++ b/spec/services/ccms/submitters/upload_documents_service_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe CCMS::Submitters::UploadDocumentsService do
+RSpec.describe CCMS::Submitters::UploadDocumentsService, :ccms do
   let(:legal_aid_application) do
     create :legal_aid_application,
            :with_applicant,

--- a/spec/services/pdf_converter_spec.rb
+++ b/spec/services/pdf_converter_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe PdfConverter do
   subject do
     described_class.call(attachment.id)
   end
+  before { allow(Libreconv).to receive(:convert) }
   context 'when attachment is statement of case' do
     let(:statement_of_case) { create :statement_of_case }
     let(:file) { OpenStruct.new(name: 'hello_world.pdf', content_type: 'application/pdf') }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -59,6 +59,8 @@ VCR.configure do |vcr_config|
 end
 
 RSpec.configure do |config|
+  config.filter_run_excluding :i18n
+
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,12 +25,13 @@ unless ENV['NOCOVERAGE']
     add_filter 'spec/'
     add_filter 'services/migration_helpers/'
     add_filter 'config/environments/'
+    add_filter 'app/services/ccms/' unless ENV['INC_CCMS']
   end
 
   SimpleCov.formatter = SimpleCov::Formatter::Codecov if ENV['CODECOV_TOKEN']
 
   SimpleCov.at_exit do
-    say("<%= color('Code coverage below 100%', RED) %>") if SimpleCov.result.coverage_statistics[:line].percent < 100
+    say("<%= color('Code coverage below 100%', RED) %>") if SimpleCov.result.coverage_statistics[:line].percent < SimpleCov.minimum_coverage[:line]
     SimpleCov.result.format!
   end
 end
@@ -60,6 +61,7 @@ end
 
 RSpec.configure do |config|
   config.filter_run_excluding :i18n
+  config.filter_run_excluding :ccms unless ENV['INC_CCMS']
 
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2429)

### Stub out libreconv
As we only expect it to be called, not necessarily testing the outcome.
This reduces the time taken to run `rspec spec/services/pdf_converter_spec.rb`
from `Finished in 23.84 seconds` to `Finished in 1.63 seconds`

### Remove LibreOffice from the CircleCI

As we are stubbing it we may not need to install it ...
It has reduced the `install_packages_for_testing` step time from `55s` to `21s`

### Remove the i18n rspec tests

These could be run as a separate shell script via a github action?
It can be removed as it doesn't affect coverage

### Remove the ccms rspec tests

There are ~600 CCMS service tests and they take almost half the time to run the full suite.
As they rarely change, they have been tagged in rspec with `:ccms` and ignored by default

To run the CCMS tests locally, if you are changing the values you can run rspec with `INC_CCMS=true bundle exec rspec` and they will not be ignored and the coverage will be monitored

### Add scheduled, overnight, jobs

There a github action that runs:
* i18n checks _only_ at 7.05AM 

And a circle job that runs each night
* rspec (including ccms, excluding i18n) at 2:15AM

Both of them will output a message to the standard dev alerts channel when they fail

# Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase master`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
