### PR TITLE
[AP-3062] Do not validate on first or last name

### DIFF
--- a/app/services/hmrc/parsed_response/validator.rb
+++ b/app/services/hmrc/parsed_response/validator.rb
@@ -61,7 +61,6 @@ module HMRC
       def validate_response_individual
         errors << error(:individual, "individual must match applicant") unless individual &&
           applicant &&
-          applicant.last_name.casecmp?(individual["lastName"]) &&
           applicant.national_insurance_number.casecmp?(individual["nino"]) &&
           applicant.date_of_birth.iso8601 == individual["dateOfBirth"]
       end

--- a/spec/services/hmrc/parsed_response/validator_spec.rb
+++ b/spec/services/hmrc/parsed_response/validator_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe HMRC::ParsedResponse::Validator do
     let(:applicant) { create(:legal_aid_application, :with_applicant).applicant }
 
     let(:valid_individual_response) do
-      { "firstName" => applicant.first_name,
-        "lastName" => applicant.last_name,
+      { "firstName" => "not-checked",
+        "lastName" => "not-checked",
         "nino" => applicant.national_insurance_number,
         "dateOfBirth" => applicant.date_of_birth }
     end
@@ -198,13 +198,13 @@ RSpec.describe HMRC::ParsedResponse::Validator do
       it { expect(call).to be_truthy }
     end
 
-    context "when response data has \"individuals/matching/individual\" details matching request with case differences" do
+    context "when response data has \"individuals/matching/individual\" details matching but different name" do
       let(:hmrc_response) { create(:hmrc_response, legal_aid_application:, response: response_hash) }
       let(:legal_aid_application) { create(:legal_aid_application, :with_applicant) }
 
       let(:valid_individual_response) do
-        { "firstName" => applicant.first_name.upcase,
-          "lastName" => applicant.last_name.upcase,
+        { "firstName" => "Foo",
+          "lastName" => "Bar",
           "nino" => applicant.national_insurance_number.downcase,
           "dateOfBirth" => applicant.date_of_birth }
       end
@@ -220,30 +220,6 @@ RSpec.describe HMRC::ParsedResponse::Validator do
       end
 
       it { expect(call).to be_truthy }
-    end
-
-    context "when response data \"individuals/matching/individual\" details do not match applicant first name" do
-      let(:hmrc_response) { create(:hmrc_response, legal_aid_application:, response: response_hash) }
-      let(:legal_aid_application) { create(:legal_aid_application, :with_applicant) }
-
-      let(:response_hash) do
-        {
-          "submission" => "must-be-present",
-          "status" => "completed",
-          "data" => [
-            { "individuals/matching/individual" => {
-              "firstName" => "Name does not need to match",
-              "lastName" => applicant.last_name,
-              "nino" => applicant.national_insurance_number.downcase,
-              "dateOfBirth" => applicant.date_of_birth,
-            } },
-            { "income/paye/paye" => { "income" => [] } },
-            { "employments/paye/employments" => valid_employments_response },
-          ],
-        }
-      end
-
-      it { expect(instance.call).to be_truthy }
     end
 
     context "when response data \"individuals/matching/individual\" details are missing" do


### PR DESCRIPTION
## What
Do not validate on first or last name, only nino and dob

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3062)

Avoid mismatches resulting from unusual
names and spelling mistakes either by our
users or in HMRC records.

We want some level of validation so we can
be confident our request of HMRC results in
a response for the individual/applicant entered
in our system. We have decided as a team (CB/JS/SR)
that the unique nature of a nino coupled with a date
of birth should suffice to give us warning of inappropriate
responses from HMRC.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
