### PR TITLE
Rubocop fixes

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -159,21 +159,6 @@ RSpec/BeforeAfterAll:
 # Prefixes: when, with, without
 RSpec/ContextWording:
   Exclude:
-    - 'spec/requests/citizens/cash_outgoings_spec.rb'
-    - 'spec/requests/citizens/check_answers_spec.rb'
-    - 'spec/requests/citizens/consent_spec.rb'
-    - 'spec/requests/citizens/gather_transactions_spec.rb'
-    - 'spec/requests/citizens/identify_types_of_incomes_spec.rb'
-    - 'spec/requests/citizens/identify_types_of_outgoings_spec.rb'
-    - 'spec/requests/citizens/legal_aid_applications_spec.rb'
-    - 'spec/requests/citizens/student_finance/annual_amounts_spec.rb'
-    - 'spec/requests/citizens/student_finance_spec.rb'
-    - 'spec/requests/errors_spec.rb'
-    - 'spec/requests/feedbacks_spec.rb'
-    - 'spec/requests/providers/address_lookups_spec.rb'
-    - 'spec/requests/providers/address_selections_spec.rb'
-    - 'spec/requests/providers/addresses_spec.rb'
-    - 'spec/requests/providers/applicant_bank_accounts_spec.rb'
     - 'spec/requests/providers/applicant_details_spec.rb'
     - 'spec/requests/providers/applicant_employed_spec.rb'
     - 'spec/requests/providers/applicants_spec.rb'

--- a/spec/cassettes/Providers_AddressSelectionsController/GET_/providers/applications/_legal_aid_application_id/address_selections/edit/when_the_provider_is_authenticated/when_a_postcode_has_been_entered_before/but_the_lookup_does_not_return_any_valid_results/renders_the_manual_address_selection_page.yml
+++ b/spec/cassettes/Providers_AddressSelectionsController/GET_/providers/applications/_legal_aid_application_id/address_selections/edit/when_the_provider_is_authenticated/when_a_postcode_has_been_entered_before/but_the_lookup_does_not_return_any_valid_results/renders_the_manual_address_selection_page.yml
@@ -19,7 +19,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 10 May 2022 14:02:43 GMT
+      - Thu, 26 May 2022 11:18:22 GMT
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -45,5 +45,5 @@ http_interactions:
         : 0,\r\n    \"format\" : \"JSON\",\r\n    \"dataset\" : \"DPA\",\r\n    \"lr\"
         : \"EN\",\r\n    \"maxresults\" : 100,\r\n    \"epoch\" : \"92\",\r\n    \"output_srs\"
         : \"EPSG:27700\"\r\n  }\r\n}"
-  recorded_at: Tue, 10 May 2022 14:02:43 GMT
+  recorded_at: Thu, 26 May 2022 11:18:22 GMT
 recorded_with: VCR 6.1.0

--- a/spec/cassettes/Providers_AddressSelectionsController/GET_/providers/applications/_legal_aid_application_id/address_selections/edit/when_the_provider_is_authenticated/when_a_postcode_has_been_entered_before/performs_an_address_lookup_with_the_provided_postcode.yml
+++ b/spec/cassettes/Providers_AddressSelectionsController/GET_/providers/applications/_legal_aid_application_id/address_selections/edit/when_the_provider_is_authenticated/when_a_postcode_has_been_entered_before/performs_an_address_lookup_with_the_provided_postcode.yml
@@ -19,7 +19,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 10 May 2022 14:02:42 GMT
+      - Thu, 26 May 2022 11:18:22 GMT
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -135,5 +135,5 @@ http_interactions:
         \     \"ENTRY_DATE\" : \"15/06/2020\",\r\n      \"BLPU_STATE_DATE\" : \"15/06/2020\",\r\n
         \     \"LANGUAGE\" : \"EN\",\r\n      \"MATCH\" : 1.0,\r\n      \"MATCH_DESCRIPTION\"
         : \"EXACT\",\r\n      \"DELIVERY_POINT_SUFFIX\" : \"1N\"\r\n    }\r\n  } ]\r\n}"
-  recorded_at: Tue, 10 May 2022 14:02:42 GMT
+  recorded_at: Thu, 26 May 2022 11:18:21 GMT
 recorded_with: VCR 6.1.0

