### PR TITLE
AP-3065 Retain cron pods so we can examine logs

### DIFF
--- a/app/services/reports/mis/application_details_report.rb
+++ b/app/services/reports/mis/application_details_report.rb
@@ -21,7 +21,7 @@ module Reports
               legal_aid_application = LegalAidApplication.find(laa_id)
               csv << ApplicationDetailCsvLine.call(legal_aid_application)
               line_count += 1
-              log "#{line_count} lines created" if line_count % 100 == 0
+              log "#{line_count} lines created" if (line_count % 100).zero?
             end
           end
         rescue StandardError => e

--- a/app/services/reports/mis/application_details_report.rb
+++ b/app/services/reports/mis/application_details_report.rb
@@ -14,7 +14,6 @@ module Reports
 
       def generate_temp_file
         line_count = 0
-        begin
           CSV.open(tempfile_name, "w") do |csv|
             csv << ApplicationDetailCsvLine.header_row
             legal_aid_application_ids.each do |laa_id|
@@ -23,10 +22,8 @@ module Reports
               line_count += 1
               log "#{line_count} lines created" if (line_count % 100).zero?
             end
-          end
-        rescue StandardError => e
-          log "#{e.class} :: #{e.message}"
-          log e.backtrace
+          rescue StandardError => e
+            log "#{e.class} :: #{e.message}"
         end
       end
 

--- a/app/services/reports/mis/application_details_report.rb
+++ b/app/services/reports/mis/application_details_report.rb
@@ -13,15 +13,20 @@ module Reports
     private
 
       def generate_temp_file
-        CSV.open(tempfile_name, "w") do |csv|
-          csv << ApplicationDetailCsvLine.header_row
-          legal_aid_application_ids.each do |laa_id|
-            legal_aid_application = LegalAidApplication.find(laa_id)
-            csv << ApplicationDetailCsvLine.call(legal_aid_application)
+        line_count = 0
+        begin
+          CSV.open(tempfile_name, "w") do |csv|
+            csv << ApplicationDetailCsvLine.header_row
+            legal_aid_application_ids.each do |laa_id|
+              legal_aid_application = LegalAidApplication.find(laa_id)
+              csv << ApplicationDetailCsvLine.call(legal_aid_application)
+              line_count += 1
+              log "#{line_count} lines created" if line_count % 100 == 0
+            end
           end
         rescue StandardError => e
-          log "#{self.class.name}##{__method__} - #{e.message}"
-          raise e
+          log "#{e.class} :: #{e.message}"
+          log e.backtrace
         end
       end
 

--- a/app/services/reports/mis/application_details_report.rb
+++ b/app/services/reports/mis/application_details_report.rb
@@ -14,16 +14,16 @@ module Reports
 
       def generate_temp_file
         line_count = 0
-          CSV.open(tempfile_name, "w") do |csv|
-            csv << ApplicationDetailCsvLine.header_row
-            legal_aid_application_ids.each do |laa_id|
-              legal_aid_application = LegalAidApplication.find(laa_id)
-              csv << ApplicationDetailCsvLine.call(legal_aid_application)
-              line_count += 1
-              log "#{line_count} lines created" if (line_count % 100).zero?
-            end
-          rescue StandardError => e
-            log "#{e.class} :: #{e.message}"
+        CSV.open(tempfile_name, "w") do |csv|
+          csv << ApplicationDetailCsvLine.header_row
+          legal_aid_application_ids.each do |laa_id|
+            legal_aid_application = LegalAidApplication.find(laa_id)
+            csv << ApplicationDetailCsvLine.call(legal_aid_application)
+            line_count += 1
+            log "#{line_count} lines created" if (line_count % 100).zero?
+          end
+        rescue StandardError => e
+          log "#{e.class} :: #{e.message}"
         end
       end
 

--- a/helm_deploy/apply-for-legal-aid/templates/cronjob-admin-report.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/cronjob-admin-report.yaml
@@ -10,8 +10,8 @@ metadata:
 spec:
   schedule: '0 10,13,16,20 * * *'
   concurrencyPolicy: Forbid
-  successfulJobsHistoryLimit: 1
-  failedJobsHistoryLimit: 1
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
   jobTemplate:
     spec:
       template:

--- a/helm_deploy/apply-for-legal-aid/templates/cronjob-admin-report.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/cronjob-admin-report.yaml
@@ -10,8 +10,8 @@ metadata:
 spec:
   schedule: '0 10,13,16,20 * * *'
   concurrencyPolicy: Forbid
-  successfulJobsHistoryLimit: 3
-  failedJobsHistoryLimit: 3
+  successfulJobsHistoryLimit: 2
+  failedJobsHistoryLimit: 2
   jobTemplate:
     spec:
       template:

--- a/lib/tasks/jobs/create_admin_reports.rake
+++ b/lib/tasks/jobs/create_admin_reports.rake
@@ -3,7 +3,7 @@ namespace :job do
     desc "Upload admin reports"
     task upload: :environment do
       Rails.logger.info "rake job:admin_reports:upload queued at #{Time.zone.now}"
-      ReportsUploaderJob.perform_later
+      ReportsUploaderJob.perform_now
     end
   end
 end

--- a/spec/services/reports/mis/application_details_report_spec.rb
+++ b/spec/services/reports/mis/application_details_report_spec.rb
@@ -59,7 +59,7 @@ module Reports
           before { allow_any_instance_of(ApplicationDetailCsvLine).to receive(:call).and_raise(StandardError, "fake error") }
 
           it "logs the error message" do
-            expect(Rails.logger).to receive(:info).with("ApplicationDetailsReport - Reports::MIS::ApplicationDetailsReport#generate_temp_file - fake error")
+            expect(Rails.logger).to receive(:info).with("ApplicationDetailsReport - StandardError :: fake error")
             report.run
           end
         end


### PR DESCRIPTION

## Retain cron pods so we can examine logs

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3065)

Recen change to create CSV in tempfile and attach that hasn't worked - jobs are still failing silently.  This change is to retain the cron job pods so that we can look at the logs and see what went wrong.


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
