### PR TITLE
Testing bugfix

### DIFF
--- a/spec/factories/legal_aid_applications.rb
+++ b/spec/factories/legal_aid_applications.rb
@@ -258,6 +258,11 @@ FactoryBot.define do
           end
         else
           evaluator.explicit_proceedings.each do |trait|
+            # TODO: Remove the following line once the :with_application_proceeding_types trait has been removed.  During the transition period,
+            # These traits are often called together, and the :with_application_proceeding_types trait will have created the relevant Proceeding.
+            #
+            next if Proceeding.exists?(ccms_code: trait.to_s.upcase)
+
             lead = evaluator.set_lead_proceeding == trait
             create :proceeding, trait, legal_aid_application: application, lead_proceeding: lead
           end

--- a/spec/factories/legal_aid_applications.rb
+++ b/spec/factories/legal_aid_applications.rb
@@ -258,8 +258,8 @@ FactoryBot.define do
           end
         else
           evaluator.explicit_proceedings.each do |trait|
-            # TODO: Remove the following line once the :with_application_proceeding_types trait has been removed.  During the transition period,
-            # These traits are often called together, and the :with_application_proceeding_types trait will have created the relevant Proceeding.
+            # TODO: Remove the following line once the :with_proceeding_types trait has been removed.  During the transition period,
+            # These traits are often called together, and the :with_proceeding_types trait will have created the relevant Proceeding.
             #
             next if Proceeding.exists?(ccms_code: trait.to_s.upcase)
 


### PR DESCRIPTION

## Testing bugfix


TEsts were failing with duplicate key.

This was caused by the LegalAidApplication factory traits `:with_proceeding_types` and `:with_proceedings` being called together.  The `:with_proceeding_types` trait creates a `Proceeding` as well as an `ApplicationProceedingType`, causing the `:with_proceeding` trait to fail when it creates the same `Proceeding`.

This is fixed by modifying the `:with_proceedings` trait to only create the`Proceeding` if it doesn't already exist.  This can be reverted once we've removed the `:with_proceeding_types` trait.


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
