### PR TITLE
Remove redundant blazer db_url config

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -111,8 +111,6 @@ module LaaApplyForLegalAid
     config.x.hmrc_interface.client_secret = ENV.fetch("HMRC_API_SECRET", nil)
     config.x.hmrc_interface.duration_check = ENV.fetch("HMRC_DURATION_CHECK", 3)
 
-    config.x.db_url = Rails.env.production? ? "postgres://#{ENV.fetch('POSTGRES_USER', nil)}:#{ENV.fetch('POSTGRES_PASSWORD', nil)}@#{ENV.fetch('POSTGRES_HOST', nil)}:5432/#{ENV.fetch('POSTGRES_DATABASE', nil)}" : "postgres://localhost:5432/apply_for_legal_aid_dev"
-
     config.active_job.queue_adapter = :sidekiq
 
     config.x.slack_alert_email = ENV.fetch("SLACK_ALERT_EMAIL", nil)


### PR DESCRIPTION
Once upon a time in #933, we added the [blazer] gem.

Several years later, we removed the [blazer] gem in #2025.

We forgot to remove the `db_url` variable from the config though.

This removes the redundant config.

[blazer]: https://github.com/ankane/blazer
