### PR TITLE
Fix GOVUK Rubocop RSpec/ExcessiveDocstringSpacing offences

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -540,13 +540,6 @@ RSpec/ExampleWording:
     - 'spec/services/provider_details_creator_spec.rb'
     - 'spec/support/shared_examples/provider_auth_shared_examples.rb'
 
-# Offense count: 57
-# Cop supports --auto-correct.
-RSpec/ExcessiveDocstringSpacing:
-  Exclude:
-    - 'spec/forms/legal_aid_applications/shared_ownership_form_spec.rb'
-    - 'spec/validators/document_category_validator_spec.rb'
-
 # Offense count: 1
 # Cop supports --auto-correct.
 RSpec/ExpectActual:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -555,16 +555,6 @@ RSpec/ExcessiveDocstringSpacing:
     - 'spec/models/legal_aid_application_spec.rb'
     - 'spec/models/legal_framework/serializable_merits_task_spec.rb'
     - 'spec/models/transaction_type_spec.rb'
-    - 'spec/requests/admin/roles_spec.rb'
-    - 'spec/requests/providers/applicant_employed_spec.rb'
-    - 'spec/requests/providers/application_merits_task/statement_of_case_spec.rb'
-    - 'spec/requests/providers/capital_assessment_results_spec.rb'
-    - 'spec/requests/providers/capital_income_assessment_results_spec.rb'
-    - 'spec/requests/providers/check_provider_answers_spec.rb'
-    - 'spec/requests/providers/legal_aid_applications_spec.rb'
-    - 'spec/requests/providers/merits_task_lists_controller_spec.rb'
-    - 'spec/requests/providers/offline_accounts_spec.rb'
-    - 'spec/requests/providers/savings_and_investments_spec.rb'
     - 'spec/validators/document_category_validator_spec.rb'
 
 # Offense count: 1

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -545,16 +545,6 @@ RSpec/ExampleWording:
 RSpec/ExcessiveDocstringSpacing:
   Exclude:
     - 'spec/forms/legal_aid_applications/shared_ownership_form_spec.rb'
-    - 'spec/models/application_merits_task/involved_child_spec.rb'
-    - 'spec/models/bank_account_spec.rb'
-    - 'spec/models/cfe/v2/result_spec.rb'
-    - 'spec/models/cfe/v3/result_spec.rb'
-    - 'spec/models/cfe/v4/result_spec.rb'
-    - 'spec/models/firm_spec.rb'
-    - 'spec/models/host_env_spec.rb'
-    - 'spec/models/legal_aid_application_spec.rb'
-    - 'spec/models/legal_framework/serializable_merits_task_spec.rb'
-    - 'spec/models/transaction_type_spec.rb'
     - 'spec/validators/document_category_validator_spec.rb'
 
 # Offense count: 1

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -565,13 +565,6 @@ RSpec/ExcessiveDocstringSpacing:
     - 'spec/requests/providers/merits_task_lists_controller_spec.rb'
     - 'spec/requests/providers/offline_accounts_spec.rb'
     - 'spec/requests/providers/savings_and_investments_spec.rb'
-    - 'spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_entities_spec.rb'
-    - 'spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_variable_attributes_spec.rb'
-    - 'spec/services/ccms/requestors/case_add_requestor_xml_blocks/passported_attributes_spec.rb'
-    - 'spec/services/ccms/submitters/add_applicant_service_spec.rb'
-    - 'spec/services/ccms/submitters/add_case_service_spec.rb'
-    - 'spec/services/ccms/submitters/check_applicant_status_service_spec.rb'
-    - 'spec/services/ccms/submitters/check_case_status_service_spec.rb'
     - 'spec/validators/document_category_validator_spec.rb'
 
 # Offense count: 1

--- a/spec/forms/legal_aid_applications/shared_ownership_form_spec.rb
+++ b/spec/forms/legal_aid_applications/shared_ownership_form_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe LegalAidApplications::SharedOwnershipForm, type: :form do
     let(:params) { { shared_ownership: "no" } }
     let(:form_params) { params.merge(model: legal_aid_application) }
 
