### PR TITLE
Ap 3265 new blue box for bank statement upload journey

### DIFF
--- a/app/controllers/providers/bank_statements_controller.rb
+++ b/app/controllers/providers/bank_statements_controller.rb
@@ -6,7 +6,7 @@ module Providers
 
     def show
       legal_aid_application.set_transaction_period
-      legal_aid_application.provider_assess_means!
+      legal_aid_application.provider_assess_means! unless legal_aid_application.checking_non_passported_means?
     end
 
     def update

--- a/app/controllers/providers/bank_statements_controller.rb
+++ b/app/controllers/providers/bank_statements_controller.rb
@@ -4,7 +4,10 @@ module Providers
 
     before_action :set_form, only: %i[show update destroy]
 
-    def show; end
+    def show
+      legal_aid_application.set_transaction_period
+      legal_aid_application.provider_assess_means!
+    end
 
     def update
       if upload_button_pressed?

--- a/app/controllers/providers/means/cash_incomes_controller.rb
+++ b/app/controllers/providers/means/cash_incomes_controller.rb
@@ -5,7 +5,6 @@ module Providers
 
       def show; end
 
-      # :nocov:
       def update
         if aggregated_cash_income.update(form_params)
           update_no_cash_income(form_params)
@@ -35,7 +34,6 @@ module Providers
         val = params.permit(:none_selected)[:none_selected] == "true"
         legal_aid_application.update!(no_cash_income: val)
       end
-      # :nocov:
     end
   end
 end

--- a/app/controllers/providers/means/cash_outgoings_controller.rb
+++ b/app/controllers/providers/means/cash_outgoings_controller.rb
@@ -5,9 +5,6 @@ module Providers
 
       def show; end
 
-      # TODO: remove nocov and re-enable disabled tests in the
-      #  controller once the flow ticket ()AP-3264) is complete
-      # :nocov:
       def update
         if aggregated_cash_outgoings.update(form_params)
           update_no_cash_outgoings(form_params)
@@ -27,17 +24,14 @@ module Providers
         params
           .require(:aggregated_cash_outgoings)
           .except(:cash_outgoings)
-          .merge({
-            legal_aid_application_id: legal_aid_application[:id],
-            none_selected: params[:aggregated_cash_outgoings][:none_selected],
-          })
+          .merge({ legal_aid_application_id: legal_aid_application[:id],
+                   none_selected: params[:aggregated_cash_outgoings][:none_selected] })
       end
 
       def update_no_cash_outgoings(params)
         val = params.permit(:none_selected)[:none_selected] == "true"
         legal_aid_application.update!(no_cash_outgoings: val)
       end
-      # :nocov:
     end
   end
 end

--- a/app/controllers/providers/means/student_finances_controller.rb
+++ b/app/controllers/providers/means/student_finances_controller.rb
@@ -5,8 +5,6 @@ module Providers
         @form = ::StudentFinances::AnnualAmountForm.new(model: irregular_income)
       end
 
-      # :nocov:
-      # Can be tested once this controller is added to a flow
       def update
         @form = ::StudentFinances::AnnualAmountForm.new(form_params)
         if @form.save
@@ -16,11 +14,9 @@ module Providers
           render :show
         end
       end
-    # :nocov:
 
     private
 
-      # :nocov:
       def irregular_income
         legal_aid_application.irregular_incomes.find_by(income_type: "student_loan")
       end
@@ -36,7 +32,6 @@ module Providers
       def student_finance
         @student_finance ||= params[:irregular_income][:student_finance]
       end
-      # :nocov:
     end
   end
 end

--- a/app/controllers/providers/means_summaries_controller.rb
+++ b/app/controllers/providers/means_summaries_controller.rb
@@ -6,6 +6,12 @@ module Providers
     end
 
     def update
+      if legal_aid_application.provider.bank_statement_upload_permissions?
+        redirect_to providers_legal_aid_application_capital_income_assessment_result_path
+        legal_aid_application.provider_enter_merits!
+        return
+      end
+
       unless draft_selected? || legal_aid_application.provider_entering_merits?
         redirect_to(problem_index_path) && return unless check_financial_eligibility
 

--- a/app/models/base_aggregated_cash_transaction.rb
+++ b/app/models/base_aggregated_cash_transaction.rb
@@ -161,9 +161,9 @@ private
 
       next if value.blank?
 
-      errors.add(value_attr, I18n.t("errors.#{self.class.to_s.underscore}.invalid_type")) unless number? value
-      errors.add(value_attr, I18n.t("errors.#{self.class.to_s.underscore}.negative")) unless valid_amount? value
-      errors.add(value_attr, I18n.t("errors.#{self.class.to_s.underscore}.too_many_decimals")) unless CurrencyValidator::ONLY_2_DECIMALS_PATTERN.match? value
+      errors.add(value_attr, I18n.t("errors.#{self.class.to_s.underscore}.invalid_type")) unless number?(value)
+      errors.add(value_attr, I18n.t("errors.#{self.class.to_s.underscore}.negative")) unless valid_amount?(value)
+      errors.add(value_attr, I18n.t("errors.#{self.class.to_s.underscore}.too_many_decimals")) unless CurrencyValidator::ONLY_2_DECIMALS_PATTERN.match?(value.to_s)
     end
   end
 

--- a/app/models/concerns/non_passported_state_machine.rb
+++ b/app/models/concerns/non_passported_state_machine.rb
@@ -50,6 +50,13 @@ class NonPassportedStateMachine < BaseStateMachine
       transitions from: :analysing_bank_transactions, to: :provider_assessing_means
     end
 
+    event :provider_assess_means do
+      transitions from: %i[provider_confirming_applicant_eligibility
+                           provider_assessing_means
+                           checking_non_passported_means],
+                  to: :provider_assessing_means
+    end
+
     event :check_non_passported_means do
       transitions from: %i[
         provider_assessing_means

--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -78,6 +78,7 @@ class LegalAidApplication < ApplicationRecord
            :complete_passported_means!,
            :enter_applicant_details!,
            :provider_confirm_applicant_eligibility!,
+           :provider_assess_means!,
            :provider_enter_means!,
            :provider_enter_merits!,
            :provider_used_delegated_functions!,
@@ -501,6 +502,10 @@ class LegalAidApplication < ApplicationRecord
 
   def hmrc_response_use_case_one
     hmrc_responses.detect { |response| response.use_case == "one" }
+  end
+
+  def uploading_bank_statements?
+    provider.bank_statement_upload_permissions? && !provider_received_citizen_consent?
   end
 
 private

--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -508,6 +508,10 @@ class LegalAidApplication < ApplicationRecord
     provider.bank_statement_upload_permissions? && !provider_received_citizen_consent?
   end
 
+  def uploaded_bank_statements?
+    provider.bank_statement_upload_permissions? && attachments.bank_statement_evidence.exists?
+  end
+
 private
 
   def bank_transactions_by_type(type)

--- a/app/services/ccms/manual_review_determiner.rb
+++ b/app/services/ccms/manual_review_determiner.rb
@@ -15,7 +15,8 @@ module CCMS
              :non_passported?,
              :has_restrictions?,
              :policy_disregards?,
-             :manually_entered_employment_information?, to: :legal_aid_application
+             :manually_entered_employment_information?,
+             :uploaded_bank_statements?, to: :legal_aid_application
 
     delegate :capital_contribution_required?, to: :cfe_result
 
@@ -31,7 +32,7 @@ module CCMS
         has_restrictions? ||
         policy_disregards? ||
         manually_entered_employment_information? ||
-        uploaded_bank_statements
+        uploaded_bank_statements?
     end
 
     def review_reasons
@@ -58,6 +59,7 @@ module CCMS
       application_review_reasons << :restrictions if has_restrictions?
       application_review_reasons << :policy_disregards if policy_disregards?
       application_review_reasons << :further_employment_details if manually_entered_employment_information?
+      application_review_reasons << :uploaded_bank_statements if uploaded_bank_statements?
       application_review_reasons
     end
 
@@ -65,8 +67,10 @@ module CCMS
       Setting.manually_review_all_cases? && non_passported?
     end
 
-    def uploaded_bank_statements
-      legal_aid_application.provider.bank_statement_upload_permissions? && legal_aid_application.attachments.bank_statement_evidence.exists?
-    end
+    # def uploaded_bank_statements?
+    #   legal_aid_application.provider.bank_statement_upload_permissions? &&
+    #     legal_aid_application.attachments.bank_statement_evidence.exists? &&
+    #     legal_aid_application.cfe_result.nil? # not sure if this final and is reequired, might be overkill, but we should not be making the cfe call with these cases
+    # end
   end
 end

--- a/app/services/ccms/manual_review_determiner.rb
+++ b/app/services/ccms/manual_review_determiner.rb
@@ -30,7 +30,8 @@ module CCMS
         capital_contribution_required? ||
         has_restrictions? ||
         policy_disregards? ||
-        manually_entered_employment_information?
+        manually_entered_employment_information? ||
+        uploaded_bank_statements
     end
 
     def review_reasons
@@ -62,6 +63,10 @@ module CCMS
 
     def manually_review_all_non_passported?
       Setting.manually_review_all_cases? && non_passported?
+    end
+
+    def uploaded_bank_statements
+      legal_aid_application.provider.bank_statement_upload_permissions? && legal_aid_application.attachments.bank_statement_evidence.exists?
     end
   end
 end

--- a/app/services/flow/flows/provider_capital.rb
+++ b/app/services/flow/flows/provider_capital.rb
@@ -15,7 +15,13 @@ module Flow
               :income_summary
             end
           end,
-          check_answers: :means_summaries,
+          check_answers: lambda do |application|
+            if application.uploading_bank_statements?
+              application.transaction_types.credits.any? ? :cash_incomes : :means_summaries
+            else
+              :income_summary
+            end
+          end,
         },
         cash_incomes: {
           path: ->(application) { urls.providers_legal_aid_application_means_cash_income_path(application) },
@@ -36,10 +42,18 @@ module Flow
               :outgoings_summary
             end
           end,
+          check_answers: lambda do |application|
+            if application.uploading_bank_statements?
+              application.transaction_types.debits.any? ? :cash_outgoings : :means_summaries
+            else
+              :outgoings_summary
+            end
+          end,
         },
         cash_outgoings: {
           path: ->(application) { urls.providers_legal_aid_application_means_cash_outgoing_path(application) },
           forward: :has_dependants,
+          check_answers: :means_summaries,
         },
         # Dependant steps here (see ProviderDependants)
         # Property steps here (see ProviderProperty)
