### PR TITLE
AP-2950 Include all manually entered employment income data for result panel/caseworker reviews

### DIFF
--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -471,6 +471,10 @@ class LegalAidApplication < ApplicationRecord
     out.transform_values { |attachment| attachment.map(&:original_filename) }
   end
 
+  def manually_entered_employment_information?
+    extra_employment_information? || full_employment_details.present?
+  end
+
   private
 
   def bank_transactions_by_type(type)

--- a/app/services/manual_review_detailer.rb
+++ b/app/services/manual_review_detailer.rb
@@ -11,7 +11,7 @@ class ManualReviewDetailer
     details = []
     details << I18n.t('shared.assessment_results.manual_check_required.restrictions') if @legal_aid_application.has_restrictions?
     details << I18n.t('shared.assessment_results.manual_check_required.policy_disregards') if @legal_aid_application.policy_disregards?
-    details << I18n.t('shared.assessment_results.manual_check_required.extra_employment_information') if @legal_aid_application.extra_employment_information?
+    details << I18n.t('shared.assessment_results.manual_check_required.extra_employment_information') if @legal_aid_application.manually_entered_employment_information?
     details
   end
 end

--- a/app/services/results_panel_selector.rb
+++ b/app/services/results_panel_selector.rb
@@ -9,7 +9,7 @@ class ResultsPanelSelector
 
   def call
     return eligible_or_non_eligible if %w[eligible not_eligible].include?(assessment_result)
-    return 'shared/assessment_results/manual_check_required' if restrictions? || disregards? || extra_employment_information?
+    return 'shared/assessment_results/manual_check_required' if restrictions? || disregards? || manually_entered_employment_information?
 
     "shared/assessment_results/#{cfe_result}#{capital_contribution}#{income_contribution}"
   end
@@ -44,12 +44,12 @@ class ResultsPanelSelector
     @legal_aid_application.policy_disregards?
   end
 
-  def extra_employment_information?
-    @legal_aid_application.extra_employment_information?
+  def manually_entered_employment_information?
+    @legal_aid_application.manually_entered_employment_information?
   end
 
   def eligible_or_non_eligible
-    return 'shared/assessment_results/manual_check_required' if extra_employment_information?
+    return 'shared/assessment_results/manual_check_required' if manually_entered_employment_information?
 
     "shared/assessment_results/#{assessment_result}"
   end

--- a/spec/models/legal_aid_application_spec.rb
+++ b/spec/models/legal_aid_application_spec.rb
@@ -1293,6 +1293,35 @@ RSpec.describe LegalAidApplication, type: :model do
     end
   end
 
+  describe 'manually_entered_employment_information?' do
+    let(:laa) { create :legal_aid_application }
+
+    context 'when no employment information has been entered by the provider' do
+      it 'returns false' do
+        expect(laa.manually_entered_employment_information?).to eq false
+      end
+    end
+
+    context 'when extra employment information has been entered by the provider' do
+      before do
+        laa.update!(extra_employment_information: true)
+        laa.update!(extra_employment_information_details: 'test details')
+      end
+
+      it 'returns true' do
+        expect(laa.manually_entered_employment_information?).to eq true
+      end
+    end
+
+    context 'when full employment information has been entered by the provider' do
+      before { laa.update!(full_employment_details: 'test details') }
+
+      it 'returns true' do
+        expect(laa.manually_entered_employment_information?).to eq true
+      end
+    end
+  end
+
   private
 
   def uploaded_evidence_output

--- a/spec/services/manual_review_detailer_spec.rb
+++ b/spec/services/manual_review_detailer_spec.rb
@@ -19,7 +19,19 @@ RSpec.describe ManualReviewDetailer do
         before do
           allow(legal_aid_application).to receive(:has_restrictions?).and_return(false)
           allow(legal_aid_application).to receive(:policy_disregards?).and_return(false)
