### PR TITLE
Fix: Update Mock HMRC data

### DIFF
--- a/app/services/hmrc/create_responses_service.rb
+++ b/app/services/hmrc/create_responses_service.rb
@@ -27,7 +27,11 @@ module HMRC
     private
 
     def use_mock?
-      Rails.configuration.x.hmrc_use_dev_mock && !Rails.env.production?
+      Rails.configuration.x.hmrc_use_dev_mock && not_production_environment?
+    end
+
+    def not_production_environment?
+      !HostEnv.production?
     end
   end
 end

--- a/spec/services/hmrc/create_responses_service_spec.rb
+++ b/spec/services/hmrc/create_responses_service_spec.rb
@@ -27,9 +27,34 @@ RSpec.describe HMRC::CreateResponsesService do
       context 'when HMRC_USE_DEV_MOCK is set to true' do
         let(:hmrc_use_dev_mock) { 'true' }
 
-        it 'calls the MockInterfaceResponseService and creates no SubmissionWorker jobs' do
-          expect { call }.to_not change(HMRC::SubmissionWorker.jobs, :size)
-          expect(HMRC::MockInterfaceResponseService).to have_received(:call).twice
+        context 'the host is set to' do
+          before { allow(HostEnv).to receive(:environment).and_return(host) }
+
+          context 'production' do
+            let(:host) { :production }
+
+            it 'creates two jobs to request the data and does not invoke the MockInterfaceResponseService' do
+              expect { call }.to change(HMRC::SubmissionWorker.jobs, :size).by(2)
+              expect(HMRC::MockInterfaceResponseService).to_not have_received(:call)
+            end
+          end
+
+          context 'staging' do
+            let(:host) { :staging }
+            it 'calls the MockInterfaceResponseService and creates no SubmissionWorker jobs' do
+              expect { call }.to_not change(HMRC::SubmissionWorker.jobs, :size)
+              expect(HMRC::MockInterfaceResponseService).to have_received(:call).twice
+            end
+          end
+
+          context 'uat' do
+            let(:host) { :uat }
+
+            it 'calls the MockInterfaceResponseService and creates no SubmissionWorker jobs' do
+              expect { call }.to_not change(HMRC::SubmissionWorker.jobs, :size)
+              expect(HMRC::MockInterfaceResponseService).to have_received(:call).twice
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
## What

The original used Rails.env.production?  but that is always set
because it is set in the Dockerfile.  This uses HostEnv to allow
checking for any environment except production


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
