### PR TITLE
Remove `enable_employed_journey` setting

### DIFF
--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -22,7 +22,6 @@ module Admin
                                       :manually_review_all_cases,
                                       :allow_welsh_translation,
                                       :enable_ccms_submission,
-                                      :enable_employed_journey,
                                       :enable_mini_loop,
                                       :enable_loop,
                                       :enhanced_bank_upload)

--- a/app/controllers/providers/confirm_dwp_non_passported_applications_controller.rb
+++ b/app/controllers/providers/confirm_dwp_non_passported_applications_controller.rb
@@ -55,10 +55,6 @@ module Providers
       form.correct_dwp_result?
     end
 
-    def employed_journey_enabled?
-      Setting.enable_employed_journey?
-    end
-
     def hmrc_call_enabled?
       Rails.configuration.x.collect_hmrc_data
     end
@@ -68,7 +64,7 @@ module Providers
     end
 
     def make_hmrc_call?
-      employed_journey_enabled? && hmrc_call_enabled? && user_has_employment_permissions?
+      hmrc_call_enabled? && user_has_employment_permissions?
     end
 
     alias_method :display_hmrc_inset_text?, :make_hmrc_call?

--- a/app/controllers/providers/provider_base_controller.rb
+++ b/app/controllers/providers/provider_base_controller.rb
@@ -10,8 +10,7 @@ module Providers
   private
 
     def display_employment_income?
-      Setting.enable_employed_journey? &&
-        @legal_aid_application.provider.employment_permissions? &&
+      @legal_aid_application.provider.employment_permissions? &&
         @legal_aid_application.cfe_result.version >= 4 &&
         @legal_aid_application.cfe_result.jobs?
     end

--- a/app/forms/settings/setting_form.rb
+++ b/app/forms/settings/setting_form.rb
@@ -6,7 +6,6 @@ module Settings
                   :manually_review_all_cases,
                   :allow_welsh_translation,
                   :enable_ccms_submission,
-                  :enable_employed_journey,
                   :enable_mini_loop,
                   :enable_loop,
                   :enhanced_bank_upload
@@ -15,7 +14,6 @@ module Settings
               :manually_review_all_cases,
               :allow_welsh_translation,
               :enable_ccms_submission,
-              :enable_employed_journey,
               :enable_mini_loop,
               :enable_loop,
               :enhanced_bank_upload,

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -1,4 +1,6 @@
 class Setting < ApplicationRecord
+  self.ignored_columns = %i[enable_employed_journey]
+
   def self.mock_true_layer_data?
     setting.mock_true_layer_data?
   end
@@ -21,10 +23,6 @@ class Setting < ApplicationRecord
 
   def self.alert_via_sentry?
     setting.alert_via_sentry
-  end
-
-  def self.enable_employed_journey?
-    setting.enable_employed_journey
   end
 
   def self.enable_mini_loop?

--- a/app/services/flow/flows/provider_start.rb
+++ b/app/services/flow/flows/provider_start.rb
@@ -41,7 +41,7 @@ module Flow
           forward: lambda do |application|
             next_step = application.used_delegated_functions? ? :substantive_applications : :open_banking_consents
 
-            if Setting.enable_employed_journey? && application.provider.employment_permissions?
+            if application.provider.employment_permissions?
               application.employment_journey_ineligible? ? :use_ccms_employed : next_step
             else
               application.applicant_not_employed? ? next_step : :use_ccms_employed

--- a/app/services/hmrc/status_analyzer.rb
+++ b/app/services/hmrc/status_analyzer.rb
@@ -18,8 +18,6 @@ module HMRC
     end
 
     def call
-      return :employed_journey_not_enabled unless Setting.enable_employed_journey?
-
       return :provider_not_enabled_for_employed_journey unless provider.employment_permissions?
 
       return :applicant_not_employed if applicant_not_employed && no_employment_payments

--- a/app/views/admin/settings/show.html.erb
+++ b/app/views/admin/settings/show.html.erb
@@ -47,16 +47,6 @@
     ) %>
 
     <%= form.govuk_collection_radio_buttons(
-        :enable_employed_journey,
-        yes_no_options,
-        :value,
-        :label,
-        inline: true,
-        hint: { text: t('.hints.enable_employed_journey')},
-        legend: { text: t('.labels.enable_employed_journey') }
-    ) %>
-
-    <%= form.govuk_collection_radio_buttons(
           :enable_mini_loop,
           yes_no_options,
           :value,

--- a/app/views/providers/capital_income_assessment_results/_other_income.html.erb
+++ b/app/views/providers/capital_income_assessment_results/_other_income.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-accordion__section-content">
   <h2 class="govuk-heading-m">
-    <%= Setting.enable_employed_journey? && @legal_aid_application.provider.employment_permissions? && @cfe_result.jobs? ? t('.title') : t('.income') %>
+    <%= @legal_aid_application.provider.employment_permissions? && @cfe_result.jobs? ? t('.title') : t('.income') %>
   </h2>
   <table class="govuk-table">
     <tbody>

--- a/app/views/providers/capital_income_assessment_results/_result_details.html.erb
+++ b/app/views/providers/capital_income_assessment_results/_result_details.html.erb
@@ -13,7 +13,7 @@
         </span>
         </h2>
       </div>
-        <% if Setting.enable_employed_journey? && @legal_aid_application.provider.employment_permissions? && @cfe_result.jobs? %>
+        <% if @legal_aid_application.provider.employment_permissions? && @cfe_result.jobs? %>
           <%= render 'employment_income' %>
         <% end %>
         <%= render 'other_income' %>

--- a/app/views/providers/means_summaries/_income_assessment.html.erb
+++ b/app/views/providers/means_summaries/_income_assessment.html.erb
@@ -6,7 +6,7 @@
   <%= render('shared/check_answers/bank_statements', bank_statements: @legal_aid_application.attachments.bank_statement_evidence, read_only: false) %>
 <% end %>
 
-<% if Setting.enable_employed_journey? && @legal_aid_application.provider.employment_permissions? %>
+<% if @legal_aid_application.provider.employment_permissions? %>
   <% if @legal_aid_application.hmrc_employment_income? %>
     <% if @legal_aid_application.has_multiple_employments? %>
       <%= render 'shared/check_answers/full_employment_details', read_only: false %>

--- a/app/views/providers/use_ccms_employed/index.html.erb
+++ b/app/views/providers/use_ccms_employed/index.html.erb
@@ -2,7 +2,7 @@
   <%= page_template(page_title: t('.title_html'), head_title: t('.head_title'), column_width: 'full', template: :basic) do %>
     <%= page_heading(size: 'l') %>
 
-    <% if Setting.enable_employed_journey? && @legal_aid_application.employment_journey_ineligible? %>
+    <% if @legal_aid_application.employment_journey_ineligible? %>
       <div class="maximize-text-width">
         <p class="govuk-body"><%= t '.warning_list_title' %></p>
         <%= list_from_translation_path '.use_ccms_employed.index.ineligible_employed' %>

--- a/app/views/shared/check_answers/_income_details.html.erb
+++ b/app/views/shared/check_answers/_income_details.html.erb
@@ -15,7 +15,7 @@
         student_loan: :mei_student_loan,
         pension: :mei_pension
         }
