### PR TITLE
Fix bug with miniloop settings page

### DIFF
--- a/app/views/admin/settings/show.html.erb
+++ b/app/views/admin/settings/show.html.erb
@@ -67,7 +67,7 @@
         ) %>
 
     <%= form.govuk_collection_radio_buttons(
-          :enable_cfe_v5,
+          :enable_mini_loop,
           yes_no_options,
           :value,
           :label,


### PR DESCRIPTION
## What

Fix bug with enabling miniloop on the admin settings page (where it was enabling the enable_cfe_v5 flag instead).

Describe what you did and why.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
