### PR TITLE
AP-3167: Allow change of substantive cost limits

### DIFF
--- a/app/controllers/providers/limitations_controller.rb
+++ b/app/controllers/providers/limitations_controller.rb
@@ -8,7 +8,7 @@ module Providers
     end
 
     def update
-      if @legal_aid_application.used_delegated_functions?
+      if form_needs_checking?
         clear_limit_and_reason
         @form = LegalAidApplications::EmergencyCostOverrideForm.new(form_params)
         render :show unless save_continue_or_draft(@form)
@@ -19,17 +19,27 @@ module Providers
 
   private
 
+    def form_needs_checking?
+      legal_aid_application.used_delegated_functions? || @legal_aid_application.substantive_cost_overridable?
+    end
+
     def clear_limit_and_reason
       atc = params[:legal_aid_application]
-      return unless atc[:emergency_cost_override].to_s == "false"
 
-      atc[:emergency_cost_requested] = nil
-      atc[:emergency_cost_reasons] = nil
+      atc[:emergency_cost_requested] = nil if atc[:emergency_cost_override].to_s == "false"
+      atc[:emergency_cost_reasons] = nil if atc[:emergency_cost_override].to_s == "false"
+      atc[:substantive_cost_requested] = nil if atc[:substantive_cost_override].to_s == "false"
+      atc[:substantive_cost_reasons] = nil if atc[:substantive_cost_override].to_s == "false"
     end
 
     def form_params
       merge_with_model(legal_aid_application) do
-        params.require(:legal_aid_application).permit(:emergency_cost_override, :emergency_cost_requested, :emergency_cost_reasons)
+        params.require(:legal_aid_application).permit(:emergency_cost_override,
+                                                      :emergency_cost_requested,
+                                                      :emergency_cost_reasons,
+                                                      :substantive_cost_override,
+                                                      :substantive_cost_requested,
+                                                      :substantive_cost_reasons)
       end
     end
   end

--- a/app/forms/legal_aid_applications/emergency_cost_override_form.rb
+++ b/app/forms/legal_aid_applications/emergency_cost_override_form.rb
@@ -2,23 +2,45 @@ module LegalAidApplications
   class EmergencyCostOverrideForm < BaseForm
     form_for LegalAidApplication
 
-    attr_accessor :emergency_cost_override, :emergency_cost_requested, :emergency_cost_reasons
+    attr_accessor :emergency_cost_override, :emergency_cost_requested, :emergency_cost_reasons,
+                  :substantive_cost_override, :substantive_cost_requested, :substantive_cost_reasons
 
-    validates :emergency_cost_override, presence: true, unless: :draft?
-    validates :emergency_cost_reasons, presence: true, if: :requested_override?
+    validates :emergency_cost_override, presence: true, unless: :emergency_ignorable?
+    validates :emergency_cost_reasons, presence: true, if: :requested_emergency_override?
     validates(
       :emergency_cost_requested,
       currency: { greater_than_or_equal_to: 0, allow_blank: true },
       presence: { unless: :draft? },
-      if: :requested_override?,
+      if: :requested_emergency_override?,
     )
 
-    def requested_override?
+    validates :substantive_cost_override, presence: true, unless: :substantive_ignorable?
+    validates :substantive_cost_reasons, presence: true, if: :requested_substantive_override?
+    validates(
+      :substantive_cost_requested,
+      currency: { greater_than_or_equal_to: 0, less_than_or_equal_to: 25_000, allow_blank: true },
+      presence: { unless: :draft? },
+      if: :requested_substantive_override?,
+    )
+
+    def emergency_ignorable?
+      draft? || !model.used_delegated_functions?
+    end
+
+    def substantive_ignorable?
+      draft? || !model.substantive_cost_overridable?
+    end
+
+    def requested_emergency_override?
       emergency_cost_override.to_s == "true"
     end
 
+    def requested_substantive_override?
+      substantive_cost_override.to_s == "true"
+    end
+
     def attributes_to_clean
-      [:emergency_cost_requested]
+      %i[emergency_cost_requested substantive_cost_requested]
     end
   end
 end

--- a/app/views/providers/check_provider_answers/_shared.html.erb
+++ b/app/views/providers/check_provider_answers/_shared.html.erb
@@ -67,3 +67,19 @@
           read_only: @read_only
         ) %>
   <% end %>
+
+  <% if @legal_aid_application.substantive_cost_overridable? %>
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <h2 class="govuk-heading-m"><%= t '.substantive_cost_limit' %></h2>
+      </div>
+      <div class="govuk-grid-column-one-third">
+        <p><%= link_to_accessible t('.change'), providers_legal_aid_application_limitations_path(@legal_aid_application), class: 'govuk-link govuk-link-right' %></p>
+      </div>
+    </div>
+    <%= render(
+          'shared/check_answers/substantive_costs',
+          legal_aid_application: @legal_aid_application,
+          read_only: @read_only
+        ) %>
+  <% end %>

--- a/app/views/providers/check_provider_answers/_shared.html.erb
+++ b/app/views/providers/check_provider_answers/_shared.html.erb
@@ -39,20 +39,6 @@
       ) %>
 
   <% if @legal_aid_application.used_delegated_functions? %>
