### PR TITLE
AP-2739 Evidence upload validation

### DIFF
--- a/app/controllers/providers/uploaded_evidence_collections_controller.rb
+++ b/app/controllers/providers/uploaded_evidence_collections_controller.rb
@@ -11,6 +11,8 @@ module Providers
       elsif draft_button_pressed?
         populate_submission_form
         save_continue_or_draft(submission_form)
+      elsif delete_button_pressed?
+        destroy
       elsif save_or_continue
         convert_new_files_to_pdf
       else
@@ -94,6 +96,10 @@ module Providers
       params[:draft_button].present?
     end
 
+    def delete_button_pressed?
+      params[:delete_button].present?
+    end
+
     def upload_form
       @upload_form ||= Providers::UploadedEvidenceCollectionForm.new(uploaded_evidence_collection_params)
     end
@@ -119,10 +125,6 @@ module Providers
       @uploaded_evidence_collection ||= legal_aid_application.uploaded_evidence_collection || legal_aid_application.build_uploaded_evidence_collection
     end
 
-    # TODO: remove the nocov on a future ticket
-    # delete function has been removed due to limitations
-    # with the forms - ticket to be created for this work
-    # :nocov:
     def delete_original_and_pdf_files
       original_attachment = Attachment.find(attachment_id)
       delete_attachment(Attachment.find(original_attachment.pdf_attachment_id)) if original_attachment.pdf_attachment_id.present?
@@ -130,17 +132,11 @@ module Providers
     rescue StandardError
       original_attachment
     end
-    # :nocov:
 
-    # TODO: remove the nocov on a future ticket
-    # delete function has been removed due to limitations
-    # with the forms - ticket to be created for this work
-    # :nocov:
     def delete_attachment(attachment)
       attachment.document.purge_later
       attachment.destroy
     end
-    # :nocov:
 
     def attachment_id
       params[:attachment_id]
@@ -152,14 +148,9 @@ module Providers
       "#{I18n.t('accessibility.problem_text')} #{upload_form.errors.messages[:original_file].first}"
     end
 
-    # TODO: remove the nocov on a future ticket
-    # delete function has been removed due to limitations
-    # with the forms - ticket to be created for this work
-    # :nocov:
     def files_deleted_message(deleted_file_name)
       I18n.t('activemodel.attributes.uploaded_evidence_collection.file_deleted', file_name: deleted_file_name)
     end
-    # :nocov:
 
     def successful_upload
       return if upload_form.errors.present?

--- a/app/controllers/providers/uploaded_evidence_collections_controller.rb
+++ b/app/controllers/providers/uploaded_evidence_collections_controller.rb
@@ -2,6 +2,7 @@
 module Providers
   class UploadedEvidenceCollectionsController < ProviderBaseController
     def show
+      RequiredDocumentCategoryAnalyser.call(legal_aid_application)
       populate_upload_form
     end
 
@@ -43,7 +44,7 @@ module Providers
       no_files = params[:uploaded_evidence_collection].nil?
       update_attachment_type unless no_files
       populate_submission_form
-      return false unless submission_form.valid?
+      return false unless submission_form.model.valid?
 
       if no_files
         legal_aid_application.reload
@@ -54,17 +55,13 @@ module Providers
     end
 
     def populate_upload_form
-      RequiredDocumentCategoryAnalyser.call(legal_aid_application)
       required_documents
       @upload_form = Providers::UploadedEvidenceCollectionForm.new(model: uploaded_evidence_collection)
       attachment_type_options
     end
 
     def populate_submission_form
-      RequiredDocumentCategoryAnalyser.call(legal_aid_application)
-      required_documents
       @submission_form = Providers::UploadedEvidenceSubmissionForm.new(model: uploaded_evidence_collection)
-      attachment_type_options
     end
 
     def perform_upload

--- a/app/controllers/providers/uploaded_evidence_collections_controller.rb
+++ b/app/controllers/providers/uploaded_evidence_collections_controller.rb
@@ -8,6 +8,9 @@ module Providers
     def update
       if upload_button_pressed?
         perform_upload
+      elsif draft_button_pressed?
+        populate_submission_form
+        save_continue_or_draft(submission_form)
       elsif save_or_continue
         convert_new_files_to_pdf
       else
