### PR TITLE
AP-2618 Use Proceedings on Limitations views

### DIFF
--- a/app/views/providers/limitations/_proceeding_type.html.erb
+++ b/app/views/providers/limitations/_proceeding_type.html.erb
@@ -21,22 +21,22 @@
       </summary>
 
       <div class="govuk-details__text">
-        <% type=proceeding_type.application_proceeding_type %>
-        <% if type.used_delegated_functions_on %>
-        <h4 class="govuk-heading-m"><%= t('.emergency_certificate') %></h4>
-        <p><strong><%= t('.form_of_service') %></strong>
-          <%= t('.form_of_service_type') %>
-        </p>
-        <p><strong><%= t('.allowable_work') %></strong>
-          <%= type.delegated_functions_scope_limitation.description %>
-        </p>
+        <% proceeding = proceeding_type.proceeding %>
+        <% if proceeding.used_delegated_functions_on %>
+          <h4 class="govuk-heading-m"><%= t('.emergency_certificate') %></h4>
+          <p><strong><%= t('.form_of_service') %></strong>
+            <%= t('.form_of_service_type') %>
+          </p>
+          <p><strong><%= t('.allowable_work') %></strong>
+            <%= proceeding.delegated_functions_scope_limitation_description %>
+          </p>
         <% end %>
         <h4 class="govuk-heading-m"><%= t('.substantive_certificate') %></h4>
         <p><strong><%= t('.form_of_service') %></strong>
           <%= t('.form_of_service_type') %>
         </p>
         <p><strong><%= t('.allowable_work') %></strong>
-          <%= type.substantive_scope_limitation.description %>
+          <%= proceeding.substantive_scope_limitation_description %>
         </p>
       </div>
     </details>

--- a/app/views/providers/limitations/_proceeding_types.html.erb
+++ b/app/views/providers/limitations/_proceeding_types.html.erb
@@ -5,7 +5,7 @@
 
   <dl class="govuk-summary-list govuk-!-padding-bottom-4">
     <%= render partial: 'providers/limitations/proceeding_type',
-               collection: @legal_aid_application.application_proceedings_by_name,
+               collection: @legal_aid_application.proceedings_by_name,
                locals: {translation_path: 'providers.limitations.show'} %>
   </dl>
 

--- a/app/views/providers/limitations/_proceeding_types_with_df.html.erb
+++ b/app/views/providers/limitations/_proceeding_types_with_df.html.erb
@@ -11,7 +11,7 @@
 
     <dl class="govuk-summary-list govuk-!-padding-bottom-4">
       <%= render partial: 'providers/limitations/proceeding_type',
-                 collection: @legal_aid_application.application_proceedings_by_name,
+                 collection: @legal_aid_application.proceedings_by_name,
                  locals: {translation_path: 'providers.limitations.show'} %>
     </dl>
 

--- a/features/accessibility/provider.feature
+++ b/features/accessibility/provider.feature
@@ -3,6 +3,7 @@ Feature: Provider accessibility
   @javascript @vcr
   Scenario: I start a new non-passported application and enter client details
     Given I am logged in as a provider
+    And I enable callbacks on ApplicationProceedingType
     Then I visit the application service
     And the page is accessible
     Then I click link "Start"
@@ -46,6 +47,7 @@ Feature: Provider accessibility
     Then I click 'Save and continue'
     Then I should be on a page showing "DWP records show that your client does not receive a passporting benefit – is this correct?"
     And the page is accessible
+    Then I disable callbacks on ApplicationProceedingType
 
   @javascript @vcr
   Scenario: I complete the financial assessment eligibility section for a non-passported application

--- a/features/providers/civil_application_journey.feature
+++ b/features/providers/civil_application_journey.feature
@@ -905,8 +905,9 @@ Feature: Civil application journeys
     And I click 'Save and continue'
     Then I should be on a page showing 'Do you have evidence that your client receives Universal Credit?'
     And I choose 'Yes'
