### PR TITLE
AP-2453: Revert CI to only use main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -257,7 +257,7 @@ jobs:
           docker push "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${REPO_NAME}:${CIRCLE_SHA1}"
 
           case "${CIRCLE_BRANCH}" in
-            master|main)
+            main)
               docker tag app "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${REPO_NAME}:latest"
               docker push "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${REPO_NAME}:latest"
           esac
@@ -362,7 +362,7 @@ workflows:
       - lint_checks:
           filters:
             branches:
-              ignore: (master|main)
+              ignore: main
       - build_and_push:
           requires:
           - lint_checks
@@ -381,7 +381,7 @@ workflows:
       - lint_checks:
           filters:
             branches:
-              only: (master|main)
+              only: main
       - build_and_push:
           requires:
           - lint_checks
@@ -429,7 +429,7 @@ workflows:
         cron: "0 2 * * *"
         filters:
           branches:
-            only: (master|main)
+            only: main
     jobs:
     - clean_up_ecr
 
@@ -439,6 +439,6 @@ workflows:
         cron: "15 2 * * *"
         filters:
           branches:
-            only: (master|main)
+            only: main
     jobs:
     - full_unit_tests

--- a/.github/workflows/anonymise_check.yml
+++ b/.github/workflows/anonymise_check.yml
@@ -1,9 +1,9 @@
 name: Check anonymise rules
 on:
   push:
-    branches: [master, main]
+    branches: [main]
   pull_request:
-    branches: [master, main]
+    branches: [main]
 
 jobs:
   check-anonymise-rules:

--- a/.github/workflows/brakeman-analysis.yml
+++ b/.github/workflows/brakeman-analysis.yml
@@ -6,9 +6,9 @@ name: Brakeman Scan
 # This section configures the trigger for the workflow. Feel free to customize depending on your convention
 on:
   push:
-    branches: [master, main]
+    branches: [main]
   pull_request:
-    branches: [master, main]
+    branches: [main]
 
 jobs:
   brakeman-scan:


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2453)

Revert the CI changes to only use main from now on

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
