### PR TITLE
Rubocop fixes

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -161,13 +161,6 @@ RSpec/ContextWording:
   Exclude:
     - 'spec/factory_specs/legal_aid_application_factory_spec.rb'
     - 'spec/factory_specs/v4/cfe_result_factory_spec.rb'
-    - 'spec/forms/applicants/email_form_spec.rb'
-    - 'spec/forms/citizens/other_assets_form_spec.rb'
-    - 'spec/forms/legal_aid_applications/dependant_form_spec.rb'
-    - 'spec/forms/legal_aid_applications/percentage_home_form_spec.rb'
-    - 'spec/forms/legal_aid_applications/restrictions_form_spec.rb'
-    - 'spec/forms/legal_aid_applications/used_multiple_delegated_functions_form_spec.rb'
-    - 'spec/forms/opponents/opponent_form_spec.rb'
     - 'spec/forms/outstanding_mortgage_form_spec.rb'
     - 'spec/forms/providers/application_merits_task/involved_child_form_spec.rb'
     - 'spec/forms/providers/proceeding_merits_task/attempts_to_settle_form_spec.rb'

--- a/spec/forms/applicants/email_form_spec.rb
+++ b/spec/forms/applicants/email_form_spec.rb
@@ -42,11 +42,11 @@ RSpec.describe Applicants::EmailForm, type: :form do
       end
     end
 
-    context "stripping whitespace" do
+    context "when stripping whitespace" do
       let(:fake_email_address) { Faker::Internet.safe_email }
       let(:email) { "  #{fake_email_address}  " }
 
-      it "updates the applicant email with the email address without whitespece" do
+      it "updates the applicant email with the email address without whitespace" do
         subject.save
         expect(applicant.reload.email).to eq fake_email_address
       end

--- a/spec/forms/citizens/other_assets_form_spec.rb
+++ b/spec/forms/citizens/other_assets_form_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Citizens::OtherAssetsForm do
   let(:oad_with_second_home) { create :other_assets_declaration, :with_second_home }
   let(:oad_with_all_values) { create :other_assets_declaration, :with_all_values }
 
