### PR TITLE
ap-2697 Add employment permissions

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -45,6 +45,10 @@ class Provider < ApplicationRecord
     user_permissions.map(&:role).include?('application.non_passported.*')
   end
 
+  def employment_permissions?
+    user_permissions.map(&:role).include?('application.non_passported.employment.*')
+  end
+
   def ccms_apply_role?
     return true if Rails.configuration.x.laa_portal.mock_saml == 'true'
 

--- a/db/data/20211125142125_add_employment_to_permissions_table.rb
+++ b/db/data/20211125142125_add_employment_to_permissions_table.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddEmploymentToPermissionsTable < ActiveRecord::Migration[6.1]
+  def up
+    Permission.create(role: 'application.non_passported.employment.*', description: 'Can create, edit, delete employment applications')
+  end
+
+  def down
+    Permission.where(role: 'application.non_passported.employment.*').delete_all
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20211112125241)
+DataMigrate::Data.define(version: 20211125142125)

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -60,6 +60,7 @@ RSpec.describe Provider, type: :model do
 
       it 'returns the permission for the provider' do
         expect(provider.user_permissions).to eq [passported_permission]
+        expect(provider.employment_permissions?).to be false
       end
     end
 


### PR DESCRIPTION

## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2697)

Add a new permission and a method to check for employment permissions.

Currently employment is a child of non_passported permission. There is no specific reason why it is not `application.employment.*` and it is an easy change if this is preferred. My thinking is that employed would only be of use to users with non_passported permssion. However all users have non_passported permissions so it is not a strong argument for how I have implemented it.

I have tested using `provider.employment_permissions?` to change the flow and it works as expected.

  The ticket is light on details about the `done when` for this spike. We can either merge this PR in readiness for when it is needed, or wait until it is needed and it can be done as part of another ticket now we know that the existing permissions system we have can be used for employment.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
