### PR TITLE
AP-2506: Improve handling of email errors

### DIFF
--- a/app/services/govuk_emails/delivery_man.rb
+++ b/app/services/govuk_emails/delivery_man.rb
@@ -19,6 +19,8 @@ module GovukEmails
       return unless scheduled_mail.waiting? # in case another job has picked it up
 
       eligible_for_delivery? ? deliver_now : cancel!
+    rescue Notifications::Client::BadRequestError
+      @scheduled_mail.cancel!
     rescue StandardError => e
       Sentry.capture_exception(e)
     end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2506)

When we send an email to an unallowed account using Notify on non-live environments it returns a BadRequestError.

These will never succeed, but previously we stored the ScheduledMail and kept retrying.  This now traps the error and swallows it so sentry will not get excessive alerts, it also cancels the ScheduledMail so that subsequent attempts will not occur

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
