### PR TITLE
AP-3197 Add table captions and make links descriptive

### DIFF
--- a/app/views/citizens/accounts/index.html.erb
+++ b/app/views/citizens/accounts/index.html.erb
@@ -25,7 +25,8 @@
       </dl>
 
       <table class="govuk-table">
-         <thead class="govuk-table__head">
+        <caption class="govuk-table__caption govuk-table__caption--m govuk-visually-hidden"><%= t('.table_caption') %></caption>
+        <thead class="govuk-table__head">
           <tr class="govuk-table__row">
             <th class="govuk-table__header" scope="col"><%= t '.type_heading' %></th>
             <th class="govuk-table__header" scope="col"><%= t '.account_number_heading' %></th>

--- a/app/views/providers/application_merits_task/has_other_involved_children/show.html.erb
+++ b/app/views/providers/application_merits_task/has_other_involved_children/show.html.erb
@@ -10,8 +10,8 @@
 
     <% if @legal_aid_application.involved_children.count > 0 %>
     <h1 class="govuk-heading-xl"><%= t('.existing', count: "#{pluralize(@legal_aid_application.involved_children.count, 'child')}") %></h1>
-    <div class="govuk-summary-list">
-      <table class="govuk-table">
+    <table class="govuk-table">
+        <caption class="govuk-table__caption govuk-table__caption--m govuk-visually-hidden"><%= t('.table_caption') %></caption>
         <thead class="govuk-table__head">
           <tr class="govuk-table__row">
             <th class="govuk-table__header">Name</th>
@@ -38,7 +38,6 @@
           <% end %>
         </tbody>
       </table>
-    </div>
     <% end %>
 
     <%= form.govuk_collection_radio_buttons :has_other_involved_child,

--- a/app/views/providers/bank_transactions/_list_selected.html.erb
+++ b/app/views/providers/bank_transactions/_list_selected.html.erb
@@ -1,4 +1,5 @@
 <table class="govuk-table">
+  <caption class="govuk-table__caption govuk-table__caption--m govuk-visually-hidden"><%= t('.caption', category: category) %></caption>
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
       <th class="govuk-table__header" scope="col"><%= t('.col_date') %></th>
@@ -21,14 +22,14 @@
         </td>
         <td class="govuk-table__cell">
           <%= button_to_accessible(
+                t('.remove_link'),
                 remove_transaction_type_providers_legal_aid_application_bank_transaction_path(@legal_aid_application, bank_transaction),
                 method: :patch,
                 class: 'button-as-link',
                 form_class: 'remote-remove-transaction',
+                suffix: bank_transaction.description + " " + value_with_currency_unit(bank_transaction.amount, bank_transaction.currency) + " " + l(bank_transaction.happened_at.to_date, format: :short_date),
                 remote: true
-              ) do %>
-                <%= t('.remove_link') %><span class="govuk-visually-hidden"> <%= bank_transaction.description %> <%= value_with_currency_unit(bank_transaction.amount, bank_transaction.currency) %></span>
-              <% end %>
+              ) %>
         </td>
       </tr>
     <% end %>

--- a/app/views/providers/check_client_details/show.html.erb
+++ b/app/views/providers/check_client_details/show.html.erb
@@ -9,6 +9,7 @@
     <%= govuk_fieldset_header page_title %>
 
     <table class="govuk-table">
+      <caption class="govuk-table__caption govuk-table__caption--m govuk-visually-hidden"><%= t('.table_caption') %></caption>
       <thead class="govuk-table__head">
       </thead>
       <tbody class="govuk-table__body">

--- a/app/views/providers/confirm_multiple_delegated_functions/show.html.erb
+++ b/app/views/providers/confirm_multiple_delegated_functions/show.html.erb
@@ -20,6 +20,7 @@
       </div>
 
       <table class="govuk-table">
+        <caption class="govuk-table__caption govuk-table__caption--m govuk-visually-hidden"><%= t('.table_caption') %></caption>
         <thead class="govuk-table__head">
           <tr class="govuk-table__row">
             <th scope="col" class="govuk-table__header">Proceeding</th>

