### PR TITLE
AP-2425 Display proceedings in correct order

### DIFF
--- a/app/webpack/src/modules/proceedings.js
+++ b/app/webpack/src/modules/proceedings.js
@@ -109,7 +109,8 @@ function searchOnUserInput (searchInputBox) {
 function showResults (results, inputText) {
   if (results.length > 0) {
     const codes = results.map(obj => obj.code);
-    codes.forEach(code => {
+    const proceedingsContainer = document.querySelector('.govuk-radios')
+    codes.forEach((code, idx) => {
       // const element = $('#' + code)
       const element = document.getElementById(code);
 
@@ -134,6 +135,8 @@ function showResults (results, inputText) {
           span.innerHTML = span.innerHTML.replace(regExp, '<mark class="highlight">$&</mark>');
         }
       })
+      // move to top of list, but after previously added elements
+      proceedingsContainer.insertBefore(element, proceedingsContainer.children[idx])
       // show hidden proceedings item
       show(element);
       hide(document.querySelector('.no-proceeding-items'));

--- a/app/webpack/src/modules/proceedings.js
+++ b/app/webpack/src/modules/proceedings.js
@@ -109,7 +109,8 @@ function searchOnUserInput (searchInputBox) {
 function showResults (results, inputText) {
   if (results.length > 0) {
     const codes = results.map(obj => obj.code);
-    const proceedingsContainer = document.querySelector('.govuk-radios')
+    let proceedingsContainer = document.querySelector('.govuk-radios') // with MP flag on
+    if (proceedingsContainer == null) { proceedingsContainer = document.querySelector('#proceeding-list') } // with MP flag off
     codes.forEach((code, idx) => {
       // const element = $('#' + code)
       const element = document.getElementById(code);


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2325)

The proceedings search results returned from the backend are ordered by relevance, but previously were displayed randomly in the frontend. They are now displayed in the correct order. 

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
