### PR TITLE
Rubocop fixes

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -159,20 +159,6 @@ RSpec/BeforeAfterAll:
 # Prefixes: when, with, without
 RSpec/ContextWording:
   Exclude:
-    - 'spec/models/application_digest_spec.rb'
-    - 'spec/models/application_merits_task/involved_child_spec.rb'
-    - 'spec/models/application_merits_task/opponent_spec.rb'
-    - 'spec/models/attachment_spec.rb'
-    - 'spec/models/bank_account_spec.rb'
-    - 'spec/models/bank_transaction_spec.rb'
-    - 'spec/models/cash_transaction_spec.rb'
-    - 'spec/models/ccms/opponent_id_spec.rb'
-    - 'spec/models/ccms/submission_spec.rb'
-    - 'spec/models/cfe/remarked_transaction_collection_spec.rb'
-    - 'spec/models/cfe/remarked_transaction_spec.rb'
-    - 'spec/models/cfe/remarks_spec.rb'
-    - 'spec/models/cfe/v1/result_spec.rb'
-    - 'spec/models/cfe/v2/result_spec.rb'
     - 'spec/models/cfe/v3/result_spec.rb'
     - 'spec/models/cfe/v4/result_spec.rb'
     - 'spec/models/concerns/cfe_submission_state_machine_spec.rb'

--- a/spec/models/application_digest_spec.rb
+++ b/spec/models/application_digest_spec.rb
@@ -167,15 +167,15 @@ RSpec.describe ApplicationDigest do
       end
     end
 
-    context "use_ccms" do
-      context "application is not at use_ccms" do
+    context "with use_ccms" do
+      context "when application is not at use_ccms" do
         it "is false" do
           subject
           expect(digest.use_ccms).to be false
         end
       end
 
-      context "application is at use_ccms" do
+      context "when application is at use_ccms" do
         it "is true" do
           described_class.create_or_update!(laa_at_use_ccms.id)
           digest = described_class.find_by(legal_aid_application_id: laa_at_use_ccms.id)
@@ -184,8 +184,8 @@ RSpec.describe ApplicationDigest do
       end
     end
 
-    context "passported" do
-      context "application is passported" do
+    context "when passported" do
+      context "when application is passported" do
         before do
           allow_any_instance_of(LegalAidApplication).to receive(:passported?).and_return(true)
           subject
@@ -196,7 +196,7 @@ RSpec.describe ApplicationDigest do
         end
       end
 
-      context "application is NOT passported" do
+      context "when application is NOT passported" do
         before do
           allow_any_instance_of(LegalAidApplication).to receive(:passported?).and_return(false)
           subject
@@ -208,8 +208,8 @@ RSpec.describe ApplicationDigest do
       end
     end
 
-    context "delegated_functions" do
-      context "delegated_functions not used" do
+    context "with delegated_functions" do
+      context "and delegated_functions not used" do
         it "returns false and nils" do
           subject
           expect(digest.df_used).to be false
@@ -219,7 +219,7 @@ RSpec.describe ApplicationDigest do
         end
       end
 
-      context "delegated_functions used" do
+      context "and delegated_functions used" do
         before do
           # DF used on DA001 and SE014 only - used and reported dates specified in array
           # Good Friday on 2nd April, Easter Monday 5th April

--- a/spec/models/application_merits_task/involved_child_spec.rb
+++ b/spec/models/application_merits_task/involved_child_spec.rb
@@ -15,7 +15,7 @@ module ApplicationMeritsTask
 
       let(:involved_child) { build :involved_child, full_name: }
 
-      context "first name and last name" do
+      context "with first name and last name" do
         let(:full_name) { "John Smith" }
 
         it "separates out first and last name" do
@@ -31,7 +31,7 @@ module ApplicationMeritsTask
         end
       end
 
-      context "first name, middle name, last name" do
+      context "with first name, middle name, last name" do
         let(:full_name) { "Philip   Stephen    Richards" }
 
         it "separates out first and last name" do
@@ -39,7 +39,7 @@ module ApplicationMeritsTask
         end
       end
 
