### PR TITLE
Rubocop fixes

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -159,16 +159,6 @@ RSpec/BeforeAfterAll:
 # Prefixes: when, with, without
 RSpec/ContextWording:
   Exclude:
-    - 'spec/models/legal_framework/serializable_merits_task_list_spec.rb'
-    - 'spec/models/legal_framework/serializable_merits_task_spec.rb'
-    - 'spec/models/other_assets_declaration_spec.rb'
-    - 'spec/models/proceeding_merits_task/chances_of_success_spec.rb'
-    - 'spec/models/proceeding_merits_task/proceeding_linked_child_spec.rb'
-    - 'spec/models/proceeding_spec.rb'
-    - 'spec/models/provider_spec.rb'
-    - 'spec/models/savings_amount_spec.rb'
-    - 'spec/models/scheduled_mailing_spec.rb'
-    - 'spec/models/transaction_type_spec.rb'
     - 'spec/models/true_layer_bank_spec.rb'
     - 'spec/models/vehicle_spec.rb'
     - 'spec/policies/legal_aid_application_policy_spec.rb'

--- a/spec/models/legal_framework/serializable_merits_task_list_spec.rb
+++ b/spec/models/legal_framework/serializable_merits_task_list_spec.rb
@@ -24,7 +24,7 @@ module LegalFramework
     end
 
     describe "#tasks_for" do
-      context "application group" do
+      context "with application group" do
         it "returns an array of serializable merits tasks" do
           tasks = smtl.tasks_for(:application)
           expect(tasks.size).to eq 3
@@ -33,7 +33,7 @@ module LegalFramework
         end
       end
 
-      context "ccms_code" do
+      context "with ccms_code" do
         it "returns an array of serializable merits tasks" do
           tasks = smtl.tasks_for(:DA004)
           expect(tasks.size).to eq 1
@@ -42,7 +42,7 @@ module LegalFramework
         end
       end
 
-      context "invalid_task_group" do
+      context "with invalid_task_group" do
         it "raises an exception" do
           expect { smtl.tasks_for(:XX001) }.to raise_error KeyError, "key not found: :XX001"
         end
@@ -50,7 +50,7 @@ module LegalFramework
     end
 
     describe "#mark_as_complete!" do
