### PR TITLE
AP-2737 Refactor ObtainDocumentIdService to use DocumentCategory

### DIFF
--- a/app/models/document_category.rb
+++ b/app/models/document_category.rb
@@ -3,5 +3,11 @@ class DocumentCategory < ApplicationRecord
     DocumentCategoryPopulator.call
   end
 
-  scope :valid_document_categories, -> { where(display_on_evidence_upload: true).pluck(:name) }
+  def self.valid_document_category_names
+    where(display_on_evidence_upload: true).pluck(:name)
+  end
+
+  def self.submittable_category_names
+    where(submit_to_ccms: true).pluck(:name)
+  end
 end

--- a/app/models/document_category.rb
+++ b/app/models/document_category.rb
@@ -3,7 +3,7 @@ class DocumentCategory < ApplicationRecord
     DocumentCategoryPopulator.call
   end
 
-  def self.valid_document_category_names
+  def self.displayable_document_category_names
     where(display_on_evidence_upload: true).pluck(:name)
   end
 

--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -532,7 +532,7 @@ class LegalAidApplication < ApplicationRecord
 
   def validate_document_categories
     required_document_categories.each do |category|
-      errors.add(:required_document_categories, 'must be valid document categories') unless DocumentCategory.valid_document_categories.include?(category)
+      errors.add(:required_document_categories, 'must be valid document categories') unless DocumentCategory.valid_document_category_names.include?(category)
     end
   end
 end

--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -532,7 +532,7 @@ class LegalAidApplication < ApplicationRecord
 
   def validate_document_categories
     required_document_categories.each do |category|
-      errors.add(:required_document_categories, 'must be valid document categories') unless DocumentCategory.valid_document_category_names.include?(category)
+      errors.add(:required_document_categories, 'must be valid document categories') unless DocumentCategory.displayable_document_category_names.include?(category)
     end
   end
 end

--- a/app/services/ccms/submitters/obtain_document_id_service.rb
+++ b/app/services/ccms/submitters/obtain_document_id_service.rb
@@ -1,7 +1,7 @@
 module CCMS
   module Submitters
     class ObtainDocumentIdService < BaseSubmissionService
-      NON_PDF_VERSION_ATTACHMENTS = %w[statement_of_case gateway_evidence].freeze
+      # NON_PDF_VERSION_ATTACHMENTS = %w[statement_of_case gateway_evidence].freeze
 
       def call
         return unless populate_documents
@@ -19,10 +19,8 @@ module CCMS
 
       private
 
-      def pdf_attachments
-        # Ignore the original document and use the pdf attachment it was converted to
-
-        @pdf_attachments ||= attachments.reject { |a| NON_PDF_VERSION_ATTACHMENTS.include? a.attachment_type }
+      def submittable_attachments
+        @submittable_attachments ||= attachments.select { |a| DocumentCategory.submittable_category_names.include?(a.attachment_type) }
       end
 
       def attachments
@@ -34,7 +32,7 @@ module CCMS
       end
 
       def populate_documents
