### PR TITLE
AP-2568 Parse HMRC response

### DIFF
--- a/app/models/hmrc/employment.rb
+++ b/app/models/hmrc/employment.rb
@@ -1,0 +1,16 @@
+module HMRC
+  class Employment
+    attr_reader :payments
+
+    def initialize(hmrc_income_array)
+      @payments = hmrc_income_array.map { |payment_hash| EmploymentPayment.new(payment_hash) }
+      sort_payments_most_recent_first
+    end
+
+    private
+
+    def sort_payments_most_recent_first
+      @payments.sort! { |a, b| b.payment_date <=> a.payment_date }
+    end
+  end
+end

--- a/app/models/hmrc/employment_income_summary.rb
+++ b/app/models/hmrc/employment_income_summary.rb
@@ -1,0 +1,44 @@
+module HMRC
+  # Utility class to parse the HMRC response record and present in a fashion that will be easy to
+  # iterate through and display on the page
+  #
+  # Usage:
+  #
+  # summary = EmploymentIncomeSummary.new(legal_aid_application_id)
+  # summary.employments.each do |employment|
+  #   employment.payments.each do |payment|
+  #     puts payment.payment_date
+  #     puts payment.gross_pay
+  #     puts payment.tax
+  #     puts payment.national_insurance
+  #   end
+  # end
+  #
+  class EmploymentIncomeSummary
+    attr_reader :employments
+
+    def initialize(legal_aid_application_id)
+      @legal_aid_application_id = legal_aid_application_id
+      @employments = []
+      parse_response
+    end
+
+    def num_employments
+      @employments.size
+    end
+
+    private
+
+    def parse_response
+      data_array = hmrc_response['data']
+      paye_hash = data_array.detect { |hash| hash.key?('income/paye/paye') }
+      income_array = paye_hash.dig('income/paye/paye', 'income')
+
+      @employments << Employment.new(income_array)
+    end
+
+    def hmrc_response
+      @hmrc_response ||= Response.use_case_one_for(@legal_aid_application_id).response
+    end
+  end
+end

--- a/app/models/hmrc/employment_payment.rb
+++ b/app/models/hmrc/employment_payment.rb
@@ -1,0 +1,25 @@
+module HMRC
+  class EmploymentPayment
+    def initialize(payment_hash)
+      @payment_hash = payment_hash
+    end
+
+    def payment_date
+      Date.parse @payment_hash.fetch('paymentDate')
+    end
+
+    def gross_pay
+      @payment_hash.fetch('grossEarningsForNics').fetch('inPayPeriod1')
+    end
+
+    def tax
+      @payment_hash['taxDeductedOrRefunded'] || 0.0
+    end
+
+    def national_insurance
+      return 0.0 unless @payment_hash.key?('employeeNics')
+
+      @payment_hash.fetch('employeeNics').fetch('inPayPeriod1')
+    end
+  end
+end

--- a/app/models/hmrc/response.rb
+++ b/app/models/hmrc/response.rb
@@ -5,5 +5,9 @@ module HMRC
     USE_CASES = %w[one two].freeze
     belongs_to :legal_aid_application, inverse_of: :hmrc_responses
     validates :use_case, presence: true, inclusion: { in: USE_CASES, message: 'Invalid use case' }
+
+    def self.use_case_one_for(laa_id)
+      where(legal_aid_application_id: laa_id, use_case: 'one').order(:created_at).last
+    end
   end
 end

--- a/spec/factories/hmrc/responses.rb
+++ b/spec/factories/hmrc/responses.rb
@@ -1,11 +1,15 @@
+require Rails.root.join('spec/factory_helpers/hmrc_response/use_case_one.rb')
+
 module HMRC
   FactoryBot.define do
     factory :hmrc_response, class: HMRC::Response do
       legal_aid_application
+      submission_id { SecureRandom.uuid }
       use_case { 'one' }
 
       trait :use_case_one do
         use_case { 'one' }
+        response { ::FactoryHelpers::HMRCResponse::UseCaseOne.new(submission_id).response }
       end
 
       trait :use_case_two do

