### PR TITLE
Ap 2619 convert merits tasks flow to use proceeding

### DIFF
--- a/app/controllers/providers/proceeding_merits_task/attempts_to_settle_controller.rb
+++ b/app/controllers/providers/proceeding_merits_task/attempts_to_settle_controller.rb
@@ -10,21 +10,17 @@ module Providers
         @application_proceeding_type = application_proceeding_type
         @form = Providers::ProceedingMeritsTask::AttemptsToSettleForm.new(form_params.merge(proceeding_id: proceeding.id,
                                                                                             application_proceeding_type_id: application_proceeding_type.id))
-        render :show unless update_task_save_continue_or_draft(proceeding_type.ccms_code.to_sym, :attempts_to_settle)
+        render :show unless update_task_save_continue_or_draft(proceeding.ccms_code.to_sym, :attempts_to_settle)
       end
 
       private
 
       def legal_aid_application
-        @legal_aid_application ||= application_proceeding_type.legal_aid_application
-      end
-
-      def proceeding_type
-        @proceeding_type ||= application_proceeding_type.proceeding_type
+        @legal_aid_application ||= proceeding.legal_aid_application
       end
 
       def application_proceeding_type
-        @application_proceeding_type ||= ApplicationProceedingType.find(merits_task_list_id)
+        @application_proceeding_type ||= proceeding.application_proceeding_type
       end
 
       def attempts_to_settle
@@ -32,7 +28,7 @@ module Providers
       end
 
       def proceeding
-        @proceeding = application_proceeding_type.proceeding
+        @proceeding ||= Proceeding.find(merits_task_list_id)
       end
 
       def merits_task_list_id

--- a/app/controllers/providers/proceeding_merits_task/chances_of_success_controller.rb
+++ b/app/controllers/providers/proceeding_merits_task/chances_of_success_controller.rb
@@ -7,7 +7,7 @@ module Providers
 
       def create
         @form = ChancesOfSuccesses::SuccessLikelyForm.new(form_params.merge(proceeding_id: proceeding.id, application_proceeding_type_id: application_proceeding_type.id))
-        render :index unless update_task_save_continue_or_draft(proceeding_type.ccms_code.to_sym, :chances_of_success)
+        render :index unless update_task_save_continue_or_draft(proceeding.ccms_code.to_sym, :chances_of_success)
       end
 
       private
@@ -17,23 +17,19 @@ module Providers
       end
 
       def legal_aid_application
-        @legal_aid_application ||= application_proceeding_type.legal_aid_application
-      end
-
-      def proceeding_type
-        @proceeding_type ||= application_proceeding_type.proceeding_type
+        @legal_aid_application ||= proceeding.legal_aid_application
       end
 
       def chances_of_success
-        @chances_of_success ||= application_proceeding_type.chances_of_success || application_proceeding_type.build_chances_of_success
+        @chances_of_success ||= proceeding.chances_of_success
       end
 
       def proceeding
-        @proceeding = application_proceeding_type.proceeding
+        @proceeding ||= Proceeding.find(params[:merits_task_list_id])
       end
 
       def application_proceeding_type
-        @application_proceeding_type = ApplicationProceedingType.find(params[:merits_task_list_id])
+        @application_proceeding_type ||= proceeding.application_proceeding_type
       end
 
       def form_params

--- a/app/controllers/providers/proceeding_merits_task/linked_children_controller.rb
+++ b/app/controllers/providers/proceeding_merits_task/linked_children_controller.rb
@@ -7,21 +7,21 @@ module Providers
 
       def update
         @form = Providers::ProceedingMeritsTask::LinkedChildrenForm.new(form_params)
-        render :show unless update_task_save_continue_or_draft(proceeding_type.ccms_code.to_sym, :children_proceeding)
+        render :show unless update_task_save_continue_or_draft(proceeding.ccms_code.to_sym, :children_proceeding)
       end
 
       private
 
       def legal_aid_application
-        @legal_aid_application ||= application_proceeding_type.legal_aid_application
-      end
-
-      def proceeding_type
-        @proceeding_type ||= application_proceeding_type.proceeding_type
+        @legal_aid_application ||= proceeding.legal_aid_application
       end
 
       def application_proceeding_type
-        @application_proceeding_type ||= ApplicationProceedingType.find(merits_task_list_id)
+        @application_proceeding_type ||= proceeding.application_proceeding_type
+      end
+
+      def proceeding
+        @proceeding ||= Proceeding.find(merits_task_list_id)
       end
 
       def merits_task_list_id

--- a/app/controllers/providers/proceeding_merits_task/success_prospects_controller.rb
+++ b/app/controllers/providers/proceeding_merits_task/success_prospects_controller.rb
@@ -7,17 +7,13 @@ module Providers
 
       def update
         @form = ChancesOfSuccesses::SuccessProspectForm.new(form_params)
-        render :show unless update_task_save_continue_or_draft(proceeding_type.ccms_code.to_sym, :chances_of_success)
+        render :show unless update_task_save_continue_or_draft(proceeding.ccms_code.to_sym, :chances_of_success)
       end
 
       private
 
       def legal_aid_application
-        @legal_aid_application ||= LegalAidApplication.find(proceeding.legal_aid_application_id)
-      end
-
-      def proceeding_type
-        @proceeding_type ||= application_proceeding_type.proceeding_type
+        @legal_aid_application ||= proceeding.legal_aid_application
       end
 
       def chances_of_success
@@ -25,11 +21,11 @@ module Providers
       end
 
       def application_proceeding_type
