### PR TITLE
Use bundler-audit to audit gems

### DIFF
--- a/.github/workflows/bundle-audit.yml
+++ b/.github/workflows/bundle-audit.yml
@@ -1,0 +1,15 @@
+name: Bundle audit
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  bundle-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - run: bundle exec bundle-audit check --update

--- a/Gemfile
+++ b/Gemfile
@@ -101,6 +101,7 @@ gem "govuk_design_system_formbuilder", ">= 3.0.1"
 
 group :development, :test do
   gem "awesome_print", "~> 1.9.2"
+  gem "bundler-audit"
   gem "byebug", platforms: %i[mri mingw x64_mingw]
   gem "dotenv-rails", ">= 2.7.6"
   gem "erb_lint", "0.1.3", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -130,6 +130,9 @@ GEM
       msgpack (~> 1.2)
     browser (5.3.1)
     builder (3.2.4)
+    bundler-audit (0.9.1)
+      bundler (>= 1.2.0, < 3)
+      thor (~> 1.0)
     business (2.3.0)
     byebug (11.1.3)
     capybara (3.37.1)
@@ -723,6 +726,7 @@ DEPENDENCIES
   axe-core-cucumber
   bootsnap (>= 1.1.0)
   browser
+  bundler-audit
   business
   byebug
   capybara (>= 3.36.0, < 4.0)


### PR DESCRIPTION
This adds the `bundler-audit` gem to automatically check installed gems in
Gemfile.lock for security advisories, and prompt us to upgrade to patched
versions as soon as possible.

This uses GitHub actions to run the check as part of CI, and it is triggered by
default pull_request events (opened, synchronized, reopened) against the main
branch. This seemed to be the trigger used across the application, so I have
adopted the same approach.