### PR TITLE
Rubocop fixes

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -159,18 +159,6 @@ RSpec/BeforeAfterAll:
 # Prefixes: when, with, without
 RSpec/ContextWording:
   Exclude:
-    - 'spec/lib/alert_manager_spec.rb'
-    - 'spec/lib/authorized_ip_ranges_spec.rb'
-    - 'spec/lib/id_p_settings_adapter_spec.rb'
-    - 'spec/lib/omni_auth/strategies/moj_oauth2_spec.rb'
-    - 'spec/lib/task_helpers/ccms_payload_yamlizer_spec.rb'
-    - 'spec/mailers/feedback_mailer_spec.rb'
-    - 'spec/mailers/submit_application_reminder_mailer_spec.rb'
-    - 'spec/mailers/submit_citizen_financial_reminder_mailer_spec.rb'
-    - 'spec/mailers/submit_provider_financial_reminder_mailer_spec.rb'
-    - 'spec/models/aggregated_cash_income_spec.rb'
-    - 'spec/models/aggregated_cash_outgoings_spec.rb'
-    - 'spec/models/applicant_spec.rb'
     - 'spec/models/application_digest_spec.rb'
     - 'spec/models/application_merits_task/involved_child_spec.rb'
     - 'spec/models/application_merits_task/opponent_spec.rb'

--- a/spec/lib/alert_manager_spec.rb
+++ b/spec/lib/alert_manager_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe AlertManager do
     describe ".capture_exception" do
       let(:exception) { RuntimeError.new("my new error") }
 
-      context "production environment" do
+      context "when in the production environment" do
         before { allow(HostEnv).to receive(:environment).and_return(sample_sending_environment) }
 
         it "delegates to Sentry" do
@@ -24,7 +24,7 @@ RSpec.describe AlertManager do
           described_class.capture_exception(exception)
         end
 
-        context "ignorable exception" do
+        context "with ignorable exception" do
           let(:exception) { Geckoboard::UnexpectedStatusError.new("You have exceeded the API rate limit blah blah blah") }
 
           it "ignores the error" do
@@ -34,7 +34,7 @@ RSpec.describe AlertManager do
         end
       end
 
-      context "non-production environment" do
+      context "when in a non-production environment" do
         it "does not pass on to sentry" do
           expect(Sentry).not_to receive(:capture_exception)
           described_class.capture_exception(exception)
@@ -50,7 +50,7 @@ RSpec.describe AlertManager do
     describe ".capture_message" do
       let(:message) { "This is my test message" }
 
-      context "production environment" do
+      context "when in the production environment" do
         before { allow(HostEnv).to receive(:environment).and_return(sample_sending_environment) }
 
         it "delegates to Sentry" do
@@ -64,7 +64,7 @@ RSpec.describe AlertManager do
         end
       end
 
-      context "non-production environment" do
+      context "when in a non-production environment" do
         it "does not pass on to sentry" do
           expect(Sentry).not_to receive(:capture_message)
           described_class.capture_exception(message)
@@ -84,7 +84,7 @@ RSpec.describe AlertManager do
     describe ".capture_exception" do
       let(:exception) { RuntimeError.new("my new error") }
 
-      context "production environment" do
+      context "when in the production environment" do
         before { allow(HostEnv).to receive(:environment).and_return(sample_sending_environment) }
 
         it "delegates to SlackAlerter" do
@@ -99,7 +99,7 @@ RSpec.describe AlertManager do
         end
       end
 
-      context "non-production environment" do
+      context "when in a non-production environment" do
         it "does not pass on to SlackAlerter" do
           expect(SlackAlerter).not_to receive(:capture_exception)
           described_class.capture_exception(exception)
@@ -115,7 +115,7 @@ RSpec.describe AlertManager do
     describe ".capture_message" do
       let(:message) { "This is my test message" }
 
-      context "production environment" do
+      context "when in a production environment" do
         before { allow(HostEnv).to receive(:environment).and_return(sample_sending_environment) }
 
         it "delegates to SlackAlerter" do
@@ -130,7 +130,7 @@ RSpec.describe AlertManager do
         end
       end
 
-      context "non-production environment" do
+      context "when in a non-production environment" do
         it "does not pass on to sentry" do
           expect(Sentry).not_to receive(:capture_message)
           described_class.capture_message(message)

