### PR TITLE
AP-2463 improve proceedings search keyboard navigation

### DIFF
--- a/app/views/providers/proceedings_types/index.html.erb
+++ b/app/views/providers/proceedings_types/index.html.erb
@@ -43,13 +43,18 @@
     local: true) do |form| %>
     <div class="govuk-grid-row govuk-!-margin-top-0">
       <div id="proceeding-list" class="govuk-grid-column-two-thirds govuk-list govuk-!-margin-bottom-0">
-        <%= render partial: 'shared/forms/proceedings_types/proceeding_type_form',
-                   collection: @proceeding_types,
-                   as: :proceeding_type,
-                   locals: {
-                     model: nil,
-                     form: form
-                   } %>
+          <%= form.govuk_radio_buttons_fieldset :id, legend: {text: nil, hidden: true} do %>
+            <% @proceeding_types.each do |proceeding_type| %>
+              <div id="<%= proceeding_type.code %>" class="govuk-grid-row proceeding-item">
+                <%= form.govuk_radio_button(
+                        :id,
+                        proceeding_type.id,
+                        label: {text: proceeding_type.meaning},
+                        hint: {text: "#{proceeding_type.ccms_category_law} (#{proceeding_type.ccms_matter})"}
+                      ) %>
+              </div>
+            <% end %>
+          <% end %>
       </div>
     </div>
     <div class="govuk-grid-row no-proceeding-items" style="display: none;">

--- a/app/views/shared/forms/proceedings_types/_proceeding_type_form.html.erb
+++ b/app/views/shared/forms/proceedings_types/_proceeding_type_form.html.erb
@@ -1,8 +1,0 @@
-<div id="<%= proceeding_type.code %>" class="govuk-grid-row proceeding-item" tabindex="0">
-  <%= form.govuk_radio_button(
-          :id,
-          proceeding_type.id,
-          label: {text: proceeding_type.meaning},
-          hint: {text: "#{proceeding_type.ccms_category_law} (#{proceeding_type.ccms_matter})"}
-      ) %>
-</div>

--- a/features/step_definitions/civil_journey_steps.rb
+++ b/features/step_definitions/civil_journey_steps.rb
@@ -621,16 +621,16 @@ Then(/^proceeding search field is empty$/) do
 end
 
 Then(/^the results section is empty$/) do
-  expect(page).to_not have_css('#proceeding-list > .proceeding-item')
+  expect(page).to_not have_css('#proceeding-list .proceeding-item')
 end
 
 Then(/^proceeding suggestions has (results|no results)$/) do |results|
   wait_for_ajax
   case results
   when 'results'
-    expect(page).to have_css('#proceeding-list > .proceeding-item')
+    expect(page).to have_css('#proceeding-list .proceeding-item')
   when 'no results'
-    expect(page).to_not have_css('#proceeding-list > .proceeding-item')
+    expect(page).to_not have_css('#proceeding-list .proceeding-item')
   end
 end
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2463)

Remove tabindex which was causing unusual tabbing behaviour
Updated index page to use formbuilder fieldset and removed separate template

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
