### PR TITLE
[AP-3445] Providers can submit more accurate income data

### DIFF
--- a/app/controllers/providers/means/identify_types_of_incomes_controller.rb
+++ b/app/controllers/providers/means/identify_types_of_incomes_controller.rb
@@ -1,6 +1,8 @@
 module Providers
   module Means
     class IdentifyTypesOfIncomesController < ProviderBaseController
+      before_action :redirect_if_enhanced_bank_upload_enabled
+
       def show
         @none_selected = legal_aid_application.no_credit_transaction_types_selected?
       end
@@ -64,6 +66,12 @@ module Providers
             .credits
             .where.not(transaction_type_id: except)
             .destroy_all
+        end
+      end
+
+      def redirect_if_enhanced_bank_upload_enabled
+        if Setting.enhanced_bank_upload?
+          redirect_to providers_legal_aid_application_means_regular_incomes_path(legal_aid_application)
         end
       end
     end

--- a/app/controllers/providers/means/regular_incomes_controller.rb
+++ b/app/controllers/providers/means/regular_incomes_controller.rb
@@ -1,0 +1,42 @@
+module Providers
+  module Means
+    class RegularIncomesController < ProviderBaseController
+      before_action :redirect_unless_enhanced_bank_upload_enabled
+
+      def show
+        @form = RegularIncomeForm.new(legal_aid_application:)
+      end
+
+      def update
+        @form = RegularIncomeForm.new(regular_income_params)
+
+        if @form.save
+          go_forward
+        else
+          render :show, status: :unprocessable_entity
+        end
+      end
+
+    private
+
+      def regular_income_params
+        params
+          .require(:providers_means_regular_income_form)
+          .permit(regular_transaction_params, transaction_type_ids: [])
+          .merge(legal_aid_application:)
+      end
+
+      def regular_transaction_params
+        RegularIncomeForm::INCOME_TYPES.map { |income_type|
+          ["#{income_type}_amount".to_sym, "#{income_type}_frequency".to_sym]
+        }.flatten
+      end
+
+      def redirect_unless_enhanced_bank_upload_enabled
+        unless Setting.enhanced_bank_upload?
+          redirect_to providers_legal_aid_application_means_identify_types_of_income_path(legal_aid_application)
+        end
+      end
+    end
+  end
+end

--- a/app/forms/providers/means/regular_income_form.rb
+++ b/app/forms/providers/means/regular_income_form.rb
@@ -1,0 +1,165 @@
+module Providers
+  module Means
+    class RegularIncomeForm
+      include ActiveModel::Model
+
+      INCOME_TYPES = %w[
+        benefits
+        friends_or_family
+        maintenance_in
+        property_or_lodger
+        student_loan
+        pension
+      ].freeze
+
+      attr_reader :transaction_type_ids, :legal_aid_application
+
+      INCOME_TYPES.each do |income_type|
+        attr_accessor "#{income_type}_amount".to_sym,
+                      "#{income_type}_frequency".to_sym
+      end
+
+      validates :transaction_type_ids, presence: true, unless: :none_selected?
+      validate :all_regular_transactions_valid
+
+      def initialize(params = {})
+        @none_selected = none_selected.in?(params["transaction_type_ids"] || [])
+        @legal_aid_application = params.delete(:legal_aid_application)
+        @transaction_type_ids = params["transaction_type_ids"] || @legal_aid_application.transaction_type_ids
+
+        regular_transactions.each do |transaction|
+          transaction_type = transaction.transaction_type
+          public_send("#{transaction_type.name}_amount=", transaction.amount)
+          public_send("#{transaction_type.name}_frequency=", transaction.frequency)
+        end
+
+        super
+      end
+
+      def save
+        return false unless valid?
+
+        ApplicationRecord.transaction do
+          destroy_transactions!
+
+          regular_transactions.each(&:save!)
+
+          build_legal_aid_application_transaction_types
+          legal_aid_application.assign_attributes(
+            no_credit_transaction_types_selected: none_selected?,
+          )
+          legal_aid_application.save!
+        end
+
+        true
+      end
+
+      def transaction_type_ids=(ids)
+        @transaction_type_ids = if none_selected?
+                                  []
+                                else
+                                  ids.compact_blank
+                                end
+      end
+
+      def transaction_type_options
+        TransactionType.not_children.credits
+      end
+
+      def none_selected
+        "none"
+      end
+
+    private
+
+      def none_selected?
+        @none_selected
+      end
+
+      def transaction_types
+        transaction_type_options.where(id: transaction_type_ids)
+      end
+
+      def destroy_transactions!
+        destroy_legal_aid_application_transaction_types!
+        destroy_regular_income_transactions!
+        destroy_cash_income_transactions!
+      end
+
+      def destroy_legal_aid_application_transaction_types!
+        legal_aid_application
+          .legal_aid_application_transaction_types
+          .credits
+          .where.not(transaction_type_id: transaction_type_ids)
+          .destroy_all
+      end
+
+      def destroy_regular_income_transactions!
+        legal_aid_application
+          .regular_incomes
+          .without(existing_income_regular_transactions)
+          .destroy_all
+      end
+
+      def destroy_cash_income_transactions!
+        legal_aid_application
+          .cash_transactions
+          .credits
+          .where.not(transaction_type_id: transaction_type_ids)
+          .destroy_all
+      end
+
+      def existing_income_regular_transactions
+        legal_aid_application
+          .regular_incomes
+          .where(transaction_type_id: transaction_type_ids)
+      end
+
+      def build_legal_aid_application_transaction_types
+        transaction_type_ids.each do |transaction_type_id|
+          next if transaction_type_id.in?(legal_aid_application.transaction_type_ids)
+
+          legal_aid_application.legal_aid_application_transaction_types.build(
+            transaction_type_id:,
+          )
+        end
+      end
+
+      def regular_transactions
+        @regular_transactions ||= transaction_types.map do |transaction_type|
+          RegularTransaction.find_or_initialize_by(
+            legal_aid_application:,
+            transaction_type:,
+          )
+        end
+      end
+
+      def all_regular_transactions_valid
+        regular_transactions.each do |transaction|
+          transaction_type = transaction.transaction_type
+          transaction.amount = public_send("#{transaction_type.name}_amount")
+          transaction.frequency = public_send("#{transaction_type.name}_frequency")
+
+          next if transaction.valid?
+
+          transaction.errors.each do |error|
+            add_regular_transaction_error_to_form(
+              transaction.transaction_type.name,
+              error,
+            )
+          end
+        end
+      end
+
+      def add_regular_transaction_error_to_form(transaction_type, error)
+        attribute = if error.attribute.in?(%i[amount frequency])
+                      "#{transaction_type}_#{error.attribute}".to_sym
+                    else
+                      :base
+                    end
+
+        errors.add(attribute, error.type, **error.options)
+      end
+    end
+  end
+end

--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -50,6 +50,8 @@ class LegalAidApplication < ApplicationRecord
   has_many :involved_children, class_name: "ApplicationMeritsTask::InvolvedChild", dependent: :destroy
   has_many :hmrc_responses, class_name: "HMRC::Response", dependent: :destroy, inverse_of: :legal_aid_application
   has_many :employments, dependent: :destroy
