### PR TITLE
AP-2723 Replace ApplicationProceedingTypes with Proceedings in CCMS code

### DIFF
--- a/app/models/application_proceeding_type.rb
+++ b/app/models/application_proceeding_type.rb
@@ -80,10 +80,6 @@ class ApplicationProceedingType < ApplicationRecord
   end
   ##############################
 
-  def proceeding_case_p_num
-    "P_#{proceeding_case_id}"
-  end
-
   private
 
   def check_only_one_lead_proceeding

--- a/app/models/proceeding.rb
+++ b/app/models/proceeding.rb
@@ -87,4 +87,8 @@ class Proceeding < ApplicationRecord
     rec = self.class.order(proceeding_case_id: :desc).first
     rec.nil? || rec.proceeding_case_id.nil? ? FIRST_PROCEEDING_CASE_ID : rec.proceeding_case_id
   end
+
+  def proceeding_case_p_num
+    "P_#{proceeding_case_id}"
+  end
 end

--- a/app/services/ccms/attribute_value_generator.rb
+++ b/app/services/ccms/attribute_value_generator.rb
@@ -22,8 +22,7 @@ module CCMS
   # value to insert.
   class AttributeValueGenerator # rubocop:disable Metrics/ClassLength
     STANDARD_METHOD_NAMES = %r{^(
-                                appl_proceeding_type
-                                |applicant
+                                applicant
                                 |application
                                 |bank_account
                                 |lead_proceeding
@@ -40,7 +39,6 @@ module CCMS
                                 |vehicle
                                 |wage_slip
                                 )_(\S+)$}x.freeze
-    APPLICATION_PROCEEDING_TYPE_REGEX = /^appl_proceeding_type_(\S+)$/.freeze
     APPLICANT_REGEX = /^applicant_(\S+)$/.freeze
     APPLICATION_REGEX = /^application_(\S+)$/.freeze
     BANK_REGEX = /^bank_account_(\S+)$/.freeze
@@ -68,7 +66,7 @@ module CCMS
 
     attr_reader :legal_aid_application
 
-    delegate :lead_application_proceeding_type,
+    delegate :lead_proceeding,
              :vehicle,
              :used_delegated_functions?, to: :legal_aid_application
 
@@ -345,10 +343,6 @@ module CCMS
 
     def applicant
       @applicant ||= legal_aid_application.applicant
-    end
-
-    def lead_proceeding
-      @lead_proceeding ||= legal_aid_application.lead_proceeding
     end
 
     def standardly_named_method?(method)

--- a/spec/models/application_proceeding_type_spec.rb
+++ b/spec/models/application_proceeding_type_spec.rb
@@ -29,15 +29,6 @@ RSpec.describe ApplicationProceedingType do
     end
   end
 
-  describe '#proceeding_case_p_num' do
-    it 'prefixes the proceeding case id with P_' do
-      legal_aid_application = create :legal_aid_application, :with_proceeding_types
-      application_proceeding_type = legal_aid_application.application_proceeding_types.first
-      allow(application_proceeding_type).to receive(:proceeding_case_id).and_return 55_200_301
-      expect(application_proceeding_type.proceeding_case_p_num).to eq 'P_55200301'
-    end
-  end
-
   describe 'delegated functions' do
     let(:application) do
       create :legal_aid_application,

--- a/spec/models/proceeding_spec.rb
+++ b/spec/models/proceeding_spec.rb
@@ -113,4 +113,13 @@ RSpec.describe Proceeding, type: :model do
       end
     end
   end
+
+  describe '#proceeding_case_p_num' do
+    it 'prefixes the proceeding case id with P_' do
+      legal_aid_application = create :legal_aid_application, :with_proceedings
+      proceeding = legal_aid_application.proceedings.first
+      allow(proceeding).to receive(:proceeding_case_id).and_return 55_200_301
+      expect(proceeding.proceeding_case_p_num).to eq 'P_55200301'
+    end
+  end
 end

--- a/spec/services/ccms/requestors/case_add_requestor_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_spec.rb
@@ -89,17 +89,6 @@ module CCMS
         end
 
         context 'when DF assigned scope limitations are present' do
-          let(:df_scope_limitation) { create :scope_limitation, code: 'ZZ999', description: 'Default scope limitation.', substantive: false, delegated_functions: true }
-          let(:apt) { legal_aid_application.application_proceeding_types.first }
-
-          before do
-            # setup the df scope limitation to be the default for this proceeding type and add it to the application proceeding types
-            pt = apt.proceeding_type
-            pt.eligible_scope_limitations << df_scope_limitation
-            apt.delegated_functions_scope_limitation = df_scope_limitation
-            pt.proceeding_type_scope_limitations.find_by(scope_limitation_id: df_scope_limitation.id).update!(substantive_default: false, delegated_functions_default: true)
-          end
-
           context 'DF not used' do
             it 'does not add the extra scope limitation to the XML, and specifies the AA001 for requested scope' do
               expect(CCMS::OpponentId).to receive(:next_serial_id).and_return(88_123_456, 88_123_457, 88_123_458)
@@ -114,8 +103,6 @@ module CCMS
             let(:df_date) { Date.parse('2020-11-23') }
             before do
               proceeding.update!(used_delegated_functions_on: df_date, used_delegated_functions_reported_on: df_date)
-              application_proceeding_type.update!(used_delegated_functions_on: df_date, used_delegated_functions_reported_on: df_date)
-
               legal_aid_application.reload
             end
 

--- a/spec/services/ccms/requestors/case_add_requestor_xml_blocks/passported_attributes_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_xml_blocks/passported_attributes_spec.rb
@@ -391,24 +391,26 @@ module CCMS
         end
 
         context 'ProceedingCaseId' do
+          let(:proceeding_case_id) { legal_aid_application.proceedings.first.proceeding_case_p_num }
+
           context 'ProceedingCaseId section' do
             it 'has a p number' do
               block = XmlExtractor.call(xml, :proceeding_case_id)
-              expect(block.text).to eq application_proceeding_type.proceeding_case_p_num
+              expect(block.text).to eq proceeding_case_id
             end
           end
 
           context 'in merits assessment block' do
             it 'has a p number' do
               block = XmlExtractor.call(xml, :proceeding_merits, 'PROCEEDING_ID')
-              expect(block).to have_text_response(application_proceeding_type.proceeding_case_p_num)
+              expect(block).to have_text_response(proceeding_case_id)
             end
           end
 
           context 'in means assessment block' do
             it 'has a p number' do
               block = XmlExtractor.call(xml, :proceeding, 'PROCEEDING_ID')
-              expect(block).to have_text_response(application_proceeding_type.proceeding_case_p_num)
+              expect(block).to have_text_response(proceeding_case_id)
             end
           end
         end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2723)

Removal of `ApplicationProceedingTypes` from the CCMS `AttributeValueGenerator` class and specs. There are still some references to `ApplicationProceedingTypes` in that code but these can't be removed until `ChancesOfSuccess` has been converted to use only `Proceedings`.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