-        @application_proceeding_type = ApplicationProceedingType.find(params[:merits_task_list_id])
+        @application_proceeding_type ||= proceeding.application_proceeding_type
       end
 
       def proceeding
-        @proceeding = Proceeding.find(params[:merits_task_list_id])
+        @proceeding ||= Proceeding.find(params[:merits_task_list_id])
       end
 
       def form_params

--- a/app/controllers/providers/proceeding_merits_task/success_prospects_controller.rb
+++ b/app/controllers/providers/proceeding_merits_task/success_prospects_controller.rb
@@ -13,7 +13,7 @@ module Providers
       private
 
       def legal_aid_application
-        @legal_aid_application ||= application_proceeding_type.legal_aid_application
+        @legal_aid_application ||= LegalAidApplication.find(proceeding.legal_aid_application_id)
       end
 
       def proceeding_type
@@ -26,6 +26,10 @@ module Providers
 
       def application_proceeding_type
         @application_proceeding_type = ApplicationProceedingType.find(params[:merits_task_list_id])
+      end
+
+      def proceeding
+        @proceeding = Proceeding.find(params[:merits_task_list_id])
       end
 
       def form_params

--- a/app/helpers/task_list_helper.rb
+++ b/app/helpers/task_list_helper.rb
@@ -29,7 +29,7 @@ module TaskListHelper
   def proceeding_task_url(name, application, ccms_code)
     url = "providers_merits_task_list_#{url_fragment(name)}_path".to_sym
 
-    __send__(url, application_proceeding_type_id(application, ccms_code))
+    __send__(url, proceeding_id(application, ccms_code))
   end
 
   def url_fragment(name)
@@ -41,13 +41,10 @@ module TaskListHelper
     I18n.t("providers.merits_task_lists.task_list_item.urls.#{name}")
   end
 
-  def application_proceeding_type_id(application, ccms_code)
+  def proceeding_id(application, ccms_code)
     return nil unless ccms_code && application
 
-    apt = application.application_proceeding_types.find do |x|
-      x.proceeding_type.ccms_code == ccms_code.to_s
-    end
-
-    apt.id
+    proceeding = application.proceedings.find_by(ccms_code: ccms_code)
+    proceeding.id
   end
 end

--- a/app/models/proceeding.rb
+++ b/app/models/proceeding.rb
@@ -43,4 +43,12 @@ class Proceeding < ApplicationRecord
            category_of_law: proceeding_type.ccms_category_law,
            category_law_code: proceeding_type.ccms_category_law_code
   end
+
+  # TODO: remove once LFA migration complete
+  #
+  # temporary method to return the corresponding application_proceeding_type
+  def application_proceeding_type
+    proceeding_type = ProceedingType.find_by ccms_code: ccms_code
+    legal_aid_application.application_proceeding_types.find_by(proceeding_type_id: proceeding_type.id)
+  end
 end

--- a/app/models/proceeding.rb
+++ b/app/models/proceeding.rb
@@ -51,4 +51,8 @@ class Proceeding < ApplicationRecord
     proceeding_type = ProceedingType.find_by ccms_code: ccms_code
     legal_aid_application.application_proceeding_types.find_by(proceeding_type_id: proceeding_type.id)
   end
+
+  def section8?
+    ccms_code.in? %w[SE003 SE004 SE013 SE014]
+  end
 end

--- a/app/services/flow/flows/provider_merits.rb
+++ b/app/services/flow/flows/provider_merits.rb
@@ -81,8 +81,7 @@ module Flow
         success_prospects: {
           path: ->(application) do
             proceeding = application.proceedings.find(application.provider_step_params['merits_task_list_id'])
-            application_proceeding_type = proceeding.application_proceeding_type
-            urls.providers_merits_task_list_success_prospects_path(application_proceeding_type)
+            urls.providers_merits_task_list_success_prospects_path(proceeding)
           end,
           forward: :merits_task_lists,
           check_answers: :check_merits_answers

--- a/app/services/flow/flows/provider_merits.rb
+++ b/app/services/flow/flows/provider_merits.rb
@@ -93,9 +93,8 @@ module Flow
         },
         linked_children: {
           path: ->(application) do
-            application_proceeding_type_id = application.provider_step_params['merits_task_list_id']
-            application_proceeding_type = application.application_proceeding_types.find(application_proceeding_type_id)
-            urls.providers_merits_task_list_linked_children_path(application_proceeding_type)
+            proceeding = application.proceedings.find(application.provider_step_params['merits_task_list_id'])
+            urls.providers_merits_task_list_linked_children_path(proceeding)
           end,
           forward: :merits_task_lists,
           check_answers: :check_merits_answers

--- a/app/services/flow/flows/provider_merits.rb
+++ b/app/services/flow/flows/provider_merits.rb
@@ -64,7 +64,8 @@ module Flow
         },
         chances_of_success: {
           forward: ->(application) do
-            application_proceeding_type = application.application_proceeding_types.find(application.provider_step_params['merits_task_list_id'])
+            proceeding = application.proceedings.find(application.provider_step_params['merits_task_list_id'])
+            application_proceeding_type = proceeding.application_proceeding_type
             if application_proceeding_type.chances_of_success.success_likely?
               :merits_task_lists
             else
@@ -72,14 +73,15 @@ module Flow
             end
           end,
           check_answers: ->(application) do
-            application_proceeding_type = application.application_proceeding_types.find(application.provider_step_params['merits_task_list_id'])
+            proceeding = application.proceedings.find(application.provider_step_params['merits_task_list_id'])
+            application_proceeding_type = proceeding.application_proceeding_type
             application_proceeding_type.chances_of_success.success_likely? ? :check_merits_answers : :success_prospects
           end
         },
         success_prospects: {
           path: ->(application) do
-            application_proceeding_type_id = application.provider_step_params['merits_task_list_id']
-            application_proceeding_type = application.application_proceeding_types.find(application_proceeding_type_id)
+            proceeding = application.proceedings.find(application.provider_step_params['merits_task_list_id'])
+            application_proceeding_type = proceeding.application_proceeding_type
             urls.providers_merits_task_list_success_prospects_path(application_proceeding_type)
           end,
           forward: :merits_task_lists,

--- a/app/views/providers/proceeding_merits_task/attempts_to_settle/show.html.erb
+++ b/app/views/providers/proceeding_merits_task/attempts_to_settle/show.html.erb
@@ -1,7 +1,7 @@
 <%= form_with(
       builder: GOVUKDesignSystemFormBuilder::FormBuilder,
       model: @form,
-      url: providers_merits_task_list_attempts_to_settle_path(@application_proceeding_type),
+      url: providers_merits_task_list_attempts_to_settle_path(@proceeding),
       method: :patch,
       local: true
     ) do |form| %>

--- a/app/views/providers/proceeding_merits_task/attempts_to_settle/show.html.erb
+++ b/app/views/providers/proceeding_merits_task/attempts_to_settle/show.html.erb
@@ -7,13 +7,13 @@
     ) do |form| %>
     <%= page_template(
             page_title: t('.h1-heading'),
-            head_title: "#{@application_proceeding_type.proceeding_type.meaning} - "+ t('.h1-heading'),
+            head_title: "#{@proceeding.meaning} - "+ t('.h1-heading'),
             template: :basic,
             form: form
         ) do %>
 
     <%= form.govuk_fieldset legend: {size: 'xl', tag: 'h1', text: page_title},
