### PR TITLE
Fix: Flickering provider test

### DIFF
--- a/spec/requests/providers/has_other_proceedings_controller_spec.rb
+++ b/spec/requests/providers/has_other_proceedings_controller_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe Providers::HasOtherProceedingsController, type: :request do
 
         it 'sets a new lead application_proceeding_type when the original one is deleted' do
           subject
-          expect(legal_aid_application.application_proceeding_types[0].lead_proceeding).to eq true
+          expect(legal_aid_application.application_proceeding_types.order(:created_at)[0].lead_proceeding).to eq true
         end
 
         it 'sets a new lead proceeding when the original one is deleted' do


### PR DESCRIPTION
## What

This will probably be removed soon, but this should help prevent
the dependabot PRs flickering in the meantime.

The sequence of the ApplicationProceedingTypes was not always
returning the eldest as the first in the array

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