-    <h2 class="govuk-heading-m"><%= t '.section_emergency.heading' %></h2>
-    <%= render(
-            'shared/check_answers/emergency_limitations',
-            legal_aid_application: @legal_aid_application
-        ) %>
-  <% end %>
-
-  <h2 class="govuk-heading-m"><%= t('.section_substantive.heading') %></h2>
-  <%= render(
-          'shared/check_answers/substantive_limitations',
-          legal_aid_application: @legal_aid_application
-      ) %>
-
-  <% if @legal_aid_application.used_delegated_functions? %>
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <h2 class="govuk-heading-m"><%= t '.emergency_cost_limit' %></h2>

--- a/app/views/providers/limitations/_cost_limits.html.erb
+++ b/app/views/providers/limitations/_cost_limits.html.erb
@@ -1,0 +1,26 @@
+<h2 class="govuk-heading-m">
+  <%= t(title_translation_path) %>
+</h2>
+
+<p><%= t('.default_substantive_limit_is') %> <strong><%= gds_number_to_currency(@legal_aid_application.default_substantive_cost_limitation,  precision: 0) %></strong></p>
+
+<% if @legal_aid_application.substantive_cost_overridable? %>
+  <%= form.govuk_radio_buttons_fieldset(:substantive_cost_override,
+                                        legend: { size: 's', tag: 'h2', text: t('.substantive_cost_override_question') }) do %>
+    <%= form.govuk_radio_button(:substantive_cost_override, true, link_errors: true, label: {text: t('generic.yes')} ) do %>
+      <%= form.govuk_text_field(
+            :substantive_cost_requested,
+            label: {text: t('.enter_substantive_cost_limit')},
+            value: number_to_currency_or_original_string(@form.substantive_cost_requested),
+            prefix_text: t('currency.gbp'),
+            width: 'one-third',
+            ) %>
+
+      <%= form.govuk_text_area(
+            :substantive_cost_reasons,
+            label: {text: t('.enter_substantive_cost_reasons')}
+          ) %>
+    <% end %>
+    <%= form.govuk_radio_button(:substantive_cost_override, false, label: {text:  t('generic.no')}) %>
+  <% end %>
+<% end %>

--- a/app/views/providers/limitations/_proceeding_types.html.erb
+++ b/app/views/providers/limitations/_proceeding_types.html.erb
@@ -1,4 +1,9 @@
-<%= page_template(page_title: t('.h1-heading')) do %>
+<%= form_with(model: @form,
+              url: providers_legal_aid_application_limitations_path(@legal_aid_application),
+              method: :patch,
+              local: true) do |form| %>
+  <%= page_template(page_title: t('.h1-heading'), template: :basic, form: form) do %>
+  <h1 class="govuk-heading-xl"><%= t('.h1-heading') %></h1>
   <h2 class="govuk-heading-l">
     <%= t('.proceedings_heading') %>
   </h2>
@@ -9,20 +14,13 @@
                locals: {translation_path: 'providers.limitations.show'} %>
   </dl>
 
-  <h2 class="govuk-heading-l">
-    <%= t('.cost_heading') %>
-  </h2>
-  <p class="govuk-body">
-  <div class="govuk-!-padding-bottom-1"></div>
-  <p><%= t('.substantive_certificate') %>: <strong><%= gds_number_to_currency(@legal_aid_application.default_substantive_cost_limitation,  precision: 0) %></strong></p>
-  </p>
+    <%= render partial: 'providers/limitations/cost_limits',
+               locals: { title_translation_path: '.cost_heading', form: form } %>
+    <div class="govuk-!-padding-bottom-6"></div>
 
-  <div class="govuk-!-padding-bottom-6"></div>
-
-  <%= next_action_buttons_with_form(
-        url: providers_legal_aid_application_limitations_path,
-        method: :patch,
-        show_draft: true
-      ) %>
-
+    <%= next_action_buttons(
+          show_draft: true,
+          form: form
+        ) %>
+  <% end %>
 <% end %>

--- a/app/views/providers/limitations/_proceeding_types_with_df.html.erb
+++ b/app/views/providers/limitations/_proceeding_types_with_df.html.erb
@@ -44,13 +44,8 @@
       <%= form.govuk_radio_button(:emergency_cost_override, false, label: {text:  t('generic.no')}) %>
     <% end %>
 
-    <h2 class="govuk-heading-m">
-      <%= t('.substantive_certificate') %>
-    </h2>
-
-      <div class="govuk-!-padding-bottom-1"></div>
-      <p><%= t('.default_limit_is') %> <strong><%= gds_number_to_currency(@legal_aid_application.default_substantive_cost_limitation,  precision: 0) %></strong></p>
-    </p>
+    <%= render partial: 'providers/limitations/cost_limits',
+               locals: { title_translation_path: '.substantive_certificate', form: form } %>
 
     <div class="govuk-!-padding-bottom-6"></div>
 

