### PR TITLE
AP-2931 fix header nav links

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -20,7 +20,6 @@
       <%= home_link %>
       <% unless current_journey == :citizens %>
         <div class="no-print">
-          <%= menu_button if user_header_link %>
           <nav>
             <%= user_header_link %>
           </nav>

--- a/app/views/shared/_provider_header_link.html.erb
+++ b/app/views/shared/_provider_header_link.html.erb
@@ -1,3 +1,4 @@
+<%= menu_button %>
 <ul id="navigation" class="govuk-header__navigation" aria-label="Top Level Navigation">
   <li class="govuk-header__navigation-item">
     <%= link_to_accessible(current_provider.username, providers_provider_path, class: 'govuk-header__link') %>

--- a/app/webpack/stylesheets/layout.scss
+++ b/app/webpack/stylesheets/layout.scss
@@ -4,10 +4,11 @@
 .govuk-header {
   #navigation {
     line-height: 30px;
+    margin-top: 0;
 
     a {
       margin-left: 1em;
-      padding: 5px 0 6px;
+      padding: 5px 0;
     }
   }
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2931)

The links on the right of the header were misaligned. Now they are aligned with the rest of the header

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