+  has_many :regular_transactions, dependent: :destroy
+  has_many :regular_incomes, -> { credits }, class_name: "RegularTransaction"
 
   before_save :set_open_banking_consent_choice_at
   before_create :create_app_ref
@@ -217,7 +219,11 @@ class LegalAidApplication < ApplicationRecord
   end
 
   def income_types?
-    transaction_types.credits.any?
+    if Setting.enhanced_bank_upload?
+      regular_transactions.credits.any?
+    else
+      transaction_types.credits.any?
+    end
   end
 
   def outgoing_types?

--- a/app/models/regular_transaction.rb
+++ b/app/models/regular_transaction.rb
@@ -1,0 +1,17 @@
+class RegularTransaction < ApplicationRecord
+  FREQUENCIES = %w[weekly monthly].freeze
+
+  belongs_to :legal_aid_application
+  belongs_to :transaction_type
+
+  validates :amount, currency: { greater_than: 0 }
+  validates :frequency, inclusion: { in: FREQUENCIES }
+
+  def self.credits
+    includes(:transaction_type).where(transaction_types: { operation: :credit })
+  end
+
+  def self.debits
+    includes(:transaction_type).where(transaction_types: { operation: :debit })
+  end
+end

--- a/app/views/providers/means/regular_incomes/show.html.erb
+++ b/app/views/providers/means/regular_incomes/show.html.erb
@@ -1,0 +1,35 @@
+<%= form_with model: @form,
+              url: providers_legal_aid_application_means_regular_incomes_path(@legal_aid_application),
+              method: :patch do |f| %>
+  <%= page_template page_title: page_title, template: :basic, form: f do %>
+
+    <%= f.govuk_check_boxes_fieldset :transaction_type_ids, legend: {size: "xl", tag: "h1"} do %>
+
+      <% @form.transaction_type_options.each_with_index do |transaction_type, index| %>
+        <%= f.govuk_check_box :transaction_type_ids,
+                              transaction_type.id,
+                              link_errors: index == 0,
+                              label: { text: t(".labels.#{transaction_type.name}") },
+                              hint: {text: t(".hints.#{transaction_type.name}") } do %>
+          <%= f.govuk_text_field "#{transaction_type.name}_amount".to_sym,
+                                 width: "one-quarter",
+                                 prefix_text: "£" %>
+          <%= f.govuk_collection_radio_buttons "#{transaction_type.name}_frequency".to_sym,
+                                               RegularTransaction::FREQUENCIES,
+                                               :itself,
+                                               ->(option) { option.humanize },
+                                               legend: {tag: "p", size: "s"} %>
+        <% end %>
+      <% end %>
+
+      <%= f.govuk_check_box_divider %>
+
+      <%= f.govuk_check_box :transaction_type_ids,
+                            @form.none_selected,
+                            exclusive: true,
+                            label: {text: t(".labels.none")} %>
+    <% end %>
+
+    <%= f.govuk_submit t("generic.save_and_continue") %>
+  <% end %>
+<% end %>

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -484,6 +484,40 @@ en:
               file_virus: "%{file_name} contains a virus"
               no_file_chosen: Upload your client's bank statements
               system_down: There was a problem uploading your file - try again
+        providers/means/regular_income_form:
+          attributes:
+            benefits_amount:
+              greater_than: Enter a number greater than 0
+              not_a_number: Enter the amount of benefits received
+              too_many_decimals: Enter a number with no more than 2 decimal places
+            benefits_frequency:
+              inclusion: Select how often your client receives benefits
+            friends_or_family_amount:
+              greater_than: Enter a number greater than 0
+              not_a_number: Enter the amount received from friends or family
+              too_many_decimals: Enter a number with no more than 2 decimal places
+            friends_or_family_frequency:
+              inclusion: Select how often your client receives income from friends or family
+            income_types:
+              blank: Select at least one of the options
+            maintenance_in_amount:
+              greater_than: Enter a number greater than 0
+              not_a_number: Enter the amount of maintenance received
+              too_many_decimals: Enter a number with no more than 2 decimal places
+            maintenance_in_frequency:
+              inclusion: Select how often your client receives maintenance
+            property_or_lodger_amount:
+              greater_than: Enter a number greater than 0
+              not_a_number: Enter the amount received from property or lodgers
+              too_many_decimals: Enter a number with no more than 2 decimal places
+            property_or_lodger_frequency:
+              inclusion: Select how often your client receives income from property or lodgers
+            pension_amount:
+              greater_than: Enter a number greater than 0
+              not_a_number: Enter the amount of pension received
+              too_many_decimals: Enter a number with no more than 2 decimal places
+            pension_frequency:
+              inclusion: Select how often your client receives pension income
         reports:
           application_type: Select if you want to search all cases or a particular type
           submitted_to_ccms: Select if you want to search cases submitted to CCMS only

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -11,6 +11,8 @@ en:
         postcode: This must be a UK postcode, for example SW1A 2AA.
       applicant:
         national_insurance_number: For example, 'QQ 12 34 56 C'.
+      providers_means_regular_income_form:
+        transaction_type_ids: Select all that apply
       student_finance: This includes any type of student loan, grant or bursary.
     label:
       applicant:
@@ -28,6 +30,12 @@ en:
       legal_aid_application:
         own_vehicle:
           <<: *true_false
+      providers_means_regular_income_form:
+        benefits_amount: Enter amount
+        friends_or_family_amount: Enter amount
+        maintenance_in_amount: Enter amount
+        property_or_lodger_amount: Enter amount
+        pension_amount: Enter amount
       application_merits_task/opponent: &opponent
         understands_terms_of_court_order_details: Tell us why you think the court would enforce a breach of an order
         warning_letter_sent_details: Tell us why a warning letter has not been sent
@@ -58,3 +66,11 @@ en:
           <<: *true_false
         enhanced_bank_upload:
           <<: *true_false
+    legend:
+      providers_means_regular_income_form:
+        benefits_frequency: Select frequency
+        friends_or_family_frequency: Select frequency
+        maintenance_in_frequency: Select frequency
+        property_or_lodger_frequency: Select frequency
+        pension_frequency: Select frequency
+        transaction_type_ids: Which of the following payments does your client receive?

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -696,6 +696,23 @@ en:
           page_heading: Which payments does your client make?
         update:
           none_selected: Select if your client makes any regular payments
+      regular_incomes:
+        show:
+          hints:
+            benefits: For example, Child Benefit or tax credits
+            friends_or_family: >-
+              Select if a friend or relative regularly gives your client money to help with
+              living costs. Do not include one-off payments.
+            maintenance_in: This includes child maintenance
+            property_or_lodger: ""
+            pension: Include State, workplace and personal pensions
+          labels:
+            benefits: Benefits
+            friends_or_family: Financial help from friends or family
+            maintenance_in: Maintenance payments from a former partner
+            property_or_lodger: Income from a property or lodger
+            none: My client receives none of these payments
+            pension: Pension
       has_dependants:
         show:
           page_title: "Does your client have any dependants?"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -124,6 +124,7 @@ Rails.application.routes.draw do
         resource :employment_income, only: %i[show update]
         resource :student_finance, only: %i[show update]
         resource :cash_income, only: %i[show update]
