### PR TITLE
Fix: Restart CCMS submissions

### DIFF
--- a/spec/services/ccms_restart_submissions_spec.rb
+++ b/spec/services/ccms_restart_submissions_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe CCMSRestartSubmissions do
 
     it 'changes the states to submitting_assessment' do
       subject
-      expect(LegalAidApplication.first.reload.state).to eql 'submitting_assessment'
-      expect(LegalAidApplication.last.reload.state).to eql 'submitting_assessment'
+      expect(LegalAidApplication.first.reload.state).to eql 'generating_reports'
+      expect(LegalAidApplication.last.reload.state).to eql 'generating_reports'
     end
   end
 end


### PR DESCRIPTION
## What

There was a bug in the `restart_submission` event that bypassed the generate reports step
This fix redirects the event to duplicate the steps undertaken in the `generate_reports`
event that generate the means/merits report and trigger the email to providers

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
