### PR TITLE
AP-2598: Update student finance content

### DIFF
--- a/app/views/providers/income_summary/index.html.erb
+++ b/app/views/providers/income_summary/index.html.erb
@@ -42,7 +42,7 @@
     <% if @legal_aid_application.student_finance? %>
       <div>
        <h3 class="govuk-heading-m govuk-!-padding-top-6"><%= t('.student_finance') %></h3>
-        <p class="gov-body"><%= t('.client_told_us') %> <%= gds_number_to_currency(@legal_aid_application.value_of_student_finance) %><%= t('.academic_year') %></p>
+        <p class="gov-body"><p><%= t('.academic_year_html', student_finance: value_with_currency_unit(@legal_aid_application.value_of_student_finance, t('currency.gbp'))) %></p></p>
       </div>
     <% end %>
 

--- a/app/views/providers/means_summaries/show.html.erb
+++ b/app/views/providers/means_summaries/show.html.erb
@@ -8,11 +8,10 @@
          url: :income_summary,
           transaction_types: TransactionType.credits
       ) %>
-
-  <% if @student_finance %>
+  <% if @legal_aid_application.value_of_student_finance %>
     <h3 class="govuk-heading-m"><%= t('.student_finance.heading') %></h3>
 
-    <p><%= t('.student_finance.info', student_finance: value_with_currency_unit(@student_finance, t('currency.gbp'))) %></p>
+    <p><%= t('.student_finance.info_html', student_finance: value_with_currency_unit(@legal_aid_application.value_of_student_finance, t('currency.gbp'))) %></p>
   <% end %>
 
   <%= render(

--- a/app/views/providers/no_income_summaries/show.html.erb
+++ b/app/views/providers/no_income_summaries/show.html.erb
@@ -27,7 +27,7 @@
       <% if @student_finance %>
         <h2 class="govuk-heading-l"><%= t('.student_finance.heading') %></h2>
 
-        <p><%= t('.student_finance.info', student_finance: value_with_currency_unit(@student_finance, t('currency.gbp'))) %></p>
+        <p><%= t('.student_finance.info_html', student_finance: value_with_currency_unit(@student_finance, t('currency.gbp'))) %></p>
       <% end %>
 
       <div class="govuk-!-padding-bottom-2"></div>

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -421,8 +421,7 @@ en:
         col_description: Description
         remove_link: Remove
       index:
-        academic_year: ' in student finance this academic year.'
-        client_told_us: Your client also told us they'll get
+        academic_year_html: '<strong>%{student_finance}</strong> this academic year.'
         following_payments: Your client also told us they received the following payments. These will be included in the financial eligibility calculation.
         other_heading: Other income
         page_heading: "Sort your client's income into categories"
@@ -520,7 +519,7 @@ en:
         h2-heading: Your client's income and outgoings
         student_finance:
           heading: Student finance
-          info: Your client also told us they'll get %{student_finance} in student finance this academic year.
+          info_html: '<strong>%{student_finance}</strong> this academic year.'
         dependants:
           heading: Dependants
           has_dependants: Does your client have any dependants?
@@ -626,7 +625,7 @@ en:
         is_this_correct: Is this correct?
         student_finance:
           heading: Student finance
-          info: Your client also told us they'll get %{student_finance} in student finance this academic year.
+          info_html: '<strong>%{student_finance}</strong> this academic year.'
         error: Select yes if your client does not receive these payments
     no_outgoings_summaries:
       show:

--- a/features/providers/non_passported_journey.feature
+++ b/features/providers/non_passported_journey.feature
@@ -319,7 +319,7 @@ Feature: Non-passported applicant journeys
     And I click 'Save and continue'
     Then I should be on the 'income_summary' page showing "Sort your client's income into categories"
     And I should see 'Student finance'
-    And I should see 'in student finance this academic year.'
+    And I should see 'this academic year.'
     Then I click the first link 'View statements and add transactions'
     Then I select the first checkbox
     And I click 'Save and continue'
@@ -349,7 +349,7 @@ Feature: Non-passported applicant journeys
     When I select 'England Infected Blood Support Scheme'
     And I click 'Save and continue'
     Then I should be on the 'means_summary' page showing 'Check your answers'
-    And I should not see 'Student finance'
+    And I should see 'Student finance'
 
   @javascript
   Scenario: Fill in the Applicant employment information after negative benefit check result and used delegated functions


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2598)

Update the display of student finance amounts in both income summary pages and the means summary page.
Fixes a bug on the means summary that meant the student finance amount was never displayed

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
