### PR TITLE
Fix: Update HMRC::CreateResponseService invocation

### DIFF
--- a/app/controllers/providers/confirm_dwp_non_passported_applications_controller.rb
+++ b/app/controllers/providers/confirm_dwp_non_passported_applications_controller.rb
@@ -68,11 +68,9 @@ module Providers
     end
 
     def make_hmrc_call?
-      correct_dwp_result? && employed_journey_enabled? && hmrc_call_enabled? && user_has_employment_permissions?
-    end
-
-    def display_hmrc_inset_text?
       employed_journey_enabled? && hmrc_call_enabled? && user_has_employment_permissions?
     end
+
+    alias_method :display_hmrc_inset_text?, :make_hmrc_call?
   end
 end

--- a/spec/requests/providers/confirm_dwp_non_passported_applications_spec.rb
+++ b/spec/requests/providers/confirm_dwp_non_passported_applications_spec.rb
@@ -183,9 +183,9 @@ RSpec.describe Providers::ConfirmDWPNonPassportedApplicationsController, type: :
           context "the user has employed permissions" do
             before { allow_any_instance_of(Provider).to receive(:employment_permissions?).and_return(true) }
 
-            it "does not call the HMRC::CreateResponsesService" do
+            it "calls the HMRC::CreateResponsesService" do
               subject
-              expect(HMRC::CreateResponsesService).to_not have_received(:call)
+              expect(HMRC::CreateResponsesService).to have_received(:call)
             end
           end
 


### PR DESCRIPTION
## What

Remove the correct_dwp_result? check from the make_hmrc_call? method

This was an oversight as the HMRC call should be made if the client is employed regardless of the providers response to the DWP result check question

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
