### PR TITLE
Rubocop fixes

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -159,13 +159,6 @@ RSpec/BeforeAfterAll:
 # Prefixes: when, with, without
 RSpec/ContextWording:
   Exclude:
-    - 'spec/models/cfe/v3/result_spec.rb'
-    - 'spec/models/cfe/v4/result_spec.rb'
-    - 'spec/models/concerns/cfe_submission_state_machine_spec.rb'
-    - 'spec/models/concerns/translatable_model_attribute_spec.rb'
-    - 'spec/models/dashboard/widget_data_providers/number_provider_firms_spec.rb'
-    - 'spec/models/dashboard/widget_data_providers/percentage_declined_open_banking_spec.rb'
-    - 'spec/models/dependant_spec.rb'
     - 'spec/models/firm_spec.rb'
     - 'spec/models/hmrc/response_spec.rb'
     - 'spec/models/host_env_spec.rb'

--- a/spec/models/cfe/v3/result_spec.rb
+++ b/spec/models/cfe/v3/result_spec.rb
@@ -22,10 +22,10 @@ module CFE
 
         let(:application) { cfe_result.legal_aid_application }
 
-        context "manual check not required" do
+        context "when manual check not required" do
           before { allow(manual_review_determiner).to receive(:manual_review_required?).and_return(false) }
 
-          context "eligible" do
+          context "when eligible" do
             let(:cfe_result) { create :cfe_v3_result, :eligible }
 
             it "returns eligible" do
@@ -33,7 +33,7 @@ module CFE
             end
           end
 
-          context "not_eligible" do
+          context "when not_eligible" do
             let(:cfe_result) { create :cfe_v3_result, :not_eligible }
 
             it "returns not_eligible" do
@@ -41,7 +41,7 @@ module CFE
             end
           end
 
-          context "capital_contribution_required" do
+          context "when capital_contribution_required" do
             let(:cfe_result) { create :cfe_v3_result, :with_capital_contribution_required }
 
             it "returns capital_contribution_required" do
@@ -49,7 +49,7 @@ module CFE
             end
           end
 
-          context "income_contribution_required" do
+          context "when income_contribution_required" do
             let(:cfe_result) { create :cfe_v3_result, :with_income_contribution_required }
 
             it "returns income_contribution_required" do
@@ -57,7 +57,7 @@ module CFE
             end
           end
 
-          context "capital_and_income_contribution_required" do
+          context "when capital_and_income_contribution_required" do
             let(:cfe_result) { create :cfe_v3_result, :with_capital_and_income_contributions_required }
 
             it "returns capital_and_income_contribution_required" do
@@ -66,10 +66,10 @@ module CFE
           end
         end
 
-        context "manual check IS required and restrictions do not exist" do
+        context "when manual check IS required and restrictions do not exist" do
           before { allow(manual_review_determiner).to receive(:manual_review_required?).and_return(true) }
 
-          context "eligible" do
+          context "when eligible" do
             let(:cfe_result) { create :cfe_v3_result, :eligible }
 
             it "returns eligible" do
@@ -77,7 +77,7 @@ module CFE
             end
           end
 
-          context "not_eligible" do
+          context "when not_eligible" do
             let(:cfe_result) { create :cfe_v3_result, :not_eligible }
 
             it "returns not_eligible" do
@@ -85,7 +85,7 @@ module CFE
             end
           end
 
-          context "capital_contribution_required" do
+          context "when capital_contribution_required" do
             let(:cfe_result) { create :cfe_v3_result, :with_capital_contribution_required }
 
             it "returns capital_contribution_required" do
@@ -93,7 +93,7 @@ module CFE
             end
           end
 
-          context "income_contribution_required" do
+          context "when income_contribution_required" do
             let(:cfe_result) { create :cfe_v3_result, :with_income_contribution_required }
 
             it "returns income_contribution_required" do
@@ -101,7 +101,7 @@ module CFE
             end
           end
 
-          context "capital_and_income_contribution_required" do
+          context "when capital_and_income_contribution_required" do
             let(:cfe_result) { create :cfe_v3_result, :with_capital_and_income_contributions_required }
 
             it "returns capital_and_income_contribution_required" do
@@ -110,13 +110,13 @@ module CFE
           end
         end
 
