### PR TITLE
AP-3378 add bank_statement filenames to review page

### DIFF
--- a/app/views/providers/means_summaries/show.html.erb
+++ b/app/views/providers/means_summaries/show.html.erb
@@ -4,7 +4,7 @@
   <h2 class="govuk-heading-l"><%= t('.h2-heading') %></h2>
 
   <% if bank_statement_upload %>
-    <%= render('shared/check_answers/bank_statements', bank_statements: @legal_aid_application.attachments.bank_statement_evidence) %>
+    <%= render('shared/check_answers/bank_statements', bank_statements: @legal_aid_application.attachments.bank_statement_evidence, read_only: false) %>
   <% end %>
 
   <% if Setting.enable_employed_journey? && @legal_aid_application.provider.employment_permissions? %>

--- a/app/views/shared/_review_application.html.erb
+++ b/app/views/shared/_review_application.html.erb
@@ -95,6 +95,11 @@
 <section class="income_payments_and_assets page_break_before">
   <div class="govuk-!-padding-bottom-6"></div>
   <h2 class="govuk-heading-l"><%= t('.income_payments_and_assets_heading') %></h2>
+
+  <% if @legal_aid_application.uploading_bank_statements? %>
+    <%= render('shared/check_answers/bank_statements', bank_statements: @legal_aid_application.attachments.bank_statement_evidence, read_only: true) %>
+  <% end %>
+
   <% if display_employment_income? %>
     <%= render 'shared/employment_income_table' %>
   <% end %>

--- a/app/views/shared/check_answers/_bank_statements.html.erb
+++ b/app/views/shared/check_answers/_bank_statements.html.erb
@@ -1,12 +1,12 @@
-<h3 class="govuk-heading-m"><%= "Bank statements" %></h2>
+<h3 class="govuk-heading-m"><%= t('.section_heading') %></h3>
 
 <dl class="govuk-summary-list govuk-!-margin-bottom-9">
 
   <%= check_answer_link(
     name: :bank_statements,
     url: providers_legal_aid_application_bank_statements_path,
-    question: "Upload bank statements",
+    question: t('.bank_statement_question'),
     answer: attachments_with_size(bank_statements),
-    read_only: false
+    read_only: read_only
   ) %>
 </dl>

--- a/config/locales/en/shared.yml
+++ b/config/locales/en/shared.yml
@@ -202,6 +202,9 @@ en:
         offline_savings_amount: Amount in offline savings accounts
       bank_transaction_table:
         total: '%{text} total'
+      bank_statements:
+        section_heading: Bank statements
+        bank_statement_question: Uploaded bank statements
       capital_result:
         contribution: Capital contribution
         lower_limit_label: Capital lower limit

--- a/features/providers/check_your_answers.feature
+++ b/features/providers/check_your_answers.feature
@@ -296,7 +296,7 @@ Feature: Checking answers backwards and forwards
     Given csrf is enabled
     And I have completed a non-passported employed application with bank statement upload as far as the end of the means section
     Then I should be on the 'means_summary' page showing 'Check your answers'
-    And I should see 'Upload bank statements'
+    And I should see 'Uploaded bank statements'
     And I should see 'Does your client receive student finance?'
     And the answer for 'student finance question' should be 'No'
     And I should not see 'Which bank accounts does your client have?'


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3378)

Add a bank statement section to the review_and_print page only visible if bank statements have been uploaded
Amend an existing partial to reuse it for the review page
Add some translations
fix an issue with a < / h 2 >  tag

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
