### PR TITLE
[AP-3028] handle HMRC unexpected responses

### DIFF
--- a/app/models/hmrc/response.rb
+++ b/app/models/hmrc/response.rb
@@ -33,8 +33,7 @@ module HMRC
   private
 
     def persist_employment_records
-      valid = HMRC::ParsedResponse::Validator.call(self, applicant: legal_aid_application.applicant)
-      HMRC::ParsedResponse::Persistor.call(legal_aid_application) if valid
+      HMRC::ParsedResponse::Persistor.call(self)
     end
   end
 end

--- a/app/models/hmrc/response.rb
+++ b/app/models/hmrc/response.rb
@@ -33,11 +33,8 @@ module HMRC
   private
 
     def persist_employment_records
-      return if response.blank?
-
-      return unless use_case == "one" && response["status"] == "completed"
-
-      HMRC::ParsedResponse::Persistor.call(legal_aid_application)
+      valid = HMRC::ParsedResponse::Validator.call(self, applicant: legal_aid_application.applicant)
+      HMRC::ParsedResponse::Persistor.call(legal_aid_application) if valid
     end
   end
 end

--- a/app/services/hmrc/mock_data/unknown_response.json.erb
+++ b/app/services/hmrc/mock_data/unknown_response.json.erb
@@ -16,7 +16,7 @@
     },
     {
       "income/paye/paye": {
-       "income": [
+        "income": [
           {
             "taxYear": "20-21",
             "payFrequency": "M1",

--- a/app/services/hmrc/parsed_response/validator.rb
+++ b/app/services/hmrc/parsed_response/validator.rb
@@ -60,9 +60,9 @@ module HMRC
       def validate_response_individual
         errors << error(:individual, "individual must match applicant") unless individual &&
           applicant &&
-          applicant.first_name == individual["firstName"] &&
-          applicant.last_name == individual["lastName"] &&
-          applicant.national_insurance_number == individual["nino"] &&
+          applicant.first_name.casecmp?(individual["firstName"]) &&
+          applicant.last_name.casecmp?(individual["lastName"]) &&
+          applicant.national_insurance_number.casecmp?(individual["nino"]) &&
           applicant.date_of_birth.iso8601 == individual["dateOfBirth"]
       end
 

--- a/app/services/hmrc/parsed_response/validator.rb
+++ b/app/services/hmrc/parsed_response/validator.rb
@@ -23,7 +23,7 @@ module HMRC
         validate_response_income
         validate_response_individual
 
-        AlertManager.capture_message("HMRC Response is unacceptable - #{errors.map(&:message).join(', ')}") unless errors.empty?
+        send_message unless errors.empty?
         errors.empty?
       end
 
@@ -90,6 +90,10 @@ module HMRC
 
       def error(*args)
         Error.new(*args)
+      end
+
+      def send_message
+        AlertManager.capture_message("HMRC Response is unacceptable (id: #{hmrc_response.id}) - #{errors.map(&:message).join(', ')}")
       end
     end
   end

--- a/app/services/hmrc/parsed_response/validator.rb
+++ b/app/services/hmrc/parsed_response/validator.rb
@@ -1,0 +1,96 @@
+module HMRC
+  module ParsedResponse
+    class Validator
+      attr_accessor :errors
+
+      Error = Struct.new(:attribute, :message)
+
+      def self.call(hmrc_response, applicant:)
+        new(hmrc_response, applicant:).call
+      end
+
+      def initialize(hmrc_response, applicant:)
+        @hmrc_response = hmrc_response
+        @response = hmrc_response.response
+        @applicant = applicant
+        @errors = []
+      end
+
+      def call
+        validate_use_case
+        validate_response
+        validate_response_data
+        validate_response_income
+        validate_response_individual
+
+        AlertManager.capture_message("HMRC Response is unacceptable") unless errors.empty?
+        errors.empty?
+      end
+
+    private
+
+      attr_reader :hmrc_response, :response, :applicant
+
+      def validate_use_case
+        errors << error(:use_case, "use_case must be \"one\"") if hmrc_response.use_case != "one"
+      end
+
+      def validate_response
+        errors << error(:response, "response must be present") unless response
+        errors << error(:response, "response status must be \"completed\"") if response&.dig("status") != "completed"
+        errors << error(:response, "response submission must be present") if response&.dig("submission").blank?
+      end
+
+      def validate_response_data
+        errors << error(:data, "data must be an array") unless data.is_a?(Array)
+      end
+
+      def validate_response_income
+        errors << error(:income, "income must be an array") unless income.is_a?(Array)
+
+        errors << error(:income, "inPayPeriod1 must be numeric") if income&.any? do |payment|
+          !payment&.dig("grossEarningsForNics")&.dig("inPayPeriod1").is_a?(Numeric)
+        end
+
+        errors << error(:income, "paymentDate must be a valid iso8601 formatted date") if income&.any? do |payment|
+          !valid_iso8601_date?(payment&.dig("paymentDate"))
+        end
+      end
+
+      def validate_response_individual
+        errors << error(:individual, "individual must match applicant") unless individual &&
+          applicant &&
+          applicant.first_name == individual["firstName"] &&
+          applicant.last_name == individual["lastName"] &&
+          applicant.national_insurance_number == individual["nino"] &&
+          applicant.date_of_birth.iso8601 == individual["dateOfBirth"]
+      end
+
+      def data
+        @data ||= response&.dig("data")
+      end
+
+      def paye
+        @paye ||= data&.find { |hash| hash["income/paye/paye"] }
+      end
+
+      def income
+        @income ||= paye&.dig("income/paye/paye", "income")
+      end
+
+      def individual
+        @individual ||= data&.find { |hash| hash["individuals/matching/individual"] }&.dig("individuals/matching/individual")
+      end
+
+      def valid_iso8601_date?(date)
+        Date.iso8601(date)
+      rescue Date::Error
+        false
+      end
+
+      def error(*args)
+        Error.new(*args)
+      end
+    end
+  end
+end

--- a/app/services/hmrc/parsed_response/validator.rb
+++ b/app/services/hmrc/parsed_response/validator.rb
@@ -23,7 +23,7 @@ module HMRC
         validate_response_income
         validate_response_individual
 
-        AlertManager.capture_message("HMRC Response is unacceptable") unless errors.empty?
+        AlertManager.capture_message("HMRC Response is unacceptable - #{errors.map(&:message).join(', ')}") unless errors.empty?
         errors.empty?
       end
 

--- a/features/providers/employed_journey.feature
+++ b/features/providers/employed_journey.feature
@@ -3,7 +3,7 @@ Feature: Employed journey
 @javascript
 Scenario: Completing the means journey for an employed applicant with HMRC data
   Given the feature flag for enable_employed_journey is enabled
-  Given I start the means review journey with employment income from HMRC
+  Given I start the means review journey with employment income for a single job from HMRC
   Then I should be on the 'client_completed_means' page showing 'Your client has shared their financial information'
   When I click 'Continue'
   Then I should be on the 'employment_income' page showing 'The information on this page has been provided by HMRC.'

--- a/features/step_definitions/civil_journey_steps.rb
+++ b/features/step_definitions/civil_journey_steps.rb
@@ -313,17 +313,15 @@ Given("I start the merits application and the applicant has uploaded transaction
   )
 end
 
-Given("I start the means review journey with employment income from HMRC") do
+Given("I start the means review journey with employment income for a single job from HMRC") do
   @legal_aid_application = create(
     :application,
     :with_applicant,
+    :with_single_employment,
     :with_proceedings,
     :with_non_passported_state_machine,
     :provider_assessing_means,
   )
-
-  @hmrc_response = create(:hmrc_response, :use_case_one, legal_aid_application: @legal_aid_application)
-  @hmrc_response.__send__(:persist_employment_records)
 
   @legal_aid_application.provider.permissions << Permission.where(role: "application.non_passported.employment.*").first
 
@@ -336,17 +334,12 @@ Given("I start the means review journey with employment income from HMRC") do
 end
 
 Given("I start the means review journey with no employment income from HMRC") do
-  @applicant = create(
-    :applicant,
-    :employed,
-  )
-
   @legal_aid_application = create(
     :application,
     :with_proceedings,
     :with_non_passported_state_machine,
     :provider_assessing_means,
-    applicant: @applicant,
+    applicant: build(:applicant, :employed),
   )
 
   @legal_aid_application.provider.permissions << Permission.where(role: "application.non_passported.employment.*").first
@@ -363,13 +356,11 @@ Given("I start the means review journey with employment income for multiple jobs
   @legal_aid_application = create(
     :application,
     :with_applicant,
+    :with_multiple_employments,
     :with_proceedings,
     :with_non_passported_state_machine,
     :provider_assessing_means,
   )
-
-  @hmrc_response = create(:hmrc_response, :multiple_employments_usecase1, legal_aid_application: @legal_aid_application)
-  @hmrc_response.__send__(:persist_employment_records)
 
   @legal_aid_application.provider.permissions << Permission.where(role: "application.non_passported.employment.*").first
 

--- a/spec/factories/hmrc/responses.rb
+++ b/spec/factories/hmrc/responses.rb
@@ -7,6 +7,10 @@ module HMRC
       submission_id { SecureRandom.uuid }
       use_case { "one" }
 
+      trait :with_legal_aid_applicant do
+        legal_aid_application { build(:legal_aid_application, :with_applicant) }
+      end
+
       trait :use_case_one do
         use_case { "one" }
         response { ::FactoryHelpers::HMRCResponse::UseCaseOne.new(submission_id).response }

--- a/spec/factories/legal_aid_applications.rb
+++ b/spec/factories/legal_aid_applications.rb
@@ -10,6 +10,10 @@ FactoryBot.define do
       applicant { build :applicant, with_bank_accounts: with_bank_accounts }
     end
 
+    trait :with_employments do
+      employments { build_list(:employment, 3) }
+    end
+
     trait :with_applicant_and_address do
       transient do
         with_bank_accounts { 0 }

--- a/spec/factories/legal_aid_applications.rb
+++ b/spec/factories/legal_aid_applications.rb
@@ -10,7 +10,11 @@ FactoryBot.define do
       applicant { build :applicant, with_bank_accounts: with_bank_accounts }
     end
 
-    trait :with_employments do
+    trait :with_single_employment do
+      employments { [association(:employment)] }
+    end
+
+    trait :with_multiple_employments do
       employments { build_list(:employment, 3) }
     end
 

--- a/spec/models/hmrc/response_spec.rb
+++ b/spec/models/hmrc/response_spec.rb
@@ -1,147 +1,161 @@
 require "rails_helper"
 
-module HMRC
-  RSpec.describe Response, type: :model do
-    subject(:response) { build(:hmrc_response) }
+RSpec.describe HMRC::Response, type: :model do
+  subject(:response) { build(:hmrc_response) }
 
-    describe "validations" do
-      subject(:valid) { response.valid? }
+  context "when validating" do
+    before { response.validate }
 
+    context "with valid use_case" do
       it "is valid with all valid attributes" do
-        expect(valid).to be true
-      end
-
-      context "when the use case is not valid for apply" do
-        let(:response) { build(:hmrc_response, use_case: "three") }
-
-        it { is_expected.to be false }
+        expect(response).to be_valid
       end
     end
 
-    describe ".use_case_for" do
-      context "there are application id does not exist" do
-        it "returns nil" do
-          expect(described_class.use_case_one_for(SecureRandom.uuid)).to be_nil
-        end
-      end
+    context "with invalid use_case" do
+      let(:response) { build(:hmrc_response, use_case: "three") }
 
-      context "there is only one use case one record with the specified application id" do
-        let!(:response1) { create :hmrc_response, :use_case_one }
-        let!(:response_uc2) { create :hmrc_response, :use_case_two, legal_aid_application_id: response1.legal_aid_application_id }
-        let!(:response2) { create :hmrc_response, :use_case_one }
+      it { expect(response).to be_invalid }
+      it { expect(response.errors.messages_for(:use_case)).to include("Invalid use case") }
+    end
 
-        it "returns the record for the application we specify" do
-          expect(described_class.use_case_one_for(response1.legal_aid_application_id)).to eq response1
-        end
-      end
+    context "with nil use_case" do
+      let(:response) { build(:hmrc_response, use_case: nil) }
 
-      context "there are multiple use case one records with the specified application id" do
-        let!(:response1) { create :hmrc_response, :use_case_one, created_at: 5.minutes.ago }
-        let!(:response_uc2) { create :hmrc_response, :use_case_two, legal_aid_application_id: response1.legal_aid_application_id }
-        let!(:response1_last) { create :hmrc_response, :use_case_one, legal_aid_application_id: response1.legal_aid_application_id }
-        let!(:response2) { create :hmrc_response, :use_case_one }
+      it { expect(response).to be_invalid }
+      it { expect(response.errors.messages_for(:use_case)).to include("can't be blank") }
+    end
 
-        it "returns the last created use case one record for the specified application id" do
-          expect(described_class.use_case_one_for(response1.legal_aid_application_id)).to eq response1_last
-        end
+    context "with blank use_case" do
+      let(:response) { build(:hmrc_response, use_case: "") }
+
+      it { expect(response).to be_invalid }
+      it { expect(response.errors.messages_for(:use_case)).to include("can't be blank") }
+    end
+  end
+
+  describe ".use_case_for" do
+    context "there are application id does not exist" do
+      it "returns nil" do
+        expect(described_class.use_case_one_for(SecureRandom.uuid)).to be_nil
       end
     end
 
-    describe "#employment_income?" do
-      context "when there is no hmrc data" do
-        let(:response) { create :hmrc_response }
+    context "there is only one use case one record with the specified application id" do
+      let!(:response1) { create :hmrc_response, :use_case_one }
+      let!(:response_uc2) { create :hmrc_response, :use_case_two, legal_aid_application_id: response1.legal_aid_application_id }
+      let!(:response2) { create :hmrc_response, :use_case_one }
 
-        it "returns false" do
-          expect(response.employment_income?).to eq false
-        end
-      end
-
-      context "when the hmrc data does not contain employment income data" do
-        let(:response) { create :hmrc_response }
-        let(:response_data_with_no_employment_income) do
-          { "submission" => "f3730ebf-4b56-4bc1-b419-417bdf2ce9d2",
-            "status" => "completed",
-            "data" =>
-             [{ "correlation_id" => "f3730ebf-4b56-4bc1-b419-417bdf2ce9d2", "use_case" => "use_case_one" },
-              { "individuals/matching/individual" => { "firstName" => "tesdt", "lastName" => "test", "nino" => "XX123456X", "dateOfBirth" => "1970-01-01" } },
-              { "income/paye/paye" => { "income" => [] } }] }
-        end
-
-        before { response.response = response_data_with_no_employment_income }
-
-        it "returns false" do
-          expect(response.employment_income?).to eq false
-        end
-      end
-
-      context "when the hmrc data contains employment income data" do
-        let(:response) { create :hmrc_response, :use_case_one }
-
-        it "returns true" do
-          expect(response.employment_income?).to eq true
-        end
+      it "returns the record for the application we specify" do
+        expect(described_class.use_case_one_for(response1.legal_aid_application_id)).to eq response1
       end
     end
 
-    describe ".after_update" do
-      let(:persistor_class) { HMRC::ParsedResponse::Persistor }
-      let(:validator_class) { HMRC::ParsedResponse::Validator }
-      let(:hmrc_response) { create(:hmrc_response, :use_case_one, :with_legal_aid_applicant) }
+    context "there are multiple use case one records with the specified application id" do
+      let!(:response1) { create :hmrc_response, :use_case_one, created_at: 5.minutes.ago }
+      let!(:response_uc2) { create :hmrc_response, :use_case_two, legal_aid_application_id: response1.legal_aid_application_id }
+      let!(:response1_last) { create :hmrc_response, :use_case_one, legal_aid_application_id: response1.legal_aid_application_id }
+      let!(:response2) { create :hmrc_response, :use_case_one }
 
-      it "calls HMRC::ParsedResponse::Validator" do
-        allow(validator_class).to receive(:call)
-        hmrc_response.update!(url: "my_url")
-        expect(validator_class).to have_received(:call).with(hmrc_response, applicant: kind_of(Applicant))
+      it "returns the last created use case one record for the specified application id" do
+        expect(described_class.use_case_one_for(response1.legal_aid_application_id)).to eq response1_last
       end
+    end
+  end
 
-      context "when response is persistable" do
-        before do
-          allow(validator_class).to receive(:call).and_return(true)
-          allow(persistor_class).to receive(:call)
-          hmrc_response.update!(url: "my_url")
-        end
+  describe "#employment_income?" do
+    context "when there is no hmrc data" do
+      let(:response) { create :hmrc_response }
 
-        it "calls HMRC::ParsedResponse::Persistor" do
-          expect(persistor_class).to have_received(:call).with(hmrc_response.legal_aid_application)
-        end
-      end
-
-      context "when response is not persistable" do
-        before do
-          allow(validator_class).to receive(:call).and_return(false)
-          allow(persistor_class).to receive(:call)
-          hmrc_response.update!(url: "my_url")
-        end
-
-        it "does not call HMRC::ParsedResponse::Persistor" do
-          expect(persistor_class).not_to have_received(:call)
-        end
+      it "returns false" do
+        expect(response.employment_income?).to eq false
       end
     end
 
-    describe "#status" do
-      context "normal payload" do
-        let(:response) { create :hmrc_response, :use_case_one }
-
-        it "returns a 'completed' status" do
-          expect(response.status).to eq "completed"
-        end
+    context "when the hmrc data does not contain employment income data" do
+      let(:response) { create :hmrc_response }
+      let(:response_data_with_no_employment_income) do
+        { "submission" => "f3730ebf-4b56-4bc1-b419-417bdf2ce9d2",
+          "status" => "completed",
+          "data" =>
+           [{ "correlation_id" => "f3730ebf-4b56-4bc1-b419-417bdf2ce9d2", "use_case" => "use_case_one" },
+            { "individuals/matching/individual" => { "firstName" => "tesdt", "lastName" => "test", "nino" => "XX123456X", "dateOfBirth" => "1970-01-01" } },
+            { "income/paye/paye" => { "income" => [] } }] }
       end
 
-      context "processing payload" do
-        let(:response) { create :hmrc_response, :processing }
+      before { response.response = response_data_with_no_employment_income }
 
-        it "returns a 'processing' status" do
-          expect(response.status).to eq "processing"
-        end
+      it "returns false" do
+        expect(response.employment_income?).to eq false
+      end
+    end
+
+    context "when the hmrc data contains employment income data" do
+      let(:response) { create :hmrc_response, :use_case_one }
+
+      it "returns true" do
+        expect(response.employment_income?).to eq true
+      end
+    end
+  end
+
+  describe ".after_update" do
+    let(:persistor_class) { HMRC::ParsedResponse::Persistor }
+    let(:hmrc_response) { create(:hmrc_response, :use_case_one, :with_legal_aid_applicant) }
+    let(:trigger_update) { hmrc_response.update!(url: "my_url") }
+
+    before do
+      allow(HMRC::ParsedResponse::Persistor).to receive(:call).and_call_original
+    end
+
+    it "calls HMRC::ParsedResponse::Persistor" do
+      trigger_update
+      expect(persistor_class).to have_received(:call).with(hmrc_response)
+    end
+
+    context "with a valid HMR response" do
+      before do
+        allow(HMRC::ParsedResponse::Validator).to receive(:call).and_return(true)
       end
 
-      context "nil payload" do
-        let(:response) { create :hmrc_response, :nil_response }
+      it "creates one employment record" do
+        expect { trigger_update }.to change { hmrc_response.legal_aid_application.employments.count }.from(0).to(1)
+      end
+    end
 
-        it "returns nil" do
-          expect(response.status).to be_nil
-        end
+    context "with an invalid HMR response" do
+      before do
+        allow(HMRC::ParsedResponse::Validator).to receive(:call).and_return(false)
+      end
+
+      it "does not create an employment record" do
+        expect { trigger_update }.to change { hmrc_response.legal_aid_application.employments.count }.by(0)
+      end
+    end
+  end
+
+  describe "#status" do
+    context "normal payload" do
+      let(:response) { create :hmrc_response, :use_case_one }
+
+      it "returns a 'completed' status" do
+        expect(response.status).to eq "completed"
+      end
+    end
+
+    context "processing payload" do
+      let(:response) { create :hmrc_response, :processing }
+
+      it "returns a 'processing' status" do
+        expect(response.status).to eq "processing"
+      end
+    end
+
+    context "nil payload" do
+      let(:response) { create :hmrc_response, :nil_response }
+
+      it "returns nil" do
+        expect(response.status).to be_nil
       end
     end
   end

--- a/spec/models/legal_aid_application_spec.rb
+++ b/spec/models/legal_aid_application_spec.rb
@@ -1298,18 +1298,18 @@ RSpec.describe LegalAidApplication, type: :model do
   end
 
   describe "hmrc_employment_income?" do
-    let(:laa) { create :legal_aid_application }
-
     context "when there are no Employment records" do
+      let(:laa) { create(:legal_aid_application) }
+
+      before { laa.employments.destroy_all }
+
       it "returns false" do
         expect(laa.hmrc_employment_income?).to eq false
       end
     end
 
     context "when there are Employment records" do
-      let!(:hmrc_response) { create :hmrc_response, :use_case_one, legal_aid_application: laa }
-
-      before { hmrc_response.__send__(:persist_employment_records) }
+      let(:laa) { create(:legal_aid_application, :with_employments) }
 
       it "returns true" do
         expect(laa.hmrc_employment_income?).to eq true

--- a/spec/models/legal_aid_application_spec.rb
+++ b/spec/models/legal_aid_application_spec.rb
@@ -1309,7 +1309,7 @@ RSpec.describe LegalAidApplication, type: :model do
     end
 
     context "when there are Employment records" do
-      let(:laa) { create(:legal_aid_application, :with_employments) }
+      let(:laa) { create(:legal_aid_application, :with_multiple_employments) }
 
       it "returns true" do
         expect(laa.hmrc_employment_income?).to eq true

--- a/spec/services/hmrc/parsed_response/validator_spec.rb
+++ b/spec/services/hmrc/parsed_response/validator_spec.rb
@@ -612,7 +612,8 @@ RSpec.describe HMRC::ParsedResponse::Validator do
       end
 
       it "sends message to AlertManager with errors" do
-        expect(AlertManager).to have_received(:capture_message).with("HMRC Response is unacceptable - response status must be \"completed\", individual must match applicant")
+        expect(AlertManager).to have_received(:capture_message)
+                                  .with("HMRC Response is unacceptable (id: #{hmrc_response.id}) - response status must be \"completed\", individual must match applicant")
       end
     end
   end

--- a/spec/services/hmrc/parsed_response/validator_spec.rb
+++ b/spec/services/hmrc/parsed_response/validator_spec.rb
@@ -595,16 +595,24 @@ RSpec.describe HMRC::ParsedResponse::Validator do
     end
 
     context "when response data is invalid" do
-      let(:hmrc_response) { create(:hmrc_response, response: nil) }
+      let(:hmrc_response) { create(:hmrc_response, response: response_hash) }
+
+      let(:response_hash) do
+        { "submission" => "must-be-present",
+          "status" => "foobar",
+          "data" => [
+            { "individuals/matching/individual" => {} },
+            { "income/paye/paye" => { "income" => [] } },
+          ] }
+      end
 
       before do
         allow(AlertManager).to receive(:capture_message)
         call
       end
 
-      it "sends error response to AlertManager" do
-        call
-        expect(AlertManager).to have_received(:capture_message)
+      it "sends message to AlertManager with errors" do
+        expect(AlertManager).to have_received(:capture_message).with("HMRC Response is unacceptable - response status must be \"completed\", individual must match applicant")
       end
     end
   end

--- a/spec/services/hmrc/parsed_response/validator_spec.rb
+++ b/spec/services/hmrc/parsed_response/validator_spec.rb
@@ -151,6 +151,29 @@ RSpec.describe HMRC::ParsedResponse::Validator do
       it { expect(call).to be_truthy }
     end
 
+    context "when response data has \"individuals/matching/individual\" details matching request with case differences" do
+      let(:hmrc_response) { create(:hmrc_response, legal_aid_application:, response: response_hash) }
+      let(:legal_aid_application) { create(:legal_aid_application, :with_applicant) }
+
+      let(:valid_individual_response) do
+        { "firstName" => applicant.first_name.upcase,
+          "lastName" => applicant.last_name.upcase,
+          "nino" => applicant.national_insurance_number.downcase,
+          "dateOfBirth" => applicant.date_of_birth }
+      end
+
+      let(:response_hash) do
+        { "submission" => "must-be-present",
+          "status" => "completed",
+          "data" => [
+            { "individuals/matching/individual" => valid_individual_response },
+            { "income/paye/paye" => { "income" => [] } },
+          ] }
+      end
+
+      it { expect(call).to be_truthy }
+    end
+
     context "when response data \"individuals/matching/individual\" details are missing" do
       let(:hmrc_response) { create(:hmrc_response, response: response_hash) }
 

--- a/spec/services/hmrc/parsed_response/validator_spec.rb
+++ b/spec/services/hmrc/parsed_response/validator_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe HMRC::ParsedResponse::Validator do
   describe ".call" do
     subject(:call) { described_class.call(hmrc_response, applicant:) }
 
+    let(:instance) { described_class.new(hmrc_response, applicant:) }
     let(:applicant) { create(:legal_aid_application, :with_applicant).applicant }
 
     let(:valid_individual_response) do
@@ -35,8 +36,8 @@ RSpec.describe HMRC::ParsedResponse::Validator do
     end
 
     context "when applicant is nil" do
-      let(:hmrc_response) { create(:hmrc_response, use_case: "one", response: valid_response_hash) }
       let(:instance) { described_class.new(hmrc_response, applicant: nil) }
+      let(:hmrc_response) { create(:hmrc_response, use_case: "one", response: valid_response_hash) }
 
       it { expect(instance.call).to be_falsey }
 
@@ -47,8 +48,8 @@ RSpec.describe HMRC::ParsedResponse::Validator do
     end
 
     context "when response is nil" do
-      let(:hmrc_response) { create(:hmrc_response, response: nil) }
-      let(:instance) { described_class.new(hmrc_response, applicant:) }
+      let(:hmrc_response) { create(:hmrc_response, response: response_hash) }
+      let(:response_hash) { nil }
 
       it { expect(call).to be_falsey }
 
@@ -59,12 +60,18 @@ RSpec.describe HMRC::ParsedResponse::Validator do
     end
 
     context "when response is empty hash" do
-      let(:hmrc_response) { create(:hmrc_response, response: {}) }
+      let(:hmrc_response) { create(:hmrc_response, response: response_hash) }
+      let(:response_hash) { {} }
 
-      it { expect(call).to be_falsey }
+      it { expect(instance.call).to be_falsey }
+
+      it {
+        instance.call
+        expect(instance.errors.collect(&:message).size).to be >= 1
+      }
     end
 
-    context "when response status is not completed" do
+    context "when response status is not \"completed\"" do
       let(:hmrc_response) { create(:hmrc_response, response: response_hash) }
 
       let(:response_hash) do
@@ -73,7 +80,12 @@ RSpec.describe HMRC::ParsedResponse::Validator do
           "data" => [] }
       end
 
-      it { expect(call).to be_falsey }
+      it { expect(instance.call).to be_falsey }
+
+      it {
+        instance.call
+        expect(instance.errors.collect(&:message)).to include("response status must be \"completed\"")
+      }
     end
 
     context "when response submission is nil" do
@@ -85,7 +97,12 @@ RSpec.describe HMRC::ParsedResponse::Validator do
           "data" => [] }
       end
 
-      it { expect(call).to be_falsey }
+      it { expect(instance.call).to be_falsey }
+
+      it {
+        instance.call
+        expect(instance.errors.collect(&:message)).to include("response submission must be present")
+      }
     end
 
     context "when response submission is blank" do
@@ -97,7 +114,12 @@ RSpec.describe HMRC::ParsedResponse::Validator do
           "data" => [] }
       end
 
-      it { expect(call).to be_falsey }
+      it { expect(instance.call).to be_falsey }
+
+      it {
+        instance.call
+        expect(instance.errors.collect(&:message)).to include("response submission must be present")
+      }
     end
 
     context "when response submission is missing" do
@@ -108,7 +130,12 @@ RSpec.describe HMRC::ParsedResponse::Validator do
           "data" => [] }
       end
 
-      it { expect(call).to be_falsey }
+      it { expect(instance.call).to be_falsey }
+
+      it {
+        instance.call
+        expect(instance.errors.collect(&:message)).to include("response submission must be present")
+      }
     end
 
     context "when response data is a hash" do
@@ -120,7 +147,12 @@ RSpec.describe HMRC::ParsedResponse::Validator do
           "data" => {} }
       end
 
-      it { expect(call).to be_falsey }
+      it { expect(instance.call).to be_falsey }
+
+      it {
+        instance.call
+        expect(instance.errors.collect(&:message)).to include("data must be an array")
+      }
     end
 
     context "when response data is nil" do
@@ -132,7 +164,12 @@ RSpec.describe HMRC::ParsedResponse::Validator do
           "data" => nil }
       end
 
