### PR TITLE
Tech-Debt: Remove sidekiq alive

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,7 +59,6 @@ gem 'jwt'
 # background processing
 gem 'redis-namespace'
 gem 'sidekiq', '~> 6.3.1'
-gem 'sidekiq_alive', '>= 2.0.1'
 gem 'sidekiq-status', '>= 1.1.4'
 
 # URL and path parsing

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -617,8 +617,6 @@ GEM
     sidekiq-status (2.1.0)
       chronic_duration
       sidekiq (>= 5.0)
-    sidekiq_alive (2.1.2)
-      sidekiq
     simplecov (0.21.2)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -770,7 +768,6 @@ DEPENDENCIES
   shoulda-matchers (~> 5.0)
   sidekiq (~> 6.3.1)
   sidekiq-status (>= 1.1.4)
-  sidekiq_alive (>= 2.0.1)
   simple_command!
   simplecov
   simplecov-rcov

--- a/bin/sidekiq_health_check
+++ b/bin/sidekiq_health_check
@@ -1,0 +1,9 @@
+#!/usr/bin/env ruby
+
+module Worker
+  def self.healthcheck
+    abort 'sidekiq not found' unless system('pgrep -f sidekiq')
+  end
+end
+
+Worker.healthcheck

--- a/helm_deploy/apply-for-legal-aid/templates/deployment_worker.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/deployment_worker.yaml
@@ -35,15 +35,13 @@ spec:
           ports:
             - containerPort: 7433
           livenessProbe:
-            httpGet:
-              path: /
-              port: 7433
+            exec:
+              command: ['bin/sidekiq_health_check']
             initialDelaySeconds: 60
             timeoutSeconds: 5
           readinessProbe:
-            httpGet:
-              path: /
-              port: 7433
+            exec:
+              command: ['bin/sidekiq_health_check']
             initialDelaySeconds: 60
             timeoutSeconds: 5
           lifecycle:


### PR DESCRIPTION
## What

Test to see if removing sidekiq alive is feasible in Apply (and maybe others?)

It doesn't help with the sidekiq gem update but it does reduce our gemfile size?

Should we remove it or close and ignore this PR?

| Remove sidekiq alive | close and kill this PR | user |
| :-: |:-: |---|
| yes |  | @colinbruce 
| yes |  | @willc-work  
|  |  | @kmahern  
|  |  | @RoseSAK  
|  |  | @stephenrichards  
| yes |  | @mpw5  

Feel free to edit this comment with your response - if you care enough to comment! 😃 

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
