### PR TITLE
AP-3286 DigestExtractor bug fix

### DIFF
--- a/app/models/application_digest.rb
+++ b/app/models/application_digest.rb
@@ -65,6 +65,7 @@ class ApplicationDigest < ApplicationRecord
       WorkingDayCalculator.working_days_between(laa.earliest_delegated_functions_date, laa.earliest_delegated_functions_reported_date) + 1
     end
 
+
     def determine_hmrc_data_used?(laa)
       status = HMRC::StatusAnalyzer.call(laa)
       case status
@@ -72,7 +73,8 @@ class ApplicationDigest < ApplicationRecord
         :provider_not_enabled_for_employed_journey,
         :applicant_not_employed,
         :hmrc_multiple_employments,
-        :no_hmrc_data
+        :no_hmrc_data,
+        :unexpected_employment_data
         false
       when :hmrc_single_employment
         true

--- a/spec/models/application_digest_spec.rb
+++ b/spec/models/application_digest_spec.rb
@@ -103,6 +103,14 @@ RSpec.describe ApplicationDigest do
             end
           end
 
+          context "and unexpected data" do
+            let(:hmrc_status) { :unexpected_employment_data }
+
+            it "returns true" do
+              expect(digest.hmrc_data_used).to be false
+            end
+          end
+
           context "and single employment" do
             let(:hmrc_status) { :hmrc_single_employment }
 


### PR DESCRIPTION


## DigestExtractor bug fix

the DigestExractor has been failing every night becaues it didn't recognise the new status
generated by the HMRC::StatusAnalyser.  This fixes that



[Link to story](https://dsdmoj.atlassian.net/browse/AP-3286)

Describe what you did and why.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