-      context "just last name" do
+      context "with just last name" do
         let(:full_name) { "Prince" }
 
         it "returns unspecified as first name" do
@@ -47,7 +47,7 @@ module ApplicationMeritsTask
         end
       end
 
-      context "double-barrelled names" do
+      context "with double-barrelled names" do
         let(:full_name) { "Jacob Rees-Mogg" }
 
         it "is not phased by the hyphen" do
@@ -55,7 +55,7 @@ module ApplicationMeritsTask
         end
       end
 
-      context "irish names" do
+      context "with Irish names" do
         let(:full_name) { "Daira O'Brien" }
 
         it "is not phased by the apostrophe" do
@@ -67,7 +67,7 @@ module ApplicationMeritsTask
     describe "CCMSOpponentIdGenerator concern" do
       let(:expected_id) { Faker::Number.number(digits: 8) }
 
-      context "ccms_opponent_id is nil" do
+      context "when ccms_opponent_id is nil" do
         before { expect(CCMS::OpponentId).to receive(:next_serial_id).and_return(expected_id) }
 
         let(:involved_child) { create :involved_child, full_name: "John Doe", ccms_opponent_id: nil }
@@ -82,7 +82,7 @@ module ApplicationMeritsTask
         end
       end
 
-      context "ccms_opponent_id is already populated" do
+      context "when ccms_opponent_id is already populated" do
         before { expect(CCMS::OpponentId).not_to receive(:next_serial_id) }
 
         let(:involved_child) { create :involved_child, full_name: "John Doe", ccms_opponent_id: 4553 }

--- a/spec/models/application_merits_task/opponent_spec.rb
+++ b/spec/models/application_merits_task/opponent_spec.rb
@@ -13,7 +13,7 @@ module ApplicationMeritsTask
     describe "CCMSOpponentIdGenerator concern" do
       let(:expected_id) { Faker::Number.number(digits: 8) }
 
-      context "ccms_opponent_id is nil" do
+      context "when ccms_opponent_id is nil" do
         before { expect(CCMS::OpponentId).to receive(:next_serial_id).and_return(expected_id) }
 
         let(:opponent) { create :opponent, ccms_opponent_id: nil }
@@ -28,7 +28,7 @@ module ApplicationMeritsTask
         end
       end
 
-      context "ccms_opponent_id is already populated" do
+      context "when ccms_opponent_id is already populated" do
         before { expect(CCMS::OpponentId).not_to receive(:next_serial_id) }
 
         let(:opponent) { create :opponent, ccms_opponent_id: 1234 }

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Attachment do
   let!(:means1) { create :attachment, :means_report }
   let!(:bank) { create :attachment, :bank_transaction_report }
 
-  context "scopes" do
+  context "with scopes" do
     it "returns the expected collections" do
       expect(described_class.statement_of_case).to match_array [soc1, soc2]
       expect(described_class.merits_report).to match_array [merits1, merits2]

--- a/spec/models/bank_account_spec.rb
+++ b/spec/models/bank_account_spec.rb
@@ -17,14 +17,14 @@ RSpec.describe BankAccount, type: :model do
       expect(bank_account.account_type_label).to eq(not_defined_account_type)
     end
 
-    context "savings type" do
+    context "with savings type" do
       it "returns Bank Savings" do
         bank_account = create :bank_account, account_type: "SAVINGS"
         expect(bank_account.account_type_label).to eq("Bank Savings")
       end
     end
 
-    context "transactions type" do
+    context "with transactions type" do
       it "returns Bank Current" do
         bank_account = create :bank_account, account_type: "TRANSACTION"
         expect(bank_account.account_type_label).to eq("Bank Current")
@@ -79,7 +79,7 @@ RSpec.describe BankAccount, type: :model do
   describe "#latest_balance" do
     let(:bank_account) { create :bank_account }
 
-    context "transactions exist" do
+    context "when transactions exist" do
       before { create_transactions }
 
       it "returns the running balance of the latest transaction" do
@@ -87,7 +87,7 @@ RSpec.describe BankAccount, type: :model do
       end
     end
 
