### PR TITLE
[AP-3423] - Add GovukComponents gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -99,6 +99,9 @@ gem "secure_headers"
 # DFE formbuilder
 gem "govuk_design_system_formbuilder", ">= 3.0.1"
 
+# DFE ViewComponent library
+gem "govuk-components"
+
 group :development, :test do
   gem "awesome_print", "~> 1.9.2"
   gem "byebug", platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -308,6 +308,13 @@ GEM
       multi_json (~> 1.11)
       os (>= 0.9, < 2.0)
       signet (~> 0.15)
+    govuk-components (3.1.5)
+      actionpack (>= 6.1)
+      activemodel (>= 6.1)
+      html-attributes-utils (~> 0.9, >= 0.9.2)
+      pagy (~> 5.10.1)
+      railties (>= 6.1)
+      view_component (~> 2.56.2)
     govuk_design_system_formbuilder (3.1.2)
       actionview (>= 6.1)
       activemodel (>= 6.1)
@@ -695,6 +702,9 @@ GEM
     unicode-display_width (2.2.0)
     vcr (6.1.0)
     version_gem (1.1.0)
+    view_component (2.56.2)
+      activesupport (>= 5.0.0, < 8.0)
+      method_source (~> 1.0)
     virtus (2.0.0)
       axiom-types (~> 0.1)
       coercible (~> 1.0)
@@ -761,6 +771,7 @@ DEPENDENCIES
   faker (>= 1.9.1)
   geckoboard-ruby
   google_drive (>= 3.0.7)
+  govuk-components
   govuk_design_system_formbuilder (>= 3.0.1)
   govuk_notify_rails (~> 2.2.0)
   guard-cucumber

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -49,19 +49,13 @@
     <a href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
 
     <%= render partial: 'layouts/header' %>
+
     <div class="govuk-width-container">
-      <div class="govuk-phase-banner no-print">
-        <p class="govuk-phase-banner__content">
-          <strong class="govuk-tag govuk-phase-banner__content__tag ">
-            <%= t 'layouts.application.header.phase' %>
-          </strong>
-          <span class="govuk-phase-banner__text">
-            <%= t 'layouts.application.header.phase_banner_text_1' %>
-            <%= link_to_accessible t('layouts.application.header.feedback'), new_feedback_path, class: 'govuk-link' %>
-            <%= t 'layouts.application.header.phase_banner_text_2' %>
-          </span>
-        </p>
-      </div>
+      <%= govuk_phase_banner(
+        tag: {text: t(".header.phase")},
+        text: t(".header.phase_banner_html", link: govuk_link_to(t(".header.feedback"), new_feedback_path)),
+        classes: "no-print"
+      ) %>
 
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-one-half show-empty">

--- a/config/locales/cy/layouts.yml
+++ b/config/locales/cy/layouts.yml
@@ -27,8 +27,7 @@ cy:
         gov_uk_link_title: egapemoh KU.VOG eht ot oG
         feedback: kcabdeef
         phase: ateb
-        phase_banner_text_1: ruoy – ecivres wen a si sihT
-        phase_banner_text_2: ".ti evorpmi ot su pleh lliw"
+        phase_banner_html: This is a new service – your %{link} will help us to improve it.
         title: dia lagel rof ylppA
     logout:
       admin: tuo ngis nimdA

--- a/config/locales/en/layouts.yml
+++ b/config/locales/en/layouts.yml
@@ -26,8 +26,7 @@ en:
         gov_uk_link_title: Go to the GOV.UK homepage
         feedback: feedback
         phase: beta
-        phase_banner_text_1: This is a new service – your
-        phase_banner_text_2: will help us to improve it.
+        phase_banner_html: This is a new service – your %{link} will help us to improve it.
         title: Apply for legal aid
     logout:
       admin: Admin sign out


### PR DESCRIPTION
Pretty much every view in the application leans primarily on GOV.UK Design
System components.

This introduces the [govuk-components] gem to help us manage this complexity.

Rather than relying on copy-paste to ensure we render the design system
components accurately, we can render these resuable components. They are well
tested, customisable, and should reflect the design system accurately.

[govuk-components]: https://github.com/DFE-Digital/govuk-components

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3423)