-        context "manual check IS required and restrictions exist" do
+        context "when manual check IS required and restrictions exist" do
           before do
             allow(manual_review_determiner).to receive(:manual_review_required?).and_return(true)
             application.has_restrictions = true
           end
 
-          context "eligible" do
+          context "when eligible" do
             let(:cfe_result) { create :cfe_v3_result, :eligible }
 
             it "returns manual_check_required" do
@@ -124,7 +124,7 @@ module CFE
             end
           end
 
-          context "not_eligible" do
+          context "when not_eligible" do
             let(:cfe_result) { create :cfe_v3_result, :not_eligible }
 
             it "returns manual_check_required" do
@@ -132,7 +132,7 @@ module CFE
             end
           end
 
-          context "capital_contribution_required" do
+          context "when capital_contribution_required" do
             let(:cfe_result) { create :cfe_v3_result, :with_capital_contribution_required }
 
             it "returns manual_check_required" do
@@ -140,7 +140,7 @@ module CFE
             end
           end
 
-          context "income_contribution_required" do
+          context "when income_contribution_required" do
             let(:cfe_result) { create :cfe_v3_result, :with_income_contribution_required }
 
             it "returns manual_check_required" do
@@ -148,7 +148,7 @@ module CFE
             end
           end
 
-          context "capital_and_income_contribution_required" do
+          context "when capital_and_income_contribution_required" do
             let(:cfe_result) { create :cfe_v3_result, :with_capital_and_income_contributions_required }
 
             it "returns manual_check_required" do
@@ -159,19 +159,19 @@ module CFE
       end
 
       describe "#assessment_result" do
-        context "eligible" do
+        context "when eligible" do
           it "returns eligible" do
             expect(eligible_result.assessment_result).to eq "eligible"
           end
         end
 
-        context "not_eligible" do
+        context "when not_eligible" do
           it "returns not_eligible" do
             expect(not_eligible_result.assessment_result).to eq "not_eligible"
           end
         end
 
-        context "contribution_required" do
+        context "when contribution_required" do
           it "returns contribution_required" do
             expect(contribution_required_result.assessment_result).to eq "contribution_required"
           end
@@ -185,13 +185,13 @@ module CFE
       end
 
       describe "eligible?" do
-        context "returns true" do
+        context "when it returns true" do
           it "returns boolean response for eligible" do
             expect(eligible_result.eligible?).to be true
           end
         end
 
-        context "returns false" do
+        context "when it returns false" do
           it "returns false response for eligible" do
             expect(not_eligible_result.eligible?).to be false
           end
@@ -205,13 +205,13 @@ module CFE
       end
 
       describe "capital_contribution_required?" do
-        context "contribution not required" do
+        context "when contribution not required" do
           it "returns false for capital_contribution_required" do
             expect(eligible_result.capital_contribution_required?).to be false
           end
         end
 
-        context "contribution is required" do
+        context "when contribution is required" do
           it "returns true for capital_contribution_required" do
             expect(contribution_required_result.capital_contribution_required?).to be true
           end
@@ -273,12 +273,12 @@ module CFE
       end
 
       describe "vehicles?" do
-        context "vehicle(s) exist" do
+        context "when vehicle(s) exist" do
           it "returns a boolean response if vehicles exist" do
             expect(eligible_result.vehicles?).to be true
           end
 
-          context "vehicles dont exist"
+          context "when vehicles do not exist"
           it "returns a boolean response if vehicles exist" do
             expect(no_vehicles.vehicles?).to be false
           end
@@ -320,19 +320,19 @@ module CFE
       ################################################################
 
       describe "#additional_property?" do
-        context "present" do
+        context "when present" do
           it "returns true" do
             expect(additional_property.additional_property?).to be true
           end
         end
 
-        context "not present" do
+        context "when not present" do
           it "returns false" do
             expect(no_additional_properties.additional_property?).to be false
           end
         end
 
-        context "present but zero" do
+        context "when present but zero" do
           it "returns false" do
             expect(eligible_result.additional_property?).to be false
           end

--- a/spec/models/cfe/v4/result_spec.rb
+++ b/spec/models/cfe/v4/result_spec.rb
@@ -30,10 +30,10 @@ module CFE
 
         let(:application) { cfe_result.legal_aid_application }
 