-      it { expect(call).to be_falsey }
+      it { expect(instance.call).to be_falsey }
+
+      it {
+        instance.call
+        expect(instance.errors.collect(&:message)).to include("data must be an array")
+      }
     end
 
     context "when response data has \"individuals/matching/individual\" details matching request" do
@@ -185,7 +222,12 @@ RSpec.describe HMRC::ParsedResponse::Validator do
           ] }
       end
 
-      it { expect(call).to be_falsey }
+      it { expect(instance.call).to be_falsey }
+
+      it {
+        instance.call
+        expect(instance.errors.collect(&:message)).to include("individual must match applicant")
+      }
     end
 
     context "when response data \"individuals/matching/individual\" details are empty" do
@@ -200,7 +242,12 @@ RSpec.describe HMRC::ParsedResponse::Validator do
           ] }
       end
 
-      it { expect(call).to be_falsey }
+      it { expect(instance.call).to be_falsey }
+
+      it {
+        instance.call
+        expect(instance.errors.collect(&:message)).to include("individual must match applicant")
+      }
     end
 
     context "when response data \"individuals/matching/individual\" details has invalid dateOfBirth date" do
@@ -221,7 +268,12 @@ RSpec.describe HMRC::ParsedResponse::Validator do
           ] }
       end
 
