### PR TITLE
AP-2565 Move HMRC call

### DIFF
--- a/app/controllers/providers/applicant_employed_controller.rb
+++ b/app/controllers/providers/applicant_employed_controller.rb
@@ -7,7 +7,6 @@ module Providers
 
     def create
       @form = Applicants::EmployedForm.new(form_params)
-      HMRC::CreateResponsesService.call(legal_aid_application) if @form.employed.eql?('true') && Rails.configuration.x.collect_hmrc_data
       render :index unless save_continue_or_draft(@form)
     end
 

--- a/app/controllers/providers/confirm_dwp_non_passported_applications_controller.rb
+++ b/app/controllers/providers/confirm_dwp_non_passported_applications_controller.rb
@@ -9,8 +9,9 @@ module Providers
       return continue_or_draft if draft_selected?
 
       if form.valid?
-        details_checked! if form.correct_dwp_result? && !details_checked?
-        return go_forward(form.correct_dwp_result?)
+        details_checked! if correct_dwp_result? && !details_checked?
+        HMRC::CreateResponsesService.call(legal_aid_application) if make_hmrc_call?
+        return go_forward(correct_dwp_result?)
       end
 
       render :show
@@ -46,6 +47,26 @@ module Providers
       temp_page_history = page_history
       temp_page_history.delete_if { |path| path.include?('check_benefits') }
       page_history_service.write(temp_page_history)
+    end
+
+    def correct_dwp_result?
+      form.correct_dwp_result?
+    end
+
+    def employed_journey_enabled?
+      Setting.enable_employed_journey?
+    end
+
+    def hmrc_call_enabled?
+      Rails.configuration.x.collect_hmrc_data
+    end
+
+    def user_has_employment_permissions?
+      legal_aid_application.provider.employment_permissions?
+    end
+
+    def make_hmrc_call?
+      correct_dwp_result? && employed_journey_enabled? && hmrc_call_enabled? && user_has_employment_permissions?
     end
   end
 end

--- a/app/controllers/providers/confirm_dwp_non_passported_applications_controller.rb
+++ b/app/controllers/providers/confirm_dwp_non_passported_applications_controller.rb
@@ -1,5 +1,7 @@
 module Providers
   class ConfirmDWPNonPassportedApplicationsController < ProviderBaseController
+    helper_method :display_hmrc_inset_text?
+
     def show
       delete_check_benefits_from_history
       form
@@ -67,6 +69,10 @@ module Providers
 
     def make_hmrc_call?
       correct_dwp_result? && employed_journey_enabled? && hmrc_call_enabled? && user_has_employment_permissions?
+    end
+
+    def display_hmrc_inset_text?
+      employed_journey_enabled? && hmrc_call_enabled? && user_has_employment_permissions?
     end
   end
 end

--- a/app/views/providers/applicant_employed/index.html.erb
+++ b/app/views/providers/applicant_employed/index.html.erb
@@ -17,7 +17,6 @@
           yes_no_options,
           :value,
           :label,
-          hint: {text: t('.hint')},
           legend: {text: content_for(:page_title), size: 'xl', tag: 'h1'}
         ) %>
 

--- a/app/views/providers/confirm_dwp_non_passported_applications/show.html.erb
+++ b/app/views/providers/confirm_dwp_non_passported_applications/show.html.erb
@@ -16,6 +16,12 @@
                                               legend: {text: t('.title_html'), tag: 'h1', size: 'l'},
                                               classes: ['govuk-!-margin-top-4'] %>
 
+      <% if display_hmrc_inset_text? %>
+        <div class="govuk-inset-text">
+          <%= t('.hmrc_inset_text') %>
+        </div>
+      <% end %>
+
       <% if @form.errors.any? %>
         <%= link_to_accessible @form.errors.map { |error| error.message }.first, "#correct_dwp_result-true-field", class: 'govuk-heading-s' %>
       <% end %>
@@ -26,7 +32,7 @@
             url: providers_legal_aid_application_confirm_dwp_non_passported_applications_path,
             method: :patch,
             show_draft: true,
-            continue_button_text: t('generic.continue')
+            continue_button_text: t('generic.save_and_continue')
           ) %>
     <% end %>
   <% end %>

