### PR TITLE
AP-2927 Do not display check employment details for unemployed

### DIFF
--- a/app/controllers/providers/client_completed_means_controller.rb
+++ b/app/controllers/providers/client_completed_means_controller.rb
@@ -1,9 +1,18 @@
 module Providers
   class ClientCompletedMeansController < ProviderBaseController
-    def show; end
+    def show
+      define_action_list
+    end
 
     def update
       continue_or_draft
+    end
+
+    private
+
+    def define_action_list
+      @action_list = %w[sort_transactions dependants capital]
+      @action_list.prepend('review_employment') if @legal_aid_application.applicant.employed?
     end
   end
 end

--- a/app/views/providers/client_completed_means/show.html.erb
+++ b/app/views/providers/client_completed_means/show.html.erb
@@ -2,17 +2,12 @@
 
   <p class="govuk-body-l"><%= t('.what_to_do') %></p>
 
-  <h2 class="govuk-heading-m"><%= t('.point_1_heading') %></h2>
-  <p class="govuk-body"><%= t('.point_1_text') %></p>
+  <% @action_list.each_with_index do |action, index| %>
 
-  <h2 class="govuk-heading-m"><%= t('.point_2_heading') %></h2>
-  <p class="govuk-body"><%= t('.point_2_text') %></p>
+    <h2 class="govuk-heading-m"><%= "#{index + 1}. #{t(".#{action}_heading")}" %> </h2>
+    <p class="govuk-body"><%= t(".#{action}_text") %></p>
+  <% end %>
 
-  <h2 class="govuk-heading-m"><%= t('.point_3_heading') %></h2>
-  <p class="govuk-body"><%= t('.point_3_text') %></p>
-
-  <h2 class="govuk-heading-m"><%= t('.point_4_heading') %></h2>
-  <p class="govuk-body"><%= t('.point_4_text') %></p>
 
   <div class="govuk-!-padding-bottom-4"></div>
 

--- a/app/views/providers/client_completed_means/show.html.erb
+++ b/app/views/providers/client_completed_means/show.html.erb
@@ -8,7 +8,6 @@
     <p class="govuk-body"><%= t(".#{action}_text") %></p>
   <% end %>
 
-
   <div class="govuk-!-padding-bottom-4"></div>
 
   <%= next_action_buttons_with_form(

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -282,14 +282,14 @@ en:
       show:
         h1-heading: Continue %{client_name}'s financial assessment
         what_to_do: "Your client has shared their financial information. You need to do the following:"
-        point_1_heading: 1. Review their employment details
-        point_1_text: We'll show you the information HMRC shared with us.
-        point_2_heading: 2. Sort their bank transactions into categories
-        point_2_text: Your client selected the categories their income and outgoings fall into. View their bank statements and sort transactions into these categories.
-        point_3_heading: 3. Tell us about their dependants
-        point_3_text: Provide details of your client's dependants (if they have any).
-        point_4_heading: 4. Tell us about their capital
-        point_4_text: Provide details of your client's savings, investments and other assets
+        review_employment_heading: Review their employment details
+        review_employment_text: We'll show you the information HMRC shared with us.
+        sort_transactions_heading: Sort their bank transactions into categories
+        sort_transactions_text: Your client selected the categories their income and outgoings fall into. View their bank statements and sort transactions into these categories.
+        dependants_heading: Tell us about their dependants
+        dependants_text: Provide details of your client's dependants (if they have any).
+        capital_heading: Tell us about their capital
+        capital_text: Provide details of your client's savings, investments and other assets
     confirm_offices:
       show:
         h1-heading: Is %{office_code} your office account number?

--- a/spec/requests/providers/client_completed_means_spec.rb
+++ b/spec/requests/providers/client_completed_means_spec.rb
@@ -23,6 +23,23 @@ RSpec.describe Providers::ClientCompletedMeansController, type: :request do
         expect(response).to have_http_status(:ok)
         expect(response.body).to include('Your client has shared their financial information')
       end
+
+      context 'when the applicant is not employed' do
+        let(:applicant) { create :applicant, :not_employed }
+        it 'does not include reviewing employment details in action list' do
+          expect(response.body).not_to include('Review their employment details')
+        end
+
+        it 'includes sorting transactions as first point' do
+          expect(response.body).to include('1. Sort their bank transactions into categories')
+        end
+      end
+
+      context 'when the applicant is employed' do
+        it 'includes reviewing employment details in action list' do
+          expect(response.body).to include('1. Review their employment details')
+        end
+      end
     end
   end
 


### PR DESCRIPTION

## Do not display check employment details for unemployed

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2927)

After the applicant has supplied bank details, the provider continues the financial assessment.  At the beginning of that, there is a page which shows a numbered list of the things still to do.  Included in that list was the step to enter employment details, shown regardless of whether or not the applicant is employed.  

This PR removes that for applicants who are not employed.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