+        resource :regular_incomes, only: %i[show update]
         resource :identify_types_of_income, only: %i[show update]
         resource :identify_types_of_outgoing, only: %i[show update]
         resource :has_dependants, only: %i[show update]

--- a/db/anonymise/rules.rb
+++ b/db/anonymise/rules.rb
@@ -142,6 +142,7 @@ NINO_REGEXP = /^[A-CEGHJ-PR-TW-Z]{1}[A-CEGHJ-NPR-TW-Z]{1}[0-9]{6}[A-DFM]{1}$/
     name: -> { Faker::Name.name },
     email: -> { Faker::Internet.email },
   },
+  regular_transactions: {},
   savings_amounts: {},
   scheduled_mailings: {
     # Should we just not export this?

--- a/db/migrate/20220902150227_create_regular_transactions.rb
+++ b/db/migrate/20220902150227_create_regular_transactions.rb
@@ -1,0 +1,11 @@
+class CreateRegularTransactions < ActiveRecord::Migration[7.0]
+  def change
+    create_table :regular_transactions, id: :uuid do |t|
+      t.references :legal_aid_application, null: false, foreign_key: { on_delete: :cascade }, index: false, type: :uuid
+      t.references :transaction_type, null: false, foreign_key: true, index: false, type: :uuid
+      t.decimal :amount, null: false
+      t.string :frequency, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220915104106_add_regular_transactions_indexes.rb
+++ b/db/migrate/20220915104106_add_regular_transactions_indexes.rb
@@ -1,0 +1,8 @@
+class AddRegularTransactionsIndexes < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :regular_transactions, :legal_aid_application_id, algorithm: :concurrently
+    add_index :regular_transactions, :transaction_type_id, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_30_144657) do
+ActiveRecord::Schema[7.0].define(version: 2022_09_15_104106) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -739,6 +739,17 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_30_144657) do
     t.index ["username"], name: "index_providers_on_username", unique: true
   end
 
+  create_table "regular_transactions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "legal_aid_application_id", null: false
+    t.uuid "transaction_type_id", null: false
+    t.decimal "amount", null: false
+    t.string "frequency", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["legal_aid_application_id"], name: "index_regular_transactions_on_legal_aid_application_id"
+    t.index ["transaction_type_id"], name: "index_regular_transactions_on_transaction_type_id"
+  end
+
   create_table "savings_amounts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "legal_aid_application_id", null: false
     t.decimal "offline_current_accounts"
@@ -885,6 +896,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_30_144657) do
   add_foreign_key "proceedings", "legal_aid_applications"
   add_foreign_key "providers", "firms"
   add_foreign_key "providers", "offices", column: "selected_office_id"
+  add_foreign_key "regular_transactions", "legal_aid_applications", on_delete: :cascade
+  add_foreign_key "regular_transactions", "transaction_types"
   add_foreign_key "savings_amounts", "legal_aid_applications"
   add_foreign_key "scheduled_mailings", "legal_aid_applications", on_delete: :cascade
   add_foreign_key "statement_of_cases", "legal_aid_applications", on_delete: :cascade

--- a/features/providers/check_your_answers.feature
+++ b/features/providers/check_your_answers.feature
@@ -343,6 +343,60 @@ Feature: Checking answers backwards and forwards
     Then I should be on the 'means_summary' page showing 'Check your answers'
 
   @javascript
+  Scenario: I am able to view and amend provider means answers for enhanced bank upload flow
+    Given csrf is enabled
+    And the feature flag for enhanced_bank_upload is enabled
+    And I have completed a non-passported employed application with enhanced bank upload as far as the end of the means section
+    Then I should be on the "means_summary" page showing "Check your answers"
+
+    And I should see "Uploaded bank statements"
+    And I should see "Does your client receive student finance?"
+    And the answer for "student finance question" should be "No"
+    And I should not see "Which bank accounts does your client have?"
+
+    When I click Check Your Answers Change link for "bank statements"
+    And I upload an evidence file named "hello_world.pdf"
+    And I click "Save and continue"
+    Then I should be on the "means_summary" page showing "Check your answers"
+    And I should see "hello_world.pdf"
+
+    When I click Check Your Answers Change link for "What payments does your client receive?"
+    And I check "Benefits"
+    Then I fill "Benefits amount" with "1000"
+    Then I choose "providers-means-regular-income-form-benefits-frequency-monthly-field"
+    And I click "Save and continue"
+    Then I should be on a page with title "Select payments your client receives in cash"
+    When I check "None of the above"
+    And I click "Save and continue"
+    Then I should be on the "means_summary" page showing "Check your answers"
+
+    When I click Check Your Answers Change link for "What payments does your client receive?"
+    And I check "My client receives none of these payments"
+    And I click "Save and continue"
+    Then I should be on the "means_summary" page showing "Check your answers"
+
+    When I click Check Your Answers Change link for "student finance"
+    And I choose "Yes"
+    And I enter amount "5000"
+    And I click "Save and continue"
+    Then I should be on the "means_summary" page showing "Check your answers"
+    And the answer for "student finance question" should be "Yes"
+    And the answer for "student finance annual amount" should be "£5,000"
+
+    When I click Check Your Answers Change link for "What payments does your client make?"
+    And I check "Maintenance payments to a former partner"
+    And I click "Save and continue"
+    Then I should be on a page with title "Select payments your client makes in cash"
+    When I check "None of the above"
+    And I click "Save and continue"
+    Then I should be on the "means_summary" page showing "Check your answers"
+
+    When I click Check Your Answers Change link for "What payments does your client make?"
+    And I check "My client makes none of these payments"
+    And I click "Save and continue"
+    Then I should be on the "means_summary" page showing "Check your answers"
+
+  @javascript
   Scenario: I am able to see all necessary sections for a non-passported open banking flow
     Given I have completed a non-passported application with open banking transactions
     And I am viewing the means summary check your anwsers page

--- a/features/providers/non_passported_journey.feature
+++ b/features/providers/non_passported_journey.feature
@@ -78,6 +78,26 @@ Feature: Non-passported applicant journeys
     Then I click 'Save and continue'
     Then I should be on the 'has_dependants' page showing "Does your client have any dependants?"
 
+  @javascript @vcr
+  Scenario: Selects and categorises bank transactions with enhanced bank upload setting enabled
+    Given I start the merits application with bank transactions with no transaction type category
+    And the feature flag for enhanced_bank_upload is enabled
+    Then I should be on the "client_completed_means" page showing "Your client has shared their financial information"
+    Then I click "Continue"
+
+    Then I should be on the "regular_incomes" page showing "Which of the following payments does your client receive?"
+
+    Then I select "Benefits"
+    Then I fill "Benefits amount" with "500"
+    Then I choose "providers-means-regular-income-form-benefits-frequency-weekly-field"
+
+    Then I select "Pension"
+    Then I fill "Pension amount" with "100"
+    Then I choose "providers-means-regular-income-form-pension-frequency-monthly-field"
+
+    And I click "Save and continue"
+    Then I should be on a page with title "Select payments your client receives in cash"
+
   @javascript
   Scenario: Complete an application for an applicant that does not receive benefits with dependants
     Given I start the means application

