### PR TITLE
AP-3091 Extra employment info on application Digest

### DIFF
--- a/app/models/application_digest.rb
+++ b/app/models/application_digest.rb
@@ -83,7 +83,7 @@ class ApplicationDigest < ApplicationRecord
 
     def determine_caseworker_review?(laa)
       # return false if the assessment hasn't been done yet
-      return false if laa.cfe_result.nil?
+      return false if laa.cfe_result.nil? || laa.cfe_result.result.nil?
 
       CCMS::ManualReviewDeterminer.new(laa).manual_review_required?
     end

--- a/app/models/application_digest.rb
+++ b/app/models/application_digest.rb
@@ -1,6 +1,13 @@
 class ApplicationDigest < ApplicationRecord
   COLUMNS_TO_OMIT = %w[id updated_at created_at].freeze
-  BOOLEAN_COLUMNS = %w[use_ccms passported df_used].freeze
+  BOOLEAN_COLUMNS = %w[
+    use_ccms
+    passported
+    df_used
+    employed
+    hmrc_data_used
+    referred_to_caseworker
+  ].freeze
 
   class << self
     def create_or_update!(legal_aid_application_id)
@@ -32,6 +39,9 @@ class ApplicationDigest < ApplicationRecord
         earliest_df_date: laa.earliest_delegated_functions_date,
         df_reported_date: laa.earliest_delegated_functions_reported_date,
         working_days_to_report_df: working_days_to_report(laa),
+        employed: laa.applicant.employed?,
+        hmrc_data_used: true,
+        referred_to_caseworker: true,
       }
     end
 

--- a/app/services/flow/flows/provider_capital.rb
+++ b/app/services/flow/flows/provider_capital.rb
@@ -88,21 +88,8 @@ module Flow
             when :employed_journey_not_enabled, :provider_not_enabled_for_employed_journey, :applicant_not_employed
               application.income_types? ? :income_summary : :no_income_summaries
             else
-              raise "Unexpected hmrc status #{status}"
+              raise "Unexpected hmrc status #{status.inspect}"
             end
