### PR TITLE
AP-2500 remove title text for labelled elements

### DIFF
--- a/app/helpers/accessible_navigation_helper.rb
+++ b/app/helpers/accessible_navigation_helper.rb
@@ -14,7 +14,6 @@ module AccessibleNavigationHelper
     # match element label text only (excluding content tags) or use full label name
     name = name.scan(/^.+?(?=\s*<)/).first || name
     name = "#{name} #{suffix}" if suffix
-    options[:title] = name
     options[:aria] = { label: name }
     options
   end

--- a/spec/helpers/accessible_navigation_helper_spec.rb
+++ b/spec/helpers/accessible_navigation_helper_spec.rb
@@ -7,31 +7,31 @@ RSpec.describe AccessibleNavigationHelper, type: :helper do
     let(:html_options) { { class: 'gov_link' } }
 
     context 'with html options' do
-      it 'returns the html for a link with an aria-label, title attribute and other properties' do
+      it 'returns the html for a link with an aria-label and other properties' do
         link = link_to_accessible(name, path, html_options)
-        expect(link).to eq '<a class="gov_link" title="Start now" aria-label="Start now" href="test_path">Start now</a>'
+        expect(link).to eq '<a class="gov_link" aria-label="Start now" href="test_path">Start now</a>'
       end
     end
 
     context 'with suffix' do
       let(:html_options) { { class: 'gov_link', suffix: 'Application' } }
 
-      it 'returns with aria-label and title containing label name and suffix' do
+      it 'returns with aria-label containing label name and suffix' do
         link = link_to_accessible(name, path, html_options)
-        str = '<a class="gov_link" suffix="Application" title="Start now Application" aria-label="Start now Application" href="test_path">Start now</a>'
+        str = '<a class="gov_link" suffix="Application" aria-label="Start now Application" href="test_path">Start now</a>'
         expect(link).to eq str
       end
     end
 
     context 'with no html options' do
-      it 'returns the html for a link with an aria-label and title attribute' do
+      it 'returns the html for a link with an aria-label' do
         link = link_to_accessible(name, path)
-        expect(link).to eq '<a title="Start now" aria-label="Start now" href="test_path">Start now</a>'
+        expect(link).to eq '<a aria-label="Start now" href="test_path">Start now</a>'
       end
     end
 
     context 'with block only' do
-      it 'returns the html for a link without an aria-label and title attribute' do
+      it 'returns the html for a link without an aria-label' do
         link = link_to_accessible(path) { 'Start now' }
         expect(link).to eq '<a href="test_path">Start now</a>'
       end
@@ -44,18 +44,18 @@ RSpec.describe AccessibleNavigationHelper, type: :helper do
     let(:html_options) { { class: 'gov_button' } }
 
     context 'with html options' do
-      it 'returns the html for a button with an aria-label, title attribute and other properties' do
+      it 'returns the html for a button with an aria-label and other properties' do
         str = '<form class="button_to" method="post" action="test_path">'
-        str << '<input class="gov_button" title="Start now" aria-label="Start now" type="submit" value="Start now" /></form>'
+        str << '<input class="gov_button" aria-label="Start now" type="submit" value="Start now" /></form>'
         button = button_to_accessible(name, path, html_options)
         expect(button).to eq str
       end
     end
 
     context 'with no html options' do
-      it 'returns the html for a button with an aria-label and title attribute' do
+      it 'returns the html for a button with an aria-label' do
         str = '<form class="button_to" method="post" action="test_path">'
-        str << '<input title="Start now" aria-label="Start now" type="submit" value="Start now" /></form>'
+        str << '<input aria-label="Start now" type="submit" value="Start now" /></form>'
         button = button_to_accessible(name, path)
         expect(button).to eq str
       end
@@ -64,16 +64,16 @@ RSpec.describe AccessibleNavigationHelper, type: :helper do
     context 'with suffix' do
       let(:html_options) { { class: 'gov_button', suffix: 'Application' } }
 
-      it 'returns with aria-label and title containing label name and suffix' do
+      it 'returns with aria-label containing label name and suffix' do
         button = button_to_accessible(name, path, html_options)
         str = '<form class="button_to" method="post" action="test_path">'
-        str << '<input class="gov_button" suffix="Application" title="Start now Application" aria-label="Start now Application" type="submit" value="Start now" /></form>'
+        str << '<input class="gov_button" suffix="Application" aria-label="Start now Application" type="submit" value="Start now" /></form>'
         expect(button).to eq str
       end
     end
 
     context 'with block only' do
-      it 'returns the html for a button without an aria-label and title attribute' do
+      it 'returns the html for a button without an aria-label' do
         button = button_to_accessible(path) { 'Start now' }
         expect(button).to eq '<form class="button_to" method="post" action="test_path"><button type="submit">Start now</button></form>'
       end
@@ -82,23 +82,23 @@ RSpec.describe AccessibleNavigationHelper, type: :helper do
 
   describe '#set_accessible_properties' do
     context 'standard html label' do
-      it 'sets aria-labels and titles using the label name provided' do
+      it 'sets aria-labels using the label name provided' do
         options = set_accessible_properties('name', {})
-        expect(options).to eq({ aria: { label: 'name' }, title: 'name' })
+        expect(options).to eq({ aria: { label: 'name' } })
       end
     end
 
     context 'html label with suffix' do
-      it 'sets aria-labels and titles using the label name provided' do
+      it 'sets aria-labels using the label name provided' do
         options = set_accessible_properties('Change', { suffix: 'First Name' })
-        expect(options).to eq({ aria: { label: 'Change First Name' }, suffix: 'First Name', title: 'Change First Name' })
+        expect(options).to eq({ aria: { label: 'Change First Name' }, suffix: 'First Name' })
       end
     end
 
     context 'html label with content tagging' do
-      it 'sets aria-labels and titles using just the content of the label name provided' do
+      it 'sets aria-labels using just the content of the label name provided' do
         options = set_accessible_properties('Start now <svg label="label"></svg>', {})
-        expect(options).to eq({ aria: { label: 'Start now' }, title: 'Start now' })
+        expect(options).to eq({ aria: { label: 'Start now' } })
       end
     end
   end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2500)

Removes the line in the accessibility helper method that automatically adds a title attribute to elements  
 - it is unnecessary duplication of text/info which also causes a WAVE warning
 - further reasons for not using the title attribute: https://www.tpgi.com/using-the-html-title-attribute/ 

Updates unit tests 

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
