### PR TITLE
Allow use of focused spec running

### DIFF
--- a/output.sarif.json
+++ b/output.sarif.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.1.0",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "Brakeman",
+          "informationUri": "https://brakemanscanner.org",
+          "semanticVersion": "5.2.1",
+          "rules": [
+
+          ]
+        }
+      },
+      "results": [
+
+      ]
+    }
+  ]
+}

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -91,6 +91,18 @@ RSpec.configure do |config|
     mocks.verify_partial_doubles = true
   end
 
+  # These two settings work together to allow you to limit a spec run
+  # to individual examples or groups you care about by tagging them with
+  # `:focus` metadata. When nothing is tagged with `:focus`, all examples
+  # get run.
+  # NOTE: ENV['CI'] is a variable that is populated on circleci, at least, which
+  # thereby prevents focused running in the CI pipeline.
+  #
+  # NOTE: you can also use `fit`, `fdescribe`, `fcontext` to focus specs
+  #
+  config.filter_run_including focus: true unless ENV["CI"]
+  config.run_all_when_everything_filtered = true
+
   # This option will default to `:apply_to_host_groups` in RSpec 4 (and will
   # have no way to turn it off -- the option exists only for backwards
   # compatibility in RSpec 3). It causes shared context metadata to be


### PR DESCRIPTION



## What
Allows running individual examples, contexts
or describes using `f...`.

example

```
fit 'is a test' do
end
```

```
rspec
=> runs just the `fit` test
```

## Why
One way I like to run specific specs or groups of specs.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
