### PR TITLE
[AP-3368] Remove cash payments once the category has been removed

### DIFF
--- a/app/controllers/providers/means/identify_types_of_incomes_controller.rb
+++ b/app/controllers/providers/means/identify_types_of_incomes_controller.rb
@@ -6,9 +6,20 @@ module Providers
       end
 
       def update
-        return continue_or_draft if none_selected? || transactions_added || draft_selected?
+        synchronize_credit_transaction_types_and_cash_transactions
 
-        remove_existing_transaction_types
+        if none_selected?
+          legal_aid_application.update!(no_credit_transaction_types_selected: true)
+
+          return continue_or_draft
+        elsif transaction_types_selected?
+          legal_aid_application.update!(no_credit_transaction_types_selected: false)
+
+          return continue_or_draft
+        end
+
+        return continue_or_draft if draft_selected?
+
         legal_aid_application.errors.add :transaction_type_ids, t(".none_selected")
         render :show
       end
@@ -23,27 +34,34 @@ module Providers
         @transaction_types ||= TransactionType.credits.find_with_children(legal_aid_application_params[:transaction_type_ids])
       end
 
+      def transaction_types_selected?
+        transaction_types.present?
+      end
+
       def none_selected?
-        return unless params[:legal_aid_application][:none_selected] == "true"
-
-        LegalAidApplication.transaction do
-          remove_existing_transaction_types
-          legal_aid_application.update!(no_credit_transaction_types_selected: true)
-        end
+        params[:legal_aid_application][:none_selected] == "true"
       end
 
-      def transactions_added
-        return if transaction_types.empty?
+      def synchronize_credit_transaction_types_and_cash_transactions
+        existing_credit_tt_ids = legal_aid_application.legal_aid_application_transaction_types.credits.map(&:transaction_type_id)
 
-        LegalAidApplication.transaction do
-          remove_existing_transaction_types
-          legal_aid_application.update!(no_credit_transaction_types_selected: false)
-          legal_aid_application.transaction_types << transaction_types
+        keep = transaction_types.each_with_object([]) do |form_tt, arr|
+          add_transaction_type(form_tt) if existing_credit_tt_ids.exclude?(form_tt.id)
+          arr.append(form_tt.id)
         end
+
+        destroy_all_credit_transaction_types_and_cash_transactions(except: keep)
       end
 
-      def remove_existing_transaction_types
-        legal_aid_application.legal_aid_application_transaction_types.credits.destroy_all
+      def add_transaction_type(transaction_type)
+        legal_aid_application.transaction_types << transaction_type
+      end
+
+      def destroy_all_credit_transaction_types_and_cash_transactions(except:)
+        LegalAidApplication.transaction do
+          legal_aid_application.legal_aid_application_transaction_types.credits.where.not(transaction_type_id: except).destroy_all
+          legal_aid_application.cash_transactions.credits.where.not(transaction_type_id: except).destroy_all
+        end
       end
     end
   end

--- a/app/controllers/providers/means/identify_types_of_incomes_controller.rb
+++ b/app/controllers/providers/means/identify_types_of_incomes_controller.rb
@@ -6,7 +6,7 @@ module Providers
       end
 
       def update
-        synchronize_credit_transaction_types_and_cash_transactions
+        synchronize_credit_transaction_types
 
         if none_selected?
           legal_aid_application.update!(no_credit_transaction_types_selected: true)
@@ -42,7 +42,7 @@ module Providers
         params[:legal_aid_application][:none_selected] == "true"
       end
 
-      def synchronize_credit_transaction_types_and_cash_transactions
+      def synchronize_credit_transaction_types
         existing_credit_tt_ids = legal_aid_application.legal_aid_application_transaction_types.credits.map(&:transaction_type_id)
 
         keep = transaction_types.each_with_object([]) do |form_tt, arr|
@@ -50,17 +50,20 @@ module Providers
           arr.append(form_tt.id)
         end
 
-        destroy_all_credit_transaction_types_and_cash_transactions(except: keep)
+        destroy_all_credit_transaction_types(except: keep)
       end
 
       def add_transaction_type(transaction_type)
         legal_aid_application.transaction_types << transaction_type
       end
 
-      def destroy_all_credit_transaction_types_and_cash_transactions(except:)
+      def destroy_all_credit_transaction_types(except:)
         LegalAidApplication.transaction do
-          legal_aid_application.legal_aid_application_transaction_types.credits.where.not(transaction_type_id: except).destroy_all
-          legal_aid_application.cash_transactions.credits.where.not(transaction_type_id: except).destroy_all
+          legal_aid_application
+            .legal_aid_application_transaction_types
+            .credits
+            .where.not(transaction_type_id: except)
+            .destroy_all
         end
       end
     end

--- a/app/controllers/providers/means/identify_types_of_outgoings_controller.rb
+++ b/app/controllers/providers/means/identify_types_of_outgoings_controller.rb
@@ -6,9 +6,20 @@ module Providers
       end
 
       def update
-        return continue_or_draft if none_selected? || transactions_added || draft_selected?
+        synchronize_debit_transaction_types
 
-        remove_existing_transaction_types
+        if none_selected?
+          legal_aid_application.update!(no_debit_transaction_types_selected: true)
+
+          return continue_or_draft
+        elsif transaction_types_selected?
+          legal_aid_application.update!(no_debit_transaction_types_selected: false)
+
+          return continue_or_draft
+        end
+
+        return continue_or_draft if draft_selected?
+
         legal_aid_application.errors.add :transaction_type_ids, t(".none_selected")
         render :show
       end
@@ -20,30 +31,40 @@ module Providers
       end
 
       def transaction_types
-        TransactionType.debits.where(id: legal_aid_application_params[:transaction_type_ids])
+        @transaction_types ||= TransactionType.debits.where(id: legal_aid_application_params[:transaction_type_ids])
+      end
+
+      def transaction_types_selected?
+        transaction_types.present?
       end
 
       def none_selected?
