### PR TITLE
Fix typo: HRMC -> HMRC

### DIFF
--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -273,7 +273,7 @@ en:
         h1-heading: Continue %{client_name}'s financial assessment
         what_to_do: "Your client has shared their financial information. You need to do the following:"
         point_1_heading: 1. Review their employment details
-        point_1_text: We'll show you the information HRMC shared with us.
+        point_1_text: We'll show you the information HMRC shared with us.
         point_2_heading: 2. Sort their bank transactions into categories
         point_2_text: Your client selected the categories their income and outgoings fall into. View their bank statements and sort transactions into these categories.
         point_3_heading: 3. Tell us about their dependants


### PR DESCRIPTION
## What

Fixes a small typo on the `client_completed_means` screen.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
