### PR TITLE
AP-2953 increase resources for admin_report crontab

### DIFF
--- a/helm_deploy/apply-for-legal-aid/templates/cronjob-admin-report.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/cronjob-admin-report.yaml
@@ -8,7 +8,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  schedule: '0 20 * * *'
+  schedule: '0 10,13,16,20 * * *'
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 1
   failedJobsHistoryLimit: 1
@@ -28,8 +28,8 @@ spec:
             resources:
               limits:
                 cpu: 200m
-                memory: 1024Mi
+                memory: 2048Mi
               requests:
                 cpu: 100m
-                memory: 512Mi
+                memory: 1024Mi
           restartPolicy: Never


### PR DESCRIPTION

## Increase resources for admin_report crontab

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2953)

this is the second attempt to increase the resource sizes of this cronjob so that it
runs to completion.

The timing of the jobs has also been increased so that it runs several times throughout the
day enabling us to see whether this has been effective without waiting overnight.  If successful,
it will be set back to one overnight run again.




## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
