### PR TITLE
Fix GOVUK Rubocop RSpec/ContextWording offences.

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -159,14 +159,6 @@ RSpec/BeforeAfterAll:
 # Prefixes: when, with, without
 RSpec/ContextWording:
   Exclude:
-    - 'spec/jobs/bank_transactions_analyser_job_spec.rb'
-    - 'spec/jobs/dashboard/applicant_email_job_spec.rb'
-    - 'spec/jobs/dashboard/feedback_item_job_spec.rb'
-    - 'spec/jobs/dashboard/provider_data_job_spec.rb'
-    - 'spec/jobs/dashboard/updater_job_spec.rb'
-    - 'spec/jobs/email_monitor_job_spec.rb'
-    - 'spec/jobs/reports_uploader_job_spec.rb'
-    - 'spec/jobs/scheduled_mailings_delivery_job_spec.rb'
     - 'spec/lib/alert_manager_spec.rb'
     - 'spec/lib/authorized_ip_ranges_spec.rb'
     - 'spec/lib/id_p_settings_adapter_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -159,9 +159,6 @@ RSpec/BeforeAfterAll:
 # Prefixes: when, with, without
 RSpec/ContextWording:
   Exclude:
-    - 'spec/forms/providers/proceeding_merits_task/attempts_to_settle_form_spec.rb'
-    - 'spec/forms/savings_amounts/offline_accounts_form_spec.rb'
-    - 'spec/forms/savings_amounts/savings_amounts_form_spec.rb'
     - 'spec/helpers/accessible_navigation_helper_spec.rb'
     - 'spec/helpers/check_answer_url_helper_spec.rb'
     - 'spec/helpers/hash_format_helper_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -159,13 +159,6 @@ RSpec/BeforeAfterAll:
 # Prefixes: when, with, without
 RSpec/ContextWording:
   Exclude:
-    - 'spec/helpers/accessible_navigation_helper_spec.rb'
-    - 'spec/helpers/check_answer_url_helper_spec.rb'
-    - 'spec/helpers/hash_format_helper_spec.rb'
-    - 'spec/helpers/money_helper_spec.rb'
-    - 'spec/helpers/policy_disregards_helper_spec.rb'
-    - 'spec/helpers/task_list_helper_spec.rb'
-    - 'spec/helpers/user_transactions_helper_spec.rb'
     - 'spec/i18n_spec.rb'
     - 'spec/jobs/bank_transactions_analyser_job_spec.rb'
     - 'spec/jobs/dashboard/applicant_email_job_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -159,7 +159,6 @@ RSpec/BeforeAfterAll:
 # Prefixes: when, with, without
 RSpec/ContextWording:
   Exclude:
-    - 'spec/i18n_spec.rb'
     - 'spec/jobs/bank_transactions_analyser_job_spec.rb'
     - 'spec/jobs/dashboard/applicant_email_job_spec.rb'
     - 'spec/jobs/dashboard/feedback_item_job_spec.rb'

--- a/spec/forms/providers/proceeding_merits_task/attempts_to_settle_form_spec.rb
+++ b/spec/forms/providers/proceeding_merits_task/attempts_to_settle_form_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Providers::ProceedingMeritsTask::AttemptsToSettleForm, type: :for
   let(:params) { { attempts_made: } }
 
   describe "#save" do
-    context "validation" do
+    context "with validation" do
       before { form.valid? }
 
       context "when the parameters are populated" do

--- a/spec/forms/savings_amounts/offline_accounts_form_spec.rb
+++ b/spec/forms/savings_amounts/offline_accounts_form_spec.rb
@@ -12,10 +12,10 @@ RSpec.describe SavingsAmounts::OfflineAccountsForm, type: :form do
   let(:form_params) { params.merge(model: savings_amount) }
 
   describe "#save" do
-    context "check boxes are checked" do
+    context "when check boxes are checked" do
       let(:check_box_params) { check_box_attributes.index_with { |_attr| "true" } }
 
-      context "amounts are valid" do
+      context "when amounts are valid" do
         let(:amount_params) { attributes.index_with { |_attr| rand(1...1_000_000.0).round(2).to_s } }
 
         it "updates all amounts" do
@@ -63,21 +63,21 @@ RSpec.describe SavingsAmounts::OfflineAccountsForm, type: :form do
         end
       end
 
