### PR TITLE
Improve nino validation 

### DIFF
--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -4,7 +4,7 @@ require "omniauth"
 class Applicant < ApplicationRecord
   devise :rememberable
 
-  NINO_REGEXP = /^[A-CEGHJ-PR-TW-Z]{1}[A-CEGHJ-NPR-TW-Z]{1}[0-9]{6}[A-DFM]{1}$/
+  NINO_REGEXP = /\A(?!BG)(?!GB)(?!NK)(?!KN)(?!TN)(?!NT)(?!ZZ)[A-CEGHJ-PR-TW-Z][A-CEGHJ-NPR-TW-Z][0-9]{6}([A-DFM])\Z/
 
   has_one :legal_aid_application, dependent: :destroy
   has_many :addresses, dependent: :destroy

--- a/db/anonymise/rules.rb
+++ b/db/anonymise/rules.rb
@@ -1,6 +1,6 @@
 require "faker"
 
-NINO_REGEXP = /^[A-CEGHJ-PR-TW-Z]{1}[A-CEGHJ-NPR-TW-Z]{1}[0-9]{6}[A-DFM]{1}$/
+NINO_REGEXP = /\A(?!BG)(?!GB)(?!NK)(?!KN)(?!TN)(?!NT)(?!ZZ)[A-CEGHJ-PR-TW-Z][A-CEGHJ-NPR-TW-Z][0-9]{6}([A-DFM])\Z/
 
 @rules = {
   active_storage_attachments: {},


### PR DESCRIPTION


## What
Improve national insurance number (nino) validation

See [Crime Apply's PR](https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/pull/50)

Based on NINO allocation rules as per https://www.gov.uk/hmrc-internal-manuals/national-insurance-manual/nim39110 - improved validation to include raising validation errors for specific unused prefixes

Also strips spaces and upcases input prior to validation to allow for input variation (particularly for spaces which are shown as part of the hint text NINO example)

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
