### PR TITLE
AP-3337 display error on field when file is not uploaded

### DIFF
--- a/app/views/providers/bank_statements/show.html.erb
+++ b/app/views/providers/bank_statements/show.html.erb
@@ -5,7 +5,8 @@
                       "#{@successful_upload} #{@error_message}"
                     else
                       t('.h1-heading')
-                    end %>
+                    end
+   form_error_class = @form.errors.any? ? 'govuk-form-group--error' : '' %>
 <%= page_template(
       page_title: t('.h1-heading'),
       head_title: new_head_title,
@@ -37,11 +38,19 @@
         </p>
 
       <div class="dropzone__upload">
-        <div class="govuk-form-group script hidden" id="dropzone-form-group" aria-labelledby="dropzone-label">
+        <div class="govuk-form-group script hidden <%= form_error_class %>" id="dropzone-form-group" aria-labelledby="dropzone-label">
             <label class="govuk-label govuk-label--m" id="dropzone-label">
               <%= t('.upload_file') %>
             </label>
             <div class="govuk-hint"><%= t('.size_hint') %></div>
+          <% if @form.errors %>
+            <p id="dropzone-mandatory-error" class='govuk-error-message dropzone-error govuk-!-margin-bottom-1'>
+              <% @form.errors.errors.each do |error| %>
+                <span class="govuk-visually-hidden">Error:</span>
+                <%= error.message %>
+              <% end %>
+            </p>
+          <% end %>
 
             <span class="hidden" aria-hidden="true" id="application-id"><%= @form.legal_aid_application_id %></span>
             <span class="hidden" aria-hidden="true" id="dropzone-url" data-url="/v1/bank_statements"></span>

--- a/app/views/shared/means/_student_finances.html.erb
+++ b/app/views/shared/means/_student_finances.html.erb
@@ -5,7 +5,7 @@
   <%= form.govuk_radio_buttons_fieldset :student_finance,
                                         hint: {text: t('.hint')},
                                         legend: {text: content_for(:page_title), tag: 'h1', size: 'xl'} do %>
-    <%= form.govuk_radio_button(:student_finance, true, label: { text: t('generic.yes') } ) do %>
+    <%= form.govuk_radio_button(:student_finance, true, label: { text: t('generic.yes') }, checked: @legal_aid_application.student_finance?) do %>
       <%= form.govuk_text_field(
           :amount,
           hint: {text: amount_hint},
@@ -14,7 +14,7 @@
           width: 'one-quarter'
       ) %>
     <% end %>
-    <%= form.govuk_radio_button(:student_finance, false, label: { text: t('generic.no') } ) %>
+    <%= form.govuk_radio_button(:student_finance, false, label: { text: t('generic.no') } , checked: !@legal_aid_application.student_finance?) %>
   <% end %>
   <%= next_action_buttons(form: form) %>
 <% end %>


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3337)

When the user does not upload a file on the bank statement upload page, they get an error. This error now displays on the dropzone as well as in the error summary, as expected.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
