### PR TITLE
Fix: Update GoogleTagManager handling

### DIFF
--- a/app/views/layouts/_google_tag_manager.html.erb
+++ b/app/views/layouts/_google_tag_manager.html.erb
@@ -3,4 +3,4 @@
   j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   'https://www.googletagmanager.com/gtm.js?id='+i+dl;var n=d.querySelector('[nonce]');
   n&&j.setAttribute('nonce',n.nonce||n.getAttribute('nonce'));f.parentNode.insertBefore(j,f);
-  })(window,document,'script','dataLayer', "<%= Rails.configuration.x.google_tag_manager_tracking_id.to_json %>");</script>
+  })(window,document,'script','dataLayer', "<%= Rails.configuration.x.google_tag_manager_tracking_id %>");</script>


### PR DESCRIPTION
## What

A `fix` was added to make erblint happy, it broke GoogleAnalytics.  
A subsequent gem update reverted the requirement, so this reverts the `fix`

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
