### PR TITLE
[AP-3064] Validate and alert for missing employments

### DIFF
--- a/app/services/hmrc/parsed_response/validator.rb
+++ b/app/services/hmrc/parsed_response/validator.rb
@@ -22,6 +22,7 @@ module HMRC
         validate_response_data
         validate_response_income
         validate_response_individual
+        validate_response_employments
 
         send_message unless errors.empty?
         errors.empty?
@@ -65,6 +66,10 @@ module HMRC
           applicant.date_of_birth.iso8601 == individual["dateOfBirth"]
       end
 
+      def validate_response_employments
+        errors << error(:employments, "employments must be present") unless employments && employments.present?
+      end
+
       def data
         @data ||= response&.dig("data")
       end
@@ -79,6 +84,10 @@ module HMRC
 
       def individual
         @individual ||= data&.find { |hash| hash["individuals/matching/individual"] }&.dig("individuals/matching/individual")
+      end
+
+      def employments
+        @employments ||= data&.find { |hash| hash["employments/paye/employments"] }&.dig("employments/paye/employments")
       end
 
       def valid_iso8601_date?(date)

--- a/spec/services/hmrc/parsed_response/validator_spec.rb
+++ b/spec/services/hmrc/parsed_response/validator_spec.rb
@@ -617,6 +617,74 @@ RSpec.describe HMRC::ParsedResponse::Validator do
       }
     end
 
+    context "when response data \"employments/paye/employments\" is valid" do
+      let(:hmrc_response) { create(:hmrc_response, legal_aid_application:, response: response_hash) }
+      let(:legal_aid_application) { create(:legal_aid_application, :with_applicant) }
+
+      let(:response_hash) do
+        { "submission" => "must-be-present",
+          "status" => "completed",
+          "data" => [
+            { "individuals/matching/individual" => valid_individual_response },
+            { "income/paye/paye" => { "income" => [] } },
+            { "employments/paye/employments" => [{}] },
+          ] }
+      end
+
+      it { expect(call).to be_truthy }
+    end
+
+    context "when response data \"employments/paye/employments\" is missing" do
+      let(:hmrc_response) { create(:hmrc_response, response: response_hash) }
+
+      let(:response_hash) do
+        { "submission" => "must-be-present",
+          "status" => "completed",
+          "data" => [] }
+      end
+
+      it { expect(instance.call).to be_falsey }
+
+      it {
+        instance.call
+        expect(instance.errors.collect(&:message)).to include("employments must be present")
+      }
+    end
+
+    context "when response data \"employments/paye/employments\" is nil" do
+      let(:hmrc_response) { create(:hmrc_response, response: response_hash) }
+
+      let(:response_hash) do
+        { "submission" => "must-be-present",
+          "status" => "completed",
+          "data" => [{ "employments/paye/employments" => nil }] }
+      end
+
+      it { expect(instance.call).to be_falsey }
+
+      it {
+        instance.call
+        expect(instance.errors.collect(&:message)).to include("employments must be present")
+      }
+    end
+
+    context "when response data \"employments/paye/employments\" is empty" do
+      let(:hmrc_response) { create(:hmrc_response, response: response_hash) }
+
+      let(:response_hash) do
+        { "submission" => "must-be-present",
+          "status" => "completed",
+          "data" => [{ "employments/paye/employments" => [] }] }
+      end
+
+      it { expect(instance.call).to be_falsey }
+
+      it {
+        instance.call
+        expect(instance.errors.collect(&:message)).to include("employments must be present")
+      }
+    end
+
     context "when response data is invalid" do
       let(:hmrc_response) { create(:hmrc_response, response: response_hash) }
 

--- a/spec/services/hmrc/parsed_response/validator_spec.rb
+++ b/spec/services/hmrc/parsed_response/validator_spec.rb
@@ -14,12 +14,15 @@ RSpec.describe HMRC::ParsedResponse::Validator do
         "dateOfBirth" => applicant.date_of_birth }
     end
 
+    let(:valid_employments_response) { [{}] }
+
     let(:valid_response_hash) do
       { "submission" => "must-be-present",
         "status" => "completed",
         "data" => [
           { "individuals/matching/individual" => valid_individual_response },
           { "income/paye/paye" => { "income" => [] } },
+          { "employments/paye/employments" => valid_employments_response },
         ] }
     end
 
@@ -182,6 +185,7 @@ RSpec.describe HMRC::ParsedResponse::Validator do
           "data" => [
             { "individuals/matching/individual" => valid_individual_response },
             { "income/paye/paye" => { "income" => [] } },
+            { "employments/paye/employments" => valid_employments_response },
           ] }
       end
 
@@ -205,6 +209,7 @@ RSpec.describe HMRC::ParsedResponse::Validator do
           "data" => [
             { "individuals/matching/individual" => valid_individual_response },
             { "income/paye/paye" => { "income" => [] } },
+            { "employments/paye/employments" => valid_employments_response },
           ] }
       end
 
@@ -227,6 +232,7 @@ RSpec.describe HMRC::ParsedResponse::Validator do
               "dateOfBirth" => applicant.date_of_birth,
             } },
             { "income/paye/paye" => { "income" => [] } },
+            { "employments/paye/employments" => valid_employments_response },
           ],
         }
       end
@@ -413,6 +419,7 @@ RSpec.describe HMRC::ParsedResponse::Validator do
                 ],
               },
             },
+            { "employments/paye/employments" => valid_employments_response },
           ],
         }
       end
@@ -441,6 +448,7 @@ RSpec.describe HMRC::ParsedResponse::Validator do
                 ],
               },
             },
+            { "employments/paye/employments" => valid_employments_response },
           ],
         }
       end
@@ -507,6 +515,7 @@ RSpec.describe HMRC::ParsedResponse::Validator do
                 ],
               },
             },
+            { "employments/paye/employments" => valid_employments_response },
           ],
         }
       end
@@ -692,8 +701,9 @@ RSpec.describe HMRC::ParsedResponse::Validator do
         { "submission" => "must-be-present",
           "status" => "foobar",
           "data" => [
-            { "individuals/matching/individual" => {} },
+            { "individuals/matching/individual" => valid_individual_response },
             { "income/paye/paye" => { "income" => [] } },
+            { "employments/paye/employments" => valid_employments_response },
           ] }
       end
 
@@ -704,7 +714,7 @@ RSpec.describe HMRC::ParsedResponse::Validator do
 
       it "sends message to AlertManager with errors" do
         expect(AlertManager).to have_received(:capture_message)
-                                  .with("HMRC Response is unacceptable (id: #{hmrc_response.id}) - response status must be \"completed\", individual must match applicant")
+                                  .with("HMRC Response is unacceptable (id: #{hmrc_response.id}) - response status must be \"completed\"")
       end
     end
   end


### PR DESCRIPTION
## What
Validate for and alert on HMRC responses with missing employments

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3064)

HMRC can potentially return internal server errors
which can result in the employments not being available.

This results in no employments being persisted and therefore
users having to enter these details manually

In such instances we want to capture the error and alert
ourselves to the problem so we can investigate.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
