### PR TITLE
Tech-debt: Update DataMigrate gem reference

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ ruby "3.1.1"
 
 gem "aasm", "~> 5.2.0"
 gem "active_model_serializers", "~> 0.10.13"
-gem "data_migrate", ">= 7.0.2"
+gem "data_migrate"
 gem "discard", "~> 1.2"
 gem "geckoboard-ruby"
 gem "google_drive", ">= 3.0.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -771,7 +771,7 @@ DEPENDENCIES
   capybara (>= 3.36.0, < 4.0)
   cucumber
   cucumber-rails (>= 2.4.0)
-  data_migrate (>= 7.0.2)
+  data_migrate
   database_cleaner
   devise (>= 4.8.0)
   devise_saml_authenticatable (>= 1.7.0)


### PR DESCRIPTION
## What

The Gem itself has already been updated to 8.x so
having this locked at >7 seems superflouous

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
