### PR TITLE
AP-2865 Update hint text on file upload pages

### DIFF
--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -358,7 +358,7 @@ en:
           h2-heading: Uploaded files
           no_files: Files uploaded will appear here.
           upload_file: Attach a file
-          size_hint: The maximum file size is 7MB. You can attach more than one file.
+          size_hint: The maximum file size is 7MB. Files must be a DOC, DOCX, RTF, ODT, JPG, BMP, PNG, TIF or PDF.
           dropzone_message: Drag and drop files here or
           choose_files_btn: Choose files
           file_not_uploaded_error: Upload the selected file
@@ -446,7 +446,7 @@ en:
         benefit_evidence: evidence that your client receives Universal Credit
         employment_evidence: evidence of your client's employment
         gateway_evidence: gateway evidence for Section 8 proceedings (optional)
-        size_hint: The maximum file size is 7MB.
+        size_hint: The maximum file size is 7MB. Files must be a DOC, DOCX, RTF, ODT, JPG, BMP, PNG, TIF or PDF.
         dropzone_message: Drag and drop files here or
         choose_files_btn: Choose files
         file_not_uploaded_error: Upload the selected file


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2865)

Updates the hint text on the statement of case and evidence upload pages, bringing it in line with the prototype and  including a list of valid file types.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
