### PR TITLE
AP-2555 remote restore anonymised DB to uat

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,7 +445,7 @@ Backups are taken daily at 5:40am and stored for 7 days, these are automated bac
 
 A Cron Job takes hourly snapshots of the production database between 6am and 9pm. The previous days hourly backups are deleted at 7am each day, as these are superseded by the daily back up taken at 5.40am.
 
-## Anonymised database export and restore
+## Anonymised database export and local restore
 
 In order to create an anonymised dump of an environments database you can:
 
@@ -472,7 +472,20 @@ Success
 You can restore this locally by running:
  psql -q -P pager=off -d apply_for_legal_aid_dev -f ./tmp/uat.anon.sql
 ```
+## Anonymised database restore to UAT
 
+To apply the anonymised database export to a UAT branch you can run the restore script:
+
+```bash
+$ ./scripts/restore_anonymised_db.sh [branch-name]
+```
+Where branch name is either the full git branch name or just the start of it e.g `ap-2555-anon-uat-db` or `ap-2555`
+
+It requires that you have kubectl authenticated and your context set to the `live` cluster. The `db_export.sh script` will save 
+the anonymised database to your local `/tmp` folder. This script will copy the file to the `/tmp` folder on the selected UAT instance,
+drop the existing database and restore using the anonymised data.
+
+The script will also output the anonymised email addresses for 10 Providers. These can be used to login to the UAT instance.
 ## 3rd party integrations
 
 ### True Layer

--- a/scripts/restore_anon_db.sh
+++ b/scripts/restore_anon_db.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# This script will allow you to restore to any UAT instance
+# run in console and pass in the branch name, or just the start of it:
+# ./scripts/restore_anon_db.sh [branch-name]
+# ./scripts/restore_anon_db.sh ap-2555
+
+echo "Finding pod for branch $1 in UAT"
+POD=$(kubectl -n laa-apply-for-legalaid-uat get pods | grep -o -m4 "apply-$1-.*2/2" | head -n1 | cut -d' ' -f 1)
+echo "$POD"
+
+echo "Copying anonymised db to kubernetes pod"
+kubectl -n laa-apply-for-legalaid-uat cp ./tmp/production.anon.sql -c web laa-apply-for-legalaid-uat/"$POD":./tmp/anonymised_db.sql
+
+echo "Connect to the pod and run the rake task"
+kubectl -n laa-apply-for-legalaid-uat -c web exec "$POD" -- rake db:import_to_uat

--- a/scripts/restore_anonymised_db.sh
+++ b/scripts/restore_anonymised_db.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 # This script will allow you to restore to any UAT instance
 # run in console and pass in the branch name, or just the start of it:
-# ./scripts/restore_anon_db.sh [branch-name]
-# ./scripts/restore_anon_db.sh ap-2555
+# ./scripts/restore_anonymised_db.sh [branch-name]
+# ./scripts/restore_anonymised_db.sh ap-2555
 
 echo "Finding pod for branch $1 in UAT"
 POD=$(kubectl -n laa-apply-for-legalaid-uat get pods | grep -o -m4 "apply-$1-.*2/2" | head -n1 | cut -d' ' -f 1)


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2555)

Add shell script to copy the anonymised.sql file to the selected pod and run a rake task to drop existing DB and replace it with the anonymised version.

Also outputs a list of 10 user email addresses to make logging it easier.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
