### PR TITLE
AP-2649 update secondary heading sizes

### DIFF
--- a/app/views/providers/applicant_bank_accounts/show.html.erb
+++ b/app/views/providers/applicant_bank_accounts/show.html.erb
@@ -33,7 +33,7 @@
     <div class="govuk-!-padding-bottom-4"></div>
 
     <%= form.govuk_radio_buttons_fieldset :applicant_bank_account,
-                                          legend: { size: 'l', tag: 'h2', text: t('.offline_savings_accounts') },
+                                          legend: { size: 'm', tag: 'h2', text: t('.offline_savings_accounts') },
                                           hint: {text: t('.hints.offline_savings_accounts')} do %>
       <%= form.govuk_radio_button :applicant_bank_account,
                                   true,

--- a/app/views/providers/has_other_dependants/show.html.erb
+++ b/app/views/providers/has_other_dependants/show.html.erb
@@ -40,7 +40,7 @@
                                           yes_no_options,
                                           :value,
                                           :label,
-                                          legend: {text: content_for(:page_title), size: 'l', tag: 'h2'} %>
+                                          legend: {text: content_for(:page_title), size: 'm', tag: 'h2'} %>
 
   <%= next_action_buttons(form: form) %>
   <% end %>

--- a/app/views/providers/has_other_proceedings/show.html.erb
+++ b/app/views/providers/has_other_proceedings/show.html.erb
@@ -25,7 +25,7 @@
     <% end %>
 
     <%= form.govuk_collection_radio_buttons :has_other_proceeding, yes_no_options, :value, :label,
-                                            legend: {text: content_for(:page_title), tag: 'h2', size: 'l'} %>
+                                            legend: {text: content_for(:page_title), tag: 'h2', size: 'm'} %>
 
     <%= next_action_buttons(
             form: form,

--- a/app/views/providers/no_income_summaries/show.html.erb
+++ b/app/views/providers/no_income_summaries/show.html.erb
@@ -15,12 +15,10 @@
 
       <div class="govuk-!-padding-bottom-2"></div>
 
-      <%= form.govuk_collection_radio_buttons(
-              :no_income_summaries,
-              yes_no_options,
-              :value,
-              :label,
-              legend: { text: t('.is_this_correct'), size: 'l', tag: 'h2' }) %>
+    <%= form.govuk_radio_buttons_fieldset(:no_income_summaries, legend: { text: t('.is_this_correct'), size: 'm', tag: 'h2' }) do %>
+      <%= form.govuk_radio_button :no_income_summaries, true, link_errors: true, label: {text: t('generic.yes')} %>
+      <%= form.govuk_radio_button :no_income_summaries, false, label: {text: t('.no_radio')} %>
+    <% end %>
 
       <div class="govuk-!-padding-bottom-2"></div>
 

--- a/app/views/providers/no_outgoings_summaries/show.html.erb
+++ b/app/views/providers/no_outgoings_summaries/show.html.erb
@@ -15,12 +15,10 @@
 
       <div class="govuk-!-padding-bottom-2"></div>
 
-      <%= form.govuk_collection_radio_buttons(
-              :no_outgoings_summaries,
-              yes_no_options,
-              :value,
-              :label,
-              legend: { text: t('.is_this_correct'), size: 'l', tag: 'h2' }) %>
+      <%= form.govuk_radio_buttons_fieldset(:no_outgoings_summaries, legend: { text: t('.is_this_correct'), size: 'm', tag: 'h2' }) do %>
+        <%= form.govuk_radio_button :no_outgoings_summaries, true, link_errors: true, label: {text: t('generic.yes')} %>
+        <%= form.govuk_radio_button :no_outgoings_summaries, false, label: {text: t('.no_radio')} %>
+      <% end %>
 
       <div class="govuk-!-padding-bottom-2"></div>
 

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -630,6 +630,7 @@ en:
             income from a property or lodger
             pension payments
         is_this_correct: Is this correct?
+        no_radio: No, my client receives one or more of these
         student_finance:
           heading: Student finance
           info_html: '<strong>%{student_finance}</strong> this academic year.'
@@ -645,6 +646,7 @@ en:
             spousal or child maintenance
             for legal aid in a criminal case
         is_this_correct: Is this correct?
+        no_radio: No, my client has one or more of these outgoings
         error: Select yes if your client does not make these payments
     non_passported_client_instructions:
       show:


### PR DESCRIPTION
## Standardise secondary heading sizes 

[Link to story](https://dsdmoj.atlassian.net/browse/AP-XXX)

Update the size of several secondary headings in order to remain consistent across the service
Update 'no' radio button content on no income summaries and no outgoings summaries pages

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