--- a/app/views/providers/income_summary/_income_type_item.html.erb
+++ b/app/views/providers/income_summary/_income_type_item.html.erb
@@ -29,7 +29,7 @@
   </h2>
   <%= content_tag(:div, class: 'app-task-list__items', id: "list-item-#{name}") do %>
     <% if bank_transactions.present? %>
-      <%= render 'providers/bank_transactions/list_selected', bank_transactions: bank_transactions %>
+      <%= render 'providers/bank_transactions/list_selected', category: name, bank_transactions: bank_transactions %>
       <%= transaction_link %>
     <% else %>
       <p class="app-task-list__item">

--- a/app/views/providers/means/employment_incomes/show.html.erb
+++ b/app/views/providers/means/employment_incomes/show.html.erb
@@ -28,6 +28,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <table class="govuk-table">
+        <caption class="govuk-table__caption govuk-table__caption--m govuk-visually-hidden"><%= t('.table_caption') %></caption>
         <thead class="govuk-table__head">
         <tr class="govuk-table__row">
           <th class="govuk-table__header" style="width: 25%;" scope="col"><%= t('.date') %></th>

--- a/app/views/providers/outgoings_summary/_outgoing_type_item.html.erb
+++ b/app/views/providers/outgoings_summary/_outgoing_type_item.html.erb
@@ -23,7 +23,7 @@
   </h2>
   <%= content_tag(:div, class: 'app-task-list__items', id: "list-item-#{name}") do %>
     <% if bank_transactions.present? %>
-      <%= render 'providers/bank_transactions/list_selected', bank_transactions: bank_transactions %>
+      <%= render 'providers/bank_transactions/list_selected', category: name, bank_transactions: bank_transactions %>
       <%= transaction_link %>
     <% else %>
       <p class="app-task-list__item">

--- a/config/locales/cy/citizens.yml
+++ b/config/locales/cy/citizens.yml
@@ -21,6 +21,7 @@ cy:
         sort_code_heading: edoC troS
         type_heading: epyT
         your_accounts: stnuocca knab ruoY
+        table_caption: stnuocca dedda ruoY
         link_other_account: tnuocca knab rehtona ddA
     additional_accounts:
       index:

--- a/config/locales/en/citizens.yml
+++ b/config/locales/en/citizens.yml
@@ -18,6 +18,7 @@ en:
         account_number_heading: Account Number
         balance_heading: Balance
         sort_code_heading: Sort Code
+        table_caption: Your added accounts
         type_heading: Type
         your_accounts: Your bank accounts
         link_other_account: Add another bank account

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -235,6 +235,7 @@ en:
       show:
         heading: Check delegated functions dates
         radios_heading: Are these dates correct?
+        table_caption: Delegated functions dates
         error:
           blank_plural: Select yes if these dates are correct
           blank_singular: Select yes if this date is correct
@@ -251,6 +252,7 @@ en:
       show:
         error: Select if your client's details are correct or not
         title: Check your client's details
+        table_caption: Your client's details
         details_correct: These details are correct
         details_incorrect: I need to change these details
         name: Name
@@ -380,6 +382,7 @@ en:
         show:
           page_title: You have added %{count}
           existing: You have added %{count}
+          table_caption: Children added
           remove: Remove
           add_another: Do you need to add another child?
       remove_involved_child:
@@ -671,6 +674,7 @@ en:
           hmrc_not_employed: "You told us your client is not employed but HMRC shared the following information with us:"
           supplementary_question: Do you need to tell us anything else about your client's employment?
           employment_hint: For example, if they get cash in hand pay, have zero-hours contracts, or recently started or ended employment.
+          table_caption: Your client's employment details
           date: Date
           income: Income
           deductions: Deductions

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -54,6 +54,7 @@ en:
         col_date: Date
         col_description: Description
         remove_link: Remove
+        caption: "Transactions added for %{category}"
 
     capital_assessment_results:
       additional_property:


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3197)

Added table captions to several tables throughout the service which were missing captions. 
All captions are visually hidden but will be read out by a screenreader. 
Also updated the remove-transaction links on the income summary/outgoings to be more descriptive 

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
