### PR TITLE
Tech-Debt: Reduce Geckoboard noise

### DIFF
--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -53,7 +53,6 @@ class LegalAidApplication < ApplicationRecord
   end
 
   after_save do
-    ActiveSupport::Notifications.instrument 'dashboard.delegated_functions_used' if used_delegated_functions?
     ActiveSupport::Notifications.instrument 'dashboard.declined_open_banking' if saved_change_to_open_banking_consent?
     ActiveSupport::Notifications.instrument('dashboard.provider_updated', provider_id: provider.id) if proc { |laa| laa.state }.eql?(:assessment_submitted)
   end

--- a/app/services/dashboard_event_handler.rb
+++ b/app/services/dashboard_event_handler.rb
@@ -34,7 +34,7 @@ class DashboardEventHandler
 
   def valid_events
     %w[application_created provider_updated ccms_submission_saved firm_created feedback_created
-       application_submitted delegated_functions_used declined_open_banking applicant_emailed]
+       application_submitted declined_open_banking applicant_emailed]
   end
 
   def application_created
@@ -63,10 +63,6 @@ class DashboardEventHandler
   end
 
   def application_submitted
-    Dashboard::UpdaterJob.perform_later('Applications')
-  end
-
-  def delegated_functions_used
     Dashboard::UpdaterJob.perform_later('Applications')
   end
 

--- a/spec/services/dashboard_event_handler_spec.rb
+++ b/spec/services/dashboard_event_handler_spec.rb
@@ -114,20 +114,6 @@ RSpec.describe DashboardEventHandler do
     end
   end
 
-  context 'delegated_functions_used' do
-    subject { create :legal_aid_application, :with_proceeding_types, :with_delegated_functions }
-    # let(:used_delegated_functions_reported_on) { Date.current }
-    # let(:used_delegated_functions_on) { rand(5).days.ago.to_date }
-
-    before { ActiveJob::Base.queue_adapter = :test }
-
-    after { ActiveJob::Base.queue_adapter = :sidekiq }
-
-    it 'fires the Applications job' do
-      expect { subject }.to have_enqueued_job(Dashboard::UpdaterJob).with('Applications').at_least(1).times
-    end
-  end
-
   context 'application completed' do
     let(:legal_aid_application) { create :legal_aid_application, :with_proceeding_types, :with_delegated_functions }
     let(:used_delegated_functions_reported_on) { Date.current }


### PR DESCRIPTION
## What

We were getting a lot of noise on sentry from geckoboard re:
> Geckoboard::UnexpectedStatusError
> You have exceeded the API rate limit of 60 requests per minute. Try sending data less frequently

I think this may have been caused by the after_save hooks on LegalAidApplications, it was sending a  dashboard.delegated_functions_used every time the record was saved, so for each subsequent page save it would trigger.  

While debugging, it would actually send it 3 times on each page save!  
There used to be a separate data set but this metric is now recorded in the generic `applications` dataset and is therefore updated at many other stages, e.g. creation, submission, etc

Therefore removing this after_save hook will hopefully reduce the number of API pushes to geckoboard, reducing complaints!

Ignoring it in #2846 will help reduce sentry noise, this aims to reduce the impact on geckoboard too

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
