### PR TITLE
Add github action for deleting a UAT release on merge/close

### DIFF
--- a/.github/workflows/delete_uat_deployment.yml
+++ b/.github/workflows/delete_uat_deployment.yml
@@ -23,6 +23,9 @@ jobs:
     - name: Print helm version
       run: |
         helm version
+    - name: Print kubectl version
+      run: |
+        kubectl version
 
   merge_job:
     if: github.event.pull_request.merged == true

--- a/.github/workflows/delete_uat_deployment.yml
+++ b/.github/workflows/delete_uat_deployment.yml
@@ -23,9 +23,21 @@ jobs:
     - name: Print helm version
       run: |
         helm version
-    - name: Print kubectl version
+    - name: Authenticate to the cluster
+      env:
+        K8S_CLUSTER: ${{ secrets.K8S_CLUSTER_NAME_LIVE }}
+        K8S_CLUSTER_CERT: ${{ secrets.K8S_CLUSTER_CERT_LIVE }}
+        K8S_NAMESPACE: ${{ secrets.K8S_UAT_NAMESPACE }}
+        K8S_TOKEN: ${{ secrets.K8S_UAT_TOKEN_LIVE }}
       run: |
-        kubectl version
+        echo -n ${K8S_CLUSTER_CERT} | base64 -d > ./ca.crt
+        kubectl config set-cluster ${K8S_CLUSTER} --certificate-authority=./ca.crt --server=https://${K8S_CLUSTER}
+        kubectl config set-credentials circleci --token=${K8S_TOKEN}
+        kubectl config set-context ${K8S_CLUSTER} --cluster=${K8S_CLUSTER} --user=circleci --namespace=${K8S_NAMESPACE}
+        kubectl config use-context ${K8S_CLUSTER}
+    - name: List UAT deployments
+      run: |
+        kubectl get deployments
 
   merge_job:
     if: github.event.pull_request.merged == true

--- a/.github/workflows/delete_uat_deployment.yml
+++ b/.github/workflows/delete_uat_deployment.yml
@@ -53,6 +53,14 @@ jobs:
       run: |
         helm list | grep ${{ steps.extract_release.outputs.release }}
 
+        found=$(helm list | grep ${{ steps.extract_release.outputs.release }})
+        if [[ ! -z "$found" ]]
+        then
+          echo "delete ${{ steps.extract_release.outputs.release }} here..."
+        else
+          echo "${{ steps.extract_release.outputs.release }} not found!"
+        fi
+
   merge_job:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest

--- a/.github/workflows/delete_uat_deployment.yml
+++ b/.github/workflows/delete_uat_deployment.yml
@@ -38,9 +38,9 @@ jobs:
     - name: List UAT deployments
       run: |
         kubectl get deployments
-    - name: List UAT deployments with helm
+    - name: List UAT deployments for branch using helm
       run: |
-        helm list
+        helm list | grep ${{ steps.extract_branch.outputs.branch }}
 
   merge_job:
     if: github.event.pull_request.merged == true

--- a/.github/workflows/delete_uat_deployment.yml
+++ b/.github/workflows/delete_uat_deployment.yml
@@ -1,8 +1,8 @@
-name: On PR closed
+name: Delete UAT deployment
 
 on:
   pull_request:
-    types: [closed, reopened]
+    types: [closed]
 
 jobs:
   merge_job:
@@ -12,6 +12,7 @@ jobs:
     steps:
     - run: |
         echo PR #${{ github.event.number }} has been merged
+        echo delete UAT release here.....
 
   close_job:
     # this job will only run if the PR has been closed without being merged
@@ -21,10 +22,3 @@ jobs:
     - run: |
         echo PR #${{ github.event.number }} has been closed without being merged
         echo delete UAT release here.....
-
-  reopened_job:
-    if: github.event.pull_request.reopened == true
-    runs-on: ubuntu-latest
-    steps:
-    - run: |
-        echo PR #${{ github.event.number }} has been reopened

