### PR TITLE
Rubocop fixes

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -439,9 +439,6 @@ RSpec/ContextWording:
     - 'spec/services/true_layer/importers/import_transactions_service_spec.rb'
     - 'spec/services/true_layer_error_decoder_spec.rb'
     - 'spec/services/use_ccms_arbiter_spec.rb'
-    - 'spec/support/shared_context/ccms_soa_configuration_context.rb'
-    - 'spec/support/shared_examples/cfe_failures_shared_examples.rb'
-    - 'spec/support/shared_examples/legal_framework_failures_shared_examples.rb'
 
 # Offense count: 1
 # Cop supports --auto-correct.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -443,10 +443,6 @@ RSpec/ContextWording:
     - 'spec/support/shared_examples/cfe_failures_shared_examples.rb'
     - 'spec/support/shared_examples/legal_framework_failures_shared_examples.rb'
     - 'spec/validators/document_category_validator_spec.rb'
-    - 'spec/workers/ccms/submission_process_worker_spec.rb'
-    - 'spec/workers/hmrc/result_worker_spec.rb'
-    - 'spec/workers/hmrc/submission_worker_spec.rb'
-    - 'spec/workers/import_bank_data_worker_spec.rb'
 
 # Offense count: 1
 # Cop supports --auto-correct.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -442,7 +442,6 @@ RSpec/ContextWording:
     - 'spec/support/shared_context/ccms_soa_configuration_context.rb'
     - 'spec/support/shared_examples/cfe_failures_shared_examples.rb'
     - 'spec/support/shared_examples/legal_framework_failures_shared_examples.rb'
-    - 'spec/validators/document_category_validator_spec.rb'
 
 # Offense count: 1
 # Cop supports --auto-correct.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -429,16 +429,6 @@ RSpec/ContextWording:
     - 'spec/services/submit_citizen_reminder_service_spec.rb'
     - 'spec/services/submit_provider_reminder_service_spec.rb'
     - 'spec/services/substantive_application_deadline_calculator_spec.rb'
-    - 'spec/services/true_layer/api_client_spec.rb'
-    - 'spec/services/true_layer/bank_data_import_service_spec.rb'
-    - 'spec/services/true_layer/banks_retriever_spec.rb'
-    - 'spec/services/true_layer/importers/import_account_balance_service_spec.rb'
-    - 'spec/services/true_layer/importers/import_account_holders_service_spec.rb'
-    - 'spec/services/true_layer/importers/import_accounts_service_spec.rb'
-    - 'spec/services/true_layer/importers/import_provider_service_spec.rb'
-    - 'spec/services/true_layer/importers/import_transactions_service_spec.rb'
-    - 'spec/services/true_layer_error_decoder_spec.rb'
-    - 'spec/services/use_ccms_arbiter_spec.rb'
 
 # Offense count: 1
 # Cop supports --auto-correct.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -362,7 +362,6 @@ RSpec/ContextWording:
     - 'spec/services/ccms/parsers/document_id_response_parser_spec.rb'
     - 'spec/services/ccms/parsers/reference_data_response_parser_spec.rb'
     - 'spec/services/ccms/payload_generators/entity_attributes_generator_spec.rb'
-    - 'spec/services/ccms/requestors/case_add_requestor_spec.rb'
     - 'spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_additional_property_attributes_spec.rb'
     - 'spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_attributes_spec.rb'
     - 'spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_benefits_attrs_spec.rb'

--- a/spec/services/ccms/requestors/applicant_add_requestor_spec.rb
+++ b/spec/services/ccms/requestors/applicant_add_requestor_spec.rb
@@ -25,7 +25,7 @@ module CCMS
       let(:requestor) { described_class.new(applicant, "my_login") }
 
       describe "XML request" do
-        include_context "ccms soa configuration"
+        include_context "with ccms soa configuration"
 
         it "generates the expected XML" do
           allow(requestor).to receive(:transaction_request_id).and_return(expected_tx_id)

