### PR TITLE
enable employed journey on all but production via cli

### DIFF
--- a/lib/tasks/employ.rake
+++ b/lib/tasks/employ.rake
@@ -1,6 +1,6 @@
 desc "Temporary task to set employed journey up on localhost"
 task employ: :environment do
-  raise "rake employ can only be used in development" unless Rails.env.development?
+  raise "rake employ can only be used in development" if HostEnv.production?
 
   Setting.setting.update!(enable_employed_journey: true)
   Rails.logger.warn "Employed journey feature flag enabled"


### PR DESCRIPTION
## What

Enable rake employ for all but production

Simplifies set for employment journey testing
on non-prod

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
