### PR TITLE
ap-2812 update specs to use with_proceedings trait

### DIFF
--- a/spec/factories/legal_aid_applications.rb
+++ b/spec/factories/legal_aid_applications.rb
@@ -402,17 +402,6 @@ FactoryBot.define do
       end
     end
 
-    # this is a trait of an invalid state and should only be used to test invalid state transitions
-    trait :with_only_section8_proceeding_type do
-      after(:create) do |application|
-        application.proceeding_types << create(:proceeding_type, :as_section_8_child_residence)
-        application.application_proceeding_types.each do |app_proc_type|
-          create(:chances_of_success, :with_optional_text, application_proceeding_type: app_proc_type)
-          create(:attempts_to_settles, application_proceeding_type: app_proc_type)
-        end
-      end
-    end
-
     # this trait will mark the first domestic abuse proceeding type for the application as the lead proceeding, unless one already exists
     # the application proceeding types must have been set up before calling this trait.  Only needed for deprecated traits, not for :with_proceeding_types
     #
@@ -712,7 +701,7 @@ FactoryBot.define do
     end
 
     trait :at_checking_applicant_details do
-      with_proceeding_types
+      with_proceedings
 
       before(:create) do |application|
         application.state_machine_proxy.update!(aasm_state: :checking_applicant_details)
@@ -722,7 +711,7 @@ FactoryBot.define do
     end
 
     trait :at_checking_passported_answers do
-      with_proceeding_types
+      with_proceedings
 
       before(:create) do |application|
         application.state_machine_proxy.update!(aasm_state: :checking_passported_answers)
@@ -732,7 +721,7 @@ FactoryBot.define do
     end
 
     trait :at_applicant_details_checked do
-      with_proceeding_types
+      with_proceedings
 
       before(:create) do |application|
         application.state_machine_proxy.update!(aasm_state: :applicant_details_checked)
@@ -742,7 +731,7 @@ FactoryBot.define do
     end
 
     trait :at_client_completed_means do
-      with_proceeding_types
+      with_proceedings
 
       before(:create) do |application|
         application.state_machine_proxy.update!(aasm_state: :checking_citizen_answers)
@@ -752,7 +741,7 @@ FactoryBot.define do
     end
 
     trait :at_check_provider_answers do
-      with_proceeding_types
+      with_proceedings
 
       before(:create) do |application|
         application.state_machine_proxy.update!(aasm_state: :provider_assessing_means)
@@ -762,7 +751,7 @@ FactoryBot.define do
     end
 
     trait :at_checking_merits_answers do
-      with_proceeding_types
+      with_proceedings
       with_merits_statement_of_case
 
       before(:create) do |application|
@@ -916,28 +905,6 @@ FactoryBot.define do
 
     trait :discarded do
       discarded_at { 5.minutes.ago }
-    end
-
-    #######################################################################################################
-    #                                                                                                     #
-    #     DEPRECATED - use :with_proceeding_types instead                                                 #
-    #                                                                                                     #
-    #######################################################################################################
-    #
-    trait :with_multiple_proceeding_types do
-      after(:create) do |application, evaluator|
-        if evaluator.proceeding_types.presence
-          application.proceeding_types = evaluator.proceeding_types
-        else
-          application.proceeding_types << create(:proceeding_type, :with_real_data)
-          application.proceeding_types << create(:proceeding_type, :as_occupation_order)
-        end
-        pt = application.find_or_create_lead_proceeding_type
-        sl = create :scope_limitation, :substantive_default, joined_proceeding_type: pt
-        apt = application.application_proceeding_types.find_by(proceeding_type_id: pt.id)
-        AssignedSubstantiveScopeLimitation.create!(application_proceeding_type_id: apt.id,
-                                                   scope_limitation_id: sl.id)
-      end
     end
 
     #######################################################################################################

--- a/spec/factories/proceedings.rb
+++ b/spec/factories/proceedings.rb
@@ -32,8 +32,11 @@ FactoryBot.define do
     trait :da002 do
       lead_proceeding { false }
       ccms_code { 'DA002' }
-      meaning { 'Non-molestation order' }
-      description { 'to be represented on an application for a non-molestation order.' }
+      meaning { 'Variation or discharge under section 5 protection from harassment act 1997r' }
+      description do
+        'to be represented on an application to vary or discharge an order under section 5 Protection from Harassment Act 1997
+         where the parties are associated persons (as defined by Part IV Family Law Act 1996).'
+      end
       substantive_cost_limitation { 25_000 }
       delegated_functions_cost_limitation { rand(1...1_000_000.0).round(2) }
       substantive_scope_limitation_code { 'AA019' }
@@ -48,7 +51,7 @@ FactoryBot.define do
       end
       used_delegated_functions_on { Faker::Date.between(from: 10.days.ago, to: 2.days.ago) }
       used_delegated_functions_reported_on { Time.zone.today }
-      name { 'nonmolestation_order' }
+      name { 'variation_or_discharge_under_section_protection_from_harassment_act' }
       matter_type { 'Domestic Abuse' }
       category_of_law { 'Family' }
       category_law_code { 'MAT' }
@@ -58,8 +61,8 @@ FactoryBot.define do
     trait :da006 do
       lead_proceeding { false }
       ccms_code { 'DA006' }
-      meaning { 'Non-molestation order' }
-      description { 'to be represented on an application for a non-molestation order.' }
+      meaning { 'Extend, variation or discharge - Part IV ' }
+      description { 'to be represented on an application to extend, vary or discharge an order under Part IV Family Law Act 1996. ' }
       substantive_cost_limitation { 25_000 }
       delegated_functions_cost_limitation { rand(1...1_000_000.0).round(2) }
       substantive_scope_limitation_code { 'AA019' }
@@ -74,7 +77,7 @@ FactoryBot.define do
       end
       used_delegated_functions_on { Faker::Date.between(from: 10.days.ago, to: 2.days.ago) }
       used_delegated_functions_reported_on { Time.zone.today }
-      name { 'nonmolestation_order' }
+      name { 'extend_variation_or_discharge_part_iv' }
       matter_type { 'Domestic Abuse' }
       category_of_law { 'Family' }
       category_law_code { 'MAT' }

--- a/spec/factories/proceedings.rb
+++ b/spec/factories/proceedings.rb
@@ -29,6 +29,58 @@ FactoryBot.define do
       ccms_matter_code { 'MINJN' }
     end
 
+    trait :da002 do
+      lead_proceeding { false }
+      ccms_code { 'DA002' }
+      meaning { 'Non-molestation order' }
+      description { 'to be represented on an application for a non-molestation order.' }
+      substantive_cost_limitation { 25_000 }
+      delegated_functions_cost_limitation { rand(1...1_000_000.0).round(2) }
+      substantive_scope_limitation_code { 'AA019' }
+      substantive_scope_limitation_meaning { 'Injunction FLA-to final hearing' }
+      substantive_scope_limitation_description { 'Limited to all steps up to and including final hearing and any action necessary to implement (but not enforce) the order.' }
+      delegated_functions_scope_limitation_code { 'CV117' }
+      delegated_functions_scope_limitation_meaning { 'Interim order inc. return date' }
+      delegated_functions_scope_limitation_description do
+        'As to proceedings under Part IV Family Law Act 1996 limited to all steps up to and including obtaining and serving a
+         final order and in the event of breach leading to the exercise of a power of arrest to representation on the consideration
+         of the breach by the court (but excluding applying for a warrant of arrest, if not attached, and representation in contempt proceedings).'
+      end
+      used_delegated_functions_on { Faker::Date.between(from: 10.days.ago, to: 2.days.ago) }
+      used_delegated_functions_reported_on { Time.zone.today }
+      name { 'nonmolestation_order' }
+      matter_type { 'Domestic Abuse' }
+      category_of_law { 'Family' }
+      category_law_code { 'MAT' }
+      ccms_matter_code { 'MINJN' }
+    end
+
+    trait :da006 do
+      lead_proceeding { false }
+      ccms_code { 'DA006' }
+      meaning { 'Non-molestation order' }
+      description { 'to be represented on an application for a non-molestation order.' }
+      substantive_cost_limitation { 25_000 }
+      delegated_functions_cost_limitation { rand(1...1_000_000.0).round(2) }
+      substantive_scope_limitation_code { 'AA019' }
+      substantive_scope_limitation_meaning { 'Injunction FLA-to final hearing' }
+      substantive_scope_limitation_description { 'Limited to all steps up to and including final hearing and any action necessary to implement (but not enforce) the order.' }
+      delegated_functions_scope_limitation_code { 'CV117' }
+      delegated_functions_scope_limitation_meaning { 'Interim order inc. return date' }
+      delegated_functions_scope_limitation_description do
+        'As to proceedings under Part IV Family Law Act 1996 limited to all steps up to and including obtaining and serving a
+         final order and in the event of breach leading to the exercise of a power of arrest to representation on the consideration
+         of the breach by the court (but excluding applying for a warrant of arrest, if not attached, and representation in contempt proceedings).'
+      end
+      used_delegated_functions_on { Faker::Date.between(from: 10.days.ago, to: 2.days.ago) }
+      used_delegated_functions_reported_on { Time.zone.today }
+      name { 'nonmolestation_order' }
+      matter_type { 'Domestic Abuse' }
+      category_of_law { 'Family' }
+      category_law_code { 'MAT' }
+      ccms_matter_code { 'MINJN' }
+    end
+
     trait :da004 do
       lead_proceeding { false }
       ccms_code { 'DA004' }