--- a/spec/factory_helpers/hmrc_response/use_case_one.rb
+++ b/spec/factory_helpers/hmrc_response/use_case_one.rb
@@ -1,0 +1,172 @@
+module FactoryHelpers
+  module HMRCResponse
+    class UseCaseOne # rubocop:disable Metrics/ClassLength
+      def initialize(correlation_id, options = {})
+        @correlation_id = correlation_id
+        @options = options
+      end
+
+      def firstname
+        @firstname ||= (@options[:firstname] || Faker::Name.first_name).upcase
+      end
+
+      def lastname
+        @lastname ||= (@options[:lastname] || Faker::Name.first_name).upcase
+      end
+
+      def nino
+        @nino ||= @options[:nino] || fake_nino
+      end
+
+      def dob
+        @dob ||= (@options[:dob] || fake_dob).strftime('%Y-%m-%d')
+      end
+
+      def status
+        @status ||= @options[:status] || 'completed'
+      end
+
+      def pay_frequency
+        @pay_frequency ||= @options[:pay_frequency] || 'W4'
+      end
+
+      def tax_year
+        @tax_year ||= @options[:tax_year] || '21-22'
+      end
+
+      def last_pay_date
+        @last_pay_date ||= @options[:last_pay_date] || Time.zone.yesterday
+      end
+
+      def response
+        {
+          'submission' => @correlation_id,
+          'status' => status,
+          'data' => data_array
+        }
+      end
+
+      private
+
+      def data_array
+        [
+          correlation_element,
+          individual_element,
+          paye_element,
+          { 'income/sa/selfAssessment' => { 'registrations' => [], 'taxReturns' => [] } },
+          { 'income/sa/pensions_and_state_benefits/selfAssessment' => { 'taxReturns' => [] } },
+          { 'income/sa/source/selfAssessment' => { 'taxReturns' => [] } },
+          { 'income/sa/employments/selfAssessment' => { 'taxReturns' => [] } },
+          { 'income/sa/additional_information/selfAssessment' => { 'taxReturns' => [] } },
+          { 'income/sa/partnerships/selfAssessment' => { 'taxReturns' => [] } },
+          { 'income/sa/uk_properties/selfAssessment' => { 'taxReturns' => [] } },
+          { 'income/sa/foreign/selfAssessment' => { 'taxReturns' => [] } },
+          { 'income/sa/further_details/selfAssessment' => { 'taxReturns' => [] } },
+          { 'income/sa/interests_and_dividends/selfAssessment' => { 'taxReturns' => [] } },
+          { 'income/sa/other/selfAssessment' => { 'taxReturns' => [] } },
+          { 'income/sa/summary/selfAssessment' => { 'taxReturns' => [] } },
+          { 'income/sa/trusts/selfAssessment' => { 'taxReturns' => [] } },
+          employments_element,
+          { 'benefits_and_credits/working_tax_credit/applications' => [] },
+          { 'benefits_and_credits/child_tax_credit/applications' => [] }
+        ]
+      end
+
+      def correlation_element
+        {
+          'correlation_id' => @correlation_id,
+          'use_case' => 'use_case_one'
+        }
+      end
+
+      def individual_element
+        {
+          'individuals/matching/individual' => {
+            'firstName' => firstname,
+            'lastName' => lastname,
+            'nino' => nino,
+            'dateOfBirth' => dob
+          }
+        }
+      end
+
+      def paye_element
+        income_array = case pay_frequency
+                       when 'W4'
+                         four_weekly_income_array
+                       when 'M1'
+                         monthly_income_array
+                       else
+                         raise "Unrecognised pay frequency #{pay_frequency}"
+                       end
+        {
+          'income/paye/paye' => {
+            'income' => income_array
+          }
+        }
+      end
+
+      def monthly_income_array
+        dates = [last_pay_date, last_pay_date - 1.month, last_pay_date - 2.months]
+        dates.map { |date| income_for_date(date) }
+      end
+
+      def four_weekly_income_array
+        dates = [last_pay_date, last_pay_date - 4.weeks, last_pay_date - 8.weeks]
+        dates.map { |date| income_for_date(date) }
+      end
+
+      def income_for_date(date)
+        { 'taxYear' => tax_year,
+          'payFrequency' => pay_frequency,
+          'weekPayNumber' => week_number(date),
+          'paymentDate' => date.strftime('%Y-%m-%d'),
+          'paidHoursWorked' => 'E',
+          'taxablePayToDate' => 26_401.68,
+          'taxablePay' => 6_512.92,
+          'totalTaxToDate' => 5_442.66,
+          'taxDeductedOrRefunded' => 1_325.66,
+          'grossEarningsForNics' => {
+            'inPayPeriod1' => 6_512.92
+          } }
+      end
+
+      def employments_element
+        {
+          'employments/paye/employments' => [
+            {
+              'startDate' => '2019-06-04',
+              'endDate' => '2099-12-31'
+            }
+          ]
+        }
+      end
+
+      def income_array
+        tax_
+      end
+
+      def fake_nino
+        "#{nino_alpha}#{nino_alpha}#{nino_numeric}#{nino_alpha}"
+      end
+
+      def nino_alpha
+        %w[A B C E G H P R T W Z].sample
+      end
+
+      def nino_numeric
+        rand(100_000..999_999)
+      end
+
+      def fake_dob
+        Faker::Date.between(from: 70.years.ago, to: 16.years.ago)
+      end
+
+      # returns week number in tax year (sort of)
+      def week_number(date)
+        year_week_number = date.strftime('%U').to_i
+        year_week_number > 14 ? year_week_number - 14 : year_week_number + 38
+      end
+    end
+  end
+end