--- a/app/webpack/stylesheets/interruption-panel.scss
+++ b/app/webpack/stylesheets/interruption-panel.scss
@@ -53,6 +53,11 @@
     border-color: govuk-colour("black");
     background-color: govuk-colour("white");
   }
+
+  .govuk-inset-text {
+    color: govuk-colour("white");
+    border-left: $govuk-border-width-wide solid govuk-colour("white");;
+  }
 }
 @media (min-width: 769px) {
   .interruption-panel {

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -25,7 +25,6 @@ en:
     applicant_employed:
       index:
         heading_1: Is your client employed?
-        hint: If your client is employed we'll share their personal details with HMRC to check their employment status.
     application_confirmations:
       show:
         application_created: Application created
@@ -166,6 +165,7 @@ en:
         'no': No, my client receives a passporting benefit
         tab_title: DWP records show that your client does not receive a passporting benefit – is this correct?
         title_html: <abbr title='Department for Work and Pensions'>DWP</abbr> records show that your client does not receive a passporting benefit – is this correct?
+        hmrc_inset_text: If your client does not receive a passporting benefit, we'll check their details with HM Revenue and Customs (HMRC). You can review these details later.
     confirm_multiple_delegated_functions_dates:
       show:
         heading: Confirm when you used delegated functions

--- a/features/accessibility/provider.feature
+++ b/features/accessibility/provider.feature
@@ -55,7 +55,7 @@ Feature: Provider accessibility
     Then I click 'Save and continue'
     Then I should be on a page showing "DWP records show that your client does not receive a passporting benefit – is this correct?"
     Then I choose 'Yes'
-    Then I click 'Continue'
+    Then I click 'Save and continue'
     Then I should be on a page showing 'Is your client employed?'
     And the page is accessible
     Then I choose 'No'

--- a/features/providers/civil_application_journey.feature
+++ b/features/providers/civil_application_journey.feature
@@ -201,7 +201,7 @@ Feature: Civil application journeys
     Then I click 'Save and continue'
     Then I should be on a page showing "DWP records show that your client does not receive a passporting benefit – is this correct?"
     Then I choose 'Yes'
-    Then I click 'Continue'
+    Then I click 'Save and continue'
     Then I should be on a page showing 'Is your client employed?'
     Then I choose 'No'
     Then I click 'Save and continue'
@@ -259,7 +259,7 @@ Feature: Civil application journeys
     Then I click 'Save and continue'
     Then I should be on a page showing "DWP records show that your client does not receive a passporting benefit – is this correct?"
     Then I choose 'Yes'
-    Then I click 'Continue'
+    Then I click 'Save and continue'
     Then I should be on a page showing 'Is your client employed?'
     Then I choose 'No'
     Then I click 'Save and continue'
@@ -385,7 +385,7 @@ Feature: Civil application journeys
     Then I click 'Save and continue'
     Then I should be on a page showing "DWP records show that your client does not receive a passporting benefit – is this correct?"
     Then I choose 'Yes'
-    Then I click 'Continue'
+    Then I click 'Save and continue'
     Then I should be on a page showing 'Is your client employed?'
     Then I choose 'No'
     Then I click 'Save and continue'
@@ -411,7 +411,7 @@ Feature: Civil application journeys
     Given I start the application with a negative benefit check result
     Then I should be on a page showing "DWP records show that your client does not receive a passporting benefit – is this correct?"
     Then I choose 'Yes'
-    Then I click 'Continue'
+    Then I click 'Save and continue'
     Then I should be on a page showing 'Is your client employed?'
     Then I choose 'No'
     Then I click 'Save and continue'
@@ -480,7 +480,7 @@ Feature: Civil application journeys
     Then I click 'Save and continue'
     Then I should be on a page showing "DWP records show that your client does not receive a passporting benefit – is this correct?"
     Then I choose 'Yes'
-    Then I click 'Continue'
+    Then I click 'Save and continue'
     Then I should be on a page showing 'Is your client employed?'
     Then I choose 'No'
     Then I click 'Save and continue'
@@ -842,7 +842,7 @@ Feature: Civil application journeys
     Given I start the application with a negative benefit check result
     Then I should be on a page showing "DWP records show that your client does not receive a passporting benefit – is this correct?"
     Then I choose 'No, my client receives a passporting benefit'
-    Then I click "Continue"
+    Then I click "Save and continue"
     Then I should be on a page showing "Check your client's details"
     Then I choose 'I need to change these details'
     Then I click 'Save and continue'
@@ -861,7 +861,7 @@ Feature: Civil application journeys
     Then I click 'Save and continue'
     Then I should be on a page showing 'DWP records show that your client does not receive a passporting benefit – is this correct?'
     Then I choose 'No'
-    And I click 'Continue'
+    And I click 'Save and continue'
     Then I should be on a page showing "Check your client's details"
     Then I choose 'I need to change these details'
     And I click 'Save and continue'
@@ -894,7 +894,7 @@ Feature: Civil application journeys
     Then I click 'Save and continue'
     Then I should be on a page showing 'DWP records show that your client does not receive a passporting benefit – is this correct?'
     Then I choose 'Yes'
-    And I click 'Continue'
+    And I click 'Save and continue'
     And I should be on a page showing 'Is your client employed?'
     And I choose 'No'
     And I click 'Save and continue'
@@ -904,7 +904,7 @@ Feature: Civil application journeys
     And I click link 'Back'
     And I should be on a page showing 'DWP records show that your client does not receive a passporting benefit – is this correct?'
     Then I choose 'No, my client receives a passporting benefit'
-    And I click 'Continue'
+    And I click 'Save and continue'
     And I should be on a page showing "Check your client's details"
     Then I choose 'These details are correct'
     And I click 'Save and continue'

--- a/features/providers/non_passported_journey.feature
+++ b/features/providers/non_passported_journey.feature
@@ -284,7 +284,7 @@ Feature: Non-passported applicant journeys
     Given I start the application with a negative benefit check result
     Then I should be on a page showing "DWP records show that your client does not receive a passporting benefit – is this correct?"
     Then I choose 'Yes'
-    Then I click 'Continue'
+    Then I click 'Save and continue'
     Then I should be on a page showing 'Is your client employed?'
     Then I choose 'No'
     Then I click 'Save and continue'
@@ -357,7 +357,7 @@ Feature: Non-passported applicant journeys
     And I used delegated functions
     Then I should be on a page showing "DWP records show that your client does not receive a passporting benefit – is this correct?"
     Then I choose 'Yes'
-    Then I click 'Continue'
+    Then I click 'Save and continue'
     Then I should be on a page showing "Is your client employed?"
     Then I choose "Yes"
     Then I click 'Save and continue'
@@ -379,7 +379,7 @@ Feature: Non-passported applicant journeys
     Given I start the application with a negative benefit check result and no used delegated functions
     Then I should be on a page showing "DWP records show that your client does not receive a passporting benefit – is this correct?"
     Then I choose "Yes"
-    Then I click 'Continue'
+    Then I click 'Save and continue'
     Then I should be on a page showing "Is your client employed?"
     Then I choose "Yes"
     Then I click 'Save and continue'

--- a/features/providers/pathways_from_check_your_answers.feature
+++ b/features/providers/pathways_from_check_your_answers.feature
@@ -6,7 +6,7 @@ Feature: Pathways from check your answers
     Then I click 'Save and continue'
     Then I should be on a page showing "DWP records show that your client does not receive a passporting benefit – is this correct?"
     Then I choose 'Yes'
-    Then I click 'Continue'
+    Then I click 'Save and continue'
     Then I should be on a page showing "Is your client employed?"
     Then I choose 'No'
     Then I click 'Save and continue'
@@ -28,7 +28,7 @@ Feature: Pathways from check your answers
     Then I click 'Save and continue'
     Then I should be on a page showing "DWP records show that your client does not receive a passporting benefit – is this correct?"
     Then I choose 'Yes'
-    Then I click 'Continue'
+    Then I click 'Save and continue'
     Then I should be on a page showing "Is your client employed?"
     Then I choose 'No'
     Then I click 'Save and continue'
@@ -50,7 +50,7 @@ Feature: Pathways from check your answers
     Then I click 'Save and continue'
     Then I should be on a page showing "DWP records show that your client does not receive a passporting benefit – is this correct?"
     Then I choose 'Yes'
-    Then I click 'Continue'
+    Then I click 'Save and continue'
     Then I should be on a page showing "Is your client employed?"
     Then I choose 'No'
     Then I click 'Save and continue'

--- a/spec/factories/legal_aid_applications.rb
+++ b/spec/factories/legal_aid_applications.rb
@@ -360,7 +360,7 @@ FactoryBot.define do
           raise 'At least one domestic abuse proceeding type must be added before you can use the :with_lead_proceeding_type trait' if da_pt.nil?
 
           application.application_proceeding_types.find_by(proceeding_type_id: da_pt.id).update!(lead_proceeding: true)
-          application.proceedings.find_by(name: da_pt.name).update!(lead_proceeding: true)
+          application.proceedings.find_by(ccms_code: da_pt.ccms_code).update!(lead_proceeding: true)
         end
         application.reload
       end

--- a/spec/requests/providers/applicant_employed_spec.rb
+++ b/spec/requests/providers/applicant_employed_spec.rb
@@ -60,10 +60,7 @@ RSpec.describe Providers::ApplicantEmployedController, type: :request do
     end
 
     describe 'POST /providers/:application_id/applicant_employed' do
-      before do
-        allow(HMRC::CreateResponsesService).to receive(:call).with(legal_aid_application).and_return(double(HMRC::CreateResponsesService, call: %w[one two]))
-        post providers_legal_aid_application_applicant_employed_index_path(legal_aid_application), params: params
-      end
+      before { post providers_legal_aid_application_applicant_employed_index_path(legal_aid_application), params: params }
 
       context 'valid params' do
         let(:params) { { applicant: { employed: 'true' } } }
@@ -77,10 +74,6 @@ RSpec.describe Providers::ApplicantEmployedController, type: :request do
           it 'redirects to the use ccms employed page' do
             expect(response).to redirect_to(providers_legal_aid_application_use_ccms_employed_index_path(legal_aid_application))
           end
-
-          it 'calls the HMRC::CreateResponsesService' do
-            expect(HMRC::CreateResponsesService).to have_received(:call).once
-          end
         end
 
         context 'no' do
@@ -88,10 +81,6 @@ RSpec.describe Providers::ApplicantEmployedController, type: :request do
 
           it 'redirects to the open banking consents page' do
             expect(response).to redirect_to(providers_legal_aid_application_open_banking_consents_path(legal_aid_application))
-          end
-
-          it 'does not call the HMRC::CreateResponsesService' do
-            expect(HMRC::CreateResponsesService).to_not have_received(:call)
           end
         end
       end

--- a/spec/requests/providers/confirm_dwp_non_passported_applications_spec.rb
+++ b/spec/requests/providers/confirm_dwp_non_passported_applications_spec.rb
@@ -38,6 +38,35 @@ RSpec.describe Providers::ConfirmDWPNonPassportedApplicationsController, type: :
         expect(response.body).to have_back_link("#{page1}&back=true")
       end
     end
+
+    describe 'HMRC inset text' do
+      before { login_as application.provider }
+
+      context 'the employed journey feature flag is not enabled' do
+        it 'does not display the HMRC inset text' do
+          subject
+          expect(unescaped_response_body).not_to include(I18n.t('.providers.confirm_dwp_non_passported_applications.show.hmrc_inset_text'))
+        end
+      end
+
+      context 'the employed journey feature flag is enabled' do
+        before { Setting.setting.update!(enable_employed_journey: true) }
+        context 'the user has employed permissions' do
+          before { allow_any_instance_of(Provider).to receive(:employment_permissions?).and_return(true) }
+          it 'displays the HMRC inset text' do
+            subject
+            expect(unescaped_response_body).to include(I18n.t('.providers.confirm_dwp_non_passported_applications.show.hmrc_inset_text'))
+          end
+        end
+
+        context 'the user does not have employed permissions' do
+          it 'does not display the HMRC inset text' do
+            subject
+            expect(unescaped_response_body).not_to include(I18n.t('.providers.confirm_dwp_non_passported_applications.show.hmrc_inset_text'))
+          end
+        end
+      end
+    end
   end
 
   describe 'PATCH /providers/applications/:legal_aid_application_id/confirm_dwp_non_passported_applications' do


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2565)

Moves the call to HMRC from the Is your client employed? page to the DWP results page.

The call only takes place if the provider confirms that the non-passported DWP benefit check is correct _and_ the employed journey feature flag is enabled _and_ the provider has the correct permissions _and_ the HMRC call setting is enabled.

Also adds hint text to the DWP results page, with a helper method to identify when to display this.

Note: requires confirmation of the wording of the hint text from Jim, but the rest of the code can be reviewed now.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