--- a/spec/factory_specs/legal_aid_application_factory_spec.rb
+++ b/spec/factory_specs/legal_aid_application_factory_spec.rb
@@ -158,43 +158,6 @@ RSpec.describe 'LegalAidApplication factory' do
     end
   end
 
-  describe ':with_multiple_proceeding_types' do
-    context 'not specifying the proceeding types' do
-      let(:laa) { create :legal_aid_application, :with_multiple_proceeding_types }
-      subject { laa }
-
-      it 'seeds Proceeding Types with two real items' do
-        subject
-        expect(ProceedingType.order(:code).pluck(:code)).to eq %w[PR0208 PR0214]
-      end
-
-      it 'attached both real items to the application' do
-        expect(laa.proceeding_types.order(:code).map(&:code)).to eq %w[PR0208 PR0214]
-      end
-
-      it 'populates scope limitations table with one dummy scope limitation' do
-        expect(ScopeLimitation.count).to eq 0
-        subject
-        expect(ScopeLimitation.count).to eq 1
-      end
-
-      it 'attaches the scope limitation to the lead proceeding type as the default substantive' do
-        subject
-        expect(ProceedingTypeScopeLimitation.count).to eq 1
-        expect(laa.lead_proceeding_type.default_substantive_scope_limitation).to eq ScopeLimitation.first
-      end
-
-      it 'assigns the scope limitation to the application_proceeding_type' do
-        expect { subject }.to change { ApplicationProceedingTypesScopeLimitation.count }.by(1)
-        lead_pt = laa.lead_proceeding_type
-        apt = laa.reload.application_proceeding_types.find_by(proceeding_type_id: lead_pt.id)
-        aptsl = ApplicationProceedingTypesScopeLimitation.find_by(application_proceeding_type_id: apt.id)
-        expect(aptsl).to be_instance_of(AssignedSubstantiveScopeLimitation)
-        expect(aptsl.scope_limitation_id).to eq ScopeLimitation.first.id
-      end
-    end
-  end
-
   describe ':with_substantive_scope_limitation' do
     context 'without specifying proceeding type' do
       let(:laa) { create :legal_aid_application, :with_substantive_scope_limitation }

--- a/spec/forms/legal_aid_applications/used_multiple_delegated_functions_form_spec.rb
+++ b/spec/forms/legal_aid_applications/used_multiple_delegated_functions_form_spec.rb
@@ -6,11 +6,9 @@ RSpec.describe LegalAidApplications::UsedMultipleDelegatedFunctionsForm, type: :
            :with_proceedings,
            :with_delegated_functions_on_proceedings,
            explicit_proceedings: %i[da004 da001 se014],
-           set_lead_proceeding: :da004,
-           df_options: { DA004: [used_delegated_functions_on, used_delegated_functions_reported_on] },
-           proceeding_count: proceeding_type_count
+           set_lead_proceeding: :da001,
+           df_options: { DA001: [used_delegated_functions_on, used_delegated_functions_reported_on] }
   end
-  let(:proceeding_type_count) { 3 }
   let(:pt_without_df) { 1 }
   let(:proceedings) { legal_aid_application.proceedings }
   let(:proceedings_by_name) { legal_aid_application.proceedings_by_name }

--- a/spec/forms/legal_aid_applications/used_multiple_delegated_functions_form_spec.rb
+++ b/spec/forms/legal_aid_applications/used_multiple_delegated_functions_form_spec.rb
@@ -3,8 +3,12 @@ require 'rails_helper'
 RSpec.describe LegalAidApplications::UsedMultipleDelegatedFunctionsForm, type: :form, vcr: { cassette_name: 'gov_uk_bank_holiday_api' } do
   let(:legal_aid_application) do
     create :legal_aid_application,
-           :with_proceeding_types,
-           proceeding_types_count: proceeding_type_count
+           :with_proceedings,
+           :with_delegated_functions_on_proceedings,
+           explicit_proceedings: %i[da004 da001 se014],
+           set_lead_proceeding: :da004,
+           df_options: { DA004: [used_delegated_functions_on, used_delegated_functions_reported_on] },
+           proceeding_count: proceeding_type_count
   end
   let(:proceeding_type_count) { 3 }
   let(:pt_without_df) { 1 }
@@ -94,7 +98,7 @@ RSpec.describe LegalAidApplications::UsedMultipleDelegatedFunctionsForm, type: :
         proceedings_by_name.each_with_index do |type, i|
           next if i == pt_without_df
 
-          message = I18n.t(error_locale, scope: i18n_scope, meaning: ProceedingType.find_by(name: type.name).meaning)
+          message = I18n.t(error_locale, scope: i18n_scope, meaning: Proceeding.find_by(name: type.name).meaning)
           expect(message).not_to match(/^translation missing:/)
           expect(subject.errors[:"#{type.name}_used_delegated_functions_on"].join).to match(message)
         end
@@ -114,7 +118,7 @@ RSpec.describe LegalAidApplications::UsedMultipleDelegatedFunctionsForm, type: :
         proceedings_by_name.each_with_index do |type, i|
           next if i == pt_without_df
 
-          message = I18n.t(error_locale, scope: i18n_scope, months: months, meaning: ProceedingType.find_by(name: type.name).meaning)
+          message = I18n.t(error_locale, scope: i18n_scope, months: months, meaning: Proceeding.find_by(name: type.name).meaning)
           expect(message).not_to match(/^translation missing:/)
           expect(subject.errors[:"#{type.name}_used_delegated_functions_on"].join).to match(message)
         end
@@ -151,7 +155,7 @@ RSpec.describe LegalAidApplications::UsedMultipleDelegatedFunctionsForm, type: :
 
       it 'generates the expected error message' do
         proceedings_by_name.each do |type|
-          message = I18n.t(error_locale, scope: i18n_scope, meaning: ProceedingType.find_by(name: type.name).meaning)
+          message = I18n.t(error_locale, scope: i18n_scope, meaning: Proceeding.find_by(name: type.name).meaning)
           expect(message).not_to match(/^translation missing:/)
           expect(subject.errors[:"#{type.name}_used_delegated_functions_on"].join).to match(message)
         end
@@ -170,7 +174,7 @@ RSpec.describe LegalAidApplications::UsedMultipleDelegatedFunctionsForm, type: :
         proceedings_by_name.each_with_index do |type, i|
           next if i == pt_without_df
 
-          message = I18n.t(error_locale, scope: i18n_scope, meaning: ProceedingType.find_by(name: type.name).meaning)
+          message = I18n.t(error_locale, scope: i18n_scope, meaning: Proceeding.find_by(name: type.name).meaning)
           expect(message).not_to match(/^translation missing:/)
           expect(subject.errors[:"#{type.name}_used_delegated_functions_on"].join).to match(message)
         end
@@ -218,7 +222,7 @@ RSpec.describe LegalAidApplications::UsedMultipleDelegatedFunctionsForm, type: :
         proceedings_by_name.each_with_index do |type, i|
           next if i == pt_without_df
 
-          message = I18n.t(error_locale, scope: i18n_scope, meaning: ProceedingType.find_by(name: type.name).meaning)
+          message = I18n.t(error_locale, scope: i18n_scope, meaning: Proceeding.find_by(name: type.name).meaning)
           expect(message).not_to match(/^translation missing:/)
           expect(subject.errors[:"#{type.name}_used_delegated_functions_on"].join).to match(message)
         end

--- a/spec/helpers/providers_helper_spec.rb
+++ b/spec/helpers/providers_helper_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe ProvidersHelper, type: :helper do
-  let(:legal_aid_application) { create :legal_aid_application, :with_multiple_proceeding_types_inc_section8 }
+  let(:legal_aid_application) { create :legal_aid_application, :with_multiple_proceedings_inc_section8 }
   let(:provider_routes) do
     Rails.application.routes.routes.select do |route|
       route.defaults[:controller].to_s.split('/')[0] == 'providers' &&