--- a/.github/workflows/delete_uat_deployment.yml
+++ b/.github/workflows/delete_uat_deployment.yml
@@ -38,6 +38,9 @@ jobs:
     - name: List UAT deployments
       run: |
         kubectl get deployments
+    - name: List UAT deployments with helm
+      run: |
+        helm list
 
   merge_job:
     if: github.event.pull_request.merged == true

--- a/.github/workflows/delete_uat_deployment.yml
+++ b/.github/workflows/delete_uat_deployment.yml
@@ -12,7 +12,9 @@ jobs:
     steps:
     - run: |
         echo PR #${{ github.event.number }} has been merged
-        echo delete UAT release here.....
+
+    - run: |
+        ./bin/delete_uat_deployment
 
   close_job:
     # this job will only run if the PR has been closed without being merged
@@ -21,4 +23,5 @@ jobs:
     steps:
     - run: |
         echo PR #${{ github.event.number }} has been closed without being merged
-        echo delete UAT release here.....
+    - run: |
+        ./bin/delete_uat_deployment

--- a/.github/workflows/delete_uat_deployment.yml
+++ b/.github/workflows/delete_uat_deployment.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   push_job:
     if: github.event_name == 'push'
+    runs-on: ubuntu-latest
     steps:
     - name: Extract branch name
       shell: bash

--- a/.github/workflows/delete_uat_deployment.yml
+++ b/.github/workflows/delete_uat_deployment.yml
@@ -2,7 +2,8 @@ name: Delete UAT deployment
 
 on:
   pull_request:
-    types: [closed]
+    types:
+      - closed
 
 jobs:
   merge_job:
@@ -90,3 +91,11 @@ jobs:
         else
           echo "UAT release, ${release_name}, not found!"
         fi
+
+    - uses: actions/checkout@v2
+    - name: Setup tmate session
+      if: ${{ failure() }}
+      uses: mxschmitt/action-tmate@v3
+      timeout-minutes: 15
+      with:
+        limit-access-to-actor: true

--- a/.github/workflows/delete_uat_deployment.yml
+++ b/.github/workflows/delete_uat_deployment.yml
@@ -14,12 +14,20 @@ jobs:
       shell: bash
       run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
       id: extract_branch
