### PR TITLE
AP-3276 remove deprecated header class

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -4,7 +4,7 @@ module ApplicationHelper
     link_url = providers_legal_aid_applications_url if request.path_info.include?("providers")
     link_to_accessible(t("layouts.application.header.title"),
                        link_url,
-                       class: "govuk-header__link govuk-header__link--service-name")
+                       class: "govuk-heading-m govuk-!-margin-bottom-0 govuk-header__link govuk-header__service-name")
   end
 
   def html_title


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3276)

- Remove deprecated class and replace with new class 
- Styling wasn't preserved so had to add a couple of other classes to style the link correctly
- This is a recommended change following the update to GOVUK Frontend 4.2

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