--- a/spec/helpers/task_list_helper_spec.rb
+++ b/spec/helpers/task_list_helper_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe TaskListHelper, type: :helper do
   context 'when passed an application with section 8 proceeding_types' do
-    let(:legal_aid_application) { create :legal_aid_application, :with_multiple_proceeding_types_inc_section8 }
+    let(:legal_aid_application) { create :legal_aid_application, :with_multiple_proceedings_inc_section8 }
     context 'with a child already added' do
       before { create :involved_child, legal_aid_application: legal_aid_application }
 

--- a/spec/mailers/submit_provider_financial_reminder_mailer_spec.rb
+++ b/spec/mailers/submit_provider_financial_reminder_mailer_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe SubmitProviderFinancialReminderMailer, type: :mailer do
   describe '.eligible_for_delivery?' do
     let(:scheduled_mailing) { create :scheduled_mailing, legal_aid_application: application }
     context 'it is eligible' do
-      let(:application) { create :legal_aid_application, :with_non_passported_state_machine, :at_client_completed_means }
+      let(:application) { create :legal_aid_application, :with_proceedings, :with_non_passported_state_machine, :at_client_completed_means }
       it 'returns true' do
         expect(described_class.eligible_for_delivery?(scheduled_mailing)).to be true
       end

--- a/spec/models/aggregated_cash_income_spec.rb
+++ b/spec/models/aggregated_cash_income_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe AggregatedCashIncome, type: :model do
   let(:aci) { AggregatedCashIncome.new(legal_aid_application_id: application.id) }
-  let(:application) { create :legal_aid_application, :with_proceeding_types, proceeding_types_count: 2 }
+  let(:application) { create :legal_aid_application, :with_proceedings }
   let(:categories) { %i[benefits maintenance_in] }
   let!(:benefits) { create :transaction_type, :benefits }
   let!(:maintenance_in) { create :transaction_type, :maintenance_in }

--- a/spec/models/legal_aid_application_spec.rb
+++ b/spec/models/legal_aid_application_spec.rb
@@ -488,7 +488,7 @@ RSpec.describe LegalAidApplication, type: :model do
   end
 
   describe 'application_proceedings_by_name' do
-    let!(:legal_aid_application) { create :legal_aid_application, :with_everything, :with_proceedings }
+    let!(:legal_aid_application) { create :legal_aid_application, :with_everything, :with_proceeding_types }
 
     it 'returns all application proceeding types with proceeding type names' do
       result = legal_aid_application.application_proceedings_by_name

--- a/spec/models/legal_framework/merits_task_list_spec.rb
+++ b/spec/models/legal_framework/merits_task_list_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 module LegalFramework
   RSpec.describe MeritsTaskList, type: :model do
     before { populate_legal_framework }
-    let(:application) { create :legal_aid_application, :with_multiple_proceeding_types_inc_section8 }
+    let(:application) { create :legal_aid_application, :with_proceedings, :with_multiple_proceedings_inc_section8 }
     let(:merits_task_list) { described_class.create!(legal_aid_application_id: application.id, serialized_data: dummy_serialized_merits_task_list.to_yaml) }
 
     describe '.create!' do

--- a/spec/requests/providers/about_the_financial_assessments_spec.rb
+++ b/spec/requests/providers/about_the_financial_assessments_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe 'about financial assessments requests', type: :request do
   let(:application) do
     create(:legal_aid_application,
-           :with_proceeding_types,
+           :with_proceedings,
            :with_applicant_and_address,
            :with_non_passported_state_machine,
            :provider_confirming_applicant_eligibility)