-      it { expect(call).to be_falsey }
+      it { expect(instance.call).to be_falsey }
+
+      it {
+        instance.call
+        expect(instance.errors.collect(&:message)).to include("individual must match applicant")
+      }
     end
 
     context "when response data \"individuals/matching/individual\" details do not match applicant" do
@@ -244,7 +296,12 @@ RSpec.describe HMRC::ParsedResponse::Validator do
         }
       end
 
-      it { expect(call).to be_falsey }
+      it { expect(instance.call).to be_falsey }
+
+      it {
+        instance.call
+        expect(instance.errors.collect(&:message)).to include("individual must match applicant")
+      }
     end
 
     context "when response data \"income/paye/paye\" \"income\" is nil" do
@@ -256,7 +313,12 @@ RSpec.describe HMRC::ParsedResponse::Validator do
           "data" => [{ "income/paye/paye" => { "income" => nil } }] }
       end
 
-      it { expect(call).to be_falsey }
+      it { expect(instance.call).to be_falsey }
+
+      it {
+        instance.call
+        expect(instance.errors.collect(&:message)).to include("income must be an array")
+      }
     end
 
     context "when response data \"income/paye/paye\" \"income\" is hash" do
@@ -268,7 +330,12 @@ RSpec.describe HMRC::ParsedResponse::Validator do
           "data" => [{ "income/paye/paye" => { "income" => {} } }] }
       end
 