--- a/spec/cassettes/Providers_AddressSelectionsController/GET_/providers/applications/_legal_aid_application_id/address_selections/edit/when_the_provider_is_authenticated/when_a_postcode_has_been_entered_before/renders_the_address_selection_page.yml
+++ b/spec/cassettes/Providers_AddressSelectionsController/GET_/providers/applications/_legal_aid_application_id/address_selections/edit/when_the_provider_is_authenticated/when_a_postcode_has_been_entered_before/renders_the_address_selection_page.yml
@@ -19,7 +19,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 10 May 2022 14:02:42 GMT
+      - Thu, 26 May 2022 11:18:22 GMT
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -135,5 +135,5 @@ http_interactions:
         \     \"ENTRY_DATE\" : \"15/06/2020\",\r\n      \"BLPU_STATE_DATE\" : \"15/06/2020\",\r\n
         \     \"LANGUAGE\" : \"EN\",\r\n      \"MATCH\" : 1.0,\r\n      \"MATCH_DESCRIPTION\"
         : \"EXACT\",\r\n      \"DELIVERY_POINT_SUFFIX\" : \"1N\"\r\n    }\r\n  } ]\r\n}"
-  recorded_at: Tue, 10 May 2022 14:02:42 GMT
+  recorded_at: Thu, 26 May 2022 11:18:22 GMT
 recorded_with: VCR 6.1.0

--- a/spec/requests/citizens/cash_outgoings_spec.rb
+++ b/spec/requests/citizens/cash_outgoings_spec.rb
@@ -26,8 +26,8 @@ RSpec.describe Citizens::CashOutgoingsController, type: :request do
       patch citizens_cash_outgoing_path, params:
     end
 
-    context "valid update" do
-      context "valid params" do
+    context "with valid update" do
+      context "with valid params" do
         let(:params) { valid_params }
 
         it "redirects to new action" do
@@ -39,7 +39,7 @@ RSpec.describe Citizens::CashOutgoingsController, type: :request do
         end
       end
 
-      context "none of the above" do
+      context "with none of the above" do
         let(:params) { nothing_selected }
 
         it "redirects to new action" do
@@ -52,8 +52,8 @@ RSpec.describe Citizens::CashOutgoingsController, type: :request do
       end
     end
 
-    context "invalid update" do
-      context "invalid params" do
+    context "with invalid update" do
+      context "with invalid params" do
         let(:params) { invalid_params }
 
         it "returns http success" do
@@ -78,7 +78,7 @@ RSpec.describe Citizens::CashOutgoingsController, type: :request do
         end
       end
 
-      context "no params" do
+      context "with no params" do
         let(:params) { { aggregated_cash_outgoings: { check_box_child_care: "" } } }
 
         it "shows an error if nothing selected" do

--- a/spec/requests/citizens/check_answers_spec.rb
+++ b/spec/requests/citizens/check_answers_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe "check your answers requests", type: :request do
       expect(response.body).to include(html_compare(firm.name))
     end
 
