### PR TITLE
AP-3269: remove Rails 7 deprecation warnings

### DIFF
--- a/app/services/reports/means_report_creator.rb
+++ b/app/services/reports/means_report_creator.rb
@@ -31,9 +31,9 @@ module Reports
         template: "providers/means_reports/show",
         layout: "pdf",
         locals: {
-          :@legal_aid_application => legal_aid_application,
-          :@cfe_result => legal_aid_application.cfe_result,
-          :@manual_review_determiner => CCMS::ManualReviewDeterminer.new(legal_aid_application),
+          legal_aid_application:,
+          cfe_result: legal_aid_application.cfe_result,
+          manual_review_determiner: CCMS::ManualReviewDeterminer.new(legal_aid_application),
         },
       )
     end

--- a/app/services/reports/merits_report_creator.rb
+++ b/app/services/reports/merits_report_creator.rb
@@ -31,7 +31,7 @@ module Reports
         template: "providers/merits_reports/show",
         layout: "pdf",
         locals: {
-          :@legal_aid_application => legal_aid_application,
+          legal_aid_application:,
         },
       )
     end

--- a/app/views/providers/means_reports/show.html.erb
+++ b/app/views/providers/means_reports/show.html.erb
@@ -1,4 +1,7 @@
 <%= page_template page_title: t('.heading'), back_link: :none do %>
+  <% @legal_aid_application = legal_aid_application if @legal_aid_application.nil? %>
+  <% @cfe_result = cfe_result if @cfe_result.nil? %>
+  <% @manual_review_determiner = manual_review_determiner if @manual_review_determiner.nil? %>
 
   <%= render 'shared/application_ref', legal_aid_application: @legal_aid_application %>
 

--- a/app/views/providers/merits_reports/show.html.erb
+++ b/app/views/providers/merits_reports/show.html.erb
@@ -1,4 +1,5 @@
 <%= page_template page_title: t('.heading'), back_link: :none do %>
+  <% @legal_aid_application = legal_aid_application if @legal_aid_application.nil? %>
 
   <%= render 'shared/application_ref', legal_aid_application: @legal_aid_application %>
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3269)

Remove legacy invocation of instance variables and replace
with a line in the view that creates an instance variable is
not passed in.

This allows the instance variable to be used in all the nested
partials that require them, a ticket will be raised to address
this by switching the nested partials to not require an instance
version of the required

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