--- a/spec/services/ccms/requestors/applicant_add_status_requestor_spec.rb
+++ b/spec/services/ccms/requestors/applicant_add_status_requestor_spec.rb
@@ -8,7 +8,7 @@ module CCMS
       let(:requestor) { described_class.new(expected_tx_id, "my_login") }
 
       describe "XML request" do
-        include_context "ccms soa configuration"
+        include_context "with ccms soa configuration"
 
         it "generates the expected XML" do
           allow(requestor).to receive(:transaction_request_id).and_return(expected_tx_id)

--- a/spec/services/ccms/requestors/applicant_search_requestor_spec.rb
+++ b/spec/services/ccms/requestors/applicant_search_requestor_spec.rb
@@ -15,7 +15,7 @@ module CCMS
       let(:requestor) { described_class.new(applicant, "my_login") }
 
       describe "XML request" do
-        include_context "ccms soa configuration"
+        include_context "with ccms soa configuration"
 
         it "generates the expected XML" do
           allow(requestor).to receive(:transaction_request_id).and_return(expected_tx_id)

--- a/spec/services/ccms/requestors/case_add_requestor_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_spec.rb
@@ -88,7 +88,7 @@ module CCMS
         end
 
         context "when DF assigned scope limitations are present" do
-          context "DF not used" do
+          context "when DF are not used" do
             it "does not add the extra scope limitation to the XML, and specifies the AA001 for requested scope" do
               expect(CCMS::OpponentId).to receive(:next_serial_id).and_return(88_123_456, 88_123_457, 88_123_458)
               travel_to Time.zone.parse("2020-11-24T11:54:29.000") do
@@ -98,7 +98,7 @@ module CCMS
             end
           end
 
-          context "DF actually used" do
+          context "when DF are actually used" do
             let(:df_date) { Date.parse("2020-11-23") }
 
             before do

--- a/spec/services/ccms/requestors/case_add_status_requestor_spec.rb
+++ b/spec/services/ccms/requestors/case_add_status_requestor_spec.rb
@@ -8,7 +8,7 @@ module CCMS
       let(:requestor) { described_class.new(expected_tx_id, "my_login") }
 
       describe "XML request" do
-        include_context "ccms soa configuration"
+        include_context "with ccms soa configuration"
 
         it "generates the expected XML" do
           allow(requestor).to receive(:transaction_request_id).and_return(expected_tx_id)

--- a/spec/services/ccms/requestors/document_id_requestor_spec.rb
+++ b/spec/services/ccms/requestors/document_id_requestor_spec.rb
@@ -11,7 +11,7 @@ module CCMS
 
       describe "XML request" do
         context "when the attachment is a means report" do
-          include_context "ccms soa configuration"
+          include_context "with ccms soa configuration"
 
           it "generates the expected XML" do
             allow(requestor).to receive(:transaction_request_id).and_return(expected_tx_id)
@@ -29,7 +29,7 @@ module CCMS
         context "when the attachment is a bank transaction report" do
           let(:type) { "bank_transaction_report" }
 
-          include_context "ccms soa configuration"
+          include_context "with ccms soa configuration"
 
           it "generates the expected XML" do
             allow(requestor).to receive(:transaction_request_id).and_return(expected_tx_id)

--- a/spec/services/ccms/requestors/document_upload_requestor_spec.rb
+++ b/spec/services/ccms/requestors/document_upload_requestor_spec.rb
@@ -12,7 +12,7 @@ module CCMS
 
       describe "XML request" do
         context "when sent a normal document" do
-          include_context "ccms soa configuration"
+          include_context "with ccms soa configuration"
 
           it "generates the expected XML" do
             allow(requestor).to receive(:transaction_request_id).and_return(expected_tx_id)
@@ -30,7 +30,7 @@ module CCMS
         context "when sent a gateway evidence document" do
           let(:requestor) { described_class.new(case_ccms_reference, document_id, document_encoded_base64, "my_login", "gateway_evidence_pdf") }
 
-          include_context "ccms soa configuration"
+          include_context "with ccms soa configuration"
 
           it "generates the expected XML" do
             allow(requestor).to receive(:transaction_request_id).and_return(expected_tx_id)
