### PR TITLE
Fix: Gemfile.lock platforms

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -729,8 +729,7 @@ GEM
     zeitwerk (2.5.1)
 
 PLATFORMS
-  x86_64-darwin-20
-  x86_64-linux
+  ruby
 
 DEPENDENCIES
   aasm (~> 5.2.0)


### PR DESCRIPTION
## What

Revert to `ruby` and the let the relevant systems handle the platform


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