-      context "invalid task name" do
+      context "with invalid task name" do
         it "raises an exception" do
           expect {
             smtl.mark_as_complete!(:application, :rubbish)
@@ -58,7 +58,7 @@ module LegalFramework
         end
       end
 
-      context "invalid task group name" do
+      context "with invalid task group name" do
         it "raises an exception" do
           expect {
             smtl.mark_as_complete!(:fake, :incident_details)
@@ -66,7 +66,7 @@ module LegalFramework
         end
       end
 
-      context "task has dependencies" do
+      context "when task has dependencies" do
         it "raises an exception" do
           expect {
             smtl.mark_as_complete!(:DA001, :proceeding_children)
@@ -74,8 +74,8 @@ module LegalFramework
         end
       end
 
-      context "successful" do
-        context "application group" do
+      context "when successful" do
+        context "with application group" do
           it "marks the task as complete" do
             smtl.mark_as_complete!(:application, :incident_details)
             expect(smtl.task(:application, :incident_details).state).to eq :complete
@@ -88,7 +88,7 @@ module LegalFramework
           end
         end
 
-        context "proceeding type" do
+        context "with proceeding type" do
           it "marks the task as complete" do
             smtl.mark_as_complete!(:DA004, :chances_of_success)
             expect(smtl.task(:DA004, :chances_of_success).state).to eq :complete

--- a/spec/models/legal_framework/serializable_merits_task_spec.rb
+++ b/spec/models/legal_framework/serializable_merits_task_spec.rb
@@ -11,7 +11,7 @@ module LegalFramework
         expect(serialized_merits_task.state).to eq :waiting_for_dependency
       end
 
-      context "no dependencies" do
+      context "with no dependencies" do
         let(:serialized_merits_task) { described_class.new(:proceeding_children, dependencies: []) }
 
         it "stores empty array for dependencies" do
@@ -45,7 +45,7 @@ module LegalFramework
     end
 
     describe "#mark_as_complete!" do
-      context "has dependencies" do
+      context "with dependencies" do
         it "raises an exception" do
           expect {
             serialized_merits_task.mark_as_complete!
@@ -53,7 +53,7 @@ module LegalFramework
         end
       end
 
-      context "successful" do
+      context "when successful" do
         let(:serialized_merits_task) { described_class.new(:proceeding_children, dependencies: []) }
 
         it "marks the task as complete" do

--- a/spec/models/other_assets_declaration_spec.rb
+++ b/spec/models/other_assets_declaration_spec.rb
@@ -14,13 +14,13 @@ RSpec.describe OtherAssetsDeclaration, type: :model do
   describe "#positive" do
     subject { create :other_assets_declaration }
 
-    context "has no savings" do
+    context "with no savings" do
       it "is negative" do
         expect(subject.positive?).to be(false)
       end
     end
 
-    context "has some savings" do
+    context "with some savings" do
       before { subject.update!(land_value: rand(1...1_000_000.0).round(2)) }
 
       it "is positive" do

--- a/spec/models/proceeding_merits_task/chances_of_success_spec.rb
+++ b/spec/models/proceeding_merits_task/chances_of_success_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe ProceedingMeritsTask::ChancesOfSuccess, type: :model do
     let(:proceeding) { legal_aid_application.proceedings.first }
     let(:chances_of_success) { create :chances_of_success, success_prospect: prospect, proceeding: }
 
-    context "likely" do
+    context "when likely" do
       let(:prospect) { "likely" }
 
       it "generates the correct pretty text" do
@@ -18,15 +18,7 @@ RSpec.describe ProceedingMeritsTask::ChancesOfSuccess, type: :model do
       end
     end
 
-    context "likely" do
-      let(:prospect) { "likely" }
-
-      it "generates the correct pretty text" do
-        expect(chances_of_success.pretty_success_prospect).to eq "Likely (>50%)"
-      end
-    end
-
-    context "marginal" do
+    context "when marginal" do
       let(:prospect) { "marginal" }
 
       it "generates the correct pretty text" do
@@ -34,7 +26,7 @@ RSpec.describe ProceedingMeritsTask::ChancesOfSuccess, type: :model do
       end
     end
 
-    context "poor" do
+    context "when poor" do
       let(:prospect) { "poor" }
 
       it "generates the correct pretty text" do
@@ -42,7 +34,7 @@ RSpec.describe ProceedingMeritsTask::ChancesOfSuccess, type: :model do
       end
     end
 
-    context "borderline" do
+    context "when borderline" do
       let(:prospect) { "borderline" }
 
       it "generates the correct pretty text" do
@@ -50,7 +42,7 @@ RSpec.describe ProceedingMeritsTask::ChancesOfSuccess, type: :model do
       end
     end
 
-    context "not_known" do
+    context "when not_known" do
       let(:prospect) { "not_known" }
 
       it "generates the correct pretty text" do

--- a/spec/models/proceeding_merits_task/proceeding_linked_child_spec.rb
+++ b/spec/models/proceeding_merits_task/proceeding_linked_child_spec.rb
@@ -2,13 +2,13 @@ require "rails_helper"
 
 module ProceedingMeritsTask
   RSpec.describe ProceedingLinkedChild do
-    context "validation of correct involved child" do
+    context "when validation of correct involved child" do
       let(:laa) { create :legal_aid_application }
       let(:other_laa) { create :legal_aid_application }
       let(:proceeding) { create :proceeding, :da001, legal_aid_application: laa }
       let(:linked_child) { described_class.create(proceeding:, involved_child:) }
 
-      context "involved child belongs to this application" do
+      context "when involved child belongs to this application" do
         let(:involved_child) { create :involved_child, legal_aid_application: laa }
 
         it "is valid" do
@@ -16,7 +16,7 @@ module ProceedingMeritsTask
         end
       end
 
-      context "involved child does not belong to this application" do
+      context "when involved child does not belong to this application" do
         let(:involved_child) { create :involved_child, legal_aid_application: other_laa }
 
         it "is not valid" do

--- a/spec/models/proceeding_spec.rb
+++ b/spec/models/proceeding_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Proceeding, type: :model do
   end
 
   describe "#section8?" do
-    context "section 8 proceeding" do
+    context "with section 8 proceeding" do
       let(:proceeding) { create :proceeding, :se014 }
 
       it "returns true" do
@@ -45,7 +45,7 @@ RSpec.describe Proceeding, type: :model do
       end
     end
 
-    context "non section 8 proceeding" do
+    context "with non-section 8 proceeding" do
       let(:proceeding) { create :proceeding, :da001 }
 
       it "returns false" do
@@ -54,7 +54,7 @@ RSpec.describe Proceeding, type: :model do
     end
   end
 
-  context "domestic abuse" do
+  context "with domestic abuse" do
     let(:matter_code) { "MINJN" }
 
     it "returns false" do
@@ -69,13 +69,13 @@ RSpec.describe Proceeding, type: :model do
   end
 
   describe "#used_delegated_functions?" do
-    context "df not used" do
+    context "when df not used" do
       it "returns false" do
         expect(proceeding.used_delegated_functions?).to be false
       end
     end
 
-    context "df_used" do
+    context "when df_used" do
       let(:df_date) { 2.days.ago }
 
       it "returns true" do
@@ -89,7 +89,7 @@ RSpec.describe Proceeding, type: :model do
 
     let(:proceeding) { create :proceeding, :da001, used_delegated_functions_on: df_date }
 
-    context "delegated functions not used" do
+    context "when delegated functions not used" do
       let(:df_date) { nil }
 
       it "returns false" do
@@ -97,7 +97,7 @@ RSpec.describe Proceeding, type: :model do
       end
     end
 
-    context "delegated functions used" do
+    context "when delegated functions used" do
       let(:df_date) { Time.zone.yesterday }
 
       it "returns true" do

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -5,13 +5,13 @@ RSpec.describe Provider, type: :model do
   let(:provider) { create :provider, firm: }
 
   describe "#update_details" do
-    context "firm exists" do
+    context "when firm exists" do
       it "does not call provider details creator immediately" do
         expect(ProviderDetailsCreator).not_to receive(:call).with(provider)
         provider.update_details
       end
 
-      context "staging or production" do
+      context "when staging or production" do
         it "schedules a background job" do
           expect(HostEnv).to receive(:staging_or_production?).and_return(true)
           expect(ProviderDetailsCreatorWorker).to receive(:perform_async).with(provider.id)
@@ -19,7 +19,7 @@ RSpec.describe Provider, type: :model do
         end
       end
 
-      context "not staging or production" do
+      context "when not staging or production" do
         it "does not schedule a background job" do
           expect(HostEnv).to receive(:staging_or_production?).and_return(false)
           expect(ProviderDetailsCreatorWorker).not_to receive(:perform_async).with(provider.id)
@@ -30,7 +30,7 @@ RSpec.describe Provider, type: :model do
   end
 
   describe "#user_permissions" do
-    context "no permissions for this provider, but one permission for firm" do
+    context "with no permissions for this provider, but one permission for firm" do
       let(:firm) { create :firm, :with_passported_permissions }
       let(:provider) { create :provider, :with_no_permissions, firm: }
 
@@ -39,7 +39,7 @@ RSpec.describe Provider, type: :model do
       end
     end
 
-    context "no permissions for provider and their firm" do
+    context "with no permissions for provider and their firm" do
       let(:firm) { create :firm, :with_no_permissions }
       let(:provider) { create :provider, :with_no_permissions, firm: }
       let(:AlertManager) { instance_double(Tracker) }
@@ -54,7 +54,7 @@ RSpec.describe Provider, type: :model do
       end
     end
 
-    context "permissions exist for both firm and provider" do
+    context "when permissions exist for both firm and provider" do
       let(:firm) { create :firm, :with_passported_and_non_passported_permissions }
       let(:provider) { create :provider, :with_passported_permissions, firm: }
 
@@ -78,7 +78,7 @@ RSpec.describe Provider, type: :model do
 
     before { allow(Rails.configuration.x.laa_portal).to receive(:mock_saml).and_return(false) }
 
-    context "ccms_apply_role_present" do
+    context "with ccms_apply_role_present" do
       let(:roles) { "EMI,PUI_XXCCMS_BILL_PREPARATION,ZZZ,CCMS_Apply" }
 
       it "returns true" do
@@ -86,7 +86,7 @@ RSpec.describe Provider, type: :model do
       end
     end
 
-    context "ccms_apply role absesnt" do
+    context "with ccms_apply role absent" do
       let(:roles) { "EMI,PUI_XXCCMS_BILL_PREPARATION,ZZZ" }
 
       it "returns true" do
@@ -98,7 +98,7 @@ RSpec.describe Provider, type: :model do
   describe "#invalid_login?" do
     let(:provider) { create :provider, invalid_login_details: details }
 
-    context "details are nil" do
+    context "when details are nil" do
       let(:details) { nil }
 
       it "returns false" do
@@ -106,7 +106,7 @@ RSpec.describe Provider, type: :model do
       end
     end
 
-    context "details are empty string" do
+    context "when details are empty string" do
       let(:details) { "" }
 
       it "returns false" do
@@ -114,7 +114,7 @@ RSpec.describe Provider, type: :model do
       end
     end
 
-    context "details are present" do
+    context "when details are present" do
       let(:details) { "role" }
 
       it "returns true" do
@@ -124,8 +124,8 @@ RSpec.describe Provider, type: :model do
   end
 
   describe "#newly_created_by_devise?" do
-    context "sign_in_count of 1" do
-      context "no firm" do
+    context "with sign_in_count of 1" do
+      context "with no firm" do
         let(:provider) { create :provider, :created_by_devise }
 
         it "returns true" do
@@ -133,7 +133,7 @@ RSpec.describe Provider, type: :model do
         end
       end
 
-      context "firm exists" do
+      context "when firm exists" do
         let(:provider) { create :provider, sign_in_count: 1 }
 
         it "returns false" do
@@ -142,7 +142,7 @@ RSpec.describe Provider, type: :model do
       end
     end
 
-    context "login count greater than 1" do
+    context "with login count greater than 1" do
       let(:provider) { create :provider, sign_in_count: 4 }
 
       it "returns false" do

--- a/spec/models/savings_amount_spec.rb
+++ b/spec/models/savings_amount_spec.rb
@@ -4,13 +4,13 @@ RSpec.describe SavingsAmount, type: :model do
   describe "#positive" do
     subject { create :savings_amount }
 
-    context "has no savings" do
+    context "with no savings" do
       it "is negative" do
         expect(subject.positive?).to be(false)
       end
     end
 
-    context "has some savings" do
+    context "with some savings" do
       before { subject.update!(cash: rand(1...1_000_000.0).round(2)) }
 
       it "is positive" do
@@ -22,7 +22,7 @@ RSpec.describe SavingsAmount, type: :model do
   describe "#values?" do
     subject { create :savings_amount, :with_values }
 
-    context "has savings and investments" do
+    context "with savings and investments" do
       it "returns true" do
         expect(subject.values?).to be true
       end
@@ -36,7 +36,7 @@ RSpec.describe SavingsAmount, type: :model do
       end
     end
 
-    context "has no savings and investments" do
+    context "with no savings and investments" do
       subject { create :savings_amount, :all_nil }
 
       it "returns false" do

--- a/spec/models/scheduled_mailing_spec.rb
+++ b/spec/models/scheduled_mailing_spec.rb
@@ -70,14 +70,14 @@ RSpec.describe ScheduledMailing do
   end
 
   describe "#waiting?" do
-    context "waiting" do
+    context "when waiting" do
       it "returns true" do
         rec = create :scheduled_mailing, :due
         expect(rec.waiting?).to be true
       end
     end
 
-    context "not waiting" do
+    context "when not waiting" do
       it "returns true" do
         rec = create :scheduled_mailing, :delivered
         expect(rec.waiting?).to be false

--- a/spec/models/transaction_type_spec.rb
+++ b/spec/models/transaction_type_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe TransactionType, type: :model do
   describe "#for_income_type?" do
-    context "checks that a boolean response is returned" do
+    context "when checks that a boolean response is returned" do
       let!(:credit_transaction) { create :transaction_type, :credit_with_standard_name }
 
       it "returns true with a valid income_type" do
@@ -10,7 +10,7 @@ RSpec.describe TransactionType, type: :model do
       end
     end
 
-    context "checks for boolean response" do
+    context "with checks for boolean response" do
       let!(:debit_transaction) { create :transaction_type, :debit_with_standard_name }
 
       it "returns false when a non valid income type is used" do
@@ -22,13 +22,13 @@ RSpec.describe TransactionType, type: :model do
   describe "#for_outgoing_type?" do
     before { create :transaction_type, :child_care }
 
-    context "no such outgoing types exist" do
+    context "when no such outgoing types exist" do
       it "returns false" do
         expect(described_class.for_outgoing_type?("maintenance_out")).to be false
       end
     end
 
-    context "outgoing types do exist" do
+    context "when outgoing types do exist" do
       before { create :transaction_type, :maintenance_out }
 
       it "returns true" do
@@ -45,7 +45,7 @@ RSpec.describe TransactionType, type: :model do
     end
   end
 
-  context "hierarchies" do
+  context "with hierarchies" do
     before { Populators::TransactionTypePopulator.call }
 
     let(:benefits) { described_class.find_by(name: "benefits") }
@@ -59,13 +59,13 @@ RSpec.describe TransactionType, type: :model do
     end
 
     describe "#child?" do
-      context "is a child" do
+      context "when is a child" do
         it "returns true" do
           expect(excluded_benefits.child?).to be true
         end
       end
 
-      context "is not a child" do
+      context "when is not a child" do
         it "returns false" do
           expect(benefits.child?).to be false
         end
@@ -73,13 +73,13 @@ RSpec.describe TransactionType, type: :model do
     end
 
     describe "#parent?" do
-      context "is a parent" do
+      context "when is a parent" do
         it "returns true" do
           expect(benefits.parent?).to be true
         end
       end
 
-      context "is not a parent" do
+      context "when is not a parent" do
         it "returns true" do
           expect(pension.parent?).to be false
         end
@@ -87,13 +87,13 @@ RSpec.describe TransactionType, type: :model do
     end
 
     describe "#parent" do
-      context "is not a child" do
+      context "when is not a child" do
         it "returns nil" do
           expect(pension.parent).to be_nil
         end
       end
 
-      context "is a child" do
+      context "when is a child" do
         it "returns the parent record" do
           expect(excluded_benefits.parent).to eq benefits
         end
@@ -101,13 +101,13 @@ RSpec.describe TransactionType, type: :model do
     end
 
     describe "parent_or_self" do
-      context "is not a child" do
+      context "when is not a child" do
         it "returns self" do
           expect(pension.parent_or_self).to eq pension
         end
       end
 
-      context "is a child" do
+      context "when is a child" do
         it "returns parent" do
           expect(excluded_benefits.parent_or_self).to eq benefits
         end
@@ -115,13 +115,13 @@ RSpec.describe TransactionType, type: :model do
     end
 
     describe "#excluded_benefit?" do
-      context "is excluded benefit type" do
+      context "when a excluded benefit type" do
         it "returns true" do
           expect(excluded_benefits.excluded_benefit?).to be true
         end
       end
 
-      context "not an excluded benefit type" do
+      context "when not an excluded benefit type" do
         it "returns false" do
           expect(pension.excluded_benefit?).to be false
         end
@@ -129,13 +129,13 @@ RSpec.describe TransactionType, type: :model do
     end
 
     describe "#children" do
-      context "record with no children" do
+      context "with record with no children" do
         it "returns an empty array" do
           expect(pension.children).to be_empty
         end
       end
 
-      context "record with children" do
+      context "with record with children" do
         it "returns an array of children" do
           expect(benefits.children).to eq [excluded_benefits]
         end
@@ -143,25 +143,25 @@ RSpec.describe TransactionType, type: :model do
     end
 
     describe ".find_with_children" do
-      context "one id with no children" do
+      context "with one id with no children" do
         it "return the one record" do
           expect(described_class.find_with_children(pension.id)).to eq [pension]
         end
       end
 
-      context "one id with children" do
+      context "with one id with children" do
         it "returns the parent and child" do
           expect(described_class.find_with_children(benefits.id)).to match_array([benefits, excluded_benefits])
         end
       end
 
-      context "multiple ids all without children" do
+      context "with multiple ids all without children" do
         it "returns just the records" do
           expect(described_class.find_with_children(pension.id, excluded_benefits.id)).to match_array([pension, excluded_benefits])
         end
       end
 
-      context "multiple ids with and without children" do
+      context "with multiple ids with and without children" do
         it "returns the records and the children" do
           expect(described_class.find_with_children(pension.id, benefits.id)).to match_array([pension, benefits, excluded_benefits])
         end
@@ -169,19 +169,19 @@ RSpec.describe TransactionType, type: :model do
     end
 
     describe ".any_type_of" do
-      context "name of record with children" do
+      context "with name of record with children" do
         it "returns record and its chidlren" do
           expect(described_class.any_type_of("benefits")).to match_array([benefits, excluded_benefits])
         end
       end
 
-      context "name of record with no children" do
+      context "with name of record with no children" do
         it "returns just that record in an array" do
           expect(described_class.any_type_of("pension")).to eq [pension]
         end
       end
 
-      context "name that does not exist" do
+      context "with name that does not exist" do
         it "returns an empty collection" do
           expect(described_class.any_type_of("xxx")).to be_empty
         end


### PR DESCRIPTION
Fix GOVUK Rubocop RSpec/ContextWording offences.

Start context description with 'when', 'with', 'without', 'and', or 'but'. (https://rspec.rubystyle.guide/#context-descriptions, https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ContextWording)

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
