### PR TITLE
Ap2567 hmrc results

### DIFF
--- a/app/controllers/providers/employment_incomes_controller.rb
+++ b/app/controllers/providers/employment_incomes_controller.rb
@@ -1,0 +1,34 @@
+module Providers
+  class EmploymentIncomesController < ProviderBaseController
+    def show
+      @applicant = applicant
+      @summary_income = summary_income
+      @form = LegalAidApplications::EmploymentIncomeForm.new(model: legal_aid_application)
+    end
+
+    def update
+      @applicant = applicant
+      @summary_income = summary_income
+      @form = LegalAidApplications::EmploymentIncomeForm.new(form_params)
+      render :show unless save_continue_or_draft(@form)
+    end
+
+    private
+
+    def applicant
+      @applicant ||= legal_aid_application.applicant
+    end
+
+    def summary_income
+      @summary_income ||= HMRC::EmploymentIncomeSummary.new(legal_aid_application.id)
+    end
+
+    def form_params
+      merge_with_model(legal_aid_application) do
+        return {} unless params[:legal_aid_application]
+
+        params.require(:legal_aid_application).permit(:extra_employment_information, :employment_information_details)
+      end
+    end
+  end
+end

--- a/app/forms/legal_aid_applications/employment_income_form.rb
+++ b/app/forms/legal_aid_applications/employment_income_form.rb
@@ -1,0 +1,34 @@
+module LegalAidApplications
+  class EmploymentIncomeForm < BaseForm
+    form_for LegalAidApplication
+
+    attr_accessor :extra_employment_information, :employment_information_details
+
+    before_validation :clear_employment_info_details
+
+    validate :extra_employment_information_presence
+    validate :employment_information_details_presence
+
+    private
+
+    def extra_employment_information_presence
+      return if draft? || extra_employment_information.present?
+
+      add_blank_error_for :extra_employment_information
+    end
+
+    def employment_information_details_presence
+      return if draft? || extra_employment_information.to_s != 'true'
+
+      add_blank_error_for :employment_information_details if employment_information_details.blank?
+    end
+
+    def add_blank_error_for(attribute)
+      errors.add(attribute, I18n.t("activemodel.errors.models.legal_aid_application.attributes.#{attribute}.blank"))
+    end
+
+    def clear_employment_info_details
+      employment_information_details&.clear if extra_employment_information.to_s == 'false'
+    end
+  end
+end

