### PR TITLE
AP-2623 Use Proceeding model in ApplicationHelper

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -93,7 +93,7 @@ module ApplicationHelper
                                                                focusable: 'false')
   end
 
-  def linked_children_names(application_proceeding_type)
-    application_proceeding_type.involved_children.map(&:full_name).join('</br>').html_safe
+  def linked_children_names(proceeding)
+    proceeding.involved_children.map(&:full_name).join('</br>').html_safe
   end
 end

--- a/app/views/shared/check_answers/_merits.html.erb
+++ b/app/views/shared/check_answers/_merits.html.erb
@@ -201,7 +201,7 @@
               name: "#{apt.id}_linked_children".to_sym,
               url: providers_merits_task_list_linked_children_path(apt),
               question: t('.items.linked_children'),
-              answer: linked_children_names(apt),
+              answer: linked_children_names(apt.proceeding),
               read_only: read_only
             ) %>
       </dl>


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2623)

Refactors the `linked_children_names` method to use a `Proceeding record` instead of an `ApplicationProceedingType` record, and updates the `views/shared/check_answers/_merits.html.erb` partial to reflect that change.

Note: this change doesn't remove any references to `ApplicationProceedingType` from the `_merits.html.erb` partial. This will be done in a separate ticket.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
