### PR TITLE
Re-instate testing for CFE V1 and V2 results

### DIFF
--- a/app/models/cfe/base_result.rb
+++ b/app/models/cfe/base_result.rb
@@ -68,6 +68,10 @@ module CFE
     #                                                              #
     ################################################################
 
+    def additional_properties
+      property[:additional_properties]
+    end
+
     def additional_property?
       existing_and_not_all_zero?(property[:additional_properties].first)
     end
@@ -91,6 +95,20 @@ module CFE
     def additional_property_assessed_equity
       assessed_equity = additional_property[:assessed_equity]&.to_d
       assessed_equity.positive? ? assessed_equity : 0.0
+    end
+
+    ################################################################
+    #                                                              #
+    #  CAPITAL ITEMS                                               #
+    #                                                              #
+    ################################################################
+
+    def total_savings
+      capital[:total_liquid].to_d
+    end
+
+    def total_other_assets
+      capital[:total_non_liquid].to_d
     end
 
     ################################################################

--- a/app/models/cfe/v1/result.rb
+++ b/app/models/cfe/v1/result.rb
@@ -1,6 +1,5 @@
 ## Do not delete: This file is no longer in use but is needed for the single
 ## table inheritance table cfe_results to continue to function correctly.
-# :nocov:
 module CFE
   module V1
     class Result < CFE::BaseResult # rubocop:disable Metrics/ClassLength
@@ -70,4 +69,3 @@ module CFE
     end
   end
 end
-# :nocov:

--- a/app/models/cfe/v2/result.rb
+++ b/app/models/cfe/v2/result.rb
@@ -1,6 +1,5 @@
 ## Do not delete: This file is no longer in use but is needed for the single
 ## table inheritance table cfe_results to continue to function correctly.
-# :nocov:
 module CFE
   module V2
     class Result < CFE::BaseResult # rubocop:disable Metrics/ClassLength
@@ -269,4 +268,3 @@ module CFE
     end
   end
 end
-# :nocov:

--- a/spec/factories/cfe_results.rb
+++ b/spec/factories/cfe_results.rb
@@ -1,0 +1,89 @@
+FactoryBot.define do
+  factory :cfe_v1_result, class: CFE::V1::Result do
+    submission { create :cfe_submission }
+    legal_aid_application { submission.legal_aid_application }
+    result { CFEResults::V1::MockResults.eligible.to_json }
+
+    trait :eligible do
+      result { CFEResults::V1::MockResults.eligible.to_json }
+    end
+
+    trait :not_eligible do
+      result { CFEResults::V1::MockResults.not_eligible.to_json }
+    end
+
+    trait :contribution_required do
+      result { CFEResults::V1::MockResults.contribution_required.to_json }
+    end
+
+    trait :no_capital do
+      result { CFEResults::V1::MockResults.no_capital.to_json }
+    end
+
+    trait :no_additional_properties do
+      result { CFEResults::V1::MockResults.no_additional_properties.to_json }
+    end
+
+    trait :with_additional_properties do
+      result { CFEResults::V1::MockResults.with_additional_properties.to_json }
+    end
+  end
+
+  factory :cfe_v2_result, class: CFE::V2::Result do
+    submission { create :cfe_submission }
+    legal_aid_application { submission.legal_aid_application }
+    result { CFEResults::V2::MockResults.eligible.to_json }
+
+    trait :eligible do
+      result { CFEResults::V2::MockResults.eligible.to_json }
+    end
+
+    trait :not_eligible do
+      result { CFEResults::V2::MockResults.not_eligible.to_json }
+    end
+
+    trait :no_capital do
+      result { CFEResults::V2::MockResults.no_capital.to_json }
+    end
+
+    trait :with_capital_contribution_required do
+      result { CFEResults::V2::MockResults.with_capital_contribution_required.to_json }
+    end
+
+    trait :with_income_contribution_required do
+      result { CFEResults::V2::MockResults.with_income_contribution_required.to_json }
+    end
+
+    trait :with_capital_and_income_contributions_required do
+      result { CFEResults::V2::MockResults.with_capital_and_income_contributions_required.to_json }
+    end
+
+    trait :no_additional_properties do
+      result { CFEResults::V2::MockResults.no_additional_properties.to_json }
+    end
+
+    trait :with_additional_properties do
+      result { CFEResults::V2::MockResults.with_additional_properties.to_json }
+    end
+
+    trait :no_vehicles do
+      result { CFEResults::V2::MockResults.no_vehicles.to_json }
+    end
+
+    trait :with_maintenance_received do
+      result { CFEResults::V2::MockResults.with_maintenance_received.to_json }
+    end
+
+    trait :with_student_finance_received do
+      result { CFEResults::V2::MockResults.with_student_finance_received.to_json }
+    end
+
+    trait :with_no_mortgage_costs do
+      result { CFEResults::V2::MockResults.with_no_mortgage_costs.to_json }
+    end
+
+    trait :with_unknown_result do
+      result { CFEResults::V2::MockResults.unknown.to_json }
+    end
+  end
+end