--- a/app/views/providers/merits_reports/show.html.erb
+++ b/app/views/providers/merits_reports/show.html.erb
@@ -28,6 +28,26 @@
           read_only: true,
       ) %>
 
+  <% if @legal_aid_application.used_delegated_functions? %>
+    <h2 class="govuk-heading-m"><%= t '.emergency_cost_limit' %></h2>
+
+    <%= render(
+          'shared/check_answers/emergency_costs',
+          legal_aid_application: @legal_aid_application,
+          read_only: true,
+          ) %>
+  <% end %>
+
+  <% if @legal_aid_application.substantive_cost_overridable? %>
+    <h2 class="govuk-heading-m"><%= t '.substantive_cost_limit' %></h2>
+
+    <%= render(
+          'shared/check_answers/substantive_costs',
+          legal_aid_application: @legal_aid_application,
+          read_only: true,
+          ) %>
+  <% end %>
+
   <%= render(
         "shared/check_answers/merits",
         incident: @legal_aid_application.latest_incident,

--- a/app/views/shared/_review_application.html.erb
+++ b/app/views/shared/_review_application.html.erb
@@ -79,6 +79,19 @@
       ) %>
 <% end %>
 
+<% if @legal_aid_application.substantive_cost_overridable? %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h2 class="govuk-heading-m"><%= t '.substantive_cost_limit' %></h2>
+    </div>
+  </div>
+  <%= render(
+        'shared/check_answers/substantive_costs',
+        legal_aid_application: @legal_aid_application,
+        read_only: true
+      ) %>
+<% end %>
+
 <section class="income_payments_and_assets page_break_before">
   <div class="govuk-!-padding-bottom-6"></div>
   <h2 class="govuk-heading-l"><%= t('.income_payments_and_assets_heading') %></h2>

