### PR TITLE
AP-2496 Add JS to deselect previously selected proceeding item

### DIFF
--- a/app/webpack/src/modules/proceedings.js
+++ b/app/webpack/src/modules/proceedings.js
@@ -103,11 +103,17 @@ function searchOnUserInput (searchInputBox) {
   }
 }
 
+function deselectPreviousProceedingItem () {
+  const selected = document.querySelector('input:checked')
+  if (selected !== null) { selected.checked = false }
+}
+
 // Find the existing hidden proceeding type items
 // If they are one of the search matches returned from the V1 api, remove the hidden class
 // and highlight the search terms in the item text
 function showResults (results, inputText) {
   if (results.length > 0) {
+    deselectPreviousProceedingItem()
     const codes = results.map(obj => obj.code);
     let proceedingsContainer = document.querySelector('.govuk-radios') // with MP flag on
     if (proceedingsContainer == null) { proceedingsContainer = document.querySelector('#proceeding-list') } // with MP flag off


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2496)

Deselect the previously selected proceeding item when a new search results are returned
This is to ensure the tabbing behaviour in the proceeding items results list works correctly

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
