### PR TITLE
Introduce a `Flow::Steps::Step` struct

### DIFF
--- a/app/services/flow/flows/provider_capital.rb
+++ b/app/services/flow/flows/provider_capital.rb
@@ -33,17 +33,7 @@ module Flow
             application.uploading_bank_statements? ? :means_summaries : :income_summary
           end,
         },
-        regular_incomes: {
-          path: ->(application) { urls.providers_legal_aid_application_means_regular_incomes_path(application) },
-          forward: lambda do |application|
-            application.income_types? ? :cash_incomes : :student_finances
-          end,
-          check_answers: lambda do |application|
-            return :cash_incomes if application.income_types?
-
-            application.uploading_bank_statements? ? :means_summaries : :income_summary
-          end,
-        },
+        regular_incomes: Flow::Steps::RegularIncomeStep,
         cash_incomes: {
           path: ->(application) { urls.providers_legal_aid_application_means_cash_income_path(application) },
           forward: :student_finances,

--- a/app/services/flow/steps/regular_income_step.rb
+++ b/app/services/flow/steps/regular_income_step.rb
@@ -1,0 +1,9 @@
+module Flow
+  module Steps
+    RegularIncomeStep = Step.new(
+      ->(application) { urls.providers_legal_aid_application_means_regular_incomes_path(application) },
+      ->(application) { application.income_types? ? :cash_incomes : :student_finances },
+      ->(application) { application.income_types? ? :cash_incomes : :means_summaries },
+    )
+  end
+end

--- a/app/services/flow/steps/step.rb
+++ b/app/services/flow/steps/step.rb
@@ -1,0 +1,9 @@
+module Flow
+  module Steps
+    def self.urls
+      Rails.application.routes.url_helpers
+    end
+
+    Step = Struct.new(:path, :forward, :check_answers)
+  end
+end

--- a/spec/requests/providers/means/regular_incomes_controller_spec.rb
+++ b/spec/requests/providers/means/regular_incomes_controller_spec.rb
@@ -150,32 +150,7 @@ RSpec.describe Providers::Means::RegularIncomesController do
       end
     end
 
-    context "when checking answers for an application uploading bank statements and none is selected" do
-      it "updates the application and redirects to the means summaries page" do
-        Setting.setting.update!(enhanced_bank_upload: true)
-        non_passported_permission = create(:permission, :non_passported)
-        bank_statement_permission = create(:permission, :bank_statement_upload)
-        provider = create(:provider, permissions: [non_passported_permission, bank_statement_permission])
-        legal_aid_application = create(
-          :legal_aid_application,
-          :with_non_passported_state_machine,
-          :checking_non_passported_means,
-          provider_received_citizen_consent: false,
-          no_credit_transaction_types_selected: false,
-          provider:,
-        )
-        login_as provider
-        login_as provider
-        params = { providers_means_regular_income_form: { transaction_type_ids: ["", "none"] } }
-
-        patch providers_legal_aid_application_means_regular_incomes_path(legal_aid_application), params: params
-
-        expect(response).to redirect_to(providers_legal_aid_application_means_summary_path(legal_aid_application))
-        expect(legal_aid_application.reload.no_credit_transaction_types_selected).to be true
-      end
-    end
-
-    context "when checking answers for an application not uploading bank statements and none is selected" do
+    context "when checking answers and none is selected" do
       it "updates the application and redirects to the income summary page" do
         Setting.setting.update!(enhanced_bank_upload: true)
         legal_aid_application = create(
@@ -190,7 +165,7 @@ RSpec.describe Providers::Means::RegularIncomesController do
 
         patch providers_legal_aid_application_means_regular_incomes_path(legal_aid_application), params: params
 
-        expect(response).to redirect_to(providers_legal_aid_application_income_summary_index_path(legal_aid_application))
+        expect(response).to redirect_to(providers_legal_aid_application_means_summary_path(legal_aid_application))
         expect(legal_aid_application.reload.no_credit_transaction_types_selected).to be true
       end
     end

--- a/spec/services/flow/steps/regular_income_step_spec.rb
+++ b/spec/services/flow/steps/regular_income_step_spec.rb
@@ -1,0 +1,71 @@
+require "rails_helper"
+
+RSpec.describe Flow::Steps::RegularIncomeStep do
+  describe "#path" do
+    it "returns the regular incomes path when called" do
+      legal_aid_application = create(:legal_aid_application)
+
+      path = described_class.path.call(legal_aid_application)
+
+      expected_path = "/providers/applications/#{legal_aid_application.id}/" \
+                      "means/regular_incomes?locale=en"
+      expect(path).to eq expected_path
+    end
+  end
+
+  describe "#forward" do
+    context "when the application has income types" do
+      it "returns the cash incomes step when called" do
+        legal_aid_application = instance_double(
+          LegalAidApplication,
+          "income_types?" => true,
+        )
+
+        forward = described_class.forward.call(legal_aid_application)
+
+        expect(forward).to eq(:cash_incomes)
+      end
+    end
+
+    context "when the application does not have income types" do
+      it "returns the student finances step when called" do
+        legal_aid_application = instance_double(
+          LegalAidApplication,
+          "income_types?" => false,
+        )
+
+        forward = described_class.forward.call(legal_aid_application)
+
+        expect(forward).to eq(:student_finances)
+      end
+    end
+  end
+
+  describe "#check_answers" do
+    context "when the application has income types" do
+      it "returns the cash incomes step when called" do
+        legal_aid_application = instance_double(
+          LegalAidApplication,
+          "income_types?" => true,
+        )
+
+        check_answers = described_class.check_answers.call(legal_aid_application)
+
+        expect(check_answers).to eq(:cash_incomes)
+      end
+    end
+
+    context "when the application does not have income types" do
+      it "returns the means summaries step when called" do
+        legal_aid_application = instance_double(
+          LegalAidApplication,
+          "income_types?" => false,
+        )
+
+        check_answers = described_class.check_answers.call(legal_aid_application)
+
+        expect(check_answers).to eq(:means_summaries)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Each descendant of the `Flow::Flows::FlowSteps` class contains 
a mega `STEPS` hash that spans hundreds of lines and each step 
often has associated complexity and conditional logic.

These objects manage complex user flow and are an integral part 
of the application's functionality, however they cannot be easily 
unit-tested. This means we rely on more expensive integration tests 
to test each specific edge case of flow logic.

This introduces a minimal `Flow::Steps::Step` struct, which can be 
used to manage this complexity and introduces an interface for 
encapsulating this important user flow logic that can be more easily 
unit-tested.