### PR TITLE
[AP-3228] Handle old CFE result for empoyment journey error

### DIFF
--- a/app/controllers/providers/provider_base_controller.rb
+++ b/app/controllers/providers/provider_base_controller.rb
@@ -12,7 +12,7 @@ module Providers
     def display_employment_income?
       Setting.enable_employed_journey? &&
         @legal_aid_application.provider.employment_permissions? &&
-        @legal_aid_application.cfe_result.version_4? &&
+        @legal_aid_application.cfe_result.version >= 4 &&
         @legal_aid_application.cfe_result.jobs?
     end
   end

--- a/app/controllers/providers/provider_base_controller.rb
+++ b/app/controllers/providers/provider_base_controller.rb
@@ -12,6 +12,7 @@ module Providers
     def display_employment_income?
       Setting.enable_employed_journey? &&
         @legal_aid_application.provider.employment_permissions? &&
+        @legal_aid_application.cfe_result.version_4? &&
         @legal_aid_application.cfe_result.jobs?
     end
   end

--- a/app/controllers/providers/provider_base_controller.rb
+++ b/app/controllers/providers/provider_base_controller.rb
@@ -6,5 +6,13 @@ module Providers
     include ApplicationDependable
     include Draftable
     include Authorizable
+
+  private
+
+    def display_employment_income?
+      Setting.enable_employed_journey? &&
+        @legal_aid_application.provider.employment_permissions? &&
+        @legal_aid_application.cfe_result.jobs?
+    end
   end
 end

--- a/app/controllers/providers/review_and_print_applications_controller.rb
+++ b/app/controllers/providers/review_and_print_applications_controller.rb
@@ -12,13 +12,5 @@ module Providers
       end
       continue_or_draft
     end
-
-  private
-
-    def display_employment_income?
-      Setting.enable_employed_journey? &&
-        @legal_aid_application.provider.employment_permissions? &&
-        @legal_aid_application.cfe_result.jobs?
-    end
   end
 end

--- a/app/controllers/providers/submitted_applications_controller.rb
+++ b/app/controllers/providers/submitted_applications_controller.rb
@@ -4,13 +4,5 @@ module Providers
     helper_method :display_employment_income?
 
     def show; end
-
-  private
-
-    def display_employment_income?
-      Setting.enable_employed_journey? &&
-        @legal_aid_application.provider.employment_permissions? &&
-        @legal_aid_application.cfe_result.jobs?
-    end
   end
 end

--- a/app/models/cfe/base_result.rb
+++ b/app/models/cfe/base_result.rb
@@ -31,6 +31,10 @@ module CFE
       assessment_result == "partially_eligible"
     end
 
+    def version
+      result_hash.fetch(:version, "1").to_i
+    end
+
     def version_4?
       result_hash[:version] == "4"
     end

--- a/spec/models/cfe/v1/result_spec.rb
+++ b/spec/models/cfe/v1/result_spec.rb
@@ -79,6 +79,12 @@ module CFE
         end
       end
 
+      describe "#version" do
+        subject(:version) { eligible_result.version }
+
+        it { expect(version).to be 1 }
+      end
+
       describe "#additional_property?" do
         context "when present" do
           it "returns true" do

--- a/spec/models/cfe/v2/result_spec.rb
+++ b/spec/models/cfe/v2/result_spec.rb
@@ -247,6 +247,12 @@ module CFE
         end
       end
 
+      describe "#version" do
+        subject(:version) { eligible_result.version }
+
+        it { expect(version).to be 2 }
+      end
+
       describe "capital_contribution_required?" do
         context "when contribution not required" do
           it "returns false for capital_contribution_required" do

--- a/spec/models/cfe/v3/result_spec.rb
+++ b/spec/models/cfe/v3/result_spec.rb
@@ -198,6 +198,12 @@ module CFE
         end
       end
 
+      describe "#version" do
+        subject(:version) { eligible_result.version }
+
+        it { expect(version).to be 3 }
+      end
+
       describe "#version_4?" do
         it "returns boolean response for cfe version check" do
           expect(eligible_result.version_4?).to be false

--- a/spec/models/cfe/v4/result_spec.rb
+++ b/spec/models/cfe/v4/result_spec.rb
@@ -198,6 +198,12 @@ module CFE
         end
       end
 
+      describe "#version" do
+        subject(:version) { eligible_result.version }
+
+        it { expect(version).to be 4 }
+      end
+
       describe "#version_4?" do
         it "returns boolean response for cfe version check" do
           expect(eligible_result.version_4?).to be true

--- a/spec/requests/providers/submitted_applications_spec.rb
+++ b/spec/requests/providers/submitted_applications_spec.rb
@@ -159,6 +159,12 @@ RSpec.describe Providers::SubmittedApplicationsController, type: :request do
 
         it_behaves_like "employment data is not present"
       end
+
+      context "when application has an older CFE Result version object" do
+        let(:cfe_result) { create :cfe_v3_result, submission: cfe_submission }
+
+        it_behaves_like "employment data is not present"
+      end
     end
 
     context "when the employed journey is not enabled" do


### PR DESCRIPTION
## What
Do not show employment income for applications with  CFE result of version 3 or less

[link to bug](https://dsdmoj.atlassian.net/browse/AP-3228)

- Promote `display_employment_income?` method
- Only checks `jobs?` for version 4+ CFE results

Handles [this specific sentry error](https://sentry.io/organizations/ministryofjustice/issues/3346747387/?project=5416054&query=is%3Aunresolved) seen in production.

The error arises from calling a non-existent method `jobs?`
on prior versions of CFE results. This can happen when a provider reviewing 
at a old submitted application and is likely to happen more as and when we role out
the employment journey to other providers

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
