### PR TITLE
Fix: Update Cronjob api version

### DIFF
--- a/helm_deploy/apply-for-legal-aid/templates/.dashboard_template_cron.yaml.sample
+++ b/helm_deploy/apply-for-legal-aid/templates/.dashboard_template_cron.yaml.sample
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   # NOTE The cronjob name must not exceed 25 characters so that when appended to the release name

--- a/helm_deploy/apply-for-legal-aid/templates/cronjob-admin-report.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/cronjob-admin-report.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ .Release.Name | trunc 26 }}-daily-admin-report

--- a/helm_deploy/apply-for-legal-aid/templates/cronjob-db-backup-cleanup.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/cronjob-db-backup-cleanup.yaml
@@ -1,5 +1,5 @@
 {{- $schedule := include "apply-for-legal-aid.cronjob-schedule-db-backup-cleanup" . -}}
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ .Release.Name | trunc 26 }}-clean-db-backups

--- a/helm_deploy/apply-for-legal-aid/templates/cronjob-deliver-scheduled-mail.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/cronjob-deliver-scheduled-mail.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ .Release.Name | trunc 26 }}-scheduled-mailings

--- a/helm_deploy/apply-for-legal-aid/templates/cronjob-destroy-purgeable.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/cronjob-destroy-purgeable.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ .Release.Name | trunc 26 }}-destroy-purgeable

--- a/helm_deploy/apply-for-legal-aid/templates/cronjob-export-digest.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/cronjob-export-digest.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ .Release.Name | trunc 26 }}-export-digest

--- a/helm_deploy/apply-for-legal-aid/templates/cronjob-extract-digest.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/cronjob-extract-digest.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ .Release.Name | trunc 26 }}-extract-digest

--- a/helm_deploy/apply-for-legal-aid/templates/cronjob-hourly-db-backup.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/cronjob-hourly-db-backup.yaml
@@ -1,5 +1,5 @@
 {{- $schedule := include "apply-for-legal-aid.cronjob-schedule-hourly-db-backup" . -}}
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ .Release.Name | trunc 26 }}-hourly-db-backup

--- a/helm_deploy/apply-for-legal-aid/templates/cronjob-mark-purgeable.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/cronjob-mark-purgeable.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ .Release.Name | trunc 26 }}-mark-purgeable

--- a/helm_deploy/apply-for-legal-aid/templates/cronjob-metrics.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/cronjob-metrics.yaml
@@ -1,5 +1,5 @@
 {{- $schedule := include "apply-for-legal-aid.cronjob-schedule-metrics" . -}}
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ .Release.Name }}-metrics

--- a/helm_deploy/apply-for-legal-aid/templates/cronjob-reset-dashboard-overnight.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/cronjob-reset-dashboard-overnight.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ .Release.Name | trunc 26 }}-reset-counter


### PR DESCRIPTION
## What

We had started to see deprecation warnings when deleting Helm charts `batch/v1beta1 CronJob is deprecated in v1.21+, unavailable in v1.25+; use batch/v1 CronJob` 

This should update all cronjobs, remove the warnings and ensure the system remains future proof

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
