### PR TITLE
AP-2362:improve report generation

### DIFF
--- a/app/services/reports/base_report_creator.rb
+++ b/app/services/reports/base_report_creator.rb
@@ -36,5 +36,27 @@ module Reports
         }
       }
     end
+
+    def delete_attachment
+      legal_aid_application.send(report_type).destroy!
+      legal_aid_application.reload
+    end
+
+    def valid_report_exists
+      if report_document_exists
+        Rails.logger.info "ReportsCreator: #{report_type.humanize} already exists for #{legal_aid_application.id} and is downloadable"
+      elsif report_attachment_exists
+        Rails.logger.info "ReportsCreator: #{report_type.humanize} already exists for #{legal_aid_application.id}"
+      end
+      report_attachment_exists && report_document_exists
+    end
+
+    def report_attachment_exists
+      @report_attachment_exists ||= legal_aid_application&.send(report_type)
+    end
+
+    def report_document_exists
+      @report_document_exists ||= legal_aid_application&.send(report_type)&.document&.present?
+    end
   end
 end

--- a/app/services/reports/means_report_creator.rb
+++ b/app/services/reports/means_report_creator.rb
@@ -3,6 +3,7 @@ module Reports
     def call
       return if valid_means_report_exists
 
+      delete_attachment if means_report_attachment_exists
       attachment = legal_aid_application.attachments.create!(attachment_type: 'means_report',
                                                              attachment_name: 'means_report.pdf')
 
@@ -16,6 +17,11 @@ module Reports
     end
 
     private
+
+    def delete_attachment
+      legal_aid_application.means_report.destroy!
+      legal_aid_application.reload
+    end
 
     def valid_means_report_exists
       if means_report_document_exists

--- a/app/services/reports/means_report_creator.rb
+++ b/app/services/reports/means_report_creator.rb
@@ -1,9 +1,9 @@
 module Reports
   class MeansReportCreator < BaseReportCreator
     def call
-      return if valid_means_report_exists
+      return if valid_report_exists
 
-      delete_attachment if means_report_attachment_exists
+      delete_attachment if report_attachment_exists
       attachment = legal_aid_application.attachments.create!(attachment_type: 'means_report',
                                                              attachment_name: 'means_report.pdf')
 
@@ -18,26 +18,8 @@ module Reports
 
     private
 
-    def delete_attachment
-      legal_aid_application.means_report.destroy!
-      legal_aid_application.reload
-    end
-
-    def valid_means_report_exists
-      if means_report_document_exists
-        Rails.logger.info "ReportsCreator: Means report already exists for #{legal_aid_application.id} and is downloadable"
-      elsif means_report_attachment_exists
-        Rails.logger.info "ReportsCreator: Means report already exists for #{legal_aid_application.id}"
-      end
-      means_report_attachment_exists && means_report_document_exists
-    end
-
-    def means_report_attachment_exists
-      @means_report_attachment_exists ||= legal_aid_application&.means_report
-    end
-
-    def means_report_document_exists
-      @means_report_document_exists ||= legal_aid_application&.means_report&.document&.present?
+    def report_type
+      'means_report'
     end
 
     def html_report

--- a/app/services/reports/means_report_creator.rb
+++ b/app/services/reports/means_report_creator.rb
@@ -1,10 +1,7 @@
 module Reports
   class MeansReportCreator < BaseReportCreator
     def call
-      if legal_aid_application.means_report
-        Rails.logger.info "ReportsCreator: Means report already exists for #{legal_aid_application.id}"
-        return
-      end
+      return if valid_means_report_exists
 
       attachment = legal_aid_application.attachments.create!(attachment_type: 'means_report',
                                                              attachment_name: 'means_report.pdf')
@@ -19,6 +16,23 @@ module Reports
     end
 
     private
+
+    def valid_means_report_exists
+      if means_report_document_exists
+        Rails.logger.info "ReportsCreator: Means report already exists for #{legal_aid_application.id} and is downloadable"
+      elsif means_report_attachment_exists
+        Rails.logger.info "ReportsCreator: Means report already exists for #{legal_aid_application.id}"
+      end
+      means_report_attachment_exists && means_report_document_exists
+    end
+
+    def means_report_attachment_exists
+      @means_report_attachment_exists ||= legal_aid_application&.means_report
+    end
+
+    def means_report_document_exists
+      @means_report_document_exists ||= legal_aid_application&.means_report&.document&.present?
+    end
 
     def html_report
       ensure_case_ccms_reference_exists

--- a/app/services/reports/merits_report_creator.rb
+++ b/app/services/reports/merits_report_creator.rb
@@ -1,9 +1,9 @@
 module Reports
   class MeritsReportCreator < BaseReportCreator
     def call
-      return if valid_merits_report_exists
+      return if valid_report_exists
 
-      delete_attachment if merits_report_attachment_exists
+      delete_attachment if report_attachment_exists
       attachment = legal_aid_application.attachments.create!(attachment_type: 'merits_report',
                                                              attachment_name: 'merits_report.pdf')
 
@@ -18,26 +18,8 @@ module Reports
 
     private
 
-    def delete_attachment
-      legal_aid_application.merits_report.destroy!
-      legal_aid_application.reload
-    end
-
-    def valid_merits_report_exists
-      if merits_report_document_exists
-        Rails.logger.info "ReportsCreator: Merits report already exists for #{legal_aid_application.id} and is downloadable"
-      elsif merits_report_attachment_exists
-        Rails.logger.info "ReportsCreator: Merits report already exists for #{legal_aid_application.id}"
-      end
-      merits_report_attachment_exists && merits_report_document_exists
-    end
-
-    def merits_report_attachment_exists
-      @merits_report_attachment_exists ||= legal_aid_application&.merits_report
-    end
-
-    def merits_report_document_exists
-      @merits_report_document_exists ||= legal_aid_application&.merits_report&.document&.present?
+    def report_type
+      'merits_report'
     end
 
     def html_report

