### PR TITLE
AP-2501 Incorrect legend on /check_client_details

### DIFF
--- a/app/views/providers/check_client_details/show.html.erb
+++ b/app/views/providers/check_client_details/show.html.erb
@@ -36,7 +36,7 @@
                                             options,
                                             :value,
                                             :label,
-                                            legend: { text: '' } %>
+                                            legend: nil %>
 
     <%= next_action_buttons(
           show_draft: true,


### PR DESCRIPTION
A [change](https://github.com/DFE-Digital/govuk-formbuilder/pull/308) to the DFE GOVUK Formbuilder has resulted in an incorrect legend being displayed for the radio buttons on `/check_client_details`

![image](https://user-images.githubusercontent.com/28729201/132233665-3fc36a06-4c06-4654-87a8-188fd5ed2972.png)

This is because `legend: { text: '' }` now falls back to the default value (`Check_client_details`) instead of not displaying a legend.

This commit replaces it with `legend: nil` so that no legend is displayed.

## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2501)

Describe what you did and why.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
