### PR TITLE
AP-2622 Remove unneeded SubmittedApplication code

### DIFF
--- a/app/controllers/providers/submitted_applications_controller.rb
+++ b/app/controllers/providers/submitted_applications_controller.rb
@@ -2,9 +2,6 @@ module Providers
   class SubmittedApplicationsController < ProviderBaseController
     authorize_with_policy_method :show_submitted_application?
 
-    def show
-      @application_proceeding_type = legal_aid_application.lead_application_proceeding_type
-      @proceeding = legal_aid_application.lead_proceeding
-    end
+    def show; end
   end
 end

--- a/app/views/providers/submitted_applications/show.html.erb
+++ b/app/views/providers/submitted_applications/show.html.erb
@@ -133,8 +133,6 @@
         statement_of_case: @legal_aid_application.statement_of_case,
         gateway_evidence: @legal_aid_application&.gateway_evidence,
         opponent: @legal_aid_application.opponent,
-        chances_of_success: @proceeding.chances_of_success,
-        application_proceeding_type: @legal_aid_application.lead_application_proceeding_type,
         read_only: true
       ) %>
     </section>


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2622)

This is slightly different to what the ticket asked for. The lines of code that refer to `application_proceedings_types` aren't acually needed - they are passed to the `app/views/shared/check_answers/_merits.html.erb` partial however aren't ever used. I suspect they are a hangover from pre-multiple proceedings days.

This change simply deletes the unused code. The submitted application page appears as expected without it. It might be useful if someone could double-check my logic though 😁 

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