--- a/spec/lib/authorized_ip_ranges_spec.rb
+++ b/spec/lib/authorized_ip_ranges_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe AuthorizedIpRanges do
   describe "#authorized?" do
     subject { described_class.new.authorized?(ipaddr) }
 
-    context "IPV4" do
-      context "authorized address" do
+    context "with IPV4" do
+      context "with authorized address" do
         let(:ipaddr) { "127.0.0.1" }
 
         it "is authorised" do
@@ -13,7 +13,7 @@ RSpec.describe AuthorizedIpRanges do
         end
       end
 
-      context "unauthorized address" do
+      context "with unauthorized address" do
         let(:ipaddr) { "250.155.1.66" }
 
         it "is not authorised" do
@@ -22,8 +22,8 @@ RSpec.describe AuthorizedIpRanges do
       end
     end
 
-    context "IPV6" do
-      context "authorized address" do
+    context "with IPV6" do
+      context "with authorized address" do
         let(:ipaddr) { "::1" }
 
         it "is authorised" do
@@ -31,7 +31,7 @@ RSpec.describe AuthorizedIpRanges do
         end
       end
 
-      context "unauthorized address" do
+      context "with unauthorized address" do
         let(:ipaddr) { "fdaa:bbcc:ddee:0:14c3:d7c5:9d07:195c" }
 
         it "is not authorised" do

--- a/spec/lib/id_p_settings_adapter_spec.rb
+++ b/spec/lib/id_p_settings_adapter_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe IdPSettingsAdapter do
   end
 
   describe "IdPSettingsAdapter.settings" do
-    context "UAT settings" do
+    context "with UAT settings" do
       it "returns a hash of settings" do
         allow(described_class).to receive(:mock_saml?).and_return(true)
         expect(described_class.settings(1)).to have_key(:private_key)
@@ -30,7 +30,7 @@ RSpec.describe IdPSettingsAdapter do
       end
     end
 
-    context "Non UAT settings" do
+    context "with non UAT settings" do
       it "returns a hash of settings" do
         allow(described_class).to receive(:mock_saml?).and_return(false)
         expect(described_class.settings(1)).to have_key(:issuer)

--- a/spec/lib/omni_auth/strategies/moj_oauth2_spec.rb
+++ b/spec/lib/omni_auth/strategies/moj_oauth2_spec.rb
@@ -15,7 +15,7 @@ module OmniAuth
       let(:client_secret) { "my_client_secret" }
       let(:client) { ::OAuth2::Client.new(client_id, client_secret, {}) }
 
-      context "request_phase" do
+      context "when in request_phase" do
         before do
           allow(strategy).to receive(:session).and_return(example_session)
           allow(strategy).to receive(:authorize_params).and_return(example_auth_params)
@@ -38,7 +38,7 @@ module OmniAuth
         end
       end
 
-      context "callback phase" do
+      context "when in callback phase" do
         let(:mock_request) { double "request", params: example_request_params, scheme: "http", url: "my_url" }
 
         let(:my_access_token) { AccessTokenStruct.new(false) }

--- a/spec/lib/task_helpers/ccms_payload_yamlizer_spec.rb
+++ b/spec/lib/task_helpers/ccms_payload_yamlizer_spec.rb
@@ -20,19 +20,19 @@ RSpec.describe CcmsPayloadYamlizer do
       }
     end
 
-    context "key does not exist in the hash" do
+    context "when key does not exist in the hash" do
       it "returns the same value" do
         expect(parser.__send__(:calculate_new_key, hash, "keyz")).to eq "keyz"
       end
     end
 
-    context "key_without_square_brackets is in the hash" do
+    context "when key_without_square_brackets is in the hash" do
       it "returns the key suffixed by [1]" do
         expect(parser.__send__(:calculate_new_key, hash, "key_a")).to eq "key_a[1]"
       end
     end
 
-    context "several keys exist" do
+    context "when several keys exist" do
       it "returns the next key in sequence" do
         expect(parser.__send__(:calculate_new_key, hash, "key_b")).to eq "key_b[3]"
       end

--- a/spec/mailers/feedback_mailer_spec.rb
+++ b/spec/mailers/feedback_mailer_spec.rb
@@ -15,9 +15,9 @@ RSpec.describe FeedbackMailer, type: :mailer do
       expect(mail.delivery_method).to be_a(GovukNotifyRails::Delivery)
     end
 