--- a/app/views/shared/check_answers/_emergency_costs.html.erb
+++ b/app/views/shared/check_answers/_emergency_costs.html.erb
@@ -8,7 +8,7 @@
     <%= check_answer_no_link(
           name: :emergency_cost_requested,
           question: t(".new_cost_limit"),
-          answer: gds_number_to_currency(@legal_aid_application.emergency_cost_requested,  precision: 0)
+          answer: gds_number_to_currency(@legal_aid_application.emergency_cost_requested,  precision: 2)
         ) %>
     <%= check_answer_no_link(
           name: :emergency_cost_reasons,

--- a/app/views/shared/check_answers/_substantive_costs.html.erb
+++ b/app/views/shared/check_answers/_substantive_costs.html.erb
@@ -1,0 +1,19 @@
+<dl class="govuk-summary-list govuk-!-margin-bottom-9">
+  <%= check_answer_no_link(
+        name: :emergency_cost_override,
+        question: t('.request_higher_limit'),
+        answer: yes_no(@legal_aid_application.substantive_cost_override)
+      ) %>
+  <% if @legal_aid_application.substantive_cost_override %>
+    <%= check_answer_no_link(
+          name: :cost_requested,
+          question: t(".new_cost_limit"),
+          answer: gds_number_to_currency(@legal_aid_application.substantive_cost_requested,  precision: 0)
+        ) %>
+    <%= check_answer_no_link(
+          name: :cost_reasons,
+          question: t(".new_limit_reasons"),
+          answer: @legal_aid_application.substantive_cost_reasons
+        ) %>
+  <% end %>
+</dl>

--- a/app/views/shared/check_answers/_substantive_costs.html.erb
+++ b/app/views/shared/check_answers/_substantive_costs.html.erb
@@ -8,7 +8,7 @@
     <%= check_answer_no_link(
           name: :cost_requested,
           question: t(".new_cost_limit"),
-          answer: gds_number_to_currency(@legal_aid_application.substantive_cost_requested,  precision: 0)
+          answer: gds_number_to_currency(@legal_aid_application.substantive_cost_requested,  precision: 2)
         ) %>
     <%= check_answer_no_link(
           name: :cost_reasons,

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -306,6 +306,12 @@ en:
               too_many_decimals: Mortgage amount must not include more than 2 decimal numbers
             emergency_cost_override:
               blank: Select yes if you want to request a higher emergency cost limit
+            emergency_cost_requested:
+              blank: Enter a new emergency cost limit
+              not_a_number: Emergency cost limit must be an amount of money, like 2,500
+              greater_than_or_equal_to: The new emergency cost limit cannot be less than 0
+            emergency_cost_reasons:
+              blank: Tell us why you need a higher emergency cost limit
             substantive_cost_override:
               blank: Select yes if you want to request a higher substantive cost limit
             substantive_cost_requested:
@@ -315,12 +321,6 @@ en:
               less_than_or_equal_to: The new substantive cost limit cannot be more than £25,000
             substantive_cost_reasons:
               blank: Tell us why you need a higher substantive cost limit
-            emergency_cost_requested:
-              blank: Enter a new emergency cost limit
-              not_a_number: Emergency cost limit must be an amount of money, like 2,500
-              greater_than_or_equal_to: The new emergency cost limit cannot be less than 0
-            emergency_cost_reasons:
-              blank: Tell us why you need a higher emergency cost limit
             extra_employment_information:
               blank: Select yes if you need to tell us anything else about your client's employment
             extra_employment_information_details:

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -305,13 +305,22 @@ en:
               not_a_number: Mortgage amount must be an amount of money, like 60,000
               too_many_decimals: Mortgage amount must not include more than 2 decimal numbers
             emergency_cost_override:
-              blank: Select yes if you want to request a higher cost limit
+              blank: Select yes if you want to request a higher emergency cost limit
+            substantive_cost_override:
+              blank: Select yes if you want to request a higher substantive cost limit
+            substantive_cost_requested:
+              blank: Enter a new substantive cost limit
+              not_a_number: Substantive cost limit must be an amount of money, like 2,500
+              greater_than_or_equal_to: The new substantive cost limit cannot be less than 0
+              less_than_or_equal_to: The new substantive cost limit cannot be more than £25,000
+            substantive_cost_reasons:
+              blank: Tell us why you need a higher substantive cost limit
             emergency_cost_requested:
               blank: Enter a new emergency cost limit
-              not_a_number: Cost limit must be an amount of money, like 2,500
-              greater_than_or_equal_to: The new cost limit cannot be less than 0
+              not_a_number: Emergency cost limit must be an amount of money, like 2,500
+              greater_than_or_equal_to: The new emergency cost limit cannot be less than 0
             emergency_cost_reasons:
-              blank: Tell us why you need a higher cost limit
+              blank: Tell us why you need a higher emergency cost limit
             extra_employment_information:
               blank: Select yes if you need to tell us anything else about your client's employment
             extra_employment_information_details:

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -294,6 +294,7 @@ en:
         section_substantive:
           heading: Covered under a substantive certificate
         emergency_cost_limit: Emergency cost limit
+        substantive_cost_limit: Substantive cost limit
 
     applicant_bank_accounts:
       show:
@@ -589,16 +590,23 @@ en:
         form_of_service_type: Full representation
         incurrable_costs: "Costs you can incur: "
         allowable_work: "Work you can do: "
+      cost_limits:
+        cost_heading: Cost limits
+        substantive_certificate: Substantive certificate
+        default_substantive_limit_is: The default substantive cost limit is
+        substantive_cost_override_question: Do you want to request a higher substantive cost limit?
+        enter_substantive_cost_limit: Enter a new substantive cost limit
+        enter_substantive_cost_reasons: Tell us why you need a higher substantive cost limit
       proceeding_types_with_df:
         h1-heading: What you're applying for
         proceedings_heading: Proceedings
         cost_heading: Cost limits
-        cost_override_question: Do you want to request a higher cost limit?
+        cost_override_question: Do you want to request a higher emergency cost limit?
         enter_cost_limit: Enter a new emergency cost limit
-        enter_cost_reasons: Tell us why you need a higher cost limit
+        enter_cost_reasons: Tell us why you need a higher emergency cost limit
         substantive_certificate: Substantive certificate
         emergency_certificate: Emergency certificate
-        default_limit_is: The default cost limit is
+        default_limit_is: The default emergency cost limit is
         form_of_service: "Form of service: "
         form_of_service_type: Full representation
         incurrable_costs: "Costs you can incur: "

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -675,6 +675,8 @@ en:
         client_details_heading: Client details
         applying_for: What you’re applying for
         delegated_functions: Delegated functions
+        emergency_cost_limit: Emergency cost limit
+        substantive_cost_limit: Substantive cost limit
     means_reports:
       caseworker_review:
         required: Caseworker review required?

--- a/config/locales/en/shared.yml
+++ b/config/locales/en/shared.yml
@@ -185,6 +185,10 @@ en:
         request_higher_limit: Higher cost limit requested
         new_cost_limit: Amount requested
         new_limit_reasons: Reason
+      substantive_costs:
+        request_higher_limit: Higher cost limit requested
+        new_cost_limit: Amount requested
+        new_limit_reasons: Reason
       employed_income:
         employment: Employment notes
         employment_question: Do you need to tell us anything else about your client's employment?
@@ -476,6 +480,7 @@ en:
       payments: Regular payments
       change: Change
       emergency_cost_limit: Emergency cost limit
+      substantive_cost_limit: Substantive cost limit
       section_delegated:
         heading: Delegated functions
       section_emergency:

--- a/db/migrate/20220527111338_add_cost_overrides.rb
+++ b/db/migrate/20220527111338_add_cost_overrides.rb
@@ -1,0 +1,9 @@
+class AddCostOverrides < ActiveRecord::Migration[6.1]
+  def change
+    change_table :legal_aid_applications, bulk: true do |t|
+      t.boolean :substantive_cost_override, null: true
+      t.numeric :substantive_cost_requested, null: true
+      t.string :substantive_cost_reasons, null: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_12_125715) do
+ActiveRecord::Schema.define(version: 2022_05_27_111338) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -542,6 +542,9 @@ ActiveRecord::Schema.define(version: 2022_05_12_125715) do
     t.string "extra_employment_information_details"
     t.string "full_employment_details"
     t.datetime "client_declaration_confirmed_at"
+    t.boolean "substantive_cost_override"
+    t.decimal "substantive_cost_requested"
+    t.string "substantive_cost_reasons"
     t.index ["applicant_id"], name: "index_legal_aid_applications_on_applicant_id"
     t.index ["application_ref"], name: "index_legal_aid_applications_on_application_ref", unique: true
     t.index ["discarded_at"], name: "index_legal_aid_applications_on_discarded_at"

--- a/features/accessibility/provider.feature
+++ b/features/accessibility/provider.feature
@@ -38,7 +38,7 @@ Feature: Provider accessibility
     When I select 'I have not used delegated functions'
     And I click 'Save and continue'
     Then I should be on a page showing "What you're applying for"
-    Then I should be on a page showing "Substantive certificate"
+    Then I should be on a page showing "default substantive cost limit"
     And the page is accessible
     Then I click 'Save and continue'
     Then I should be on a page showing 'Check your answers'

--- a/features/providers/civil_application_journey.feature
+++ b/features/providers/civil_application_journey.feature
@@ -168,7 +168,7 @@ Feature: Civil application journeys
     Then I should be on a page showing 'Harassment - injunction'
     Then I should be on a page showing 'Emergency certificate'
     Then I should be on a page showing 'Substantive certificate'
-    Then I should be on a page showing "Do you want to request a higher cost limit?"
+    Then I should be on a page showing "Do you want to request a higher emergency cost limit?"
     When I choose 'Yes'
     And I enter a emergency cost requested '5000'
     And I enter legal aid application emergency cost reasons field 'This is why I require extra funding'
@@ -182,8 +182,6 @@ Feature: Civil application journeys
     Then I should be on a page showing 'FGM Protection Order Not used'
     Then I should be on a page showing 'Harassment - injunction' with a date of 2 days ago using '%-d %B %Y' format
     Then I should be on a page showing 'Occupation order' with a date of 35 days ago using '%-d %B %Y' format
-    Then I should be on a page showing 'Covered under an emergency certificate'
-    Then I should be on a page showing 'Covered under a substantive certificate'
 
   @javascript @vcr
   Scenario: Completes the application using address lookup
@@ -211,7 +209,6 @@ Feature: Civil application journeys
     Then I should be on a page showing "What you're applying for"
     Then I click 'Save and continue'
     Then I should be on a page showing 'Check your answers'
-    Then I should be on a page showing 'Covered under a substantive certificate'
     Then I click 'Save and continue'
     Then I should be on a page showing "DWP records show that your client does not receive a passporting benefit – is this correct?"
     Then I choose 'Yes'
@@ -326,7 +323,7 @@ Feature: Civil application journeys
     Then I click 'Save and continue'
     Then I should be on a page showing "What you're applying for"
     And I should be on a page showing "Emergency certificate"
-    And I should be on a page showing "Substantive certificate"
+    And I should be on a page showing "default substantive cost limit"
     Then I choose 'Yes'
     And I enter a emergency cost requested '5000'
     And I enter legal aid application emergency cost reasons field 'This is why I require extra funding'
@@ -359,7 +356,7 @@ Feature: Civil application journeys
     Then I select 'I have not used delegated functions'
     Then I click 'Save and continue'
     Then I should be on a page showing "What you're applying for"
-    Then I should be on a page showing "Substantive certificate"
+    Then I should be on a page showing "default substantive cost limit"
     Then I click 'Save and continue'
     Then I should be on a page showing 'Check your answers'
     Then I click 'Save and continue'
@@ -389,7 +386,7 @@ Feature: Civil application journeys
     Then I select 'I have not used delegated functions'
     Then I click 'Save and continue'
     Then I should be on a page showing "What you're applying for"
-    Then I should be on a page showing "Substantive certificate"
+    Then I should be on a page showing "default substantive cost limit"
     Then I click 'Save and continue'
     Then I should be on a page showing 'Check your answers'
     Then I click 'Save and continue'
@@ -453,7 +450,7 @@ Feature: Civil application journeys
     Then I select 'I have not used delegated functions'
     Then I click 'Save and continue'
     Then I should be on a page showing "What you're applying for"
-    Then I should be on a page showing "Substantive certificate"
+    Then I should be on a page showing "default substantive cost limit"
     Then I click 'Save and continue'
     Then I should be on a page showing 'Check your answers'
 

--- a/features/providers/cost_override.feature
+++ b/features/providers/cost_override.feature
@@ -24,16 +24,38 @@ Feature: Emergency cost override
     And I enter the 'nonmolestation order used delegated functions on' date of 5 days ago
     When I click 'Save and continue'
     Then I should be on a page showing "What you're applying for"
-    And I should see 'Do you want to request a higher cost limit?'
+    And I should see 'Do you want to request a higher emergency cost limit?'
     When I choose 'No'
     And I click 'Save and continue'
     Then I should be on a page showing "Check your answers"
     When I click link "Back"
     Then I should be on a page showing "What you're applying for"
-    Then I should be on a page showing "Do you want to request a higher cost limit?"
+    Then I should be on a page showing "Do you want to request a higher emergency cost limit?"
     When I choose 'Yes'
     And I enter a emergency cost requested '5000'
     And I enter legal aid application emergency cost reasons field 'This is why I require extra funding'
     And I click 'Save and continue'
     Then I should be on a page showing "Check your answers"
     Then I should be on a page showing "Emergency cost limit"
+
+  @javascript @vcr
+  Scenario: Provider should be able to request a higher substantive cost limit when the default substantive cost limit is below the 25,000 threshold
+    Given I view the limitations for an application with proceedings below the max threshold
+    Then I should see "What you're applying for"
+    And I should see "Do you want to request a higher substantive cost limit?"
+    And I should not see "Do you want to request a higher emergency cost limit?"
+
+  @javascript @vcr
+  Scenario: Provider should not be able to request a higher substantive cost limit when the default substantive cost limit is at the 25,000 threshold
+    Given I view the limitations for an application with proceedings at the max threshold
+    Then I should see "What you're applying for"
+    And I should not see "Do you want to request a higher substantive cost limit?"
+    And I should not see "Do you want to request a higher emergency cost limit?"
+
+  @javascript @vcr
+  Scenario: Provider should be able to increase both cost limits when the default substantive cost limit is below the 25,000 threshold and they have used DF
+    Given I view the limitations for an application with proceedings below the max threshold with delegated_functions
+    Then I should see "What you're applying for"
+    And I should see "Do you want to request a higher substantive cost limit?"
+    And I should see "Do you want to request a higher emergency cost limit?"
+

--- a/features/step_definitions/civil_journey_steps.rb
+++ b/features/step_definitions/civil_journey_steps.rb
@@ -385,6 +385,16 @@ Given("I start the journey as far as the start of the vehicle section") do
   )
 end
 