-                            caption: { text: @application_proceeding_type.proceeding_type.meaning, size: 'xl' } do %>
+                            caption: { text: @proceeding.meaning, size: 'xl' } do %>
       <%= form.govuk_text_area(
           :attempts_made,
           label: nil,

--- a/app/views/providers/proceeding_merits_task/chances_of_success/index.html.erb
+++ b/app/views/providers/proceeding_merits_task/chances_of_success/index.html.erb
@@ -6,7 +6,7 @@
     ) do |form| %>
     <%= page_template(
             page_title: t('.h1-heading'),
-            head_title: "#{@application_proceeding_type.proceeding_type.meaning} - "+ t('.h1-heading'),
+            head_title: "#{@proceeding.meaning} - "+ t('.h1-heading'),
             template: :basic,
             form: form,
             back_link: {}
@@ -18,7 +18,7 @@
           :value,
           :label,
           legend: {size: 'xl', tag: 'h1', text: content_for(:page_title)},
-          caption: { text: @application_proceeding_type.proceeding_type.meaning, size: 'xl' }
+          caption: { text: @proceeding.meaning, size: 'xl' }
         ) %>
 
     <%= next_action_buttons(show_draft: true, form: form) %>

--- a/app/views/providers/proceeding_merits_task/linked_children/show.html.erb
+++ b/app/views/providers/proceeding_merits_task/linked_children/show.html.erb
@@ -1,7 +1,7 @@
 <%= form_with(
       builder: GOVUKDesignSystemFormBuilder::FormBuilder,
       model: @form,
-      url: providers_merits_task_list_linked_children_path(@application_proceeding_type),
+      url: providers_merits_task_list_linked_children_path(@proceeding),
       method: :patch,
       local: true
     ) do |form| %>

--- a/app/views/providers/proceeding_merits_task/linked_children/show.html.erb
+++ b/app/views/providers/proceeding_merits_task/linked_children/show.html.erb
@@ -7,14 +7,14 @@
     ) do |form| %>
     <%= page_template(
           page_title: t('.h1-heading'),
-          head_title: "#{@application_proceeding_type.proceeding_type.meaning} - "+ t('.h1-heading'),
+          head_title: "#{@proceeding.meaning} - "+ t('.h1-heading'),
           template: :basic,
           form: form
         ) do %>
 
       <%= form.govuk_check_boxes_fieldset :linked_children,
                                           legend: {size: 'xl', tag: 'h1', text: page_title},
-                                          caption: { text: @application_proceeding_type.proceeding_type.meaning, size: 'xl' } do %>
+                                          caption: { text: @proceeding.meaning, size: 'xl' } do %>
         <span id="select-all-that-apply-hint" class="govuk-hint"><%= t('generic.select_all_that_apply') %></span>
 
         <% @form.value_list.each do |child| %>

--- a/app/views/providers/proceeding_merits_task/success_prospects/show.html.erb
+++ b/app/views/providers/proceeding_merits_task/success_prospects/show.html.erb
@@ -1,6 +1,6 @@
 <%= form_with(
         model: @form,
-        url: providers_merits_task_list_success_prospects_path(@application_proceeding_type),
+        url: providers_merits_task_list_success_prospects_path(@proceeding),
         method: :patch,
         local: true
     ) do |form| %>

