### PR TITLE
Auto Set up employed journey when seeding in dev

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -18,6 +18,7 @@ Seeder.monitor DocumentCategory
 Dir[Rails.root.join("db/seeds/*.rb")].each do |seed|
   load seed
 end
+Rake::Task["employ"].invoke if Rails.env.development?
 
 Rails.logger.info Seeder.report.join("\n")
 Rails.logger.info "Seeding completed"


### PR DESCRIPTION

## Auto setup employed journey when seeding DB in dev 



This will automatically run `rake employ` as part of `rake db:reset` or `rake db:seed` in development environment

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