@@ -48,7 +48,7 @@ module CCMS
         context "when sent a bank_transaction_report" do
           let(:requestor) { described_class.new(case_ccms_reference, document_id, document_encoded_base64, "my_login", "bank_transaction_report") }
 
-          include_context "ccms soa configuration"
+          include_context "with ccms soa configuration"
 
           it "generates the expected XML" do
             allow(requestor).to receive(:transaction_request_id).and_return(expected_tx_id)

--- a/spec/services/ccms/requestors/reference_data_requestor_spec.rb
+++ b/spec/services/ccms/requestors/reference_data_requestor_spec.rb
@@ -8,7 +8,7 @@ module CCMS
       let(:requestor) { described_class.new("my_login") }
 
       describe "XML request" do
-        include_context "ccms soa configuration"
+        include_context "with ccms soa configuration"
 
         it "generates the expected XML" do
           allow(requestor).to receive(:transaction_request_id).and_return(expected_tx_id)

--- a/spec/services/true_layer/api_client_spec.rb
+++ b/spec/services/true_layer/api_client_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe TrueLayer::ApiClient do
       expect(subject.provider.value.first).to eq(mock_provider)
     end
 
-    context "result is not json" do
+    context "when the result is not json" do
       before do
         endpoint = "#{TrueLayer::ApiClient::TRUE_LAYER_URL}/data/v1/me"
         stub_request(:get, endpoint).to_return(body: "Boom!", status: 501)
@@ -27,7 +27,7 @@ RSpec.describe TrueLayer::ApiClient do
       end
     end
 
-    context "API cannot be reached" do
+    context "when the API cannot be reached" do
       before do
         endpoint = "#{TrueLayer::ApiClient::TRUE_LAYER_URL}/data/v1/me"
         stub_request(:get, endpoint).to_timeout

--- a/spec/services/true_layer/bank_data_import_service_spec.rb
+++ b/spec/services/true_layer/bank_data_import_service_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe TrueLayer::BankDataImportService do
       expect(subject.success?).to be(true)
     end
 
-    context "the provider API call is failing" do
+    context "when the provider API call is failing" do
       before do
         endpoint = "#{TrueLayer::ApiClient::TRUE_LAYER_URL}/data/v1/me"
         stub_request(:get, endpoint).to_return(body: api_error.to_json, status: 501)
@@ -73,7 +73,7 @@ RSpec.describe TrueLayer::BankDataImportService do
       end
     end
 
-    context "a subsequent API call is failing" do
+    context "when a subsequent API call is failing" do
       before do
         endpoint = "#{TrueLayer::ApiClient::TRUE_LAYER_URL}/data/v1/accounts"
         stub_request(:get, endpoint).to_return(body: api_error.to_json, status: 501)
@@ -103,7 +103,7 @@ RSpec.describe TrueLayer::BankDataImportService do
       end
     end
 
-    context "mock_true_layer_data is on" do
+    context "when mock_true_layer_data is on" do
       let(:sample_data) { TrueLayer::SampleData }
 
       before { Setting.create!(mock_true_layer_data: true) }

