### PR TITLE
AP-2891 Display employment income data on means report when no HMRC data exists

### DIFF
--- a/app/services/cfe/create_employments_service.rb
+++ b/app/services/cfe/create_employments_service.rb
@@ -20,7 +20,7 @@ module CFE
 
     def employment_income_payload
       payload = []
-      return payload unless legal_aid_application.applicant_employed?
+      return payload unless legal_aid_application.hmrc_employment_income?
 
       employments.each_with_index { |employment, index| payload << employment_data(employment, index + 1) }
       payload

--- a/app/views/providers/means_reports/show.html.erb
+++ b/app/views/providers/means_reports/show.html.erb
@@ -49,6 +49,12 @@
       <% end %>
     </section>
 
+    <section class="print-no-break">
+      <% if @legal_aid_application.full_employment_details? %>
+        <%= render 'shared/check_answers/no_employed_income', read_only: true %>
+      <% end %>
+    </section>
+
     <div class="govuk-!-padding-bottom-8"></div>
 
     <section class="print-no-break">

--- a/app/views/providers/means_summaries/show.html.erb
+++ b/app/views/providers/means_summaries/show.html.erb
@@ -6,7 +6,7 @@
     <% if @legal_aid_application.hmrc_employment_income? %>
       <%= render 'shared/check_answers/employed_income', read_only: false %>
     <% else %>
-      <%= render 'shared/check_answers/no_employed_income' %>
+      <%= render 'shared/check_answers/no_employed_income', read_only: false %>
     <% end %>
   <% end %>
 

--- a/app/views/shared/check_answers/_no_employed_income.html.erb
+++ b/app/views/shared/check_answers/_no_employed_income.html.erb
@@ -3,16 +3,19 @@
     <h3 class="govuk-heading-m"><%= t('.employment') %></h3>
   </div>
   <div class="govuk-grid-column-one-third govuk-summary-list--no-border align-text-right">
-    <p>
-      <%= link_to_accessible(t('generic.change'), providers_legal_aid_application_no_employment_income_path(@legal_aid_application),
-                             class: 'govuk-link change-link') %>
-    </p>
+    <% unless read_only %>
+      <p>
+        <%= link_to_accessible(t('generic.change'), providers_legal_aid_application_no_employment_income_path(@legal_aid_application),
+                               class: 'govuk-link change-link') %>
+      </p>
+    <% end %>
   </div>
 </div>
 <dl class="govuk-summary-list govuk-!-margin-bottom-9">
   <%= check_answer_no_link(
         name: :full_employment_details,
         question: t('.full_employment_details'),
-        answer: @legal_aid_application.full_employment_details
+        answer: @legal_aid_application.full_employment_details,
+        read_only: read_only
       ) %>
 </dl>

--- a/spec/services/cfe/create_employments_service_spec.rb
+++ b/spec/services/cfe/create_employments_service_spec.rb
@@ -28,6 +28,15 @@ RSpec.describe CFE::CreateEmploymentsService do
       end
     end
 
+    context 'applicant employed but has no HMRC data' do
+      let(:applicant) { create :applicant, :employed }
+      let(:expected_payload) { empty_payload }
+
+      it 'sends empty array' do
+        described_class.call(submission)
+      end
+    end
+
     context 'applicant employed' do
       let(:applicant) { create :applicant, :employed }
       let(:expected_payload) { full_payload }

--- a/spec/services/cfe/create_employments_service_spec.rb
+++ b/spec/services/cfe/create_employments_service_spec.rb
@@ -19,12 +19,15 @@ RSpec.describe CFE::CreateEmploymentsService do
       stub_request(:post, service.cfe_url).with(body: expected_payload.to_json).to_return(body: dummy_response)
     end
 
+    let(:employment_income_payload) { submission.submission_histories.first.request_payload }
+
     context 'applicant not employed' do
       let(:applicant) { create :applicant, :not_employed }
       let(:expected_payload) { empty_payload }
 
       it 'sends empty array' do
         described_class.call(submission)
+        expect(employment_income_payload).to eq expected_payload.to_json
       end
     end
 
@@ -34,6 +37,7 @@ RSpec.describe CFE::CreateEmploymentsService do
 
       it 'sends empty array' do
         described_class.call(submission)
+        expect(employment_income_payload).to eq expected_payload.to_json
       end
     end
 
@@ -47,6 +51,7 @@ RSpec.describe CFE::CreateEmploymentsService do
 
       it 'sends array of payment data' do
         described_class.call(submission)
+        expect(employment_income_payload).to eq expected_payload.to_json
       end
 
       it 'updates the state on the submission record from irregular_income_created to employments_created' do


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2891)

Update the caseworker means report to display full employment income information entered by the solicitor when no data is returned for the applicant by the HMRC API.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