-    context "personalisation" do
+    context "with personalisation" do
       describe "application_status" do
-        context "pre_dwp_check" do
+        context "with pre_dwp_check" do
           before { allow_any_instance_of(LegalAidApplication).to receive(:pre_dwp_check?).and_return(true) }
 
           it "has a status of pre dwp check" do
@@ -33,7 +33,7 @@ RSpec.describe FeedbackMailer, type: :mailer do
           end
         end
 
-        context "passported" do
+        context "when passported" do
           before do
             allow_any_instance_of(LegalAidApplication).to receive(:pre_dwp_check?).and_return(false)
             allow_any_instance_of(LegalAidApplication).to receive(:passported?).and_return(true)
@@ -44,7 +44,7 @@ RSpec.describe FeedbackMailer, type: :mailer do
           end
         end
 
-        context "non-passported" do
+        context "when non-passported" do
           before do
             allow_any_instance_of(LegalAidApplication).to receive(:pre_dwp_check?).and_return(false)
             allow_any_instance_of(LegalAidApplication).to receive(:passported?).and_return(false)

--- a/spec/mailers/submit_application_reminder_mailer_spec.rb
+++ b/spec/mailers/submit_application_reminder_mailer_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe SubmitApplicationReminderMailer, type: :mailer do
   describe ".eligible_for_delivery" do
     let(:scheduled_mailing) { create :scheduled_mailing, :due, legal_aid_application_id: application.id }
 
-    context "ineligible_state" do
+    context "with ineligible_state" do
       before do
         allow(scheduled_mailing).to receive(:legal_aid_application).and_return(application)
         allow(application).to receive(:state).and_return("use_ccms")
@@ -54,7 +54,7 @@ RSpec.describe SubmitApplicationReminderMailer, type: :mailer do
       end
     end
 
-    context "elgible" do
+    context "when elgible" do
       it "returns true" do
         expect(described_class.eligible_for_delivery?(scheduled_mailing)).to be true
       end

--- a/spec/mailers/submit_citizen_financial_reminder_mailer_spec.rb
+++ b/spec/mailers/submit_citizen_financial_reminder_mailer_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe SubmitCitizenFinancialReminderMailer, type: :mailer do
   describe ".eligible_for_delivery?" do
     let(:scheduled_mailing) { create :scheduled_mailing, legal_aid_application: application }
 
-    context "it is eligible" do
+    context "when it is eligible" do
       let(:application) { create :legal_aid_application, :with_non_passported_state_machine, :at_check_provider_answers }
 
       it "returns true" do
@@ -43,7 +43,7 @@ RSpec.describe SubmitCitizenFinancialReminderMailer, type: :mailer do
       end
     end
 
-    context "it is not eligible" do
+    context "when it is not eligible" do
       let(:application) { create :legal_aid_application, :with_non_passported_state_machine, :at_assessment_submitted }
 
       it "returns false" do

--- a/spec/mailers/submit_provider_financial_reminder_mailer_spec.rb
+++ b/spec/mailers/submit_provider_financial_reminder_mailer_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe SubmitProviderFinancialReminderMailer, type: :mailer do
   describe ".eligible_for_delivery?" do
     let(:scheduled_mailing) { create :scheduled_mailing, legal_aid_application: application }
 
-    context "it is eligible" do
+    context "when it is eligible" do
       let(:application) { create :legal_aid_application, :with_proceedings, :with_non_passported_state_machine, :at_client_completed_means }
 
       it "returns true" do
@@ -41,7 +41,7 @@ RSpec.describe SubmitProviderFinancialReminderMailer, type: :mailer do
       end
     end
 
-    context "it is not eligible" do
+    context "when it is not eligible" do
       let(:application) { create :legal_aid_application, :at_assessment_submitted }
 
       it "returns false" do

--- a/spec/models/aggregated_cash_income_spec.rb
+++ b/spec/models/aggregated_cash_income_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe AggregatedCashIncome, type: :model do
       travel_back
     end
 
-    context "no cash income transaction records" do
+    context "with no cash income transaction records" do
       it "returns an empty model" do
         aci = described_class.find_by(legal_aid_application_id: application.id)
         expect(aci.check_box_benefits).to be_nil
