### PR TITLE
AP-2633 Fix ingress annotation for UAT deployments

### DIFF
--- a/bin/uat_deploy
+++ b/bin/uat_deploy
@@ -5,7 +5,7 @@ deploy() {
   RELEASE_BRANCH=$(echo $CIRCLE_BRANCH | tr '[:upper:]' '[:lower:]' | sed 's:^\w*\/::' | tr -s ' _/[]().' '-' | cut -c1-30 | sed 's/-$//')
   RELEASE_NAME="apply-$RELEASE_BRANCH"
   RELEASE_HOST="$RELEASE_BRANCH-$UAT_HOST"
-  IDENTIFIER="$RELEASE_NAME-laa-apply-for-legal-aid-laa-apply-for-legalaid-uat-blue"
+  IDENTIFIER="$RELEASE_NAME-apply-for-legal-aid-laa-apply-for-legalaid-uat-blue"
 
   echo "Deploying CIRCLE_SHA1: $CIRCLE_SHA1 under release name: '$RELEASE_NAME'..."
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2633)

UAT Ingress notation has incorrect naming. This fixes the uat_deploy script so that the ingress is set correctly.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
