### PR TITLE
AP-2643: Update CircleCI images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ executors:
           GITHUB_TEAM_NAME_SLUG: laa-apply-for-legal-aid
   linting-executor:
     docker:
-      - image: circleci/ruby:3.0.2-node-browsers
+      - image: cimg/ruby:3.0.2-browsers
         environment:
           - RAILS_ENV=test
           - TZ: "Europe/London"
@@ -29,11 +29,11 @@ executors:
 
   test-executor:
     docker:
-      - image: circleci/ruby:3.0.2-node-browsers
+      - image: cimg/ruby:3.0.2-browsers
         environment:
           GITHUB_TEAM_NAME_SLUG: laa-apply-for-legal-aid
-      - image: circleci/postgres:10.5
-      - image: circleci/redis:5.0
+      - image: cimg/postgres:10.5
+      - image: cimg/redis:5.0
       - image: ghcr.io/ministryofjustice/hmpps-clamav:latest
 
 references:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,7 @@
 version: 2.1
 
 orbs:
+  browser-tools: circleci/browser-tools@1.2.3
   slack: circleci/slack@4.4.4
 
 executors:
@@ -35,7 +36,6 @@ executors:
       - image: cimg/postgres:10.18
       - image: cimg/redis:5.0
       - image: ghcr.io/ministryofjustice/hmpps-clamav:latest
-
 references:
   decrypt_secrets: &decrypt_secrets
     run:
@@ -249,6 +249,8 @@ jobs:
   integration_tests:
     executor: test-executor
     steps:
+    - browser-tools/install-chrome
+    - browser-tools/install-chromedriver
     - checkout
     - *install_lib_ffi
     - *install_packages_for_testing

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ executors:
       - image: cimg/ruby:3.0.2-browsers
         environment:
           GITHUB_TEAM_NAME_SLUG: laa-apply-for-legal-aid
-      - image: cimg/postgres:10.5
+      - image: cimg/postgres:10.18
       - image: cimg/redis:5.0
       - image: ghcr.io/ministryofjustice/hmpps-clamav:latest
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2643)

Replace `circleci/*` with `cimg/`
Replace `-node-browsers` with just `-browsers`
Load `chrome` and `chromedrivers` as part of the integration tests job only, they aren't needed for rspec

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
