### PR TITLE
AP-2531 Cronjob Logging

### DIFF
--- a/app/jobs/reports_uploader_job.rb
+++ b/app/jobs/reports_uploader_job.rb
@@ -2,7 +2,7 @@ class ReportsUploaderJob < ApplicationJob
   # :nocov:
   def perform # rubocop:disable Metrics/AbcSize Layout/LineLength
     Rails.logger.info "ReportsUploaderJob - starting at #{Time.zone.now}"
-    if admin_report.submitted_applications && admin_report.submitted_applications.blob
+    unless admin_report.submitted_applications&.blob.nil?
       Rails.logger.info 'ReportsUploaderJon - preexisting record as follows:'
       Rails.logger.info "ReportsUploaderJon - blob key: #{admin_report.submitted_applications.blob.key}, blob_id: #{admin_report.submitted_applications.blob.id}"
     end

--- a/app/jobs/reports_uploader_job.rb
+++ b/app/jobs/reports_uploader_job.rb
@@ -1,23 +1,57 @@
 class ReportsUploaderJob < ApplicationJob
-  def perform
+  # :nocov:
+  def perform # rubocop:disable Metrics/AbcSize Layout/LineLength
+    Rails.logger.info "ReportsUploaderJob - starting at #{Time.zone.now}"
+    if admin_report.submitted_applications && admin_report.submitted_applications.blob
+      Rails.logger.info 'ReportsUploaderJon - preexisting record as follows:'
+      Rails.logger.info "ReportsUploaderJon - blob key: #{admin_report.submitted_applications.blob.key}, blob_id: #{admin_report.submitted_applications.blob.id}"
+    end
     upload_submitted_applications
     upload_non_passported_applications
     admin_report.save
+    # rubocop:disable Layout/LineLength
+    Rails.logger.info "ReportsUploaderJob - Submitted applications report attached as blob with key #{admin_report.submitted_applications.blob.key}, blob_id: #{admin_report.submitted_applications.blob.id}"
+    Rails.logger.info "ReportsUploaderJob - Non Passported applications report attached as blob with key: #{admin_report.non_passported_applications.blob.key}, blob_id: #{admin_report.non_passported_applications.blob.id}"
+    Rails.logger.info "ReportsUploaderJob - AdminReport record updated at #{admin_report.updated_at}"
+    # rubocop:enable Layout/LineLength
+
+    log_scheduled_sidekiq_jobs
   end
 
   private
 
   def upload_submitted_applications
+    Rails.logger.info "ReportsUploaderJob - creating submitted applications report at #{Time.zone.now}"
     data = Reports::MIS::ApplicationDetailsReport.new.run
+    Rails.logger.info "ReportsUploaderJob - submitted applications report completed at #{Time.zone.now}"
     admin_report.submitted_applications.attach io: StringIO.new(data), filename: 'submitted_applications_report', content_type: 'text/csv'
   end
 
   def upload_non_passported_applications
+    Rails.logger.info "ReportsUploaderJob - creating submitted applications report at #{Time.zone.now}"
     data = Reports::MIS::NonPassportedApplicationsReport.new.run
+    Rails.logger.info "ReportsUploaderJob - submitted applications report completed at #{Time.zone.now}"
     admin_report.non_passported_applications.attach io: StringIO.new(data), filename: 'non_passported_applications_report', content_type: 'text/csv'
   end
 
   def admin_report
     @admin_report ||= AdminReport.first || AdminReport.create!
   end
+
+  def log_scheduled_sidekiq_jobs
+    ss = Sidekiq::ScheduledSet.new
+    Rails.logger.info "Sidekiq Scheduled set size: #{ss.size}"
+    ss.each { |job| log_job(job) }
+  end
+
+  def log_job(job) # rubocop:disable Metrics/AbcSize
+    Rails.logger.info '>>>>>>>'
+    Rails.logger.info "    JID: #{job.jid}"
+    Rails.logger.info "    Queue: #{job.queue}"
+    Rails.logger.info "    Class: #{job.item['class']}"
+    Rails.logger.info "    Args: #{job.item['args']}"
+    Rails.logger.info "    Created: #{Time.zone.at(job.created_at)}"
+    Rails.logger.info "    Scheduled: #{Time.zone.at(job.score)}"
+  end
+  # :nocov:
 end

--- a/helm_deploy/apply-for-legal-aid/templates/cronjob-admin-report.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/cronjob-admin-report.yaml
@@ -10,11 +10,14 @@ metadata:
 spec:
   schedule: '0 20 * * *'
   concurrencyPolicy: Forbid
-  successfulJobsHistoryLimit: 0
+  successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 0
   jobTemplate:
     spec:
       template:
+        metadata:
+          labels:
+            reportuploader: cronjob
         spec:
           containers:
           - name: daily-admin-report

--- a/lib/tasks/jobs/create_admin_reports.rake
+++ b/lib/tasks/jobs/create_admin_reports.rake
@@ -2,6 +2,7 @@ namespace :job do
   namespace :admin_reports do
     desc 'Upload admin reports'
     task upload: :environment do
+      Rails.logger.info "rake job:admin_reports:upload started at #{Time.zone.now}"
       ReportsUploaderJob.perform_now
     end
   end

--- a/spec/models/legal_aid_application_spec.rb
+++ b/spec/models/legal_aid_application_spec.rb
@@ -473,8 +473,8 @@ RSpec.describe LegalAidApplication, type: :model do
       application_proceeding_names = result.map(&:name)
       proceeding_names = legal_aid_application.application_proceeding_types.map { |type| ProceedingType.find(type.proceeding_type_id).name }
 
-      expect(application_proceeding_types).to eq(legal_aid_application.application_proceeding_types)
-      expect(application_proceeding_names).to eq(proceeding_names)
+      expect(application_proceeding_types).to match_array(legal_aid_application.application_proceeding_types)
+      expect(application_proceeding_names).to match_array(proceeding_names)
     end
   end
 


### PR DESCRIPTION
## Add debugging log messages to the ReportsUploaderJob

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2531)

This is an interim PR to help us get to the bottom of what is happening to the Submitted Applications report, which appears to be deleted from S3 storage sometime after creation.

This PR does two things:
- set the cronjob `successfulJobsHistoryLimit` value to 3 so that the containers stay around and enable us to view the logs
- Adds lots of debugging logs to the `ReportsUploaderJob`

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