--- a/app/views/providers/proceeding_merits_task/success_prospects/show.html.erb
+++ b/app/views/providers/proceeding_merits_task/success_prospects/show.html.erb
@@ -6,7 +6,7 @@
     ) do |form| %>
   <%= page_template(
           page_title: t('.h1-heading'),
-          head_title: "#{@application_proceeding_type.proceeding_type.meaning} - "+ t('.h1-heading'),
+          head_title: "#{@proceeding.meaning} - "+ t('.h1-heading'),
           template: :basic,
           form: form,
           back_link: {}

--- a/app/views/shared/check_answers/_merits.html.erb
+++ b/app/views/shared/check_answers/_merits.html.erb
@@ -160,48 +160,48 @@
   </section>
 <% end %>
 
-<% @legal_aid_application.application_proceeding_types.each do |apt| %>
+<% @legal_aid_application.proceedings.each do |proceeding| %>
   <div class="govuk-!-padding-bottom-6"></div>
   <section class="print-no-break">
-    <h2 class="govuk-heading-l"><%= apt.proceeding_type.meaning %></h2>
+    <h2 class="govuk-heading-l"><%= proceeding.meaning %></h2>
 
     <dl class="govuk-summary-list govuk-!-margin-bottom-2">
       <%= check_answer_link(
-            name: "#{apt.id}_success_likely".to_sym,
-            url: providers_merits_task_list_chances_of_success_index_path(apt),
+            name: "#{proceeding.id}_success_likely".to_sym,
+            url: providers_merits_task_list_chances_of_success_index_path(proceeding),
             question: t('.items.prospects_of_success'),
-            answer: yes_no(apt.chances_of_success.success_likely),
+            answer: yes_no(proceeding.chances_of_success.success_likely),
             read_only: read_only
           ) %>
       <%= check_answer_link(
-            name: "#{apt.id}_success_prospect".to_sym,
-            url: providers_merits_task_list_success_prospects_path(apt),
+            name: "#{proceeding.id}_success_prospect".to_sym,
+            url: providers_merits_task_list_success_prospects_path(proceeding),
             question: t('.items.success_prospect'),
-            answer: t("shared.forms.success_prospect.#{apt.chances_of_success.success_prospect}"),
+            answer: t("shared.forms.success_prospect.#{proceeding.chances_of_success.success_prospect}"),
             read_only: read_only
-          ) unless apt.chances_of_success.success_likely? %>
+          ) unless proceeding.chances_of_success.success_likely? %>
     </dl>
 
-    <div class='govuk-body'><%= apt.chances_of_success.success_prospect_details %></div>
+    <div class='govuk-body'><%= proceeding.chances_of_success.success_prospect_details %></div>
 
-    <% if apt.attempts_to_settle %>
+    <% if proceeding.attempts_to_settle %>
       <dl class="govuk-summary-list govuk-!-margin-bottom-2">
         <%= check_answer_link(
-              name: "#{apt.id}_attempts_to_settle".to_sym,
-              url: providers_merits_task_list_attempts_to_settle_path(apt),
+              name: "#{proceeding.id}_attempts_to_settle".to_sym,
+              url: providers_merits_task_list_attempts_to_settle_path(proceeding),
               question: t('.items.attempts_to_settle'),
-              answer: apt.attempts_to_settle.attempts_made,
+              answer: proceeding.attempts_to_settle.attempts_made,
               read_only: read_only
             ) %>
       </dl>
     <% end %>
-    <% if apt.proceeding_type.ccms_matter_code.eql?('KSEC8') %>
+    <% if proceeding.section8? %>
       <dl class="govuk-summary-list govuk-!-margin-bottom-2">
         <%= check_answer_link(
-              name: "#{apt.id}_linked_children".to_sym,
-              url: providers_merits_task_list_linked_children_path(apt),
+              name: "#{proceeding.id}_linked_children".to_sym,
+              url: providers_merits_task_list_linked_children_path(proceeding),
               question: t('.items.linked_children'),
-              answer: linked_children_names(apt.proceeding),
+              answer: linked_children_names(proceeding),
               read_only: read_only
             ) %>
       </dl>

--- a/features/providers/merits_task_list.feature
+++ b/features/providers/merits_task_list.feature
@@ -58,6 +58,10 @@ Feature: Merits task list
     And I click 'Save and continue'
     Then I should be on the 'check_merits_answers' page showing 'Check your answers and submit application'
     And the page is accessible
+    Then I click Check Your Merits Answers Change link for 'Success Likely' for 'Inherent jurisdiction high court injunction'
+    Then I should be on the 'chances_of_success' page showing 'Is the chance of a successful outcome 50% or better?'
+    And I click 'Save and continue'
+    Then I should be on the 'check_merits_answers' page showing 'Check your answers and submit application'
 
   @javascript @vcr
   Scenario: Removing children

--- a/features/step_definitions/civil_journey_steps.rb
+++ b/features/step_definitions/civil_journey_steps.rb
@@ -184,7 +184,7 @@ Given("I am checking the applicant's means answers") do
 end
 
 Given('I have completed the non-passported means assessment and start the merits assessment') do
