### PR TITLE
Fix CircleCi Build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,10 +158,10 @@ jobs:
         command: |
           COMMITS_IN_BRANCH=$(git rev-list main.. --count)
           ALL_FILES_CHANGED=$(git diff --name-only HEAD~$COMMITS_IN_BRANCH)
-          RUBY_VERSION_CHANGED=$((echo "$ALL_FILES_CHANGED" | grep ".ruby-version" || true) | wc -l | xargs) 
-          TOKEN=$(curl -s -H "Content-Type: application/json" -X POST -d '{"username": "'${DOCKER_HUB_USERNAME}'", "password": "'${DOCKER_HUB_PAT}'"}' https://hub.docker.com/v2/users/login/ | jq -r .token)
-          VERSION_EXISTS=$(curl -s -H "Authorization: JWT ${TOKEN}" https://hub.docker.com/v2/repositories/ministryofjustice/apply-ci/tags | jq -r '.results|.[]|.name|startswith("latest-$(cat .ruby-version)")')
-          if [ "$RUBY_VERSION_CHANGED" = "1" ]; then 
+          RUBY_VERSION_CHANGED=$((echo "$ALL_FILES_CHANGED" | grep ".ruby-version" || true) | wc -l | xargs)
+          if [ "$RUBY_VERSION_CHANGED" = "1" ]; then
+            TOKEN=$(curl -s -H "Content-Type: application/json" -X POST -d '{"username": "'${DOCKER_HUB_USERNAME}'", "password": "'${DOCKER_HUB_PAT}'"}' https://hub.docker.com/v2/users/login/ | jq -r .token)
+            VERSION_EXISTS=$(curl -s -H "Authorization: JWT ${TOKEN}" https://hub.docker.com/v2/repositories/ministryofjustice/apply-ci/tags | jq -r '.results|.[]|.name|startswith("latest-$(cat .ruby-version)")')
             if [ "$VERSION_EXISTS" = "false" ]; then
               echo "${DOCKER_HUB_PAT}" | docker login -u "${DOCKER_HUB_USERNAME}" --password-stdin
               docker build -f ./docker/apply_ci.dockerfile . -t ministryofjustice/apply-ci:latest-$(cat .ruby-version)


### PR DESCRIPTION
Only log in to Docker when required. 

Prevent failed log ins blocking the pipeline when Docker log in is not required.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