+    Then I scroll down
     And I click 'Save and continue'
-    Then I should be on a page showing 'You'll need to tell us if your client:'
+    Then I should be on a page showing "You'll need to tell us if your client:"
     And I click 'Save and continue'
     And I should be on a page showing 'Does your client own the home that they live in?'
 

--- a/features/providers/civil_application_journey.feature
+++ b/features/providers/civil_application_journey.feature
@@ -82,6 +82,7 @@ Feature: Civil application journeys
   @javascript @vcr
   Scenario: Completes the application using address lookup
     Given I start the journey as far as the applicant page
+    And I enable callbacks on ApplicationProceedingType
     Then I enter name 'Test', 'User'
     Then I enter the date of birth '03-04-1999'
     Then I enter national insurance number 'CB987654A'
@@ -168,10 +169,12 @@ Feature: Civil application journeys
     Then I should be on a page showing 'Occupation order' with a date of 35 days ago using '%-d %B %Y' format
     Then I should be on a page showing 'Covered under an emergency certificate'
     Then I should be on a page showing 'Covered under a substantive certificate'
+    Then I disable callbacks on ApplicationProceedingType
 
   @javascript @vcr
   Scenario: Completes the application using address lookup
     Given I start the journey as far as the applicant page
+    And I enable callbacks on ApplicationProceedingType
     Then I enter name 'Test', 'User'
     Then I enter the date of birth '03-04-1999'
     Then I enter national insurance number 'CB987654A'
@@ -214,10 +217,12 @@ Feature: Civil application journeys
     Then I am on the About the Financial Assessment page
     Then I click 'Send link'
     Then I am on the application confirmation page
+    Then I disable callbacks on ApplicationProceedingType
 
   @localhost_request @javascript @vcr
   Scenario: Completes the application using manual address
     Given I start the journey as far as the applicant page
+    And I enable callbacks on ApplicationProceedingType
     Then I enter name 'Test', 'User'
     Then I enter the date of birth '03-04-1999'
     Then I enter national insurance number 'CB987654A'
@@ -269,6 +274,7 @@ Feature: Civil application journeys
     Then I am on the About the Financial Assessment page
     Then I click 'Send link'
     Then I am on the application confirmation page
+    Then I disable callbacks on ApplicationProceedingType
 
   @javascript @vcr
   Scenario: I can see that the applicant receives benefits
@@ -317,6 +323,7 @@ Feature: Civil application journeys
   @javascript @vcr
   Scenario: I can see that the applicant does not receive benefits
     Given I start the journey as far as the applicant page
+    And I enable callbacks on ApplicationProceedingType
     Then I enter name 'Test', 'Paul'
     Then I enter the date of birth '10-12-1961'
     Then I enter national insurance number 'JA293483B'
@@ -342,10 +349,12 @@ Feature: Civil application journeys
     Then I should be on a page showing 'Check your answers'
     Then I click 'Save and continue'
     Then I should be on a page showing "DWP records show that your client does not receive a passporting benefit – is this correct?"
+    Then I disable callbacks on ApplicationProceedingType
 
   @javascript @vcr
   Scenario: I am instructed to use CCMS on the passported journey with an applicant does not receive benefits
     When I start the journey as far as the applicant page
+    And I enable callbacks on ApplicationProceedingType
     Then I enter name 'Test', 'Paul'
     Then I enter the date of birth '10-12-1961'
     Then I enter national insurance number 'JA293483B'
@@ -391,6 +400,7 @@ Feature: Civil application journeys
     Then I click 'Save and continue'
     Then I am on the About the Financial Assessment page
     Then I should be on a page showing 'test@test.com'
+    Then I disable callbacks on ApplicationProceedingType
 
   @javascript @vcr
   Scenario: I am instructed to use CCMS when the applicant is not eligible
@@ -903,6 +913,7 @@ Feature: Civil application journeys
   @javascript @vcr
   Scenario: Allows return to, and proceed from, Delegated Function date view
     Given I start the journey as far as the applicant page
