### PR TITLE
bugfix: update dependabot delete script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -403,6 +403,7 @@ workflows:
           - lint_checks
           <<: *generic-slack-fail-post-step
       - delete_dependabot_deployment:
+          context: laa-apply-for-legalaid-uat
           filters:
             branches:
               only:

--- a/bin/delete_dependabot_deployment
+++ b/bin/delete_dependabot_deployment
@@ -6,13 +6,13 @@ echo "Attempting to delete UAT dependabot release"
 echo "$RELEASE_NAME"
 
 
-UAT_RELEASES=$(helm list --namespace=${KUBE_ENV_UAT_NAMESPACE} --all)
+UAT_RELEASES=$(helm list --namespace=${K8S_NAMESPACE} --all)
 echo "Current UAT releases:"
 echo "$UAT_RELEASES"
 
 if [[ $UAT_RELEASES == *"$RELEASE_NAME"* ]]
 then
-  helm delete $RELEASE_NAME --namespace=${KUBE_ENV_UAT_NAMESPACE}
+  helm delete $RELEASE_NAME --namespace=${K8S_NAMESPACE}
   echo "Deleted UAT dependabot release $RELEASE_NAME"
 else
   echo "UAT dependabot release $RELEASE_NAME was not found"


### PR DESCRIPTION

the delete script was failing to authenticate with the cluster after we updated the ENV_VARs
this PR fixes the issue by:
set a context for deleting depenadbot job in circleci
update the ENV_VAR use for the namespace

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