-        return unless params[:legal_aid_application][:none_selected] == "true"
-
-        LegalAidApplication.transaction do
-          remove_existing_transaction_types
-          legal_aid_application.update!(no_debit_transaction_types_selected: true)
-        end
+        params[:legal_aid_application][:none_selected] == "true"
       end
 
-      def transactions_added
-        return if transaction_types.empty?
+      def synchronize_debit_transaction_types
+        existing_debit_tt_ids = legal_aid_application.legal_aid_application_transaction_types.debits.map(&:transaction_type_id)
 
-        LegalAidApplication.transaction do
-          remove_existing_transaction_types
-          legal_aid_application.update!(no_debit_transaction_types_selected: false)
-          legal_aid_application.transaction_types << transaction_types
+        keep = transaction_types.each_with_object([]) do |form_tt, arr|
+          add_transaction_type(form_tt) if existing_debit_tt_ids.exclude?(form_tt.id)
+          arr.append(form_tt.id)
         end
+
+        destroy_all_debit_transaction_types(except: keep)
       end
 
-      def remove_existing_transaction_types
-        legal_aid_application.legal_aid_application_transaction_types.debits.destroy_all
+      def add_transaction_type(transaction_type)
+        legal_aid_application.transaction_types << transaction_type
+      end
+
+      def destroy_all_debit_transaction_types(except:)
+        LegalAidApplication.transaction do
+          legal_aid_application
+            .legal_aid_application_transaction_types
+            .debits
+            .where.not(transaction_type_id: except)
+            .destroy_all
+        end
       end
     end
   end

--- a/app/models/legal_aid_application_transaction_type.rb
+++ b/app/models/legal_aid_application_transaction_type.rb
@@ -5,7 +5,6 @@ class LegalAidApplicationTransactionType < ApplicationRecord
   scope :credits, -> { includes(:transaction_type).where(transaction_types: { operation: :credit }) }
   scope :debits, -> { includes(:transaction_type).where(transaction_types: { operation: :debit }) }
 
-  # TODO: after_destroy instead??
   after_commit :cascade_delete_cash_transactions, on: :destroy
 
 private

--- a/app/models/legal_aid_application_transaction_type.rb
+++ b/app/models/legal_aid_application_transaction_type.rb
@@ -4,4 +4,16 @@ class LegalAidApplicationTransactionType < ApplicationRecord
 
   scope :credits, -> { includes(:transaction_type).where(transaction_types: { operation: :credit }) }
   scope :debits, -> { includes(:transaction_type).where(transaction_types: { operation: :debit }) }
+
+  # TODO: after_destroy instead??
+  after_commit :cascade_delete_cash_transactions, on: :destroy
+
+private
+
+  def cascade_delete_cash_transactions
+    legal_aid_application
+      .cash_transactions
+      .where(transaction_type_id:)
+      .destroy_all
+  end
 end

--- a/app/models/transaction_type.rb
+++ b/app/models/transaction_type.rb
@@ -58,7 +58,7 @@ class TransactionType < ApplicationRecord
   end
 
   def self.find_with_children(*ids)
-    all_ids = (ids + TransactionType.where(parent_id: ids).pluck(:id)).flatten
+    all_ids = (ids + TransactionType.where(parent_id: ids.compact).pluck(:id)).flatten
     where(id: all_ids)
   end
 

--- a/spec/factories/legal_aid_applications.rb
+++ b/spec/factories/legal_aid_applications.rb
@@ -816,18 +816,6 @@ FactoryBot.define do
       end
     end
 
-    # TODO: prefer in spec definition?!
-    #
-    # trait :with_benefits_cash_transactions do
-    #   after :create do |application|
-    #     tt = create(:transaction_type, :benefits)
-    #     application.transaction_types << tt
-    #     create(:cash_transaction, legal_aid_application: application, transaction_type: tt, amount: 101, month_number: 1, transaction_date: Time.zone.now.to_date)
-    #     create(:cash_transaction, legal_aid_application: application, transaction_type: tt, amount: 102, month_number: 2, transaction_date: 1.month.ago)
-    #     create(:cash_transaction, legal_aid_application: application, transaction_type: tt, amount: 103, month_number: 3, transaction_date: 2.months.ago)
-    #   end
-    # end
-
     trait :with_cfe_v1_result do
       after :create do |application|
         cfe_submission = create :cfe_submission, legal_aid_application: application

--- a/spec/factories/legal_aid_applications.rb
+++ b/spec/factories/legal_aid_applications.rb
@@ -816,6 +816,18 @@ FactoryBot.define do
       end
     end
 
+    # TODO: prefer in spec definition?!
+    #
+    # trait :with_benefits_cash_transactions do
+    #   after :create do |application|
+    #     tt = create(:transaction_type, :benefits)
+    #     application.transaction_types << tt
+    #     create(:cash_transaction, legal_aid_application: application, transaction_type: tt, amount: 101, month_number: 1, transaction_date: Time.zone.now.to_date)
+    #     create(:cash_transaction, legal_aid_application: application, transaction_type: tt, amount: 102, month_number: 2, transaction_date: 1.month.ago)
+    #     create(:cash_transaction, legal_aid_application: application, transaction_type: tt, amount: 103, month_number: 3, transaction_date: 2.months.ago)
+    #   end
+    # end
+
     trait :with_cfe_v1_result do
       after :create do |application|
         cfe_submission = create :cfe_submission, legal_aid_application: application

--- a/spec/models/legal_aid_application_transaction_type_spec.rb
+++ b/spec/models/legal_aid_application_transaction_type_spec.rb
@@ -52,4 +52,49 @@ RSpec.describe LegalAidApplicationTransactionType, type: :model do
       expect(debits).to contain_exactly(a_debit)
     end
   end
