### PR TITLE
Ap 3281 add csv file type to bank_statement upload

### DIFF
--- a/app/forms/providers/bank_statement_form.rb
+++ b/app/forms/providers/bank_statement_form.rb
@@ -24,6 +24,7 @@ module Providers
     ].freeze
 
     WORD_DOCUMENT = "application/vnd.openxmlformats-officedocument.wordprocessingml.document".freeze
+    CSV_DOCUMENT = "text/csv".freeze
 
     attr_accessor :original_file,
                   :original_filename,
@@ -116,7 +117,9 @@ module Providers
 
     def disallowed_content_type
       return if Marcel::Magic.by_magic(original_file)&.type.in?(ALLOWED_CONTENT_TYPES)
+      # TODO: why isn't the file_type being caught in ALLOWED_CONTENT_TYPES?
       return if original_file.content_type == WORD_DOCUMENT
+      return if original_file.content_type == CSV_DOCUMENT
 
       errors.add(:original_file, :content_type_invalid, file_name: original_filename)
     end

--- a/app/webpack/src/dropzone.js
+++ b/app/webpack/src/dropzone.js
@@ -74,7 +74,7 @@ document.addEventListener('DOMContentLoaded', event => {
     const applicationId = document.querySelector('#application-id').textContent.trim()
     const url = document.querySelector('#dropzone-url').getAttribute('data-url')
     const chooseFilesBtn = document.querySelector('#dz-upload-button')
-    url.includes("bank_statement") ? ACCEPTED_FILES.push('.csv') : ACCEPTED_FILES
+    url.includes("bank_statement") ? ACCEPTED_FILES.push('text/csv') : ACCEPTED_FILES
 
     chooseFilesBtn.addEventListener('click', (e) => {
       e.preventDefault() // prevent submitting form by default

--- a/app/webpack/src/dropzone.js
+++ b/app/webpack/src/dropzone.js
@@ -74,6 +74,7 @@ document.addEventListener('DOMContentLoaded', event => {
     const applicationId = document.querySelector('#application-id').textContent.trim()
     const url = document.querySelector('#dropzone-url').getAttribute('data-url')
     const chooseFilesBtn = document.querySelector('#dz-upload-button')
+    url.includes("bank_statement") ? ACCEPTED_FILES.push('.csv') : ACCEPTED_FILES
 
     chooseFilesBtn.addEventListener('click', (e) => {
       e.preventDefault() // prevent submitting form by default

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -468,7 +468,7 @@ en:
         providers/bank_statement_form:
           attributes:
             original_file:
-              content_type_invalid: "%{file_name} must be a DOC, DOCX, RTF, ODT, JPG, BMP, PNG, TIF or PDF"
+              content_type_invalid: "%{file_name} must be a DOC, DOCX, RTF, ODT, JPG, BMP, PNG, TIF, CSV or PDF"
               file_empty: "%{file_name} has no content"
               file_too_big: "%{file_name} must be smaller than %{size}MB"
               file_virus: "%{file_name} contains a virus"

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -465,7 +465,7 @@ en:
         info: We need bank statements from the last 3 months for all of your client's bank accounts.
         h2-heading: Uploaded files
         upload_file: Upload files
-        size_hint: The maximum file size is 7MB. Files must be a DOC, DOCX, RTF, ODT, JPG, BMP, PNG, TIF or PDF.
+        size_hint: The maximum file size is 7MB. Files must be a DOC, DOCX, RTF, ODT, JPG, BMP, PNG, TIF, CSV or PDF.
         dropzone_message: Drag and drop files here or
         choose_files_btn: Choose files
         file_not_uploaded_error: Upload the selected file

--- a/spec/fixtures/files/sample_csv.csv
+++ b/spec/fixtures/files/sample_csv.csv
@@ -1,0 +1,6 @@
+John,Doe,120 jefferson st.,Riverside, NJ, 08075
+Jack,McGinnis,220 hobo Av.,Phila, PA,09119
+"John ""Da Man""",Repici,120 Jefferson St.,Riverside, NJ,08075
+Stephen,Tyler,"7452 Terrace ""At the Plaza"" road",SomeTown,SD, 91234
+,Blankman,,SomeTown, SD, 00298
+"Joan ""the bone"", Anne",Jet,"9th, at Terrace plc",Desert City,CO,00123

--- a/spec/requests/providers/application_merits_task/statement_of_case_spec.rb
+++ b/spec/requests/providers/application_merits_task/statement_of_case_spec.rb
@@ -146,6 +146,23 @@ module Providers
             expect(response).to have_http_status(:ok)
           end
 
+          context "when the file is a csv" do
+            let(:original_file) { uploaded_file("spec/fixtures/files/sample_csv.csv", "text/csv") }
+            let(:button_clicked) { upload_button }
+
+            it "does not save the object" do
+              subject
+              expect(legal_aid_application.reload.attachments.length).to match(0)
+              expect(statement_of_case).to be_nil
+            end
+
+            it "returns error message" do
+              subject
+              error = I18n.t("#{i18n_error_path}.content_type_invalid", file_name: original_file.original_filename)
+              expect(response.body).to include(error)
+            end
+          end
+
           context "when a word document" do
             let(:original_file) { uploaded_file("spec/fixtures/files/documents/hello_world.docx", "application/vnd.openxmlformats-officedocument.wordprocessingml.document") }
             let(:button_clicked) { upload_button }

--- a/spec/requests/providers/bank_statements_spec.rb
+++ b/spec/requests/providers/bank_statements_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe "Providers::BankStatementsController", type: :request do
         let(:attachments) { [attachment] }
         let(:attachment) { create(:attachment, :bank_statement) }
 
-        # NOTE: factory implicitily attachs the hello_world.pdf
+        # NOTE: factory implicitly attaches the hello_world.pdf
         it "displays the name of the uploaded file on the page" do
           request
           expect(response.body).to include("hello_world.pdf")
@@ -106,6 +106,20 @@ RSpec.describe "Providers::BankStatementsController", type: :request do
     context "when upload button clicked" do
       let(:button_clicked) { upload_button }
 
+      context "when the file is a csv" do
+        let(:file) { uploaded_file("spec/fixtures/files/sample_csv.csv", "text/csv") }
+
+        it "saves the object" do
+          request
+          expect(legal_aid_application.reload.attachments.length).to match(1)
+        end
+
+        it "stores the original filename" do
+          request
+          expect(legal_aid_application.reload.attachments.last.original_filename).to eq "sample_csv.csv"
+        end
+      end
+
       context "with acceptable bank statement" do
         let(:file) { uploaded_file("spec/fixtures/files/acceptable.pdf", "application/pdf") }
 
@@ -156,7 +170,7 @@ RSpec.describe "Providers::BankStatementsController", type: :request do
           end
         end
 
-        context "when the application has one bank statment attachment already" do
+        context "when the application has one bank statement attachment already" do
           let(:bank_statement_evidence) { create(:attachment, :bank_statement, attachment_name: "bank_statement_evidence") }
           let!(:legal_aid_application) { create(:legal_aid_application, attachments: [bank_statement_evidence]) }
 
@@ -240,7 +254,7 @@ RSpec.describe "Providers::BankStatementsController", type: :request do
 
         it "displays error indicating file is of the wrong content type" do
           request
-          expect(response.body).to have_selector("h2", text: "There is a problem").and have_link("zip.zip must be a DOC, DOCX, RTF, ODT, JPG, BMP, PNG, TIF or PDF")
+          expect(response.body).to have_selector("h2", text: "There is a problem").and have_link("zip.zip must be a DOC, DOCX, RTF, ODT, JPG, BMP, PNG, TIF, CSV or PDF")
         end
       end
 

--- a/spec/requests/v1/bank_statements_spec.rb
+++ b/spec/requests/v1/bank_statements_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe "POST /v1/bank_statements", type: :request do
         end
       end
 
-      context "when the application has one bank statment attachment already" do
+      context "when the application has one bank statement attachment already" do
         let(:bank_statement_evidence) { create(:attachment, :bank_statement, attachment_name: "bank_statement_evidence") }
         let!(:legal_aid_application) { create(:legal_aid_application, attachments: [bank_statement_evidence]) }
 
@@ -84,7 +84,7 @@ RSpec.describe "POST /v1/bank_statements", type: :request do
         end
       end
 
-      context "when the application has multiple attachments for statement of case already" do
+      context "when the application has multiple attachments for bank statement already" do
         let(:bs1) { create(:attachment, :bank_statement, attachment_name: "bank_statement_evidence") }
         let(:bs2) { create(:attachment, :bank_statement, attachment_name: "bank_statement_evidence_1") }
         let!(:legal_aid_application) { create(:legal_aid_application, attachments: [bs1, bs2]) }
@@ -93,6 +93,15 @@ RSpec.describe "POST /v1/bank_statements", type: :request do
           request
           expect(legal_aid_application.attachments.count).to be 3
           expect(legal_aid_application.attachments.order(:attachment_name).last.attachment_name).to eql("bank_statement_evidence_2")
+        end
+      end
+
+      context "when the file is a csv" do
+        let(:file) { uploaded_file("spec/fixtures/files/sample_csv.csv", "text/csv") }
+
+        it "saves the object" do
+          request
+          expect(legal_aid_application.attachments.count).to be 1
         end
       end
 

--- a/spec/requests/v1/statement_of_cases_spec.rb
+++ b/spec/requests/v1/statement_of_cases_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "POST /v1/statement_of_case", type: :request do
   let(:params) { { legal_aid_application_id: id, file: } }
 
   describe "POST /v1/statement_of_cases" do
-    subject { post v1_statement_of_cases_path, params: }
+    subject(:request) { post v1_statement_of_cases_path, params: }
 
     context "when the application exists" do
       it "returns http success" do


### PR DESCRIPTION

## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3281)
Add csv to the allowed file types for bank statement for both JS and ruby solutions

Add tests to ensure that csv can be uploaded on bank_statement and not on statement _of_case

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