--- a/app/services/reports/merits_report_creator.rb
+++ b/app/services/reports/merits_report_creator.rb
@@ -3,6 +3,7 @@ module Reports
     def call
       return if valid_merits_report_exists
 
+      delete_attachment if merits_report_attachment_exists
       attachment = legal_aid_application.attachments.create!(attachment_type: 'merits_report',
                                                              attachment_name: 'merits_report.pdf')
 
@@ -16,6 +17,11 @@ module Reports
     end
 
     private
+
+    def delete_attachment
+      legal_aid_application.merits_report.destroy!
+      legal_aid_application.reload
+    end
 
     def valid_merits_report_exists
       if merits_report_document_exists

--- a/app/services/reports/merits_report_creator.rb
+++ b/app/services/reports/merits_report_creator.rb
@@ -1,10 +1,7 @@
 module Reports
   class MeritsReportCreator < BaseReportCreator
     def call
-      if legal_aid_application.merits_report
-        Rails.logger.info "ReportsCreator: Merits report already exists for #{legal_aid_application.id}"
-        return
-      end
+      return if valid_merits_report_exists
 
       attachment = legal_aid_application.attachments.create!(attachment_type: 'merits_report',
                                                              attachment_name: 'merits_report.pdf')
@@ -19,6 +16,23 @@ module Reports
     end
 
     private
+
+    def valid_merits_report_exists
+      if merits_report_document_exists
+        Rails.logger.info "ReportsCreator: Merits report already exists for #{legal_aid_application.id} and is downloadable"
+      elsif merits_report_attachment_exists
+        Rails.logger.info "ReportsCreator: Merits report already exists for #{legal_aid_application.id}"
+      end
+      merits_report_attachment_exists && merits_report_document_exists
+    end
+
+    def merits_report_attachment_exists
+      @merits_report_attachment_exists ||= legal_aid_application&.merits_report
+    end
+
+    def merits_report_document_exists
+      @merits_report_document_exists ||= legal_aid_application&.merits_report&.document&.present?
+    end
 
     def html_report
       ensure_case_ccms_reference_exists

--- a/spec/services/reports/means_report_creator_spec.rb
+++ b/spec/services/reports/means_report_creator_spec.rb
@@ -95,7 +95,10 @@ RSpec.describe Reports::MeansReportCreator do
           end
 
           it 'creates a new report if the existing one is not downloadable' do
-            expect { subject }.to change { Attachment.count }.by(1)
+            # the count won';'t change as we delete one and create one
+            expect { subject }.not_to change { Attachment.count }
+            # check the original one has been deleted
+            expect { attachment.reload }.to raise_error(ActiveRecord::RecordNotFound)
             expect(Rails.logger).to have_received(:info).with(expected_log)
           end
         end

--- a/spec/services/reports/means_report_creator_spec.rb
+++ b/spec/services/reports/means_report_creator_spec.rb
@@ -77,9 +77,28 @@ RSpec.describe Reports::MeansReportCreator do
         expect(legal_aid_application.means_report.document.filename).to eq('means_report.pdf')
       end
 
-      it 'does not attach a report if one already exists' do
-        create :attachment, :means_report, legal_aid_application: legal_aid_application
-        expect { subject }.not_to change { Attachment.count }
+      context 'when an attachment record exists' do
+        let!(:attachment) { create :attachment, :means_report, legal_aid_application: legal_aid_application }
+        let(:expected_log) { "ReportsCreator: Means report already exists for #{legal_aid_application.id} and is downloadable" }
+        before { allow(Rails.logger).to receive(:info) }
+
+        it 'does not attach a report if one already exists' do
+          expect { subject }.not_to change { Attachment.count }
+          expect(Rails.logger).to have_received(:info).with(expected_log).once
+        end
+
+        context 'when the attachment has no document' do
+          let(:expected_log) { "ReportsCreator: Means report already exists for #{legal_aid_application.id}" }
+          before do
+            allow(legal_aid_application).to receive(:means_report).and_return(attachment)
+            allow(attachment).to receive(:document).and_return(nil)
+          end
+
+          it 'creates a new report if the existing one is not downloadable' do
+            expect { subject }.to change { Attachment.count }.by(1)
+            expect(Rails.logger).to have_received(:info).with(expected_log)
+          end
+        end
       end
 
       context 'ccms case ref does not exist' do

--- a/spec/services/reports/merits_report_creator_spec.rb
+++ b/spec/services/reports/merits_report_creator_spec.rb
@@ -45,7 +45,10 @@ RSpec.describe Reports::MeritsReportCreator do
         end
 
         it 'creates a new report if the existing one is not downloadable' do
-          expect { subject }.to change { Attachment.count }.by(1)
+          # the count won';'t change as we delete one and create one
+          expect { subject }.not_to change { Attachment.count }
+          # check the original one has been deleted
+          expect { attachment.reload }.to raise_error(ActiveRecord::RecordNotFound)
           expect(Rails.logger).to have_received(:info).with(expected_log)
         end
       end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2362)

Update the report generation, previously we would see an occasional error when reports did not have a document attached (see the logging introduced by #2755).

This adds some logic to the means and merit report generators to extend the checks for existing records.
* If an attachment exists and its linked document is present, it will continue to log the state and exit the generator
* If an attachment exists and its linked document cannot be found, it destroys the existing attachment and recreates from scratch

It extends the logging (that can be checked on kibana) so we can monitor for extra occurences

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