--- a/spec/factories/cfe_results/v1/mock_results.rb
+++ b/spec/factories/cfe_results/v1/mock_results.rb
@@ -1,0 +1,99 @@
+module CFEResults
+  module V1
+    class MockResults
+      def self.eligible # rubocop:disable Metrics/MethodLength
+        {
+          assessment_result: 'eligible',
+          applicant: {
+            receives_qualifying_benefit: true,
+            age_at_submission: 39
+          },
+          capital: {
+            total_liquid: '350.0',
+            total_non_liquid: '0.0',
+            pensioner_capital_disregard: '0.0',
+            total_capital: '350.0',
+            capital_contribution: '0.0',
+            liquid_capital_items: [
+              {
+                description: 'Off-line bank accounts',
+                value: '350.0'
+              }
+            ],
+            non_liquid_capital_items: []
+          },
+          property: {
+            total_mortgage_allowance: '100000.0',
+            total_property: '-100000.0',
+            main_home: { value: '0.0',
+                         transaction_allowance: '0.0',
+                         allowable_outstanding_mortgage: '0.0',
+                         percentage_owned: '0.0',
+                         net_equity: '0.0',
+                         main_home_equity_disregard: '100000.0',
+                         assessed_equity: '-100000.0',
+                         shared_with_housing_assoc: false },
+            additional_properties: [
+              {
+                value: '0.0',
+                transaction_allowance: '0.0',
+                allowable_outstanding_mortgage: '0.0',
+                percentage_owned: '0.0',
+                assessed_equity: '0.0'
+              }
+            ]
+          },
+          vehicles: {
+            total_vehicle: '0.0',
+            vehicles: [
+              {
+                in_regular_use: true,
+                value: '900.0',
+                loan_amount_outstanding: '0.0',
+                date_of_purchase: '2013-06-01',
+                included_in_assessment: false,
+                assessed_value: '0.0'
+              }
+            ]
+          }
+        }
+      end
+
+      def self.not_eligible
+        eligible.merge assessment_result: 'not_eligible'
+      end
+
+      def self.contribution_required
+        new_capital_section = eligible[:capital]
+        new_capital_section[:capital_contribution] = '465.66'
+        eligible.merge assessment_result: 'contribution_required', capital: new_capital_section
+      end
+
+      def self.no_capital
+        new_capital_section = eligible[:capital]
+        new_capital_section[:total_liquid] = '0.0'
+        new_capital_section[:total_capital] = '0.0'
+        eligible.merge capital: new_capital_section
+      end
+
+      def self.no_additional_properties
+        result = eligible
+        result[:property][:additional_properties] = []
+        result
+      end
+
+      def self.with_additional_properties
+        result = eligible
+        property = {
+          value: '350255.0',
+          transaction_allowance: '012550',
+          allowable_outstanding_mortgage: '45000.0',
+          percentage_owned: '100.0',
+          assessed_equity: '224000'
+        }
+        result[:property][:additional_properties] = [property]
+        result
+      end
+    end
+  end
+end