@@ -44,7 +44,7 @@ RSpec.describe 'about financial assessments requests', type: :request do
         let(:application) do
           create(
             :legal_aid_application,
-            :with_proceeding_types,
+            :with_proceedings,
             :with_applicant_and_address,
             :with_non_passported_state_machine,
             :provider_assessing_means

--- a/spec/requests/providers/application_merits_task/date_client_told_incidents_spec.rb
+++ b/spec/requests/providers/application_merits_task/date_client_told_incidents_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 module Providers
   module ApplicationMeritsTask
     RSpec.describe DateClientToldIncidentsController, type: :request do
-      let(:legal_aid_application) { create :legal_aid_application, :with_multiple_proceeding_types_inc_section8 }
+      let(:legal_aid_application) { create :legal_aid_application, :with_multiple_proceedings_inc_section8 }
       let(:login_provider) { login_as legal_aid_application.provider }
       let(:smtl) { create :legal_framework_merits_task_list, legal_aid_application: legal_aid_application }
       let(:application_proceeding_type) do

--- a/spec/requests/providers/application_merits_task/has_other_involved_children_spec.rb
+++ b/spec/requests/providers/application_merits_task/has_other_involved_children_spec.rb
@@ -3,13 +3,12 @@ require 'rails_helper'
 module Providers
   module ApplicationMeritsTask
     RSpec.describe HasOtherInvolvedChildrenController, type: :request do
-      let(:pt_da) { create :proceeding_type, :with_real_data }
-      let(:pt_s8) { create :proceeding_type, :as_section_8_child_residence }
-      let(:application) { create :legal_aid_application, :with_proceeding_types, explicit_proceeding_types: [pt_da, pt_s8] }
+      let(:application) do
+        create :legal_aid_application, :with_proceedings, explicit_proceedings: %i[da001 se014]
+      end
       let(:provider) { application.provider }
       let(:child1) { create :involved_child, legal_aid_application: application }
       let(:smtl) { create :legal_framework_merits_task_list, legal_aid_application: application }
-      let(:application_proceeding_type) { legal_aid_application.application_proceeding_types.detect { |apt| apt.proceeding_type_id == pt_s8.id } }
       before do
         allow(LegalFramework::MeritsTasksService).to receive(:call).with(application).and_return(smtl)
         login_as provider

--- a/spec/requests/providers/application_merits_task/has_other_involved_children_spec.rb
+++ b/spec/requests/providers/application_merits_task/has_other_involved_children_spec.rb
@@ -3,9 +3,7 @@ require 'rails_helper'
 module Providers
   module ApplicationMeritsTask
     RSpec.describe HasOtherInvolvedChildrenController, type: :request do
-      let(:application) do
-        create :legal_aid_application, :with_proceedings, explicit_proceedings: %i[da001 se014]
-      end
+      let(:application) { create :legal_aid_application, :with_multiple_proceedings_inc_section8 }
       let(:provider) { application.provider }
       let(:child1) { create :involved_child, legal_aid_application: application }
       let(:smtl) { create :legal_framework_merits_task_list, legal_aid_application: application }

--- a/spec/requests/providers/application_merits_task/opponents_spec.rb
+++ b/spec/requests/providers/application_merits_task/opponents_spec.rb
@@ -3,9 +3,7 @@ require 'rails_helper'
 module Providers
   module ApplicationMeritsTask
     RSpec.describe OpponentsController, type: :request do
-      let(:legal_aid_application) do
-        create :legal_aid_application, :with_proceedings, explicit_proceedings: %i[da001 se014]
-      end
+      let(:legal_aid_application) { create :legal_aid_application, :with_multiple_proceedings_inc_section8 }
       let(:login_provider) { login_as legal_aid_application.provider }
       let(:smtl) { create :legal_framework_merits_task_list, legal_aid_application: legal_aid_application }
       let(:proceeding) { laa.proceedings.detect { |p| p.ccms_code == 'SE014' } }

--- a/spec/requests/providers/application_merits_task/opponents_spec.rb
+++ b/spec/requests/providers/application_merits_task/opponents_spec.rb
@@ -3,12 +3,12 @@ require 'rails_helper'
 module Providers
   module ApplicationMeritsTask
     RSpec.describe OpponentsController, type: :request do
-      let(:pt_da) { create :proceeding_type, :with_real_data }
-      let(:pt_s8) { create :proceeding_type, :as_section_8_child_residence }
-      let(:legal_aid_application) { create :legal_aid_application, :with_proceeding_types, explicit_proceeding_types: [pt_da, pt_s8] }
+      let(:legal_aid_application) do
+        create :legal_aid_application, :with_proceedings, explicit_proceedings: %i[da001 se014]
+      end
       let(:login_provider) { login_as legal_aid_application.provider }
       let(:smtl) { create :legal_framework_merits_task_list, legal_aid_application: legal_aid_application }
-      let(:application_proceeding_type) { legal_aid_application.application_proceeding_types.detect { |apt| apt.proceeding_type_id == pt_s8.id } }
+      let(:proceeding) { laa.proceedings.detect { |p| p.ccms_code == 'SE014' } }
 
       describe 'GET /providers/applications/:legal_aid_application_id/opponent' do
         subject { get providers_legal_aid_application_opponent_path(legal_aid_application) }
@@ -30,7 +30,7 @@ module Providers
 
         context 'with an existing opponent' do
           let(:opponent) { create :opponent }
-          let(:legal_aid_application) { create :legal_aid_application, :with_proceeding_types, explicit_proceeding_types: [pt_da, pt_s8], opponent: opponent }
+          let(:legal_aid_application) { create :legal_aid_application, :with_proceedings, explicit_proceedings: %i[da001 se014], opponent: opponent }
 
           it 'renders successfully' do
             expect(response).to have_http_status(:ok)

--- a/spec/requests/providers/application_merits_task/statement_of_case_spec.rb
+++ b/spec/requests/providers/application_merits_task/statement_of_case_spec.rb
@@ -84,7 +84,7 @@ module Providers
 
         describe 'redirect on success' do
           context 'when the application has a section 8 proceeding type' do
-            let(:legal_aid_application) { create :legal_aid_application, :with_proceedings, explicit_proceedings: %i[da001 se014], set_lead_proceeding: :da001 }
+            let(:legal_aid_application) { create :legal_aid_application, :with_proceedings, :with_multiple_proceedings_inc_section8 }
 
             context 'and involved children exist' do
               before { create :involved_child, legal_aid_application: legal_aid_application }

--- a/spec/requests/providers/application_merits_task/statement_of_case_spec.rb
+++ b/spec/requests/providers/application_merits_task/statement_of_case_spec.rb
@@ -4,7 +4,7 @@ require 'sidekiq/testing'
 module Providers
   module ApplicationMeritsTask
     RSpec.describe StatementOfCasesController, type: :request do
-      let(:legal_aid_application) { create :legal_aid_application, :with_multiple_proceeding_types_inc_section8 }
+      let(:legal_aid_application) { create :legal_aid_application, :with_multiple_proceedings_inc_section8 }
       let(:provider) { legal_aid_application.provider }
       let(:soc) { nil }
       let(:i18n_error_path) { 'activemodel.errors.models.application_merits_task/statement_of_case.attributes.original_file' }
@@ -84,7 +84,7 @@ module Providers
 
         describe 'redirect on success' do
           context 'when the application has a section 8 proceeding type' do
-            let(:legal_aid_application) { create :legal_aid_application, :with_multiple_proceeding_types_inc_section8 }
+            let(:legal_aid_application) { create :legal_aid_application, :with_proceedings, explicit_proceedings: %i[da001 se014], set_lead_proceeding: :da001 }
 
             context 'and involved children exist' do
               before { create :involved_child, legal_aid_application: legal_aid_application }

--- a/spec/requests/providers/check_benefits_spec.rb
+++ b/spec/requests/providers/check_benefits_spec.rb
@@ -160,7 +160,6 @@ RSpec.describe Providers::CheckBenefitsController, type: :request do
                  :with_proceedings,
                  :with_delegated_functions_on_proceedings,
                  explicit_proceedings: [:da004],
-                 set_lead_proceeding: :da004,
                  df_options: { DA004: [Time.zone.today, Time.zone.today] }
         end
 

--- a/spec/requests/providers/check_benefits_spec.rb
+++ b/spec/requests/providers/check_benefits_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe Providers::CheckBenefitsController, type: :request do
     end
 
     context 'when the check benefit result is positive' do
-      let(:application) { create :legal_aid_application, :with_applicant, :with_positive_benefit_check_result, :at_checking_applicant_details }
+      let(:application) { create :legal_aid_application, :with_applicant, :with_proceedings, :with_positive_benefit_check_result, :at_checking_applicant_details }
 
       it 'displays the passported result page' do
         subject
@@ -103,7 +103,7 @@ RSpec.describe Providers::CheckBenefitsController, type: :request do
     end
 
     context 'when the check benefit result is negative' do
-      let(:application) { create :legal_aid_application, :with_applicant, :with_negative_benefit_check_result, :at_checking_applicant_details }
+      let(:application) { create :legal_aid_application, :with_applicant, :with_proceedings, :with_negative_benefit_check_result, :at_checking_applicant_details }
 
       it 'displays the confirm dwp non passported_applications page' do
         subject
@@ -157,8 +157,11 @@ RSpec.describe Providers::CheckBenefitsController, type: :request do
         let!(:application) do
           create :legal_aid_application,
                  :with_positive_benefit_check_result,
-                 :with_proceeding_types,
-                 :with_delegated_functions
+                 :with_proceedings,
+                 :with_delegated_functions_on_proceedings,
+                 explicit_proceedings: [:da004],
+                 set_lead_proceeding: :da004,
+                 df_options: { DA004: [Time.zone.today, Time.zone.today] }
         end
 
         it 'displays the substantive application page' do

--- a/spec/requests/providers/check_client_details_spec.rb
+++ b/spec/requests/providers/check_client_details_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Providers::CheckClientDetailsController, type: :request do
-  let(:application) { create(:legal_aid_application, :with_proceeding_types, :with_applicant_and_address) }
+  let(:application) { create(:legal_aid_application, :with_proceedings, :with_applicant_and_address) }
   let(:application_id) { application.id }
 
   describe 'GET /providers/applications/:legal_aid_application_id/check_client_details' do

--- a/spec/requests/providers/check_merits_answers_spec.rb
+++ b/spec/requests/providers/check_merits_answers_spec.rb
@@ -12,6 +12,11 @@ RSpec.describe 'check merits answers requests', type: :request do
              :with_involved_children,
              :provider_entering_merits
     end
+    let(:da001) { application.proceedings.find_by(ccms_code: 'DA001') }
+
+    let!(:chances_of_success) do
+      create :chances_of_success, :with_optional_text, proceeding: da001
+    end
 
     subject { get "/providers/applications/#{application.id}/check_merits_answers" }
 
@@ -119,7 +124,7 @@ RSpec.describe 'check merits answers requests', type: :request do
     let(:application) do
       create :legal_aid_application,
              :with_everything,
-             :with_multiple_proceeding_types_inc_section8,
+             :with_proceedings,
              :checking_merits_answers
     end
     let(:params) { {} }
@@ -204,9 +209,15 @@ RSpec.describe 'check merits answers requests', type: :request do
     let(:application) do
       create :legal_aid_application,
              :with_everything,
-             :with_proceeding_types,
-             :with_chances_of_success,
-             :checking_merits_answers
+             :with_proceedings,
+             :checking_merits_answers,
+             explicit_proceedings: %i[da004],
+             set_lead_proceeding: :da004
+    end
+    let(:da004) { application.proceedings.find_by(ccms_code: 'DA004') }
+
+    let!(:chances_of_success) do
+      create :chances_of_success, :with_optional_text, proceeding: da004
     end
 
     subject { patch "/providers/applications/#{application.id}/check_merits_answers/reset" }

--- a/spec/requests/providers/check_merits_answers_spec.rb
+++ b/spec/requests/providers/check_merits_answers_spec.rb
@@ -12,11 +12,6 @@ RSpec.describe 'check merits answers requests', type: :request do
              :with_involved_children,
              :provider_entering_merits
     end
-    let(:da001) { application.proceedings.find_by(ccms_code: 'DA001') }
-
-    let!(:chances_of_success) do
-      create :chances_of_success, :with_optional_text, proceeding: da001
-    end
 
     subject { get "/providers/applications/#{application.id}/check_merits_answers" }
 
@@ -211,8 +206,7 @@ RSpec.describe 'check merits answers requests', type: :request do
              :with_everything,
              :with_proceedings,
              :checking_merits_answers,
-             explicit_proceedings: %i[da004],
-             set_lead_proceeding: :da004
+             explicit_proceedings: %i[da004]
     end
     let(:da004) { application.proceedings.find_by(ccms_code: 'DA004') }
 

--- a/spec/requests/providers/check_passported_answers_spec.rb
+++ b/spec/requests/providers/check_passported_answers_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'check passported answers requests', type: :request do
     let!(:application) do
       create :legal_aid_application,
              :with_everything,
-             :with_proceeding_types,
+             :with_proceedings,
              :with_passported_state_machine,
              :provider_entering_means,
              vehicle: vehicle,
@@ -71,7 +71,7 @@ RSpec.describe 'check passported answers requests', type: :request do
         let(:application) do
           create :legal_aid_application,
                  :with_everything,
-                 :with_proceeding_types,
+                 :with_proceedings,
                  :with_no_savings,
                  :with_passported_state_machine,
                  :provider_entering_means
@@ -87,7 +87,7 @@ RSpec.describe 'check passported answers requests', type: :request do
         let(:application) do
           create :legal_aid_application,
                  :with_everything,
-                 :with_proceeding_types,
+                 :with_proceedings,
                  :with_no_other_assets,
                  :with_passported_state_machine,
                  :provider_entering_means
@@ -103,7 +103,7 @@ RSpec.describe 'check passported answers requests', type: :request do
         let(:application) do
           create :legal_aid_application,
                  :with_everything,
-                 :with_proceeding_types,
+                 :with_proceedings,
                  :with_passported_state_machine,
                  :provider_entering_means,
                  has_restrictions: false
@@ -119,7 +119,7 @@ RSpec.describe 'check passported answers requests', type: :request do
         let(:application) do
           create :legal_aid_application,
                  :with_applicant,
-                 :with_proceeding_types,
+                 :with_proceedings,
                  :with_policy_disregards,
                  :without_own_home,
                  :with_passported_state_machine,
@@ -165,7 +165,7 @@ RSpec.describe 'check passported answers requests', type: :request do
         let(:application) do
           create :legal_aid_application,
                  :with_everything,
-                 :with_proceeding_types,
+                 :with_proceedings,
                  :without_own_home,
                  :with_passported_state_machine,
                  :provider_entering_means
@@ -185,7 +185,7 @@ RSpec.describe 'check passported answers requests', type: :request do
         let(:application) do
           create :legal_aid_application,
                  :with_everything,
-                 :with_proceeding_types,
+                 :with_proceedings,
                  :with_own_home_owned_outright,
                  :with_passported_state_machine,
                  :provider_entering_means
@@ -200,7 +200,7 @@ RSpec.describe 'check passported answers requests', type: :request do
         let!(:application) do
           create :legal_aid_application,
                  :with_everything,
-                 :with_proceeding_types,
+                 :with_proceedings,
                  :with_passported_state_machine,
                  :provider_entering_means,
                  :with_populated_policy_disregards,
@@ -218,7 +218,7 @@ RSpec.describe 'check passported answers requests', type: :request do
           create :legal_aid_application,
                  :with_everything,
                  :with_no_other_assets,
-                 :with_proceeding_types,
+                 :with_proceedings,
                  :with_home_sole_owner,
                  :with_passported_state_machine,
                  :provider_entering_means
@@ -318,7 +318,7 @@ RSpec.describe 'check passported answers requests', type: :request do
              :with_everything,
              :with_passported_state_machine,
              :checking_passported_answers,
-             :with_proceeding_types
+             :with_proceedings
     end
 
     subject { patch "/providers/applications/#{application.id}/check_passported_answers/reset" }
@@ -332,7 +332,7 @@ RSpec.describe 'check passported answers requests', type: :request do
       let(:application) do
         create :legal_aid_application,
                :with_everything,
-               :with_proceeding_types,
+               :with_proceedings,
                :with_passported_state_machine,
                :provider_entering_means
       end

--- a/spec/requests/providers/check_provider_answers_spec.rb
+++ b/spec/requests/providers/check_provider_answers_spec.rb
@@ -166,7 +166,7 @@ RSpec.describe Providers::CheckProviderAnswersController, type: :request do
       end
 
       context 'when client has completed their journey' do
-        let(:application) { create(:legal_aid_application, :with_proceeding_types, :with_applicant_and_address, :with_non_passported_state_machine, :provider_assessing_means) }
+        let(:application) { create(:legal_aid_application, :with_proceedings, :with_applicant_and_address, :with_non_passported_state_machine, :provider_assessing_means) }
         it 'redirects to client completed means page' do
           expect(response).to redirect_to(providers_legal_aid_application_client_completed_means_path(application))
         end
@@ -230,9 +230,7 @@ RSpec.describe Providers::CheckProviderAnswersController, type: :request do
             :legal_aid_application,
             :with_passported_state_machine,
             :at_entering_applicant_details,
-            :with_proceeding_types,
-            :with_delegated_functions,
-            delegated_functions_date: used_delegated_functions_on,
+            :with_proceedings,
             applicant: applicant
           )
         end