+    And I enable callbacks on ApplicationProceedingType
     Then I enter name 'Test', 'User'
     Then I enter the date of birth '03-04-1999'
     Then I enter national insurance number 'CB987654A'
@@ -924,6 +935,7 @@ Feature: Civil application journeys
     Then I enter the 'nonmolestation order used delegated functions on' date of 5 days ago
     Then I click 'Save and continue'
     Then I should be on a page showing "What you're applying for"
+    Then I enable callbacks on ApplicationProceedingType
 
   @javascript @vcr
   Scenario: Checking passported answers for an application with multiple procedings

--- a/features/providers/merits_task_list.feature
+++ b/features/providers/merits_task_list.feature
@@ -98,9 +98,7 @@ Feature: Merits task list
 
   @javascript
   Scenario: Uploading a file for statement of case
-    Given the method populate of ProceedingType is rerun
-    And the method populate of ProceedingTypeScopeLimitation is rerun
-    And I have completed a non-passported application and reached the merits task_list
+    Given I have completed a non-passported application and reached the merits task_list
     Then I should be on the 'merits_task_list' page showing 'Children involved in this application\nNOT STARTED'
     When I click link 'Latest incident details'
     Then I should be on a page showing 'When did your client contact you about the latest domestic abuse incident?'

--- a/features/step_definitions/debug_steps.rb
+++ b/features/step_definitions/debug_steps.rb
@@ -16,3 +16,30 @@ When(/^the feature flag for (.*?) is (enabled|disabled)$/) do |flag, enabled|
   value = enabled.eql?('enabled')
   Setting.setting.update!("#{flag}": value)
 end
+
+When(/^I display the setup$/) do
+  puts ">>>>>>>>>>>> LegalAidAppliation count: #{LegalAidApplication.count} #{__FILE__}:#{__LINE__} <<<<<<<<<<<<".yellow
+  laa = LegalAidApplication.first
+  puts ">>>>>>>>>>>> id: #{laa.id} #{__FILE__}:#{__LINE__} <<<<<<<<<<<<".yellow
+  puts ">>>>>>>>>>>> proceeding types #{__FILE__}:#{__LINE__} <<<<<<<<<<<<".yellow
+  ap ProceedingType.order(:ccms_code).pluck(:ccms_code, :id)
+  puts ">>>>>>>>>>>> apts #{__FILE__}:#{__LINE__} <<<<<<<<<<<<".yellow
+  ap laa.application_proceeding_types
+  puts ">>>>>>>>>>>>  #{__FILE__}:#{__LINE__} <<<<<<<<<<<<".yellow
+  ap laa.proceedings
+  puts ">>>>>>>>>>>> end of setup #{__FILE__}:#{__LINE__} <<<<<<<<<<<<".yellow
+end
+
+# TODO: remove after LFA migration complete
+When(/^I enable callbacks on ApplicationProceedingType$/) do
+  ApplicationProceedingType.set_callback(:create, :after, :create_proceeding)
+  ApplicationProceedingType.set_callback(:update, :after, :update_proceeding)
+  ApplicationProceedingType.set_callback(:destroy, :before, :destroy_proceeding)
+end
+
+# TODO: remove after LFA migration complete
+When(/^I disable callbacks on ApplicationProceedingType$/) do
+  ApplicationProceedingType.skip_callback(:create, :after, :create_proceeding)
+  ApplicationProceedingType.skip_callback(:update, :after, :update_proceeding)
+  ApplicationProceedingType.skip_callback(:destroy, :before, :destroy_proceeding)
+end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2618)

Updates three Limitations partials to use `Proceedings` via the `proceedings_by_name` method on the `LegalAidApplication` model instead of `ApplicationProceedingTypes` via the `application_proceedings_by_name` method.

The ticket mentions updating the Limitations controller too, however that file contains no references to ApplicationProceedingTypes so no change has been made.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
