### PR TITLE
Remove `enable_employed_journey` column from settings

### DIFF
--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -1,6 +1,4 @@
 class Setting < ApplicationRecord
-  self.ignored_columns = %i[enable_employed_journey]
-
   def self.mock_true_layer_data?
     setting.mock_true_layer_data?
   end

--- a/db/migrate/20220830144657_remove_enable_employed_journey_from_settings.rb
+++ b/db/migrate/20220830144657_remove_enable_employed_journey_from_settings.rb
@@ -1,0 +1,5 @@
+class RemoveEnableEmployedJourneyFromSettings < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :settings, :enable_employed_journey, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_24_162240) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_30_144657) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -779,7 +779,6 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_24_162240) do
     t.boolean "enable_ccms_submission", default: true, null: false
     t.boolean "alert_via_sentry", default: true, null: false
     t.datetime "digest_extracted_at", default: "1970-01-01 00:00:01"
-    t.boolean "enable_employed_journey", default: false, null: false
     t.boolean "enable_mini_loop", default: false, null: false
     t.boolean "enable_loop", default: false, null: false
     t.boolean "enhanced_bank_upload", default: false, null: false


### PR DESCRIPTION
Before, in #4216, the `enable_employed_journey` setting was removed and the
associated column was ignored.

Now that change has been deployed successfully, we can safely remove the column
from the database table.

This removes the column from the settings table and removes the
`.ignored_columns` method defined in the Setting model.

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2637)