-      it { expect(call).to be_falsey }
+      it { expect(instance.call).to be_falsey }
+
+      it {
+        instance.call
+        expect(instance.errors.collect(&:message)).to include("income must be an array")
+      }
     end
 
     context "when response data \"income/paye/paye\" \"income\" contains invalid inPayPeriod1 string" do
@@ -294,7 +361,12 @@ RSpec.describe HMRC::ParsedResponse::Validator do
         }
       end
 
-      it { expect(call).to be_falsey }
+      it { expect(instance.call).to be_falsey }
+
+      it {
+        instance.call
+        expect(instance.errors.collect(&:message)).to include("inPayPeriod1 must be numeric")
+      }
     end
 
     context "when response data \"income/paye/paye\" \"income\" contains valid inPayPeriod1 float" do
@@ -383,7 +455,12 @@ RSpec.describe HMRC::ParsedResponse::Validator do
         }
       end
 
-      it { expect(call).to be_falsey }
+      it { expect(instance.call).to be_falsey }
+
+      it {
+        instance.call
+        expect(instance.errors.collect(&:message)).to include("inPayPeriod1 must be numeric")
+      }
     end
 
     context "when response data \"income/paye/paye\" \"income\" contains valid format of paymentDate" do
@@ -438,7 +515,12 @@ RSpec.describe HMRC::ParsedResponse::Validator do
         }
       end
 
