### PR TITLE
[AP-3039] use net_housing_costs instead of gross_housing_costs

### DIFF
--- a/app/models/cfe/v4/result.rb
+++ b/app/models/cfe/v4/result.rb
@@ -249,6 +249,10 @@ module CFE
       #                                                              #
       ################################################################
 
+      def net_housing_costs
+        disposable_income_summary[:net_housing_costs].abs
+      end
+
       def moe_housing
         monthly_outgoing_equivalents[:rent_or_mortgage].abs
       end
@@ -266,7 +270,7 @@ module CFE
       end
 
       def total_monthly_outgoings
-        moe_housing + moe_childcare + moe_maintenance_out + moe_legal_aid
+        net_housing_cost + moe_childcare + moe_maintenance_out + moe_legal_aid
       end
 
       def total_monthly_outgoings_including_tax_and_ni

--- a/app/models/cfe/v4/result.rb
+++ b/app/models/cfe/v4/result.rb
@@ -270,7 +270,7 @@ module CFE
       end
 
       def total_monthly_outgoings
-        net_housing_cost + moe_childcare + moe_maintenance_out + moe_legal_aid
+        net_housing_costs + moe_childcare + moe_maintenance_out + moe_legal_aid
       end
 
       def total_monthly_outgoings_including_tax_and_ni

--- a/app/views/providers/capital_income_assessment_results/_outgoings.html.erb
+++ b/app/views/providers/capital_income_assessment_results/_outgoings.html.erb
@@ -2,7 +2,7 @@
   <h2 class="govuk-heading-m"><%= t('.title') %></h2>
   <table class="govuk-table">
     <tbody>
-    <%= render partial: 'shared/results_detail_row', locals: { caption: t('.housing_costs'), value: gds_number_to_currency(@cfe_result.moe_housing) } %>
+    <%= render partial: 'shared/results_detail_row', locals: { caption: t('.housing_costs'), value: gds_number_to_currency(@cfe_result.net_housing_costs) } %>
     <%= render partial: 'shared/results_detail_row', locals: { caption: t('.childcare_costs'), value: gds_number_to_currency(@cfe_result.moe_childcare) } %>
     <%= render partial: 'shared/results_detail_row', locals: { caption: t('.maintenance_out'), value: gds_number_to_currency(@cfe_result.moe_maintenance_out) } %>
     <%= render partial: 'shared/results_detail_row', locals: { caption: t('.legal_aid'), value: gds_number_to_currency(@cfe_result.moe_legal_aid) } %>

--- a/app/views/shared/check_answers/_outgoings_details.html.erb
+++ b/app/views/shared/check_answers/_outgoings_details.html.erb
@@ -2,7 +2,7 @@
   <dl class="govuk-summary-list govuk-!-margin-bottom-9">
     <%
       {
-          housing: :moe_housing,
+          housing: :net_housing_costs,
           childcare: :moe_childcare,
           maintenance_out: :moe_maintenance_out,
           legal_aid: :moe_legal_aid

--- a/spec/factories/cfe_results/v4/mock_results.rb
+++ b/spec/factories/cfe_results/v4/mock_results.rb
@@ -323,6 +323,13 @@ module CFEResults
         result
       end
 
+      def self.with_housing_costs_difference
+        result = eligible
+        result[:result_summary][:disposable_income][:gross_housing_costs] = 1000.0
+        result[:result_summary][:disposable_income][:net_housing_costs] = 545.0
+        result
+      end
+
       def self.with_monthly_income_equivalents
         result = eligible
         other_income = result[:assessment][:gross_income][:other_income]

--- a/spec/factories/cfe_results/v4/results.rb
+++ b/spec/factories/cfe_results/v4/results.rb
@@ -67,6 +67,10 @@ module CFEResults
           result { CFEResults::V4::MockResults.with_mortgage_costs.to_json }
         end
 
+        trait :with_housing_costs_difference do
+          result { CFEResults::V4::MockResults.with_housing_costs_difference.to_json }
+        end
+
         trait :with_monthly_income_equivalents do
           result { CFEResults::V4::MockResults.with_monthly_income_equivalents.to_json }
         end

--- a/spec/models/cfe/v4/result_spec.rb
+++ b/spec/models/cfe/v4/result_spec.rb
@@ -470,6 +470,32 @@ module CFE
       end
 
       ################################################################
+      #  OUTGOINGS                                                   #
+      ################################################################
+
+      describe "#net_housing_costs" do
+        subject(:net_housing_costs) { instance.net_housing_costs }
+
+        let(:instance) { build(:cfe_v4_result, :with_housing_costs_difference) }
+
+        it "returns [:result_summary][:disposable_income][:net_housing_costs]" do
+          expect(net_housing_costs).to be 545.0
+        end
+      end
+
+      # describe "#moe_housing" do
+      # end
+
+      # describe "#moe_childcare" do
+      # end
+
+      # describe "#moe_maintenance_out" do
+      # end
+
+      # describe "#moe_legal_aid" do
+      # end
+
+      ################################################################
       #  DISPOSABLE INCOME                                           #
       ################################################################
 


### PR DESCRIPTION
## What
Replace monthly equivalent housing costs with net_housing_costs

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3039)

The monthly outgoing equivalents use gross_housing_costs
which does not take thresholds and other factors into account.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