-  @pt1 = create :proceeding_type, :with_real_data, :with_scope_limitations
+  @pt1 = ProceedingType.find_by(ccms_code: 'DA001')
   @legal_aid_application = create(
     :application,
     :with_applicant,
@@ -293,7 +293,7 @@ Given('I start the application with a negative benefit check result and no used 
 end
 
 Given('I start the merits application and the applicant has uploaded transaction data') do
-  @pt1 = create :proceeding_type, :with_real_data, :with_scope_limitations
+  @pt1 = ProceedingType.find_by(ccms_code: 'DA001')
   @legal_aid_application = create(
     :application,
     :with_applicant,
@@ -326,12 +326,14 @@ Given('I start the journey as far as the start of the vehicle section') do
 end
 
 Given('I have completed a non-passported application and reached the merits task_list') do
+  @pt1 = ProceedingType.find_by(ccms_code: 'SE014')
+  @pt2 = ProceedingType.find_by(ccms_code: 'DA001')
   @legal_aid_application = create(
     :application,
     :with_applicant,
-    :with_multiple_proceeding_types_inc_section8,
     :with_non_passported_state_machine,
-    :provider_entering_merits
+    :provider_entering_merits,
+    :with_proceeding_types, explicit_proceeding_types: [@pt1, @pt2]
   )
   create :legal_framework_merits_task_list, legal_aid_application: @legal_aid_application
   login_as @legal_aid_application.provider

--- a/features/step_definitions/civil_journey_steps.rb
+++ b/features/step_definitions/civil_journey_steps.rb
@@ -654,6 +654,15 @@ Given('I click Check Your Answers Change link for dependant {string}') do |depen
   end
 end
 
+Given('I click Check Your Merits Answers Change link for {string} for {string}') do |field_name, meaning|
+  proceeding = @legal_aid_application.proceedings.find_by(meaning: meaning)
+  field_name.downcase!
+  field_name.gsub!(/\s+/, '_')
+  within "#app-check-your-answers__#{proceeding.id}_#{field_name}" do
+    click_link('Change')
+  end
+end
+
 Given('I click has other dependants remove link for dependant {string}') do |dependant|
   within "#dependant_#{dependant}" do
     click_link('Remove')

--- a/spec/helpers/providers_helper_spec.rb
+++ b/spec/helpers/providers_helper_spec.rb
@@ -66,8 +66,9 @@ RSpec.describe ProvidersHelper, type: :helper do
     context 'when saved as draft and linking children' do
       it do
         legal_aid_application.provider_step = 'linked_children'
-        legal_aid_application.provider_step_params = { merits_task_list_id: legal_aid_application.lead_application_proceeding_type.id }
-        expect(subject).to eq("/providers/merits_task_list/#{legal_aid_application.lead_application_proceeding_type.id}/linked_children?locale=en")
+        lead_proceeding = legal_aid_application.proceedings.find_by(lead_proceeding: true)
+        legal_aid_application.provider_step_params = { merits_task_list_id: lead_proceeding.id }
+        expect(subject).to eq("/providers/merits_task_list/#{lead_proceeding.id}/linked_children?locale=en")
       end
     end
 

--- a/spec/helpers/task_list_helper_spec.rb
+++ b/spec/helpers/task_list_helper_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe TaskListHelper, type: :helper do
         <<~RESULT
           <li class="app-task-list__item">
             <span class="app-task-list__task-name">
-                <a aria_describedby="children_application-status" title="Children involved in this application" aria-label="Children involved in this application" href="/providers/applications/#{legal_aid_application.id}/has_other_involved_children?locale=en">Children involved in this application</a>
+                <a aria_describedby="children_application-status" aria-label="Children involved in this application" href="/providers/applications/#{legal_aid_application.id}/has_other_involved_children?locale=en">Children involved in this application</a>
             </span>
             <strong class="govuk-tag  app-task-list__tag" id="children_application_status">Completed</strong>
           </li>
@@ -30,7 +30,7 @@ RSpec.describe TaskListHelper, type: :helper do
         <<~RESULT
           <li class="app-task-list__item">
             <span class="app-task-list__task-name">
-                <a aria_describedby="children_application-status" title="Children involved in this application" aria-label="Children involved in this application" href="/providers/applications/#{legal_aid_application.id}/involved_children/new?locale=en">Children involved in this application</a>
+                <a aria_describedby="children_application-status" aria-label="Children involved in this application" href="/providers/applications/#{legal_aid_application.id}/involved_children/new?locale=en">Children involved in this application</a>
             </span>
             <strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="children_application_status">Not started</strong>
           </li>
@@ -42,6 +42,28 @@ RSpec.describe TaskListHelper, type: :helper do
                                      status: :not_started,
                                      legal_aid_application: legal_aid_application,
                                      ccms_code: nil)).to eq expected
+      end
+    end
+
+    context 'chances of success' do
+      let!(:proceeding) { create :proceeding, :da001, legal_aid_application: legal_aid_application }
+
+      let(:expected) do
+        <<~RESULT
+          <li class="app-task-list__item">
+            <span class="app-task-list__task-name">
+                <a aria_describedby="chances_of_success-status" aria-label="Chances of success" href="/providers/merits_task_list/#{proceeding.id}/chances_of_success?locale=en">Chances of success</a>
+            </span>
+            <strong class="govuk-tag  app-task-list__tag" id="chances_of_success_status">Completed</strong>
+          </li>
+        RESULT
+      end
+
+      it 'returns a link' do
+        expect(helper.task_list_item(name: :chances_of_success,
+                                     status: :complete,
+                                     legal_aid_application: legal_aid_application,
+                                     ccms_code: :DA001)).to eq expected
       end
     end
   end

--- a/spec/helpers/task_list_helper_spec.rb
+++ b/spec/helpers/task_list_helper_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe TaskListHelper, type: :helper do
     end
 
     context 'chances of success' do
-      let!(:proceeding) { create :proceeding, :da001, legal_aid_application: legal_aid_application }
+      let(:proceeding) { legal_aid_application.proceedings.find_by(ccms_code: 'DA001') }
 
       let(:expected) do
         <<~RESULT

--- a/spec/models/proceeding_spec.rb
+++ b/spec/models/proceeding_spec.rb
@@ -19,4 +19,34 @@ RSpec.describe Proceeding, type: :model do
                               :used_delegated_functions_on,
                               :used_delegated_functions_reported_on)
   }