+
+  describe ".after_commit" do
+    let(:instance) do
+      create(:legal_aid_application_transaction_type,
+             legal_aid_application:,
+             transaction_type: credit_transaction_type)
+    end
+
+    before do
+      create(:legal_aid_application_transaction_type,
+             legal_aid_application:,
+             transaction_type: debit_transaction_type)
+
+      legal_aid_application.cash_transactions.create!(transaction_type_id: credit_transaction_type.id, amount: 101, month_number: 1, transaction_date: Time.zone.now.to_date)
+      legal_aid_application.cash_transactions.create!(transaction_type_id: debit_transaction_type.id, amount: 103, month_number: 3, transaction_date: 2.months.ago)
+
+      allow(instance).to receive(:cascade_delete_cash_transactions).and_call_original
+    end
+
+    context "when destroying object instance" do
+      let(:action) { instance.destroy! }
+
+      it "does not call cascade_delete_cash_transactions" do
+        action
+        expect(instance).to have_received(:cascade_delete_cash_transactions)
+      end
+
+      it "cascades delete to cash transactions of that type" do
+        expect { action }.to change(legal_aid_application.cash_transactions, :count).by(-1)
+      end
+    end
+
+    context "when updating object instance" do
+      let(:action) { instance.update!(updated_at: Time.zone.now) }
+
+      it "does not call cascade_delete_cash_transactions" do
+        action
+        expect(instance).not_to have_received(:cascade_delete_cash_transactions)
+      end
+
+      it "does not delete cash transactions" do
+        expect { action }.not_to change(legal_aid_application.cash_transactions, :count)
+      end
+    end
+  end
 end

--- a/spec/models/legal_aid_application_transaction_type_spec.rb
+++ b/spec/models/legal_aid_application_transaction_type_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe LegalAidApplicationTransactionType, type: :model do
     context "when destroying object instance" do
       let(:action) { instance.destroy! }
 
-      it "does not call cascade_delete_cash_transactions" do
+      it "calls cascade_delete_cash_transactions" do
         action
         expect(instance).to have_received(:cascade_delete_cash_transactions)
       end

--- a/spec/models/legal_aid_application_transaction_type_spec.rb
+++ b/spec/models/legal_aid_application_transaction_type_spec.rb
@@ -67,33 +67,25 @@ RSpec.describe LegalAidApplicationTransactionType, type: :model do
 
       legal_aid_application.cash_transactions.create!(transaction_type_id: credit_transaction_type.id, amount: 101, month_number: 1, transaction_date: Time.zone.now.to_date)
       legal_aid_application.cash_transactions.create!(transaction_type_id: debit_transaction_type.id, amount: 103, month_number: 3, transaction_date: 2.months.ago)
-
-      allow(instance).to receive(:cascade_delete_cash_transactions).and_call_original
     end
 
     context "when destroying object instance" do
       let(:action) { instance.destroy! }
 
-      it "calls cascade_delete_cash_transactions" do
-        action
-        expect(instance).to have_received(:cascade_delete_cash_transactions)
-      end
-
-      it "cascades delete to cash transactions of that type" do
+      it "deletes related cash transaction" do
         expect { action }.to change(legal_aid_application.cash_transactions, :count).by(-1)
+        transaction_types = legal_aid_application.cash_transactions.map(&:transaction_type)
+        expect(transaction_types).not_to include(credit_transaction_type)
       end
     end
 
     context "when updating object instance" do
       let(:action) { instance.update!(updated_at: Time.zone.now) }
 
-      it "does not call cascade_delete_cash_transactions" do
-        action
-        expect(instance).not_to have_received(:cascade_delete_cash_transactions)
-      end
-
       it "does not delete cash transactions" do
         expect { action }.not_to change(legal_aid_application.cash_transactions, :count)
+        transaction_types = legal_aid_application.cash_transactions.map(&:transaction_type)
+        expect(transaction_types).to include(credit_transaction_type, debit_transaction_type)
       end
     end
   end

--- a/spec/models/transaction_type_spec.rb
+++ b/spec/models/transaction_type_spec.rb
@@ -206,11 +206,17 @@ RSpec.describe TransactionType, type: :model do
           expect(described_class.find_with_children(pension.id, benefits.id)).to match_array([pension, benefits, excluded_benefits])
         end
       end
+
+      context "with nil" do
+        it "returns empty array" do
+          expect(described_class.find_with_children(nil)).to match_array([])
+        end
+      end
     end
 
     describe ".any_type_of" do
       context "with name of record with children" do
-        it "returns record and its chidlren" do
+        it "returns record and its children" do
           expect(described_class.any_type_of("benefits")).to match_array([benefits, excluded_benefits])
         end
       end

--- a/spec/requests/providers/means/identify_types_of_incomes_controller_spec.rb
+++ b/spec/requests/providers/means/identify_types_of_incomes_controller_spec.rb
@@ -2,14 +2,13 @@ require "rails_helper"
 
 RSpec.describe Providers::Means::IdentifyTypesOfIncomesController do
   let(:legal_aid_application) { create :legal_aid_application }
+  let!(:outgoing_types) { create_list :transaction_type, 3, :debit_with_standard_name }
   let!(:income_types) { create_list :transaction_type, 3, :credit_with_standard_name }
   let(:non_child_income_types) { income_types.reject(&:child?) }
   let(:provider) { legal_aid_application.provider }
   let(:login) { login_as provider }
 
-  before do
-    login
-  end
+  before { login }
 
   describe "GET /providers/applications/:legal_aid_application_id/means/identify_types_of_income" do
     subject(:request) { get providers_legal_aid_application_means_identify_types_of_income_path(legal_aid_application) }
@@ -42,8 +41,14 @@ RSpec.describe Providers::Means::IdentifyTypesOfIncomesController do
   end
 
   describe "PATCH /providers/applications/:legal_aid_application_id/means/identify_types_of_income" do
