### PR TITLE
AP-2736 attachment validation

### DIFF
--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -2,16 +2,18 @@ class Attachment < ApplicationRecord
   belongs_to :legal_aid_application
   has_one_attached :document
 
-  enum(
-    attachment_type: {
-      statement_of_case: 'statement_of_case'.freeze,
-      statement_of_case_pdf: 'statement_of_case_pdf'.freeze,
-      merits_report: 'merits_report'.freeze,
-      means_report: 'means_report'.freeze,
-      bank_transaction_report: 'bank_transaction_report'.freeze,
-      gateway_evidence: 'gateway_evidence'.freeze,
-      gateway_evidence_pdf: 'gateway_evidence_pdf'.freeze
-    },
-    _prefix: false
-  )
+  # enum(
+  #   attachment_type: {
+  #     statement_of_case: 'statement_of_case'.freeze,
+  #     statement_of_case_pdf: 'statement_of_case_pdf'.freeze,
+  #     merits_report: 'merits_report'.freeze,
+  #     means_report: 'means_report'.freeze,
+  #     bank_transaction_report: 'bank_transaction_report'.freeze,
+  #     gateway_evidence: 'gateway_evidence'.freeze,
+  #     gateway_evidence_pdf: 'gateway_evidence_pdf'.freeze
+  #   },
+  #   _prefix: false
+  # )
+  validates :attachment_type, inclusion: { in: DocumentCategory.valid_attachment_category_names,
+                                message: "%{value} is not a valid attachment type" }
 end

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -2,18 +2,9 @@ class Attachment < ApplicationRecord
   belongs_to :legal_aid_application
   has_one_attached :document
 
-  # enum(
-  #   attachment_type: {
-  #     statement_of_case: 'statement_of_case'.freeze,
-  #     statement_of_case_pdf: 'statement_of_case_pdf'.freeze,
-  #     merits_report: 'merits_report'.freeze,
-  #     means_report: 'means_report'.freeze,
-  #     bank_transaction_report: 'bank_transaction_report'.freeze,
-  #     gateway_evidence: 'gateway_evidence'.freeze,
-  #     gateway_evidence_pdf: 'gateway_evidence_pdf'.freeze
-  #   },
-  #   _prefix: false
-  # )
-  validates :attachment_type, inclusion: { in: DocumentCategory.valid_attachment_category_names,
-                                message: "%{value} is not a valid attachment type" }
+  validates_with DocumentCategoryValidator
+
+  DocumentCategoryValidator::VALID_DOCUMENT_TYPES.each do |named_scope|
+    scope named_scope.to_sym, -> { where(attachment_type: named_scope) }
+  end
 end

--- a/app/models/document_category.rb
+++ b/app/models/document_category.rb
@@ -1,4 +1,6 @@
 class DocumentCategory < ApplicationRecord
+  validates_with DocumentCategoryValidator
+
   def self.populate
     DocumentCategoryPopulator.call
   end

--- a/app/validators/document_category_validator.rb
+++ b/app/validators/document_category_validator.rb
@@ -1,0 +1,34 @@
+# This validator has three uses:
+# - to be a single source of truth for the valid attachment types / document category names
+# - to validate the attachment_type field on Attachment model
+# - to validate the name field on the DocumentCategory model
+#
+class DocumentCategoryValidator < ActiveModel::Validator
+  VALID_DOCUMENT_TYPES = %w[
+    bank_transaction_report
+    benefit_evidence
+    benefit_evidence_pdf
+    gateway_evidence
+    gateway_evidence_pdf
+    means_report
+    merits_report
+    statement_of_case
+    statement_of_case_pdf
+  ].freeze
+
+  def validate(record)
+    attr = case record.class.to_s
+           when 'Attachment'
+             :attachment_type
+           when 'DocumentCategory'
+             :name
+           else
+             raise ArgumentError, 'Unexpected record sent to DocumentCategoryValidator'
+           end
+
+    return if record.__send__(attr).in?(VALID_DOCUMENT_TYPES)
+
+    record.errors.add attr,
+                      I18n.t('activemodel.errors.models.attachment.attributes.attachment_type.invalid', attachment_type: record.__send__(attr))
+  end
+end

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -206,6 +206,10 @@ en:
           attributes:
             code:
               blank: A proceeding must be selected
