### PR TITLE
AP-3026 Handle pending response from HMRC

### DIFF
--- a/spec/requests/providers/full_employment_details_controller_spec.rb
+++ b/spec/requests/providers/full_employment_details_controller_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 RSpec.describe Providers::FullEmploymentDetailsController, type: :request do
   let(:application) { create :legal_aid_application, :with_applicant, :with_non_passported_state_machine }
   let(:provider) { application.provider }
+  let(:before_actions) { {} }
 
   describe "GET /providers/applications/:id/full_employment_details" do
     subject(:request) { get providers_legal_aid_application_full_employment_details_path(application) }
@@ -15,23 +16,36 @@ RSpec.describe Providers::FullEmploymentDetailsController, type: :request do
 
     context "when the provider is authenticated" do
       before do
+        before_actions
         login_as provider
         request
       end
 
       context "when the no job data is returned" do
-        before { create :hmrc_response, :use_case_one, legal_aid_application_id: application.id }
+        let(:before_action) { create :hmrc_response, :nil_response, legal_aid_application_id: application.id }
 
         it "returns http success" do
           expect(response).to have_http_status(:ok)
         end
+
+        it "displays the 'no data' message" do
+          expect(response.body).to include(html_compare("HMRC has no record of your client's employment in the last 3 months"))
+        end
       end
 
       context "when the applicant has multiple jobs" do
-        before { create :hmrc_response, :multiple_employments_usecase1, legal_aid_application_id: application.id }
+        let(:before_actions) do
+          create :hmrc_response, :multiple_employments_usecase1, legal_aid_application_id: application.id
+          create_list :employment, 2, legal_aid_application: application
+        end
 
         it "returns http success" do
           expect(response).to have_http_status(:ok)
+        end
+
+        it "displays the 'multiple job' message" do
+          expect(response.body).to include(html_compare("HMRC found a record of your client's employment"))
+          expect(response.body).to include(html_compare("HMRC says your client had more than one job in the last 3 months."))
         end
       end
     end


### PR DESCRIPTION
[Link to story](https://dsdmoj.atlassian.net/jira/software/c/projects/AP/boards/233?modal=detail&selectedIssue=AP-3026)

When there is a pending response from HMRC: 
-display full employment details screen
-send a message to Sentry containing the correlation id

Also improve tests for full employment details controller by testing correct rendering of full employment details screen.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
