### PR TITLE
ap-2885: add path to date_client_told_incidents path step

### DIFF
--- a/app/services/flow/flows/provider_merits.rb
+++ b/app/services/flow/flows/provider_merits.rb
@@ -49,6 +49,7 @@ module Flow
           }
         },
         date_client_told_incidents: {
+          path: ->(application) { urls.providers_legal_aid_application_date_client_told_incident_path(application) },
           forward: :opponents,
           check_answers: :check_merits_answers
         },

--- a/app/services/flow/flows/provider_merits.rb
+++ b/app/services/flow/flows/provider_merits.rb
@@ -64,6 +64,10 @@ module Flow
           check_answers: :check_merits_answers
         },
         chances_of_success: {
+          path: ->(application) do
+            proceeding = application.proceedings.find(application.provider_step_params['merits_task_list_id'])
+            urls.providers_merits_task_list_chances_of_success_index_path(proceeding)
+          end,
           forward: ->(application) do
             proceeding = application.proceedings.find(application.provider_step_params['merits_task_list_id'])
             if proceeding.chances_of_success.success_likely?

--- a/spec/helpers/providers_helper_spec.rb
+++ b/spec/helpers/providers_helper_spec.rb
@@ -81,6 +81,15 @@ RSpec.describe ProvidersHelper, type: :helper do
       end
     end
 
+    context 'when saved as draft and returning to chances_of_success' do
+      it do
+        legal_aid_application.provider_step = 'chances_of_success'
+        lead_proceeding = legal_aid_application.proceedings.find_by(lead_proceeding: true)
+        legal_aid_application.provider_step_params = { merits_task_list_id: lead_proceeding.id }
+        expect(subject).to eq("/providers/merits_task_list/#{lead_proceeding.id}/chances_of_success?locale=en")
+      end
+    end
+
     context 'when removing a dependant' do
       let(:dependant) { create :dependant, legal_aid_application: legal_aid_application }
 

--- a/spec/helpers/providers_helper_spec.rb
+++ b/spec/helpers/providers_helper_spec.rb
@@ -72,6 +72,15 @@ RSpec.describe ProvidersHelper, type: :helper do
       end
     end
 
+    context 'when saved as draft and returning to date_client_told_incident' do
+      it do
+        legal_aid_application.provider_step = 'date_client_told_incidents'
+        legal_aid_application.provider_step_params = { application_merits_task_incident: { told_on_3i: '', told_on_2i: '', told_on_1i: '', occurred_on_3i: '', occurred_on_2i: '',
+                                                                                           occurred_on_1i: '' } }
+        expect(subject).to eq("/providers/applications/#{legal_aid_application.id}/date_client_told_incident?locale=en")
+      end
+    end
+
     context 'when removing a dependant' do
       let(:dependant) { create :dependant, legal_aid_application: legal_aid_application }
 

--- a/spec/requests/providers/application_merits_task/date_client_told_incidents_spec.rb
+++ b/spec/requests/providers/application_merits_task/date_client_told_incidents_spec.rb
@@ -148,11 +148,11 @@ module Providers
             subject
             expect(response).to redirect_to provider_draft_endpoint
           end
-        end
 
-        it 'does not set the task to complete' do
-          subject
-          expect(legal_aid_application.legal_framework_merits_task_list.serialized_data).to match(/name: :opponent_details\n\s+dependencies: \*\d\n\s+state: :not_started/)
+          it 'does not set the task to complete' do
+            subject
+            expect(legal_aid_application.legal_framework_merits_task_list.serialized_data).to match(/name: :latest_incident_details\n\s+dependencies: \*\d\n\s+state: :not_started/)
+          end
         end
       end
     end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/jira/software/c/projects/AP/boards/233?modal=detail&selectedIssue=AP-2885)

Flow::FlowError: :path of step :date_client_told_incidents is not defined" was being raised in Sentry. After investigations, this is raised when the user clicks Save and come back later on the 'Latest incident details' page. When they click on applicant name to continue the application they are then unable to progress the application, as they are taken to the applicant details page rather than the latest incident details page (resulting in a further 'enter_applicant_details' cannot transition from 'provider_entering_merits' sentry error)

I noticed that the same issue was affecting the chances_of_success page so I have also added a path to this step.

- Added path to date_client_told_incidents step in provider_merits flow
- Added path to chances_of_success step in provider_merits flow

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
