### PR TITLE
Disable sentry alert when hmrc return no employments for applicant

### DIFF
--- a/app/services/hmrc/mock_data/no_employments.json.erb
+++ b/app/services/hmrc/mock_data/no_employments.json.erb
@@ -1,0 +1,98 @@
+{
+  "submission": "<%= @submission_id %>",
+  "status": "completed",
+  "data": [
+    {
+      "correlation_id": "794cb770-6024-4eba-ae59-5ae9857f0a2d",
+      "use_case": "use_case_one"
+    },
+    {
+      "individuals/matching/individual": {
+        "firstName": "Claudia",
+        "lastName": "Fournier",
+        "nino": "JC928374B",
+        "dateOfBirth": "1977-05-19"
+      }
+    },
+    {
+      "income/paye/paye": {
+        "income": []
+      }
+    },
+    {
+      "employments/paye/employments": []
+    },
+    {
+      "income/sa/selfAssessment": {
+        "registrations": [],
+        "taxReturns": []
+      }
+    },
+    {
+      "income/sa/pensions_and_state_benefits/selfAssessment": {
+        "taxReturns": []
+      }
+    },
+    {
+      "income/sa/source/selfAssessment": {
+        "taxReturns": []
+      }
+    },
+    {
+      "income/sa/employments/selfAssessment": {
+        "taxReturns": []
+      }
+    },
+    {
+      "income/sa/additional_information/selfAssessment": {
+        "taxReturns": []
+      }
+    },
+    {
+      "income/sa/partnerships/selfAssessment": {
+        "taxReturns": []
+      }
+    },
+    {
+      "income/sa/uk_properties/selfAssessment": {
+        "taxReturns": []
+      }
+    },
+    {
+      "income/sa/foreign/selfAssessment": {
+        "taxReturns": []
+      }
+    },
+    {
+      "income/sa/further_details/selfAssessment": {
+        "taxReturns": []
+      }
+    },
+    {
+      "income/sa/interests_and_dividends/selfAssessment": {
+        "taxReturns": []
+      }
+    },
+    {
+      "income/sa/other/selfAssessment": {
+        "taxReturns": []
+      }
+    },
+    {
+      "income/sa/summary/selfAssessment": {
+        "taxReturns": []
+      }
+    },
+    {
+      "income/sa/trusts/selfAssessment": {
+        "taxReturns": []
+      }
+    },
+    {
+      "benefits_and_credits/working_tax_credit/applications": []
+    },
+    {
+      "benefits_and_credits/child_tax_credit/applications": []
+    }
+  ]
+}

--- a/app/services/hmrc/mock_interface_response_service.rb
+++ b/app/services/hmrc/mock_interface_response_service.rb
@@ -13,6 +13,7 @@ module HMRC
       weekly_single_employment: { first_name: "John", last_name: "Smith", nino: "AA333333A", dob: "1933-03-03" },
       tax_refund: { first_name: "Lucky", last_name: "Taxpayer", nino: "BB222222B", dob: "2002-02-02" },
       nic_refund: { first_name: "Nick", last_name: "Overpaid", nino: "CC444444C", dob: "2004-04-04" },
+      no_employments: { first_name: "Claudia", last_name: "Fournier", nino: "JC928374B", dob: "1977-05-19" },
     }.freeze
 
     def self.call(*args)

--- a/app/services/hmrc/parsed_response/validator.rb
+++ b/app/services/hmrc/parsed_response/validator.rb
@@ -103,16 +103,20 @@ module HMRC
         AlertManager.capture_message("HMRC Response is unacceptable (id: #{hmrc_response.id}) - #{errors.map(&:message).join(', ')}")
       end
 
-      def client_details_not_found
-        { "error" => "submitted client details could not be found in HMRC service" }
+      def client_details_not_found?
+        data&.include?({ "error" => "submitted client details could not be found in HMRC service" })
       end
 
-      def no_employments_found
+      def no_employments_found?
         errors == [error(:employments, "employments must be present")]
       end
 
+      def hmrc_not_found?
+        client_details_not_found? || no_employments_found?
+      end
+
       def errors_ignoreable?
-        errors.empty? || errors.map(&:attribute).include?(:use_case) || data&.include?(client_details_not_found) || no_employments_found
+        errors.empty? || errors.map(&:attribute).include?(:use_case) || hmrc_not_found?
       end
     end
   end

--- a/app/services/hmrc/parsed_response/validator.rb
+++ b/app/services/hmrc/parsed_response/validator.rb
@@ -107,8 +107,12 @@ module HMRC
         { "error" => "submitted client details could not be found in HMRC service" }
       end
 
+      def no_employments_found
+        errors == [error(:employments, "employments must be present")]
+      end
+
       def errors_ignoreable?
-        errors.empty? || errors.map(&:attribute).include?(:use_case) || data&.include?(client_details_not_found)
+        errors.empty? || errors.map(&:attribute).include?(:use_case) || data&.include?(client_details_not_found) || no_employments_found
       end
     end
   end

--- a/spec/services/hmrc/parsed_response/validator_spec.rb
+++ b/spec/services/hmrc/parsed_response/validator_spec.rb
@@ -733,5 +733,42 @@ RSpec.describe HMRC::ParsedResponse::Validator do
         expect(AlertManager).not_to have_received(:capture_message)
       end
     end
+
+    context "when client has no employments recorded by HMRC" do
+      let(:hmrc_response) { create(:hmrc_response, use_case: "one", response: response_hash) }
+      let(:response_hash) do
+        { "submission" => "must-be-present",
+          "status" => "completed",
+          "data" => [
+            { "individuals/matching/individual" => valid_individual_response },
+            { "income/paye/paye" => { "income" => [] } },
+            { "income/sa/selfAssessment" => { "registrations" => [], "taxReturns" => [] } },
+            { "income/sa/pensions_and_state_benefits/selfAssessment" => { "taxReturns" => [] } },
+            { "income/sa/source/selfAssessment" => { "taxReturns" => [] } },
+            { "income/sa/employments/selfAssessment" => { "taxReturns" => [] } },
+            { "income/sa/additional_information/selfAssessment" => { "taxReturns" => [] } },
+            { "income/sa/partnerships/selfAssessment" => { "taxReturns" => [] } },
+            { "income/sa/uk_properties/selfAssessment" => { "taxReturns" => [] } },
+            { "income/sa/foreign/selfAssessment" => { "taxReturns" => [] } },
+            { "income/sa/further_details/selfAssessment" => { "taxReturns" => [] } },
+            { "income/sa/interests_and_dividends/selfAssessment" => { "taxReturns" => [] } },
+            { "income/sa/other/selfAssessment" => { "taxReturns" => [] } },
+            { "income/sa/summary/selfAssessment" => { "taxReturns" => [] } },
+            { "income/sa/trusts/selfAssessment" => { "taxReturns" => [] } },
+            { "employments/paye/employments" => [] },
+            { "benefits_and_credits/working_tax_credit/applications" => [{ "awards" => [] }] },
+          ] }
+      end
+
+      before do
+        allow(AlertManager).to receive(:capture_message)
+      end
+
+      it { expect(instance.call).to be_falsey }
+
+      it "does not send message to AlertManager with errors" do
+        expect(AlertManager).not_to have_received(:capture_message)
+      end
+    end
   end
 end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-XXX)

This is a pr to disable sentry alerting where HMRC returns that they have a record of the applicant, but no associated employments.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
