### PR TITLE
AP-3126 update date hint text

### DIFF
--- a/app/helpers/time_helper.rb
+++ b/app/helpers/time_helper.rb
@@ -1,5 +1,5 @@
 module TimeHelper
-  def number_of_days_ago(number_of_days, format = "%d %m %Y")
+  def number_of_days_ago(number_of_days, format = "%d %_m %Y")
     Time.zone.now.ago(number_of_days.days).strftime(format)
   end
 end

--- a/app/views/providers/application_merits_task/date_client_told_incidents/show.html.erb
+++ b/app/views/providers/application_merits_task/date_client_told_incidents/show.html.erb
@@ -11,8 +11,9 @@
 
     <%= form.govuk_fieldset legend: {size: 'xl', tag: 'h1', text: page_title} do %>
       <%= form.govuk_date_field :told_on, legend: { text: t("shared.forms.date_input_fields.told_on_label") },
-                                hint: { text: t("shared.forms.date_input_fields.told_on_hint")} %>
-      <%= form.govuk_date_field :occurred_on, legend: { text: t("shared.forms.date_input_fields.occurred_on_label") } %>
+                                hint: { text: t("shared.forms.date_input_fields.date_hint", options: number_of_days_ago(0))} %>
+      <%= form.govuk_date_field :occurred_on, legend: { text: t("shared.forms.date_input_fields.occurred_on_label") },
+                                hint: { text: t("shared.forms.date_input_fields.date_hint", options: number_of_days_ago(0))} %>
     <% end %>
 
     <div class="govuk-!-padding-bottom-4"></div>

--- a/app/views/providers/application_merits_task/involved_children/_form.html.erb
+++ b/app/views/providers/application_merits_task/involved_children/_form.html.erb
@@ -9,7 +9,7 @@
 
   <%= form.govuk_text_field :full_name, width: 'three-quarters', label: { size: 'm', text: t('.name') } %>
 
-  <%= form.govuk_date_field :date_of_birth, legend: {text: t('.date_of_birth')} %>
+  <%= form.govuk_date_field :date_of_birth, legend: {text: t('.date_of_birth')}, hint: {text: t('.dob_hint')} %>
 
   <div class="govuk-!-padding-bottom-2"></div>
   <%= next_action_buttons(

--- a/config/locales/cy/shared.yml
+++ b/config/locales/cy/shared.yml
@@ -227,7 +227,7 @@ cy:
         occurred_on_label: "?rucco tnedicni eht did nehW"
         told_on_label: "?tnedicni esuba citsemod tsetal eht tuoba uoy tcatnoc tneilc
           ruoy did nehW"
-        told_on_hint: .9102 3 13 elpmaxe roF
+        date_hint: ".%{options} ,elpmaxe roF"
         used_delegated_functions_on_label: snoitcnuf detageled desu uoy etaD
         used_delegated_functions_on_hint: ".%{options} ,elpmaxe roF"
       policy_disregards:

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -347,6 +347,7 @@ en:
         form:
           name: Full name
           date_of_birth: Date of birth
+          dob_hint: For example, 31 3 2017.
           hint: Add one child at a time. You can add more later.
         show:
           page_title: Edit the details for %{name}

--- a/config/locales/en/shared.yml
+++ b/config/locales/en/shared.yml
@@ -296,7 +296,7 @@ en:
         date_of_birth_label: Date of birth
         occurred_on_label: When did the incident occur?
         told_on_label: When did your client contact you about the latest domestic abuse incident?
-        told_on_hint: For example 31 3 2019.
+        date_hint: "For example %{options}."
         used_delegated_functions_on_label: Date you used delegated functions
         used_delegated_functions_on_hint: "For example, %{options}."
       dependants:

--- a/spec/helpers/time_helper_spec.rb
+++ b/spec/helpers/time_helper_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe TimeHelper, type: :helper do
     end
 
     it "returns a valid date" do
-      expect(helper.number_of_days_ago(days)).to eq "29 09 2020"
+      expect(helper.number_of_days_ago(days)).to eq "29  9 2020"
     end
   end
 end

--- a/spec/requests/providers/used_multiple_delegated_functions_spec.rb
+++ b/spec/requests/providers/used_multiple_delegated_functions_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Providers::UsedMultipleDelegatedFunctionsController, type: :reque
 
     context "dynamic date hint text" do
       it "contains a valid date" do
-        hint_text_date = Time.zone.now.ago(5.days).strftime("%d %m %Y")
+        hint_text_date = Time.zone.now.ago(5.days).strftime("%d %_m %Y")
 
         subject
         expect(response.body).to include(hint_text_date)


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3126)

Update date hint text on a few pages:
- Delegated functions page - remove leading zero from month
- Involved children - add date hint text 
- Latest incident details - add hint text to occured_on field, and update told_on hint text to be today's date

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
