### PR TITLE
AP-3359: Add client involvement type to mini loop

### DIFF
--- a/app/controllers/providers/proceeding_loop/client_involvement_type_controller.rb
+++ b/app/controllers/providers/proceeding_loop/client_involvement_type_controller.rb
@@ -1,0 +1,35 @@
+module Providers
+  module ProceedingLoop
+    class ClientInvolvementTypeController < ProviderBaseController
+      include PreDWPCheckVisible
+      before_action :proceeding
+
+      def show
+        @form = Proceedings::ClientInvolvementTypeForm.new(model: proceeding)
+      end
+
+      def update
+        @form = Proceedings::ClientInvolvementTypeForm.new(form_params)
+        render :show unless save_continue_or_draft(@form)
+      end
+
+    private
+
+      def proceeding
+        @proceeding = Proceeding.find(proceeding_id_param)
+      end
+
+      def proceeding_id_param
+        params.require(:id)
+      end
+
+      def form_params
+        merge_with_model(proceeding) do
+          return {} unless params[:proceeding]
+
+          params.require(:proceeding).permit(:client_involvement_type_ccms_code)
+        end
+      end
+    end
+  end
+end

--- a/app/forms/proceedings/client_involvement_type_form.rb
+++ b/app/forms/proceedings/client_involvement_type_form.rb
@@ -1,0 +1,24 @@
+module Proceedings
+  class ClientInvolvementTypeForm < BaseForm
+    form_for Proceeding
+
+    attr_accessor :client_involvement_type_ccms_code
+
+    validates :client_involvement_type_ccms_code, presence: true
+
+    def save
+      extrapolate_client_involvement_type_description if client_involvement_type_ccms_code
+      super
+    end
+
+    def client_involvement_types
+      @client_involvement_types ||= LegalFramework::ClientInvolvementTypes::All.call
+    end
+
+  private
+
+    def extrapolate_client_involvement_type_description
+      model.client_involvement_type_description = client_involvement_types.filter_map { |cit| cit.description if cit.ccms_code == client_involvement_type_ccms_code }.reduce
+    end
+  end
+end

--- a/app/services/flow/flows/provider_start.rb
+++ b/app/services/flow/flows/provider_start.rb
@@ -68,13 +68,22 @@ module Flow
           carry_on_sub_flow: true,
           check_answers: :check_provider_answers,
         },
+        client_involvement_type: {
+          path: lambda do |application|
+            proceeding = Flow::ProceedingLoop.next_proceeding(application)
+            urls.providers_legal_aid_application_client_involvement_type_path(application, proceeding)
+          end,
+          forward: ->(application) { Flow::ProceedingLoop.next_step(application) },
+          carry_on_sub_flow: false, # TODO: This may need changing when the full loop is implemented as a change of CIT affects the LOS and scopes, defaults and otherwise
+          check_answers: :check_provider_answers,
+        },
         delegated_functions: {
           path: lambda do |application|
             proceeding = Flow::ProceedingLoop.next_proceeding(application)
             urls.providers_legal_aid_application_delegated_function_path(application, proceeding)
           end,
           forward: ->(application) { Flow::ProceedingLoop.next_step(application) },
-          carry_on_sub_flow: false,
+          carry_on_sub_flow: false, # TODO: This may need changing when the full loop is implemented as a change of DF affects the LOS and scopes, defaults and otherwise
           check_answers: :check_provider_answers,
         },
         used_multiple_delegated_functions: {

--- a/app/services/flow/proceeding_loop.rb
+++ b/app/services/flow/proceeding_loop.rb
@@ -16,7 +16,12 @@ module Flow
       return :used_multiple_delegated_functions unless Setting.enable_mini_loop?
 
       if application_before_loop? || application_inside_proceeding_loop?
-        :delegated_functions # TODO: This may update to the CIT page when it gets added as the next step of the mini loop
+        case @application.provider_step
+        when "delegated_functions", "in_scope_of_laspos", "has_other_proceedings"
+          :client_involvement_type
+        when "client_involvement_type"
+          :delegated_functions
+        end
       else
         :limitations
       end

--- a/app/services/legal_framework/add_proceeding_service.rb
+++ b/app/services/legal_framework/add_proceeding_service.rb
@@ -40,11 +40,9 @@ module LegalFramework
         category_of_law: proceeding_type.ccms_category_law,
         category_law_code: proceeding_type.ccms_category_law_code,
         ccms_matter_code: proceeding_type.ccms_matter_code,
-        # TODO: These two fields will, once the designs are complete need to be populated from
-        # from providers decisions, until then we hard code the new values
-        # which match the current values we send to CCMS by default
-        client_involvement_type_ccms_code: "A",
-        client_involvement_type_description: "Applicant/claimant/petitioner",
+        # TODO: remove the following lines when the mini-loop feature flag is removed
+        client_involvement_type_ccms_code: Setting.enable_mini_loop? ? nil : "A",
+        client_involvement_type_description: Setting.enable_mini_loop? ? nil : "Applicant/claimant/petitioner",
       }
     end
 