@@ -85,6 +88,10 @@ module Providers
 
     def upload_button_pressed?
       params[:upload_button].present?
+    end
+
+    def draft_button_pressed?
+      params[:draft_button].present?
     end
 
     def upload_form

--- a/app/controllers/v1/uploaded_evidence_collections_controller.rb
+++ b/app/controllers/v1/uploaded_evidence_collections_controller.rb
@@ -1,16 +1,20 @@
 module V1
   class UploadedEvidenceCollectionsController < ApiController
+    include MalwareScanning
     def create
-      if legal_aid_application
-        file = form_params[:file]
-        legal_aid_application.attachments.create document: file,
-                                                 attachment_type: 'uncategorised',
-                                                 original_filename: file.original_filename,
-                                                 attachment_name: sequenced_attachment_name
-        render '', status: :ok
-      else
-        render '', status: :not_found
-      end
+      return head :not_found unless legal_aid_application
+
+      file = form_params[:file]
+      malware_scan = malware_scan_result(file)
+
+      return render json: { error: original_file_error_for(:file_virus) }, status: :bad_request if malware_scan.virus_found?
+      return render json: { error: original_file_error_for(:system_down) }, status: :bad_request unless malware_scan.scanner_working
+
+      legal_aid_application.attachments.create document: file,
+                                               attachment_type: 'uncategorised',
+                                               original_filename: file.original_filename,
+                                               attachment_name: sequenced_attachment_name
+      head :ok
     end
 
     private
@@ -47,6 +51,14 @@ module V1
         most_recent_name =~ /^#{name}_(\d+)$/
         "#{name}_#{Regexp.last_match(1).to_i + 1}"
       end
+    end
+
+    def provider_uploader
+      legal_aid_application.provider
+    end
+
+    def error_path
+      'uploaded_evidence_collection'
     end
   end
 end

--- a/app/forms/providers/uploaded_evidence_collection_form.rb
+++ b/app/forms/providers/uploaded_evidence_collection_form.rb
@@ -8,22 +8,14 @@ module Providers
     validate :file_uploaded?
 
     def save
-      return if original_file.nil?
+      return unless original_file
 
       model.save(validate: false) if attachments_made?
     end
 
-    # TODO: method will need to be changed on the validation ticket
-    # https://dsdmoj.atlassian.net/browse/AP-2739 and the nocov removed
-    # :nocov:
     def files?
-      # For now we return if it is empty so application can progress to the next page
-      # but the line below will need to be removed
-      return if files.empty?
-
       original_file.present?
     end
-    # :nocov:
 
     private
 

--- a/app/forms/providers/uploaded_evidence_collection_form.rb
+++ b/app/forms/providers/uploaded_evidence_collection_form.rb
@@ -13,10 +13,6 @@ module Providers
       model.save(validate: false) if attachments_made?
     end
 
-    def files?
-      original_file.present?
-    end
-
     private
 
     def create_attachment(original_file)

--- a/app/forms/providers/uploaded_evidence_submission_form.rb
+++ b/app/forms/providers/uploaded_evidence_submission_form.rb
@@ -3,35 +3,5 @@ module Providers
     form_for UploadedEvidenceCollection
 
     attr_accessor :provider_uploader
-
-    validate :all_evidence_categorised
-    validate :mandatory_evidence_uploaded
-
-    def all_evidence_categorised
-      return true unless uncategorised_evidence_exists
-
-      errors.add(:uploaded_evidence_collection_select,
-                 I18n.t("#{error_path}.uncategorised_evidence"))
-    end
-
-    def uncategorised_evidence_exists
-      model.original_attachments.any? { |attachment| attachment.attachment_type == 'uncategorised' }
-    end
-
-    def mandatory_evidence_uploaded
-      model.mandatory_evidence_types.each do |type|
-        next if model.categorised_evidence_types.include?(type)
-
-        errors.add("uploaded_evidence_collection_#{type}",
-                   I18n.t("#{error_path}.#{type}_missing",
-                          benefit: model.legal_aid_application.dwp_override.passporting_benefit.titleize))
-      end
-    end
-
-    private
-
-    def error_path
-      '.activemodel.errors.models.uploaded_evidence_collection.attributes.original_file'
-    end
   end
 end

