### PR TITLE
AP-3120 change home link to back

### DIFF
--- a/app/views/providers/declarations/show.html.erb
+++ b/app/views/providers/declarations/show.html.erb
@@ -1,4 +1,4 @@
-<%= page_template(page_title: t('.h1-heading'), back_link: { text: t('generic.home') }) do %>
+<%= page_template(page_title: t('.h1-heading')) do %>
   <p class="govuk-body"><%= t('.statement') %></p>
   <ul class="govuk-list govuk-list--bullet print-add-bullet">
     <%- t('.statement-bullets').each do |bullet| %>


### PR DESCRIPTION
## What

On the provider declaration page, change the home link to read back, to be consistent

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3120)

Describe what you did and why.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
