### PR TITLE
Fix: Remove overnight test run

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -208,68 +208,6 @@ jobs:
           path: ~/project/coverage
           destination: coverage
 
-
-  full_unit_tests:
-    executor: test-executor
-    steps:
-    - checkout
-    - *decrypt_secrets
-    - *restore_gems_cache
-    - *install_gems
-    - *save_gems_cache
-    - *setup_database
-    - *restore_js_packages_cache
-    - *install_js_packages
-    - *save_js_packages_cache
-    - run:
-        name: Run ruby tests
-        command: INC_CCMS=true INC_I18N=true bundle exec rspec --format progress --format RspecJunitFormatter -o /tmp/test-results/rspec/rspec.xml
-    - store_test_results:
-        path: /tmp/test-results/rspec
-    - store_artifacts:
-        path: ./coverage
-    - slack/notify:
-        event: fail
-        custom: |
-          {
-            "blocks": [
-              {
-                "type": "section",
-                "fields": [
-                  {
-                    "type": "mrkdwn",
-                    "text": ":circleci: :nope: The full CCMS run has failed. Run: \n\n `INC_CCMS=true bundle exec rspec --tag ccms` \n\n locally to trace and resolve the issue."
-                  }
-                ]
-              },
-              {
-                "type": "section",
-                "fields": [
-                  {
-                    "type": "mrkdwn",
-                    "text": "*Project*: $CIRCLE_PROJECT_REPONAME"
-                  },
-                  {
-                    "type": "mrkdwn",
-                    "text": "*Mentions*: @here"
-                  }
-                ]
-              },
-              {
-                "type": "actions",
-                "elements": [
-                  {
-                    "type": "button",
-                    "text": {
-                      "type": "plain_text",
-                      "text": "View Job"
-                    },
-                    "url": "${CIRCLE_BUILD_URL}"
-                  }
-                ]
-              }
-            ]
-          }
   integration_tests:
     parallelism: 3
     executor: test-executor
@@ -553,13 +491,3 @@ workflows:
             only: main
     jobs:
     - clean_up_ecr
-
-  full_ccms_unit_test_run:
-    triggers:
-    - schedule:
-        cron: "15 2 * * *"
-        filters:
-          branches:
-            only: main
-    jobs:
-    - full_unit_tests

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -68,8 +68,6 @@ VCR.configure do |vcr_config|
 end
 
 RSpec.configure do |config|
-  config.filter_run_excluding :i18n unless ENV['INC_I18N'].to_s == 'true'
-
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.


### PR DESCRIPTION
## What

Now that the rspec tests are running in parallel, we no longer need the I18n tests to behind a flag, also we don't need the full test suite to run overnight


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
