### PR TITLE
Fix flaky rspec array comparison

### DIFF
--- a/spec/models/legal_aid_application_spec.rb
+++ b/spec/models/legal_aid_application_spec.rb
@@ -1310,7 +1310,7 @@ RSpec.describe LegalAidApplication, type: :model do
 
     context 'evidence has been uploaded' do
       it 'returns a hash of evidence filenames grouped by category' do
-        expect(laa.uploaded_evidence_by_category).to eq(uploaded_evidence_output)
+        deep_match(laa.uploaded_evidence_by_category, uploaded_evidence_output)
       end
     end
   end
@@ -1351,5 +1351,12 @@ private
       'benefit_evidence' => ['Fake Benefit Evidence 1', 'Fake Benefit Evidence 2'],
       'gateway_evidence' => ['Fake Gateway Evidence 1', 'Fake Gateway Evidence 2'],
     }
+  end
+
+  def deep_match(actual, expected)
+    expect(actual.keys.sort).to eq expected.keys.sort
+    actual.each do |key, ids|
+      expect(ids).to match_array(expected[key])
+    end
   end
 end


### PR DESCRIPTION
## What

In `spec/models/legal_aid_application_spec.rb` we test the output of `uploaded_evidence_by_category`, which is a hash of arrays. The elements of those arrays are not always populated in the same order, which causes a test to fail. 

This adds a `deep_match` method (shamelessly stolen from https://github.com/ministryofjustice/check-financial-eligibility/pull/826/commits/bd67f5f18032da34bc3a18dd834e77cbca09cccd) which allows for comparison of nested data structures and updates the test to use it.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
