### PR TITLE
AP-2774 Display solicitor answers on CYA when no HMRC data exists

### DIFF
--- a/app/views/providers/means_summaries/show.html.erb
+++ b/app/views/providers/means_summaries/show.html.erb
@@ -2,7 +2,9 @@
 
   <h2 class="govuk-heading-l"><%= t('.h2-heading') %></h2>
 
-  <%= render 'shared/check_answers/employed_income' %>
+  <% if Setting.enable_employed_journey? && @legal_aid_application.provider.employment_permissions? %>
+    <%= render 'shared/check_answers/employed_income' %>
+  <% end %>
 
   <%= render(
          'shared/check_answers/income_summary',

--- a/app/views/providers/means_summaries/show.html.erb
+++ b/app/views/providers/means_summaries/show.html.erb
@@ -3,7 +3,11 @@
   <h2 class="govuk-heading-l"><%= t('.h2-heading') %></h2>
 
   <% if Setting.enable_employed_journey? && @legal_aid_application.provider.employment_permissions? %>
-    <%= render 'shared/check_answers/employed_income' %>
+    <% if @legal_aid_application.hmrc_employment_income? %>
+      <%= render 'shared/check_answers/employed_income' %>
+    <% else %>
+      <%= render 'shared/check_answers/no_employed_income' %>
+    <% end %>
   <% end %>
 
   <%= render(

--- a/app/views/shared/check_answers/_no_employed_income.html.erb
+++ b/app/views/shared/check_answers/_no_employed_income.html.erb
@@ -1,0 +1,18 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h3 class="govuk-heading-m"><%= t('.employment') %></h3>
+  </div>
+  <div class="govuk-grid-column-one-third govuk-summary-list--no-border align-text-right">
+    <p>
+      <%= link_to_accessible(t('generic.change'), providers_legal_aid_application_no_employment_income_path(@legal_aid_application),
+                             class: 'govuk-link change-link') %>
+    </p>
+  </div>
+</div>
+<dl class="govuk-summary-list govuk-!-margin-bottom-9">
+  <%= check_answer_no_link(
+        name: :full_employment_details,
+        question: t('.full_employment_details'),
+        answer: @legal_aid_application.full_employment_details
+      ) %>
+</dl>

--- a/config/locales/en/shared.yml
+++ b/config/locales/en/shared.yml
@@ -229,6 +229,9 @@ en:
           notification_of_latest_incident: When did your client contact you about the latest domestic abuse incident?
           date_of_latest_incident: When did the incident occur?
           gateway_evidence: Upload supporting evidence
+      no_employed_income:
+        employment: Employment income
+        full_employment_details: Your client's employment details
       no_link_cash_transaction_item:
         no_transactions: "No"
         html:

--- a/features/providers/employed_journey.feature
+++ b/features/providers/employed_journey.feature
@@ -15,6 +15,36 @@ Scenario: Completing the means journey for an employed applicant with HMRC data
   When I fill "legal aid application extra employment information details error" with "some extra details about employment"
   And I click 'Save and continue'
   Then I should be on the 'no_income_summary' page showing "Your client's income"
+  Then I choose 'Yes'
+  Then I click 'Save and continue'
+  Then I should be on the 'has_dependants' page showing "Does your client have any dependants?"
+  Then I choose "No"
+  Then I click 'Save and continue'
+  Then I should be on a page showing "Your client's outgoings"
+  Then I choose "Yes"
+  Then I click 'Save and continue'
+  Then I should be on a page showing "Does your client own the home that they live in?"
+  Then I choose "No"
+  Then I click 'Save and continue'
+  Then I should be on a page showing "Does your client own a vehicle?"
+  Then I choose "No"
+  Then I click 'Save and continue'
+  Then I should be on a page showing "Your client’s bank accounts"
+  Then I choose 'No'
+  Then I click 'Save and continue'
+  Then I should be on a page showing "Which types of savings or investments does your client have?"
+  Then I select "None of these"
+  Then I click 'Save and continue'
+  Then I should be on a page showing "Which types of assets does your client have?"
+  Then I select "None of these"
+  Then I click 'Save and continue'
+  Then I should be on the 'policy_disregards' page showing 'schemes or charities'
+  When I select "None of these"
+  And I click 'Save and continue'
+  Then I should be on the 'means_summary' page showing 'Check your answers'
+  And the answer for 'extra_employment_information' should be 'Yes'
+  And the answer for 'extra_employment_information_details' should be 'some extra details about employment'
+
 
 @javascript
 Scenario: Completing the means journey for an employed applicant with no HMRC data
@@ -28,3 +58,31 @@ Scenario: Completing the means journey for an employed applicant with no HMRC da
   Then I fill "legal aid application full employment details error" with "all the details about employment"
   And I click 'Save and continue'
   Then I should be on the 'no_income_summary' page showing "Your client's income"
+  Then I choose 'Yes'
+  Then I click 'Save and continue'
+  Then I should be on the 'has_dependants' page showing "Does your client have any dependants?"
+  Then I choose "No"
+  Then I click 'Save and continue'
+  Then I should be on a page showing "Your client's outgoings"
+  Then I choose "Yes"
+  Then I click 'Save and continue'
+  Then I should be on a page showing "Does your client own the home that they live in?"
+  Then I choose "No"
+  Then I click 'Save and continue'
+  Then I should be on a page showing "Does your client own a vehicle?"
+  Then I choose "No"
+  Then I click 'Save and continue'
+  Then I should be on a page showing "Your client’s bank accounts"
+  Then I choose 'No'
+  Then I click 'Save and continue'
+  Then I should be on a page showing "Which types of savings or investments does your client have?"
+  Then I select "None of these"
+  Then I click 'Save and continue'
+  Then I should be on a page showing "Which types of assets does your client have?"
+  Then I select "None of these"
+  Then I click 'Save and continue'
+  Then I should be on the 'policy_disregards' page showing 'schemes or charities'
+  When I select "None of these"
+  And I click 'Save and continue'
+  Then I should be on the 'means_summary' page showing 'Check your answers'
+  And the answer for 'full_employment_details' should be 'all the details about employment'


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2774)

- Adds a new partial to render a CYA block to display the solicitor's answer when no employment income is returned by HMRC.
- Updates the employed journey feature tests to include all steps up to the check your answers page.
- Hides all employment journey CYA changes behind the feature flag/firm permission as we don't want solicitors seeing them yet.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
