### PR TITLE
LND: Test tidy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,6 +135,12 @@ jobs:
     - *restore_gems_cache
     - *install_gems
     - *save_gems_cache
+    - *restore_js_packages_cache
+    - *install_js_packages
+    - *save_js_packages_cache
+    - run:
+        name: Run JavaScript tests
+        command: bin/rails javascript_tests
     - run:
         name: Run Rubocop
         command:  bundle exec rubocop
@@ -159,9 +165,6 @@ jobs:
     - *restore_js_packages_cache
     - *install_js_packages
     - *save_js_packages_cache
-    - run:
-        name: Run JavaScript tests
-        command: bin/rails javascript_tests
     - run:
         name: Setup Code Climate test-reporter
         command: |

--- a/Gemfile
+++ b/Gemfile
@@ -152,7 +152,7 @@ group :test do
   gem 'shoulda-matchers', '~> 5.1'
   gem 'simplecov', require: false
   gem 'simplecov-rcov'
-  gem 'vcr'
+  gem 'vcr', github: 'vcr/vcr', branch: 'master'
   gem 'webdrivers', '~> 5.0', '>= 5.0.0'
   gem 'webmock'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,6 +28,13 @@ GIT
   specs:
     simple_command (0.1.0)
 
+GIT
+  remote: https://github.com/vcr/vcr.git
+  revision: 8ced6c96e01737a418cd270e0382a8c2c6d85f7f
+  branch: master
+  specs:
+    vcr (6.0.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -713,7 +720,6 @@ GEM
       tzinfo (>= 1.0.0)
     uber (0.1.0)
     unicode-display_width (2.1.0)
-    vcr (6.0.0)
     virtus (2.0.0)
       axiom-types (~> 0.1)
       coercible (~> 1.0)
@@ -841,7 +847,7 @@ DEPENDENCIES
   spring-watcher-listen (~> 2.0.0)
   sprockets (< 4)
   tzinfo-data
-  vcr
+  vcr!
   webdack-uuid_migration (~> 1.4.0)
   webdrivers (~> 5.0, >= 5.0.0)
   webmock

--- a/app/controllers/concerns/providers/authorizable.rb
+++ b/app/controllers/concerns/providers/authorizable.rb
@@ -16,7 +16,7 @@ module Providers
     end
 
     included do
-      include Pundit
+      include Pundit::Authorization
       before_action :authorize_portal_user?
       before_action :authorize_legal_aid_application
       rescue_from Pundit::NotAuthorizedError, with: :provider_not_authorized

--- a/spec/services/hmrc/mock_interface_response_service_spec.rb
+++ b/spec/services/hmrc/mock_interface_response_service_spec.rb
@@ -244,7 +244,6 @@ RSpec.describe HMRC::MockInterfaceResponseService do
       let(:applicant) { create :applicant, first_name: 'Jeremy', last_name: 'Irons', national_insurance_number: 'BB313661B', date_of_birth: '1966-06-06' }
 
       it 'updates the hmrc_response.response value' do
-        ap hmrc_data
         expect(hmrc_data[1]['individuals/matching/individual']['firstName']).to eq 'Jeremy'
         expect(hmrc_data[2]['income/paye/paye']['income'][0]['payFrequency']).to eq 'W4'
       end


### PR DESCRIPTION
## What

Try and reduce some noise in the test outputs 

The Sprocket warnings are part of the RailsAdmin gem and are addressed in an upcoming v3 release that switches to webpacker and, therefore, removes the sprockets noise

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