-
-            # if Setting.enable_employed_journey? && application.provider.employment_permissions?
-            #   # either applicant has multiple jobs or no job data is returned even though they're employed
-            #   if application.has_multiple_employments? || (application.applicant.employed? && !application.hmrc_employment_income?)
-            #     :full_employment_details
-            #   elsif application.hmrc_employment_income?
-            #     :employment_incomes
-            #   else
-            #     application.income_types? ? :income_summary : :no_income_summaries
-            #   end
-            # else
-            #   application.income_types? ? :income_summary : :no_income_summaries
-            # end
           end,
         },
         employment_incomes: {

--- a/app/services/flow/flows/provider_capital.rb
+++ b/app/services/flow/flows/provider_capital.rb
@@ -79,18 +79,30 @@ module Flow
         client_completed_means: {
           path: ->(application) { urls.providers_legal_aid_application_client_completed_means_path(application) },
           forward: lambda do |application|
-            if Setting.enable_employed_journey? && application.provider.employment_permissions?
-              # either applicant has multiple jobs or no job data is returned even though they're employed
-              if application.has_multiple_employments? || (application.applicant.employed? && !application.hmrc_employment_income?)
-                :full_employment_details
-              elsif application.hmrc_employment_income?
-                :employment_incomes
-              else
-                application.income_types? ? :income_summary : :no_income_summaries
-              end
-            else
+            status = HMRC::StatusAnalyzer.call(application)
+            case status
+            when :hmrc_multiple_employments, :no_hmrc_data
+              :full_employment_details
+            when :hmrc_single_employment
+              :employment_incomes
+            when :employed_journey_not_enabled, :provider_not_enabled_for_employed_journey, :applicant_not_employed
               application.income_types? ? :income_summary : :no_income_summaries
+            else
+              raise "Unexpected hmrc status #{status}"
             end
+
+            # if Setting.enable_employed_journey? && application.provider.employment_permissions?
+            #   # either applicant has multiple jobs or no job data is returned even though they're employed
+            #   if application.has_multiple_employments? || (application.applicant.employed? && !application.hmrc_employment_income?)
+            #     :full_employment_details
+            #   elsif application.hmrc_employment_income?
+            #     :employment_incomes
+            #   else
+            #     application.income_types? ? :income_summary : :no_income_summaries
+            #   end
+            # else
+            #   application.income_types? ? :income_summary : :no_income_summaries
+            # end
           end,
         },
         employment_incomes: {

--- a/app/services/hmrc/status_analyzer.rb
+++ b/app/services/hmrc/status_analyzer.rb
@@ -1,0 +1,33 @@
+module HMRC
+  class StatusAnalyzer
+    delegate :provider,
+             :applicant,
+             :has_multiple_employments?,
+             :hmrc_employment_income?,
+             to: :legal_aid_application
+
+    attr_reader :legal_aid_application
+
+    def self.call(legal_aid_application)
+      new(legal_aid_application).call
+    end
+
+    def initialize(legal_aid_application)
+      @legal_aid_application = legal_aid_application
+    end
+
+    def call
+      return :employed_journey_not_enabled unless Setting.enable_employed_journey?
+
+      return :provider_not_enabled_for_employed_journey unless provider.employment_permissions?
+
+      return :applicant_not_employed unless applicant.employed?
+
+      return :hmrc_multiple_employments if has_multiple_employments?
+
+      return :no_hmrc_data unless hmrc_employment_income?
+
+      :hmrc_single_employment
+    end
+  end
+end

--- a/db/migrate/20220512125715_add_employed_field_to_digest.rb
+++ b/db/migrate/20220512125715_add_employed_field_to_digest.rb
@@ -1,6 +1,6 @@
 class AddEmployedFieldToDigest < ActiveRecord::Migration[6.1]
   def change
-    change_table :application_digests do |t|
+    change_table :application_digests, bulk: true do |t|
       t.boolean :employed, null: false, default: false
       t.boolean :hmrc_data_used, null: false, default: false
       t.boolean :referred_to_caseworker, null: false, default: false

--- a/db/migrate/20220512125715_add_employed_field_to_digest.rb
+++ b/db/migrate/20220512125715_add_employed_field_to_digest.rb
@@ -1,0 +1,9 @@
+class AddEmployedFieldToDigest < ActiveRecord::Migration[6.1]
+  def change
+    change_table :application_digests do |t|
+      t.boolean :employed, null: false, default: false
+      t.boolean :hmrc_data_used, null: false, default: false
+      t.boolean :referred_to_caseworker, null: false, default: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -103,9 +103,9 @@ ActiveRecord::Schema.define(version: 2022_05_12_125715) do
     t.string "unlock_token"
     t.datetime "locked_at"
     t.string "true_layer_secure_data_id"
+    t.boolean "employed"
     t.datetime "remember_created_at"
     t.string "remember_token"
-    t.boolean "employed"
     t.boolean "self_employed", default: false
     t.boolean "armed_forces", default: false
     t.index ["confirmation_token"], name: "index_applicants_on_confirmation_token", unique: true
@@ -537,9 +537,9 @@ ActiveRecord::Schema.define(version: 2022_05_12_125715) do
     t.boolean "no_cash_income"
     t.boolean "no_cash_outgoings"
     t.date "purgeable_on"
+    t.string "required_document_categories", default: [], null: false, array: true
     t.boolean "extra_employment_information"
     t.string "extra_employment_information_details"
-    t.string "required_document_categories", default: [], null: false, array: true
     t.string "full_employment_details"
     t.datetime "client_declaration_confirmed_at"
     t.index ["applicant_id"], name: "index_legal_aid_applications_on_applicant_id"
@@ -589,7 +589,7 @@ ActiveRecord::Schema.define(version: 2022_05_12_125715) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "scanner_working"
-    t.index ["uploader_type", "uploader_id"], name: "index_malware_scan_results_on_uploader"
+    t.index ["uploader_type", "uploader_id"], name: "index_malware_scan_results_on_uploader_type_and_uploader_id"
   end
 
   create_table "offices", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_20_073516) do
+ActiveRecord::Schema.define(version: 2022_05_12_125715) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -131,6 +131,9 @@ ActiveRecord::Schema.define(version: 2022_04_20_073516) do
     t.integer "working_days_to_submit_df"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "employed", default: false, null: false
+    t.boolean "hmrc_data_used", default: false, null: false
+    t.boolean "referred_to_caseworker", default: false, null: false
     t.index ["legal_aid_application_id"], name: "index_application_digests_on_legal_aid_application_id", unique: true
   end
 

--- a/features/step_definitions/civil_journey_steps.rb
+++ b/features/step_definitions/civil_journey_steps.rb
@@ -316,7 +316,7 @@ end
 Given("I start the means review journey with employment income for a single job from HMRC") do
   @legal_aid_application = create(
     :application,
-    :with_applicant,
+    :with_employed_applicant,
     :with_single_employment,
     :with_proceedings,
     :with_non_passported_state_machine,
@@ -355,7 +355,7 @@ end
 Given("I start the means review journey with employment income for multiple jobs from HMRC") do
   @legal_aid_application = create(
     :application,
-    :with_applicant,
+    :with_employed_applicant,
     :with_multiple_employments,
     :with_proceedings,
     :with_non_passported_state_machine,

--- a/lib/tasks/digest.rake
+++ b/lib/tasks/digest.rake
@@ -10,7 +10,7 @@ namespace :digest do
   end
 
   namespace :extraction_date do
-    desc "Reset the last_exracted date so that all application_digest records are refreshed"
+    desc "Reset the last_extracted date so that all application_digest records are refreshed"
     task reset: :environment do
       Setting.setting.update!(digest_extracted_at: 20.years.ago)
     end

--- a/lib/tasks/digest.rake
+++ b/lib/tasks/digest.rake
@@ -8,4 +8,11 @@ namespace :digest do
   task export: :environment do
     DigestExporter.call
   end
+
+  namespace :extraction_date do
+    desc "Reset the last_exracted date so that all application_digest records are refreshed"
+    task reset: :environment do
+      Setting.setting.update!(digest_extracted_at: 20.years.ago)
+    end
+  end
 end

--- a/spec/factories/applicants.rb
+++ b/spec/factories/applicants.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
     date_of_birth { Faker::Date.birthday }
     email { Faker::Internet.safe_email }
     national_insurance_number { Faker::Base.regexify(Applicant::NINO_REGEXP) }
+    employed { false }
 
     trait :with_address do
       addresses { build_list :address, 1 }

--- a/spec/factories/legal_aid_applications.rb
+++ b/spec/factories/legal_aid_applications.rb
@@ -10,6 +10,14 @@ FactoryBot.define do
       applicant { build :applicant, with_bank_accounts: }
     end
 
+    trait :with_employed_applicant do
+      # use :with_bank_accounts: 2 to create 2 bank accounts for the applicant
+      transient do
+        with_bank_accounts { 0 }
+      end
+      applicant { build :applicant, employed: true, with_bank_accounts: }
+    end
+
     trait :with_single_employment do
       employments { [association(:employment)] }
     end

--- a/spec/factories/permissions.rb
+++ b/spec/factories/permissions.rb
@@ -12,5 +12,10 @@ FactoryBot.define do
       role { "application.non_passported.*" }
       description { "Can create, view, modify non-passported applications" }
     end
+
+    trait :employed do
+      role { "application.non_passported.employment.*" }
+      description { "Can submit applications for employed applicants " }
+    end
   end
 end

--- a/spec/forms/applicants/employed_form_spec.rb
+++ b/spec/forms/applicants/employed_form_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Applicants::EmployedForm, type: :form do
   subject { described_class.new(form_params) }
 
   let!(:application) { create :legal_aid_application, applicant: }
-  let(:applicant) { create :applicant }
+  let(:applicant) { create :applicant, employed: nil }
 
   let(:params) { { employed: true } }
   let(:form_params) { params.merge(model: applicant) }

--- a/spec/models/application_digest_spec.rb
+++ b/spec/models/application_digest_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe ApplicationDigest do
         context "when an unknown result is received from HMRC::StatusAnalyzer" do
           let(:hmrc_status) { :what_is_this? }
 
-          it "raises" do
+          it "raises an error" do
             expect { subject }.to raise_error RuntimeError, "Unexpected response from HMRC::StatusAnalyser :what_is_this?"
           end
         end

--- a/spec/models/application_digest_spec.rb
+++ b/spec/models/application_digest_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe ApplicationDigest do
           context "and single employment" do
             let(:hmrc_status) { :hmrc_single_employment }
 
-            it "returns false" do
+            it "returns true" do
               expect(digest.hmrc_data_used).to be true
             end
           end

--- a/spec/models/application_digest_spec.rb
+++ b/spec/models/application_digest_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe ApplicationDigest do
                :assessment_submitted,
                :with_everything,
                :with_proceedings,
+               :with_cfe_v4_result,
                explicit_proceedings: %i[da001 se013 se014],
                provider:,
                merits_submitted_at: submission_time
@@ -64,9 +65,85 @@ RSpec.describe ApplicationDigest do
         end
       end
 
-      describe "hmrc_data_used"
+      describe "hmrc_data_used" do
+        before { allow(HMRC::StatusAnalyzer).to receive(:call).with(laa).and_return(hmrc_status) }
 
-      describe "referred_to_caseworker"
+        context "when HMRC::StatusAnalyzer runs succesfully" do
+          before { subject }
+
+          context "and provider not enabled for employed journey" do
+            let(:hmrc_status) { :provider_not_enabled_for_employed_journey }
+
+            it "returns false" do
+              expect(digest.hmrc_data_used).to be false
+            end
+          end
+
+          context "and applicant not employed" do
+            let(:hmrc_status) { :applicant_not_employed }
+
+            it "returns false" do
+              expect(digest.hmrc_data_used).to be false
+            end
+          end
+
+          context "but no hrmrc data" do
+            let(:hmrc_status) { :no_hmrc_data }
+
+            it "returns false" do
+              expect(digest.hmrc_data_used).to be false
+            end
+          end
+
+          context "and multiple employments" do
+            let(:hmrc_status) { :hmrc_multiple_employments }
+
+            it "returns false" do
+              expect(digest.hmrc_data_used).to be false
+            end
+          end
+
+          context "and single employment" do
+            let(:hmrc_status) { :hmrc_single_employment }
+
+            it "returns false" do
+              expect(digest.hmrc_data_used).to be true
+            end
+          end
+        end
+
+        context "when an unknown result is received from HMRC::StatusAnalyzer" do
+          let(:hmrc_status) { :what_is_this? }
+
+          it "raises" do
+            expect { subject }.to raise_error RuntimeError, "Unexpected response from HMRC::StatusAnalyser :what_is_this?"
+          end
+        end
+      end
+
+      describe "referred_to_caseworker" do
+        before { allow(CCMS::ManualReviewDeterminer).to receive(:new).and_return(mock_determiner) }
+
+        let(:mock_determiner) { instance_double(CCMS::ManualReviewDeterminer, manual_review_required?: review_required) }
+
+        context "when not referred to caseworker" do
+          let(:review_required) { false }
+
+          it "returns false" do
+            subject
+            expect(digest.referred_to_caseworker).to be false
+          end
+        end
+
+        context "when referred to caseworker" do
+          let(:review_required) { true }
+
+          it "returns true" do
+            subject
+            expect(digest.referred_to_caseworker).to be true
+          end
+        end
+      end
     end
 
     context "when no digest record exists for this application" do
@@ -110,7 +187,7 @@ RSpec.describe ApplicationDigest do
     context "passported" do
       context "application is passported" do
         before do
-          expect_any_instance_of(LegalAidApplication).to receive(:passported?).and_return(true)
+          allow_any_instance_of(LegalAidApplication).to receive(:passported?).and_return(true)
           subject
         end
 
@@ -121,7 +198,7 @@ RSpec.describe ApplicationDigest do
 
       context "application is NOT passported" do
         before do
-          expect_any_instance_of(LegalAidApplication).to receive(:passported?).and_return(false)
+          allow_any_instance_of(LegalAidApplication).to receive(:passported?).and_return(false)
           subject
         end
 

--- a/spec/models/application_digest_spec.rb
+++ b/spec/models/application_digest_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe ApplicationDigest do
                merits_submitted_at: submission_time
       end
     end
-    let(:laa_at_use_ccms) { create :legal_aid_application, :use_ccms }
+    let(:laa_at_use_ccms) { create :legal_aid_application, :use_ccms, :with_applicant }
 
     let(:digest) { described_class.find_by(legal_aid_application_id: laa.id) }
 
@@ -45,6 +45,28 @@ RSpec.describe ApplicationDigest do
         expect(digest.matter_types).to eq "Domestic Abuse;Section 8 orders"
         expect(digest.proceedings).to eq "DA001;SE013;SE014"
       end
+
+      describe "applicant employment status" do
+        context "when not employed" do
+          it "writes false to the digest record" do
+            subject
+            expect(digest.employed).to be false
+          end
+        end
+
+        context "when employed" do
+          before { laa.applicant.update(employed: true) }
+
+          it "writes true to the digest record" do
+            subject
+            expect(digest.employed).to be true
+          end
+        end
+      end
+
+      describe "hmrc_data_used"
+
+      describe "referred_to_caseworker"
     end
 
     context "when no digest record exists for this application" do

--- a/spec/models/application_digest_spec.rb
+++ b/spec/models/application_digest_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe ApplicationDigest do
             end
           end
 
-          context "but no hrmrc data" do
+          context "but no hmrc data" do
             let(:hmrc_status) { :no_hmrc_data }
 
             it "returns false" do

--- a/spec/requests/providers/applicant_employed_spec.rb
+++ b/spec/requests/providers/applicant_employed_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe Providers::ApplicantEmployedController, type: :request do
   let(:legal_aid_application) { create :legal_aid_application, applicant: }
-  let(:applicant) { create :applicant }
+  let(:applicant) { create :applicant, employed: nil }
   let(:login) { login_as legal_aid_application.provider }
 
   before do

--- a/spec/requests/providers/client_completed_means_spec.rb
+++ b/spec/requests/providers/client_completed_means_spec.rb
@@ -97,6 +97,16 @@ RSpec.describe Providers::ClientCompletedMeansController, type: :request do
             end
           end
 
+          context "unknown result obtained from HMRC::StatusAnalyzer" do
+            before do
+              allow(HMRC::StatusAnalyzer).to receive(:call).with(legal_aid_application).and_return(:xxx)
+            end
+
+            it "raises" do
+              expect { subject }.to raise_error RuntimeError, "Unexpected hmrc status :xxx"
+            end
+          end
+
           context "no employment income data was received from HMRC" do
             before { allow_any_instance_of(LegalAidApplication).to receive(:hmrc_employment_income?).and_return(false) }
 

--- a/spec/requests/providers/client_completed_means_spec.rb
+++ b/spec/requests/providers/client_completed_means_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe Providers::ClientCompletedMeansController, type: :request do
               allow(HMRC::StatusAnalyzer).to receive(:call).with(legal_aid_application).and_return(:xxx)
             end
 
-            it "raises" do
+            it "raises an error" do
               expect { subject }.to raise_error RuntimeError, "Unexpected hmrc status :xxx"
             end
           end

--- a/spec/services/digest_extractor_spec.rb
+++ b/spec/services/digest_extractor_spec.rb
@@ -2,9 +2,9 @@ require "rails_helper"
 
 RSpec.describe DigestExtractor do
   describe ".call" do
-    let!(:laa1) { create :legal_aid_application, updated_at: 5.days.ago }
-    let!(:laa2) { create :legal_aid_application, updated_at: 3.days.ago }
-    let!(:laa3) { create :legal_aid_application, updated_at: 1.minute.ago }
+    let!(:laa1) { create :legal_aid_application, :with_applicant, updated_at: 5.days.ago }
+    let!(:laa2) { create :legal_aid_application, :with_applicant, updated_at: 3.days.ago }
+    let!(:laa3) { create :legal_aid_application, :with_applicant, updated_at: 1.minute.ago }
 
     before { Setting.setting.update!(digest_extracted_at: 4.days.ago) }
 

--- a/spec/services/digest_extractor_spec.rb
+++ b/spec/services/digest_extractor_spec.rb
@@ -2,9 +2,9 @@ require "rails_helper"
 
 RSpec.describe DigestExtractor do
   describe ".call" do
-    let!(:laa1) { create :legal_aid_application, :with_applicant, updated_at: 5.days.ago }
-    let!(:laa2) { create :legal_aid_application, :with_applicant, updated_at: 3.days.ago }
-    let!(:laa3) { create :legal_aid_application, :with_applicant, updated_at: 1.minute.ago }
+    let!(:laa1) { create :legal_aid_application, :with_applicant, :with_cfe_v3_result, updated_at: 5.days.ago }
+    let!(:laa2) { create :legal_aid_application, :with_applicant, :with_cfe_v3_result, updated_at: 3.days.ago }
+    let!(:laa3) { create :legal_aid_application, :with_applicant, :with_cfe_v3_result, updated_at: 1.minute.ago }
 
     before { Setting.setting.update!(digest_extracted_at: 4.days.ago) }
 

--- a/spec/services/hmrc/status_analyzer_spec.rb
+++ b/spec/services/hmrc/status_analyzer_spec.rb
@@ -1,0 +1,72 @@
+require "rails_helper"
+
+module HMRC
+  RSpec.describe StatusAnalyzer do
+    describe ".call" do
+      subject(:service_call) { described_class.call(laa) }
+      before do
+        Setting.setting.update!(enable_employed_journey: feature_flag)
+        if provider_employed_permissions
+          permission = create :permission, :employed
+          laa.provider.firm.permissions << permission
+          laa.provider.permissions << permission
+        end
+        laa.applicant.update!(employed: true) if applicant_employed
+      end
+
+      let(:feature_flag) { true }
+      let(:laa) { create :legal_aid_application, :with_applicant }
+      let(:provider_employed_permissions) { true }
+      let(:applicant_employed) { true }
+
+      context "when employed journey flag not set to true" do
+        let(:feature_flag) { false }
+        let(:provider_employed_permissions) { false }
+
+        it "returns employed_journey_not_enabled" do
+          expect(service_call).to eq :employed_journey_not_enabled
+        end
+      end
+
+      context "when provider not enabled for employment journey" do
+        let(:provider_employed_permissions) { false }
+
+        it "returns provider_not_enabled_for_employed_journey" do
+          expect(service_call).to eq :provider_not_enabled_for_employed_journey
+        end
+      end
+
+      context "when provider_enabled_for_employement journey" do
+        context "and applicant not employed" do
+          let(:applicant_employed) { false }
+
+          it "returns not employed" do
+            expect(service_call).to eq :applicant_not_employed
+          end
+        end
+
+        context "and applicant has multiple employements" do
+          before { create_list :employment, 2, legal_aid_application: laa }
+
+          it "returns hmrc_multiple_employments" do
+            expect(service_call).to eq :hmrc_multiple_employments
+          end
+        end
+
+        context "and applicant has single employment" do
+          before { create :employment, legal_aid_application: laa }
+
+          it "returns hmrc_multiple_employments" do
+            expect(service_call).to eq :hmrc_single_employment
+          end
+        end
+
+        context "but applicant has no hmrc data" do
+          it "returns no_hmrc_data" do
+            expect(service_call).to eq :no_hmrc_data
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/services/hmrc/status_analyzer_spec.rb
+++ b/spec/services/hmrc/status_analyzer_spec.rb
@@ -36,7 +36,7 @@ module HMRC
         end
       end
 
-      context "when provider_enabled_for_employement journey" do
+      context "when provider_enabled_for_employment journey" do
         context "and applicant not employed" do
           let(:applicant_employed) { false }
 
@@ -56,7 +56,7 @@ module HMRC
         context "and applicant has single employment" do
           before { create :employment, legal_aid_application: laa }
 
-          it "returns hmrc_multiple_employments" do
+          it "returns hmrc_single_employment" do
             expect(service_call).to eq :hmrc_single_employment
           end
         end

--- a/spec/services/hmrc/status_analyzer_spec.rb
+++ b/spec/services/hmrc/status_analyzer_spec.rb
@@ -45,7 +45,7 @@ module HMRC
           end
         end
 
-        context "and applicant has multiple employements" do
+        context "and applicant has multiple employments" do
           before { create_list :employment, 2, legal_aid_application: laa }
 
           it "returns hmrc_multiple_employments" do


### PR DESCRIPTION
## Add extra information to the applicaiton digest to be reported on the Apply Dashboard

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3091)

- added three new boolean columns to the `application_digests` table to hold the extra information
  - `employed`
  - `hmrc_data_used`
  - `referred_to_caseworker`
-  Created service class `HMRC::StatusAnalyzer` to give results about the state of the HMRC responses
- Refactored the `provider_capital` flow to use `HMRC::StatusAnalyzer` rather than nested `ifs`
- Used the `HMRC::StatusAnalyzer` to populate the `hmrc_data_used` column on `application_digests`
- Added trait `:with_employed_applicant` to `LegalAidApplication` factory, and used it in cucumber tests that now required it.

## Deployment Notes

After this has been deployed, run the following command on live to reset the last-extracted date to ensure that all
existing records are updated.
    `rake digest:extraction_date:reset`

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