+
+  describe '#application_proceeding_type' do
+    let(:pt1) { create :proceeding_type, :with_real_data }
+    let(:pt2) { create :proceeding_type, :as_section_8_child_residence }
+    let(:laa) { create :legal_aid_application, :with_proceeding_types, explicit_proceeding_types: [pt1, pt2] }
+
+    it 'returns the corresponding record' do
+      proceeding = laa.proceedings.first
+      apt = proceeding.application_proceeding_type
+      expect(apt.proceeding_type.ccms_code).to eq proceeding.ccms_code
+    end
+  end
+
+  describe '#section8?' do
+    context 'section 8 proceeding' do
+      let(:proceeding) { create :proceeding, :se014 }
+
+      it 'returns true' do
+        expect(proceeding.section8?).to eq true
+      end
+    end
+
+    context 'non section 8 proceeding' do
+      let(:proceeding) { create :proceeding, :da001 }
+
+      it 'returns false' do
+        expect(proceeding.section8?).to eq false
+      end
+    end
+  end
 end

--- a/spec/requests/providers/check_merits_answers_spec.rb
+++ b/spec/requests/providers/check_merits_answers_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe 'check merits answers requests', type: :request do
         expect(response.body).to have_change_link(:incident_details, providers_legal_aid_application_date_client_told_incident_path)
         expect(response.body).to have_change_link(:opponent_details, providers_legal_aid_application_opponent_path)
         expect(response.body).to have_change_link(:statement_of_case, providers_legal_aid_application_statement_of_case_path(application))
-        application.application_proceeding_types.each do |proceeding|
+        application.proceedings.each do |proceeding|
           expect(response.body).to have_change_link(:success_likely,
                                                     providers_merits_task_list_chances_of_success_index_path(proceeding))
         end

--- a/spec/requests/providers/proceeding_merits_task/attempts_to_settle_controller_spec.rb
+++ b/spec/requests/providers/proceeding_merits_task/attempts_to_settle_controller_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe Providers::ProceedingMeritsTask::AttemptsToSettleController, type
   let(:proceeding_type) { ProceedingType.find_by(ccms_code: 'SE014') }
   let(:smtl) { create :legal_framework_merits_task_list, legal_aid_application: legal_aid_application }
   let(:provider) { legal_aid_application.provider }
-  let!(:proceeding) { create :proceeding, :da001, legal_aid_application: legal_aid_application }
-  let!(:proceeding_two) { create :proceeding, :se014, legal_aid_application: legal_aid_application }
+  let(:proceeding) { legal_aid_application.proceedings.find_by(ccms_code: 'DA001') }
+  let(:proceeding_two) { legal_aid_application.proceedings.find_by(ccms_code: 'SE014') }
 
   describe 'GET /providers/applications/merits_task_list/:merits_task_list_id/attempts_to_settle' do
     subject { get providers_merits_task_list_attempts_to_settle_path(proceeding_two) }

--- a/spec/requests/providers/proceeding_merits_task/attempts_to_settle_controller_spec.rb
+++ b/spec/requests/providers/proceeding_merits_task/attempts_to_settle_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Providers::ProceedingMeritsTask::AttemptsToSettleController, type
   let!(:proceeding_two) { create :proceeding, :se014, legal_aid_application: legal_aid_application }
 
   describe 'GET /providers/applications/merits_task_list/:merits_task_list_id/attempts_to_settle' do
-    subject { get providers_merits_task_list_attempts_to_settle_path(application_proceeding_type) }
+    subject { get providers_merits_task_list_attempts_to_settle_path(proceeding_two) }
 
     context 'when the provider is not authenticated' do
       before { subject }
@@ -32,7 +32,7 @@ RSpec.describe Providers::ProceedingMeritsTask::AttemptsToSettleController, type
 
       it 'displays the correct proceeding type as a header' do
         subject
-        expect(unescaped_response_body).to include(application_proceeding_type.proceeding_type.meaning)
+        expect(unescaped_response_body).to include(proceeding_two.meaning)
       end
     end
   end
@@ -42,7 +42,7 @@ RSpec.describe Providers::ProceedingMeritsTask::AttemptsToSettleController, type
       {
         proceeding_merits_task_attempts_to_settle: {
           attempts_made: 'Details of settlement attempt',
-          application_proceeding_type_id: application_proceeding_type.id
+          application_proceeding_type_id: proceeding_two.application_proceeding_type.id
         }
       }
     end
@@ -54,7 +54,7 @@ RSpec.describe Providers::ProceedingMeritsTask::AttemptsToSettleController, type
       end
 
       subject do
-        patch providers_merits_task_list_attempts_to_settle_path(application_proceeding_type), params: params.merge(submit_button)
+        patch providers_merits_task_list_attempts_to_settle_path(proceeding_two), params: params.merge(submit_button)
       end
 
       context 'Form submitted using Continue button' do
@@ -99,7 +99,7 @@ RSpec.describe Providers::ProceedingMeritsTask::AttemptsToSettleController, type
         let(:submit_button) { { draft_button: 'Save as draft' } }
 
         subject do
-          patch providers_merits_task_list_attempts_to_settle_path(application_proceeding_type), params: params.merge(submit_button)
+          patch providers_merits_task_list_attempts_to_settle_path(proceeding_two), params: params.merge(submit_button)
         end
 
         it "redirects provider to provider's applications page" do

--- a/spec/requests/providers/proceeding_merits_task/chances_of_success_spec.rb
+++ b/spec/requests/providers/proceeding_merits_task/chances_of_success_spec.rb
@@ -19,7 +19,7 @@ module Providers
       end
 
       describe 'GET /providers/merits_task_list/:id/chances_of_success' do
