### PR TITLE
AP-2609 Mark purgeable service

### DIFF
--- a/app/services/mark_purgeable_service.rb
+++ b/app/services/mark_purgeable_service.rb
@@ -1,14 +1,16 @@
 class MarkPurgeableService
-  THRESHOLD_DATE = 23.months.ago.freeze
-
   def self.call
     new.call
+  end
+
+  def initialize
+    @threshold_date = 23.months.ago
   end
 
   def call
     # update all records whose updated date is more than 23 months ago and set the purgeable_on date to the updated date + 2 years.
     connection = ActiveRecord::Base.connection.raw_connection
     connection.prepare('mark_recs_purgeable', "UPDATE legal_aid_applications SET purgeable_on = date_trunc('day', updated_at) + interval '730' day WHERE updated_at < $1")
-    connection.exec_prepared('mark_recs_purgeable', [THRESHOLD_DATE])
+    connection.exec_prepared('mark_recs_purgeable', [@threshold_date])
   end
 end

--- a/app/services/mark_purgeable_service.rb
+++ b/app/services/mark_purgeable_service.rb
@@ -1,0 +1,11 @@
+class MarkPurgeableService
+  def self.call
+    new.call
+  end
+
+  def call
+    connection = ActiveRecord::Base.connection.raw_connection
+    connection.prepare('mark_recs_purgeable', 'UPDATE legal_aid_applications SET purgeable = true WHERE updated_at < $1')
+    connection.exec_prepared('mark_recs_purgeable', [23.months.ago])
+  end
+end

--- a/app/services/mark_purgeable_service.rb
+++ b/app/services/mark_purgeable_service.rb
@@ -1,11 +1,14 @@
 class MarkPurgeableService
+  THRESHOLD_DATE = 23.months.ago.freeze
+
   def self.call
     new.call
   end
 
   def call
+    # update all records whose updated date is more than 23 months ago and set the purgeable_on date to the updated date + 2 years.
     connection = ActiveRecord::Base.connection.raw_connection
-    connection.prepare('mark_recs_purgeable', 'UPDATE legal_aid_applications SET purgeable = true WHERE updated_at < $1')
-    connection.exec_prepared('mark_recs_purgeable', [23.months.ago])
+    connection.prepare('mark_recs_purgeable', "UPDATE legal_aid_applications SET purgeable_on = date_trunc('day', updated_at) + interval '730' day WHERE updated_at < $1")
+    connection.exec_prepared('mark_recs_purgeable', [THRESHOLD_DATE])
   end
 end

--- a/db/migrate/20211104141141_add_purgeable_tolegal_aid_applications.rb
+++ b/db/migrate/20211104141141_add_purgeable_tolegal_aid_applications.rb
@@ -1,5 +1,5 @@
 class AddPurgeableTolegalAidApplications < ActiveRecord::Migration[6.1]
   def change
-    add_column :legal_aid_applications, :purgeable, :boolean, default: false
+    add_column :legal_aid_applications, :purgeable_on, :date, default: nil
   end
 end

--- a/db/migrate/20211104141141_add_purgeable_tolegal_aid_applications.rb
+++ b/db/migrate/20211104141141_add_purgeable_tolegal_aid_applications.rb
@@ -1,0 +1,5 @@
+class AddPurgeableTolegalAidApplications < ActiveRecord::Migration[6.1]
+  def change
+    add_column :legal_aid_applications, :purgeable, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -544,6 +544,7 @@ ActiveRecord::Schema.define(version: 2021_11_05_083833) do
     t.string "emergency_cost_reasons"
     t.boolean "no_cash_income"
     t.boolean "no_cash_outgoings"
+    t.boolean "purgeable", default: false
     t.index ["applicant_id"], name: "index_legal_aid_applications_on_applicant_id"
     t.index ["application_ref"], name: "index_legal_aid_applications_on_application_ref", unique: true
     t.index ["discarded_at"], name: "index_legal_aid_applications_on_discarded_at"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -544,7 +544,7 @@ ActiveRecord::Schema.define(version: 2021_11_05_083833) do
     t.string "emergency_cost_reasons"
     t.boolean "no_cash_income"
     t.boolean "no_cash_outgoings"
