### PR TITLE
AP-3065 Refactor Admin Report creation to use temporary file

### DIFF
--- a/app/jobs/reports_uploader_job.rb
+++ b/app/jobs/reports_uploader_job.rb
@@ -6,8 +6,9 @@ class ReportsUploaderJob < ApplicationJob
       log "preexisting record as follows:"
       log "blob key: #{blob.key}, blob_id: #{blob.id}"
     end
-    upload_application_details_report
+    tempfile_name = attach_application_details_report
     admin_report.save
+    File.unlink(tempfile_name)
     log "Application Details report attached as blob with key #{blob.key}, blob_id: #{blob.id}"
     log "AdminReport record updated at #{admin_report.updated_at}"
   end
@@ -18,13 +19,14 @@ class ReportsUploaderJob < ApplicationJob
 
 private
 
-  def upload_application_details_report
+  def attach_application_details_report
     log "creating submitted applications report at #{Time.zone.now}"
-    data = Reports::MIS::ApplicationDetailsReport.new.run
+    tempfile_name = Reports::MIS::ApplicationDetailsReport.new.run
     log "application_details_report completed at #{Time.zone.now}"
-    admin_report.application_details_report.attach io: StringIO.new(data),
+    admin_report.application_details_report.attach io: File.open(tempfile_name),
                                                    filename: "application_details_report",
                                                    content_type: "text/csv"
+    tempfile_name
   end
 
   def admin_report
@@ -36,6 +38,6 @@ private
   end
 
   def log(message)
-    Rails.logger.info "ReportsUploaderJob - #{message}"
+    Rails.logger.info "ReportsUploaderJob :: #{message}"
   end
 end

--- a/app/services/reports/mis/application_details_report.rb
+++ b/app/services/reports/mis/application_details_report.rb
@@ -20,7 +20,7 @@ module Reports
             csv << ApplicationDetailCsvLine.call(legal_aid_application)
           end
         rescue StandardError => e
-          log "generate_csv_string - #{e.message}"
+          log "#{self.class.name}##{__method__} - #{e.message}"
           raise e
         end
       end

--- a/app/services/reports/mis/application_details_report.rb
+++ b/app/services/reports/mis/application_details_report.rb
@@ -4,24 +4,25 @@ module Reports
   module MIS
     class ApplicationDetailsReport
       def run
-        generate_csv_string
+        generate_temp_file
+        tempfile_name
       rescue StandardError => e
         notify_error(e)
       end
 
     private
 
-      def generate_csv_string
-        CSV.generate do |csv|
+      def generate_temp_file
+        CSV.open(tempfile_name, "w") do |csv|
           csv << ApplicationDetailCsvLine.header_row
           legal_aid_application_ids.each do |laa_id|
             legal_aid_application = LegalAidApplication.find(laa_id)
             csv << ApplicationDetailCsvLine.call(legal_aid_application)
           end
+        rescue StandardError => e
+          log "generate_csv_string - #{e.message}"
+          raise e
         end
-      rescue StandardError => e
-        log "generate_csv_string - #{e.message}"
-        raise e
       end
 
       def legal_aid_application_ids
@@ -36,6 +37,14 @@ module Reports
 
       def log(message)
         Rails.logger.info "ApplicationDetailsReport - #{message}"
+      end
+
+      def tempfile_name
+        @tempfile_name ||= Rails.root.join("tmp/admin_report_#{string_time}.csv")
+      end
+
+      def string_time
+        Time.zone.now.strftime("%F-%H-%M-%S")
       end
     end
   end

--- a/spec/jobs/reports_uploader_job_spec.rb
+++ b/spec/jobs/reports_uploader_job_spec.rb
@@ -1,58 +1,59 @@
 require "rails_helper"
 
 RSpec.describe ReportsUploaderJob, type: :job do
-  subject { report_uploader.perform }
+  # subject { report_uploader.perform }
 
   let(:report_uploader) { described_class.new }
 
   describe "#expiration" do
-    subject(:expiration) { report_uploader.expiration }
-
     it "returns 24 hours in seconds" do
-      expect(expiration).to eq 86_400
+      expect(report_uploader.expiration).to eq 86_400
     end
   end
 
   describe "#perform" do
-    before do
-      allow_any_instance_of(Reports::MIS::ApplicationDetailsReport).to receive(:run).and_return("csv string, application details")
+    before { allow(Reports::MIS::ApplicationDetailsReport).to receive(:new).and_return(mock_report_generator) }
+
+    let(:mock_report_generator) { instance_double Reports::MIS::ApplicationDetailsReport, run: tempfile_name }
+    let(:admin_report) { AdminReport.first }
+    let(:generated_file_contents) { "aaa,bbb,ccc\nddd,eee,fff" }
+    let(:tempfile_name) do
+      filename = Rails.root.join("tmp/my_temp_file.csv")
+      File.open(filename, "w") { |fp| fp.puts generated_file_contents }
+      filename
     end
 
     context "AdminReport record does not exist" do