@@ -129,10 +143,12 @@ module Flow
               application.income_types? ? :income_summary : :no_income_summaries
             end
           end,
+          check_answers: :means_summaries,
         },
         full_employment_details: {
           path: ->(application) { urls.providers_legal_aid_application_means_full_employment_details_path(application) },
           forward: ->(application) { application.income_types? ? :income_summary : :no_income_summaries },
+          check_answers: :means_summaries,
         },
         income_summary: {
           path: ->(application) { urls.providers_legal_aid_application_income_summary_index_path(application) },

--- a/app/services/flow/flows/provider_dependants.rb
+++ b/app/services/flow/flows/provider_dependants.rb
@@ -7,6 +7,8 @@ module Flow
           forward: lambda do |application|
             if application.has_dependants?
               :dependants
+            elsif application.uploading_bank_statements?
+              :own_homes
             else
               application.outgoing_types? ? :outgoings_summary : :no_outgoings_summaries
             end
@@ -32,6 +34,8 @@ module Flow
           forward: lambda { |application, has_other_dependant|
             if has_other_dependant
               :dependants
+            elsif application.uploading_bank_statements?
+              :own_homes
             else
               application.outgoing_types? ? :outgoings_summary : :no_outgoings_summaries
             end

--- a/app/services/flow/flows/provider_start.rb
+++ b/app/services/flow/flows/provider_start.rb
@@ -131,6 +131,7 @@ module Flow
         bank_statements: {
           path: ->(application) { urls.providers_legal_aid_application_bank_statements_path(application) },
           forward: :employment_incomes,
+          check_answers: :means_summaries,
         },
 
         email_addresses: {

--- a/app/services/flow/flows/provider_start.rb
+++ b/app/services/flow/flows/provider_start.rb
@@ -130,8 +130,9 @@ module Flow
         },
         bank_statements: {
           path: ->(application) { urls.providers_legal_aid_application_bank_statements_path(application) },
-          forward: :check_provider_answers,
+          forward: :employment_incomes,
         },
+
         email_addresses: {
           path: ->(application) { urls.providers_legal_aid_application_email_address_path(application) },
           forward: :about_the_financial_assessments,

--- a/app/services/flow/flows/provider_vehicle.rb
+++ b/app/services/flow/flows/provider_vehicle.rb
@@ -8,7 +8,7 @@ module Flow
             if application.own_vehicle?
               :vehicles_estimated_values
             elsif application.non_passported?
-              :applicant_bank_accounts
+              application.uploading_bank_statements? ? :savings_and_investments : :applicant_bank_accounts
             else
               :offline_accounts
             end
@@ -30,7 +30,13 @@ module Flow
         },
         vehicles_regular_uses: {
           path: ->(application) { urls.providers_legal_aid_application_vehicles_regular_use_path(application) },
-          forward: ->(application) { application.non_passported? ? :applicant_bank_accounts : :offline_accounts },
+          forward: lambda do |application|
+            if application.non_passported?
+              application.uploading_bank_statements? ? :savings_and_investments : :applicant_bank_accounts
+            else
+              :offline_accounts
+            end
+          end,
           check_answers: ->(app) { app.checking_non_passported_means? ? :means_summaries : :check_passported_answers },
         },
       }.freeze

--- a/app/services/results_panel_selector.rb
+++ b/app/services/results_panel_selector.rb
@@ -8,6 +8,7 @@ class ResultsPanelSelector
   end
 
   def call
+    return "shared/assessment_results/no_cfe_result" if @legal_aid_application.provider.bank_statement_upload_permissions? && @legal_aid_application.attachments.bank_statement_evidence.exists?
     return eligible_or_non_eligible if %w[eligible not_eligible].include?(assessment_result)
     return "shared/assessment_results/manual_check_required" if restrictions? || disregards? || manually_entered_employment_information?
 
@@ -15,6 +16,12 @@ class ResultsPanelSelector
   end
 
 private
+
+  def no_cfe_result?
+    if @legal_aid_application.provider.bank_statement_upload_permissions? && @legal_aid_application.attachments.bank_statement_evidence.exists?
+      "_no_cfe_result"
+    end
+  end
 
   def cfe_result
     @cfe_result ||= @legal_aid_application.cfe_result.overview

--- a/app/views/providers/capital_income_assessment_results/show.html.erb
+++ b/app/views/providers/capital_income_assessment_results/show.html.erb
@@ -1,6 +1,8 @@
+<% head_title = @legal_aid_application.provider.bank_statement_upload_permissions? ? ".no_cfe_assessment" : ".tab_title.#{@cfe_result.assessment_result}" %>
+
 <%= page_template(
         page_title: t(".page_title", result: t(".result.#{@cfe_result.assessment_result}") ),
-        head_title: t(".tab_title.#{@cfe_result.assessment_result}" ),
+        head_title: t(head_title),
         template: :basic,
         column_width: :full
     ) do %>
@@ -9,7 +11,7 @@
     <%= render @result_partial %>
   </div>
 
-  <%= render 'result_details' %>
+  <%= render 'result_details' unless @legal_aid_application.provider.bank_statement_upload_permissions? && @legal_aid_application.attachments.bank_statement_evidence.exists? %>
 
   <br><br>
 

--- a/app/views/providers/means_summaries/show.html.erb
+++ b/app/views/providers/means_summaries/show.html.erb
@@ -18,11 +18,12 @@
     <% end %>
   <% end %>
 
+  <% income_url = @legal_aid_application.provider.bank_statement_upload_permissions? ? :identify_types_of_incomes : :income_summary %>
   <%= render(
          'shared/check_answers/income_summary',
          income_type: t('.credits-section-heading'),
-         url: :income_summary,
-          transaction_types: TransactionType.credits
+         url: income_url,
+         transaction_types: TransactionType.credits
       ) %>
 
   <% if @legal_aid_application.value_of_student_finance %>
@@ -31,10 +32,11 @@
     <p><%= t('.student_finance.info_html', student_finance: value_with_currency_unit(@legal_aid_application.value_of_student_finance, t('currency.gbp'))) %></p>
   <% end %>
 
+  <% outgoings_url = @legal_aid_application.provider.bank_statement_upload_permissions? ? :identify_types_of_outgoings : :outgoings_summary %>
   <%= render(
           'shared/check_answers/income_summary',
           income_type: t('.debits-section-heading'),
-          url: :outgoings_summary,
+          url: outgoings_url,
           transaction_types: TransactionType.debits
       ) %>
 

--- a/app/views/providers/means_summaries/show.html.erb
+++ b/app/views/providers/means_summaries/show.html.erb
@@ -2,6 +2,10 @@
 
   <h2 class="govuk-heading-l"><%= t('.h2-heading') %></h2>
 
+  <% if @legal_aid_application.provider.bank_statement_upload_permissions? %>
+    <%= render('shared/check_answers/bank_statements', bank_statements: @legal_aid_application.attachments.bank_statement_evidence) %>
+  <% end %>
+
   <% if Setting.enable_employed_journey? && @legal_aid_application.provider.employment_permissions? %>
     <% if @legal_aid_application.hmrc_employment_income? %>
       <% if @legal_aid_application.has_multiple_employments? %>
@@ -20,6 +24,7 @@
          url: :income_summary,
           transaction_types: TransactionType.credits
       ) %>
+
   <% if @legal_aid_application.value_of_student_finance %>
     <h3 class="govuk-heading-m"><%= t('.student_finance.heading') %></h3>
 

--- a/app/views/shared/assessment_results/_no_cfe_result.html.erb
+++ b/app/views/shared/assessment_results/_no_cfe_result.html.erb
@@ -1,0 +1,11 @@
+<h1 class="govuk-heading-l">
+  <%= t('.heading', name: @legal_aid_application.applicant_full_name) %>
+</h1>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <p class="govuk-body"><%= t('.cannot_calculate') %></p>
+    <p class="govuk-body"><%= t('.caseworker_check') %></p>
+    <p class="govuk-body"><%= t('.continue') %></p>
+  </div>
+</div>

--- a/app/views/shared/check_answers/_bank_statements.html.erb
+++ b/app/views/shared/check_answers/_bank_statements.html.erb
@@ -1,0 +1,12 @@
+<h3 class="govuk-heading-m"><%= "Bank statements" %></h2>
+
+<dl class="govuk-summary-list govuk-!-margin-bottom-9">
+
+  <%= check_answer_link(
+    name: :bank_statements,
+    url: providers_legal_aid_application_bank_statements_path,
+    question: "Upload bank statements",
+    answer: attachments_with_size(bank_statements),
+    read_only: false
+  ) %>
+</dl>

--- a/app/views/shared/check_answers/_employed_income.html.erb
+++ b/app/views/shared/check_answers/_employed_income.html.erb
@@ -1,4 +1,4 @@
-<div class="govuk-grid-row">
+<div class="govuk-grid-row" id="app-check-your-answers__employment">
   <div class="govuk-grid-column-two-thirds">
     <h3 class="govuk-heading-m"><%= t('.employment') %></h3>
   </div>

--- a/app/views/shared/check_answers/_full_employment_details.html.erb
+++ b/app/views/shared/check_answers/_full_employment_details.html.erb
@@ -1,4 +1,4 @@
-<div class="govuk-grid-row">
+<div class="govuk-grid-row" id="app-check-your-answers__employment">
   <div class="govuk-grid-column-two-thirds">
     <h3 class="govuk-heading-m"><%= t('.employment') %></h3>
   </div>

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -77,6 +77,7 @@ en:
 
     capital_income_assessment_results:
       show:
