### PR TITLE
AP-2426 Fix highlighting of numbers in proceedings search results

### DIFF
--- a/app/webpack/src/modules/proceedings.js
+++ b/app/webpack/src/modules/proceedings.js
@@ -128,11 +128,9 @@ function showResults (results, inputText) {
       // Highlight any text that matches the user's input
       const terms = inputText.split(' ')
       terms.forEach(term => {
-        if (term.length > 2) {
-          const regExp = RegExp(term.trim(), 'gi');
-          main.innerHTML = main.innerHTML.replace(regExp, '<mark class="highlight">$&</mark>');
-          span.innerHTML = span.innerHTML.replace(regExp, '<mark class="highlight">$&</mark>');
-        }
+        const regExp = RegExp(term.trim(), 'gi');
+        main.innerHTML = main.innerHTML.replace(regExp, '<mark class="highlight">$&</mark>');
+        span.innerHTML = span.innerHTML.replace(regExp, '<mark class="highlight">$&</mark>');
       })
       // show hidden proceedings item
       show(element);


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2426)

Remove min length for highlighted terms so that numbers can be highlighted in the proceedings search results

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
