### PR TITLE
Fix: Date display

### DIFF
--- a/config/initializers/date_formats.rb
+++ b/config/initializers/date_formats.rb
@@ -1,21 +1,10 @@
-# The below hotfix is taken from https://stackoverflow.com/a/71328079
-# Overrides the rails 7 removal of to_s and allows our default
-# format to be applied rather than having to find each date
-# and manually add `.to_fs` to the end of it
+# The below hotfix overrides the rails 7 removal of to_s and
+# allows our default format to be applied rather than having
+# to find each date and manually add `.to_fs` to the end of it
 require "date"
 
 class Date
-  def to_s(format = :default)
-    if (formatter = DATE_FORMATS[format])
-      if formatter.respond_to?(:call)
-        formatter.call(self).to_s
-      else
-        strftime(formatter)
-      end
-    else
-      to_default_s
-    end
-  end
+  alias_method :to_s, :to_fs
 end
 
 # Note - if using `l(date)` in an erb, format is defined in locale at en.date.formats

--- a/config/initializers/date_formats.rb
+++ b/config/initializers/date_formats.rb
@@ -1,5 +1,6 @@
-# The below hotfix overrides the rails 7 removal of to_s and
-# allows our default format to be applied rather than having
+# The below hotfix overrides the rails 7 removal of to_s
+# https://guides.rubyonrails.org/7_0_release_notes.html#active-support-deprecations
+# and allows our default format to be applied rather than having
 # to find each date and manually add `.to_fs` to the end of it
 require "date"
 

--- a/config/initializers/date_formats.rb
+++ b/config/initializers/date_formats.rb
@@ -1,3 +1,23 @@
+# The below hotfix is taken from https://stackoverflow.com/a/71328079
+# Overrides the rails 7 removal of to_s and allows our default
+# format to be applied rather than having to find each date
+# and manually add `.to_fs` to the end of it
+require "date"
+
+class Date
+  def to_s(format = :default)
+    if (formatter = DATE_FORMATS[format])
+      if formatter.respond_to?(:call)
+        formatter.call(self).to_s
+      else
+        strftime(formatter)
+      end
+    else
+      to_default_s
+    end
+  end
+end
+
 # Note - if using `l(date)` in an erb, format is defined in locale at en.date.formats
 Date::DATE_FORMATS[:default] = "%e %B %Y"
 Time::DATE_FORMATS[:datetime] = "%H:%M %d-%b-%Y"

--- a/spec/requests/providers/substantive_applications_spec.rb
+++ b/spec/requests/providers/substantive_applications_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Providers::SubstantiveApplicationsController, type: :request, vcr
            :at_applicant_details_checked,
            :with_proceedings,
            :with_delegated_functions_on_proceedings,
+           :with_substantive_application_deadline_on,
            explicit_proceedings: [:da004],
            df_options: { DA004: [Time.zone.today, Time.zone.today] },
            applicant:
@@ -28,6 +29,11 @@ RSpec.describe Providers::SubstantiveApplicationsController, type: :request, vcr
 
     it "renders successfully" do
       expect(response).to have_http_status(:ok)
+    end
+
+    it "renders the date correctly" do
+      target_date = SubstantiveApplicationDeadlineCalculator.call(legal_aid_application.earliest_delegated_functions_date)
+      expect(response.body).to include("You must submit a substantive application by #{target_date.strftime('%e %B %Y')}")
     end
 
     context "when not authenticated" do


### PR DESCRIPTION
## What

The update to rails 7 removed the automatic conversion of dates to_s.  This meant that the default date format was not being applied and was falling back to YYYY-MM-DD

The hotfix applied means that we do not have to manually update each date with .to_fs any more

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
