### PR TITLE
ap-3128: Remove sentry alert where hmrc can't find client details

### DIFF
--- a/app/services/hmrc/parsed_response/validator.rb
+++ b/app/services/hmrc/parsed_response/validator.rb
@@ -103,8 +103,12 @@ module HMRC
         AlertManager.capture_message("HMRC Response is unacceptable (id: #{hmrc_response.id}) - #{errors.map(&:message).join(', ')}")
       end
 
+      def client_details_not_found
+        { "error" => "submitted client details could not be found in HMRC service" }
+      end
+
       def errors_ignoreable?
-        errors.empty? || errors.map(&:attribute).include?(:use_case)
+        errors.empty? || errors.map(&:attribute).include?(:use_case) || data&.include?(client_details_not_found)
       end
     end
   end

--- a/spec/services/hmrc/parsed_response/validator_spec.rb
+++ b/spec/services/hmrc/parsed_response/validator_spec.rb
@@ -714,5 +714,24 @@ RSpec.describe HMRC::ParsedResponse::Validator do
         end
       end
     end
+
+    context "when client details are not found by HMRC" do
+      let(:hmrc_response) { create(:hmrc_response, use_case: "one", response: response_hash) }
+      let(:response_hash) do
+        { "submission" => "must-be-present",
+          "status" => "failed",
+          "data" => [{ "error" => "submitted client details could not be found in HMRC service" }] }
+      end
+
+      before do
+        allow(AlertManager).to receive(:capture_message)
+      end
+
+      it { expect(instance.call).to be_falsey }
+
+      it "does not send message to AlertManager with errors" do
+        expect(AlertManager).not_to have_received(:capture_message)
+      end
+    end
   end
 end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/jira/software/c/projects/AP/boards/233?modal=detail&selectedIssue=AP-3128)

Stop sentry alerting where HMRC has no re record of the client details

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
