### PR TITLE
AP-2953 Increase memory allocation for admin report generation

### DIFF
--- a/helm_deploy/apply-for-legal-aid/templates/cronjob-admin-report.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/cronjob-admin-report.yaml
@@ -28,8 +28,8 @@ spec:
             resources:
               limits:
                 cpu: 200m
-                memory: 512Mi
+                memory: 1024Mi
               requests:
                 cpu: 100m
-                memory: 256Mi
+                memory: 512Mi
           restartPolicy: Never


### PR DESCRIPTION
## AP-2953 Increase memory allocation for admin report generation

The cronjob that generates the admin report each night is failing, suspected out of memory

This PR increasese the memory of the cronjob pod that runs that job


[Link to story](https://dsdmoj.atlassian.net/browse/AP-2953)

Describe what you did and why.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
