### PR TITLE
Tech-Debt: Remove Faraday warnings

### DIFF
--- a/app/services/true_layer/api_client.rb
+++ b/app/services/true_layer/api_client.rb
@@ -57,7 +57,7 @@ module TrueLayer
 
     def connection
       @connection ||= Faraday.new(url: TRUE_LAYER_URL) do |conn|
-        conn.authorization :Bearer, token
+        conn.request :authorization, 'Bearer', token
         conn.response :logger if Rails.configuration.x.logs_faraday_response
         conn.adapter Faraday.default_adapter
       end

--- a/spec/models/aggregated_cash_income_spec.rb
+++ b/spec/models/aggregated_cash_income_spec.rb
@@ -70,6 +70,7 @@ RSpec.describe AggregatedCashIncome, type: :model do
         before do
           application.application_proceeding_types.first.update!(used_delegated_functions_on: Date.parse('2021-01-28'),
                                                                  used_delegated_functions_reported_on: Date.parse('2021-01-28'))
+          application.reload
         end
 
         it 'sets the months based on the delegated functions date' do


### PR DESCRIPTION
## What

There has been an update to faraday recently and it has made rspec very noisy.  This follows the guidance to update the handling of authorisation and remove the warnings

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
