### PR TITLE
Fix GOVUK Rubocop RSpec/ContextWording offences.

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -159,10 +159,6 @@ RSpec/BeforeAfterAll:
 # Prefixes: when, with, without
 RSpec/ContextWording:
   Exclude:
-    - 'spec/factory_specs/legal_aid_application_factory_spec.rb'
-    - 'spec/factory_specs/v4/cfe_result_factory_spec.rb'
-    - 'spec/forms/outstanding_mortgage_form_spec.rb'
-    - 'spec/forms/providers/application_merits_task/involved_child_form_spec.rb'
     - 'spec/forms/providers/proceeding_merits_task/attempts_to_settle_form_spec.rb'
     - 'spec/forms/savings_amounts/offline_accounts_form_spec.rb'
     - 'spec/forms/savings_amounts/savings_amounts_form_spec.rb'

--- a/spec/factory_specs/legal_aid_application_factory_spec.rb
+++ b/spec/factory_specs/legal_aid_application_factory_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe "LegalAidApplication factory" do
         end
       end
 
-      context ":with_applicant specified" do
-        context ":with_bank_accounts not specified" do
+      context "when :with_applicant specified" do
+        context "and :with_bank_accounts not specified" do
           it "has an applicant but no bank accounts" do
             legal_aid_application = create :legal_aid_application, :with_applicant
             expect(legal_aid_application.applicant).to be_present
@@ -19,7 +19,7 @@ RSpec.describe "LegalAidApplication factory" do
           end
         end
 
-        context ":with_bank_accounts specified" do
+        context "when :with_bank_accounts specified" do
           it "has the specified number of bank accounts" do
             legal_aid_application = create :legal_aid_application, :with_applicant, with_bank_accounts: 3
             expect(legal_aid_application.applicant).to be_present
@@ -30,7 +30,7 @@ RSpec.describe "LegalAidApplication factory" do
     end
 
     describe "when used :with_everything" do
-      context ":with_bank_accounts not specified" do
+      context "and :with_bank_accounts not specified" do
         it "creates applicant but no bank accounts" do
           legal_aid_application = create :legal_aid_application, :with_everything
           expect(legal_aid_application.applicant).to be_present
@@ -38,7 +38,7 @@ RSpec.describe "LegalAidApplication factory" do
         end
       end
 
-      context ":with_bank_accounts specified" do
+      context "when :with_bank_accounts specified" do
         it "creates applicant and the specified number of bank accounts" do
           legal_aid_application = create :legal_aid_application, :with_everything, with_bank_accounts: 2
           expect(legal_aid_application.applicant).to be_present

--- a/spec/factory_specs/v4/cfe_result_factory_spec.rb
+++ b/spec/factory_specs/v4/cfe_result_factory_spec.rb
@@ -31,8 +31,8 @@ RSpec.describe "cfe_result version 4 factory" do
                                                     proceeding_types]
     end
 
-    context "within result_summary" do
-      context "within overall_result" do
+    context "when within result_summary" do
+      context "and within overall_result" do
         it "has required keys in matter_types" do
           expect(matter_types.first.keys).to match_array %i[matter_type result]
         end
@@ -42,12 +42,12 @@ RSpec.describe "cfe_result version 4 factory" do
         end
       end
 
-      context "within gross_income" do
+      context "when within gross_income" do
         it "has required keys" do
           expect(gross_income_summary.keys).to match_array %i[total_gross_income proceeding_types]
         end
 
-        context "within proceeding_types" do
+        context "and within proceeding_types" do
           let(:proceeding_types) { gross_income_summary[:proceeding_types].first }
 
           it "has required keys" do
@@ -56,7 +56,7 @@ RSpec.describe "cfe_result version 4 factory" do
         end
       end
 
-      context "within disposable_income" do
+      context "when within disposable_income" do
         it "has required keys" do
           expect(disposable_income_summary.keys).to match_array %i[dependant_allowance
                                                                    employment_income
@@ -70,7 +70,7 @@ RSpec.describe "cfe_result version 4 factory" do
                                                                    proceeding_types]
         end
 
-        context "within proceeding_types" do
+        context "and within proceeding_types" do
           let(:proceeding_types) { disposable_income_summary[:proceeding_types].first }
 
           it "has required keys" do
@@ -79,7 +79,7 @@ RSpec.describe "cfe_result version 4 factory" do
         end
       end
 
-      context "within capital" do
+      context "when within capital" do
         it "has required keys" do
           expect(capital_summary.keys).to match_array %i[total_liquid
                                                          total_non_liquid
@@ -93,7 +93,7 @@ RSpec.describe "cfe_result version 4 factory" do
                                                          proceeding_types]
         end
 
-        context "within proceeding_types" do
+        context "and within proceeding_types" do
           let(:proceeding_types) { capital_summary[:proceeding_types].first }
 
           it "has required keys" do
@@ -103,7 +103,7 @@ RSpec.describe "cfe_result version 4 factory" do
       end
     end
 
-    context "within assessment" do
+    context "when within assessment" do
       it "has required keys" do
         expect(assessment.keys).to match_array %i[id
                                                   client_reference_id

--- a/spec/forms/outstanding_mortgage_form_spec.rb
+++ b/spec/forms/outstanding_mortgage_form_spec.rb
@@ -40,13 +40,13 @@ RSpec.describe LegalAidApplications::OutstandingMortgageForm, type: :form do
       expect { subject.save }.not_to change { LegalAidApplication }
     end
 
-    context "is called" do
+    context "when it is called" do
       before do
         subject.save
         legal_aid_application.reload
       end
 
-      it "updates ammount" do
+      it "updates amount" do
         expect(legal_aid_application.outstanding_mortgage_amount).to eq(amount.to_d)
       end
 

--- a/spec/forms/providers/application_merits_task/involved_child_form_spec.rb
+++ b/spec/forms/providers/application_merits_task/involved_child_form_spec.rb
@@ -18,13 +18,13 @@ module Providers
       end
 
       describe "#valid?" do
-        context "all fields valid" do
+        context "when all fields are valid" do
           it "returns true" do
             expect(subject).to be_valid
           end
         end
 
-        context "missing name" do
+        context "when missing name" do
           let(:full_name) { "" }
 
           it "returns false" do
@@ -33,7 +33,7 @@ module Providers
           end
         end
 
-        context "missing date of birth" do
+        context "when missing date of birth" do
           let(:params) do
             {
               full_name:,
@@ -49,7 +49,7 @@ module Providers
           end
         end
 
-        context "invalid date of birth" do
+        context "with invalid date of birth" do
           let(:params) do
             {
               full_name:,


### PR DESCRIPTION
Fix GOVUK Rubocop RSpec/ContextWording offences.

Start context description with 'when', 'with', 'without', 'and', or 'but'. (https://rspec.rubystyle.guide/#context-descriptions, https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ContextWording)

## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-XXX)

Describe what you did and why.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
