### PR TITLE
Fix mock HMRC data generation

### DIFF
--- a/app/services/hmrc/mock_interface_response_service.rb
+++ b/app/services/hmrc/mock_interface_response_service.rb
@@ -20,7 +20,7 @@ module HMRC
     end
 
     def call
-      @hmrc_response.update!(response: return_json.to_json, submission_id: @submission_id)
+      @hmrc_response.update!(response: return_json, submission_id: @submission_id)
     end
 
     private

--- a/app/services/hmrc/mock_interface_response_service.rb
+++ b/app/services/hmrc/mock_interface_response_service.rb
@@ -16,11 +16,11 @@ module HMRC
     def initialize(hmrc_response)
       @hmrc_response = hmrc_response
       @application = @hmrc_response.legal_aid_application
-      @submission_id = @hmrc_response.submission_id
+      @submission_id = SecureRandom.uuid
     end
 
     def call
-      @hmrc_response.update!(response: return_json.to_json)
+      @hmrc_response.update!(response: return_json.to_json, submission_id: @submission_id)
     end
 
     private

--- a/spec/services/hmrc/mock_interface_response_service_spec.rb
+++ b/spec/services/hmrc/mock_interface_response_service_spec.rb
@@ -173,7 +173,7 @@ RSpec.describe HMRC::MockInterfaceResponseService do
   end
 
   it 'updates the hmrc_response.response value' do
-    expect(JSON.parse(hmrc_response.reload.response)).to match_json_expression not_found_response
+    expect(hmrc_response.reload.response).to match_json_expression not_found_response
   end
 
   it 'updates the hmrc_response.submission_id value' do
@@ -184,7 +184,7 @@ RSpec.describe HMRC::MockInterfaceResponseService do
     let(:applicant) { create :applicant, first_name: 'Langley', last_name: 'Yorke', national_insurance_number: 'MN212451D', date_of_birth: '1992-07-22' }
 
     it 'updates the hmrc_response.response value' do
-      expect(JSON.parse(hmrc_response.reload.response)).to match_json_expression employed_response
+      expect(hmrc_response.reload.response).to match_json_expression employed_response
     end
   end
 end

--- a/spec/services/hmrc/mock_interface_response_service_spec.rb
+++ b/spec/services/hmrc/mock_interface_response_service_spec.rb
@@ -167,10 +167,17 @@ RSpec.describe HMRC::MockInterfaceResponseService do
     }
   end
 
-  before { service }
+  before do
+    allow(SecureRandom).to receive(:uuid).and_return('dummy_uuid')
+    service
+  end
 
   it 'updates the hmrc_response.response value' do
     expect(JSON.parse(hmrc_response.reload.response)).to match_json_expression not_found_response
+  end
+
+  it 'updates the hmrc_response.submission_id value' do
+    expect(hmrc_response.reload.submission_id).to eq 'dummy_uuid'
   end
 
   context 'when the applicant is known to the mock response service' do


### PR DESCRIPTION
## What

The `HMRC::MockInterfaceResponseService` does not set the `submission_id` on the `HMRC::Response` record. This causes the process to fail as the `submission_id` is used to subsequently update the `Response` with the correct json payload.

This changes the `MockInterfaceResponseService` so that it generates a `submission_id` uuid, and updates the `Response record` with it, in its initializer.


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
