### PR TITLE
Move the credits and debits scope specs to correct class

### DIFF
--- a/spec/models/legal_aid_application_transaction_type_spec.rb
+++ b/spec/models/legal_aid_application_transaction_type_spec.rb
@@ -1,17 +1,22 @@
 require "rails_helper"
 
 RSpec.describe LegalAidApplicationTransactionType, type: :model do
-  describe "relationships" do
-    let(:credit_transaction_type) { create :transaction_type, :credit_with_standard_name }
-    let(:debit_transaction_type) { create :transaction_type, :debit_with_standard_name }
-    let(:legal_aid_application) { create :legal_aid_application }
+  let(:legal_aid_application) { create(:legal_aid_application) }
+  let(:credit_transaction_type) { create(:transaction_type, :credit_with_standard_name) }
+  let(:debit_transaction_type) { create(:transaction_type, :debit_with_standard_name) }
 
-    before do
+  describe ".credits" do
+    subject(:credits) { described_class.credits }
+
+    let!(:a_credit) do
       create(
         :legal_aid_application_transaction_type,
         legal_aid_application:,
         transaction_type: credit_transaction_type,
       )
+    end
+
+    before do
       create(
         :legal_aid_application_transaction_type,
         legal_aid_application:,
@@ -19,22 +24,32 @@ RSpec.describe LegalAidApplicationTransactionType, type: :model do
       )
     end
 
-    describe "legal_aid_application has_many" do
-      it "returns all" do
-        expect(legal_aid_application.transaction_types).to contain_exactly(credit_transaction_type, debit_transaction_type)
-      end
+    it "returns credits only" do
+      expect(credits).to contain_exactly(a_credit)
+    end
+  end
+
+  describe ".debits" do
+    subject(:debits) { described_class.debits }
+
+    let!(:a_debit) do
+      create(
+        :legal_aid_application_transaction_type,
+        legal_aid_application:,
+        transaction_type: debit_transaction_type,
+      )
     end
 
-    describe "legal_aid_application credit transaction_types" do
-      it "returns just the credit types" do
-        expect(legal_aid_application.transaction_types.credits).to contain_exactly(credit_transaction_type)
-      end
+    before do
+      create(
+        :legal_aid_application_transaction_type,
+        legal_aid_application:,
+        transaction_type: credit_transaction_type,
+      )
     end
 
-    describe "legal_aid_application debit transaction_types" do
-      it "returns just the debit types" do
-        expect(legal_aid_application.transaction_types.debits).to contain_exactly(debit_transaction_type)
-      end
+    it "returns debits only" do
+      expect(debits).to contain_exactly(a_debit)
     end
   end
 end

--- a/spec/models/transaction_type_spec.rb
+++ b/spec/models/transaction_type_spec.rb
@@ -1,6 +1,46 @@
 require "rails_helper"
 
+RSpec.shared_context "with credit and debit transaction types" do
+  let(:credit_transaction_type) { create(:transaction_type, :benefits) }
+  let(:debit_transaction_type) { create(:transaction_type, :rent_or_mortgage) }
+
+  before do
+    credit_transaction_type
+    debit_transaction_type
+  end
+end
+
 RSpec.describe TransactionType, type: :model do
+  describe ".all" do
+    subject(:all) { described_class.all }
+
+    include_context "with credit and debit transaction types"
+
+    it "returns all" do
+      expect(all).to contain_exactly(credit_transaction_type, debit_transaction_type)
+    end
+  end
+
+  describe ".credits" do
+    subject(:credits) { described_class.credits }
+
+    include_context "with credit and debit transaction types"
+
+    it "returns just the credit types" do
+      expect(credits).to contain_exactly(credit_transaction_type)
+    end
+  end
+
+  describe ".debits" do
+    subject(:debits) { described_class.debits }
+
+    include_context "with credit and debit transaction types"
+
+    it "returns just the debit types" do
+      expect(debits).to contain_exactly(debit_transaction_type)
+    end
+  end
+
   describe "#for_income_type?" do
     context "when checks that a boolean response is returned" do
       let!(:credit_transaction) { create :transaction_type, :credit_with_standard_name }


### PR DESCRIPTION

## What
Moved scope specs to correct model class spec and replaced with specs that 
excercise the owning classes scopes.

Both transaction_types and legal_aid_application_transaction_types
have `.credits` and `.debits` scopes. The transaction_types model's
scopes were being tested in the legal_aid_application_transaction_types
specs and there were no specs excercising the expected behaviour of
the transaction_types model's scopes. I have added the later and moved
and rejigged the former.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