-    subject(:request) { patch providers_legal_aid_application_means_identify_types_of_income_path(legal_aid_application), params: params.merge(submit_button) }
+    subject(:request) do
+      patch(
+        providers_legal_aid_application_means_identify_types_of_income_path(legal_aid_application),
+        params: params.merge(submit_button),
+      )
+    end
 
+    let(:submit_button) { {} }
     let(:params) do
       {
         legal_aid_application: {
@@ -51,8 +56,6 @@ RSpec.describe Providers::Means::IdentifyTypesOfIncomesController do
         },
       }
     end
-
-    let(:submit_button) { {} }
 
     context "when no transaction types selected" do
       let(:transaction_type_ids) { [] }
@@ -86,26 +89,16 @@ RSpec.describe Providers::Means::IdentifyTypesOfIncomesController do
         expect { request }.to change { legal_aid_application.reload.no_credit_transaction_types_selected }.to(false)
       end
 
-      context "when provider is on passported journey" do
-        before do
-          legal_aid_application.provider.permissions.find_by(role: "application.non_passported.bank_statement_upload.*")&.destroy!
-          legal_aid_application.update!(provider_received_citizen_consent: nil)
-        end
-
-        it "redirects to the cash income page" do
-          request
-          expect(response).to redirect_to(providers_legal_aid_application_means_cash_income_path)
-        end
+      it "redirects to the cash income page" do
+        request
+        expect(response).to redirect_to(providers_legal_aid_application_means_cash_income_path)
       end
     end
 
     context "when application has transaction types of other kind" do
       let(:transaction_type_ids) { [] }
       let(:other_transaction_type) { create :transaction_type, :debit }
-
-      let(:legal_aid_application) do
-        create :legal_aid_application, :with_applicant, transaction_types: [other_transaction_type]
-      end
+      let(:legal_aid_application) { create :legal_aid_application, :with_applicant, transaction_types: [other_transaction_type] }
 
       it "does not remove existing transaction of other type" do
         expect { request }.not_to change { legal_aid_application.transaction_types.count }
@@ -127,29 +120,30 @@ RSpec.describe Providers::Means::IdentifyTypesOfIncomesController do
         expect { request }.not_to change(legal_aid_application.legal_aid_application_transaction_types, :count)
       end
 
+      it "redirects to the means student finance page" do
+        request
+        expect(response).to redirect_to(providers_legal_aid_application_means_student_finance_path(legal_aid_application))
+      end
+
       context "when application has existing transaction categories" do
         let(:legal_aid_application) do
-          create :legal_aid_application, :with_applicant, :with_non_passported_state_machine, transaction_types: income_types
+          create :legal_aid_application, :with_applicant, :with_non_passported_state_machine, transaction_types: income_types + outgoing_types
         end
 
-        it "removes transaction types from the application" do
+        it "removes credit transaction types from the application" do
           expect { request }.to change(legal_aid_application.legal_aid_application_transaction_types, :count).by(-3)
         end
       end
 
       context "with existing credit and debit cash transactions" do
         let(:benefits_credit) { create(:transaction_type, :benefits) }
-        let(:friends_or_family_credit) { create(:transaction_type, :friends_or_family) }
         let(:rent_or_mortgage_debit) { create(:transaction_type, :rent_or_mortgage) }
 
         let(:legal_aid_application) do
-          laa = create(:legal_aid_application, :with_applicant, :with_non_passported_state_machine, transaction_types: [benefits_credit, friends_or_family_credit, rent_or_mortgage_debit])
+          laa = create(:legal_aid_application, :with_applicant, :with_non_passported_state_machine, transaction_types: [benefits_credit, rent_or_mortgage_debit])
           laa.cash_transactions.create!(transaction_type_id: benefits_credit.id, amount: 101, month_number: 1, transaction_date: Time.zone.now.to_date)
           laa.cash_transactions.create!(transaction_type_id: benefits_credit.id, amount: 102, month_number: 2, transaction_date: 1.month.ago)
           laa.cash_transactions.create!(transaction_type_id: benefits_credit.id, amount: 103, month_number: 3, transaction_date: 2.months.ago)
-          laa.cash_transactions.create!(transaction_type_id: friends_or_family_credit.id, amount: 201, month_number: 1, transaction_date: Time.zone.now.to_date)
-          laa.cash_transactions.create!(transaction_type_id: friends_or_family_credit.id, amount: 202, month_number: 2, transaction_date: 1.month.ago)
-          laa.cash_transactions.create!(transaction_type_id: friends_or_family_credit.id, amount: 203, month_number: 3, transaction_date: 2.months.ago)
           laa.cash_transactions.create!(transaction_type_id: rent_or_mortgage_debit.id, amount: 301, month_number: 1, transaction_date: Time.zone.now.to_date)
           laa.cash_transactions.create!(transaction_type_id: rent_or_mortgage_debit.id, amount: 302, month_number: 2, transaction_date: 1.month.ago)
           laa.cash_transactions.create!(transaction_type_id: rent_or_mortgage_debit.id, amount: 303, month_number: 3, transaction_date: 2.months.ago)
@@ -162,30 +156,6 @@ RSpec.describe Providers::Means::IdentifyTypesOfIncomesController do
 
         it "does not remove any debit cash transactions" do
           expect { request }.not_to change { legal_aid_application.cash_transactions.debits.present? }.from(true)
-        end
-      end
-
-      context "when provider is on passported journey" do
-        before do
-          legal_aid_application.provider.permissions.find_by(role: "application.non_passported.bank_statement_upload.*")&.destroy!
-          legal_aid_application.update!(provider_received_citizen_consent: nil)
-        end
-
-        it "redirects to the means student finance page" do
-          request
-          expect(response).to redirect_to(providers_legal_aid_application_means_student_finance_path(legal_aid_application))
-        end
-      end
-
-      context "when provider is on bank statement upload journey" do
-        before do
-          legal_aid_application.provider.permissions << Permission.find_or_create_by(role: "application.non_passported.bank_statement_upload.*")
-          legal_aid_application.update!(provider_received_citizen_consent: false)
-        end
-
-        it "redirects to the means student finance page" do
-          request
-          expect(response).to redirect_to(providers_legal_aid_application_means_student_finance_path(legal_aid_application))
         end
       end
     end