+        no_cfe_assessment: A caseworker needs to review your application
         page_title: "Capital and Income Assessment Result: %{result}"
         tab_title:
           eligible: Your client could be eligible for free legal aid

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -517,10 +517,13 @@ en:
         status: Status
         uploaded: Uploaded
         title: Uploaded files
+    has_other_dependants:
+      show:
+        error: Select yes if they have other dependants
 
     identify_types_of_outgoings:
       show:
-        page_heading: Which regular payments does your client make?
+        page_heading: Which payments does your client make?
       update:
         none_selected: Select if your client makes any regular payments
     income_summary:
@@ -668,10 +671,10 @@ en:
           ni: National Insurance
       cash_incomes:
         show:
-          page_heading: Select payments your client receive in cash
+          page_heading: Select payments your client receives in cash
       identify_types_of_incomes:
         show:
-          page_heading: Which types of income does your client receive?
+          page_heading: Which payments does your client receive?
         update:
           none_selected: Select if your client receives any types of income
       has_dependants:
@@ -715,7 +718,6 @@ en:
           remove: Remove
           warning:
             delete: Are you sure you want to delete this dependant?
-          error: Select yes if they have other dependants
       remove_dependants:
         show:
           page_title: "Are you sure you want to remove %{name}?"

--- a/config/locales/en/shared.yml
+++ b/config/locales/en/shared.yml
@@ -37,6 +37,24 @@ en:
             check_box_child_care: Childcare payments
             check_box_maintenance_out: Maintenance payments to a former partner
             check_box_legal_aid: Payments towards legal aid in a criminal case
+        providers:
+          cash_incomes:
+            hint: Enter the total cash amount you received in each month, or enter 0 if you received none.
+          cash_outgoings:
+            hint: Enter the total cash amount you paid in each month, or enter 0 if you paid none.
+          means:
+            cash_incomes:
+              check_box_benefits: Benefits
+              check_box_friends_or_family: Financial help from friends or family
+              check_box_maintenance_in: Maintenance payments from a former partner
+              check_box_property_or_lodger: Income from a property or lodger
+              check_box_pension: Pension
+            cash_outgoings:
+              hint: Enter the total cash amount you paid in each month, or enter 0 if you paid none.
+              check_box_rent_or_mortgage: Housing payments
+              check_box_child_care: Childcare payments
+              check_box_maintenance_out: Maintenance payments to a former partner
+              check_box_legal_aid: Payments towards legal aid in a criminal case
     applicant_declaration:
       confirm_following: Confirm the following
       submission_list_summary: You agree that

--- a/config/locales/en/shared.yml
+++ b/config/locales/en/shared.yml
@@ -75,6 +75,11 @@ en:
       apply_ref: 'Apply service case reference:'
       ccms_ref_html: "<abbr title='Client and Cost Management System'>CCMS</abbr> case reference:"
     assessment_results:
+      no_cfe_result:
+        heading: A caseworker needs to review your application
+        cannot_calculate: We cannot calculate your client's financial eligibility yet because you uploaded bank statements
+        caseworker_check: A caseworker will check your client's bank statements to see if they need to pay towards legal aid.
+        continue: Continue your application to provide details of the case
       eligible:
         heading: "%{name} could be eligible for legal aid"
         details:

--- a/features/accessibility/provider.feature
+++ b/features/accessibility/provider.feature
@@ -85,7 +85,7 @@ Feature: Provider accessibility
     And the page is accessible
     Then I choose "No"
     Then I click 'Save and continue'
-    Then I should be on a page showing "Which types of income does your client receive?"
+    Then I should be on a page showing "Which payments does your client receive?"
     And the page is accessible
     Then I select 'Benefits'
     And I click 'Save and continue'
@@ -114,7 +114,7 @@ Feature: Provider accessibility
     And the page is accessible
     Then I choose "No"
     Then I click 'Save and continue'
-    Then I should be on the 'identify_types_of_outgoing' page showing "Which regular payments does your client make?"
+    Then I should be on the 'identify_types_of_outgoing' page showing "Which payments does your client make?"
     And the page is accessible
     Then I select 'Housing payments'
     Then I click 'Save and continue'

--- a/features/providers/bank_statement_upload.feature
+++ b/features/providers/bank_statement_upload.feature
@@ -34,8 +34,7 @@ Feature: Bank statement upload
     Then I should see 'acceptable.pdf UPLOADED'
 
     When I click 'Save and continue'
-    # TODO: placeholder as flow will change in future iterations
-    Then I should be on a page with title "Check your answers"
+    Then I should be on a page showing "The information on this page has been provided by HMRC"
 
     When I click link "Back"
     Then I should be on a page with title "Upload bank statements"
@@ -46,14 +45,77 @@ Feature: Bank statement upload
 
   @javascript
   Scenario: Deleting a file
-      Given I upload the fixture file named 'acceptable.pdf'
-      And I upload an evidence file named 'hello_world.pdf'
-      And I upload an evidence file named 'hello_world.docx'
-      Then I should see 'acceptable.pdf UPLOADED'
-      And I should see 'hello_world.pdf UPLOADED'
-      And I should see 'hello_world.docx UPLOADED'
+    Given I upload the fixture file named 'acceptable.pdf'
+    And I upload an evidence file named 'hello_world.pdf'
+    And I upload an evidence file named 'hello_world.docx'
+    Then I should see 'acceptable.pdf UPLOADED'
+    And I should see 'hello_world.pdf UPLOADED'
+    And I should see 'hello_world.docx UPLOADED'
 
-      When I click delete for the file 'hello_world.pdf'
-      Then I should see 'hello_world.pdf has been successfully deleted'
-      And I should see 'acceptable.pdf UPLOADED'
-      And I should see 'hello_world.docx UPLOADED'
+    When I click delete for the file 'hello_world.pdf'
+    Then I should see 'hello_world.pdf has been successfully deleted'
+    And I should see 'acceptable.pdf UPLOADED'
+    And I should see 'hello_world.docx UPLOADED'
+
+  @javascript
+  Scenario: New bank upload permissions flow
+    Given I upload the fixture file named 'acceptable.pdf'
+    And I upload an evidence file named 'hello_world.pdf'
+    When I click 'Save and continue'
+    Then I should be on a page showing "The information on this page has been provided by HMRC"
+    Then I should be on a page showing "Do you need to tell us anything else about your client's employment?"
+
+    When I choose "No"
+    When I click 'Save and continue'
+    Then I should be on a page with title "Which payments does your client receive?"
+
+    When I select 'Benefits'
+    And I click 'Save and continue'
+    Then I should be on a page with title "Select payments your client receives in cash"
+
+    When I select 'None of the above'
+    And I click 'Save and continue'
+    Then I should be on a page with title "Does your client receive student finance?"
+
+    When I choose "Yes"
+    And I enter amount '5000'
+    And I click 'Save and continue'
+    Then I should be on a page with title "Which payments does your client make?"
+
+    When I check "Housing payments"
+    And I click 'Save and continue'
+    Then I should be on a page with title "Select payments your client makes in cash"
+
+    When I select 'Housing payments'
+    But I select 'None of the above'
+    And I click 'Save and continue'
+    Then I should be on a page with title "Does your client have any dependants?"
+
+    When I choose "No"
+    And I click 'Save and continue'
+    Then I should be on a page with title "Does your client own the home that they live in?"
+
+    When I choose "No"
+    And I click 'Save and continue'
+    Then I should be on a page with title "Does your client own a vehicle?"
+
+    When I choose "No"
+    And I click 'Save and continue'
+    Then I should be on a page with title "Which savings or investments does your client have?"
+
+    When I select "Money not in a bank account"
+    And I fill "Cash" with "10000"
+    And I click 'Save and continue'
+    Then I should be on a page with title "Which assets does your client have?"
+
+    When I select 'None of these'
+    And I click 'Save and continue'
+    Then I should be on a page with title "Is your client prohibited from selling or borrowing against their assets?"
+
+    When I choose "No"
+    And I click 'Save and continue'
+    Then I should be on a page with title "Select if your client has received payments from these schemes or charities"
+
+    When I select 'England Infected Blood Support Scheme'
+    And I click 'Save and continue'
+    Then I should be on a page with title "Check your answers"

--- a/features/providers/bank_statement_upload.feature
+++ b/features/providers/bank_statement_upload.feature
@@ -119,3 +119,54 @@ Feature: Bank statement upload
     When I select 'England Infected Blood Support Scheme'
     And I click 'Save and continue'
     Then I should be on a page with title "Check your answers"
+
+  @javascript
+  Scenario: Checking answers for bank statement upload flow
+    Given the feature flag for enable_employed_journey is enabled
+    And I have completed a non-passported employed application with bank statement upload as far as the end of the means section
+    Then I should be on the 'means_summary' page showing 'Check your answers'
+
+    When I click Check Your Answers Change link for 'bank statements'
+    And I upload an evidence file named 'hello_world.pdf'
+    And I click 'Save and continue'
+    Then I should be on the 'means_summary' page showing 'Check your answers'
+    And I should see 'hello_world.pdf'
+#
+#    When I click Check Your Answers Change link for 'employment'
+#    Then I should be on a page showing 'This information has been provided by HMRC'
+#    When I select 'No'
+#    And I click 'Save and continue'
+#    Then I should be on the 'means_summary' page showing 'Check your answers'
+#    And the answer for 'employment notes' should be 'No'
+
+    When I click Check Your Answers Change link for 'income'
+    And I check 'Benefits'
+    And I click 'Save and continue'
+    Then I should be on a page with title 'Select payments your client receives in cash'
+    When I check 'None of the above'
+    And I click 'Save and continue'
+    Then I should be on the 'means_summary' page showing 'Check your answers'
+
+    When I click Check Your Answers Change link for 'income'
+    And I check 'My client receives none of these payments'
+    And I click 'Save and continue'
+    Then I should be on the 'means_summary' page showing 'Check your answers'
+
+    When I click Check Your Answers Change link for 'outgoings'
+    And I check 'Maintenance payments to a former partner'
+    And I click 'Save and continue'
+    Then I should be on a page with title 'Select payments your client makes in cash'
+    When I check 'None of the above'
+    And I click 'Save and continue'
+    Then I should be on the 'means_summary' page showing 'Check your answers'
+
+    When I click Check Your Answers Change link for 'outgoings'
+    And I check 'My client makes none of these payments'
+    And I click 'Save and continue'
+    Then I should be on the 'means_summary' page showing 'Check your answers'
+
+
+
+
+
+

