### PR TITLE
AP-3240 Unemployed applicant with HMRC employment income

### DIFF
--- a/app/controllers/providers/client_completed_means_controller.rb
+++ b/app/controllers/providers/client_completed_means_controller.rb
@@ -12,7 +12,11 @@ module Providers
 
     def define_action_list
       @action_list = %w[sort_transactions dependants capital]
-      @action_list.prepend("review_employment") if @legal_aid_application.applicant.employed?
+      @action_list.prepend("review_employment") if employed_journey?
+    end
+
+    def employed_journey?
+      @legal_aid_application.applicant.employed? || @legal_aid_application.employment_payments.any?
     end
   end
 end

--- a/app/controllers/providers/employment_incomes_controller.rb
+++ b/app/controllers/providers/employment_incomes_controller.rb
@@ -1,6 +1,6 @@
 module Providers
   class EmploymentIncomesController < ProviderBaseController
-    before_action :employments
+    before_action :employments_and_payments
 
     def show
       @applicant = applicant
@@ -19,8 +19,9 @@ module Providers
       @applicant ||= legal_aid_application.applicant
     end
 
-    def employments
+    def employments_and_payments
       @employments = @legal_aid_application.employments
+      @eligible_employment_payments = @legal_aid_application.eligible_employment_payments
     end
 
     def form_params

--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -297,6 +297,14 @@ class LegalAidApplication < ApplicationRecord
     extra_employment_information_details.present? || full_employment_details.present?
   end
 
+  def employment_payments
+    employments.map(&:employment_payments).flatten
+  end
+
+  def eligible_employment_payments
+    employment_payments.select { |p| p.date >= transaction_period_start_on }
+  end
+
   def outstanding_mortgage?
     outstanding_mortgage_amount?
   end

--- a/app/services/flow/flows/provider_capital.rb
+++ b/app/services/flow/flows/provider_capital.rb
@@ -83,7 +83,7 @@ module Flow
             case status
             when :hmrc_multiple_employments, :no_hmrc_data
               :full_employment_details
-            when :hmrc_single_employment
+            when :hmrc_single_employment, :unexpected_employment_data
               :employment_incomes
             when :employed_journey_not_enabled, :provider_not_enabled_for_employed_journey, :applicant_not_employed
               application.income_types? ? :income_summary : :no_income_summaries

--- a/app/services/hmrc/mock_data/recently_employed.json.erb
+++ b/app/services/hmrc/mock_data/recently_employed.json.erb
@@ -10,7 +10,7 @@
       "individuals/matching/individual": {
         "firstName": "John",
         "lastName": "Jobseeker",
-        "nino": "EE555555E",
+        "nino": "BB123456B",
         "dateOfBirth": "2005-05-05"
       }
     },

--- a/app/services/hmrc/mock_interface_response_service.rb
+++ b/app/services/hmrc/mock_interface_response_service.rb
@@ -14,7 +14,7 @@ module HMRC
       tax_refund: { first_name: "Lucky", last_name: "Taxpayer", nino: "BB222222B", dob: "2002-02-02" },
       nic_refund: { first_name: "Nick", last_name: "Overpaid", nino: "CC444444C", dob: "2004-04-04" },
       no_employments: { first_name: "Claudia", last_name: "Fournier", nino: "JC928374B", dob: "1977-05-19" },
-      recently_employed: { first_name: "John", last_name: "Jobseeker", nino: "EE555555E", dob: "2005-05-05" },
+      recently_employed: { first_name: "John", last_name: "Jobseeker", nino: "BB123456B", dob: "2005-05-05" },
       formerly_employed: { first_name: "Mark", last_name: "Slacker", nino: "AA123456A", dob: "2006-06-06" },
     }.freeze
 

--- a/app/services/hmrc/status_analyzer.rb
+++ b/app/services/hmrc/status_analyzer.rb
@@ -4,6 +4,7 @@ module HMRC
              :applicant,
              :has_multiple_employments?,
              :hmrc_employment_income?,
+             :eligible_employment_payments,
              to: :legal_aid_application
 
     attr_reader :legal_aid_application
@@ -21,13 +22,23 @@ module HMRC
 
       return :provider_not_enabled_for_employed_journey unless provider.employment_permissions?
 
-      return :applicant_not_employed unless applicant.employed?
+      return :applicant_not_employed if applicant_not_employed && no_employment_payments
+
+      return :unexpected_employment_data if applicant_not_employed && eligible_employment_payments.any?
 
       return :hmrc_multiple_employments if has_multiple_employments?
 
       return :no_hmrc_data unless hmrc_employment_income?
 
       :hmrc_single_employment