@@ -313,6 +283,15 @@ RSpec.describe Providers::Means::IdentifyTypesOfIncomesController do
           end
         end
       end
+    end
+
+    context "when the provider is not authenticated" do
+      let(:login) { nil }
+      let(:transaction_type_ids) { [] }
+
+      before { request }
+
+      it_behaves_like "a provider not authenticated"
     end
 
     context "when submitted with Save as draft" do

--- a/spec/requests/providers/means/identify_types_of_incomes_controller_spec.rb
+++ b/spec/requests/providers/means/identify_types_of_incomes_controller_spec.rb
@@ -181,10 +181,6 @@ RSpec.describe Providers::Means::IdentifyTypesOfIncomesController do
         laa
       end
 
-      # xit "removes the deselected credit transaction types" do
-      #   expect { request }.to change(legal_aid_application.legal_aid_application_transaction_types.credits, :count).by(-1)
-      # end
-      # OR
       it "synchronizes credit transaction types" do
         expect(legal_aid_application.legal_aid_application_transaction_types.credits.map(&:transaction_type)).to match_array [benefits_credit, friends_or_family_credit]
         request
@@ -195,10 +191,6 @@ RSpec.describe Providers::Means::IdentifyTypesOfIncomesController do
         expect { request }.not_to change(legal_aid_application.legal_aid_application_transaction_types.debits, :count)
       end
 
-      # xit "removes deselected credit cash transactions" do
-      #   expect { request }.to change(legal_aid_application.cash_transactions.credits, :count).by(-1)
-      # end
-      # OR
       it "synchronizes credit transaction types cash transactions" do
         expect(legal_aid_application.cash_transactions.credits.map(&:transaction_type).uniq).to match_array [benefits_credit, friends_or_family_credit]
         request
@@ -311,17 +303,13 @@ RSpec.describe Providers::Means::IdentifyTypesOfIncomesController do
 
       context "with existing credit and debit cash transactions" do
         let(:benefits_credit) { create(:transaction_type, :benefits) }
-        let(:friends_or_family_credit) { create(:transaction_type, :friends_or_family) }
         let(:rent_or_mortgage_debit) { create(:transaction_type, :rent_or_mortgage) }
 
         let(:legal_aid_application) do
-          laa = create(:legal_aid_application, :with_applicant, :with_non_passported_state_machine, transaction_types: [benefits_credit, friends_or_family_credit, rent_or_mortgage_debit])
+          laa = create(:legal_aid_application, :with_applicant, :with_non_passported_state_machine, transaction_types: [benefits_credit, rent_or_mortgage_debit])
           laa.cash_transactions.create!(transaction_type_id: benefits_credit.id, amount: 101, month_number: 1, transaction_date: Time.zone.now.to_date)
           laa.cash_transactions.create!(transaction_type_id: benefits_credit.id, amount: 102, month_number: 2, transaction_date: 1.month.ago)
           laa.cash_transactions.create!(transaction_type_id: benefits_credit.id, amount: 103, month_number: 3, transaction_date: 2.months.ago)
-          laa.cash_transactions.create!(transaction_type_id: friends_or_family_credit.id, amount: 201, month_number: 1, transaction_date: Time.zone.now.to_date)
-          laa.cash_transactions.create!(transaction_type_id: friends_or_family_credit.id, amount: 202, month_number: 2, transaction_date: 1.month.ago)
-          laa.cash_transactions.create!(transaction_type_id: friends_or_family_credit.id, amount: 203, month_number: 3, transaction_date: 2.months.ago)
           laa.cash_transactions.create!(transaction_type_id: rent_or_mortgage_debit.id, amount: 301, month_number: 1, transaction_date: Time.zone.now.to_date)
           laa.cash_transactions.create!(transaction_type_id: rent_or_mortgage_debit.id, amount: 302, month_number: 2, transaction_date: 1.month.ago)
           laa.cash_transactions.create!(transaction_type_id: rent_or_mortgage_debit.id, amount: 303, month_number: 3, transaction_date: 2.months.ago)

--- a/spec/requests/providers/means/identify_types_of_incomes_controller_spec.rb
+++ b/spec/requests/providers/means/identify_types_of_incomes_controller_spec.rb
@@ -54,11 +54,11 @@ RSpec.describe Providers::Means::IdentifyTypesOfIncomesController do
 
     let(:submit_button) { {} }
 
-    context "when transaction types not selected" do
+    context "when no transaction types selected" do
       let(:transaction_type_ids) { [] }
 
       it "does not add transaction types to the application" do
-        expect { request }.not_to change(LegalAidApplicationTransactionType, :count)
+        expect { request }.not_to change(legal_aid_application.legal_aid_application_transaction_types, :count)
       end
 
       it "displays an error" do
@@ -124,16 +124,44 @@ RSpec.describe Providers::Means::IdentifyTypesOfIncomesController do
       end
 
       it "does not add transaction types to the application" do
-        expect { request }.not_to change(LegalAidApplicationTransactionType, :count)
+        expect { request }.not_to change(legal_aid_application.legal_aid_application_transaction_types, :count)
       end
 
-      context "when application has existing transactions" do
+      context "when application has existing transaction categories" do
         let(:legal_aid_application) do
           create :legal_aid_application, :with_applicant, :with_non_passported_state_machine, transaction_types: income_types
         end
 
         it "removes transaction types from the application" do