--- a/app/services/flow/flows/provider_capital.rb
+++ b/app/services/flow/flows/provider_capital.rb
@@ -78,6 +78,16 @@ module Flow
         },
         client_completed_means: {
           path: ->(application) { urls.providers_legal_aid_application_client_completed_means_path(application) },
+          forward: ->(application) do
+            if Setting.enable_employed_journey?
+              :employment_incomes
+            else
+              application.income_types? ? :income_summary : :no_income_summaries
+            end
+          end
+        },
+        employment_incomes: {
+          path: ->(application) { urls.providers_legal_aid_application_employment_income_path(application) },
           forward: ->(application) { application.income_types? ? :income_summary : :no_income_summaries }
         },
         income_summary: {

--- a/app/services/flow/flows/provider_capital.rb
+++ b/app/services/flow/flows/provider_capital.rb
@@ -79,7 +79,7 @@ module Flow
         client_completed_means: {
           path: ->(application) { urls.providers_legal_aid_application_client_completed_means_path(application) },
           forward: ->(application) do
-            if Setting.enable_employed_journey?
+            if Setting.enable_employed_journey? && application.provider.employment_permissions?
               :employment_incomes
             else
               application.income_types? ? :income_summary : :no_income_summaries

--- a/app/views/providers/employment_incomes/show.html.erb
+++ b/app/views/providers/employment_incomes/show.html.erb
@@ -1,0 +1,71 @@
+<%= form_with(model: @form,
+              url: providers_legal_aid_application_employment_income_path(@legal_aid_application),
+              method: :patch,
+              local: true) do |form| %>
+
+  <div class="moj-banner">
+    <div class="moj-banner__message">
+      <h2 class="govuk-heading-m"><%= t('.hmrc-information') %></h2>
+    </div>
+  </div>
+
+  <%= page_template page_title: t('.page_heading', name: @applicant.full_name), template: :basic, form: form do %>
+
+    <%= form.govuk_radio_buttons_fieldset(:has_extra_employment_information,
+                                          legend: { size: 'xl', tag: 'h1', text: page_title}) do %>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <table class="govuk-table">
+        <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th class="govuk-table__header" style="width: 20%;" scope="col"><%= t('.date') %></th>
+          <th class="govuk-table__header" style="width: 20%;" scope="col"><%= t('.income') %></th>
+          <th class="govuk-table__header" style="width: 20%;" scope="col"></th>
+          <th class="govuk-table__header" style="width: 20%;" scope="col"><%= t('.deductions') %></th>
+          <th class="govuk-table__header" style="width: 20%;" scope="col"></th>
+        </tr>
+        </thead>
+
+        <tbody class="govuk-table__body">
+        <% @summary_income.employments.each do |employment| %>
+          <% employment.payments.each do |payment| %>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell" style="width: 25%;"><%= l(payment.payment_date.to_date, format: :short_date) %></td>
+            <td class="govuk-table__cell" style="width: 10%;"><b><%= t('.gross') %></b></td>
+            <td class="govuk-table__cell" style="width: 10%;"><b></b><%= gds_number_to_currency(payment.gross_pay) %></td>
+            <td class="govuk-table__cell" style="width: 35%;"><b><%= t('.tax') %></b>
+            <br>
+            <b><%= t('.ni') %></b>
+            </td>
+            <td class="govuk-table__cell" style="width: 20%;">
+              <%= payment.tax > 0 ? "-#{gds_number_to_currency(payment.tax)}" : gds_number_to_currency(payment.tax) %>
+              <br>
+              <%= payment.national_insurance > 0 ? "-#{gds_number_to_currency(payment.national_insurance)}" : gds_number_to_currency(payment.national_insurance) %>
+            </td>
+          </tr>
+          <% end %>
+        <% end %>
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+      <h2 class="govuk-heading-l"><%= t('.supplementary_question') %></h2>
+      <span class="govuk-hint"><%= t('.employment_hint') %></span>
+      <%= form.govuk_radio_button :extra_employment_information, true, link_errors: true, label: { text: t('generic.yes') } do %>
+        <%= form.govuk_text_area :employment_information_details,
+                                 label: {text: t('.enter_details')},
+                                 hint: {text: t('.details_hint')},
+                                 rows: 5 %>
+
+      <% end %>
+      <%= form.govuk_radio_button :extra_employment_information, false, label: { text: t('generic.no') } %>
+    <% end %>
+
+    <%= next_action_buttons(
+          show_draft: true,
+          form: form
+        ) %>
+  <% end %>
+<% end %>

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -317,6 +317,10 @@ en:
               greater_than_or_equal_to: The new cost limit cannot be less than 0
             emergency_cost_reasons:
               blank: Tell us why you need a higher cost limit
+            employment_information_details:
+              blank: Enter the details you need to tell us about (check wording with Jim)
+            extra_employment_information:
+              blank: Just answer the question (check wording with Jim)
             own_home:
               citizens:
                 blank: Select yes if you own the home you live in

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -318,9 +318,9 @@ en:
             emergency_cost_reasons:
               blank: Tell us why you need a higher cost limit
             employment_information_details:
-              blank: Enter the details you need to tell us about (check wording with Jim)
+              blank: Enter details about your client’s employment
             extra_employment_information:
-              blank: Just answer the question (check wording with Jim)
+              blank: Select yes if you need to tell us anything else about your client's employment
             own_home:
               citizens:
                 blank: Select yes if you own the home you live in

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -379,6 +379,20 @@ en:
       show:
         h1-heading: Details of the latest domestic abuse incident
         details_label: What happened during the incident?
+    employment_incomes:
+      show:
+        hmrc-information: The information on this page has been provided by HMRC.
+        page_heading: Review %{name}'s employment income
+        supplementary_question: Do you need to tell us anything else about your client's employment?
+        employment_hint: For example, if they get cash in hand pay, have zero-hours contracts, or recently started or ended employment.
+        date: Date
+        income: Income
+        deductions: Deductions
+        gross: Gross
+        enter_details: Enter details
+        details_hint: You'll need to upload supporting evidence later.
+        tax: Tax
+        ni: National Insurance
     end_of_applications:
       show:
         heading: Application complete

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -220,6 +220,7 @@ Rails.application.routes.draw do
       resource :check_client_details, only: %i[show update]
       resource :received_benefit_confirmation, only: %i[show update]
       resource :has_evidence_of_benefit, only: %i[show update]
+      resource :employment_income, only: %i[show update]
     end
 
     resources :merits_task_list, only: [] do

--- a/db/migrate/20211209134144_add_employment_attrs_to_legal_aid_application.rb
+++ b/db/migrate/20211209134144_add_employment_attrs_to_legal_aid_application.rb
@@ -1,0 +1,6 @@
+class AddEmploymentAttrsToLegalAidApplication < ActiveRecord::Migration[6.1]
+  def change
+    add_column :legal_aid_applications, :extra_employment_information, :boolean
+    add_column :legal_aid_applications, :employment_information_details, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -558,6 +558,8 @@ ActiveRecord::Schema.define(version: 2021_12_09_141633) do
     t.boolean "no_cash_outgoings"
     t.date "purgeable_on"
     t.string "required_document_categories", default: [], null: false, array: true
+    t.boolean "extra_employment_information"
+    t.string "employment_information_details"
     t.index ["applicant_id"], name: "index_legal_aid_applications_on_applicant_id"
     t.index ["application_ref"], name: "index_legal_aid_applications_on_application_ref", unique: true
     t.index ["discarded_at"], name: "index_legal_aid_applications_on_discarded_at"

--- a/spec/requests/providers/client_completed_means_spec.rb
+++ b/spec/requests/providers/client_completed_means_spec.rb
@@ -32,7 +32,6 @@ RSpec.describe Providers::ClientCompletedMeansController, type: :request do
     context 'when the provider is authenticated' do
       before do
         login_as provider
-        subject
       end
 
       context 'Continue button pressed' do
@@ -51,7 +50,22 @@ RSpec.describe Providers::ClientCompletedMeansController, type: :request do
         end
 
         it 'sets the application as draft' do
+          subject
           expect(legal_aid_application.reload).to be_draft
+        end
+      end
+
+      context 'the employed journey feature flag is enabled' do
+        before { Setting.setting.update!(enable_employed_journey: true) }
+        context 'the user has employed permissions' do
+          before { allow_any_instance_of(Provider).to receive(:employment_permissions?).and_return(true) }
+
+          let(:submit_button) { { continue_button: 'Continue' } }
+
+          it 'redirects to next page' do
+            subject
+            expect(response).to redirect_to(providers_legal_aid_application_employment_income_path(legal_aid_application))
+          end
         end
       end
     end

--- a/spec/requests/providers/employed_incomes_spec.rb
+++ b/spec/requests/providers/employed_incomes_spec.rb
@@ -1,0 +1,118 @@
+require 'rails_helper'
+
+RSpec.describe 'employed incomes request', type: :request do
+  let(:application) { create :legal_aid_application, :with_applicant, :with_non_passported_state_machine }
+  let(:provider) { application.provider }
+  before { create :hmrc_response, :use_case_one, legal_aid_application_id: application.id }
+
+  describe 'GET /providers/applications/:id/employed_income' do
+    subject { get providers_legal_aid_application_employment_income_path(application) }
+
+    context 'when the provider is not authenticated' do
+      before { subject }
+      it_behaves_like 'a provider not authenticated'
+    end
+
+    context 'when the provider is authenticated' do
+      before do
+        login_as provider
+        subject
+      end
+
+      it 'returns http success' do
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+
+  describe 'PATCH /providers/applications/:id/employed_income' do
+    subject { patch providers_legal_aid_application_employment_income_path(application), params: params.merge(submit_button) }
+    let(:params) do
+      {
+        legal_aid_application: {
+          extra_employment_information: extra_employment_information,
+          employment_information_details: employment_information_details
+        }
+      }
+    end
+    let(:employment_information_details) { Faker::Lorem.paragraph }
+    let(:extra_employment_information) { 'true' }
+
+    context 'when the provider is authenticated' do
+      before do
+        login_as provider
+        subject
+      end
+
+      context 'Form submitted with continue button' do
+        let(:submit_button) do
+          {
+            continue_button: 'Continue'
+          }
+        end
+
+        it 'updates legal aid application restriction information' do
+          expect(application.reload.extra_employment_information).to eq true
+          expect(application.reload.employment_information_details).to_not be_empty
+        end
+
+        context 'when the provider has confirmed the information' do
+          it 'redirects to income summary page' do
+            expect(response).to redirect_to(providers_legal_aid_application_no_income_summary_path(application))
+          end
+        end
+
+        context 'when the applicant has reported income' do
+          let!(:salary) { create :transaction_type, :credit, name: 'salary' }
+          let!(:benefits) { create :transaction_type, :credit, name: 'benefits' }
+          let(:application) { create :legal_aid_application, :with_applicant, :with_non_passported_state_machine, transaction_types: [salary, benefits] }
+
+          it 'redirects to check passported answers' do
+            expect(response).to redirect_to(providers_legal_aid_application_income_summary_index_path(application))
+          end
+        end
+
+        context 'invalid params' do
+          let(:employment_information_details) { '' }
+
+          it 'displays error' do
+            expect(response.body).to include(I18n.t('activemodel.errors.models.legal_aid_application.attributes.employment_information_details.blank'))
+          end
+
+          context 'no params' do
+            let(:extra_employment_information) { '' }
+
+            it 'displays error' do
+              expect(response.body).to include(I18n.t('activemodel.errors.models.legal_aid_application.attributes.extra_employment_information.blank'))
+            end
+          end
+        end
+      end
+
+      context 'Form submitted with Save as draft button' do
+        let(:submit_button) do
+          {
+            draft_button: 'Save as draft'
+          }
+        end
+
+        context 'after success' do
+          before do
+            login_as provider
+            subject
+            application.reload
+          end
+
+          it 'updates the legal_aid_application.extra_employment_information' do
+            expect(application.extra_employment_information).to eq true
+            expect(application.employment_information_details).to_not be_empty
+          end
+
+          it 'redirects to the list of applications' do
+            expect(response).to redirect_to providers_legal_aid_applications_path
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/providers/employed_incomes_spec.rb
+++ b/spec/requests/providers/employed_incomes_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe 'employed incomes request', type: :request do
             let(:extra_employment_information) { '' }
 
             it 'displays error' do
-              expect(response.body).to include(I18n.t('activemodel.errors.models.legal_aid_application.attributes.extra_employment_information.blank'))
+              expect(unescaped_response_body).to include(I18n.t('activemodel.errors.models.legal_aid_application.attributes.extra_employment_information.blank'))
             end
           end
         end


### PR DESCRIPTION

## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2567)

also 

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2569)

Add a new view and controller and add them to the provider flow
Add new attributes about employment details to LegalAidApplication (ap-2569)
Display the HMRC response to the user at the start of the client journey (before income summary pages)
Add tests



## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
