### PR TITLE
AP-2615 LegalAidApplication - use Proceeding

### DIFF
--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -130,10 +130,12 @@ class LegalAidApplication < ApplicationRecord
     _prefix: true
   )
 
+  # TODO: remove this once LFA migration is complete. Replaced by #lead_proceeding below
   def lead_proceeding_type
     ProceedingType.find(lead_application_proceeding_type.proceeding_type_id)
   end
 
+  # TODO: remove this once LFA migration is complete. Replaced by #lead_proceeding below
   def lead_application_proceeding_type
     application_proceeding_types.find_by(lead_proceeding: true)
   end
@@ -142,6 +144,7 @@ class LegalAidApplication < ApplicationRecord
     proceedings.find_by(lead_proceeding: true)
   end
 
+  # TODO: remove this once LFA migration is complete. Replaced by #find_or_set_lead_proceeding below
   def find_or_create_lead_proceeding_type
     apt = lead_application_proceeding_type
     if apt.nil?
@@ -160,6 +163,7 @@ class LegalAidApplication < ApplicationRecord
     lead_proc
   end
 
+  # TODO: remove this once LFA migration is complete. Replaced by #proceedings_by_name below
   def application_proceedings_by_name
     # returns an array of OpenStructs containing:
     # - name of the proceeding type

--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -138,6 +138,10 @@ class LegalAidApplication < ApplicationRecord
     application_proceeding_types.find_by(lead_proceeding: true)
   end
 
+  def lead_proceeding
+    proceedings.find_by(lead_proceeding: true)
+  end
+
   def find_or_create_lead_proceeding_type
     apt = lead_application_proceeding_type
     if apt.nil?

--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -16,7 +16,7 @@ class LegalAidApplication < ApplicationRecord
   belongs_to :office, optional: true
   has_many :application_proceeding_types, inverse_of: :legal_aid_application, dependent: :destroy
   has_many :proceedings, dependent: :destroy
-  has_many :chances_of_success, through: :application_proceeding_types
+  has_many :chances_of_success, through: :proceedings
   has_many :attachments, dependent: :destroy
   has_many :proceeding_types, through: :application_proceeding_types
   has_one :benefit_check_result, dependent: :destroy

--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -26,7 +26,7 @@ class LegalAidApplication < ApplicationRecord
   has_one :gateway_evidence, dependent: :destroy
   has_one :opponent, class_name: 'ApplicationMeritsTask::Opponent', dependent: :destroy
   has_one :latest_incident, -> { order(occurred_on: :desc) }, class_name: 'ApplicationMeritsTask::Incident', inverse_of: :legal_aid_application, dependent: :destroy
-  has_many :attempts_to_settles, class_name: 'ProceedingMeritsTask::AttemptsToSettle', through: :application_proceeding_types
+  has_many :attempts_to_settles, class_name: 'ProceedingMeritsTask::AttemptsToSettle', through: :proceedings
   has_many :legal_aid_application_transaction_types, dependent: :destroy
   has_many :transaction_types, through: :legal_aid_application_transaction_types
   has_many :cash_transactions, dependent: :destroy

--- a/app/models/proceeding.rb
+++ b/app/models/proceeding.rb
@@ -11,6 +11,8 @@ class Proceeding < ApplicationRecord
            through: :proceeding_linked_children,
            source: :involved_child
 
+  scope :in_order_of_addition, -> { order(:created_at) }
+
   # TODO: remove once migration from application_proceeding_types to proceedings is completed
   #
   # temporary method to create test data from existing proceeding types

--- a/spec/factories/legal_aid_applications.rb
+++ b/spec/factories/legal_aid_applications.rb
@@ -211,6 +211,33 @@ FactoryBot.define do
       merits_submitted_at { Time.current }
     end
 
+    # :with_proceedings trait
+    # ============================
+    # takes optional arguments
+    #    proceeding as the lead proceeding
+    #  - proceeding_count, (1 is assumed if absent) - will generate random proceeding.
+    #
+    # examples:
+    #   - create :legal_aid_application, :with_proceedings
+    #   - create :legal_aid_application, :with_proceedings, proceeding_count: 3
+    #
+    # Note that the first domestic_abuse proceeding will be set as lead proceeding
+    trait :with_proceedings do
+      transient do
+        proceeding_count { 1 }
+        assign_lead_proceeding { true }
+      end
+
+      after(:create) do |application, evaluator|
+        raise ':with_proceedings trait can only have a proceeding count of 1 or 2' unless evaluator.proceeding_count.in?([1, 2])
+
+        traits = %i[da001 se014]
+        (0..evaluator.proceeding_count - 1).each do |i|
+          create :proceeding, traits[i], legal_aid_application: application, lead_proceeding: i == 0
+        end
+      end
+    end
+
     # :with_proceeding_types trait
     # ============================
     # takes optional arguments