-          allow(legal_aid_application).to receive(:extra_employment_information?).and_return(true)
+          allow(legal_aid_application).to receive(:full_employment_details).and_return('test details')
+        end
+
+        it 'returns an array with one entry' do
+          expect(described_class.call(legal_aid_application)).to eq [I18n.t('shared.assessment_results.manual_check_required.extra_employment_information')]
+        end
+      end
+
+      context 'no restrictions, no policy disregards, with full employment details manually entered by the provider' do
+        before do
+          allow(legal_aid_application).to receive(:has_restrictions?).and_return(false)
+          allow(legal_aid_application).to receive(:policy_disregards?).and_return(false)
+          allow(legal_aid_application).to receive(:full_employment_details).and_return('test details')
         end
 
         it 'returns an array with one entry' do
@@ -46,6 +58,20 @@ RSpec.describe ManualReviewDetailer do
         allow(legal_aid_application).to receive(:has_restrictions?).and_return(true)
         allow(legal_aid_application).to receive(:policy_disregards?).and_return(true)
         allow(legal_aid_application).to receive(:extra_employment_information?).and_return(true)
+      end
+
+      it 'returns an array with three entries' do
+        expect(described_class.call(legal_aid_application)).to eq [I18n.t('shared.assessment_results.manual_check_required.restrictions'),
+                                                                   I18n.t('shared.assessment_results.manual_check_required.policy_disregards'),
+                                                                   I18n.t('shared.assessment_results.manual_check_required.extra_employment_information')]
+      end
+    end
+
+    context 'with restrictions, with policy disregards and with full employment details manually entered by the provider' do
+      before do
+        allow(legal_aid_application).to receive(:has_restrictions?).and_return(true)
+        allow(legal_aid_application).to receive(:policy_disregards?).and_return(true)
+        allow(legal_aid_application).to receive(:full_employment_details).and_return('test details')
       end
 
       it 'returns an array with three entries' do

--- a/spec/services/results_panel_selector_spec.rb
+++ b/spec/services/results_panel_selector_spec.rb
@@ -106,5 +106,47 @@ RSpec.describe ResultsPanelSelector do
         end
       end
     end
+
+    context 'eligible with no restrictions or disregards, with full employment details manually entered by the provider' do
+      let(:cfe_result) { create :cfe_v4_result, :eligible }
+
+      before do
+        allow(legal_aid_application).to receive(:has_restrictions?).and_return(false)
+        allow(legal_aid_application).to receive(:policy_disregards?).and_return(false)
+        allow(legal_aid_application).to receive(:full_employment_details).and_return('test details')
+      end
+
+      it 'returns the correct capital specific partial' do
+        expect(described_class.call(legal_aid_application)).to eq 'shared/assessment_results/manual_check_required'
+      end
+    end
+
+    context 'income_contribution_with no restrictions or disregards, with full employment details manually entered by the provider' do
+      let(:cfe_result) { create :cfe_v4_result, :with_income_contribution_required }
+
+      before do
+        allow(legal_aid_application).to receive(:has_restrictions?).and_return(false)
+        allow(legal_aid_application).to receive(:policy_disregards?).and_return(true)
+        allow(legal_aid_application).to receive(:full_employment_details).and_return('test details')
+      end
+
+      it 'returns the income_contribution name' do
+        expect(described_class.call(legal_aid_application)).to eq 'shared/assessment_results/manual_check_required'
+      end
+    end
+
+    context 'partially_eligible with capital_contribution no restrictions or disregards, with extra full employment details manually entered by the provider' do
+      let(:cfe_result) { create :cfe_v4_result, :partially_eligible_with_capital_contribution_required }
+
+      before do
+        allow(legal_aid_application).to receive(:has_restrictions?).and_return(false)
+        allow(legal_aid_application).to receive(:policy_disregards?).and_return(false)
+        allow(legal_aid_application).to receive(:full_employment_details).and_return('test details')
+      end
+
+      it 'returns the correct capital specific partial' do
+        expect(described_class.call(legal_aid_application)).to eq 'shared/assessment_results/manual_check_required'
+      end
+    end
   end
 end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2950)

* Adds a new method to the `LegalAidApplication` model to returns a boolean value indicating whether _any_ employment income data has been manually entered by the provider. This returns true if either `extra_employment_information` is true or `full_employment_details` contains data.
* Amends the `ManualReviewDetailer` service class to use that method to determine whether casworker review is required.
* Amends the `ResultsPanelSelector` service class to use that method to determine the correct result panel to display.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
