### PR TITLE
[AP-2640 ]Add feature test hooks to mock hmrc calls

### DIFF
--- a/features/providers/check_multiple_employment.feature
+++ b/features/providers/check_multiple_employment.feature
@@ -1,5 +1,5 @@
 Feature: check_multiple_employment
-  @javascript @vcr
+  @javascript @vcr @hmrc_use_dev_mock
   Scenario: I am able to complete an application for an employed applicant with multiple employers
     Given I am logged in as a provider
     And csrf is enabled

--- a/features/providers/check_pending_employment.feature
+++ b/features/providers/check_pending_employment.feature
@@ -1,5 +1,5 @@
 Feature: check_pending_employment
-  @javascript @vcr
+  @javascript @vcr @hmrc_use_dev_mock
   Scenario: I am able to complete an application for an employed applicant with pending HMRC request
     Given I am logged in as a provider
     And csrf is enabled

--- a/features/providers/check_single_employment.feature
+++ b/features/providers/check_single_employment.feature
@@ -1,5 +1,5 @@
 Feature: check_single_employment
-  @javascript @vcr
+  @javascript @vcr @hmrc_use_dev_mock
   Scenario: I am able to complete an application for an employed applicant with a single employer
     Given I am logged in as a provider
     And csrf is enabled

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -12,6 +12,7 @@ require "webmock/cucumber"
 require "factory_bot"
 require "webdrivers"
 require "axe-cucumber-steps"
+require "cucumber/rspec/doubles"
 
 # HACK: this method was available in cucumber 3.1 but not cucumber 4 and VCR relies on it to
 # generate cassette names.

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -1,0 +1,9 @@
+# before and after hooks for feature tests
+#
+Before("@hmrc_use_dev_mock") do
+  allow(Rails.configuration.x).to receive(:hmrc_use_dev_mock).and_return(true)
+end
+
+After("@hmrc_use_dev_mock") do
+  allow(Rails.configuration.x).to receive(:hmrc_use_dev_mock).and_call_original
+end


### PR DESCRIPTION
## Note
This is merge into branch to fix failing cukes

## What
Enable Mock HMRC calls during employed journey feature tests

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2640)

Employed journey tests are dependant on the
hmrc mock/sandobox data. This relies on a
config setting being in place and the test
were failing on CI as the mock was not enabled.

This stubs that config so feature tests can be run against it.

Should we be doing this however? We should, perhaps,
be using vcr to record (or otherise stub) real staging
hmrc responses - so long as no sensitive info is exposed.


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