-      item_list = Setting.enable_employed_journey? && @legal_aid_application.applicant.employed? ? employed_items.merge(non_employed_items) : non_employed_items
+      item_list = @legal_aid_application.applicant.employed? ? employed_items.merge(non_employed_items) : non_employed_items
       item_list.each do |name, value_method|
     %>
       <%= render 'shared/means_report/item', name: name, scope: 'income', value_method: value_method, suppress_border: name == :pension %>

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -39,7 +39,6 @@ en:
           manually_review_all_cases: Manually review all non-passported applications
           allow_welsh_translation: Allow Welsh translation
           enable_ccms_submission: Allow CCMS submissions
-          enable_employed_journey: Allow employed applications
           enable_evidence_upload: Enable the new evidence upload feature
           enable_mini_loop: Enable mini loop for proceeding types/CIT and DF
           enable_loop: Enable loop for proceeding types/levels of service
@@ -51,7 +50,6 @@ en:
             Select Yes to additionally route all non-passported applications to caseworker for review.
           allow_welsh_translation: Select Yes to translate the service into Welsh
           enable_ccms_submission: Yes by default, only set to No if CCMS is being taken offline
-          enable_employed_journey: Select Yes to allow solicitors to submit applications for employed applicants
           enable_evidence_upload: Select Yes to enable the new evidence upload feature for solicitors
           enable_mini_loop: Select Yes to turn on mini loop for proceeding type choices for CIT and DF
           enable_loop: Select Yes to turn on the extended loop for proceeding type choices for levels of service

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -50,8 +50,6 @@ en:
           <<: *true_false
         allow_welsh_translation:
           <<: *true_false
-        enable_employed_journey:
-          <<: *true_false
         enable_evidence_upload:
           <<: *true_false
         enable_mini_loop:

--- a/features/providers/employed_journey.feature
+++ b/features/providers/employed_journey.feature
@@ -2,7 +2,6 @@ Feature: Employed journey
 
 @javascript
 Scenario: Completing the means journey for an employed applicant with HMRC data
-  Given the feature flag for enable_employed_journey is enabled
   Given I start the means review journey with employment income for a single job from HMRC
   Then I should be on the 'client_completed_means' page showing 'Your client has shared their financial information'
   When I click 'Continue'
@@ -57,7 +56,6 @@ Scenario: Completing the means journey for an employed applicant with HMRC data
 
 @javascript
 Scenario: Completing the means journey for an employed applicant with no HMRC data
-  Given the feature flag for enable_employed_journey is enabled
   Given I start the means review journey with no employment income from HMRC
   Then I should be on the 'client_completed_means' page showing 'Your client has shared their financial information'
   When I click 'Continue'
@@ -107,7 +105,6 @@ Scenario: Completing the means journey for an employed applicant with no HMRC da
 
 @javascript
 Scenario: Completing the means journey for an employed applicant with multiple jobs
-  Given the feature flag for enable_employed_journey is enabled
   Given I start the means review journey with employment income for multiple jobs from HMRC
   Then I should be on the 'client_completed_means' page showing 'Your client has shared their financial information'
   When I click 'Continue'

--- a/features/step_definitions/bank_statement_uploaded_steps.rb
+++ b/features/step_definitions/bank_statement_uploaded_steps.rb
@@ -1,6 +1,4 @@
 Given("I have completed a non-passported employed application and reached the open banking consent with bank statement upload enabled") do
-  Setting.setting.update!(enable_employed_journey: true)
-
   # These changes are to add existing categories (as would have been selected by the applicant)
   # to the application e.g. housing, benefits, the categories are now selected by the provider
   # so should not be necessary, however in practice this means that the checkboxes are not being populated
