### PR TITLE
Send bank_statement_evidence_pdf to CCMS as `BSTMT` document type

### DIFF
--- a/app/services/ccms/requestors/document_upload_requestor.rb
+++ b/app/services/ccms/requestors/document_upload_requestor.rb
@@ -42,10 +42,10 @@ module CCMS
 
       def document_type(xml)
         case @document_type
-        when "bank_transaction_report"
+        in "bank_transaction_report" | "bank_statement_evidence_pdf"
           xml.__send__(:"casebio:DocumentType", "BSTMT")
           xml.__send__(:"casebio:FileExtension", "csv")
-        when "gateway_evidence_pdf"
+        in "gateway_evidence_pdf"
           xml.__send__(:"casebio:DocumentType", "STATE")
           xml.__send__(:"casebio:FileExtension", "pdf")
         else

--- a/spec/services/ccms/requestors/document_upload_requestor_spec.rb
+++ b/spec/services/ccms/requestors/document_upload_requestor_spec.rb
@@ -62,6 +62,24 @@ module CCMS
             )
           end
         end
+
+        context "when sent a bank_statement_evidence_pdf document" do
+          let(:requestor) { described_class.new(case_ccms_reference, document_id, document_encoded_base64, "my_login", "bank_statement_evidence_pdf") }
+
+          include_context "with ccms soa configuration"
+
+          it "generates the expected XML" do
+            allow(requestor).to receive(:transaction_request_id).and_return(expected_tx_id)
+            expect(requestor.formatted_xml).to be_soap_envelope_with(
+              command: "casebim:DocumentUploadRQ",
+              transaction_id: expected_tx_id,
+              matching: %w[
+                <casebio:DocumentType>BSTMT</casebio:DocumentType>
+                <casebio:FileExtension>csv</casebio:FileExtension>
+              ],
+            )
+          end
+        end
       end
 
       describe "#transaction_request_id" do


### PR DESCRIPTION

## What

Send bank_statement_evidence_pdf to CCMS as `BSTMT` document type

BA confirms that this is the preferable document type to assign
for bank statement uploads. I had wrongly assumed that the
`DocumentCategory#ccms_document_type`, previously set for
`bank_statement_evidence_pdf` to be `BSTMT`, would be sent across
but it is a hardcoded value that is sent based on name.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
