### PR TITLE
Fix `undefined method `any?' for nil:NilClass`

### DIFF
--- a/app/models/cfe/v4/result.rb
+++ b/app/models/cfe/v4/result.rb
@@ -334,7 +334,7 @@ module CFE
       end
 
       def jobs?
-        jobs.any?
+        jobs&.any?
       end
 
     private

--- a/spec/models/cfe/v4/result_spec.rb
+++ b/spec/models/cfe/v4/result_spec.rb
@@ -718,6 +718,12 @@ module CFE
             subject(:jobs?) { with_employments.jobs? }
 
             it { is_expected.to be(true) }
+
+            context "without employment_income" do
+              before { allow(with_employments).to receive(:jobs).and_return(nil) }
+
+              it { is_expected.to be_falsey }
+            end
           end
         end
 


### PR DESCRIPTION
## What
Fix `undefined method any?' for nil:NilClass`

Seen against a CFE::V4::Result object in production
which did not have any `employment_income`

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