-        pdf_attachments.each do |attachment|
+        submittable_attachments.each do |attachment|
           SubmissionDocument.create!(
             submission: submission,
             attachment_id: attachment.id,

--- a/app/services/ccms/submitters/obtain_document_id_service.rb
+++ b/app/services/ccms/submitters/obtain_document_id_service.rb
@@ -1,8 +1,6 @@
 module CCMS
   module Submitters
     class ObtainDocumentIdService < BaseSubmissionService
-      # NON_PDF_VERSION_ATTACHMENTS = %w[statement_of_case gateway_evidence].freeze
-
       def call
         return unless populate_documents
 

--- a/spec/models/document_category_spec.rb
+++ b/spec/models/document_category_spec.rb
@@ -15,4 +15,28 @@ RSpec.describe DocumentCategory, type: :model do
       described_class.populate
     end
   end
+
+  describe '.valid_document_category_names' do
+    before { described_class.populate }
+    it 'returns an array of names to display on evidence upload page' do
+      expect(described_class.valid_document_category_names).to eq %w[benefit_evidence gateway_evidence]
+    end
+  end
+
+  describe '.submittable_category_names' do
+    before { described_class.populate }
+    let(:expected_categories) do
+      %w[
+        bank_transaction_report
+        benefit_evidence_pdf
+        gateway_evidence_pdf
+        means_report
+        merits_report
+        statement_of_case_pdf
+      ]
+    end
+    it 'returns an array of names that should be uploaded to CCMS' do
+      expect(described_class.submittable_category_names).to eq expected_categories
+    end
+  end
 end

--- a/spec/models/document_category_spec.rb
+++ b/spec/models/document_category_spec.rb
@@ -16,10 +16,10 @@ RSpec.describe DocumentCategory, type: :model do
     end
   end
 
-  describe '.valid_document_category_names' do
+  describe '.displayable_document_category_names' do
     before { described_class.populate }
     it 'returns an array of names to display on evidence upload page' do
-      expect(described_class.valid_document_category_names).to eq %w[benefit_evidence gateway_evidence]
+      expect(described_class.displayable_document_category_names).to eq %w[benefit_evidence gateway_evidence]
     end
   end
 

--- a/spec/models/legal_aid_application_spec.rb
+++ b/spec/models/legal_aid_application_spec.rb
@@ -1144,7 +1144,7 @@ RSpec.describe LegalAidApplication, type: :model do
 
   describe 'required_document_categories' do
     let(:laa) { create :legal_aid_application }
-    before { allow(DocumentCategory).to receive(:valid_document_categories).and_return %w[benefit_evidence gateway_evidence] }
+    before { allow(DocumentCategory).to receive(:valid_document_category_names).and_return %w[benefit_evidence gateway_evidence] }
 
     it 'defaults to an empty array' do
       expect(laa.required_document_categories).to eq []

--- a/spec/models/legal_aid_application_spec.rb
+++ b/spec/models/legal_aid_application_spec.rb
@@ -1144,7 +1144,7 @@ RSpec.describe LegalAidApplication, type: :model do
 
   describe 'required_document_categories' do
     let(:laa) { create :legal_aid_application }
-    before { allow(DocumentCategory).to receive(:valid_document_category_names).and_return %w[benefit_evidence gateway_evidence] }
+    before { allow(DocumentCategory).to receive(:displayable_document_category_names).and_return %w[benefit_evidence gateway_evidence] }
 
     it 'defaults to an empty array' do
       expect(laa.required_document_categories).to eq []

--- a/spec/services/ccms/submitters/obtain_document_id_service_spec.rb
+++ b/spec/services/ccms/submitters/obtain_document_id_service_spec.rb
@@ -23,6 +23,7 @@ module CCMS
 
       around do |example|
         VCR.turn_off!
+        DocumentCategory.populate
         example.run
         VCR.turn_on!
       end
@@ -52,9 +53,32 @@ module CCMS
             create :gateway_evidence, :with_original_and_pdf_files_attached, legal_aid_application: legal_aid_application
           end
 
-          it 'populates the documents array with statement_of_case, gateway_evidence, means_report and merits_report' do
+          let(:all_attachment_types) do
+            %w[
+              merits_report
+              means_report
+              bank_transaction_report
+              statement_of_case_pdf
+              statement_of_case
+              gateway_evidence_pdf
+              gateway_evidence
+            ]
+          end
+
+          let(:submittable_document_types) do
+            %w[
+              merits_report
+              means_report
+              bank_transaction_report
+              statement_of_case_pdf
+              gateway_evidence_pdf
+            ]
+          end
+
+          it 'only populates the documents array with submittable documents' do
+            expect(legal_aid_application.attachments.map(&:attachment_type)).to eq all_attachment_types
             subject.call
-            expect(submission.submission_documents.count).to eq 5
+            expect(submission.submission_documents.map(&:document_type)).to eq submittable_document_types
           end
 
           it 'populates document array with gateway_evidence' do


### PR DESCRIPTION
## Refactor ObtainDocumentIdService to use DocumentCategory

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2737)

ObtainDocumentIdService used a hard-coded list of attachment types to exclude from uploading to CCMS.  This PR refactors that code to use the `submit_to_ccms` field on the DocumentCategory record to decide whether or not to upload it to CCMS.  This is because this list will change over time, and the control of what to upload and what to omit is all in one place.

- Refactored `valid_document_categories` scope on `DocumentCategory` to a class method `.displayable_document_category_names` - it returns an array of names, not an array of records, and so isn't a scope
- Added class method `.submittable_category_names` to DocumentCategory
- Refactored `ObtainDocumentIdService` to use `DocumentCategory.submittable_category_names` rather than a hard-coded list

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