--- a/spec/factories/cfe_results/v2/mock_results.rb
+++ b/spec/factories/cfe_results/v2/mock_results.rb
@@ -1,0 +1,342 @@
+module CFEResults
+  module V2
+    class MockResults # rubocop:disable Metrics/ClassLength
+      def self.eligible # rubocop:disable Metrics/MethodLength
+        {
+          version: '2',
+          timestamp: '2020-01-28T16:37:07.921+00:00',
+          success: true,
+          assessment: {
+            id: '41188692-9fa1-488d-818f-67f8509ff21a',
+            client_reference_id: 'CLIENT-REF-0007',
+            submission_date: '2020-01-28',
+            matter_proceeding_type: 'domestic_abuse',
+            assessment_result: 'eligible',
+            applicant: {
+              date_of_birth: '1996-08-15',
+              involvement_type: 'applicant',
+              has_partner_opponent: false,
+              receives_qualifying_benefit: false,
+              self_employed: false
+            },
+            gross_income: {
+              monthly_student_loan: '0.0',
+              monthly_other_income: '75.0',
+              monthly_state_benefits: '75.0',
+              total_gross_income: '150.0',
+              upper_threshold: '999999999999.0',
+              assessment_result: 'eligible',
+              monthly_income_equivalents:
+                {
+                  friends_or_family: '50.59',
+                  maintenance_in: '54.17',
+                  property_or_lodger: '450.0',
+                  pension: '82.52'
+                },
+              monthly_outgoing_equivalents:
+                {
+                  child_care: '0.0',
+                  maintenance_out: '-3.64',
+                  rent_or_mortgage: '-15.75',
+                  legal_aid: '-7.0'
+                },
+              state_benefits: [
+                {
+                  name: 'benefit_type_1',
+                  monthly_value: '75.0',
+                  excluded_from_income_assessment: true,
+                  state_benefit_payments: [
+                    {
+                      payment_date: '2020-01-28',
+                      amount: '75.0'
+                    },
+                    {
+                      payment_date: '2019-12-28',
+                      amount: '75.0'
+                    },
+                    {
+                      payment_date: '2019-11-28',
+                      amount: '75.0'
+                    }
+                  ]
+                }
+              ],
+              other_income: [
+                {
+                  name: 'Trust fund',
+                  monthly_income: '75.0',
+                  payments: [
+                    {
+                      payment_date: '2020-01-28',
+                      amount: '75.0'
+                    },
+                    {
+                      payment_date: '2019-12-28',
+                      amount: '75.0'
+                    },
+                    {
+                      payment_date: '2019-11-28',
+                      amount: '75.0'
+                    }
+                  ]
+                }
+              ]
+            },
+            disposable_income: {
+              outgoings: {
+                childcare_costs: [
+                  {
+                    payment_date: '2020-01-28',
+                    amount: '100.0'
+                  },
+                  {
+                    payment_date: '2019-12-28',
+                    amount: '100.0'
+                  },
+                  {
+                    payment_date: '2019-11-28',
+                    amount: '100.0'
+                  }
+                ],
+                housing_costs: [
+                  {
+                    payment_date: '2020-01-28',
+                    amount: '125.0'
+                  },
+                  {
+                    payment_date: '2019-12-28',
+                    amount: '125.0'
+                  },
+                  {
+                    payment_date: '2019-11-28',
+                    amount: '125.0'
+                  }
+                ],
+                maintenance_costs: [
+                  {
+                    payment_date: '2020-01-28',
+                    amount: '50.0'
+                  },
+                  {
+                    payment_date: '2019-12-28',
+                    amount: '50.0'
+                  },
+                  {
+                    payment_date: '2019-11-28',
+                    amount: '50.0'
+                  }
+                ]
+              },
+              deductions: {
+                dependants_allowance: '291.86',
+                disregarded_state_benefits: '1500'
+              },
+              childcare_allowance: '0.0',
+              dependant_allowance: '0.0',
+              maintenance_allowance: '0.0',
+              gross_housing_costs: '125.0',
+              housing_benefit: '0.0',
+              net_housing_costs: '125.0',
+              total_outgoings_and_allowances: '175.0',
+              total_disposable_income: '0.0',
+              lower_threshold: '315.0',
+              upper_threshold: '733.0',
+              assessment_result: 'eligible',
+              income_contribution: '0.0'
+            },
+            capital: {
+              capital_items: {
+                liquid: [
+                  {
+                    description: 'Ab quasi autem rerum.',
+                    value: '6692.12'
+                  }
+                ],
+                non_liquid: [
+                  {
+                    description: 'Omnis sit et corrupti.',
+                    value: '3902.92'
+                  }
+                ],
+                vehicles: [
+                  {
+                    value: '1784.61',
+                    loan_amount_outstanding: '3225.77',
+                    date_of_purchase: '2014-07-01',
+                    in_regular_use: true,
+                    included_in_assessment: false,
+                    assessed_value: '0.0'
+                  }
+                ],
+                properties: {
+                  main_home: {
+                    value: '5985.82',
+                    'outstanding_ mortgage': '7201.44',
+                    percentage_owned: '1.87',
+                    main_home: true,
+                    shared_with_housing_assoc: false,
+                    transaction_allowance: '179.57',
+                    allowable_outstanding_mortgage: '7201.44',
+                    net_value: '-1395.19',
+                    net_equity: '-26.09',
+                    main_home_equity_disregard: '100000.0',
+                    assessed_equity: '0.0'
+                  },
+                  additional_properties: [
+                    {
+                      value: '0.0',
+                      outstanding_mortgage: '8202.39',
+                      percentage_owned: '8.33',
+                      main_home: false,
+                      shared_with_housing_assoc: true,
+                      transaction_allowance: '113.46',
+                      allowable_outstanding_mortgage: '8202.39',
+                      net_value: '-4533.94',
+                      net_equity: '-8000.82',
+                      main_home_equity_disregard: '0.0',
+                      assessed_equity: '0.0'
+                    }
+                  ]
+                }
+              },
+              total_liquid: '5649.13',
+              total_non_liquid: '3902.92',
+              total_vehicle: '0.0',
+              total_property: '1134.0',
+              total_mortgage_allowance: '100000.0',
+              total_capital: '9552.05',
+              pensioner_capital_disregard: '0.0',
+              assessed_capital: '9552.05',
+              lower_threshold: '3000.0',
+              upper_threshold: '999999999999.0',
+              assessment_result: 'eligible',
+              capital_contribution: '0.0'
+            },
+            remarks: {
+            }
+          }
+        }
+      end
+
+      def self.not_eligible
+        not_eligible_result = eligible
+        not_eligible_result[:assessment][:assessment_result] = 'not_eligible'
+        not_eligible_result[:assessment][:disposable_income][:assessment_result] = 'not_eligible'
+        not_eligible_result[:assessment][:capital][:assessment_result] = 'not_eligible'
+        not_eligible_result
+      end
+
+      def self.with_capital_contribution_required
+        result = eligible
+        result[:assessment][:assessment_result] = 'contribution_required'
+        new_capital_section = result[:assessment][:capital]
+        new_capital_section[:capital_contribution] = '465.66'
+        new_capital_section[:assessment_result] = 'contribution_required'
+        result[:assessment][:capital] = new_capital_section
+        result
+      end
+
+      def self.with_income_contribution_required
+        result = eligible
+        result[:assessment][:assessment_result] = 'contribution_required'
+        new_disposable_income = eligible[:assessment][:disposable_income]
+        new_disposable_income[:assessment_result] = 'contribution_required'
+        new_disposable_income[:income_contribution] = 366.82
+        result[:assessment][:disposable_income] = new_disposable_income
+        result
+      end
+
+      def self.with_capital_and_income_contributions_required # rubocop:disable Metrics/AbcSize
+        result = eligible
+        result[:assessment][:assessment_result] = 'contribution_required'
+
+        new_disposable_income = eligible[:assessment][:disposable_income]
+        new_disposable_income[:assessment_result] = 'contribution_required'
+        new_disposable_income[:income_contribution] = 366.82
+        result[:assessment][:disposable_income] = new_disposable_income
+
+        result[:assessment][:assessment_result] = 'contribution_required'
+        new_capital_section = result[:assessment][:capital]
+        new_capital_section[:capital_contribution] = '465.66'
+        new_capital_section[:assessment_result] = 'contribution_required'
+        result[:assessment][:capital] = new_capital_section
+
+        result
+      end
+
+      def self.no_additional_properties
+        result = eligible
+        result[:assessment][:capital][:capital_items][:properties][:additional_properties] = []
+        result
+      end
+
+      def self.no_vehicles
+        result = eligible
+        result[:assessment][:capital][:capital_items][:vehicles] = []
+        result
+      end
+
+      def self.with_no_mortgage_costs
+        result = eligible
+        result[:assessment][:disposable_income][:gross_housing_costs] = 0.0
+        result
+      end
+
+      def self.no_capital
+        result = eligible
+        new_capital_section = result[:assessment][:capital]
+        new_capital_section[:capital_items][:liquid] = []
+        new_capital_section[:capital_items][:non_liquid] = []
+        new_capital_section[:capital_items][:vehicles] = []
+        new_capital_section[:capital_items][:properties][:main_home] = {}
+        new_capital_section[:capital_items][:properties][:additional_properties] = {}
+        new_capital_section[:total_liquid] = '0.0'
+        new_capital_section[:total_non_liquid] = '0.0'
+        new_capital_section[:total_vehicle] = '0.0'
+        new_capital_section[:total_property] = '0.0'
+        new_capital_section[:total_capital] = '0.0'
+        result[:assessment][:capital] = new_capital_section
+        result
+      end
+
+      def self.with_additional_properties
+        result = eligible
+        property = {
+          value: '5781.91',
+          outstanding_mortgage: '10202.39',
+          percentage_owned: '8.33',
+          main_home: false,
+          shared_with_housing_assoc: true,
+          transaction_allowance: '113.46',
+          allowable_outstanding_mortgage: '8202.00',
+          net_value: '-4533.94',
+          net_equity: '-8000.82',
+          main_home_equity_disregard: '0.0',
+          assessed_equity: '125.33'
+        }
+        result[:assessment][:capital][:capital_items][:properties][:additional_properties] = [property]
+        result
+      end
+
+      def self.with_maintenance_received
+        result = eligible
+        result[:assessment][:disposable_income][:maintenance_allowance] = '150.00'
+        result
+      end
+
+      def self.with_student_finance_received
+        result = eligible
+        result[:assessment][:gross_income][:monthly_student_loan] = '125.00'
+        result
+      end
+
+      def self.unknown
+        result = eligible
+        result[:assessment][:assessment_result] = 'unknown'
+        result[:assessment][:capital][:assessment_result] = 'unknown'
+        result[:assessment][:disposable_income][:assessment_result] = 'unknown'
+        result
+      end
+    end
+  end
+end

