### PR TITLE
[AP-3039] Minimal fix to use `net_housing_costs` instead of `rent_or_mortgage`

### DIFF
--- a/app/models/cfe/v4/result.rb
+++ b/app/models/cfe/v4/result.rb
@@ -250,7 +250,7 @@ module CFE
       ################################################################
 
       def moe_housing
-        monthly_outgoing_equivalents[:rent_or_mortgage].abs
+        disposable_income_summary[:net_housing_costs].abs
       end
 
       def moe_childcare

--- a/spec/factories/cfe_results/v4/mock_results.rb
+++ b/spec/factories/cfe_results/v4/mock_results.rb
@@ -45,7 +45,7 @@ module CFEResults
               dependant_allowance: 0.0,
               gross_housing_costs: 0.0,
               housing_benefit: 0.0,
-              net_housing_costs: 0.0,
+              net_housing_costs: 125.0,
               maintenance_allowance: 0.0,
               total_outgoings_and_allowances: 0.0,
               total_disposable_income: 0.0,
@@ -341,6 +341,7 @@ module CFEResults
         monthly_equivalents = monthly_equivalents.transform_values { |x| x + 10 }
         other_income[:monthly_equivalents][:all_sources] = monthly_equivalents
         result[:assessment][:disposable_income] = other_income
+        result[:result_summary][:disposable_income][:net_housing_costs] += 10.0
 
         result
       end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3039)

`net_housing_costs` deals with caps and other housing cost
edge cases, as well as - i believe from conversions with
other devs - being a month equivalent.

However this feels icky as it breaks the basic pattern of
having the values for moe in the `month_equivalent` response
from CFE.

**Should this be handled in CFE instead and apply remain
unchanged?**

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
