### PR TITLE
Fix: Use new docker image for tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,10 +27,9 @@ executors:
         environment:
           TERM: dumb
     resource_class: small
-
   test-executor:
     docker:
-      - image: cimg/ruby:3.1.0-browsers
+      - image: ministryofjustice/apply-ci:latest
         environment:
           GITHUB_TEAM_NAME_SLUG: laa-apply-for-legal-aid
       - image: cimg/postgres:10.18
@@ -65,16 +64,6 @@ references:
       command: |
         wget http://mirrors.kernel.org/ubuntu/pool/main/libf/libffi/libffi6_3.2.1-8_amd64.deb
         sudo apt install ./libffi6_3.2.1-8_amd64.deb
-
-  install_packages_for_testing: &install_packages_for_testing
-    run:
-      name: Install System packages needed for testing
-      command: |
-        sudo apt-get update
-        sudo apt-get install -y postgresql-client
-        sudo apt-get install -y clamav-daemon
-        sudo apt-get install -y wkhtmltopdf
-        sudo apt-get install -y git-crypt
 
   install_js_packages: &install_js_packages
     run:
@@ -157,8 +146,6 @@ jobs:
     executor: test-executor
     steps:
     - checkout
-    - *install_lib_ffi
-    - *install_packages_for_testing
     - *decrypt_secrets
     - *restore_gems_cache
     - *install_gems
@@ -196,8 +183,6 @@ jobs:
     executor: test-executor
     steps:
     - checkout
-    - *install_lib_ffi
-    - *install_packages_for_testing
     - *decrypt_secrets
     - *restore_gems_cache
     - *install_gems
@@ -261,8 +246,6 @@ jobs:
     - browser-tools/install-chrome
     - browser-tools/install-chromedriver
     - checkout
-    - *install_lib_ffi
-    - *install_packages_for_testing
     - *decrypt_secrets
     - *restore_gems_cache
     - *install_gems

--- a/.github/workflows/ci-docker-image.yml
+++ b/.github/workflows/ci-docker-image.yml
@@ -1,0 +1,18 @@
+name: Docker/generate apply-ci image
+on:
+  schedule:
+    - cron:  '30 5 * * *'
+jobs:
+  build-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_PAT }}
+      - uses: actions/checkout@v2
+      - name: Build the Docker image
+        run: docker build . --file ./docker/apply_ci.dockerfile --tag ministryofjustice/apply-ci:latest
+      - name: Push the Docker image
+        run: docker push ministryofjustice/apply-ci:latest

--- a/docker/apply_ci.dockerfile
+++ b/docker/apply_ci.dockerfile
@@ -1,0 +1,10 @@
+FROM cimg/ruby:3.1.0-browsers
+MAINTAINER apply for legal aid team
+
+RUN wget http://mirrors.kernel.org/ubuntu/pool/main/libf/libffi/libffi6_3.2.1-8_amd64.deb -O /tmp/libffi6_3.2.1-8_amd64.deb
+RUN sudo apt-get update
+RUN sudo apt install /tmp/libffi6_3.2.1-8_amd64.deb
+RUN sudo apt-get install -y postgresql-client \
+                            clamav-daemon \
+                            wkhtmltopdf \
+                            git-crypt


### PR DESCRIPTION
## What

### Step one

Create a new `apply-ci.dockerfile`, this replaces steps in the CircleCI jobs that were taking minutes for each job to pull down and install the same packages

### Step two

Create a new Github Action that will build and push an image from the new dockerfile to dockerhub on a daily basis, but should be amended to weekly when we are happy with the stability

### Step three

Switch CircleCI to use the new image from dockerhub and remove the jobs that were no longer needed

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