--- a/spec/factories/legal_aid_applications.rb
+++ b/spec/factories/legal_aid_applications.rb
@@ -854,6 +854,20 @@ FactoryBot.define do
       end
     end
 
+    trait :with_cfe_v1_result do
+      after :create do |application|
+        cfe_submission = create :cfe_submission, legal_aid_application: application
+        create :cfe_v1_result, submission: cfe_submission
+      end
+    end
+
+    trait :with_cfe_v2_result do
+      after :create do |application|
+        cfe_submission = create :cfe_submission, legal_aid_application: application
+        create :cfe_v2_result, submission: cfe_submission
+      end
+    end
+
     trait :with_cfe_v3_result do
       after :create do |application|
         cfe_submission = create :cfe_submission, legal_aid_application: application

--- a/spec/models/cfe/v1/result_spec.rb
+++ b/spec/models/cfe/v1/result_spec.rb
@@ -1,0 +1,189 @@
+require 'rails_helper'
+
+module CFE
+  module V1
+    RSpec.describe Result, type: :model do
+      let(:eligible_result) { create :cfe_v1_result }
+      let(:not_eligible_result) { create :cfe_v1_result, :not_eligible }
+      let(:contribution_required_result) { create :cfe_v1_result, :contribution_required }
+      let(:contribution_and_restriction_result) { create :cfe_v1_result, :contribution_required, submission: cfe_submission }
+      let(:no_additional_properties) { create :cfe_v1_result, :no_additional_properties }
+      let(:additional_property) { create :cfe_v1_result, :with_additional_properties }
+      let(:capital_result) { contribution_required_result.capital }
+      let(:legal_aid_application) { create :legal_aid_application, :with_restrictions, :with_cfe_v1_result }
+      let(:cfe_submission) { create :cfe_submission, legal_aid_application: legal_aid_application }
+      let(:expected_capital_result_keys) do
+        %i[
+          total_liquid
+          total_non_liquid
+          pensioner_capital_disregard
+          total_capital
+          capital_contribution
+          liquid_capital_items
+          non_liquid_capital_items
+        ]
+      end
+
+      describe '#overview' do
+        context 'applicant is eligible' do
+          it 'returns assessment result' do
+            expect(eligible_result.overview).to eq 'eligible'
+          end
+        end
+
+        context 'applicant has contribution required and restrictions' do
+          it 'returns manual_check_required' do
+            expect(contribution_and_restriction_result.capital_contribution_required?).to be true
+            expect(legal_aid_application.has_restrictions?).to be true
+            expect(contribution_and_restriction_result.overview).to eq 'manual_check_required'
+          end
+        end
+
+        context 'applicant has contribution required and no restrictions' do
+          it 'returns manual_check_required' do
+            expect(contribution_required_result.capital_contribution_required?).to be true
+            expect(contribution_required_result.overview).to eq 'capital_contribution_required'
+          end
+        end
+      end
+
+      describe '#assessment_result' do
+        context 'eligible' do
+          it 'returns eligible' do
+            expect(eligible_result.assessment_result).to eq 'eligible'
+          end
+        end
+
+        context 'not_eligible' do
+          it 'returns not_eligible' do
+            expect(not_eligible_result.assessment_result).to eq 'not_eligible'
+          end
+        end
+
+        context 'contribution_required' do
+          it 'returns contribution_required' do
+            expect(contribution_required_result.assessment_result).to eq 'contribution_required'
+          end
+        end
+      end
+
+      describe '#capital' do
+        it 'returns the capital hash' do
+          expect(capital_result.keys).to match_array(expected_capital_result_keys)
+        end
+      end
+
+      describe '#capital_contribution' do
+        it 'returns the value of the capital contribution' do
+          expect(contribution_required_result.capital_contribution).to eq 465.66
+        end
+      end
+
+      describe '#additional_property?' do
+        context 'present' do
+          it 'returns true' do
+            expect(additional_property.additional_property?).to be true
+          end
+        end
+        context 'not present' do
+          it 'returns false' do
+            expect(no_additional_properties.additional_property?).to be false
+          end
+        end
+        context 'present but zero' do
+          it 'returns false' do
+            expect(eligible_result.additional_property?).to be false
+          end
+        end
+      end
+
+      describe 'additional_property_value' do
+        it 'returns the value of the first additional property' do
+          expect(additional_property.additional_property_value).to eq 350_255.0
+        end
+      end
+
+      describe 'additional_property_transaction_allowance' do
+        it 'returns the transaction allowance for the first additional property' do
+          expect(additional_property.additional_property_transaction_allowance).to eq(-12_550.0)
+        end
+      end
+
+      describe 'additional_property_mortgage' do
+        it 'returns the mortgage for the first additional property' do
+          expect(additional_property.additional_property_mortgage).to eq(-45_000.0)
+        end
+      end
+
+      describe 'additional_property_assessed_equity' do
+        it 'returns the assessed equity for the first additional property' do
+          expect(additional_property.additional_property_assessed_equity).to eq 224_000.0
+        end
+      end
+
+      context 'vehicles' do
+        let(:result) { not_eligible_result }
+        let(:vehicle) { result.vehicle }
+        describe '#vehicle' do
+          it 'returns the vehicle hash' do
+            expect(vehicle.keys).to match_array(%i[
+                                                  in_regular_use
+                                                  value
+                                                  loan_amount_outstanding
+                                                  date_of_purchase
+                                                  included_in_assessment
+                                                  assessed_value
+                                                ])
+          end
+        end
+
+        describe '#vehicles?' do
+          it 'returns true' do
+            expect(result.vehicles?).to be true
+          end
+        end
+
+        describe '#vehicle_value' do
+          it 'returns the value' do
+            expect(result.vehicle_value).to eq 900.0
+          end
+        end
+
+        describe '#total_vehicles' do
+          it 'returns the zero' do
+            expect(result.total_vehicles).to be_zero
+          end
+        end
+      end
+
+      context 'capital_items' do
+        let(:result) { contribution_required_result }
+        describe '#non_liquid_capital_items' do
+          it 'returns empty array' do
+            expect(result.non_liquid_capital_items).to eq []
+          end
+        end
+
+        describe '#liquid_capital_items' do
+          let(:expected_items) do
+            [
+              {
+                description: 'Off-line bank accounts',
+                value: '350.0'
+              }
+            ]
+          end
+          it 'returns array of items' do
+            expect(result.liquid_capital_items).to eq expected_items
+          end
+        end
+
+        describe '#total_property' do
+          it 'returns the value' do
+            expect(result.total_property).to eq(-100_000.0)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/models/cfe/v2/result_spec.rb
+++ b/spec/models/cfe/v2/result_spec.rb
@@ -1,0 +1,566 @@
+require 'rails_helper'
+
+module CFE
+  module V2
+    RSpec.describe Result, type: :model do
+      let(:eligible_result) { create :cfe_v2_result }
+      let(:not_eligible_result) { create :cfe_v2_result, :not_eligible }
+      let(:contribution_required_result) { create :cfe_v2_result, :with_capital_contribution_required }
+      let(:income_contribution_required_result) { create :cfe_v2_result, :with_income_contribution_required }
+      let(:no_additional_properties) { create :cfe_v2_result, :no_additional_properties }
+      let(:additional_property) { create :cfe_v2_result, :with_additional_properties }
+      let(:no_vehicles) { create :cfe_v2_result, :no_vehicles }
+      let(:with_maintenance) { create :cfe_v2_result, :with_maintenance_received }
+      let(:with_student_finance) { create :cfe_v2_result, :with_student_finance_received }
+      let(:no_mortgage) { create :cfe_v2_result, :with_no_mortgage_costs }
+      let(:legal_aid_application) { create :legal_aid_application, :with_restrictions, :with_cfe_v2_result }
+      let(:contribution_and_restriction_result) { create :cfe_v2_result, :with_capital_contribution_required, submission: cfe_submission }
+      let(:cfe_submission) { create :cfe_submission, legal_aid_application: legal_aid_application }
+      let(:manual_review_determiner) { CCMS::ManualReviewDeterminer.new(application) }
+
+      describe '#overview' do
+        subject { cfe_result.overview }
+
+        let(:application) { cfe_result.legal_aid_application }
+
+        context 'manual check not required' do
+          before { allow(manual_review_determiner).to receive(:manual_review_required?).and_return(false) }
+
+          context 'eligible' do
+            let(:cfe_result) { create :cfe_v2_result, :eligible }
+            it 'returns eligible' do
+              expect(subject).to eq 'eligible'
+            end
+          end
+
+          context 'not_eligible' do
+            let(:cfe_result) { create :cfe_v2_result, :not_eligible }
+            it 'returns not_eligible' do
+              expect(subject).to eq 'not_eligible'
+            end
+          end
+
+          context 'capital_contribution_required' do
+            let(:cfe_result) { create :cfe_v2_result, :with_capital_contribution_required }
+            it 'returns capital_contribution_required' do
+              expect(subject).to eq 'capital_contribution_required'
+            end
+          end
+
+          context 'income_contribution_required' do
+            let(:cfe_result) { create :cfe_v2_result, :with_income_contribution_required }
+            it 'returns income_contribution_required' do
+              expect(subject).to eq 'income_contribution_required'
+            end
+          end
+
+          context 'capital_and_income_contribution_required' do
+            let(:cfe_result) { create :cfe_v2_result, :with_capital_and_income_contributions_required }
+            it 'returns capital_and_income_contribution_required' do
+              expect(subject).to eq 'capital_and_income_contribution_required'
+            end
+          end
+        end
+
+        context 'manual check IS required and restrictions do not exist' do
+          before { allow(manual_review_determiner).to receive(:manual_review_required?).and_return(true) }
+
+          context 'eligible' do
+            let(:cfe_result) { create :cfe_v2_result, :eligible }
+            it 'returns eligible' do
+              expect(subject).to eq 'eligible'
+            end
+          end
+
+          context 'not_eligible' do
+            let(:cfe_result) { create :cfe_v2_result, :not_eligible }
+            it 'returns not_eligible' do
+              expect(subject).to eq 'not_eligible'
+            end
+          end
+
+          context 'capital_contribution_required' do
+            let(:cfe_result) { create :cfe_v2_result, :with_capital_contribution_required }
+            it 'returns capital_contribution_required' do
+              expect(subject).to eq 'capital_contribution_required'
+            end
+          end
+
+          context 'income_contribution_required' do
+            let(:cfe_result) { create :cfe_v2_result, :with_income_contribution_required }
+            it 'returns income_contribution_required' do
+              expect(subject).to eq 'income_contribution_required'
+            end
+          end
+
+          context 'capital_and_income_contribution_required' do
+            let(:cfe_result) { create :cfe_v2_result, :with_capital_and_income_contributions_required }
+            it 'returns capital_and_income_contribution_required' do
+              expect(subject).to eq 'capital_and_income_contribution_required'
+            end
+          end
+        end
+
+        context 'manual check IS required and restrictions exist' do
+          before do
+            allow(manual_review_determiner).to receive(:manual_review_required?).and_return(true)
+            application.has_restrictions = true
+          end
+
+          context 'eligible' do
+            let(:cfe_result) { create :cfe_v2_result, :eligible }
+            it 'returns manual_check_required' do
+              expect(subject).to eq 'manual_check_required'
+            end
+          end
+
+          context 'not_eligible' do
+            let(:cfe_result) { create :cfe_v2_result, :not_eligible }
+            it 'returns manual_check_required' do
+              expect(subject).to eq 'manual_check_required'
+            end
+          end
+
+          context 'capital_contribution_required' do
+            let(:cfe_result) { create :cfe_v2_result, :with_capital_contribution_required }
+            it 'returns manual_check_required' do
+              expect(subject).to eq 'manual_check_required'
+            end
+          end
+
+          context 'income_contribution_required' do
+            let(:cfe_result) { create :cfe_v2_result, :with_income_contribution_required }
+            it 'returns manual_check_required' do
+              expect(subject).to eq 'manual_check_required'
+            end
+          end
+
+          context 'capital_and_income_contribution_required' do
+            let(:cfe_result) { create :cfe_v2_result, :with_capital_and_income_contributions_required }
+            it 'returns manual_check_required' do
+              expect(subject).to eq 'manual_check_required'
+            end
+          end
+        end
+      end
+
+      describe '#assessment_result' do
+        context 'eligible' do
+          it 'returns eligible' do
+            expect(eligible_result.assessment_result).to eq 'eligible'
+          end
+        end
+
+        context 'not_eligible' do
+          it 'returns not_eligible' do
+            expect(not_eligible_result.assessment_result).to eq 'not_eligible'
+          end
+        end
+
+        context 'contribution_required' do
+          it 'returns contribution_required' do
+            expect(contribution_required_result.assessment_result).to eq 'contribution_required'
+          end
+        end
+      end
+
+      describe '#capital_contribution' do
+        it 'returns the value of the capital contribution' do
+          expect(contribution_required_result.capital_contribution).to eq 465.66
+        end
+      end
+
+      context 'disposable income' do
+        let(:result) { income_contribution_required_result }
+
+        describe '#income_contribution' do
+          it 'returns required contribution' do
+            expect(result.income_contribution).to eq 366.82
+          end
+        end
+
+        describe '#total_disposable_income_asssessed' do
+          it 'returns the value' do
+            expect(result.total_disposable_income_assessed).to eq '0.0'
+          end
+        end
+
+        describe '#total_gross_income_assessed' do
+          it 'returns the value' do
+            expect(result.total_gross_income_assessed).to eq '150.0'
+          end
+        end
+
+        describe '#gross_income_upper_threshold' do
+          it 'returns the value' do
+            expect(result.gross_income_upper_threshold).to eq '999999999999.0'
+          end
+        end
+
+        describe '#disposable_income_lower_threshold' do
+          it 'returns the value' do
+            expect(result.disposable_income_lower_threshold).to eq '315.0'
+          end
+        end
+
+        describe '#disposable_income_upper_threshold' do
+          it 'returns the value' do
+            expect(result.disposable_income_upper_threshold).to eq '733.0'
+          end
+        end
+
+        describe '#monthly_state_benefits' do
+          it 'returns the value' do
+            expect(result.monthly_state_benefits).to eq '75.0'
+            expect(result.total_gross_income).to eq 150.0
+            expect(result.total_capital).to eq '9552.05'
+          end
+        end
+      end
+
+      describe 'eligible?' do
+        context 'returns true' do
+          it 'returns boolean response for eligible' do
+            expect(eligible_result.eligible?).to be true
+          end
+        end
+
+        context 'returns false' do
+          it 'returns false response for eligible' do
+            expect(not_eligible_result.eligible?).to be false
+          end
+        end
+      end
+
+      describe 'capital_contribution_required?' do
+        context 'contribution not required ' do
+          it 'returns false for capital_contribution_required' do
+            expect(eligible_result.capital_contribution_required?).to be false
+          end
+        end
+
+        context 'contribution is required ' do
+          it 'returns true for capital_contribution_required' do
+            expect(contribution_required_result.capital_contribution_required?).to be true
+          end
+        end
+      end
+
+      ################################################################
+      #  CAPITAL ITEMS                                               #
+      ################################################################
+
+      #  Are the next 2 tests testing the correct thing? Currently checks that an array contains items, what if there are no items?
+      describe 'non_liquid_capital_items' do
+        it 'returns the description and value for first item in non liquid items array' do
+          expect(eligible_result.non_liquid_capital_items.first[:description]).to be_a String
+          expect(eligible_result.non_liquid_capital_items.first[:value].to_d).to eq 3902.92
+        end
+      end
+
+      describe 'liquid_capital_items' do
+        it 'returns the description and value for first item in liquid items array' do
+          expect(eligible_result.liquid_capital_items.first[:description]).to be_a String
+          expect(eligible_result.liquid_capital_items.first[:value].to_d).to eq 6692.12
+        end
+      end
+
+      describe 'total_property' do
+        it 'returns the assessed value for total property' do
+          expect(eligible_result.total_property).to eq 1134.00
+        end
+      end
+
+      describe 'total_savings' do
+        it 'returns the assessed value for liquid assets' do
+          expect(eligible_result.total_savings).to eq 5649.13
+        end
+      end
+
+      describe 'total_other_assets' do
+        it 'returns the assessed value for non liquid assets' do
+          expect(eligible_result.total_other_assets).to eq 3902.92
+        end
+      end
+
+      ################################################################
+      # VEHICLES                                                     #
+      ################################################################
+
+      describe 'vehicle' do
+        it 'returns a vehicle' do
+          expect(eligible_result.vehicle).to be_kind_of(Hash)
+          expect(eligible_result.vehicle[:value].to_d).to eq 1784.61
+        end
+      end
+
+      describe 'vehicles?' do
+        context 'vehicle(s) exist' do
+          it 'returns a boolean response if vehicles exist' do
+            expect(eligible_result.vehicles?).to be true
+          end
+
+          context 'vehicles dont exist'
+          it 'returns a boolean response if vehicles exist' do
+            expect(no_vehicles.vehicles?).to be false
+          end
+        end
+      end
+
+      describe 'vehicle_value' do
+        it 'returns the assessed value for applicants vehicle' do
+          expect(eligible_result.vehicle_value).to eq 1784.61
+        end
+      end
+
+      describe 'vehicle_loan_amount_outstanding' do
+        it 'returns the loan value outstanding on applicants vehicle' do
+          expect(eligible_result.vehicle_loan_amount_outstanding).to eq 3225.77
+        end
+      end
+
+      describe 'vehicle_disregard' do
+        it 'returns the vehicle disregard for applicants vehicle ' do
+          expect(eligible_result.vehicle_disregard).to eq 1784.61
+        end
+      end
+
+      describe 'vehicle_assessed_amount' do
+        it 'returns the assessed value for the applicants vehicle' do
+          expect(eligible_result.vehicle_assessed_amount).to eq 0.0
+        end
+      end
+
+      describe 'total_vehicles' do
+        it 'returns the assessed value for all applicants vehicle(s)' do
+          expect(eligible_result.total_vehicles).to eq 0.0
+        end
+      end
+
+      ################################################################
+      #  ADDITIONAL PROPERTY                                         #
+      ################################################################
+
+      describe '#additional_property?' do
+        context 'present' do
+          it 'returns true' do
+            expect(additional_property.additional_property?).to be true
+          end
+        end
+
+        context 'not present' do
+          it 'returns false' do
+            expect(no_additional_properties.additional_property?).to be false
+          end
+        end
+
+        context 'present but zero' do
+          it 'returns false' do
+            expect(eligible_result.additional_property?).to be false
+          end
+        end
+      end
+
+      describe 'additional_property_value' do
+        it 'returns the value of the first additional property' do
+          expect(additional_property.additional_property_value).to eq 5_781.91
+        end
+      end
+
+      describe 'additional_property_transaction_allowance' do
+        it 'returns the transaction allowance for the first additional property' do
+          expect(additional_property.additional_property_transaction_allowance).to eq(-113.46)
+        end
+      end
+
+      describe 'additional_property_mortgage' do
+        it 'returns the mortgage for the first additional property' do
+          expect(additional_property.additional_property_mortgage).to eq(-8202.00)
+        end
+      end
+
+      describe 'additional_property_assessed_equity' do
+        it 'returns the assessed equity for the first additional property' do
+          expect(additional_property.additional_property_assessed_equity).to eq 125.33
+        end
+      end
+
+      describe 'monthly_other_income' do
+        it 'returns the assessed montly other income for the applicant' do
+          expect(eligible_result.monthly_other_income).to eq 75
+        end
+      end
+
+      ################################################################
+      #  MAIN HOME                                                   #
+      ################################################################
+
+      describe 'main_home_value' do
+        it 'returns the assessed value for the main home' do
+          expect(eligible_result.main_home_value).to eq 5985.82
+        end
+      end
+
+      describe 'main_home_outstanding_mortgage' do
+        it 'returns the assessed value for the main home' do
+          expect(eligible_result.main_home_outstanding_mortgage).to eq(-7201.44)
+        end
+      end
+
+      describe 'main_home_transaction_allowance' do
+        it 'returns the assessed value for the main home' do
+          expect(eligible_result.main_home_transaction_allowance).to eq(-179.57)
+        end
+      end
+
+      describe 'main_home_equity_disregard' do
+        it 'returns the assessed value for the main home' do
+          expect(eligible_result.main_home_equity_disregard).to eq(-100_000.0)
+        end
+      end
+
+      describe 'main_home_assessed_equity' do
+        it 'returns the assessed value for the main home' do
+          expect(eligible_result.main_home_assessed_equity).to eq 0.0
+        end
+      end
+
+      ################################################################
+      #  OUTGOINGS                                                   #
+      ################################################################
+
+      describe 'housing_costs' do
+        it 'returns the housing costs as a hash' do
+          expect(eligible_result.housing_costs).to include(:amount)
+          expect(eligible_result.housing_costs).to include(:payment_date)
+        end
+      end
+
+      describe 'childcare_costs' do
+        it 'returns the childcare costs as a hash' do
+          expect(eligible_result.childcare_costs).to be_kind_of(Hash)
+          expect(eligible_result.childcare_costs).to include(:amount)
+          expect(eligible_result.childcare_costs).to include(:payment_date)
+        end
+      end
+
+      describe 'maintenance_costs' do
+        it 'returns the maintenance costs as a hash' do
+          expect(eligible_result.maintenance_costs).to be_kind_of(Hash)
+          expect(eligible_result.maintenance_costs).to include(:amount)
+          expect(eligible_result.maintenance_costs).to include(:payment_date)
+        end
+      end
+
+      ################################################################
+      #  DISPOSABLE INCOME                                           #
+      ################################################################
+
+      describe 'maintenance_per_month' do
+        context 'when maintenance is received' do
+          subject(:maintenance_per_month) { with_maintenance.maintenance_per_month }
+          it { is_expected.to eq 150.00 }
+        end
+
+        context 'when maintenance is not received' do
+          subject(:maintenance_per_month) { eligible_result.maintenance_per_month }
+          it { is_expected.to eq 0.00 }
+        end
+      end
+
+      describe 'mei_student_loan' do
+        context 'when student_loan is received' do
+          subject(:mei_student_loan) { with_student_finance.mei_student_loan }
+          it { is_expected.to eq 125.00 }
+        end
+
+        context 'when student_loan is not received' do
+          subject(:mei_student_loan) { eligible_result.mei_student_loan }
+          it { is_expected.to eq 0.00 }
+        end
+      end
+
+      describe 'monthly equivalent income' do
+        let(:result) { eligible_result }
+        it 'returns the expected values' do
+          expect(result.mei_friends_or_family).to eq 50.59
+          expect(result.mei_maintenance_in).to eq 54.17
+          expect(result.mei_property_or_lodger).to eq 450.0
+          expect(result.mei_pension).to eq 82.52
+          expect(result.total_monthly_income).to eq 712.28
+        end
+      end
+
+      describe 'monthly outgoing equivalents' do
+        let(:result) { eligible_result }
+        it 'returns the expected values' do
+          expect(result.moe_housing).to eq 15.75
+          expect(result.moe_childcare).to be_zero
+          expect(result.moe_maintenance_out).to eq 3.64
+          expect(result.moe_legal_aid).to eq 7.0
+          expect(result.total_monthly_outgoings).to eq 26.39
+        end
+      end
+
+      describe 'deductions' do
+        let(:result) { eligible_result }
+        it 'returns the expected values' do
+          expect(result.dependants_allowance).to eq 291.86
+          expect(result.disregarded_state_benefits).to eq 1500.0
+          expect(result.total_deductions).to eq 1791.86
+        end
+      end
+
+      ################################################################
+      #  TOTALS                                                      #
+      ################################################################
+
+      describe 'mortgage per month' do
+        context 'when mortgage is paid' do
+          it 'returns the value of mortgage per month' do
+            expect(eligible_result.mortgage_per_month).to eq 125.0
+          end
+        end
+
+        context 'when no mortgage is paid' do
+          it 'returns the value of mortgage per month' do
+            expect(no_mortgage.mortgage_per_month).to eq 0.0
+          end
+        end
+      end
+
+      describe 'pensioner_capital_disregard' do
+        it 'returns the total pension disregard' do
+          expect(eligible_result.pensioner_capital_disregard).to eq 0.0
+        end
+      end
+
+      describe 'total_capital_before_pensioner_disregard' do
+        it 'returns total capital before pension disregard' do
+          expect(eligible_result.total_capital_before_pensioner_disregard).to eq 10_686.05
+        end
+      end
+
+      describe 'total_disposable_capital' do
+        it 'returns total disposable capital' do
+          expect(eligible_result.total_disposable_capital).to eq 10_686.05
+        end
+      end
+
+      ################################################################
+      #  REMARKS                                                     #
+      ################################################################
+
+      describe 'remarks' do
+        it 'returns a CFE::Remarks object' do
+          expect(eligible_result.remarks).to be_instance_of(CFE::Remarks)
+        end
+
+        it 'instantiates the Remarks class with the remarks part of the hash' do
+          expect(CFE::Remarks).to receive(:new).with({})
+          eligible_result.remarks
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Re-instate testing for CFE V1 and V2 results

Occasionally, unit tests on Circle-CI would fail due to test coverage being less than 100%.

This could be reliably reproduced on Circle CI by using the seed 51620.

It turns out that with certain seeds, the `:nocov:` at the beginning and end of `app/models/cfe/v1/results.rb` and 
`app/models/cfe/v1/results.rb` were not being honoured, and they were being counted as not tested.

This PR re-instates the tests (and factories, and mock result objects) for those two files.


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