--- a/app/forms/providers/uploaded_evidence_submission_form.rb
+++ b/app/forms/providers/uploaded_evidence_submission_form.rb
@@ -2,18 +2,36 @@ module Providers
   class UploadedEvidenceSubmissionForm < BaseFileUploaderForm
     form_for UploadedEvidenceCollection
 
-    attr_accessor :original_file, :provider_uploader, :upload_button_pressed
+    attr_accessor :provider_uploader
 
-    # TODO: method will need to be changed on the validation ticket
-    # https://dsdmoj.atlassian.net/browse/AP-2739 and the nocov removed
-    # :nocov:
-    def files?
-      # For now we return if it is empty so application can progress to the next page
-      # but the line below will need to be removed
-      return true if original_file.nil?
+    validate :all_evidence_categorised
+    validate :mandatory_evidence_uploaded
 
-      original_file.present?
+    def all_evidence_categorised
+      return true unless uncategorised_evidence_exists
+
+      errors.add(:uploaded_evidence_collection_select,
+                 I18n.t("#{error_path}.uncategorised_evidence"))
     end
-    # :nocov:
+
+    def uncategorised_evidence_exists
+      model.original_attachments.any? { |attachment| attachment.attachment_type == 'uncategorised' }
+    end
+
+    def mandatory_evidence_uploaded
+      model.mandatory_evidence_types.each do |type|
+        next if model.categorised_evidence_types.include?(type)
+
+        errors.add("uploaded_evidence_collection_#{type}",
+                   I18n.t("#{error_path}.#{type}_missing",
+                          benefit: model.legal_aid_application.dwp_override.passporting_benefit.titleize))
+      end
+    end
+
+    private
+
+    def error_path
+      '.activemodel.errors.models.uploaded_evidence_collection.attributes.original_file'
+    end
   end
 end

--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -287,7 +287,7 @@ class LegalAidApplication < ApplicationRecord
   end
 
   def employment_evidence_required?
-    extra_employment_information_details.present?
+    extra_employment_information_details.present? || full_employment_details.present?
   end
 
   def outstanding_mortgage?

--- a/app/models/uploaded_evidence_collection.rb
+++ b/app/models/uploaded_evidence_collection.rb
@@ -2,19 +2,54 @@ class UploadedEvidenceCollection < ApplicationRecord
   belongs_to :legal_aid_application
   belongs_to :provider_uploader, class_name: 'Provider', optional: true
 
+  validate :all_evidence_categorised
+  validate :all_mandatory_evidence_uploaded
+
   def original_attachments
     legal_aid_application.attachments.displayable_evidence_types
   end
 
-  def application_evidence_types
-    legal_aid_application.required_document_categories
+  private
+
+  def all_evidence_categorised
+    return true unless uncategorised_evidence_exists?
+
+    errors.add(:'uploaded-files-table-container',
+               I18n.t("#{error_path}.uncategorised_evidence"))
+    false
+  end
+
+  def uncategorised_evidence_exists?
+    original_attachments.any? { |attachment| attachment.attachment_type == 'uncategorised' }
+  end
+
+  def all_mandatory_evidence_uploaded
+    mandatory_evidence_types.each do |type|
+      next if categorised_evidence_types.include?(type)
+
+      errors.add("uploaded_files_table_container#{type}", I18n.t("#{error_path}.#{type}_missing", benefit: passporting_benefit))
+    end
+
+    mandatory_evidence_types.all? { |mandatory_type| categorised_evidence_types.include?(mandatory_type) }
   end
 
   def mandatory_evidence_types
     DocumentCategory.where(name: application_evidence_types, mandatory: true).pluck(:name)
   end
 
+  def application_evidence_types
+    legal_aid_application.required_document_categories
+  end
+
   def categorised_evidence_types
     original_attachments.pluck(:attachment_type).uniq
+  end
+
+  def passporting_benefit
+    legal_aid_application.dwp_override ? legal_aid_application.dwp_override.passporting_benefit.titleize : nil
+  end
+
+  def error_path
+    '.activemodel.errors.models.uploaded_evidence_collection.attributes.original_file'
   end
 end

