### PR TITLE
AP-2647 Remove duplicate Emergency Cost Limit section

### DIFF
--- a/app/views/shared/check_answers/_merits.html.erb
+++ b/app/views/shared/check_answers/_merits.html.erb
@@ -156,7 +156,6 @@
           read_only: read_only
         ) %>
     </dl>
-
   </section>
 <% end %>
 
@@ -205,44 +204,6 @@
               read_only: read_only
             ) %>
       </dl>
-    </section>
-
-      <% if read_only %>
-        <h2 class="govuk-heading-m">
-          <%= t '.cost-override-heading' %>
-        </h2>
-
-        <dl class="govuk-summary-list govuk-!-margin-bottom-2">
-          <%= check_answer_link(
-                name: :emergency_cost_override,
-                url: providers_legal_aid_application_limitations_path(@legal_aid_application),
-                question: t('.items.override_requested'),
-                answer: yes_no(@legal_aid_application.emergency_cost_override),
-                read_only: true
-              ) %>
-        </dl>
-
-        <% if @legal_aid_application.emergency_cost_override %>
-          <dl class="govuk-summary-list govuk-!-margin-bottom-2">
-            <%= check_answer_link(
-                  name: :emergency_cost_requested,
-                  url: providers_legal_aid_application_limitations_path(@legal_aid_application),
-                  question: t('.items.cost_override_question'),
-                  answer: gds_number_to_currency(@legal_aid_application.emergency_cost_requested,  precision: 0),
-                  read_only: true
-                ) %>
-          </dl>
-
-          <dl class="govuk-summary-list govuk-!-margin-bottom-2">
-            <%= check_answer_link(
-                  name: :emergency_cost_requested,
-                  url: providers_legal_aid_application_limitations_path(@legal_aid_application),
-                  question: t('.items.enter_cost_reasons'),
-                  answer: @legal_aid_application.emergency_cost_reasons,
-                  read_only: true
-                ) %>
-          </dl>
-      <% end %>
     <% end %>
-  <% end %>
+  </section>
 <% end %>

--- a/config/locales/en/shared.yml
+++ b/config/locales/en/shared.yml
@@ -208,7 +208,6 @@ en:
       merits: &merits
         complete-application-heading: Complete the application
         complete-application-text: By submitting this application you are confirming that, to the best of your knowledge, the details you are providing are correct.
-        cost-override-heading: Emergency cost override
         case-details-heading: Case details
         involved-children-heading: Children involved in this application
         opponent-heading: Opponent details
@@ -216,9 +215,6 @@ en:
         statement-of-case-heading: Statement of case
         gateway-evidence-heading: Supporting evidence
         items:
-          override_requested: Do you want to request a higher cost limit?
-          cost_override_question: What is the new requested emergency cost limit?
-          enter_cost_reasons: Tell us why you need a higher cost limit.
           prospects_of_success: Is the chance of a successful outcome 50% or better?
           success_prospect: What is the chance of a successful outcome?
           statement_of_case: Statement of case


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2647)

Emergency Cost Limit details are displayed twice on the certificate page. This removes the incorrect second occurrence from the merits CYA partial.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
