### PR TITLE
Tech debt: Update YAML.safe_load instantiation pattern

### DIFF
--- a/app/models/legal_framework/serializable_merits_task_list.rb
+++ b/app/models/legal_framework/serializable_merits_task_list.rb
@@ -34,7 +34,7 @@ module LegalFramework
     end
 
     def self.new_from_serialized(yaml_string)
-      YAML.safe_load(yaml_string, SAFE_SERIALIZABLE_CLASSES, aliases: true)
+      YAML.safe_load(yaml_string, permitted_classes: SAFE_SERIALIZABLE_CLASSES, aliases: true)
     end
 
     def empty?

--- a/app/services/metrics/sidekiq_queue_sizes.rb
+++ b/app/services/metrics/sidekiq_queue_sizes.rb
@@ -30,7 +30,7 @@ module Metrics
 
     def queues
       sidekiq_config = File.read(Rails.root.join('config/sidekiq.yml'))
-      YAML.safe_load(sidekiq_config, [Symbol])[:queues]
+      YAML.safe_load(sidekiq_config, permitted_classes: [Symbol])[:queues]
     end
   end
 end


### PR DESCRIPTION
## What

The pattern we currently use causes a lot of errors
as it is unsupported in the next update of ruby

This PR adds the new, permitted_classes: pattern.
It works with the current version of ruby _and_ the
next, 3.1, release of ruby

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
