### PR TITLE
Rubocop fixes

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -159,21 +159,6 @@ RSpec/BeforeAfterAll:
 # Prefixes: when, with, without
 RSpec/ContextWording:
   Exclude:
-    - 'spec/models/true_layer_bank_spec.rb'
-    - 'spec/models/vehicle_spec.rb'
-    - 'spec/policies/legal_aid_application_policy_spec.rb'
-    - 'spec/presenters/applicant_account_presenter_spec.rb'
-    - 'spec/requests/admin/legal_aid_applications/submissions_controller_spec.rb'
-    - 'spec/requests/admin/legal_aid_applications_controller_spec.rb'
-    - 'spec/requests/admin/providers_spec.rb'
-    - 'spec/requests/admin/roles/permissions_spec.rb'
-    - 'spec/requests/admin/settings_spec.rb'
-    - 'spec/requests/admin_users/sessions_controller_spec.rb'
-    - 'spec/requests/applicants/omniauth_callbacks_spec.rb'
-    - 'spec/requests/auth_spec.rb'
-    - 'spec/requests/backable_spec.rb'
-    - 'spec/requests/citizens/bank_spec.rb'
-    - 'spec/requests/citizens/cash_incomes_spec.rb'
     - 'spec/requests/citizens/cash_outgoings_spec.rb'
     - 'spec/requests/citizens/check_answers_spec.rb'
     - 'spec/requests/citizens/consent_spec.rb'

--- a/spec/models/true_layer_bank_spec.rb
+++ b/spec/models/true_layer_bank_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe TrueLayerBank, type: :model, vcr: { cassette_name: "true_layer_ba
         expect(described_class.available_banks).to eq(result)
       end
 
-      context "mock bank is enabled" do
+      context "when mock bank is enabled" do
         let(:enable_mock) { true }
 
         it "includes mock bank" do

--- a/spec/models/vehicle_spec.rb
+++ b/spec/models/vehicle_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Vehicle, type: :model do
   describe "#purchased_on" do
     let(:vehicle) { create :vehicle, purchased_on:, more_than_three_years_old: }
 
-    context "purchased_on is populated" do
+    context "when purchased_on is populated" do
       let(:purchased_on) { 6.months.ago.to_date }
       let(:more_than_three_years_old) { nil }
 
@@ -13,10 +13,10 @@ RSpec.describe Vehicle, type: :model do
       end
     end
 
-    context "purchased_on is nil" do
+    context "when purchased_on is nil" do
       let(:purchased_on) { nil }
 
-      context "more than three years old" do
+      context "when more than three years old" do
         let(:more_than_three_years_old) { true }
 
         it "returns a date 4 years ago" do
@@ -24,7 +24,7 @@ RSpec.describe Vehicle, type: :model do
         end
       end
 
-      context "less than three years old" do
+      context "when less than three years old" do
         let(:more_than_three_years_old) { false }
 
         it "returns a date 2 years ago" do

--- a/spec/policies/legal_aid_application_policy_spec.rb
+++ b/spec/policies/legal_aid_application_policy_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe LegalAidApplicationPolicy do
     ]
   end
 
-  context "Provider from another firm" do
+  context "with a Provider from another firm" do
     let(:authorization_context) { AuthorizationContext.new(provider, Providers::ProviderBaseController) }
     let(:legal_aid_application) { create(:legal_aid_application) }
     let(:provider) { create(:provider) }
@@ -33,11 +33,11 @@ RSpec.describe LegalAidApplicationPolicy do
     end
   end
 
-  context "provider who created the application" do
+  context "with provider who created the application" do
     let(:legal_aid_application) { create(:legal_aid_application, :with_negative_benefit_check_result, provider:) }
     let(:provider) { create :provider, :with_no_permissions }
 
-    context "controller is pre-DWP check" do
+    context "when controller is pre-DWP check" do
       let(:authorization_context) { AuthorizationContext.new(provider, pre_dwp_check_controller) }
 
       it "permits all actions" do
@@ -47,11 +47,11 @@ RSpec.describe LegalAidApplicationPolicy do
       end
     end
 
-    context "application is passported" do
+    context "when application is passported" do
       let(:legal_aid_application) { create(:legal_aid_application, :with_positive_benefit_check_result, provider:) }
       let(:authorization_context) { AuthorizationContext.new(provider, post_dwp_check_controller) }
 
-      context "provider has passported rights" do
+      context "when provider has passported rights" do
         let(:provider)  { create :provider, :with_passported_permissions }
 
         it "permits all actions" do
@@ -61,8 +61,8 @@ RSpec.describe LegalAidApplicationPolicy do
         end
       end
 
-      context "provider does not have passported rights" do
-        let(:provider)  { create :provider, :with_non_passported_permissions }
+      context "when provider does not have passported rights" do
+        let(:provider) { create :provider, :with_non_passported_permissions }
 
         it "does not permit any actions" do
           controller_actions.each do |action|