--- a/spec/requests/providers/confirm_multiple_delegated_functions_dates_spec.rb
+++ b/spec/requests/providers/confirm_multiple_delegated_functions_dates_spec.rb
@@ -1,7 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe Providers::ConfirmMultipleDelegatedFunctionsController, type: :request do
-  let!(:legal_aid_application) { create :legal_aid_application, :with_multiple_proceeding_types }
+  let!(:legal_aid_application) do
+    create :legal_aid_application,
+           :with_proceedings,
+           :with_delegated_functions_on_proceedings,
+           df_options: { DA001: [Time.zone.now, Time.zone.now] }
+  end
   let(:login_provider) { login_as legal_aid_application.provider }
 
   before do
@@ -47,6 +52,7 @@ RSpec.describe Providers::ConfirmMultipleDelegatedFunctionsController, type: :re
       it 'error singular' do
         expect(response.body).to include(I18n.t("#{base_error_translation}.error.blank_singular"))
       end
+
       context 'when the legal aid app has multiple DF dates over a month' do
         let!(:legal_aid_application) do
           create :legal_aid_application,

--- a/spec/requests/providers/gateway_evidence_spec.rb
+++ b/spec/requests/providers/gateway_evidence_spec.rb
@@ -3,7 +3,7 @@ require 'sidekiq/testing'
 
 module Providers
   RSpec.describe GatewayEvidencesController, type: :request do
-    let(:legal_aid_application) { create :legal_aid_application, :with_proceeding_types }
+    let(:legal_aid_application) { create :legal_aid_application, :with_proceedings }
     let(:provider) { legal_aid_application.provider }
     let(:i18n_error_path) { 'activemodel.errors.models.gateway_evidence.attributes.original_file' }
 

--- a/spec/requests/providers/has_evidence_of_benefits_spec.rb
+++ b/spec/requests/providers/has_evidence_of_benefits_spec.rb
@@ -1,7 +1,16 @@
 require 'rails_helper'
 
 RSpec.describe Providers::HasEvidenceOfBenefitsController, type: :request do
-  let(:legal_aid_application) { create :legal_aid_application, :with_dwp_override, :checking_applicant_details, :with_proceeding_types, :with_delegated_functions }
+  let(:legal_aid_application) do
+    create :legal_aid_application,
+           :with_dwp_override,
+           :checking_applicant_details,
+           :with_proceedings,
+           :with_delegated_functions_on_proceedings,
+           explicit_proceedings: %i[da004],
+           df_options: { DA004: [Time.zone.now, Time.zone.now] }
+  end
+
   let(:login) { login_as legal_aid_application.provider }
   let(:enable_evidence_upload_flag) { false }
 

--- a/spec/requests/providers/has_other_proceedings_controller_spec.rb
+++ b/spec/requests/providers/has_other_proceedings_controller_spec.rb
@@ -1,9 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe Providers::HasOtherProceedingsController, type: :request do
-  let(:pt1) { create :proceeding_type, :with_real_data }
-  let(:pt2) { create :proceeding_type, :as_occupation_order }
-  let(:legal_aid_application) { create :legal_aid_application, :with_proceeding_types, explicit_proceeding_types: [pt1, pt2] }
+  let(:legal_aid_application) do
+    create :legal_aid_application,
+           :with_proceedings,
+           explicit_proceedings: %i[da001 da002]
+  end
 
   let(:provider) { legal_aid_application.provider }
   let(:next_flow_step) { flow_forward_path }
@@ -53,8 +55,7 @@ RSpec.describe Providers::HasOtherProceedingsController, type: :request do
     end
 
     context 'when the user is checking answers and has deleted the domestic abuse proceeding but left the section 8' do
-      let(:proceeding_type) { create :proceeding_type, code: 'SE003', ccms_matter: 'Section 8 orders' }
-      let(:legal_aid_application) { create :legal_aid_application, :at_checking_applicant_details, assign_lead_proceeding: false, explicit_proceeding_types: [proceeding_type] }
+      let(:legal_aid_application) { create :legal_aid_application, :at_checking_applicant_details, :with_proceedings, explicit_proceedings: [:se014], set_lead_proceeding: false }
       let(:params) { { legal_aid_application: { has_other_proceeding: 'false' } } }
 
       it 'redirects to the page to add another proceeding type' do
@@ -72,8 +73,7 @@ RSpec.describe Providers::HasOtherProceedingsController, type: :request do
     end
 
     context 'with only Section 8 proceedings selected' do