--- a/app/views/providers/check_provider_answers/_shared.html.erb
+++ b/app/views/providers/check_provider_answers/_shared.html.erb
@@ -26,7 +26,7 @@
   <% if Setting.enable_mini_loop? %>
     <% @legal_aid_application.proceedings.in_order_of_addition.each do |proceeding| %>
       <%= render(
-            'shared/check_answers/delegated_function_details',
+            'shared/check_answers/proceeding_details',
             proceeding: proceeding,
             read_only: @read_only
           ) %>

--- a/app/views/providers/proceeding_loop/client_involvement_type/show.html.erb
+++ b/app/views/providers/proceeding_loop/client_involvement_type/show.html.erb
@@ -1,0 +1,21 @@
+<%= form_with(
+      model: @form,
+      url: providers_legal_aid_application_client_involvement_type_path,
+      method: :patch,
+      local: true
+    ) do |form| %>
+  <%= page_template page_title: @proceeding.meaning, template: :basic, form: form do %>
+    <span class="govuk-caption-l"><%= position_in_array(@proceeding) %></span>
+    <%= form.govuk_collection_radio_buttons(:client_involvement_type_ccms_code,
+                                            @form.client_involvement_types,
+                                            :ccms_code,
+                                            :description,
+                                            legend: {size: 'xl', tag: 'h1', text: content_for(:page_title)},
+                                            hint: { text: t('.question'), class: 'govuk-heading-m' }) %>
+
+    <%= next_action_buttons(
+          form: form,
+          show_draft: true
+        ) %>
+  <% end %>
+<% end %>

--- a/app/views/shared/check_answers/_client_involvement_type_details.html.erb
+++ b/app/views/shared/check_answers/_client_involvement_type_details.html.erb
@@ -1,0 +1,8 @@
+<% read_only = false unless local_assigns.key?(:read_only) %>
+<%= check_answer_link(
+      name: :"#{proceeding.name}_client_involvement_type",
+      url: providers_legal_aid_application_client_involvement_type_path(@legal_aid_application, proceeding),
+      question: t('.question'),
+      answer: proceeding.client_involvement_type_description,
+      read_only: read_only
+    ) %>

--- a/app/views/shared/check_answers/_delegated_function_details.erb
+++ b/app/views/shared/check_answers/_delegated_function_details.erb
@@ -1,16 +1,8 @@
 <% read_only = false unless local_assigns.key?(:read_only) %>
-<div class="govuk-grid-row" id="app-check-your-answers__delegated_functions">
-  <div class="govuk-grid-column-full">
-    <h2 class="govuk-heading-m"><%= proceeding.meaning %></h2>
-  </div>
-</div>
-
-<dl class="govuk-summary-list govuk-!-margin-bottom-9">
-  <%= check_answer_link(
-        name: :"#{proceeding.name}_used_delegated_functions_on",
-        url: providers_legal_aid_application_delegated_function_path(@legal_aid_application, proceeding),
-        question: t('.question'),
-        answer: proceeding.used_delegated_functions_on&.strftime('%-d %B %Y') || t(".not_used"),
-        read_only: read_only
-      ) %>
-</dl>
+<%= check_answer_link(
+      name: :"#{proceeding.name}_used_delegated_functions_on",
+      url: providers_legal_aid_application_delegated_function_path(@legal_aid_application, proceeding),
+      question: t('.question'),
+      answer: proceeding.used_delegated_functions_on&.strftime('%-d %B %Y') || t(".not_used"),
+      read_only: read_only
+    ) %>