-    context "no bank transactions" do
+    context "with no bank transactions" do
       it "returns the balance from the bank account record" do
         expect(bank_account.bank_transactions.size).to eq 0
         expect(bank_account.latest_balance).to eq bank_account.balance

--- a/spec/models/bank_transaction_spec.rb
+++ b/spec/models/bank_transaction_spec.rb
@@ -8,21 +8,21 @@ RSpec.describe BankTransaction do
     let(:excluded_benefits) { TransactionType.find_by(name: "excluded_benefits") }
     let(:pension) { TransactionType.find_by(name: "pension") }
 
-    context "transaction type is not a child" do
+    context "when transaction type is not a child" do
       it "returns the transaction type" do
         trx = create :bank_transaction, :credit, transaction_type: pension
         expect(trx.parent_transaction_type).to eq pension
       end
     end
 
-    context "transaction type is a child" do
+    context "when transaction type is a child" do
       it "returns the transaction type parent" do
         trx = create :bank_transaction, :credit, transaction_type: excluded_benefits
         expect(trx.parent_transaction_type).to eq benefits
       end
     end
 
-    describe "scope by parent_transaction_type" do
+    describe "with scope by parent_transaction_type" do
       it "groups the transactions keyed by parent transaction type" do
         trx_p1 = create :bank_transaction, :credit, transaction_type: pension
         trx_p2 = create :bank_transaction, :credit, transaction_type: pension
@@ -38,8 +38,8 @@ RSpec.describe BankTransaction do
     end
   end
 
-  context "serialization of meta data" do
-    context "meta data is null" do
+  context "with serialization of meta data" do
+    context "and meta data is null" do
       let(:tx) { create :bank_transaction }
 
       it "returns nil" do
@@ -54,7 +54,7 @@ RSpec.describe BankTransaction do
       end
     end
 
-    context "meta data is populated" do
+    context "when meta data is populated" do
       it "returns a hash" do
         bt = create :bank_transaction, :with_meta
         expect(bt.meta_data[:code]).to eq "UC"

--- a/spec/models/cash_transaction_spec.rb
+++ b/spec/models/cash_transaction_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe CashTransaction, type: :model do
     end
   end
 
-  context "date formatting" do
+  context "with date formatting" do
     let(:ctx) { create :cash_transaction, transaction_date: Date.new(2021, 2, 2), month_number: 1 }
 
     describe ".period_start" do

--- a/spec/models/ccms/opponent_id_spec.rb
+++ b/spec/models/ccms/opponent_id_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 module CCMS
   RSpec.describe OpponentId do
     describe ".next_serial_id" do
-      context "no record in the ccms_opponent_ids table" do
+      context "with no record in the ccms_opponent_ids table" do
         it "creates one record" do
           expect(described_class.count).to be_zero
           described_class.next_serial_id
@@ -16,7 +16,7 @@ module CCMS
         end
       end
 
-      context "a record already exists in the ccms_opponent_ids table" do
+      context "when a record already exists in the ccms_opponent_ids table" do
         before { described_class.create!(serial_id: 88_123_456) }
 
         it "returns the next value" do

--- a/spec/models/ccms/submission_spec.rb
+++ b/spec/models/ccms/submission_spec.rb
@@ -15,7 +15,7 @@ module CCMS
              case_poll_count:
     end
 
-    context "Validations" do
+    context "with Validations" do
       it "errors if no legal aid application id is present" do
         submission.legal_aid_application = nil
         expect(submission).not_to be_valid
@@ -34,7 +34,7 @@ module CCMS
     describe "#process!" do
       let(:history) { SubmissionHistory.find_by(submission_id: submission.id) }
 
