### PR TITLE
Allow localhost for content security policy

### DIFF
--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -1,5 +1,8 @@
+# rubocop:disable Lint/PercentStringArray
+connect_src = %w['self' https://www.google-analytics.com https://*.justice.gov.uk]
+connect_src << "http://localhost:*" if Rails.env.development?
+
 SecureHeaders::Configuration.configure do |config|
-  # rubocop:disable Lint/PercentStringArray
   config.csp = {
     default_src: %w['self'],
     img_src: %w['self'
@@ -10,7 +13,7 @@ SecureHeaders::Configuration.configure do |config|
     script_src: %w['self' nonce https://www.google-analytics.com https://www.googletagmanager.com],
     style_src: %w['self' 'unsafe-inline'],
     object_src: %w['none'],
-    connect_src: %w['self' https://www.google-analytics.com https://*.justice.gov.uk http://localhost:*],
+    connect_src:,
   }
-  # rubocop:enable Lint/PercentStringArray
 end
+# rubocop:enable Lint/PercentStringArray

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -10,7 +10,7 @@ SecureHeaders::Configuration.configure do |config|
     script_src: %w['self' nonce https://www.google-analytics.com https://www.googletagmanager.com],
     style_src: %w['self' 'unsafe-inline'],
     object_src: %w['none'],
-    connect_src: %w['self' https://www.google-analytics.com https://*.justice.gov.uk],
+    connect_src: %w['self' https://www.google-analytics.com https://*.justice.gov.uk http://localhost:*],
   }
   # rubocop:enable Lint/PercentStringArray
 end


### PR DESCRIPTION
## What
Allow localhost running versions of our APIs to connect via JS.

Without this config change javascript search for proceeding types
does not function when LFA is running on localhost, at least.

example error when inspect proceedings select page from chrome console
```
Refused to connect to 'http://localhost:4001/proceeding_types/searches' because it violates the following Content Security Policy directive: "connect-src 'self' www.google-analytics.com *.justice.gov.uk".
```

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
