### PR TITLE
AP-2721 Remove ApplicationProceedingType from Merits Task List

### DIFF
--- a/app/controllers/providers/proceeding_merits_task/attempts_to_settle_controller.rb
+++ b/app/controllers/providers/proceeding_merits_task/attempts_to_settle_controller.rb
@@ -2,14 +2,11 @@ module Providers
   module ProceedingMeritsTask
     class AttemptsToSettleController < ProviderBaseController
       def show
-        @application_proceeding_type = application_proceeding_type
         @form = Providers::ProceedingMeritsTask::AttemptsToSettleForm.new(model: attempts_to_settle)
       end
 
       def update
-        @application_proceeding_type = application_proceeding_type
-        @form = Providers::ProceedingMeritsTask::AttemptsToSettleForm.new(form_params.merge(proceeding_id: proceeding.id,
-                                                                                            application_proceeding_type_id: application_proceeding_type.id))
+        @form = Providers::ProceedingMeritsTask::AttemptsToSettleForm.new(form_params.merge(proceeding_id: proceeding.id))
         render :show unless update_task_save_continue_or_draft(proceeding.ccms_code.to_sym, :attempts_to_settle)
       end
 
@@ -19,12 +16,8 @@ module Providers
         @legal_aid_application ||= proceeding.legal_aid_application
       end
 
-      def application_proceeding_type
-        @application_proceeding_type ||= proceeding.application_proceeding_type
-      end
-
       def attempts_to_settle
-        @attempts_to_settle ||= @application_proceeding_type.attempts_to_settle || @application_proceeding_type.build_attempts_to_settle
+        @attempts_to_settle ||= proceeding.attempts_to_settle || proceeding.build_attempts_to_settle
       end
 
       def proceeding

--- a/app/controllers/providers/proceeding_merits_task/chances_of_success_controller.rb
+++ b/app/controllers/providers/proceeding_merits_task/chances_of_success_controller.rb
@@ -6,7 +6,7 @@ module Providers
       end
 
       def create
-        @form = ChancesOfSuccesses::SuccessLikelyForm.new(form_params.merge(proceeding_id: proceeding.id, application_proceeding_type_id: application_proceeding_type.id))
+        @form = ChancesOfSuccesses::SuccessLikelyForm.new(form_params.merge(proceeding_id: proceeding.id))
         render :index unless update_task_save_continue_or_draft(proceeding.ccms_code.to_sym, :chances_of_success)
       end
 
@@ -26,10 +26,6 @@ module Providers
 
       def proceeding
         @proceeding ||= Proceeding.find(params[:merits_task_list_id])
-      end
-
-      def application_proceeding_type
-        @application_proceeding_type ||= proceeding.application_proceeding_type
       end
 
       def form_params

--- a/app/controllers/providers/proceeding_merits_task/linked_children_controller.rb
+++ b/app/controllers/providers/proceeding_merits_task/linked_children_controller.rb
@@ -2,7 +2,7 @@ module Providers
   module ProceedingMeritsTask
     class LinkedChildrenController < ProviderBaseController
       def show
-        @form = Providers::ProceedingMeritsTask::LinkedChildrenForm.new(model: application_proceeding_type)
+        @form = Providers::ProceedingMeritsTask::LinkedChildrenForm.new(model: proceeding)
       end
 
       def update
@@ -16,10 +16,6 @@ module Providers
         @legal_aid_application ||= proceeding.legal_aid_application
       end
 
-      def application_proceeding_type
-        @application_proceeding_type ||= proceeding.application_proceeding_type
-      end
-
       def proceeding
         @proceeding ||= Proceeding.find(merits_task_list_id)
       end
@@ -29,8 +25,8 @@ module Providers
       end
 
       def form_params
-        merge_with_model(application_proceeding_type) do
-          params.require(:proceeding_merits_task_application_proceeding_type_linked_child).permit(linked_children: [])
+        merge_with_model(proceeding) do
+          params.require(:proceeding_merits_task_proceeding_linked_child).permit(linked_children: [])
         end
       end
     end

