### PR TITLE
AP-2510 Remove data seed from schema migration

### DIFF
--- a/db/migrate/20210913150028_re_seed.rb
+++ b/db/migrate/20210913150028_re_seed.rb
@@ -1,9 +1,0 @@
-class ReSeed < ActiveRecord::Migration[6.1]
-  def up
-    ProceedingType.populate
-  end
-
-  def down
-    nil
-  end
-end


### PR DESCRIPTION

## Remove data seed from schema migration

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2510)

Data seeding in database schema migrations can cause problems later on.  This removes the code to populate the 
DefaultCostLimitation table.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