--- a/features/providers/bank_statement_upload.feature
+++ b/features/providers/bank_statement_upload.feature
@@ -108,7 +108,7 @@ Feature: Bank statement upload
     And I click 'Save and continue'
     Then I should be on a page with title "Which assets does your client have?"
 
-    When I select 'None of these'
+    When I select 'My client has none of these assets'
     And I click 'Save and continue'
     Then I should be on a page with title "Is your client prohibited from selling or borrowing against their assets?"
 

--- a/features/providers/categorizing_bank_transactions.feature
+++ b/features/providers/categorizing_bank_transactions.feature
@@ -9,7 +9,7 @@ Feature: Completing and checking means answers backwards and forwards
     Then I should be on a page showing "Your client's income"
     Then I choose "No"
     Then I click 'Save and continue'
-    And I should be on a page showing 'Which types of income does your client receive?'
+    And I should be on a page showing 'Which payments does your client receive?'
     And I should see 'Benefits'
     And I should see 'Financial help from friends or family'
     And I should see 'Maintenance payments'

--- a/features/providers/civil_application_journey.feature
+++ b/features/providers/civil_application_journey.feature
@@ -491,7 +491,7 @@ Feature: Civil application journeys
     Then I should be on a page showing "Your client's income"
     Then I choose "No"
     Then I click 'Save and continue'
-    Then I should be on the 'identify_types_of_income' page showing "Which types of income does your client receive?"
+    Then I should be on the 'identify_types_of_income' page showing "Which payments does your client receive?"
     Then I select 'Benefits'
     And I click 'Save and continue'
     Then I should be on the 'income_summary' page showing "Sort your client's income into categories"
@@ -550,7 +550,7 @@ Feature: Civil application journeys
     Then I should be on a page showing "Your client's income"
     Then I choose "No"
     Then I click 'Save and continue'
-    Then I should be on the 'identify_types_of_income' page showing "Which types of income does your client receive?"
+    Then I should be on the 'identify_types_of_income' page showing "Which payments does your client receive?"
     Then I select 'Benefits'
     And I click 'Save and continue'
     Then I should be on the 'income_summary' page showing "Sort your client's income into categories"

--- a/features/providers/complete_and_check_means_answers.feature
+++ b/features/providers/complete_and_check_means_answers.feature
@@ -14,7 +14,7 @@ Feature: Completing and checking means answers backwards and forwards
     Then I should be on a page showing "Your client's outgoings"
     Then I choose "No"
     Then I click 'Save and continue'
-    Then I should be on a page showing "Which regular payments does your client make?"
+    Then I should be on a page showing "Which payments does your client make?"
     Then I select 'Housing payments'
     Then I select 'Payments towards legal aid in a criminal case'
     Then I click 'Save and continue'
@@ -66,7 +66,7 @@ Feature: Completing and checking means answers backwards and forwards
     Then I click Check Your Answers Change link for 'Outgoings'
     Then I should be on a page showing "Sort your client's regular payments into categories"
     Then I click link 'Add another type of regular payment'
-    Then I should be on a page showing 'Which regular payments does your client make?'
+    Then I should be on a page showing 'Which payments does your client make?'
     Then I select 'Payments towards legal aid in a criminal case'
     Then I click 'Save and continue'
     Then I should be on a page showing "Sort your client's regular payments into categories"

--- a/features/providers/non_passported_journey.feature
+++ b/features/providers/non_passported_journey.feature
@@ -42,7 +42,7 @@ Feature: Non-passported applicant journeys
     Then I should be on a page showing "Your client's income"
     Then I choose "No"
     Then I click 'Save and continue'
-    Then I should be on the 'identify_types_of_income' page showing "Which types of income does your client receive?"
+    Then I should be on the 'identify_types_of_income' page showing "Which payments does your client receive?"
     Then I select 'Benefits'
     And I click 'Save and continue'
     Then I should be on the 'income_summary' page showing "Sort your client's income into categories"
@@ -56,7 +56,7 @@ Feature: Non-passported applicant journeys
     Then I should be on a page showing "Your client's outgoings"
     Then I choose "No"
     Then I click 'Save and continue'
-    Then I should be on the 'identify_types_of_outgoing' page showing "Which regular payments does your client make?"
+    Then I should be on the 'identify_types_of_outgoing' page showing "Which payments does your client make?"
     Then I select 'Housing payments'
     And I click 'Save and continue'
     Then I should be on the 'outgoings_summary' page showing "Sort your client's regular payments into categories"
@@ -313,7 +313,7 @@ Feature: Non-passported applicant journeys
     Then I should be on a page showing "Student finance"
     Then I choose "No"
     And I click 'Save and continue'
-    Then I should be on the 'identify_types_of_income' page showing "Which types of income does your client receive?"
+    Then I should be on the 'identify_types_of_income' page showing "Which payments does your client receive?"
     Then I select 'Benefits'
     And I click 'Save and continue'
     Then I should be on the 'income_summary' page showing "Sort your client's income into categories"

