### PR TITLE
AP-2576 Add employment data to certificate

### DIFF
--- a/app/controllers/providers/submitted_applications_controller.rb
+++ b/app/controllers/providers/submitted_applications_controller.rb
@@ -1,7 +1,16 @@
 module Providers
   class SubmittedApplicationsController < ProviderBaseController
     authorize_with_policy_method :show_submitted_application?
+    helper_method :display_employment_income?
 
     def show; end
+
+    private
+
+    def display_employment_income?
+      Setting.enable_employed_journey? &&
+        @legal_aid_application.provider.employment_permissions? &&
+        @legal_aid_application.cfe_result.jobs?
+    end
   end
 end

--- a/app/views/providers/submitted_applications/_employment_income_table.html.erb
+++ b/app/views/providers/submitted_applications/_employment_income_table.html.erb
@@ -1,0 +1,52 @@
+<section class="print-no-break">
+  <h3 class="govuk-heading-m"><%= t('.heading') %></h3>
+  <table class="govuk-table govuk-!-margin-bottom-3">
+    <caption class="govuk-table__caption govuk-!-padding-bottom-2">
+      <%= t('date.date_period', from: date_from(@legal_aid_application), to: date_to(@legal_aid_application)) %>
+    </caption>
+    <tbody class="govuk-table__body">
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">
+            <%= t('.monthly_income_before_tax') %>
+          </td>
+          <td class="govuk-table__cell govuk-table__cell--numeric">
+            <%= gds_number_to_currency @legal_aid_application.cfe_result.employment_income_gross_income %>
+          </td>
+        </tr>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">
+            <%= t('.benefits_in_kind') %>
+          </td>
+          <td class="govuk-table__cell govuk-table__cell--numeric">
+            <%= gds_number_to_currency @legal_aid_application.cfe_result.employment_income_benefits_in_kind %>
+          </td>
+        </tr>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">
+            <%= t('.tax') %>
+          </td>
+          <td class="govuk-table__cell govuk-table__cell--numeric">
+            <%= gds_number_to_currency @legal_aid_application.cfe_result.employment_income_tax %>
+          </td>
+        </tr>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">
+            <%= t('.national_insurance') %>
+          </td>
+          <td class="govuk-table__cell govuk-table__cell--numeric">
+            <%= gds_number_to_currency @legal_aid_application.cfe_result.employment_income_national_insurance %>
+          </td>
+        </tr>
+        <% if @legal_aid_application.extra_employment_information %>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell">
+              <%= t('.employment_details') %>
+            </td>
+            <td class="govuk-table__cell govuk-table__cell--numeric">
+              <%= gds_number_to_currency @legal_aid_application.extra_employment_information_details %>
+            </td>
+          </tr>
+        <% end %>
+    </tbody>
+  </table>
+</section>

--- a/app/views/providers/submitted_applications/show.html.erb
+++ b/app/views/providers/submitted_applications/show.html.erb
@@ -85,16 +85,12 @@
     <section class="income_payments_and_assets page_break_before">
       <div class="govuk-!-padding-bottom-6"></div>
       <h2 class="govuk-heading-l"><%= t('.income_payments_and_assets_heading') %></h2>
-      <% if Setting.enable_employed_journey? &&
-            @legal_aid_application.provider.employment_permissions? &&
-            @legal_aid_application.cfe_result.jobs? %>
+      <% if display_employment_income? %>
           <%= render 'employment_income_table' %>
       <% end %>
 
       <section class="print-no-break">
-        <h3 class="govuk-heading-m govuk-!-padding-top-8"><%= Setting.enable_employed_journey? &&
-                                        @legal_aid_application.provider.employment_permissions? &&
-                                        @legal_aid_application.cfe_result.jobs? ? t('.other_income') : t('.income') %></h3>
+        <h3 class="govuk-heading-m govuk-!-padding-top-8"><%= display_employment_income? ? t('.other_income') : t('.income') %></h3>
         <% if @legal_aid_application.applicant_receives_benefit? %>
             <strong class="govuk-tag app-tag--capitalize">
               <%= t('.passported') %>

--- a/app/views/providers/submitted_applications/show.html.erb
+++ b/app/views/providers/submitted_applications/show.html.erb
@@ -85,8 +85,16 @@
     <section class="income_payments_and_assets page_break_before">
       <div class="govuk-!-padding-bottom-6"></div>
       <h2 class="govuk-heading-l"><%= t('.income_payments_and_assets_heading') %></h2>
+      <% if Setting.enable_employed_journey? &&
+            @legal_aid_application.provider.employment_permissions? &&
+            @legal_aid_application.cfe_result.jobs? %>
+          <%= render 'employment_income_table' %>
+      <% end %>
+
       <section class="print-no-break">
-        <h3 class="govuk-heading-m"><%= t('.income') %></h3>
+        <h3 class="govuk-heading-m govuk-!-padding-top-8"><%= Setting.enable_employed_journey? &&
+                                        @legal_aid_application.provider.employment_permissions? &&
+                                        @legal_aid_application.cfe_result.jobs? ? t('.other_income') : t('.income') %></h3>
         <% if @legal_aid_application.applicant_receives_benefit? %>
             <strong class="govuk-tag app-tag--capitalize">
               <%= t('.passported') %>

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -888,6 +888,7 @@ en:
         income_payments_and_assets_heading: Income, regular payments and assets
         income: Income
         irregular_income: Irregular income
+        other_income: Other income
         passported: Passported
         payments: Regular payments
         change: Change
@@ -909,6 +910,13 @@ en:
           heading: Client declaration
           signature: "Client signature:"
           date: "Date:"
+      employment_income_table:
+        benefits_in_kind: Benefits in kind
+        employment_details: Employment details
+        heading: Income
+        monthly_income_before_tax: Monthly income before tax
+        national_insurance: National insurance
+        tax: Tax
     substantive_applications:
       show:
         heading: Do you want to make a substantive application now?


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2576)

Adds a new partial to display income from employment on the certificate page. This is only displayed if the feature flag is on, the solicitor has permission, and employment data exists. If this is the case the name of the subsequent section is changed from 'Income' to 'Other income'.

Also adds tests. We don't test many of the other components on that page but it felt useful to have them to ensure that the display logic was working correctly. These can be removed/reduced if it seems unnecessary. 

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
