### PR TITLE
fix warning text icons

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -87,7 +87,7 @@
         <% end %>
         <% if flash[:notice] %>
           <div class='govuk-warning-text'>
-            <span class='govuk-warning-text__icon' aria-hidden='true'>i</span>
+            <span class='govuk-warning-text__icon' aria-hidden='true'>!</span>
             <strong class='govuk-warning-text__text'>
               <span class='govuk-warning-text__assistive'>Notice</span>
               <%= flash[:notice] %>

--- a/app/views/providers/substantive_applications/show.html.erb
+++ b/app/views/providers/substantive_applications/show.html.erb
@@ -18,7 +18,7 @@
     <% end %>
 
     <div class='govuk-warning-text'>
-      <span class='govuk-warning-text__icon' aria-hidden='true'>i</span>
+      <span class='govuk-warning-text__icon' aria-hidden='true'>!</span>
       <strong class='govuk-warning-text__text'>
         <span class='govuk-warning-text__assistive'>Notice</span>
         <%= t('.must_submit_by', deadline: @form.substantive_application_deadline_on) %>


### PR DESCRIPTION

## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2759)

In a couple of places the warning text icon has an 'i' instead of an exclamation mark

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
