### PR TITLE
Add enhanced bank upload journey permissions

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -57,6 +57,10 @@ class Provider < ApplicationRecord
     user_permissions.map(&:role).include?("application.full_section_8.*")
   end
 
+  def enhanced_bank_upload_permissions?
+    user_permissions.map(&:role).include?("application.non_passported.enhanced_bank_upload.*")
+  end
+
   def ccms_apply_role?
     return true if Rails.configuration.x.laa_portal.mock_saml == "true"
 

--- a/db/seeds/permissions.rb
+++ b/db/seeds/permissions.rb
@@ -5,6 +5,7 @@ class PermissionsPopulator
     "application.non_passported.employment.*" => "Can create, edit, delete employment applications",
     "application.non_passported.bank_statement_upload.*" => "Can upload bank statements",
     "application.full_section_8.*" => "Can use full set of section 8 proceedings",
+    "application.non_passported.enhanced_bank_upload.*" => "Can use enhanced bank upload journey",
   }.freeze
 
   def self.run

--- a/spec/factories/permissions.rb
+++ b/spec/factories/permissions.rb
@@ -27,5 +27,10 @@ FactoryBot.define do
       role { "application.full_section_8.*" }
       description { "Can use full set of section 8 proceedings" }
     end
+
+    trait :enhanced_bank_upload do
+      role { "application.non_passported.enhanced_bank_upload.*" }
+      description { "Can use enhanced bank upload journey" }
+    end
   end
 end

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -186,4 +186,28 @@ RSpec.describe Provider, type: :model do
       end
     end
   end
+
+  describe "#enhanced_bank_upload_permissions?" do
+    context "when the provider does not have enhanced bank upload permissions" do
+      it "returns false" do
+        provider = build_stubbed(:provider)
+
+        permission = provider.enhanced_bank_upload_permissions?
+
+        expect(permission).to be(false)
+      end
+    end
+
+    context "when the provider has enhanced bank upload permissions" do
+      it "returns true" do
+        provider = build_stubbed(:provider)
+        enhanced_bank_upload_permission = build_stubbed(:permission, :enhanced_bank_upload)
+        allow(provider).to receive(:permissions).and_return([enhanced_bank_upload_permission])
+
+        permission = provider.enhanced_bank_upload_permissions?
+
+        expect(permission).to be(true)
+      end
+    end
+  end
 end


### PR DESCRIPTION
In #4218 a new enhanced bank upload journey feature flag was added to the
Settings.

This adds a new role to permissions that will allow users of permitted firms to
use the enhanced bank upload journey.