### PR TITLE
AP-2636 Add feature flag for employed journeys

### DIFF
--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -20,7 +20,8 @@ module Admin
       params.require(:setting).permit(:mock_true_layer_data,
                                       :manually_review_all_cases,
                                       :allow_welsh_translation,
-                                      :enable_ccms_submission)
+                                      :enable_ccms_submission,
+                                      :enable_employed_journey)
     end
 
     def setting

--- a/app/forms/settings/setting_form.rb
+++ b/app/forms/settings/setting_form.rb
@@ -5,12 +5,14 @@ module Settings
     attr_accessor :mock_true_layer_data,
                   :manually_review_all_cases,
                   :allow_welsh_translation,
-                  :enable_ccms_submission
+                  :enable_ccms_submission,
+                  :enable_employed_journey
 
     validates :mock_true_layer_data,
               :manually_review_all_cases,
               :allow_welsh_translation,
               :enable_ccms_submission,
+              :enable_employed_journey,
               presence: true
   end
 end

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -23,6 +23,10 @@ class Setting < ApplicationRecord
     setting.alert_via_sentry
   end
 
+  def self.enable_employed_journey?
+    setting.enable_employed_journey
+  end
+
   def self.setting
     Setting.first || Setting.create!
   end

--- a/app/views/admin/settings/show.html.erb
+++ b/app/views/admin/settings/show.html.erb
@@ -46,6 +46,16 @@
         legend: { text: t('.labels.enable_ccms_submission') }
     ) %>
 
+    <%= form.govuk_collection_radio_buttons(
+        :enable_employed_journey,
+        yes_no_options,
+        :value,
+        :label,
+        inline: true,
+        hint: { text: t('.hints.enable_employed_journey')},
+        legend: { text: t('.labels.enable_employed_journey') }
+    ) %>
+
     <%= form.submit(t('generic.submit'), class: 'govuk-button form-button') %>
   <% end %>
 <% end %>

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -38,6 +38,7 @@ en:
           manually_review_all_cases: Manually review all non-passported applications
           allow_welsh_translation: Allow Welsh translation
           enable_ccms_submission: Allow CCMS submissions
+          enable_employed_journey: Allow employed applications
         hints:
           mock_true_layer_data: Select Yes and TrueLayer data will be replaced by mock data from %{bank_transaction_filename}
           manually_review_all_cases: |
@@ -45,6 +46,7 @@ en:
             Select Yes to additionally route all non-passported applications to caseworker for review.
           allow_welsh_translation: Select Yes to translate the service into Welsh
           enable_ccms_submission: Yes by default, only set to No if CCMS is being taken offline
+          enable_employed_journey: Select Yes to allow solicitors to submit applications for employed applicants 
     submitted_applications_reports:
       show:
         heading_1: Submitted Applications

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -50,3 +50,5 @@ en:
           <<: *true_false
         allow_welsh_translation:
           <<: *true_false
+        enable_employed_journey:
+          <<: *true_false

--- a/db/migrate/20211112174848_add_employed_journey_flag_to_settings.rb
+++ b/db/migrate/20211112174848_add_employed_journey_flag_to_settings.rb
@@ -1,0 +1,5 @@
+class AddEmployedJourneyFlagToSettings < ActiveRecord::Migration[6.1]
+  def change
+    add_column :settings, :enable_employed_journey, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_05_083833) do
+ActiveRecord::Schema.define(version: 2021_11_12_174848) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -829,6 +829,7 @@ ActiveRecord::Schema.define(version: 2021_11_05_083833) do
     t.boolean "enable_ccms_submission", default: true, null: false
     t.boolean "alert_via_sentry", default: true, null: false
     t.datetime "digest_extracted_at", default: "1970-01-01 00:00:01"
+    t.boolean "enable_employed_journey", default: false, null: false
   end
 
   create_table "state_machine_proxies", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/lib/tasks/setup_db_for_testing.rake
+++ b/lib/tasks/setup_db_for_testing.rake
@@ -6,7 +6,8 @@ namespace :settings do
                     bank_transaction_filename: 'db/sample_data/bank_transactions_2.csv',
                     manually_review_all_cases: false,
                     allow_welsh_translation: false,
-                    enable_ccms_submission: true)
+                    enable_ccms_submission: true,
+                    enable_employed_journey: false)
 
     pp Setting.first
   end

--- a/spec/models/setting_spec.rb
+++ b/spec/models/setting_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Setting do
         expect(rec.allow_welsh_translation?).to be false
         expect(rec.bank_transaction_filename).to eq 'db/sample_data/bank_transactions.csv'
         expect(rec.alert_via_sentry?).to be true
+        expect(rec.enable_employed_journey?).to be false
       end
     end
 
@@ -23,7 +24,8 @@ RSpec.describe Setting do
           allow_welsh_translation: false,
           enable_ccms_submission: false,
           bank_transaction_filename: 'my_special_file.csv',
-          alert_via_sentry: true
+          alert_via_sentry: true,
+          enable_employed_journey: true
         )
       end
 
@@ -35,6 +37,7 @@ RSpec.describe Setting do
         expect(rec.enable_ccms_submission?).to be false
         expect(rec.bank_transaction_filename).to eq 'my_special_file.csv'
         expect(rec.alert_via_sentry?).to be true
+        expect(rec.enable_employed_journey?).to be true
       end
     end
   end
@@ -49,6 +52,7 @@ RSpec.describe Setting do
       expect(Setting.enable_ccms_submission?).to be true
       expect(Setting.bank_transaction_filename).to eq 'db/sample_data/bank_transactions.csv'
       expect(Setting.alert_via_sentry?).to be true
+      expect(Setting.enable_employed_journey?).to be false
     end
   end
 end

--- a/spec/requests/admin/settings_spec.rb
+++ b/spec/requests/admin/settings_spec.rb
@@ -36,7 +36,8 @@ RSpec.describe Admin::SettingsController, type: :request do
       {
         setting: {
           mock_true_layer_data: 'true',
-          allow_welsh_translation: 'true'
+          allow_welsh_translation: 'true',
+          enable_employed_journey: 'true'
         }
       }
     end
@@ -52,6 +53,7 @@ RSpec.describe Admin::SettingsController, type: :request do
       subject
       expect(setting.mock_true_layer_data?).to eq(true)
       expect(setting.allow_welsh_translation?).to eq(true)
+      expect(setting.enable_employed_journey?).to eq(true)
     end
 
     it 'create settings if they do not exist' do


### PR DESCRIPTION

## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2636)

Adds a feature flag setting to allow employed journeys to be enabled/disabled.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
