### PR TITLE
AP-2098 Silence GET warnings

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -4,8 +4,9 @@ Rails.application.reloader.to_prepare do
 end
 
 OmniAuth.config.allowed_request_methods = %i[post get]
+OmniAuth.config.silence_get_warning = true # Warnings silenced for now.  See ticket AP-2098 for attempts to resolve this
 OmniAuth.config.logger = Rails.logger
-# normally in dev mode, if the user fails to authenticate, an excesption is raised.
+# normally in dev mode, if the user fails to authenticate, an exception is raised.
 # This block here makes sure that dev behaviour is the same as production, i.e.
 # is redirectied to /auth/failure
 #


### PR DESCRIPTION

## Silence GET warnings

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2098)

Omniauth is printing warnings about not using GET in omniauth requests.  We are unable to resolve this at the moment, but this PR will silence the warnings in the log, reducing the possibility of bad actors being warned about this potential vulnerabililty.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
