### PR TITLE
Fix: CCMS tests were failing

### DIFF
--- a/spec/services/ccms/requestors/case_add_requestor_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_spec.rb
@@ -30,9 +30,8 @@ module CCMS
                  address: address
         end
         let(:proceeding) { legal_aid_application.proceedings.detect { |p| p.ccms_code == 'DA001' } }
-        let(:application_proceeding_type) { create :application_proceeding_type, legal_aid_application: legal_aid_application }
         let!(:chances_of_success) do
-          create :chances_of_success, :with_optional_text, application_proceeding_type: application_proceeding_type, proceeding: proceeding
+          create :chances_of_success, :with_optional_text, proceeding: proceeding
         end
         let(:vehicle) { create :vehicle, estimated_value: 3030, payment_remaining: 881, purchased_on: Date.new(2008, 8, 22), used_regularly: true }
         let(:other_assets_declaration) do

--- a/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_additional_property_attributes_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_additional_property_attributes_spec.rb
@@ -31,7 +31,7 @@ module CCMS
         let(:proceeding) { legal_aid_application.proceedings.detect { |p| p.ccms_code == 'DA001' } }
         let(:application_proceeding_type) { create :application_proceeding_type, legal_aid_application: legal_aid_application }
         let!(:chances_of_success) do
-          create :chances_of_success, :with_optional_text, application_proceeding_type: application_proceeding_type, proceeding: proceeding
+          create :chances_of_success, :with_optional_text, proceeding: proceeding
         end
 
         let(:ccms_reference) { '300000054005' }

--- a/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_attributes_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_attributes_spec.rb
@@ -33,7 +33,7 @@ module CCMS
         let!(:proceeding) { legal_aid_application.proceedings.detect { |p| p.ccms_code == 'DA001' } }
         let!(:application_proceeding_type) { create :application_proceeding_type, legal_aid_application: legal_aid_application }
         let!(:chances_of_success) do
-          create :chances_of_success, :with_optional_text, application_proceeding_type: application_proceeding_type, proceeding: proceeding
+          create :chances_of_success, :with_optional_text, proceeding: proceeding
         end
         let(:opponent) { legal_aid_application.opponent }
         let(:ccms_reference) { '300000054005' }

--- a/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_benefits_attrs_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_benefits_attrs_spec.rb
@@ -31,7 +31,7 @@ module CCMS
         let!(:proceeding) { legal_aid_application.proceedings.detect { |p| p.ccms_code == 'DA001' } }
         let!(:application_proceeding_type) { create :application_proceeding_type, legal_aid_application: legal_aid_application }
         let!(:chances_of_success) do
-          create :chances_of_success, :with_optional_text, application_proceeding_type: application_proceeding_type, proceeding: proceeding
+          create :chances_of_success, :with_optional_text, proceeding: proceeding
         end
         let(:ccms_reference) { '300000054005' }
         let(:submission) { create :submission, :case_ref_obtained, legal_aid_application: legal_aid_application, case_ccms_reference: ccms_reference }

--- a/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_dependant_child_attributes_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_dependant_child_attributes_spec.rb
@@ -40,7 +40,7 @@ module CCMS
           let!(:proceeding) { legal_aid_application.proceedings.detect { |p| p.ccms_code == 'DA001' } }
           let!(:application_proceeding_type_one) { create :application_proceeding_type, legal_aid_application: legal_aid_application }
           let!(:chances_of_success) do
-            create :chances_of_success, :with_optional_text, application_proceeding_type: application_proceeding_type_one, proceeding: proceeding
+            create :chances_of_success, :with_optional_text, proceeding: proceeding
           end
 
           context 'with dependant children' do

--- a/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_entities_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_entities_spec.rb
@@ -32,7 +32,7 @@ module CCMS
         let!(:proceeding) { legal_aid_application.proceedings.detect { |p| p.ccms_code == 'DA001' } }
         let!(:application_proceeding_type_one) { create :application_proceeding_type, legal_aid_application: legal_aid_application }
         let!(:chances_of_success) do
-          create :chances_of_success, :with_optional_text, application_proceeding_type: application_proceeding_type_one, proceeding: proceeding
+          create :chances_of_success, :with_optional_text, proceeding: proceeding
         end
         let(:opponent) { legal_aid_application.opponent }
         let(:ccms_reference) { '300000054005' }

--- a/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_variable_attributes_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_variable_attributes_spec.rb
@@ -32,7 +32,7 @@ module CCMS
         let!(:proceeding) { legal_aid_application.reload.proceedings.detect { |p| p.ccms_code == 'DA001' } }
         let!(:application_proceeding_type_one) { create :application_proceeding_type, legal_aid_application: legal_aid_application }
         let!(:chances_of_success) do
-          create :chances_of_success, :with_optional_text, application_proceeding_type: application_proceeding_type_one, proceeding: proceeding
+          create :chances_of_success, :with_optional_text, proceeding: proceeding
         end
 
         let(:ccms_reference) { '300000054005' }

