### PR TITLE
ap-2575: Add employment income to cfe results page

### DIFF
--- a/app/views/providers/capital_income_assessment_results/_employment_income.html.erb
+++ b/app/views/providers/capital_income_assessment_results/_employment_income.html.erb
@@ -1,0 +1,12 @@
+<div class="govuk-accordion__section-content">
+  <h2 class="govuk-heading-m"><%= t('.title') %></h2>
+  <table class="govuk-table">
+    <tbody>
+    <%= render partial: 'shared/results_detail_row', locals: { caption: t('.monthly_income_before_tax'), value: gds_number_to_currency(@cfe_result.employment_income_gross_income) } %>
+    <%= render partial: 'shared/results_detail_row', locals: { caption: t('.benefits_in_kind'), value: gds_number_to_currency(@cfe_result.employment_income_benefits_in_kind) } %>
+    <%= render partial: 'shared/results_detail_row', locals: { caption: t('.tax'), value: gds_number_to_currency(@cfe_result.employment_income_tax) } %>
+    <%= render partial: 'shared/results_detail_row', locals: { caption: t('.national_insurance'), value: gds_number_to_currency(@cfe_result.employment_income_national_insurance) } %>
+    <%= render partial: 'shared/results_detail_row', locals: { caption: t('.fixed_employment_deduction'), value: gds_number_to_currency(@cfe_result.employment_income_fixed_employment_deduction) } %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/providers/capital_income_assessment_results/_employment_income.html.erb
+++ b/app/views/providers/capital_income_assessment_results/_employment_income.html.erb
@@ -7,6 +7,7 @@
     <%= render partial: 'shared/results_detail_row', locals: { caption: t('.tax'), value: gds_number_to_currency(@cfe_result.employment_income_tax) } %>
     <%= render partial: 'shared/results_detail_row', locals: { caption: t('.national_insurance'), value: gds_number_to_currency(@cfe_result.employment_income_national_insurance) } %>
     <%= render partial: 'shared/results_detail_row', locals: { caption: t('.fixed_employment_deduction'), value: gds_number_to_currency(@cfe_result.employment_income_fixed_employment_deduction) } %>
+    <%= render partial: 'shared/results_total_row', locals: { caption: t('.total'), value: gds_number_to_currency(@cfe_result.employment_income_net_employment_income) } %>
     </tbody>
   </table>
 </div>

--- a/app/views/providers/capital_income_assessment_results/_other_income.html.erb
+++ b/app/views/providers/capital_income_assessment_results/_other_income.html.erb
@@ -10,7 +10,7 @@
     <%= render partial: 'shared/results_detail_row', locals: { caption: t('.property_or_lodger'), value: gds_number_to_currency(@cfe_result.mei_property_or_lodger) } %>
     <%= render partial: 'shared/results_detail_row', locals: { caption: t('.student_loan_or_grant'), value: gds_number_to_currency(@cfe_result.mei_student_loan) } %>
     <%= render partial: 'shared/results_detail_row', locals: { caption: t('.pension'), value: gds_number_to_currency(@cfe_result.mei_pension) } %>
-    <%= render partial: 'shared/results_total_row', locals: { caption: t('.total_income'), value: gds_number_to_currency(@cfe_result.total_gross_income) } %>
+    <%= render partial: 'shared/results_total_row', locals: { caption: t('.total'), value: gds_number_to_currency(@cfe_result.total_gross_income) } %>
     </tbody>
   </table>
 </div>

--- a/app/views/providers/capital_income_assessment_results/_other_income.html.erb
+++ b/app/views/providers/capital_income_assessment_results/_other_income.html.erb
@@ -1,5 +1,7 @@
 <div class="govuk-accordion__section-content">
-  <h2 class="govuk-heading-m"><%= t('.title') %></h2>
+  <h2 class="govuk-heading-m">
+    <%= Setting.enable_employed_journey? && @legal_aid_application.provider.employment_permissions? && @cfe_result.jobs? ? t('.title') : t('.income') %>
+  </h2>
   <table class="govuk-table">
     <tbody>
     <%= render partial: 'shared/results_detail_row', locals: { caption: t('.benefits'), value: gds_number_to_currency(@cfe_result.monthly_state_benefits) } %>

--- a/app/views/providers/capital_income_assessment_results/_result_details.html.erb
+++ b/app/views/providers/capital_income_assessment_results/_result_details.html.erb
@@ -13,7 +13,10 @@
         </span>
         </h2>
       </div>
-        <%= render 'income' %>
+        <% if Setting.enable_employed_journey? && @legal_aid_application.provider.employment_permissions? && @cfe_result.jobs? %>
+          <%= render 'employment_income' %>
+        <% end %>
+        <%= render 'other_income' %>
         <%= render 'outgoings' %>
         <%= render 'deductions' %>
         <%= render 'disposable_income' %>

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -89,8 +89,16 @@ en:
         dependants_allowance: Dependants allowance
         excluded_benefits: Income from benefits excluded from calculation
         total_deductions: Total deductions
