### PR TITLE
AP-2924 disable previews in dropzone

### DIFF
--- a/app/webpack/src/dropzone.js
+++ b/app/webpack/src/dropzone.js
@@ -93,7 +93,8 @@ document.addEventListener('DOMContentLoaded', event => {
         'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').getAttribute('content')
       },
       maxFilesize: 7,
-      acceptedFiles: ACCEPTED_FILES.join(', ')
+      acceptedFiles: ACCEPTED_FILES.join(', '),
+      disablePreviews: true
     })
     dropzone.on('drop', () => {
       removeErrorMessages()


### PR DESCRIPTION
## What

This was a spike ticket investigating the styling/removal of the file preview animation in dropzone.
This PR is just to disable the preview for now.
See ticket for further info and link to design ticket for potentially presenting a more GOV.UK style preview in the future

[Link to story](https://dsdmoj.atlassian.net/browse/AP-XXX)

Describe what you did and why.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
