### PR TITLE
Fix: Update CFE service calls

### DIFF
--- a/app/services/cfe/submission_manager.rb
+++ b/app/services/cfe/submission_manager.rb
@@ -29,6 +29,7 @@ module CFE
       CreateOtherIncomeService,
       CreateIrregularIncomesService,
       CreateEmploymentsService,
+      CreateCashTransactionsService,
     ].freeze
 
     def self.call(legal_aid_application_id)
@@ -44,7 +45,6 @@ module CFE
     def call
       call_common_services
       call_non_passported_services
-      CreateCashTransactionsService.call(submission) unless submission.passported?
       ObtainAssessmentResultService.call(submission)
       true
     rescue SubmissionError => e

--- a/spec/services/cfe/submission_manager_spec.rb
+++ b/spec/services/cfe/submission_manager_spec.rb
@@ -149,12 +149,6 @@ module CFE
             submission_manager.call
           end
 
-          it "does not call the CreateCashTransactionsService" do
-            expect(CreateCashTransactionsService).not_to receive(:call)
-
-            submission_manager.call
-          end
-
           describe "#submission" do
             it "associates the application with the submission" do
               expect(submission.legal_aid_application_id).to eq application.id


### PR DESCRIPTION
## What

While investigating a CFE issue, this caused me some issues. I have extracted the fix to it's own PR...

There was a test that was "passing" because the submission_manager failed and therefore the Service was never "called"
I deleted it so that it does not cause confusion and, complying with the commit message that added it, have removed the CreateCashTransactionsService one-off call and incorporated it into the NON_PASSPORTED_SERVICES array

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