-      let(:proceeding_type) { create :proceeding_type, code: 'SE003', ccms_matter: 'Section 8 orders' }
-      let(:legal_aid_application) { create :legal_aid_application, :with_proceeding_types, assign_lead_proceeding: false, explicit_proceeding_types: [proceeding_type] }
+      let(:legal_aid_application) { create :legal_aid_application, :with_proceedings, assign_lead_proceeding: false, explicit_proceedings: [:se013] }
 
       context 'choose no' do
         let(:params) { { legal_aid_application: { has_other_proceeding: 'false' } } }
@@ -94,9 +94,11 @@ RSpec.describe Providers::HasOtherProceedingsController, type: :request do
     end
 
     context 'with at least one domestic abuse and at least one section 8 proceeding' do
-      let(:pt1) { create :proceeding_type, :as_occupation_order }
-      let(:pt2) { create :proceeding_type, :as_prohibited_steps_order }
-      let(:legal_aid_application) { create :legal_aid_application, :with_proceeding_types, explicit_proceeding_types: [pt1, pt2] }
+      let(:legal_aid_application) do
+        create :legal_aid_application,
+               :with_proceedings,
+               explicit_proceedings: %i[da004 se014]
+      end
 
       let(:params) { { legal_aid_application: { has_other_proceeding: 'false' } } }
 

--- a/spec/requests/providers/in_scope_of_laspos_controller_spec.rb
+++ b/spec/requests/providers/in_scope_of_laspos_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Providers::InScopeOfLasposController, type: :request do
-  let(:legal_aid_application) { create :legal_aid_application, :with_multiple_proceeding_types }
+  let(:legal_aid_application) { create :legal_aid_application, :with_proceedings }
   let(:provider) { legal_aid_application.provider }
   let(:next_flow_step) { flow_forward_path }
 

--- a/spec/requests/providers/legal_aid_applications_spec.rb
+++ b/spec/requests/providers/legal_aid_applications_spec.rb
@@ -174,8 +174,10 @@ RSpec.describe 'providers legal aid application requests', type: :request do
         let(:legal_aid_application) do
           create :legal_aid_application,
                  :with_applicant,
-                 :with_proceeding_types,
-                 :with_delegated_functions,
+                 :with_proceedings,
+                 :with_delegated_functions_on_proceedings,
+                 explicit_proceedings: [:da004],
+                 df_options: { DA004: [Time.zone.today, Time.zone.today] },
                  substantive_application_deadline_on: Time.zone.today + 3.days
         end
         let(:search_term) { legal_aid_application.application_ref }
@@ -189,15 +191,17 @@ RSpec.describe 'providers legal aid application requests', type: :request do
         end
       end
 
-      context 'when searching for an Emergency application with a substantiuve due date and the application has been submitted' do
+      context 'when searching for an Emergency application with a substantive due date and the application has been submitted' do
         let(:legal_aid_application) do
           create :legal_aid_application,
                  :with_applicant,
                  :with_everything,
-                 :with_proceeding_types,
-                 :with_delegated_functions,
-                 merits_submitted_at: Time.zone.today,
-                 substantive_application_deadline_on: Time.zone.today + 3.days
+                 :with_proceedings,
+                 :with_delegated_functions_on_proceedings,
+                 explicit_proceedings: [:da004],
+                 df_options: { DA004: [Time.zone.today, Time.zone.today] },
+                 substantive_application_deadline_on: Time.zone.today + 3.days,
+                 merits_submitted_at: Time.zone.today
         end
         let(:search_term) { legal_aid_application.application_ref }
         let(:params) { { search_term: search_term } }

--- a/spec/requests/providers/means_reports_spec.rb
+++ b/spec/requests/providers/means_reports_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Providers::MeansReportsController, type: :request do
   include ActionView::Helpers::NumberHelper
 
-  let(:legal_aid_application) { create :legal_aid_application, :with_proceeding_types, :with_everything, :with_cfe_v3_result, :assessment_submitted }
+  let(:legal_aid_application) { create :legal_aid_application, :with_proceedings, :with_everything, :with_cfe_v3_result, :assessment_submitted }
   let(:login_provider) { login_as legal_aid_application.provider }
   let!(:submission) { create :submission, legal_aid_application: legal_aid_application }
   let(:cfe_result) { legal_aid_application.cfe_result }

--- a/spec/requests/providers/merits_reports_spec.rb
+++ b/spec/requests/providers/merits_reports_spec.rb
@@ -3,11 +3,16 @@ require 'rails_helper'
 RSpec.describe Providers::MeritsReportsController, type: :request do
   let(:legal_aid_application) do
     create :legal_aid_application,
-           :with_proceeding_types,
+           :with_proceedings,
            :with_everything,
            :assessment_submitted,
-           :with_chances_of_success
+           explicit_proceedings: %i[da004]
   end
+  let(:da004) { legal_aid_application.proceedings.find_by(ccms_code: 'DA004') }
+  let!(:chances_of_success) do
+    create :chances_of_success, :with_optional_text, proceeding: da004
+  end
+
   let(:login_provider) { login_as legal_aid_application.provider }
   let!(:submission) { create :submission, legal_aid_application: legal_aid_application }
   let(:before_subject) { nil }

--- a/spec/requests/providers/merits_task_lists_controller_spec.rb
+++ b/spec/requests/providers/merits_task_lists_controller_spec.rb
@@ -2,12 +2,10 @@ require 'rails_helper'
 
 RSpec.describe Providers::MeritsTaskListsController, type: :request do
   let(:login_provider) { login_as legal_aid_application.provider }
-  let(:pt_da) { create :proceeding_type, :with_real_data }
-  let(:pt_s8) { create :proceeding_type, :as_section_8_child_residence }
   let(:legal_aid_application) do
     create :legal_aid_application,
-           :with_proceeding_types,
-           explicit_proceeding_types: [pt_da, pt_s8]
+           :with_proceedings,
+           explicit_proceedings: %i[da001 se014]
   end
 
   let(:proceeding_names) do

--- a/spec/requests/providers/merits_task_lists_controller_spec.rb
+++ b/spec/requests/providers/merits_task_lists_controller_spec.rb
@@ -2,11 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Providers::MeritsTaskListsController, type: :request do
   let(:login_provider) { login_as legal_aid_application.provider }
-  let(:legal_aid_application) do
-    create :legal_aid_application,
-           :with_proceedings,
-           explicit_proceedings: %i[da001 se014]
-  end
+  let(:legal_aid_application) { create :legal_aid_application, :with_multiple_proceedings_inc_section8 }
 
   let(:proceeding_names) do
     legal_aid_application.application_proceeding_types.map do |type|

--- a/spec/requests/providers/open_banking_consents_spec.rb
+++ b/spec/requests/providers/open_banking_consents_spec.rb
@@ -70,8 +70,11 @@ RSpec.describe 'does client use online banking requests', type: :request do
             create :legal_aid_application,
                    :with_non_passported_state_machine,
                    :applicant_details_checked,
-                   :with_proceeding_types,
-                   :with_delegated_functions, applicant: applicant
+                   :with_proceedings,
+                   :with_delegated_functions_on_proceedings,
+                   explicit_proceedings: [:da004],
+                   df_options: { DA004: [Time.zone.today, Time.zone.today] },
+                   applicant: applicant
           end
 
           let(:applicant) { create :applicant, :not_employed }

--- a/spec/requests/providers/other_assets_controller_spec.rb
+++ b/spec/requests/providers/other_assets_controller_spec.rb
@@ -209,9 +209,10 @@ RSpec.describe 'provider other assets requests', type: :request do
                 let(:application) do
                   create :legal_aid_application,
                          :with_positive_benefit_check_result,
-                         :with_proceeding_types,
-                         :with_delegated_functions,
-                         delegated_functions_date: Date.new(2021, 1, 5)
+                         :with_proceedings,
+                         :with_delegated_functions_on_proceedings,
+                         explicit_proceedings: [:da004],
+                         df_options: { DA004: [Date.new(2021, 1, 5), Date.new(2021, 1, 5)] }
                 end
                 let(:policy_disregards) { false }
 

--- a/spec/requests/providers/proceeding_merits_task/attempts_to_settle_controller_spec.rb
+++ b/spec/requests/providers/proceeding_merits_task/attempts_to_settle_controller_spec.rb
@@ -1,12 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Providers::ProceedingMeritsTask::AttemptsToSettleController, type: :request do
-  let!(:legal_aid_application) do
-    create :legal_aid_application,
-           :with_proceedings,
-           explicit_proceedings: %i[da001 se014]
-  end
-  let(:proceeding_type) { ProceedingType.find_by(ccms_code: 'SE014') }
+  let(:legal_aid_application) { create :legal_aid_application, :with_multiple_proceedings_inc_section8 }
   let(:smtl) { create :legal_framework_merits_task_list, legal_aid_application: legal_aid_application }
   let(:provider) { legal_aid_application.provider }
   let(:proceeding) { legal_aid_application.proceedings.find_by(ccms_code: 'SE014') }
