### PR TITLE
Fix couple of rubocop violations

### DIFF
--- a/spec/services/hmrc/mock_interface_response_service_spec.rb
+++ b/spec/services/hmrc/mock_interface_response_service_spec.rb
@@ -227,7 +227,7 @@ RSpec.describe HMRC::MockInterfaceResponseService do
       _links: [
         {
           href: "https://main-laa-hmrc-interface-uat.apps.live-1.cloud-platform.service.justice.gov.uk/api/v1/submission/status/2151e48d-b88b-4c1e-af97-7987295f687f",
-        }
+        },
       ],
     }
   end
@@ -242,7 +242,7 @@ RSpec.describe HMRC::MockInterfaceResponseService do
           use_case: "use_case_one",
         },
         {
-          'individuals/matching/individual': {
+          "individuals/matching/individual": {
             firstName: "Henry",
             lastName: "Unknown",
             nino: "WX311689D",
@@ -250,7 +250,7 @@ RSpec.describe HMRC::MockInterfaceResponseService do
           },
         },
         {
-          'income/paye/paye': {
+          "income/paye/paye": {
             income: [
               {
                 taxYear: "20-21",
@@ -287,18 +287,18 @@ RSpec.describe HMRC::MockInterfaceResponseService do
                 grossEarningsForNics: {
                   inPayPeriod1: "£2526",
                 },
-              }
+              },
             ],
           },
         },
         {
-          'employments/paye/employments': [
+          "employments/paye/employments": [
             {
               startDate: "2017-07-24",
               endDate: "Ongoing",
-            }
+            },
           ],
-        }
+        },
       ],
     }
   end


### PR DESCRIPTION
## What
Fix a couple of rubocop violations that snuck into `main`

`Style/TrailingCommaInArrayLiteral` and
`Style/QuotedSymbols`. Came in from govuk-rubocop
recently i guess?!

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
