### PR TITLE
Fix: remove legacy env var name from staging job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -324,7 +324,7 @@ jobs:
         command: |
           helm upgrade apply-for-legal-aid ./helm_deploy/apply-for-legal-aid/. \
                         --install --wait \
-                        --namespace=${KUBE_ENV_STAGING_NAMESPACE} \
+                        --namespace=${K8S_NAMESPACE} \
                         --values ./helm_deploy/apply-for-legal-aid/values-staging.yaml \
                         --set image.repository="${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${REPO_NAME}" \
                         --set image.tag="${CIRCLE_SHA1}"


### PR DESCRIPTION

## What

There was a missed, legacy, ENV_VAR in the staging deploy job, this removes it 

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