-        subject { get providers_merits_task_list_chances_of_success_index_path(application_proceeding_type) }
+        subject { get providers_merits_task_list_chances_of_success_index_path(proceeding) }
 
         it 'renders successfully' do
           subject
@@ -47,7 +47,7 @@ module Providers
 
         subject do
           post(
-            providers_merits_task_list_chances_of_success_index_path(application_proceeding_type, proceeding),
+            providers_merits_task_list_chances_of_success_index_path(proceeding),
             params: params.merge(submit_button)
           )
         end
@@ -102,7 +102,7 @@ module Providers
 
           it 'redirects to next page' do
             subject
-            expect(response).to redirect_to(providers_merits_task_list_success_prospects_path(application_proceeding_type))
+            expect(response).to redirect_to(providers_merits_task_list_success_prospects_path(proceeding))
           end
 
           context 'success_prospect was :likely' do

--- a/spec/requests/providers/proceeding_merits_task/chances_of_success_spec.rb
+++ b/spec/requests/providers/proceeding_merits_task/chances_of_success_spec.rb
@@ -8,9 +8,10 @@ module Providers
       let(:pt_da) { create :proceeding_type, :with_real_data }
       let(:pt_s8) { create :proceeding_type, :as_section_8_child_residence }
       let(:legal_aid_application) { create :legal_aid_application, :with_proceeding_types, explicit_proceeding_types: [pt_da, pt_s8] }
-      let!(:proceeding) { create :proceeding, :da001, legal_aid_application: legal_aid_application }
-      let!(:proceeding_two) { create :proceeding, :se014, legal_aid_application: legal_aid_application }
-      let(:application_proceeding_type) { legal_aid_application.application_proceeding_types.first }
+      let(:proceeding) { legal_aid_application.proceedings.find_by(ccms_code: 'DA001') }
+      let!(:proceeding_two) { legal_aid_application.proceedings.find_by(ccms_code: 'SE014') }
+      let(:proceeding_type) { ProceedingType.find_by(ccms_code: 'SE014') }
+      let(:application_proceeding_type) { legal_aid_application.application_proceeding_types.find_by(proceeding_type_id: proceeding_type) }
       let(:login) { login_as legal_aid_application.provider }
 
       before do

--- a/spec/requests/providers/proceeding_merits_task/linked_children_spec.rb
+++ b/spec/requests/providers/proceeding_merits_task/linked_children_spec.rb
@@ -6,6 +6,7 @@ module Providers
       let(:pt_da) { create :proceeding_type, :with_real_data }
       let(:pt_s8) { create :proceeding_type, :as_section_8_child_residence }
       let!(:legal_aid_application) { create :legal_aid_application, :with_proceeding_types, :with_involved_children, explicit_proceeding_types: [pt_da, pt_s8] }
+      let!(:proceeding) { create :proceeding, :se014, legal_aid_application: legal_aid_application }
       let(:involved_children_names) { legal_aid_application.involved_children.map(&:full_name) }
       let(:application_proceeding_type) { legal_aid_application.application_proceeding_types.find_by(proceeding_type_id: proceeding_type) }
       let(:proceeding_type) { ProceedingType.find_by(ccms_code: 'SE014') }
@@ -18,7 +19,7 @@ module Providers
       end
 
       describe 'GET /providers/merits_task_list/:merits_task_list_id/linked_children' do
-        subject { get providers_merits_task_list_linked_children_path(application_proceeding_type) }
+        subject { get providers_merits_task_list_linked_children_path(proceeding) }
 
         context 'when the provider is not authenticated' do
           let(:login) { nil }
@@ -49,7 +50,7 @@ module Providers
 
         before { legal_aid_application&.legal_framework_merits_task_list&.mark_as_complete!(:application, :children_application) }
 
-        subject { patch providers_merits_task_list_linked_children_path(application_proceeding_type), params: params }
+        subject { patch providers_merits_task_list_linked_children_path(proceeding), params: params }
 
         context 'all selected' do
           it 'adds involved children to the proceeding type' do
@@ -86,7 +87,7 @@ module Providers
 
         context 'when a user has previously linked two children' do
           let(:update) do
-            patch providers_merits_task_list_linked_children_path(application_proceeding_type), params: new_params
+            patch providers_merits_task_list_linked_children_path(proceeding), params: new_params
           end
 
           let(:first_child) { legal_aid_application.involved_children.first }
@@ -124,7 +125,7 @@ module Providers
           let(:submit_button) { { draft_button: 'Save as draft' } }
 
           subject do
-            patch providers_merits_task_list_linked_children_path(application_proceeding_type), params: params.merge(submit_button)
+            patch providers_merits_task_list_linked_children_path(proceeding), params: params.merge(submit_button)
           end
 
           it "redirects provider to provider's applications page" do

--- a/spec/requests/providers/proceeding_merits_task/linked_children_spec.rb
+++ b/spec/requests/providers/proceeding_merits_task/linked_children_spec.rb
@@ -6,7 +6,7 @@ module Providers
       let(:pt_da) { create :proceeding_type, :with_real_data }
       let(:pt_s8) { create :proceeding_type, :as_section_8_child_residence }
       let!(:legal_aid_application) { create :legal_aid_application, :with_proceeding_types, :with_involved_children, explicit_proceeding_types: [pt_da, pt_s8] }
