### PR TITLE
Replace npm with yarn

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -33,7 +33,7 @@ class ApplicationRequirementSetup
       copy_sample_files
       setup_database
       remove_logs
-      npm_install
+      yarn_install
       restart
       install_clam_av
     end
@@ -65,9 +65,9 @@ class ApplicationRequirementSetup
     system! 'bin/rails log:clear tmp:clear'
   end
 
-  def npm_install
+  def yarn_install
     puts "\n== Installing JavaScript dependencies =="
-    system! 'npm install'
+    system! 'yarn install'
   end
 
   def restart


### PR DESCRIPTION
## What

Replace npm with yarn in our setup script.

Yarn is predominately used throughout codebase, this change make it consistent  and stops conflicting/mixing of package and yarn lock files.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
