### PR TITLE
add safe operator when checking for dwp_benefit type

### DIFF
--- a/app/models/uploaded_evidence_collection.rb
+++ b/app/models/uploaded_evidence_collection.rb
@@ -27,7 +27,7 @@ private
       next if categorised_evidence_types.include?(type)
 
       # link the error message to the dropzone
-      errors.add("dz-upload-button", I18n.t("#{error_path}.#{type}_missing", benefit: passporting_benefit), mandatory_evidence: true)
+      errors.add("dz-upload-button", I18n.t("#{error_path}.#{type}_missing", benefit: passporting_benefit_title), mandatory_evidence: true)
     end
 
     mandatory_evidence_types.all? { |mandatory_type| categorised_evidence_types.include?(mandatory_type) }
@@ -45,8 +45,8 @@ private
     original_attachments.pluck(:attachment_type).uniq
   end
 
-  def passporting_benefit
-    legal_aid_application.dwp_override ? legal_aid_application.dwp_override.passporting_benefit.titleize : nil
+  def passporting_benefit_title
+    legal_aid_application&.dwp_override&.passporting_benefit&.titleize
   end
 
   def error_path


### PR DESCRIPTION

## What

Bugfix
https://sentry.io/organizations/ministryofjustice/issues/3407948574/?project=5416054&referrer=slack

An error is being thrown when a user reaches uploaded evidence collection and they dont add mandatory evidence as the validation is looking for a benefit type, in this case the required evidence was for employment not benefits.

This change returns nil when a dwp_benefit override doesnt exist and subsequently the correct error is presented to the user

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