--- a/app/controllers/providers/proceeding_merits_task/success_prospects_controller.rb
+++ b/app/controllers/providers/proceeding_merits_task/success_prospects_controller.rb
@@ -17,11 +17,7 @@ module Providers
       end
 
       def chances_of_success
-        @chances_of_success ||= application_proceeding_type.chances_of_success || application_proceeding_type.build_chances_of_success
-      end
-
-      def application_proceeding_type
-        @application_proceeding_type ||= proceeding.application_proceeding_type
+        @chances_of_success ||= proceeding.chances_of_success || proceeding.build_chances_of_success
       end
 
       def proceeding

--- a/app/forms/chances_of_successes/success_likely_form.rb
+++ b/app/forms/chances_of_successes/success_likely_form.rb
@@ -2,7 +2,7 @@ module ChancesOfSuccesses
   class SuccessLikelyForm < BaseForm
     form_for ProceedingMeritsTask::ChancesOfSuccess
 
-    attr_accessor :success_likely, :proceeding_id, :application_proceeding_type_id
+    attr_accessor :success_likely, :proceeding_id
 
     validates :success_likely, presence: true, unless: :draft?
     before_validation :set_success_prospect

--- a/app/forms/providers/proceeding_merits_task/linked_children_form.rb
+++ b/app/forms/providers/proceeding_merits_task/linked_children_form.rb
@@ -1,7 +1,7 @@
 module Providers
   module ProceedingMeritsTask
     class LinkedChildrenForm < BaseForm
-      form_for ::ProceedingMeritsTask::ApplicationProceedingTypeLinkedChild
+      form_for ::ProceedingMeritsTask::ProceedingLinkedChild
 
       attr_accessor :linked_children
 
@@ -17,7 +17,6 @@ module Providers
         return false unless valid?
 
         ActiveRecord::Base.transaction do
-          update_involved_children_on_application_proceeding_type
           update_involved_children_on_proceeding
         end
         true
@@ -26,13 +25,6 @@ module Providers
       end
 
       private
-
-      def update_involved_children_on_application_proceeding_type
-        application_proceeding_type.involved_children.delete_all
-        linked_children.filter_map(&:presence).each do |child_id|
-          application_proceeding_type.application_proceeding_type_linked_children.create!(involved_child_id: child_id)
-        end
-      end
 
       def update_involved_children_on_proceeding
         proceeding.involved_children.delete_all
@@ -62,11 +54,11 @@ module Providers
       end
 
       def proceeding
-        application_proceeding_type.proceeding
+        @proceeding ||= model
       end
 
       def children_ids
-        @children_ids ||= application_proceeding_type.involved_children.map(&:id)
+        @children_ids ||= proceeding.involved_children.map(&:id)
       end
     end
   end

--- a/app/models/legal_framework/serializable_merits_task_list.rb
+++ b/app/models/legal_framework/serializable_merits_task_list.rb
@@ -61,7 +61,7 @@ module LegalFramework
     def serialize_proceeding_types_tasks
       @lfa_response[:proceeding_types].each do |proceeding_type_hash|
         ccms_code = proceeding_type_hash[:ccms_code].to_sym
-        proceeding_name = ProceedingType.find_by(ccms_code: ccms_code).meaning
+        proceeding_name = Proceeding.find_by(ccms_code: ccms_code).meaning
         @tasks[:proceedings][ccms_code] = { name: proceeding_name, tasks: [] }
         proceeding_type_hash[:tasks].each do |task_name, dependencies|
           @tasks[:proceedings][ccms_code][:tasks] << SerializableMeritsTask.new(task_name, dependencies: dependencies)

--- a/app/models/proceeding_merits_task/attempts_to_settle.rb
+++ b/app/models/proceeding_merits_task/attempts_to_settle.rb
@@ -1,6 +1,5 @@
 module ProceedingMeritsTask
   class AttemptsToSettle < ApplicationRecord