@@ -33,8 +31,6 @@ Given("I have completed a non-passported employed application and reached the op
 end
 
 Given("I have completed a non-passported employed application with bank statement upload as far as the end of the means section") do
-  Setting.setting.update!(enable_employed_journey: true)
-
   @legal_aid_application = create(
     :application,
     :with_proceedings,

--- a/features/step_definitions/check_your_answers_steps.rb
+++ b/features/step_definitions/check_your_answers_steps.rb
@@ -1,8 +1,6 @@
 require "rspec/expectations"
 
 Given("I have completed a non-passported application with open banking transactions") do
-  Setting.setting.update!(enable_employed_journey: true)
-
   @legal_aid_application = create(
     :legal_aid_application,
     :with_proceedings,

--- a/features/step_definitions/employment_setup_steps.rb
+++ b/features/step_definitions/employment_setup_steps.rb
@@ -1,5 +1,4 @@
 Given(/^the system is prepped for the employed journey$/) do
-  Setting.setting.update!(enable_employed_journey: true)
   employment_permission = Permission.find_by(role: "application.non_passported.employment.*")
   Provider.all.each do |provider|
     next if provider.permissions.include?(employment_permission)

--- a/features/step_definitions/means_report_steps.rb
+++ b/features/step_definitions/means_report_steps.rb
@@ -1,6 +1,4 @@
 Given("I have completed a non-passported employed application with bank statement uploads") do
-  Setting.setting.update!(enable_employed_journey: true)
-
   @legal_aid_application = create(
     :legal_aid_application,
     :with_proceedings,
@@ -27,8 +25,6 @@ Given("I have completed a non-passported employed application with bank statemen
 end
 
 Given("I have completed a non-passported application with truelayer") do
-  Setting.setting.update!(enable_employed_journey: true)
-
   @legal_aid_application = create(
     :legal_aid_application,
     :with_proceedings,
@@ -67,8 +63,6 @@ Given("I have completed a non-passported application with truelayer") do
 end
 
 Given("I have completed a passported application") do
-  Setting.setting.update!(enable_employed_journey: true)
-
   @legal_aid_application = create(
     :legal_aid_application,
     :with_proceedings,

--- a/lib/tasks/employ.rake
+++ b/lib/tasks/employ.rake
@@ -2,9 +2,6 @@ desc "Temporary task to set employed journey up on localhost"
 task employ: :environment do
   raise "rake employ can only be used in development" if HostEnv.production?
 
-  Setting.setting.update!(enable_employed_journey: true)
-  Rails.logger.warn "Employed journey feature flag enabled"
-
   employment_permission = Permission.find_by(role: "application.non_passported.employment.*")
 
   Firm.all.each do |firm|

--- a/lib/tasks/setup_db_for_testing.rake
+++ b/lib/tasks/setup_db_for_testing.rake
@@ -7,7 +7,6 @@ namespace :settings do
                     manually_review_all_cases: false,
                     allow_welsh_translation: false,
                     enable_ccms_submission: true,
-                    enable_employed_journey: false,
                     enable_evidence_upload: false,
                     enable_mini_loop: false,
                     enable_loop: false,

--- a/spec/factories/legal_aid_applications.rb
+++ b/spec/factories/legal_aid_applications.rb
@@ -303,7 +303,7 @@ FactoryBot.define do
     # date in an array for each proceeding ccms_code.
     # example:
     #   {
-    #     DA001: [Date.yesterday, Date.today],
+    #     DA001: [Date.yesterday, Date.current],
     #     DA004: [nil, nil],
     #     SE013: [2.days.ago, 1.day.ago]
     #   }

--- a/spec/models/setting_spec.rb
+++ b/spec/models/setting_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe Setting do
         expect(rec.allow_welsh_translation?).to be false
         expect(rec.bank_transaction_filename).to eq "db/sample_data/bank_transactions.csv"
         expect(rec.alert_via_sentry?).to be true
-        expect(rec.enable_employed_journey?).to be false
         expect(rec.enable_mini_loop?).to be false
         expect(rec.enable_loop?).to be false
         expect(rec.enhanced_bank_upload?).to be false
@@ -28,7 +27,6 @@ RSpec.describe Setting do
           enable_ccms_submission: false,
           bank_transaction_filename: "my_special_file.csv",
           alert_via_sentry: true,
-          enable_employed_journey: true,
           enable_mini_loop: true,
           enable_loop: true,
           enhanced_bank_upload: true,
@@ -43,7 +41,6 @@ RSpec.describe Setting do
         expect(rec.enable_ccms_submission?).to be false
         expect(rec.bank_transaction_filename).to eq "my_special_file.csv"
         expect(rec.alert_via_sentry?).to be true
-        expect(rec.enable_employed_journey?).to be true
         expect(rec.enable_mini_loop?).to be true
         expect(rec.enable_loop?).to be true
         expect(rec.enhanced_bank_upload?).to be true
@@ -61,7 +58,6 @@ RSpec.describe Setting do
       expect(described_class.enable_ccms_submission?).to be true
       expect(described_class.bank_transaction_filename).to eq "db/sample_data/bank_transactions.csv"
       expect(described_class.alert_via_sentry?).to be true
-      expect(described_class.enable_employed_journey?).to be false
       expect(described_class.enable_mini_loop?).to be false
       expect(described_class.enable_loop?).to be false
       expect(described_class.enhanced_bank_upload?).to be false

--- a/spec/requests/admin/settings_spec.rb
+++ b/spec/requests/admin/settings_spec.rb
@@ -39,7 +39,6 @@ RSpec.describe Admin::SettingsController, type: :request do
         setting: {
           mock_true_layer_data: "true",
           allow_welsh_translation: "true",
-          enable_employed_journey: "true",
           enable_ccms_submission: "true",
           enable_mini_loop: "true",
           enable_loop: "true",
@@ -57,7 +56,6 @@ RSpec.describe Admin::SettingsController, type: :request do
       subject
       expect(setting.mock_true_layer_data?).to be(true)
       expect(setting.allow_welsh_translation?).to be(true)
-      expect(setting.enable_employed_journey?).to be(true)
       expect(setting.enable_mini_loop?).to be(true)
       expect(setting.enable_loop?).to be(true)
       expect(setting.enhanced_bank_upload?).to be(true)
@@ -88,7 +86,6 @@ RSpec.describe Admin::SettingsController, type: :request do
             setting: {
               mock_true_layer_data: "true",
               allow_welsh_translation: "true",
-              enable_employed_journey: "true",
               enable_ccms_submission: "false",
             },
           }

--- a/spec/requests/providers/capital_income_assessment_results_spec.rb
+++ b/spec/requests/providers/capital_income_assessment_results_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Providers::CapitalIncomeAssessmentResultsController, type: :reque
 
     let(:before_tasks) do
       create(:policy_disregards, :with_selected_value, legal_aid_application:) if add_policy_disregards?
-
+      allow_any_instance_of(Provider).to receive(:employment_permissions?).and_return(true)
       Setting.setting.update!(manually_review_all_cases: false)
       login_provider
       subject
@@ -27,7 +27,7 @@ RSpec.describe Providers::CapitalIncomeAssessmentResultsController, type: :reque
     context "with no restrictions" do
       context "without policy disregards" do
         context "when eligible" do
-          let!(:cfe_result) { create :cfe_v3_result, :eligible }
+          let!(:cfe_result) { create :cfe_v4_result, :eligible }
 
           it "returns http success" do
             expect(response).to have_http_status(:ok)
@@ -39,7 +39,7 @@ RSpec.describe Providers::CapitalIncomeAssessmentResultsController, type: :reque
         end
 
         context "when not eligible" do
-          let!(:cfe_result) { create :cfe_v3_result, :not_eligible }
+          let!(:cfe_result) { create :cfe_v4_result, :not_eligible }
 
           it "returns http success" do
             expect(response).to have_http_status(:ok)
@@ -51,7 +51,7 @@ RSpec.describe Providers::CapitalIncomeAssessmentResultsController, type: :reque
         end
 
         context "when capital contribution required" do
-          let(:cfe_result) { create :cfe_v3_result, :with_capital_contribution_required }
+          let(:cfe_result) { create :cfe_v4_result, :with_capital_contribution_required }
 
           it "returns http success" do
             expect(response).to have_http_status(:ok)
@@ -63,7 +63,7 @@ RSpec.describe Providers::CapitalIncomeAssessmentResultsController, type: :reque
         end
 
         context "when income contribution required" do
-          let(:cfe_result) { create :cfe_v3_result, :with_income_contribution_required }
+          let(:cfe_result) { create :cfe_v4_result, :with_income_contribution_required }
 
           it "returns http success" do
             expect(response).to have_http_status(:ok)
@@ -75,7 +75,7 @@ RSpec.describe Providers::CapitalIncomeAssessmentResultsController, type: :reque
         end
 
         context "when both income and capital contribution required" do
-          let(:cfe_result) { create :cfe_v3_result, :with_capital_and_income_contributions_required }
+          let(:cfe_result) { create :cfe_v4_result, :with_capital_and_income_contributions_required }
 
           it "returns http success" do
             expect(response).to have_http_status(:ok)
@@ -97,7 +97,7 @@ RSpec.describe Providers::CapitalIncomeAssessmentResultsController, type: :reque
         let(:add_policy_disregards?) { true }
 
         context "when eligible" do
-          let!(:cfe_result) { create :cfe_v3_result, :eligible }
+          let!(:cfe_result) { create :cfe_v4_result, :eligible }
 
           it "returns http success" do
             expect(response).to have_http_status(:ok)
@@ -109,7 +109,7 @@ RSpec.describe Providers::CapitalIncomeAssessmentResultsController, type: :reque
         end
 
         context "when not eligible" do
-          let!(:cfe_result) { create :cfe_v3_result, :not_eligible }
+          let!(:cfe_result) { create :cfe_v4_result, :not_eligible }
 
           it "returns http success" do
             expect(response).to have_http_status(:ok)
@@ -121,7 +121,7 @@ RSpec.describe Providers::CapitalIncomeAssessmentResultsController, type: :reque
         end
 
         context "when capital contribution required" do
-          let(:cfe_result) { create :cfe_v3_result, :with_capital_contribution_required }
+          let(:cfe_result) { create :cfe_v4_result, :with_capital_contribution_required }
 
           it "returns http success" do
             expect(response).to have_http_status(:ok)
@@ -135,7 +135,7 @@ RSpec.describe Providers::CapitalIncomeAssessmentResultsController, type: :reque
         end
 
         context "when income contribution required" do
-          let(:cfe_result) { create :cfe_v3_result, :with_income_contribution_required }
+          let(:cfe_result) { create :cfe_v4_result, :with_income_contribution_required }
 
           it "returns http success" do
             expect(response).to have_http_status(:ok)
@@ -149,7 +149,7 @@ RSpec.describe Providers::CapitalIncomeAssessmentResultsController, type: :reque
         end
 
         context "when both income and capital contribution required" do
-          let(:cfe_result) { create :cfe_v3_result, :with_capital_and_income_contributions_required }
+          let(:cfe_result) { create :cfe_v4_result, :with_capital_and_income_contributions_required }
 
           it "returns http success" do
             expect(response).to have_http_status(:ok)
@@ -176,7 +176,7 @@ RSpec.describe Providers::CapitalIncomeAssessmentResultsController, type: :reque
 
       context "without policy disregards" do
         context "when eligible" do
-          let!(:cfe_result) { create :cfe_v3_result, :eligible }
+          let!(:cfe_result) { create :cfe_v4_result, :eligible }
 
           it "returns http success" do
             expect(response).to have_http_status(:ok)
@@ -188,7 +188,7 @@ RSpec.describe Providers::CapitalIncomeAssessmentResultsController, type: :reque
         end
 
         context "when capital contribution required" do
-          let(:cfe_result) { create :cfe_v3_result, :with_capital_contribution_required }
+          let(:cfe_result) { create :cfe_v4_result, :with_capital_contribution_required }
 
           it "returns http success" do
             expect(response).to have_http_status(:ok)
@@ -202,7 +202,7 @@ RSpec.describe Providers::CapitalIncomeAssessmentResultsController, type: :reque
         end
 
         context "when income contribution required" do
-          let(:cfe_result) { create :cfe_v3_result, :with_income_contribution_required }
+          let(:cfe_result) { create :cfe_v4_result, :with_income_contribution_required }
 
           it "returns http success" do
             expect(response).to have_http_status(:ok)
@@ -216,7 +216,7 @@ RSpec.describe Providers::CapitalIncomeAssessmentResultsController, type: :reque
         end
 
         context "when both income and capital contribution required" do
-          let(:cfe_result) { create :cfe_v3_result, :with_capital_and_income_contributions_required }
+          let(:cfe_result) { create :cfe_v4_result, :with_capital_and_income_contributions_required }
 
           it "returns http success" do
             expect(response).to have_http_status(:ok)
@@ -234,7 +234,7 @@ RSpec.describe Providers::CapitalIncomeAssessmentResultsController, type: :reque
         let(:add_policy_disregards?) { true }
 
         context "when eligible" do
-          let!(:cfe_result) { create :cfe_v3_result, :eligible }
+          let!(:cfe_result) { create :cfe_v4_result, :eligible }
 
           it "returns http success" do
             expect(response).to have_http_status(:ok)
@@ -246,7 +246,7 @@ RSpec.describe Providers::CapitalIncomeAssessmentResultsController, type: :reque
         end
 
         context "when capital contribution required" do
-          let(:cfe_result) { create :cfe_v3_result, :with_capital_contribution_required }
+          let(:cfe_result) { create :cfe_v4_result, :with_capital_contribution_required }
 
           it "returns http success" do
             expect(response).to have_http_status(:ok)
@@ -262,7 +262,7 @@ RSpec.describe Providers::CapitalIncomeAssessmentResultsController, type: :reque
         end
 
         context "when income contribution required" do
-          let(:cfe_result) { create :cfe_v3_result, :with_income_contribution_required }
+          let(:cfe_result) { create :cfe_v4_result, :with_income_contribution_required }
 
           it "returns http success" do
             expect(response).to have_http_status(:ok)
@@ -278,7 +278,7 @@ RSpec.describe Providers::CapitalIncomeAssessmentResultsController, type: :reque
         end
 
         context "when both income and capital contribution required" do
-          let(:cfe_result) { create :cfe_v3_result, :with_capital_and_income_contributions_required }
+          let(:cfe_result) { create :cfe_v4_result, :with_capital_and_income_contributions_required }
 
           it "returns http success" do
             expect(response).to have_http_status(:ok)
@@ -401,13 +401,13 @@ RSpec.describe Providers::CapitalIncomeAssessmentResultsController, type: :reque
 
     context "when unauthenticated" do
       let(:before_tasks) { subject }
-      let!(:cfe_result) { create :cfe_v3_result, :eligible }
+      let!(:cfe_result) { create :cfe_v4_result, :eligible }
 
       it_behaves_like "a provider not authenticated"
     end
 
     context "with unknown result" do
-      let(:cfe_result) { create :cfe_v3_result, result: {}.to_json }
+      let(:cfe_result) { create :cfe_v4_result, result: {}.to_json }
       let(:before_tasks) do
         login_provider
       end
@@ -417,88 +417,52 @@ RSpec.describe Providers::CapitalIncomeAssessmentResultsController, type: :reque
       end
     end
 
-    context "when enable_employed_journey is true" do
-      let(:before_tasks) do
-        Setting.setting.update!(enable_employed_journey: true)
-        allow_any_instance_of(Provider).to receive(:employment_permissions?).and_return(true)
-        login_provider
-        subject
+    context "when applicant has employment(s)" do
+      let(:cfe_result) { create :cfe_v4_result, :with_employments }
+      let(:td) { "\n  </th>\n  <td class=\"govuk-table__cell govuk-table__cell--numeric\">\n    " }
+      let(:td_bold) { "\n  </th>\n  <td class=\"govuk-table__cell govuk-table__cell--numeric\">\n    <b>" }
+      let(:monthly_income_before_tax) { I18n.t("providers.capital_income_assessment_results.employment_income.monthly_income_before_tax") }
+      let(:benefits_in_kind) { I18n.t("providers.capital_income_assessment_results.employment_income.benefits_in_kind") }
+      let(:tax) { I18n.t("providers.capital_income_assessment_results.employment_income.tax") }
+      let(:national_insurance) { I18n.t("providers.capital_income_assessment_results.employment_income.national_insurance") }
+      let(:fixed_employment_deduction) { I18n.t("providers.capital_income_assessment_results.employment_income.fixed_employment_deduction") }
+      let(:total_employment) { I18n.t("providers.capital_income_assessment_results.employment_income.total") }
+      let(:total_outgoings) { I18n.t("providers.capital_income_assessment_results.outgoings.total_outgoings") }
+      let(:total_other_income) { I18n.t("providers.capital_income_assessment_results.other_income.total") }
+      let(:total_deductions) { I18n.t("providers.capital_income_assessment_results.deductions.total_deductions") }
+      let(:total_disposable_income) { I18n.t("providers.capital_income_assessment_results.disposable_income.total_income") }
+      let(:total_disposable_outgoings) { I18n.t("providers.capital_income_assessment_results.disposable_income.total_outgoings") }
+      let(:total_disposable_deductions) { I18n.t("providers.capital_income_assessment_results.disposable_income.total_deductions") }
+      let(:total_disposable) { I18n.t("providers.capital_income_assessment_results.disposable_income.total_disposable") }
+
+      it "displays the employment income" do
+        expect(unescaped_response_body).to include(I18n.t("providers.capital_income_assessment_results.other_income.title"))
+        expect(unescaped_response_body).to include(I18n.t("providers.capital_income_assessment_results.employment_income.title"))
+        expect(unescaped_response_body).to include(monthly_income_before_tax + td + gds_number_to_currency(cfe_result.employment_income_gross_income))
+        expect(unescaped_response_body).to include(benefits_in_kind + td + gds_number_to_currency(cfe_result.employment_income_benefits_in_kind))
+        expect(unescaped_response_body).to include(tax + td + gds_number_to_currency(cfe_result.employment_income_tax))
+        expect(unescaped_response_body).to include(national_insurance + td + gds_number_to_currency(cfe_result.employment_income_national_insurance))
+        expect(unescaped_response_body).to include(fixed_employment_deduction + td + gds_number_to_currency(cfe_result.employment_income_fixed_employment_deduction))
+        expect(unescaped_response_body).to include(total_employment + td + gds_number_to_currency(cfe_result.employment_income_net_employment_income))
       end
 
-      context "when applicant has employment(s)" do
-        let(:cfe_result) { create :cfe_v4_result, :with_employments }
-        let(:td) { "\n  </th>\n  <td class=\"govuk-table__cell govuk-table__cell--numeric\">\n    " }
-        let(:td_bold) { "\n  </th>\n  <td class=\"govuk-table__cell govuk-table__cell--numeric\">\n    <b>" }
-        let(:monthly_income_before_tax) { I18n.t("providers.capital_income_assessment_results.employment_income.monthly_income_before_tax") }
-        let(:benefits_in_kind) { I18n.t("providers.capital_income_assessment_results.employment_income.benefits_in_kind") }
-        let(:tax) { I18n.t("providers.capital_income_assessment_results.employment_income.tax") }
-        let(:national_insurance) { I18n.t("providers.capital_income_assessment_results.employment_income.national_insurance") }
-        let(:fixed_employment_deduction) { I18n.t("providers.capital_income_assessment_results.employment_income.fixed_employment_deduction") }
-        let(:total_employment) { I18n.t("providers.capital_income_assessment_results.employment_income.total") }
-        let(:total_outgoings) { I18n.t("providers.capital_income_assessment_results.outgoings.total_outgoings") }
-        let(:total_other_income) { I18n.t("providers.capital_income_assessment_results.other_income.total") }
-        let(:total_deductions) { I18n.t("providers.capital_income_assessment_results.deductions.total_deductions") }
-        let(:total_disposable_income) { I18n.t("providers.capital_income_assessment_results.disposable_income.total_income") }
-        let(:total_disposable_outgoings) { I18n.t("providers.capital_income_assessment_results.disposable_income.total_outgoings") }
-        let(:total_disposable_deductions) { I18n.t("providers.capital_income_assessment_results.disposable_income.total_deductions") }
-        let(:total_disposable) { I18n.t("providers.capital_income_assessment_results.disposable_income.total_disposable") }
-
-        it "displays the employment income" do
-          expect(unescaped_response_body).to include(I18n.t("providers.capital_income_assessment_results.other_income.title"))
-          expect(unescaped_response_body).to include(I18n.t("providers.capital_income_assessment_results.employment_income.title"))
-          expect(unescaped_response_body).to include(monthly_income_before_tax + td + gds_number_to_currency(cfe_result.employment_income_gross_income))
-          expect(unescaped_response_body).to include(benefits_in_kind + td + gds_number_to_currency(cfe_result.employment_income_benefits_in_kind))
-          expect(unescaped_response_body).to include(tax + td + gds_number_to_currency(cfe_result.employment_income_tax))
-          expect(unescaped_response_body).to include(national_insurance + td + gds_number_to_currency(cfe_result.employment_income_national_insurance))
-          expect(unescaped_response_body).to include(fixed_employment_deduction + td + gds_number_to_currency(cfe_result.employment_income_fixed_employment_deduction))
-          expect(unescaped_response_body).to include(total_employment + td + gds_number_to_currency(cfe_result.employment_income_net_employment_income))
-        end
-
-        it "displays the correct totals" do
-          expect(unescaped_response_body).to include(total_outgoings + td + gds_number_to_currency(cfe_result.total_monthly_outgoings))
-          expect(unescaped_response_body).to include(total_other_income + td + gds_number_to_currency(cfe_result.total_gross_income))
-          expect(unescaped_response_body).to include(total_deductions + td + gds_number_to_currency(cfe_result.total_deductions))
-          expect(unescaped_response_body).to include(total_disposable_income + td + gds_number_to_currency(cfe_result.total_monthly_income_including_employment_income))
-          expect(unescaped_response_body).to include(total_disposable_outgoings + td + gds_number_to_currency(cfe_result.total_monthly_outgoings_including_tax_and_ni))
-          expect(unescaped_response_body).to include(total_disposable_deductions + td + gds_number_to_currency(cfe_result.total_deductions_including_fixed_employment_allowance))
-          expect(unescaped_response_body).to include(total_disposable + td_bold + gds_number_to_currency(cfe_result.total_disposable_income_assessed))
-        end
-      end
-
-      context "when applicant has no employment(s)" do
-        let(:cfe_result) { create :cfe_v4_result, :with_no_employments }
-
-        it "does not display employment income" do
-          expect(unescaped_response_body).not_to include(I18n.t("providers.capital_income_assessment_results.employment_income.title"))
-          expect(unescaped_response_body).to include(I18n.t("providers.capital_income_assessment_results.other_income.income"))
-        end
+      it "displays the correct totals" do
+        expect(unescaped_response_body).to include(total_outgoings + td + gds_number_to_currency(cfe_result.total_monthly_outgoings))
+        expect(unescaped_response_body).to include(total_other_income + td + gds_number_to_currency(cfe_result.total_gross_income))
+        expect(unescaped_response_body).to include(total_deductions + td + gds_number_to_currency(cfe_result.total_deductions))
+        expect(unescaped_response_body).to include(total_disposable_income + td + gds_number_to_currency(cfe_result.total_monthly_income_including_employment_income))
+        expect(unescaped_response_body).to include(total_disposable_outgoings + td + gds_number_to_currency(cfe_result.total_monthly_outgoings_including_tax_and_ni))
+        expect(unescaped_response_body).to include(total_disposable_deductions + td + gds_number_to_currency(cfe_result.total_deductions_including_fixed_employment_allowance))
+        expect(unescaped_response_body).to include(total_disposable + td_bold + gds_number_to_currency(cfe_result.total_disposable_income_assessed))
       end
     end
 
-    context "when enable_employed_journey is false" do
-      let(:before_tasks) do
-        Setting.setting.update!(enable_employed_journey: false)
-        allow_any_instance_of(Provider).to receive(:employment_permissions?).and_return(false)
-        login_provider
-        subject
-      end
+    context "when applicant has no employment(s)" do
+      let(:cfe_result) { create :cfe_v4_result, :with_no_employments }
 
-      context "when applicant has employment(s)" do
-        let(:cfe_result) { create :cfe_v4_result, :with_employments }
-
-        it "does not display employment income" do
-          expect(unescaped_response_body).not_to include(I18n.t("providers.capital_income_assessment_results.employment_income.title"))
-          expect(unescaped_response_body).to include(I18n.t("providers.capital_income_assessment_results.other_income.income"))
-        end
-      end
-
-      context "when applicant has no employment(s)" do
-        let(:cfe_result) { create :cfe_v4_result, :with_employments }
-
-        it "does not display employment income" do
-          expect(unescaped_response_body).not_to include(I18n.t("providers.capital_income_assessment_results.employment_income.title"))
-          expect(unescaped_response_body).to include(I18n.t("providers.capital_income_assessment_results.other_income.income"))
-        end
+      it "does not display employment income" do
+        expect(unescaped_response_body).not_to include(I18n.t("providers.capital_income_assessment_results.employment_income.title"))
+        expect(unescaped_response_body).to include(I18n.t("providers.capital_income_assessment_results.other_income.income"))
       end
     end
   end

--- a/spec/requests/providers/confirm_dwp_non_passported_applications_spec.rb
+++ b/spec/requests/providers/confirm_dwp_non_passported_applications_spec.rb
@@ -43,30 +43,19 @@ RSpec.describe Providers::ConfirmDWPNonPassportedApplicationsController, type: :
     describe "HMRC inset text" do
       before { login_as application.provider }
 
-      context "the employed journey feature flag is not enabled" do
-        it "does not display the HMRC inset text" do
+      context "the user has employed permissions" do
+        before { allow_any_instance_of(Provider).to receive(:employment_permissions?).and_return(true) }
+
+        it "displays the HMRC inset text" do
           subject
-          expect(unescaped_response_body).not_to include(I18n.t(".providers.confirm_dwp_non_passported_applications.show.hmrc_inset_text"))
+          expect(unescaped_response_body).to include(I18n.t(".providers.confirm_dwp_non_passported_applications.show.hmrc_inset_text"))
         end
       end
 
-      context "the employed journey feature flag is enabled" do
-        before { Setting.setting.update!(enable_employed_journey: true) }
-
-        context "the user has employed permissions" do
-          before { allow_any_instance_of(Provider).to receive(:employment_permissions?).and_return(true) }
-
-          it "displays the HMRC inset text" do
-            subject
-            expect(unescaped_response_body).to include(I18n.t(".providers.confirm_dwp_non_passported_applications.show.hmrc_inset_text"))
-          end
-        end
-
-        context "the user does not have employed permissions" do
-          it "does not display the HMRC inset text" do
-            subject
-            expect(unescaped_response_body).not_to include(I18n.t(".providers.confirm_dwp_non_passported_applications.show.hmrc_inset_text"))
-          end
+      context "the user does not have employed permissions" do
+        it "does not display the HMRC inset text" do
+          subject
+          expect(unescaped_response_body).not_to include(I18n.t(".providers.confirm_dwp_non_passported_applications.show.hmrc_inset_text"))
         end
       end
     end
@@ -117,30 +106,19 @@ RSpec.describe Providers::ConfirmDWPNonPassportedApplicationsController, type: :
           expect(application.reload.state_machine_proxy.type).to eq "NonPassportedStateMachine"
         end
 
-        context "the employed journey feature flag is not enabled" do
-          it "does not call the HMRC::CreateResponsesService" do
+        context "the user has employed permissions" do
+          before { allow_any_instance_of(Provider).to receive(:employment_permissions?).and_return(true) }
+
+          it "calls the HMRC::CreateResponsesService" do
             subject
-            expect(HMRC::CreateResponsesService).to_not have_received(:call)
+            expect(HMRC::CreateResponsesService).to have_received(:call).once
           end
         end
 
-        context "the employed journey feature flag is enabled" do
-          before { Setting.setting.update!(enable_employed_journey: true) }
-
-          context "the user has employed permissions" do
-            before { allow_any_instance_of(Provider).to receive(:employment_permissions?).and_return(true) }
-
-            it "calls the HMRC::CreateResponsesService" do
-              subject
-              expect(HMRC::CreateResponsesService).to have_received(:call).once
-            end
-          end
-
-          context "the user does not have employed permissions" do
-            it "does not call the HMRC::CreateResponsesService" do
-              subject
-              expect(HMRC::CreateResponsesService).not_to have_received(:call)
-            end
+        context "the user does not have employed permissions" do
+          it "does not call the HMRC::CreateResponsesService" do
+            subject
+            expect(HMRC::CreateResponsesService).not_to have_received(:call)
           end
         end
       end
@@ -170,30 +148,19 @@ RSpec.describe Providers::ConfirmDWPNonPassportedApplicationsController, type: :
           expect(application.reload.state_machine_proxy.type).to eq "PassportedStateMachine"
         end
 
-        context "the employed journey feature flag is not enabled" do
-          it "does not call the HMRC::CreateResponsesService" do
+        context "the user has employed permissions" do
+          before { allow_any_instance_of(Provider).to receive(:employment_permissions?).and_return(true) }
+
+          it "calls the HMRC::CreateResponsesService" do
             subject
-            expect(HMRC::CreateResponsesService).to_not have_received(:call)
+            expect(HMRC::CreateResponsesService).to have_received(:call)
           end
         end
 
-        context "the employed journey feature flag is enabled" do
-          before { Setting.setting.update!(enable_employed_journey: true) }
-
-          context "the user has employed permissions" do
-            before { allow_any_instance_of(Provider).to receive(:employment_permissions?).and_return(true) }
-
-            it "calls the HMRC::CreateResponsesService" do
-              subject
-              expect(HMRC::CreateResponsesService).to have_received(:call)
-            end
-          end
-
-          context "the user has does not have employed permissions" do
-            it "does not call the HMRC::CreateResponsesService" do
-              subject
-              expect(HMRC::CreateResponsesService).to_not have_received(:call)
-            end
+        context "the user has does not have employed permissions" do
+          it "does not call the HMRC::CreateResponsesService" do
+            subject
+            expect(HMRC::CreateResponsesService).to_not have_received(:call)
           end
         end
       end
@@ -230,30 +197,19 @@ RSpec.describe Providers::ConfirmDWPNonPassportedApplicationsController, type: :
         expect(application.reload).to be_draft
       end
 
-      context "the employed journey feature flag is not enabled" do
+      context "the user has employed permissions" do
+        before { allow_any_instance_of(Provider).to receive(:employment_permissions?).and_return(true) }
+
         it "does not call the HMRC::CreateResponsesService" do
           subject
           expect(HMRC::CreateResponsesService).to_not have_received(:call)
         end
       end
 
-      context "the employed journey feature flag is enabled" do
-        before { Setting.setting.update!(enable_employed_journey: true) }
-
-        context "the user has employed permissions" do
-          before { allow_any_instance_of(Provider).to receive(:employment_permissions?).and_return(true) }
-
-          it "does not call the HMRC::CreateResponsesService" do
-            subject
-            expect(HMRC::CreateResponsesService).to_not have_received(:call)
-          end
-        end
-
-        context "the user has does not have employed permissions" do
-          it "does not call the HMRC::CreateResponsesService" do
-            subject
-            expect(HMRC::CreateResponsesService).to_not have_received(:call)
-          end
+      context "the user has does not have employed permissions" do
+        it "does not call the HMRC::CreateResponsesService" do
+          subject
+          expect(HMRC::CreateResponsesService).to_not have_received(:call)
         end
       end
     end

--- a/spec/services/hmrc/status_analyzer_spec.rb
+++ b/spec/services/hmrc/status_analyzer_spec.rb
@@ -5,7 +5,6 @@ module HMRC
     describe ".call" do
       subject(:service_call) { described_class.call(laa) }
       before do
-        Setting.setting.update!(enable_employed_journey: feature_flag)
         if provider_employed_permissions
           permission = create :permission, :employed
           laa.provider.firm.permissions << permission
@@ -18,15 +17,6 @@ module HMRC
       let(:laa) { create :legal_aid_application, :with_applicant, :with_transaction_period }
       let(:provider_employed_permissions) { true }
       let(:applicant_employed) { true }
-
-      context "when employed journey flag not set to true" do
-        let(:feature_flag) { false }
-        let(:provider_employed_permissions) { false }
-
-        it "returns employed_journey_not_enabled" do
-          expect(service_call).to eq :employed_journey_not_enabled
-        end
-      end
 
       context "when provider not enabled for employment journey" do
         let(:provider_employed_permissions) { false }


### PR DESCRIPTION
Before, this setting could be used to enable/disable the employed journey for
users so the feature could be incrementally deployed and released.

Now the feature has been turned on in all environments (and won't be turned
off), the setting can be removed.

This removes all references to the `enable_employed_journey` setting from the
code, although it leaves the database column in place.

A subsequent migration will be run to remove the ignored column once this change
has been successfully deployed to production.

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2637)