### PR TITLE
AP-2877 Employment data alignment

### DIFF
--- a/app/views/providers/employment_incomes/show.html.erb
+++ b/app/views/providers/employment_incomes/show.html.erb
@@ -30,10 +30,10 @@
       <table class="govuk-table">
         <thead class="govuk-table__head">
         <tr class="govuk-table__row">
-          <th class="govuk-table__header" style="width: 20%;" scope="col"><%= t('.date') %></th>
-          <th class="govuk-table__header" style="width: 20%;" scope="col"><%= t('.income') %></th>
-          <th class="govuk-table__header" style="width: 20%;" scope="col"></th>
-          <th class="govuk-table__header" style="width: 20%;" scope="col"><%= t('.deductions') %></th>
+          <th class="govuk-table__header" style="width: 25%;" scope="col"><%= t('.date') %></th>
+          <th class="govuk-table__header" style="width: 10%;" scope="col"><%= t('.income') %></th>
+          <th class="govuk-table__header" style="width: 10%;" scope="col"></th>
+          <th class="govuk-table__header" style="width: 35%;" scope="col"><%= t('.deductions') %></th>
           <th class="govuk-table__header" style="width: 20%;" scope="col"></th>
         </tr>
         </thead>

--- a/app/views/providers/employment_incomes/show.html.erb
+++ b/app/views/providers/employment_incomes/show.html.erb
@@ -44,12 +44,12 @@
           <tr class="govuk-table__row">
             <td class="govuk-table__cell" style="width: 25%;"><%= l(payment.payment_date.to_date, format: :short_date) %></td>
             <td class="govuk-table__cell" style="width: 10%;"><b><%= t('.gross') %></b></td>
-            <td class="govuk-table__cell" style="width: 10%;"><b></b><%= gds_number_to_currency(payment.gross_pay) %></td>
+            <td class="govuk-table__cell govuk-table__cell--numeric" style="width: 10%;"><b></b><%= gds_number_to_currency(payment.gross_pay) %></td>
             <td class="govuk-table__cell" style="width: 35%;"><b><%= t('.tax') %></b>
             <br>
             <b><%= t('.ni') %></b>
             </td>
-            <td class="govuk-table__cell" style="width: 20%;">
+            <td class="govuk-table__cell govuk-table__cell--numeric" style="width: 20%;">
               <%= payment.tax > 0 ? "-#{gds_number_to_currency(payment.tax)}" : gds_number_to_currency(payment.tax) %>
               <br>
               <%= payment.national_insurance > 0 ? "-#{gds_number_to_currency(payment.national_insurance)}" : gds_number_to_currency(payment.national_insurance) %>


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2877)

When Tax or National Insurance values on the Employment Income Review screen have more then five significant digits they exceed the column width and wrap incorrectly.

1. Update `app/views/providers/employment_incomes/show.html.erb` so that the widths of the table header columns match the widths of the table body columns. This improves the amount of space available for the data.

2. Add the `govuk-table__cell--numeric` class to Income and Deductions values to bring them into line with other monetary values in the service, and also with the prototype design.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
