### PR TITLE
ap-2724: Remove dependency on application proceeding type from merits…

### DIFF
--- a/app/services/reports/merits_report_creator.rb
+++ b/app/services/reports/merits_report_creator.rb
@@ -29,8 +29,7 @@ module Reports
         template: 'providers/merits_reports/show',
         layout: 'pdf',
         locals: {
-          :@legal_aid_application => legal_aid_application,
-          :@application_proceeding_type => legal_aid_application.lead_application_proceeding_type
+          :@legal_aid_application => legal_aid_application
         }
       )
     end


### PR DESCRIPTION
…_report_creator



## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2724)

Removed reference to application_proceeding_types from merits_report_creator (I believe this was no longer required as references to it had already been removed from app/views/providers/merits_report/show.html.erb).

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
