### PR TITLE
Fix flaky chances of success tests

### DIFF
--- a/spec/models/proceeding_merits_task/chances_of_success_spec.rb
+++ b/spec/models/proceeding_merits_task/chances_of_success_spec.rb
@@ -2,13 +2,14 @@ require 'rails_helper'
 
 RSpec.describe ProceedingMeritsTask::ChancesOfSuccess, type: :model do
   describe '#pretty_success_propsect' do
-    let(:chances_of_success) { create :chances_of_success, application_proceeding_type: application_proceeding_type, success_prospect: prospect, proceeding: proceeding }
-
     let(:pt_da) { create :proceeding_type, :with_real_data }
     let(:pt_s8) { create :proceeding_type, :as_section_8_child_residence }
-    let(:legal_aid_application) { create :legal_aid_application, :with_proceeding_types, explicit_proceeding_types: [pt_da, pt_s8] }
-    let!(:application_proceeding_type) { legal_aid_application.application_proceeding_types.first }
-    let!(:proceeding) { create :proceeding, :da001, legal_aid_application: legal_aid_application }
+    let(:legal_aid_application) do
+      create :legal_aid_application, :with_proceeding_types, :with_proceedings, explicit_proceeding_types: [pt_da, pt_s8], explicit_proceedings: %i[da001 se014]
+    end
+    let(:application_proceeding_type) { legal_aid_application.application_proceeding_types.first }
+    let(:proceeding) { legal_aid_application.proceedings.first }
+    let(:chances_of_success) { create :chances_of_success, application_proceeding_type: application_proceeding_type, success_prospect: prospect, proceeding: proceeding }
 
     context 'likely' do
       let(:prospect) { 'likely' }


### PR DESCRIPTION
## What

Tests in `spec/models/proceeding_merits_task/chances_of_success_spec.rb` are occasionally failing due to the way `application_proceeding_types` and `proceedings` are set up.

By creating the `proceeding` after the creation of the `application` and `application_proceeding_types`, and by creating different numbers of `application_proceeding_types` and `proceedings`, it is possible for the `proceeding_case_id` to be non-unique.

This changes the set up so that identical `application_proceeding_types` and `proceedings` are created simultaneously, replicating what happens in the real service. This should prevent the unique constraint being violated.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
