### PR TITLE
Remove pii from Kibana logs

### DIFF
--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -1,4 +1,20 @@
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.
-Rails.application.config.filter_parameters += %i[password statement]
+Rails.application.config.filter_parameters += %i[
+  password
+  statement
+  name
+  date_of_birth
+  national_insurance_number
+  address
+  city
+  county
+  post_code
+  email
+  emergency_cost_reasons
+  understands_terms_of_court_order_details
+  warning_letter_sent_details
+  bail_conditions_set_details
+  success_prospect_details_marginal
+]


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2060)

- Currently we are logging some pii information to Kibana
- Went through the provider and citizen journeys attempting to find where this data was being logged.
- The examples I found were all caused by Rails parameter logging and can be filtered by adding to filter_parameter_logging.rb
- I have also included as many free text fields as possible on the basis that these could contain pii.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