+        attachment:
+          attributes:
+            attachment_type:
+              invalid: "'%{attachment_type}' is invalid"
         dependant:
           attributes:
             name:

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe Attachment do
+  context 'validation' do
+    let(:laa) { create :legal_aid_application }
+    let(:invalid_attachment_type) { 'invalid_type' }
+    let(:valid_attachment_types) do
+      %w[
+        statement_of_case
+        statement_of_case_pdf
+        merits_report
+        means_report
+        bank_transaction_report
+        gateway_evidence
+        gateway_evidence_pdf
+      ]
+    end
+
+    subject { Attachment.create! legal_aid_application: laa, attachment_type: attachment_type }
+
+    context 'valid attachment types' do
+      let(:attachment_type) { valid_attachment_types.sample }
+      it 'does not fail when trying to create a record with an invalid attachment type' do
+        expect { subject }.not_to raise_error ArgumentError
+      end
+    end
+
+    context 'invalid attachment type' do
+      let(:attachment_type) { invalid_attachment_type }
+      it 'fails when trying to create a record with an invalid attachment type' do
+        expect { subject }.to raise_error ArgumentError, "'invalid_type' is not a valid attachment_type"
+      end
+    end
+  end
+end

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -1,35 +1,19 @@
 require 'rails_helper'
 
 RSpec.describe Attachment do
-  context 'validation' do
-    let(:laa) { create :legal_aid_application }
-    let(:invalid_attachment_type) { 'invalid_type' }
-    let(:valid_attachment_types) do
-      %w[
-        statement_of_case
-        statement_of_case_pdf
-        merits_report
-        means_report
-        bank_transaction_report
-        gateway_evidence
-        gateway_evidence_pdf
-      ]
-    end
+  let!(:soc1) { create :attachment }
+  let!(:soc2) { create :attachment }
+  let!(:merits1) { create :attachment, :merits_report }
+  let!(:merits2) { create :attachment, :merits_report }
+  let!(:means1) { create :attachment, :means_report }
+  let!(:bank) { create :attachment, :bank_transaction_report }
 
-    subject { Attachment.create! legal_aid_application: laa, attachment_type: attachment_type }
-
-    context 'valid attachment types' do
-      let(:attachment_type) { valid_attachment_types.sample }
-      it 'does not fail when trying to create a record with an invalid attachment type' do
-        expect { subject }.not_to raise_error ArgumentError
-      end
-    end
-
-    context 'invalid attachment type' do
-      let(:attachment_type) { invalid_attachment_type }
-      it 'fails when trying to create a record with an invalid attachment type' do
-        expect { subject }.to raise_error ArgumentError, "'invalid_type' is not a valid attachment_type"
-      end
+  context 'scopes' do
+    it 'returns the expected collections' do
+      expect(Attachment.statement_of_case).to match_array [soc1, soc2]
+      expect(Attachment.merits_report).to match_array [merits1, merits2]
+      expect(Attachment.means_report).to eq [means1]
+      expect(Attachment.bank_transaction_report).to eq [bank]
     end
   end
 end

--- a/spec/requests/providers/has_other_proceedings_controller_spec.rb
+++ b/spec/requests/providers/has_other_proceedings_controller_spec.rb
@@ -135,12 +135,7 @@ RSpec.describe Providers::HasOtherProceedingsController, type: :request do
         end
 
         subject { delete providers_legal_aid_application_has_other_proceedings_path(legal_aid_application), params: params }
-
-        it 'sets a new lead application_proceeding_type when the original one is deleted' do
-          subject
-          expect(legal_aid_application.application_proceeding_types.order(:created_at)[0].lead_proceeding).to eq true
-        end
-
+        
         it 'sets a new lead proceeding when the original one is deleted' do
           subject
           expect(legal_aid_application.proceedings[0].lead_proceeding).to eq true

--- a/spec/requests/providers/has_other_proceedings_controller_spec.rb
+++ b/spec/requests/providers/has_other_proceedings_controller_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe Providers::HasOtherProceedingsController, type: :request do
         end
 
         subject { delete providers_legal_aid_application_has_other_proceedings_path(legal_aid_application), params: params }