--- a/features/step_definitions/bank_statement_uploaded_steps.rb
+++ b/features/step_definitions/bank_statement_uploaded_steps.rb
@@ -60,3 +60,25 @@ Given("I have completed a non-passported employed application with bank statemen
 
   visit(providers_legal_aid_application_means_summary_path(@legal_aid_application))
 end
+
+Given "I have completed a non-passported employed application with enhanced bank upload as far as the end of the means section" do
+  @legal_aid_application = create(
+    :legal_aid_application,
+    :with_proceedings,
+    :with_employed_applicant,
+    :with_single_employment,
+    :with_extra_employment_information,
+    :without_open_banking_consent,
+    :checking_non_passported_means,
+  )
+
+  create :attachment, :bank_statement, legal_aid_application: @legal_aid_application
+
+  @legal_aid_application.provider.permissions << Permission.find_by(role: "application.non_passported.employment.*")
+  @legal_aid_application.provider.permissions << Permission.find_by(role: "application.non_passported.bank_statement_upload.*")
+  @legal_aid_application.provider.save!
+
+  login_as @legal_aid_application.provider
+
+  visit(providers_legal_aid_application_means_summary_path(@legal_aid_application))
+end

--- a/spec/factories/cash_transactions.rb
+++ b/spec/factories/cash_transactions.rb
@@ -3,6 +3,7 @@ FactoryBot.define do
     legal_aid_application
     transaction_type
     amount { Faker::Number.decimal(l_digits: 3, r_digits: 2) }
+    month_number { 1 }
 
     trait :credit_month1 do
       transaction_date { Time.zone.today.at_beginning_of_month - 1.month }

--- a/spec/factories/regular_transactions.rb
+++ b/spec/factories/regular_transactions.rb
@@ -1,0 +1,16 @@
+FactoryBot.define do
+  factory :regular_transaction do
+    legal_aid_application
+    transaction_type
+    amount { 500.00 }
+    frequency { "weekly" }
+
+    trait :benefits do
+      association :transaction_type, :benefits
+    end
+
+    trait :maintenance_in do
+      association :transaction_type, :maintenance_in
+    end
+  end
+end

--- a/spec/forms/providers/means/regular_income_form_spec.rb
+++ b/spec/forms/providers/means/regular_income_form_spec.rb
@@ -1,0 +1,481 @@
+require "rails_helper"
+
+# rubocop:disable Rails/SaveBang
+RSpec.describe Providers::Means::RegularIncomeForm do
+  describe "validations" do
+    context "when neither a income type or none are selected" do
+      it "is invalid" do
+        params = { "transaction_type_ids" => [""] }
+
+        form = described_class.new(params)
+
+        expect(form).to be_invalid
+        expect(form.errors).to be_added(:transaction_type_ids, :blank)
+      end
+    end
+
+    context "when at least one income type is selected, but an amount is missing" do
+      it "is invalid" do
+        benefits = create(:transaction_type, :benefits)
+        pension = create(:transaction_type, :pension)
+        params = {
+          "transaction_type_ids" => ["", benefits.id, pension.id],
+          "benefits_amount" => "",
+          "benefits_frequency" => "weekly",
+          "pension_amount" => "100",
+          "pension_frequency" => "monthly",
+        }
+
+        form = described_class.new(params)
+
+        expect(form).to be_invalid
+        expect(form.errors).to be_added(:benefits_amount, :not_a_number, value: "")
+      end
+    end
+
+    context "when at least one income type is selected, but an invalid amount is given" do
+      it "is invalid" do
+        benefits = create(:transaction_type, :benefits)
+        pension = create(:transaction_type, :pension)
+        params = {
+          "transaction_type_ids" => ["", benefits.id, pension.id],
+          "benefits_amount" => "-1000",
+          "benefits_frequency" => "weekly",
+          "pension_amount" => "100",
+          "pension_frequency" => "monthly",
+        }
+
+        form = described_class.new(params)
+
+        expect(form).to be_invalid
+        expect(form.errors).to be_added(:benefits_amount, :greater_than, value: -1000, count: 0)
+      end
+    end
+
+    context "when at least one income type is selected, but a frequency is missing" do
+      it "is invalid" do
+        benefits = create(:transaction_type, :benefits)
+        pension = create(:transaction_type, :pension)
+        params = {
+          "transaction_type_ids" => ["", benefits.id, pension.id],
+          "benefits_amount" => "250",
+          "benefits_frequency" => "",
+          "pension_amount" => "100",
+          "pension_frequency" => "monthly",
+        }
+
+        form = described_class.new(params)
+
+        expect(form).to be_invalid
+        expect(form.errors).to be_added(:benefits_frequency, :inclusion, value: "")
+      end
+    end
+
+    context "when at least one income type is selected, but an invalid frequency is given" do
+      it "is invalid" do
+        benefits = create(:transaction_type, :benefits)
+        pension = create(:transaction_type, :pension)
+        params = {
+          "transaction_type_ids" => ["", benefits.id, pension.id],
+          "benefits_amount" => "250",
+          "benefits_frequency" => "invalid",
+          "pension_amount" => "100",
+          "pension_frequency" => "monthly",
+        }
+
+        form = described_class.new(params)
+
+        expect(form).to be_invalid
+        expect(form.errors).to be_added(:benefits_frequency, :inclusion, value: "invalid")
+      end
+    end
+
+    context "when none is selected" do
+      it "is valid" do
+        params = { "transaction_type_ids" => ["", "none"] }
+
+        form = described_class.new(params)
+
+        expect(form).to be_valid
+      end
+    end
+
+    context "when the correct attributes are provided" do
+      it "is valid" do
+        legal_aid_application = create(:legal_aid_application)
+        benefits = create(:transaction_type, :benefits)
+        pension = create(:transaction_type, :pension)
+        params = {
+          "transaction_type_ids" => ["", benefits.id, pension.id],
+          "benefits_amount" => "250",
+          "benefits_frequency" => "weekly",
+          "pension_amount" => "100",
+          "pension_frequency" => "monthly",
+        }.merge(legal_aid_application:)
+
+        form = described_class.new(params)
+
+        expect(form).to be_valid
+      end
+    end
+  end
+
+  describe "#new" do
+    context "when the application has regular transactions" do
+      it "assigns the correct attributes" do
+        legal_aid_application = create(:legal_aid_application)
+        benefits = create(:transaction_type, :benefits)
+        _transaction_type = create(
+          :legal_aid_application_transaction_type,
+          legal_aid_application:,
+          transaction_type: benefits,
+        )
+        _regular_transaction = create(
+          :regular_transaction,
+          legal_aid_application:,
+          transaction_type: benefits,
+          amount: 250,
+          frequency: "weekly",
+        )
+
+        form = described_class.new(legal_aid_application:)
+
+        expect(form.transaction_type_ids).to contain_exactly(benefits.id)
+        expect(form.benefits_amount).to eq(250)
+        expect(form.benefits_frequency).to eq("weekly")
+      end
+    end
+  end
+
+  describe "#save" do
+    context "when the form is invalid" do
+      it "returns false" do
+        legal_aid_application = build_stubbed(:legal_aid_application)
+        form = described_class.new(legal_aid_application:)
+
+        result = form.save
+
+        expect(result).to be false
+      end
+
+      it "does not update an application's transaction types" do
+        legal_aid_application = create(:legal_aid_application)
+        benefits = create(:transaction_type, :benefits)
+        transaction_type = create(
+          :legal_aid_application_transaction_type,
+          legal_aid_application:,
+          transaction_type: benefits,
+        )
+        form = described_class.new(legal_aid_application:)
+
+        form.save
+
+        expect(legal_aid_application.legal_aid_application_transaction_types)
+          .to contain_exactly(transaction_type)
+      end
+
+      it "does not update an application's regular transactions" do
+        legal_aid_application = create(:legal_aid_application)
+        regular_transaction = create(
+          :regular_transaction,
+          legal_aid_application:,
+        )
+        form = described_class.new(legal_aid_application:)
+
+        form.save
+
+        expect(legal_aid_application.regular_transactions)
+          .to contain_exactly(regular_transaction)
+      end
+
+      it "does not update an application's cash transactions" do
+        legal_aid_application = create(:legal_aid_application)
+        cash_transaction = create(:cash_transaction, legal_aid_application:)
+        form = described_class.new(legal_aid_application:)
+
+        form.save
+
+        expect(legal_aid_application.cash_transactions)
+          .to contain_exactly(cash_transaction)
+      end
+    end
+
+    context "when none is selected" do
+      it "returns true" do
+        legal_aid_application = create(:legal_aid_application)
+        params = {
+          "transaction_type_ids" => ["", "none"],
+          legal_aid_application:,
+        }
+        form = described_class.new(params)
+
+        result = form.save
+
+        expect(result).to be true
+      end
+
+      it "updates `no_credit_transaction_types_selected` on the application" do
+        legal_aid_application = create(
+          :legal_aid_application,
+          no_credit_transaction_types_selected: false,
+        )
+        params = {
+          "transaction_type_ids" => ["", "none"],
+          legal_aid_application:,
+        }
+        form = described_class.new(params)
+
+        form.save
+
+        expect(legal_aid_application.reload.no_credit_transaction_types_selected)
+          .to be true
+      end
+
+      it "destroys any existing income transaction types" do
+        legal_aid_application = create(:legal_aid_application)
+        benefits = create(:transaction_type, :benefits)
+        child_care = create(:transaction_type, :child_care)
+        _income_transaction_type = create(
+          :legal_aid_application_transaction_type,
+          legal_aid_application:,
+          transaction_type: benefits,
+        )
+        outgoing_transaction_type = create(
+          :legal_aid_application_transaction_type,
+          legal_aid_application:,
+          transaction_type: child_care,
+        )
+        params = {
+          "transaction_type_ids" => ["", "none"],
+          legal_aid_application:,
+        }
+        form = described_class.new(params)
+
+        form.save
+
+        expect(legal_aid_application.legal_aid_application_transaction_types)
+          .to contain_exactly(outgoing_transaction_type)
+      end
+
+      it "destroys any existing income regular transactions" do
+        legal_aid_application = create(:legal_aid_application)
+        benefits = create(:transaction_type, :benefits)
+        child_care = create(:transaction_type, :child_care)
+        _income_regular_transaction = create(
+          :regular_transaction,
+          legal_aid_application:,
+          transaction_type: benefits,
+        )
+        outgoing_regular_transaction = create(
+          :regular_transaction,
+          legal_aid_application:,
+          transaction_type: child_care,
+        )
+        params = {
+          "transaction_type_ids" => ["", "none"],
+          legal_aid_application:,
+        }
+        form = described_class.new(params)
+
+        form.save
+
+        expect(legal_aid_application.regular_transactions)
+          .to contain_exactly(outgoing_regular_transaction)
+      end
+
+      it "destroys any existing cash transactions" do
+        legal_aid_application = create(:legal_aid_application)
+        benefits = create(:transaction_type, :benefits)
+        child_care = create(:transaction_type, :child_care)
+        _income_cash_transaction = create(
+          :cash_transaction,
+          legal_aid_application:,
+          transaction_type: benefits,
+        )
+        outgoing_cash_transaction = create(
+          :cash_transaction,
+          legal_aid_application:,
+          transaction_type: child_care,
+        )
+        params = {
+          "transaction_type_ids" => ["", "none"],
+          legal_aid_application:,
+        }
+        form = described_class.new(params)
+
+        form.save
+
+        expect(legal_aid_application.cash_transactions)
+          .to contain_exactly(outgoing_cash_transaction)
+      end
+    end
+
+    context "when the correct attributes are provided" do
+      it "returns true" do
+        legal_aid_application = create(:legal_aid_application)
+        benefits = create(:transaction_type, :benefits)
+        params = {
+          "transaction_type_ids" => ["", benefits.id],
+          "benefits_amount" => "250.50",
+          "benefits_frequency" => "weekly",
+          legal_aid_application:,
+        }
+        form = described_class.new(params)
+
+        result = form.save
+
+        expect(result).to be true
+      end
+
+      it "updates `no_credit_transaction_types_selected` on the application" do
+        legal_aid_application = create(
+          :legal_aid_application,
+          no_credit_transaction_types_selected: true,
+        )
+        benefits = create(:transaction_type, :benefits)
+        params = {
+          "transaction_type_ids" => ["", benefits.id],
+          "benefits_amount" => "250.50",
+          "benefits_frequency" => "weekly",
+          legal_aid_application:,
+        }
+        form = described_class.new(params)
+
+        form.save
+
+        expect(legal_aid_application.reload.no_credit_transaction_types_selected).to be false
+      end
+
+      it "updates the application's income transaction types" do
+        legal_aid_application = create(:legal_aid_application)
+        benefits = create(:transaction_type, :benefits)
+        pension = create(:transaction_type, :pension)
+        maintenance_in = create(:transaction_type, :maintenance_in)
+        child_care = create(:transaction_type, :child_care)
+        _old_income_transaction_type = create(
+          :legal_aid_application_transaction_type,
+          legal_aid_application:,
+          transaction_type: maintenance_in,
+        )
+        existing_income_transaction_type = create(
+          :legal_aid_application_transaction_type,
+          legal_aid_application:,
+          transaction_type: benefits,
+        )
+        outgoing_transaction_type = create(
+          :legal_aid_application_transaction_type,
+          legal_aid_application:,
+          transaction_type: child_care,
+        )
+        params = {
+          "transaction_type_ids" => ["", benefits.id, pension.id],
+          "benefits_amount" => "250.50",
+          "benefits_frequency" => "weekly",
+          "pension_amount" => "100",
+          "pension_frequency" => "monthly",
+          legal_aid_application:,
+        }
+        form = described_class.new(params)
+
+        form.save
+
+        new_transaction_type = LegalAidApplicationTransactionType.find_by!(
+          legal_aid_application_id: legal_aid_application.id,
+          transaction_type_id: pension.id,
+        )
+        transaction_types = legal_aid_application.legal_aid_application_transaction_types
+        expect(transaction_types).to contain_exactly(
+          existing_income_transaction_type,
+          outgoing_transaction_type,
+          new_transaction_type,
+        )
+      end
+
+      it "updates the application's income regular transactions" do
+        legal_aid_application = create(:legal_aid_application)
+        benefits = create(:transaction_type, :benefits)
+        pension = create(:transaction_type, :pension)
+        maintenance_in = create(:transaction_type, :maintenance_in)
+        child_care = create(:transaction_type, :child_care)
+        _old_income_regular_transaction = create(
+          :regular_transaction,
+          legal_aid_application:,
+          transaction_type: maintenance_in,
+        )
+        existing_income_regular_transaction = create(
+          :regular_transaction,
+          legal_aid_application:,
+          transaction_type: benefits,
+        )
+        outgoing_regular_transaction = create(
+          :regular_transaction,
+          legal_aid_application:,
+          transaction_type: child_care,
+        )
+        params = {
+          "transaction_type_ids" => ["", benefits.id, pension.id],
+          "benefits_amount" => "250.50",
+          "benefits_frequency" => "weekly",
+          "pension_amount" => "100",
+          "pension_frequency" => "monthly",
+          legal_aid_application:,
+        }
+        form = described_class.new(params)
+
+        form.save
+
+        new_regular_transaction = RegularTransaction.find_by!(
+          legal_aid_application_id: legal_aid_application.id,
+          transaction_type_id: pension.id,
+        )
+        regular_transactions = legal_aid_application.regular_transactions
+        expect(regular_transactions).to contain_exactly(
+          existing_income_regular_transaction,
+          outgoing_regular_transaction,
+          new_regular_transaction,
+        )
+      end
+
+      it "updates the application's income cash transactions" do
+        legal_aid_application = create(:legal_aid_application)
+        benefits = create(:transaction_type, :benefits)
+        pension = create(:transaction_type, :pension)
+        maintenance_in = create(:transaction_type, :maintenance_in)
+        child_care = create(:transaction_type, :child_care)
+        _old_income_cash_transaction = create(
+          :cash_transaction,
+          legal_aid_application:,
+          transaction_type: maintenance_in,
+        )
+        existing_income_cash_transaction = create(
+          :cash_transaction,
+          legal_aid_application:,
+          transaction_type: benefits,
+        )
+        outgoing_cash_transaction = create(
+          :cash_transaction,
+          legal_aid_application:,
+          transaction_type: child_care,
+        )
+        params = {
+          "transaction_type_ids" => ["", benefits.id, pension.id],
+          "benefits_amount" => "250.50",
+          "benefits_frequency" => "weekly",
+          "pension_amount" => "100",
+          "pension_frequency" => "monthly",
+          legal_aid_application:,
+        }
+        form = described_class.new(params)
+
+        form.save
+
+        cash_transactions = legal_aid_application.cash_transactions
+        expect(cash_transactions).to contain_exactly(
+          existing_income_cash_transaction,
+          outgoing_cash_transaction,
+        )
+      end
+    end
+  end
+end
+# rubocop:enable Rails/SaveBang

--- a/spec/models/legal_aid_application_spec.rb
+++ b/spec/models/legal_aid_application_spec.rb
@@ -163,6 +163,56 @@ RSpec.describe LegalAidApplication, type: :model do
     end
   end
 
+  describe "#income_types?" do
+    context "when enhanced bank upload journey is enabled" do
+      it "returns true if regular payment credits exist" do
+        Setting.setting.update!(enhanced_bank_upload: true)
+        benefits = build_stubbed(:regular_transaction, :benefits)
+        regular_transactions = class_double(RegularTransaction, credits: [benefits])
+        legal_aid_application = build_stubbed(:legal_aid_application)
+        allow(legal_aid_application).to receive(:regular_transactions).and_return(regular_transactions)
+
+        income_types_exist = legal_aid_application.income_types?
+
+        expect(income_types_exist).to be true
+      end
+
+      it "returns false if no regular payment credits exist" do
+        Setting.setting.update!(enhanced_bank_upload: true)
+        regular_transactions = class_double(RegularTransaction, credits: [])
+        legal_aid_application = build_stubbed(:legal_aid_application)
+        allow(legal_aid_application).to receive(:regular_transactions).and_return(regular_transactions)
+
+        income_types_exist = legal_aid_application.income_types?
+
+        expect(income_types_exist).to be false
+      end
+    end
+
+    context "when enhanced bank upload journey is disabled" do
+      it "returns true if transaction type credits exist" do
+        benefits = build_stubbed(:transaction_type, :benefits)
+        transaction_types = class_double(TransactionType, credits: [benefits])
+        legal_aid_application = build_stubbed(:legal_aid_application)
+        allow(legal_aid_application).to receive(:transaction_types).and_return(transaction_types)
+
+        income_types_exist = legal_aid_application.income_types?
+
+        expect(income_types_exist).to be true
+      end
+
+      it "returns false if no transaction type credits exist" do
+        transaction_types = class_double(TransactionType, credits: [])
+        legal_aid_application = build_stubbed(:legal_aid_application)
+        allow(legal_aid_application).to receive(:transaction_types).and_return(transaction_types)
+
+        income_types_exist = legal_aid_application.income_types?
+
+        expect(income_types_exist).to be false
+      end
+    end
+  end
+
   describe "#statement_of_case_uploaded?" do
     let(:legal_aid_application) { create :legal_aid_application }
 

--- a/spec/models/regular_transaction_spec.rb
+++ b/spec/models/regular_transaction_spec.rb
@@ -1,0 +1,100 @@
+require "rails_helper"
+
+RSpec.describe RegularTransaction, type: :model do
+  describe "validations" do
+    context "when amount is blank" do
+      it "is invalid" do
+        regular_transaction = build_stubbed(:regular_transaction, amount: nil)
+
+        expect(regular_transaction).to be_invalid
+        expect(regular_transaction.errors).to be_added(
+          :amount,
+          :not_a_number,
+          value: "",
+        )
+      end
+    end
+
+    context "when amount is invalid" do
+      it "is invalid" do
+        regular_transaction = build_stubbed(:regular_transaction, amount: "-1000")
+
+        expect(regular_transaction).to be_invalid
+        expect(regular_transaction.errors).to be_added(
+          :amount,
+          :greater_than,
+          value: -1000,
+          count: 0,
+        )
+      end
+    end
+
+    context "when frequency is blank" do
+      it "is invalid" do
+        regular_transaction = build_stubbed(:regular_transaction, frequency: nil)
+
+        expect(regular_transaction).to be_invalid
+        expect(regular_transaction.errors).to be_added(
+          :frequency,
+          :inclusion,
+          value: nil,
+        )
+      end
+    end
+
+    context "when frequency is invalid" do
+      it "is invalid" do
+        regular_transaction = build_stubbed(:regular_transaction, frequency: "invalid")
+
+        expect(regular_transaction).to be_invalid
+        expect(regular_transaction.errors).to be_added(
+          :frequency,
+          :inclusion,
+          value: "invalid",
+        )
+      end
+    end
+
+    context "when correct attributes are provided" do
+      it "is valid" do
+        legal_aid_application = build_stubbed(:legal_aid_application)
+        benefits = build_stubbed(:transaction_type, :benefits)
+
+        record = described_class.new(
+          legal_aid_application:,
+          transaction_type: benefits,
+          amount: "1500.50",
+          frequency: "monthly",
+        )
+
+        expect(record).to be_valid
+      end
+    end
+  end
+
+  describe ".credits" do
+    it "returns payments where the transaction type is a credit" do
+      credit = create(:transaction_type, :benefits)
+      debit = create(:transaction_type, :child_care)
+      credit_payment = create(:regular_transaction, transaction_type: credit)
+      _debit_payment = create(:regular_transaction, transaction_type: debit)
+
+      records = described_class.credits
+
+      expect(records).to contain_exactly(credit_payment)
+    end
+  end
+
+  describe ".debits" do
+    it "returns payments where the transaction type is a debit" do
+      credit = create(:transaction_type, :benefits)
+      debit = create(:transaction_type, :child_care)
+      _credit_payment = create(:regular_transaction, transaction_type: credit)
+      debit_payment = create(:regular_transaction, transaction_type: debit)
+
+      records = described_class.debits
+
+      expect(records).to contain_exactly(debit_payment)
+    end
+  end
+end

--- a/spec/requests/providers/client_completed_means_spec.rb
+++ b/spec/requests/providers/client_completed_means_spec.rb
@@ -136,6 +136,14 @@ RSpec.describe Providers::ClientCompletedMeansController, type: :request do
           it "redirects to next page" do
             expect(subject).to redirect_to(providers_legal_aid_application_means_identify_types_of_income_path(legal_aid_application))
           end
+
+          context "when enhanced_bank_upload is enabled" do
+            before { Setting.setting.update!(enhanced_bank_upload: true) }
+
+            it "redirects to the identify incomes page" do
+              expect(subject).to redirect_to(providers_legal_aid_application_means_regular_incomes_path(legal_aid_application))
+            end
+          end
         end
       end
     end

--- a/spec/requests/providers/means/identify_types_of_incomes_controller_spec.rb
+++ b/spec/requests/providers/means/identify_types_of_incomes_controller_spec.rb
@@ -38,6 +38,19 @@ RSpec.describe Providers::Means::IdentifyTypesOfIncomesController do
 
       it_behaves_like "a provider not authenticated"
     end
+
+    context "when the enhanced_bank_upload setting is enabled" do
+      it "redirects to the identify income types page" do
+        Setting.setting.update!(enhanced_bank_upload: true)
+        legal_aid_application = create(:legal_aid_application)
+        provider = legal_aid_application.provider
+        login_as provider
+
+        get providers_legal_aid_application_means_identify_types_of_income_path(legal_aid_application)
+
+        expect(response).to redirect_to(providers_legal_aid_application_means_regular_incomes_path(legal_aid_application))
+      end
+    end
   end
 
   describe "PATCH /providers/applications/:legal_aid_application_id/means/identify_types_of_income" do
@@ -284,6 +297,19 @@ RSpec.describe Providers::Means::IdentifyTypesOfIncomesController do
       before { request }
 
       it_behaves_like "a provider not authenticated"
+    end
+
+    context "when the enhanced_bank_upload setting is enabled" do
+      it "redirects to the identify income types page" do
+        Setting.setting.update!(enhanced_bank_upload: true)
+        legal_aid_application = create(:legal_aid_application)
+        provider = legal_aid_application.provider
+        login_as provider
+
+        patch providers_legal_aid_application_means_identify_types_of_income_path(legal_aid_application)
+
+        expect(response).to redirect_to(providers_legal_aid_application_means_regular_incomes_path(legal_aid_application))
+      end
     end
 
     context "when submitted with Save as draft" do

--- a/spec/requests/providers/means/regular_incomes_controller_spec.rb
+++ b/spec/requests/providers/means/regular_incomes_controller_spec.rb
@@ -1,0 +1,253 @@
+require "rails_helper"
+
+RSpec.describe Providers::Means::RegularIncomesController do
+  describe "GET /providers/applications/:legal_aid_application_id/means/regular_incomes" do
+    it "returns ok" do
+      Setting.setting.update!(enhanced_bank_upload: true)
+      legal_aid_application = create(:legal_aid_application)
+      provider = legal_aid_application.provider
+      login_as provider
+
+      get providers_legal_aid_application_means_regular_incomes_path(legal_aid_application)
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    context "when the application has regular transactions" do
+      it "renders the income data" do
+        Setting.setting.update!(enhanced_bank_upload: true)
+        legal_aid_application = create(:legal_aid_application)
+        benefits = create(:transaction_type, :benefits)
+        _transaction_type = create(
+          :legal_aid_application_transaction_type,
+          legal_aid_application:,
+          transaction_type: benefits,
+        )
+        _regular_transaction = create(
+          :regular_transaction,
+          legal_aid_application:,
+          transaction_type: benefits,
+          amount: 500,
+          frequency: "weekly",
+        )
+        provider = legal_aid_application.provider
+        login_as provider
+
+        get providers_legal_aid_application_means_regular_incomes_path(legal_aid_application)
+
+        expect(page).to have_checked_field("Benefits")
+        benefits_amount = page.find_field("providers-means-regular-income-form-benefits-amount-field").value
+        expect(benefits_amount).to eq("500.0")
+        frequency_amount = page.find_field("providers-means-regular-income-form-benefits-frequency-weekly-field").value
+        expect(frequency_amount).to eq("weekly")
+      end
+    end
+
+    context "when the provider is not authenticated" do
+      it "redirects to the provider login page" do
+        legal_aid_application = create(:legal_aid_application)
+
+        get providers_legal_aid_application_means_regular_incomes_path(legal_aid_application)
+
+        expect(response).to redirect_to(new_provider_session_path)
+      end
+    end
+
+    context "when the enhanced_bank_upload setting is not enabled" do
+      it "redirects to the identify income types page" do
+        legal_aid_application = create(:legal_aid_application)
+        provider = legal_aid_application.provider
+        login_as provider
+
+        get providers_legal_aid_application_means_regular_incomes_path(legal_aid_application)
+
+        expect(response).to redirect_to(providers_legal_aid_application_means_identify_types_of_income_path(legal_aid_application))
+      end
+    end
+  end
+
+  describe "PATCH /providers/applications/:legal_aid_application_id/means/regular_incomes" do
+    context "when none is selected" do
+      it "updates the application and redirects to the student finance page" do
+        Setting.setting.update!(enhanced_bank_upload: true)
+        legal_aid_application = create(
+          :legal_aid_application,
+          no_credit_transaction_types_selected: false,
+        )
+        provider = legal_aid_application.provider
+        login_as provider
+        params = {
+          providers_means_regular_income_form: {
+            transaction_type_ids: ["", "none"],
+          },
+        }
+
+        patch providers_legal_aid_application_means_regular_incomes_path(legal_aid_application), params: params
+
+        expect(response).to redirect_to(providers_legal_aid_application_means_student_finance_path(legal_aid_application))
+        expect(legal_aid_application.reload.no_credit_transaction_types_selected).to be true
+      end
+    end
+
+    context "when regular transactions are selected" do
+      it "updates the application and redirects to the cash income page" do
+        Setting.setting.update!(enhanced_bank_upload: true)
+        legal_aid_application = create(
+          :legal_aid_application,
+          no_credit_transaction_types_selected: true,
+        )
+        benefits = create(:transaction_type, :benefits)
+        pension = create(:transaction_type, :pension)
+        provider = legal_aid_application.provider
+        login_as provider
+        params = {
+          providers_means_regular_income_form: {
+            transaction_type_ids: ["", benefits.id, pension.id],
+            benefits_amount: 250,
+            benefits_frequency: "weekly",
+            pension_amount: 100,
+            pension_frequency: "monthly",
+          },
+        }
+
+        patch providers_legal_aid_application_means_regular_incomes_path(legal_aid_application), params: params
+
+        expect(response).to redirect_to(providers_legal_aid_application_means_cash_income_path(legal_aid_application))
+        expect(legal_aid_application.reload.no_credit_transaction_types_selected).to be false
+        identified_income = legal_aid_application.regular_transactions.credits
+        expect(identified_income.pluck(:transaction_type_id, :amount, :frequency))
+          .to contain_exactly([benefits.id, 250, "weekly"], [pension.id, 100, "monthly"])
+      end
+    end
+
+    context "when the form is invalid" do
+      it "returns unprocessable entity, renders errors, and does not update the application" do
+        Setting.setting.update!(enhanced_bank_upload: true)
+        legal_aid_application = create(
+          :legal_aid_application,
+          no_credit_transaction_types_selected: nil,
+        )
+        benefits = create(:transaction_type, :benefits)
+        maintenance_in_payment = create(:regular_transaction, :maintenance_in, legal_aid_application:)
+        provider = legal_aid_application.provider
+        login_as provider
+        params = {
+          providers_means_regular_income_form: {
+            transaction_type_ids: ["", benefits.id],
+            benefits_amount: "",
+            benefits_frequency: "",
+          },
+        }
+
+        patch providers_legal_aid_application_means_regular_incomes_path(legal_aid_application), params: params
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(page).to have_css("p", class: "govuk-error-message", text: "Enter the amount of benefits received")
+        expect(page).to have_css("p", class: "govuk-error-message", text: "Select how often your client receives benefits")
+        expect(legal_aid_application.reload.no_credit_transaction_types_selected).to be_nil
+        identified_income = legal_aid_application.regular_transactions.credits
+        expect(identified_income).to contain_exactly(maintenance_in_payment)
+      end
+    end
+
+    context "when checking answers for an application uploading bank statements and none is selected" do
+      it "updates the application and redirects to the means summaries page" do
+        Setting.setting.update!(enhanced_bank_upload: true)
+        non_passported_permission = create(:permission, :non_passported)
+        bank_statement_permission = create(:permission, :bank_statement_upload)
+        provider = create(:provider, permissions: [non_passported_permission, bank_statement_permission])
+        legal_aid_application = create(
+          :legal_aid_application,
+          :with_non_passported_state_machine,
+          :checking_non_passported_means,
+          provider_received_citizen_consent: false,
+          no_credit_transaction_types_selected: false,
+          provider:,
+        )
+        login_as provider
+        login_as provider
+        params = { providers_means_regular_income_form: { transaction_type_ids: ["", "none"] } }
+
+        patch providers_legal_aid_application_means_regular_incomes_path(legal_aid_application), params: params
+
+        expect(response).to redirect_to(providers_legal_aid_application_means_summary_path(legal_aid_application))
+        expect(legal_aid_application.reload.no_credit_transaction_types_selected).to be true
+      end
+    end
+
+    context "when checking answers for an application not uploading bank statements and none is selected" do
+      it "updates the application and redirects to the income summary page" do
+        Setting.setting.update!(enhanced_bank_upload: true)
+        legal_aid_application = create(
+          :legal_aid_application,
+          :with_non_passported_state_machine,
+          :checking_non_passported_means,
+          no_credit_transaction_types_selected: false,
+        )
+        provider = legal_aid_application.provider
+        login_as provider
+        params = { providers_means_regular_income_form: { transaction_type_ids: ["", "none"] } }
+
+        patch providers_legal_aid_application_means_regular_incomes_path(legal_aid_application), params: params
+
+        expect(response).to redirect_to(providers_legal_aid_application_income_summary_index_path(legal_aid_application))
+        expect(legal_aid_application.reload.no_credit_transaction_types_selected).to be true
+      end
+    end
+
+    context "when checking answers and regular transactions are selected" do
+      it "updates the application and redirects to the cash income page" do
+        Setting.setting.update!(enhanced_bank_upload: true)
+        legal_aid_application = create(
+          :legal_aid_application,
+          :with_non_passported_state_machine,
+          :checking_non_passported_means,
+          no_credit_transaction_types_selected: true,
+        )
+        benefits = create(:transaction_type, :benefits)
+        pension = create(:transaction_type, :pension)
+        provider = legal_aid_application.provider
+        login_as provider
+        params = {
+          providers_means_regular_income_form: {
+            transaction_type_ids: ["", benefits.id, pension.id],
+            benefits_amount: 250,
+            benefits_frequency: "weekly",
+            pension_amount: 100,
+            pension_frequency: "monthly",
+          },
+        }
+
+        patch providers_legal_aid_application_means_regular_incomes_path(legal_aid_application), params: params
+
+        expect(response).to redirect_to(providers_legal_aid_application_means_cash_income_path(legal_aid_application))
+        expect(legal_aid_application.reload.no_credit_transaction_types_selected).to be false
+        identified_income = legal_aid_application.regular_transactions.credits
+        expect(identified_income.pluck(:transaction_type_id, :amount, :frequency))
+          .to contain_exactly([benefits.id, 250, "weekly"], [pension.id, 100, "monthly"])
+      end
+    end
+
+    context "when the provider is not authenticated" do
+      it "redirects to the provider login page" do
+        legal_aid_application = create(:legal_aid_application)
+
+        patch providers_legal_aid_application_means_regular_incomes_path(legal_aid_application)
+
+        expect(response).to redirect_to(new_provider_session_path)
+      end
+    end
+
+    context "when the enhanced_bank_upload setting is not enabled" do
+      it "redirects to the identify income types page" do
+        legal_aid_application = create(:legal_aid_application)
+        provider = legal_aid_application.provider
+        login_as provider
+
+        patch providers_legal_aid_application_means_regular_incomes_path(legal_aid_application)
+
+        expect(response).to redirect_to(providers_legal_aid_application_means_identify_types_of_income_path(legal_aid_application))
+      end
+    end
+  end
+end


### PR DESCRIPTION
Before, when providers with employment and bank upload permissions submitted
income data for their client, they could only specify which transactions their
client received.

This data is not granular enough, and makes it impossible to obtain a financial
eligibility assessment (CFE) result for the client.

As part of ongoing work to iterate on the bank upload journey, providers are now
able to tell us how much (amount), and how often (frequency) their client
receives these income payments.

Next steps will include:

- ensuring providers can select the cash transactions
- ensuring cash transactions are updated when regular payments are updated
- replicating this functionality for the outgoings page
- updating the frequencies to reflect the designs
- allowing providers to save and come back later

This user journey is restricted by feature flag at the flow and controller level.

## Video

https://user-images.githubusercontent.com/25187547/189706162-a35dbbde-3424-472c-af55-1514e2c89ae7.mp4

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3445)