-    context "firms with special characters in the name" do
+    context "with firms with special characters in the name" do
       let(:firm) { create :firm, name: %q(O'Keefe & Sons - "Pay less with  <The master builders>!") }
 
       it "finds the firm even though it has special characters" do

--- a/spec/requests/citizens/consent_spec.rb
+++ b/spec/requests/citizens/consent_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Citizens::ConsentsController, type: :request do
       end
     end
 
-    context "no values given" do
+    context "with no values given" do
       let(:params) { { legal_aid_application: { open_banking_consent: nil } } }
 
       it "returns an error" do

--- a/spec/requests/citizens/gather_transactions_spec.rb
+++ b/spec/requests/citizens/gather_transactions_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe "citizen accounts request", type: :request do
       expect(page_history_service.read).to be_nil
     end
 
-    context "background worker is still working" do
+    context "when background worker is still working" do
       let(:worker) { { "status" => "working" } }
 
       it "returns http success" do
@@ -80,7 +80,7 @@ RSpec.describe "citizen accounts request", type: :request do
       end
     end
 
-    context "background worker generated an error" do
+    context "when background worker generates an error" do
       let(:error) { true_layer_error }
       let(:worker) { { "status" => "complete", "errors" => true_layer_error.to_json } }
 

--- a/spec/requests/citizens/identify_types_of_incomes_spec.rb
+++ b/spec/requests/citizens/identify_types_of_incomes_spec.rb
@@ -153,7 +153,7 @@ RSpec.describe Citizens::IdentifyTypesOfIncomesController, type: :request do
       end
     end
 
-    context "the wrong transaction type is passed in" do
+    context "when the wrong transaction type is passed in" do
       let!(:income_types) { create_list :transaction_type, 3, :debit_with_standard_name }
       let(:transaction_type_ids) { income_types.map(&:id) }
 
@@ -162,14 +162,14 @@ RSpec.describe Citizens::IdentifyTypesOfIncomesController, type: :request do
       end
     end
 
-    context "When checking citizen answers" do
+    context "when checking citizen answers" do
       before do
         get citizens_legal_aid_application_path(legal_aid_application.generate_secure_id)
         legal_aid_application.check_citizen_answers!
         patch citizens_identify_types_of_income_path, params:
       end
 
-      context "change to none selected" do
+      context "with change to none selected" do
         let(:params) { { legal_aid_application: { none_selected: "true" } } }
 
         it "redirects to the check answers page" do

--- a/spec/requests/citizens/identify_types_of_outgoings_spec.rb
+++ b/spec/requests/citizens/identify_types_of_outgoings_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe "IndentifyTypesOfOutgoingsController", type: :request do
       end
     end
 
-    context "the wrong transaction type is passed in" do
+    context "when the wrong transaction type is passed in" do
       let!(:income_types) { create_list :transaction_type, 3, :credit_with_standard_name }
       let(:transaction_type_ids) { income_types.map(&:id) }
 

--- a/spec/requests/citizens/legal_aid_applications_spec.rb
+++ b/spec/requests/citizens/legal_aid_applications_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "citizen home requests", type: :request do
       expect(session["page_history_id"]).not_to be_nil
     end
 
-    context "the link is not set to expire" do
+    context "when the link is not set to expire" do
       let(:secure_id) do
         SecureData.create_and_store!(
           legal_aid_application: { id: application_id },
@@ -84,7 +84,7 @@ RSpec.describe "citizen home requests", type: :request do
       expect(unescaped_response_body).to include(application.provider.firm.name.html_safe)
     end
 
-    context "if a provider is logged in" do
+    context "when a provider is logged in" do
       let(:provider_username) { "stepriponikas.bonstart" }
       let(:provider) { create :provider, username: provider_username }
 

--- a/spec/requests/citizens/student_finance/annual_amounts_spec.rb
+++ b/spec/requests/citizens/student_finance/annual_amounts_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "annual_amounts", type: :request do
       }
     end
 
-    context "adds an amount" do
+    context "when it adds an amount" do
       before { get citizens_legal_aid_application_path(legal_aid_application.generate_secure_id) }
 
       let(:amount) { 2345 }
@@ -48,7 +48,7 @@ RSpec.describe "annual_amounts", type: :request do
       describe "update record" do
         before { patch citizens_student_finances_annual_amount_path, params: }
 
-        context "update amount" do
+        context "when amount is updated" do
           let(:amount) { 5000 }
 
           it "updates the same record without creating a new one" do
@@ -60,7 +60,7 @@ RSpec.describe "annual_amounts", type: :request do
       end
     end
 
-    context "shows an error when field is empty" do
+    context "when field is empty" do
       before do
         get citizens_legal_aid_application_path(legal_aid_application.generate_secure_id)
         patch citizens_student_finances_annual_amount_path, params:

--- a/spec/requests/citizens/student_finance_spec.rb
+++ b/spec/requests/citizens/student_finance_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "student_finance", type: :request do
       } }
     end
 
-    context "responds YES to student finance" do
+    context "when responds YES to student finance" do
       before do
         get citizens_legal_aid_application_path(legal_aid_application.generate_secure_id)
         patch citizens_student_finance_path, params:
@@ -42,7 +42,7 @@ RSpec.describe "student_finance", type: :request do
       end
     end
 
-    context "responds NO to student finance" do
+    context "when responds NO to student finance" do
       before do
         get citizens_legal_aid_application_path(legal_aid_application.generate_secure_id)
         patch citizens_student_finance_path, params:
@@ -59,7 +59,7 @@ RSpec.describe "student_finance", type: :request do
       end
     end
 
-    context "No response is entered to student finance" do
+    context "when no response is entered to student finance" do
       before do
         get citizens_legal_aid_application_path(legal_aid_application.generate_secure_id)
         patch citizens_student_finance_path, params:
@@ -76,7 +76,7 @@ RSpec.describe "student_finance", type: :request do
       end
     end
 
-    context "When checking citizen answers" do
+    context "when checking citizen answers" do
       before do
         get citizens_legal_aid_application_path(legal_aid_application.generate_secure_id)
         legal_aid_application.check_citizen_answers!

--- a/spec/requests/errors_spec.rb
+++ b/spec/requests/errors_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe ErrorsController, type: :request do
   describe "actions that result in error pages being shown" do
     describe "unknown page" do
-      context "default locale" do
+      context "with default locale" do
         before { get "/unknown/path" }
 
         it "redirect to page not found" do
@@ -11,7 +11,7 @@ RSpec.describe ErrorsController, type: :request do
         end
       end
 
