### PR TITLE
AP-2876: Update dependant routing

### DIFF
--- a/app/controllers/providers/remove_dependants_controller.rb
+++ b/app/controllers/providers/remove_dependants_controller.rb
@@ -8,6 +8,7 @@ module Providers
     def update
       if form.valid?
         dependant&.destroy! if form.remove_dependant?
+        legal_aid_application.update!(has_dependants: nil) unless legal_aid_application.dependants.any?
         return go_forward
       end
 

--- a/app/services/flow/flows/provider_dependants.rb
+++ b/app/services/flow/flows/provider_dependants.rb
@@ -42,7 +42,7 @@ module Flow
         },
         remove_dependants: {
           path: ->(application, dependant) { urls.providers_legal_aid_application_remove_dependant_path(application, dependant) },
-          forward: :has_other_dependants,
+          forward: ->(application) { application.dependants.any? ? :has_other_dependants : :has_dependants },
         },
       }.freeze
     end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2876)

When the user removes the final dependant, direct them to the has_dependants page with the yes/no option cleared, otherwise continue routing them to the has_other_dependants page

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
