### PR TITLE
AP-2416: Handle accented characters

### DIFF
--- a/app/controllers/concerns/providers/application_dependable.rb
+++ b/app/controllers/concerns/providers/application_dependable.rb
@@ -13,6 +13,7 @@ module Providers
     end
 
     included do
+      before_action :encode_upload_header
       before_action :set_legal_aid_application
 
       def legal_aid_application
@@ -40,6 +41,29 @@ module Providers
       def provider_step
         respond_to?(:current_step) ? __send__(:current_step) : controller_name
       end
+
+      def encode_upload_header(x_params = nil)
+        return unless request.content_mime_type&.symbol == :multipart_form
+
+        x_params ||= params
+
+        x_params.each do |_k, v|
+          case v
+          when ActionController::Parameters
+            encode_upload_header(v)
+          when ActionDispatch::Http::UploadedFile
+            encode_header(v.headers)
+          end
+        end
+      end
+
+      # :nocov:
+      def encode_header(headers)
+        headers.encode!(Encoding::UTF_8)
+      rescue EncodingError
+        headers.force_encoding(Encoding::UTF_8)
+      end
+      # :nocov:
     end
   end
 end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2416)

This was impossible to test in code, I wrote explicit Rspec and cucumber tests and they all passed, including `BROWSER=chrome cucumber`

Then I found [this unmerged PR](https://github.com/rails/rails/pull/41517) to fix it but in the meantime I used the fix from the original issue [here](https://github.com/rails/rails/issues/38080#issuecomment-589856401) and tested in browser

Because the headers do not seem to be generated when running tests the encode_header block needs `:nocov:` because the tests never hit it 😢 

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase master`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