@@ -72,11 +72,11 @@ RSpec.describe LegalAidApplicationPolicy do
       end
     end
 
-    context "application is non-passported" do
+    context "when application is non-passported" do
       let(:legal_aid_application) { create(:legal_aid_application, :with_negative_benefit_check_result, :with_non_passported_state_machine, provider:) }
       let(:authorization_context) { AuthorizationContext.new(provider, post_dwp_check_controller) }
 
-      context "provider has non-passported rights" do
+      context "when provider has non-passported rights" do
         let(:provider) { create :provider, :with_non_passported_permissions }
 
         it "permits all actions" do
@@ -86,7 +86,7 @@ RSpec.describe LegalAidApplicationPolicy do
         end
       end
 
-      context "provider does not have non-passported rights" do
+      context "when provider does not have non-passported rights" do
         let(:provider) { create :provider, :with_passported_permissions }
 
         it "does not permit any actions" do

--- a/spec/requests/admin/legal_aid_applications/submissions_controller_spec.rb
+++ b/spec/requests/admin/legal_aid_applications/submissions_controller_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Admin::LegalAidApplications::SubmissionsController, type: :reques
     end
   end
 
-  context "Downloads" do
+  context "with Downloads" do
     let(:submission) { legal_aid_application.ccms_submission }
     let!(:history) { create(:ccms_submission_history, :with_xml, submission:) }
 
@@ -61,7 +61,7 @@ RSpec.describe Admin::LegalAidApplications::SubmissionsController, type: :reques
       end
     end
 
-    context "pdf" do
+    context "with pdf" do
       describe "GET download_means_report" do
         subject { get download_means_report_admin_legal_aid_applications_submission_path(legal_aid_application, format: :pdf) }
 

--- a/spec/requests/admin/legal_aid_applications_controller_spec.rb
+++ b/spec/requests/admin/legal_aid_applications_controller_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Admin::LegalAidApplicationsController, type: :request do
   describe "GET /admin/legal_aid_applications" do
     subject { get admin_legal_aid_applications_path(params) }
 
-    context "not from a whitelisted IP address" do
+    context "when not from a whitelisted IP address" do
       it "redirects to error page" do
         # stub the response to request.env['HTTP_X_REAL_IP']
         Rails.application.env_config["HTTP_X_REAL_IP"] = "55.6.7.8"
@@ -212,7 +212,7 @@ RSpec.describe Admin::LegalAidApplicationsController, type: :request do
         end
       end
 
-      context "application has no applicant" do
+      context "when application has no applicant" do
         let!(:application) { create :legal_aid_application }
 
         it "gets deleted too" do

--- a/spec/requests/admin/providers_spec.rb
+++ b/spec/requests/admin/providers_spec.rb
@@ -18,7 +18,7 @@ module Admin
         get admin_firm_providers_path(firm_id)
       end
 
-      context "all firms" do
+      context "with all firms" do
         let(:firm_id) { "0" }
 
         it "displays an appropriate heading" do
@@ -32,7 +32,7 @@ module Admin
         end
       end
 
-      context "firm specified" do
+      context "with firm specified" do
         let(:firm_id) { my_firm.id }
 
         it "displays a heading mentioning the firm name" do

--- a/spec/requests/admin/roles/permissions_spec.rb
+++ b/spec/requests/admin/roles/permissions_spec.rb
@@ -31,13 +31,13 @@ RSpec.describe Admin::Roles::PermissionsController, type: :request do
 
     let(:params) { {} }
 
-    context "Save and Continue button pressed with no changes" do
+    context "when Save and Continue button pressed with no changes" do
       it "redirects to main admin page" do
         expect(subject).to redirect_to(admin_root_path)
       end
     end
 
