### PR TITLE
AP-2719 BUGFIX: Substantive scope limitations appearing on Emergency Applications

### DIFF
--- a/app/services/ccms/requestors/case_add_requestor.rb
+++ b/app/services/ccms/requestors/case_add_requestor.rb
@@ -230,14 +230,14 @@ module CCMS
         xml.__send__('casebio:ScopeLimitation') do
           xml.__send__('casebio:ScopeLimitation', proceeding.substantive_scope_limitation_code)
           xml.__send__('casebio:ScopeLimitationWording', proceeding.substantive_scope_limitation_description)
-          xml.__send__('casebio:DelegatedFunctionsApply', proceeding.used_delegated_functions?)
+          xml.__send__('casebio:DelegatedFunctionsApply', false)
         end
         return if proceeding.used_delegated_functions_on.nil?
 
         xml.__send__('casebio:ScopeLimitation') do
           xml.__send__('casebio:ScopeLimitation', proceeding.delegated_functions_scope_limitation_code)
           xml.__send__('casebio:ScopeLimitationWording', proceeding.delegated_functions_scope_limitation_description)
-          xml.__send__('casebio:DelegatedFunctionsApply', proceeding.used_delegated_functions?)
+          xml.__send__('casebio:DelegatedFunctionsApply', true)
         end
       end
 

--- a/spec/data/ccms/mp_df_case_add_request.xml
+++ b/spec/data/ccms/mp_df_case_add_request.xml
@@ -109,7 +109,7 @@
                     <casebio:ScopeLimitation>
                       <casebio:ScopeLimitation>FM062</casebio:ScopeLimitation>
                       <casebio:ScopeLimitationWording>Limited to all steps up to and including final hearing and any action necessary to implement (but not enforce) the order.</casebio:ScopeLimitationWording>
-                      <casebio:DelegatedFunctionsApply>true</casebio:DelegatedFunctionsApply>
+                      <casebio:DelegatedFunctionsApply>false</casebio:DelegatedFunctionsApply>
                     </casebio:ScopeLimitation>
                     <casebio:ScopeLimitation>
                       <casebio:ScopeLimitation>CV117</casebio:ScopeLimitation>

--- a/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_attributes_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_attributes_spec.rb
@@ -452,10 +452,8 @@ module CCMS
         context 'EMERGENCY_DPS_APP_AMD' do
           context 'delegated functions used' do
             before do
-              legal_aid_application.application_proceeding_types.each do |apt|
-                apt.update!(used_delegated_functions_on: Date.yesterday,
-                            used_delegated_functions_reported_on: Date.current)
-                apt.delegated_functions_scope_limitation = apt.proceeding_type.default_substantive_scope_limitation
+              legal_aid_application.proceedings.each do |proceeding|
+                proceeding.update!(used_delegated_functions_on: Date.yesterday, used_delegated_functions_reported_on: Date.current)
               end
             end
             it 'generates the block with true' do

--- a/spec/services/ccms/requestors/case_add_requestor_xml_blocks/passported_attributes_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_xml_blocks/passported_attributes_spec.rb
@@ -66,8 +66,8 @@ module CCMS
 
           context 'on a Delegated Functions case' do
             before do
-              legal_aid_application.application_proceeding_types.each do |apt|
-                apt.update!(used_delegated_functions_on: Time.zone.today, used_delegated_functions_reported_on: Time.zone.today)
+              legal_aid_application.proceedings.each do |proceeding|
+                proceeding.update!(used_delegated_functions_on: Time.zone.today, used_delegated_functions_reported_on: Time.zone.today)
               end
             end
 
@@ -470,8 +470,8 @@ module CCMS
         context 'DELEGATED_FUNCTIONS_DATE blocks' do
           context 'delegated functions used' do
             before do
-              legal_aid_application.application_proceeding_types.each do |apt|
-                apt.update!(used_delegated_functions_on: Time.zone.today, used_delegated_functions_reported_on: Time.zone.today)
+              legal_aid_application.proceedings.each do |proceeding|
+                proceeding.update!(used_delegated_functions_on: Time.zone.today, used_delegated_functions_reported_on: Time.zone.today)
               end
             end
 


### PR DESCRIPTION
## What

Substantive scope limitations are incorrectly appearing on emergency applications in CCMS.

This is because the `generate_scope_limitations` method in the `CaseAddRequestor` class sets the `DelegatedFunctionsApply` attribute as `proceeding.used_delegated_functions?` for both the substantive and delegated functions scope limitations. This means that for a DF application, both scope limitations have a `DelegatedFunctionsApply` attribue of `true`.

This is incorrect - only the delegated functions scope limitation should have a `DelegatedFunctionsApply` attribue of `true`.

This PR changes that method so that the substantive scope limitation always has a `DelegatedFunctionsApply` attribute of `false`, and the delegated functions scope limitations always has a `DelegatedFunctionsApply` attribute of true.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