--- a/app/models/uploaded_evidence_collection.rb
+++ b/app/models/uploaded_evidence_collection.rb
@@ -5,4 +5,16 @@ class UploadedEvidenceCollection < ApplicationRecord
   def original_attachments
     legal_aid_application.attachments.displayable_evidence_types
   end
+
+  def application_evidence_types
+    legal_aid_application.required_document_categories
+  end
+
+  def mandatory_evidence_types
+    DocumentCategory.where(name: application_evidence_types, mandatory: true).pluck(:name)
+  end
+
+  def categorised_evidence_types
+    original_attachments.pluck(:attachment_type).uniq
+  end
 end

--- a/app/services/required_document_category_analyser.rb
+++ b/app/services/required_document_category_analyser.rb
@@ -9,7 +9,7 @@ class RequiredDocumentCategoryAnalyser
 
   def call
     required_document_categories = []
-    required_document_categories << 'benefit_evidence' if @application.dwp_override
+    required_document_categories << 'benefit_evidence' if @application.dwp_override&.has_evidence_of_benefit?
     required_document_categories << 'gateway_evidence' if @application.section_8_proceedings?
     required_document_categories << 'employment_evidence' if @application.employment_evidence_required?
     @application.update!(required_document_categories: required_document_categories)

--- a/app/validators/document_category_validator.rb
+++ b/app/validators/document_category_validator.rb
@@ -8,6 +8,8 @@ class DocumentCategoryValidator < ActiveModel::Validator
     bank_transaction_report
     benefit_evidence
     benefit_evidence_pdf
+    employment_evidence
+    employment_evidence_pdf
     gateway_evidence
     gateway_evidence_pdf
     means_report

--- a/app/views/providers/uploaded_evidence_collections/_upload_evidence.html.erb
+++ b/app/views/providers/uploaded_evidence_collections/_upload_evidence.html.erb
@@ -7,8 +7,7 @@
 
   <%= form.govuk_error_summary %>
 
-  <%= render partial: 'shared/forms/error_summary_hidden', locals: { error_message: t('.file_not_uploaded_error'),
-                                                              field_id: 'uploaded-evidence-collection-original-file-field' } %>
+  <%= render partial: 'shared/forms/error_summary_hidden', locals: { field_id: 'uploaded-evidence-collection-original-file-field' } %>
 
   <%= form.govuk_fieldset legend: {text: page_title, tag: 'h1', size: 'xl'} do %>
 

--- a/app/views/providers/uploaded_evidence_collections/_upload_evidence.html.erb
+++ b/app/views/providers/uploaded_evidence_collections/_upload_evidence.html.erb
@@ -7,9 +7,6 @@
 
   <%= form.govuk_error_summary %>
 
-  <%= render partial: 'shared/forms/error_summary_hidden', locals: { error_message: t('.file_not_uploaded_error'),
-                                                              field_id: 'uploaded-evidence-collection-original-file-field' } %>
-
   <%= form.govuk_fieldset legend: {text: page_title, tag: 'h1', size: 'xl'} do %>
 
     <div class="govuk-!-padding-bottom-6"></div>
@@ -18,7 +15,7 @@
 
     <ul class="govuk-list govuk-list--bullet govuk-!-padding-bottom-2">
       <% @required_documents.each do |evidence| %>
-        <li><%= t(".#{evidence}") %></li>
+        <li><%= evidence == 'benefit_evidence' ? t(".#{evidence}", benefit: @legal_aid_application.dwp_override.passporting_benefit.titleize) : t(".#{evidence}") %></li>
       <% end %>
     </ul>
 

--- a/app/views/providers/uploaded_evidence_collections/_upload_evidence.html.erb
+++ b/app/views/providers/uploaded_evidence_collections/_upload_evidence.html.erb
@@ -7,6 +7,9 @@
 
   <%= form.govuk_error_summary %>
 
+  <%= render partial: 'shared/forms/error_summary_hidden', locals: { error_message: t('.file_not_uploaded_error'),
+                                                              field_id: 'uploaded-evidence-collection-original-file-field' } %>
+
   <%= form.govuk_fieldset legend: {text: page_title, tag: 'h1', size: 'xl'} do %>
 
     <div class="govuk-!-padding-bottom-6"></div>

