### PR TITLE
AP-2614 remove conditionally revealed text

### DIFF
--- a/app/views/providers/substantive_applications/show.html.erb
+++ b/app/views/providers/substantive_applications/show.html.erb
@@ -14,15 +14,16 @@
       </p>
 
       <%= form.govuk_radio_button :substantive_application, true, label: { text: t('generic.yes') } %>
-
-      <%= form.govuk_radio_button :substantive_application, false, label: { text: t('.no_start_later') } do %>
-        <p class="govuk-body">
-          <%= t('.must_submit_by', deadline: @form.substantive_application_deadline_on) %>
-        </p>
-      <% end %>
+      <%= form.govuk_radio_button :substantive_application, false, label: { text: t('.no_start_later') } %>
     <% end %>
 
-    <div class="govuk-!-padding-bottom-4"></div>
+    <div class='govuk-warning-text'>
+      <span class='govuk-warning-text__icon' aria-hidden='true'>i</span>
+      <strong class='govuk-warning-text__text'>
+        <span class='govuk-warning-text__assistive'>Notice</span>
+        <%= t('.must_submit_by', deadline: @form.substantive_application_deadline_on) %>
+      </strong>
+    </div>
 
     <%= next_action_buttons(show_draft: true, form: form) %>
   <% end %>


### PR DESCRIPTION
## AP-2614 remove conditionally revealed text from substantive application page

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2614)

Donditionally revealed text content is no longer deemed to be accessible by the GOV.UK Design system - remove this content and replace with warning text below the radios fieldset

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
