### PR TITLE
AP-2782 Prevent duplicate HMRC requests

### DIFF
--- a/app/services/hmrc/create_responses_service.rb
+++ b/app/services/hmrc/create_responses_service.rb
@@ -12,6 +12,8 @@ module HMRC
     end
 
     def call
+      return unless @legal_aid_application.hmrc_responses.empty?
+
       USE_CASES.each do |use_case|
         hmrc_response = @legal_aid_application.hmrc_responses.create(use_case: use_case)
         HMRC::SubmissionWorker.perform_async(hmrc_response.id)

--- a/spec/services/hmrc/create_responses_service_spec.rb
+++ b/spec/services/hmrc/create_responses_service_spec.rb
@@ -15,5 +15,15 @@ RSpec.describe HMRC::CreateResponsesService do
         expect { call }.to change(HMRC::SubmissionWorker.jobs, :size).by(2)
       end
     end
+
+    context 'when requests already exist' do
+      let!(:hmrc_response) { create :hmrc_response, legal_aid_application: legal_aid_application }
+      it 'does not create any more hmrc_response records' do
+        expect { call }.not_to change { legal_aid_application.hmrc_responses.count }
+      end
+      it 'does not create any jobs to request the data' do
+        expect { call }.not_to change(HMRC::SubmissionWorker.jobs, :size)
+      end
+    end
   end
 end


### PR DESCRIPTION

## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2782)

Adds a guard clause to the call method of the CreateResponsesService class to prevent duplicate calls to HMRC being made.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