-    it "does not create a new legal aid application " do
+    it "does not create a new legal aid application" do
       expect { @form.save }.not_to change(LegalAidApplication, :count)
     end
 

--- a/spec/models/application_merits_task/involved_child_spec.rb
+++ b/spec/models/application_merits_task/involved_child_spec.rb
@@ -23,7 +23,7 @@ module ApplicationMeritsTask
         end
       end
 
-      context "with  multiple embedded spaces" do
+      context "with multiple embedded spaces" do
         let(:full_name) { "Michael      Winner" }
 
         it "separates out first and last name" do

--- a/spec/models/bank_account_spec.rb
+++ b/spec/models/bank_account_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe BankAccount, type: :model do
     end
   end
 
-  describe "#benefits " do
+  describe "#benefits" do
     it "returns true if benefits present" do
       bank_account = create :bank_account
       create :bank_transaction, :benefits, bank_account: bank_account
@@ -62,7 +62,7 @@ RSpec.describe BankAccount, type: :model do
     end
   end
 
-  describe "#tax_credits " do
+  describe "#tax_credits" do
     it "returns false if tax credits not present" do
       bank_account = create :bank_account
       create :bank_transaction, :benefits, bank_account: bank_account

--- a/spec/models/cfe/v2/result_spec.rb
+++ b/spec/models/cfe/v2/result_spec.rb
@@ -248,13 +248,13 @@ module CFE
       end
 
       describe "capital_contribution_required?" do
-        context "contribution not required " do
+        context "contribution not required" do
           it "returns false for capital_contribution_required" do
             expect(eligible_result.capital_contribution_required?).to be false
           end
         end
 
-        context "contribution is required " do
+        context "contribution is required" do
           it "returns true for capital_contribution_required" do
             expect(contribution_required_result.capital_contribution_required?).to be true
           end
@@ -335,7 +335,7 @@ module CFE
       end
 
       describe "vehicle_disregard" do
-        it "returns the vehicle disregard for applicants vehicle " do
+        it "returns the vehicle disregard for applicants vehicle" do
           expect(eligible_result.vehicle_disregard).to eq 1784.61
         end
       end

--- a/spec/models/cfe/v3/result_spec.rb
+++ b/spec/models/cfe/v3/result_spec.rb
@@ -205,13 +205,13 @@ module CFE
       end
 
       describe "capital_contribution_required?" do
-        context "contribution not required " do
+        context "contribution not required" do
           it "returns false for capital_contribution_required" do
             expect(eligible_result.capital_contribution_required?).to be false
           end
         end
 
-        context "contribution is required " do
+        context "contribution is required" do
           it "returns true for capital_contribution_required" do
             expect(contribution_required_result.capital_contribution_required?).to be true
           end
@@ -298,7 +298,7 @@ module CFE
       end
 
       describe "vehicle_disregard" do
-        it "returns the vehicle disregard for applicants vehicle " do
+        it "returns the vehicle disregard for applicants vehicle" do
           expect(eligible_result.vehicle_disregard).to eq 1784.61
         end
       end

--- a/spec/models/cfe/v4/result_spec.rb
+++ b/spec/models/cfe/v4/result_spec.rb
@@ -205,13 +205,13 @@ module CFE
       end
 
       describe "capital_contribution_required?" do
-        context "contribution not required " do
+        context "contribution not required" do
           it "returns false for capital_contribution_required" do
             expect(eligible_result.capital_contribution_required?).to be false
           end
         end
 
-        context "contribution is required " do
+        context "contribution is required" do
           it "returns true for capital_contribution_required" do
             expect(contribution_required_result.capital_contribution_required?).to be true
           end
@@ -370,7 +370,7 @@ module CFE
       end
 
       describe "vehicle_disregard" do
-        it "returns the vehicle disregard for applicants vehicle " do
+        it "returns the vehicle disregard for applicants vehicle" do
           expect(eligible_result.vehicle_disregard).to eq 0.0
         end
       end

--- a/spec/models/firm_spec.rb
+++ b/spec/models/firm_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe "Firm" do
     end
 
     context "returns all records" do
-      it "returns all  record" do
+      it "returns all record" do
         expect(Firm.search("")).to match_array([firm3, firm2, firm])
       end
     end

