### PR TITLE
AP-3024: Improve admin CFE display

### DIFF
--- a/app/helpers/hash_format_helper.rb
+++ b/app/helpers/hash_format_helper.rb
@@ -22,7 +22,11 @@ private
       dl_contents = ""
       dl_contents << content_tag(:dt, standardize_key(key))
       value.each do |val|
-        dl_contents << format_hash(val)
+        dl_contents << if val.is_a?(Hash)
+                         format_hash(val)
+                       else
+                         content_tag(:dd, val)
+                       end
       end
       dl_contents.html_safe
     end

--- a/app/views/admin/legal_aid_applications/submissions/show.html.erb
+++ b/app/views/admin/legal_aid_applications/submissions/show.html.erb
@@ -1,7 +1,3 @@
-<%
-  empty_cfe_result = {result: 'nil'}
-%>
-
 <%= back_link() %>
 <div class='govuk-body'>
   <h1 class="govuk-heading-l">Legal Aid Application</h1>
@@ -59,18 +55,18 @@
         <dd><%= cfe_submission.error_message ||= 'N/A' %></dd>
       </dl>
       <details>
+        <section>
+          <% if cfe_submission.result&.result %>
+            <%= format_hash(JSON.parse(cfe_submission.result.result)) %>
+          <% else %>
+            <p class="govuk-body">No result available</p>
+          <% end %>
+        </section>
         <summary class="govuk-heading-m govuk-details__summary"
           title="CFE result"
           aria-label="CFE result">
           CFE result
         </summary>
-        <section>
-          <% if cfe_submission.result&.result.nil? %>
-            <p class="govuk-body">No result available</p>
-          <% else %>
-            <%= format_hash(JSON.parse(cfe_submission.result&.result)) %>
-          <% end %>
-        </section>
       </details>
     <% end %>
   <% end %>

--- a/app/views/admin/legal_aid_applications/submissions/show.html.erb
+++ b/app/views/admin/legal_aid_applications/submissions/show.html.erb
@@ -65,7 +65,11 @@
           CFE result
         </summary>
         <section>
-          <%= format_hash(JSON.parse(cfe_submission.result&.result || empty_cfe_result)) %>
+          <% if cfe_submission.result&.result.nil? %>
+            <p class="govuk-body">No result available</p>
+          <% else %>
+            <%= format_hash(JSON.parse(cfe_submission.result&.result)) %>
+          <% end %>
         </section>
       </details>
     <% end %>

--- a/spec/helpers/hash_format_helper_spec.rb
+++ b/spec/helpers/hash_format_helper_spec.rb
@@ -26,6 +26,20 @@ RSpec.describe HashFormatHelper, type: :helper do
       end
     end
 
+    context "when passed an array of GUIDs" do
+      let(:source) do
+        { multiple_employments: %w[159de866-8a9e-44cf-86b4-a3ed01da0533 cb2dd4ff-6f61-4ef6-82c3-b4e02b1ac42a] }
+      end
+
+      let(:expected_response) do
+        '<dl class="govuk-body kvp govuk-!-margin-bottom-0"><dt>Multiple Employments</dt>' \
+          "<dd>159de866-8a9e-44cf-86b4-a3ed01da0533</dd>" \
+          "<dd>cb2dd4ff-6f61-4ef6-82c3-b4e02b1ac42a</dd></dl>"
+      end
+
+      it { is_expected.to eql expected_response }
+    end
+
     context "when passed invalid data" do
       before do
         allow(Rails.logger).to receive(:info).at_least(:once)


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3024)
* Improve handling of remarks - the array of GUIDs returned by CFE for remarks broke the logic of the hash loop this ensures that a hash is rendered the same as before, but anything else will be treated as a string and output simply
* Improve handling when a CFE Result is missing, this is an edge case but occurred while working on debugging the issue.  It should never occur in production but will ensure the page does not crash if it does

![image](https://user-images.githubusercontent.com/6757677/161019229-c369aefa-146b-4c1a-84a2-533ec41016cc.png)


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
