### PR TITLE
Add missing translation for means reports

### DIFF
--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -892,6 +892,7 @@ en:
           further_employment_details: Further employment details
           multiple_employments: Multiple employments
           refunds: Tax or NI refunds
+          uploaded_bank_statements: Bank statements uploaded
       show:
         heading: Means report
         caseworker-review-section-heading: Caseworker Review

--- a/spec/services/ccms/manual_review_determiner_spec.rb
+++ b/spec/services/ccms/manual_review_determiner_spec.rb
@@ -288,6 +288,18 @@ module CCMS
           expect(subject).to eq restrictions_reasons
         end
       end
+
+      context "with uploaded bank statements" do
+        let(:legal_aid_application) { create(:legal_aid_application) }
+
+        before do
+          allow(legal_aid_application).to receive(:uploading_bank_statements?).and_return true
+        end
+
+        it "adds uploaded_bank_statements to the review reasons" do
+          expect(subject).to include(:uploaded_bank_statements)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## What

[Relates story](https://dsdmoj.atlassian.net/browse/AP-3386)

uploaded_bank_statements are raising a missing translation
error locally when displaying the means_report. This falls back to 
humanized key value on hosted envs. This fixes


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