-      it { expect(call).to be_falsey }
+      it { expect(instance.call).to be_falsey }
+
+      it {
+        instance.call
+        expect(instance.errors.collect(&:message)).to include("paymentDate must be a valid iso8601 formatted date")
+      }
     end
 
     context "when response data \"income/paye/paye\" \"income\" contains non-iso8601 format of paymentDate" do
@@ -465,7 +547,12 @@ RSpec.describe HMRC::ParsedResponse::Validator do
         }
       end
 
-      it { expect(call).to be_falsey }
+      it { expect(instance.call).to be_falsey }
+
+      it {
+        instance.call
+        expect(instance.errors.collect(&:message)).to include("paymentDate must be a valid iso8601 formatted date")
+      }
     end
 
     context "when response data \"income/paye/paye\" \"income\" contains multiple paymentDates including one invalid" do
@@ -499,7 +586,12 @@ RSpec.describe HMRC::ParsedResponse::Validator do
         }
       end
 
-      it { expect(call).to be_falsey }
+      it { expect(instance.call).to be_falsey }
+
+      it {
+        instance.call
+        expect(instance.errors.collect(&:message)).to include("paymentDate must be a valid iso8601 formatted date")
+      }
     end
 
     context "when response data is invalid" do

--- a/spec/services/hmrc/parsed_response/validator_spec.rb
+++ b/spec/services/hmrc/parsed_response/validator_spec.rb
@@ -1,0 +1,496 @@
+require "rails_helper"
+
+RSpec.describe HMRC::ParsedResponse::Validator do
+  describe ".call" do
+    subject(:call) { described_class.call(hmrc_response, applicant:) }
+
+    let(:applicant) { create(:legal_aid_application, :with_applicant).applicant }
+
+    let(:valid_individual_response) do
+      { "firstName" => applicant.first_name,
+        "lastName" => applicant.last_name,
+        "nino" => applicant.national_insurance_number,
+        "dateOfBirth" => applicant.date_of_birth }
+    end
+
+    let(:valid_response_hash) do
+      { "submission" => "must-be-present",
+        "status" => "completed",
+        "data" => [
+          { "individuals/matching/individual" => valid_individual_response },
+          { "income/paye/paye" => { "income" => [] } },
+        ] }
+    end
+
+    context "when response has persistable employment details" do
+      let(:hmrc_response) { create(:hmrc_response, use_case: "one", response: valid_response_hash) }
+
+      it { expect(call).to be_truthy }
+    end
+
+    context "when HRMC response use_case is \"two\"" do
+      let(:hmrc_response) { create(:hmrc_response, use_case: "two", response: valid_response_hash) }
+
+      it { expect(call).to be_falsey }
+    end
+
+    context "when applicant is nil" do
+      let(:hmrc_response) { create(:hmrc_response, use_case: "one", response: valid_response_hash) }
+      let(:instance) { described_class.new(hmrc_response, applicant: nil) }
+
+      it { expect(instance.call).to be_falsey }
+
+      it {
+        instance.call
+        expect(instance.errors.collect(&:message)).to include("individual must match applicant")
+      }
+    end
+
+    context "when response is nil" do
+      let(:hmrc_response) { create(:hmrc_response, response: nil) }
+      let(:instance) { described_class.new(hmrc_response, applicant:) }
+
+      it { expect(call).to be_falsey }
+
+      it {
+        instance.call
+        expect(instance.errors.collect(&:message)).to include("response must be present")
+      }
+    end
+
+    context "when response is empty hash" do
+      let(:hmrc_response) { create(:hmrc_response, response: {}) }
+
+      it { expect(call).to be_falsey }
+    end
+
+    context "when response status is not completed" do
+      let(:hmrc_response) { create(:hmrc_response, response: response_hash) }
+
+      let(:response_hash) do
+        { "submission" => "must-be-present",
+          "status" => "foobar",
+          "data" => [] }
+      end
+
+      it { expect(call).to be_falsey }
+    end
+
+    context "when response submission is nil" do
+      let(:hmrc_response) { create(:hmrc_response, response: response_hash) }
+
+      let(:response_hash) do
+        { "submission" => nil,
+          "status" => "completed",
+          "data" => [] }
+      end
+
+      it { expect(call).to be_falsey }
+    end
+
+    context "when response submission is blank" do
+      let(:hmrc_response) { create(:hmrc_response, response: response_hash) }
+
+      let(:response_hash) do
+        { "submission" => "",
+          "status" => "completed",
+          "data" => [] }
+      end
+
+      it { expect(call).to be_falsey }
+    end
+
+    context "when response submission is missing" do
+      let(:hmrc_response) { create(:hmrc_response, response: response_hash) }
+
+      let(:response_hash) do
+        { "status" => "completed",
+          "data" => [] }
+      end
+
+      it { expect(call).to be_falsey }
+    end
+
+    context "when response data is a hash" do
+      let(:hmrc_response) { create(:hmrc_response, response: response_hash) }
+
+      let(:response_hash) do
+        { "submission" => "must-be-present",
+          "status" => "completed",
+          "data" => {} }
+      end
+
+      it { expect(call).to be_falsey }
+    end
+
+    context "when response data is nil" do
+      let(:hmrc_response) { create(:hmrc_response, response: response_hash) }
+
+      let(:response_hash) do
+        { "submission" => "must-be-present",
+          "status" => "completed",
+          "data" => nil }
+      end
+
+      it { expect(call).to be_falsey }
+    end
+
+    context "when response data has \"individuals/matching/individual\" details matching request" do
+      let(:hmrc_response) { create(:hmrc_response, legal_aid_application:, response: response_hash) }
+      let(:legal_aid_application) { create(:legal_aid_application, :with_applicant) }
+
+      let(:response_hash) do
+        { "submission" => "must-be-present",
+          "status" => "completed",
+          "data" => [
+            { "individuals/matching/individual" => valid_individual_response },
+            { "income/paye/paye" => { "income" => [] } },
+          ] }
+      end
+
+      it { expect(call).to be_truthy }
+    end
+
+    context "when response data \"individuals/matching/individual\" details are missing" do
+      let(:hmrc_response) { create(:hmrc_response, response: response_hash) }
+
+      let(:response_hash) do
+        { "submission" => "must-be-present",
+          "status" => "completed",
+          "data" => [
+            { "income/paye/paye" => { "income" => [] } },
+          ] }
+      end
+
+      it { expect(call).to be_falsey }
+    end
+
+    context "when response data \"individuals/matching/individual\" details are empty" do
+      let(:hmrc_response) { create(:hmrc_response, response: response_hash) }
+
+      let(:response_hash) do
+        { "submission" => "must-be-present",
+          "status" => "completed",
+          "data" => [
+            { "individuals/matching/individual" => {} },
+            { "income/paye/paye" => { "income" => [] } },
+          ] }
+      end
+
+      it { expect(call).to be_falsey }
+    end
+
+    context "when response data \"individuals/matching/individual\" details has invalid dateOfBirth date" do
+      let(:hmrc_response) { create(:hmrc_response, legal_aid_application:, response: response_hash) }
+      let(:legal_aid_application) { create(:legal_aid_application, :with_applicant) }
+
+      let(:response_hash) do
+        { "submission" => "must-be-present",
+          "status" => "completed",
+          "data" => [
+            { "individuals/matching/individual" => {
+              "firstName" => legal_aid_application.applicant.first_name,
+              "lastName" => legal_aid_application.applicant.last_name,
+              "nino" => legal_aid_application.applicant.national_insurance_number,
+              "dateOfBirth" => "1999-99-99",
+            } },
+            { "income/paye/paye" => { "income" => [] } },
+          ] }
+      end
+
+      it { expect(call).to be_falsey }
+    end
+
+    context "when response data \"individuals/matching/individual\" details do not match applicant" do
+      let(:hmrc_response) { create(:hmrc_response, legal_aid_application:, response: response_hash) }
+      let(:legal_aid_application) { create(:legal_aid_application, :with_applicant) }
+
+      let(:response_hash) do
+        {
+          "submission" => "must-be-present",
+          "status" => "completed",
+          "data" => [
+            { "individuals/matching/individual" => {
+              "firstName" => legal_aid_application.applicant.first_name,
+              "lastName" => legal_aid_application.applicant.last_name,
+              "nino" => "FOOBAR",
+              "dateOfBirth" => legal_aid_application.applicant.date_of_birth,
+            } },
+            { "income/paye/paye" => { "income" => [] } },
+          ],
+        }
+      end
+
+      it { expect(call).to be_falsey }
+    end
+
+    context "when response data \"income/paye/paye\" \"income\" is nil" do
+      let(:hmrc_response) { create(:hmrc_response, response: response_hash) }
+
+      let(:response_hash) do
+        { "submission" => "must-be-present",
+          "status" => "completed",
+          "data" => [{ "income/paye/paye" => { "income" => nil } }] }
+      end
+
+      it { expect(call).to be_falsey }
+    end
+
+    context "when response data \"income/paye/paye\" \"income\" is hash" do
+      let(:hmrc_response) { create(:hmrc_response, response: response_hash) }
+
+      let(:response_hash) do
+        { "submission" => "must-be-present",
+          "status" => "completed",
+          "data" => [{ "income/paye/paye" => { "income" => {} } }] }
+      end
+
+      it { expect(call).to be_falsey }
+    end
+
+    context "when response data \"income/paye/paye\" \"income\" contains invalid inPayPeriod1 string" do
+      let(:hmrc_response) { create(:hmrc_response, response: response_hash) }
+
+      let(:response_hash) do
+        {
+          "submission" => "must-be-present",
+          "status" => "completed",
+          "data" => [
+            {
+              "income/paye/paye" => {
+                "income" => [
+                  {
+                    "grossEarningsForNics" => {
+                      "inPayPeriod1" => "decimal-expected-here",
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        }
+      end
+
+      it { expect(call).to be_falsey }
+    end
+
+    context "when response data \"income/paye/paye\" \"income\" contains valid inPayPeriod1 float" do
+      let(:hmrc_response) { create(:hmrc_response, response: response_hash) }
+
+      let(:response_hash) do
+        {
+          "submission" => "must-be-present",
+          "status" => "completed",
+          "data" => [
+            { "individuals/matching/individual" => valid_individual_response },
+            {
+              "income/paye/paye" => {
+                "income" => [
+                  {
+                    "paymentDate" => "2021-01-01",
+                    "grossEarningsForNics" => {
+                      "inPayPeriod1" => 2345.29,
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        }
+      end
+
+      it { expect(call).to be_truthy }
+    end
+
+    context "when response data \"income/paye/paye\" \"income\" contains valid inPayPeriod1 integer" do
+      let(:hmrc_response) { create(:hmrc_response, response: response_hash) }
+
+      let(:response_hash) do
+        {
+          "submission" => "must-be-present",
+          "status" => "completed",
+          "data" => [
+            { "individuals/matching/individual" => valid_individual_response },
+            {
+              "income/paye/paye" => {
+                "income" => [
+                  {
+                    "paymentDate" => "2021-01-01",
+                    "grossEarningsForNics" => {
+                      "inPayPeriod1" => 2345,
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        }
+      end
+
+      it { expect(call).to be_truthy }
+    end
+
+    context "when response data \"income/paye/paye\" \"income\" contains multiple inPayPeriod1 including one invalid string" do
+      let(:hmrc_response) { create(:hmrc_response, response: response_hash) }
+
+      let(:response_hash) do
+        {
+          "submission" => "must-be-present",
+          "status" => "completed",
+          "data" => [
+            {
+              "income/paye/paye" => {
+                "income" => [
+                  {
+                    "paymentDate" => "2021-01-01",
+                    "grossEarningsForNics" => {
+                      "inPayPeriod1" => 2345.29,
+                    },
+                  },
+                  {
+                    "paymentDate" => "2021-01-01",
+                    "grossEarningsForNics" => {
+                      "inPayPeriod1" => "decimal-expected-here",
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        }
+      end
+
+      it { expect(call).to be_falsey }
+    end
+
+    context "when response data \"income/paye/paye\" \"income\" contains valid format of paymentDate" do
+      let(:hmrc_response) { create(:hmrc_response, response: response_hash) }
+
+      let(:response_hash) do
+        {
+          "submission" => "must-be-present",
+          "status" => "completed",
+          "data" => [
+            { "individuals/matching/individual" => valid_individual_response },
+            {
+              "income/paye/paye" => {
+                "income" => [
+                  {
+                    "paymentDate" => "2021-11-30",
+                    "grossEarningsForNics" => {
+                      "inPayPeriod1" => 2345.29,
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        }
+      end
+
+      it { expect(call).to be_truthy }
+    end
+
+    context "when response data \"income/paye/paye\" \"income\" contains invalid date for paymentDate" do
+      let(:hmrc_response) { create(:hmrc_response, response: response_hash) }
+
+      let(:response_hash) do
+        {
+          "submission" => "must-be-present",
+          "status" => "completed",
+          "data" => [
+            {
+              "income/paye/paye" => {
+                "income" => [
+                  {
+                    "paymentDate" => "2021-11-32",
+                    "grossEarningsForNics" => {
+                      "inPayPeriod1" => 2345.29,
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        }
+      end
+
+      it { expect(call).to be_falsey }
+    end
+
+    context "when response data \"income/paye/paye\" \"income\" contains non-iso8601 format of paymentDate" do
+      let(:hmrc_response) { create(:hmrc_response, response: response_hash) }
+
+      let(:response_hash) do
+        {
+          "submission" => "must-be-present",
+          "status" => "completed",
+          "data" => [
+            {
+              "income/paye/paye" => {
+                "income" => [
+                  {
+                    "paymentDate" => "01-11-2021",
+                    "grossEarningsForNics" => {
+                      "inPayPeriod1" => 2345.29,
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        }
+      end
+
+      it { expect(call).to be_falsey }
+    end
+
+    context "when response data \"income/paye/paye\" \"income\" contains multiple paymentDates including one invalid" do
+      let(:hmrc_response) { create(:hmrc_response, response: response_hash) }
+
+      let(:response_hash) do
+        {
+          "submission" => "must-be-present",
+          "status" => "completed",
+          "data" => [
+            {},
+            {
+              "income/paye/paye" => {
+                "income" => [
+                  {
+                    "paymentDate" => "2021-01-01",
+                    "grossEarningsForNics" => {
+                      "inPayPeriod1" => 2345.29,
+                    },
+                  },
+                  {
+                    "paymentDate" => "2021-01-32",
+                    "grossEarningsForNics" => {
+                      "inPayPeriod1" => 2345.29,
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        }
+      end
+
+      it { expect(call).to be_falsey }
+    end
+
+    context "when response data is invalid" do
+      let(:hmrc_response) { create(:hmrc_response, response: nil) }
+
+      before do
+        allow(AlertManager).to receive(:capture_message)
+        call
+      end
+
+      it "sends error response to AlertManager" do
+        call
+        expect(AlertManager).to have_received(:capture_message)
+      end
+    end
+  end
+end


### PR DESCRIPTION

## What
Use validator "service" object for HMRC response

Used to determine whether employment records can be created from
the HMRC response.

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3028)

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