--- a/app/views/shared/check_answers/_proceeding_details.erb
+++ b/app/views/shared/check_answers/_proceeding_details.erb
@@ -1,0 +1,19 @@
+<% read_only = false unless local_assigns.key?(:read_only) %>
+<div class="govuk-grid-row" id="app-check-your-answers__delegated_functions">
+  <div class="govuk-grid-column-full">
+    <h2 class="govuk-heading-m"><%= proceeding.meaning %></h2>
+  </div>
+</div>
+
+<dl class="govuk-summary-list govuk-!-margin-bottom-9">
+  <%= render(
+        'shared/check_answers/delegated_function_details',
+        proceeding: proceeding,
+        read_only: @read_only
+      ) %>
+  <%= render(
+        'shared/check_answers/client_involvement_type_details',
+        proceeding: proceeding,
+        read_only: @read_only
+      ) %>
+</dl>

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -438,6 +438,10 @@ en:
           attributes:
             base:
               none_selected: Select if your client has received any of these payments
+        proceeding:
+          attributes:
+            client_involvement_type_ccms_code:
+              blank: Select your client’s role in this proceeding
         proceedings:
           attributes:
             used_delegated_functions:

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -1251,4 +1251,8 @@ en:
         page_title: Enter your client's email address
         label: Email address
         hint: We'll use this to send your client a link to the service.+
+    proceeding_loop:
+      client_involvement_type:
+        show:
+          question: What is your client’s role in this proceeding?
 

--- a/config/locales/en/shared.yml
+++ b/config/locales/en/shared.yml
@@ -285,6 +285,8 @@ en:
         section_laspo:
           heading: LASPO
           question: Are the Section 8 proceedings you're applying for in scope of LASPO?
+      client_involvement_type_details:
+        question: Client role
       delegated_function_details:
         question: Delegated functions
         not_used: Not used

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -225,6 +225,7 @@ Rails.application.routes.draw do
       resource :used_multiple_delegated_functions, only: %i[show update] # TODO: Delete after mini loop implemented
       resource :confirm_multiple_delegated_functions, only: %i[show update] # TODO: Refactor after mini loop
       resources :delegated_functions, only: %i[show update]
+      resources :client_involvement_type, only: %i[show update], controller: "proceeding_loop/client_involvement_type"
       resource :use_ccms, only: %i[show]
       resources :use_ccms_employed, only: %i[index]
       resource :substantive_application, only: %i[show update]

--- a/features/cassettes/mini-loop/When_the_application_has_a_single_proceeding_and_I_m_going_to_use_delegated_functions.yml
+++ b/features/cassettes/mini-loop/When_the_application_has_a_single_proceeding_and_I_m_going_to_use_delegated_functions.yml
@@ -1,0 +1,119 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/client_involvement_types
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Faraday v1.10.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 04 Aug 2022 12:08:01 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Vary:
+      - Accept, Origin
+      Etag:
+      - W/"8bf337339345d42d16a9e6062fb65ccf"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - f70d838c0897c9778772e7fdeae9123f
+      X-Runtime:
+      - '0.004861'
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '[{"ccms_code":"A","description":"Applicant/claimant/petitioner"},{"ccms_code":"D","description":"Defendant/respondent"},{"ccms_code":"W","description":"Subject
+        of proceedings (child)"},{"ccms_code":"I","description":"Intervenor"},{"ccms_code":"Z","description":"Joined
+        party"}]'
+  recorded_at: Thu, 04 Aug 2022 12:08:01 GMT
+- request:
+    method: get
+    uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/client_involvement_types
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Faraday v1.10.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 04 Aug 2022 12:08:01 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Vary:
+      - Accept, Origin
+      Etag:
+      - W/"8bf337339345d42d16a9e6062fb65ccf"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 9b7381ce7bc3971fef0267cc2b5aad97
+      X-Runtime:
+      - '0.004664'
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '[{"ccms_code":"A","description":"Applicant/claimant/petitioner"},{"ccms_code":"D","description":"Defendant/respondent"},{"ccms_code":"W","description":"Subject
+        of proceedings (child)"},{"ccms_code":"I","description":"Intervenor"},{"ccms_code":"Z","description":"Joined
+        party"}]'
+  recorded_at: Thu, 04 Aug 2022 12:08:01 GMT
+recorded_with: VCR 6.1.0