-    belongs_to :application_proceeding_type
     belongs_to :proceeding
   end
 end

--- a/app/models/proceeding_merits_task/chances_of_success.rb
+++ b/app/models/proceeding_merits_task/chances_of_success.rb
@@ -1,6 +1,5 @@
 module ProceedingMeritsTask
   class ChancesOfSuccess < ApplicationRecord
-    belongs_to :application_proceeding_type
     belongs_to :proceeding
 
     # TODO: remove once LFA migration is complete

--- a/app/services/flow/flows/provider_merits.rb
+++ b/app/services/flow/flows/provider_merits.rb
@@ -98,7 +98,7 @@ module Flow
         },
         merits_task_lists: {
           path: ->(application) { urls.providers_legal_aid_application_merits_task_list_path(application) },
-          forward: ->(application) { application.proceeding_types.size > 1 ? :gateway_evidences : :check_merits_answers }
+          forward: ->(application) { application.proceedings.size > 1 ? :gateway_evidences : :check_merits_answers }
         },
         gateway_evidences: {
           path: ->(application) { urls.providers_legal_aid_application_gateway_evidence_path(application) },

--- a/app/services/flow/flows/provider_merits.rb
+++ b/app/services/flow/flows/provider_merits.rb
@@ -65,8 +65,7 @@ module Flow
         chances_of_success: {
           forward: ->(application) do
             proceeding = application.proceedings.find(application.provider_step_params['merits_task_list_id'])
-            application_proceeding_type = proceeding.application_proceeding_type
-            if application_proceeding_type.chances_of_success.success_likely?
+            if proceeding.chances_of_success.success_likely?
               :merits_task_lists
             else
               :success_prospects
@@ -74,8 +73,7 @@ module Flow
           end,
           check_answers: ->(application) do
             proceeding = application.proceedings.find(application.provider_step_params['merits_task_list_id'])
-            application_proceeding_type = proceeding.application_proceeding_type
-            application_proceeding_type.chances_of_success.success_likely? ? :check_merits_answers : :success_prospects
+            proceeding.chances_of_success.success_likely? ? :check_merits_answers : :success_prospects
           end
         },
         success_prospects: {

--- a/app/services/legal_framework/merits_tasks_retriever_service.rb
+++ b/app/services/legal_framework/merits_tasks_retriever_service.rb
@@ -16,7 +16,7 @@ module LegalFramework
     private
 
     def proceeding_types_codes
-      legal_aid_application.application_proceeding_types.map { |apt| apt.proceeding_type.ccms_code }
+      legal_aid_application.proceedings.map(&:ccms_code)
     end
   end
 end

--- a/app/services/reports/mis/application_detail_csv_line.rb
+++ b/app/services/reports/mis/application_detail_csv_line.rb
@@ -208,9 +208,9 @@ module Reports
       end
 
       def proceeding_details
-        @line << proceeding_types.map(&:ccms_matter).uniq.sort.join(', ')
+        @line << proceedings.map(&:matter_type).uniq.sort.join(', ')
         @line << proceedings.count
-        @line << proceeding_types.map(&:meaning).sort.join(', ')
+        @line << proceedings.map(&:meaning).sort.join(', ')
         @line << laspo_question
       end
 

--- a/db/migrate/20211223105917_allow_null_apt_on_chances_of_success.rb
+++ b/db/migrate/20211223105917_allow_null_apt_on_chances_of_success.rb
@@ -1,0 +1,6 @@
+class AllowNullAptOnChancesOfSuccess < ActiveRecord::Migration[6.1]
+  def change
+    # Change to allow null values
+    change_column :chances_of_successes, :application_proceeding_type_id, :uuid, null: true
+  end
+end

--- a/db/migrate/20211223105917_allow_null_apt_on_chances_of_success.rb
+++ b/db/migrate/20211223105917_allow_null_apt_on_chances_of_success.rb
@@ -1,6 +1,18 @@
 class AllowNullAptOnChancesOfSuccess < ActiveRecord::Migration[6.1]
-  def change
-    # Change to allow null values
+  def up
+    # Change to allow null values on aplication_proceeding_type_id and NOT on proceeding_id
     change_column :chances_of_successes, :application_proceeding_type_id, :uuid, null: true
+    change_column :attempts_to_settles, :application_proceeding_type_id, :uuid, null: true
+
+    change_column :chances_of_successes, :proceeding_id, :uuid, null: false
+    change_column :attempts_to_settles, :proceeding_id, :uuid, null: false
+  end
+
+  def down
+    change_column :chances_of_successes, :application_proceeding_type_id, :uuid, null: false
+    change_column :attempts_to_settles, :application_proceeding_type_id, :uuid, null: false
+
+    change_column :chances_of_successes, :proceeding_id, :uuid, null: true
+    change_column :attempts_to_settles, :proceeding_id, :uuid, null: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_14_154807) do
+ActiveRecord::Schema.define(version: 2021_12_23_105917) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -365,7 +365,7 @@ ActiveRecord::Schema.define(version: 2021_12_14_154807) do
     t.string "success_prospect"
     t.text "success_prospect_details"
     t.boolean "success_likely"
-    t.uuid "application_proceeding_type_id", null: false
+    t.uuid "application_proceeding_type_id"
     t.uuid "proceeding_id"
     t.index ["application_proceeding_type_id"], name: "index_chances_of_successes_on_application_proceeding_type_id"
     t.index ["proceeding_id"], name: "index_chances_of_successes_on_proceeding_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -181,8 +181,8 @@ ActiveRecord::Schema.define(version: 2021_12_23_105917) do
     t.text "attempts_made"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.uuid "application_proceeding_type_id", null: false
-    t.uuid "proceeding_id"
+    t.uuid "application_proceeding_type_id"
+    t.uuid "proceeding_id", null: false
     t.index ["application_proceeding_type_id"], name: "index_attempts_to_settles_on_application_proceeding_type_id"
     t.index ["proceeding_id"], name: "index_attempts_to_settles_on_proceeding_id"
   end
@@ -366,7 +366,7 @@ ActiveRecord::Schema.define(version: 2021_12_23_105917) do
     t.text "success_prospect_details"
     t.boolean "success_likely"
     t.uuid "application_proceeding_type_id"
-    t.uuid "proceeding_id"
+    t.uuid "proceeding_id", null: false
     t.index ["application_proceeding_type_id"], name: "index_chances_of_successes_on_application_proceeding_type_id"
     t.index ["proceeding_id"], name: "index_chances_of_successes_on_proceeding_id"
   end

--- a/spec/factories/chances_of_successes.rb
+++ b/spec/factories/chances_of_successes.rb
@@ -1,11 +1,5 @@
 FactoryBot.define do
   factory :chances_of_success, class: 'ProceedingMeritsTask::ChancesOfSuccess' do
-    trait :with_application_proceeding_type do
-      before(:create) do |chances_of_success|
-        create(:application_proceeding_type, chances_of_success: chances_of_success)
-      end
-    end
-
     trait :with_optional_text do
       application_purpose { Faker::Lorem.paragraph }
       success_prospect { 'marginal' }

--- a/spec/factories/legal_aid_applications.rb
+++ b/spec/factories/legal_aid_applications.rb
@@ -389,8 +389,8 @@ FactoryBot.define do
         AssignedSubstantiveScopeLimitation.create!(application_proceeding_type_id: apt.id,
                                                    scope_limitation_id: sl.id)
         application.application_proceeding_types.each do |app_proc_type|
-          create(:chances_of_success, :with_optional_text, application_proceeding_type: app_proc_type, proceeding: app_proc_type.proceeding)
-          create(:attempts_to_settles, application_proceeding_type: app_proc_type, proceeding: app_proc_type.proceeding)
+          create(:chances_of_success, :with_optional_text, proceeding: app_proc_type.proceeding)
+          create(:attempts_to_settles, proceeding: app_proc_type.proceeding)
         end
       end
     end
@@ -665,7 +665,7 @@ FactoryBot.define do
       end
       after(:create) do |application, evaluator|
         application.application_proceeding_types.each do |apt|
-          apt.chances_of_success = create(:chances_of_success, application_proceeding_type: apt, success_prospect: evaluator.prospect, proceeding: apt.proceeding)
+          apt.chances_of_success = create(:chances_of_success, success_prospect: evaluator.prospect, proceeding: apt.proceeding)
         end
       end
     end

--- a/spec/factories/proceeding_merits_task/proceeding_linked_children.rb
+++ b/spec/factories/proceeding_merits_task/proceeding_linked_children.rb
@@ -1,0 +1,8 @@
+module ProceedingMeritsTask
+  FactoryBot.define do
+    factory :proceeding_linked_child, class: ProceedingMeritsTask::ProceedingLinkedChild do
+      involved_child
+      proceeding
+    end
+  end
+end

--- a/spec/models/legal_aid_application_spec.rb
+++ b/spec/models/legal_aid_application_spec.rb
@@ -660,9 +660,8 @@ RSpec.describe LegalAidApplication, type: :model do
     context 'delegated functions' do
       let(:legal_aid_application) { create :legal_aid_application, :with_proceedings, proceeding_count: 4, set_lead_proceeding: :da004 }
       let(:da004) { legal_aid_application.proceedings.find_by(ccms_code: 'DA004') }
-      let(:application_proceeding_type) { create :application_proceeding_type, legal_aid_application: legal_aid_application }
       let!(:chances_of_success) do
-        create :chances_of_success, :with_optional_text, application_proceeding_type: application_proceeding_type, proceeding: da004
+        create :chances_of_success, :with_optional_text, proceeding: da004
       end
 
       it 'returns the substantive cost limitation for the first proceeding type' do
@@ -1044,9 +1043,8 @@ RSpec.describe LegalAidApplication, type: :model do
     let(:proceeding_se014) { laa.proceedings.detect { |p| p.ccms_code == 'SE014' } }
 
     it 'returns an array of all the  chances of success records' do
-      # TODO: remove the :with_application_proceeding_type trait once LFA conversion is complete and application_proceeding_type is no longer a required field on chances_of_success
-      cos_da001 = create :chances_of_success, :with_application_proceeding_type, proceeding: proceeding_da001
-      cos_se014 = create :chances_of_success, :with_application_proceeding_type, proceeding: proceeding_se014
+      cos_da001 = create :chances_of_success, proceeding: proceeding_da001
+      cos_se014 = create :chances_of_success, proceeding: proceeding_se014
 
       expect(laa.chances_of_success).to match_array([cos_da001, cos_se014])
     end
@@ -1056,12 +1054,10 @@ RSpec.describe LegalAidApplication, type: :model do
     let(:laa) { create :legal_aid_application, :with_proceedings, proceeding_count: 4 }
     let(:proceeding_da001) { laa.proceedings.detect { |p| p.ccms_code == 'DA001' } }
     let(:proceeding_se014) { laa.proceedings.detect { |p| p.ccms_code == 'SE014' } }
-    let(:apt) { create :application_proceeding_type }
 
     it 'returns an array of attempt_to_settle records attached to the application' do
-      # TODO: remove the application_proceeding_type from these lines once the LFA migration is complete
-      ats_da001 = create :attempts_to_settles, proceeding: proceeding_da001, application_proceeding_type: apt
-      ats_se014 = create :attempts_to_settles, proceeding: proceeding_se014, application_proceeding_type: apt
+      ats_da001 = create :attempts_to_settles, proceeding: proceeding_da001
+      ats_se014 = create :attempts_to_settles, proceeding: proceeding_se014
 
       expect(laa.attempts_to_settles).to match_array([ats_da001, ats_se014])
     end
@@ -1140,8 +1136,7 @@ RSpec.describe LegalAidApplication, type: :model do
       prospects = %w[likely borderline marginal]
       laa.proceedings.each_with_index do |proceeding, i|
         proceeding.chances_of_success = create(:chances_of_success, proceeding: proceeding,
-                                                                    success_prospect: prospects[i],
-                                                                    application_proceeding_type: create(:application_proceeding_type))
+                                                                    success_prospect: prospects[i])
       end
       expect(laa.lowest_prospect_of_success).to eq 'Borderline'
     end