--- a/spec/models/host_env_spec.rb
+++ b/spec/models/host_env_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe HostEnv do
   describe "root_url" do
-    it "returns the root  url" do
+    it "returns the root url" do
       expect(described_class.root_url).to eq "http://www.example.com/?locale=en"
     end
   end

--- a/spec/models/legal_aid_application_spec.rb
+++ b/spec/models/legal_aid_application_spec.rb
@@ -662,7 +662,7 @@ RSpec.describe LegalAidApplication, type: :model do
     let!(:proceeding2) { create :proceeding, :se013, legal_aid_application: laa, used_delegated_functions_on: date2 }
     let!(:proceeding3) { create :proceeding, :se014, legal_aid_application: laa }
 
-    context "there are application_proceeding_type records with dates " do
+    context "there are application_proceeding_type records with dates" do
       let(:date1) { Time.zone.today }
       let(:date2) { Time.zone.yesterday }
 
@@ -850,7 +850,7 @@ RSpec.describe LegalAidApplication, type: :model do
 
     before { allow(Rails.configuration.x.ccms_soa).to receive(:submit_applications_to_ccms).and_return(true) }
 
-    it "schedules a PostSubmissionProcessingJob " do
+    it "schedules a PostSubmissionProcessingJob" do
       expect(PostSubmissionProcessingJob).to receive(:perform_later).with(
         legal_aid_application.id,
         feedback_url,
@@ -1083,7 +1083,7 @@ RSpec.describe LegalAidApplication, type: :model do
     let(:proceeding_da001) { laa.proceedings.detect { |p| p.ccms_code == "DA001" } }
     let(:proceeding_se014) { laa.proceedings.detect { |p| p.ccms_code == "SE014" } }
 
-    it "returns an array of all the  chances of success records" do
+    it "returns an array of all the chances of success records" do
       cos_da001 = create :chances_of_success, proceeding: proceeding_da001
       cos_se014 = create :chances_of_success, proceeding: proceeding_se014
 

--- a/spec/models/legal_framework/serializable_merits_task_spec.rb
+++ b/spec/models/legal_framework/serializable_merits_task_spec.rb
@@ -14,7 +14,7 @@ module LegalFramework
       context "no dependencies" do
         let(:serialized_merits_task) { described_class.new(:proceeding_children, dependencies: []) }
 
-        it " stores empty array for dependencies" do
+        it "stores empty array for dependencies" do
           expect(serialized_merits_task.dependencies).to be_empty
         end
       end

--- a/spec/models/transaction_type_spec.rb
+++ b/spec/models/transaction_type_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe TransactionType, type: :model do
     context "checks that a boolean response is returned" do
       let!(:credit_transaction) { create :transaction_type, :credit_with_standard_name }
 
-      it " returns true with a valid income_type" do
+      it "returns true with a valid income_type" do
         expect(described_class.for_income_type?(credit_transaction["name"])).to eq true
       end
     end
@@ -13,7 +13,7 @@ RSpec.describe TransactionType, type: :model do
     context "checks for boolean response" do
       let!(:debit_transaction) { create :transaction_type, :debit_with_standard_name }
 
-      it " returns false when a non valid income type is used" do
+      it "returns false when a non valid income type is used" do
         expect(described_class.for_income_type?(debit_transaction["name"])).to eq false
       end
     end

--- a/spec/requests/admin/roles_spec.rb
+++ b/spec/requests/admin/roles_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Admin::RolesController, type: :request do
     end
 
     context "when the search field is used" do
-      it " returns the relevant firm" do
+      it "returns the relevant firm" do
         expect(Firm.search("Nelson")).to eq([firm4])
       end
 

--- a/spec/requests/providers/applicant_employed_spec.rb
+++ b/spec/requests/providers/applicant_employed_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe Providers::ApplicantEmployedController, type: :request do
     let!(:legal_aid_application) { create :legal_aid_application, provider: provider, applicant: applicant }
     let(:applicant) { create :applicant }
 
-    context "applicant is employed and  the provider has employed permissions" do
+    context "applicant is employed and the provider has employed permissions" do
       before { allow_any_instance_of(Provider).to receive(:employment_permissions?).and_return(true) }
 
       it "redirects to the proceedings search page" do

--- a/spec/requests/providers/application_merits_task/statement_of_case_spec.rb
+++ b/spec/requests/providers/application_merits_task/statement_of_case_spec.rb
@@ -363,7 +363,7 @@ module Providers
             context "text is entered and an additional file is uploaded" do
               let(:entered_text) { "Now we have two attached files" }
 
-              it "updates the text and attaches  the additional file" do
+              it "updates the text and attaches the additional file" do
                 subject
                 expect(statement_of_case.reload.statement).to eq entered_text
                 expect(statement_of_case.original_attachments.count).to eq 3

--- a/spec/requests/providers/capital_assessment_results_spec.rb
+++ b/spec/requests/providers/capital_assessment_results_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe Providers::CapitalAssessmentResultsController, type: :request do
   let(:login_provider) { login_as legal_aid_application.provider }
 
-  describe "GET  /providers/applications/:legal_aid_application_id/capital_assessment_result" do
+  describe "GET /providers/applications/:legal_aid_application_id/capital_assessment_result" do
     subject { get providers_legal_aid_application_capital_assessment_result_path(legal_aid_application) }
     let(:cfe_result) { create :cfe_v3_result }
     let(:legal_aid_application) { cfe_result.legal_aid_application }

--- a/spec/requests/providers/capital_income_assessment_results_spec.rb
+++ b/spec/requests/providers/capital_income_assessment_results_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Providers::CapitalIncomeAssessmentResultsController, type: :reque
   include ActionView::Helpers::NumberHelper
   let(:login_provider) { login_as legal_aid_application.provider }
 
-  describe "GET  /providers/applications/:legal_aid_application_id/capital_income_assessment_result" do
+  describe "GET /providers/applications/:legal_aid_application_id/capital_income_assessment_result" do
     subject { get providers_legal_aid_application_capital_income_assessment_result_path(legal_aid_application) }
     let!(:applicant) { create :applicant, with_bank_accounts: 2, legal_aid_application: legal_aid_application }
     let(:legal_aid_application) { cfe_result.legal_aid_application }

--- a/spec/requests/providers/check_provider_answers_spec.rb
+++ b/spec/requests/providers/check_provider_answers_spec.rb
@@ -200,7 +200,7 @@ RSpec.describe Providers::CheckProviderAnswersController, type: :request do
     end
   end
 
-  describe "PATCH  /providers/applications/:legal_aid_application_id/check_provider_answers/continue" do
+  describe "PATCH /providers/applications/:legal_aid_application_id/check_provider_answers/continue" do
     context "Continue" do
       subject { patch "/providers/applications/#{application_id}/check_provider_answers/continue", params: params }
 

--- a/spec/requests/providers/legal_aid_applications_spec.rb
+++ b/spec/requests/providers/legal_aid_applications_spec.rb
@@ -263,7 +263,7 @@ RSpec.describe "providers legal aid application requests", type: :request do
         expect { subject }.not_to change(LegalAidApplication, :count)
       end
 
-      it "redirects to new applicant page " do
+      it "redirects to new applicant page" do
         subject
         expect(response).to redirect_to(new_providers_applicant_path)
       end

--- a/spec/requests/providers/offline_accounts_spec.rb
+++ b/spec/requests/providers/offline_accounts_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe "providers offine accounts", type: :request do
         context "applicant does not own home" do
           before { get providers_legal_aid_application_own_home_path(application) }
 
-          it "points to the own  home page" do
+          it "points to the own home page" do
             subject
             expect(response.body).to have_back_link(providers_legal_aid_application_own_home_path(application, back: true))
           end

--- a/spec/requests/providers/savings_and_investments_spec.rb
+++ b/spec/requests/providers/savings_and_investments_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe "providers savings and investments", type: :request do
         context "applicant does not own home" do
           before { get providers_legal_aid_application_own_home_path(application) }
 
-          it "points to the own  home page" do
+          it "points to the own home page" do
             subject
             expect(response.body).to have_back_link(providers_legal_aid_application_own_home_path(application, back: true))
           end

--- a/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_entities_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_entities_spec.rb
@@ -156,7 +156,7 @@ module CCMS
               expect(xml).to have_means_entity "BANKACC"
             end
 
-            it "adds the correct ccms instance label " do
+            it "adds the correct ccms instance label" do
               doc = Nokogiri::XML(xml).remove_namespaces!
               instance_label = doc.xpath(' //MeansAssesments//AssesmentDetails//Entity[EntityName = "BANKACC"]/Instances/InstanceLabel').text
               expect(instance_label).to include "the bank account1"
@@ -219,7 +219,7 @@ module CCMS
             expect(block).to have_text_response "."
           end
 
-          it "includes the correct ccms instance label " do
+          it "includes the correct ccms instance label" do
             doc = Nokogiri::XML(xml).remove_namespaces!
             instance_label = doc.xpath(' //MeansAssesments//AssesmentDetails//Entity[EntityName = "CHANGE_IN_CIRCUMSTANCE"]/Instances/InstanceLabel').text
             expect(instance_label).to eq "the change in circumstance1"
@@ -232,7 +232,7 @@ module CCMS
               expect(xml).to have_means_entity "CARS_AND_MOTOR_VEHICLES"
             end
 
-            it "includes the correct ccms instance label " do
+            it "includes the correct ccms instance label" do
               doc = Nokogiri::XML(xml).remove_namespaces!
               instance_label = doc.xpath(' //MeansAssesments//AssesmentDetails//Entity[EntityName = "CARS_AND_MOTOR_VEHICLES"]/Instances/InstanceLabel').text
               expect(instance_label).to eq "the cars & motor vehicle1"
@@ -259,7 +259,7 @@ module CCMS
               expect(xml).to have_means_entity "THIRDPARTACC"
             end
 
-            it "includes the correct ccms instance label " do
+            it "includes the correct ccms instance label" do
               doc = Nokogiri::XML(xml).remove_namespaces!
               instance_label = doc.xpath(' //MeansAssesments//AssesmentDetails//Entity[EntityName = "THIRDPARTACC"]/Instances/InstanceLabel').text
               expect(instance_label).to eq "the third party bank account1"
@@ -325,7 +325,7 @@ module CCMS
               expect(xml).to have_means_entity "CLICAPITAL"
             end
 
-            it "includes the correct ccms instance label " do
+            it "includes the correct ccms instance label" do
               doc = Nokogiri::XML(xml).remove_namespaces!
               instance_label = doc.xpath(' //MeansAssesments//AssesmentDetails//Entity[EntityName = "CLICAPITAL"]/Instances/InstanceLabel').text
               expect(instance_label).to eq "the client's capital bond1"
@@ -353,7 +353,7 @@ module CCMS
               expect(xml).to have_means_entity "LAND"
             end
 
-            it "includes the correct ccms instance label " do
+            it "includes the correct ccms instance label" do
               doc = Nokogiri::XML(xml).remove_namespaces!
               instance_label = doc.xpath(' //MeansAssesments//AssesmentDetails//Entity[EntityName = "LAND"]/Instances/InstanceLabel').text
               expect(instance_label).to eq "the land1"
@@ -399,7 +399,7 @@ module CCMS
               expect(xml).to have_means_entity "CAR_USED"
             end
 
-            it "includes the correct ccms instance label " do
+            it "includes the correct ccms instance label" do
               doc = Nokogiri::XML(xml).remove_namespaces!
               instance_label = doc.xpath(' //MeansAssesments//AssesmentDetails//Entity[EntityName = "CAR_USED"]/Instances/InstanceLabel').text
               expect(instance_label).to eq "the car used1"
@@ -465,7 +465,7 @@ module CCMS
               expect(xml).to have_means_entity "LIFE_ASSURANCE"
             end
 
-            it "adds the correct ccms instance label " do
+            it "adds the correct ccms instance label" do
               doc = Nokogiri::XML(xml).remove_namespaces!
               instance_label = doc.xpath(' //MeansAssesments//AssesmentDetails//Entity[EntityName = "LIFE_ASSURANCE"]/Instances/InstanceLabel').text
               expect(instance_label).to eq "life assurance & endowment policy1"
@@ -535,7 +535,7 @@ module CCMS
               expect(xml).to have_means_entity "TRUST"
             end
 
-            it "includes the correct ccms instance label " do
+            it "includes the correct ccms instance label" do
               doc = Nokogiri::XML(xml).remove_namespaces!
               instance_label = doc.xpath(' //MeansAssesments//AssesmentDetails//Entity[EntityName = "TRUST"]/Instances/InstanceLabel').text
               expect(instance_label).to eq "the trust1"

--- a/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_variable_attributes_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_variable_attributes_spec.rb
@@ -556,7 +556,7 @@ module CCMS
           context "maintenance payments" do
             subject(:block) { XmlExtractor.call(xml, :global_means, attribute) }
 
-            describe "are received by the applicant " do
+            describe "are received by the applicant" do
               let!(:cfe_result) { create :cfe_v3_result, :with_maintenance_received, submission: cfe_submission }
 
               context "GB_INPUT_C_8WP3_303A" do

--- a/spec/services/ccms/requestors/case_add_requestor_xml_blocks/passported_attributes_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_xml_blocks/passported_attributes_spec.rb
@@ -222,7 +222,7 @@ module CCMS
               expect(block).not_to be_present, "Expected block for valuable possessions entity not to be generated, but was \n #{block}"
             end
 
-            it "assigns the sequence number of 1 to the next entity " do
+            it "assigns the sequence number of 1 to the next entity" do
               bank_accounts_sequence = XmlExtractor.call(xml, :bank_accounts_sequence).text.to_i
               expect(bank_accounts_sequence).to eq 1
             end
@@ -534,7 +534,7 @@ module CCMS
           end
         end
 
-        context "GB_INPUT_B_2WP2_1A  - Applicant is a beneficiary of a will?" do
+        context "GB_INPUT_B_2WP2_1A - Applicant is a beneficiary of a will?" do
           context "not a beneficiary" do
             before { legal_aid_application.other_assets_declaration = create :other_assets_declaration, :all_nil }
 
@@ -1107,7 +1107,7 @@ module CCMS
           context "applicant DOES NOT own additional property" do
             before { expect(legal_aid_application.other_assets_declaration).to receive(:second_home_value).and_return(nil) }
 
-            it "returns false when client does NOT own additiaonl property " do
+            it "returns false when client does NOT own additiaonl property" do
               block = XmlExtractor.call(xml, :global_means, "GB_INPUT_B_4WP2_1A")
               expect(block).to have_boolean_response false
             end

--- a/spec/services/ccms/submitters/add_applicant_service_spec.rb
+++ b/spec/services/ccms/submitters/add_applicant_service_spec.rb
@@ -47,7 +47,7 @@ module CCMS
             expect(history.details).to be_nil
           end
 
-          it "stores the reqeust body in the  submission history record" do
+          it "stores the reqeust body in the submission history record" do
             subject.call
             expect(history.request).to be_soap_envelope_with(
               command: "clientbim:ClientAddRQ",
@@ -125,7 +125,7 @@ module CCMS
             expect(history.success).to be false
           end
 
-          it "stores the reqeust body in the  submission history record" do
+          it "stores the reqeust body in the submission history record" do
             expect(history.request).to be_soap_envelope_with(
               command: "clientbim:ClientAddRQ",
               transaction_id: "20190301030405123456",

--- a/spec/services/ccms/submitters/add_case_service_spec.rb
+++ b/spec/services/ccms/submitters/add_case_service_spec.rb
@@ -64,7 +64,7 @@ module CCMS
             expect(history.details).to be_nil
           end
 
-          it "stores the reqeust body in the  submission history record" do
+          it "stores the reqeust body in the submission history record" do
             subject.call
             expect(history.request).to be_soap_envelope_with(
               command: "casebim:CaseAddRQ",
@@ -91,7 +91,7 @@ module CCMS
             expect(history.details).to be_nil
           end
 
-          it "stores the request body in the  submission history record" do
+          it "stores the request body in the submission history record" do
             subject.call
             expect(history.request).to be_soap_envelope_with(
               command: "casebim:CaseAddRQ",
@@ -159,7 +159,7 @@ module CCMS
             expect(history.success).to be false
           end
 
-          it "stores the reqeust body in the  submission history record" do
+          it "stores the reqeust body in the submission history record" do
             expect(history.request).to be_soap_envelope_with(
               command: "casebim:CaseAddRQ",
               transaction_id: "20190301030405123456",

--- a/spec/services/ccms/submitters/check_applicant_status_service_spec.rb
+++ b/spec/services/ccms/submitters/check_applicant_status_service_spec.rb
@@ -47,7 +47,7 @@ module CCMS
                 expect(history.request).not_to be_nil
               end
 
-              it "stores the reqeust body in the  submission history record" do
+              it "stores the reqeust body in the submission history record" do
                 subject.call
                 expect(history.request).to be_soap_envelope_with(
                   command: "clientbim:ClientAddUpdtStatusRQ",
@@ -82,7 +82,7 @@ module CCMS
                 expect(history.details).to match "Poll limit exceeded"
               end
 
-              it "stores the reqeust body in the  submission history record" do
+              it "stores the reqeust body in the submission history record" do
                 subject.call
                 expect(history.request).to be_soap_envelope_with(
                   command: "clientbim:ClientAddUpdtStatusRQ",
@@ -115,7 +115,7 @@ module CCMS
               expect(history.details).to be_nil
             end
 
-            it "stores the reqeust body in the  submission history record" do
+            it "stores the reqeust body in the submission history record" do
               subject.call
               expect(history.request).to be_soap_envelope_with(
                 command: "clientbim:ClientAddUpdtStatusRQ",

--- a/spec/services/ccms/submitters/check_case_status_service_spec.rb
+++ b/spec/services/ccms/submitters/check_case_status_service_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe CCMS::Submitters::CheckCaseStatusService, :ccms do
             expect(history.details).to be_nil
           end
 
-          it "stores the request body in the  submission history record" do
+          it "stores the request body in the submission history record" do
             subject.call
             expect(history.request).to be_soap_envelope_with(
               command: "casebim:CaseAddUpdtStatusRQ",
@@ -77,7 +77,7 @@ RSpec.describe CCMS::Submitters::CheckCaseStatusService, :ccms do
             expect(history.details).to eq "Poll limit exceeded"
           end
 
-          it "stores the reqeust body in the  submission history record" do
+          it "stores the reqeust body in the submission history record" do
             subject.call
             expect(history.request).to be_soap_envelope_with(
               command: "casebim:CaseAddUpdtStatusRQ",
@@ -114,7 +114,7 @@ RSpec.describe CCMS::Submitters::CheckCaseStatusService, :ccms do
           expect(history.details).to be_nil
         end
 
-        it "stores the reqeust body in the  submission history record" do
+        it "stores the reqeust body in the submission history record" do
           subject.call
           expect(history.request).to be_soap_envelope_with(
             command: "casebim:CaseAddUpdtStatusRQ",
@@ -160,7 +160,7 @@ RSpec.describe CCMS::Submitters::CheckCaseStatusService, :ccms do
         expect(history.details).to match(/oops/)
       end
 
-      it "stores the reqeust body in the  submission history record" do
+      it "stores the reqeust body in the submission history record" do
         expect(history.request).to be_soap_envelope_with(
           command: "casebim:CaseAddUpdtStatusRQ",
           transaction_id: "20190101121530123456",

--- a/spec/validators/document_category_validator_spec.rb
+++ b/spec/validators/document_category_validator_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe DocumentCategoryValidator do
     let(:invalid_name) { "xxx-zzz" }
     let(:valid_names) { DocumentCategoryValidator::VALID_DOCUMENT_TYPES }
 
-    context "valid names " do
+    context "valid names" do
       let(:name) { valid_names.sample }
 
       it "does not fail when trying to create a record with an valid name" do


### PR DESCRIPTION
Fix GOVUK Rubocop RSpec/ExcessiveDocstringSpacing offences.

"RSpec/ExcessiveDocstringSpacing: Excessive whitespace. (https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ExcessiveDocstringSpacing)"

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
