### PR TITLE
AP-2729 Add evidence upload feature flag

### DIFF
--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -22,7 +22,8 @@ module Admin
                                       :manually_review_all_cases,
                                       :allow_welsh_translation,
                                       :enable_ccms_submission,
-                                      :enable_employed_journey)
+                                      :enable_employed_journey,
+                                      :enable_evidence_upload)
     end
 
     def setting

--- a/app/forms/settings/setting_form.rb
+++ b/app/forms/settings/setting_form.rb
@@ -6,13 +6,15 @@ module Settings
                   :manually_review_all_cases,
                   :allow_welsh_translation,
                   :enable_ccms_submission,
-                  :enable_employed_journey
+                  :enable_employed_journey,
+                  :enable_evidence_upload
 
     validates :mock_true_layer_data,
               :manually_review_all_cases,
               :allow_welsh_translation,
               :enable_ccms_submission,
               :enable_employed_journey,
+              :enable_evidence_upload,
               presence: true
   end
 end

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -27,6 +27,10 @@ class Setting < ApplicationRecord
     setting.enable_employed_journey
   end
 
+  def self.enable_evidence_upload?
+    setting.enable_evidence_upload
+  end
+
   def self.setting
     Setting.first || Setting.create!
   end

--- a/app/views/admin/settings/show.html.erb
+++ b/app/views/admin/settings/show.html.erb
@@ -56,6 +56,16 @@
         legend: { text: t('.labels.enable_employed_journey') }
     ) %>
 
+    <%= form.govuk_collection_radio_buttons(
+        :enable_evidence_upload,
+        yes_no_options,
+        :value,
+        :label,
+        inline: true,
+        hint: { text: t('.hints.enable_evidence_upload')},
+        legend: { text: t('.labels.enable_evidence_upload') }
+    ) %>
+
     <%= form.submit(t('generic.submit'), class: 'govuk-button form-button') %>
   <% end %>
 <% end %>

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -39,6 +39,7 @@ en:
           allow_welsh_translation: Allow Welsh translation
           enable_ccms_submission: Allow CCMS submissions
           enable_employed_journey: Allow employed applications
+          enable_evidence_upload: Enable the new evidence upload feature
         hints:
           mock_true_layer_data: Select Yes and TrueLayer data will be replaced by mock data from %{bank_transaction_filename}
           manually_review_all_cases: |
@@ -46,7 +47,8 @@ en:
             Select Yes to additionally route all non-passported applications to caseworker for review.
           allow_welsh_translation: Select Yes to translate the service into Welsh
           enable_ccms_submission: Yes by default, only set to No if CCMS is being taken offline
-          enable_employed_journey: Select Yes to allow solicitors to submit applications for employed applicants 
+          enable_employed_journey: Select Yes to allow solicitors to submit applications for employed applicants
+          enable_evidence_upload: Select Yes to enable the new evidence upload feature for solicitors
     submitted_applications_reports:
       show:
         heading_1: Submitted Applications

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -52,3 +52,5 @@ en:
           <<: *true_false
         enable_employed_journey:
           <<: *true_false
+        enable_evidence_upload:
+          <<: *true_false

--- a/db/migrate/20211208161719_add_evidence_upload_flag_to_settings.rb
+++ b/db/migrate/20211208161719_add_evidence_upload_flag_to_settings.rb
@@ -1,0 +1,5 @@
+class AddEvidenceUploadFlagToSettings < ActiveRecord::Migration[6.1]
+  def change
+    add_column :settings, :enable_evidence_upload, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -841,6 +841,7 @@ ActiveRecord::Schema.define(version: 2021_12_09_083010) do
     t.boolean "alert_via_sentry", default: true, null: false
     t.datetime "digest_extracted_at", default: "1970-01-01 00:00:01"
     t.boolean "enable_employed_journey", default: false, null: false
+    t.boolean "enable_evidence_upload", default: false, null: false
   end
 
   create_table "state_machine_proxies", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/lib/tasks/setup_db_for_testing.rake
+++ b/lib/tasks/setup_db_for_testing.rake
@@ -7,7 +7,8 @@ namespace :settings do
                     manually_review_all_cases: false,
                     allow_welsh_translation: false,
                     enable_ccms_submission: true,
-                    enable_employed_journey: false)
+                    enable_employed_journey: false,
+                    enable_evidence_upload: false)
 
     pp Setting.first
   end

--- a/spec/models/setting_spec.rb
+++ b/spec/models/setting_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Setting do
         expect(rec.bank_transaction_filename).to eq 'db/sample_data/bank_transactions.csv'
         expect(rec.alert_via_sentry?).to be true
         expect(rec.enable_employed_journey?).to be false
+        expect(rec.enable_evidence_upload?).to be false
       end
     end
 
@@ -25,7 +26,8 @@ RSpec.describe Setting do
           enable_ccms_submission: false,
           bank_transaction_filename: 'my_special_file.csv',
           alert_via_sentry: true,
-          enable_employed_journey: true
+          enable_employed_journey: true,
+          enable_evidence_upload: true
         )
       end
 
@@ -38,6 +40,7 @@ RSpec.describe Setting do
         expect(rec.bank_transaction_filename).to eq 'my_special_file.csv'
         expect(rec.alert_via_sentry?).to be true
         expect(rec.enable_employed_journey?).to be true
+        expect(rec.enable_evidence_upload?).to be true
       end
     end
   end
@@ -53,6 +56,7 @@ RSpec.describe Setting do
       expect(Setting.bank_transaction_filename).to eq 'db/sample_data/bank_transactions.csv'
       expect(Setting.alert_via_sentry?).to be true
       expect(Setting.enable_employed_journey?).to be false
+      expect(Setting.enable_evidence_upload?).to be false
     end
   end
 end

--- a/spec/requests/admin/settings_spec.rb
+++ b/spec/requests/admin/settings_spec.rb
@@ -38,7 +38,8 @@ RSpec.describe Admin::SettingsController, type: :request do
           mock_true_layer_data: 'true',
           allow_welsh_translation: 'true',
           enable_employed_journey: 'true',
-          enable_ccms_submission: 'true'
+          enable_ccms_submission: 'true',
+          enable_evidence_upload: 'true'
         }
       }
     end
@@ -55,6 +56,7 @@ RSpec.describe Admin::SettingsController, type: :request do
       expect(setting.mock_true_layer_data?).to eq(true)
       expect(setting.allow_welsh_translation?).to eq(true)
       expect(setting.enable_employed_journey?).to eq(true)
+      expect(setting.enable_evidence_upload?).to eq(true)
     end
 
     it 'create settings if they do not exist' do
@@ -70,14 +72,6 @@ RSpec.describe Admin::SettingsController, type: :request do
       before { allow_any_instance_of(CCMS::RestartSubmissions).to receive(:call).and_return(true) }
 
       context 'from false to true' do
-        # let(:params) do
-        #   {
-        #     setting: {
-        #       enable_ccms_submission: 'true'
-        #     }
-        #   }
-        # end
-
         it 'calls CCMS::RestartSubmissions' do
           expect(CCMS::RestartSubmissions).to receive(:call)
           subject
@@ -91,7 +85,8 @@ RSpec.describe Admin::SettingsController, type: :request do
               mock_true_layer_data: 'true',
               allow_welsh_translation: 'true',
               enable_employed_journey: 'true',
-              enable_ccms_submission: 'false'
+              enable_ccms_submission: 'false',
+              enable_evidence_upload: 'false'
             }
           }
         end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2729)

Adds a setting to allow the new evidence upload feature to be toggled for solicitors.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
