### PR TITLE
AP-2974 fix validation errors not appearing the second time

### DIFF
--- a/app/views/providers/application_merits_task/statement_of_cases/_show_new.html.erb
+++ b/app/views/providers/application_merits_task/statement_of_cases/_show_new.html.erb
@@ -53,7 +53,7 @@
 
             <span class="hidden" aria-hidden="true" id="application-id"><%= @form.model.legal_aid_application_id %></span>
             <span class="hidden" aria-hidden="true" id="dropzone-url" data-url="/v1/statement_of_cases"></span>
-            <p id="dropzone-error" class="govuk-error-message hidden">
+            <p id="dropzone-file-error" class="govuk-error-message dropzone-error hidden">
               <span class="govuk-visually-hidden">Error:</span>
             </p>
             <div class="dropzone" id="dropzone-form">

--- a/app/views/providers/uploaded_evidence_collections/_upload_evidence.html.erb
+++ b/app/views/providers/uploaded_evidence_collections/_upload_evidence.html.erb
@@ -42,7 +42,7 @@
         </label>
         <div class="govuk-hint"><%= t('.size_hint') %></div>
         <% if @mandatory_evidence_errors %>
-            <p id="dropzone-error" class='govuk-error-message govuk-!-margin-bottom-1'>
+            <p id="dropzone-mandatory-error" class='govuk-error-message dropzone-error govuk-!-margin-bottom-1'>
               <% @mandatory_evidence_errors.each do |error| %>
                 <span class="govuk-visually-hidden">Error:</span>
                 <%= error.message %>
@@ -52,7 +52,7 @@
 
         <span class="hidden" aria-hidden="true" id="application-id"><%= @upload_form.model.legal_aid_application_id %></span>
         <span class="hidden" aria-hidden="true" id="dropzone-url" data-url="/v1/uploaded_evidence_collections"></span>
-        <p id="dropzone-error" class="govuk-error-message hidden">
+        <p id="dropzone-file-error" class="govuk-error-message dropzone-error hidden">
           <span class="govuk-visually-hidden">Error:</span>
         </p>
         <div class="dropzone" id="dropzone-form">

--- a/app/webpack/src/dropzone.js
+++ b/app/webpack/src/dropzone.js
@@ -37,7 +37,7 @@ function addErrorMessage (msg) {
   // show error message on the dropzone form field
   const dropzoneElem = document.querySelector('#dropzone-form-group')
   dropzoneElem.classList.add('govuk-form-group--error')
-  const fieldErrorMsg = document.querySelector('#dropzone-error')
+  const fieldErrorMsg = document.querySelector('#dropzone-file-error')
   const div = document.createElement('div')
   div.innerText = msg
   fieldErrorMsg.appendChild(div)
@@ -76,19 +76,20 @@ document.addEventListener('DOMContentLoaded', event => {
       acceptedFiles: ACCEPTED_FILES.join(', ')
     })
     dropzone.on('drop', () => {
-      const dropzoneError = document.querySelector('#dropzone-error')
-      if (dropzoneError) {
-        dropzoneError.querySelectorAll('div').forEach(div => {
-          div.remove()
-        })
-      }
+      document.querySelectorAll('.dropzone-error').forEach((dzError) => {
+        if (dzError) {
+          dzError.querySelectorAll('div').forEach(div => {
+            div.remove()
+          })
+        }
+      })
       const errorSummary = document.querySelector('.govuk-error-summary')
       errorSummary.querySelectorAll('li').forEach(listItem => {
         listItem.remove()
       })
       errorSummary.classList.add('hidden') // toggle error-summary-hideable
       document.querySelector('#dropzone-form-group').classList.remove('govuk-form-group--error')
-      document.querySelector('#dropzone-form-group > p.govuk-error-message').remove()
+      document.querySelector('#dropzone-form-group > p.govuk-error-message').classList.add('hidden')
     })
     dropzone.on('addedfile', file => {
       setTimeout(() => { statusMessage.innerHTML = 'Your files are being uploaded.' }, screenReaderMessageDelay)

--- a/app/webpack/src/dropzone.js
+++ b/app/webpack/src/dropzone.js
@@ -49,6 +49,23 @@ function addErrorMessage (msg) {
   errorSummary.focus()
 }
 
+function removeErrorMessages() {
+  document.querySelectorAll('.dropzone-error').forEach((dzError) => {
+    if (dzError) {
+      dzError.querySelectorAll('div').forEach(div => {
+        div.remove()
+      })
+    }
+  })
+  const errorSummary = document.querySelector('.govuk-error-summary')
+  errorSummary.querySelectorAll('li').forEach(listItem => {
+    listItem.remove()
+  })
+  errorSummary.classList.add('hidden') // toggle error-summary-hideable
+  document.querySelector('#dropzone-form-group').classList.remove('govuk-form-group--error')
+  document.querySelector('#dropzone-form-group > p.govuk-error-message').classList.add('hidden')
+}
+
 document.addEventListener('DOMContentLoaded', event => {
   const dropzoneElem = document.querySelector('#dropzone-form')
   const statusMessage = document.querySelector(('#file-upload-status-message'))
@@ -59,12 +76,14 @@ document.addEventListener('DOMContentLoaded', event => {
 
     chooseFilesBtn.addEventListener('click', (e) => {
       e.preventDefault() // prevent submitting form by default
+      removeErrorMessages()
     })
     // use enter key to add files
     chooseFilesBtn.addEventListener('keydown', (e) => {
       const KEY_ENTER = 13
       if (e.keyCode === KEY_ENTER) {
         e.preventDefault() // prevent submitting form by default
+        removeErrorMessages()
       }
     })
 
@@ -77,20 +96,7 @@ document.addEventListener('DOMContentLoaded', event => {
       acceptedFiles: ACCEPTED_FILES.join(', ')
     })
     dropzone.on('drop', () => {
-      document.querySelectorAll('.dropzone-error').forEach((dzError) => {
-        if (dzError) {
-          dzError.querySelectorAll('div').forEach(div => {
-            div.remove()
-          })
-        }
-      })
-      const errorSummary = document.querySelector('.govuk-error-summary')
-      errorSummary.querySelectorAll('li').forEach(listItem => {
-        listItem.remove()
-      })
-      errorSummary.classList.add('hidden') // toggle error-summary-hideable
-      document.querySelector('#dropzone-form-group').classList.remove('govuk-form-group--error')
-      document.querySelector('#dropzone-form-group > p.govuk-error-message').classList.add('hidden')
+      removeErrorMessages()
     })
     dropzone.on('addedfile', file => {
       setTimeout(() => { statusMessage.innerHTML = 'Your files are being uploaded.' }, screenReaderMessageDelay)

--- a/app/webpack/src/dropzone.js
+++ b/app/webpack/src/dropzone.js
@@ -11,6 +11,7 @@ const ACCEPTED_FILES = [
   'application/pdf',
   'application/msword',
   'application/vnd.oasis.opendocument.text',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
   'text/rtf',
   'text/plain',
   'application/rtf',


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2974)

- Fixed the validation errors so that the correct error is displayed if there is a second error (on second upload)
- The errors are hidden if a valid file is then uploaded
- Fixed on both evidence upload and statement of case page
- Moved the code to hide error messages into a separate function, and called this function on the 'drop' event and on the 'Choose files' click event
- Added a new accepted document type that supports MS Word 2007 files 

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
