### PR TITLE
Fix: Update the dashboard event handling for abandoning CCMS

### DIFF
--- a/app/services/dashboard_event_handler.rb
+++ b/app/services/dashboard_event_handler.rb
@@ -53,7 +53,7 @@ private
 
   def ccms_submission_saved
     Dashboard::UpdaterJob.perform_later("Applications") if payload[:state].in?(%w[failed completed])
-    Dashboard::UpdaterJob.set(wait: 1.minute).perform_later("PendingCCMSSubmissions") if payload[:state].in?(%w[initialised failed completed])
+    Dashboard::UpdaterJob.set(wait: 1.minute).perform_later("PendingCCMSSubmissions") if payload[:state].in?(%w[initialised failed abandoned completed])
   end
 
   def declined_open_banking

--- a/spec/services/dashboard_event_handler_spec.rb
+++ b/spec/services/dashboard_event_handler_spec.rb
@@ -95,6 +95,19 @@ RSpec.describe DashboardEventHandler do
       end
     end
 
+    context "saved with_state abandoned" do
+      let(:state) { "abandoned" }
+
+      it "does not fire additional Application jobs" do
+        # one is fired from creating the LegalAidApplication required by the ccms_submission factory
+        expect { subject }.to have_enqueued_job(Dashboard::UpdaterJob).with("Applications").at_most(1).times
+      end
+
+      it "fires the PendingCCMSSubmissions job" do
+        expect { subject }.to have_enqueued_job(Dashboard::UpdaterJob).with("PendingCCMSSubmissions").once
+      end
+    end
+
     context "saved with document_ids_obtained" do
       let(:state) { "document_ids_obtained" }
 

--- a/spec/services/dashboard_event_handler_spec.rb
+++ b/spec/services/dashboard_event_handler_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe DashboardEventHandler do
       end
     end
 
-    context "saved with_state completed" do
+    context "saved with state completed" do
       let(:state) { "completed" }
 
       it "fires the Applications job" do
@@ -95,7 +95,7 @@ RSpec.describe DashboardEventHandler do
       end
     end
 
-    context "saved with_state abandoned" do
+    context "saved with state abandoned" do
       let(:state) { "abandoned" }
 
       it "does not fire additional Application jobs" do


### PR DESCRIPTION
## What

This ensures that when we take the decision to abandon a CCMS submission the dashboard will update sooner. 

At the moment it waits until the next CCMS submission is kicked off before updating geckoboard or has to be manually triggered by a developer

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
