### PR TITLE
AP-2535 fix table sort arrows

### DIFF
--- a/app/helpers/table_sort_helper.rb
+++ b/app/helpers/table_sort_helper.rb
@@ -67,6 +67,7 @@ module TableSortHelper
     content_tag(:th, role: 'columnheader', scope: 'col', 'data-sort-type': type, class: classes) do
       content_tag(:span, class: 'aria-sort-description') { content } +
         sort_span_combine_right(combine_right) +
+        tag.br(class: 'hidden') +
         content_tag(:span, ', button', class: 'govuk-visually-hidden') +
         simple_span_sort_indicator
     end

--- a/app/webpack/stylesheets/table-sort.scss
+++ b/app/webpack/stylesheets/table-sort.scss
@@ -30,12 +30,26 @@
     white-space: nowrap;
   }
 }
+
+@media (min-width: 555px) {
+  br.hidden {
+    display: block;
+  }
+}
+
 @media (min-width: 700px) {
   th.select-clear-all {
     min-width: 98px;
     box-sizing: border-box;
   }
 }
+
+@media (min-width: 850px) {
+  br.hidden {
+    display: none;
+  }
+}
+
 td.tick-box-cell,
 td.sortable-cell {
   padding-left:6px;


### PR DESCRIPTION
## What

add break which is hidden at certain breakpoints so the arrows wrap to a new line if there is not enough space

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2535)

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