-        context "manual check not required" do
+        context "when manual check not required" do
           before { allow(manual_review_determiner).to receive(:manual_review_required?).and_return(false) }
 
-          context "eligible" do
+          context "when eligible" do
             let(:cfe_result) { create :cfe_v4_result, :eligible }
 
             it "returns eligible" do
@@ -41,7 +41,7 @@ module CFE
             end
           end
 
-          context "not_eligible" do
+          context "when not_eligible" do
             let(:cfe_result) { create :cfe_v4_result, :not_eligible }
 
             it "returns not_eligible" do
@@ -49,7 +49,7 @@ module CFE
             end
           end
 
-          context "capital_contribution_required" do
+          context "when capital_contribution_required" do
             let(:cfe_result) { create :cfe_v4_result, :with_capital_contribution_required }
 
             it "returns capital_contribution_required" do
@@ -57,7 +57,7 @@ module CFE
             end
           end
 
-          context "income_contribution_required" do
+          context "when income_contribution_required" do
             let(:cfe_result) { create :cfe_v4_result, :with_income_contribution_required }
 
             it "returns income_contribution_required" do
@@ -65,7 +65,7 @@ module CFE
             end
           end
 
-          context "capital_and_income_contribution_required" do
+          context "when capital_and_income_contribution_required" do
             let(:cfe_result) { create :cfe_v4_result, :with_capital_and_income_contributions_required }
 
             it "returns capital_and_income_contribution_required" do
@@ -74,10 +74,10 @@ module CFE
           end
         end
 
-        context "manual check IS required and restrictions do not exist" do
+        context "when manual check IS required and restrictions do not exist" do
           before { allow(manual_review_determiner).to receive(:manual_review_required?).and_return(true) }
 
-          context "eligible" do
+          context "when eligible" do
             let(:cfe_result) { create :cfe_v4_result, :eligible }
 
             it "returns eligible" do
@@ -85,7 +85,7 @@ module CFE
             end
           end
 
-          context "not_eligible" do
+          context "when not_eligible" do
             let(:cfe_result) { create :cfe_v4_result, :not_eligible }
 
             it "returns not_eligible" do
@@ -93,7 +93,7 @@ module CFE
             end
           end
 
-          context "capital_contribution_required" do
+          context "when capital_contribution_required" do
             let(:cfe_result) { create :cfe_v4_result, :with_capital_contribution_required }
 
             it "returns capital_contribution_required" do
@@ -101,7 +101,7 @@ module CFE
             end
           end
 
-          context "income_contribution_required" do
+          context "when income_contribution_required" do
             let(:cfe_result) { create :cfe_v4_result, :with_income_contribution_required }
 
             it "returns income_contribution_required" do
@@ -109,7 +109,7 @@ module CFE
             end
           end
 
-          context "capital_and_income_contribution_required" do
+          context "when capital_and_income_contribution_required" do
             let(:cfe_result) { create :cfe_v4_result, :with_capital_and_income_contributions_required }
 
             it "returns capital_and_income_contribution_required" do
@@ -118,13 +118,13 @@ module CFE
           end
         end
 
-        context "manual check IS required and restrictions exist" do
+        context "when manual check IS required and restrictions exist" do
           before do
             allow(manual_review_determiner).to receive(:manual_review_required?).and_return(true)
             application.has_restrictions = true
           end
 
-          context "eligible" do
+          context "when eligible" do
             let(:cfe_result) { create :cfe_v4_result, :eligible }
 
             it "returns manual_check_required" do
@@ -132,7 +132,7 @@ module CFE
             end
           end
 
-          context "not_eligible" do
+          context "when not_eligible" do
             let(:cfe_result) { create :cfe_v4_result, :not_eligible }
 
             it "returns manual_check_required" do
@@ -140,7 +140,7 @@ module CFE
             end
           end
 
-          context "income_contribution_required" do
+          context "when income_contribution_required" do
             let(:cfe_result) { create :cfe_v4_result, :with_income_contribution_required }
 
             it "returns manual_check_required" do
@@ -148,7 +148,7 @@ module CFE
             end
           end
 
