### PR TITLE
AP-2764: Update check_merits_answers confirmation bullet points

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -74,6 +74,11 @@ module ApplicationHelper
     render 'shared/forms/list_items', translation_path: prefix + translation_path, params: params
   end
 
+  def bullet_list_from_translation_array(locale_path, params: {})
+    keys = [I18n.locale, locale_path.split('.').map(&:to_sym)].flatten
+    render 'shared/forms/list_with_items', locale_path: locale_path, items: I18n.backend.send(:translations).dig(*keys), params: params
+  end
+
   def yes_no(boolean)
     boolean ? t('generic.yes') : t('generic.no')
   end

--- a/app/views/providers/check_merits_answers/show.html.erb
+++ b/app/views/providers/check_merits_answers/show.html.erb
@@ -19,7 +19,7 @@
     <p class="govuk-body"><%= t('.text') %></p>
 
     <% params = { provider_firm_name: @legal_aid_application.provider.firm.name } %>
-    <%= list_from_translation_path '.check_merits_answers.show', params: params %>
+    <%= bullet_list_from_translation_array('providers.check_merits_answers.show.list', params: params) %>
 
     <div class="govuk-warning-text">
       <span class="govuk-warning-text__icon govuk_two_line_warning" aria-hidden="true">!</span>

--- a/app/views/shared/forms/_list_items.html.erb
+++ b/app/views/shared/forms/_list_items.html.erb
@@ -1,15 +1,11 @@
 <div class="govuk-list">
-  <% if translation_path.include? 'warning' %>
-    <ul class="govuk-list govuk-list--bullet">
-      <% t("#{translation_path}.list", **params).each_line do |item| %>
+  <ul class="govuk-list govuk-list--bullet">
+    <% t("#{translation_path}.list", **params).each_line do |item| %>
+      <% if translation_path.include? 'warning' %>
         <li><strong><%= item %></strong></li>
+      <% else %>
+        <li><%= item %></li>
       <% end %>
-    </ul>
-    <% else %>
-    <ul class="govuk-list govuk-list--bullet">
-      <% t("#{translation_path}.list", **params).each_line do |item| %>
-       <li><%= item %></li>
-      <% end %>
-    </ul>
-  <% end %>
+    <% end %>
+  </ul>
 </div>

--- a/app/views/shared/forms/_list_with_items.html.erb
+++ b/app/views/shared/forms/_list_with_items.html.erb
@@ -1,0 +1,7 @@
+<div class="govuk-list">
+  <ul class="govuk-list govuk-list--bullet">
+    <% items.each do |key, _v| %>
+      <li><%= t(key, scope: locale_path, **params) %></li>
+    <% end %>
+  </ul>
+</div>

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -213,14 +213,15 @@ en:
         h1-heading: Check your answers and submit application
         sub-heading: Confirm the following
         text: "Your client agrees that:"
-        list: |
-          they've instructed %{provider_firm_name} to represent them
-          we can share their information with other government departments like the Department for Work and Pensions and HM Revenue and Customs
-          we can check their details with bank and credit reference agencies
-          they may have to pay towards legal aid
-          they may have to repay the legal costs if they keep or gain property or money at the end of the case (the 'statutory charge')
-          the information they’ve given is complete and correct
-          they’ll report any changes to their financial situation immediately
+        list:
+          a: they've instructed %{provider_firm_name} to represent them
+          b_html: they've read the <a href="/privacy_policy">LAA privacy_policy</a>
+          c: we can share their information with other government departments like the DWP and HMRC
+          d: we can check their details with bank and credit reference agencies
+          e: they may have to pay towards legal aid
+          f: they may have to repay the legal costs if they keep or gain property or money at the end of the case (the 'statutory charge')
+          g: the information they’ve given is complete and correct
+          h: they’ll report any changes to their financial situation immediately
         sign_app_text: "If your client gives wrong or incomplete information, does not report changes, or is found to have committed benefit fraud, they may:"
         warning:
           list: |

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -215,7 +215,7 @@ en:
         text: "Your client agrees that:"
         list:
           a: they've instructed %{provider_firm_name} to represent them
-          b_html: they've read the <a href="/privacy_policy">LAA privacy_policy</a>
+          b_html: they've read the <a href="/privacy_policy">LAA privacy policy</a>
           c: we can share their information with other government departments like the DWP and HMRC
           d: we can check their details with bank and credit reference agencies
           e: they may have to pay towards legal aid


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2764)

Update the bullet points on check_merits_answers to match the prototype
* Add new privacy policy bullet point with a clickable link
* Update share information text with contractions of OGDs

This adds a new helper method and partial to handle a single bullet point with clickable text
The current list  helper/partial could not handle _any_ html values 

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