--- a/spec/factories/proceedings.rb
+++ b/spec/factories/proceedings.rb
@@ -25,6 +25,52 @@ FactoryBot.define do
       name { 'inherent_jurisdiction_high_court_injunction' }
     end
 
+    trait :da004 do
+      lead_proceeding { false }
+      ccms_code { 'DA004' }
+      meaning { 'Non-molestation order' }
+      description { 'to be represented on an application for a non-molestation order.' }
+      substantive_cost_limitation { rand(1...1_000_000.0).round(2) }
+      delegated_functions_cost_limitation { rand(1...1_000_000.0).round(2) }
+      substantive_scope_limitation_code { 'AA019' }
+      substantive_scope_limitation_meaning { 'Injunction FLA-to final hearing' }
+      substantive_scope_limitation_description { 'Limited to all steps up to and including final hearing and any action necessary to implement (but not enforce) the order.' }
+      delegated_functions_scope_limitation_code { 'CV117' }
+      delegated_functions_scope_limitation_meaning { 'Interim order inc. return date' }
+      delegated_functions_scope_limitation_description do
+        'As to proceedings under Part IV Family Law Act 1996 limited to all steps up to and including obtaining and serving a
+         final order and in the event of breach leading to the exercise of a power of arrest to representation on the consideration
+         of the breach by the court (but excluding applying for a warrant of arrest, if not attached, and representation in contempt proceedings).'
+      end
+      used_delegated_functions_on { nil }
+      used_delegated_functions_reported_on { nil }
+      name { 'nonmolestation_order' }
+    end
+
+    trait :se013 do
+      lead_proceeding { false }
+      ccms_code { 'SE013' }
+      meaning { 'Child arrangements order (contact)' }
+      description { 'to be represented on an application for a child arrangements order –where the child(ren) will live' }
+      substantive_cost_limitation { rand(1...1_000_000.0).round(2) }
+      delegated_functions_cost_limitation { rand(1...1_000_000.0).round(2) }
+      substantive_scope_limitation_code { 'FM059' }
+      substantive_scope_limitation_meaning { 'FHH Children' }
+      substantive_scope_limitation_description do
+        'Limited to Family Help (Higher) and to all steps necessary to negotiate and conclude a settlement.
+        To include the issue of proceedings and representation in those proceedings save in relation to or at a contested final hearing.'
+      end
+      delegated_functions_scope_limitation_code { 'CV117' }
+      delegated_functions_scope_limitation_meaning { 'Interim order inc. return date' }
+      delegated_functions_scope_limitation_description do
+        'Limited to Family Help (Higher) and to all steps necessary to negotiate and conclude a settlement.
+        To include the issue of proceedings and representation in those proceedings save in relation to or at a contested final hearing.'
+      end
+      used_delegated_functions_on { nil }
+      used_delegated_functions_reported_on { nil }
+      name { 'child_arrangements_order_contact' }
+    end
+
     trait :se014 do
       lead_proceeding { false }
       ccms_code { 'SE014' }
@@ -46,7 +92,7 @@ FactoryBot.define do
       end
       used_delegated_functions_on { nil }
       used_delegated_functions_reported_on { nil }
-      name { 'child_arrangements_order_contact' }
+      name { 'child_arrangements_order_residence' }
     end
   end
 end

--- a/spec/factory_specs/legal_aid_application_factory_spec.rb
+++ b/spec/factory_specs/legal_aid_application_factory_spec.rb
@@ -181,7 +181,7 @@ RSpec.describe 'LegalAidApplication factory' do
       it 'attaches the scope limitation to the lead proceeding type as the default substantive' do
         subject
         expect(ProceedingTypeScopeLimitation.count).to eq 1