-    t.boolean "purgeable", default: false
+    t.date "purgeable_on"
     t.index ["applicant_id"], name: "index_legal_aid_applications_on_applicant_id"
     t.index ["application_ref"], name: "index_legal_aid_applications_on_application_ref", unique: true
     t.index ["discarded_at"], name: "index_legal_aid_applications_on_discarded_at"

--- a/helm_deploy/apply-for-legal-aid/templates/cronjob-mark-purgeable.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/cronjob-mark-purgeable.yaml
@@ -1,0 +1,35 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: {{ .Release.Name | trunc 26 }}-mark-purgeable
+  labels:
+    app: {{ template "apply-for-legal-aid.name" . }}
+    chart: {{ template "apply-for-legal-aid.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  schedule: '0 1 * * *'
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            reportuploader: cronjob
+        spec:
+          containers:
+          - name: mark-purgeable
+            image: '{{ .Values.image.repository }}:{{ .Values.image.tag }}'
+            imagePullPolicy: IfNotPresent
+            command: ['rake', "purge:mark"]
+{{ include "apply-for-legal-aid.envs" . | nindent 12 }}
+            resources:
+              limits:
+                cpu: 200m
+                memory: 512Mi
+              requests:
+                cpu: 100m
+                memory: 256Mi
+          restartPolicy: Never

--- a/lib/tasks/purge.rake
+++ b/lib/tasks/purge.rake
@@ -1,0 +1,6 @@
+namespace :purge do
+  desc 'Mark old records as purgeable'
+  task mark: :environment do
+    MarkPurgeableService.call
+  end
+end

--- a/spec/services/mark_purgeable_service_spec.rb
+++ b/spec/services/mark_purgeable_service_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe MarkPurgeableService do
+  describe '.call' do
+    let!(:old1) { create :legal_aid_application, updated_at: 24.months.ago }
+    let!(:old2) { create :legal_aid_application, updated_at: 23.months.ago - 1.day }
+    let!(:new1) { create :legal_aid_application, updated_at: 23.months.ago + 1.day }
+    let!(:new2) { create :legal_aid_application, updated_at: 6.months.ago }
+
+    it 'marks all records not updated for 23 months as purgeable' do
+      described_class.call
+      expect(old1.reload.purgeable?).to be true
+      expect(old2.reload.purgeable?).to be true
+      expect(new1.reload.purgeable?).to be false
+      expect(new2.reload.purgeable?).to be false
+    end
+  end
+end

--- a/spec/services/mark_purgeable_service_spec.rb
+++ b/spec/services/mark_purgeable_service_spec.rb
@@ -2,17 +2,19 @@ require 'rails_helper'
 
 RSpec.describe MarkPurgeableService do
   describe '.call' do
-    let!(:old1) { create :legal_aid_application, updated_at: 24.months.ago }
-    let!(:old2) { create :legal_aid_application, updated_at: 23.months.ago - 1.day }
+    let(:old_date1) { 24.months.ago }
+    let(:old_date2) { 23.months.ago - 1.day }
+    let!(:old1) { create :legal_aid_application, updated_at: old_date1 }
+    let!(:old2) { create :legal_aid_application, updated_at: old_date2 }
     let!(:new1) { create :legal_aid_application, updated_at: 23.months.ago + 1.day }
     let!(:new2) { create :legal_aid_application, updated_at: 6.months.ago }
 
     it 'marks all records not updated for 23 months as purgeable' do
       described_class.call
-      expect(old1.reload.purgeable?).to be true
-      expect(old2.reload.purgeable?).to be true
-      expect(new1.reload.purgeable?).to be false
-      expect(new2.reload.purgeable?).to be false
+      expect(old1.reload.purgeable_on).to eq (old_date1 + 730.days).to_date
+      expect(old2.reload.purgeable_on).to eq (old_date2 + 730.days).to_date
+      expect(new1.reload.purgeable_on).to be_nil
+      expect(new2.reload.purgeable_on).to be_nil
     end
   end
 end


### PR DESCRIPTION

## Mark purgeable service

Service to mark as purgaeble those records ripe for deletion

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2609)

- Added purgeable column to `LegalAidApplication`
- Service to mark all records over a certain age as purgeable
- Rake take to run that service
- Cronjob to run the rake task nightly

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