@@ -56,7 +56,7 @@ RSpec.describe AggregatedCashIncome, type: :model do
         expect(aci.month3).to eq month3_tx_date
       end
 
-      context "delegated functions not used" do
+      context "when delegated functions not used" do
         it "sets the months based on the transaction period end date" do
           expect(application.used_delegated_functions?).to be false
           expect(application.transaction_period_finish_on).to eq Date.parse("2021-03-12")
@@ -66,7 +66,7 @@ RSpec.describe AggregatedCashIncome, type: :model do
         end
       end
 
-      context "delegated functions are used" do
+      context "when delegated functions are used" do
         before do
           application.proceedings.first.update!(used_delegated_functions_on: Date.parse("2021-01-28"),
                                                 used_delegated_functions_reported_on: Date.parse("2021-01-28"))
@@ -83,7 +83,7 @@ RSpec.describe AggregatedCashIncome, type: :model do
       end
     end
 
-    context "cash income transaction records exist" do
+    context "when cash income transaction records exist" do
       let!(:pension1) { create :cash_transaction, :credit_month1, legal_aid_application: application, transaction_type: pension }
       let!(:pension2) { create :cash_transaction, :credit_month2, legal_aid_application: application, transaction_type: pension }
       let!(:pension3) { create :cash_transaction, :credit_month3, legal_aid_application: application, transaction_type: pension }
@@ -139,8 +139,8 @@ RSpec.describe AggregatedCashIncome, type: :model do
       aci.update(params)
     end
 
-    context "valid params" do
-      context "none selected" do
+    context "with valid params" do
+      context "and none selected" do
         let(:params) { none_selected_params }
 
         it "is valid" do
@@ -152,7 +152,7 @@ RSpec.describe AggregatedCashIncome, type: :model do
         end
       end
 
-      context "categories selected" do
+      context "with categories selected" do
         let(:params) { valid_params }
 
         it "is valid" do
@@ -175,8 +175,8 @@ RSpec.describe AggregatedCashIncome, type: :model do
       end
     end
 
-    context "invalid params" do
-      context "missing month value" do
+    context "with invalid params" do
+      context "and missing month value" do
         let(:params) { missing_month_params }
 
         it "is invalid" do
@@ -190,7 +190,7 @@ RSpec.describe AggregatedCashIncome, type: :model do
         end
       end
 
-      context "amount negative" do
+      context "when amount negative" do
         let(:params) { valid_params.merge({ benefits1: "-1" }) }
 
         it "is invalid" do
@@ -203,7 +203,7 @@ RSpec.describe AggregatedCashIncome, type: :model do
         end
       end
 
-      context "amount not numerical" do
+      context "when amount not numerical" do
         let(:params) { valid_params.merge({ benefits1: "$%^&" }) }
 
         it "is invalid" do
@@ -216,7 +216,7 @@ RSpec.describe AggregatedCashIncome, type: :model do
         end
       end
 
-      context "amount too many decimals" do
+      context "when amount has too many decimals" do
         let(:params) { valid_params.merge({ benefits1: "9.99999" }) }
 
         it "is invalid" do
@@ -229,7 +229,7 @@ RSpec.describe AggregatedCashIncome, type: :model do
         end
       end
 
-      context "no categories selected" do
+      context "with no categories selected" do
         let(:params) { { legal_aid_application_id: application.id } }
 
         it "is invalid" do
@@ -241,7 +241,7 @@ RSpec.describe AggregatedCashIncome, type: :model do
         end
       end
 
-      context "none selected with values" do
+      context "when none selected with values" do
         let(:params) { none_selected_with_params }
 
         it "is invalid" do
@@ -256,12 +256,12 @@ RSpec.describe AggregatedCashIncome, type: :model do
   end
 
   describe "#update" do
-    context "previous values" do
+    context "with revious values" do
       before do
         aci.update(valid_params)
       end
 
-      context "upon successful validation" do
+      context "with successful validation" do
         let(:subject) { aci.update(additional_valid_params) }
 
         it "updates with previously selected checkboxes" do
@@ -286,10 +286,10 @@ RSpec.describe AggregatedCashIncome, type: :model do
       end
     end
 
-    context "no cash income records exist" do
+    context "when no cash income records exist" do
       let(:subject) { aci.update(params) }
 