--- a/features/cassettes/mini-loop/When_the_application_has_a_single_proceeding_and_I_m_not_using_delegated_functions.yml
+++ b/features/cassettes/mini-loop/When_the_application_has_a_single_proceeding_and_I_m_not_using_delegated_functions.yml
@@ -1,0 +1,119 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/client_involvement_types
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Faraday v1.10.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 04 Aug 2022 12:27:21 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Vary:
+      - Accept, Origin
+      Etag:
+      - W/"8bf337339345d42d16a9e6062fb65ccf"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - ba7be032f4ac435c1a0e7f0279baa73b
+      X-Runtime:
+      - '0.003920'
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '[{"ccms_code":"A","description":"Applicant/claimant/petitioner"},{"ccms_code":"D","description":"Defendant/respondent"},{"ccms_code":"W","description":"Subject
+        of proceedings (child)"},{"ccms_code":"I","description":"Intervenor"},{"ccms_code":"Z","description":"Joined
+        party"}]'
+  recorded_at: Thu, 04 Aug 2022 12:27:21 GMT
+- request:
+    method: get
+    uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/client_involvement_types
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Faraday v1.10.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 04 Aug 2022 12:27:22 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Vary:
+      - Accept, Origin
+      Etag:
+      - W/"8bf337339345d42d16a9e6062fb65ccf"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - f7b40e9e6f5455ba52d4752eeafe0eeb
+      X-Runtime:
+      - '0.004953'
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '[{"ccms_code":"A","description":"Applicant/claimant/petitioner"},{"ccms_code":"D","description":"Defendant/respondent"},{"ccms_code":"W","description":"Subject
+        of proceedings (child)"},{"ccms_code":"I","description":"Intervenor"},{"ccms_code":"Z","description":"Joined
+        party"}]'
+  recorded_at: Thu, 04 Aug 2022 12:27:22 GMT
+recorded_with: VCR 6.1.0

--- a/features/cassettes/mini-loop/When_the_application_has_a_single_proceeding_and_I_m_using_delegated_functions.yml
+++ b/features/cassettes/mini-loop/When_the_application_has_a_single_proceeding_and_I_m_using_delegated_functions.yml
@@ -1,0 +1,235 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/client_involvement_types
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Faraday v1.10.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 04 Aug 2022 11:01:21 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Vary:
+      - Accept, Origin
+      Etag:
+      - W/"8bf337339345d42d16a9e6062fb65ccf"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 9ec6e0112acb1b734b2dca17c1a89824
+      X-Runtime:
+      - '0.052977'
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '[{"ccms_code":"A","description":"Applicant/claimant/petitioner"},{"ccms_code":"D","description":"Defendant/respondent"},{"ccms_code":"W","description":"Subject
+        of proceedings (child)"},{"ccms_code":"I","description":"Intervenor"},{"ccms_code":"Z","description":"Joined
+        party"}]'
+  recorded_at: Thu, 04 Aug 2022 11:01:21 GMT
+- request:
+    method: get
+    uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/client_involvement_types
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Faraday v1.10.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 04 Aug 2022 11:01:21 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Vary:
+      - Accept, Origin
+      Etag:
+      - W/"8bf337339345d42d16a9e6062fb65ccf"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 911c5a77f259d9e28bb1f5f2bfc679aa
+      X-Runtime:
+      - '0.044000'
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '[{"ccms_code":"A","description":"Applicant/claimant/petitioner"},{"ccms_code":"D","description":"Defendant/respondent"},{"ccms_code":"W","description":"Subject
+        of proceedings (child)"},{"ccms_code":"I","description":"Intervenor"},{"ccms_code":"Z","description":"Joined
+        party"}]'
+  recorded_at: Thu, 04 Aug 2022 11:01:21 GMT
+- request:
+    method: get
+    uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/client_involvement_types
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Faraday v1.10.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 04 Aug 2022 11:01:22 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Vary:
+      - Accept, Origin
+      Etag:
+      - W/"8bf337339345d42d16a9e6062fb65ccf"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 72035077d070e658aeb96a0fe93201e5
+      X-Runtime:
+      - '0.004616'
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '[{"ccms_code":"A","description":"Applicant/claimant/petitioner"},{"ccms_code":"D","description":"Defendant/respondent"},{"ccms_code":"W","description":"Subject
+        of proceedings (child)"},{"ccms_code":"I","description":"Intervenor"},{"ccms_code":"Z","description":"Joined
+        party"}]'
+  recorded_at: Thu, 04 Aug 2022 11:01:22 GMT
+- request:
+    method: get
+    uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/client_involvement_types
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Faraday v1.10.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 04 Aug 2022 11:01:23 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Vary:
+      - Accept, Origin
+      Etag:
+      - W/"8bf337339345d42d16a9e6062fb65ccf"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 7ba54a73501a99cb5beafadbf9a33eb3
+      X-Runtime:
+      - '0.004425'
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '[{"ccms_code":"A","description":"Applicant/claimant/petitioner"},{"ccms_code":"D","description":"Defendant/respondent"},{"ccms_code":"W","description":"Subject
+        of proceedings (child)"},{"ccms_code":"I","description":"Intervenor"},{"ccms_code":"Z","description":"Joined
+        party"}]'
+  recorded_at: Thu, 04 Aug 2022 11:01:23 GMT
+recorded_with: VCR 6.1.0

