### PR TITLE
TechDebt: Improve ccms test handling

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,7 +173,12 @@ jobs:
         command: bin/rails javascript_tests
     - run:
         name: Run ruby tests
-        command: bundle exec rspec --format progress --format RspecJunitFormatter -o /tmp/test-results/rspec/rspec.xml
+        command: |
+          COMMITS_IN_BRANCH=$(git rev-list master.. --count)
+          ALL_FILES_CHANGED=$(git diff --name-only HEAD~$COMMITS_IN_BRANCH)
+          CCMS_FILES_CHANGED=$((echo "$ALL_FILES_CHANGED" | grep "/services/ccms\S*\." || true) | wc -l)
+          CCMS_TESTS_SHOULD_RUN=$(if [ "$CCMS_FILES_CHANGED" -ne "0" ]; then echo true; fi)
+          INC_CCMS=$CCMS_TESTS_SHOULD_RUN bundle exec rspec --format progress --format RspecJunitFormatter -o /tmp/test-results/rspec/rspec.xml
     - store_test_results:
         path: /tmp/test-results/rspec
     - store_artifacts:

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,7 +25,7 @@ unless ENV['NOCOVERAGE']
     add_filter 'spec/'
     add_filter 'services/migration_helpers/'
     add_filter 'config/environments/'
-    add_filter 'app/services/ccms/' unless ENV['INC_CCMS']
+    add_filter 'app/services/ccms/' unless ENV['INC_CCMS'].to_s == 'true'
   end
 
   SimpleCov.formatter = SimpleCov::Formatter::Codecov if ENV['CODECOV_TOKEN']
@@ -61,7 +61,7 @@ end
 
 RSpec.configure do |config|
   config.filter_run_excluding :i18n
-  config.filter_run_excluding :ccms unless ENV['INC_CCMS']
+  config.filter_run_excluding :ccms unless ENV['INC_CCMS'].to_s == 'true'
 
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest


### PR DESCRIPTION
## What

This adds some git & bash magic to the circle ci job.
If your commits on a branch include changes to files that match the regex `/services/ccms/*.*` the standard circle unit test job will run the CCMS tests too.

The overnight job will still run to ensure nothing slips through, but this should increase confidence that CCMS changes are monitored without having to manually run jobs

> ### Things to note
> The first unit_test should have taken the reduced time
> The TEMP commit should run all the tests because I changed a file that matched the /service/ccms/. pattern
> 
> Once this has been approved, I'll remove the temp commit, it's only to prove the theory

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase master`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
