### PR TITLE
AP-2593 Use Proceeding in ApplicationsDetailsCSVLine

### DIFF
--- a/app/models/application_proceeding_type.rb
+++ b/app/models/application_proceeding_type.rb
@@ -35,8 +35,6 @@ class ApplicationProceedingType < ApplicationRecord
 
   scope :using_delegated_functions, -> { where.not(used_delegated_functions_on: nil).order(:used_delegated_functions_on) }
 
-  scope :not_using_delegated_functions, -> { where(used_delegated_functions_on: nil) }
-
   before_save :check_only_one_lead_proceeding
 
   before_create do
@@ -79,10 +77,6 @@ class ApplicationProceedingType < ApplicationRecord
 
   def proceeding_case_p_num
     "P_#{proceeding_case_id}"
-  end
-
-  def pretty_df_date
-    used_delegated_functions_on&.strftime('%F') || 'n/a'
   end
 
   def proceeding

--- a/app/models/proceeding.rb
+++ b/app/models/proceeding.rb
@@ -12,6 +12,12 @@ class Proceeding < ApplicationRecord
            source: :involved_child
 
   scope :in_order_of_addition, -> { order(:created_at) }
+  scope :using_delegated_functions, -> { where.not(used_delegated_functions_on: nil).order(:used_delegated_functions_on) }
+  scope :not_using_delegated_functions, -> { where(used_delegated_functions_on: nil) }
+
+  def pretty_df_date
+    used_delegated_functions_on&.strftime('%F') || 'n/a'
+  end
 
   # TODO: remove once migration from application_proceeding_types to proceedings is completed
   #

--- a/app/services/reports/mis/application_detail_csv_line.rb
+++ b/app/services/reports/mis/application_detail_csv_line.rb
@@ -6,7 +6,6 @@ module Reports
       attr_reader :laa
 
       delegate :applicant_receives_benefit?,
-               :application_proceeding_types,
                :cash_transactions,
                :ccms_submission,
                :cfe_result,
@@ -18,13 +17,14 @@ module Reports
                :gateway_evidence,
                :involved_children,
                :irregular_incomes,
-               :lead_application_proceeding_type,
+               :lead_proceeding,
                :office,
                :other_assets_declaration,
                :outstanding_mortgage_amount,
                :own_home,
                :percentage_home,
                :proceeding_types,
+               :proceedings,
                :property_value,
                :provider,
                :opponent,
@@ -39,7 +39,7 @@ module Reports
                :lowest_prospect_of_success,
                :vehicle, to: :laa
 
-      delegate :chances_of_success, to: :lead_application_proceeding_type
+      delegate :chances_of_success, to: :lead_proceeding
 
       delegate :case_ccms_reference, to: :ccms_submission
 
@@ -201,12 +201,12 @@ module Reports
 
       def application_details
         @line << case_ccms_reference
-        @line << (application_proceeding_types.count > 1 ? 'Multi' : 'Single')
+        @line << (proceedings.count > 1 ? 'Multi' : 'Single')
       end
 
       def proceeding_details
         @line << proceeding_types.map(&:ccms_matter).uniq.sort.join(', ')
-        @line << application_proceeding_types.count
+        @line << proceedings.count
         @line << proceeding_types.map(&:meaning).sort.join(', ')
         @line << laspo_question
       end
@@ -231,7 +231,7 @@ module Reports
         @line << yesno(used_delegated_functions?)
         @line << proceedings_df_used
         @line << proceedings_df_not_used
-        @line << application_proceeding_types.map(&:pretty_df_date).join(', ')
+        @line << proceedings.map(&:pretty_df_date).join(', ')
         @line << (used_delegated_functions? ? used_delegated_functions_reported_on&.strftime('%Y-%m-%d') : '')
       end
 
@@ -383,11 +383,11 @@ module Reports
       end
 
       def proceedings_df_used
-        application_proceeding_types.using_delegated_functions.map { |apt| apt.proceeding_type.meaning }.join(', ')
+        proceedings.using_delegated_functions.map(&:meaning).join(', ')
       end
 
       def proceedings_df_not_used
-        application_proceeding_types.not_using_delegated_functions.map { |apt| apt.proceeding_type.meaning }.join(', ')
+        proceedings.not_using_delegated_functions.map(&:meaning).join(', ')
       end
     end
   end

--- a/spec/factories/legal_aid_applications.rb
+++ b/spec/factories/legal_aid_applications.rb
@@ -306,6 +306,7 @@ FactoryBot.define do
           raise 'At least one domestic abuse proceeding type must be added before you can use the :with_lead_proceeding_type trait' if da_pt.nil?
 
           application.application_proceeding_types.find_by(proceeding_type_id: da_pt.id).update!(lead_proceeding: true)
+          application.proceedings.find_by(name: da_pt.name).update!(lead_proceeding: true)
         end
         application.reload
       end
@@ -398,6 +399,9 @@ FactoryBot.define do
           apt.update!(used_delegated_functions_on: used_dates[i] || Date.current,
                       used_delegated_functions_reported_on: reported_dates[i] || Date.current)
           apt.delegated_functions_scope_limitation = apt.proceeding_type.default_delegated_functions_scope_limitation
+
+          application.proceedings.find_by(name: apt.proceeding_type.name).update!(used_delegated_functions_on: apt.used_delegated_functions_on,
+                                                                                  used_delegated_functions_reported_on: apt.used_delegated_functions_reported_on)
         end
       end
     end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-593)

Refactors the `ApplicationsDetailsCSVLine` model to use `Proceedings` instead of `ApplicationProceedingTypes`.

This requires moving some methods from the `ApplicationProceedingType` model to the `Proceeding` model, and some factory changes.

Note: this change leaves some references to `ApplicationProceedingType` in `application_detail_csv_line_spec`. These cannot be removed until the `ChancesOfSuccess` model has been refactored to remove reliance on `ApplicationProceedingTypes`.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