--- a/features/providers/mini-loop/multi_proceeding.feature
+++ b/features/providers/mini-loop/multi_proceeding.feature
@@ -1,5 +1,5 @@
 Feature: mini-loop
-  @javascript
+  @javascript @vcr
   Scenario: When the application has a single proceeding and I'm using delegated functions
     Given the feature flag for enable_mini_loop is enabled
     And I have started an application with multiple proceedings
@@ -8,10 +8,16 @@ Feature: mini-loop
     Then I should be on the 'in_scope_of_laspo' page showing "Are the Section 8 proceedings you're applying for in scope of the Legal Aid, Sentencing and Punishment of Offenders Act 2012 (LASPO)?"
     When I choose 'No'
     And I click 'Save and continue'
-    Then I should see 'Proceeding 1 of 2\nInherent jurisdiction high court injunction'
+    Then I should see 'Proceeding 1 of 2\nInherent jurisdiction high court injunction\nWhat is your client’s role in this proceeding?'
+    When I choose 'Applicant/claimant/petitioner'
+    And I click 'Save and continue'
+    Then I should see 'Proceeding 1 of 2\nInherent jurisdiction high court injunction\nHave you used delegated functions for this proceeding?'
     When I choose 'No'
     And I click 'Save and continue'
-    Then I should see 'Proceeding 2 of 2\nChild arrangements order'
+    Then I should see 'Proceeding 2 of 2\nChild arrangements order \(contact\)\nWhat is your client’s role in this proceeding?'
+    When I choose 'Defendant/respondent'
+    And I click 'Save and continue'
+    Then I should see 'Proceeding 2 of 2\nChild arrangements order \(contact\)\nHave you used delegated functions for this proceeding?'
     When I choose 'Yes'
     And I enter the 'delegated functions on' date of 5 days ago
     When I click 'Save and continue'

--- a/features/providers/mini-loop/single_proceeding.feature
+++ b/features/providers/mini-loop/single_proceeding.feature
@@ -1,22 +1,28 @@
 Feature: Mini-loop
-  @javascript
+  @javascript @vcr
   Scenario: When the application has a single proceeding and I'm not using delegated functions
     Given the feature flag for enable_mini_loop is enabled
     And I have started an application and reached the proceedings list
     When I choose 'No'
     And I click 'Save and continue'
-    Then I should see 'Proceeding 1\nInherent jurisdiction high court injunction'
+    Then I should see 'Proceeding 1\nInherent jurisdiction high court injunction\nWhat is your client’s role in this proceeding?'
+    When I choose 'Applicant/claimant/petitioner'
+    And I click 'Save and continue'
+    Then I should see 'Proceeding 1\nInherent jurisdiction high court injunction\nHave you used delegated functions for this proceeding?'
     When I choose 'No'
     And I click 'Save and continue'
     Then I should be on the 'limitations' page showing 'Inherent jurisdiction high court injunction'
 
