### PR TITLE
AP-2198: Update Circle CI UAT variable handling

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -399,6 +399,7 @@ workflows:
           - lint_checks
           <<: *generic-slack-fail-post-step
       - deploy_uat:
+          context: laa-apply-for-legalaid-uat
           requires:
           - build_and_push
           <<: *generic-slack-fail-post-step
@@ -435,10 +436,12 @@ workflows:
           - lint_checks
           <<: *generic-slack-fail-post-step
       - deploy_main_uat:
+          context: laa-apply-for-legalaid-uat
           requires:
             - build_and_push
           <<: *generic-slack-fail-post-step
       - delete_uat_branch:
+          context: laa-apply-for-legalaid-uat
           requires:
             - build_and_push
           <<: *generic-slack-fail-post-step

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,13 +161,13 @@ jobs:
           RUBY_VERSION_CHANGED=$((echo "$ALL_FILES_CHANGED" | grep ".ruby-version" || true) | wc -l | xargs)
           if [ "$RUBY_VERSION_CHANGED" = "1" ]; then
             TOKEN=$(curl -s -H "Content-Type: application/json" -X POST -d '{"username": "'${DOCKER_HUB_USERNAME}'", "password": "'${DOCKER_HUB_PAT}'"}' https://hub.docker.com/v2/users/login/ | jq -r .token)
-            VERSION_EXISTS=$(curl -s -H "Authorization: JWT ${TOKEN}" https://hub.docker.com/v2/repositories/ministryofjustice/apply-ci/tags | jq -r '.results|.[]|.name|startswith("latest-$(cat .ruby-version)")')
-            if [ "$VERSION_EXISTS" = "false" ]; then
+            VERSION_EXISTS=$(curl -s -H "Authorization: JWT ${TOKEN}" https://hub.docker.com/v2/repositories/ministryofjustice/apply-ci/tags | jq -r --arg RUBYVER "latest-$(cat .ruby-version)" '.results|.[]|select(.name==$RUBYVER)|.name|endswith($RUBYVER)')
+            if [ "$VERSION_EXISTS" = "true" ]; then
+              echo "latest-$(cat .ruby-version) image already exists"
+            else
               echo "${DOCKER_HUB_PAT}" | docker login -u "${DOCKER_HUB_USERNAME}" --password-stdin
               docker build -f ./docker/apply_ci.dockerfile . -t ministryofjustice/apply-ci:latest-$(cat .ruby-version)
               docker push ministryofjustice/apply-ci:latest-$(cat .ruby-version)
-            else
-              echo "latest-$(cat .ruby-version) image already exists"
             fi
           else
             echo ".ruby-version not changed"

--- a/bin/delete_uat_release
+++ b/bin/delete_uat_release
@@ -12,7 +12,7 @@ then
 
   echo "Attempting to delete UAT release $UAT_RELEASE"
 
-  UAT_RELEASES=$(helm list --namespace=${KUBE_ENV_UAT_NAMESPACE} --all)
+  UAT_RELEASES=$(helm list --namespace=${K8S_NAMESPACE} --all)
 
   echo "Current UAT releases:"
   echo "$UAT_RELEASES"
@@ -20,7 +20,7 @@ then
   if [[ $UAT_RELEASES == *"$UAT_RELEASE"* ]]
   then
     echo "Deleting UAT release $UAT_RELEASE"
-    helm delete $UAT_RELEASE --namespace=${KUBE_ENV_UAT_NAMESPACE}
+    helm delete $UAT_RELEASE --namespace=${K8S_NAMESPACE}
   else
     echo "UAT release $UAT_RELEASE was not found"
   fi

--- a/bin/uat_deploy
+++ b/bin/uat_deploy
@@ -7,13 +7,13 @@ deploy() {
   LEGACY_RELEASE_HOST="$RELEASE_BRANCH-$UAT_HOST"
   RELEASE_HOST="$RELEASE_BRANCH-applyforlegalaid-uat.cloud-platform.service.justice.gov.uk"
   INGRESS_NAME=$(echo "$RELEASE_NAME-apply-for-legal-aid" | cut -c1-53 | sed 's/-$//')
-  IDENTIFIER="$INGRESS_NAME-${K8S_UAT_NAMESPACE}-green"
+  IDENTIFIER="$INGRESS_NAME-${K8S_NAMESPACE}-green"
 
   echo "Deploying CIRCLE_SHA1: $CIRCLE_SHA1 under release name: '$RELEASE_NAME'..."
 
   helm upgrade $RELEASE_NAME ./helm_deploy/apply-for-legal-aid/. \
                 --install --wait \
-                --namespace=${K8S_UAT_NAMESPACE} \
+                --namespace=${K8S_NAMESPACE} \
                 --values ./helm_deploy/apply-for-legal-aid/values-uat.yaml \
                 --set deploy.host="$RELEASE_HOST" \
                 --set image.repository="$IMG_REPO" \

--- a/helm_deploy/apply-for-legal-aid/README.md
+++ b/helm_deploy/apply-for-legal-aid/README.md
@@ -3,21 +3,12 @@
 This describes the setup for helm and what is required to be in place to perform deploys.
 
 ## CI configuration
+The values are now stored in environment variables and contexts in circle ci - a full set of key value pairs can be found in lastpass
 
-In order for a deploy to be successful, a set of configurations need to be in place:
-
-* `APPLICATION_DEPLOY_NAME` - name of the deployable app
-* `<ENV>_HOST` - base hostname for the deployable app
-* `GIT_CRYPT_KEY` - key to allow the decription of secrets required for deploy
-* `KUBE_ENV_<ENV>_NAME`
-* `KUBE_ENV_<ENV>_NAMESPACE`
-* `KUBE_ENV_<ENV>_CACERT`
-* `KUBE_ENV_<ENV>_TOKEN`
-
-For more information on how to correctly configure CircleCI to be able to deploy to the K8S environment, click [here](https://ministryofjustice.github.io/cloud-platform-user-docs/02-deploying-an-app/004-use-circleci-to-upgrade-app/#add-variables-to-circleci).
+For more information on how to correctly configure CircleCI to be able to deploy to the K8S environment, click [here](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/using-circleci-for-continuous-deployment.html#add-variables-to-circleci).
 
 ## Deploy
 
-Deploys are normally triggered through CI (CircleCI) after a branch is pushed to the repo (they require manual approval in order to be initiated).
+Deploys are normally triggered through CI (CircleCI) after a branch is pushed to the repo, they require manual approval in order to complete deploy to production
 
-**NOTE:** A manually deploy can be triggered through the developer's console by executing the same command that CircleCI executes to trigger the deploy (refer to the `.circleci/config.yml` for more details).
+**NOTE:** A manual deploy can be triggered through the developer's console by executing the same command that CircleCI executes to trigger the deploy (refer to the `.circleci/config.yml` for more details).


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2198)

Update CircleCI config
* create a new context for uat in circleci with values required for UAT namespace access
* refactor K8S_UAT_NAMESPACE calls to use K8S_NAMESPACE, the same as staging and prod
* Update the circleci uat jobs to use `context: laa-apply-for-legalaid-uat` and import the new values
* Update the dockerhub scripts to ensure that new test images can be created

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
