### PR TITLE
AP-2648 Add Extra fields to Proceeding table

### DIFF
--- a/app/models/proceeding.rb
+++ b/app/models/proceeding.rb
@@ -32,6 +32,9 @@ class Proceeding < ApplicationRecord
            delegated_functions_scope_limitation_description: proceeding_type.default_delegated_functions_scope_limitation.description,
            used_delegated_functions_on: nil,
            used_delegated_functions_reported_on: nil,
-           name: proceeding_type.name
+           name: proceeding_type.name,
+           matter_type: proceeding_type.ccms_matter,
+           category_of_law: proceeding_type.ccms_category_law,
+           category_law_code: proceeding_type.ccms_category_law_code
   end
 end

--- a/app/services/proceeding_sync_service.rb
+++ b/app/services/proceeding_sync_service.rb
@@ -27,7 +27,7 @@ class ProceedingSyncService
                                                          proceeding_case_id: @application_proceeding_type.proceeding_case_id).first
   end
 
-  def payload
+  def payload # rubocop:disable Metrics/MethodLength
     {
       legal_aid_application_id: @application_proceeding_type.legal_aid_application.id,
       proceeding_case_id: @application_proceeding_type.proceeding_case_id,
@@ -39,7 +39,10 @@ class ProceedingSyncService
       delegated_functions_cost_limitation: @proceeding_type.default_cost_limitation_delegated_functions,
       used_delegated_functions_on: @application_proceeding_type.used_delegated_functions_on,
       used_delegated_functions_reported_on: @application_proceeding_type.used_delegated_functions_reported_on,
-      name: @proceeding_type.name
+      name: @proceeding_type.name,
+      matter_type: @proceeding_type.ccms_matter,
+      category_of_law: @proceeding_type.ccms_category_law,
+      category_law_code: @proceeding_type.ccms_category_law_code
     }
   end
 

--- a/db/data/20211103105816_populate_extra_proceedings_fields.rb
+++ b/db/data/20211103105816_populate_extra_proceedings_fields.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class PopulateExtraProceedingsFields < ActiveRecord::Migration[6.1]
+  def up
+    Proceeding.all.each do |proceeding|
+      pt = ProceedingType.find_by(ccms_code: proceeding.ccms_code)
+      proceeding.update!(matter_type: pt.ccms_matter,
+                         category_of_law: pt.ccms_category_law,
+                         category_law_code: pt.ccms_category_law_code)
+    end
+  end
+
+  def down
+    ActiveRecord::Base.connection.execute 'UPDATE proceedings SET matter_type = NULL, category_of_law = NULL, category_law_code = NULL'
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20211022112819)
+DataMigrate::Data.define(version: 20211103105816)

--- a/db/migrate/20211103105546_add_extra_fields_to_proceedings.rb
+++ b/db/migrate/20211103105546_add_extra_fields_to_proceedings.rb
@@ -1,0 +1,7 @@
+class AddExtraFieldsToProceedings < ActiveRecord::Migration[6.1]
+  def change
+    add_column :proceedings, :matter_type, :string
+    add_column :proceedings, :category_of_law, :string
+    add_column :proceedings, :category_law_code, :string
+  end
+end

--- a/db/migrate/20211103112548_set_new_proceeding_fields_to_not_null.rb
+++ b/db/migrate/20211103112548_set_new_proceeding_fields_to_not_null.rb
@@ -1,0 +1,7 @@
+class SetNewProceedingFieldsToNotNull < ActiveRecord::Migration[6.1]
+  def change
+    change_column_null(:proceedings, :matter_type, false)
+    change_column_null(:proceedings, :category_of_law, false)
+    change_column_null(:proceedings, :category_law_code, false)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_02_101801) do
+ActiveRecord::Schema.define(version: 2021_11_03_112548) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -103,9 +103,9 @@ ActiveRecord::Schema.define(version: 2021_11_02_101801) do
     t.string "unlock_token"
     t.datetime "locked_at"
     t.string "true_layer_secure_data_id"
+    t.boolean "employed"
     t.datetime "remember_created_at"
     t.string "remember_token"
-    t.boolean "employed"
     t.index ["confirmation_token"], name: "index_applicants_on_confirmation_token", unique: true
     t.index ["email"], name: "index_applicants_on_email"
     t.index ["unlock_token"], name: "index_applicants_on_unlock_token", unique: true
@@ -588,7 +588,7 @@ ActiveRecord::Schema.define(version: 2021_11_02_101801) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "scanner_working"
-    t.index ["uploader_type", "uploader_id"], name: "index_malware_scan_results_on_uploader"
+    t.index ["uploader_type", "uploader_id"], name: "index_malware_scan_results_on_uploader_type_and_uploader_id"
   end
 
   create_table "offices", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -717,6 +717,9 @@ ActiveRecord::Schema.define(version: 2021_11_02_101801) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "name", null: false
+    t.string "matter_type", null: false
+    t.string "category_of_law", null: false
+    t.string "category_law_code", null: false
     t.index ["legal_aid_application_id"], name: "index_proceedings_on_legal_aid_application_id"
   end
 

--- a/spec/factories/proceedings.rb
+++ b/spec/factories/proceedings.rb
@@ -23,6 +23,9 @@ FactoryBot.define do
       used_delegated_functions_on { nil }
       used_delegated_functions_reported_on { nil }
       name { 'inherent_jurisdiction_high_court_injunction' }
+      matter_type { 'Domestic Abuse' }
+      category_of_law { 'Family' }
+      category_law_code { 'MAT' }
     end
 
     trait :da004 do
@@ -45,6 +48,9 @@ FactoryBot.define do
       used_delegated_functions_on { nil }
       used_delegated_functions_reported_on { nil }
       name { 'nonmolestation_order' }
+      matter_type { 'Domestic Abuse' }
+      category_of_law { 'Family' }
+      category_law_code { 'MAT' }
     end
 
     trait :se013 do
@@ -69,6 +75,9 @@ FactoryBot.define do
       used_delegated_functions_on { nil }
       used_delegated_functions_reported_on { nil }
       name { 'child_arrangements_order_contact' }
+      matter_type { 'Section 8 orders' }
+      category_of_law { 'Family' }
+      category_law_code { 'MAT' }
     end
 
     trait :se014 do
@@ -93,6 +102,9 @@ FactoryBot.define do
       used_delegated_functions_on { nil }
       used_delegated_functions_reported_on { nil }
       name { 'child_arrangements_order_residence' }
+      matter_type { 'Section 8 orders' }
+      category_of_law { 'Family' }
+      category_law_code { 'MAT' }
     end
   end
 end


### PR DESCRIPTION
## Add Extra fields to Proceeding table

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2468)

- Migration to add extra fields:
  - `matter_type`
  - `category_of_law`
  - `category_law_code`
- Data migration to populate those fields on existing records
- Migration to make those fields `NOT NULL`
- Modified creation of `Proceeding` record to include the new values
- Modified Factory

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