--- a/spec/models/legal_framework/serializable_merits_task_list_spec.rb
+++ b/spec/models/legal_framework/serializable_merits_task_list_spec.rb
@@ -2,7 +2,10 @@ require 'rails_helper'
 
 module LegalFramework
   RSpec.describe SerializableMeritsTaskList, type: :model do
-    before { populate_legal_framework }
+    before do
+      create :proceeding, :da004
+      create :proceeding, :da001
+    end
     let(:smtl) { described_class.new(dummy_response_hash) }
 
     describe '.new' do
@@ -31,7 +34,7 @@ module LegalFramework
 
       context 'ccms_code' do
         it 'returns an array of serializable merits tasks' do
-          tasks = smtl.tasks_for(:DA005)
+          tasks = smtl.tasks_for(:DA004)
           expect(tasks.size).to eq 1
           expect(tasks.map(&:class).uniq).to eq [SerializableMeritsTask]
           expect(tasks.map(&:name)).to eq %i[chances_of_success]
@@ -85,8 +88,8 @@ module LegalFramework
         end
         context 'proceeding type' do
           it 'marks the task as complete' do
-            smtl.mark_as_complete!(:DA005, :chances_of_success)
-            expect(smtl.task(:DA005, :chances_of_success).state).to eq :complete
+            smtl.mark_as_complete!(:DA004, :chances_of_success)
+            expect(smtl.task(:DA004, :chances_of_success).state).to eq :complete
           end
         end
       end
