### PR TITLE
AP-2617 Use Proceedings in shared CYA partials

### DIFF
--- a/app/views/shared/check_answers/_emergency_limitations.html.erb
+++ b/app/views/shared/check_answers/_emergency_limitations.html.erb
@@ -6,12 +6,12 @@
       ) %>
   <%= check_answer_no_link(
         name: :incurrable_costs,
-        question: t(".costs"),
-        answer: gds_number_to_currency(@legal_aid_application.default_delegated_functions_cost_limitation,  precision: 0)
+        question: t('.costs'),
+        answer: gds_number_to_currency(@legal_aid_application.default_delegated_functions_cost_limitation, precision: 0)
       ) %>
   <%= check_answer_no_link(
         name: :allowable_work,
-        question: t(".work"),
-        answer: @legal_aid_application.application_proceeding_types.first.delegated_functions_scope_limitation.description
+        question: t('.work'),
+        answer: @legal_aid_application.lead_proceeding.delegated_functions_scope_limitation_description
       ) %>
 </dl>


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2617)

Updates `emergency_limitations` partial use `Proceeding` objects instead of `ApplicationProceedingType` objects. Also fixes a couple of minor stylistic things.


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