-          expect { request }.to change(LegalAidApplicationTransactionType, :count).by(-3)
+          expect { request }.to change(legal_aid_application.legal_aid_application_transaction_types, :count).by(-3)
+        end
+      end
+
+      context "with existing credit and debit cash transactions" do
+        let(:benefits_credit) { create(:transaction_type, :benefits) }
+        let(:friends_or_family_credit) { create(:transaction_type, :friends_or_family) }
+        let(:rent_or_mortgage_debit) { create(:transaction_type, :rent_or_mortgage) }
+
+        let(:legal_aid_application) do
+          laa = create(:legal_aid_application, :with_applicant, :with_non_passported_state_machine, transaction_types: [benefits_credit, friends_or_family_credit, rent_or_mortgage_debit])
+          laa.cash_transactions.create!(transaction_type_id: benefits_credit.id, amount: 101, month_number: 1, transaction_date: Time.zone.now.to_date)
+          laa.cash_transactions.create!(transaction_type_id: benefits_credit.id, amount: 102, month_number: 2, transaction_date: 1.month.ago)
+          laa.cash_transactions.create!(transaction_type_id: benefits_credit.id, amount: 103, month_number: 3, transaction_date: 2.months.ago)
+          laa.cash_transactions.create!(transaction_type_id: friends_or_family_credit.id, amount: 201, month_number: 1, transaction_date: Time.zone.now.to_date)
+          laa.cash_transactions.create!(transaction_type_id: friends_or_family_credit.id, amount: 202, month_number: 2, transaction_date: 1.month.ago)
+          laa.cash_transactions.create!(transaction_type_id: friends_or_family_credit.id, amount: 203, month_number: 3, transaction_date: 2.months.ago)
+          laa.cash_transactions.create!(transaction_type_id: rent_or_mortgage_debit.id, amount: 301, month_number: 1, transaction_date: Time.zone.now.to_date)
+          laa.cash_transactions.create!(transaction_type_id: rent_or_mortgage_debit.id, amount: 302, month_number: 2, transaction_date: 1.month.ago)
+          laa.cash_transactions.create!(transaction_type_id: rent_or_mortgage_debit.id, amount: 303, month_number: 3, transaction_date: 2.months.ago)
+          laa
+        end
+
+        it "removes all credit cash transactions" do
+          expect { request }.to change { legal_aid_application.cash_transactions.credits.present? }.from(true).to(false)
+        end
+
+        it "does not remove any debit cash transactions" do
+          expect { request }.not_to change { legal_aid_application.cash_transactions.debits.present? }.from(true)
         end
       end
 
@@ -159,6 +187,56 @@ RSpec.describe Providers::Means::IdentifyTypesOfIncomesController do
           request
           expect(response).to redirect_to(providers_legal_aid_application_means_student_finance_path(legal_aid_application))
         end
+      end
+    end
+
+    context "when existing transaction types are deselected" do
+      let(:transaction_type_ids) { [friends_or_family_credit.id] }
+
+      let(:benefits_credit) { create(:transaction_type, :benefits) }
+      let(:friends_or_family_credit) { create(:transaction_type, :friends_or_family) }
+      let(:rent_or_mortgage_debit) { create(:transaction_type, :rent_or_mortgage) }
+
+      let(:legal_aid_application) do
+        laa = create(:legal_aid_application, :with_applicant, :with_non_passported_state_machine, transaction_types: [benefits_credit, friends_or_family_credit, rent_or_mortgage_debit])
+        laa.cash_transactions.create!(transaction_type_id: benefits_credit.id, amount: 101, month_number: 1, transaction_date: Time.zone.now.to_date)
+        laa.cash_transactions.create!(transaction_type_id: benefits_credit.id, amount: 102, month_number: 2, transaction_date: 1.month.ago)
+        laa.cash_transactions.create!(transaction_type_id: benefits_credit.id, amount: 103, month_number: 3, transaction_date: 2.months.ago)
+        laa.cash_transactions.create!(transaction_type_id: friends_or_family_credit.id, amount: 201, month_number: 1, transaction_date: Time.zone.now.to_date)
+        laa.cash_transactions.create!(transaction_type_id: friends_or_family_credit.id, amount: 202, month_number: 2, transaction_date: 1.month.ago)
+        laa.cash_transactions.create!(transaction_type_id: friends_or_family_credit.id, amount: 203, month_number: 3, transaction_date: 2.months.ago)
+        laa.cash_transactions.create!(transaction_type_id: rent_or_mortgage_debit.id, amount: 301, month_number: 1, transaction_date: Time.zone.now.to_date)
+        laa.cash_transactions.create!(transaction_type_id: rent_or_mortgage_debit.id, amount: 302, month_number: 2, transaction_date: 1.month.ago)
+        laa.cash_transactions.create!(transaction_type_id: rent_or_mortgage_debit.id, amount: 303, month_number: 3, transaction_date: 2.months.ago)
+        laa
+      end
+
+      # xit "removes the deselected credit transaction types" do
+      #   expect { request }.to change(legal_aid_application.legal_aid_application_transaction_types.credits, :count).by(-1)
+      # end
+      # OR
+      it "synchronizes credit transaction types" do
+        expect(legal_aid_application.legal_aid_application_transaction_types.credits.map(&:transaction_type)).to match_array [benefits_credit, friends_or_family_credit]
+        request
+        expect(legal_aid_application.legal_aid_application_transaction_types.credits.map(&:transaction_type)).to match_array [friends_or_family_credit]
+      end
+
+      it "does not remove existing debit transaction types" do
+        expect { request }.not_to change(legal_aid_application.legal_aid_application_transaction_types.debits, :count)
+      end
+
+      # xit "removes deselected credit cash transactions" do
+      #   expect { request }.to change(legal_aid_application.cash_transactions.credits, :count).by(-1)
+      # end
+      # OR
+      it "synchronizes credit transaction types cash transactions" do
+        expect(legal_aid_application.cash_transactions.credits.map(&:transaction_type).uniq).to match_array [benefits_credit, friends_or_family_credit]
+        request
+        expect(legal_aid_application.cash_transactions.credits.map(&:transaction_type).uniq).to match_array [friends_or_family_credit]
+      end
+
+      it "does not remove any debit cash transactions" do
+        expect { request }.not_to change(legal_aid_application.cash_transactions.debits, :count)
       end
     end
 
