### PR TITLE
BUGFIX - Refactor DigestExporter to use less memory

### DIFF
--- a/app/services/digest_exporter.rb
+++ b/app/services/digest_exporter.rb
@@ -43,7 +43,7 @@ class DigestExporter
 
   def extraction_date
     [
-      "Extracted at: #{Time.now}"
+      "Extracted at: #{Time.zone.now}"
     ]
   end
 

--- a/helm_deploy/apply-for-legal-aid/templates/cronjob-export-digest.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/cronjob-export-digest.yaml
@@ -8,7 +8,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  schedule: '15 2 * * *'
+  schedule: '15 * * * *'
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 1
@@ -28,8 +28,8 @@ spec:
             resources:
               limits:
                 cpu: 200m
-                memory: 1024Mi
+                memory: 2048Mi
               requests:
                 cpu: 100m
-                memory: 512Mi
+                memory: 1024Mi
           restartPolicy: Never

--- a/helm_deploy/apply-for-legal-aid/templates/cronjob-export-digest.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/cronjob-export-digest.yaml
@@ -27,9 +27,9 @@ spec:
 {{ include "apply-for-legal-aid.envs" . | nindent 12 }}
             resources:
               limits:
-                cpu: 200m
-                memory: 2048Mi
+                cpu: 400m
+                memory: 4096Mi
               requests:
-                cpu: 100m
-                memory: 1024Mi
+                cpu: 400m
+                memory: 4096Mi
           restartPolicy: Never

--- a/spec/services/digest_exporter_spec.rb
+++ b/spec/services/digest_exporter_spec.rb
@@ -7,23 +7,27 @@ RSpec.describe DigestExporter do
     let(:google_session) { double GoogleDrive::Session }
     let(:spreadsheet) { double 'Spreadsheet' }
     let(:worksheet) { double 'Worksheet' }
-    let(:column_headings) { ApplicationDigest.column_headers }
+    let(:column_headings) { ApplicationDigest.column_headers + [extracted_at] }
+    let(:fixed_time) { Time.zone.now }
+    let(:extracted_at) { "Extracted at: #{fixed_time.strftime('%Y-%m-%d %H:%M:%S %z')}" }
 
     before do
       create_list :application_digest, 4
     end
 
     it 'loads all the digest records' do
-      expect(GoogleDrive::Session).to receive(:from_service_account_key).and_return(google_session)
-      expect(google_session).to receive(:spreadsheet_by_key).and_return(spreadsheet).exactly(2)
-      expect(spreadsheet).to receive(:worksheets).and_return([worksheet]).at_least(2)
-      expect(worksheet).to receive(:max_rows).and_return(10)
-      expect(worksheet).to receive(:delete_rows).with(1, 9)
-      expect(worksheet).to receive(:save).exactly(3).times
-      expect(worksheet).to receive(:update_cells).with(1, 1, [column_headings])
-      expect(worksheet).to receive(:insert_rows).exactly(4).times
+      travel_to fixed_time do
+        expect(GoogleDrive::Session).to receive(:from_service_account_key).and_return(google_session)
+        expect(google_session).to receive(:spreadsheet_by_key).and_return(spreadsheet).exactly(2)
+        expect(spreadsheet).to receive(:worksheets).and_return([worksheet]).at_least(2)
+        expect(worksheet).to receive(:max_rows).and_return(10)
+        expect(worksheet).to receive(:delete_rows).with(1, 9)
+        expect(worksheet).to receive(:save).exactly(3).times
+        expect(worksheet).to receive(:update_cells).with(1, 1, [column_headings])
+        expect(worksheet).to receive(:insert_rows).exactly(4).times
 
-      described_class.call
+        described_class.call
+      end
     end
   end
 end


### PR DESCRIPTION
## Refactor DigestExporter to use less memory



 - Refactor `DigestExporter` to not read all ApplicationDigest records into memory at once
 - increase resources on Crontab job

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