-      let!(:proceeding) { create :proceeding, :se014, legal_aid_application: legal_aid_application }
+      let(:proceeding) { legal_aid_application.proceedings.find_by(ccms_code: 'SE014') }
       let(:involved_children_names) { legal_aid_application.involved_children.map(&:full_name) }
       let(:application_proceeding_type) { legal_aid_application.application_proceeding_types.find_by(proceeding_type_id: proceeding_type) }
       let(:proceeding_type) { ProceedingType.find_by(ccms_code: 'SE014') }

--- a/spec/requests/providers/proceeding_merits_task/success_prospects_spec.rb
+++ b/spec/requests/providers/proceeding_merits_task/success_prospects_spec.rb
@@ -3,19 +3,22 @@ require 'rails_helper'
 module Providers
   module ProceedingMeritsTask
     RSpec.describe SuccessProspectsController, type: :request do
-      let!(:legal_aid_application) { create :legal_aid_application }
+      let!(:legal_aid_application) { create :legal_aid_application, :with_proceeding_types, explicit_proceeding_types: [pt_da, pt_s8] }
       let!(:proceeding) { create :proceeding, :da001, legal_aid_application: legal_aid_application }
+      let!(:proceeding_two) { create :proceeding, :se014, legal_aid_application: legal_aid_application }
+      let(:pt_da) { create :proceeding_type, :with_real_data }
+      let(:pt_s8) { create :proceeding_type, :as_section_8_child_residence }
       let(:application_proceeding_type) do
         create :application_proceeding_type,
                :with_chances_of_success,
                legal_aid_application: legal_aid_application,
-               proceeding_type: create(:proceeding_type, :with_real_data)
+               proceeding_type: pt_da
       end
 
       let(:provider) { legal_aid_application.provider }
 
       describe 'GET /providers/merits_task_list/:id/success_prospects' do
-        subject { get providers_merits_task_list_success_prospects_path(application_proceeding_type) }
+        subject { get providers_merits_task_list_success_prospects_path(proceeding) }
 
         context 'when the provider is not authenticated' do
           before { subject }
@@ -35,7 +38,7 @@ module Providers
       end
 
       describe 'PATCH providers/merits_task_list/:id/success_prospects' do
-        subject { patch providers_merits_task_list_success_prospects_path(application_proceeding_type), params: params.merge(submit_button) }
+        subject { patch providers_merits_task_list_success_prospects_path(proceeding), params: params.merge(submit_button) }
         let(:success_prospect) { 'marginal' }
         let(:success_prospect_details) { Faker::Lorem.paragraph }
         let(:params) do
@@ -61,8 +64,8 @@ module Providers
             end
 
             it 'updates the record' do
-              expect(application_proceeding_type.chances_of_success.reload.success_prospect).to eq(success_prospect)
-              expect(application_proceeding_type.chances_of_success.reload.success_prospect_details).to eq(success_prospect_details)
+              expect(proceeding.application_proceeding_type.chances_of_success.reload.success_prospect).to eq(success_prospect)
+              expect(proceeding.application_proceeding_type.chances_of_success.reload.success_prospect_details).to eq(success_prospect_details)
             end
 
             it 'redirects to the next page' do
@@ -78,8 +81,8 @@ module Providers
             end
 
             it 'updates the record' do
-              expect(application_proceeding_type.chances_of_success.reload.success_prospect).to eq(success_prospect)
-              expect(application_proceeding_type.chances_of_success.reload.success_prospect_details).to eq(success_prospect_details)
+              expect(proceeding.application_proceeding_type.chances_of_success.reload.success_prospect).to eq(success_prospect)
+              expect(proceeding.application_proceeding_type.chances_of_success.reload.success_prospect_details).to eq(success_prospect_details)
             end
 
             it 'redirects to provider applications home page' do

--- a/spec/requests/providers/proceeding_merits_task/success_prospects_spec.rb
+++ b/spec/requests/providers/proceeding_merits_task/success_prospects_spec.rb
@@ -4,8 +4,8 @@ module Providers
   module ProceedingMeritsTask
     RSpec.describe SuccessProspectsController, type: :request do
       let!(:legal_aid_application) { create :legal_aid_application, :with_proceeding_types, explicit_proceeding_types: [pt_da, pt_s8] }
-      let!(:proceeding) { create :proceeding, :da001, legal_aid_application: legal_aid_application }
-      let!(:proceeding_two) { create :proceeding, :se014, legal_aid_application: legal_aid_application }
+      let(:proceeding) { legal_aid_application.proceedings.find_by(ccms_code: 'DA001') }
+      let(:proceeding_two) { legal_aid_application.proceedings.find_by(ccms_code: 'SE014') }
       let(:pt_da) { create :proceeding_type, :with_real_data }
       let(:pt_s8) { create :proceeding_type, :as_section_8_child_residence }
       let(:application_proceeding_type) do


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/jira/software/c/projects/AP/boards/233?modal=detail&selectedIssue=AP-2619)
[Link to story](https://dsdmoj.atlassian.net/jira/software/c/projects/AP/boards/233?modal=detail&selectedIssue=AP-2625)

- Amended task_list_helper.rb to include proceeding_id rather than application_proceeding_type_id in proceeding_task_url
- Amended attempts_to_settle_controller.rb, chances_of_success_controller.rb, linked_children_controller.rb and success_prospects_controller.rb to use proceeding_id.
- Amended flow defined in provider_merits.rb to use proceeding_id.
- Amended app/views/providers/proceeding_merits_task/attempts_to_settle/show.html.erb, app/views/providers/proceeding_merits_task/chances_of_success/index.html.erb, app/views/providers/proceeding_merits_task/linked_children/show.html.erb and app/views/providers/proceeding_merits_task/success_prospects/show.html.erb to reference proceeding rather than application_proceeding_type

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
