### PR TITLE
Ap 3026 handle pending HMRC response

### DIFF
--- a/app/controllers/providers/full_employment_details_controller.rb
+++ b/app/controllers/providers/full_employment_details_controller.rb
@@ -1,6 +1,9 @@
 module Providers
   class FullEmploymentDetailsController < ProviderBaseController
+    delegate :hmrc_response_use_case_one, to: :legal_aid_application
+
     def show
+      message_sentry if hmrc_still_pending?
       @form = LegalAidApplications::FullEmploymentDetailsForm.new(model: legal_aid_application)
     end
 
@@ -17,6 +20,22 @@ module Providers
 
         params.require(:legal_aid_application).permit(:full_employment_details)
       end
+    end
+
+    def message_sentry
+      Sentry.capture_message("HMRC response still pending: correlation id: #{correlation_id}")
+    end
+
+    def correlation_id
+      return nil if hmrc_response_use_case_one.nil?
+
+      hmrc_response_use_case_one.correlation_id
+    end
+
+    def hmrc_still_pending?
+      return true if hmrc_response_use_case_one.nil?
+
+      hmrc_response_use_case_one.status == "processing"
     end
   end
 end

--- a/app/controllers/providers/full_employment_details_controller.rb
+++ b/app/controllers/providers/full_employment_details_controller.rb
@@ -23,13 +23,7 @@ module Providers
     end
 
     def message_sentry
-      Sentry.capture_message("HMRC response still pending: correlation id: #{correlation_id}")
-    end
-
-    def correlation_id
-      return nil if hmrc_response_use_case_one.nil?
-
-      hmrc_response_use_case_one.correlation_id
+      Sentry.capture_message("HMRC response still pending")
     end
 
     def hmrc_still_pending?

--- a/app/models/hmrc/response.rb
+++ b/app/models/hmrc/response.rb
@@ -12,6 +12,21 @@ module HMRC
       where(legal_aid_application_id: laa_id, use_case: "one").order(:created_at).last
     end
 
+    def correlation_id
+      return nil if response.blank?
+
+      first_data = response["data"]&.first
+      return nil if first_data.blank?
+
+      first_data["correlation_id"]
+    end
+
+    def status
+      return nil if response.blank?
+
+      response["status"]
+    end
+
     def employment_income?
       return false if response.nil?
 

--- a/app/models/hmrc/response.rb
+++ b/app/models/hmrc/response.rb
@@ -12,15 +12,6 @@ module HMRC
       where(legal_aid_application_id: laa_id, use_case: "one").order(:created_at).last
     end
 
-    def correlation_id
-      return nil if response.blank?
-
-      first_data = response["data"]&.first
-      return nil if first_data.blank?
-
-      first_data["correlation_id"]
-    end
-
     def status
       return nil if response.blank?
 

--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -480,6 +480,10 @@ class LegalAidApplication < ApplicationRecord
     extra_employment_information? || full_employment_details.present?
   end
 
+  def hmrc_response_use_case_one
+    hmrc_responses.detect { |response| response.use_case == "one" }
+  end
+
 private
 
   def bank_transactions_by_type(type)

--- a/spec/factories/hmrc/responses.rb
+++ b/spec/factories/hmrc/responses.rb
@@ -21,7 +21,7 @@ module HMRC
       end
 
       trait :processing do
-        response { ::FactoryHelpers::HMRCResponse::UseCaseOne.new(submission_id, status: "processing") }
+        response { ::FactoryHelpers::HMRCResponse::UseCaseOne.new(submission_id, status: "processing").response }
       end
 
       trait :in_progress do

--- a/spec/models/hmrc/response_spec.rb
+++ b/spec/models/hmrc/response_spec.rb
@@ -125,25 +125,6 @@ module HMRC
       end
     end
 
-    describe "#correlation_id" do
-      context "normal payload" do
-        let(:uuid) { SecureRandom.uuid }
-        let(:response) { create :hmrc_response, :use_case_one, submission_id: uuid }
-
-        it "extracts the correlation id" do
-          expect(response.correlation_id).to eq uuid
-        end
-      end
-
-      context "nil payload" do
-        let(:response) { create :hmrc_response, :nil_response }
-
-        it "returns nil" do
-          expect(response.correlation_id).to be_nil
-        end
-      end
-    end
-
     describe "#status" do
       context "normal payload" do
         let(:response) { create :hmrc_response, :use_case_one }

--- a/spec/models/hmrc/response_spec.rb
+++ b/spec/models/hmrc/response_spec.rb
@@ -124,5 +124,50 @@ module HMRC
         end
       end
     end
+
+    describe "#correlation_id" do
+      context "normal payload" do
+        let(:uuid) { SecureRandom.uuid }
+        let(:response) { create :hmrc_response, :use_case_one, submission_id: uuid }
+
+        it "extracts the correlation id" do
+          expect(response.correlation_id).to eq uuid
+        end
+      end
+
+      context "nil payload" do
+        let(:response) { create :hmrc_response, :nil_response }
+
+        it "returns nil" do
+          expect(response.correlation_id).to be_nil
+        end
+      end
+    end
+
+    describe "#status" do
+      context "normal payload" do
+        let(:response) { create :hmrc_response, :use_case_one }
+
+        it "returns a 'completed' status" do
+          expect(response.status).to eq "completed"
+        end
+      end
+
+      context "processing payload" do
+        let(:response) { create :hmrc_response, :processing }
+
+        it "returns a 'processing' status" do
+          expect(response.status).to eq "processing"
+        end
+      end
+
+      context "nil payload" do
+        let(:response) { create :hmrc_response, :nil_response }
+
+        it "returns nil" do
+          expect(response.status).to be_nil
+        end
+      end
+    end
   end
 end

--- a/spec/models/legal_aid_application_spec.rb
+++ b/spec/models/legal_aid_application_spec.rb
@@ -1360,6 +1360,16 @@ RSpec.describe LegalAidApplication, type: :model do
         expect(laa.manually_entered_employment_information?).to eq true
       end
     end
+
+    describe "#hmrc_response_use_case_one" do
+      let(:laa) { create :legal_aid_application }
+      let!(:use_case_one) { create :hmrc_response, :use_case_one, legal_aid_application: laa }
+      let!(:use_case_two) { create :hmrc_response, :use_case_two, legal_aid_application: laa }
+
+      it "returns the use case one record" do
+        expect(laa.hmrc_response_use_case_one).to eq use_case_one
+      end
+    end
   end
 
 private

--- a/spec/requests/providers/full_employment_details_controller_spec.rb
+++ b/spec/requests/providers/full_employment_details_controller_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Providers::FullEmploymentDetailsController, type: :request do
         describe "Sending a message to Sentry" do
           let(:before_actions) do
             create :hmrc_response, :processing, legal_aid_application_id: application.id
-            expect(Sentry).to receive(:capture_message).with(/HMRC response still pending: correlation id/)
+            expect(Sentry).to receive(:capture_message).with(/HMRC response still pending/)
           end
 
           it "sends the message to Sentry and is successful" do


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/jira/software/c/projects/AP/boards/233?modal=detail&selectedIssue=AP-3026)

When there is a pending response from HMRC: 
-display full employment details screen
-send a message to Sentry containing the correlation id

Also improve tests for full employment details controller by testing correct rendering of full employment details screen.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
