### PR TITLE
Fix: Update CCMS Submission geckoboard widget

### DIFF
--- a/app/models/dashboard/widget_data_providers/pending_ccms_submissions.rb
+++ b/app/models/dashboard/widget_data_providers/pending_ccms_submissions.rb
@@ -23,7 +23,7 @@ module Dashboard
       end
 
       def self.pending_submissions
-        CCMS::Submission.where.not(aasm_state: %w[failed completed]).count
+        CCMS::Submission.where.not(aasm_state: %w[failed completed abandoned]).count
       end
     end
   end

--- a/spec/models/dashboard/widget_data_providers/pending_ccms_submissions_spec.rb
+++ b/spec/models/dashboard/widget_data_providers/pending_ccms_submissions_spec.rb
@@ -17,7 +17,7 @@ module Dashboard
       end
 
       describe ".data" do
-        let(:aasm_states) { CCMS::Submission.aasm.states.map(&:name) - %i[failed completed] }
+        let(:aasm_states) { CCMS::Submission.aasm.states.map(&:name) - %i[failed completed abandoned] }
         let(:expected_data) { [{ "number" => 4 }] }
 
         it "sends expected data" do
@@ -26,6 +26,7 @@ module Dashboard
           end
           create :ccms_submission, aasm_state: "failed"
           create :ccms_submission, aasm_state: "completed"
+          create :ccms_submission, aasm_state: "abandoned"
           expect(described_class.data).to eq expected_data
         end
       end


### PR DESCRIPTION
## What

[We implemented a state of `abandoned` so we could track submissions that we manually excluded from continuing, but did not exclude them from the widget.  Therefore they would perpetually appear on the queue without this fix

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
