### PR TITLE
[AP-3217] Specs for bank transaction employment remarks

### DIFF
--- a/spec/models/cfe/remarks_spec.rb
+++ b/spec/models/cfe/remarks_spec.rb
@@ -123,7 +123,26 @@ module CFE
         end
       end
 
-      context "with duplicate employment category, reason and transaction remarks" do
+      context "with duplicate reason and transaction for non-employment category remark" do
+        let(:duplicate_remarks) do
+          {
+            some_other_category: {
+              amount_variation: %w[
+                d55743b5-c1c4-4c9a-98a3-bad709aac422
+              ],
+            },
+          }
+        end
+
+        # NOTE: hash key order is significant due to `break` statement
+        let(:remarks_hash) { duplicate_remarks.merge!(populated_hash) }
+
+        it "raises \"Category mismatch\" error" do
+          expect { remarks.review_transactions }.to raise_error(/category/i)
+        end
+      end
+
+      context "with duplicate reason and transaction for employment category remark" do
         let(:employment_remarks) do
           {
             employment_tax: {

--- a/spec/models/cfe/remarks_spec.rb
+++ b/spec/models/cfe/remarks_spec.rb
@@ -122,6 +122,26 @@ module CFE
           expect(tx.reasons).to eq [:unknown_frequency]
         end
       end
+
+      context "with duplicate employment category, reason and transaction remarks" do
+        let(:employment_remarks) do
+          {
+            employment_tax: {
+              refunds: %w[d55743b5-c1c4-4c9a-98a3-bad709aac422],
+            },
+            employment_nic: {
+              refunds: %w[d55743b5-c1c4-4c9a-98a3-bad709aac422],
+            },
+          }
+        end
+
+        # NOTE: hash key order is significant due to `break` statement
+        let(:remarks_hash) { employment_remarks.merge!(populated_hash) }
+
+        it "does not raise \"Category mismatch\" error" do
+          expect { remarks.review_transactions }.not_to raise_error
+        end
+      end
     end
 
     def empty_hash


### PR DESCRIPTION
## What
Spec the ignoring of employment related bank transaction remarks

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3217)

These have been ignored to prevent a category mismatch error
from preventing generation of bank_transaction reports in a related
PR.

- [x] add negative test that replicates seen bug [AP-3217]
- [x] add positive test for Category mismatch error
~~- [ ] add positive test for Transaction Id mismatch error~~


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.


[AP-3217]: https://dsdmoj.atlassian.net/browse/AP-3217?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