@@ -68,9 +63,8 @@ RSpec.describe Providers::ProceedingMeritsTask::AttemptsToSettleController, type
         context 'when the application is in draft' do
           let(:legal_aid_application) do
             create :legal_aid_application,
-                   :with_proceedings,
-                   :draft,
-                   explicit_proceedings: %i[da001 se014]
+                   :with_multiple_proceedings_inc_section8,
+                   :draft
           end
 
           it 'redirects provider back to the merits task list' do

--- a/spec/requests/providers/proceeding_merits_task/success_prospects_spec.rb
+++ b/spec/requests/providers/proceeding_merits_task/success_prospects_spec.rb
@@ -3,11 +3,9 @@ require 'rails_helper'
 module Providers
   module ProceedingMeritsTask
     RSpec.describe SuccessProspectsController, type: :request do
-      let!(:legal_aid_application) { create :legal_aid_application, :with_proceeding_types, explicit_proceeding_types: [pt_da, pt_s8] }
+      let!(:legal_aid_application) { create :legal_aid_application, :with_proceedings }
       let(:proceeding) { legal_aid_application.proceedings.find_by(ccms_code: 'DA001') }
       let(:proceeding_two) { legal_aid_application.proceedings.find_by(ccms_code: 'SE014') }
-      let(:pt_da) { create :proceeding_type, :with_real_data }
-      let(:pt_s8) { create :proceeding_type, :as_section_8_child_residence }
 
       let(:provider) { legal_aid_application.provider }
 

--- a/spec/requests/providers/proceedings_types_spec.rb
+++ b/spec/requests/providers/proceedings_types_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Providers::ProceedingsTypesController, :vcr, type: :request do
-  let(:legal_aid_application) { create :legal_aid_application, :with_applicant, :with_proceeding_types }
+  let(:legal_aid_application) { create :legal_aid_application, :with_applicant, :with_proceedings }
   let(:application_proceeding_type) { legal_aid_application.application_proceeding_types.first }
   let(:provider) { legal_aid_application.provider }
 

--- a/spec/requests/providers/received_benefit_confirmations_spec.rb
+++ b/spec/requests/providers/received_benefit_confirmations_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Providers::ReceivedBenefitConfirmationsController, type: :request do
-  let(:application) { create(:legal_aid_application, :with_proceeding_types, :at_checking_applicant_details, :with_applicant_and_address) }
+  let(:application) { create(:legal_aid_application, :with_proceedings, :at_checking_applicant_details, :with_applicant_and_address) }
   let(:application_id) { application.id }
 
   describe 'GET /providers/applications/:legal_aid_application_id/received_benefit_confirmation' do

--- a/spec/requests/providers/restrictions_spec.rb
+++ b/spec/requests/providers/restrictions_spec.rb
@@ -63,9 +63,10 @@ RSpec.describe 'provider restrictions request', type: :request do
                      :non_passported,
                      :with_non_passported_state_machine,
                      :provider_assessing_means,
-                     :with_proceeding_types,
-                     :with_delegated_functions,
-                     delegated_functions_reported_date: Date.new(2021, 1, 9)
+                     :with_proceedings,
+                     :with_delegated_functions_on_proceedings,
+                     explicit_proceedings: [:da004],
+                     df_options: { DA004: [1.day.ago, Date.new(2021, 1, 9)] }
             end
 
             it 'redirects to policy disregards' do
@@ -80,9 +81,10 @@ RSpec.describe 'provider restrictions request', type: :request do
                      :non_passported,
                      :with_non_passported_state_machine,
                      :provider_assessing_means,
-                     :with_proceeding_types,
-                     :with_delegated_functions,
-                     delegated_functions_date: Date.new(2020, 12, 19)
+                     :with_proceedings,
+                     :with_delegated_functions_on_proceedings,
+                     explicit_proceedings: [:da004],
+                     df_options: { DA004: [Date.new(2020, 12, 19), Date.new(2020, 12, 19)] }
             end
 
             it 'redirects to check passported answers' do

--- a/spec/requests/providers/substantive_applications_spec.rb
+++ b/spec/requests/providers/substantive_applications_spec.rb
@@ -3,9 +3,11 @@ RSpec.describe Providers::SubstantiveApplicationsController, type: :request, vcr
   let(:state) { :with_passported_state_machine }
   let(:legal_aid_application) do
     create :legal_aid_application,
-           :with_proceeding_types,
-           :with_delegated_functions,
-           state, :applicant_details_checked,
+           :at_applicant_details_checked,
+           :with_proceedings,
+           :with_delegated_functions_on_proceedings,
+           explicit_proceedings: [:da004],
+           df_options: { DA004: [Time.zone.today, Time.zone.today] },
            applicant: applicant
   end
 

--- a/spec/services/ccms/submitters/add_case_service_spec.rb
+++ b/spec/services/ccms/submitters/add_case_service_spec.rb
@@ -10,6 +10,8 @@ module CCMS
                :with_everything_and_address,
                :with_cfe_v3_result,
                :with_positive_benefit_check_result,
+               explicit_proceedings: [:da001],
+               set_lead_proceeding: :da001,
                office_id: office.id,
                populate_vehicle: true
       end

--- a/spec/services/cfe/create_assessment_service_spec.rb
+++ b/spec/services/cfe/create_assessment_service_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 module CFE
   RSpec.describe CreateAssessmentService do
-    let(:application) { create :legal_aid_application, :with_proceeding_types }
+    let(:application) { create :legal_aid_application, :with_proceedings }
     let!(:applicant) { create :applicant, legal_aid_application: application }
     let(:submission) { create :cfe_submission, aasm_state: 'initialised', legal_aid_application: application }
     let(:service) { described_class.new(submission) }
@@ -70,7 +70,7 @@ module CFE
         client_reference_id: application.application_ref,
         submission_date: Time.zone.today.strftime('%Y-%m-%d'),
         proceeding_types: {
-          ccms_codes: application.proceeding_types.map(&:ccms_code)
+          ccms_codes: application.proceedings.map(&:ccms_code)
         }
       }
     end

--- a/spec/services/dashboard_event_handler_spec.rb
+++ b/spec/services/dashboard_event_handler_spec.rb
@@ -115,9 +115,12 @@ RSpec.describe DashboardEventHandler do
   end
 
   context 'application completed' do
-    let(:legal_aid_application) { create :legal_aid_application, :with_proceeding_types, :with_delegated_functions }
-    let(:used_delegated_functions_reported_on) { Date.current }
-    let(:used_delegated_functions_on) { rand(12).days.ago.to_date }
+    let(:legal_aid_application) do
+      create :legal_aid_application, :with_proceedings,
+             :with_delegated_functions_on_proceedings,
+             explicit_proceedings: [:da004],
+             df_options: { DA004: [rand(12).days.ago.to_date, Time.zone.now] }
+    end
 
     before do
       allow_any_instance_of(DashboardEventHandler).to receive(:firm_created)

--- a/spec/services/govuk_emails/delivery_man_spec.rb
+++ b/spec/services/govuk_emails/delivery_man_spec.rb
@@ -56,7 +56,14 @@ RSpec.describe GovukEmails::DeliveryMan do
         # this simulates trying to send a message in staging that generates the following error
         # BadRequestError: Can’t send to this recipient using a team-only API key
         let(:scheduled_mailing) { create :scheduled_mailing, :waiting, legal_aid_application: application }
-        let(:application) { create :legal_aid_application, :with_applicant, :with_proceeding_types, :with_delegated_functions, substantive_application_deadline_on: Date.tomorrow }
+        let(:application) do
+          create :legal_aid_application,
+                 :with_applicant,
+                 :with_proceedings,
+                 :with_delegated_functions_on_proceedings,
+                 explicit_proceedings: [:da004],
+                 df_options: { DA004: [Time.zone.today, Time.zone.today] }
+        end
         let(:response_error_stub) { ErrorResponseStruct.new(400, 'BadRequestError: Can’t send to this recipient using a team-only API key') }
 
         before do

