### PR TITLE
AP-3059 Omit third bullet point for employed applicants

### DIFF
--- a/app/views/providers/open_banking_consents/show.html.erb
+++ b/app/views/providers/open_banking_consents/show.html.erb
@@ -14,7 +14,7 @@
         <%= t('.info') %>
       </p>
 
-      <%= list_from_translation_path('.open_banking_consents.show') %>
+      <%= list_from_translation_path(".open_banking_consents.show.#{@legal_aid_application.applicant_employed? ? "employed" : "unemployed"}") %>
 
       <details class="govuk-details" data-module="govuk-details">
         <summary class="govuk-details__summary">

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -755,10 +755,15 @@ en:
       show:
         heading: Do you agree with the following?
         info: "Your client:"
-        list: |
-          uses online banking for all of their current accounts
-          will let a trusted third-party financial service provider called TrueLayer collect 3 months of their bank statements on behalf of the LAA
-          is not employed
+        employed:
+          list: |
+            uses online banking for all of their current accounts
+            will let a trusted third-party financial service provider called TrueLayer collect 3 months of their bank statements on behalf of the LAA
+        unemployed:
+          list: |
+            uses online banking for all of their current accounts
+            will let a trusted third-party financial service provider called TrueLayer collect 3 months of their bank statements on behalf of the LAA
+            is not employed
         details_summary: What is TrueLayer?
         details_content: |
           TrueLayer acts as a messenger between your client's bank and the LAA.

--- a/spec/requests/providers/open_banking_consents_spec.rb
+++ b/spec/requests/providers/open_banking_consents_spec.rb
@@ -1,9 +1,10 @@
 require "rails_helper"
 
 RSpec.describe "does client use online banking requests", type: :request do
-  let(:application) { create :legal_aid_application, :with_non_passported_state_machine, :applicant_details_checked }
+  let(:application) { create :legal_aid_application, :with_non_passported_state_machine, :applicant_details_checked, applicant: }
   let(:application_id) { application.id }
   let(:provider) { application.provider }
+  let(:applicant) { create :applicant }
 
   describe "GET /providers/applications/:legal_aid_application_id/applicant" do
     subject { get "/providers/applications/#{application_id}/does-client-use-online-banking" }
@@ -33,6 +34,22 @@ RSpec.describe "does client use online banking requests", type: :request do
 
         it "resets the state to provider_confirming_applicant_eligibility" do
           expect(application.reload.state).to eq "provider_confirming_applicant_eligibility"
+        end
+      end
+
+      context "when the applicant is employed" do
+        let(:applicant) { create :applicant, :employed }
+
+        it "does not show the bullet point about being unemployed" do
+          expect(unescaped_response_body).not_to include("is not employed")
+        end
+      end
+
+      context "when applicant is not employed" do
+        let(:applicant) { create :applicant, :not_employed }
+
+        it "does show the bullet point about being unemployed" do
+          expect(unescaped_response_body).to include("is not employed")
         end
       end
     end


### PR DESCRIPTION

## Omit third bullet point for employed applicants

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3059)

On the banking consents page, it displayed three bullet points, the third of which said that the provider agreed that the applicant was not employed.  This change is to remove that if the applicant is employed, and only display it when not employed.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