--- a/app/views/providers/uploaded_evidence_collections/_uploaded_files.html.erb
+++ b/app/views/providers/uploaded_evidence_collections/_uploaded_files.html.erb
@@ -34,7 +34,8 @@
           <%= button_to_accessible(
                 t('.delete'),
                 providers_legal_aid_application_uploaded_evidence_collection_path(@legal_aid_application),
-                method: :delete,
+                method: :patch,
+                name: 'delete_button',
                 class: 'button-as-link',
                 params: { attachment_id: attachment.id },
                 suffix: attachment.document.filename

--- a/app/views/providers/uploaded_evidence_collections/show.html.erb
+++ b/app/views/providers/uploaded_evidence_collections/show.html.erb
@@ -25,6 +25,9 @@
         local: true
       ) do |form| %>
 
+      <%= form.govuk_error_summary if @submission_form %>
+      <%= @submission_form.errors.full_messages if @submission_form %>
+
     <div id="uploaded-files-table-container">
       <%= render partial: 'uploaded_files', locals: { attachments: @legal_aid_application.uploaded_evidence_collection.original_attachments } %>
     </div>

--- a/app/views/providers/uploaded_evidence_collections/show.html.erb
+++ b/app/views/providers/uploaded_evidence_collections/show.html.erb
@@ -11,6 +11,7 @@
       page_title: t('.h1-heading'),
       head_title: new_head_title,
       template: :basic,
+      show_errors_for: @submission_form&.model,
       back_link: { path: providers_legal_aid_application_merits_task_list_path(@legal_aid_application) }
     ) do %>
 
@@ -24,9 +25,6 @@
         method: :patch,
         local: true
       ) do |form| %>
-
-      <%= form.govuk_error_summary if @submission_form %>
-      <%= @submission_form.errors.full_messages if @submission_form %>
 
     <div id="uploaded-files-table-container">
       <%= render partial: 'uploaded_files', locals: { attachments: @legal_aid_application.uploaded_evidence_collection.original_attachments } %>

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -509,12 +509,15 @@ en:
         uploaded_evidence_collection:
           attributes:
             original_file:
-              no_file_chosen: You must choose at least one file
+              benefits_evidence_missing: Upload evidence that your client receives %{benefit}
               content_type_invalid: The selected file must be a DOC, DOCX, RTF, ODT, JPG, BMP, PNG, TIF or PDF
+              employment_evidence_missing: Upload evidence of your client's employment
               file_empty: The selected file is empty
               file_too_big: The selected file must be smaller than %{size}MB
               file_virus: The selected file contains a virus
-
+              no_file_chosen: You must choose at least one file
+              system_down: There was a problem uploading your file - try again
+              uncategorised_evidence: Select a category for each uploaded file
         vehicle:
           attributes:
             estimated_value:

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -509,7 +509,7 @@ en:
         uploaded_evidence_collection:
           attributes:
             original_file:
-              benefits_evidence_missing: Upload evidence that your client receives %{benefit}
+              benefit_evidence_missing: Upload evidence that your client receives %{benefit}
               content_type_invalid: The selected file must be a DOC, DOCX, RTF, ODT, JPG, BMP, PNG, TIF or PDF
               employment_evidence_missing: Upload evidence of your client's employment
               file_empty: The selected file is empty

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -443,7 +443,7 @@ en:
     uploaded_evidence_collections:
       upload_evidence:
         list_text: 'Use this page to upload:'
-        benefit_evidence: evidence that your client receives Universal Credit
+        benefit_evidence: evidence that your client receives %{benefit}
         employment_evidence: evidence of your client's employment
         gateway_evidence: gateway evidence for Section 8 proceedings (optional)
         size_hint: The maximum file size is 7MB. Files must be a DOC, DOCX, RTF, ODT, JPG, BMP, PNG, TIF or PDF.

--- a/db/seeds/document_categories.csv
+++ b/db/seeds/document_categories.csv
@@ -2,6 +2,8 @@ name,submit_to_ccms,ccms_document_type,display_on_evidence_upload,mandatory
 bank_transaction_report,TRUE,BSTMT,FALSE,FALSE
 benefit_evidence,FALSE,,TRUE,TRUE
 benefit_evidence_pdf,TRUE,ADMIN1,FALSE,FALSE
