### PR TITLE
Add explicit check for zeitwork compliance

### DIFF
--- a/spec/zeitwork_spec.rb
+++ b/spec/zeitwork_spec.rb
@@ -1,0 +1,7 @@
+require "rails_helper"
+
+RSpec.describe "Zeitwerk compliance" do
+  it "eager loads all files without errors" do
+    expect { Rails.application.eager_load! }.not_to raise_error
+  end
+end


### PR DESCRIPTION
## What

This is not strictly necessary for CI hosted test suite runs
due to rails 6/7 default behaviour of eager loadong during test 
suite run on envs with ENV['CI'] set, including circleci. This would
resut in an eager load error being raised regardless.

However this test would fail locally or anywhere if the app is not zeitwork compliant
explictly and is recommended particulalry for rails migrations/bumps.

see https://edgeguides.rubyonrails.org/classic_to_zeitwerk_howto.html#check-zeitwerk-compliance-in-the-test-suite
for more.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
