### PR TITLE
Tech-Debt: Remove unused gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,6 @@ ruby '3.0.2'
 
 gem 'aasm', '~> 5.2.0'
 gem 'active_model_serializers', '~> 0.10.12'
-gem 'after_commit_everywhere', '~> 1.0'
 gem 'discard', '~> 1.2'
 gem 'geckoboard-ruby'
 gem 'govuk_notify_rails', '~> 2.1.2'
@@ -139,7 +138,6 @@ end
 group :test do
   gem 'axe-core-cucumber'
   gem 'capybara', '>= 3.32.2', '< 4.0'
-  gem 'climate_control' # Allows environment variables to be modified within specs
   gem 'codecov', require: false
   gem 'cucumber', require: false
   gem 'cucumber-rails', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,8 +87,6 @@ GEM
       zeitwerk (~> 2.3)
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
-    after_commit_everywhere (1.0.0)
-      activerecord (>= 4.2)
     akami (1.3.1)
       gyoku (>= 0.4.0)
       nokogiri
@@ -154,7 +152,6 @@ GEM
     childprocess (3.0.0)
     chronic_duration (0.10.6)
       numerizer (~> 0.1.1)
-    climate_control (1.0.1)
     codecov (0.5.2)
       simplecov (>= 0.15, < 0.22)
     coderay (1.1.3)
@@ -694,7 +691,6 @@ DEPENDENCIES
   aasm (~> 5.2.0)
   active_model_serializers (~> 0.10.12)
   addressable
-  after_commit_everywhere (~> 1.0)
   awesome_print (~> 1.9.2)
   aws-sdk-s3
   axe-core-cucumber
@@ -703,7 +699,6 @@ DEPENDENCIES
   business
   byebug
   capybara (>= 3.32.2, < 4.0)
-  climate_control
   codecov
   cucumber
   cucumber-rails

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -90,12 +90,6 @@ Shoulda::Matchers.configure do |config|
   end
 end
 
-# Modify ENV variables within a spec. See:
-#   https://github.com/thoughtbot/climate_control
-def with_modified_env(options, &block)
-  ClimateControl.modify(options, &block)
-end
-
 def uploaded_file(path, content_type = nil, binary: false)
   Rack::Test::UploadedFile.new(Rails.root.join(path), content_type, binary)
 end


### PR DESCRIPTION
## What

The after_commit_everywhere was being flagged as a dependabot update
but I could find no use or invocation of it in the application

The ClimateControl gem was configured in rails_helper but, again,
never invoked

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase master`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
