### PR TITLE
AP-3409 Accessibility fixes for proceeding loop pages

### DIFF
--- a/app/views/providers/proceeding_loop/client_involvement_type/show.html.erb
+++ b/app/views/providers/proceeding_loop/client_involvement_type/show.html.erb
@@ -6,12 +6,12 @@
     ) do |form| %>
   <%= page_template page_title: @proceeding.meaning, template: :basic, form: form do %>
     <span class="govuk-caption-l"><%= position_in_array(@proceeding) %></span>
+    <h1 class="govuk-heading-xl"><%= page_title %></h1>
     <%= form.govuk_collection_radio_buttons(:client_involvement_type_ccms_code,
                                             @form.client_involvement_types,
                                             :ccms_code,
                                             :description,
-                                            legend: {size: 'xl', tag: 'h1', text: content_for(:page_title)},
-                                            hint: { text: t('.question'), class: 'govuk-heading-m' }) %>
+                                            legend: {size: 'm', tag: 'h2', text: t('.question')}) %>
 
     <%= next_action_buttons(
           form: form,

--- a/app/views/providers/proceeding_loop/confirm_delegated_functions_date/show.html.erb
+++ b/app/views/providers/proceeding_loop/confirm_delegated_functions_date/show.html.erb
@@ -5,18 +5,14 @@
       local: true
     ) do |form| %>
 
-  <span class="govuk-caption-l"><%= position_in_array(@proceeding) %></span>
   <%= page_template page_title: @proceeding.meaning, template: :basic, form: form do %>
+    <span class="govuk-caption-l"><%= position_in_array(@proceeding) %></span>
+    <h1 class="govuk-heading-xl govuk-!-margin-top-2"><%= page_title %></h1>
+
+    <%= govuk_warning_text(text: t(".warning_text")) %>
+
     <%= form.govuk_radio_buttons_fieldset :confirm_delegated_functions_date,
-                                          legend: { size: 'xl', tag: 'h1', text: page_title } do %>
-      <div class="govuk-warning-text">
-        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-        <strong class="govuk-warning-text__text">
-          <span class="govuk-warning-text__assistive"><%= t(".warning_text") %></span>
-          <%= t(".warning_text") %>
-        </strong>
-      </div>
-      <h2 class="govuk-heading-m govuk-!-margin-top-2"><%= t('.question', date: @proceeding.used_delegated_functions_on.strftime('%-d %B %Y')) %></h2>
+                                          legend: { size: 'm', tag: 'h2', text: t('.question', date: @proceeding.used_delegated_functions_on.strftime('%-d %B %Y')) } do %>
       <%= form.govuk_radio_button :confirm_delegated_functions_date, true, label: { text: t('generic.yes')}, link_errors: true %>
       <%= form.govuk_radio_button :confirm_delegated_functions_date, false, label: { text: t(".details_incorrect")} %>
     <% end %>

--- a/app/views/providers/proceeding_loop/delegated_functions/show.html.erb
+++ b/app/views/providers/proceeding_loop/delegated_functions/show.html.erb
@@ -6,7 +6,7 @@
     ) do |form| %>
   <%= page_template page_title: @proceeding.meaning, template: :basic, form: form do %>
     <span class="govuk-caption-l"><%= position_in_array(@proceeding) %></span>
-    <h1 class="govuk-heading-xl govuk-!-margin-top-2" style="margin-bottom: 0.5em"><%= page_title %></h1>
+    <h1 class="govuk-heading-xl govuk-!-margin-top-2"><%= page_title %></h1>
     <%= form.govuk_radio_buttons_fieldset(:used_delegated_functions,
                                           legend: { size: 'm', tag: 'h2', text: t('.question')}) do %>
       <%= form.govuk_radio_button :used_delegated_functions, true, label: { text: t('generic.yes') } do %>

--- a/app/views/providers/proceeding_loop/emergency_defaults/show.html.erb
+++ b/app/views/providers/proceeding_loop/emergency_defaults/show.html.erb
@@ -4,9 +4,9 @@
       method: :patch,
       local: true
     ) do |form| %>
-  <span class="govuk-caption-l"><%= position_in_array(@proceeding) %></span>
-  <h1 class="govuk-heading-xl"><%= @proceeding.meaning %></h1>
   <%= page_template template: :basic, form: form do %>
+    <span class="govuk-caption-l"><%= position_in_array(@proceeding) %></span>
+    <h1 class="govuk-heading-xl"><%= @proceeding.meaning %></h1>
     <%= form.govuk_radio_buttons_fieldset :accepted_emergency_defaults,
                                           inline: true,
                                           legend: { size: 'l', tag: 'h2', text: t('.question') } do %>

--- a/app/views/providers/proceeding_loop/emergency_level_of_service/show.html.erb
+++ b/app/views/providers/proceeding_loop/emergency_level_of_service/show.html.erb
@@ -4,9 +4,9 @@
       method: :patch,
       local: true
     ) do |form| %>
-  <span class="govuk-caption-l"><%= position_in_array(@proceeding) %></span>
-  <h1 class="govuk-heading-xl"><%= @proceeding.meaning %></h1>
   <%= page_template template: :basic, form: form do %>
+    <span class="govuk-caption-l"><%= position_in_array(@proceeding) %></span>
+    <h1 class="govuk-heading-xl"><%= @proceeding.meaning %></h1>
     <% if form.object.levels_of_service.length > 1 %>
       <%= form.govuk_radio_buttons_fieldset(:emergency_level_of_service, legend: { text: t('.instruction'), tag: 'h2', size: 'm'} ) do %>
         <% form.object.levels_of_service.each do |level| %>

--- a/app/views/providers/proceeding_loop/substantive_defaults/show.html.erb
+++ b/app/views/providers/proceeding_loop/substantive_defaults/show.html.erb
@@ -4,9 +4,9 @@
       method: :patch,
       local: true
     ) do |form| %>
-  <span class="govuk-caption-l"><%= position_in_array(@proceeding) %></span>
-  <h1 class="govuk-heading-xl"><%= @proceeding.meaning %></h1>
   <%= page_template template: :basic, form: form do %>
+    <span class="govuk-caption-l"><%= position_in_array(@proceeding) %></span>
+    <h1 class="govuk-heading-xl"><%= @proceeding.meaning %></h1>
     <%= form.govuk_radio_buttons_fieldset :accepted_substantive_defaults,
                                           inline: true,
                                           legend: { size: 'l', tag: 'h2', text: t('.question') } do %>

--- a/app/views/providers/proceeding_loop/substantive_level_of_service/show.html.erb
+++ b/app/views/providers/proceeding_loop/substantive_level_of_service/show.html.erb
@@ -4,9 +4,9 @@
       method: :patch,
       local: true
     ) do |form| %>
-  <span class="govuk-caption-l"><%= position_in_array(@proceeding) %></span>
-  <h1 class="govuk-heading-xl"><%= @proceeding.meaning %></h1>
   <%= page_template template: :basic, form: form do %>
+    <span class="govuk-caption-l"><%= position_in_array(@proceeding) %></span>
+    <h1 class="govuk-heading-xl"><%= @proceeding.meaning %></h1>
     <% if form.object.levels_of_service.length > 1 %>
       <%= form.govuk_radio_buttons_fieldset(:substantive_level_of_service, legend: { text: t('.instruction'), tag: 'h2', size: 'm'} ) do %>
         <% form.object.levels_of_service.each do |level| %>


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3409)

Update page and form layouts to improve accessibility of proceeding loop pages
- move headings into page template so error summary appears in the correct place at the top of the page
- ensure form fields are linked to the correct heading and question

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