--- a/features/step_definitions/bank_statement_uploaded_steps.rb
+++ b/features/step_definitions/bank_statement_uploaded_steps.rb
@@ -17,3 +17,26 @@ Given("I have completed a non-passported application and reached the open bankin
 
   visit(providers_legal_aid_application_open_banking_consents_path(@legal_aid_application))
 end
+
+Given("I have completed a non-passported employed application with bank statement upload as far as the end of the means section") do
+  @legal_aid_application = create(
+    :application,
+    :with_employed_applicant,
+    :with_single_employment,
+    :with_non_passported_state_machine,
+    :checking_non_passported_means,
+    :with_proceedings,
+    explicit_proceedings: %i[se014 da001],
+    transaction_period_finish_on: "2022-07-08",
+  )
+
+  create :attachment, :bank_statement, legal_aid_application: @legal_aid_application
+
+  permission = Permission.find_by(role: "application.non_passported.bank_statement_upload.*")
+  @legal_aid_application.provider.permissions << permission
+  @legal_aid_application.provider.save!
+
+  login_as @legal_aid_application.provider
+
+  visit(providers_legal_aid_application_means_summary_path(@legal_aid_application))
+end

--- a/features/step_definitions/bank_statement_uploaded_steps.rb
+++ b/features/step_definitions/bank_statement_uploaded_steps.rb
@@ -4,7 +4,9 @@ Given("I have completed a non-passported application and reached the open bankin
     :with_applicant,
     :with_non_passported_state_machine,
     :provider_confirming_applicant_eligibility,
-    :with_proceedings, explicit_proceedings: %i[se014 da001]
+    :with_proceedings,
+    explicit_proceedings: %i[se014 da001],
+    transaction_period_finish_on: "2022-07-08",
   )
 
   permission = Permission.find_by(role: "application.non_passported.bank_statement_upload.*")

--- a/spec/concerns/non_passported_state_machine_spec.rb
+++ b/spec/concerns/non_passported_state_machine_spec.rb
@@ -1,11 +1,41 @@
 require "rails_helper"
 
 RSpec.describe NonPassportedStateMachine do
-  describe "provider_enter_means!" do
+  describe "#applicant_enter_means!" do
+    subject(:event) { legal_aid_application.applicant_enter_means! }
+
+    let(:legal_aid_application) { create(:legal_aid_application, :use_ccms_offline_accounts) }
+
+    it "sets state to provider_entering_means" do
+      expect { event }.to change(legal_aid_application, :state).from("use_ccms").to("applicant_entering_means")
+    end
+
     it "sets the ccms_reason to nil" do
-      legal_aid_application = create :legal_aid_application, :use_ccms_offline_accounts
-      legal_aid_application.applicant_enter_means!
-      expect(legal_aid_application.ccms_reason).to be_nil
+      expect { event }.to change(legal_aid_application, :ccms_reason).from("offline_accounts").to(nil)
+    end
+  end
+
+  describe "#provider_assess_means!" do
+    subject(:event) { legal_aid_application.provider_assess_means! }
+
+    context "when from state provider_confirming_applicant_eligibility" do
+      let(:legal_aid_application) { create(:legal_aid_application, :provider_confirming_applicant_eligibility) }
+
+      it "sets state to provider_assessing_means" do
+        expect { event }.to change(legal_aid_application, :state)
+                              .from("provider_confirming_applicant_eligibility")
+                              .to("provider_assessing_means")
+      end
+    end
+
+    context "when from state checking_non_passported_means" do
+      let(:legal_aid_application) { create(:legal_aid_application, :checking_non_passported_means) }
+
+      it "sets state to provider_assessing_means" do
+        expect { event }.to change(legal_aid_application, :state)
+                              .from("checking_non_passported_means")
+                              .to("provider_assessing_means")
+      end
     end
   end
 end

--- a/spec/factories/legal_aid_applications.rb
+++ b/spec/factories/legal_aid_applications.rb
@@ -130,6 +130,7 @@ FactoryBot.define do
 
     trait :checking_non_passported_means do
       before(:create) do |application|
+        application.change_state_machine_type("NonPassportedStateMachine")
         application.state_machine_proxy.update!(aasm_state: :checking_non_passported_means)
       end
     end
@@ -166,6 +167,7 @@ FactoryBot.define do
 
     trait :provider_confirming_applicant_eligibility do
       before(:create) do |application|
+        application.change_state_machine_type("NonPassportedStateMachine")
         application.state_machine_proxy.update!(aasm_state: :provider_confirming_applicant_eligibility)
       end
     end

--- a/spec/models/legal_aid_application_spec.rb
+++ b/spec/models/legal_aid_application_spec.rb
@@ -1481,6 +1481,47 @@ RSpec.describe LegalAidApplication, type: :model do
         end
       end
     end
+
+    describe "#uploading_bank_statements?" do
+      let(:laa) { create :legal_aid_application, provider:, provider_received_citizen_consent: consent }
+
+      context "when provider does not have bank statement role" do
+        let(:provider) { create :provider }
+        let(:consent) { nil }
+
+        it "returns false" do
+          expect(laa.uploading_bank_statements?).to be false
+        end
+      end
+
+      context "when provider has bank statement upload role" do
+        let(:provider) { create :provider, :with_bank_statement_upload_permissions }
+
+        context "when client permission to use true layer received" do
+          let(:consent) { true }
+
+          it "returns false" do
+            expect(laa.uploading_bank_statements?).to be false
+          end
+        end
+
+        context "when client permission to use true layer not received" do
+          let(:consent) { false }
+
+          it "returns true" do
+            expect(laa.uploading_bank_statements?).to be true
+          end
+        end
+
+        context "when client permission to use true layer not specified" do
+          let(:consent) { nil }
+
+          it "returns true" do
+            expect(laa.uploading_bank_statements?).to be true
+          end
+        end
+      end
+    end
   end
 
 private

--- a/spec/requests/providers/identify_types_of_outgoings_spec.rb
+++ b/spec/requests/providers/identify_types_of_outgoings_spec.rb
@@ -9,7 +9,9 @@ RSpec.describe Providers::IdentifyTypesOfOutgoingsController do
   before { login }
 
   describe "GET /providers/identify_types_of_outgoing" do
-    before { get providers_legal_aid_application_identify_types_of_outgoing_path(legal_aid_application) }
+    subject(:request) { get providers_legal_aid_application_identify_types_of_outgoing_path(legal_aid_application) }
+
+    before { request }
 
     it "returns http success" do
       expect(response).to have_http_status(:ok)
@@ -34,7 +36,7 @@ RSpec.describe Providers::IdentifyTypesOfOutgoingsController do
   end
 
   describe "PATCH /providers/identify_types_of_outgoing" do
-    subject do
+    subject(:request) do
       patch(
         providers_legal_aid_application_identify_types_of_outgoing_path(legal_aid_application),
         params: params.merge(submit_button),
@@ -52,18 +54,18 @@ RSpec.describe Providers::IdentifyTypesOfOutgoingsController do
     end
 
     it "does not add transaction types to the application" do
-      expect { subject }.not_to change(LegalAidApplicationTransactionType, :count)
+      expect { request }.not_to change(LegalAidApplicationTransactionType, :count)
     end
 
     it "displays an error" do
-      subject
+      request
       expect(response.body).to match("govuk-error-summary")
       expect(unescaped_response_body).to match(I18n.t("providers.identify_types_of_outgoings.update.none_selected"))
       expect(unescaped_response_body).not_to include("translation missing")
     end
 
     it "returns http success" do
-      subject
+      request
       expect(response).to have_http_status(:ok)
     end
 
@@ -71,16 +73,34 @@ RSpec.describe Providers::IdentifyTypesOfOutgoingsController do
       let(:transaction_type_ids) { outgoing_types.map(&:id) }
 
       it "adds transaction types to the application" do
-        expect { subject }.to change(LegalAidApplicationTransactionType, :count).by(outgoing_types.length)
+        expect { request }.to change(LegalAidApplicationTransactionType, :count).by(outgoing_types.length)
         expect(legal_aid_application.reload.transaction_types).to match_array(outgoing_types)
       end
 
-      it "redirects to the next step" do
-        expect(subject).to redirect_to(flow_forward_path)
+      it "sets no_debit_transaction_types_selected to false" do
+        expect { request }.to change { legal_aid_application.reload.no_debit_transaction_types_selected }.to(false)
       end
 
-      it "sets no_debit_transaction_types_selected to false" do
-        expect { subject }.to change { legal_aid_application.reload.no_debit_transaction_types_selected }.to(false)
+      context "when provider does not have bank_statement_upload permissions" do
+        before do
+          legal_aid_application.provider.permissions.find_by(role: "application.non_passported.bank_statement_upload.*")&.destroy
+        end
+
+        it "redirects to the outgoings summary page" do
+          request
+          expect(response).to redirect_to(providers_legal_aid_application_outgoings_summary_index_path(legal_aid_application))
+        end
+      end
+
+      context "when provider does have bank_statement_upload permissions" do
+        before do
+          legal_aid_application.provider.permissions << Permission.find_or_create_by(role: "application.non_passported.bank_statement_upload.*")
+        end
+
+        it "redirects to the means cash outgoings page" do
+          request
+          expect(response).to redirect_to(providers_legal_aid_application_means_cash_outgoing_path(legal_aid_application))
+        end
       end
 
       context "Form submitted with Save as draft button" do
@@ -88,7 +108,7 @@ RSpec.describe Providers::IdentifyTypesOfOutgoingsController do
         let(:submit_button) { { draft_button: "Save as draft" } }
 
         it "redirects to the list of applications" do
-          subject
+          request
           expect(response).to redirect_to providers_legal_aid_applications_path
         end
       end
@@ -99,11 +119,11 @@ RSpec.describe Providers::IdentifyTypesOfOutgoingsController do
       let(:legal_aid_application) { create :legal_aid_application, :with_applicant, :with_non_passported_state_machine, transaction_types: [other_transaction_type] }
 
       it "does not remove existing transation of other type" do
-        expect { subject }.not_to change { legal_aid_application.transaction_types.count }
+        expect { request }.not_to change { legal_aid_application.transaction_types.count }
       end
 
       it "does not delete transaction types" do
-        expect { subject }.not_to change(TransactionType, :count)
+        expect { request }.not_to change(TransactionType, :count)
       end
     end
 
@@ -111,29 +131,43 @@ RSpec.describe Providers::IdentifyTypesOfOutgoingsController do
       let(:params) { { legal_aid_application: { none_selected: "true" } } }
 
       it "does not add transaction types to the application" do
-        expect { subject }.not_to change(LegalAidApplicationTransactionType, :count)
-      end
-
-      it "redirects to the next step" do
-        expect(subject).to redirect_to(flow_forward_path)
+        expect { request }.not_to change(LegalAidApplicationTransactionType, :count)
       end
 
       it "sets no_debit_transaction_types_selected to true" do
-        expect { subject }.to change { legal_aid_application.reload.no_debit_transaction_types_selected }.to(true)
+        expect { request }.to change { legal_aid_application.reload.no_debit_transaction_types_selected }.to(true)
       end
 
-      context "and application has transactions" do
+      context "when application has transactions" do
         let(:legal_aid_application) do
           create :legal_aid_application, :with_applicant, :with_non_passported_state_machine, transaction_types: outgoing_types
         end
 
         it "removes transaction types from the application" do
-          expect { subject }.to change(LegalAidApplicationTransactionType, :count)
+          expect { request }.to change(LegalAidApplicationTransactionType, :count)
             .by(-outgoing_types.length)
         end
+      end
 
-        it "redirects to the next step" do
-          expect(subject).to redirect_to(flow_forward_path)
+      context "when provider does not have bank_statement_upload permissions" do
+        before do
+          legal_aid_application.provider.permissions.find_by(role: "application.non_passported.bank_statement_upload.*")&.destroy
+        end
+
+        it "redirects to the outgoings summary page" do
+          request
+          expect(response).to redirect_to(providers_legal_aid_application_outgoings_summary_index_path(legal_aid_application))
+        end
+      end
+
+      context "when provider does have bank_statement_upload permissions" do
+        before do
+          legal_aid_application.provider.permissions << Permission.find_or_create_by(role: "application.non_passported.bank_statement_upload.*")
+        end
+
+        it "redirects to the means has dependants page" do
+          request
+          expect(response).to redirect_to(providers_legal_aid_application_means_has_dependants_path(legal_aid_application))
         end
       end
     end
@@ -143,12 +177,12 @@ RSpec.describe Providers::IdentifyTypesOfOutgoingsController do
       let(:transaction_type_ids) { income_types.map(&:id) }
 
       it "does not add the transaction types" do
-        expect { subject }.not_to change { legal_aid_application.transaction_types.count }
+        expect { request }.not_to change { legal_aid_application.transaction_types.count }
       end
     end
 
     context "when the provider is not authenticated" do
-      before { subject }
+      before { request }
 
       let(:login) { nil }
 

--- a/spec/requests/providers/means/cash_incomes_controller_spec.rb
+++ b/spec/requests/providers/means/cash_incomes_controller_spec.rb
@@ -1,130 +1,128 @@
 require "rails_helper"
 
-RSpec.describe Providers::Means::CashIncomesController, type: :request do
+RSpec.describe "Providers::Means::CashIncomesController", type: :request do
+  before do
+    create(:transaction_type, :benefits)
+    legal_aid_application.set_transaction_period
+  end
+
   let(:legal_aid_application) { create :legal_aid_application, :with_applicant, :with_passported_state_machine, :provider_entering_means }
-
-  # TODO: reinstate the two let! commands below once the PATCH test has been reisinstated
-  # let!(:benefits) { create :transaction_type, :benefits }
-  # let!(:maintenance_in) { create :transaction_type, :maintenance_in }
-
   let(:next_flow_step) { flow_forward_path }
   let(:provider) { legal_aid_application.provider }
 
-  before { legal_aid_application.set_transaction_period }
+  let(:nothing_selected) do
+    {
+      aggregated_cash_income: {
+        check_box_benefits: "",
+        none_selected: "true",
+      },
+    }
+  end
+
+  let(:valid_params) do
+    {
+      aggregated_cash_income: {
+        check_box_benefits: "true",
+        benefits1: "1",
+        benefits2: "2",
+        benefits3: "3",
+        none_selected: "",
+      },
+    }
+  end
+
+  let(:invalid_params) do
+    {
+      aggregated_cash_income: {
+        check_box_benefits: "true",
+        benefits1: "1.11111",
+        benefits2: "$",
+        benefits3: "-1",
+        check_box_maintenance_in: "true",
+        maintenance_in1: "",
+        maintenance_in2: "",
+        maintenance_in3: "",
+      },
+    }
+  end
 
   describe "GET /providers/applications/:legal_aid_application_id/means/cash_income" do
-    before do
-      login_as provider
-      get providers_legal_aid_application_means_cash_income_path(legal_aid_application)
-    end
+    subject(:request) { get providers_legal_aid_application_means_cash_income_path(legal_aid_application) }
+
+    before { login_as provider }
 
     it "shows the page" do
+      request
       expect(response.body).to include(I18n.t("providers.means.cash_incomes.show.page_heading"))
     end
   end
 
-  # TODO: reinstate these tests once the flow has been set up properly(ticket AP-3264)
-  xdescribe "PATCH /providers/applications/:legal_aid_application_id/means/cash_income" do
-    before do
-      login_as provider
-      patch providers_legal_aid_application_means_cash_income_path(legal_aid_application), params:
-    end
+  describe "PATCH /providers/applications/:legal_aid_application_id/means/cash_income" do
+    subject(:request) { patch providers_legal_aid_application_means_cash_income_path(legal_aid_application), params: }
 
-    context "with valid update" do
-      context "and valid params" do
-        let(:params) { valid_params }
+    before { login_as provider }
 
-        it "redirects to new action" do
-          expect(response).to redirect_to(next_flow_step)
-        end
+    context "with valid params" do
+      let(:params) { valid_params }
 
-        it "updates the model attribute for no cash income to false" do
-          expect(legal_aid_application.reload.no_cash_income).to be(false)
-        end
+      it "redirects to student_finances" do
+        request
+        expect(response).to redirect_to(providers_legal_aid_application_means_student_finance_path(legal_aid_application))
       end
 
-      context "with none of the above" do
-        let(:params) { nothing_selected }
-
-        it "redirects to new action" do
-          expect(response).to redirect_to(next_flow_step)
-        end
-
-        it "updates the model attribute for no cash income to true" do
-          expect(legal_aid_application.reload.no_cash_income).to be(true)
-        end
+      it "updates the model attribute for no cash income to false" do
+        expect { request }.to change { legal_aid_application.reload.no_cash_income }.from(nil).to(false)
       end
     end
 
-    context "with invalid update" do
-      context "with invalid params" do
-        let(:params) { invalid_params }
+    context "with nothing selected" do
+      let(:params) { nothing_selected }
 
-        it "returns http success" do
-          expect(response).to have_http_status(:ok)
-        end
-
-        it "shows an error for no amount entered" do
-          expect(response.body).to include(I18n.t("errors.aggregated_cash_income.blank", category: "in maintenance",
-                                                                                         month: (Time.zone.today - 1.month).strftime("%B")))
-        end
-
-        it "shows an error for an invalid amount" do
-          expect(response.body).to include(I18n.t("errors.aggregated_cash_income.invalid_type"))
-        end
-
-        it "shows an error for a negtive amount" do
-          expect(response.body).to include(I18n.t("errors.aggregated_cash_income.negative"))
-        end
-
-        it "shows an error for an amount with too many decimals" do
-          expect(response.body).to include(I18n.t("errors.aggregated_cash_income.too_many_decimals"))
-        end
+      it "redirects to student_finances" do
+        request
+        expect(response).to redirect_to(providers_legal_aid_application_means_student_finance_path(legal_aid_application))
       end
 
-      context "with no params" do
-        let(:params) { { aggregated_cash_income: { check_box_benefits: "" } } }
-
-        it "shows an error if nothing selected" do
-          expect(response.body).to include(I18n.t("activemodel.errors.models.aggregated_cash_income.credits.attributes.cash_income.blank"))
-        end
+      it "updates the model attribute for no cash income to true" do
+        expect { request }.to change { legal_aid_application.reload.no_cash_income }.from(nil).to(true)
       end
     end
 
-    def nothing_selected
-      {
-        aggregated_cash_income: {
-          check_box_benefits: "",
-          none_selected: "true",
-        },
-      }
+    context "with invalid params" do
+      let(:params) { invalid_params }
+
+      before { request }
+
+      it "returns http success" do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "shows an error for no amount entered" do
+        expect(response.body).to include(I18n.t("errors.aggregated_cash_income.blank", category: "in maintenance",
+                                                                                       month: (Time.zone.today - 1.month).strftime("%B")))
+      end
+
+      it "shows an error for an invalid amount" do
+        expect(response.body).to include(I18n.t("errors.aggregated_cash_income.invalid_type"))
+      end
+
+      it "shows an error for a negtive amount" do
+        expect(response.body).to include(I18n.t("errors.aggregated_cash_income.negative"))
+      end
+
+      it "shows an error for an amount with too many decimals" do
+        expect(response.body).to include(I18n.t("errors.aggregated_cash_income.too_many_decimals"))
+      end
     end
 
-    def valid_params
-      {
-        aggregated_cash_income: {
-          check_box_benefits: "true",
-          benefits1: "1",
-          benefits2: "2",
-          benefits3: "3",
-          none_selected: "",
-        },
-      }
-    end
+    context "with no params" do
+      let(:params) { { aggregated_cash_income: { check_box_benefits: "" } } }
 
-    def invalid_params
-      {
-        aggregated_cash_income: {
-          check_box_benefits: "true",
-          benefits1: "1.11111",
-          benefits2: "$",
-          benefits3: "-1",
-          check_box_maintenance_in: "true",
-          maintenance_in1: "",
-          maintenance_in2: "",
-          maintenance_in3: "",
-        },
-      }
+      before { request }
+
+      it "shows an error if nothing selected" do
+        expect(response.body).to include(I18n.t("activemodel.errors.models.aggregated_cash_income.credits.attributes.cash_income.blank"))
+      end
     end
   end
 end

--- a/spec/requests/providers/means/cash_outgoings_spec.rb
+++ b/spec/requests/providers/means/cash_outgoings_spec.rb
@@ -1,130 +1,126 @@
 require "rails_helper"
 
 RSpec.describe "Providers::Means::CashOutgoingsController", type: :request do
-  let(:legal_aid_application) { create :legal_aid_application, :with_applicant, :with_non_passported_state_machine, :applicant_entering_means }
+  before do
+    create(:transaction_type, :child_care)
+    legal_aid_application.set_transaction_period
+  end
 
-  # TODO: remove nocov in controller and re-enable disabled tests and let statements below
-  #  once the flow ticket (AP-3264) is complete
-  # let!(:child_care) { create :transaction_type, :child_care }
-  # let!(:maintenance_out) { create :transaction_type, :maintenance_out }
-  let(:next_flow_step) { flow_forward_path }
+  let(:legal_aid_application) { create :legal_aid_application, :with_applicant, :with_non_passported_state_machine, :applicant_entering_means }
   let(:provider) { legal_aid_application.provider }
 
-  before { legal_aid_application.set_transaction_period }
+  let(:valid_params) do
+    {
+      aggregated_cash_outgoings: {
+        check_box_child_care: "true",
+        child_care1: "1",
+        child_care2: "2",
+        child_care3: "3",
+        none_selected: "",
+      },
+    }
+  end
+
+  let(:nothing_selected_params) do
+    {
+      aggregated_cash_outgoings: {
+        check_box_child_care: "",
+        none_selected: "true",
+      },
+    }
+  end
+
+  let(:invalid_params) do
+    {
+      aggregated_cash_outgoings: {
+        check_box_child_care: "true",
+        child_care1: "1.11111",
+        child_care2: "$",
+        child_care3: "-1",
+        check_box_maintenance_out: "true",
+        maintenance_out1: "",
+        maintenance_out2: "",
+        maintenance_out3: "",
+      },
+    }
+  end
 
   describe "GET /providers/applications/:legal_aid_application_id/means/cash_outgoings" do
-    before do
-      login_as provider
-      get providers_legal_aid_application_means_cash_outgoing_path(legal_aid_application)
-    end
+    subject(:request) { get providers_legal_aid_application_means_cash_outgoing_path(legal_aid_application) }
 
-    it "shows the page" do
-      expect(response.body).to include(I18n.t("providers.means.cash_outgoings.show.page_heading"))
+    before { login_as provider }
+
+    it "render applicable page title" do
+      request
+      expect(response.body).to include("Select payments your client makes in cash")
     end
   end
 
-  # TODO: reinstate tests once flow ticket complete (ticket AP-3264)
-  xdescribe "PATCH providers/applications/:legal_aid_application_id/means/cash_outgoing" do
-    before do
-      login_as provider
-      get providers_legal_aid_application_means_cash_outgoing_path(legal_aid_application), params:
-    end
+  describe "PATCH providers/applications/:legal_aid_application_id/means/cash_outgoing" do
+    subject(:request) { patch providers_legal_aid_application_means_cash_outgoing_path(legal_aid_application), params: }
 
-    context "with valid update" do
-      context "with valid params" do
-        let(:params) { valid_params }
+    before { login_as provider }
 
-        it "redirects to new action" do
-          expect(response).to redirect_to(next_flow_step)
-        end
+    context "with valid params" do
+      let(:params) { valid_params }
 
-        it "updates the model attribute for no cash outgoings to false" do
-          expect(legal_aid_application.reload.no_cash_outgoings).to be(false)
-        end
+      it "redirects to has_dependants" do
+        request
+        expect(response).to redirect_to(providers_legal_aid_application_means_has_dependants_path(legal_aid_application))
       end
 
-      context "with none of the above" do
-        let(:params) { nothing_selected }
-
-        it "redirects to new action" do
-          expect(response).to redirect_to(next_flow_step)
-        end
-
-        it "updates the model attribute for no cash outgoings to true" do
-          expect(legal_aid_application.reload.no_cash_outgoings).to be(true)
-        end
+      it "updates the model attribute for no cash outgoings to false" do
+        expect { request }.to change { legal_aid_application.reload.no_cash_outgoings }.from(nil).to(false)
       end
     end
 
-    context "with invalid update" do
-      context "with invalid params" do
-        let(:params) { invalid_params }
+    context "with nothing selected of the above" do
+      let(:params) { nothing_selected_params }
 
-        it "returns http success" do
-          expect(response).to have_http_status(:ok)
-        end
-
-        it "shows an error for no amount entered" do
-          expected_month = (Time.zone.today - 1.month).strftime("%B")
-          expect(response.body).to include(I18n.t("errors.aggregated_cash_outgoings.blank", category: "in maintenance", month: expected_month))
-        end
-
-        it "shows an error for an invalid amount" do
-          expect(response.body).to include(I18n.t("errors.aggregated_cash_outgoings.invalid_type"))
-        end
-
-        it "shows an error for a negtive amount" do
-          expect(response.body).to include(I18n.t("errors.aggregated_cash_outgoings.negative"))
-        end
-
-        it "shows an error for an amount with too many decimals" do
-          expect(response.body).to include(I18n.t("errors.aggregated_cash_outgoings.too_many_decimals"))
-        end
+      it "redirects to has_dependants" do
+        request
+        expect(response).to redirect_to(providers_legal_aid_application_means_has_dependants_path(legal_aid_application))
       end
 
-      context "with no params" do
-        let(:params) { { aggregated_cash_outgoings: { check_box_child_care: "" } } }
-
-        it "shows an error if nothing selected" do
-          expect(response.body).to include(I18n.t("activemodel.errors.models.aggregated_cash_outgoings.debits.attributes.cash_outgoings.blank"))
-        end
+      it "updates the model attribute for no cash outgoings to true" do
+        expect { request }.to change { legal_aid_application.reload.no_cash_outgoings }.from(nil).to(true)
       end
     end
 
-    def nothing_selected
-      {
-        aggregated_cash_outgoings: {
-          check_box_child_care: "",
-          none_selected: "true",
-        },
-      }
+    context "with invalid params" do
+      let(:params) { invalid_params }
+
+      before { request }
+
+      it "returns http success" do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "shows an error for no amount entered" do
+        expected_month = (Time.zone.today - 1.month).strftime("%B")
+        expect(response.body).to include(I18n.t("errors.aggregated_cash_outgoings.blank", category: "in maintenance", month: expected_month))
+      end
+
+      it "shows an error for an invalid amount" do
+        expect(response.body).to include(I18n.t("errors.aggregated_cash_outgoings.invalid_type"))
+      end
+
+      it "shows an error for a negtive amount" do
+        expect(response.body).to include(I18n.t("errors.aggregated_cash_outgoings.negative"))
+      end
+
+      it "shows an error for an amount with too many decimals" do
+        expect(response.body).to include(I18n.t("errors.aggregated_cash_outgoings.too_many_decimals"))
+      end
     end
 
-    def valid_params
-      {
-        aggregated_cash_outgoings: {
-          check_box_child_care: "true",
-          child_care1: "1",
-          child_care2: "2",
-          child_care3: "3",
-          none_selected: "",
-        },
-      }
-    end
+    context "with no params" do
+      let(:params) { { aggregated_cash_outgoings: { check_box_child_care: "" } } }
 
-    def invalid_params
-      {
-        aggregated_cash_outgoings: {
-          check_box_child_care: "true",
-          child_care1: "1.11111",
-          child_care2: "$",
-          child_care3: "-1",
-          check_box_maintenance_out: "true",
-          maintenance_out1: "",
-          maintenance_out2: "",
-          maintenance_out3: "",
-        },
-      }
+      it "shows an error if nothing selected" do
+        request
+        expect(response.body).to include(I18n.t("activemodel.errors.models.aggregated_cash_outgoings.debits.attributes.cash_outgoings.blank"))
+      end
     end
   end
 end

--- a/spec/requests/providers/means/has_other_dependants_controller_spec.rb
+++ b/spec/requests/providers/means/has_other_dependants_controller_spec.rb
@@ -4,21 +4,19 @@ RSpec.describe Providers::Means::HasOtherDependantsController, type: :request do
   let(:legal_aid_application) { create :legal_aid_application, :with_applicant }
   let(:provider) { legal_aid_application.provider }
 
-  before do
-    login_as provider
-    subject
-  end
+  before { login_as provider }
 
   describe "GET /providers/:application_id/means/has_other_dependants" do
-    subject { get providers_legal_aid_application_means_has_other_dependants_path(legal_aid_application) }
+    subject(:request) { get providers_legal_aid_application_means_has_other_dependants_path(legal_aid_application) }
 
     it "returns http success" do
+      request
       expect(response).to have_http_status(:ok)
     end
   end
 
   describe "PATCH /providers/:application_id/means/has_other_dependants" do
-    subject { patch providers_legal_aid_application_means_has_other_dependants_path(legal_aid_application), params: }
+    subject(:request) { patch providers_legal_aid_application_means_has_other_dependants_path(legal_aid_application), params: }
 
     let(:params) do
       {
@@ -28,52 +26,97 @@ RSpec.describe Providers::Means::HasOtherDependantsController, type: :request do
       }
     end
 
-    context "choose yes" do
+    context "when provider chooses yes" do
       let(:has_other_dependant) { "true" }
 
       it "redirects to the page to add another dependant" do
+        request
         expect(response).to redirect_to(new_providers_legal_aid_application_means_dependant_path(legal_aid_application))
       end
     end
 
-    context "choose no" do
+    context "when providers chooses no" do
       let(:has_other_dependant) { "false" }
 
       it "redirects to the outgoings summary page" do
+        request
         expect(response).to redirect_to(providers_legal_aid_application_no_outgoings_summary_path(legal_aid_application))
+      end
+
+      context "when provider does not have bank_statement_upload permissions" do
+        before do
+          legal_aid_application.provider.permissions.find_by(role: "application.non_passported.bank_statement_upload.*")&.destroy
+        end
+
+        context "with transaction type debits on application" do
+          before do
+            legal_aid_application.transaction_types << create(:transaction_type, :debit)
+          end
+
+          it "redirects to the outgoings summary index page" do
+            request
+            expect(response).to redirect_to(providers_legal_aid_application_outgoings_summary_index_path(legal_aid_application))
+          end
+        end
+
+        context "without transaction type debits on application" do
+          before do
+            legal_aid_application.transaction_types.destroy_all
+          end
+
+          it "redirects to the no outgoings summary index page" do
+            request
+            expect(response).to redirect_to(providers_legal_aid_application_no_outgoings_summary_path(legal_aid_application))
+          end
+        end
+      end
+
+      context "when provider does have bank_statement_upload permissions" do
+        before do
+          legal_aid_application.provider.permissions << Permission.find_or_create_by(role: "application.non_passported.bank_statement_upload.*")
+        end
+
+        it "redirects to the means student finance page" do
+          request
+          expect(response).to redirect_to(providers_legal_aid_application_means_own_home_path(legal_aid_application))
+        end
       end
     end
 
-    context "choose something else" do
+    context "when provider chooses something else" do
       let(:has_other_dependant) { "not sure" }
 
       it "show errors" do
+        request
         expect(response.body).to include(I18n.t("providers.has_other_dependants.show.error"))
       end
     end
 
-    context "choose nothing" do
+    context "when provider chooses nothing" do
       let(:params) { nil }
 
       it "show errors" do
+        request
         expect(response.body).to include(I18n.t("providers.has_other_dependants.show.error"))
       end
     end
 
-    context "while provider checking answers of citizen and more dependants" do
+    context "when provider checking answers of citizen and more dependants" do
       let(:legal_aid_application) { create :legal_aid_application, :with_applicant, :with_non_passported_state_machine, :checking_non_passported_means }
       let(:has_other_dependant) { "true" }
 
       it "redirects to the page to add another dependant" do
+        request
         expect(response).to redirect_to(new_providers_legal_aid_application_means_dependant_path(legal_aid_application))
       end
     end
 
-    context "while provider checking answers of citizen and no more dependants" do
+    context "when provider checking answers of citizen and no more dependants" do
       let(:legal_aid_application) { create :legal_aid_application, :with_applicant, :with_non_passported_state_machine, :checking_non_passported_means }
       let(:has_other_dependant) { "false" }
 
       it "redirects to the means summary page" do
+        request
         expect(response).to redirect_to(providers_legal_aid_application_means_summary_path(legal_aid_application))
       end
     end

--- a/spec/requests/providers/means/identify_types_of_incomes_spec.rb
+++ b/spec/requests/providers/means/identify_types_of_incomes_spec.rb
@@ -13,15 +13,15 @@ RSpec.describe Providers::Means::IdentifyTypesOfIncomesController do
   end
 
   describe "GET /providers/applications/:legal_aid_application_id/means/identify_types_of_income" do
-    subject { get target_url }
+    subject(:request) { get target_url }
 
     it "returns http success" do
-      subject
+      request
       expect(response).to have_http_status(:ok)
     end
 
     it "displays the income type labels" do
-      subject
+      request
       non_child_income_types.map(&:providers_label_name).each do |label|
         expect(unescaped_response_body).to include(label)
       end
@@ -29,21 +29,21 @@ RSpec.describe Providers::Means::IdentifyTypesOfIncomesController do
     end
 
     it "does not display expanded details list" do
-      subject
+      request
       expect(unescaped_response_body).not_to match(I18n.t("shared.forms.types_of_income_form.expanded_explanation.heading"))
     end
 
     context "when the provider is not authenticated" do
       let(:login) { nil }
 
-      before { subject }
+      before { request }
 
       it_behaves_like "a provider not authenticated"
     end
   end
 
   describe "PATCH /providers/applications/:legal_aid_application_id/means/identify_types_of_income" do
-    subject { patch target_url, params: params.merge(submit_button) }
+    subject(:request) { patch target_url, params: params.merge(submit_button) }
 
     let(:transaction_type_ids) { [] }
     let(:params) do
@@ -56,18 +56,18 @@ RSpec.describe Providers::Means::IdentifyTypesOfIncomesController do
     let(:submit_button) { {} }
 
     it "does not add transaction types to the application" do
-      expect { subject }.not_to change(LegalAidApplicationTransactionType, :count)
+      expect { request }.not_to change(LegalAidApplicationTransactionType, :count)
     end
 
     it "displays an error" do
-      subject
+      request
       expect(response.body).to match("govuk-error-summary")
       expect(unescaped_response_body).to match(I18n.t("providers.identify_types_of_incomes.update.none_selected"))
       expect(unescaped_response_body).not_to include("translation missing")
     end
 
     it "returns http success" do
-      subject
+      request
       expect(response).to have_http_status(:ok)
     end
 
@@ -75,16 +75,34 @@ RSpec.describe Providers::Means::IdentifyTypesOfIncomesController do
       let(:transaction_type_ids) { income_types.map(&:id) }
 
       it "adds transaction types to the application" do
-        expect { subject }.to change(LegalAidApplicationTransactionType, :count).by(income_types.length)
+        expect { request }.to change(LegalAidApplicationTransactionType, :count).by(income_types.length)
         expect(legal_aid_application.reload.transaction_types).to match_array(income_types)
       end
 
-      it "redirects to the next step" do
-        expect(subject).to redirect_to(flow_forward_path)
+      it "sets no_credit_transaction_types_selected to false" do
+        expect { request }.to change { legal_aid_application.reload.no_credit_transaction_types_selected }.to(false)
       end
 
-      it "sets no_credit_transaction_types_selected to false" do
-        expect { subject }.to change { legal_aid_application.reload.no_credit_transaction_types_selected }.to(false)
+      context "when provider does not have bank_statement_upload permissions" do
+        before do
+          legal_aid_application.provider.permissions.find_by(role: "application.non_passported.bank_statement_upload.*")&.destroy
+        end
+
+        it "redirects to the income summary index page" do
+          request
+          expect(response).to redirect_to(providers_legal_aid_application_income_summary_index_path)
+        end
+      end
+
+      context "when provider does have bank_statement_upload permissions" do
+        before do
+          legal_aid_application.provider.permissions << Permission.find_or_create_by(role: "application.non_passported.bank_statement_upload.*")
+        end
+
+        it "redirects to the means cash incomes page" do
+          request
+          expect(response).to redirect_to(providers_legal_aid_application_means_cash_income_path(legal_aid_application))
+        end
       end
     end
 
@@ -95,41 +113,55 @@ RSpec.describe Providers::Means::IdentifyTypesOfIncomesController do
       end
 
       it "does not remove existing transation of other type" do
-        expect { subject }.not_to change { legal_aid_application.transaction_types.count }
+        expect { request }.not_to change { legal_aid_application.transaction_types.count }
       end
 
       it "does not delete transaction types" do
-        expect { subject }.not_to change(TransactionType, :count)
+        expect { request }.not_to change(TransactionType, :count)
       end
     end
 
     context 'when "none selected" has been selected' do
       let(:params) { { legal_aid_application: { none_selected: "true" } } }
 
-      it "does not add transaction types to the application" do
-        expect { subject }.not_to change(LegalAidApplicationTransactionType, :count)
-      end
-
-      it "redirects to the next step" do
-        expect(subject).to redirect_to(flow_forward_path)
-      end
-
       it "sets no_credit_transaction_types_selected to true" do
-        expect { subject }.to change { legal_aid_application.reload.no_credit_transaction_types_selected }.to(true)
+        expect { request }.to change { legal_aid_application.reload.no_credit_transaction_types_selected }.to(true)
       end
 
-      context "and application has transactions" do
+      it "does not add transaction types to the application" do
+        expect { request }.not_to change(LegalAidApplicationTransactionType, :count)
+      end
+
+      context "when application has transactions" do
         let(:legal_aid_application) do
           create :legal_aid_application, :with_applicant, :with_non_passported_state_machine, transaction_types: income_types
         end
 
         it "removes transaction types from the application" do
-          expect { subject }.to change(LegalAidApplicationTransactionType, :count)
+          expect { request }.to change(LegalAidApplicationTransactionType, :count)
             .by(-income_types.length)
         end
+      end
 
-        it "redirects to the next step" do
-          expect(subject).to redirect_to(flow_forward_path)
+      context "when provider does not have bank_statement_upload permissions" do
+        before do
+          legal_aid_application.provider.permissions.find_by(role: "application.non_passported.bank_statement_upload.*")&.destroy
+        end
+
+        it "redirects to the income summary index page" do
+          request
+          expect(response).to redirect_to(providers_legal_aid_application_income_summary_index_path(legal_aid_application))
+        end
+      end
+
+      context "when provider does have bank_statement_upload permissions" do
+        before do
+          legal_aid_application.provider.permissions << Permission.find_or_create_by(role: "application.non_passported.bank_statement_upload.*")
+        end
+
+        it "redirects to the means student finance page" do
+          request
+          expect(response).to redirect_to(providers_legal_aid_application_means_student_finance_path(legal_aid_application))
         end
       end
     end
@@ -139,7 +171,7 @@ RSpec.describe Providers::Means::IdentifyTypesOfIncomesController do
       let(:transaction_type_ids) { income_types.map(&:id) }
 
       it "does not add the transaction types" do
-        expect { subject }.not_to change { legal_aid_application.transaction_types.count }
+        expect { request }.not_to change { legal_aid_application.transaction_types.count }
       end
     end
 
@@ -147,7 +179,7 @@ RSpec.describe Providers::Means::IdentifyTypesOfIncomesController do
       let(:submit_button) { { draft_button: "Save as draft" } }
 
       it "redirects to the list of applications" do
-        subject
+        request
         expect(response).to redirect_to providers_legal_aid_applications_path
       end
     end

--- a/spec/requests/providers/means/student_finance_spec.rb
+++ b/spec/requests/providers/means/student_finance_spec.rb
@@ -5,17 +5,109 @@ RSpec.describe "student_finance", type: :request do
   let(:provider) { legal_aid_application.provider }
 
   describe "GET /providers/applications/:legal_aid_application_id/means/student_finance" do
-    before do
-      login_as provider
-      get providers_legal_aid_application_means_student_finance_path(legal_aid_application)
-    end
+    subject(:request) { get providers_legal_aid_application_means_student_finance_path(legal_aid_application) }
+
+    before { login_as provider }
 
     it "returns success" do
+      request
       expect(response).to be_successful
     end
 
     it "contains the correct content" do
+      request
       expect(response.body).to include("Does your client receive student finance?")
+    end
+  end
+
+  describe "PATCH /providers/applications/:legal_aid_application_id/means/student_finance" do
+    subject(:request) { patch providers_legal_aid_application_means_student_finance_path(legal_aid_application), params: }
+
+    before { login_as provider }
+
+    let(:params) do
+      {
+        irregular_income: {
+          amount:,
+          student_finance:,
+        },
+      }
+    end
+
+    context "when irregular incomes do not already exist" do
+      let(:amount) { 2345 }
+      let(:student_finance) { "true" }
+
+      it "redirects to the identify_types_of_outgoing page" do
+        request
+        expect(response).to redirect_to(providers_legal_aid_application_identify_types_of_outgoing_path)
+      end
+
+      it "creates an irregular income record" do
+        expect { request }.to change(IrregularIncome, :count).by(1)
+      end
+
+      it "creates an irregular income record with the expected attributes" do
+        request
+        irregular_income = legal_aid_application.reload.irregular_incomes.first
+        expect(irregular_income).to have_attributes(amount: 2345,
+                                                    frequency: "annual",
+                                                    income_type: "student_loan")
+      end
+    end
+
+    context "when irregular incomes already exist" do
+      let(:amount) { 5000 }
+      let(:student_finance) { "true" }
+
+      before do
+        patch(providers_legal_aid_application_means_student_finance_path(legal_aid_application),
+              params: { irregular_income: { amount: 1111, student_finance: "true" } })
+      end
+
+      it "does not create a record" do
+        expect { request }.not_to change(IrregularIncome, :count)
+      end
+
+      it "updates the existing record with the expected attributes" do
+        request
+        irregular_income = legal_aid_application.reload.irregular_incomes.first
+        expect(irregular_income.amount).to eq 5000
+      end
+    end
+
+    context "when amount field is empty" do
+      let(:amount) { "" }
+      let(:student_finance) { "true" }
+
+      it "displays an error" do
+        request
+        expect(response.body).to include I18n.t("activemodel.errors.models.irregular_income.attributes.amount.blank")
+      end
+    end
+
+    context "when responds NO to student finance" do
+      let(:student_finance) { "false" }
+      let(:amount) { "" }
+
+      it "redirects to the identify_types_of_outgoing page" do
+        request
+        expect(response).to redirect_to(providers_legal_aid_application_identify_types_of_outgoing_path)
+      end
+
+      it "updates the legal aid application record" do
+        expect { request }.to change { legal_aid_application.reload.student_finance }.from(nil).to(false)
+      end
+    end
+
+    context "when student finance is nil" do
+      let(:student_finance) { nil }
+      let(:amount) { "" }
+
+      it "displays an error" do
+        request
+        expect(response.body).to include I18n.t("activemodel.errors.models.legal_aid_application.attributes.student_finance.blank")
+      end
     end
   end
 end

--- a/spec/services/ccms/manual_review_determiner_spec.rb
+++ b/spec/services/ccms/manual_review_determiner_spec.rb
@@ -229,6 +229,21 @@ module CCMS
             expect(subject).to be false
           end
         end
+
+        context "with uploaded_bank_statements" do
+          let(:provider) { create :provider, :with_bank_statement_upload_permissions }
+          let(:legal_aid_application) { create :legal_aid_application, attachments: [bank_statement], provider: }
+          let(:bank_statement) { create :attachment, :bank_statement }
+
+          # let!(:cfe_result) { nil }
+          # this test needs to be nil for cfe_result so need to inbterceopt the error
+          # reported when cfe_result is nil as we dont expect a cfe resullt for these cases.
+          let!(:cfe_result) { create :cfe_v4_result, submission: cfe_submission }
+
+          it "returns true" do
+            expect(subject).to be true
+          end
+        end
       end
     end
 


### PR DESCRIPTION

## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3265)

Add a new blue result panel when the provider uses the bank statement upload feature to advise their eligibility has not been assessed. Also add a manul_review flag to these cases and skip the cfe result.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
