### PR TITLE
Fix flaky rack-attack spec

### DIFF
--- a/spec/requests/feedbacks_spec.rb
+++ b/spec/requests/feedbacks_spec.rb
@@ -211,12 +211,16 @@ RSpec.describe "FeedbacksController", type: :request do
 
       describe "when three feedbacks are submitted in quick succession" do
         it "returns a 429 status for the final submission" do
+          freeze_time
+
           post feedback_index_path, params:, headers: { "HTTP_REFERER" => originating_page }
           expect(response).to have_http_status(:ok)
           expect(Feedback.count).to eq 1
+
           post feedback_index_path, params:, headers: { "HTTP_REFERER" => originating_page }
           expect(response).to have_http_status(:ok)
           expect(Feedback.count).to eq 2
+
           post feedback_index_path, params:, headers: { "HTTP_REFERER" => originating_page }
           expect(response).to have_http_status(:too_many_requests)
           expect(Feedback.count).to eq 2


### PR DESCRIPTION
Before, if the offending spec took longer than 10 seconds to make the first two
requests, the third request would be successful and the test would fail.

This is something I'd seen a few times, most recently [in this run].

[in this run]: https://app.circleci.com/pipelines/github/ministryofjustice/laa-apply-for-legal-aid/17300/workflows/6b49be0f-8c15-4eb0-98c3-d94ec84deeee/jobs/90881

This freezes time so the test will always pass, no matter how slow our CI test
suite is.