-      context "Welsh locale" do
+      context "with Welsh locale" do
         around(:each) do |example|
           I18n.with_locale(:cy) { example.run }
         end
@@ -25,7 +25,7 @@ RSpec.describe ErrorsController, type: :request do
     end
 
     describe "object not found" do
-      context "default locale" do
+      context "with default locale" do
         before { get feedback_path(SecureRandom.uuid) }
 
         it "redirect to page not found" do
@@ -33,7 +33,7 @@ RSpec.describe ErrorsController, type: :request do
         end
       end
 
-      context "Welsh locale" do
+      context "with Welsh locale" do
         around(:each) do |example|
           I18n.with_locale(:cy) { example.run }
         end

--- a/spec/requests/feedbacks_spec.rb
+++ b/spec/requests/feedbacks_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "FeedbacksController", type: :request do
     end
 
     describe "creation of feedback record" do
-      context "any type of user" do
+      context "with any type of user" do
         it "create a feedback" do
           expect { subject }.to change(Feedback, :count).by(1)
         end
@@ -45,7 +45,7 @@ RSpec.describe "FeedbacksController", type: :request do
         end
       end
 
-      context "as a logged in provider" do
+      context "when a logged in provider" do
         let(:originating_page) { address_lookup_page }
 
         before { sign_in provider }
@@ -57,7 +57,7 @@ RSpec.describe "FeedbacksController", type: :request do
           expect(feedback.originating_page).to eq URI(address_lookup_page).path.split("/").last
         end
 
-        context "gives feedback during application" do
+        context "when feedback given during application" do
           let(:page_history) do
             [originating_page, "/feedback/new"]
           end
@@ -70,7 +70,7 @@ RSpec.describe "FeedbacksController", type: :request do
           end
         end
 
-        context "gives feedback outside of an application" do
+        context "when feedback given outside of an application" do
           let(:page_history) do
             ["/feedback/new"]
           end
@@ -96,7 +96,7 @@ RSpec.describe "FeedbacksController", type: :request do
         end
       end
 
-      context "as a provider after logging out" do
+      context "when as a provider after logging out" do
         let(:originating_page) { address_lookup_page }
         let(:params) { { feedback: attributes_for(:feedback), signed_out: true } }
 
@@ -108,7 +108,7 @@ RSpec.describe "FeedbacksController", type: :request do
         end
       end
 