-        
+
         it 'sets a new lead proceeding when the original one is deleted' do
           subject
           expect(legal_aid_application.proceedings[0].lead_proceeding).to eq true

--- a/spec/validators/document_category_validator_spec.rb
+++ b/spec/validators/document_category_validator_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe DocumentCategoryValidator do
 
     context 'valid attachment types' do
       let(:attachment_type) { valid_attachment_types.sample }
-      it 'does not fail when trying to create a record with an invalid attachment type' do
+      it 'does not fail when trying to create a record with an valid attachment type' do
         record = subject
         expect(record).to be_instance_of(Attachment)
         expect(record).to be_valid
@@ -39,7 +39,7 @@ RSpec.describe DocumentCategoryValidator do
 
     context 'valid names ' do
       let(:name) { valid_names.sample }
-      it 'does not fail when trying to create a record with an invalid name' do
+      it 'does not fail when trying to create a record with an valid name' do
         record = subject
         expect(record).to be_instance_of(DocumentCategory)
         expect(record).to be_valid

--- a/spec/validators/document_category_validator_spec.rb
+++ b/spec/validators/document_category_validator_spec.rb
@@ -1,0 +1,65 @@
+require 'rails_helper'
+
+class DummyDocumentCategory
+  include ActiveModel::Model
+  include ActiveModel::Validations
+  validates_with DocumentCategoryValidator
+end
+
+RSpec.describe DocumentCategoryValidator do
+  context 'Attachment' do
+    let(:laa) { create :legal_aid_application }
+    let(:invalid_attachment_type) { 'xxx-zzz' }
+    let(:valid_attachment_types) { DocumentCategoryValidator::VALID_DOCUMENT_TYPES }
+
+    subject { Attachment.create! legal_aid_application: laa, attachment_type: attachment_type }
+
+    context 'valid attachment types' do
+      let(:attachment_type) { valid_attachment_types.sample }
+      it 'does not fail when trying to create a record with an invalid attachment type' do
+        record = subject
+        expect(record).to be_instance_of(Attachment)
+        expect(record).to be_valid
+      end
+    end
+
+    context 'invalid attachment type' do
+      let(:attachment_type) { invalid_attachment_type }
+      it 'fails when trying to create a record with an invalid attachment type' do
+        expect { subject }.to raise_error ActiveRecord::RecordInvalid, "Validation failed: Attachment type 'xxx-zzz' is invalid"
+      end
+    end
+  end
+
+  context 'DocumentCategory' do
+    let(:invalid_name) { 'xxx-zzz' }
+    let(:valid_names) { DocumentCategoryValidator::VALID_DOCUMENT_TYPES }
+
+    subject { DocumentCategory.create! name: name }
+
+    context 'valid names ' do
+      let(:name) { valid_names.sample }
+      it 'does not fail when trying to create a record with an invalid name' do
+        record = subject
+        expect(record).to be_instance_of(DocumentCategory)
+        expect(record).to be_valid
+      end
+    end
+
+    context 'invalid attachment type' do
+      let(:name) { invalid_name }
+      it 'fails when trying to create a record with an invalid attachment type' do
+        expect { subject }.to raise_error ActiveRecord::RecordInvalid, "Validation failed: Name 'xxx-zzz' is invalid"
+      end
+    end
+  end
+
+  context 'DummyClass' do
+    it 'raises' do
+      dummy = DummyDocumentCategory.new
+      expect {
+        dummy.valid?
+      }.to raise_error ArgumentError, 'Unexpected record sent to DocumentCategoryValidator'
+    end
+  end
+end


### PR DESCRIPTION

## Validate Attachment based on DocumentCategoryValidator 

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2736)

The `Attachment` model previously validated attachment types based on a hard-coded enum in the model itself.
This means that there is a risk of the canonical list of document types being in several places in the code.
This PR fixes that by placing the list in the `DocumentCategoryValidator` class.

- created `DocumentCategoryValidator` class to validate `Attachment#attachment_type` and `DocumentCategory#name`
- Added scopes to the `Attachment` based on valid document types from `DocumentCategoryValidator`


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
