### PR TITLE
AP-3042: Update employment_income error display

### DIFF
--- a/app/views/providers/employment_incomes/show.html.erb
+++ b/app/views/providers/employment_incomes/show.html.erb
@@ -61,17 +61,15 @@
       </table>
     </div>
   </div>
-
-      <h2 class="govuk-heading-l"><%= t('.supplementary_question') %></h2>
-      <div class="govuk-hint"><%= t('.employment_hint') %></div>
-      <%= form.govuk_radio_button :extra_employment_information, true, link_errors: true, label: { text: t('generic.yes') } do %>
+      <%= form.govuk_radio_buttons_fieldset :extra_employment_information, legend: {text: t('.supplementary_question')}, hint: {text: t('.employment_hint')} do %>
+        <%= form.govuk_radio_button :extra_employment_information, true, link_errors: true, label: { text: t('generic.yes') } do %>
         <%= form.govuk_text_area :extra_employment_information_details,
                                  label: {text: t('.enter_details')},
                                  hint: {text: t('.details_hint')},
                                  rows: 5 %>
-
+        <% end %>
+        <%= form.govuk_radio_button :extra_employment_information, false, label: { text: t('generic.no') } %>
       <% end %>
-      <%= form.govuk_radio_button :extra_employment_information, false, label: { text: t('generic.no') } %>
     <% end %>
 
     <%= next_action_buttons(


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3042)

Re-factor the employment_income error display - move the radio buttons into a govuk_radio_buttons_fieldset this then, correctly, handles the expected error display

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