-          context "capital_and_income_contribution_required" do
+          context "when capital_and_income_contribution_required" do
             let(:cfe_result) { create :cfe_v4_result, :with_capital_and_income_contributions_required }
 
             it "returns manual_check_required" do
@@ -159,19 +159,19 @@ module CFE
       end
 
       describe "#assessment_result" do
-        context "eligible" do
+        context "when eligible" do
           it "returns eligible" do
             expect(eligible_result.assessment_result).to eq "eligible"
           end
         end
 
-        context "not_eligible" do
+        context "when not_eligible" do
           it "returns not_eligible" do
             expect(not_eligible_result.assessment_result).to eq "not_eligible"
           end
         end
 
-        context "contribution_required" do
+        context "when contribution_required" do
           it "returns contribution_required" do
             expect(contribution_required_result.assessment_result).to eq "contribution_required"
           end
@@ -185,13 +185,13 @@ module CFE
       end
 
       describe "eligible?" do
-        context "returns true" do
+        context "when it returns true" do
           it "returns boolean response for eligible" do
             expect(eligible_result.eligible?).to be true
           end
         end
 
-        context "returns false" do
+        context "when it returns false" do
           it "returns false response for eligible" do
             expect(not_eligible_result.eligible?).to be false
           end
@@ -205,13 +205,13 @@ module CFE
       end
 
       describe "capital_contribution_required?" do
-        context "contribution not required" do
+        context "when contribution not required" do
           it "returns false for capital_contribution_required" do
             expect(eligible_result.capital_contribution_required?).to be false
           end
         end
 
-        context "contribution is required" do
+        context "when contribution is required" do
           it "returns true for capital_contribution_required" do
             expect(contribution_required_result.capital_contribution_required?).to be true
           end
@@ -224,13 +224,13 @@ module CFE
 
       describe "thresholds" do
         describe "#gross_income_upper_threshold" do
-          context "only domestic abuse" do
+          context "with only domestic abuse" do
             it "returns N/a" do
               expect(eligible_result.gross_income_upper_threshold).to eq "N/a"
             end
           end
 
-          context "domestic abuse and section 8 mixed" do
+          context "with domestic abuse and section 8 mixed" do
             it "returns the section 8 threshold" do
               expect(partially_eligible_result.gross_income_upper_threshold).to eq 2657.0
             end
@@ -238,13 +238,13 @@ module CFE
         end
 
         describe "#disposable_income_upper_threshold" do
-          context "only domestic abuse" do
+          context "with only domestic abuse" do
             it "returns N/a" do
               expect(eligible_result.disposable_income_upper_threshold).to eq "N/a"
             end
           end
 
-          context "domestic abuse and section 8 mixed" do
+          context "with domestic abuse and section 8 mixed" do
             it "returns the section 8 threshold" do
               expect(partially_eligible_result.disposable_income_upper_threshold).to eq 733.0
             end
@@ -344,13 +344,13 @@ module CFE
       end
 
       describe "vehicles?" do
-        context "vehicle(s) exist" do
+        context "when vehicle(s) exist" do
           it "returns a boolean response if vehicles exist" do
             expect(eligible_result.vehicles?).to be true
           end
         end
 
-        context "vehicles don't exist" do
+        context "when vehicles do not exist" do
           it "returns a boolean response if vehicles do not exist" do
             expect(with_no_vehicles.vehicles?).to be false
           end
@@ -392,19 +392,19 @@ module CFE
       ################################################################
 
       describe "#additional_property?" do
-        context "present" do
+        context "when present" do
           it "returns true" do
             expect(additional_property.additional_property?).to be true
           end
         end
 
-        context "not present" do
+        context "when not present" do
           it "returns false" do
             expect(no_additional_properties.additional_property?).to be false
           end
         end
 
-        context "present but zero" do
+        context "when present but zero" do
           it "returns false" do
             expect(eligible_result.additional_property?).to be false
           end
@@ -505,8 +505,8 @@ module CFE
       #  THRESHOLDS                                                  #
       ################################################################
 