-  @javascript
+  @javascript @vcr
   Scenario: When the application has a single proceeding and I'm going to use delegated functions
     Given the feature flag for enable_mini_loop is enabled
     And I have started an application and reached the proceedings list
     When I choose 'No'
     And I click 'Save and continue'
-    Then I should see 'Proceeding 1\nInherent jurisdiction high court injunction'
+    Then I should see 'Proceeding 1\nInherent jurisdiction high court injunction\nWhat is your client’s role in this proceeding?'
+    When I choose 'Applicant/claimant/petitioner'
+    And I click 'Save and continue'
+    Then I should see 'Proceeding 1\nInherent jurisdiction high court injunction\nHave you used delegated functions for this proceeding?'
     When I choose 'Yes'
     And I enter the 'delegated functions on' date of 5 days ago
     When I click 'Save and continue'

--- a/spec/cassettes/ClientInvolvementTypeController/GET_/providers/applications/_legal_aid_application_id/client_involvement_type/_proceeding_id/when_the_provider_is_authenticated/displays_the_heading.yml
+++ b/spec/cassettes/ClientInvolvementTypeController/GET_/providers/applications/_legal_aid_application_id/client_involvement_type/_proceeding_id/when_the_provider_is_authenticated/displays_the_heading.yml
@@ -1,0 +1,61 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/client_involvement_types
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Faraday v1.10.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 04 Aug 2022 10:18:47 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Vary:
+      - Accept, Origin
+      Etag:
+      - W/"8bf337339345d42d16a9e6062fb65ccf"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - '08b10f5a4e2bc135080af68207dd5542'
+      X-Runtime:
+      - '0.004508'
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '[{"ccms_code":"A","description":"Applicant/claimant/petitioner"},{"ccms_code":"D","description":"Defendant/respondent"},{"ccms_code":"W","description":"Subject
+        of proceedings (child)"},{"ccms_code":"I","description":"Intervenor"},{"ccms_code":"Z","description":"Joined
+        party"}]'
+  recorded_at: Thu, 04 Aug 2022 10:18:47 GMT
+recorded_with: VCR 6.1.0

--- a/spec/cassettes/ClientInvolvementTypeController/GET_/providers/applications/_legal_aid_application_id/client_involvement_type/_proceeding_id/when_the_provider_is_authenticated/returns_http_success.yml
+++ b/spec/cassettes/ClientInvolvementTypeController/GET_/providers/applications/_legal_aid_application_id/client_involvement_type/_proceeding_id/when_the_provider_is_authenticated/returns_http_success.yml
@@ -1,0 +1,61 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/client_involvement_types
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Faraday v1.10.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 04 Aug 2022 10:18:47 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Vary:
+      - Accept, Origin
+      Etag:
+      - W/"8bf337339345d42d16a9e6062fb65ccf"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 6a63b3e97b4bb94e8e8f98ee288dd4b7
+      X-Runtime:
+      - '0.004331'
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '[{"ccms_code":"A","description":"Applicant/claimant/petitioner"},{"ccms_code":"D","description":"Defendant/respondent"},{"ccms_code":"W","description":"Subject
+        of proceedings (child)"},{"ccms_code":"I","description":"Intervenor"},{"ccms_code":"Z","description":"Joined
+        party"}]'
+  recorded_at: Thu, 04 Aug 2022 10:18:47 GMT
+recorded_with: VCR 6.1.0

--- a/spec/cassettes/ClientInvolvementTypeController/POST_/providers/applications/_legal_aid_application_id/client_involvement_type/_proceeding_id/when_the_provider_is_authenticated/when_the_Continue_button_is_pressed/redirects_to_next_page.yml
+++ b/spec/cassettes/ClientInvolvementTypeController/POST_/providers/applications/_legal_aid_application_id/client_involvement_type/_proceeding_id/when_the_provider_is_authenticated/when_the_Continue_button_is_pressed/redirects_to_next_page.yml
@@ -1,0 +1,61 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/client_involvement_types
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Faraday v1.10.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 04 Aug 2022 10:18:46 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Vary:
+      - Accept, Origin
+      Etag:
+      - W/"8bf337339345d42d16a9e6062fb65ccf"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - aaffa3d15f7f2f3d508006223a5cf14e
+      X-Runtime:
+      - '0.050659'
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '[{"ccms_code":"A","description":"Applicant/claimant/petitioner"},{"ccms_code":"D","description":"Defendant/respondent"},{"ccms_code":"W","description":"Subject
+        of proceedings (child)"},{"ccms_code":"I","description":"Intervenor"},{"ccms_code":"Z","description":"Joined
+        party"}]'
+  recorded_at: Thu, 04 Aug 2022 10:18:46 GMT
+recorded_with: VCR 6.1.0