-    - name: Print branch name
+    - name: output branch name
+      run: echo ${{ steps.extract_branch.outputs.branch }}
+
+    - name: Extract release name
+      id: extract_release
+      shell: bash
+      run: |
+        branch=${{ steps.extract_branch.outputs.branch }
+        truncated_branch=$(echo $branch | sed 's:^\w*\/::' | tr -s ' _/[]().' '-' | cut -c1-30 | sed 's/-$//')
+        echo "##[set-output name=release;]$(echo "apply-${truncated_branch}")"
+    - name: Print branch and relase name
       run: |
         echo "Branch name is ${{ steps.extract_branch.outputs.branch }}"
-    - name: Print apply release name
-      run: |
-        echo "apply-$(echo ${{ steps.extract_branch.outputs.branch }} | sed 's:^\w*\/::' | tr -s ' _/[]().' '-' | cut -c1-30 | sed 's/-$//')"
+        echo "Release name is ${{ steps.extract_release.outputs.release }}"
     - name: Print helm version
       run: |
         helm version

--- a/.github/workflows/delete_uat_deployment.yml
+++ b/.github/workflows/delete_uat_deployment.yml
@@ -20,6 +20,9 @@ jobs:
     - name: Print apply release name
       run: |
         echo "apply-$(echo ${{ steps.extract_branch.outputs.branch }} | sed 's:^\w*\/::' | tr -s ' _/[]().' '-' | cut -c1-30 | sed 's/-$//')"
+    - name: Print helm version
+      run: |
+        helm version
 
   merge_job:
     if: github.event.pull_request.merged == true

--- a/.github/workflows/delete_uat_deployment.yml
+++ b/.github/workflows/delete_uat_deployment.yml
@@ -1,13 +1,12 @@
 name: Delete UAT deployment
 
 on:
-  push:
   pull_request:
     types: [closed]
 
 jobs:
-  push_job:
-    if: github.event_name == 'push'
+  merge_job:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
     - name: Extract branch name
@@ -23,14 +22,48 @@ jobs:
         truncated_branch=$(echo $branch | sed 's:^\w*\/::' | tr -s ' _/[]().' '-' | cut -c1-30 | sed 's/-$//')
         echo "##[set-output name=release;]$(echo "apply-${truncated_branch}")"
 
-    - name: Print branch and release name
+    - name: Authenticate to the cluster
+      env:
+        K8S_CLUSTER: ${{ secrets.K8S_CLUSTER_NAME_LIVE }}
+        K8S_CLUSTER_CERT: ${{ secrets.K8S_CLUSTER_CERT_LIVE }}
+        K8S_NAMESPACE: ${{ secrets.K8S_UAT_NAMESPACE }}
+        K8S_TOKEN: ${{ secrets.K8S_UAT_TOKEN_LIVE }}
       run: |
-        echo "Branch name is ${{ steps.extract_branch.outputs.branch }}"
-        echo "Release name is ${{ steps.extract_release.outputs.release }}"
+        echo -n ${K8S_CLUSTER_CERT} | base64 -d > ./ca.crt
+        kubectl config set-cluster ${K8S_CLUSTER} --certificate-authority=./ca.crt --server=https://${K8S_CLUSTER}
+        kubectl config set-credentials circleci --token=${K8S_TOKEN}
+        kubectl config set-context ${K8S_CLUSTER} --cluster=${K8S_CLUSTER} --user=circleci --namespace=${K8S_NAMESPACE}
+        kubectl config use-context ${K8S_CLUSTER}
 
-    - name: Print helm version
+    - name: Delete UAT release
       run: |
-        helm version
+        release_name=${{ steps.extract_release.outputs.release }}
+        found=$(helm list --all | grep $release_name)
+
+        if [[ ! -z "$found" ]]
+        then
+          echo "Deleting UAT release ${release_name}..."
+          helm delete $release_name
+        else
+          echo "UAT release, ${release_name}, not found!"
+        fi
+
+  close_job:
+    if: github.event.pull_request.merged == false
+    runs-on: ubuntu-latest
+    steps:
+    - name: Extract branch name
+      shell: bash
+      run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+      id: extract_branch
+
+    - name: Extract release name
+      id: extract_release
+      shell: bash
+      run: |
+        branch=${{ steps.extract_branch.outputs.branch }}
+        truncated_branch=$(echo $branch | sed 's:^\w*\/::' | tr -s ' _/[]().' '-' | cut -c1-30 | sed 's/-$//')
+        echo "##[set-output name=release;]$(echo "apply-${truncated_branch}")"
 
     - name: Authenticate to the cluster
       env:
@@ -45,11 +78,7 @@ jobs:
         kubectl config set-context ${K8S_CLUSTER} --cluster=${K8S_CLUSTER} --user=circleci --namespace=${K8S_NAMESPACE}
         kubectl config use-context ${K8S_CLUSTER}
 
-    - name: List UAT deployments for release name with kubectl
-      run: |
-        kubectl get deployments | grep ${{ steps.extract_release.outputs.release }}
-
-    - name: List UAT deployments for release name using helm
+    - name: Delete UAT release
       run: |
         release_name=${{ steps.extract_release.outputs.release }}
         found=$(helm list --all | grep $release_name)
@@ -61,23 +90,3 @@ jobs:
         else
           echo "UAT release, ${release_name}, not found!"
         fi
-
-  merge_job:
-    if: github.event.pull_request.merged == true
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - run: |
-        echo "PR #${{ github.event.number }} has been merged"
-    - run: |
-        ./bin/delete_uat_deployment
-
-  close_job:
-    if: github.event.pull_request.merged == false
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - run: |
-        echo "PR #${{ github.event.number }} has been closed without being merged"
-    - run: |
-        ./bin/delete_uat_deployment

--- a/.github/workflows/delete_uat_deployment.yml
+++ b/.github/workflows/delete_uat_deployment.yml
@@ -1,6 +1,7 @@
 name: Delete UAT deployment
 
 on:
+  push:
   pull_request:
     types: [closed]
 

--- a/.github/workflows/delete_uat_deployment.yml
+++ b/.github/workflows/delete_uat_deployment.yml
@@ -16,7 +16,10 @@ jobs:
       id: extract_branch
     - name: Print branch name
       run: |
-        echo "Branch name is ${{ steps.extract_branch.outputs.branch }}""
+        echo "Branch name is ${{ steps.extract_branch.outputs.branch }}"
+    - name: Print apply release name
+      run |
+        echo "apply-$(echo ${{ steps.extract_branch.outputs.branch }} | sed 's:^\w*\/::' | tr -s ' _/[]().' '-' | cut -c1-30 | sed 's/-$//')"
 
   merge_job:
     if: github.event.pull_request.merged == true

--- a/.github/workflows/delete_uat_deployment.yml
+++ b/.github/workflows/delete_uat_deployment.yml
@@ -18,7 +18,7 @@ jobs:
       run: |
         echo "Branch name is ${{ steps.extract_branch.outputs.branch }}"
     - name: Print apply release name
-      run |
+      run: |
         echo "apply-$(echo ${{ steps.extract_branch.outputs.branch }} | sed 's:^\w*\/::' | tr -s ' _/[]().' '-' | cut -c1-30 | sed 's/-$//')"
 
   merge_job:

--- a/.github/workflows/delete_uat_deployment.yml
+++ b/.github/workflows/delete_uat_deployment.yml
@@ -6,22 +6,22 @@ on:
 
 jobs:
   merge_job:
-    # this job will only run if the PR has been merged
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
     - run: |
-        echo PR #${{ github.event.number }} has been merged
-
+        echo "PR #${{ github.event.number }} has been merged"
     - run: |
         ./bin/delete_uat_deployment
 
   close_job:
-    # this job will only run if the PR has been closed without being merged
     if: github.event.pull_request.merged == false
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/checkout@v2
     - run: |
-        echo PR #${{ github.event.number }} has been closed without being merged
+        echo "PR #${{ github.event.number }} has been closed without being merged"
+    - run: |
+        ls -la ./bin/delete_uat_deployment
     - run: |
         ./bin/delete_uat_deployment

--- a/.github/workflows/delete_uat_deployment.yml
+++ b/.github/workflows/delete_uat_deployment.yml
@@ -61,6 +61,14 @@ jobs:
           echo "${{ steps.extract_release.outputs.release }} not found!"
         fi
 
+    - uses: actions/checkout@v2
+    - name: Setup tmate session
+      if: ${{ failure() }}
+      uses: mxschmitt/action-tmate@v3
+      timeout-minutes: 15
+      with:
+        limit-access-to-actor: true
+
   merge_job:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest

--- a/.github/workflows/delete_uat_deployment.yml
+++ b/.github/workflows/delete_uat_deployment.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   push_job:
     if: github.event_name == 'push'
+    steps:
     - name: Extract branch name
       shell: bash
       run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"

--- a/.github/workflows/delete_uat_deployment.yml
+++ b/.github/workflows/delete_uat_deployment.yml
@@ -51,23 +51,16 @@ jobs:
 
     - name: List UAT deployments for release name using helm
       run: |
-        helm list | grep ${{ steps.extract_release.outputs.release }}
+        release_name=${{ steps.extract_release.outputs.release }}
+        found=$(helm list --all | grep $release_name)
 
-        found=$(helm list | grep ${{ steps.extract_release.outputs.release }})
         if [[ ! -z "$found" ]]
         then
-          echo "delete ${{ steps.extract_release.outputs.release }} here..."
+          echo "Deleting UAT release ${release_name}..."
+          # helm delete $release_name
         else
-          echo "${{ steps.extract_release.outputs.release }} not found!"
+          echo "UAT release, ${release_name}, not found!"
         fi
-
-    - uses: actions/checkout@v2
-    - name: Setup tmate session
-      if: ${{ failure() }}
-      uses: mxschmitt/action-tmate@v3
-      timeout-minutes: 15
-      with:
-        limit-access-to-actor: true
 
   merge_job:
     if: github.event.pull_request.merged == true

--- a/.github/workflows/delete_uat_deployment.yml
+++ b/.github/workflows/delete_uat_deployment.yml
@@ -14,23 +14,24 @@ jobs:
       shell: bash
       run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
       id: extract_branch
-    - name: output branch name
-      run: echo ${{ steps.extract_branch.outputs.branch }}
 
     - name: Extract release name
       id: extract_release
       shell: bash
       run: |
-        branch=${{ steps.extract_branch.outputs.branch }
+        branch=${{ steps.extract_branch.outputs.branch }}
         truncated_branch=$(echo $branch | sed 's:^\w*\/::' | tr -s ' _/[]().' '-' | cut -c1-30 | sed 's/-$//')
         echo "##[set-output name=release;]$(echo "apply-${truncated_branch}")"
-    - name: Print branch and relase name
+
+    - name: Print branch and release name
       run: |
         echo "Branch name is ${{ steps.extract_branch.outputs.branch }}"
         echo "Release name is ${{ steps.extract_release.outputs.release }}"
+
     - name: Print helm version
       run: |
         helm version
+
     - name: Authenticate to the cluster
       env:
         K8S_CLUSTER: ${{ secrets.K8S_CLUSTER_NAME_LIVE }}
@@ -43,12 +44,14 @@ jobs:
         kubectl config set-credentials circleci --token=${K8S_TOKEN}
         kubectl config set-context ${K8S_CLUSTER} --cluster=${K8S_CLUSTER} --user=circleci --namespace=${K8S_NAMESPACE}
         kubectl config use-context ${K8S_CLUSTER}
-    - name: List UAT deployments
+
+    - name: List UAT deployments for release name with kubectl
       run: |
-        kubectl get deployments
-    - name: List UAT deployments for branch using helm
+        kubectl get deployments | grep ${{ steps.extract_release.outputs.release }}
+
+    - name: List UAT deployments for release name using helm
       run: |
-        helm list | grep ${{ steps.extract_branch.outputs.branch }}
+        helm list | grep ${{ steps.extract_release.outputs.release }}
 
   merge_job:
     if: github.event.pull_request.merged == true

--- a/.github/workflows/delete_uat_deployment.yml
+++ b/.github/workflows/delete_uat_deployment.yml
@@ -1,14 +1,26 @@
 name: Delete UAT deployment
 
 on:
+  push:
   pull_request:
     types: [closed]
 
 jobs:
+  push_job:
+    if: github.event_name == 'push'
+    - name: Extract branch name
+      shell: bash
+      run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+      id: extract_branch
+    - name: Print branch name
+      run: |
+        echo "Branch name is ${{ steps.extract_branch.outputs.branch }}""
+
   merge_job:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/checkout@v2
     - run: |
         echo "PR #${{ github.event.number }} has been merged"
     - run: |
@@ -21,7 +33,5 @@ jobs:
     - uses: actions/checkout@v2
     - run: |
         echo "PR #${{ github.event.number }} has been closed without being merged"
-    - run: |
-        ls -la ./bin/delete_uat_deployment
     - run: |
         ./bin/delete_uat_deployment

--- a/.github/workflows/delete_uat_deployment.yml
+++ b/.github/workflows/delete_uat_deployment.yml
@@ -1,7 +1,6 @@
 name: Delete UAT deployment
 
 on:
-  push:
   pull_request:
     types: [closed]
 
@@ -57,7 +56,7 @@ jobs:
         if [[ ! -z "$found" ]]
         then
           echo "Deleting UAT release ${release_name}..."
-          # helm delete $release_name
+          helm delete $release_name
         else
           echo "UAT release, ${release_name}, not found!"
         fi

--- a/.github/workflows/on_pr_closed.yml
+++ b/.github/workflows/on_pr_closed.yml
@@ -1,0 +1,30 @@
+name: On PR closed
+
+on:
+  pull_request:
+    types: [ closed reopened ]
+
+jobs:
+  merge_job:
+    # this job will only run if the PR has been merged
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+    - run: |
+        echo PR #${{ github.event.number }} has been merged
+
+  close_job:
+    # this job will only run if the PR has been closed without being merged
+    if: github.event.pull_request.merged == false
+    runs-on: ubuntu-latest
+    steps:
+    - run: |
+        echo PR #${{ github.event.number }} has been closed without being merged
+        echo delete UAT release here.....
+
+  reopened_job:
+    if: github.event.pull_request.reopened == true
+    runs-on: ubuntu-latest
+    steps:
+    - run: |
+        echo PR #${{ github.event.number }} has been reopened

--- a/.github/workflows/on_pr_closed.yml
+++ b/.github/workflows/on_pr_closed.yml
@@ -2,7 +2,7 @@ name: On PR closed
 
 on:
   pull_request:
-    types: [ closed ]
+    types: [closed, reopened]
 
 jobs:
   merge_job:

--- a/.github/workflows/on_pr_closed.yml
+++ b/.github/workflows/on_pr_closed.yml
@@ -2,7 +2,7 @@ name: On PR closed
 
 on:
   pull_request:
-    types: [ closed reopened ]
+    types: [ closed ]
 
 jobs:
   merge_job:

--- a/bin/delete_uat_deployment
+++ b/bin/delete_uat_deployment
@@ -1,0 +1,2 @@
+#!/bin/sh
+echo "Deleting UAT deployment"

--- a/bin/delete_uat_deployment
+++ b/bin/delete_uat_deployment
@@ -1,2 +1,9 @@
 #!/bin/sh
 echo "Deleting UAT deployment"
+
+function _delete_uat_deployment() {
+  # uat_release="apply-$(echo $MERGED_BRANCH | sed 's:^\w*\/::' | tr -s ' _/[]().' '-' | cut -c1-30 | sed 's/-$//')"
+  # echo "UAT release for branch $uat_release"
+}
+
+_delete_uat_deployment

--- a/bin/delete_uat_deployment
+++ b/bin/delete_uat_deployment
@@ -1,9 +1,8 @@
 #!/bin/sh
-echo "Deleting UAT deployment"
 
 function _delete_uat_deployment() {
-  # uat_release="apply-$(echo $MERGED_BRANCH | sed 's:^\w*\/::' | tr -s ' _/[]().' '-' | cut -c1-30 | sed 's/-$//')"
-  # echo "UAT release for branch $uat_release"
+  uat_release=$1
+  echo "Deleting UAT deployment release for branch \"$uat_release\"..."
 }
 
-_delete_uat_deployment
+_delete_uat_deployment $@

--- a/bin/delete_uat_deployment
+++ b/bin/delete_uat_deployment
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-function _delete_uat_deployment() {
+_delete_uat_deployment() {
   uat_release=$1
   echo "Deleting UAT deployment release for branch \"$uat_release\"..."
 }


### PR DESCRIPTION
## What

Github action for deleting UAT releases after merge or close of PR
(and optionally opening if reopened?!)

Automate cleanup unused UAT instances that are no longer required.

NOTE: Circle CI does some f this on merge, which may become superfluos

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
