### PR TITLE
Fix: Docker image job

### DIFF
--- a/.github/workflows/ci-docker-image.yml
+++ b/.github/workflows/ci-docker-image.yml
@@ -1,8 +1,8 @@
-name: Docker/generate apply-ci image
+name: "Generate apply-ci docker image"
 on:
   schedule:
     - cron:  '30 5 * * *'
-  workflow_dispatch
+  workflow_dispatch:
 jobs:
   build-push:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What

The previous invocation of workflow_disptach caused an error
Try changing to a symbol even though no instructions follow it

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
