### PR TITLE
Make changes to content on HMRC 'no data' page

### DIFF
--- a/app/views/providers/no_employment_incomes/show.html.erb
+++ b/app/views/providers/no_employment_incomes/show.html.erb
@@ -13,10 +13,10 @@
         <li><%= t '.details_3' %></li>
         <li><%= t '.details_4' %></li>
       </ul>
-      <p class="govuk-body"><%= t('.caseworker_will_ask') %></p>
 
       <%= form.govuk_text_area :full_employment_details,
-                                label: {text: t('.employment_details_header'), tag: 'h2', size: 'm' },
+                                label: { text: t('.employment_details_header'), tag: 'h2', size: 'm' },
+                                hint: { text: t('.employment_details_hint') },
                                 rows: 10 %>
 
     <%= next_action_buttons(

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -663,8 +663,9 @@ en:
         details_2: how much National Insurance they paid
         details_3: how much tax they paid
         details_4: any benefits in kind they received
-        caseworker_will_ask: A caseworker will ask for evidence of this.
         employment_details_header: Enter your client's employment details
+        employment_details_hint: You'll need to upload supporting evidence later.
+
     no_income_summaries:
       show:
         page_heading: "Your client's income"


### PR DESCRIPTION

## What

[Link to story](https://dsdmoj.atlassian.net/jira/software/c/projects/AP/boards/233?modal=detail&selectedIssue=AP-2779)

Update the content on the page where the provider has said their client is employed but HMRC returns no data.

Removed the line ‘A caseworker will ask for evidence of this’ and added the hint: "You'll need to upload supporting evidence later." under the heading "Enter your client’s employment details:"


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