-        expect(laa.proceeding_types.first.default_substantive_scope_limitation).to eq ScopeLimitation.first
+        expect(laa.lead_proceeding_type.default_substantive_scope_limitation).to eq ScopeLimitation.first
       end
 
       it 'assigns the scope limitation to the application_proceeding_type' do

--- a/spec/models/legal_aid_application_spec.rb
+++ b/spec/models/legal_aid_application_spec.rb
@@ -1016,4 +1016,18 @@ RSpec.describe LegalAidApplication, type: :model do
       expect(legal_aid_application.year_to_calculation_date).to eq [expected_start_date, calc_date]
     end
   end
+
+  describe '#chances of success' do
+    let(:laa) { create :legal_aid_application, :with_proceedings, proceeding_count: 2 }
+    let(:proceeding_da001) { laa.proceedings.detect { |p| p.ccms_code == 'DA001' } }
+    let(:proceeding_se014) { laa.proceedings.detect { |p| p.ccms_code == 'SE014' } }
+
+    it 'returns an array of all the  chances of success records' do
+      # TODO: remove the :with_application_proceeding_type trait once LFA conversion is complete and application_proceeding_type is no longer a required field on chances_of_success
+      cos_da001 = create :chances_of_success, :with_application_proceeding_type, proceeding: proceeding_da001
+      cos_se014 = create :chances_of_success, :with_application_proceeding_type, proceeding: proceeding_se014
+
+      expect(laa.chances_of_success).to match_array([cos_da001, cos_se014])
+    end
+  end
 end

--- a/spec/models/legal_aid_application_spec.rb
+++ b/spec/models/legal_aid_application_spec.rb
@@ -1043,7 +1043,15 @@ RSpec.describe LegalAidApplication, type: :model do
       ats_se014 = create :attempts_to_settles, proceeding: proceeding_se014, application_proceeding_type: apt
 
       expect(laa.attempts_to_settles).to match_array([ats_da001, ats_se014])
+    end
+  end
 
+  describe '#lead_proceeding' do
+    let(:laa) { create :legal_aid_application, :with_proceedings, proceeding_count: 2 }
+    let(:proceeding_da001) { laa.proceedings.detect{ |p| p.ccms_code == 'DA001' } }
+
+    it 'returns the domestic abuse proceeding' do
+      expect(laa.lead_proceeding).to eq proceeding_da001
     end
   end
 end

--- a/spec/models/legal_aid_application_spec.rb
+++ b/spec/models/legal_aid_application_spec.rb
@@ -1030,4 +1030,20 @@ RSpec.describe LegalAidApplication, type: :model do
       expect(laa.chances_of_success).to match_array([cos_da001, cos_se014])
     end
   end
+
+  describe '#attempts_to_settle' do
+    let(:laa) { create :legal_aid_application, :with_proceedings, proceeding_count: 2 }
+    let(:proceeding_da001) { laa.proceedings.detect { |p| p.ccms_code == 'DA001' } }
+    let(:proceeding_se014) { laa.proceedings.detect { |p| p.ccms_code == 'SE014' } }
+    let(:apt) { create :application_proceeding_type }
+
+    it 'returns an array of attempt_to_settle records attached to the application' do
+      # TODO: remove the application_proceeding_type from these lines once the LFA migration is complete and application_proceeding_type_id is no longer a required field on attempts_to_settle
+      ats_da001 = create :attempts_to_settles, proceeding: proceeding_da001, application_proceeding_type: apt
+      ats_se014 = create :attempts_to_settles, proceeding: proceeding_se014, application_proceeding_type: apt
+
+      expect(laa.attempts_to_settles).to match_array([ats_da001, ats_se014])
+
+    end
+  end
 end


### PR DESCRIPTION

## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2615)

- changed association `has_many :attempts_to_settle` to be made through `proceedings` rather than `application_proceeding_types`
- changed association `has_many :chances_of_success` to be made through `proceedings` rather than `application_proceeding_types`
- added method `#lead_proceeding` to replace `#lead_proceeding_type`
- added method `#find_or_set_lead_proceeding` to replace `#find_or_create_lead_proceeding_type`
- added_method '#proceedings_by_name` to replace `#application_proceedings_by_name`
- changed `#lowest_prospect_of_success` to use `proceedings` instead of `application_proceeding_types`
- added `with_proceedings` traits to legal aid application factory

Describe what you did and why.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
