### PR TITLE
add test for method only used in CCMS tests

### DIFF
--- a/app/models/concerns/delegated_functions.rb
+++ b/app/models/concerns/delegated_functions.rb
@@ -3,6 +3,8 @@ module DelegatedFunctions
     application_proceeding_types.any?(&:used_delegated_functions?)
   end
 
+  # TODO: move the logic from the method below into used_delegated_functions? method above
+  # and remove the associated tests for this method on legal_aid_application
   def proceedings_used_delegated_functions?
     proceedings.any?(&:used_delegated_functions?)
   end

--- a/spec/models/legal_aid_application_spec.rb
+++ b/spec/models/legal_aid_application_spec.rb
@@ -441,6 +441,22 @@ RSpec.describe LegalAidApplication, type: :model do
     end
   end
 
+  describe '#proceedings_used_delegated_functions?' do
+    context 'application uses df' do
+      let(:legal_aid_application) { create :legal_aid_application, :with_proceedings, explicit_proceedings: [:da004], set_lead_proceeding: :da004 }
+      it 'returns true' do
+        expect(legal_aid_application.proceedings_used_delegated_functions?).to be(true)
+      end
+    end
+
+    context 'application does not use df' do
+      let(:legal_aid_application) { create :legal_aid_application, :with_proceedings }
+      it 'returns false' do
+        expect(legal_aid_application.proceedings_used_delegated_functions?).to be(false)
+      end
+    end
+  end
+
   describe '#read_only?' do
     context 'provider application not submitted' do
       let(:legal_aid_application) { create :legal_aid_application, :with_non_passported_state_machine }


### PR DESCRIPTION

## What

Bugfix - a method on delegated functions was only covered by tests in CCMS files. This meant that running rspec tests without CCMS tests would result in 99.99% coverage issue. This adds a test to cover the method in question and also a note to merge it with the method above when application_proceeding_type are removed.

Describe what you did and why.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
