### PR TITLE
Fix: Full CCMS test run on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -198,10 +198,8 @@ jobs:
     - *install_js_packages
     - *save_js_packages_cache
     - run:
-        environment:
-          INC_CCMS: true
         name: Run ruby tests
-        command: bundle exec rspec --format progress --format RspecJunitFormatter -o /tmp/test-results/rspec/rspec.xml
+        command: INC_CCMS=true INC_I18N=true bundle exec rspec --format progress --format RspecJunitFormatter -o /tmp/test-results/rspec/rspec.xml
     - store_test_results:
         path: /tmp/test-results/rspec
     - store_artifacts:

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -65,7 +65,7 @@ VCR.configure do |vcr_config|
 end
 
 RSpec.configure do |config|
-  config.filter_run_excluding :i18n
+  config.filter_run_excluding :i18n unless ENV['INC_I18N'].to_s == 'true'
   config.filter_run_excluding :ccms unless ENV['INC_CCMS'].to_s == 'true'
 
   # rspec-expectations config goes here. You can use an alternate


### PR DESCRIPTION
## What
The overnight, full test run on circle had stopped running all the tests:
![image](https://user-images.githubusercontent.com/6757677/145219148-cc650791-bf74-4ef7-a26c-7cb24fac727d.png)

This PR:
* Adds a method of ensuring the i18n tests are run to spec helper
* Moves the ENV_VARs inline to the command, setting it in the run/environment way was not being loaded by rspec, this should ensure _all_ tests are run

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
