### PR TITLE
Update Benefit Checker failure page

### DIFF
--- a/app/views/problem/index.html.erb
+++ b/app/views/problem/index.html.erb
@@ -1,5 +1,5 @@
 <%= page_template page_title: t('.title'), back_link: :none do %>
-  <p><%= t('.try_later') %></p>
+  <p><%= t('.ccms_or_try_later_html') %></p>
   <p><%= t('.answers_saved') %></p>
 
   <p class="govuk-body">

--- a/config/locales/cy/errors.yml
+++ b/config/locales/cy/errors.yml
@@ -37,5 +37,5 @@ cy:
   problem:
     index:
       title: ecivres eht htiw melborp a si ereht ,yrroS
-      try_later: ".retal niaga yrT"
+      ccms_or_try_later_html: ".retal niaga yrT"
       answers_saved: ".srewsna ruoy devas eW"

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -37,5 +37,5 @@ en:
   problem:
     index:
       title: Sorry, there is a problem with the service
-      try_later: Try again later.
-      answers_saved: We saved your answers.
+      ccms_or_try_later_html: <a href="https://portal.legalservices.gov.uk/">Use CCMS to complete your application</a> or try again later.
+      answers_saved: We've saved your answers.

--- a/spec/requests/problem_spec.rb
+++ b/spec/requests/problem_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe ProblemController, type: :request do
 
     it 'displays the correct content' do
       expect(unescaped_response_body).to match(I18n.t('problem.index.title'))
-      expect(unescaped_response_body).to match(I18n.t('problem.index.try_later'))
+      expect(unescaped_response_body).to match(I18n.t('problem.index.ccms_or_try_later_html'))
       expect(unescaped_response_body).to match(I18n.t('problem.index.answers_saved'))
     end
   end


### PR DESCRIPTION
## What

Improves the wording of the error page displayed when calls to DWP fail, adding a reference to using CCMS.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