-      context "amounts are empty" do
+      context "when amounts are empty" do
         let(:amount_params) { attributes.index_with { |_attr| "" } }
         let(:expected_error) { /enter the( estimated)? total/i }
 
         it_behaves_like "it has an error"
       end
 
-      context "amounts are not numbers" do
+      context "when amounts are not numbers" do
         let(:amount_params) { attributes.index_with { |_attr| Faker::Lorem.word } }
         let(:expected_error) { /must be an amount of money, like 60,000/ }
 
         it_behaves_like "it has an error"
       end
 
-      context "amounts have a £ symbol" do
+      context "when amounts have a £ symbol" do
         let(:amount_params) { attributes.index_with { |_attr| "£#{rand(1...1_000_000.0).round(2)}" } }
 
         it "strips the values of £ symbols" do
@@ -94,7 +94,7 @@ RSpec.describe SavingsAmounts::OfflineAccountsForm, type: :form do
       end
     end
 
-    context "some check boxes are unchecked" do
+    context "when some check boxes are unchecked" do
       let(:check_box_params) do
         {
           check_box_offline_current_accounts: "true",
@@ -103,7 +103,7 @@ RSpec.describe SavingsAmounts::OfflineAccountsForm, type: :form do
         }
       end
 
-      context "amounts are invalid" do
+      context "when amounts are invalid" do
         let(:amount_params) do
           {
             offline_current_accounts: rand(1...1_000_000.0).round(2).to_s,
@@ -131,7 +131,7 @@ RSpec.describe SavingsAmounts::OfflineAccountsForm, type: :form do
         end
       end
 
-      context "amounts are not valid" do
+      context "when amounts are not valid" do
         let(:amount_params) { attributes.index_with { |_attr| Faker::Lorem.word } }
 
         it "empties amounts" do
@@ -147,7 +147,7 @@ RSpec.describe SavingsAmounts::OfflineAccountsForm, type: :form do
         end
       end
 
-      context "none of the amount check boxes is checked" do
+      context "when the 'none of these' check box is checked" do
         let(:check_box_params) do
           {
             check_box_offline_current_accounts: "",
@@ -162,7 +162,7 @@ RSpec.describe SavingsAmounts::OfflineAccountsForm, type: :form do
         end
       end
 
-      context "no check box at all is checked" do
+      context "when no check box at all is checked" do
         let(:check_box_params) do
           {
             check_box_offline_current_accounts: "",

--- a/spec/forms/savings_amounts/savings_amounts_form_spec.rb
+++ b/spec/forms/savings_amounts/savings_amounts_form_spec.rb
@@ -184,7 +184,7 @@ RSpec.describe SavingsAmounts::SavingsAmountsForm, type: :form do
         end
       end
 
-      context "if none of the check boxes are checked" do
+      context "when none of the check boxes are checked" do
         let(:check_box_params) do
           boxes = check_box_attributes.index_with { |_attr| "" }
           boxes[:none_selected] = ""
@@ -192,13 +192,13 @@ RSpec.describe SavingsAmounts::SavingsAmountsForm, type: :form do
         end
         let(:journey) { "citizens" }
 
-        it "returns true" do
+        it "doesnt save and validation returns an error message" do
           expect(subject.save).to be(false)
           expect(subject.errors[:check_box_cash]).to include(I18n.t("activemodel.errors.models.savings_amount.attributes.base.#{journey}.none_selected"))
         end
       end
 
-      context "none of these check box is checked" do
+      context "when the 'none selected' check box is checked" do
         let(:check_box_params) do
           boxes = check_box_attributes.index_with { |_attr| "" }
           boxes[:none_selected] = "true"

--- a/spec/helpers/accessible_navigation_helper_spec.rb
+++ b/spec/helpers/accessible_navigation_helper_spec.rb
@@ -81,21 +81,21 @@ RSpec.describe AccessibleNavigationHelper, type: :helper do
   end
 
   describe "#set_accessible_properties" do
-    context "standard html label" do
+    context "with standard html label" do
       it "sets aria-labels using the label name provided" do
         options = set_accessible_properties("name", {})
         expect(options).to eq({ aria: { label: "name" } })
       end
     end
 
-    context "html label with suffix" do
+    context "with html label with suffix" do
       it "sets aria-labels using the label name provided" do
         options = set_accessible_properties("Change", { suffix: "First Name" })
         expect(options).to eq({ aria: { label: "Change First Name" }, suffix: "First Name" })
       end
     end
 
-    context "html label with content tagging" do
+    context "with html label with content tagging" do
       it "sets aria-labels using just the content of the label name provided" do
         options = set_accessible_properties('Start now <svg label="label"></svg>', {})
         expect(options).to eq({ aria: { label: "Start now" } })

--- a/spec/helpers/check_answer_url_helper_spec.rb
+++ b/spec/helpers/check_answer_url_helper_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe CheckAnswerUrlHelper, type: :helper do
   let(:application) { create :legal_aid_application }
 
   describe "#check_answer_url_for" do
-    context "provider" do
+    context "when a provider" do
       it "returns the path" do
         url = check_answer_url_for(:providers, :own_homes, application)
         expect(url).to eq "/providers/applications/#{application.id}/own_home?locale=en"
@@ -25,15 +25,15 @@ RSpec.describe CheckAnswerUrlHelper, type: :helper do
       end
     end
 
-    context "citizen" do
-      context "default locale" do
+    context "when a citizen" do
+      context "with default locale" do
         it "returns the path with en locale" do
           url = check_answer_url_for(:citizens, :consents)
           expect(url).to eq "/citizens/consent?locale=en"
         end
       end
 
-      context "Welsh locale" do
+      context "with Welsh locale" do
         around(:each) do |example|
           I18n.with_locale(:cy) { example.run }
         end

--- a/spec/helpers/hash_format_helper_spec.rb
+++ b/spec/helpers/hash_format_helper_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe HashFormatHelper, type: :helper do
       it { is_expected.to eql expected_response }
     end
 
-    context "hash has key but no value" do
+    context "when hash has key but no value" do
       let(:source) { { result: nil } }
 
       it "returns empty string" do

--- a/spec/helpers/money_helper_spec.rb
+++ b/spec/helpers/money_helper_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe MoneyHelper, type: :helper do
   describe "#number_to_currency_or_original_string" do
     let(:result) { number_to_currency_or_original_string(value) }
 
-    context "is a number" do
+    context "when a number" do
       let(:value) { BigDecimal("12_345.5", 12) }
 
       it "formats the currency" do
@@ -42,7 +42,7 @@ RSpec.describe MoneyHelper, type: :helper do
       end
     end
 
-    context "invalid numeric string" do
+    context "when an invalid numeric string" do
       let(:value) { "12345.5678" }
 
       it "returns original value" do
@@ -50,7 +50,7 @@ RSpec.describe MoneyHelper, type: :helper do
       end
     end
 
-    context "invalid alphanumeric string" do
+    context "when an invalid alphanumeric string" do
       let(:value) { "123xc45.5678" }
 
       it "returns original value" do
@@ -62,7 +62,7 @@ RSpec.describe MoneyHelper, type: :helper do
   describe "#number?" do
     let(:result) { number?(value) }
 
-    context "int numeric" do
+    context "when int numeric" do
       let(:value) { 12 }
 
       it "returns true when integer" do
@@ -70,7 +70,7 @@ RSpec.describe MoneyHelper, type: :helper do
       end
     end
 
-    context "string numeric" do
+    context "when string numeric" do
       let(:value) { "12.25" }
 
       it "returns true when numeric string" do
@@ -78,7 +78,7 @@ RSpec.describe MoneyHelper, type: :helper do
       end
     end
 
-    context "string word" do
+    context "when a string word" do
       let(:value) { "fifty" }
 
       it "returns false when not numeric string or integer" do
@@ -90,7 +90,7 @@ RSpec.describe MoneyHelper, type: :helper do
   describe "#valid_amount?" do
     let(:result) { valid_amount?(value) }
 
-    context "int numeric" do
+    context "when int numeric" do
       let(:value) { 12 }
 
       it "returns true when integer greater than zero" do
@@ -98,7 +98,7 @@ RSpec.describe MoneyHelper, type: :helper do
       end
     end
 
-    context "int zero" do
+    context "when int zero" do
       let(:value) { 0 }
 
       it "returns true when integer zero" do
@@ -106,7 +106,7 @@ RSpec.describe MoneyHelper, type: :helper do
       end
     end
 
-    context "int negative" do
+    context "when int negative" do
       let(:value) { -1 }
 
       it "returns false when integer less than zero" do
@@ -114,7 +114,7 @@ RSpec.describe MoneyHelper, type: :helper do
       end
     end
 
-    context "string numeric" do
+    context "when string numeric" do
       let(:value) { "12.25" }
 
       it "returns true when numeric string greater than zero" do
@@ -122,7 +122,7 @@ RSpec.describe MoneyHelper, type: :helper do
       end
     end
 
-    context "string negative" do
+    context "when string negative" do
       let(:value) { "-1" }
 
       it "returns false when numeric string less than zero" do
@@ -134,7 +134,7 @@ RSpec.describe MoneyHelper, type: :helper do
   describe "#gds_number_to_currency" do
     let(:result) { gds_number_to_currency(value) }
 
-    context "int pounds with pence" do
+    context "when int pounds with pence" do
       let(:value) { 12_345.2499 }
 
       it "displays pounds and pence" do
@@ -142,7 +142,7 @@ RSpec.describe MoneyHelper, type: :helper do
       end
     end
 
-    context "int pounds only" do
+    context "when int pounds only" do
       let(:value) { 12_345.0000 }
 
       it "displays pounds only" do
@@ -150,7 +150,7 @@ RSpec.describe MoneyHelper, type: :helper do
       end
     end
 
-    context "string numeric pounds" do
+    context "when string numeric pounds" do
       let(:value) { "5000.0000" }
 
       it "displays pounds only" do
@@ -158,7 +158,7 @@ RSpec.describe MoneyHelper, type: :helper do
       end
     end
 
-    context "string numeric pounds and pence" do
+    context "when string numeric pounds and pence" do
       let(:value) { "5000.2499" }
 
       it "displays pounds and pence" do
@@ -166,7 +166,7 @@ RSpec.describe MoneyHelper, type: :helper do
       end
     end
 
-    context "preserves other options" do
+    context "when it preserves other options" do
       let(:value) { 12_345.25 }
       let(:opts) { { unit: "$", delimiter: " ", separator: "," } }
       let(:result) { gds_number_to_currency(value, opts) }
@@ -176,7 +176,7 @@ RSpec.describe MoneyHelper, type: :helper do
       end
     end
 
-    context "returns when not numeric" do
+    context "when not numeric" do
       let(:value) { "fifty" }
 
       it "displays pounds only" do
@@ -184,7 +184,7 @@ RSpec.describe MoneyHelper, type: :helper do
       end
     end
 
-    context "BigDecimal" do
+    context "when a BigDecimal" do
       let(:value) { BigDecimal("12345.25") }
 
       it "displays pounds and pence when BigDecimal" do

--- a/spec/helpers/policy_disregards_helper_spec.rb
+++ b/spec/helpers/policy_disregards_helper_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe PolicyDisregardsHelper, type: :helper do
   describe "#policy_disregards_hash" do
     let(:result) { policy_disregards_list(policy_disregards) }
 
-    context "no disregards selected" do
+    context "with no disregards selected" do
       let(:policy_disregards) { create :policy_disregards, none_selected: true }
 
       it "does not return nil" do
@@ -18,7 +18,7 @@ RSpec.describe PolicyDisregardsHelper, type: :helper do
       end
     end
 
-    context "disregards selected" do
+    context "with disregards selected" do
       let(:policy_disregards) { create :policy_disregards, none_selected: false, england_infected_blood_support: true }
 
       it "returns the correct hash" do

--- a/spec/helpers/task_list_helper_spec.rb
+++ b/spec/helpers/task_list_helper_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe TaskListHelper, type: :helper do
       end
     end
 
-    context "chances of success" do
+    context "with chances of success" do
       let(:proceeding) { legal_aid_application.proceedings.find_by(ccms_code: "DA001") }
 
       let(:expected) do

--- a/spec/helpers/user_transactions_helper_spec.rb
+++ b/spec/helpers/user_transactions_helper_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe UserTransactionsHelper, type: :helper do
   describe "#incomings_list" do
     subject { helper.incomings_list(legal_aid_application.transaction_types.credits, locale_namespace:) }
 
-    context "for citizen" do
+    context "when for a citizen" do
       let(:locale_namespace) { "transaction_types.names.citizens" }
 
       it "returns correct hash" do
@@ -31,7 +31,7 @@ RSpec.describe UserTransactionsHelper, type: :helper do
         end
       end
 
-      context "no transactions" do
+      context "with no transactions" do
         let(:legal_aid_application) { create :legal_aid_application }
 
         it "returns nil" do
@@ -46,14 +46,14 @@ RSpec.describe UserTransactionsHelper, type: :helper do
 
     let(:transaction_type) { create :transaction_type, :maintenance_out }
 
-    context "for citizen" do
+    context "when for a citizen" do
       let(:locale_namespace) { "transaction_types.names.citizens" }
 
       it "returns correct hash" do
         expect(subject[:items].first.to_h).to match hash_result
       end
 
-      context "no transactions" do
+      context "with no transactions" do
         let(:legal_aid_application) { create :legal_aid_application }
 
         it "returns nil" do

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "I18n", :i18n do
   let(:i18n) { I18n::Tasks::BaseTask.new }
   let(:missing_keys) { i18n.missing_keys[locale] || I18n::Tasks::Data::Tree::Siblings.new }
 
-  context "English" do
+  context "with English" do
     let(:locale) { "en" }
 
     it "does not have missing keys" do
@@ -14,7 +14,7 @@ RSpec.describe "I18n", :i18n do
     end
   end
 
-  context "Welsh" do
+  context "with Welsh" do
     let(:locale) { "cy" }
     let(:welsh_paths) { ["/accessibility_statement", "/citizen", "/contact", "/error", "/feedback", "/privacy_policy"] }
 

--- a/spec/jobs/bank_transactions_analyser_job_spec.rb
+++ b/spec/jobs/bank_transactions_analyser_job_spec.rb
@@ -36,8 +36,8 @@ module Banking
         expect(legal_aid_application.reload.state).to eq("provider_assessing_means")
       end
 
-      context "transactions analysis" do
-        context "pending" do
+      context "with transactions analysis" do
+        context "when pending" do
           before do
             allow_any_instance_of(NonPassportedStateMachine).to receive(:aasm_state).and_return("analysing_bank_transactions")
           end
@@ -48,7 +48,7 @@ module Banking
           end
         end
 
-        context "complete" do
+        context "when complete" do
           it "calls ProviderEmailService" do
             expect(provider_email_service).to receive(:send_email)
             subject

--- a/spec/jobs/dashboard/applicant_email_job_spec.rb
+++ b/spec/jobs/dashboard/applicant_email_job_spec.rb
@@ -19,7 +19,7 @@ module Dashboard
       end
 
       describe "#perform" do
-        context "job is not in the suspended list" do
+        context "when job is not in the suspended list" do
           before { allow(HostEnv).to receive(:environment).and_return(:production) }
 
           it "calls the applicant email job" do
@@ -28,7 +28,7 @@ module Dashboard
           end
         end
 
-        context "job is in the suspended list" do
+        context "when job is in the suspended list" do
           before { allow(HostEnv).to receive(:environment).and_return(:development) }
 
           it "does not call the applicant email job" do
@@ -37,13 +37,13 @@ module Dashboard
           end
         end
 
-        context "job is sending email to an Apply team email" do
+        context "when job is sending email to an Apply team email" do
           let(:applicant) { create :applicant, email: Rails.configuration.x.email_domain.suffix }
           let(:application) { create :legal_aid_application, applicant: }
 
           before { allow(HostEnv).to receive(:environment).and_return(:production) }
 
-          context "in production environment" do
+          context "when in production environment" do
             before { allow(Rails.env).to receive(:production?).and_return(true) }
 
             it "does not call the applicant email job" do
@@ -52,7 +52,7 @@ module Dashboard
             end
           end
 
-          context "not in production environment" do
+          context "when not in production environment" do
             before { allow(Rails.env).to receive(:production?).and_return(false) }
 
             it "calls the applicant email job" do

--- a/spec/jobs/dashboard/feedback_item_job_spec.rb
+++ b/spec/jobs/dashboard/feedback_item_job_spec.rb
@@ -20,21 +20,25 @@ module Dashboard
       end
 
       describe "#perform" do
-        context "job is not in the suspended list" do
+        context "when in the production environment" do
           before { allow(HostEnv).to receive(:environment).and_return(:production) }
 
-          it "calls the runs the geckoboard feedback updater" do
-            expect_any_instance_of(Dashboard::SingleObject::Feedback).to receive(:run)
-            subject
+          context "and the job is not in the suspended list" do
+            it "runs the geckoboard feedback updater" do
+              expect_any_instance_of(Dashboard::SingleObject::Feedback).to receive(:run)
+              subject
+            end
           end
         end
 
-        context "job is not in the suspended list" do
+        context "when in the UAT environment" do
           before { allow(HostEnv).to receive(:environment).and_return(:uat) }
 
-          it "calls the runs the geckoboard feedback updater" do
-            expect_any_instance_of(Dashboard::SingleObject::Feedback).not_to receive(:run)
-            subject
+          context "and the job is not in the suspended list" do
+            it "does not run the geckoboard feedback updater" do
+              expect_any_instance_of(Dashboard::SingleObject::Feedback).not_to receive(:run)
+              subject
+            end
           end
         end
       end

--- a/spec/jobs/dashboard/provider_data_job_spec.rb
+++ b/spec/jobs/dashboard/provider_data_job_spec.rb
@@ -19,21 +19,25 @@ module Dashboard
       end
 
       describe "#perform" do
-        context "job is not in the suspended list" do
+        context "when in the production environment" do
           before { allow(HostEnv).to receive(:environment).and_return(:production) }
 
-          it "calls runs ProviderData" do
-            expect_any_instance_of(Dashboard::SingleObject::ProviderData).to receive(:run)
-            subject
+          context "and the job is not in the suspended list" do
+            it "runs ProviderData" do
+              expect_any_instance_of(Dashboard::SingleObject::ProviderData).to receive(:run)
+              subject
+            end
           end
         end
 
-        context "job is not in the suspended list" do
+        context "when in the test environment" do
           before { allow(HostEnv).to receive(:environment).and_return(:test) }
 
-          it "does not run ProviderData" do
-            expect_any_instance_of(Dashboard::SingleObject::ProviderData).not_to receive(:run)
-            subject
+          context "and the job is not in the suspended list" do
+            it "does not run ProviderData" do
+              expect_any_instance_of(Dashboard::SingleObject::ProviderData).not_to receive(:run)
+              subject
+            end
           end
         end
       end

--- a/spec/jobs/dashboard/updater_job_spec.rb
+++ b/spec/jobs/dashboard/updater_job_spec.rb
@@ -5,19 +5,23 @@ module Dashboard
     let(:suspended_list) { Rails.configuration.x.suspended_dashboard_updater_jobs }
 
     describe "#perform" do
-      context "job is not in the suspended list" do
+      context "when in the production environment" do
         before { allow(HostEnv).to receive(:environment).and_return(:production) }
 
-        it "instantiates widget with the specified parameter" do
-          expect(Dashboard::Widget).to receive(:new).with("MyWidget").and_return(double("WidgetDataProvider", run: nil))
-          described_class.perform_now("MyWidget")
+        context "and job is not in the suspended list" do
+          it "instantiates widget with the specified parameter" do
+            expect(Dashboard::Widget).to receive(:new).with("MyWidget").and_return(double("WidgetDataProvider", run: nil))
+            described_class.perform_now("MyWidget")
+          end
         end
       end
 
-      context "job is in the suspended list (host environment: test)" do
-        it "does not instantiate widget with the specified parameter" do
-          expect(Dashboard::Widget).not_to receive(:new).with("MyWidget")
-          described_class.perform_now("MyWidget")
+      context "when in the test environment" do
+        context "and job is in the suspended list" do
+          it "does not instantiate widget with the specified parameter" do
+            expect(Dashboard::Widget).not_to receive(:new).with("MyWidget")
+            described_class.perform_now("MyWidget")
+          end
         end
       end
     end

--- a/spec/jobs/email_monitor_job_spec.rb
+++ b/spec/jobs/email_monitor_job_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe EmailMonitorJob, type: :job do
       described_class.new.perform
     end
 
-    context "no subsequent job in queue" do
+    context "with no subsequent job in queue" do
       let(:job) { double "Job", perform_later: nil }
 
       before { allow(GovukEmails::Monitor).to receive(:call).at_least(1) }
@@ -26,7 +26,7 @@ RSpec.describe EmailMonitorJob, type: :job do
       end
     end
 
-    context "subsequen monitor job already in queue" do
+    context "with subsequent monitor job already in queue" do
       before { allow(GovukEmails::Monitor).to receive(:call).at_least(1) }
 
       it "does not schedule another job" do

--- a/spec/jobs/reports_uploader_job_spec.rb
+++ b/spec/jobs/reports_uploader_job_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe ReportsUploaderJob, type: :job do
       filename
     end
 
-    context "AdminReport record does not exist" do
+    context "when AdminReport record does not exist" do
       before { AdminReport.delete_all }
 
       it "creates an admin report" do
@@ -42,7 +42,7 @@ RSpec.describe ReportsUploaderJob, type: :job do
       end
     end
 
-    context "AdminReport record already exists" do
+    context "when AdminReport record already exists" do
       before { create :admin_report, :with_reports_attached }
 
       it "does not create another record" do

--- a/spec/jobs/scheduled_mailings_delivery_job_spec.rb
+++ b/spec/jobs/scheduled_mailings_delivery_job_spec.rb
@@ -10,14 +10,14 @@ RSpec.describe ScheduledMailingsDeliveryJob do
     let!(:mailing_two) { create :scheduled_mailing, :due_later }
 
     describe "perform" do
-      context "calling DeliveryMan" do
+      context "when calling DeliveryMan" do
         it "calls DeliveryMan for each due item" do
           expect(GovukEmails::DeliveryMan).to receive(:call).with(mailing_one.id)
           subject
         end
       end
 
-      context "rescheduling the next Delivery job" do
+      context "when rescheduling the next Delivery job" do
         let(:short_delay) { ScheduledMailingsDeliveryJob::DEFAULT_DELAY - 20.seconds }
         let(:early_job) { MockQueuedJob.new(described_class, short_delay.from_now) }
 
@@ -26,7 +26,7 @@ RSpec.describe ScheduledMailingsDeliveryJob do
           allow(GovukEmails::DeliveryMan).to receive(:call)
         end
 
-        context "Delivery job already scheduled for a few seconds from now" do
+        context "when Delivery job is already scheduled for a few seconds from now" do
           let(:job_queue) { [early_job] }
 
           it "does not schedule another job" do
@@ -35,7 +35,7 @@ RSpec.describe ScheduledMailingsDeliveryJob do
           end
         end
 
-        context "nothing in the queue" do
+        context "when nothing is in the queue" do
           let(:job_queue) { [] }
           let(:job) { double "Sidekiq Job", perform_later: nil }
           let(:delay) { ScheduledMailingsDeliveryJob::DEFAULT_DELAY }
@@ -47,7 +47,7 @@ RSpec.describe ScheduledMailingsDeliveryJob do
         end
       end
 
-      context "scheduling the Monitoring job" do
+      context "when scheduling the Monitoring job" do
         let(:short_delay) { EmailMonitorJob::DEFAULT_DELAY - 20.seconds }
         let(:early_job) { MockQueuedJob.new(EmailMonitorJob, short_delay.from_now) }
 
@@ -56,7 +56,7 @@ RSpec.describe ScheduledMailingsDeliveryJob do
           allow(GovukEmails::DeliveryMan).to receive(:call)
         end
 
-        context "monitoring job already scheduled for a few seconds from now" do
+        context "when monitoring the job already scheduled for a few seconds from now" do
           let(:job_queue) { [early_job] }
 
           it "does not schedule another job" do
@@ -65,10 +65,10 @@ RSpec.describe ScheduledMailingsDeliveryJob do
           end
         end
 
-        context "nothing in the queue" do
+        context "when nothing is in the queue" do
           let(:job_queue) { [] }
 
-          it "starts a montoring job" do
+          it "starts a monitoring job" do
             expect(EmailMonitorJob).to receive(:perform_later)
             subject
           end


### PR DESCRIPTION
Fix GOVUK Rubocop RSpec/ContextWording offences.

Start context description with 'when', 'with', 'without', 'and', or 'but'. (https://rspec.rubystyle.guide/#context-descriptions, https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ContextWording)

## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-XXX)

Describe what you did and why.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