--- a/spec/factory_specs/hmrc_response/use_case_one_helper_spec.rb
+++ b/spec/factory_specs/hmrc_response/use_case_one_helper_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+module FactoryHelpers
+  module HMRCResponse
+    RSpec.describe UseCaseOne do
+      let(:correlation_id) { SecureRandom.uuid }
+      it 'returns a hash with expected keys' do
+        response = described_class.new(correlation_id).response
+        expect(response['submission']).to eq correlation_id
+        expect(response['status']).to eq 'completed'
+        expect(response['data'].size).to eq 19
+      end
+
+      it 'can be used inside a factory' do
+        rec = create :hmrc_response, :use_case_one
+        expect(rec.response['status']).to eq 'completed'
+        expect(rec.response['data'].size).to eq 19
+      end
+    end
+  end
+end

--- a/spec/models/hmrc/employment_income_summary_spec.rb
+++ b/spec/models/hmrc/employment_income_summary_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+module HMRC
+  RSpec.describe EmploymentIncomeSummary do
+    describe '.new' do
+      context 'When only one employment' do
+        let(:laa) { create :legal_aid_application }
+
+        before { create :hmrc_response, :use_case_one, legal_aid_application_id: laa.id }
+
+        subject { described_class.new(laa.id) }
+
+        it 'creates an array of one Employment object' do
+          expect(subject.num_employments).to eq 1
+          expect(subject.employments.first.class).to eq Employment
+        end
+      end
+    end
+  end
+end

