### PR TITLE
AP-3065 Remove debugging and multiple runs per day

### DIFF
--- a/app/services/reports/mis/application_details_report.rb
+++ b/app/services/reports/mis/application_details_report.rb
@@ -20,8 +20,9 @@ module Reports
             legal_aid_application = LegalAidApplication.find(laa_id)
             csv << ApplicationDetailCsvLine.call(legal_aid_application)
             line_count += 1
-            log "#{line_count} lines created" if (line_count % 100).zero?
+            log "#{line_count} lines processed" if (line_count % 500).zero?
           end
+          log "#{line_count} lines written to tempfile"
         rescue StandardError => e
           log "#{e.class} :: #{e.message}"
         end

--- a/helm_deploy/apply-for-legal-aid/templates/cronjob-admin-report.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/cronjob-admin-report.yaml
@@ -8,7 +8,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  schedule: '2 * * *'
+  schedule: '0 2 * * *'
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 1
   failedJobsHistoryLimit: 1

--- a/helm_deploy/apply-for-legal-aid/templates/cronjob-admin-report.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/cronjob-admin-report.yaml
@@ -8,10 +8,10 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  schedule: '0 10,13,16,20 * * *'
+  schedule: '2 * * *'
   concurrencyPolicy: Forbid
-  successfulJobsHistoryLimit: 2
-  failedJobsHistoryLimit: 2
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 1
   jobTemplate:
     spec:
       template:


### PR DESCRIPTION

## Remove debugging and multiple runs per day

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3065)

Now that we have found the reason why the admin report was failing, and fixed it, we can remove some of the debugging and revert back to generating the report just once per day

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