-      context "as an applicant" do
+      context "when as an applicant" do
         let(:originating_page) { additional_accounts_page }
         let(:session_vars) do
           {
@@ -132,7 +132,7 @@ RSpec.describe "FeedbacksController", type: :request do
       expect(feedback.source).to eq("Unknown")
     end
 
-    context "provider feedback" do
+    context "with provider feedback" do
       let(:originating_page) { address_lookup_page }
 
       it "contains provider email" do
@@ -142,11 +142,11 @@ RSpec.describe "FeedbacksController", type: :request do
       end
     end
 
-    context "provider feedback" do
+    context "with applicant feedback" do
       let(:originating_page) { additional_accounts_page }
       let(:session_vars) { { current_application_id: application.id } }
 
-      context "no appliction id in the page history" do
+      context "and no application id in the page history" do
         it "contains provider email" do
           subject
           expect(feedback.source).to eq "Applicant"
@@ -190,7 +190,7 @@ RSpec.describe "FeedbacksController", type: :request do
       end
     end
 
-    context "submitting feedback using link in submission email" do
+    context "when submitting feedback using link in submission email" do
       let(:application) { create :legal_aid_application }
       let(:params) { { feedback: attributes_for(:feedback), application_id: application.id, submission_feedback: "true" } }
 
@@ -254,7 +254,7 @@ RSpec.describe "FeedbacksController", type: :request do
       expect(response.body).to include('<input type="hidden" name="submission_feedback" id="submission_feedback" value="false" autocomplete="off" />')
     end
 
-    context "has come here as applicant or signed in provider" do
+    context "when here as applicant or signed in provider" do
       let(:session_vars) { {} }
 
       it "hash a hidden form field with no value" do
@@ -262,7 +262,7 @@ RSpec.describe "FeedbacksController", type: :request do
       end
     end
 
-    context "provider signed out" do
+    context "with provider signed out" do
       let(:provider) { create :provider }
 
       before do
@@ -305,7 +305,7 @@ RSpec.describe "FeedbacksController", type: :request do
       expect(response.body).to include("<input type=\"hidden\" name=\"application_id\" id=\"application_id\" value=\"#{application.id}\" autocomplete=\"off\" />")
     end
 
-    context "has come here as applicant or signed in provider" do
+    context "when here as applicant or signed in provider" do
       let(:session_vars) { {} }
 
       it "hash a hidden form field with no value" do

--- a/spec/requests/providers/address_lookups_spec.rb
+++ b/spec/requests/providers/address_lookups_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe Providers::AddressLookupsController, type: :request do
         end
       end
 
-      context "Form submitted using Save as draft button" do
+      context "with form submitted using Save as draft button" do
         let(:submit_button) { { draft_button: "Save as draft" } }
 
         it "redirects provider to provider's applications page" do

--- a/spec/requests/providers/address_selections_spec.rb
+++ b/spec/requests/providers/address_selections_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Providers::AddressSelectionsController, type: :request do
         login_as provider
       end
 
-      context "a postcode has been entered before", :vcr do
+      context "when a postcode has been entered before", :vcr do
         let(:postcode) { "SW1H 9EA" }
         let!(:address) { create :address, postcode:, applicant: }
 
@@ -53,7 +53,7 @@ RSpec.describe Providers::AddressSelectionsController, type: :request do
         end
       end
 
-      context "no postcode have been entered yet" do
+      context "when no postcode have been entered yet" do
         before { get providers_legal_aid_application_address_lookup_path(legal_aid_application) }
 
         it "redirects to the postcode entering page" do
@@ -153,7 +153,7 @@ RSpec.describe Providers::AddressSelectionsController, type: :request do
         end
       end
 
-      context "Form submitted using Save as draft button" do
+      context "with form submitted using Save as draft button" do
         let(:submit_button) { { draft_button: "Save as draft" } }
 
         it "redirects provider to provider's applications page" do

--- a/spec/requests/providers/addresses_spec.rb
+++ b/spec/requests/providers/addresses_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe "address requests", type: :request do
         end
       end
 
-      context "a previous address lookup failed" do
+      context "when a previous address lookup failed" do
         let(:address_params) do
           {
             address:
@@ -138,7 +138,7 @@ RSpec.describe "address requests", type: :request do
         end
       end
 
-      context "Form submitted using Save as draft button" do
+      context "with form submitted using Save as draft button" do
         let(:submit_button) { { draft_button: "Save as draft" } }
 
         it "redirects provider to provider's applications page" do

--- a/spec/requests/providers/applicant_bank_accounts_spec.rb
+++ b/spec/requests/providers/applicant_bank_accounts_spec.rb
@@ -60,13 +60,13 @@ RSpec.describe Providers::ApplicantBankAccountsController, type: :request do
       }
     end
 
-    context "the provider is authenticated" do
+    context "when the provider is authenticated" do
       before do
         login_as provider
         subject
       end
 
-      context "neither option is chosen" do
+      context "when neither option is chosen" do
         let(:applicant_bank_account) { nil }
 
         it "shows an error" do
@@ -74,14 +74,14 @@ RSpec.describe Providers::ApplicantBankAccountsController, type: :request do
         end
       end
 
-      context "The NO option is chosen" do
+      context "when the NO option is chosen" do
         let(:applicant_bank_account) { "false" }
 
         it "redirects to the savings and investments page" do
           expect(response).to redirect_to(providers_legal_aid_application_savings_and_investment_path(legal_aid_application))
         end
 
-        context "savings amount is not nil" do
+        context "when savings amount is not nil" do
           let(:offline_savings_accounts) { "" }
 
           it "resets the account balance to nil for offline savings account" do
@@ -90,10 +90,10 @@ RSpec.describe Providers::ApplicantBankAccountsController, type: :request do
         end
       end
 
-      context "The YES option is chosen" do
+      context "when the YES option is chosen" do
         let(:applicant_bank_account) { "true" }
 
-        context "no amount is entered" do
+        context "when no amount is entered" do
           let(:offline_savings_accounts) { "" }
 
           it "displays the correct error" do
@@ -101,7 +101,7 @@ RSpec.describe Providers::ApplicantBankAccountsController, type: :request do
           end
         end
 
-        context "an invalid input is entered" do
+        context "when an invalid input is entered" do
           let(:offline_savings_accounts) { "abc" }
 
           it "displays the correct error" do
@@ -109,7 +109,7 @@ RSpec.describe Providers::ApplicantBankAccountsController, type: :request do
           end
         end
 
-        context "a valid savings amount is entered" do
+        context "when a valid savings amount is entered" do
           let(:offline_savings_accounts) { rand(1...1_000_000.0).round(2) }
 
           it "updates the savings amount" do


### PR DESCRIPTION
Fix GOVUK Rubocop RSpec/ContextWording offences.

Start context description with 'when', 'with', 'without', 'and', or 'but'. (https://rspec.rubystyle.guide/#context-descriptions, https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ContextWording)

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