--- a/spec/models/hmrc/employment_payment_spec.rb
+++ b/spec/models/hmrc/employment_payment_spec.rb
@@ -1,0 +1,116 @@
+require 'rails_helper'
+
+module HMRC
+  RSpec.describe EmploymentPayment do
+    subject { described_class.new(struct) }
+
+    context 'valid payment structure' do
+      let(:struct) { valid_payment_struct }
+
+      it 'stores and returns required values' do
+        expect(subject.payment_date).to eq Date.new(2021, 11, 12)
+        expect(subject.gross_pay).to eq 327.59
+        expect(subject.tax).to eq(-128)
+        expect(subject.national_insurance).to eq(-22.46)
+      end
+    end
+
+    context 'No entry in struct of employee national insurance contribs or tax' do
+      let(:struct) { no_nics_or_tax_struct }
+      it 'stores and returns required values' do
+        expect(subject.payment_date).to eq Date.new(2021, 10, 14)
+        expect(subject.gross_pay).to eq 572.8
+        expect(subject.tax).to eq 0
+        expect(subject.national_insurance).to eq 0
+      end
+    end
+
+    context 'No entry in struct for payment date' do
+      let(:struct) { no_payment_date_struct }
+      it 'raises' do
+        expect {
+          subject.payment_date
+        }.to raise_error KeyError, 'key not found: "paymentDate"'
+      end
+    end
+
+    context 'No entry in struct for grossEarningsForNics' do
+      let(:struct) { no_gross_earnings_struct }
+      it 'raises' do
+        expect {
+          subject.gross_pay
+        }.to raise_error KeyError, 'key not found: "grossEarningsForNics"'
+      end
+    end
+
+    def valid_payment_struct
+      {
+        'taxYear' => '21-22',
+        'payFrequency' => 'W4',
+        'weekPayNumber' => 32,
+        'paymentDate' => '2021-11-12',
+        'paidHoursWorked' => 'A',
+        'taxablePayToDate' => 8751.71,
+        'taxablePay' => 327.59,
+        'totalTaxToDate' => 202,
+        'taxDeductedOrRefunded' => -128,
+        'employeePensionContribs' => {
+          'notPaidYTD' => 202.65, 'notPaid' => 0.01
+        },
+        'grossEarningsForNics' => {
+          'inPayPeriod1' => 327.59
+        },
+        'totalEmployerNics' => {
+          'inPayPeriod1' => 0, 'ytd1' => 523.32
+        },
+        'employeeNics' => {
+          'inPayPeriod1' => -22.46, 'ytd1' => 414.75
+        }
+      }
+    end
+
+    def no_nics_or_tax_struct
+      {
+        'taxYear' => '21-22',
+        'payFrequency' => 'W4',
+        'weekPayNumber' => 28,
+        'paymentDate' => '2021-10-14',
+        'paidHoursWorked' => 'E',
+        'taxablePayToDate' => 4045.4,
+        'taxablePay' => 572.8,
+        'totalTaxToDate' => 0,
+        'taxDeductedOrRefunded' => 0,
+        'grossEarningsForNics' => {
+          'inPayPeriod1' => 572.8
+        }
+      }
+    end
+
+    def no_gross_earnings_struct
+      {
+        'taxYear' => '21-22',
+        'payFrequency' => 'W4',
+        'weekPayNumber' => 28,
+        'paidHoursWorked' => 'E',
+        'taxablePayToDate' => 4045.4,
+        'paymentDate' => '2021-10-14',
+        'taxablePay' => 572.8,
+        'totalTaxToDate' => 0,
+        'taxDeductedOrRefunded' => 0
+      }
+    end
+
+    def no_payment_date_struct
+      {
+        'taxYear' => '21-22',
+        'payFrequency' => 'W4',
+        'weekPayNumber' => 28,
+        'paidHoursWorked' => 'E',
+        'taxablePayToDate' => 4045.4,
+        'taxablePay' => 572.8,
+        'totalTaxToDate' => 0,
+        'taxDeductedOrRefunded' => 0
+      }
+    end
+  end
+end

--- a/spec/models/hmrc/employment_spec.rb
+++ b/spec/models/hmrc/employment_spec.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+
+module HMRC
+  RSpec.describe Employment do
+    describe '.new' do
+      subject { described_class.new(income_array) }
+
+      let(:expected_payment_dates) do
+        [
+          Date.new(2021, 11, 11),
+          Date.new(2021, 10, 14),
+          Date.new(2021, 9, 16)
+        ]
+      end
+
+      it 'sorts payments into date order most recent first' do
+        expect(subject.payments.map(&:payment_date)).to eq expected_payment_dates
+      end
+
+      it 'has three EmploymentPayment objects' do
+        expect(subject.payments.size).to eq 3
+        expect(subject.payments.map(&:class).uniq).to eq [EmploymentPayment]
+      end
+    end
+
+    def income_array
+      [
+        {
+          'taxYear' => '21-22',
+          'payFrequency' => 'W4',
+          'weekPayNumber' => 24,
+          'paymentDate' => '2021-09-16',
+          'paidHoursWorked' => 'E',
+          'taxablePayToDate' => 3472.6,
+          'taxablePay' => 572.8,
+          'totalTaxToDate' => 0,
+          'taxDeductedOrRefunded' => 0,
+          'grossEarningsForNics' => {
+            'inPayPeriod1' => 572.8
+          }
+        },
+        { 'taxYear' => '21-22',
+          'payFrequency' => 'W4',
+          'weekPayNumber' => 32,
+          'paymentDate' => '2021-11-11',
+          'paidHoursWorked' => 'E',
+          'taxablePayToDate' => 4618.2,
+          'taxablePay' => 572.8,
+          'totalTaxToDate' => 0,
+          'taxDeductedOrRefunded' => 0,
+          'grossEarningsForNics' => {
+            'inPayPeriod1' => 572.8
+          } },
+        { 'taxYear' => '21-22',
+          'payFrequency' => 'W4',
+          'weekPayNumber' => 28,
+          'paymentDate' => '2021-10-14',
+          'paidHoursWorked' => 'E',
+          'taxablePayToDate' => 4045.4,
+          'taxablePay' => 572.8,
+          'totalTaxToDate' => 0,
+          'taxDeductedOrRefunded' => 0,
+          'grossEarningsForNics' => {
+            'inPayPeriod1' => 572.8
+          } }
+      ]
+    end
+  end
+end

