### PR TITLE
Fix: Docker build action

### DIFF
--- a/.github/workflows/ci-docker-image.yml
+++ b/.github/workflows/ci-docker-image.yml
@@ -17,4 +17,5 @@ jobs:
         run: |
           docker build . --file ./docker/apply_ci.dockerfile --tag ministryofjustice/apply-ci:latest --tag ministryofjustice/apply-ci:latest-$(cat .ruby-version)
       - name: Push the Docker image
-        run: docker push ministryofjustice/apply-ci:latest
+        run: |
+          docker push ministryofjustice/apply-ci


### PR DESCRIPTION
## What

The previous push command pushed a specific tag, `latest`,
removing the tag should push both tagged versions from
the github container, i.e. latest & latest-ruby-version

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
