### PR TITLE
[AP-3365] conditional display of cash payment CYA sections

### DIFF
--- a/app/views/providers/means_summaries/_income_assessment.html.erb
+++ b/app/views/providers/means_summaries/_income_assessment.html.erb
@@ -25,7 +25,7 @@
       transaction_types: TransactionType.credits
     ) %>
 
-<%= render 'income_cash_payments', read_only: false %>
+<%= render('income_cash_payments', read_only: false) if @legal_aid_application.uploading_bank_statements? %>
 
 <%= render 'shared/check_answers/student_finance', read_only: false %>
 
@@ -38,7 +38,7 @@
       transaction_types: TransactionType.debits
     ) %>
 
-<%= render 'outgoings_cash_payments', read_only: false %>
+<%= render('outgoings_cash_payments', read_only: false) if @legal_aid_application.uploading_bank_statements? %>
 
 <h2 class="govuk-heading-l"><%= t('.dependants.heading') %></h2>
 

--- a/features/providers/check_your_answers.feature
+++ b/features/providers/check_your_answers.feature
@@ -353,11 +353,9 @@ Feature: Checking answers backwards and forwards
       | h2  | Your client's income |
       | h3  | Employment income |
       | h3  | What payments does your client receive? |
-      | h3  | Payments your client receives in cash |
       | h3  | Student finance |
       | h2  | Your client's outgoings |
       | h3  | What payments does your client make? |
-      | h3  | Payments your client makes in cash |
       | h2  | Your client's capital |
       | h3  | Property |
       | h3  | Vehicles |
@@ -368,6 +366,9 @@ Feature: Checking answers backwards and forwards
       | h2  | Restrictions on your client's assets |
       | h2  | Payments from scheme or charities |
 
+    And I should not see "Payments your client receives in cash"
+    And I should not see "Payments your client makes in cash"
+
     And the "What payments does your client receive?" section's questions and answers should exist:
       | question | answer |
       | Benefits | £666.00 |
@@ -376,20 +377,12 @@ Feature: Checking answers backwards and forwards
       | Income from a property or lodger | None |
       | Pension | None |
 
-    And the "Payments your client receives in cash" section's questions should exist:
-      | question |
-      | Benefits |
-
     And the "What payments does your client make?" section's questions and answers should exist:
       | question | answer |
       | Housing payments | £999.00 |
       | Childcare payments | None |
       | Maintenance payments to a former partner | Yes, but none specified |
       | Payments towards legal aid in a criminal case | None |
-
-    And the "Payments your client makes in cash" section's questions should exist:
-      | question |
-      | Housing payments |
 
   @javascript
   Scenario: I am able to see all necessary sections for a non-passported bank statement upload flow


### PR DESCRIPTION
## What
Only display cash payments section if uploading bank statements

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3365)

**This is one solution** to handle the difference between the needs
of the non passported bank statement and trulayer journeys.

The banks statement journey will have no categorised bank transactions
so we just show Yes/No answers in the "What payments does your client receive/make?" 
sections. The "Payments your client receives/makes in cash" sections then display the 
monthly amounts entered per category.

The truelayer journey will have categorised bank transactions as well as
cash potentially. This is displayed as a £ total per Category or "None". The
"Payments your client receives/makes in cash" section is not shown because
cash is already included in the totals of the "What payments does your client receive/make?" 
section


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
