### PR TITLE
AP-2959 remove right alignment

### DIFF
--- a/app/views/shared/check_answers/_employed_income.html.erb
+++ b/app/views/shared/check_answers/_employed_income.html.erb
@@ -21,11 +21,10 @@
       ) %>
 
   <% if @legal_aid_application.extra_employment_information? %>
-    <%= check_answer_no_link(
+    <%= check_long_question_no_link(
           name: :extra_employment_information_details,
           question: t('.employment_details'),
           answer: @legal_aid_application.extra_employment_information_details,
-          read_only: read_only
         ) %>
   <% end %>
 </dl>

--- a/app/views/shared/check_answers/_full_employment_details.html.erb
+++ b/app/views/shared/check_answers/_full_employment_details.html.erb
@@ -12,10 +12,9 @@
   </div>
 </div>
 <dl class="govuk-summary-list govuk-!-margin-bottom-9">
-  <%= check_answer_no_link(
+  <%= check_long_question_no_link(
         name: :full_employment_details,
         question: t('.full_employment_details'),
-        answer: @legal_aid_application.full_employment_details,
-        read_only: read_only
+        answer: @legal_aid_application.full_employment_details
       ) %>
 </dl>


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2959)

Removed right-alignment of the employment notes field on the means report, to bring it in line with GDS guidelines

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
