### PR TITLE
Fix: Update I18n-task gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -113,7 +113,7 @@ group :development, :test do
   gem 'erb_lint', '0.1.1', require: false
   gem 'hirb'
   gem 'htmlentities'
-  gem 'i18n-tasks', '>= 0.9.35'
+  gem 'i18n-tasks', github: 'glebm/i18n-tasks', branch: 'main'
   gem 'json_expressions'
   gem 'nokogiri', '>= 1.12.5'
   gem 'overcommit'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,6 +6,22 @@ GIT
     ruby-saml-idp (0.3.2)
 
 GIT
+  remote: https://github.com/glebm/i18n-tasks.git
+  revision: d51327cb48870f984303da55fe1a0605cf0e70d3
+  branch: main
+  specs:
+    i18n-tasks (0.9.37)
+      activesupport (>= 4.0.2)
+      ast (>= 2.1.0)
+      erubi
+      highline (>= 2.0.0)
+      i18n
+      parser (>= 2.2.3.0)
+      rails-i18n
+      rainbow (>= 2.2.2, < 4.0)
+      terminal-table (>= 1.5.1)
+
+GIT
   remote: https://github.com/nebulab/simple_command.git
   revision: 48ecd83e6f8de6ef354f729109ed4c6e69aaf87c
   branch: master
@@ -354,16 +370,6 @@ GEM
       socksify
     i18n (1.8.11)
       concurrent-ruby (~> 1.0)
-    i18n-tasks (0.9.37)
-      activesupport (>= 4.0.2)
-      ast (>= 2.1.0)
-      erubi
-      highline (>= 2.0.0)
-      i18n
-      parser (>= 2.2.3.0)
-      rails-i18n
-      rainbow (>= 2.2.2, < 4.0)
-      terminal-table (>= 1.5.1)
     ice_nine (0.11.2)
     iniparse (1.5.0)
     interception (0.5)
@@ -781,7 +787,7 @@ DEPENDENCIES
   guard-rubocop
   hirb
   htmlentities
-  i18n-tasks (>= 0.9.35)
+  i18n-tasks!
   json_expressions
   jwt
   launchy


### PR DESCRIPTION
## What

Load from master - this has had a patch to handle aliased keys
that allows the Psych 4 update applied by Ruby 3.1

This should stop the overnight i18n tests from failing

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