-    context "Save and Continue button pressed with new permission changes" do
+    context "when Save and Continue button pressed with new permission changes" do
       let!(:permission2) { create :permission, :non_passported }
       let!(:params) do
         {

--- a/spec/requests/admin/settings_spec.rb
+++ b/spec/requests/admin/settings_spec.rb
@@ -69,14 +69,14 @@ RSpec.describe Admin::SettingsController, type: :request do
     context "when the enable_ccms_submission is changed" do
       before { allow_any_instance_of(CCMS::RestartSubmissions).to receive(:call).and_return(true) }
 
-      context "from false to true" do
+      context "when from false to true" do
         it "calls CCMS::RestartSubmissions" do
           expect(CCMS::RestartSubmissions).to receive(:call)
           subject
         end
       end
 
-      context "from true to false" do
+      context "when from true to false" do
         let(:params) do
           {
             setting: {
@@ -95,7 +95,7 @@ RSpec.describe Admin::SettingsController, type: :request do
       end
     end
 
-    context "Setting already exist" do
+    context "when Setting already exist" do
       before { Setting.create! }
 
       it "does not add another Setting object" do
@@ -103,7 +103,7 @@ RSpec.describe Admin::SettingsController, type: :request do
       end
     end
 
-    context "no params where sent" do
+    context "when no params were sent" do
       let(:params) do
         {
           setting: {

--- a/spec/requests/admin_users/sessions_controller_spec.rb
+++ b/spec/requests/admin_users/sessions_controller_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe AdminUsers::SessionsController, type: :request do
       expect(unescaped_response_body).to include("admin_user_username")
     end
 
-    context "in production environment" do
+    context "when in production environment" do
       before do
         allow(Rails.configuration.x.admin_portal).to receive(:show_form).and_return(false)
       end

--- a/spec/requests/applicants/omniauth_callbacks_spec.rb
+++ b/spec/requests/applicants/omniauth_callbacks_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe "applicants omniauth call back", type: :request do
       end
     end
 
-    context "on authentication failure" do
+    context "with authentication failure" do
       before do
         OmniAuth.config.mock_auth[:true_layer] = :invalid_credentials
 

--- a/spec/requests/auth_spec.rb
+++ b/spec/requests/auth_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "AuthController", type: :request do
   describe "GET failure" do
     subject { get "/auth/failure", params: }
 
-    context "origin from citizens/banks" do
+    context "with origin from citizens/banks" do
       let(:origin_path) { citizens_banks_path }
 
       it "redirects to citizens_consent_path" do
@@ -21,7 +21,7 @@ RSpec.describe "AuthController", type: :request do
       end
     end
 
-    context "origin from elsewhere" do
+    context "with origin from elsewhere" do
       let(:origin_path) { root_path }
 
       it "redirects to access denied" do
@@ -30,7 +30,7 @@ RSpec.describe "AuthController", type: :request do
       end
     end
 
-    context "no origin" do
+    context "with no origin" do
       it "redirects to access denied" do
         get "/auth/failure"
         expect(response).to redirect_to error_path(:access_denied)

--- a/spec/requests/backable_spec.rb
+++ b/spec/requests/backable_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "Backable", :vcr, type: :request do
       expect(response.body).to have_back_link("#{page2}&back=true")
     end
 
-    context "we reload the current page several times" do
+    context "when we reload the current page several times" do
       before do
         get page3
         get page3
@@ -45,7 +45,7 @@ RSpec.describe "Backable", :vcr, type: :request do
       end
     end
 
-    context "we go back once" do
+    context "when we go back once" do
       it "redirects to same page without the param" do
         get "#{page2}&back=true"
         expect(response).to redirect_to(page2)

--- a/spec/requests/citizens/bank_spec.rb
+++ b/spec/requests/citizens/bank_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Citizens::BanksController, type: :request do
       expect(response.body).not_to include("mock")
     end
 
-    context "enable_mock is set to true" do
+    context "when enable_mock is set to true" do
       let(:enable_mock) { true }
 
       it "shows the mock bank" do
@@ -52,7 +52,7 @@ RSpec.describe Citizens::BanksController, type: :request do
       expect(session[:locale]).to eq(:en)
     end
 
-    context "Welsh locale" do
+    context "with Welsh locale" do
       before { post citizens_banks_path, params: { provider_id: } }
 
       around(:each) do |example|
@@ -64,7 +64,7 @@ RSpec.describe Citizens::BanksController, type: :request do
       end
     end
 
-    context "no bank was selected" do
+    context "with no bank selected" do
       let(:provider_id) { nil }
 
       it "returns http success" do

--- a/spec/requests/citizens/cash_incomes_spec.rb
+++ b/spec/requests/citizens/cash_incomes_spec.rb
@@ -26,8 +26,8 @@ RSpec.describe Citizens::CashIncomesController, type: :request do
       patch citizens_cash_income_path, params:
     end
 
-    context "valid update" do
-      context "valid params" do
+    context "with valid update" do
+      context "and valid params" do
         let(:params) { valid_params }
 
         it "redirects to new action" do
@@ -39,7 +39,7 @@ RSpec.describe Citizens::CashIncomesController, type: :request do
         end
       end
 
-      context "none of the above" do
+      context "with none of the above" do
         let(:params) { nothing_selected }
 
         it "redirects to new action" do
@@ -52,8 +52,8 @@ RSpec.describe Citizens::CashIncomesController, type: :request do
       end
     end
 
-    context "invalid update" do
-      context "invalid params" do
+    context "with invalid update" do
+      context "with invalid params" do
         let(:params) { invalid_params }
 
         it "returns http success" do
@@ -78,7 +78,7 @@ RSpec.describe Citizens::CashIncomesController, type: :request do
         end
       end
 
-      context "no params" do
+      context "with no params" do
         let(:params) { { aggregated_cash_income: { check_box_benefits: "" } } }
 
         it "shows an error if nothing selected" do


### PR DESCRIPTION
Fix GOVUK Rubocop RSpec/ContextWording offences.

Start context description with 'when', 'with', 'without', 'and', or 'but'. (https://rspec.rubystyle.guide/#context-descriptions, https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ContextWording)

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
