### PR TITLE
AP-2763 Test to ensure 100% code coverage

### DIFF
--- a/spec/models/legal_aid_application_spec.rb
+++ b/spec/models/legal_aid_application_spec.rb
@@ -1191,4 +1191,37 @@ RSpec.describe LegalAidApplication, type: :model do
       end
     end
   end
+
+  describe '#online_current_account_balance' do
+    let(:laa) { create :legal_aid_application, :with_applicant }
+    context 'no current accounts' do
+      it 'returns nil' do
+        expect(laa.online_current_accounts_balance).to be_nil
+      end
+    end
+
+    context 'with bank accounts' do
+      let(:balance1) { BigDecimal(rand(1...1_000_000.0), 2) }
+      let(:balance2) { BigDecimal(rand(1...1_000_000.0), 2) }
+      let(:bank_provider) { create :bank_provider, applicant: laa.applicant}
+
+      before do
+        create :bank_account, bank_provider: bank_provider, account_type: account_type, balance: balance1
+        create :bank_account, bank_provider: bank_provider, account_type: account_type, balance: balance2
+      end
+
+      context 'only savings' do
+        let(:account_type) { 'SAVINGS' }
+        it 'returns nil' do
+          expect(laa.online_current_accounts_balance).to be_nil
+        end
+      end
+      context 'only current' do
+        let(:account_type) { 'TRANSACTION' }
+        it 'returns the sum of the balances' do
+          expect(laa.online_current_accounts_balance).to eq balance1 + balance2
+        end
+      end
+    end
+  end
 end

--- a/spec/models/legal_aid_application_spec.rb
+++ b/spec/models/legal_aid_application_spec.rb
@@ -1203,7 +1203,7 @@ RSpec.describe LegalAidApplication, type: :model do
     context 'with bank accounts' do
       let(:balance1) { BigDecimal(rand(1...1_000_000.0), 2) }
       let(:balance2) { BigDecimal(rand(1...1_000_000.0), 2) }
-      let(:bank_provider) { create :bank_provider, applicant: laa.applicant}
+      let(:bank_provider) { create :bank_provider, applicant: laa.applicant }
 
       before do
         create :bank_account, bank_provider: bank_provider, account_type: account_type, balance: balance1


### PR DESCRIPTION

## Test to ensure 100% code coverage

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2763)

Occasionally, runnng the rspec suite of tests would result in less than 100% coverage, the culprit being the `online_current_accounts_balance` method on LegalAidApplication.  This PR adds a test to ensure that method is always adequately tested.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