+    end
+
+    def applicant_not_employed
+      !applicant.employed
+    end
+
+    def no_employment_payments
+      eligible_employment_payments.empty?
     end
   end
 end

--- a/app/views/providers/employment_incomes/show.html.erb
+++ b/app/views/providers/employment_incomes/show.html.erb
@@ -9,7 +9,7 @@
     </div>
   </div>
 
-  <% if @employments.any? && @applicant.not_employed? %>
+  <% if @eligible_employment_payments.any? && @applicant.not_employed? %>
     <% page_heading = 'not_employed' %>
   <% else %>
     <% page_heading = 'employed' %>
@@ -20,7 +20,7 @@
     <%= form.govuk_radio_buttons_fieldset(:has_extra_employment_information,
                                           legend: { size: 'xl', tag: 'h1', text: page_title}) do %>
 
-    <% if @employments.any? && @applicant.not_employed? %>
+    <% if @eligible_employment_payments.any? && @applicant.not_employed? %>
         <div class="govuk-!-padding-bottom-6"></div>
         <p class="govuk-body-l"> <%= t('.hmrc_not_employed') %> </p>
     <% end %>

--- a/features/providers/check_multiple_employment.feature
+++ b/features/providers/check_multiple_employment.feature
@@ -119,3 +119,18 @@ Feature: Check multiple employment
 
     When I click 'View completed application'
     Then I should be on a page showing "Application for civil legal aid certificate"
+
+  @javascript @vcr @hmrc_use_dev_mock
+  Scenario: I am able to continue if applicant is unemployed buy has income from previous employment
+    Given I am logged in as a provider
+    And csrf is enabled
+    And an applicant named John Jobseeker has completed his true layer interaction
+    And the system is prepped for the employed journey
+
+    When I visit the applications page
+    And I click link 'John Jobseeker'
+    Then I should be on a page showing "Continue John Jobseeker's financial assessment"
+
+    When I click 'Continue'
+    Then I should be on a page showing "HMRC found a record of your client's employment"
+

--- a/features/providers/check_multiple_employment.feature
+++ b/features/providers/check_multiple_employment.feature
@@ -121,7 +121,7 @@ Feature: Check multiple employment
     Then I should be on a page showing "Application for civil legal aid certificate"
 
   @javascript @vcr @hmrc_use_dev_mock
-  Scenario: I am able to continue if applicant is unemployed buy has income from previous employment
+  Scenario: I am able to continue if applicant is unemployed but has income from previous employment
     Given I am logged in as a provider
     And csrf is enabled
     And an applicant named John Jobseeker has completed his true layer interaction

--- a/spec/factories/applicants.rb
+++ b/spec/factories/applicants.rb
@@ -76,7 +76,7 @@ FactoryBot.define do
       last_name { "Jobseeker" }
       date_of_birth { Date.new(2005, 5, 5) }
       email { Faker::Internet.safe_email }
-      national_insurance_number { "EE555555E" }
+      national_insurance_number { "BB123456B" }
     end
 
     # use :with_bank_accounts: 2 to create 2 bank accounts for the applicant

--- a/spec/factories/applicants.rb
+++ b/spec/factories/applicants.rb
@@ -70,6 +70,15 @@ FactoryBot.define do
       national_insurance_number { "KY123456D" }
     end
 
+    trait :john_jobseeker do
+      not_employed
+      first_name { "John" }
+      last_name { "Jobseeker" }
+      date_of_birth { Date.new(2005, 5, 5) }
+      email { Faker::Internet.safe_email }
+      national_insurance_number { "EE555555E" }
+    end
+
     # use :with_bank_accounts: 2 to create 2 bank accounts for the applicant
     transient do
       with_bank_accounts { 0 }

--- a/spec/factories/employments.rb
+++ b/spec/factories/employments.rb
@@ -89,5 +89,37 @@ FactoryBot.define do
                net_employment_income: 1902.3
       end
     end
+
+    trait :with_payments_in_transaction_period do
+      after(:create) do |employment|
+        start_date = employment.legal_aid_application.transaction_period_start_on + 2.days
+        [start_date + 2.days, start_date + 32.days, start_date + 64.days].each do |payment_date|
+          create :employment_payment,
+                 employment:,
+                 date: payment_date,
+                 gross: 2345.29,
+                 benefits_in_kind: 0.0,
+                 tax: -257.2,
+                 national_insurance: -185.79,
+                 net_employment_income: 1902.3
+        end
+      end
+    end
+
+    trait :with_payments_before_transaction_period do
+      after(:create) do |employment|
+        start_date = employment.legal_aid_application.transaction_period_start_on - 92.days
+        [start_date + 2.days, start_date + 32.days, start_date + 64.days].each do |payment_date|
+          create :employment_payment,
+                 employment:,
+                 date: payment_date,
+                 gross: 2345.29,
+                 benefits_in_kind: 0.0,
+                 tax: -257.2,
+                 national_insurance: -185.79,
+                 net_employment_income: 1902.3
+        end
+      end
+    end
   end
 end

