### PR TITLE
Tech-debt: Update simple_command gem loading

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem "savon", "~> 2.12.1"
 gem "sentry-rails", ">= 4.8.0"
 gem "sentry-ruby"
 gem "sentry-sidekiq"
-gem "simple_command", github: "nebulab/simple_command", branch: "master"
+gem "simple_command"
 gem "tzinfo-data"
 gem "webdack-uuid_migration", "~> 1.4.0"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,13 +5,6 @@ GIT
   specs:
     ruby-saml-idp (0.3.2)
 
-GIT
-  remote: https://github.com/nebulab/simple_command.git
-  revision: 48ecd83e6f8de6ef354f729109ed4c6e69aaf87c
-  branch: master
-  specs:
-    simple_command (0.1.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -636,6 +629,7 @@ GEM
       faraday (>= 0.17.5, < 3.0)
       jwt (>= 1.5, < 3.0)
       multi_json (~> 1.10)
+    simple_command (1.0.1)
     simplecov (0.21.2)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -793,7 +787,7 @@ DEPENDENCIES
   shoulda-matchers (~> 5.1)
   sidekiq (~> 6.4.2)
   sidekiq-status (~> 2.1.3)
-  simple_command!
+  simple_command
   simplecov
   simplecov-rcov
   spring


### PR DESCRIPTION
## What

SimpleCommand has been poorly maintained in the past and gem releases have been few and far between leaving users reliant on the main github branch ([see comments from September 2020!](https://github.com/ministryofjustice/laa-apply-for-legal-aid/commit/8a9c6f1529aff5b02746156bc77f12f615c956df)).

New versions have been released, so this reverts to loading gem versions and manually updates to the latest release


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