-      context "invalid state" do
+      context "with invalid state" do
         it "raises if state is invalid" do
           submission.aasm_state = "xxxxx"
           expect {
@@ -43,7 +43,7 @@ module CCMS
         end
       end
 
-      context "valid state" do
+      context "with valid state" do
         let(:service) { CCMS::Submitters::ObtainCaseReferenceService }
         let(:service_instance) { service.new(submission) }
 
@@ -57,7 +57,7 @@ module CCMS
           expect(service_instance).to receive(:call).with(no_args)
         end
 
-        context "case_ref_obtained state" do
+        context "with case_ref_obtained state" do
           let(:state) { :case_ref_obtained }
           let(:service) { CCMS::Submitters::ObtainApplicantReferenceService }
 
@@ -66,7 +66,7 @@ module CCMS
           end
         end
 
-        context "applicant_submitted state" do
+        context "with applicant_submitted state" do
           let(:state) { :applicant_submitted }
           let(:service) { CCMS::Submitters::CheckApplicantStatusService }
 
@@ -75,7 +75,7 @@ module CCMS
           end
         end
 
-        context "applicant_ref_obtained state" do
+        context "with applicant_ref_obtained state" do
           let(:state) { :applicant_ref_obtained }
           let(:service) { CCMS::Submitters::ObtainDocumentIdService }
 
@@ -84,7 +84,7 @@ module CCMS
           end
         end
 
-        context "case_submitted state" do
+        context "with case_submitted state" do
           let(:state) { :case_submitted }
           let(:service) { CCMS::Submitters::CheckCaseStatusService }
 
@@ -93,7 +93,7 @@ module CCMS
           end
         end
 
-        context "case_created state" do
+        context "with case_created state" do
           let(:state) { :case_created }
           let(:service) { CCMS::Submitters::UploadDocumentsService }
 
@@ -102,7 +102,7 @@ module CCMS
           end
         end
 
-        context "document_ids_obtained state" do
+        context "with document_ids_obtained state" do
           let(:state) { :document_ids_obtained }
           let(:service) { CCMS::Submitters::AddCaseService }
 
@@ -113,7 +113,7 @@ module CCMS
       end
     end
 
-    context "state change:" do
+    context "with state change:" do
       describe "#obtain_case_ref" do
         it "changes state" do
           expect { submission.obtain_case_ref }.to change(submission, :aasm_state).to("case_ref_obtained")
@@ -136,7 +136,7 @@ module CCMS
     end
 
     describe "#process_async!" do
-      context "submission is in initialised state" do
+      context "when submission is in initialised state" do
         it "calls SubmissionProcessWorker with a delay of 5 seconds" do
           expect(SubmissionProcessWorker).to receive(:perform_async).with(submission.id, submission.aasm_state)
           submission.process_async!

--- a/spec/models/cfe/remarked_transaction_collection_spec.rb
+++ b/spec/models/cfe/remarked_transaction_collection_spec.rb
@@ -5,13 +5,13 @@ module CFE
     describe "#transactions" do
       let(:collection) { described_class.new }
 
-      context "empty collection" do
+      context "with empty collection" do
         it "returns an empty hash" do
           expect(collection.transactions).to eq({})
         end
       end
 
-      context "with_transactions" do
+      context "with with_transactions" do
         let(:tx_id1) { SecureRandom.uuid }
         let(:tx_id2) { SecureRandom.uuid }
         let(:category1) { :state_benefits }

--- a/spec/models/cfe/remarked_transaction_spec.rb
+++ b/spec/models/cfe/remarked_transaction_spec.rb
@@ -15,7 +15,7 @@ module CFE
     end
 
     describe "#update" do
-      context "non-matching tx_id" do
+      context "with non-matching tx_id" do
         it "raises" do
           expect {
             transaction.update(SecureRandom.uuid, category, :unknown_frequency)
@@ -23,7 +23,7 @@ module CFE
         end
       end
 
-      context "non-matching category" do
+      context "with non-matching category" do
         it "raises" do
           expect {
             transaction.update(tx_id, :other_income, :unknown_frequency)
@@ -31,15 +31,15 @@ module CFE
         end
       end
 
-      context "adding a new reason" do
-        it "returns both the reasons in alphebetic order" do
+      context "when adding a new reason" do
+        it "returns both the reasons in alphabetical order" do
           transaction.update(tx_id, category, :amount_variation)
           expect(transaction.reasons).to eq(%i[amount_variation unknown_frequency])
         end
       end
 
-      context "adding duplicate reason" do
-        it "returns both the reasons in alphebetic order" do
+      context "when adding a duplicate reason" do
+        it "returns both the reasons in alphabetical order" do
           transaction.update(tx_id, category, :amount_variation)
           transaction.update(tx_id, category, :unknown_frequency)
           expect(transaction.reasons).to eq(%i[amount_variation unknown_frequency])

--- a/spec/models/cfe/remarks_spec.rb
+++ b/spec/models/cfe/remarks_spec.rb
@@ -5,7 +5,7 @@ module CFE
     let(:remarks) { described_class.new(remarks_hash) }
 
     describe "#caseworker_review_required?" do
-      context "no remarks" do
+      context "with no remarks" do
         let(:remarks_hash) { empty_hash }
 
         it "returns false" do
@@ -13,7 +13,7 @@ module CFE
         end
       end
 
-      context "remarks exist" do
+      context "when remarks exist" do
         let(:remarks_hash) { populated_hash }
 
         it "returns false" do
@@ -23,7 +23,7 @@ module CFE
     end
 
     describe "#review_reasons" do
-      context "no remarks" do
+      context "with no remarks" do
         let(:remarks_hash) { empty_hash }
 
         it "returns empty array" do
@@ -41,7 +41,7 @@ module CFE
     end
 
     describe "#review_categories_by_reason" do
-      context "no remarks" do
+      context "with no remarks" do
         let(:remarks_hash) { empty_hash }
 
         it "returns empty hash" do
@@ -79,7 +79,7 @@ module CFE
     end
 
     describe "#review_transactions" do
-      context "no remarks" do
+      context "with no remarks" do
         let(:remarks_hash) { empty_hash }
         let(:collection) { remarks.review_transactions }
 

--- a/spec/models/cfe/v1/result_spec.rb
+++ b/spec/models/cfe/v1/result_spec.rb
@@ -25,13 +25,13 @@ module CFE
       end
 
       describe "#overview" do
-        context "applicant is eligible" do
+        context "when applicant is eligible" do
           it "returns assessment result" do
             expect(eligible_result.overview).to eq "eligible"
           end
         end
 
-        context "applicant has contribution required and restrictions" do
+        context "when applicant has contribution required and restrictions" do
           it "returns manual_check_required" do
             expect(contribution_and_restriction_result.capital_contribution_required?).to be true
             expect(legal_aid_application.has_restrictions?).to be true
@@ -39,7 +39,7 @@ module CFE
           end
         end
 
-        context "applicant has contribution required and no restrictions" do
+        context "when applicant has contribution required and no restrictions" do
           it "returns manual_check_required" do
             expect(contribution_required_result.capital_contribution_required?).to be true
             expect(contribution_required_result.overview).to eq "capital_contribution_required"
@@ -48,19 +48,19 @@ module CFE
       end
 
       describe "#assessment_result" do
-        context "eligible" do
+        context "when eligible" do
           it "returns eligible" do
             expect(eligible_result.assessment_result).to eq "eligible"
           end
         end
 
-        context "not_eligible" do
+        context "when not_eligible" do
           it "returns not_eligible" do
             expect(not_eligible_result.assessment_result).to eq "not_eligible"
           end
         end
 
-        context "contribution_required" do
+        context "when contribution_required" do
           it "returns contribution_required" do
             expect(contribution_required_result.assessment_result).to eq "contribution_required"
           end
@@ -80,19 +80,19 @@ module CFE
       end
 
       describe "#additional_property?" do
-        context "present" do
+        context "when present" do
           it "returns true" do
             expect(additional_property.additional_property?).to be true
           end
         end
 
-        context "not present" do
+        context "when not present" do
           it "returns false" do
             expect(no_additional_properties.additional_property?).to be false
           end
         end
 
-        context "present but zero" do
+        context "when present but zero" do
           it "returns false" do
             expect(eligible_result.additional_property?).to be false
           end
@@ -123,7 +123,7 @@ module CFE
         end
       end
 
-      context "vehicles" do
+      context "with vehicles" do
         let(:result) { not_eligible_result }
         let(:vehicle) { result.vehicle }
 
@@ -159,7 +159,7 @@ module CFE
         end
       end
 
-      context "capital_items" do
+      context "with capital_items" do
         let(:result) { contribution_required_result }
 
         describe "#non_liquid_capital_items" do

--- a/spec/models/cfe/v2/result_spec.rb
+++ b/spec/models/cfe/v2/result_spec.rb
@@ -23,10 +23,10 @@ module CFE
 
         let(:application) { cfe_result.legal_aid_application }
 
-        context "manual check not required" do
+        context "when manual check not required" do
           before { allow(manual_review_determiner).to receive(:manual_review_required?).and_return(false) }
 
-          context "eligible" do
+          context "when eligible" do
             let(:cfe_result) { create :cfe_v2_result, :eligible }
 
             it "returns eligible" do
@@ -34,7 +34,7 @@ module CFE
             end
           end
 
-          context "not_eligible" do
+          context "when not_eligible" do
             let(:cfe_result) { create :cfe_v2_result, :not_eligible }
 
             it "returns not_eligible" do
@@ -42,7 +42,7 @@ module CFE
             end
           end
 
-          context "capital_contribution_required" do
+          context "with capital_contribution_required" do
             let(:cfe_result) { create :cfe_v2_result, :with_capital_contribution_required }
 
             it "returns capital_contribution_required" do
@@ -50,7 +50,7 @@ module CFE
             end
           end
 
-          context "income_contribution_required" do
+          context "with income_contribution_required" do
             let(:cfe_result) { create :cfe_v2_result, :with_income_contribution_required }
 
             it "returns income_contribution_required" do
@@ -58,7 +58,7 @@ module CFE
             end
           end
 
-          context "capital_and_income_contribution_required" do
+          context "with capital_and_income_contribution_required" do
             let(:cfe_result) { create :cfe_v2_result, :with_capital_and_income_contributions_required }
 
             it "returns capital_and_income_contribution_required" do
@@ -67,10 +67,10 @@ module CFE
           end
         end
 
-        context "manual check IS required and restrictions do not exist" do
+        context "when manual check IS required and restrictions do not exist" do
           before { allow(manual_review_determiner).to receive(:manual_review_required?).and_return(true) }
 
-          context "eligible" do
+          context "and eligible" do
             let(:cfe_result) { create :cfe_v2_result, :eligible }
 
             it "returns eligible" do
@@ -78,7 +78,7 @@ module CFE
             end
           end
 
-          context "not_eligible" do
+          context "and not_eligible" do
             let(:cfe_result) { create :cfe_v2_result, :not_eligible }
 
             it "returns not_eligible" do
@@ -86,7 +86,7 @@ module CFE
             end
           end
 
-          context "capital_contribution_required" do
+          context "with capital_contribution_required" do
             let(:cfe_result) { create :cfe_v2_result, :with_capital_contribution_required }
 
             it "returns capital_contribution_required" do
@@ -94,7 +94,7 @@ module CFE
             end
           end
 
-          context "income_contribution_required" do
+          context "with income_contribution_required" do
             let(:cfe_result) { create :cfe_v2_result, :with_income_contribution_required }
 
             it "returns income_contribution_required" do
@@ -102,7 +102,7 @@ module CFE
             end
           end
 
-          context "capital_and_income_contribution_required" do
+          context "with capital_and_income_contribution_required" do
             let(:cfe_result) { create :cfe_v2_result, :with_capital_and_income_contributions_required }
 
             it "returns capital_and_income_contribution_required" do
@@ -111,13 +111,13 @@ module CFE
           end
         end
 
-        context "manual check IS required and restrictions exist" do
+        context "when manual check IS required and restrictions exist" do
           before do
             allow(manual_review_determiner).to receive(:manual_review_required?).and_return(true)
             application.has_restrictions = true
           end
 
-          context "eligible" do
+          context "and eligible" do
             let(:cfe_result) { create :cfe_v2_result, :eligible }
 
             it "returns manual_check_required" do
@@ -125,7 +125,7 @@ module CFE
             end
           end
 
-          context "not_eligible" do
+          context "and not_eligible" do
             let(:cfe_result) { create :cfe_v2_result, :not_eligible }
 
             it "returns manual_check_required" do
@@ -133,7 +133,7 @@ module CFE
             end
           end
 
-          context "capital_contribution_required" do
+          context "when capital_contribution_required" do
             let(:cfe_result) { create :cfe_v2_result, :with_capital_contribution_required }
 
             it "returns manual_check_required" do
@@ -141,7 +141,7 @@ module CFE
             end
           end
 
-          context "income_contribution_required" do
+          context "when income_contribution_required" do
             let(:cfe_result) { create :cfe_v2_result, :with_income_contribution_required }
 
             it "returns manual_check_required" do
@@ -149,7 +149,7 @@ module CFE
             end
           end
 
-          context "capital_and_income_contribution_required" do
+          context "when capital_and_income_contribution_required" do
             let(:cfe_result) { create :cfe_v2_result, :with_capital_and_income_contributions_required }
 
             it "returns manual_check_required" do
@@ -160,19 +160,19 @@ module CFE
       end
 
       describe "#assessment_result" do
-        context "eligible" do
+        context "when eligible" do
           it "returns eligible" do
             expect(eligible_result.assessment_result).to eq "eligible"
           end
         end
 
-        context "not_eligible" do
+        context "when not_eligible" do
           it "returns not_eligible" do
             expect(not_eligible_result.assessment_result).to eq "not_eligible"
           end
         end
 
-        context "contribution_required" do
+        context "when contribution_required" do
           it "returns contribution_required" do
             expect(contribution_required_result.assessment_result).to eq "contribution_required"
           end
@@ -185,7 +185,7 @@ module CFE
         end
       end
 
-      context "disposable income" do
+      context "with disposable income" do
         let(:result) { income_contribution_required_result }
 
         describe "#income_contribution" do
@@ -234,13 +234,13 @@ module CFE
       end
 
       describe "eligible?" do
-        context "returns true" do
+        context "when returns true" do
           it "returns boolean response for eligible" do
             expect(eligible_result.eligible?).to be true
           end
         end
 
-        context "returns false" do
+        context "when returns false" do
           it "returns false response for eligible" do
             expect(not_eligible_result.eligible?).to be false
           end
@@ -248,13 +248,13 @@ module CFE
       end
 
       describe "capital_contribution_required?" do
-        context "contribution not required" do
+        context "when contribution not required" do
           it "returns false for capital_contribution_required" do
             expect(eligible_result.capital_contribution_required?).to be false
           end
         end
 
-        context "contribution is required" do
+        context "when contribution is required" do
           it "returns true for capital_contribution_required" do
             expect(contribution_required_result.capital_contribution_required?).to be true
           end
@@ -310,13 +310,13 @@ module CFE
       end
 
       describe "vehicles?" do
-        context "vehicle(s) exist" do
-          it "returns a boolean response if vehicles exist" do
+        context "when vehicle(s) exist" do
+          it "returns a boolean response" do
             expect(eligible_result.vehicles?).to be true
           end
 
-          context "vehicles dont exist"
-          it "returns a boolean response if vehicles exist" do
+          context "when vehicles do not exist"
+          it "returns a boolean response" do
             expect(no_vehicles.vehicles?).to be false
           end
         end
@@ -357,19 +357,19 @@ module CFE
       ################################################################
 
       describe "#additional_property?" do
-        context "present" do
+        context "when present" do
           it "returns true" do
             expect(additional_property.additional_property?).to be true
           end
         end
 
-        context "not present" do
+        context "when not present" do
           it "returns false" do
             expect(no_additional_properties.additional_property?).to be false
           end
         end
 
-        context "present but zero" do
+        context "when present but zero" do
           it "returns false" do
             expect(eligible_result.additional_property?).to be false
           end


### PR DESCRIPTION
Fix GOVUK Rubocop RSpec/ContextWording offences.

Start context description with 'when', 'with', 'without', 'and', or 'but'. (https://rspec.rubystyle.guide/#context-descriptions, https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ContextWording)

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
