### PR TITLE
[AP-3183] Use github action service account for delete uat release action

### DIFF
--- a/.github/actions/delete-uat-release/action.yml
+++ b/.github/actions/delete-uat-release/action.yml
@@ -55,12 +55,13 @@ runs:
         K8S_CLUSTER: ${{ inputs.k8s_cluster }}
         K8S_CLUSTER_CERT: ${{ inputs.k8s_cluster_cert }}
         K8S_NAMESPACE: ${{ inputs.k8s_namespace }}
+        K8S_SERVICE_ACCOUNT: ${{ inputs.k8s_service_account }}
         K8S_TOKEN: ${{ inputs.k8s_token }}
       run: |
         echo -n ${K8S_CLUSTER_CERT} | base64 -d > ./ca.crt
         kubectl config set-cluster ${K8S_CLUSTER} --certificate-authority=./ca.crt --server=https://${K8S_CLUSTER}
-        kubectl config set-credentials circleci --token=${K8S_TOKEN}
-        kubectl config set-context ${K8S_CLUSTER} --cluster=${K8S_CLUSTER} --user=circleci --namespace=${K8S_NAMESPACE}
+        kubectl config set-credentials github-action --token=${K8S_TOKEN}
+        kubectl config set-context ${K8S_CLUSTER} --cluster=${K8S_CLUSTER} --user=github-action --namespace=${K8S_NAMESPACE}
         kubectl config use-context ${K8S_CLUSTER}
 
     - name: Delete UAT release

--- a/.github/actions/delete-uat-release/action.yml
+++ b/.github/actions/delete-uat-release/action.yml
@@ -55,7 +55,6 @@ runs:
         K8S_CLUSTER: ${{ inputs.k8s_cluster }}
         K8S_CLUSTER_CERT: ${{ inputs.k8s_cluster_cert }}
         K8S_NAMESPACE: ${{ inputs.k8s_namespace }}
-        K8S_SERVICE_ACCOUNT: ${{ inputs.k8s_service_account }}
         K8S_TOKEN: ${{ inputs.k8s_token }}
       run: |
         echo -n ${K8S_CLUSTER_CERT} | base64 -d > ./ca.crt

--- a/.github/workflows/delete-uat-release.yml
+++ b/.github/workflows/delete-uat-release.yml
@@ -21,3 +21,11 @@ jobs:
       - name: Result
         shell: bash
         run: echo ${{ steps.delete_uat.outputs.delete-message }}
+
+      - uses: actions/checkout@v3
+      - name: Setup tmate session
+        if: ${{ failure() }}
+        uses: mxschmitt/action-tmate@v3
+        timeout-minutes: 15
+        with:
+          limit-access-to-actor: true

--- a/.github/workflows/delete-uat-release.yml
+++ b/.github/workflows/delete-uat-release.yml
@@ -14,10 +14,10 @@ jobs:
         id: delete_uat
         uses: ./.github/actions/delete-uat-release
         with:
-          k8s_cluster: ${{ secrets.K8S_CLUSTER_NAME_LIVE }}
-          k8s_cluster_cert: ${{ secrets.K8S_CLUSTER_CERT_LIVE }}
-          k8s_namespace: ${{ secrets.K8S_UAT_NAMESPACE }}
-          k8s_token: ${{ secrets.K8S_UAT_TOKEN_LIVE }}
+          k8s_cluster: ${{ secrets.K8S_GHA_UAT_CLUSTER_NAME }}
+          k8s_cluster_cert: ${{ secrets.K8S_GHA_UAT_CLUSTER_CERT }}
+          k8s_namespace: ${{ secrets.K8S_GHA_UAT_NAMESPACE }}
+          k8s_token: ${{ secrets.K8S_GHA_UAT_TOKEN }}
       - name: Result
         shell: bash
         run: echo ${{ steps.delete_uat.outputs.delete-message }}


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3183)

Previously used circleci credentials. This uses
a new separate account to mitigate potential exposure
impact

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