-  context "second home params" do
+  context "with second home params" do
     let(:valid_second_home_params) do
       { check_box_second_home: "yes",
         second_home_value: "859374.00",
@@ -35,7 +35,7 @@ RSpec.describe Citizens::OtherAssetsForm do
     end
 
     describe "instantiation" do
-      context "from an existing record" do
+      context "when from an existing record" do
         let(:form) { described_class.new(current_params(empty_oad)) }
 
         context "with values all nil" do
@@ -53,11 +53,11 @@ RSpec.describe Citizens::OtherAssetsForm do
         end
       end
 
-      context "from an existing record and form params" do
+      context "when from an existing record and form params" do
         let(:form) { described_class.new(form_params(empty_oad)) }
 
-        context "valid form params" do
-          context "all fields present" do
+        context "with valid form params" do
+          context "and all fields present" do
             let(:submitted_params) { valid_second_home_params }
 
             it "is valid" do
@@ -65,7 +65,7 @@ RSpec.describe Citizens::OtherAssetsForm do
             end
           end
 
-          context "no fields present" do
+          context "with no fields present" do
             let(:submitted_params) { empty_second_home_params }
 
             it "is valid" do
@@ -74,8 +74,8 @@ RSpec.describe Citizens::OtherAssetsForm do
           end
         end
 
-        context "invalid form params" do
-          context "non-numeric characters" do
+        context "with invalid form params" do
+          context "and non-numeric characters" do
             let(:submitted_params) { alpha_second_home_params }
 
             it "is not valid" do
@@ -112,14 +112,14 @@ RSpec.describe Citizens::OtherAssetsForm do
     let(:valuable_items_value) { "566.0" }
 
     describe "instantiation" do
-      context "from an existing record" do
+      context "when from an existing record" do
         let(:form) { described_class.new(current_params(oad_with_all_values)) }
 
-        context "from an existing record and form params" do
+        context "when from an existing record and form params" do
           let(:form) { described_class.new(form_params(empty_oad)) }
 
-          context "valid form params" do
-            context "all fields present" do
+          context "with valid form params" do
+            context "and all fields present" do
               let(:submitted_params) { params }
 
               it "is valid" do
@@ -128,7 +128,7 @@ RSpec.describe Citizens::OtherAssetsForm do
               end
             end
 
-            context "no form fields present" do
+            context "with no form fields present" do
               let(:submitted_params) { { none_selected: "true" } }
 
               it "is valid" do
@@ -137,7 +137,7 @@ RSpec.describe Citizens::OtherAssetsForm do
             end
           end
 
-          context "invalid form params" do
+          context "with invalid form params" do
             let(:submitted_params) { params }
 
             describe "when valuable_items_value is below threshold" do
@@ -150,7 +150,7 @@ RSpec.describe Citizens::OtherAssetsForm do
             end
           end
 
-          context "invalid params - each value suffixed with an x" do
+          context "with invalid params - each value suffixed with an x" do
             let(:submitted_params) { params.each { |_key, val| val.sub!(/$/, "x") } }
 
             it "is not valid" do

--- a/spec/forms/legal_aid_applications/dependant_form_spec.rb
+++ b/spec/forms/legal_aid_applications/dependant_form_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe LegalAidApplications::DependantForm, type: :form do
     context "with two character year" do
       let(:year) { date.strftime("%y") }
 
-      context "in 20th century" do
+      context "when in 20th century" do
         let(:date) { Faker::Date.between from: 99.years.ago, to: turn_of_century }
 
         it "constructs correct date" do
@@ -59,7 +59,7 @@ RSpec.describe LegalAidApplications::DependantForm, type: :form do
         end
       end
 
-      context "in 21st century" do
+      context "when in 21st century" do
         let(:date) { Faker::Date.between from: turn_of_century, to: Time.zone.today }
 
         it "constructs correct date" do

--- a/spec/forms/legal_aid_applications/percentage_home_form_spec.rb
+++ b/spec/forms/legal_aid_applications/percentage_home_form_spec.rb
@@ -42,28 +42,28 @@ RSpec.describe LegalAidApplications::PercentageHomeForm, type: :form do
       end
     end
 
-    context "percentage_home is empty" do
+    context "when percentage_home is empty" do
       let(:percentage_home) { "" }
       let(:expected_error) { I18n.t("activemodel.errors.models.legal_aid_application.attributes.percentage_home.blank") }
 
       it_behaves_like "it has an error"
     end
 
-    context "percentage_home is not a number" do
+    context "when percentage_home is not a number" do
       let(:percentage_home) { "one thousand percent!" }
       let(:expected_error) { I18n.t("activemodel.errors.models.legal_aid_application.attributes.percentage_home.not_a_number") }
 
       it_behaves_like "it has an error"
     end
 
-    context "percentage_home is less than 0" do
+    context "when percentage_home is less than 0" do
       let(:percentage_home) { -1 }
       let(:expected_error) { I18n.t("activemodel.errors.models.legal_aid_application.attributes.percentage_home.less_than_or_equal_to") }
 
       it_behaves_like "it has an error"
     end
 
-    context "percentage_home is more than 100" do
+    context "when percentage_home is more than 100" do
       let(:percentage_home) { 100.1 }
       let(:expected_error) { I18n.t("activemodel.errors.models.legal_aid_application.attributes.percentage_home.greater_than_or_equal_to") }
 

--- a/spec/forms/legal_aid_applications/restrictions_form_spec.rb
+++ b/spec/forms/legal_aid_applications/restrictions_form_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe LegalAidApplications::RestrictionsForm, type: :form do
       expect(application.has_restrictions).to be true
     end
 
-    context "has no restrictions" do
+    context "when there are no restrictions" do
       let(:has_restrictions) { "false" }
       let(:restrictions_details) { "" }
 
@@ -43,7 +43,7 @@ RSpec.describe LegalAidApplications::RestrictionsForm, type: :form do
       end
     end
 
-    context "params invalid" do
+    context "with invalid params" do
       let(:has_restrictions) { "true" }
       let(:restrictions_details) { "" }
 
@@ -55,7 +55,7 @@ RSpec.describe LegalAidApplications::RestrictionsForm, type: :form do
         expect(subject.errors[:restrictions_details]).to include I18n.t("activemodel.errors.models.legal_aid_application.attributes.restrictions_details.#{journey}.blank")
       end
 
-      context "no restrictions present" do
+      context "with no restrictions present" do
         let(:has_restrictions) { "" }
 
         it "is invalid" do

--- a/spec/forms/legal_aid_applications/used_multiple_delegated_functions_form_spec.rb
+++ b/spec/forms/legal_aid_applications/used_multiple_delegated_functions_form_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe LegalAidApplications::UsedMultipleDelegatedFunctionsForm, type: :
       proceedings.reload
     end
 
-    context "two of the three proceeding types have delegated functions" do
+    context "when two of the three proceeding types have delegated functions" do
       it "updates each proceeding" do
         expect(proceedings.map(&:used_delegated_functions_on)).to match_array([nil, used_delegated_functions_on, used_delegated_functions_on])
         expect(proceedings.map(&:used_delegated_functions_reported_on)).to match_array([nil,
@@ -37,7 +37,7 @@ RSpec.describe LegalAidApplications::UsedMultipleDelegatedFunctionsForm, type: :
                                                                                         used_delegated_functions_reported_on])
       end
 
-      context "date is just within 12 months ago" do
+      context "and the date is just within 12 months ago" do
         let(:used_delegated_functions_on) { today - 12.months + 3.days }
 
         it "is valid" do
@@ -104,7 +104,7 @@ RSpec.describe LegalAidApplications::UsedMultipleDelegatedFunctionsForm, type: :
       end
     end
 
-    context "date is older than 12 months ago" do
+    context "when date is older than 12 months ago" do
       let(:used_delegated_functions_on) { 13.months.ago }
       let(:error_locale) { "used_delegated_functions_on.date_not_in_range" }
 

--- a/spec/forms/opponents/opponent_form_spec.rb
+++ b/spec/forms/opponents/opponent_form_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe Opponents::OpponentForm, type: :form do
       expect(opponent.bail_conditions_set_details).to eq(sample_params["bail_conditions_set_details"])
     end
 
-    context "details are empty but they don't have to be entered" do
+    context "when details are empty but they don't have to be entered" do
       let(:custom_params) do
         {
           understands_terms_of_court_order: "true",
@@ -98,7 +98,7 @@ RSpec.describe Opponents::OpponentForm, type: :form do
       end
     end
 
-    context "radio button are empty" do
+    context "when radio buttons are empty" do
       let(:custom_params) do
         {
           understands_terms_of_court_order: "",
@@ -131,7 +131,7 @@ RSpec.describe Opponents::OpponentForm, type: :form do
       end
     end
 
-    context "details are empty even though they should be present" do
+    context "when details are empty even though they should be present" do
       let(:custom_params) do
         {
           understands_terms_of_court_order: "false",
@@ -186,7 +186,7 @@ RSpec.describe Opponents::OpponentForm, type: :form do
       expect(opponent.bail_conditions_set_details).to eq(sample_params["bail_conditions_set_details"])
     end
 
-    context "radio button are empty" do
+    context "when radio buttons are empty" do
       let(:custom_params) do
         {
           understands_terms_of_court_order: "",
@@ -204,7 +204,7 @@ RSpec.describe Opponents::OpponentForm, type: :form do
       end
     end
 
-    context "details are empty even though they should be present" do
+    context "when details are empty even though they should be present" do
       let(:custom_params) do
         {
           understands_terms_of_court_order: "false",

--- a/spec/forms/savings_amounts/savings_amounts_form_spec.rb
+++ b/spec/forms/savings_amounts/savings_amounts_form_spec.rb
@@ -12,10 +12,10 @@ RSpec.describe SavingsAmounts::SavingsAmountsForm, type: :form do
   let(:form_params) { params.merge(model: savings_amount) }
 
   describe "#save" do
-    context "check boxes are checked" do
+    context "when check boxes are checked" do
       let(:check_box_params) { check_box_attributes.index_with { |_attr| "true" } }
 
-      context "amounts are valid" do
+      context "and the amounts are valid" do
         let(:amount_params) { attributes.index_with { |_attr| rand(1...1_000_000.0).round(2).to_s } }
 
         it "updates all amounts" do
@@ -67,22 +67,22 @@ RSpec.describe SavingsAmounts::SavingsAmountsForm, type: :form do
         end
       end
 
-      context "amounts are empty" do
+      context "when the amounts are empty" do
         let(:amount_params) { attributes.index_with { |_attr| "" } }
         let(:expected_error) { /enter the( estimated)? total/i }
 
         it_behaves_like "it has an error"
       end
 
-      context "amounts are not numbers" do
+      context "when the amounts are not numbers" do
         let(:amount_params) { attributes.index_with { |_attr| Faker::Lorem.word } }
         let(:expected_error) { /must be an amount of money, like 60,000/ }
 
         it_behaves_like "it has an error"
       end
 
-      context "amounts are less than 0" do
-        context "that are not bank account attributes" do
+      context "when the amounts are less than 0" do
+        context "and are not bank account attributes" do
           let(:attribute_map) do
             {
               cash: /total.*cash savings/i,
@@ -115,7 +115,7 @@ RSpec.describe SavingsAmounts::SavingsAmountsForm, type: :form do
         end
       end
 
-      context "amounts have a £ symbol" do
+      context "when the amounts have a £ symbol" do
         let(:amount_params) { attributes.index_with { |_attr| "£#{rand(1...1_000_000.0).round(2)}" } }
 
         it "strips the values of £ symbols" do
@@ -132,14 +132,14 @@ RSpec.describe SavingsAmounts::SavingsAmountsForm, type: :form do
       end
     end
 
-    context "some check boxes are unchecked" do
+    context "when some check boxes are unchecked" do
       let(:check_box_params) do
         boxes = check_box_attributes.index_with { |_attr| "" }
         boxes[:check_box_cash] = "true"
         boxes
       end
 
-      context "amounts are invalid" do
+      context "and the amounts are invalid" do
         let(:amount_params) { attributes.index_with { |_attr| rand(1...1_000_000.0).round(2).to_s } }
 
         it "empties amounts if checkbox is unchecked" do
@@ -166,7 +166,7 @@ RSpec.describe SavingsAmounts::SavingsAmountsForm, type: :form do
         end
       end
 
-      context "amounts are not valid" do
+      context "when the amounts are not valid" do
         let(:amount_params) { attributes.index_with { |_attr| Faker::Lorem.word } }
 
         it "empties amounts" do


### PR DESCRIPTION
Fix GOVUK Rubocop RSpec/ContextWording offences.

Start context description with 'when', 'with', 'without', 'and', or 'but'. (https://rspec.rubystyle.guide/#context-descriptions, https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ContextWording)

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
