### PR TITLE
Add fake attachment original name rule

### DIFF
--- a/db/anonymise/rules.rb
+++ b/db/anonymise/rules.rb
@@ -31,7 +31,9 @@ NINO_REGEXP = /^[A-CEGHJ-PR-TW-Z]{1}[A-CEGHJ-NPR-TW-Z]{1}[0-9]{6}[A-DFM]{1}$/
     national_insurance_number: -> { Faker::Base.regexify(NINO_REGEXP) },
   },
   application_digests: {},
-  attachments: {},
+  attachments: {
+    original_filename: -> { "#{Faker::Bank.name}.pdf" },
+  },
   attempts_to_settles: {
     attempts_made: -> { Faker::Lorem.sentence },
   },


### PR DESCRIPTION
## What
Add rule to anonymise orginal_filename of attachments

This should be done to handle the edge case
where attachments can have PII in the name.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
