### PR TITLE
AP-2853: Remove legacy ingress values

### DIFF
--- a/bin/uat_deploy
+++ b/bin/uat_deploy
@@ -17,7 +17,7 @@ deploy() {
                 --set deploy.host="$RELEASE_HOST" \
                 --set image.repository="$IMG_REPO" \
                 --set image.tag="${CIRCLE_SHA1}" \
-                --set ingress.hosts="$RELEASE_HOST" \
+                --set ingress.hosts="{$RELEASE_HOST}" \
                 --set ingress.annotations."external-dns\.alpha\.kubernetes\.io/set-identifier"="$IDENTIFIER"
 }
 

--- a/bin/uat_deploy
+++ b/bin/uat_deploy
@@ -4,7 +4,6 @@ deploy() {
   IMG_REPO="$ECR_ENDPOINT/$GITHUB_TEAM_NAME_SLUG/$REPO_NAME"
   RELEASE_BRANCH=$(echo $CIRCLE_BRANCH | tr '[:upper:]' '[:lower:]' | sed 's:^\w*\/::' | tr -s ' _/[]().' '-' | cut -c1-30 | sed 's/-$//')
   RELEASE_NAME="apply-$RELEASE_BRANCH"
-  LEGACY_RELEASE_HOST="$RELEASE_BRANCH-$UAT_HOST"
   RELEASE_HOST="$RELEASE_BRANCH-applyforlegalaid-uat.cloud-platform.service.justice.gov.uk"
   INGRESS_NAME=$(echo "$RELEASE_NAME-apply-for-legal-aid" | cut -c1-53 | sed 's/-$//')
   IDENTIFIER="$INGRESS_NAME-${K8S_UAT_NAMESPACE}-green"
@@ -18,7 +17,7 @@ deploy() {
                 --set deploy.host="$RELEASE_HOST" \
                 --set image.repository="$IMG_REPO" \
                 --set image.tag="${CIRCLE_SHA1}" \
-                --set ingress.hosts="{$RELEASE_HOST,$LEGACY_RELEASE_HOST}" \
+                --set ingress.hosts="$RELEASE_HOST" \
                 --set ingress.annotations."external-dns\.alpha\.kubernetes\.io/set-identifier"="$IDENTIFIER"
 }
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2853)

Updated the uat_deploy script to remove the `LEGACY_RELEASE_HOST` value and leave the `ingress.hosts` value as an array to avoid refactoring the `ingress.yaml` file and leave us able to add further hosts in the future if needed

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