--- a/spec/models/legal_aid_application_spec.rb
+++ b/spec/models/legal_aid_application_spec.rb
@@ -1429,7 +1429,7 @@ RSpec.describe LegalAidApplication, type: :model do
       context "with one employment with no employment payments" do
         before { create :employment, legal_aid_application: laa }
 
-        it "returns and empty collections" do
+        it "returns an empty collections" do
           expect(laa.eligible_employment_payments).to be_empty
         end
       end

--- a/spec/models/legal_aid_application_spec.rb
+++ b/spec/models/legal_aid_application_spec.rb
@@ -1408,6 +1408,79 @@ RSpec.describe LegalAidApplication, type: :model do
         expect(laa.hmrc_response_use_case_one).to eq use_case_one
       end
     end
+
+    describe "#eligible_employment_payments" do
+      let(:laa) { create :legal_aid_application, :with_transaction_period }
+
+      context "with one employment with employment payments" do
+        before do
+          emp = create :employment, legal_aid_application: laa
+          create :employment_payment, employment: emp, date: 1.month.ago
+          create :employment_payment, employment: emp, date: 2.months.ago
+        end
+
+        it "returns two employment records" do
+          payments = laa.eligible_employment_payments
+          expect(payments.size).to eq 2
+          expect(payments.map(&:class).uniq).to eq [EmploymentPayment]
+        end
+      end
+
+      context "with one employment with no employment payments" do
+        before { create :employment, legal_aid_application: laa }
+
+        it "returns and empty collections" do
+          expect(laa.eligible_employment_payments).to be_empty
+        end
+      end
+
+      context "with no employments" do
+        it "returns an empty collection" do
+          expect(laa.eligible_employment_payments).to be_empty
+        end
+      end
+
+      context "with multiple employments" do
+        before do
+          emp1 = create :employment, legal_aid_application: laa
+          create :employment_payment, employment: emp1, date: 1.month.ago
+          create :employment_payment, employment: emp1, date: 2.months.ago
+          emp2 = create :employment, legal_aid_application: laa
+          create :employment_payment, employment: emp2, date: 1.month.ago
+        end
+
+        it "returns one collection of three records" do
+          expect(laa.eligible_employment_payments.size).to eq 3
+        end
+      end
+
+      context "with all payments before start of transaction period" do
+        before do
+          emp1 = create :employment, legal_aid_application: laa
+          create :employment_payment, employment: emp1, date: laa.transaction_period_start_on - 3.days
+          create :employment_payment, employment: emp1, date: laa.transaction_period_start_on - 10.days
+          emp2 = create :employment, legal_aid_application: laa
+          create :employment_payment, employment: emp2, date: laa.transaction_period_start_on - 1.month
+        end
+
+        it "returns an empty collection" do
+          expect(laa.eligible_employment_payments).to be_empty
+        end
+      end
+
+      context "with one payment in transaction period, others before" do
+        before do
+          emp1 = create :employment, legal_aid_application: laa
+          create :employment_payment, employment: emp1, date: laa.transaction_period_start_on - 3.days
+          create :employment_payment, employment: emp1, date: laa.transaction_period_start_on + 2.days
+          create :employment_payment, employment: emp1, date: laa.transaction_period_start_on - 10.days
+        end
+
+        it "returns a collection of just the one record in the transaction period" do
+          expect(laa.eligible_employment_payments.size).to eq 1
+        end
+      end
+    end
   end
 
 private


### PR DESCRIPTION
## Unemployed applicant with HMRC employment income

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3240)

In the above scenario, the provider should be told that's the case, shown the details and be given the opportunity to provide an explanation.  This has now been
fixed by:

 - making it follow the not_employed journey only if the applicant is not employed AND there are no eligible employment payments (i.e. within the transaction period).
 

Changes
- new method `#employment_payments` added to `LegalAidApplication` to return all employment_payments from all employments
- new method '#eligible_employment_payments` added to `LegalAidApplication` to return only those employment payments which fall within the transaction period
- `HMRC::StatusAnalyzer` amended to add new return status `:unexpected_employment_data` in this case
- The `ProviderCapital` flow updated to redirect to the correct page when `:unexpected_employment_data` returned from `HMRC::StatusAnalyser`

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
