### PR TITLE
[AP-3062] Do no validate individual against applicant

### DIFF
--- a/app/services/hmrc/parsed_response/persistor.rb
+++ b/app/services/hmrc/parsed_response/persistor.rb
@@ -22,7 +22,7 @@ module HMRC
       attr_reader :hmrc_response
 
       def persistable?
-        Validator.call(hmrc_response, applicant: @application.applicant)
+        Validator.call(hmrc_response)
       end
 
       def destroy_existing_employments

--- a/app/services/hmrc/parsed_response/validator.rb
+++ b/app/services/hmrc/parsed_response/validator.rb
@@ -5,14 +5,13 @@ module HMRC
 
       Error = Struct.new(:attribute, :message)
 
-      def self.call(hmrc_response, applicant:)
-        new(hmrc_response, applicant:).call
+      def self.call(hmrc_response)
+        new(hmrc_response).call
       end
 
-      def initialize(hmrc_response, applicant:)
+      def initialize(hmrc_response)
         @hmrc_response = hmrc_response
         @response = hmrc_response.response
-        @applicant = applicant
         @errors = []
       end
 
@@ -30,7 +29,7 @@ module HMRC
 
     private
 
-      attr_reader :hmrc_response, :response, :applicant
+      attr_reader :hmrc_response, :response
 
       def validate_use_case
         errors << error(:use_case, "use_case must be \"one\", but was \"#{hmrc_response.use_case}\"") if hmrc_response.use_case != "one"
@@ -59,11 +58,7 @@ module HMRC
       end
 
       def validate_response_individual
-        errors << error(:individual, "individual must match applicant") unless individual &&
-          applicant &&
-          applicant.last_name.casecmp?(individual["lastName"]) &&
-          applicant.national_insurance_number.casecmp?(individual["nino"]) &&
-          applicant.date_of_birth.iso8601 == individual["dateOfBirth"]
+        errors << error(:individual, "individual must be present") unless individual
       end
 
       def validate_response_employments


### PR DESCRIPTION
## What
Do not validate for matching individual/applicant

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3062)

Since we have requested the HMRC details for the
applicant any record found should adhere to their
matching criteria. We therefore should not need
to confirm this in their response.

Discussed (CB/JS) and decided to remove for now pending 
further information from business (via DF). 
This follows on from actual responses being returned where the 
surname only matches was entered wrongly by provider but
matched correctly from HMRC based on their criteria (see HMRC
developer hub for more)

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
