### PR TITLE
AP-2733 Change copy on has_benefit_evidence page 

### DIFF
--- a/app/helpers/gov_uk_form_helper.rb
+++ b/app/helpers/gov_uk_form_helper.rb
@@ -1,9 +1,19 @@
 module GovUkFormHelper
-  # Creates a template variable for yes/no options for radio buttons in a form
+  RadioOption = Struct.new(:value, :label, :radio_hint)
 
-  def yes_no_options
-    [OpenStruct.new(value: true, label: I18n.t('generic.yes')),
-     OpenStruct.new(value: false, label: I18n.t('generic.no'))]
+  # Creates a template variable for yes/no options for radio buttons on a form for use with govuk_collection_radio_buttons method.
+  #
+  # include hash for radio button hints if required, e.g.
+  #
+  # yes_no_options                                               - will print no hints under individual radio buttons
+  # yes_no_options(yes: 'this means Go!', no: 'This means Stop') - will print hints under both radios
+  # yes_no_options(yes: 'This means Go!')                        - will print hint under yes radio only
+  #
+  def yes_no_options(radio_hints = {})
+    [
+      RadioOption.new(true, I18n.t('generic.yes'), radio_hints[:yes]),
+      RadioOption.new(false, I18n.t('generic.no'), radio_hints[:no])
+    ]
   end
 
   # Either passing in the heading text and let this method sort out its formatting,

--- a/app/views/providers/has_evidence_of_benefits/show.html.erb
+++ b/app/views/providers/has_evidence_of_benefits/show.html.erb
@@ -7,11 +7,12 @@
           local: true
       ) do |form| %>
 
-    <%= form.govuk_collection_radio_buttons :has_evidence_of_benefit,
-                                            yes_no_options(yes: Setting.enable_evidence_upload? ? t('.radio_hint_yes') : nil),
-                                            :value,
-                                            :label,
-                                            :radio_hint,
+    <%= form.govuk_collection_radio_buttons :has_evidence_of_benefit, # attribute name
+                                            yes_no_options(yes: Setting.enable_evidence_upload? ? t('.radio_hint_yes') : nil), # collection
+                                            :value, # value method
+                                            :label, # text method
+                                            :radio_hint, #hint method,
+                                            bold_labels: false,
                                             legend: { text: content_for(:page_title), tag: 'h1', size: 'xl' },
                                             hint: { text: Setting.enable_evidence_upload? ? t('.evidence_hint') : t('.hint') } %>
 

--- a/app/views/providers/has_evidence_of_benefits/show.html.erb
+++ b/app/views/providers/has_evidence_of_benefits/show.html.erb
@@ -8,11 +8,12 @@
       ) do |form| %>
 
     <%= form.govuk_collection_radio_buttons :has_evidence_of_benefit,
-                                            yes_no_options,
+                                            yes_no_options(yes: Setting.enable_evidence_upload? ? t('.radio_hint_yes') : nil),
                                             :value,
                                             :label,
+                                            :radio_hint,
                                             legend: { text: content_for(:page_title), tag: 'h1', size: 'xl' },
-                                            hint: { text: t('.hint') } %>
+                                            hint: { text: Setting.enable_evidence_upload? ? t('.evidence_hint') : t('.hint') } %>
 
     <%= next_action_buttons(
             show_draft: true,

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -504,6 +504,8 @@ en:
       show:
         page_title: "Do you have evidence that your client receives %{passporting_benefit}?"
         hint: "For example, a letter from the DWP. A caseworker will request this after you've submitted your application."
+        evidence_hint: 'For example, a letter from the DWP, a bank statement from the last 3 months showing benefits paid in, or any other relevant documents.'
+        radio_hint_yes: "You'll need to upload supporting evidence later."
     limitations:
       proceeding_types:
         h1-heading: What you're applying for


### PR DESCRIPTION
## Change copy on has_benefit_evidence page if evidence upload flag enabled

## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2733)

- Amended  `yes_no_options` helper method to optionally take hint text for individual radio buttons
- Amended  `yes_no_options` to use a `Struct` rather than `OpenStruct`
- Display new copy on page if evidence upload setting is TRUE

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
