### PR TITLE
AP-2532 Ensure state is changed before changing state machine

### DIFF
--- a/app/services/flow/flows/provider_dwp_override.rb
+++ b/app/services/flow/flows/provider_dwp_override.rb
@@ -9,6 +9,7 @@ module Flow
               application.change_state_machine_type('NonPassportedStateMachine')
               :applicant_employed
             else
+              application.check_applicant_details! unless application.checking_applicant_details?
               application.change_state_machine_type('PassportedStateMachine')
               :check_client_details
             end

--- a/features/providers/civil_application_journey.feature
+++ b/features/providers/civil_application_journey.feature
@@ -853,6 +853,36 @@ Feature: Civil application journeys
     Then I should be on a page showing 'Is your client employed?'
 
   @javascript @vcr
+  Scenario: When Provider accepts non-passported DWP result, continues, then goes back to change
+    Given I complete the non-passported journey as far as check your answers
+    Then I click 'Save and continue'
+    Then I should be on a page showing 'DWP records show that your client does not receive a passporting benefit – is this correct?'
+    Then I choose 'Yes'
+    And I click 'Continue'
+    And I should be on a page showing 'Is your client employed?'
+    And I choose 'No'
+    And I click 'Save and continue'
+    And I should be on a page showing 'Check if you can continue using this service'
+    And I click link 'Back'
+    And I should be on a page showing 'Is your client employed?'
+    And I click link 'Back'
+    And I should be on a page showing 'DWP records show that your client does not receive a passporting benefit – is this correct?'
+    Then I choose 'No, my client receives a passporting benefit'
+    And I click 'Continue'
+    And I should be on a page showing "Check your client's details"
+    Then I choose 'These details are correct'
+    And I click 'Save and continue'
+    And I should be on a page showing 'Which passporting benefit does your client receive?'
+    Then I choose 'Universal Credit'
+    And I click 'Save and continue'
+    Then I should be on a page showing 'Do you have evidence that your client receives Universal Credit?'
+    And I choose 'Yes'
+    And I click 'Save and continue'
+    Then I should be on a page showing 'You'll need to tell us if your client:'
+    And I click 'Save and continue'
+    And I should be on a page showing 'Does your client own the home that they live in?'
+
+  @javascript @vcr
   Scenario: Allows return to, and proceed from, Delegated Function date view
     Given I start the journey as far as the applicant page
     Then I enter name 'Test', 'User'


### PR DESCRIPTION
## Ensure state is changed before changing state machine



This PR fixes the issue no. 2 on ticket AP-2531:  Sentry alert : https://sentry.io/organizations/ministryofjustice/issues/2677034844/events/370f371176584f4a8b4588ef6baa9cbc/

The exception occurs when an applicant is not recognised as receiving passporting benefits by the DWP checker, and the provider continues before going back to override the DWP Benefit check result.  At that point, the state machine, which was the `NonPassportedStateMachine` is changed

[Link to story](https://dsdmoj.atlassian.net/browse/AP-XXX)

Describe what you did and why.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
