### PR TITLE
AP-2827 Capture exceptions during Report Generation

### DIFF
--- a/app/jobs/reports_uploader_job.rb
+++ b/app/jobs/reports_uploader_job.rb
@@ -1,5 +1,4 @@
 class ReportsUploaderJob < ApplicationJob
-  # :nocov:
   def perform # rubocop:disable Metrics/AbcSize
     log "starting at #{Time.zone.now}"
     unless admin_report.application_details_report&.blob.nil?
@@ -10,8 +9,6 @@ class ReportsUploaderJob < ApplicationJob
     admin_report.save
     log "Application Details report attached as blob with key #{blob.key}, blob_id: #{blob.id}"
     log "AdminReport record updated at #{admin_report.updated_at}"
-
-    log_scheduled_sidekiq_jobs
   end
 
   private
@@ -33,24 +30,7 @@ class ReportsUploaderJob < ApplicationJob
     admin_report.application_details_report.blob
   end
 
-  def log_scheduled_sidekiq_jobs
-    ss = Sidekiq::ScheduledSet.new
-    log "Sidekiq Scheduled set size: #{ss.size}"
-    ss.each { |job| log_job(job) }
-  end
-
   def log(message)
     Rails.logger.info "ReportsUploaderJob - #{message}"
   end
-
-  def log_job(job) # rubocop:disable Metrics/AbcSize
-    log '>>>>>>>'
-    log "    JID: #{job.jid}"
-    log "    Queue: #{job.queue}"
-    log "    Class: #{job.item['class']}"
-    log "    Args: #{job.item['args']}"
-    log "    Created: #{Time.zone.at(job.created_at)}"
-    log "    Scheduled: #{Time.zone.at(job.score)}"
-  end
-  # :nocov:
 end

--- a/lib/tasks/jobs/create_admin_reports.rake
+++ b/lib/tasks/jobs/create_admin_reports.rake
@@ -2,8 +2,8 @@ namespace :job do
   namespace :admin_reports do
     desc 'Upload admin reports'
     task upload: :environment do
-      Rails.logger.info "rake job:admin_reports:upload started at #{Time.zone.now}"
-      ReportsUploaderJob.perform_now
+      Rails.logger.info "rake job:admin_reports:upload queued at #{Time.zone.now}"
+      ReportsUploaderJob.perform_later
     end
   end
 end

--- a/spec/jobs/reports_uploader_job_spec.rb
+++ b/spec/jobs/reports_uploader_job_spec.rb
@@ -2,7 +2,6 @@ require 'rails_helper'
 
 RSpec.describe ReportsUploaderJob, type: :job do
   let(:report_uploader) { described_class.new }
-  let(:admin_report) { AdminReport.first }
   subject { report_uploader.perform }
 
   describe '#perform' do
@@ -10,20 +9,41 @@ RSpec.describe ReportsUploaderJob, type: :job do
       allow_any_instance_of(Reports::MIS::ApplicationDetailsReport).to receive(:run).and_return('csv string, application details')
     end
 
-    it 'creates an admin report' do
-      expect { subject }.to change { AdminReport.count }.by(1)
-    end
+    context 'AdminReport record does not exist' do
+      let(:admin_report) { AdminReport.first }
+      it 'creates an admin report' do
+        expect { subject }.to change { AdminReport.count }.by(1)
+      end
 
-    it 'attaches application_details report to admin report' do
-      subject
-      expect(admin_report.application_details_report).to be_a_kind_of(ActiveStorage::Attached::One)
-    end
-
-    context 'when submitted applications report is attached' do
-      it 'attaches the correct csv string to admin report' do
+      it 'attaches application_details report to admin report' do
         subject
-        blob = admin_report.application_details_report.attachment
-        expect(blob.download).to eq 'csv string, application details'
+        expect(admin_report.reload.application_details_report).to be_a_kind_of(ActiveStorage::Attached::One)
+      end
+
+      context 'when submitted applications report is attached' do
+        it 'attaches the correct csv string to admin report' do
+          subject
+          blob = admin_report.application_details_report.attachment
+          expect(blob.download).to eq 'csv string, application details'
+        end
+      end
+    end
+
+    context 'AdminReport record already exists' do
+      before do
+        # create an AdminReport record with the correct attachments
+        report_uploader.perform
+      end
+
+      it 'does not create another record' do
+        subject
+        expect { subject }.not_to change { AdminReport.count }
+      end
+
+      it 'updates the existing record' do
+        original_updated_time = AdminReport.first.updated_at
+        subject
+        expect(AdminReport.first.updated_at > original_updated_time).to be true
       end
     end
   end

--- a/spec/services/reports/mis/application_details_report_spec.rb
+++ b/spec/services/reports/mis/application_details_report_spec.rb
@@ -31,16 +31,27 @@ module Reports
       let(:report) { described_class.new }
 
       describe '#run' do
-        it 'returns a csv string with a header line' do
-          csv_string = report.run
-          lines = csv_string.split("\n")
-          expect(lines.first).to match(/^Firm name,User name,Office ID/)
+        context 'runs successfully' do
+          it 'returns a csv string with a header line' do
+            csv_string = report.run
+            lines = csv_string.split("\n")
+            expect(lines.first).to match(/^Firm name,User name,Office ID/)
+          end
+
+          it 'returns a header and seven detail lines' do
+            csv_string = report.run
+            lines = csv_string.split("\n")
+            expect(lines.size).to eq num_applications + 1
+          end
         end
 
-        it 'returns a header and seven detail lines' do
-          csv_string = report.run
-          lines = csv_string.split("\n")
-          expect(lines.size).to eq num_applications + 1
+        context 'exception' do
+          before { expect(report).to receive(:generate_csv_string).and_raise(RuntimeError) }
+
+          it 'notifies sentry' do
+            expect(Sentry).to receive(:capture_message)
+            report.run
+          end
         end
       end
     end


### PR DESCRIPTION

## Capture exceptions during Report Generation

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2827)

Several changes to ensure that we are alerted when an exception occurs during generation of reports overnight:
- Full test coverage of ReportsUploader job
- backgrounding of report generation rather than in the cronjob ephemeral pod
- Capturing exceptions and explicitly sending them to Sentry.  The exception is not re-raised because we don't particularly want the job to be retried lots of times.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