-      context "valid params" do
+      context "with valid params" do
         let(:params) { valid_params }
 
         it "creates the expected cash income records" do
@@ -297,8 +297,8 @@ RSpec.describe AggregatedCashIncome, type: :model do
         end
       end
 
-      context "invalid params" do
-        context "non-numeric values" do
+      context "with invalid params" do
+        context "and non-numeric values" do
           let(:params) { non_numeric_params }
 
           it "does not create the Cash Transaction records" do
@@ -316,7 +316,7 @@ RSpec.describe AggregatedCashIncome, type: :model do
           end
         end
 
-        context "too many decimal numbers" do
+        context "with too many decimal numbers" do
           let(:params) { too_many_decimal_params }
 
           it "does not create the Cash Transaction records" do
@@ -334,7 +334,7 @@ RSpec.describe AggregatedCashIncome, type: :model do
           end
         end
 
-        context "negative value" do
+        context "with a negative value" do
           let(:params) { negative_params }
 
           it "does not create the Cash Transaction records" do
@@ -352,7 +352,7 @@ RSpec.describe AggregatedCashIncome, type: :model do
           end
         end
 
-        context "missing value" do
+        context "with missing value" do
           let(:params) { missing_value_params }
 
           it "does not create the Cash Transaction records" do
@@ -372,12 +372,12 @@ RSpec.describe AggregatedCashIncome, type: :model do
       end
     end
 
-    context "cash income records already exist" do
+    context "when cash income records already exist" do
       before do
         aci.update(valid_params)
       end
 
-      context "preexisting records" do
+      context "with preexisting records" do
         let(:subject) { aci.update(corrected_valid_params) }
 
         it "does not change the record count when records updated" do
@@ -398,7 +398,7 @@ RSpec.describe AggregatedCashIncome, type: :model do
         end
       end
 
-      context "preexisting transaction types" do
+      context "with preexisting transaction types" do
         let(:subject) { aci.update(none_selected_params) }
 
         it "removes all records when none selected" do
@@ -406,7 +406,7 @@ RSpec.describe AggregatedCashIncome, type: :model do
         end
       end
 
-      context "additional transaction types" do
+      context "with additional transaction types" do
         let(:subject) { aci.update(additional_valid_params) }
 
         it "adds to prexisting transaction types" do
@@ -414,7 +414,7 @@ RSpec.describe AggregatedCashIncome, type: :model do
         end
       end
 
-      context "previous months preexisting" do
+      context "with previous months preexisting" do
         let(:subject) { aci.update(corrected_valid_params) }
 
         before do
@@ -442,7 +442,7 @@ RSpec.describe AggregatedCashIncome, type: :model do
     end
   end
 
-  context "date labeling" do
+  context "with date labeling" do
     around(:each) do |example|
       travel_to Time.zone.local(2021, 1, 4, 13, 24, 44)
       example.run
@@ -458,7 +458,7 @@ RSpec.describe AggregatedCashIncome, type: :model do
     let(:aci) { described_class.find_by(legal_aid_application_id: application.id) }
 
     describe "#period" do
-      context "locale :en" do
+      context "with locale :en" do
         it "displays the start and end dates of the period" do
           expect(aci.period(1)).to eq "December 2020"
           expect(aci.period(2)).to eq "November 2020"
@@ -466,7 +466,7 @@ RSpec.describe AggregatedCashIncome, type: :model do
         end
       end
 
-      context "locale :cy" do
+      context "with locale :cy" do
         around(:each) do |example|
           I18n.with_locale(:cy) { example.run }
         end
@@ -480,7 +480,7 @@ RSpec.describe AggregatedCashIncome, type: :model do
     end
 
     describe "#month name" do
-      context "locale :en" do
+      context "with locale :en" do
         it "displays the month name" do
           expect(aci.month_name(1)).to eq "December"
           expect(aci.month_name(2)).to eq "November"
@@ -488,7 +488,7 @@ RSpec.describe AggregatedCashIncome, type: :model do
         end
       end
 
-      context "locale :cy" do
+      context "with locale :cy" do
         around(:each) do |example|
           I18n.with_locale(:cy) { example.run }
         end

--- a/spec/models/aggregated_cash_outgoings_spec.rb
+++ b/spec/models/aggregated_cash_outgoings_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe AggregatedCashOutgoings, type: :model do
   before { application.set_transaction_period }
 
   describe "#find_by" do
