### PR TITLE
Improve test code coverage about invalid uploaded file header

### DIFF
--- a/app/controllers/concerns/providers/application_dependable.rb
+++ b/app/controllers/concerns/providers/application_dependable.rb
@@ -57,13 +57,11 @@ module Providers
         end
       end
 
-      # :nocov:
       def encode_header(headers)
         headers.encode!(Encoding::UTF_8)
       rescue EncodingError
         headers.force_encoding(Encoding::UTF_8)
       end
-      # :nocov:
     end
   end
 end

--- a/spec/requests/providers/gateway_evidence_spec.rb
+++ b/spec/requests/providers/gateway_evidence_spec.rb
@@ -133,6 +133,19 @@ module Providers
           end
         end
 
+        context 'with invalid uploaded file header' do
+          let(:original_file) { uploaded_file('spec/fixtures/files/documents/hello_world.docx', 'application/vnd.openxmlformats-officedocument.wordprocessingml.document') }
+
+          before do
+            allow_any_instance_of(Http::UploadedFile).to receive(:head).and_return("\xC3hello_world.docx".force_encoding(Encoding::ASCII_8BIT))
+          end
+
+          it 'updates the record' do
+            subject
+            expect(gateway_evidence.original_attachments.first).to be_present
+          end
+        end
+
         context 'no file chosen' do
           let(:original_file) { nil }
 


### PR DESCRIPTION
## What

On #2785 @colinbruce fixes a recurrent issue with an invalid header when an user attempts to upload a file. This pr try to add a test to cover this issue.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