@@ -238,12 +316,46 @@ RSpec.describe Providers::Means::IdentifyTypesOfIncomesController do
     end
 
     context "when submitted with Save as draft" do
-      let(:submit_button) { { draft_button: "Save as draft" } }
-      let(:transaction_type_ids) { [] }
+      let(:params) do
+        {
+          draft_button: "Save as draft",
+          legal_aid_application: {
+            none_selected: "true",
+          },
+        }
+      end
 
       it "redirects to the list of applications" do
         request
         expect(response).to redirect_to providers_legal_aid_applications_path
+      end
+
+      context "with existing credit and debit cash transactions" do
+        let(:benefits_credit) { create(:transaction_type, :benefits) }
+        let(:friends_or_family_credit) { create(:transaction_type, :friends_or_family) }
+        let(:rent_or_mortgage_debit) { create(:transaction_type, :rent_or_mortgage) }
+
+        let(:legal_aid_application) do
+          laa = create(:legal_aid_application, :with_applicant, :with_non_passported_state_machine, transaction_types: [benefits_credit, friends_or_family_credit, rent_or_mortgage_debit])
+          laa.cash_transactions.create!(transaction_type_id: benefits_credit.id, amount: 101, month_number: 1, transaction_date: Time.zone.now.to_date)
+          laa.cash_transactions.create!(transaction_type_id: benefits_credit.id, amount: 102, month_number: 2, transaction_date: 1.month.ago)
+          laa.cash_transactions.create!(transaction_type_id: benefits_credit.id, amount: 103, month_number: 3, transaction_date: 2.months.ago)
+          laa.cash_transactions.create!(transaction_type_id: friends_or_family_credit.id, amount: 201, month_number: 1, transaction_date: Time.zone.now.to_date)
+          laa.cash_transactions.create!(transaction_type_id: friends_or_family_credit.id, amount: 202, month_number: 2, transaction_date: 1.month.ago)
+          laa.cash_transactions.create!(transaction_type_id: friends_or_family_credit.id, amount: 203, month_number: 3, transaction_date: 2.months.ago)
+          laa.cash_transactions.create!(transaction_type_id: rent_or_mortgage_debit.id, amount: 301, month_number: 1, transaction_date: Time.zone.now.to_date)
+          laa.cash_transactions.create!(transaction_type_id: rent_or_mortgage_debit.id, amount: 302, month_number: 2, transaction_date: 1.month.ago)
+          laa.cash_transactions.create!(transaction_type_id: rent_or_mortgage_debit.id, amount: 303, month_number: 3, transaction_date: 2.months.ago)
+          laa
+        end
+
+        it "removes all credit cash transactions" do
+          expect { request }.to change { legal_aid_application.cash_transactions.credits.present? }.from(true).to(false)
+        end
+
+        it "does not remove any debit cash transactions" do
+          expect { request }.not_to change { legal_aid_application.cash_transactions.debits.present? }.from(true)
+        end
       end
     end
   end

--- a/spec/requests/providers/means/identify_types_of_outgoings_controller_spec.rb
+++ b/spec/requests/providers/means/identify_types_of_outgoings_controller_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Providers::Means::IdentifyTypesOfOutgoingsController do
   let(:legal_aid_application) { create :legal_aid_application, :with_non_passported_state_machine, :with_applicant }
   let(:provider) { legal_aid_application.provider }
   let(:login) { login_as provider }
+  let!(:income_types) { create_list :transaction_type, 3, :credit_with_standard_name }
   let!(:outgoing_types) { create_list :transaction_type, 3, :debit_with_standard_name }
 
   before { login }
@@ -115,22 +116,47 @@ RSpec.describe Providers::Means::IdentifyTypesOfOutgoingsController do
         expect { request }.to change { legal_aid_application.reload.no_debit_transaction_types_selected }.to(true)
       end
 
-      context "when application has transactions" do
+      context "when application has existing transaction categories" do
         let(:legal_aid_application) do
-          create :legal_aid_application, :with_applicant, :with_non_passported_state_machine, transaction_types: outgoing_types
+          create :legal_aid_application, :with_applicant, :with_non_passported_state_machine, transaction_types: outgoing_types + income_types
         end
 
-        it "removes transaction types from the application" do
-          expect { request }.to change(LegalAidApplicationTransactionType, :count)
-            .by(-outgoing_types.length)
+        it "removes debit transaction types from the application" do
+          expect { request }.to change(legal_aid_application.legal_aid_application_transaction_types, :count).by(-3)
+        end
+      end
+
+      context "with existing credit and debit cash transactions" do
+        let(:benefits_credit) { create(:transaction_type, :benefits) }
+        let(:rent_or_mortgage_debit) { create(:transaction_type, :rent_or_mortgage) }
+
+        let(:legal_aid_application) do
+          laa = create(:legal_aid_application, :with_applicant, :with_non_passported_state_machine, transaction_types: [benefits_credit, rent_or_mortgage_debit])
+          laa.cash_transactions.create!(transaction_type_id: benefits_credit.id, amount: 101, month_number: 1, transaction_date: Time.zone.now.to_date)
+          laa.cash_transactions.create!(transaction_type_id: benefits_credit.id, amount: 102, month_number: 2, transaction_date: 1.month.ago)
+          laa.cash_transactions.create!(transaction_type_id: benefits_credit.id, amount: 103, month_number: 3, transaction_date: 2.months.ago)
+          laa.cash_transactions.create!(transaction_type_id: rent_or_mortgage_debit.id, amount: 301, month_number: 1, transaction_date: Time.zone.now.to_date)
+          laa.cash_transactions.create!(transaction_type_id: rent_or_mortgage_debit.id, amount: 302, month_number: 2, transaction_date: 1.month.ago)
+          laa.cash_transactions.create!(transaction_type_id: rent_or_mortgage_debit.id, amount: 303, month_number: 3, transaction_date: 2.months.ago)
+          laa
+        end
+
+        it "removes all debit cash transactions" do
+          expect { request }.to change { legal_aid_application.cash_transactions.debits.present? }.from(true).to(false)
+        end
+
+        it "does not remove any credit cash transactions" do
+          expect { request }.not_to change { legal_aid_application.cash_transactions.credits.present? }.from(true)
         end
       end
 
       context "with previously selected income categories" do