-    context "no cash income transaction records" do
+    context "with no cash income transaction records" do
       it "returns an empty model" do
         aco = described_class.find_by(legal_aid_application_id: application.id)
         expect(aco.check_box_rent_or_mortgage).to be_nil
@@ -45,7 +45,7 @@ RSpec.describe AggregatedCashOutgoings, type: :model do
       end
     end
 
-    context "cash income transaction records exist" do
+    context "when cash income transaction records exist" do
       let!(:maintenance_out1) { create :cash_transaction, :credit_month1, legal_aid_application: application, transaction_type: maintenance_out }
       let!(:maintenance_out2) { create :cash_transaction, :credit_month2, legal_aid_application: application, transaction_type: maintenance_out }
       let!(:maintenance_out3) { create :cash_transaction, :credit_month3, legal_aid_application: application, transaction_type: maintenance_out }
@@ -90,8 +90,8 @@ RSpec.describe AggregatedCashOutgoings, type: :model do
       aco.update(params)
     end
 
-    context "valid params" do
-      context "none selected" do
+    context "with valid params" do
+      context "and none selected" do
         let(:params) { none_selected_params }
 
         it "is valid" do
@@ -103,7 +103,7 @@ RSpec.describe AggregatedCashOutgoings, type: :model do
         end
       end
 
-      context "categories selected" do
+      context "with categories selected" do
         let(:params) { valid_params }
 
         it "is valid" do
@@ -126,8 +126,8 @@ RSpec.describe AggregatedCashOutgoings, type: :model do
       end
     end
 
-    context "invalid params" do
-      context "missing month value" do
+    context "with invalid params" do
+      context "and missing month value" do
         let(:params) { missing_month_params }
 
         it "is invalid" do
@@ -145,7 +145,7 @@ RSpec.describe AggregatedCashOutgoings, type: :model do
         end
       end
 
-      context "amount negative" do
+      context "with amount negative" do
         let(:params) { valid_params.merge({ rent_or_mortgage1: "-1" }) }
 
         it "is invalid" do
@@ -158,7 +158,7 @@ RSpec.describe AggregatedCashOutgoings, type: :model do
         end
       end
 
-      context "amount not numerical" do
+      context "when amount not numerical" do
         let(:params) { valid_params.merge({ rent_or_mortgage1: "$%^&" }) }
 
         it "is invalid" do
@@ -171,7 +171,7 @@ RSpec.describe AggregatedCashOutgoings, type: :model do
         end
       end
 
-      context "amount too many decimals" do
+      context "when amount has too many decimals" do
         let(:params) { valid_params.merge({ rent_or_mortgage1: "9.99999" }) }
 
         it "is invalid" do
@@ -184,7 +184,7 @@ RSpec.describe AggregatedCashOutgoings, type: :model do
         end
       end
 
-      context "no categories selected" do
+      context "with no categories selected" do
         let(:params) { { legal_aid_application_id: application.id } }
 
         it "is invalid" do
@@ -196,7 +196,7 @@ RSpec.describe AggregatedCashOutgoings, type: :model do
         end
       end
 
-      context "none selected with values" do
+      context "when none selected with values" do
         let(:params) { none_selected_with_params }
 
         it "is invalid" do
@@ -211,12 +211,12 @@ RSpec.describe AggregatedCashOutgoings, type: :model do
   end
 
   describe "#update" do
-    context "previous values" do
+    context "with previous values" do
       before do
         aco.update(valid_params)
       end
 
-      context "upon successful validation" do
+      context "with successful validation" do
         let(:subject) { aco.update(additional_valid_params) }
 
         it "updates with previously selected checkboxes" do
@@ -237,10 +237,10 @@ RSpec.describe AggregatedCashOutgoings, type: :model do
       end
     end
 
-    context "no cash income records exist" do
+    context "when no cash income records exist" do
       let(:subject) { aco.update(params) }
 
-      context "valid params" do
+      context "with valid params" do
         let(:params) { valid_params }
 
         it "creates the expected cash income records" do
@@ -248,8 +248,8 @@ RSpec.describe AggregatedCashOutgoings, type: :model do
         end
       end
 