--- a/spec/services/legal_aid_applications/calculation_date_service_spec.rb
+++ b/spec/services/legal_aid_applications/calculation_date_service_spec.rb
@@ -8,9 +8,10 @@ RSpec.describe LegalAidApplications::CalculationDateService do
   let(:benefit_check_result) { create :benefit_check_result, result: applicant_receives_benefit ? 'yes' : 'no' }
   let(:legal_aid_application) do
     create :legal_aid_application,
-           :with_proceeding_types,
-           :with_delegated_functions,
-           delegated_functions_date: used_delegated_functions_on,
+           :with_proceedings,
+           :with_delegated_functions_on_proceedings,
+           explicit_proceedings: [:da004],
+           df_options: { DA004: [used_delegated_functions_on, used_delegated_functions_on] },
            transaction_period_finish_on: transaction_period_finish_on,
            benefit_check_result: benefit_check_result,
            merits_submitted_at: merits_submitted_at

--- a/spec/services/legal_framework/merits_tasks_service_spec.rb
+++ b/spec/services/legal_framework/merits_tasks_service_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 module LegalFramework
   RSpec.describe MeritsTasksService do
-    let(:application) { create :legal_aid_application, :with_proceeding_types }
+    let(:application) { create :legal_aid_application, :with_proceedings }
     let(:service) { described_class.call(application) }
     let(:submission) { create :legal_framework_submission }
 
@@ -67,7 +67,7 @@ module LegalFramework
         },
         proceeding_types: [
           {
-            ccms_code: application.proceeding_types.first.ccms_code,
+            ccms_code: application.proceedings.first.ccms_code,
             tasks: {
               chances_of_success: [] # the merits tasks for this one proceeding type, and any dependencies
             }

--- a/spec/services/reports/bank_transactions/bank_transaction_report_creator_spec.rb
+++ b/spec/services/reports/bank_transactions/bank_transaction_report_creator_spec.rb
@@ -5,7 +5,7 @@ module Reports
     RSpec.describe BankTransactionReportCreator do
       let(:legal_aid_application) do
         create :legal_aid_application,
-               :with_proceeding_types,
+               :with_proceedings,
                :with_everything,
                :with_benefits_transactions,
                :with_uncategorised_credit_transactions,

--- a/spec/services/reports/merits_report_creator_spec.rb
+++ b/spec/services/reports/merits_report_creator_spec.rb
@@ -3,12 +3,18 @@ require 'rails_helper'
 RSpec.describe Reports::MeritsReportCreator do
   let(:legal_aid_application) do
     create :legal_aid_application,
-           :with_multiple_proceeding_types_inc_section8,
-           :with_lead_proceeding_type,
+           :with_proceedings,
            :with_everything,
            :generating_reports,
+           explicit_proceedings: %i[da004],
+           set_lead_proceeding: :da004,
            ccms_submission: ccms_submission
   end
+  let(:da004) { legal_aid_application.proceedings.find_by(ccms_code: 'DA004') }
+  let!(:chances_of_success) do
+    create :chances_of_success, :with_optional_text, proceeding: da004
+  end
+
   let(:ccms_submission) { create :ccms_submission, :case_ref_obtained }
 
   subject do
@@ -57,12 +63,19 @@ RSpec.describe Reports::MeritsReportCreator do
     context 'ccms case ref does not exist' do
       let(:legal_aid_application) do
         create :legal_aid_application,
-               :with_multiple_proceeding_types_inc_section8,
-               :with_lead_proceeding_type,
+               :with_proceedings,
                :with_everything,
                :generating_reports,
-               ccms_submission: ccms_submission
+               ccms_submission: ccms_submission,
+               explicit_proceedings: %i[da004],
+               set_lead_proceeding: :da004
       end
+
+      let(:da004) { legal_aid_application.proceedings.find_by(ccms_code: 'DA004') }
+      let!(:chances_of_success) do
+        create :chances_of_success, :with_optional_text, proceeding: da004
+      end
+
       let(:ccms_submission) { create :ccms_submission }
 
       before do
@@ -75,14 +88,20 @@ RSpec.describe Reports::MeritsReportCreator do
       end
 
       context 'ccms submission does not exist' do
-        let(:legal_aid_application) do
+        let!(:legal_aid_application) do
           create :legal_aid_application,
-                 :with_multiple_proceeding_types_inc_section8,
-                 :with_lead_proceeding_type,
+                 :with_proceedings,
                  :with_everything,
-                 :generating_reports
+                 :generating_reports,
+                 explicit_proceedings: %i[da004],
+                 set_lead_proceeding: :da004
         end
         let(:ccms_submission) { create :ccms_submission }
+
+        let(:da004) { legal_aid_application.proceedings.find_by(ccms_code: 'DA004') }
+        let!(:chances_of_success) do
+          create :chances_of_success, :with_optional_text, proceeding: da004
+        end
 
         before do
           allow(legal_aid_application).to receive(:case_ccms_reference).and_return(nil)

--- a/spec/services/reports/mis/application_detail_csv_line_spec.rb
+++ b/spec/services/reports/mis/application_detail_csv_line_spec.rb
@@ -5,10 +5,11 @@ module Reports
     RSpec.describe ApplicationDetailCsvLine do
       let(:legal_aid_application) do
         create :application,
-               :with_proceeding_types,
-               :with_delegated_functions,
-               delegated_functions_date: used_delegated_functions_on,
-               delegated_functions_reported_date: used_delegated_functions_reported_on,
+               :with_proceedings,
+               :with_delegated_functions_on_proceedings,
+               explicit_proceedings: [:da004],
+               set_lead_proceeding: :da004,
+               df_options: { DA004: [used_delegated_functions_on, used_delegated_functions_reported_on] },
                application_ref: 'L-X99-ZZZ',
                applicant: applicant,
                own_home: own_home_status,
@@ -29,7 +30,7 @@ module Reports
 
       let(:application_without_df) do
         create :application,
-               :with_proceeding_types,
+               :with_proceedings,
                application_ref: 'L-X99-ZZZ',
                applicant: applicant,
                own_home: own_home_status,
@@ -193,7 +194,7 @@ module Reports
               expect(value_for('Case Type')).to eq 'Passported'
               expect(value_for('Single/Multi Proceedings')).to eq 'Single'
               expect(value_for('Matter types')).to eq 'Domestic Abuse'
-              expect(value_for('Proceeding types selected')).to match(/^Meaning-DA\d{3,4}$/)
+              expect(value_for('Proceeding types selected')).to match(/^Non-molestation order/)
               expect(value_for('Delegated functions used')).to eq 'Yes'
               expect(value_for('Delegated functions dates')).to eq '2020-01-01'
               expect(value_for('Delegated functions reported')).to eq '2020-02-21'

--- a/spec/services/reports/mis/non_passported_applications_report_spec.rb
+++ b/spec/services/reports/mis/non_passported_applications_report_spec.rb
@@ -41,6 +41,7 @@ module Reports
         travel_to(Time.zone.local(2020, 9, 1, 2, 3, 4)) do
           create :legal_aid_application,
                  :with_applicant,
+                 :with_proceedings,
                  :with_negative_benefit_check_result,
                  :with_non_passported_state_machine,
                  :at_client_completed_means,

--- a/spec/services/reports/reports_creator_spec.rb
+++ b/spec/services/reports/reports_creator_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Reports::ReportsCreator do
   let(:legal_aid_application) do
     create :legal_aid_application,
-           :with_proceeding_types,
+           :with_proceedings,
            :with_ccms_submission,
            :with_everything,
            :with_passported_state_machine,
@@ -25,7 +25,7 @@ RSpec.describe Reports::ReportsCreator do
     context 'when the application is non-passported and has transactions' do
       let(:legal_aid_application) do
         create :legal_aid_application,
-               :with_proceeding_types,
+               :with_proceedings,
                :with_everything,
                :with_ccms_submission,
                :with_benefits_transactions,

--- a/spec/services/submit_application_reminder_service_spec.rb
+++ b/spec/services/submit_application_reminder_service_spec.rb
@@ -7,9 +7,12 @@ RSpec.describe SubmitApplicationReminderService, :vcr do
   let(:application) do
     create :application,
            :with_applicant,
-           :with_proceeding_types,
-           :with_delegated_functions,
+           :with_proceedings,
+           :with_delegated_functions_on_proceedings,
            :with_substantive_application_deadline_on,
+           explicit_proceedings: [:da004],
+           set_lead_proceeding: :da004,
+           df_options: { DA004: [Time.zone.today, Time.zone.today] },
            provider: provider
   end
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2812)

What does this ticket do?
This PR swaps out in a vast majority of places the trait :with_proceeding_types for the trait :with_proceedings and adds e.g multiple proceeding types, delegated functions, section8 proceedings etc.

All changes are to spec file and there are no changes to any actual methods used in the application.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