--- a/spec/services/true_layer/banks_retriever_spec.rb
+++ b/spec/services/true_layer/banks_retriever_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe TrueLayer::BanksRetriever, vcr: { cassette_name: "true_layer_bank
       expect(described_class.banks).to eq(subject.banks)
     end
 
-    context "on failure" do
+    context "when there is a failure" do
       let(:uri) { URI.parse(described_class::API_URL_OPEN_BANKING) }
 
       before do

--- a/spec/services/true_layer/importers/import_account_balance_service_spec.rb
+++ b/spec/services/true_layer/importers/import_account_balance_service_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe TrueLayer::Importers::ImportAccountBalanceService do
   describe "#call" do
     subject { described_class.call(api_client, bank_account) }
 
-    context "request is successful" do
+    context "when a request is successful" do
       before do
         stub_true_layer_account_balances
       end
@@ -23,7 +23,7 @@ RSpec.describe TrueLayer::Importers::ImportAccountBalanceService do
       end
     end
 
-    context "request is not successful" do
+    context "when a request is not successful" do
       before do
         stub_true_layer_error
       end

--- a/spec/services/true_layer/importers/import_account_holders_service_spec.rb
+++ b/spec/services/true_layer/importers/import_account_holders_service_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe TrueLayer::Importers::ImportAccountHoldersService do
     let(:bank_account_holder2) { bank_provider.bank_account_holders.find_by(full_name: mock_account_holder2[:full_name]) }
     let!(:existing_bank_account_holder) { create :bank_account_holder, bank_provider: }
 
-    context "request is successful" do
+    context "when the request is successful" do
       before do
         stub_true_layer_account_holders
       end
@@ -37,7 +37,7 @@ RSpec.describe TrueLayer::Importers::ImportAccountHoldersService do
       end
     end
 
-    context "request is not successful" do
+    context "when the request is not successful" do
       before do
         stub_true_layer_error
       end

--- a/spec/services/true_layer/importers/import_accounts_service_spec.rb
+++ b/spec/services/true_layer/importers/import_accounts_service_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe TrueLayer::Importers::ImportAccountsService do
     let!(:existing_bank_account) { create :bank_account, bank_provider: }
     let!(:existing_bank_account_transaction) { create :bank_transaction, bank_account: existing_bank_account }
 
-    context "request is successful" do
+    context "when the request is successful" do
       before do
         stub_true_layer_accounts
       end
@@ -44,7 +44,7 @@ RSpec.describe TrueLayer::Importers::ImportAccountsService do
       end
     end
 
-    context "request is not successful" do
+    context "when the request is not successful" do
       before do
         stub_true_layer_error
       end

--- a/spec/services/true_layer/importers/import_provider_service_spec.rb
+++ b/spec/services/true_layer/importers/import_provider_service_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe TrueLayer::Importers::ImportProviderService do
     let(:existing_true_layer_provider_id) { SecureRandom.hex }
     let!(:existing_provider) { create :bank_provider, applicant:, true_layer_provider_id: existing_true_layer_provider_id }
 
-    context "request is successful" do
+    context "when the request is successful" do
       before do
         stub_true_layer_provider
       end
@@ -34,7 +34,7 @@ RSpec.describe TrueLayer::Importers::ImportProviderService do
         expect(command.result).to eq(bank_provider)
       end
 
-      context "existing provider has same true_layer_provider_id" do
+      context "when the existing provider has the same true_layer_provider_id" do
         let(:existing_true_layer_provider_id) { mock_provider[:provider][:provider_id] }
 
         it "does not create another bank provider" do
@@ -55,7 +55,7 @@ RSpec.describe TrueLayer::Importers::ImportProviderService do
       end
     end
 
-    context "request is not successful" do
+    context "when the request is not successful" do
       before do
         stub_true_layer_error
       end

--- a/spec/services/true_layer/importers/import_transactions_service_spec.rb
+++ b/spec/services/true_layer/importers/import_transactions_service_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe TrueLayer::Importers::ImportTransactionsService do
     let(:transaction2) { bank_account.bank_transactions.find_by(true_layer_id: mock_transaction2[:transaction_id]) }
     let!(:existing_transaction) { create :bank_transaction, bank_account: }
 
-    context "request is successful" do
+    context "when the request is successful" do
       before do
         stub_true_layer_transactions
       end
@@ -65,7 +65,7 @@ RSpec.describe TrueLayer::Importers::ImportTransactionsService do
       end
     end
 
-    context "request is not successful" do
+    context "when the request is not successful" do
       before do
         stub_true_layer_error
       end

--- a/spec/services/true_layer_error_decoder_spec.rb
+++ b/spec/services/true_layer_error_decoder_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe TrueLayerErrorDecoder do
   let(:error_description) { "TrueLayer's detailed explanation of the error" }
 
   describe "#error_heading" do
-    context "known error" do
+    context "when a known error occurs" do
       let(:error_code) { "account_temporarily_locked" }
 
       it "returns the correct translation" do
@@ -15,7 +15,7 @@ RSpec.describe TrueLayerErrorDecoder do
       end
     end
 
-    context "unknown error" do
+    context "when an unknown error occurs" do
       let(:error_code) { "flux_capacitor_outage" }
       let(:error_description) { "The flux capacitor is not working" }
 
@@ -31,7 +31,7 @@ RSpec.describe TrueLayerErrorDecoder do
   end
 
   describe "#error_details" do
-    context "known error" do
+    context "when a known error occurs" do
       let(:error_code) { "internal_server_error" }
 
       it "returns the correct translation" do
@@ -39,7 +39,7 @@ RSpec.describe TrueLayerErrorDecoder do
       end
     end
 
-    context "unknown error" do
+    context "when an unknown error occurs" do
       let(:error_code) { "flux_capacitor_outage" }
       let(:error_description) { "The flux capacitor is not working" }
 
@@ -50,7 +50,7 @@ RSpec.describe TrueLayerErrorDecoder do
   end
 
   describe "#show_link?" do
-    context "link shown" do
+    context "when the link is shown" do
       let(:error_code) { "wrong_credentials" }
 
       it "returns true" do
@@ -58,7 +58,7 @@ RSpec.describe TrueLayerErrorDecoder do
       end
     end
 
-    context "no link shown" do
+    context "when no link is shown" do
       let(:error_code) { "account_permanently_locked" }
 
       it "returns true" do

--- a/spec/services/use_ccms_arbiter_spec.rb
+++ b/spec/services/use_ccms_arbiter_spec.rb
@@ -13,13 +13,13 @@ RSpec.describe UseCCMSArbiter do
     allow(provider).to receive(:non_passported_permissions?).and_return(provider_non_passported_permission)
   end
 
-  context "applicant receives benefit" do
+  context "when the applicant receives benefit" do
     let(:receives_benefit) { true }
 
-    context "provider does not have non-passported permissions" do
+    context "when the provider does not have non-passported permissions" do
       let(:provider_non_passported_permission) { false }
 
-      context "provider has passported permissions" do
+      context "when the provider has passported permissions" do
         let(:provider_passported_permission) { true }
 
         it "returns false" do
@@ -32,7 +32,7 @@ RSpec.describe UseCCMSArbiter do
         end
       end
 
-      context "provider does not have passported permissions" do
+      context "when the provider does not have passported permissions" do
         let(:provider_passported_permission) { false }
 
         it "returns true" do
@@ -46,10 +46,10 @@ RSpec.describe UseCCMSArbiter do
       end
     end
 
-    context "provider does have non-passported permissions" do
+    context "when the provider does have non-passported permissions" do
       let(:provider_non_passported_permission) { false }
 
-      context "provider has passported permissions" do
+      context "when the provider has passported permissions" do
         let(:provider_passported_permission) { true }
 
         it "returns false" do
@@ -62,7 +62,7 @@ RSpec.describe UseCCMSArbiter do
         end
       end
 
-      context "provider does not have passported permissions" do
+      context "when the provider does not have passported permissions" do
         let(:provider_passported_permission) { false }
 
         it "returns true" do
@@ -77,11 +77,11 @@ RSpec.describe UseCCMSArbiter do
     end
   end
 
-  context "applicant does not receive benefit" do
+  context "when the applicant does not receive benefit" do
     let(:receives_benefit) { false }
     let(:provider_passported_permission) { true }
 
-    context "provider has non_passported permissions" do
+    context "when the provider has non_passported permissions" do
       let(:provider_non_passported_permission) { true }
 
       it "returns false" do
@@ -94,7 +94,7 @@ RSpec.describe UseCCMSArbiter do
       end
     end
 
-    context "provider does not have passported permissions" do
+    context "when the provider does not have passported permissions" do
       let(:provider_non_passported_permission) { false }
 
       it "returns true" do

--- a/spec/support/shared_context/ccms_soa_configuration_context.rb
+++ b/spec/support/shared_context/ccms_soa_configuration_context.rb
@@ -8,7 +8,7 @@ RSpec.configure do |rspec|
   rspec.shared_context_metadata_behavior = :apply_to_host_groups
 end
 
-RSpec.shared_context "ccms soa configuration", shared_context: :metadata do
+RSpec.shared_context "with ccms soa configuration", shared_context: :metadata do
   before do
     allow(Rails.configuration.x).to receive(:ccms_soa).and_return(
       double(

--- a/spec/support/shared_examples/cfe_failures_shared_examples.rb
+++ b/spec/support/shared_examples/cfe_failures_shared_examples.rb
@@ -2,7 +2,7 @@ module CFE
   RSpec.shared_examples "a failed call to CFE" do
     # shared examples for testing failure conditions when posting to Check Financial Eligibility Service
     #
-    context "http status 422" do
+    context "with http status 422" do
       before do
         stub_request(:post, service.cfe_url)
           .with(body: service.request_body)
@@ -31,7 +31,7 @@ module CFE
       end
     end
 
-    context "other failing http status" do
+    context "with another failing http status" do
       before do
         stub_request(:post, service.cfe_url)
           .with(body: service.request_body)
@@ -56,7 +56,7 @@ module CFE
       end
     end
 
-    context "connection error" do
+    context "when there is a connection error" do
       it "creates a CFE::Submission error and writes a history record with a backtrace" do
         stub_request(:post, service.cfe_url).to_raise(Faraday::ConnectionFailed.new("my faraday connection failed"))
         expect {

--- a/spec/support/shared_examples/legal_framework_failures_shared_examples.rb
+++ b/spec/support/shared_examples/legal_framework_failures_shared_examples.rb
@@ -2,7 +2,7 @@ module LegalFramework
   RSpec.shared_examples "a failed call to LegalFrameworkAPI" do
     # shared examples for testing failure conditions when posting to LegalFrameworkAPI Service
     #
-    context "http status 422" do
+    context "with http status 422" do
       before do
         stub_request(:post, service.legal_framework_url)
           .with(body: service.request_body)
@@ -31,7 +31,7 @@ module LegalFramework
       end
     end
 
-    context "other failing http status" do
+    context "with another failing http status" do
       before do
         stub_request(:post, service.legal_framework_url)
           .with(body: service.request_body)
@@ -56,7 +56,7 @@ module LegalFramework
       end
     end
 
-    context "connection error" do
+    context "when there is a connection error" do
       it "creates a LegalFramework::Submission error and writes a history record with a backtrace" do
         stub_request(:post, service.legal_framework_url).to_raise(Faraday::ConnectionFailed.new("my faraday connection failed"))
         expect {

--- a/spec/validators/document_category_validator_spec.rb
+++ b/spec/validators/document_category_validator_spec.rb
@@ -7,24 +7,24 @@ class DummyDocumentCategory
 end
 
 RSpec.describe DocumentCategoryValidator do
-  context "Attachment" do
+  context "with Attachment" do
     subject { Attachment.create! legal_aid_application: laa, attachment_type: }
 
     let(:laa) { create :legal_aid_application }
     let(:invalid_attachment_type) { "xxx-zzz" }
     let(:valid_attachment_types) { DocumentCategoryValidator::VALID_DOCUMENT_TYPES }
 
-    context "valid attachment types" do
+    context "with valid attachment types" do
       let(:attachment_type) { valid_attachment_types.sample }
 
-      it "does not fail when trying to create a record with an valid attachment type" do
+      it "does not fail when trying to create a record with a valid attachment type" do
         record = subject
         expect(record).to be_instance_of(Attachment)
         expect(record).to be_valid
       end
     end
 
-    context "invalid attachment type" do
+    context "with invalid attachment type" do
       let(:attachment_type) { invalid_attachment_type }
 
       it "fails when trying to create a record with an invalid attachment type" do
@@ -33,13 +33,13 @@ RSpec.describe DocumentCategoryValidator do
     end
   end
 
-  context "DocumentCategory" do
+  context "with DocumentCategory" do
     subject { DocumentCategory.create! name: }
 
     let(:invalid_name) { "xxx-zzz" }
     let(:valid_names) { DocumentCategoryValidator::VALID_DOCUMENT_TYPES }
 
-    context "valid names" do
+    context "with valid names" do
       let(:name) { valid_names.sample }
 
       it "does not fail when trying to create a record with an valid name" do
@@ -49,7 +49,7 @@ RSpec.describe DocumentCategoryValidator do
       end
     end
 
-    context "invalid attachment type" do
+    context "with an invalid attachment type" do
       let(:name) { invalid_name }
 
       it "fails when trying to create a record with an invalid attachment type" do
@@ -58,7 +58,7 @@ RSpec.describe DocumentCategoryValidator do
     end
   end
 
-  context "DummyClass" do
+  context "with DummyClass" do
     it "raises" do
       dummy = DummyDocumentCategory.new
       expect {

--- a/spec/workers/ccms/submission_process_worker_spec.rb
+++ b/spec/workers/ccms/submission_process_worker_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe CCMS::SubmissionProcessWorker do
       subject
     end
 
-    context "the state changes to completed" do
+    context "when the state changes to completed" do
       before do
         allow(submission).to receive(:aasm_state).and_return(:complete)
         allow(submission).to receive(:completed?).and_return(true)
@@ -34,7 +34,7 @@ RSpec.describe CCMS::SubmissionProcessWorker do
 
     context "when an error occurs" do
       context "when @retry_count is" do
-        context "below the halfway point" do
+        context "when below the halfway point" do
           before { worker.retry_count = 4 }
 
           it "does not raise a sentry error" do
@@ -42,7 +42,7 @@ RSpec.describe CCMS::SubmissionProcessWorker do
             subject
           end
 
-          context "raises a not tracked error" do
+          context "when a not tracked error is raised" do
             before do
               # this should trigger state_unchanged? and therefore SubmissionStateUnchanged
               allow(submission).to receive(:aasm_state).and_return(state)
@@ -54,7 +54,7 @@ RSpec.describe CCMS::SubmissionProcessWorker do
           end
         end
 
-        context "on the halfway point" do
+        context "when at the halfway point" do
           before { worker.retry_count = 5 }
 
           it "does not raise a sentry error" do
@@ -62,7 +62,7 @@ RSpec.describe CCMS::SubmissionProcessWorker do
             subject
           end
 
-          context "raises a not tracked error" do
+          context "when a not tracked error is raised" do
             before do
               # this should trigger state_unchanged? and therefore SubmissionStateUnchanged
               allow(submission).to receive(:aasm_state).and_return(state)
@@ -74,7 +74,7 @@ RSpec.describe CCMS::SubmissionProcessWorker do
           end
         end
 
-        context "one above the halfway point" do
+        context "when one above the halfway point" do
           before { worker.retry_count = 6 }
 
           let(:expected_error) do
@@ -89,7 +89,7 @@ RSpec.describe CCMS::SubmissionProcessWorker do
             subject
           end
 
-          context "raises a not tracked error" do
+          context "when a not tracked error is raised" do
             before do
               # this should trigger state_unchanged? and therefore SubmissionStateUnchanged
               allow(submission).to receive(:aasm_state).and_return(state)
@@ -101,7 +101,7 @@ RSpec.describe CCMS::SubmissionProcessWorker do
           end
         end
 
-        context "above the halfway point" do
+        context "when above the halfway point" do
           before { worker.retry_count = 7 }
 
           it "does not raise a sentry error" do
@@ -109,7 +109,7 @@ RSpec.describe CCMS::SubmissionProcessWorker do
             subject
           end
 
-          context "raises a not tracked error" do
+          context "when a not tracked error is raised" do
             before do
               # this should trigger state_unchanged? and therefore SubmissionStateUnchanged
               allow(submission).to receive(:aasm_state).and_return(state)
@@ -121,7 +121,7 @@ RSpec.describe CCMS::SubmissionProcessWorker do
           end
         end
 
-        context "at MAX_RETRIES" do
+        context "when at MAX_RETRIES" do
           before { worker.retry_count = 10 }
 
           let(:expected_error) do
@@ -138,7 +138,7 @@ RSpec.describe CCMS::SubmissionProcessWorker do
             subject
           end
 
-          context "raises a tracked error" do
+          context "when a tracked error is raised" do
             before do
               # this should trigger state_unchanged? and therefore SubmissionStateUnchanged
               allow(submission).to receive(:aasm_state).and_return(state)

--- a/spec/workers/hmrc/result_worker_spec.rb
+++ b/spec/workers/hmrc/result_worker_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe HMRC::ResultWorker do
       end
 
       context "when @retry_count is" do
-        context "below the halfway point" do
+        context "when below the halfway point" do
           before { worker.retry_count = 4 }
 
           it "raises an error but does not pass it to sentry" do
@@ -93,7 +93,7 @@ RSpec.describe HMRC::ResultWorker do
           end
         end
 
-        context "on the halfway point" do
+        context "when at the halfway point" do
           before { worker.retry_count = 5 }
 
           it "raises an error but does not pass it to sentry" do
@@ -102,7 +102,7 @@ RSpec.describe HMRC::ResultWorker do
           end
         end
 
-        context "one above the halfway point" do
+        context "when one above the halfway point" do
           before { worker.retry_count = 6 }
 
           let(:expected_error) do
@@ -117,7 +117,7 @@ RSpec.describe HMRC::ResultWorker do
           end
         end
 
-        context "above the halfway point" do
+        context "when above the halfway point" do
           before { worker.retry_count = 7 }
 
           it "raises an error but does not pass it to sentry" do
@@ -126,7 +126,7 @@ RSpec.describe HMRC::ResultWorker do
           end
         end
 
-        context "at MAX_RETRIES" do
+        context "when at MAX_RETRIES" do
           before { worker.retry_count = 10 }
 
           let(:expected_error) do

--- a/spec/workers/hmrc/submission_worker_spec.rb
+++ b/spec/workers/hmrc/submission_worker_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe HMRC::SubmissionWorker do
       end
 
       context "when @retry_count is" do
-        context "below the halfway point" do
+        context "when below the halfway point" do
           before { worker.retry_count = 4 }
 
           it "raises an error but does not pass it to sentry" do
@@ -55,7 +55,7 @@ RSpec.describe HMRC::SubmissionWorker do
           end
         end
 
-        context "on the halfway point" do
+        context "when at the halfway point" do
           before { worker.retry_count = 5 }
 
           it "raises an error but does not pass it to sentry" do
@@ -64,7 +64,7 @@ RSpec.describe HMRC::SubmissionWorker do
           end
         end
 
-        context "one above the halfway point" do
+        context "when one above the halfway point" do
           before { worker.retry_count = 6 }
 
           let(:expected_error) do
@@ -79,7 +79,7 @@ RSpec.describe HMRC::SubmissionWorker do
           end
         end
 
-        context "above the halfway point" do
+        context "when above the halfway point" do
           before { worker.retry_count = 7 }
 
           it "raises an error but does not pass it to sentry" do
@@ -88,7 +88,7 @@ RSpec.describe HMRC::SubmissionWorker do
           end
         end
 
-        context "at MAX_RETRIES" do
+        context "when at MAX_RETRIES" do
           before { worker.retry_count = 10 }
 
           let(:expected_error) do

--- a/spec/workers/import_bank_data_worker_spec.rb
+++ b/spec/workers/import_bank_data_worker_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe ImportBankDataWorker, type: :worker do
     described_class.drain
   end
 
-  context "it generates an error" do
+  context "when an error is generated" do
     let(:api_error) do
       {
         error_description: "Feature not supported by the provider",


### PR DESCRIPTION
Fix GOVUK Rubocop RSpec/ContextWording offences.

Start context description with 'when', 'with', 'without', 'and', or 'but'. (https://rspec.rubystyle.guide/#context-descriptions, https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ContextWording)

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
