### PR TITLE
AP-2731 Add required_document_categories field

### DIFF
--- a/app/models/document_category.rb
+++ b/app/models/document_category.rb
@@ -2,4 +2,6 @@ class DocumentCategory < ApplicationRecord
   def self.populate
     DocumentCategoryPopulator.call
   end
+
+  scope :valid_document_categories, -> { where(display_on_evidence_upload: true).pluck(:name) }
 end

--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -60,6 +60,7 @@ class LegalAidApplication < ApplicationRecord
   end
 
   validates :provider, presence: true
+  validate :validate_document_categories
 
   delegate :bank_transactions, to: :applicant, allow_nil: true
   delegate :full_name, to: :applicant, prefix: true, allow_nil: true
@@ -512,5 +513,11 @@ class LegalAidApplication < ApplicationRecord
 
   def set_open_banking_consent_choice_at
     self.open_banking_consent_choice_at = Time.current if will_save_change_to_open_banking_consent?
+  end
+
+  def validate_document_categories
+    required_document_categories.each do |category|
+      errors.add(:required_document_categories, 'must be valid document categories') unless DocumentCategory.valid_document_categories.include?(category)
+    end
   end
 end

--- a/db/migrate/20211209141633_add_required_document_categories_to_legal_aid_applications.rb
+++ b/db/migrate/20211209141633_add_required_document_categories_to_legal_aid_applications.rb
@@ -1,0 +1,5 @@
+class AddRequiredDocumentCategoriesToLegalAidApplications < ActiveRecord::Migration[6.1]
+  def change
+    add_column :legal_aid_applications, :required_document_categories, :string, array: true, null: false, default: []
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_09_083010) do
+ActiveRecord::Schema.define(version: 2021_12_09_141633) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -555,6 +555,7 @@ ActiveRecord::Schema.define(version: 2021_12_09_083010) do
     t.boolean "no_cash_income"
     t.boolean "no_cash_outgoings"
     t.date "purgeable_on"
+    t.string "required_document_categories", default: [], null: false, array: true
     t.index ["applicant_id"], name: "index_legal_aid_applications_on_applicant_id"
     t.index ["application_ref"], name: "index_legal_aid_applications_on_application_ref", unique: true
     t.index ["discarded_at"], name: "index_legal_aid_applications_on_discarded_at"

--- a/spec/models/legal_aid_application_spec.rb
+++ b/spec/models/legal_aid_application_spec.rb
@@ -1146,4 +1146,30 @@ RSpec.describe LegalAidApplication, type: :model do
       expect(laa.lowest_prospect_of_success).to eq 'Borderline'
     end
   end
+
+  describe 'required_document_categories' do
+    let(:laa) { create :legal_aid_application }
+    before { allow(DocumentCategory).to receive(:valid_document_categories).and_return %w[benefit_evidence gateway_evidence] }
+
+    it 'defaults to an empty array' do
+      expect(laa.required_document_categories).to eq []
+    end
+
+    it 'allows a valid document category to be added' do
+      laa.required_document_categories << 'benefit_evidence'
+      laa.save!
+      expect(laa.required_document_categories).to eq ['benefit_evidence']
+    end
+
+    it 'allows multiple valid document categories to be added' do
+      laa.required_document_categories = %w[gateway_evidence benefit_evidence]
+      laa.save!
+      expect(laa.required_document_categories).to eq %w[gateway_evidence benefit_evidence]
+    end
+
+    it 'errors when an invalid document category is added' do
+      laa.required_document_categories << 'invalid_evidence'
+      expect { laa.save! }.to raise_error(ActiveRecord::RecordInvalid)
+    end
+  end
 end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2731)

Adds a field to the `LegalAidApplication` model to hold an array of document categories required for evidence upload.

This defaults to an empty array and is validated against the list of categories held in the `document_categories` table via a scope on the `DocumentCategory` model.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
