### PR TITLE
AP-2716 Reinstate HMRC check

### DIFF
--- a/app/views/providers/applicant_employed/index.html.erb
+++ b/app/views/providers/applicant_employed/index.html.erb
@@ -17,6 +17,7 @@
           yes_no_options,
           :value,
           :label,
+          hint: {text: t('.hint')},
           legend: {text: content_for(:page_title), size: 'xl', tag: 'h1'}
         ) %>
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -73,6 +73,6 @@ Rails.application.configure do
   # Verifies that versions and hashed value of the package contents in the project's package.json
   config.webpacker.check_yarn_integrity = false
 
-  # Swirch to determine whether or not o collect HMRC data
-  config.x.collect_hmrc_data = false
+  # Switch to determine whether or not o collect HMRC data
+  config.x.collect_hmrc_data = true
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -100,6 +100,7 @@ Rails.application.configure do
   # set the id of the Digest Export spreadsheet to use in this environment
   config.x.digest_export.spreadsheet_id = '1dXnEdiqqP_fOeWzDsbXY83lwwK8pvf8j4jsUqaGnGMs'
 
-  # Swirch to determine whether or not o collect HMRC data
-  config.x.collect_hmrc_data = false
+  # Switch to determine whether or not o collect HMRC data
+  config.x.collect_hmrc_data = true
+
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -102,5 +102,4 @@ Rails.application.configure do
 
   # Switch to determine whether or not o collect HMRC data
   config.x.collect_hmrc_data = true
-
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -76,6 +76,6 @@ Rails.application.configure do
   # set the id of the Digest Export spreadsheet to use in this environment
   config.x.digest_export.spreadsheet_id = '1dXnEdiqqP_fOeWzDsbXY83lwwK8pvf8j4jsUqaGnGMs'
 
-  # Swirch to determine whether or not o collect HMRC data
+  # Switch to determine whether or not o collect HMRC data
   config.x.collect_hmrc_data = true
 end


### PR DESCRIPTION

## Reinstate HMRC check

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2716)

- Set the rails configuration flag `collect_hmrc_data` to true
- re-instated copy about collecting HRMC data on applicant_employed page

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