--- a/spec/services/ccms/requestors/case_add_requestor_xml_blocks/passported_attributes_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_xml_blocks/passported_attributes_spec.rb
@@ -37,9 +37,7 @@ module CCMS
         let(:xml) { requestor.formatted_xml }
         let!(:success_prospect) { :likely }
         let!(:chances_of_success) do
-          create :chances_of_success, success_prospect: success_prospect, success_prospect_details: 'details',
-                                      application_proceeding_type: application_proceeding_type,
-                                      proceeding: proceeding
+          create :chances_of_success, success_prospect: success_prospect, success_prospect_details: 'details', proceeding: proceeding
         end
 
         before do
@@ -896,9 +894,7 @@ module CCMS
             let!(:da004) { legal_aid_application.proceedings.detect { |p| p.ccms_code == 'DA004' } }
             let(:application_proceeding_type) { create :application_proceeding_type, legal_aid_application: legal_aid_application }
             let!(:chances_of_success) do
-              create :chances_of_success, :with_optional_text,
-                     application_proceeding_type: application_proceeding_type,
-                     proceeding: da004
+              create :chances_of_success, :with_optional_text, proceeding: da004
             end
 
             it 'returns hard coded statement' do
@@ -1357,9 +1353,7 @@ module CCMS
             let!(:proceeding_da004) { legal_aid_application.proceedings.detect { |p| p.ccms_code == 'DA004' } }
             let!(:application_proceeding_type_one) { create :application_proceeding_type, legal_aid_application: legal_aid_application }
             let!(:chances_of_success) do
-              create :chances_of_success, success_prospect: success_prospect, success_prospect_details: 'details',
-                                          application_proceeding_type: application_proceeding_type_one,
-                                          proceeding: proceeding_da004
+              create :chances_of_success, success_prospect: success_prospect, success_prospect_details: 'details', proceeding: proceeding_da004
             end
 
             it 'REQUESTED_SCOPE should populated with MULTIPLE in proceedings section' do
@@ -1504,9 +1498,7 @@ module CCMS
             let(:proceeding_da004) { legal_aid_application.proceedings.detect { |p| p.ccms_code == 'DA004' } }
             let(:application_proceeding_type) { create :application_proceeding_type, legal_aid_application: legal_aid_application }
             let!(:chances_of_success) do
-              create :chances_of_success, success_prospect: success_prospect, success_prospect_details: 'details',
-                                          application_proceeding_type: application_proceeding_type,
-                                          proceeding: proceeding_da004
+              create :chances_of_success, success_prospect: success_prospect, success_prospect_details: 'details', proceeding: proceeding_da004
             end
 
             it 'returns false' do
@@ -1541,9 +1533,7 @@ module CCMS
             let!(:proceeding_da004) { legal_aid_application.proceedings.detect { |p| p.ccms_code == 'DA004' } }
             let!(:application_proceeding_type_one) { create :application_proceeding_type, legal_aid_application: legal_aid_application }
             let!(:chances_of_success) do
-              create :chances_of_success, success_prospect: success_prospect, success_prospect_details: 'details',
-                                          application_proceeding_type: application_proceeding_type_one,
-                                          proceeding: proceeding_da004
+              create :chances_of_success, success_prospect: success_prospect, success_prospect_details: 'details', proceeding: proceeding_da004
             end
 
             it 'returns Both' do

--- a/spec/services/ccms/submitters/add_case_service_spec.rb
+++ b/spec/services/ccms/submitters/add_case_service_spec.rb
@@ -16,7 +16,7 @@ module CCMS
       let(:proceeding) { legal_aid_application.proceedings.detect { |p| p.ccms_code == 'DA001' } }
       let(:application_proceeding_type_one) { create :application_proceeding_type, legal_aid_application: legal_aid_application }
       let!(:chances_of_success) do
-        create :chances_of_success, :with_optional_text, application_proceeding_type: application_proceeding_type_one, proceeding: proceeding
+        create :chances_of_success, :with_optional_text, proceeding: proceeding
       end
       let(:applicant) { legal_aid_application.applicant }
       let(:office) { create :office }

--- a/spec/services/ccms/submitters/upload_documents_service_spec.rb
+++ b/spec/services/ccms/submitters/upload_documents_service_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe CCMS::Submitters::UploadDocumentsService, :ccms do
            :submitting_assessment
   end
   let!(:proceeding) { create :proceeding, :da001, legal_aid_application: legal_aid_application }
-  let!(:chances_of_success) { create :chances_of_success, application_proceeding_type: legal_aid_application.lead_application_proceeding_type, proceeding: proceeding }
+  let!(:chances_of_success) { create :chances_of_success, proceeding: proceeding }
   let(:statement_of_case) { create :statement_of_case, :with_original_and_pdf_files_attached, legal_aid_application: legal_aid_application }
   let(:statement_of_case_attachment) { statement_of_case.original_attachments.first }
   let(:means_report_attachment) { legal_aid_application.means_report }


### PR DESCRIPTION
## What

After AP-2721 (#3227) removed the application_proceeding_type from chances_of_success
these all started failing because the factory could not add a non-existent field


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