-      let(:admin_report) { AdminReport.first }
+      before { AdminReport.delete_all }
 
       it "creates an admin report" do
-        expect { subject }.to change(AdminReport, :count).by(1)
+        expect { report_uploader.perform }.to change(AdminReport, :count).by(1)
       end
 
-      it "attaches application_details report to admin report" do
-        subject
+      it "attaches generated file to admin report" do
+        report_uploader.perform
         expect(admin_report.reload.application_details_report).to be_a_kind_of(ActiveStorage::Attached::One)
       end
 
       context "when submitted applications report is attached" do
-        it "attaches the correct csv string to admin report" do
-          subject
+        it "attaches the contents of the generated file to the admin report" do
+          report_uploader.perform
           blob = admin_report.application_details_report.attachment
-          expect(blob.download).to eq "csv string, application details"
+          expect(blob.download.chomp).to eq generated_file_contents
         end
       end
     end
 
     context "AdminReport record already exists" do
-      before do
-        # create an AdminReport record with the correct attachments
-        report_uploader.perform
-      end
+      before { create :admin_report, :with_reports_attached }
 
       it "does not create another record" do
-        subject
-        expect { subject }.not_to change(AdminReport, :count)
+        expect { report_uploader.perform }.not_to change(AdminReport, :count)
       end
 
       it "updates the existing record" do
         original_updated_time = AdminReport.first.updated_at
-        subject
+        report_uploader.perform
         expect(AdminReport.first.updated_at > original_updated_time).to be true
       end
     end

--- a/spec/jobs/reports_uploader_job_spec.rb
+++ b/spec/jobs/reports_uploader_job_spec.rb
@@ -1,8 +1,6 @@
 require "rails_helper"
 
 RSpec.describe ReportsUploaderJob, type: :job do
-  # subject { report_uploader.perform }
-
   let(:report_uploader) { described_class.new }
 
   describe "#expiration" do

--- a/spec/services/reports/mis/application_details_report_spec.rb
+++ b/spec/services/reports/mis/application_details_report_spec.rb
@@ -32,21 +32,22 @@ module Reports
 
       describe "#run" do
         context "runs successfully" do
-          it "returns a csv string with a header line" do
-            csv_string = report.run
-            lines = csv_string.split("\n")
-            expect(lines.first).to match(/^Firm name,User name,Office ID/)
+          it "the name of a file based on current date and time" do
+            travel_to Time.zone.local(2022, 4, 27, 13, 22, 3).in_time_zone
+            filename = report.run
+            expect(filename.to_s).to match(/\/tmp\/admin_report_2022-04-27-13-22-03.csv$/)
+            travel_back
           end
 
-          it "returns a header and seven detail lines" do
-            csv_string = report.run
-            lines = csv_string.split("\n")
+          it "writes a header line and 7 detail lines to the csv file" do
+            filename = report.run
+            lines = File.read(filename).split("\n")
             expect(lines.size).to eq num_applications + 1
           end
         end
 
         context "exception" do
-          before { expect(report).to receive(:generate_csv_string).and_raise(RuntimeError) }
+          before { expect(report).to receive(:generate_temp_file).and_raise(RuntimeError) }
 
           it "notifies sentry" do
             expect(Sentry).to receive(:capture_message)

--- a/spec/services/reports/mis/application_details_report_spec.rb
+++ b/spec/services/reports/mis/application_details_report_spec.rb
@@ -59,7 +59,7 @@ module Reports
           before { allow_any_instance_of(ApplicationDetailCsvLine).to receive(:call).and_raise(StandardError, "fake error") }
 
           it "logs the error message" do
-            expect(Rails.logger).to receive(:info).with("ApplicationDetailsReport - generate_csv_string - fake error")
+            expect(Rails.logger).to receive(:info).with("ApplicationDetailsReport - Reports::MIS::ApplicationDetailsReport#generate_temp_file - fake error")
             report.run
           end
         end


### PR DESCRIPTION
## Refactor Admin Report creation to use temporary file

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3065)

The cronjob that runs the ReportsUploaderJob to create the admin report CSV
file and attach it to the AdminReport record is failing silently, we think because
the contab pod is running out of memory (The whole CSV file is created in memory).

This change refactors it to output the data line by line to a temporary file, and
then attach that file to the AdminReport record

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
