### PR TITLE
AP-2813 Remove ProceedingType from CFE Result v4

### DIFF
--- a/app/models/cfe/v4/result.rb
+++ b/app/models/cfe/v4/result.rb
@@ -126,7 +126,7 @@ module CFE
 
         results = {}
         overall_result[:proceeding_types].each do |hash|
-          results[proceeding_type_meaning(hash[:ccms_code])] = elig_yes_no(hash[:result])
+          results[proceeding_meaning(hash[:ccms_code])] = elig_yes_no(hash[:result])
         end
         results
       end
@@ -345,8 +345,8 @@ module CFE
         disposable_income_breakdown[:deductions] || { dependants_allowance: 0.0, disregarded_state_benefits: 0.0 }
       end
 
-      def proceeding_type_meaning(ccms_code)
-        ProceedingType.find_by(ccms_code: ccms_code).meaning
+      def proceeding_meaning(ccms_code)
+        Proceeding.find_by(ccms_code: ccms_code).meaning
       end
 
       def elig_yes_no(result)

--- a/spec/factories/cfe_results/v4/mock_results.rb
+++ b/spec/factories/cfe_results/v4/mock_results.rb
@@ -427,7 +427,7 @@ module CFEResults
             result: 'ineligible'
           },
           {
-            ccms_code: 'SE003',
+            ccms_code: 'SE014',
             result: 'partially_eligible'
           }
         ]

--- a/spec/factories/proceedings.rb
+++ b/spec/factories/proceedings.rb
@@ -87,7 +87,7 @@ FactoryBot.define do
     trait :da006 do
       lead_proceeding { false }
       ccms_code { 'DA006' }
-      meaning { 'Extend, variation or discharge - Part IV ' }
+      meaning { 'Extend, variation or discharge - Part IV' }
       description { 'to be represented on an application to extend, vary or discharge an order under Part IV Family Law Act 1996. ' }
       substantive_cost_limitation { 25_000 }
       delegated_functions_cost_limitation { rand(1...1_000_000.0).round(2) }

--- a/spec/models/cfe/v4/result_spec.rb
+++ b/spec/models/cfe/v4/result_spec.rb
@@ -282,9 +282,9 @@ module CFE
 
       describe '#results_by_proceeding_type' do
         before do
-          create :proceeding_type, ccms_code: 'DA006', meaning: 'Domestic abuse 006'
-          create :proceeding_type, ccms_code: 'SE003', meaning: 'Section Eight 003'
-          create :proceeding_type, ccms_code: 'SE013', meaning: 'Section Eight 013'
+          create :proceeding, :da006
+          create :proceeding, :se013
+          create :proceeding, :se014
         end
         let(:cfe_result) { with_mixed_proceeding_type_results }
         let(:expected_result_before_transformation) do
@@ -298,16 +298,16 @@ module CFE
               result: 'ineligible'
             },
             {
-              ccms_code: 'SE003',
+              ccms_code: 'SE014',
               result: 'partially_eligible'
             }
           ]
         end
         let(:result_after_transformation) do
           {
-            'Domestic abuse 006' => 'Yes',
-            'Section Eight 013' => 'No',
-            'Section Eight 003' => 'Yes'
+            'Child arrangements order (contact)' => 'No',
+            'Child arrangements order (residence)' => 'Yes',
+            'Extend, variation or discharge - Part IV' => 'Yes'
           }
         end
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2813)

Updates v4 of the CFE `Result` model to replace a reference to the deprecated `ProceedingType` model with `Proceeding`. Also updates tests, factories and fixtures.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