--- a/spec/cassettes/Proceedings_ClientInvolvementTypeForm/_save/when_the_client_involvement_type_submitted_is_valid/updates_the_proceeding.yml
+++ b/spec/cassettes/Proceedings_ClientInvolvementTypeForm/_save/when_the_client_involvement_type_submitted_is_valid/updates_the_proceeding.yml
@@ -1,0 +1,61 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/client_involvement_types
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Faraday v1.10.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 04 Aug 2022 11:15:51 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Vary:
+      - Accept, Origin
+      Etag:
+      - W/"8bf337339345d42d16a9e6062fb65ccf"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - ec1362d1f1e2ac7390df92bcf2414eeb
+      X-Runtime:
+      - '0.040680'
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '[{"ccms_code":"A","description":"Applicant/claimant/petitioner"},{"ccms_code":"D","description":"Defendant/respondent"},{"ccms_code":"W","description":"Subject
+        of proceedings (child)"},{"ccms_code":"I","description":"Intervenor"},{"ccms_code":"Z","description":"Joined
+        party"}]'
+  recorded_at: Thu, 04 Aug 2022 11:15:51 GMT
+recorded_with: VCR 6.1.0

--- a/spec/forms/proceedings/client_involvement_type_form_spec.rb
+++ b/spec/forms/proceedings/client_involvement_type_form_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe Proceedings::ClientInvolvementTypeForm, :vcr, type: :form do
+  subject(:cit_form) { described_class.new(form_params) }
+
+  let(:proceeding) { create :proceeding, :da001, :without_cit }
+  let(:params) do
+    {
+      client_involvement_type_ccms_code: cit,
+    }
+  end
+  let(:form_params) { params.merge(model: proceeding) }
+
+  describe "#save" do
+    subject(:save_form) { cit_form.save }
+
+    before { save_form }
+
+    context "when the client_involvement_type submitted is valid" do
+      let(:cit) { "A" }
+
+      it "updates the proceeding" do
+        expect(proceeding.reload.client_involvement_type_ccms_code).to eq "A"
+      end
+    end
+
+    context "when the client_involvement_type submitted is missing" do
+      let(:cit) { nil }
+
+      it "is invalid" do
+        expect(cit_form).to be_invalid
+      end
+
+      it "generates the expected error message" do
+        expect(cit_form.errors.map(&:attribute)).to eq [:client_involvement_type_ccms_code]
+      end
+    end
+  end
+end

--- a/spec/requests/providers/in_scope_of_laspos_controller_spec.rb
+++ b/spec/requests/providers/in_scope_of_laspos_controller_spec.rb
@@ -24,7 +24,12 @@ RSpec.describe Providers::InScopeOfLasposController, type: :request do
   describe "PATCH /providers/:application_id/in_scope_of_laspo" do
     subject { patch providers_legal_aid_application_in_scope_of_laspo_path(legal_aid_application), params: }
 
-    before { subject }
+    before do
+      allow(Setting).to receive(:enable_mini_loop?).and_return(mini_loop?)
+      subject
+    end
+
+    let(:mini_loop?) { false }
 
     context "choose yes" do
       let(:params) { { legal_aid_application: { in_scope_of_laspo: true } } }
@@ -47,6 +52,15 @@ RSpec.describe Providers::InScopeOfLasposController, type: :request do
 
       it "redirects to the next page" do
         expect(response).to redirect_to(next_flow_step)
+      end
+
+      context "when the mini_loop flag is on" do
+        let(:mini_loop?) { true }
+
+        it "redirects to the next page" do
+          proceeding_id = legal_aid_application.proceedings.first.id
+          expect(response).to redirect_to(providers_legal_aid_application_client_involvement_type_path(legal_aid_application.id, proceeding_id))
+        end
       end
     end
 

