### PR TITLE
AP-2866 Parse HMRC Responses with no employments

### DIFF
--- a/app/services/cfe/create_employments_service.rb
+++ b/app/services/cfe/create_employments_service.rb
@@ -20,7 +20,7 @@ module CFE
 
     def employment_income_payload
       payload = []
-      return payload unless legal_aid_application.applicant_employed?
+      return payload unless legal_aid_application.hmrc_employment_income?
 
       employments.each_with_index { |employment, index| payload << employment_data(employment, index + 1) }
       payload

--- a/spec/services/cfe/create_employments_service_spec.rb
+++ b/spec/services/cfe/create_employments_service_spec.rb
@@ -28,6 +28,15 @@ RSpec.describe CFE::CreateEmploymentsService do
       end
     end
 
+    context 'applicant employed but has no HMRC data' do
+      let(:applicant) { create :applicant, :employed }
+      let(:expected_payload) { empty_payload }
+
+      it 'sends empty array' do
+        described_class.call(submission)
+      end
+    end
+
     context 'applicant employed' do
       let(:applicant) { create :applicant, :employed }
       let(:expected_payload) { full_payload }

--- a/spec/services/cfe/create_employments_service_spec.rb
+++ b/spec/services/cfe/create_employments_service_spec.rb
@@ -19,12 +19,15 @@ RSpec.describe CFE::CreateEmploymentsService do
       stub_request(:post, service.cfe_url).with(body: expected_payload.to_json).to_return(body: dummy_response)
     end
 
+    let(:employment_income_payload) { submission.submission_histories.first.request_payload }
+
     context 'applicant not employed' do
       let(:applicant) { create :applicant, :not_employed }
       let(:expected_payload) { empty_payload }
 
       it 'sends empty array' do
         described_class.call(submission)
+        expect(employment_income_payload).to eq expected_payload.to_json
       end
     end
 
@@ -34,6 +37,7 @@ RSpec.describe CFE::CreateEmploymentsService do
 
       it 'sends empty array' do
         described_class.call(submission)
+        expect(employment_income_payload).to eq expected_payload.to_json
       end
     end
 
@@ -47,6 +51,7 @@ RSpec.describe CFE::CreateEmploymentsService do
 
       it 'sends array of payment data' do
         described_class.call(submission)
+        expect(employment_income_payload).to eq expected_payload.to_json
       end
 
       it 'updates the state on the submission record from irregular_income_created to employments_created' do


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2866)

When making a CFE submission for an applicant that is employed but is not found in the HMRC API, the parsing of the HMRC Response fails.

This is caused by a check in the CreateEmploymentsService which assumes that if an applicant is employed then they will have HMRC data; this will not always be the case.

This replaces the call to `legal_aid_application.employed?` in the guard before processing the response with
`legal_aid_application.hmrc_employment_income?` which ensures that we only try to parse employment data when the data actually exists.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
