### PR TITLE
[Security] Selectively bump nth-check to 2.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,17 +23,17 @@
     "webpack-dev-server": "^4.11.0"
   },
   "resolutions": {
-    "minimist": "^1.2.2",
-    "serialize-javascript": "^3.1.0",
     "acorn": "^7.1.1",
-    "kind-of": "^6.0.3",
-    "yargs-parser": "^13.1.2",
-    "is-svg": "^4.2.2",
-    "ssri": "^8.0.1",
-    "glob-parent": "^5.1.2",
     "css-what": "^5.0.1",
+    "glob-parent": "^5.1.2",
+    "is-svg": "^4.2.2",
+    "kind-of": "^6.0.3",
+    "minimist": "^1.2.2",
     "normalize-url": "^4.5.1",
-    "nth-check": "^2.1.1"
+    "nth-check": "^2.1.1",
+    "serialize-javascript": "^3.1.0",
+    "ssri": "^8.0.1",
+    "yargs-parser": "^13.1.2"
   },
   "jest": {
     "testEnvironment": "jest-environment-jsdom-global",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "ssri": "^8.0.1",
     "glob-parent": "^5.1.2",
     "css-what": "^5.0.1",
-    "normalize-url": "^4.5.1"
+    "normalize-url": "^4.5.1",
+    "nth-check": "^2.1.1"
   },
   "jest": {
     "testEnvironment": "jest-environment-jsdom-global",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2769,7 +2769,7 @@ bonjour-service@^1.0.11:
     fast-deep-equal "^3.1.3"
     multicast-dns "^7.2.4"
 
-boolbase@^1.0.0, boolbase@~1.0.0:
+boolbase@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
@@ -6995,12 +6995,12 @@ npm-run-path@^4.0.1:
   dependencies:
     path-key "^3.0.0"
 
-nth-check@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-1.0.2.tgz#b2bd295c37e3dd58a3bf0700376663ba4d9cf05c"
-  integrity sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==
+nth-check@^1.0.2, nth-check@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-2.1.1.tgz#c9eab428effce36cd6b92c924bdb000ef1f1ed1d"
+  integrity sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==
   dependencies:
-    boolbase "~1.0.0"
+    boolbase "^1.0.0"
 
 num2fraction@^1.2.2:
   version "1.2.2"


### PR DESCRIPTION

## What

nth-check is vulnerable to Inefficient Regular Expression Complexity

**References**
https://github.com/advisories/GHSA-rp65-9cf3-cjxr
https://nvd.nist.gov/vuln/detail/CVE-2021-3803
https://huntr.dev/bounties/8cf8cc06-d2cf-4b4e-b42c-99fafb0b04d0

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
