### PR TITLE
AP-2448 Add translation for failed address lookup

### DIFF
--- a/config/locales/en/forms.yml
+++ b/config/locales/en/forms.yml
@@ -4,7 +4,8 @@ en:
     address:
       errors:
         no_results: We could not find any addresses for that postcode. Enter the address manually.
-        unsuccessful: We could not find any addresses for that postcode. Enter the address manually.
+        unsuccessful: Sorry, there is a problem with the service. Please enter the address manually.
+        service_unavailable: Sorry, there is a problem with the service. Please enter the address manually.
     address_lookup:
       address_manual_link: Enter address manually
       heading: Enter your client's correspondence address


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2448)

If a postcode lookup fails due to a connection failure (eg if wifi is turned off), the user should see the manual address entry screen with an appropriate message however instead  an error is presented to the user.

This commit adds the correct wording to the `config/locales/en/forms.yml` locale. It also corrects the wording which is displayed when an unsuccessful response is received from the OS API, as it is currently a bit misleading (new wordings have been agreed with Jim.)

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
