### PR TITLE
[AP-3422] - Refactor model callbacks

### DIFF
--- a/app/models/ccms/submission.rb
+++ b/app/models/ccms/submission.rb
@@ -10,7 +10,7 @@ module CCMS
     validates :legal_aid_application_id, presence: true
     # rubocop:enable Rails/RedundantPresenceValidationOnBelongsTo
 
-    after_save do
+    after_commit on: %i[create update] do
       ActiveSupport::Notifications.instrument "dashboard.ccms_submission_saved", id:, state: aasm_state
     end
 

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -21,7 +21,7 @@ class Feedback < ApplicationRecord
 
   validates :done_all_needed, inclusion: { in: [true, false] }
 
-  after_create do
+  after_commit on: :create do
     ActiveSupport::Notifications.instrument "dashboard.feedback_created", feedback_id: id
   end
 end

--- a/app/models/firm.rb
+++ b/app/models/firm.rb
@@ -10,7 +10,7 @@ class Firm < ApplicationRecord
     self.permission_ids = [passported_permission_id]
   end
 
-  after_create do
+  after_commit on: :create do
     ActiveSupport::Notifications.instrument "dashboard.firm_created"
   end
 

--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -53,13 +53,12 @@ class LegalAidApplication < ApplicationRecord
 
   before_save :set_open_banking_consent_choice_at
   before_create :create_app_ref
-  after_create do
+  after_commit on: :create do
     ActiveSupport::Notifications.instrument "dashboard.application_created", id:, state:
   end
 
-  after_save do
+  after_commit on: %i[create update] do
     ActiveSupport::Notifications.instrument "dashboard.declined_open_banking" if saved_change_to_open_banking_consent?
-    ActiveSupport::Notifications.instrument("dashboard.provider_updated", provider_id: provider.id) if proc { |laa| laa.state }.eql?(:assessment_submitted)
   end
 
   validate :validate_document_categories

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -11,7 +11,7 @@ class Provider < ApplicationRecord
   has_many :actor_permissions, as: :permittable
   has_many :permissions, through: :actor_permissions
 
-  after_create do
+  after_commit on: :create do
     ActiveSupport::Notifications.instrument "dashboard.provider_updated", provider_id: id
   end
 

--- a/spec/models/ccms/submission_spec.rb
+++ b/spec/models/ccms/submission_spec.rb
@@ -15,6 +15,38 @@ module CCMS
              case_poll_count:
     end
 
+    describe ".after_commit callback" do
+      context "when a submission is created" do
+        it "fires the dashboard.ccms_submission_saved event" do
+          submission = build(:submission, aasm_state: :initialised)
+          allow(ActiveSupport::Notifications).to receive(:instrument)
+
+          submission.save!
+
+          expect(ActiveSupport::Notifications).to have_received(:instrument).with(
+            "dashboard.ccms_submission_saved",
+            id: submission.id,
+            state: "initialised",
+          )
+        end
+      end
+
+      context "when a submission is updated" do
+        it "fires the dashboard.ccms_submission_saved event" do
+          submission = create(:submission, aasm_state: :initialised)
+          allow(ActiveSupport::Notifications).to receive(:instrument)
+
+          submission.update!(aasm_state: "completed")
+
+          expect(ActiveSupport::Notifications).to have_received(:instrument).with(
+            "dashboard.ccms_submission_saved",
+            id: submission.id,
+            state: "completed",
+          )
+        end
+      end
+    end
+
     context "with Validations" do
       it "errors if no legal aid application id is present" do
         submission.legal_aid_application = nil

--- a/spec/models/feedback_spec.rb
+++ b/spec/models/feedback_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.describe Feedback, type: :model do
+  describe ".after_commit callbacks" do
+    context "when a feedback is created" do
+      it "fires the dashboard.feedback_created event" do
+        feedback = build(:feedback)
+        allow(ActiveSupport::Notifications).to receive(:instrument)
+
+        feedback.save!
+
+        expect(ActiveSupport::Notifications).to have_received(:instrument).with(
+          "dashboard.feedback_created",
+          feedback_id: feedback.reload.id,
+        )
+      end
+    end
+
+    context "when a feedback is updated" do
+      it "does not fire the dashboard.feedback_created event" do
+        feedback = create(:feedback)
+        allow(ActiveSupport::Notifications).to receive(:instrument)
+
+        feedback.update!(satisfaction: :very_satisfied)
+
+        expect(ActiveSupport::Notifications).not_to have_received(:instrument).with(
+          "dashboard.feedback_created",
+          feedback_id: feedback.id,
+        )
+      end
+    end
+  end
+end

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -4,6 +4,36 @@ RSpec.describe Provider, type: :model do
   let(:firm) { create :firm }
   let(:provider) { create :provider, firm: }
 
+  describe ".after_commit callback" do
+    context "when a provider is created" do
+      it "fires the dashboard.provider_updated event" do
+        provider = build(:provider)
+        allow(ActiveSupport::Notifications).to receive(:instrument)
+
+        provider.save!
+
+        expect(ActiveSupport::Notifications).to have_received(:instrument).with(
+          "dashboard.provider_updated",
+          provider_id: provider.id,
+        )
+      end
+    end
+
+    context "when a provider is updated" do
+      it "does not fire the dashboard.provider_updated event" do
+        provider = create(:provider)
+        allow(ActiveSupport::Notifications).to receive(:instrument)
+
+        provider.update!(name: "Updated Provider")
+
+        expect(ActiveSupport::Notifications).not_to have_received(:instrument).with(
+          "dashboard.provider_updated",
+          provider_id: provider.id,
+        )
+      end
+    end
+  end
+
   describe "#update_details" do
     context "when firm exists" do
       it "does not call provider details creator immediately" do


### PR DESCRIPTION
Before, some models used `after_create` and `after_save` callbacks to send
notification events to various dashboards.

This is probably fine most of the time, but in the event the database
transaction rolls back, erroneous notifications would be sent (i.e a
notification is sent that an application was created, but the application wasn't
actually created).

This replaces these callbacks with their `after_commit` counterparts, which
ensures notification events are sent only after the commit to the database.

As part of this work, I identified a redundant call to
`ActiveSupport::Notifications.instrument` in
`app/models/legal_aid_application.rb:62`:

```ruby
ActiveSupport::Notifications.instrument("dashboard.provider_updated", provider_id: provider.id) if proc { |laa| laa.state }.eql?(:assessment_submitted)
```

Here `proc { |laa| laa.state }.eql?(:assessment_submitted)` will always evaluate
to false, so the notification is never sent.

This method call has been removed.

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3422)