### PR TITLE
Fix live deployments for long branch names

### DIFF
--- a/bin/uat_deploy
+++ b/bin/uat_deploy
@@ -5,7 +5,7 @@ deploy() {
   RELEASE_BRANCH=$(echo $CIRCLE_BRANCH | tr '[:upper:]' '[:lower:]' | sed 's:^\w*\/::' | tr -s ' _/[]().' '-' | cut -c1-30 | sed 's/-$//')
   RELEASE_NAME="apply-$RELEASE_BRANCH"
   RELEASE_HOST="$RELEASE_BRANCH-$UAT_HOST"
-  INGRESS_NAME=$(echo "$RELEASE_NAME-apply-for-legal-aid" | cut -c1-52)
+  INGRESS_NAME=$(echo "$RELEASE_NAME-apply-for-legal-aid" | cut -c1-53 | sed 's/-$//')
   IDENTIFIER="$INGRESS_NAME-${KUBE_ENV_UAT_NAMESPACE}-blue"
 
   echo "Deploying CIRCLE_SHA1: $CIRCLE_SHA1 under release name: '$RELEASE_NAME'..."

--- a/bin/uat_deploy_to_live
+++ b/bin/uat_deploy_to_live
@@ -5,7 +5,7 @@ deploy() {
   RELEASE_BRANCH=$(echo $CIRCLE_BRANCH | tr '[:upper:]' '[:lower:]' | sed 's:^\w*\/::' | tr -s ' _/[]().' '-' | cut -c1-30 | sed 's/-$//')
   RELEASE_NAME="apply-$RELEASE_BRANCH"
   RELEASE_HOST="$RELEASE_BRANCH-$UAT_HOST"
-  INGRESS_NAME=$(echo "$RELEASE_NAME-apply-for-legal-aid" | cut -c1-52)
+  INGRESS_NAME=$(echo "$RELEASE_NAME-apply-for-legal-aid" | cut -c1-53 | sed 's/-$//')
   IDENTIFIER="$INGRESS_NAME-${KUBE_ENV_UAT_NAMESPACE}-green"
 
   echo "Deploying CIRCLE_SHA1: $CIRCLE_SHA1 under release name: '$RELEASE_NAME'..."


### PR DESCRIPTION
## What

Some deployments are still failing due to branch names, apparently because we truncate the name in slightly the wrong place. This commit changes the truncation from 52 to 53 characters.

Tested on this failing pull request: https://github.com/ministryofjustice/laa-apply-for-legal-aid/pull/3105, deployment is now successful.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
