### PR TITLE
Fix: Update sidekiq-status and i18n - group other gem updates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,7 +63,7 @@ gem 'jwt'
 # background processing
 gem 'redis-namespace'
 gem 'sidekiq', '~> 6.4.0'
-gem 'sidekiq-status', '>= 1.1.4'
+gem 'sidekiq-status', '~> 2.1.2'
 
 # URL and path parsing
 gem 'addressable'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -368,7 +368,7 @@ GEM
     httpi (2.5.0)
       rack
       socksify
-    i18n (1.9.0)
+    i18n (1.9.1)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
     iniparse (1.5.0)
@@ -667,7 +667,7 @@ GEM
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
       redis (>= 4.2.0)
-    sidekiq-status (2.1.1)
+    sidekiq-status (2.1.2)
       chronic_duration
       sidekiq (>= 5.0)
     signet (0.16.0)
@@ -833,7 +833,7 @@ DEPENDENCIES
   sentry-sidekiq
   shoulda-matchers (~> 5.1)
   sidekiq (~> 6.4.0)
-  sidekiq-status (>= 1.1.4)
+  sidekiq-status (~> 2.1.2)
   simple_command!
   simplecov
   simplecov-rcov

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -480,7 +480,7 @@ GEM
       childprocess (>= 0.6.3, < 5)
       iniparse (~> 1.4)
       rexml (~> 3.2)
-    pagy (5.9.1)
+    pagy (5.9.2)
       activesupport
     parallel (1.21.0)
     parser (3.1.0.0)
@@ -747,7 +747,7 @@ GEM
       activesupport
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.5.3)
+    zeitwerk (2.5.4)
 
 PLATFORMS
   ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -581,7 +581,7 @@ GEM
       rspec-core (~> 3.10.0)
       rspec-expectations (~> 3.10.0)
       rspec-mocks (~> 3.10.0)
-    rspec-core (3.10.1)
+    rspec-core (3.10.2)
       rspec-support (~> 3.10.0)
     rspec-expectations (3.10.2)
       diff-lcs (>= 1.2.0, < 2.0)


### PR DESCRIPTION
## What

These were blocking each other (and everything) in the dependabot PRs
Sidekiq-status wouldn't update because i18n had been withdrawn and vice-versa

Also import other dependabot updates from today to reduce rebases needed

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