@@ -104,7 +107,7 @@ module LegalFramework
         },
         proceeding_types: [
           {
-            ccms_code: 'DA005',
+            ccms_code: 'DA004',
             tasks: {
               chances_of_success: []
             }

--- a/spec/models/proceeding_merits_task/chances_of_success_spec.rb
+++ b/spec/models/proceeding_merits_task/chances_of_success_spec.rb
@@ -5,11 +5,10 @@ RSpec.describe ProceedingMeritsTask::ChancesOfSuccess, type: :model do
     let(:pt_da) { create :proceeding_type, :with_real_data }
     let(:pt_s8) { create :proceeding_type, :as_section_8_child_residence }
     let(:legal_aid_application) do
-      create :legal_aid_application, :with_proceeding_types, :with_proceedings, explicit_proceeding_types: [pt_da, pt_s8], explicit_proceedings: %i[da001 se014]
+      create :legal_aid_application, :with_proceedings, explicit_proceedings: %i[da001 se014]
     end
-    let(:application_proceeding_type) { legal_aid_application.application_proceeding_types.first }
     let(:proceeding) { legal_aid_application.proceedings.first }
-    let(:chances_of_success) { create :chances_of_success, application_proceeding_type: application_proceeding_type, success_prospect: prospect, proceeding: proceeding }
+    let(:chances_of_success) { create :chances_of_success, success_prospect: prospect, proceeding: proceeding }
 
     context 'likely' do
       let(:prospect) { 'likely' }

--- a/spec/requests/providers/proceeding_merits_task/chances_of_success_spec.rb
+++ b/spec/requests/providers/proceeding_merits_task/chances_of_success_spec.rb
@@ -106,7 +106,7 @@ module Providers
         end
 
         context 'user has come from the check_merits_answer page' do
-          let(:legal_aid_application) { create :legal_aid_application, :with_proceedings, :checking_merits_answers, explicit_proceedings: [:da001, :se014] }
+          let(:legal_aid_application) { create :legal_aid_application, :with_proceedings, :checking_merits_answers, explicit_proceedings: %i[da001 se014] }
 
           it 'redirects back to the answers page' do
             subject

--- a/spec/requests/providers/proceeding_merits_task/chances_of_success_spec.rb
+++ b/spec/requests/providers/proceeding_merits_task/chances_of_success_spec.rb
@@ -3,15 +3,10 @@ require 'rails_helper'
 module Providers
   module ProceedingMeritsTask
     RSpec.describe ChancesOfSuccessController, type: :request do
-      let(:chances_of_success) { create :chances_of_success, application_proceeding_type: application_proceeding_type }
       let(:smtl) { create :legal_framework_merits_task_list, legal_aid_application: legal_aid_application }
-      let(:pt_da) { create :proceeding_type, :with_real_data }
-      let(:pt_s8) { create :proceeding_type, :as_section_8_child_residence }
-      let(:legal_aid_application) { create :legal_aid_application, :with_proceeding_types, explicit_proceeding_types: [pt_da, pt_s8] }
+      let(:legal_aid_application) { create :legal_aid_application, :with_proceedings, explicit_proceedings: %i[da001 se014] }
       let(:proceeding) { legal_aid_application.proceedings.find_by(ccms_code: 'DA001') }
       let!(:proceeding_two) { legal_aid_application.proceedings.find_by(ccms_code: 'SE014') }
-      let(:proceeding_type) { ProceedingType.find_by(ccms_code: 'SE014') }
-      let(:application_proceeding_type) { legal_aid_application.application_proceeding_types.find_by(proceeding_type_id: proceeding_type) }
       let(:login) { login_as legal_aid_application.provider }
 
       before do
@@ -37,7 +32,7 @@ module Providers
       describe 'POST /providers/merits_task_list/:id/chances_of_success' do
         let(:success_prospect) { :poor }
         let!(:chances_of_success) do
-          create :chances_of_success, success_prospect: success_prospect, success_prospect_details: 'details', application_proceeding_type: application_proceeding_type,
+          create :chances_of_success, success_prospect: success_prospect, success_prospect_details: 'details',
                                       proceeding: proceeding
         end
         let(:success_likely) { 'true' }
@@ -51,10 +46,6 @@ module Providers
             providers_merits_task_list_chances_of_success_index_path(proceeding),
             params: params.merge(submit_button)
           )
-        end
-
-        it 'associates with the application proceeding type' do
-          expect(chances_of_success.application_proceeding_type).to eq application_proceeding_type
         end
 
         it 'sets chances_of_success to true' do
@@ -80,7 +71,6 @@ module Providers
         end
 
         context 'false is selected' do
-          let(:next_url) { providers_merits_task_list_success_prospects_path(application_proceeding_type, proceeding) }
           let(:success_likely) { 'false' }
 
           it 'sets chances_of_success to false' do
@@ -116,7 +106,7 @@ module Providers
         end
 
         context 'user has come from the check_merits_answer page' do
-          let(:legal_aid_application) { create :legal_aid_application, :with_multiple_proceeding_types_inc_section8, :checking_merits_answers }
+          let(:legal_aid_application) { create :legal_aid_application, :with_proceedings, :checking_merits_answers, explicit_proceedings: [:da001, :se014] }
 
           it 'redirects back to the answers page' do
             subject

--- a/spec/requests/providers/proceeding_merits_task/success_prospects_spec.rb
+++ b/spec/requests/providers/proceeding_merits_task/success_prospects_spec.rb
@@ -8,12 +8,6 @@ module Providers
       let(:proceeding_two) { legal_aid_application.proceedings.find_by(ccms_code: 'SE014') }
       let(:pt_da) { create :proceeding_type, :with_real_data }
       let(:pt_s8) { create :proceeding_type, :as_section_8_child_residence }
-      let(:application_proceeding_type) do
-        create :application_proceeding_type,
-               :with_chances_of_success,
-               legal_aid_application: legal_aid_application,
-               proceeding_type: pt_da
-      end
 
       let(:provider) { legal_aid_application.provider }
 
@@ -64,8 +58,8 @@ module Providers
             end
 
             it 'updates the record' do
-              expect(proceeding.application_proceeding_type.chances_of_success.reload.success_prospect).to eq(success_prospect)
-              expect(proceeding.application_proceeding_type.chances_of_success.reload.success_prospect_details).to eq(success_prospect_details)
+              expect(proceeding.chances_of_success.reload.success_prospect).to eq(success_prospect)
+              expect(proceeding.chances_of_success.reload.success_prospect_details).to eq(success_prospect_details)
             end
 
             it 'redirects to the next page' do
@@ -81,8 +75,8 @@ module Providers
             end
 
             it 'updates the record' do
-              expect(proceeding.application_proceeding_type.chances_of_success.reload.success_prospect).to eq(success_prospect)
-              expect(proceeding.application_proceeding_type.chances_of_success.reload.success_prospect_details).to eq(success_prospect_details)
+              expect(proceeding.chances_of_success.reload.success_prospect).to eq(success_prospect)
+              expect(proceeding.chances_of_success.reload.success_prospect_details).to eq(success_prospect_details)
             end
 
             it 'redirects to provider applications home page' do

--- a/spec/requests/providers/submitted_applications_spec.rb
+++ b/spec/requests/providers/submitted_applications_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe Providers::SubmittedApplicationsController, type: :request do
   let(:application_proceeding_type) { create :application_proceeding_type, legal_aid_application: legal_aid_application }
   let!(:chances_of_success) do
     create :chances_of_success,
-           application_proceeding_type: application_proceeding_type,
            proceeding: proceeding
   end
 

--- a/spec/services/legal_framework/merits_tasks_retriever_service_spec.rb
+++ b/spec/services/legal_framework/merits_tasks_retriever_service_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 module LegalFramework
   RSpec.describe MeritsTasksRetrieverService do
-    let(:application) { create :legal_aid_application, :with_proceeding_types }
+    let(:application) { create :legal_aid_application, :with_proceedings }
     let(:submission) { create :legal_framework_submission, legal_aid_application: application }
     let(:dummy_response) { dummy_response_hash.to_json }
     let(:service) { described_class.new(submission) }
@@ -52,10 +52,9 @@ module LegalFramework
     end
 
     def expected_payload_hash
-      proceeding_types = application.proceeding_types.first
       {
         request_id: submission.id,
-        proceeding_types: [proceeding_types.ccms_code]
+        proceeding_types: [application.proceedings.first.ccms_code]
       }
     end
 
@@ -71,7 +70,7 @@ module LegalFramework
         },
         proceeding_types: [
           {
-            ccms_code: application.proceeding_types.first.ccms_code,
+            ccms_code: application.proceedings.first.ccms_code,
             tasks: {
               chances_of_success: [] # the merits tasks for this one proceeding type, and any dependencies
             }


### PR DESCRIPTION
## Remove ApplicationProceedingType from Merits Task List
[Link to story](https://dsdmoj.atlassian.net/browse/AP-2721)


- Revove ApplicationProceedingType from:
  - `MeritsTaskListController`
  - `AttemptsToSettelController`
  - `ChancesOfSuccessController`
  - `LinkedChildrenController`
  - `SucessProspectsController`
  - And associated models, services and forms
- enabled Null on application_proceeding_id fields on the following tables:
  - `chances_of_successes`
  - `attempts_to_settles`



## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
