### PR TITLE
AP-2603 Add digest_extracted_at field to Settings

### DIFF
--- a/db/migrate/20211102100659_add_digest_extracted_at_to_settings.rb
+++ b/db/migrate/20211102100659_add_digest_extracted_at_to_settings.rb
@@ -1,0 +1,5 @@
+class AddDigestExtractedAtToSettings < ActiveRecord::Migration[6.1]
+  def change
+    add_column :settings, :digest_extracted_at, :datetime, default: Time.zone.at(1)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_26_175246) do
+ActiveRecord::Schema.define(version: 2021_11_02_100659) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -799,6 +799,7 @@ ActiveRecord::Schema.define(version: 2021_10_26_175246) do
     t.boolean "allow_welsh_translation", default: false, null: false
     t.boolean "enable_ccms_submission", default: true, null: false
     t.boolean "alert_via_sentry", default: true, null: false
+    t.datetime "digest_extracted_at", default: "1970-01-01 00:00:01"
   end
 
   create_table "state_machine_proxies", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|


### PR DESCRIPTION

## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2603)

- Added field to record time of last data digest extract.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