--- a/spec/models/hmrc/response_spec.rb
+++ b/spec/models/hmrc/response_spec.rb
@@ -16,5 +16,32 @@ module HMRC
         it { is_expected.to be false }
       end
     end
+
+    describe '.use_case_for' do
+      context 'there are application id does not exist' do
+        it 'returns nil' do
+          expect(described_class.use_case_one_for(SecureRandom.uuid)).to be_nil
+        end
+      end
+
+      context 'there is only one use case one record with the specified application id' do
+        let!(:response1) { create :hmrc_response, :use_case_one }
+        let!(:response_uc2) { create :hmrc_response, :use_case_two, legal_aid_application_id: response1.legal_aid_application_id }
+        let!(:response2) { create :hmrc_response, :use_case_one }
+        it 'returns the record for the application we specify' do
+          expect(described_class.use_case_one_for(response1.legal_aid_application_id)).to eq response1
+        end
+      end
+
+      context 'there are multiple use case one records with the specified application id' do
+        let!(:response1) { create :hmrc_response, :use_case_one, created_at: 5.minutes.ago }
+        let!(:response_uc2) { create :hmrc_response, :use_case_two, legal_aid_application_id: response1.legal_aid_application_id }
+        let!(:response1_last) { create :hmrc_response, :use_case_one, legal_aid_application_id: response1.legal_aid_application_id }
+        let!(:response2) { create :hmrc_response, :use_case_one }
+        it 'returns the last created use case one record for the specified application id' do
+          expect(described_class.use_case_one_for(response1.legal_aid_application_id)).to eq response1_last
+        end
+      end
+    end
   end
 end

--- a/spec/workers/hmrc/result_worker_spec.rb
+++ b/spec/workers/hmrc/result_worker_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe HMRC::ResultWorker do
   subject(:worker) { described_class.new }
 
   let(:application) { create :legal_aid_application, :with_applicant, :with_transaction_period }
-  let(:hmrc_response) { create(:hmrc_response, :use_case_one, :in_progress, legal_aid_application: application) }
+  let(:hmrc_response) { create(:hmrc_response, :use_case_one, :in_progress, legal_aid_application: application, response: nil) }
 
   describe '.perform' do
     subject(:perform) { worker.perform(hmrc_response.id) }


### PR DESCRIPTION
## Parse HMRC response

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2568)

### Notes:
- after discussion with Pamela, it was agreed the Employment income summary page would show payment date rather than range as shown in the ticket.  The parsed response (`HMRC::EmploymentIncomeSummary`) reflects this.
- The parser currently only works when the applicant has one job - this is because we don't know how the data will be presented for applicants with more than one job.

This PR parses the HMRC and presents it in a way which is easy to display on the review income employment page.

- Created `HMRC::EmploymentIncomeSummary` to encapsulate all income from all employments
- Created `HMRC::Employment` to encapsulate each employment
- Created `HMRC::EmploymentPayment` to encapsulate each payment
- Added scope `use_case_one_for` on `HMRC::Response` to return the most recent use case `one` response for the specified `LegalAidApplication`
- Created `FactoryHelpers::HMRCResponse::UseCaseOne` to enable creation of HMRC responses in the factory

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
