### PR TITLE
Destroy cash income when updating regular income

### DIFF
--- a/app/forms/providers/means/regular_income_form.rb
+++ b/app/forms/providers/means/regular_income_form.rb
@@ -27,6 +27,7 @@ module Providers
         ApplicationRecord.transaction do
           legal_aid_application.update!(no_credit_transaction_types_selected: none_selected?)
           legal_aid_application.regular_transactions.credits.destroy_all
+          legal_aid_application.cash_transactions.credits.destroy_all
 
           unless none_selected?
             regular_transactions.each(&:save)

--- a/spec/factories/cash_transactions.rb
+++ b/spec/factories/cash_transactions.rb
@@ -3,6 +3,7 @@ FactoryBot.define do
     legal_aid_application
     transaction_type
     amount { Faker::Number.decimal(l_digits: 3, r_digits: 2) }
+    month_number { 1 }
 
     trait :credit_month1 do
       transaction_date { Time.zone.today.at_beginning_of_month - 1.month }


### PR DESCRIPTION
When a provider updates the regular income their client receives, it should destroy the relevant cash income transactions that might have been added in subsequent steps.

This destroys all the cash transactions when saving the `RegularIncomeForm`.

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3458)