### PR TITLE
bugfix: always show employment section

### DIFF
--- a/app/views/providers/means_summaries/show.html.erb
+++ b/app/views/providers/means_summaries/show.html.erb
@@ -2,9 +2,7 @@
 
   <h2 class="govuk-heading-l"><%= t('.h2-heading') %></h2>
 
-  <% if @legal_aid_application.extra_employment_information_details? %>
-    <%= render 'shared/check_answers/employed_income' %>
-  <% end %>
+  <%= render 'shared/check_answers/employed_income' %>
 
   <%= render(
          'shared/check_answers/income_summary',


### PR DESCRIPTION
## What

Discussed with Stevey, Jim and Pamela the original ticket says to hide it if there is no answer but we usually show something to allow ther user the option to change their answer.

Change the check your answers page to display the employment section all of the time, but hide the details section if the answer to the first question is No.

Describe what you did and why.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
