### PR TITLE
Do not validate hmrc_response for first name match

### DIFF
--- a/app/services/hmrc/parsed_response/validator.rb
+++ b/app/services/hmrc/parsed_response/validator.rb
@@ -60,7 +60,6 @@ module HMRC
       def validate_response_individual
         errors << error(:individual, "individual must match applicant") unless individual &&
           applicant &&
-          applicant.first_name.casecmp?(individual["firstName"]) &&
           applicant.last_name.casecmp?(individual["lastName"]) &&
           applicant.national_insurance_number.casecmp?(individual["nino"]) &&
           applicant.date_of_birth.iso8601 == individual["dateOfBirth"]

--- a/spec/services/hmrc/parsed_response/validator_spec.rb
+++ b/spec/services/hmrc/parsed_response/validator_spec.rb
@@ -211,6 +211,29 @@ RSpec.describe HMRC::ParsedResponse::Validator do
       it { expect(call).to be_truthy }
     end
 
+    context "when response data \"individuals/matching/individual\" details do not match applicant first name" do
+      let(:hmrc_response) { create(:hmrc_response, legal_aid_application:, response: response_hash) }
+      let(:legal_aid_application) { create(:legal_aid_application, :with_applicant) }
+
+      let(:response_hash) do
+        {
+          "submission" => "must-be-present",
+          "status" => "completed",
+          "data" => [
+            { "individuals/matching/individual" => {
+              "firstName" => "Name does not need to match",
+              "lastName" => applicant.last_name,
+              "nino" => applicant.national_insurance_number.downcase,
+              "dateOfBirth" => applicant.date_of_birth,
+            } },
+            { "income/paye/paye" => { "income" => [] } },
+          ],
+        }
+      end
+
+      it { expect(instance.call).to be_truthy }
+    end
+
     context "when response data \"individuals/matching/individual\" details are missing" do
       let(:hmrc_response) { create(:hmrc_response, response: response_hash) }
 


### PR DESCRIPTION
## What
Do not validate on HMRC response first name attribute

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3062)

HMRC response could have supplied a slightly different firstname.
For example, one including a middlename has been seen.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
