### PR TITLE
AP-2878: Update dropzone handling

### DIFF
--- a/app/webpack/src/dropzone.js
+++ b/app/webpack/src/dropzone.js
@@ -83,7 +83,7 @@ document.addEventListener('DOMContentLoaded', event => {
       // send the legal_aid_application id in the form data
       formData.append('legal_aid_application_id', applicationId)
     })
-    dropzone.on('success', () => {
+    dropzone.on('queuecomplete',() => {
       // refresh the page to see the uploaded files
       window.location.reload()
       setTimeout(() => { statusMessage.innerText = 'Your files have been uploaded successfully.' }, screenReaderMessageDelay);


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2878)

Trigger the page reload after the `queuecomplete` event

Success was being triggered after a successful upload, even if more jobs were on the queue.  Chrome handled this more gracefully than firefox and others, but I'm not sure it was the right way!

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
