### PR TITLE
Add capybara support to integration tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -132,6 +132,9 @@ group :development do
 end
 
 group :test do
+  gem "action_dispatch-testing-integration-capybara",
+      github: "thoughtbot/action_dispatch-testing-integration-capybara", tag: "v0.1.0",
+      require: "action_dispatch/testing/integration/capybara/rspec"
   gem "axe-core-cucumber"
   gem "capybara", ">= 3.36.0", "< 4.0"
   gem "cucumber", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,16 @@ GIT
   specs:
     ruby-saml-idp (0.3.2)
 
+GIT
+  remote: https://github.com/thoughtbot/action_dispatch-testing-integration-capybara.git
+  revision: c2393cb699335d82c599e954303903b30264378c
+  tag: v0.1.0
+  specs:
+    action_dispatch-testing-integration-capybara (0.1.0)
+      actionpack
+      activesupport
+      capybara
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -725,6 +735,7 @@ PLATFORMS
 
 DEPENDENCIES
   aasm (~> 5.3.0)
+  action_dispatch-testing-integration-capybara!
   active_model_serializers (~> 0.10.13)
   addressable
   awesome_print (~> 1.9.2)

--- a/spec/requests/errors_spec.rb
+++ b/spec/requests/errors_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe ErrorsController, type: :request do
     end
 
     it "displays the correct header" do
-      expect(response.body).to include("Page not found")
+      expect(page).to have_css("h1", text: t("page_not_found.page_title"))
     end
   end
 
@@ -71,7 +71,7 @@ RSpec.describe ErrorsController, type: :request do
     end
 
     it "displays the correct header" do
-      expect(unescaped_response_body).to match(I18n.t("errors.show.assessment_already_completed.page_title"))
+      expect(page).to have_css("h1", text: t("assessment_already_completed.page_title"))
     end
   end
 
@@ -85,7 +85,11 @@ RSpec.describe ErrorsController, type: :request do
     end
 
     it "displays the correct header" do
-      expect(response.body).to match(/Access denied/)
+      expect(page).to have_css("h1", text: t("access_denied.page_title"))
     end
+  end
+
+  def t(key, **options)
+    I18n.t(key, scope: %i[errors show], **options)
   end
 end


### PR DESCRIPTION
This project leans heavily on cucumber for feature tests, and we write **no**
RSpec system specs at all.

In my opinion this is quite unusual, and a side effect of this is that we use
RSpec request specs (which are a wrapper around
ActionDispatch::IntegrationTestCase) a lot to assert against the rendered
content.

This isn't necessarily a bad thing, since Rails integration tests can offer lots
of benefits over system tests (e.g speed, greater control over HTTP verbs and
this session etc).

While I think this combination makes it harder for us to do
accessibility-focussed test-driven development (Capybara and RSpec system specs
are excellent for this), that conversation is one for another day.

This proposed change makes use of an abstraction discussed at length in [this
blog post](https://thoughtbot.com/blog/integration-testing-with-capybara) in
order to bring Capybara into our integration tests.

I've made changes to `spec/requests/errors_spec.rb` to highlight some of the
improvements this change could bring us.

I'm not suggesting we re-write all our specs en-masse, but this is something
people can make use of if they want to -and if we want to take advantage of it
across the test suite we can add tickets to address specific areas of concerns.