### PR TITLE
ap-2732: create required_document_category_analyser

### DIFF
--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -202,7 +202,7 @@ class LegalAidApplication < ApplicationRecord
   end
 
   def section_8_proceedings?
-    proceeding_types.any? { |type| type.ccms_matter_code.eql?('KSEC8') }
+    proceedings.any? { |proceeding| proceeding.ccms_matter_code.eql?('KSEC8') }
   end
 
   def cfe_result

--- a/app/services/required_document_category_analyser.rb
+++ b/app/services/required_document_category_analyser.rb
@@ -1,0 +1,16 @@
+class RequiredDocumentCategoryAnalyser
+  def self.call(application)
+    new(application).call
+  end
+
+  def initialize(application)
+    @application = application
+  end
+
+  def call
+    required_document_categories = []
+    required_document_categories << 'benefit_evidence' if @application.dwp_override
+    required_document_categories << 'gateway_evidence' if @application.section_8_proceedings?
+    @application.update!(required_document_categories: required_document_categories)
+  end
+end

--- a/spec/factories/legal_aid_applications.rb
+++ b/spec/factories/legal_aid_applications.rb
@@ -390,6 +390,13 @@ FactoryBot.define do
       end
     end
 
+    trait :with_multiple_proceedings_inc_section8 do
+      after(:create) do |application|
+        application.proceedings << create(:proceeding, :da001)
+        application.proceedings << create(:proceeding, :se014)
+      end
+    end
+
     # this is a trait of an invalid state and should only be used to test invalid state transitions
     trait :with_only_section8_proceeding_type do
       after(:create) do |application|

--- a/spec/models/legal_aid_application_spec.rb
+++ b/spec/models/legal_aid_application_spec.rb
@@ -1172,4 +1172,23 @@ RSpec.describe LegalAidApplication, type: :model do
       expect { laa.save! }.to raise_error(ActiveRecord::RecordInvalid)
     end
   end
+
+  describe '#section_8_proceedings?' do
+    context 'with section 8 proceedings' do
+      let(:laa) { create :legal_aid_application, :with_multiple_proceedings_inc_section8 }
+
+      it 'returns true' do
+        expect(laa.section_8_proceedings?).to eq true
+      end
+    end
+
+    context 'without section 8 proceedings' do
+      let(:laa) { create :legal_aid_application }
+      let!(:proceeding) { create :proceeding, :da001, legal_aid_application: laa }
+
+      it 'returns false' do
+        expect(laa.section_8_proceedings?).to eq false
+      end
+    end
+  end
 end

--- a/spec/services/required_document_category_analyser_spec.rb
+++ b/spec/services/required_document_category_analyser_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+RSpec.describe RequiredDocumentCategoryAnalyser do
+  before { DocumentCategoryPopulator.call }
+
+  describe '#call' do
+    subject { described_class.call(application) }
+
+    context 'application has dwp result overriden' do
+      let(:application) { create :legal_aid_application, :with_dwp_override }
+      it 'updates the required_document_categories with benefit_evidence' do
+        subject
+        expect(application.required_document_categories).to eq %w[benefit_evidence]
+      end
+
+      it 'overwrites any existing required_document_categories' do
+        application.update!(required_document_categories: %w[gateway_evidence])
+        subject
+        expect(application.required_document_categories).to eq %w[benefit_evidence]
+      end
+    end
+
+    context 'application has section 8 proceedings' do
+      let(:application) { create :legal_aid_application, :with_multiple_proceedings_inc_section8 }
+      it 'updates the required_document_categories with gateway_evidence' do
+        subject
+        expect(application.required_document_categories).to eq %w[gateway_evidence]
+      end
+    end
+
+    context 'application has dwp result overriden and section 8 proceedings' do
+      let(:application) { create :legal_aid_application, :with_dwp_override, :with_multiple_proceedings_inc_section8 }
+      it 'updates the required_document_categories with gateway_evidence' do
+        subject
+        expect(application.required_document_categories).to eq %w[benefit_evidence gateway_evidence]
+      end
+    end
+
+    context 'application has neither dwp result overriden nor section 8 proceedings' do
+      let(:application) { create :legal_aid_application }
+      it 'updates the required_document_categories with an empty array' do
+        subject
+        expect(application.required_document_categories).to eq []
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2732)

- Created new required_document_category_analyser service class
- Converted section_8_proceedings? on legal_aid_application model to use proceedings rather than proceeding_types
- Added new trait on legal_aid_applications factory with_multiple_proceedings_inc_section8 to facilitate testing

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
