### PR TITLE
[AP-3066] Hardcode section 8 level of service value

### DIFF
--- a/app/models/proceeding.rb
+++ b/app/models/proceeding.rb
@@ -1,12 +1,16 @@
 class Proceeding < ApplicationRecord
   FIRST_PROCEEDING_CASE_ID = 55_000_000
 
+  LevelOfService = Struct.new(:name, :level)
+
+  DEFAULT_LEVEL_OF_SERVICE_MAPPINGS = {
+    KSEC8: LevelOfService.new("Family Help (Higher)", "1"),
+    MINJN: LevelOfService.new("Full Representation", "3"),
+  }.with_indifferent_access.freeze
+
   belongs_to :legal_aid_application
-
   has_one :attempts_to_settle, class_name: "ProceedingMeritsTask::AttemptsToSettle", dependent: :destroy
-
   has_one :chances_of_success, class_name: "ProceedingMeritsTask::ChancesOfSuccess", dependent: :destroy
-
   has_many :proceeding_linked_children, class_name: "ProceedingMeritsTask::ProceedingLinkedChild", dependent: :destroy
 
   has_many :involved_children,
@@ -42,11 +46,15 @@ class Proceeding < ApplicationRecord
   end
 
   def default_level_of_service_level
-    section8? ? "1" : "3"
+    default_level_of_service.level
   end
 
   def default_level_of_service_name
-    "Full Representation"
+    default_level_of_service.name
+  end
+
+  def default_level_of_service
+    DEFAULT_LEVEL_OF_SERVICE_MAPPINGS[ccms_matter_code]
   end
 
   def highest_proceeding_case_id

--- a/app/models/proceeding.rb
+++ b/app/models/proceeding.rb
@@ -42,7 +42,7 @@ class Proceeding < ApplicationRecord
   end
 
   def default_level_of_service_level
-    "3"
+    section8? ? "1" : "3"
   end
 
   def default_level_of_service_name

--- a/spec/models/proceeding_spec.rb
+++ b/spec/models/proceeding_spec.rb
@@ -63,8 +63,22 @@ RSpec.describe Proceeding, type: :model do
   end
 
   describe "#default_level_of_service_level" do
-    it "returns hard coded value" do
-      expect(proceeding.default_level_of_service_level).to eq "3"
+    subject(:default_level_of_service_level) { proceeding.default_level_of_service_level }
+
+    context "when matter is domestic abuse" do
+      let(:matter_code) { "MINJN" }
+
+      it "returns \"3\", meaning \"Full representation\"" do
+        expect(default_level_of_service_level).to eq "3"
+      end
+    end
+
+    context "when matter is section 8" do
+      let(:matter_code) { "KSEC8" }
+
+      it "returns \"1\", meaning \"Family help (higher)\"" do
+        expect(default_level_of_service_level).to eq "1"
+      end
     end
   end
 

--- a/spec/models/proceeding_spec.rb
+++ b/spec/models/proceeding_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe Proceeding, type: :model do
   describe "#default_level_of_service_level" do
     subject(:default_level_of_service_level) { proceeding.default_level_of_service_level }
 
-    context "when matter is domestic abuse" do
+    context "when matter is Domestic abuse" do
       let(:matter_code) { "MINJN" }
 
       it "returns \"3\", meaning \"Full representation\"" do
@@ -73,12 +73,28 @@ RSpec.describe Proceeding, type: :model do
       end
     end
 
-    context "when matter is section 8" do
+    context "when matter is \"Children - section 8\"" do
       let(:matter_code) { "KSEC8" }
 
       it "returns \"1\", meaning \"Family help (higher)\"" do
         expect(default_level_of_service_level).to eq "1"
       end
+    end
+  end
+
+  describe "#default_level_of_service_name" do
+    subject(:default_level_of_service_level) { proceeding.default_level_of_service_name }
+
+    context "when matter is Domestic abuse" do
+      let(:matter_code) { "MINJN" }
+
+      it { expect(default_level_of_service_level).to eq "Full Representation" }
+    end
+
+    context "when matter is \"Children - section 8\"" do
+      let(:matter_code) { "KSEC8" }
+
+      it { expect(default_level_of_service_level).to eq "Family Help (Higher)" }
     end
   end
 

--- a/spec/services/ccms/requestors/case_add_requestor_xml_blocks/passported_attributes_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_xml_blocks/passported_attributes_spec.rb
@@ -1275,18 +1275,38 @@ module CCMS
           end
 
           context "LEVEL_OF_SERVICE" do
-            it "is the service level number from the default level of service" do
-              %i[proceeding_merits proceeding].each do |entity|
-                block = XmlExtractor.call(xml, entity, "LEVEL_OF_SERVICE")
-                expect(block).to have_text_response proceeding.default_level_of_service_level
+            context "when lead proceeding is Domestic Abuse" do
+              it "displays the expected service level number from the default level of service" do
+                %i[proceeding_merits proceeding].each do |entity|
+                  block = XmlExtractor.call(xml, entity, "LEVEL_OF_SERVICE")
+                  expect(block).to have_text_response("1")
+                end
+              end
+            end
+
+            context "when lead proceeding is \"Children - Section 8\"" do
+              it "displays the expected service level number from the default level of service" do
+                %i[proceeding_merits proceeding].each do |entity|
+                  block = XmlExtractor.call(xml, entity, "LEVEL_OF_SERVICE")
+                  expect(block).to have_text_response("3")
+                end
               end
             end
           end
 
           context "PROCEEDING_LEVEL_OF_SERVICE" do
-            it "displays the name of the lead proceeding default level of service" do
-              block = XmlExtractor.call(xml, :proceeding_merits, "PROCEEDING_LEVEL_OF_SERVICE")
-              expect(block).to have_text_response proceeding.default_level_of_service_name
+            context "when lead proceeding is Domestic Abuse" do
+              it "displays the name of the lead proceeding default level of service" do
+                block = XmlExtractor.call(xml, :proceeding_merits, "PROCEEDING_LEVEL_OF_SERVICE")
+                expect(block).to have_text_response("Full Representation")
+              end
+            end
+
+            context "when lead proceeding is \"Children - Section 8\"" do
+              it "displays the name of the lead proceeding default level of service" do
+                block = XmlExtractor.call(xml, :proceeding_merits, "PROCEEDING_LEVEL_OF_SERVICE")
+                expect(block).to have_text_response("Family Help (Higher)")
+              end
             end
           end
 


### PR DESCRIPTION
## What
[TBC] hardcode default level-of-service for section 8 matter types

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3066)

The default "level of service" for a section 8 matter
in CCMS is "Family help (higher)", with a value of "1", not
as the current hadrcoded level-of-service, "Full representation"
with a value of "3".

This is the simplest and most immediate approach to sending a correct
default value for the section 8 matter type. Longer term we are looking
to store this data for the 6 level-of-services in LFA.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
