### PR TITLE
Fix: Blank flow feature flicker

### DIFF
--- a/features/step_definitions/evidence_upload_steps.rb
+++ b/features/step_definitions/evidence_upload_steps.rb
@@ -29,11 +29,11 @@ When("I have completed a non-passported application and reached the statement of
 end
 
 Then(/^I upload an evidence file named ['|"](.*?)['|"]/) do |filename|
-  attach_file(Rails.root.join("spec/fixtures/files/documents/#{filename}"), class: "dz-hidden-input", make_visible: true)
+  attach_file(Rails.root.join("spec/fixtures/files/documents/#{filename}"), class: "dz-hidden-input", make_visible: true, wait: 15)
 end
 
 Then(/^I upload the fixture file named ['|"](.*?)['|"]/) do |filename|
-  attach_file(Rails.root.join("spec/fixtures/files/#{filename}"), class: "dz-hidden-input", make_visible: true)
+  attach_file(Rails.root.join("spec/fixtures/files/#{filename}"), class: "dz-hidden-input", make_visible: true, wait: 15)
 end
 
 Then(/^I should be able to categorise ['|"](.*?)['|"] as ['|"](.*?)['|"]$/) do |filename, category|


### PR DESCRIPTION
## What

This extends the time that cucumber should wait for a file to upload
It defaults to the `default_max_wait_time` which we set to 10 seconds

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
