### PR TITLE
AP-2363 Improve alerting around document conversion

### DIFF
--- a/app/lib/sidekiq/exhausted_failure_message.rb
+++ b/app/lib/sidekiq/exhausted_failure_message.rb
@@ -22,6 +22,7 @@ module Sidekiq
         "HMRC::SubmissionWorker" => "HMRC submission id",
         "HMRC::ResultWorker" => "HMRC result check for id",
         "CCMS::SubmissionProcessWorker" => "CCMS submission id",
+        "PdfConverterWorker" => "Attachment id",
       }[@msg["class"]]
     end
   end

--- a/app/workers/pdf_converter_worker.rb
+++ b/app/workers/pdf_converter_worker.rb
@@ -1,8 +1,19 @@
 class PdfConverterWorker
   include Sidekiq::Worker
   include Sidekiq::Status::Worker
+  attr_accessor :retry_count
+
+  ALERT_ON_RETRY_COUNT = 3
+  sidekiq_options retry: ALERT_ON_RETRY_COUNT
+  sidekiq_retries_exhausted do |msg, _ex|
+    Sentry.capture_message Sidekiq::ExhaustedFailureMessage.call(msg)
+  end
 
   def perform(attachment_id)
     PdfConverter.call(attachment_id)
+  rescue StandardError => e
+    raise if retry_count.eql? ALERT_ON_RETRY_COUNT
+
+    raise SentryIgnoreThisSidekiqFailError, "Attempt to convert file to PDF failed on retry #{retry_count.to_i} with error #{e.message}"
   end
 end

--- a/spec/workers/pdf_converter_worker_spec.rb
+++ b/spec/workers/pdf_converter_worker_spec.rb
@@ -1,10 +1,54 @@
 require "rails_helper"
 
 RSpec.describe PdfConverterWorker, type: :worker do
+  subject(:perform) { described_class.new.perform(uuid) }
+
   let(:uuid) { SecureRandom.uuid }
+  let(:worker) { described_class.new }
 
   it "calls PdfConverter" do
     expect(PdfConverter).to receive(:call).with(uuid)
-    described_class.new.perform(uuid)
+    perform
+  end
+
+  context "when an error occurs" do
+    let(:pdf_converter) { class_double PdfConverter }
+
+    before do
+      allow(pdf_converter).to receive(:call).with(uuid).and_return(false)
+    end
+
+    context "when at ALERT_ON_RETRY_COUNT" do
+      before { worker.retry_count = 3 }
+
+      let(:expected_error) do
+        <<~MESSAGE
+          Attachment id:  failed
+          Moving PdfConverterWorker to dead set, it failed with: /An error occured
+        MESSAGE
+      end
+
+      it "raises an error" do
+        expect { perform }.to raise_error(StandardError)
+      end
+
+      it "passes the error to Sentry" do
+        described_class.within_sidekiq_retries_exhausted_block do
+          expect(Sentry).to receive(:capture_message).with(expected_error)
+        end
+      end
+    end
+
+    context "when at less than ALERT_ON_RETRY_COUNT" do
+      before { worker.retry_count = 2 }
+
+      it "raises an error" do
+        expect { perform }.to raise_error(StandardError)
+      end
+
+      it "does not pass the error to Sentry" do
+        expect(Sentry).not_to receive(:capture_message)
+      end
+    end
   end
 end


### PR DESCRIPTION
Raise Sentry alerts only when 10 attempts have failed to convert a document to PDF.

Reduce the amount of errors raised so the key issues can be focused on.

## What

[Link to story](https://dsdmoj.atlassian.net/jira/software/c/projects/AP/boards/233?modal=detail&selectedIssue=AP-2363)

Describe what you did and why.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