+employment_evidence,FALSE,,TRUE,TRUE
+employment_evidence_pdf,TRUE,ADMIN1,FALSE,FALSE
 gateway_evidence,FALSE,,TRUE,FALSE
 gateway_evidence_pdf,TRUE,STATE,FALSE,FALSE
 means_report,TRUE,ADMIN1,FALSE,FALSE

--- a/spec/models/document_category_spec.rb
+++ b/spec/models/document_category_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe DocumentCategory, type: :model do
   describe '.displayable_document_category_names' do
     before { described_class.populate }
     it 'returns an array of names to display on evidence upload page' do
-      expect(described_class.displayable_document_category_names).to eq %w[benefit_evidence gateway_evidence uncategorised]
+      expect(described_class.displayable_document_category_names).to eq %w[benefit_evidence employment_evidence gateway_evidence uncategorised]
     end
   end
 
@@ -29,6 +29,7 @@ RSpec.describe DocumentCategory, type: :model do
       %w[
         bank_transaction_report
         benefit_evidence_pdf
+        employment_evidence_pdf
         gateway_evidence_pdf
         means_report
         merits_report

--- a/spec/requests/providers/uploaded_evidence_collection_spec.rb
+++ b/spec/requests/providers/uploaded_evidence_collection_spec.rb
@@ -49,19 +49,6 @@ module Providers
 
       before { login_as provider }
 
-      # it 'updates the record' do
-      #   subject
-      #   legal_aid_application.reload
-      #   expect(legal_aid_application.uploaded_evidence_collection.original_attachments.first).to be_present
-      # end
-
-      # it 'stores the original filename' do
-      #   subject
-      #   legal_aid_application.reload
-      #   attachment = uploaded_evidence_collection.original_attachments.first
-      #   expect(attachment.original_filename).to eq 'hello_world.pdf'
-      # end
-
       context 'upload button pressed' do
         let(:params_uploaded_evidence_collection) do
           {
@@ -74,6 +61,13 @@ module Providers
           subject
           legal_aid_application.reload
           expect(uploaded_evidence_collection.original_attachments.count).to eq(1)
+        end
+
+        it 'stores the original filename' do
+          subject
+          legal_aid_application.reload
+          attachment = uploaded_evidence_collection.original_attachments.first
+          expect(attachment.original_filename).to eq 'hello_world.pdf'
         end
 
         it 'returns http success' do
@@ -283,6 +277,9 @@ module Providers
 
             context 'when all validation rules are satisfied' do
               let(:attachment_type) { 'gateway_evidence' }
+
+              before { allow(DocumentCategory).to receive(:displayable_document_category_names).and_return(['gateway_evidence']) }
+
               it 'redirects to the next page' do
                 subject
                 expect(response).to redirect_to providers_legal_aid_application_check_merits_answers_path(legal_aid_application)
@@ -352,6 +349,9 @@ module Providers
 
             context 'when all validation rules are satisfied' do
               let(:attachment_type) { 'gateway_evidence' }
+
+              before { allow(DocumentCategory).to receive(:displayable_document_category_names).and_return(['gateway_evidence']) }
+
               it 'redirects to the next page' do
                 subject
                 expect(response).to redirect_to providers_legal_aid_application_check_merits_answers_path(legal_aid_application)
@@ -421,28 +421,30 @@ module Providers
         end
       end
 
-      # context 'Save as draft' do
-      #   let(:button_clicked) { { draft_button: 'Save as draft' } }
-      #
-      #   it 'updates the record' do
-      #     subject
-      #     expect(uploaded_evidence_collection.original_attachments.first).to be_present
-      #   end
-      #
-      #   it 'redirects to provider draft endpoint' do
-      #     subject
-      #     expect(response).to redirect_to provider_draft_endpoint
-      #   end
-      #
-      #   context 'nothing specified' do
-      #     let(:original_file) { nil }
-      #
-      #     it 'redirects to provider draft endpoint' do
-      #       subject
-      #       expect(response).to redirect_to provider_draft_endpoint
-      #     end
-      #   end
-      # end
+      context 'Save as draft' do
+        let(:button_clicked) { { draft_button: 'Save as draft' } }
+
+        context 'when no files have been uploaded' do
+          it 'updates the record' do
+            subject
+            expect(uploaded_evidence_collection).to be_present
+          end
+        end
+
+        it 'redirects to provider draft endpoint' do
+          subject
+          expect(response).to redirect_to provider_draft_endpoint
+        end
+
+        context 'nothing specified' do
+          let(:original_file) { nil }
+
+          it 'redirects to provider draft endpoint' do
+            subject
+            expect(response).to redirect_to provider_draft_endpoint
+          end
+        end
+      end
     end
 
     describe 'DELETE /providers/applications/:legal_aid_application_id/uploaded_evidence_collection' do

--- a/spec/requests/v1/uploaded_evidence_collections_spec.rb
+++ b/spec/requests/v1/uploaded_evidence_collections_spec.rb
@@ -2,9 +2,11 @@ require 'rails_helper'
 
 RSpec.describe 'POST /v1/uploaded_evidence_collections', type: :request do
   let(:legal_aid_application) { create :legal_aid_application }
+  let(:uploaded_evidence_collection) { legal_aid_application.uploaded_evidence_collection }
   let(:id) { legal_aid_application.id }
   let(:file) { uploaded_file('spec/fixtures/files/documents/hello_world.pdf', 'application/pdf') }
   let(:params) { { legal_aid_application_id: id, file: file } }
+  let(:i18n_error_path) { 'activemodel.errors.models.uploaded_evidence_collection.attributes.original_file' }
 
   describe 'POST /v1/uploaded_evidence_collections' do
     subject { post v1_uploaded_evidence_collections_path, params: params }
@@ -40,7 +42,7 @@ RSpec.describe 'POST /v1/uploaded_evidence_collections', type: :request do
         end
       end
 
-      context 'when the application has multiple attachments for statement of case already' do
+      context 'when the application has multiple evidence attachments already' do
         let(:uec1) { create :attachment, :uploaded_evidence_collection }
         let(:uec2) { create :attachment, :uploaded_evidence_collection, attachment_name: 'uploaded_evidence_collection_1' }
         let(:legal_aid_application) { create :legal_aid_application, attachments: [uec1, uec2] }
@@ -49,6 +51,29 @@ RSpec.describe 'POST /v1/uploaded_evidence_collections', type: :request do
           subject
           expect(legal_aid_application.reload.attachments.length).to match(3)
           expect(legal_aid_application.reload.attachments.order(:attachment_name).last.attachment_name).to match('uploaded_evidence_collection_2')
+        end
+      end
+
+      context 'file contains a malware' do
+        let(:file) { uploaded_file('spec/fixtures/files/malware.doc') }
+
+        it 'does not save the object and raises an error' do
+          subject
+          error = I18n.t("#{i18n_error_path}.file_virus", file_name: file.original_filename)
+          expect(response.body).to include(error)
+          expect(uploaded_evidence_collection).to be_nil
+        end
+      end
+
+      context 'virus scanner is down' do
+        before { allow_any_instance_of(MalwareScanResult).to receive(:scanner_working).with(any_args).and_return(false) }
+        let(:i18n_error_path) { 'activemodel.errors.models.application_merits_task/statement_of_case.attributes.original_file' }
+
+        it 'does not save the object and raises a 500 error with text' do
+          subject
+          expect(legal_aid_application.reload.attachments.length).to match(0)
+          expect(response.status).to eq 400
+          expect(response.body).to include(I18n.t("#{i18n_error_path}.system_down"))
         end
       end
     end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2739)

Adds validation to the evidence upload screen. This takes two forms: validation of individual files (for file format, malware, etc), which is done at upload time, and validation that evidence meets requirements (ie all files have been categorised and all mandatory evidence types have at least one file categorised), which is done on submission of the form.

To implement this properly it was necessary to add `employment_evidence` as a document type, make changes to the view to dynamically display which benefits the applicant receives, and refactor the delete button functionality to remove conflicts between submitting/deleting files.

NOTE: This doesn't completely achieve everything on the ticket - errors are rendered at the top of the page but not against individual elements. Some additional work will be needed to fix that, either here or on a new ticket, but this PR has taken long enough already and needs reviewing sooner rather than later.


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
