### PR TITLE
AP-2778 digest exporter cron

### DIFF
--- a/app/services/digest_exporter.rb
+++ b/app/services/digest_exporter.rb
@@ -4,38 +4,73 @@ class DigestExporter
   end
 
   def initialize
+    log_message 'DigestExporter starting'
     secret_file = StringIO.new(google_secret.to_json)
     @session = GoogleDrive::Session.from_service_account_key(secret_file)
     @worksheet = @session.spreadsheet_by_key(spreadsheet_key).worksheets[0]
+    @rows = []
     delete_existing_data
     write_header_row
   end
 
   def call
-    ApplicationDigest.all.each_with_index { |digest, index| write_to_sheet(digest.to_google_sheet_row, index) }
-    @worksheet.save
+    save_digest_to_rows(digest_ids)
+    update_and_save_worksheet
   end
 
   private
+
+  def log_message(message)
+    message = Time.zone.now.strftime('%F %T.%L ') + message if Rails.env.development?
+    Rails.logger.info message
+  end
+
+  def update_and_save_worksheet
+    log_message 'updating cells'
+    @worksheet.update_cells(2, 1, @rows)
+    log_message 'saving worksheet'
+    @worksheet.save
+    log_message 'All records written and worksheet saved'
+  end
+
+  def digest_ids
+    @digest_ids ||= initialize_digest_ids
+  end
+
+  def initialize_digest_ids
+    log_message 'Getting digest ids'
+    ApplicationDigest.order(:created_at).pluck(:id)
+  end
+
+  def save_digest_to_rows(digest_ids)
+    log_message "#{digest_ids.size} records to be saved"
+    digest_ids.each_with_index do |digest_id, _index|
+      digest = ApplicationDigest.find(digest_id)
+      @rows << digest.to_google_sheet_row
+    end
+  end
 
   def delete_existing_data
     # You can't delete all the rows in a worksheet, so we delete all but one, and we'll overwrite that
     # with the column headers
     @worksheet.delete_rows(1, @worksheet.max_rows - 1)
     @worksheet.save
-  end
-
-  def write_to_sheet(row, index)
-    @worksheet.insert_rows(index + 2, [row])
+    log_message 'Existing data removed from spreadsheet'
   end
 
   def write_header_row
     # Overwrite the 1 remaining row with column headers
-    @worksheet.update_cells(1, 1, [ApplicationDigest.column_headers])
+    @worksheet.update_cells(1, 1, [ApplicationDigest.column_headers + extraction_date])
     @worksheet.save
 
     # It turns out that you have to re-initialise the worksheet, otherwise the deleted rows haven't really gone.
     @worksheet = @session.spreadsheet_by_key(spreadsheet_key).worksheets[0]
+  end
+
+  def extraction_date
+    [
+      "Extracted at: #{Time.zone.now}"
+    ]
   end
 
   def spreadsheet_key

--- a/helm_deploy/apply-for-legal-aid/templates/cronjob-export-digest.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/cronjob-export-digest.yaml
@@ -27,9 +27,9 @@ spec:
 {{ include "apply-for-legal-aid.envs" . | nindent 12 }}
             resources:
               limits:
-                cpu: 200m
-                memory: 1024Mi
+                cpu: 400m
+                memory: 4096Mi
               requests:
-                cpu: 100m
-                memory: 512Mi
+                cpu: 400m
+                memory: 4096Mi
           restartPolicy: Never

--- a/spec/services/digest_exporter_spec.rb
+++ b/spec/services/digest_exporter_spec.rb
@@ -7,23 +7,28 @@ RSpec.describe DigestExporter do
     let(:google_session) { double GoogleDrive::Session }
     let(:spreadsheet) { double 'Spreadsheet' }
     let(:worksheet) { double 'Worksheet' }
-    let(:column_headings) { ApplicationDigest.column_headers }
+    let(:column_headings) { ApplicationDigest.column_headers + [extracted_at] }
+    let(:fixed_time) { Time.zone.now }
+    let(:extracted_at) { "Extracted at: #{fixed_time.strftime('%Y-%m-%d %H:%M:%S %z')}" }
+    let(:rows) { ApplicationDigest.order(:created_at).map(&:to_google_sheet_row) }
 
     before do
       create_list :application_digest, 4
     end
 
     it 'loads all the digest records' do
-      expect(GoogleDrive::Session).to receive(:from_service_account_key).and_return(google_session)
-      expect(google_session).to receive(:spreadsheet_by_key).and_return(spreadsheet).exactly(2)
-      expect(spreadsheet).to receive(:worksheets).and_return([worksheet]).at_least(2)
-      expect(worksheet).to receive(:max_rows).and_return(10)
-      expect(worksheet).to receive(:delete_rows).with(1, 9)
-      expect(worksheet).to receive(:save).exactly(3).times
-      expect(worksheet).to receive(:update_cells).with(1, 1, [column_headings])
-      expect(worksheet).to receive(:insert_rows).exactly(4).times
+      travel_to fixed_time do
+        expect(GoogleDrive::Session).to receive(:from_service_account_key).and_return(google_session)
+        expect(google_session).to receive(:spreadsheet_by_key).and_return(spreadsheet).exactly(2)
+        expect(spreadsheet).to receive(:worksheets).and_return([worksheet]).at_least(2)
+        expect(worksheet).to receive(:max_rows).and_return(10)
+        expect(worksheet).to receive(:delete_rows).with(1, 9)
+        expect(worksheet).to receive(:save).exactly(3).times
+        expect(worksheet).to receive(:update_cells).with(1, 1, [column_headings])
+        expect(worksheet).to receive(:update_cells).with(2, 1, rows)
 
-      described_class.call
+        described_class.call
+      end
     end
   end
 end


### PR DESCRIPTION
## Fix issues with digest exporter cron

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2778)

The digest exporter cron job was failing every night to to running out of memory, and taking 45 minutes to run before failing.  Several steps have been taken to solve this issue:
- increase memory on kubernetes cronjob definition
- Read the ids of the digest records and process, rather than read all 9,000 into memory at the same time
- format the output into an array and write to the spreadsheet once, rather than make an API call to the spreadsheet for each line (this has reduced the running time from 45 minutes to < 3 minutes
- Add logging to that progress can be monitored
- Add Extracted at time to the header line of the worksheet

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
