### PR TITLE
Fix default for alert_via_sentry

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_13_150028) do
+ActiveRecord::Schema.define(version: 2021_09_13_110123) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -751,7 +751,7 @@ ActiveRecord::Schema.define(version: 2021_09_13_150028) do
     t.boolean "allow_welsh_translation", default: false, null: false
     t.boolean "allow_multiple_proceedings", default: false, null: false
     t.boolean "enable_ccms_submission", default: true, null: false
-    t.boolean "alert_via_sentry", default: false, null: false
+    t.boolean "alert_via_sentry", default: true, null: false
   end
 
   create_table "state_machine_proxies", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/models/setting_spec.rb
+++ b/spec/models/setting_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Setting do
         expect(rec.allow_welsh_translation?).to be false
         expect(rec.allow_multiple_proceedings?).to be false
         expect(rec.bank_transaction_filename).to eq 'db/sample_data/bank_transactions.csv'
-        expect(rec.alert_via_sentry?).to be false
+        expect(rec.alert_via_sentry?).to be true
       end
     end
 
@@ -52,7 +52,7 @@ RSpec.describe Setting do
       expect(Setting.allow_multiple_proceedings?).to be false
       expect(Setting.enable_ccms_submission?).to be true
       expect(Setting.bank_transaction_filename).to eq 'db/sample_data/bank_transactions.csv'
-      expect(Setting.alert_via_sentry?).to be false
+      expect(Setting.alert_via_sentry?).to be true
     end
   end
 end


### PR DESCRIPTION
## What

The `alert_via_sentry` setting should default to `true` but a migration hasn't run properly and is defaulting to `false`. This updates the schema and related tests.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