-        let(:income_types) { create_list :transaction_type, 3, :credit_with_standard_name }
-        let!(:legal_aid_application) do
-          create :legal_aid_application, :with_applicant,
-                 :with_non_passported_state_machine, :applicant_entering_means, transaction_types: income_types
+        let(:legal_aid_application) do
+          create(:legal_aid_application,
+                 :with_applicant,
+                 :with_non_passported_state_machine,
+                 :applicant_entering_means,
+                 transaction_types: income_types)
         end
 
         it "redirects to the income summary page" do
@@ -140,9 +166,12 @@ RSpec.describe Providers::Means::IdentifyTypesOfOutgoingsController do
       end
 
       context "with no previously selected income categories" do
-        let!(:legal_aid_application) do
-          create :legal_aid_application, :with_applicant,
-                 :with_non_passported_state_machine, :applicant_entering_means, transaction_types: []
+        let(:legal_aid_application) do
+          create(:legal_aid_application,
+                 :with_applicant,
+                 :with_non_passported_state_machine,
+                 :applicant_entering_means,
+                 transaction_types: [])
         end
 
         it "redirects to the has dependants page" do
@@ -153,7 +182,6 @@ RSpec.describe Providers::Means::IdentifyTypesOfOutgoingsController do
     end
 
     context "when the wrong transaction type is passed in" do
-      let!(:income_types) { create_list :transaction_type, 3, :credit_with_standard_name }
       let(:transaction_type_ids) { income_types.map(&:id) }
 
       it "does not add the transaction types" do

--- a/spec/requests/providers/means/identify_types_of_outgoings_controller_spec.rb
+++ b/spec/requests/providers/means/identify_types_of_outgoings_controller_spec.rb
@@ -43,7 +43,6 @@ RSpec.describe Providers::Means::IdentifyTypesOfOutgoingsController do
       )
     end
 
-    let(:transaction_type_ids) { [] }
     let(:submit_button) { {} }
     let(:params) do
       {
@@ -53,20 +52,24 @@ RSpec.describe Providers::Means::IdentifyTypesOfOutgoingsController do
       }
     end
 
-    it "does not add transaction types to the application" do
-      expect { request }.not_to change(LegalAidApplicationTransactionType, :count)
-    end
+    context "when no transaction types selected" do
+      let(:transaction_type_ids) { [] }
 
-    it "displays an error" do
-      request
-      expect(response.body).to match("govuk-error-summary")
-      expect(unescaped_response_body).to match(I18n.t("providers.means.identify_types_of_outgoings.update.none_selected"))
-      expect(unescaped_response_body).not_to include("translation missing")
-    end
+      it "does not add transaction types to the application" do
+        expect { request }.not_to change(LegalAidApplicationTransactionType, :count)
+      end
 
-    it "returns http success" do
-      request
-      expect(response).to have_http_status(:ok)
+      it "displays an error" do
+        request
+        expect(response.body).to match("govuk-error-summary")
+        expect(unescaped_response_body).to match(I18n.t("providers.means.identify_types_of_outgoings.update.none_selected"))
+        expect(unescaped_response_body).not_to include("translation missing")
+      end
+
+      it "returns http success" do
+        request
+        expect(response).to have_http_status(:ok)
+      end
     end
 
     context "when transaction types selected" do
@@ -87,17 +90,8 @@ RSpec.describe Providers::Means::IdentifyTypesOfOutgoingsController do
       end
     end
 
-    context "when form submitted with Save as draft button" do
-      let(:transaction_type_ids) { [] }
-      let(:submit_button) { { draft_button: "Save as draft" } }
-
-      it "redirects to the list of applications" do
-        request
-        expect(response).to redirect_to providers_legal_aid_applications_path
-      end
-    end
-
     context "when application has transaction types of other kind" do
+      let(:transaction_type_ids) { [] }
       let(:other_transaction_type) { create :transaction_type, :credit }
       let(:legal_aid_application) { create :legal_aid_application, :with_applicant, :with_non_passported_state_machine, transaction_types: [other_transaction_type] }
 
@@ -232,11 +226,22 @@ RSpec.describe Providers::Means::IdentifyTypesOfOutgoingsController do
     end
 
     context "when the provider is not authenticated" do
+      let(:login) { nil }
+      let(:transaction_type_ids) { [] }
+
       before { request }
 
-      let(:login) { nil }
-
       it_behaves_like "a provider not authenticated"
+    end
+
+    context "when form submitted with Save as draft button" do
+      let(:transaction_type_ids) { [] }
+      let(:submit_button) { { draft_button: "Save as draft" } }
+
+      it "redirects to the list of applications" do
+        request
+        expect(response).to redirect_to providers_legal_aid_applications_path
+      end
     end
   end
 end


### PR DESCRIPTION

## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3368)

Remove Cash transactions for both income and outgoings when the corresponding payment category is removed

At the moment, if you have selected a payment category and entered cash payments for that category, if you return to the identify types of payments page and remove that category, the cash transactions are not removed and will still show up on the cash payments page and on the CYA page.

All cash transactions need to be removed when the payment category is removed.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
