### PR TITLE
bugfix: display correct response on means report

### DIFF
--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -346,10 +346,14 @@ class LegalAidApplication < ApplicationRecord
   end
 
   def online_savings_accounts_balance
+    return nil if applicant.bank_accounts.savings.empty?
+
     applicant.bank_accounts.savings.sum(&:latest_balance)
   end
 
   def online_current_accounts_balance
+    return nil if applicant.bank_accounts.current.empty?
+
     applicant.bank_accounts.current.sum(&:latest_balance)
   end
 

--- a/app/views/shared/check_answers/_assets.html.erb
+++ b/app/views/shared/check_answers/_assets.html.erb
@@ -18,14 +18,14 @@
               name: :online_current_accounts,
               url: check_answer_url_for(journey_type, :applicant_bank_accounts, @legal_aid_application),
               question: t('.assets.current_account'),
-              answer: online_current_accounts ? gds_number_to_currency(online_current_accounts) : t('generic.none_declared'),
+              answer: online_current_accounts.present? ? gds_number_to_currency(online_current_accounts) : t('generic.none_declared'),
               read_only: read_only,
             ) %>
         <%= check_answer_link(
               name: :online_savings_accounts,
               url: check_answer_url_for(journey_type, :applicant_bank_accounts, @legal_aid_application),
               question: t('.assets.savings_account'),
-              answer: online_savings_accounts ? gds_number_to_currency(online_savings_accounts) : t('generic.none_declared'),
+              answer: online_savings_accounts.present? ? gds_number_to_currency(online_savings_accounts) : t('generic.none_declared'),
               read_only: read_only,
             ) %>
       </dl>


### PR DESCRIPTION

## What

The means report is showing £0 for the balance on accounts when they do not exist. This was noticed by a caseworker on a savings account, change made to both savings and current accounts to ensure we report these correctly on the means report. The safe operator (&) in the query returns a 0 as the savings accounts is an empty array

Describe what you did and why.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
