### PR TITLE
Amend circleci config to delete dependabot deployments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -380,6 +380,17 @@ jobs:
         command: |
           ./bin/delete_uat_release
 
+  delete_dependabot_deployment:
+    executor: cloud-platform-executor
+    steps:
+    - checkout
+    - setup_remote_docker
+    - *setup_uat_kubectl
+    - run:
+        name: Delete dependabot deployment
+        command: |
+          ./bin/delete_dependabot_deployment
+
 generic-slack-fail-post-step: &generic-slack-fail-post-step
   post-steps:
     - slack/notify:
@@ -410,6 +421,14 @@ workflows:
       - integration_tests:
           requires:
           - lint_checks
+          <<: *generic-slack-fail-post-step
+      - delete_dependabot_deployment:
+          filters:
+            branches:
+              only:
+                - /dependabot.*/
+          requires:
+          - deploy_uat
           <<: *generic-slack-fail-post-step
 
   merge_pr:

--- a/bin/delete_dependabot_deployment
+++ b/bin/delete_dependabot_deployment
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+RELEASE_BRANCH=$(echo $CIRCLE_BRANCH | tr '[:upper:]' '[:lower:]' | sed 's:^\w*\/::' | tr -s ' _/[]().' '-' | cut -c1-30 | sed 's/-$//')
+RELEASE_NAME="apply-$RELEASE_BRANCH"
+echo "Attempting to delete UAT dependabot release"
+echo "$RELEASE_NAME"
+
+
+UAT_RELEASES=$(helm list --namespace=${KUBE_ENV_UAT_NAMESPACE} --all)
+echo "Current UAT releases:"
+echo "$UAT_RELEASES"
+
+if [[ $UAT_RELEASES == *"$RELEASE_NAME"* ]]
+then
+  helm delete $RELEASE_NAME --namespace=${KUBE_ENV_UAT_NAMESPACE}
+  echo "Deleted UAT dependabot release $RELEASE_NAME"
+else
+  echo "UAT dependabot release $RELEASE_NAME was not found"
+fi


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2780)

Delete any uat deployments for branches starting 'dependabot' immediately after deployment. Uses circle job filters so that only branches matching regex /dependabot.*/ are deleted.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
