### PR TITLE
Fix: Welsh language features

### DIFF
--- a/config/locales/cy/generic.yml
+++ b/config/locales/cy/generic.yml
@@ -12,11 +12,11 @@ cy:
     continue: eunitnoC
     confirm: "?erus uoy erA"
     create_test_applications: snoitacilppa tset etaerC
-    cy: gearmyC
+    cy: Cymraeg
     destroy: yortseD
     edit: tidE
-    en: hsilgnE
-    en-GB: hsilgnE
+    en: English
+    en-GB: EnglishGBForFakerInTests
     enter_text: txet retnE
     errors:
       problem_text: melborp a si erehT

--- a/features/citizens/citizens_welsh.feature
+++ b/features/citizens/citizens_welsh.feature
@@ -24,6 +24,8 @@ Feature: Citizen journey in Welsh
     Then I choose 'HSBC'
     Then I click 'eunitnoc dna evaS'
     Then I am directed to TrueLayer
+    When I click the browser back button
+    Then I return to English
 
   @javascript @vcr
   Scenario: Follow citizen journey from Accounts page
@@ -73,6 +75,7 @@ Feature: Citizen journey in Welsh
     Then I should be on a page showing "noitamrofni laicnanif ruoy derahs ev'uoY"
     Then I click the browser back button
     Then I should be on a page showing "tnemssessa laicnanif ruoy detelpmoc ydaerla ev'uoY"
+    Then I return to English
 
   @javascript @vcr
   Scenario: View privacy policy
@@ -80,6 +83,7 @@ Feature: Citizen journey in Welsh
     Then I visit the start of the financial assessment in Welsh
     Then I click link 'ycilop ycavirP'
     Then I should be on a page showing 'esopruP'
+    Then I return to English
 
   @javascript @vcr
   Scenario: View contact information
@@ -87,6 +91,7 @@ Feature: Citizen journey in Welsh
     Then I visit the start of the financial assessment in Welsh
     Then I click link 'tcatnoC'
     Then I should be on a page showing 'su tcatnoC'
+    Then I return to English
 
   @javascript @vcr
   Scenario: View accessibility statement
@@ -94,6 +99,7 @@ Feature: Citizen journey in Welsh
     Then I visit the start of the financial assessment in Welsh
     Then I click link 'tnemetats ytilibisseccA'
     Then I should be on a page showing 'ecivres siht gnisU'
+    Then I return to English
 
   @javascript @vcr
   Scenario: Visit the feedback page
@@ -101,3 +107,4 @@ Feature: Citizen journey in Welsh
     Then I visit the start of the financial assessment in Welsh
     Then I click link 'kcabdeeF'
     Then I should be on a page showing '?ecivres siht esu ot ti saw tluciffid ro ysae woH'
+    Then I return to English

--- a/features/step_definitions/citizens_steps.rb
+++ b/features/step_definitions/citizens_steps.rb
@@ -26,6 +26,10 @@ Then('I visit the start of the financial assessment in Welsh') do
   click_link('Cymraeg')
 end
 
+Then('I return to English') do
+  click_link('English')
+end
+
 Then('I visit the first question about dependants') do
   visit citizens_legal_aid_application_path(secure_id)
   visit citizens_has_dependants_path


### PR DESCRIPTION
## What

Update the welsh language feature tests
* Ensure they render with proper labels for the language switcher helper
* Ensure each feature switches back to English at the end of the test, this prevents the locale leaking into subsequent feature tests

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
