### PR TITLE
Fix live deployments for long branch names

### DIFF
--- a/bin/uat_deploy
+++ b/bin/uat_deploy
@@ -5,7 +5,8 @@ deploy() {
   RELEASE_BRANCH=$(echo $CIRCLE_BRANCH | tr '[:upper:]' '[:lower:]' | sed 's:^\w*\/::' | tr -s ' _/[]().' '-' | cut -c1-30 | sed 's/-$//')
   RELEASE_NAME="apply-$RELEASE_BRANCH"
   RELEASE_HOST="$RELEASE_BRANCH-$UAT_HOST"
-  IDENTIFIER="$RELEASE_NAME-apply-for-legal-aid-laa-apply-for-legalaid-uat-blue"
+  INGRESS_NAME=$(echo "$RELEASE_NAME-apply-for-legal-aid" | cut -c1-52)
+  IDENTIFIER="$INGRESS_NAME-${KUBE_ENV_UAT_NAMESPACE}-blue"
 
   echo "Deploying CIRCLE_SHA1: $CIRCLE_SHA1 under release name: '$RELEASE_NAME'..."
 

--- a/bin/uat_deploy_to_live
+++ b/bin/uat_deploy_to_live
@@ -5,7 +5,8 @@ deploy() {
   RELEASE_BRANCH=$(echo $CIRCLE_BRANCH | tr '[:upper:]' '[:lower:]' | sed 's:^\w*\/::' | tr -s ' _/[]().' '-' | cut -c1-30 | sed 's/-$//')
   RELEASE_NAME="apply-$RELEASE_BRANCH"
   RELEASE_HOST="$RELEASE_BRANCH-$UAT_HOST"
-  IDENTIFIER="$RELEASE_NAME-apply-for-legal-aid-laa-apply-for-legalaid-uat-green"
+  INGRESS_NAME=$(echo "$RELEASE_NAME-apply-for-legal-aid" | cut -c1-52)
+  IDENTIFIER="$INGRESS_NAME-${KUBE_ENV_UAT_NAMESPACE}-green"
 
   echo "Deploying CIRCLE_SHA1: $CIRCLE_SHA1 under release name: '$RELEASE_NAME'..."
 


### PR DESCRIPTION
## What

On branches with long names, deployments to the live cluster fail because the annotation we set in `uat_deploy_to_live` does not match the truncated ingress name expected by cloud platform.

This commit updates the `uat_deploy_to_live` so that it also truncates long names to 52 characters, which allows deployments to succeed.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