-      context "thresholds within proceeding types" do
-        context "gross income thresholds" do
+      context "with thresholds within proceeding types" do
+        context "with gross income thresholds" do
           let(:gross_income_proceeding_types) do
             [
               {
@@ -529,7 +529,7 @@ module CFE
           end
         end
 
-        context "disposable income thresholds" do
+        context "with disposable income thresholds" do
           let(:disposable_income_proceeding_types) do
             [
               {
@@ -664,7 +664,7 @@ module CFE
       #  EMPLOYMENT_INCOME                                           #
       ################################################################
 
-      context "employment income" do
+      context "with employment income" do
         context "with employments" do
           describe "gross_income" do
             subject(:gross_income) { with_employments.employment_income_gross_income }
@@ -722,7 +722,7 @@ module CFE
         end
 
         context "with no employments" do
-          describe "employment_income" do
+          describe "with employment_income" do
             subject(:employment_income) { with_no_employments.employment_income }
 
             it { is_expected.to be_kind_of(Hash) }

--- a/spec/models/concerns/cfe_submission_state_machine_spec.rb
+++ b/spec/models/concerns/cfe_submission_state_machine_spec.rb
@@ -2,14 +2,14 @@ require "rails_helper"
 
 module CFE
   RSpec.describe CFESubmissionStateMachine do
-    context "initial state" do
+    context "with initial state" do
       it "creates an application in initialised state" do
         submission = create :cfe_submission
         expect(submission.initialised?).to be true
       end
     end
 
-    context "asssessment_created! event" do
+    context "with asssessment_created! event" do
       it "transitions from initialised to assessment_created" do
         submission = create :cfe_submission
         submission.assessment_created!
@@ -17,8 +17,8 @@ module CFE
       end
     end
 
-    context "results_obtained! event" do
-      context "passported application" do
+    context "with results_obtained! event" do
+      context "with passported application" do
         let(:legal_aid_application) { create :legal_aid_application, :with_positive_benefit_check_result }
         let(:submission) { create :cfe_submission, legal_aid_application:, aasm_state: "explicit_remarks_created" }
 
@@ -28,10 +28,10 @@ module CFE
         end
       end
 
-      context "non_passported_application" do
+      context "with non_passported_application" do
         let(:legal_aid_application) { create :legal_aid_application, :with_negative_benefit_check_result }
 
-        context "from properties_created state" do
+        context "with from properties_created state" do
           let(:submission) { create :cfe_submission, legal_aid_application:, aasm_state: "properties_created" }
 
           it "raises" do
@@ -41,10 +41,10 @@ module CFE
       end
     end
 
-    context "dependants_created! event" do
+    context "with dependants_created! event" do
       let(:submission) { create :cfe_submission, legal_aid_application:, aasm_state: "explicit_remarks_created" }
 
-      context "passported" do
+      context "when passported" do
         let(:legal_aid_application) { create :legal_aid_application, :with_positive_benefit_check_result }
 
         it "raises" do
@@ -52,7 +52,7 @@ module CFE
         end
       end
 
-      context "non_passported" do
+      context "when non_passported" do
         let(:legal_aid_application) { create :legal_aid_application, :with_negative_benefit_check_result }
 
         it "transitions from explicit_remarks_created to dependants_created" do
@@ -62,10 +62,10 @@ module CFE
       end
     end
 
-    context "outgoings_created! event" do
+    context "with outgoings_created! event" do
       let(:submission) { create :cfe_submission, legal_aid_application:, aasm_state: "dependants_created" }
 
-      context "passported" do
+      context "when passported" do
         let(:legal_aid_application) { create :legal_aid_application, :with_positive_benefit_check_result }
 
         it "raises" do
@@ -73,7 +73,7 @@ module CFE
         end
       end
 
-      context "non_passported" do
+      context "when non_passported" do
         let(:legal_aid_application) { create :legal_aid_application, :with_negative_benefit_check_result }
 
         it "transitions from properties created to dependants_created" do
@@ -83,10 +83,10 @@ module CFE
       end
     end
 
-    context "state_benefits_created! event" do
+    context "with state_benefits_created! event" do
       let(:submission) { create :cfe_submission, legal_aid_application:, aasm_state: "outgoings_created" }
 
-      context "passported" do
+      context "when passported" do
         let(:legal_aid_application) { create :legal_aid_application, :with_positive_benefit_check_result }
 
         it "raises" do
@@ -94,7 +94,7 @@ module CFE
         end
       end
 
-      context "non_passported" do
+      context "when non_passported" do
         let(:legal_aid_application) { create :legal_aid_application, :with_negative_benefit_check_result }
 
         it "transitions from properties created to dependants_created" do
@@ -104,10 +104,10 @@ module CFE
       end
     end
 
-    context "other_income_created! event" do
+    context "with other_income_created! event" do
       let(:submission) { create :cfe_submission, legal_aid_application:, aasm_state: "state_benefits_created" }
 
-      context "passported" do
+      context "when passported" do
         let(:legal_aid_application) { create :legal_aid_application, :with_positive_benefit_check_result }
 
         it "raises" do
@@ -115,7 +115,7 @@ module CFE
         end
       end
 
-      context "non_passported" do
+      context "when non_passported" do
         let(:legal_aid_application) { create :legal_aid_application, :with_negative_benefit_check_result }
 
         it "transitions from state_benefits_created to other_income_created" do
@@ -125,10 +125,10 @@ module CFE
       end
     end
 
-    context "explicit_remarks_created! event" do
+    context "with explicit_remarks_created! event" do
       let(:submission) { create :cfe_submission, legal_aid_application:, aasm_state: "properties_created" }
 
-      context "passported" do
+      context "when passported" do
         let(:legal_aid_application) { create :legal_aid_application, :with_positive_benefit_check_result }
 
         it "transitions from state_benefits_created to other_income_created" do
@@ -137,7 +137,7 @@ module CFE
         end
       end
 
-      context "non_passported" do
+      context "when non_passported" do
         let(:legal_aid_application) { create :legal_aid_application, :with_negative_benefit_check_result }
 
         it "transitions from state_benefits_created to other_income_created" do
@@ -147,7 +147,7 @@ module CFE
       end
     end
 
-    context "fail! event" do
+    context "with fail! event" do
       let(:states) { Submission.aasm.states.map(&:name) - %i[failed results_obtained] }
 
       it "transitions to failed from all states except failed and results obtained" do

--- a/spec/models/concerns/translatable_model_attribute_spec.rb
+++ b/spec/models/concerns/translatable_model_attribute_spec.rb
@@ -4,14 +4,14 @@ RSpec.describe TranslatableModelAttribute do
   let(:record) { create :legal_aid_application }
 
   describe "#enum_t" do
-    context "translation exists" do
+    context "when translation exists" do
       it "translates" do
         expect(record.state).to eq "initiated"
         expect(record.enum_t(:state)).to eq "In progress"
       end
     end
 
-    context "translation does not exist" do
+    context "when translation does not exist" do
       it "returns translation not found message" do
         allow(record).to receive(:state).and_return("unknown_state")
         expect(record.enum_t(:state)).to eq "translation missing: en.model_enum_translations.legal_aid_application.state.unknown_state"

--- a/spec/models/dashboard/widget_data_providers/number_provider_firms_spec.rb
+++ b/spec/models/dashboard/widget_data_providers/number_provider_firms_spec.rb
@@ -17,7 +17,7 @@ module Dashboard
       end
 
       describe ".data" do
-        context "no one has ever logged in" do
+        context "when no one has ever logged in" do
           let(:expected_data) { [{ "number" => 0 }] }
 
           it "sends expected data" do
@@ -25,7 +25,7 @@ module Dashboard
           end
         end
 
-        context "five users over three firms" do
+        context "with five users over three firms" do
           let(:firm1) { create :firm }
           let(:firm2) { create :firm }
           let(:firm3) { create :firm }

--- a/spec/models/dashboard/widget_data_providers/percentage_declined_open_banking_spec.rb
+++ b/spec/models/dashboard/widget_data_providers/percentage_declined_open_banking_spec.rb
@@ -17,7 +17,7 @@ module Dashboard
       end
 
       describe ".data" do
-        context "no to open banking consent" do
+        context "with no to open banking consent" do
           let(:application) { create :legal_aid_application, open_banking_consent: false }
           let(:application2) { create :legal_aid_application, open_banking_consent: true }
           let(:expected_data) { [{ "declined_open_banking" => 50 }] }
@@ -32,7 +32,7 @@ module Dashboard
           end
         end
 
-        context "yes to open banking consent" do
+        context "with yes to open banking consent" do
           let(:application) { create :legal_aid_application, open_banking_consent: true }
           let(:expected_data) { [{ "declined_open_banking" => 0 }] }
 

--- a/spec/models/dependant_spec.rb
+++ b/spec/models/dependant_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Dependant, type: :model do
   end
 
   describe "#as_json" do
-    context "dependant has nil values" do
+    context "when dependant has nil values" do
       let(:dependant) do
         create :dependant,
                date_of_birth: Date.new(2019, 3, 2),
@@ -41,7 +41,7 @@ RSpec.describe Dependant, type: :model do
       end
     end
 
-    context "dependant has values" do
+    context "when dependant has values" do
       let(:dependant) do
         create :dependant,
                date_of_birth: Date.new(2019, 3, 2),
@@ -69,7 +69,7 @@ RSpec.describe Dependant, type: :model do
   end
 
   describe "#over_fifteen?" do
-    context "Less than 15 years old" do
+    context "when less than 15 years old" do
       let(:date_of_birth) { 10.years.ago }
 
       it "returns false" do
@@ -81,7 +81,7 @@ RSpec.describe Dependant, type: :model do
       end
     end
 
-    context "more than 15 years old" do
+    context "when more than 15 years old" do
       let(:date_of_birth) { 20.years.ago }
 
       it "returns true" do
@@ -93,7 +93,7 @@ RSpec.describe Dependant, type: :model do
       end
     end
 
-    context "15 and a half years old" do
+    context "when 15 and a half years old" do
       let(:date_of_birth) { 15.years.ago + 6.months }
 
       it "returns false" do
@@ -105,7 +105,7 @@ RSpec.describe Dependant, type: :model do
       end
     end
 
-    context "14 and a half years old" do
+    context "when 14 and a half years old" do
       let(:date_of_birth) { 15.years.ago - 6.months }
 
       it "returns false" do
@@ -115,7 +115,7 @@ RSpec.describe Dependant, type: :model do
   end
 
   describe "#eighteen_or_less?" do
-    context "Less than 18 years old" do
+    context "when less than 18 years old" do
       let(:date_of_birth) { 10.years.ago }
 
       it "returns true" do
@@ -123,7 +123,7 @@ RSpec.describe Dependant, type: :model do
       end
     end
 
-    context "more than 18 years old" do
+    context "when more than 18 years old" do
       let(:date_of_birth) { 20.years.ago }
 
       it "returns false" do
@@ -131,7 +131,7 @@ RSpec.describe Dependant, type: :model do
       end
     end
 
-    context "18 and a half years old" do
+    context "when 18 and a half years old" do
       let(:date_of_birth) { 18.years.ago + 6.months }
 
       it "returns true" do
@@ -139,7 +139,7 @@ RSpec.describe Dependant, type: :model do
       end
     end
 
-    context "17 and a half years old" do
+    context "when 17 and a half years old" do
       let(:date_of_birth) { 18.years.ago - 6.months }
 
       it "returns true" do
@@ -151,7 +151,7 @@ RSpec.describe Dependant, type: :model do
   describe "ccms_relationship_to_client" do
     let(:dependant) { create :dependant, legal_aid_application:, relationship:, date_of_birth: dob }
 
-    context "adult relative" do
+    context "when adult relative" do
       let(:relationship) { "adult_relative" }
       let(:dob) { 20.years.ago }
 
@@ -160,7 +160,7 @@ RSpec.describe Dependant, type: :model do
       end
     end
 
-    context "child aged fifteen or less" do
+    context "when child aged fifteen or less" do
       let(:relationship) { "child_relative" }
       let(:dob) { 13.years.ago }
 
@@ -169,7 +169,7 @@ RSpec.describe Dependant, type: :model do
       end
     end
 
-    context "child aged sixteen or more" do
+    context "when child aged sixteen or more" do
       let(:relationship) { "child_relative" }
       let(:dob) { 17.years.ago }
 


### PR DESCRIPTION
Fix GOVUK Rubocop RSpec/ContextWording offences.

Start context description with 'when', 'with', 'without', 'and', or 'but'. (https://rspec.rubystyle.guide/#context-descriptions, https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ContextWording)

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