-      income:
-        title: Income
+      employment_income:
+        title: Employment income
+        monthly_income_before_tax: Monthly income before tax
+        benefits_in_kind: Benefits in kind
+        tax: Tax
+        national_insurance: National Insurance
+        fixed_employment_deduction: Fixed employment expenses deduction
+      other_income:
+        title: Other income
+        income: Income
         benefits: Benefits
         friends_or_family: Financial help from friends or family
         maintenance: Maintenance payments from a former partner

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -96,6 +96,7 @@ en:
         tax: Tax
         national_insurance: National Insurance
         fixed_employment_deduction: Fixed employment expenses deduction
+        total: Total
       other_income:
         title: Other income
         income: Income
@@ -105,7 +106,7 @@ en:
         property_or_lodger: Income from property or lodger
         student_loan_or_grant: Student finance
         pension: Pension
-        total_income: Total income
+        total: Total
       outgoings:
         title: Outgoings
         housing_costs: Housing payments

--- a/spec/requests/providers/capital_income_assessment_results_spec.rb
+++ b/spec/requests/providers/capital_income_assessment_results_spec.rb
@@ -289,14 +289,21 @@ RSpec.describe Providers::CapitalIncomeAssessmentResultsController, type: :reque
 
       context 'applicant has employment(s)' do
         let(:cfe_result) { create :cfe_v4_result, :with_employments }
+        let(:td) { "\n  </th>\n  <td class=\"govuk-table__cell govuk-table__cell--numeric\">\n    " }
+        let(:monthly_income_before_tax) { I18n.t('providers.capital_income_assessment_results.employment_income.monthly_income_before_tax') }
+        let(:benefits_in_kind) { I18n.t('providers.capital_income_assessment_results.employment_income.benefits_in_kind') }
+        let(:tax) { I18n.t('providers.capital_income_assessment_results.employment_income.tax') }
+        let(:national_insurance) { I18n.t('providers.capital_income_assessment_results.employment_income.national_insurance') }
+        let(:fixed_employment_deduction) { I18n.t('providers.capital_income_assessment_results.employment_income.fixed_employment_deduction') }
+
         it 'displays the employment income' do
           expect(unescaped_response_body).to include(I18n.t('providers.capital_income_assessment_results.other_income.title'))
           expect(unescaped_response_body).to include(I18n.t('providers.capital_income_assessment_results.employment_income.title'))
-          expect(unescaped_response_body).to include(I18n.t('providers.capital_income_assessment_results.employment_income.monthly_income_before_tax'))
-          expect(unescaped_response_body).to include(I18n.t('providers.capital_income_assessment_results.employment_income.benefits_in_kind'))
-          expect(unescaped_response_body).to include(I18n.t('providers.capital_income_assessment_results.employment_income.tax'))
-          expect(unescaped_response_body).to include(I18n.t('providers.capital_income_assessment_results.employment_income.national_insurance'))
-          expect(unescaped_response_body).to include(I18n.t('providers.capital_income_assessment_results.employment_income.fixed_employment_deduction'))
+          expect(unescaped_response_body).to include(monthly_income_before_tax + td + gds_number_to_currency(cfe_result.employment_income_gross_income))
+          expect(unescaped_response_body).to include(benefits_in_kind + td + gds_number_to_currency(cfe_result.employment_income_benefits_in_kind))
+          expect(unescaped_response_body).to include(tax + td + gds_number_to_currency(cfe_result.employment_income_tax))
+          expect(unescaped_response_body).to include(national_insurance + td + gds_number_to_currency(cfe_result.employment_income_national_insurance))
+          expect(unescaped_response_body).to include(fixed_employment_deduction + td + gds_number_to_currency(cfe_result.employment_income_fixed_employment_deduction))
         end
       end
 

--- a/spec/requests/providers/capital_income_assessment_results_spec.rb
+++ b/spec/requests/providers/capital_income_assessment_results_spec.rb
@@ -295,6 +295,7 @@ RSpec.describe Providers::CapitalIncomeAssessmentResultsController, type: :reque
         let(:tax) { I18n.t('providers.capital_income_assessment_results.employment_income.tax') }
         let(:national_insurance) { I18n.t('providers.capital_income_assessment_results.employment_income.national_insurance') }
         let(:fixed_employment_deduction) { I18n.t('providers.capital_income_assessment_results.employment_income.fixed_employment_deduction') }
+        let(:total) { I18n.t('providers.capital_income_assessment_results.employment_income.total') }
 
         it 'displays the employment income' do
           expect(unescaped_response_body).to include(I18n.t('providers.capital_income_assessment_results.other_income.title'))
@@ -304,6 +305,7 @@ RSpec.describe Providers::CapitalIncomeAssessmentResultsController, type: :reque
           expect(unescaped_response_body).to include(tax + td + gds_number_to_currency(cfe_result.employment_income_tax))
           expect(unescaped_response_body).to include(national_insurance + td + gds_number_to_currency(cfe_result.employment_income_national_insurance))
           expect(unescaped_response_body).to include(fixed_employment_deduction + td + gds_number_to_currency(cfe_result.employment_income_fixed_employment_deduction))
+          expect(unescaped_response_body).to include(total + td + gds_number_to_currency(cfe_result.employment_income_net_employment_income))
         end
       end
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2575)

Describe what you did and why.

Add ‘Employment income' section to the 'Income calculation’ accordion on the CFE results page and populate with results data from CFE.
Fix a couple of failure points on mock_interface_response_service.rb to allow for testing.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
