### PR TITLE
Fix: Remove IRB prompts in docker containers

### DIFF
--- a/docker/run
+++ b/docker/run
@@ -4,5 +4,7 @@ set -e
 
 ./docker/wait_for_pg
 ./docker/setup_db
+# remove irb prompts from rails console
+echo 'IRB.conf[:USE_AUTOCOMPLETE] = false' >> ~/.irbrc
 
 bundle exec puma -C config/puma.rb


### PR DESCRIPTION
## What

This should prevent the new ruby from pushing the proposals
in the rails console when working on remote containers

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