+Given(/^I view the limitations for an application with proceedings (at|below) the max threshold( with delegated_functions)?/) do |threshold, include_df|
+  limit = threshold.eql?("at") ? 25_000 : 5_000
+  @legal_aid_application = create :legal_aid_application, :with_applicant_and_address
+  create :proceeding, :da006, legal_aid_application: @legal_aid_application, substantive_cost_limitation: limit, lead_proceeding: true, used_delegated_functions_on: nil
+  create :proceeding, :se013, legal_aid_application: @legal_aid_application, substantive_cost_limitation: limit, used_delegated_functions_on: nil
+  steps %(And I used delegated functions) if include_df
+  login_as @legal_aid_application.provider
+  visit(providers_legal_aid_application_limitations_path(@legal_aid_application))
+end
+
 Given("I have completed a non-passported application and reached the merits task_list") do
   @legal_aid_application = create(
     :application,

--- a/features/support/screenshot_helper.rb
+++ b/features/support/screenshot_helper.rb
@@ -8,7 +8,7 @@ module ScreenshotHelper
   def screenshot_image(name = "capybara-screenshot")
     window = Capybara.current_session.driver.browser.manage.window
     window.resize_to(*dimensions)
-    screenshot_name = "#{name}-#{Time.current.utc.iso8601.delete('-').delete(':')}.png"
+    screenshot_name = "#{Time.current.utc.iso8601.delete('-').delete(':')}-#{name}.png"
     file_path = Rails.root.join("tmp/capybara/#{screenshot_name}").to_s
     save_screenshot(file_path)
     file_path

--- a/spec/forms/legal_aid_applications/emergency_cost_override_form_spec.rb
+++ b/spec/forms/legal_aid_applications/emergency_cost_override_form_spec.rb
@@ -3,68 +3,226 @@ require "rails_helper"
 RSpec.describe LegalAidApplications::EmergencyCostOverrideForm do
   subject(:form) { described_class.new(form_params) }
 
-  let!(:application) { create :legal_aid_application, :with_applicant_and_address }
-
-  let(:params) do
-    {
-      emergency_cost_override: overridden,
-      emergency_cost_requested: value,
-      emergency_cost_reasons: reasons,
-    }
-  end
-  let(:form_params) { params.merge(model: application) }
-
-  let(:overridden) { "false" }
-  let(:value) { nil }
-  let(:reasons) { nil }
-
   describe "validation" do
     subject(:valid?) { form.valid? }
 
-    context "when no parameters sent" do
-      let(:params) { {} }
+    let(:legal_aid_application) { create :legal_aid_application, :with_applicant_and_address }
+    let(:form_params) { params.merge(model: legal_aid_application) }
 
-      before { valid? }
+    context "when delegated_functions are not used" do
+      subject(:valid?) { form.valid? }
 
-      it { is_expected.to be false }
+      context "and the maximum substantive cost limit is below the threshold" do
+        let(:params) do
+          {
+            substantive_cost_override: substantive_overridden,
+            substantive_cost_requested: substantive_value,
+            substantive_cost_reasons: substantive_reasons,
+          }
+        end
+        let(:substantive_overridden) { "false" }
+        let(:substantive_value) { nil }
+        let(:substantive_reasons) { nil }
 
-      it "displays relevant errors" do
-        expect(form.errors[:emergency_cost_override]).to eq [I18n.t("activemodel.errors.models.legal_aid_application.attributes.emergency_cost_override.blank")]
-      end
-    end
+        before do
+          create :proceeding, :da006, legal_aid_application:, substantive_cost_limitation: 5_000, lead_proceeding: true, used_delegated_functions_on: nil
+          create :proceeding, :se013, legal_aid_application:, substantive_cost_limitation: 8_000, used_delegated_functions_on: nil
+        end
 
-    context "when the override is not requested" do
-      it { is_expected.to be true }
-    end
+        context "when no parameters sent" do
+          let(:params) { {} }
 
-    context "when the override requested" do
-      let(:overridden) { "true" }
-      let(:value) { "5,000" }
-      let(:reasons) { "Something, something, argument" }
+          before { valid? }
 
-      it { is_expected.to be true }
+          it { is_expected.to be false }
 
-      context "but no value supplied" do
-        let(:value) { nil }
+          it "displays relevant errors" do
+            expect(form.errors[:substantive_cost_override]).to eq [I18n.t("activemodel.errors.models.legal_aid_application.attributes.substantive_cost_override.blank")]
+          end
+        end
 
-        before { valid? }
+        context "when the substantive_override is not requested" do
+          it { is_expected.to be true }
+        end
 
-        it { is_expected.to be false }
+        context "when the substantive_override requested" do
+          let(:substantive_overridden) { "true" }
+          let(:substantive_value) { "5,000" }
+          let(:substantive_reasons) { "Something, something, argument" }
 
-        it "displays the relevant errors" do
-          expect(form.errors[:emergency_cost_requested]).to eq [I18n.t("activemodel.errors.models.legal_aid_application.attributes.emergency_cost_requested.blank")]
+          it { is_expected.to be true }
+
+          context "but no value supplied" do
+            let(:substantive_value) { nil }
+
+            before { valid? }
+
+            it { is_expected.to be false }
+
+            it "displays the relevant errors" do
+              expect(form.errors[:substantive_cost_requested]).to eq [I18n.t("activemodel.errors.models.legal_aid_application.attributes.substantive_cost_requested.blank")]
+            end
+          end
+
+          context "but no reasons supplied" do
+            let(:substantive_reasons) { nil }
+
+            before { valid? }
+
+            it { is_expected.to be false }
+
+            it "displays the relevant errors" do
+              expect(form.errors[:substantive_cost_reasons]).to eq [I18n.t("activemodel.errors.models.legal_aid_application.attributes.substantive_cost_reasons.blank")]
+            end
+          end
         end
       end
 
-      context "but no reasons supplied" do
-        let(:reasons) { nil }
+      context "and the maximum substantive cost limit is at the threshold" do
+        context "when no parameters sent" do
+          let(:params) { {} }
 
-        before { valid? }
+          it { is_expected.to be true }
+        end
+      end
+    end
 
-        it { is_expected.to be false }
+    context "when delegated_functions used" do
+      before do
+        create :proceeding, :da001, legal_aid_application:, substantive_cost_limitation:, lead_proceeding: true, used_delegated_functions_on: 35.days.ago.to_date
+        create :proceeding, :da004, legal_aid_application:, substantive_cost_limitation: 8_000, used_delegated_functions_on: 36.days.ago.to_date
+      end
 
-        it "displays the relevant errors" do
-          expect(form.errors[:emergency_cost_reasons]).to eq [I18n.t("activemodel.errors.models.legal_aid_application.attributes.emergency_cost_reasons.blank")]
+      context "and the maximum substantive cost limit is below the threshold" do
+        let(:substantive_cost_limitation) { 5_000 }
+        let(:params) do
+          {
+            emergency_cost_override: emergency_overridden,
+            emergency_cost_requested: emergency_value,
+            emergency_cost_reasons: emergency_reasons,
+            substantive_cost_override: substantive_overridden,
+            substantive_cost_requested: substantive_value,
+            substantive_cost_reasons: substantive_reasons,
+          }
+        end
+
+        let(:emergency_overridden) { "false" }
+        let(:emergency_value) { nil }
+        let(:emergency_reasons) { nil }
+        let(:substantive_overridden) { "false" }
+        let(:substantive_value) { nil }
+        let(:substantive_reasons) { nil }
+
+        context "when no parameters sent" do
+          let(:params) { {} }
+
+          before { valid? }
+
+          it { is_expected.to be false }
+
+          it "displays relevant errors" do
+            expect(form.errors[:emergency_cost_override]).to eq [I18n.t("activemodel.errors.models.legal_aid_application.attributes.emergency_cost_override.blank")]
+            expect(form.errors[:substantive_cost_override]).to eq [I18n.t("activemodel.errors.models.legal_aid_application.attributes.substantive_cost_override.blank")]
+          end
+        end
+
+        context "when the override is not requested" do
+          it { is_expected.to be true }
+        end
+
+        context "when the override requested" do
+          let(:emergency_overridden) { "true" }
+          let(:emergency_value) { "5,000" }
+          let(:emergency_reasons) { "Something, something, argument" }
+
+          it { is_expected.to be true }
+
+          context "but no value supplied" do
+            let(:emergency_value) { nil }
+
+            before { valid? }
+
+            it { is_expected.to be false }
+
+            it "displays the relevant errors" do
+              expect(form.errors[:emergency_cost_requested]).to eq [I18n.t("activemodel.errors.models.legal_aid_application.attributes.emergency_cost_requested.blank")]
+            end
+          end
+
+          context "but no reasons supplied" do
+            let(:emergency_reasons) { nil }
+
+            before { valid? }
+
+            it { is_expected.to be false }
+
+            it "displays the relevant errors" do
+              expect(form.errors[:emergency_cost_reasons]).to eq [I18n.t("activemodel.errors.models.legal_aid_application.attributes.emergency_cost_reasons.blank")]
+            end
+          end
+        end
+      end
+
+      context "and the maximum substantive cost limit is at the threshold" do
+        let(:substantive_cost_limitation) { 25_000 }
+        let(:params) do
+          {
+            emergency_cost_override: emergency_overridden,
+            emergency_cost_requested: emergency_value,
+            emergency_cost_reasons: emergency_reasons,
+          }
+        end
+
+        let(:emergency_overridden) { "false" }
+        let(:emergency_value) { nil }
+        let(:emergency_reasons) { nil }
+
+        context "when no parameters sent" do
+          let(:params) { {} }
+
+          before { valid? }
+
+          it { is_expected.to be false }
+
+          it "displays relevant errors" do
+            expect(form.errors[:emergency_cost_override]).to eq [I18n.t("activemodel.errors.models.legal_aid_application.attributes.emergency_cost_override.blank")]
+          end
+        end
+
+        context "when the override is not requested" do
+          it { is_expected.to be true }
+        end
+
+        context "when the override requested" do
+          let(:emergency_overridden) { "true" }
+          let(:emergency_value) { "5,000" }
+          let(:emergency_reasons) { "Something, something, argument" }
+
+          it { is_expected.to be true }
+
+          context "but no value supplied" do
+            let(:emergency_value) { nil }
+
+            before { valid? }
+
+            it { is_expected.to be false }
+
+            it "displays the relevant errors" do
+              expect(form.errors[:emergency_cost_requested]).to eq [I18n.t("activemodel.errors.models.legal_aid_application.attributes.emergency_cost_requested.blank")]
+            end
+          end
+
+          context "but no reasons supplied" do
+            let(:emergency_reasons) { nil }
+
+            before { valid? }
+
+            it { is_expected.to be false }
+
+            it "displays the relevant errors" do
+              expect(form.errors[:emergency_cost_reasons]).to eq [I18n.t("activemodel.errors.models.legal_aid_application.attributes.emergency_cost_reasons.blank")]
+            end
+          end
         end
       end
     end

--- a/spec/models/legal_aid_application_spec.rb
+++ b/spec/models/legal_aid_application_spec.rb
@@ -704,6 +704,39 @@ RSpec.describe LegalAidApplication, type: :model do
         expect(legal_aid_application.default_cost_limitation).to eq 25_000.0
       end
     end
+
+    context "when the lead application has a smaller substantive cost limit" do
+      let(:legal_aid_application) { create :legal_aid_application }
+      let!(:proceeding1) { create :proceeding, :da006, legal_aid_application:, substantive_cost_limitation: 5_000, lead_proceeding: true }
+      let!(:proceeding2) { create :proceeding, :se013, legal_aid_application: }
+
+      it "takes the largest cost value" do
+        expect(legal_aid_application.default_cost_limitation).to eq 25_000.0
+      end
+    end
+  end
+
+  describe "substantive_cost_limitation" do
+    subject(:substantive_cost_limitation) { legal_aid_application.substantive_cost_limitation }
+
+    let(:legal_aid_application) { create :legal_aid_application }
+    let!(:proceeding1) { create :proceeding, :da006, legal_aid_application:, substantive_cost_limitation: 5_000, lead_proceeding: true }
+    let!(:proceeding2) { create :proceeding, :se013, legal_aid_application:, substantive_cost_limitation: 10_000 }
+
+    context "when the provider accepts the default" do
+      it { is_expected.to eq 10_000 }
+    end
+
+    context "when the provider has overridden a smaller default" do
+      let(:legal_aid_application) do
+        create :legal_aid_application,
+               substantive_cost_override: true,
+               substantive_cost_requested: 12_000,
+               substantive_cost_reasons: "something... something... reasons"
+      end
+
+      it { is_expected.to eq 12_000 }
+    end
   end
 
   describe "#bank_transactions" do

--- a/spec/requests/providers/check_provider_answers_spec.rb
+++ b/spec/requests/providers/check_provider_answers_spec.rb
@@ -48,10 +48,6 @@ RSpec.describe Providers::CheckProviderAnswersController, type: :request do
         expect(unescaped_response_body).to include("Check your answers")
       end
 
-      it "displays the correct proceeding" do
-        expect(unescaped_response_body).to include(application.proceedings[0].substantive_scope_limitation_description)
-      end
-
       context "delegated functions not used" do
         let(:application) do
           create(


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3167)

Extend the limitations handling to allow providers to override substantive cost limits if the value is below the maximum of £25k

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