--- a/spec/requests/providers/proceeding_loop/client_involvement_type_controller_spec.rb
+++ b/spec/requests/providers/proceeding_loop/client_involvement_type_controller_spec.rb
@@ -1,0 +1,70 @@
+require "rails_helper"
+
+RSpec.describe "ClientInvolvementTypeController", :vcr, type: :request do
+  let(:application) { create(:legal_aid_application, :with_proceedings) }
+  let(:application_id) { application.id }
+  let(:proceeding_id) { application.proceedings.first.id }
+  let(:provider) { application.provider }
+
+  before { allow(Setting).to receive(:enable_mini_loop?).and_return(true) } # TODO: Remove when the mini-loop feature flag is removed
+
+  describe "GET /providers/applications/:legal_aid_application_id/client_involvement_type/:proceeding_id" do
+    subject(:get_cit) { get "/providers/applications/#{application_id}/client_involvement_type/#{proceeding_id}" }
+
+    context "when the provider is not authenticated" do
+      before { get_cit }
+
+      it_behaves_like "a provider not authenticated"
+    end
+
+    context "when the provider is authenticated" do
+      before do
+        login_as provider
+        get_cit
+      end
+
+      it "returns http success" do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "displays the heading" do
+        expect(response.body).to include("Proceeding 1")
+        expect(response.body).to include("Inherent jurisdiction high court injunction")
+        expect(response.body).to include("What is your client’s role in this proceeding?")
+      end
+    end
+  end
+
+  describe "POST /providers/applications/:legal_aid_application_id/client_involvement_type/:proceeding_id" do
+    subject(:post_cit) { patch "/providers/applications/#{application_id}/client_involvement_type/#{proceeding_id}", params: }
+
+    let(:params) do
+      {
+        proceeding: {
+          client_involvement_type: "A",
+        },
+      }
+    end
+
+    context "when the provider is not authenticated" do
+      before { post_cit }
+
+      it_behaves_like "a provider not authenticated"
+    end
+
+    context "when the provider is authenticated" do
+      before do
+        login_as provider
+      end
+
+      context "when the Continue button is pressed" do
+        let(:submit_button) { { continue_button: "Continue" } }
+
+        it "redirects to next page" do
+          post_cit
+          expect(response.body).to redirect_to(providers_legal_aid_application_delegated_function_path(application_id))
+        end
+      end
+    end
+  end
+end

--- a/spec/services/flow/proceeding_loop_spec.rb
+++ b/spec/services/flow/proceeding_loop_spec.rb
@@ -30,15 +30,25 @@ RSpec.describe Flow::ProceedingLoop do
       context "when the user enters the loop for the first time" do
         let(:provider_step) { "has_other_proceedings" }
 
-        it { is_expected.to be :delegated_functions }
+        it { is_expected.to be :client_involvement_type }
       end
 
       context "when the user is on the second of three proceedings" do
-        let(:provider_step) { "delegated_functions" }
+        context "and is on the client involvement page" do
+          let(:provider_step) { "client_involvement_type" }
 
-        before { allow(legal_aid_application).to receive(:provider_step_params).and_return({ "id" => legal_aid_application.proceedings.in_order_of_addition.second.id }) }
+          before { allow(legal_aid_application).to receive(:provider_step_params).and_return({ "id" => legal_aid_application.proceedings.in_order_of_addition.second.id }) }
 
-        it { is_expected.to be :delegated_functions }
+          it { is_expected.to be :delegated_functions }
+        end
+
+        context "and is on the delegated_function page" do
+          let(:provider_step) { "delegated_functions" }
+
+          before { allow(legal_aid_application).to receive(:provider_step_params).and_return({ "id" => legal_aid_application.proceedings.in_order_of_addition.second.id }) }
+
+          it { is_expected.to be :client_involvement_type }
+        end
       end
 
       context "when the user is on the final of the three proceedings" do


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3359)

Add the Client Involvement Type page to the mini-loop, this allows the provider
to record the CIT for each proceeding before moving on to the next proceeding or exiting the loop

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
