### PR TITLE
AP-2627 Remove unused CheckMeritsAnswers code

### DIFF
--- a/app/controllers/providers/check_merits_answers_controller.rb
+++ b/app/controllers/providers/check_merits_answers_controller.rb
@@ -3,7 +3,6 @@ module Providers
     def show
       legal_aid_application.create_opponent! unless legal_aid_application.opponent
       legal_aid_application.check_merits_answers! unless legal_aid_application.checking_merits_answers?
-      application_proceeding_type
     end
 
     def continue
@@ -17,12 +16,6 @@ module Providers
     def reset
       legal_aid_application.reset!
       redirect_to providers_legal_aid_application_gateway_evidence_path(legal_aid_application)
-    end
-
-    private
-
-    def application_proceeding_type
-      @application_proceeding_type ||= legal_aid_application.lead_application_proceeding_type
     end
   end
 end

--- a/app/views/providers/check_merits_answers/show.html.erb
+++ b/app/views/providers/check_merits_answers/show.html.erb
@@ -8,7 +8,6 @@
         incident: @legal_aid_application.latest_incident,
         statement_of_case: @legal_aid_application.statement_of_case,
         opponent: @legal_aid_application.opponent,
-        chances_of_success: @application_proceeding_type.chances_of_success,
         gateway_evidence: @legal_aid_application&.gateway_evidence,
         read_only: false
       ) %>


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2627)

Similar to [AP-2622](https://github.com/ministryofjustice/laa-apply-for-legal-aid/pull/3051), rather than change `application_proceeding_types` to `proceedings`, I've simply removed them as they are no longer being used.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
