### PR TITLE
AP-2533 file validation

### DIFF
--- a/app/views/providers/application_merits_task/statement_of_cases/show.html.erb
+++ b/app/views/providers/application_merits_task/statement_of_cases/show.html.erb
@@ -22,6 +22,9 @@
 
     <%= form.govuk_error_summary %>
 
+    <%= render partial: 'shared/forms/error_summary_hidden', locals: { error_message: t('.file_not_uploaded_error'),
+                                                                field_id: 'application-merits-task-statement-of-case-original-file-field' } %>
+
     <%= form.govuk_fieldset legend: {text: page_title, tag: 'h1', size: 'xl'} do %>
 
       <p class="govuk-body"><%= t('generic.tell_us') %></p>

--- a/app/views/shared/forms/_error_summary_hidden.html.erb
+++ b/app/views/shared/forms/_error_summary_hidden.html.erb
@@ -1,0 +1,14 @@
+<% error_message = local_assigns[:error_message] ? error_message : t('generic.errors.problem_text')
+   field_id = local_assigns[:field_id] ? field_id : '#' %>
+<div class="govuk-error-summary hidden" id="error-summary-hideable" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
+    <h2 class="govuk-error-summary__title" id="error-summary-title">
+        <%= t('generic.errors.problem_text') %>
+    </h2>
+    <div class="govuk-error-summary__body">
+        <ul class="govuk-list govuk-error-summary__list">
+            <li>
+                <%= link_to_accessible error_message, "##{field_id}" %>
+            </li>
+        </ul>
+    </div>
+</div>

--- a/app/webpack/src/file-upload-validation.js
+++ b/app/webpack/src/file-upload-validation.js
@@ -1,0 +1,19 @@
+import { hide, show } from './helpers';
+
+document.addEventListener('DOMContentLoaded', event => {
+  const fileUploadFields = document.querySelectorAll('[id$="-original-file-field"]')
+  if (fileUploadFields.length) {
+    const errorSummary = document.querySelector('#error-summary-hideable')
+    document.querySelector('#continue').addEventListener('click', (e) => {
+      fileUploadFields.forEach((field) => {
+        if (field.value) {
+          e.preventDefault()
+          show(errorSummary)
+          errorSummary.focus()
+        } else {
+          hide(errorSummary)
+        }
+      })
+    })
+  }
+})

--- a/app/webpack/src/file-upload-validation.js
+++ b/app/webpack/src/file-upload-validation.js
@@ -1,5 +1,24 @@
 import { hide, show } from './helpers';
 
+const ERROR_MESSAGE_TEXT = 'Upload the chosen file'
+
+function createErrorMessage () {
+  const errorMessage = document.createElement('span')
+  errorMessage.classList.add('govuk-error-message')
+  errorMessage.innerHTML = ERROR_MESSAGE_TEXT
+  const accessibilityMessage = document.createElement('span')
+  accessibilityMessage.classList.add('govuk-visually-hidden')
+  accessibilityMessage.innerHTML = 'Error: '
+  errorMessage.appendChild(accessibilityMessage)
+  return errorMessage
+}
+
+function addErrorMsgToField (input) {
+  const errorMessage = createErrorMessage()
+  input.parentNode.insertBefore(errorMessage, input)
+  input.parentNode.classList.add('govuk-form-group--error')
+}
+
 document.addEventListener('DOMContentLoaded', event => {
   const fileUploadFields = document.querySelectorAll('[id$="-original-file-field"]')
   if (fileUploadFields.length) {
@@ -8,6 +27,7 @@ document.addEventListener('DOMContentLoaded', event => {
       fileUploadFields.forEach((field) => {
         if (field.value) {
           e.preventDefault()
+          addErrorMsgToField(field)
           show(errorSummary)
           errorSummary.focus()
         } else {
@@ -17,3 +37,4 @@ document.addEventListener('DOMContentLoaded', event => {
     })
   }
 })
+

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -338,6 +338,7 @@ en:
           size_hint: The maximum file size is 7MB. You can attach more than one file.
           warning: Warning
           warning_text: You must provide a complete statement now. You will not be able to upload a statement later.
+          file_not_uploaded_error: Upload the chosen file
         uploaded_files:
           delete: Delete
           filename: Filename


### PR DESCRIPTION

## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2533)

Added validation to file upload pages (statement of case and gateway evidence)
Use JS to check whether a file has been selected but not uploaded, and if so display an error message

TODO:
- [ ] Add cucumber tests for file upload pages

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
