### PR TITLE
Fix flickering code coverage bug on Circle CI

### DIFF
--- a/lib/circle_ci_coverage_analyzer.rb
+++ b/lib/circle_ci_coverage_analyzer.rb
@@ -1,6 +1,5 @@
 require 'json'
 
-
 # This class is useful for debugging why coverage is not 100% on Circle-CI
 # A line to run this is included in the .circle/config.yml, however, if coverage is incomplete
 # the line:

--- a/lib/circle_ci_coverage_analyzer.rb
+++ b/lib/circle_ci_coverage_analyzer.rb
@@ -1,0 +1,48 @@
+require 'json'
+
+
+# This class is useful for debugging why coverage is not 100% on Circle-CI
+# A line to run this is included in the .circle/config.yml, however, if coverage is incomplete
+# the line:
+#
+#     SimpleCov.minimum_coverage 100
+#
+# must be changed to a value less than 100 in order to get this script to run after the tests.
+#
+# rubocop:disable Rails/Output
+class CircleCICoverageAnalyzer
+  def self.call(filename)
+    new(filename).call
+  end
+
+  def initialize(filename)
+    json = File.read(filename)
+    @data = JSON.parse(json)
+  end
+
+  def call
+    puts "Coverage percentage: #{coverage_percentage}"
+    return if coverage_percentage == 100
+
+    print_missing
+  end
+
+  private
+
+  def coverage_percentage
+    @coverage_percentage ||= @data['covered_percent']
+  end
+
+  def print_missing
+    @data['source_files'].each { |source_file| analyze_source_file(source_file) }
+  end
+
+  def analyze_source_file(source_file)
+    return if source_file['covered_percent'] == 100
+
+    puts "#{source_file['name']} :: #{source_file['covered_percent']}%"
+  end
+end
+
+CircleCICoverageAnalyzer.call(ARGV.first)
+# rubocop:enable Rails/Output

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,6 +29,8 @@ unless ENV['NOCOVERAGE']
     add_filter 'services/migration_helpers/'
     add_filter 'config/environments/'
     add_filter 'app/services/ccms/' unless ENV['INC_CCMS'].to_s == 'true'
+    add_filter 'app/models/cfe/v1/result.rb'
+    add_filter 'app/models/cfe/v2/result.rb'
   end
 
   SimpleCov.at_exit do


### PR DESCRIPTION
## Fix flickering code coverage bug on Circle CI

Coverage was below 100% on circle ci with certain seeds (This could be reliably
reproduced on Circle CI with seed 51620, but not locally).  The cause was found to be
that the two files app/models/cfe/v1/result.rb and app/models/cfe/v2/result.rb, both of which have
a :nocov: comment fore and aft were being reported as not tested.

This is fixed by adding those to files to the SimpleCov filter in spec_helper.rb

Also, the code to track this down has been added to the repo at lib/circle_ci_covereage_analyzer.rb

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