-      context "invalid params" do
-        context "non-numeric values" do
+      context "with invalid params" do
+        context "and non-numeric values" do
           let(:params) { non_numeric_params }
 
           it "does not create the Cash Transaction records" do
@@ -267,7 +267,7 @@ RSpec.describe AggregatedCashOutgoings, type: :model do
           end
         end
 
-        context "too many decimal numbers" do
+        context "with too many decimal numbers" do
           let(:params) { too_many_decimal_params }
 
           it "does not create the Cash Transaction records" do
@@ -285,7 +285,7 @@ RSpec.describe AggregatedCashOutgoings, type: :model do
           end
         end
 
-        context "negative value" do
+        context "with a negative value" do
           let(:params) { negative_params }
 
           it "does not create the Cash Transaction records" do
@@ -303,7 +303,7 @@ RSpec.describe AggregatedCashOutgoings, type: :model do
           end
         end
 
-        context "missing value" do
+        context "with a missing value" do
           let(:params) { missing_value_params }
 
           it "does not create the Cash Transaction records" do
@@ -323,12 +323,12 @@ RSpec.describe AggregatedCashOutgoings, type: :model do
       end
     end
 
-    context "cash income records already exist" do
+    context "when cash income records already exist" do
       before do
         aco.update(valid_params)
       end
 
-      context "preexisting records" do
+      context "with preexisting records" do
         let(:subject) { aco.update(corrected_valid_params) }
 
         it "does not change the record count when records updated" do
@@ -349,7 +349,7 @@ RSpec.describe AggregatedCashOutgoings, type: :model do
         end
       end
 
-      context "preexisting transaction types" do
+      context "with preexisting transaction types" do
         let(:subject) { aco.update(none_selected_params) }
 
         it "removes all records when none selected" do
@@ -357,7 +357,7 @@ RSpec.describe AggregatedCashOutgoings, type: :model do
         end
       end
 
-      context "additional transaction types" do
+      context "with additional transaction types" do
         let(:subject) { aco.update(additional_valid_params) }
 
         it "adds to prexisting transaction types" do
@@ -365,7 +365,7 @@ RSpec.describe AggregatedCashOutgoings, type: :model do
         end
       end
 
-      context "previous months preexisting" do
+      context "with previous months preexisting" do
         let(:subject) { aco.update(corrected_valid_params) }
 
         before do

--- a/spec/models/applicant_spec.rb
+++ b/spec/models/applicant_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe Applicant, type: :model do
     end
   end
 
-  context "True Layer Token" do
+  context "with True Layer Token" do
     subject { applicant.store_true_layer_token token:, expires: token_expires_at }
 
     let(:token) { SecureRandom.uuid }
@@ -137,7 +137,7 @@ RSpec.describe Applicant, type: :model do
     end
   end
 
-  context "income checks" do
+  context "with income checks" do
     let(:applicant) { create :applicant }
     let(:benefits) { create :transaction_type, :credit, name: "benefits" }
     let(:transaction_array) { [benefits] }
@@ -277,35 +277,35 @@ RSpec.describe Applicant, type: :model do
 
   describe "employment status" do
     describe "#not_employed?" do
-      context "not employed" do
+      context "when not employed" do
         it "returns true" do
           applicant = build :applicant, :not_employed
           expect(applicant.not_employed?).to be true
         end
       end
 
-      context "armed forces" do
+      context "when armed forces" do
         it "returns false" do
           applicant = build :applicant, :armed_forces
           expect(applicant.not_employed?).to be false
         end
       end
 
-      context "self employed" do
+      context "when self employed" do
         it "returns false" do
           applicant = build :applicant, :armed_forces
           expect(applicant.not_employed?).to be false
         end
       end
 
-      context "employed and self employed" do
+      context "when employed and self employed" do
         it "returns false" do
           applicant = build :applicant, :employed, :self_employed
           expect(applicant.not_employed?).to be false
         end
       end
 
-      context "all three" do
+      context "when all three" do
         it "returns false" do
           applicant = build :applicant, :employed, :self_employed, :armed_forces
           expect(applicant.not_employed?).to be false


### PR DESCRIPTION
Fix GOVUK Rubocop RSpec/ContextWording offences .

Start context description with 'when', 'with', 'without', 'and', or 'but'. (https://rspec.rubystyle.guide/#context-descriptions, https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ContextWording)

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
