### PR TITLE
AP-3495: Refactor scope limitations

### DIFF
--- a/app/forms/proceedings/emergency_defaults_form.rb
+++ b/app/forms/proceedings/emergency_defaults_form.rb
@@ -14,7 +14,7 @@ module Proceedings
 
     def initialize(*args)
       super
-      @defaults = JSON.parse(LegalFramework::ProceedingTypes::Defaults.call(args.first[:model]))
+      @defaults = JSON.parse(LegalFramework::ProceedingTypes::Defaults.call(args.first[:model], true))
       self.emergency_level_of_service = @defaults["default_level_of_service"]["level"]
       self.emergency_level_of_service_name = @defaults["default_level_of_service"]["name"]
       self.emergency_level_of_service_stage = @defaults["default_level_of_service"]["stage"]

--- a/app/forms/proceedings/emergency_defaults_form.rb
+++ b/app/forms/proceedings/emergency_defaults_form.rb
@@ -24,15 +24,25 @@ module Proceedings
     end
 
     def save
-      if accepted_emergency_defaults&.to_s == "false"
+      case accepted_emergency_defaults&.to_s
+      when "false"
         attributes[:emergency_level_of_service] = nil
         attributes[:emergency_level_of_service_name] = nil
         attributes[:emergency_level_of_service_stage] = nil
-        attributes[:delegated_functions_scope_limitation_code] = nil
-        attributes[:delegated_functions_scope_limitation_meaning] = nil
-        attributes[:delegated_functions_scope_limitation_description] = nil
+      when "true"
+        model.scope_limitations.create!(scope_type: :emergency,
+                                        code: delegated_functions_scope_limitation_code,
+                                        meaning: delegated_functions_scope_limitation_meaning,
+                                        description: delegated_functions_scope_limitation_description)
       end
       super
+    end
+
+    def exclude_from_model
+      %i[additional_params
+         delegated_functions_scope_limitation_code
+         delegated_functions_scope_limitation_meaning
+         delegated_functions_scope_limitation_description]
     end
   end
 end

--- a/app/forms/proceedings/substantive_defaults_form.rb
+++ b/app/forms/proceedings/substantive_defaults_form.rb
@@ -14,7 +14,7 @@ module Proceedings
 
     def initialize(*args)
       super
-      @defaults = JSON.parse(LegalFramework::ProceedingTypes::Defaults.call(args.first[:model]))
+      @defaults = JSON.parse(LegalFramework::ProceedingTypes::Defaults.call(args.first[:model], false))
       self.substantive_level_of_service = @defaults["default_level_of_service"]["level"]
       self.substantive_level_of_service_name = @defaults["default_level_of_service"]["name"]
       self.substantive_level_of_service_stage = @defaults["default_level_of_service"]["stage"]

--- a/app/forms/proceedings/substantive_defaults_form.rb
+++ b/app/forms/proceedings/substantive_defaults_form.rb
@@ -24,15 +24,25 @@ module Proceedings
     end
 
     def save
-      if accepted_substantive_defaults&.to_s == "false"
+      case accepted_substantive_defaults&.to_s
+      when "false"
         attributes[:substantive_level_of_service] = nil
         attributes[:substantive_level_of_service_name] = nil
         attributes[:substantive_level_of_service_stage] = nil
-        attributes[:substantive_scope_limitation_meaning] = nil
-        attributes[:substantive_scope_limitation_description] = nil
-        attributes[:substantive_scope_limitation_code] = nil
+      when "true"
+        model.scope_limitations.create!(scope_type: :substantive,
+                                        code: substantive_scope_limitation_code,
+                                        meaning: substantive_scope_limitation_meaning,
+                                        description: substantive_scope_limitation_description)
       end
       super
+    end
+
+    def exclude_from_model
+      %i[additional_params
+         substantive_scope_limitation_code
+         substantive_scope_limitation_meaning
+         substantive_scope_limitation_description]
     end
   end
 end

--- a/app/models/proceeding.rb
+++ b/app/models/proceeding.rb
@@ -53,27 +53,27 @@ class Proceeding < ApplicationRecord
   end
 
   def substantive_scope_limitation_code
-    substantive_scope_limitations.first.code
+    self["substantive_scope_limitation_code"] || substantive_scope_limitations&.first&.code
   end
 
   def substantive_scope_limitation_meaning
-    substantive_scope_limitations.first.meaning
+    self["substantive_scope_limitation_meaning"] || substantive_scope_limitations&.first&.meaning
   end
 
   def substantive_scope_limitation_description
-    substantive_scope_limitations.first.description
+    self["substantive_scope_limitation_description"] || substantive_scope_limitations&.first&.description
   end
 
   def delegated_functions_scope_limitation_code
-    emergency_scope_limitations.first.code
+    self["delegated_functions_scope_limitation_code"] || emergency_scope_limitations&.first&.code
   end
 
   def delegated_functions_scope_limitation_meaning
-    emergency_scope_limitations.first.meaning
+    self["delegated_functions_scope_limitation_meaning"] || emergency_scope_limitations&.first&.meaning
   end
 
   def delegated_functions_scope_limitation_description
-    emergency_scope_limitations.first.description
+    self["delegated_functions_scope_limitation_description"] || emergency_scope_limitations&.first&.description
   end
 
   def highest_proceeding_case_id

--- a/app/models/proceeding.rb
+++ b/app/models/proceeding.rb
@@ -44,13 +44,37 @@ class Proceeding < ApplicationRecord
     ccms_matter_code == "MINJN"
   end
 
-  # def default_level_of_service_level
-  #   "3"
-  # end
-  #
-  # def default_level_of_service_name
-  #   "Full Representation"
-  # end
+  def substantive_scope_limitations
+    scope_limitations.where(scope_type: :substantive)
+  end
+
+  def emergency_scope_limitations
+    scope_limitations.where(scope_type: :emergency)
+  end
+
+  def substantive_scope_limitation_code
+    substantive_scope_limitations.first.code
+  end
+
+  def substantive_scope_limitation_meaning
+    substantive_scope_limitations.first.meaning
+  end
+
+  def substantive_scope_limitation_description
+    substantive_scope_limitations.first.description
+  end
+
+  def delegated_functions_scope_limitation_code
+    emergency_scope_limitations.first.code
+  end
+
+  def delegated_functions_scope_limitation_meaning
+    emergency_scope_limitations.first.meaning
+  end
+
+  def delegated_functions_scope_limitation_description
+    emergency_scope_limitations.first.description
+  end
 
   def highest_proceeding_case_id
     rec = self.class.order(proceeding_case_id: :desc).first

--- a/app/models/proceeding.rb
+++ b/app/models/proceeding.rb
@@ -13,6 +13,8 @@ class Proceeding < ApplicationRecord
            through: :proceeding_linked_children,
            source: :involved_child
 
+  has_many :scope_limitations, dependent: :destroy
+
   scope :in_order_of_addition, -> { order(:created_at) }
   scope :incomplete, -> { where(used_delegated_functions: nil) }
   scope :using_delegated_functions, -> { where.not(used_delegated_functions_on: nil).order(:used_delegated_functions_on) }

--- a/app/models/scope_limitation.rb
+++ b/app/models/scope_limitation.rb
@@ -1,0 +1,5 @@
+class ScopeLimitation < ApplicationRecord
+  belongs_to :proceeding
+
+  enum scope_type: { substantive: 0, emergency: 1 }
+end

--- a/app/models/scope_limitation.rb
+++ b/app/models/scope_limitation.rb
@@ -2,4 +2,6 @@ class ScopeLimitation < ApplicationRecord
   belongs_to :proceeding
 
   enum scope_type: { substantive: 0, emergency: 1 }
+  scope :emergency, -> { where(scope_type: :emergency) }
+  scope :substantive, -> { where(scope_type: :substantive) }
 end

--- a/app/services/legal_framework/proceeding_types/defaults.rb
+++ b/app/services/legal_framework/proceeding_types/defaults.rb
@@ -3,12 +3,13 @@ module LegalFramework
     class Defaults
       PATH = "/proceeding_type_defaults".freeze
 
-      def self.call(proceeding)
-        new(proceeding).call
+      def self.call(proceeding, emergency)
+        new(proceeding, emergency).call
       end
 
-      def initialize(proceeding)
+      def initialize(proceeding, emergency)
         @proceeding = proceeding
+        @emergency = emergency
       end
 
       def call
@@ -20,7 +21,7 @@ module LegalFramework
       def request_body
         {
           proceeding_type_ccms_code: @proceeding.ccms_code,
-          delegated_functions_used: @proceeding.used_delegated_functions,
+          delegated_functions_used: @emergency,
           client_involvement_type: @proceeding.client_involvement_type_ccms_code,
         }.to_json
       end

--- a/db/anonymise/rules.rb
+++ b/db/anonymise/rules.rb
@@ -150,6 +150,7 @@ NINO_REGEXP = /^[A-CEGHJ-PR-TW-Z]{1}[A-CEGHJ-NPR-TW-Z]{1}[0-9]{6}[A-DFM]{1}$/
     arguments: -> { {} },
     addressee: -> { Faker::Internet.email },
   },
+  scope_limitations: {},
   statement_of_cases: {
     statement: -> { Faker::Lorem.sentence },
   },

--- a/db/migrate/20220915124637_create_scope_limitation.rb
+++ b/db/migrate/20220915124637_create_scope_limitation.rb
@@ -1,0 +1,15 @@
+class CreateScopeLimitation < ActiveRecord::Migration[7.0]
+  def change
+    create_table :scope_limitations, id: :uuid do |t|
+      t.belongs_to :proceeding, null: false, foreign_key: true, type: :uuid
+      t.integer :scope_type
+      t.string :code, null: false
+      t.string :meaning, null: false
+      t.string :description, null: false
+      t.date :hearing_date, null: true
+      t.string :limitation_note, null: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_09_15_104106) do
+ActiveRecord::Schema[7.0].define(version: 2022_09_15_124637) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -780,6 +780,19 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_15_104106) do
     t.string "status"
     t.string "addressee"
     t.string "govuk_message_id"
+  end
+
+  create_table "scope_limitations", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "proceeding_id", null: false
+    t.integer "scope_type"
+    t.string "code", null: false
+    t.string "meaning", null: false
+    t.string "description", null: false
+    t.date "hearing_date"
+    t.string "limitation_note"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["proceeding_id"], name: "index_scope_limitations_on_proceeding_id"
   end
 
   create_table "secure_data", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/lib/tasks/migrate_scope_limitations.rake
+++ b/lib/tasks/migrate_scope_limitations.rake
@@ -1,0 +1,49 @@
+namespace :migrate do
+  desc "AP-3495: Migrate the scope_limitation data from proceedings into their own table"
+  # This was done as a rake task as it was taking ~50 seconds to run when deploying to K8s
+  # and exceeding the liveness checks
+  task scope_limitations: :environment do
+    total = Proceeding.count
+    complete = 0
+    Rails.logger.info "Migrating Proceeding => ScopeLimitations"
+    Rails.logger.info "----------------------------------------"
+    Rails.logger.info "Proceeding.count: #{Proceeding.count}"
+    Rails.logger.info "ScopeLimitation.count: #{ScopeLimitation.count}"
+    Benchmark.benchmark do |bm|
+      bm.report("Migrate:") do
+        ActiveRecord::Base.transaction do
+          Proceeding.all.each do |proceeding|
+            percent = ((complete.to_f / total) * 100).round(2)
+            Rails.logger.info "#{percent.to_i}% processed" if percent.positive? && percent.to_s[-2..] == "99" && (percent.to_i % 5).zero?
+            if proceeding.substantive_scope_limitation_code.present?
+              ScopeLimitation.find_or_create_by!(proceeding:,
+                                                 scope_type: :substantive,
+                                                 code: proceeding.substantive_scope_limitation_code,
+                                                 meaning: proceeding.substantive_scope_limitation_meaning,
+                                                 description: proceeding.substantive_scope_limitation_description)
+            end
+            if proceeding.used_delegated_functions? && proceeding.delegated_functions_scope_limitation_code.present?
+              ScopeLimitation.find_or_create_by!(proceeding:,
+                                                 scope_type: :emergency,
+                                                 code: proceeding.delegated_functions_scope_limitation_code,
+                                                 meaning: proceeding.delegated_functions_scope_limitation_meaning,
+                                                 description: proceeding.delegated_functions_scope_limitation_description)
+            end
+            proceeding.update!(substantive_scope_limitation_code: nil,
+                               substantive_scope_limitation_meaning: nil,
+                               substantive_scope_limitation_description: nil,
+                               delegated_functions_scope_limitation_code: nil,
+                               delegated_functions_scope_limitation_meaning: nil,
+                               delegated_functions_scope_limitation_description: nil)
+            complete += 1
+          end
+        end
+      end
+    end
+    Rails.logger.info "-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-="
+    Rails.logger.info "Proceeding.count: #{Proceeding.count}"
+    Rails.logger.info "ScopeLimitation.count: #{ScopeLimitation.count}"
+    Rails.logger.info "Expect ScopeLimitation.count to eq: #{Proceeding.where(used_delegated_functions: true).count + Proceeding.count}"
+    Rails.logger.info "========================================"
+  end
+end

--- a/spec/cassettes/LegalFramework_AddProceedingService/_call/correct_params/when_the_enable_loop_feature_flag/is_off/creates_scope_limitations.yml
+++ b/spec/cassettes/LegalFramework_AddProceedingService/_call/correct_params/when_the_enable_loop_feature_flag/is_off/creates_scope_limitations.yml
@@ -1,0 +1,71 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/DA004
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Faraday v1.10.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 20 Sep 2022 13:18:33 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Vary:
+      - Accept, Origin
+      Etag:
+      - W/"fbabf0efd65b63f03290a3f99682b0d4"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - af0fb161ecdfe000f9f881198f99e18a
+      X-Runtime:
+      - '0.019690'
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '{"success":true,"ccms_code":"DA004","meaning":"Non-molestation order","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","name":"nonmolestation_order","description":"to
+        be represented on an application for a non-molestation order.","full_s8_only":false,"ccms_category_law":"Family","ccms_matter":"Domestic
+        abuse","cost_limitations":{"substantive":{"start_date":"1970-01-01","value":"25000.0"},"delegated_functions":{"start_date":"2021-09-13","value":"2250.0"}},"default_scope_limitations":{"substantive":{"code":"AA019","meaning":"Injunction
+        FLA-to final hearing","description":"As to proceedings under Part IV Family
+        Law Act 1996 limited to all steps up to and including obtaining and serving
+        a final order and in the event of breach leading to the exercise of a power
+        of arrest to representation on the consideration of the breach by the court
+        (but excluding applying for a warrant of arrest, if not attached, and representation
+        in contempt proceedings)."},"delegated_functions":{"code":"CV117","meaning":"Interim
+        order inc. return date","description":"Limited to all steps necessary to apply
+        for an interim order; where application is made without notice to include
+        representation on the return date."}},"service_levels":[{"level":3,"name":"Full
+        Representation","stage":8,"proceeding_default":true}]}'
+  recorded_at: Tue, 20 Sep 2022 13:18:33 GMT
+recorded_with: VCR 6.1.0

--- a/spec/cassettes/LegalFramework_AddProceedingService/_call/correct_params/when_the_enable_loop_feature_flag/is_off/does_not_create_scope_limitations.yml
+++ b/spec/cassettes/LegalFramework_AddProceedingService/_call/correct_params/when_the_enable_loop_feature_flag/is_off/does_not_create_scope_limitations.yml
@@ -1,0 +1,71 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/DA004
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Faraday v1.10.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 20 Sep 2022 13:18:00 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Vary:
+      - Accept, Origin
+      Etag:
+      - W/"fbabf0efd65b63f03290a3f99682b0d4"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 25608e3c9f0f37d6177601906d8d6fa5
+      X-Runtime:
+      - '0.026788'
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '{"success":true,"ccms_code":"DA004","meaning":"Non-molestation order","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","name":"nonmolestation_order","description":"to
+        be represented on an application for a non-molestation order.","full_s8_only":false,"ccms_category_law":"Family","ccms_matter":"Domestic
+        abuse","cost_limitations":{"substantive":{"start_date":"1970-01-01","value":"25000.0"},"delegated_functions":{"start_date":"2021-09-13","value":"2250.0"}},"default_scope_limitations":{"substantive":{"code":"AA019","meaning":"Injunction
+        FLA-to final hearing","description":"As to proceedings under Part IV Family
+        Law Act 1996 limited to all steps up to and including obtaining and serving
+        a final order and in the event of breach leading to the exercise of a power
+        of arrest to representation on the consideration of the breach by the court
+        (but excluding applying for a warrant of arrest, if not attached, and representation
+        in contempt proceedings)."},"delegated_functions":{"code":"CV117","meaning":"Interim
+        order inc. return date","description":"Limited to all steps necessary to apply
+        for an interim order; where application is made without notice to include
+        representation on the return date."}},"service_levels":[{"level":3,"name":"Full
+        Representation","stage":8,"proceeding_default":true}]}'
+  recorded_at: Tue, 20 Sep 2022 13:18:00 GMT
+recorded_with: VCR 6.1.0

--- a/spec/cassettes/LegalFramework_AddProceedingService/_call/correct_params/when_the_enable_loop_feature_flag/is_on/does_not_create_scope_limitations.yml
+++ b/spec/cassettes/LegalFramework_AddProceedingService/_call/correct_params/when_the_enable_loop_feature_flag/is_on/does_not_create_scope_limitations.yml
@@ -1,0 +1,71 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/DA004
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Faraday v1.10.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 20 Sep 2022 13:18:51 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Vary:
+      - Accept, Origin
+      Etag:
+      - W/"fbabf0efd65b63f03290a3f99682b0d4"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 0b453ef35ed842c7eb3ce98948ad91b9
+      X-Runtime:
+      - '0.022261'
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '{"success":true,"ccms_code":"DA004","meaning":"Non-molestation order","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","name":"nonmolestation_order","description":"to
+        be represented on an application for a non-molestation order.","full_s8_only":false,"ccms_category_law":"Family","ccms_matter":"Domestic
+        abuse","cost_limitations":{"substantive":{"start_date":"1970-01-01","value":"25000.0"},"delegated_functions":{"start_date":"2021-09-13","value":"2250.0"}},"default_scope_limitations":{"substantive":{"code":"AA019","meaning":"Injunction
+        FLA-to final hearing","description":"As to proceedings under Part IV Family
+        Law Act 1996 limited to all steps up to and including obtaining and serving
+        a final order and in the event of breach leading to the exercise of a power
+        of arrest to representation on the consideration of the breach by the court
+        (but excluding applying for a warrant of arrest, if not attached, and representation
+        in contempt proceedings)."},"delegated_functions":{"code":"CV117","meaning":"Interim
+        order inc. return date","description":"Limited to all steps necessary to apply
+        for an interim order; where application is made without notice to include
+        representation on the return date."}},"service_levels":[{"level":3,"name":"Full
+        Representation","stage":8,"proceeding_default":true}]}'
+  recorded_at: Tue, 20 Sep 2022 13:18:51 GMT
+recorded_with: VCR 6.1.0

--- a/spec/cassettes/Proceedings_EmergencyDefaultsForm/_save/when_the_submission_is_valid/and_the_user_accepts_the_defaults/without_calling_the_subject/creates_a_scope_limitation_object.yml
+++ b/spec/cassettes/Proceedings_EmergencyDefaultsForm/_save/when_the_submission_is_valid/and_the_user_accepts_the_defaults/without_calling_the_subject/creates_a_scope_limitation_object.yml
@@ -1,0 +1,63 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_type_defaults
+    body:
+      encoding: UTF-8
+      string: '{"proceeding_type_ccms_code":"DA001","delegated_functions_used":true,"client_involvement_type":"A"}'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Faraday v1.10.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 16 Sep 2022 09:41:08 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Vary:
+      - Accept, Origin
+      Etag:
+      - W/"394350725076183ab4ae0116449123c3"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 04743b710c427f1d1be655f17d47432c
+      X-Runtime:
+      - '0.061233'
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '{"success":true,"requested_params":{"proceeding_type_ccms_code":"DA001","delegated_functions_used":true,"client_involvement_type":"A"},"default_level_of_service":{"level":3,"name":"Full
+        Representation","stage":8},"default_scope":{"code":"CV117","meaning":"Interim
+        order inc. return date","description":"Limited to all steps necessary to apply
+        for an interim order; where application is made without notice to include
+        representation on the return date.","additional_params":[]}}'
+  recorded_at: Fri, 16 Sep 2022 09:41:08 GMT
+recorded_with: VCR 6.1.0

--- a/spec/cassettes/Proceedings_EmergencyDefaultsForm/_save/when_the_submission_is_valid/and_the_user_rejects_the_defaults/without_calling_the_subject/does_not_create_a_scope_limitation_object.yml
+++ b/spec/cassettes/Proceedings_EmergencyDefaultsForm/_save/when_the_submission_is_valid/and_the_user_rejects_the_defaults/without_calling_the_subject/does_not_create_a_scope_limitation_object.yml
@@ -1,0 +1,63 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_type_defaults
+    body:
+      encoding: UTF-8
+      string: '{"proceeding_type_ccms_code":"DA001","delegated_functions_used":true,"client_involvement_type":"A"}'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Faraday v1.10.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 16 Sep 2022 11:20:00 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Vary:
+      - Accept, Origin
+      Etag:
+      - W/"394350725076183ab4ae0116449123c3"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 8d3ce09d98df1c7ad34ed73b2aaa7e60
+      X-Runtime:
+      - '0.204780'
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '{"success":true,"requested_params":{"proceeding_type_ccms_code":"DA001","delegated_functions_used":true,"client_involvement_type":"A"},"default_level_of_service":{"level":3,"name":"Full
+        Representation","stage":8},"default_scope":{"code":"CV117","meaning":"Interim
+        order inc. return date","description":"Limited to all steps necessary to apply
+        for an interim order; where application is made without notice to include
+        representation on the return date.","additional_params":[]}}'
+  recorded_at: Fri, 16 Sep 2022 11:20:00 GMT
+recorded_with: VCR 6.1.0

--- a/spec/cassettes/Proceedings_EmergencyDefaultsForm/_save/when_the_user_doesn_t_answer_the_question/without_calling_the_subject/does_not_create_a_scope_limitation_object.yml
+++ b/spec/cassettes/Proceedings_EmergencyDefaultsForm/_save/when_the_user_doesn_t_answer_the_question/without_calling_the_subject/does_not_create_a_scope_limitation_object.yml
@@ -1,0 +1,63 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_type_defaults
+    body:
+      encoding: UTF-8
+      string: '{"proceeding_type_ccms_code":"DA001","delegated_functions_used":true,"client_involvement_type":"A"}'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Faraday v1.10.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 16 Sep 2022 11:20:29 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Vary:
+      - Accept, Origin
+      Etag:
+      - W/"394350725076183ab4ae0116449123c3"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - c2074d2205bce494ce28b343704719c0
+      X-Runtime:
+      - '0.036406'
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '{"success":true,"requested_params":{"proceeding_type_ccms_code":"DA001","delegated_functions_used":true,"client_involvement_type":"A"},"default_level_of_service":{"level":3,"name":"Full
+        Representation","stage":8},"default_scope":{"code":"CV117","meaning":"Interim
+        order inc. return date","description":"Limited to all steps necessary to apply
+        for an interim order; where application is made without notice to include
+        representation on the return date.","additional_params":[]}}'
+  recorded_at: Fri, 16 Sep 2022 11:20:29 GMT
+recorded_with: VCR 6.1.0

--- a/spec/cassettes/Proceedings_SubstantiveDefaultsForm/_save/when_the_submission_is_valid/and_the_user_accepts_the_defaults/without_calling_the_subject/creates_a_scope_limitation_object.yml
+++ b/spec/cassettes/Proceedings_SubstantiveDefaultsForm/_save/when_the_submission_is_valid/and_the_user_accepts_the_defaults/without_calling_the_subject/creates_a_scope_limitation_object.yml
@@ -1,0 +1,66 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_type_defaults
+    body:
+      encoding: UTF-8
+      string: '{"proceeding_type_ccms_code":"DA001","delegated_functions_used":false,"client_involvement_type":"Z"}'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Faraday v1.10.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 16 Sep 2022 12:30:43 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Vary:
+      - Accept, Origin
+      Etag:
+      - W/"8352d3267c40ba3460c3693b3f8b034e"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 1351fdbc69fec15a8967f8f8cd2d44f0
+      X-Runtime:
+      - '0.014090'
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '{"success":true,"requested_params":{"proceeding_type_ccms_code":"DA001","delegated_functions_used":false,"client_involvement_type":"Z"},"default_level_of_service":{"level":3,"name":"Full
+        Representation","stage":8},"default_scope":{"code":"AA019","meaning":"Injunction
+        FLA-to final hearing","description":"As to proceedings under Part IV Family
+        Law Act 1996 limited to all steps up to and including obtaining and serving
+        a final order and in the event of breach leading to the exercise of a power
+        of arrest to representation on the consideration of the breach by the court
+        (but excluding applying for a warrant of arrest, if not attached, and representation
+        in contempt proceedings).","additional_params":[]}}'
+  recorded_at: Fri, 16 Sep 2022 12:30:43 GMT
+recorded_with: VCR 6.1.0

--- a/spec/cassettes/Proceedings_SubstantiveDefaultsForm/_save/when_the_submission_is_valid/and_the_user_rejects_the_defaults/without_calling_the_subject/does_not_create_a_scope_limitation_object.yml
+++ b/spec/cassettes/Proceedings_SubstantiveDefaultsForm/_save/when_the_submission_is_valid/and_the_user_rejects_the_defaults/without_calling_the_subject/does_not_create_a_scope_limitation_object.yml
@@ -1,0 +1,66 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_type_defaults
+    body:
+      encoding: UTF-8
+      string: '{"proceeding_type_ccms_code":"DA001","delegated_functions_used":false,"client_involvement_type":"Z"}'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Faraday v1.10.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 16 Sep 2022 11:36:12 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Vary:
+      - Accept, Origin
+      Etag:
+      - W/"8352d3267c40ba3460c3693b3f8b034e"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 12803aad26eeaafa03bfc4975a4e7d1a
+      X-Runtime:
+      - '0.050398'
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '{"success":true,"requested_params":{"proceeding_type_ccms_code":"DA001","delegated_functions_used":false,"client_involvement_type":"Z"},"default_level_of_service":{"level":3,"name":"Full
+        Representation","stage":8},"default_scope":{"code":"AA019","meaning":"Injunction
+        FLA-to final hearing","description":"As to proceedings under Part IV Family
+        Law Act 1996 limited to all steps up to and including obtaining and serving
+        a final order and in the event of breach leading to the exercise of a power
+        of arrest to representation on the consideration of the breach by the court
+        (but excluding applying for a warrant of arrest, if not attached, and representation
+        in contempt proceedings).","additional_params":[]}}'
+  recorded_at: Fri, 16 Sep 2022 11:36:12 GMT
+recorded_with: VCR 6.1.0

--- a/spec/cassettes/Proceedings_SubstantiveDefaultsForm/_save/when_the_user_doesn_t_answer_the_question/without_calling_the_subject/does_not_create_a_scope_limitation_object.yml
+++ b/spec/cassettes/Proceedings_SubstantiveDefaultsForm/_save/when_the_user_doesn_t_answer_the_question/without_calling_the_subject/does_not_create_a_scope_limitation_object.yml
@@ -1,0 +1,66 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_type_defaults
+    body:
+      encoding: UTF-8
+      string: '{"proceeding_type_ccms_code":"DA001","delegated_functions_used":false,"client_involvement_type":"Z"}'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Faraday v1.10.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 16 Sep 2022 11:36:27 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Vary:
+      - Accept, Origin
+      Etag:
+      - W/"8352d3267c40ba3460c3693b3f8b034e"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - ad09b1a5eb4a1af301974b0642e902ee
+      X-Runtime:
+      - '0.012199'
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '{"success":true,"requested_params":{"proceeding_type_ccms_code":"DA001","delegated_functions_used":false,"client_involvement_type":"Z"},"default_level_of_service":{"level":3,"name":"Full
+        Representation","stage":8},"default_scope":{"code":"AA019","meaning":"Injunction
+        FLA-to final hearing","description":"As to proceedings under Part IV Family
+        Law Act 1996 limited to all steps up to and including obtaining and serving
+        a final order and in the event of breach leading to the exercise of a power
+        of arrest to representation on the consideration of the breach by the court
+        (but excluding applying for a warrant of arrest, if not attached, and representation
+        in contempt proceedings).","additional_params":[]}}'
+  recorded_at: Fri, 16 Sep 2022 11:36:27 GMT
+recorded_with: VCR 6.1.0

--- a/spec/factories/proceedings.rb
+++ b/spec/factories/proceedings.rb
@@ -37,15 +37,20 @@ FactoryBot.define do
       description { "to be represented on an application for an injunction, order or declaration under the inherent jurisdiction of the court." }
       substantive_cost_limitation { 25_000 }
       delegated_functions_cost_limitation { rand(1...1_000_000.0).round(2) }
-      substantive_scope_limitation_code { "FM062" }
-      substantive_scope_limitation_meaning { "Final hearing" }
-      substantive_scope_limitation_description { "Limited to all steps up to and including final hearing and any action necessary to implement (but not enforce) the order." }
-      delegated_functions_scope_limitation_code { "CV117" }
-      delegated_functions_scope_limitation_meaning { "Interim order inc. return date" }
-      delegated_functions_scope_limitation_description do
-        'Limited to Family Help (Higher) and to all steps necessary to negotiate and conclude a settlement.
-         To include the issue of proceedings and representation in those proceedings save in relation to or at a contested final hearing.'
+      after(:create) do |proceeding|
+        create(:scope_limitation, :emergency, proceeding:)
+        create(:scope_limitation, :substantive, proceeding:)
       end
+
+      # substantive_scope_limitation_code { "FM062" }
+      # substantive_scope_limitation_meaning { "Final hearing" }
+      # substantive_scope_limitation_description { "Limited to all steps up to and including final hearing and any action necessary to implement (but not enforce) the order." }
+      # delegated_functions_scope_limitation_code { "CV117" }
+      # delegated_functions_scope_limitation_meaning { "Interim order inc. return date" }
+      # delegated_functions_scope_limitation_description do
+      #   'Limited to Family Help (Higher) and to all steps necessary to negotiate and conclude a settlement.
+      #    To include the issue of proceedings and representation in those proceedings save in relation to or at a contested final hearing.'
+      # end
       used_delegated_functions { nil }
       used_delegated_functions_on { nil }
       used_delegated_functions_reported_on { nil }
@@ -68,16 +73,21 @@ FactoryBot.define do
       end
       substantive_cost_limitation { 25_000 }
       delegated_functions_cost_limitation { rand(1...1_000_000.0).round(2) }
-      substantive_scope_limitation_code { "AA019" }
-      substantive_scope_limitation_meaning { "Injunction FLA-to final hearing" }
-      substantive_scope_limitation_description { "Limited to all steps up to and including final hearing and any action necessary to implement (but not enforce) the order." }
-      delegated_functions_scope_limitation_code { "CV117" }
-      delegated_functions_scope_limitation_meaning { "Interim order inc. return date" }
-      delegated_functions_scope_limitation_description do
-        'As to proceedings under Part IV Family Law Act 1996 limited to all steps up to and including obtaining and serving a
-         final order and in the event of breach leading to the exercise of a power of arrest to representation on the consideration
-         of the breach by the court (but excluding applying for a warrant of arrest, if not attached, and representation in contempt proceedings).'
+      after(:create) do |proceeding|
+        create(:scope_limitation, :emergency, proceeding:)
+        create(:scope_limitation, :substantive, proceeding:)
       end
+
+      # substantive_scope_limitation_code { "AA019" }
+      # substantive_scope_limitation_meaning { "Injunction FLA-to final hearing" }
+      # substantive_scope_limitation_description { "Limited to all steps up to and including final hearing and any action necessary to implement (but not enforce) the order." }
+      # delegated_functions_scope_limitation_code { "CV117" }
+      # delegated_functions_scope_limitation_meaning { "Interim order inc. return date" }
+      # delegated_functions_scope_limitation_description do
+      #   'As to proceedings under Part IV Family Law Act 1996 limited to all steps up to and including obtaining and serving a
+      #    final order and in the event of breach leading to the exercise of a power of arrest to representation on the consideration
+      #    of the breach by the court (but excluding applying for a warrant of arrest, if not attached, and representation in contempt proceedings).'
+      # end
       used_delegated_functions { true }
       used_delegated_functions_on { Faker::Date.between(from: 10.days.ago, to: 2.days.ago) }
       used_delegated_functions_reported_on { Time.zone.today }
@@ -97,16 +107,21 @@ FactoryBot.define do
       description { "to be represented on an application for an occupation order." }
       substantive_cost_limitation { 25_000 }
       delegated_functions_cost_limitation { rand(1...1_000_000.0).round(2) }
-      substantive_scope_limitation_code { "AA019" }
-      substantive_scope_limitation_meaning { "Injunction FLA-to final hearing" }
-      substantive_scope_limitation_description { "Limited to all steps up to and including final hearing and any action necessary to implement (but not enforce) the order." }
-      delegated_functions_scope_limitation_code { "CV117" }
-      delegated_functions_scope_limitation_meaning { "Interim order inc. return date" }
-      delegated_functions_scope_limitation_description do
-        'As to proceedings under Part IV Family Law Act 1996 limited to all steps up to and including obtaining and serving a
-         final order and in the event of breach leading to the exercise of a power of arrest to representation on the consideration
-         of the breach by the court (but excluding applying for a warrant of arrest, if not attached, and representation in contempt proceedings).'
+      after(:create) do |proceeding|
+        create(:scope_limitation, :emergency, proceeding:)
+        create(:scope_limitation, :substantive, proceeding:)
       end
+
+      # substantive_scope_limitation_code { "AA019" }
+      # substantive_scope_limitation_meaning { "Injunction FLA-to final hearing" }
+      # substantive_scope_limitation_description { "Limited to all steps up to and including final hearing and any action necessary to implement (but not enforce) the order." }
+      # delegated_functions_scope_limitation_code { "CV117" }
+      # delegated_functions_scope_limitation_meaning { "Interim order inc. return date" }
+      # delegated_functions_scope_limitation_description do
+      #   'As to proceedings under Part IV Family Law Act 1996 limited to all steps up to and including obtaining and serving a
+      #    final order and in the event of breach leading to the exercise of a power of arrest to representation on the consideration
+      #    of the breach by the court (but excluding applying for a warrant of arrest, if not attached, and representation in contempt proceedings).'
+      # end
       used_delegated_functions { true }
       used_delegated_functions_on { Faker::Date.between(from: 10.days.ago, to: 2.days.ago) }
       used_delegated_functions_reported_on { Time.zone.today }
@@ -126,16 +141,21 @@ FactoryBot.define do
       description { "to be represented on an application to extend, vary or discharge an order under Part IV Family Law Act 1996. " }
       substantive_cost_limitation { 25_000 }
       delegated_functions_cost_limitation { rand(1...1_000_000.0).round(2) }
-      substantive_scope_limitation_code { "AA019" }
-      substantive_scope_limitation_meaning { "Injunction FLA-to final hearing" }
-      substantive_scope_limitation_description { "Limited to all steps up to and including final hearing and any action necessary to implement (but not enforce) the order." }
-      delegated_functions_scope_limitation_code { "CV117" }
-      delegated_functions_scope_limitation_meaning { "Interim order inc. return date" }
-      delegated_functions_scope_limitation_description do
-        'As to proceedings under Part IV Family Law Act 1996 limited to all steps up to and including obtaining and serving a
-         final order and in the event of breach leading to the exercise of a power of arrest to representation on the consideration
-         of the breach by the court (but excluding applying for a warrant of arrest, if not attached, and representation in contempt proceedings).'
+      after(:create) do |proceeding|
+        create(:scope_limitation, :emergency, proceeding:)
+        create(:scope_limitation, :substantive, proceeding:)
       end
+
+      # substantive_scope_limitation_code { "AA019" }
+      # substantive_scope_limitation_meaning { "Injunction FLA-to final hearing" }
+      # substantive_scope_limitation_description { "Limited to all steps up to and including final hearing and any action necessary to implement (but not enforce) the order." }
+      # delegated_functions_scope_limitation_code { "CV117" }
+      # delegated_functions_scope_limitation_meaning { "Interim order inc. return date" }
+      # delegated_functions_scope_limitation_description do
+      #   'As to proceedings under Part IV Family Law Act 1996 limited to all steps up to and including obtaining and serving a
+      #    final order and in the event of breach leading to the exercise of a power of arrest to representation on the consideration
+      #    of the breach by the court (but excluding applying for a warrant of arrest, if not attached, and representation in contempt proceedings).'
+      # end
       used_delegated_functions { true }
       used_delegated_functions_on { Faker::Date.between(from: 10.days.ago, to: 2.days.ago) }
       used_delegated_functions_reported_on { Time.zone.today }
@@ -155,16 +175,21 @@ FactoryBot.define do
       description { "to be represented on an application for a non-molestation order." }
       substantive_cost_limitation { 25_000 }
       delegated_functions_cost_limitation { rand(1...1_000_000.0).round(2) }
-      substantive_scope_limitation_code { "AA019" }
-      substantive_scope_limitation_meaning { "Injunction FLA-to final hearing" }
-      substantive_scope_limitation_description { "Limited to all steps up to and including final hearing and any action necessary to implement (but not enforce) the order." }
-      delegated_functions_scope_limitation_code { "CV117" }
-      delegated_functions_scope_limitation_meaning { "Interim order inc. return date" }
-      delegated_functions_scope_limitation_description do
-        'As to proceedings under Part IV Family Law Act 1996 limited to all steps up to and including obtaining and serving a
-         final order and in the event of breach leading to the exercise of a power of arrest to representation on the consideration
-         of the breach by the court (but excluding applying for a warrant of arrest, if not attached, and representation in contempt proceedings).'
+      after(:create) do |proceeding|
+        create(:scope_limitation, :emergency, proceeding:)
+        create(:scope_limitation, :substantive, proceeding:)
       end
+
+      # substantive_scope_limitation_code { "AA019" }
+      # substantive_scope_limitation_meaning { "Injunction FLA-to final hearing" }
+      # substantive_scope_limitation_description { "Limited to all steps up to and including final hearing and any action necessary to implement (but not enforce) the order." }
+      # delegated_functions_scope_limitation_code { "CV117" }
+      # delegated_functions_scope_limitation_meaning { "Interim order inc. return date" }
+      # delegated_functions_scope_limitation_description do
+      #   'As to proceedings under Part IV Family Law Act 1996 limited to all steps up to and including obtaining and serving a
+      #    final order and in the event of breach leading to the exercise of a power of arrest to representation on the consideration
+      #    of the breach by the court (but excluding applying for a warrant of arrest, if not attached, and representation in contempt proceedings).'
+      # end
       used_delegated_functions { true }
       used_delegated_functions_on { Faker::Date.between(from: 10.days.ago, to: 2.days.ago) }
       used_delegated_functions_reported_on { Time.zone.today }
@@ -184,18 +209,23 @@ FactoryBot.define do
       description { "to be represented on an application for a child arrangements order –where the child(ren) will live" }
       substantive_cost_limitation { 25_000 }
       delegated_functions_cost_limitation { rand(1...1_000_000.0).round(2) }
-      substantive_scope_limitation_code { "FM059" }
-      substantive_scope_limitation_meaning { "FHH Children" }
-      substantive_scope_limitation_description do
-        'Limited to Family Help (Higher) and to all steps necessary to negotiate and conclude a settlement.
-        To include the issue of proceedings and representation in those proceedings save in relation to or at a contested final hearing.'
+      after(:create) do |proceeding|
+        create(:scope_limitation, :emergency, proceeding:)
+        create(:scope_limitation, :substantive, proceeding:)
       end
-      delegated_functions_scope_limitation_code { "CV117" }
-      delegated_functions_scope_limitation_meaning { "Interim order inc. return date" }
-      delegated_functions_scope_limitation_description do
-        'Limited to Family Help (Higher) and to all steps necessary to negotiate and conclude a settlement.
-        To include the issue of proceedings and representation in those proceedings save in relation to or at a contested final hearing.'
-      end
+
+      # substantive_scope_limitation_code { "FM059" }
+      # substantive_scope_limitation_meaning { "FHH Children" }
+      # substantive_scope_limitation_description do
+      #   'Limited to Family Help (Higher) and to all steps necessary to negotiate and conclude a settlement.
+      #   To include the issue of proceedings and representation in those proceedings save in relation to or at a contested final hearing.'
+      # end
+      # delegated_functions_scope_limitation_code { "CV117" }
+      # delegated_functions_scope_limitation_meaning { "Interim order inc. return date" }
+      # delegated_functions_scope_limitation_description do
+      #   'Limited to Family Help (Higher) and to all steps necessary to negotiate and conclude a settlement.
+      #   To include the issue of proceedings and representation in those proceedings save in relation to or at a contested final hearing.'
+      # end
       used_delegated_functions { nil }
       used_delegated_functions_on { nil }
       used_delegated_functions_reported_on { nil }
@@ -215,18 +245,23 @@ FactoryBot.define do
       description { "to be represented on an application for a child arrangements order –where the child(ren) will live" }
       substantive_cost_limitation { 25_000 }
       delegated_functions_cost_limitation { rand(1...1_000_000.0).round(2) }
-      substantive_scope_limitation_code { "FM059" }
-      substantive_scope_limitation_meaning { "FHH Children" }
-      substantive_scope_limitation_description do
-        'Limited to Family Help (Higher) and to all steps necessary to negotiate and conclude a settlement.
-        To include the issue of proceedings and representation in those proceedings save in relation to or at a contested final hearing.'
+      after(:create) do |proceeding|
+        create(:scope_limitation, :emergency, proceeding:)
+        create(:scope_limitation, :substantive, proceeding:)
       end
-      delegated_functions_scope_limitation_code { "CV117" }
-      delegated_functions_scope_limitation_meaning { "Interim order inc. return date" }
-      delegated_functions_scope_limitation_description do
-        'Limited to Family Help (Higher) and to all steps necessary to negotiate and conclude a settlement.
-        To include the issue of proceedings and representation in those proceedings save in relation to or at a contested final hearing.'
-      end
+
+      # substantive_scope_limitation_code { "FM059" }
+      # substantive_scope_limitation_meaning { "FHH Children" }
+      # substantive_scope_limitation_description do
+      #   'Limited to Family Help (Higher) and to all steps necessary to negotiate and conclude a settlement.
+      #   To include the issue of proceedings and representation in those proceedings save in relation to or at a contested final hearing.'
+      # end
+      # delegated_functions_scope_limitation_code { "CV117" }
+      # delegated_functions_scope_limitation_meaning { "Interim order inc. return date" }
+      # delegated_functions_scope_limitation_description do
+      #   'Limited to Family Help (Higher) and to all steps necessary to negotiate and conclude a settlement.
+      #   To include the issue of proceedings and representation in those proceedings save in relation to or at a contested final hearing.'
+      # end
       used_delegated_functions { nil }
       used_delegated_functions_on { nil }
       used_delegated_functions_reported_on { nil }

--- a/spec/factories/proceedings.rb
+++ b/spec/factories/proceedings.rb
@@ -46,15 +46,6 @@ FactoryBot.define do
         create(:scope_limitation, :substantive, proceeding:) unless evaluator.no_scope_limitations
       end
 
-      # substantive_scope_limitation_code { "FM062" }
-      # substantive_scope_limitation_meaning { "Final hearing" }
-      # substantive_scope_limitation_description { "Limited to all steps up to and including final hearing and any action necessary to implement (but not enforce) the order." }
-      # delegated_functions_scope_limitation_code { "CV117" }
-      # delegated_functions_scope_limitation_meaning { "Interim order inc. return date" }
-      # delegated_functions_scope_limitation_description do
-      #   'Limited to Family Help (Higher) and to all steps necessary to negotiate and conclude a settlement.
-      #    To include the issue of proceedings and representation in those proceedings save in relation to or at a contested final hearing.'
-      # end
       used_delegated_functions { nil }
       used_delegated_functions_on { nil }
       used_delegated_functions_reported_on { nil }
@@ -82,16 +73,6 @@ FactoryBot.define do
         create(:scope_limitation, :substantive, proceeding:) unless evaluator.no_scope_limitations
       end
 
-      # substantive_scope_limitation_code { "AA019" }
-      # substantive_scope_limitation_meaning { "Injunction FLA-to final hearing" }
-      # substantive_scope_limitation_description { "Limited to all steps up to and including final hearing and any action necessary to implement (but not enforce) the order." }
-      # delegated_functions_scope_limitation_code { "CV117" }
-      # delegated_functions_scope_limitation_meaning { "Interim order inc. return date" }
-      # delegated_functions_scope_limitation_description do
-      #   'As to proceedings under Part IV Family Law Act 1996 limited to all steps up to and including obtaining and serving a
-      #    final order and in the event of breach leading to the exercise of a power of arrest to representation on the consideration
-      #    of the breach by the court (but excluding applying for a warrant of arrest, if not attached, and representation in contempt proceedings).'
-      # end
       used_delegated_functions { true }
       used_delegated_functions_on { Faker::Date.between(from: 10.days.ago, to: 2.days.ago) }
       used_delegated_functions_reported_on { Time.zone.today }
@@ -116,16 +97,6 @@ FactoryBot.define do
         create(:scope_limitation, :substantive, proceeding:) unless evaluator.no_scope_limitations
       end
 
-      # substantive_scope_limitation_code { "AA019" }
-      # substantive_scope_limitation_meaning { "Injunction FLA-to final hearing" }
-      # substantive_scope_limitation_description { "Limited to all steps up to and including final hearing and any action necessary to implement (but not enforce) the order." }
-      # delegated_functions_scope_limitation_code { "CV117" }
-      # delegated_functions_scope_limitation_meaning { "Interim order inc. return date" }
-      # delegated_functions_scope_limitation_description do
-      #   'As to proceedings under Part IV Family Law Act 1996 limited to all steps up to and including obtaining and serving a
-      #    final order and in the event of breach leading to the exercise of a power of arrest to representation on the consideration
-      #    of the breach by the court (but excluding applying for a warrant of arrest, if not attached, and representation in contempt proceedings).'
-      # end
       used_delegated_functions { true }
       used_delegated_functions_on { Faker::Date.between(from: 10.days.ago, to: 2.days.ago) }
       used_delegated_functions_reported_on { Time.zone.today }
@@ -150,16 +121,6 @@ FactoryBot.define do
         create(:scope_limitation, :substantive, proceeding:) unless evaluator.no_scope_limitations
       end
 
-      # substantive_scope_limitation_code { "AA019" }
-      # substantive_scope_limitation_meaning { "Injunction FLA-to final hearing" }
-      # substantive_scope_limitation_description { "Limited to all steps up to and including final hearing and any action necessary to implement (but not enforce) the order." }
-      # delegated_functions_scope_limitation_code { "CV117" }
-      # delegated_functions_scope_limitation_meaning { "Interim order inc. return date" }
-      # delegated_functions_scope_limitation_description do
-      #   'As to proceedings under Part IV Family Law Act 1996 limited to all steps up to and including obtaining and serving a
-      #    final order and in the event of breach leading to the exercise of a power of arrest to representation on the consideration
-      #    of the breach by the court (but excluding applying for a warrant of arrest, if not attached, and representation in contempt proceedings).'
-      # end
       used_delegated_functions { true }
       used_delegated_functions_on { Faker::Date.between(from: 10.days.ago, to: 2.days.ago) }
       used_delegated_functions_reported_on { Time.zone.today }
@@ -184,16 +145,6 @@ FactoryBot.define do
         create(:scope_limitation, :substantive, proceeding:) unless evaluator.no_scope_limitations
       end
 
-      # substantive_scope_limitation_code { "AA019" }
-      # substantive_scope_limitation_meaning { "Injunction FLA-to final hearing" }
-      # substantive_scope_limitation_description { "Limited to all steps up to and including final hearing and any action necessary to implement (but not enforce) the order." }
-      # delegated_functions_scope_limitation_code { "CV117" }
-      # delegated_functions_scope_limitation_meaning { "Interim order inc. return date" }
-      # delegated_functions_scope_limitation_description do
-      #   'As to proceedings under Part IV Family Law Act 1996 limited to all steps up to and including obtaining and serving a
-      #    final order and in the event of breach leading to the exercise of a power of arrest to representation on the consideration
-      #    of the breach by the court (but excluding applying for a warrant of arrest, if not attached, and representation in contempt proceedings).'
-      # end
       used_delegated_functions { true }
       used_delegated_functions_on { Faker::Date.between(from: 10.days.ago, to: 2.days.ago) }
       used_delegated_functions_reported_on { Time.zone.today }
@@ -218,18 +169,6 @@ FactoryBot.define do
         create(:scope_limitation, :substantive, proceeding:) unless evaluator.no_scope_limitations
       end
 
-      # substantive_scope_limitation_code { "FM059" }
-      # substantive_scope_limitation_meaning { "FHH Children" }
-      # substantive_scope_limitation_description do
-      #   'Limited to Family Help (Higher) and to all steps necessary to negotiate and conclude a settlement.
-      #   To include the issue of proceedings and representation in those proceedings save in relation to or at a contested final hearing.'
-      # end
-      # delegated_functions_scope_limitation_code { "CV117" }
-      # delegated_functions_scope_limitation_meaning { "Interim order inc. return date" }
-      # delegated_functions_scope_limitation_description do
-      #   'Limited to Family Help (Higher) and to all steps necessary to negotiate and conclude a settlement.
-      #   To include the issue of proceedings and representation in those proceedings save in relation to or at a contested final hearing.'
-      # end
       used_delegated_functions { nil }
       used_delegated_functions_on { nil }
       used_delegated_functions_reported_on { nil }
@@ -254,18 +193,6 @@ FactoryBot.define do
         create(:scope_limitation, :substantive, proceeding:) unless evaluator.no_scope_limitations
       end
 
-      # substantive_scope_limitation_code { "FM059" }
-      # substantive_scope_limitation_meaning { "FHH Children" }
-      # substantive_scope_limitation_description do
-      #   'Limited to Family Help (Higher) and to all steps necessary to negotiate and conclude a settlement.
-      #   To include the issue of proceedings and representation in those proceedings save in relation to or at a contested final hearing.'
-      # end
-      # delegated_functions_scope_limitation_code { "CV117" }
-      # delegated_functions_scope_limitation_meaning { "Interim order inc. return date" }
-      # delegated_functions_scope_limitation_description do
-      #   'Limited to Family Help (Higher) and to all steps necessary to negotiate and conclude a settlement.
-      #   To include the issue of proceedings and representation in those proceedings save in relation to or at a contested final hearing.'
-      # end
       used_delegated_functions { nil }
       used_delegated_functions_on { nil }
       used_delegated_functions_reported_on { nil }

--- a/spec/factories/proceedings.rb
+++ b/spec/factories/proceedings.rb
@@ -30,6 +30,10 @@ FactoryBot.define do
       used_delegated_functions_reported_on { Time.zone.today }
     end
 
+    transient do
+      no_scope_limitations { false }
+    end
+
     trait :da001 do
       lead_proceeding { true }
       ccms_code { "DA001" }
@@ -37,9 +41,9 @@ FactoryBot.define do
       description { "to be represented on an application for an injunction, order or declaration under the inherent jurisdiction of the court." }
       substantive_cost_limitation { 25_000 }
       delegated_functions_cost_limitation { rand(1...1_000_000.0).round(2) }
-      after(:create) do |proceeding|
-        create(:scope_limitation, :emergency, proceeding:)
-        create(:scope_limitation, :substantive, proceeding:)
+      after(:create) do |proceeding, evaluator|
+        create(:scope_limitation, :emergency, proceeding:) unless evaluator.no_scope_limitations
+        create(:scope_limitation, :substantive, proceeding:) unless evaluator.no_scope_limitations
       end
 
       # substantive_scope_limitation_code { "FM062" }
@@ -73,9 +77,9 @@ FactoryBot.define do
       end
       substantive_cost_limitation { 25_000 }
       delegated_functions_cost_limitation { rand(1...1_000_000.0).round(2) }
-      after(:create) do |proceeding|
-        create(:scope_limitation, :emergency, proceeding:)
-        create(:scope_limitation, :substantive, proceeding:)
+      after(:create) do |proceeding, evaluator|
+        create(:scope_limitation, :emergency, proceeding:) unless evaluator.no_scope_limitations
+        create(:scope_limitation, :substantive, proceeding:) unless evaluator.no_scope_limitations
       end
 
       # substantive_scope_limitation_code { "AA019" }
@@ -107,9 +111,9 @@ FactoryBot.define do
       description { "to be represented on an application for an occupation order." }
       substantive_cost_limitation { 25_000 }
       delegated_functions_cost_limitation { rand(1...1_000_000.0).round(2) }
-      after(:create) do |proceeding|
-        create(:scope_limitation, :emergency, proceeding:)
-        create(:scope_limitation, :substantive, proceeding:)
+      after(:create) do |proceeding, evaluator|
+        create(:scope_limitation, :emergency, proceeding:) unless evaluator.no_scope_limitations
+        create(:scope_limitation, :substantive, proceeding:) unless evaluator.no_scope_limitations
       end
 
       # substantive_scope_limitation_code { "AA019" }
@@ -141,9 +145,9 @@ FactoryBot.define do
       description { "to be represented on an application to extend, vary or discharge an order under Part IV Family Law Act 1996. " }
       substantive_cost_limitation { 25_000 }
       delegated_functions_cost_limitation { rand(1...1_000_000.0).round(2) }
-      after(:create) do |proceeding|
-        create(:scope_limitation, :emergency, proceeding:)
-        create(:scope_limitation, :substantive, proceeding:)
+      after(:create) do |proceeding, evaluator|
+        create(:scope_limitation, :emergency, proceeding:) unless evaluator.no_scope_limitations
+        create(:scope_limitation, :substantive, proceeding:) unless evaluator.no_scope_limitations
       end
 
       # substantive_scope_limitation_code { "AA019" }
@@ -175,9 +179,9 @@ FactoryBot.define do
       description { "to be represented on an application for a non-molestation order." }
       substantive_cost_limitation { 25_000 }
       delegated_functions_cost_limitation { rand(1...1_000_000.0).round(2) }
-      after(:create) do |proceeding|
-        create(:scope_limitation, :emergency, proceeding:)
-        create(:scope_limitation, :substantive, proceeding:)
+      after(:create) do |proceeding, evaluator|
+        create(:scope_limitation, :emergency, proceeding:) unless evaluator.no_scope_limitations
+        create(:scope_limitation, :substantive, proceeding:) unless evaluator.no_scope_limitations
       end
 
       # substantive_scope_limitation_code { "AA019" }
@@ -209,9 +213,9 @@ FactoryBot.define do
       description { "to be represented on an application for a child arrangements order –where the child(ren) will live" }
       substantive_cost_limitation { 25_000 }
       delegated_functions_cost_limitation { rand(1...1_000_000.0).round(2) }
-      after(:create) do |proceeding|
-        create(:scope_limitation, :emergency, proceeding:)
-        create(:scope_limitation, :substantive, proceeding:)
+      after(:create) do |proceeding, evaluator|
+        create(:scope_limitation, :emergency, proceeding:) unless evaluator.no_scope_limitations
+        create(:scope_limitation, :substantive, proceeding:) unless evaluator.no_scope_limitations
       end
 
       # substantive_scope_limitation_code { "FM059" }
@@ -245,9 +249,9 @@ FactoryBot.define do
       description { "to be represented on an application for a child arrangements order –where the child(ren) will live" }
       substantive_cost_limitation { 25_000 }
       delegated_functions_cost_limitation { rand(1...1_000_000.0).round(2) }
-      after(:create) do |proceeding|
-        create(:scope_limitation, :emergency, proceeding:)
-        create(:scope_limitation, :substantive, proceeding:)
+      after(:create) do |proceeding, evaluator|
+        create(:scope_limitation, :emergency, proceeding:) unless evaluator.no_scope_limitations
+        create(:scope_limitation, :substantive, proceeding:) unless evaluator.no_scope_limitations
       end
 
       # substantive_scope_limitation_code { "FM059" }

--- a/spec/factories/scope_limitations.rb
+++ b/spec/factories/scope_limitations.rb
@@ -1,0 +1,22 @@
+FactoryBot.define do
+  factory :scope_limitation do
+    proceeding
+
+    trait :emergency do
+      scope_type { 1 }
+      code { "CV117" }
+      meaning { "Interim order inc. return date" }
+      description do
+        'Limited to Family Help (Higher) and to all steps necessary to negotiate and conclude a settlement.
+         To include the issue of proceedings and representation in those proceedings save in relation to or at a contested final hearing.'
+      end
+    end
+
+    trait :substantive do
+      scope_type { 0 }
+      code { "FM062" }
+      meaning { "Final hearing" }
+      description { "Limited to all steps up to and including final hearing and any action necessary to implement (but not enforce) the order." }
+    end
+  end
+end

--- a/spec/forms/proceedings/emergency_defaults_form_spec.rb
+++ b/spec/forms/proceedings/emergency_defaults_form_spec.rb
@@ -65,9 +65,9 @@ RSpec.describe Proceedings::EmergencyDefaultsForm, :vcr, type: :form do
 
           it "creates a scope_limitation object" do
             expect { save_form }.to change(proceeding.scope_limitations, :count).by(1)
-            expect(proceeding.scope_limitations.where(scope_type: :emergency).first.code).to eq "CV117"
-            expect(proceeding.scope_limitations.where(scope_type: :emergency).first.meaning).to eq "Interim order inc. return date"
-            expect(proceeding.scope_limitations.where(scope_type: :emergency).first.description).to eq "Limited to all steps necessary to apply for an interim order; where application is made without notice to include representation on the return date."
+            expect(proceeding.scope_limitations.find_by(scope_type: :emergency)).to have_attributes(code: "CV117",
+                                                                                                    meaning: "Interim order inc. return date",
+                                                                                                    description: "Limited to all steps necessary to apply for an interim order; where application is made without notice to include representation on the return date.")
           end
         end
       end

--- a/spec/forms/proceedings/emergency_defaults_form_spec.rb
+++ b/spec/forms/proceedings/emergency_defaults_form_spec.rb
@@ -35,7 +35,9 @@ RSpec.describe Proceedings::EmergencyDefaultsForm, :vcr, type: :form do
   describe "#save" do
     subject(:save_form) { form.save }
 
-    before { save_form }
+    before { save_form unless skip_subject }
+
+    let(:skip_subject) { false }
 
     context "when the submission is valid" do
       context "and the user accepts the defaults" do
@@ -45,9 +47,6 @@ RSpec.describe Proceedings::EmergencyDefaultsForm, :vcr, type: :form do
             emergency_level_of_service: 3,
             emergency_level_of_service_name: "Full Representation",
             emergency_level_of_service_stage: 8,
-            delegated_functions_scope_limitation_code: "CV117",
-            delegated_functions_scope_limitation_meaning: "Interim order inc. return date",
-            delegated_functions_scope_limitation_description: "Limited to all steps necessary to apply for an interim order; where application is made without notice to include representation on the return date.",
           }
         end
 
@@ -59,9 +58,17 @@ RSpec.describe Proceedings::EmergencyDefaultsForm, :vcr, type: :form do
           expect(proceeding.reload.emergency_level_of_service).to eq 3
           expect(proceeding.reload.emergency_level_of_service_name).to eq "Full Representation"
           expect(proceeding.reload.emergency_level_of_service_stage).to eq 8
-          expect(proceeding.reload.delegated_functions_scope_limitation_code).to eq "CV117"
-          expect(proceeding.reload.delegated_functions_scope_limitation_meaning).to eq "Interim order inc. return date"
-          expect(proceeding.reload.delegated_functions_scope_limitation_description).to eq "Limited to all steps necessary to apply for an interim order; where application is made without notice to include representation on the return date."
+        end
+
+        context "without calling the subject" do
+          let(:skip_subject) { true }
+
+          it "creates a scope_limitation object" do
+            expect { save_form }.to change(proceeding.scope_limitations, :count).by(1)
+            expect(proceeding.scope_limitations.where(scope_type: :emergency).first.code).to eq "CV117"
+            expect(proceeding.scope_limitations.where(scope_type: :emergency).first.meaning).to eq "Interim order inc. return date"
+            expect(proceeding.scope_limitations.where(scope_type: :emergency).first.description).to eq "Limited to all steps necessary to apply for an interim order; where application is made without notice to include representation on the return date."
+          end
         end
       end
 
@@ -76,9 +83,14 @@ RSpec.describe Proceedings::EmergencyDefaultsForm, :vcr, type: :form do
           expect(proceeding.reload.emergency_level_of_service).to be_nil
           expect(proceeding.reload.emergency_level_of_service_name).to be_nil
           expect(proceeding.reload.emergency_level_of_service_stage).to be_nil
-          expect(proceeding.reload.delegated_functions_scope_limitation_code).to be_nil
-          expect(proceeding.reload.delegated_functions_scope_limitation_meaning).to be_nil
-          expect(proceeding.reload.delegated_functions_scope_limitation_description).to be_nil
+        end
+
+        context "without calling the subject" do
+          let(:skip_subject) { true }
+
+          it "does not create a scope_limitation object" do
+            expect { save_form }.not_to change(proceeding.scope_limitations, :count)
+          end
         end
       end
     end
@@ -92,6 +104,14 @@ RSpec.describe Proceedings::EmergencyDefaultsForm, :vcr, type: :form do
 
       it "generates the expected error message" do
         expect(form.errors.map(&:attribute)).to eq [:accepted_emergency_defaults]
+      end
+
+      context "without calling the subject" do
+        let(:skip_subject) { true }
+
+        it "does not create a scope_limitation object" do
+          expect { save_form }.not_to change(proceeding.scope_limitations, :count)
+        end
       end
     end
   end

--- a/spec/forms/proceedings/substantive_defaults_form_spec.rb
+++ b/spec/forms/proceedings/substantive_defaults_form_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe Proceedings::SubstantiveDefaultsForm, :vcr, type: :form do
   subject(:form) { described_class.new(form_params) }
 
-  let(:proceeding) { create :proceeding, :da001, :without_df_date, :with_cit_z }
+  let(:proceeding) { create :proceeding, :da001, :without_df_date, :with_cit_z, no_scope_limitations: true }
   let(:params) do
     {
       accepted_substantive_defaults: accepted,

--- a/spec/forms/proceedings/substantive_defaults_form_spec.rb
+++ b/spec/forms/proceedings/substantive_defaults_form_spec.rb
@@ -14,7 +14,9 @@ RSpec.describe Proceedings::SubstantiveDefaultsForm, :vcr, type: :form do
   describe "#save" do
     subject(:save_form) { form.save }
 
-    before { save_form }
+    before { save_form unless skip_subject }
+
+    let(:skip_subject) { false }
 
     context "when the submission is valid" do
       context "and the user accepts the defaults" do
@@ -28,9 +30,17 @@ RSpec.describe Proceedings::SubstantiveDefaultsForm, :vcr, type: :form do
           expect(proceeding.substantive_level_of_service).to eq 3
           expect(proceeding.substantive_level_of_service_name).to eq "Full Representation"
           expect(proceeding.substantive_level_of_service_stage).to eq 8
-          expect(proceeding.substantive_scope_limitation_code).to eq "FM062"
-          expect(proceeding.substantive_scope_limitation_meaning).to eq "Final hearing"
-          expect(proceeding.substantive_scope_limitation_description).to eq "Limited to all steps up to and including final hearing and any action necessary to implement (but not enforce) the order."
+        end
+
+        context "without calling the subject" do
+          let(:skip_subject) { true }
+
+          it "creates a scope_limitation object" do
+            expect { save_form }.to change(proceeding.scope_limitations, :count).by(1)
+            expect(proceeding.scope_limitations.where(scope_type: :substantive).first.code).to eq "AA019"
+            expect(proceeding.scope_limitations.where(scope_type: :substantive).first.meaning).to eq "Injunction FLA-to final hearing"
+            expect(proceeding.scope_limitations.where(scope_type: :substantive).first.description).to eq "As to proceedings under Part IV Family Law Act 1996 limited to all steps up to and including obtaining and serving a final order and in the event of breach leading to the exercise of a power of arrest to representation on the consideration of the breach by the court (but excluding applying for a warrant of arrest, if not attached, and representation in contempt proceedings)."
+          end
         end
       end
 
@@ -45,9 +55,14 @@ RSpec.describe Proceedings::SubstantiveDefaultsForm, :vcr, type: :form do
           expect(proceeding.substantive_level_of_service).to be_nil
           expect(proceeding.substantive_level_of_service_name).to be_nil
           expect(proceeding.substantive_level_of_service_stage).to be_nil
-          expect(proceeding.substantive_scope_limitation_meaning).to be_nil
-          expect(proceeding.substantive_scope_limitation_description).to be_nil
-          expect(proceeding.substantive_scope_limitation_code).to be_nil
+        end
+
+        context "without calling the subject" do
+          let(:skip_subject) { true }
+
+          it "does not create a scope_limitation object" do
+            expect { save_form }.not_to change(proceeding.scope_limitations, :count)
+          end
         end
       end
     end
@@ -61,6 +76,14 @@ RSpec.describe Proceedings::SubstantiveDefaultsForm, :vcr, type: :form do
 
       it "generates the expected error message" do
         expect(form.errors.map(&:attribute)).to eq [:accepted_substantive_defaults]
+      end
+
+      context "without calling the subject" do
+        let(:skip_subject) { true }
+
+        it "does not create a scope_limitation object" do
+          expect { save_form }.not_to change(proceeding.scope_limitations, :count)
+        end
       end
     end
   end

--- a/spec/forms/proceedings/substantive_defaults_form_spec.rb
+++ b/spec/forms/proceedings/substantive_defaults_form_spec.rb
@@ -37,9 +37,9 @@ RSpec.describe Proceedings::SubstantiveDefaultsForm, :vcr, type: :form do
 
           it "creates a scope_limitation object" do
             expect { save_form }.to change(proceeding.scope_limitations, :count).by(1)
-            expect(proceeding.scope_limitations.where(scope_type: :substantive).first.code).to eq "AA019"
-            expect(proceeding.scope_limitations.where(scope_type: :substantive).first.meaning).to eq "Injunction FLA-to final hearing"
-            expect(proceeding.scope_limitations.where(scope_type: :substantive).first.description).to eq "As to proceedings under Part IV Family Law Act 1996 limited to all steps up to and including obtaining and serving a final order and in the event of breach leading to the exercise of a power of arrest to representation on the consideration of the breach by the court (but excluding applying for a warrant of arrest, if not attached, and representation in contempt proceedings)."
+            expect(proceeding.scope_limitations.find_by(scope_type: :substantive)).to have_attributes(code: "AA019",
+                                                                                                      meaning: "Injunction FLA-to final hearing",
+                                                                                                      description: "As to proceedings under Part IV Family Law Act 1996 limited to all steps up to and including obtaining and serving a final order and in the event of breach leading to the exercise of a power of arrest to representation on the consideration of the breach by the court (but excluding applying for a warrant of arrest, if not attached, and representation in contempt proceedings).")
           end
         end
       end

--- a/spec/models/proceeding_spec.rb
+++ b/spec/models/proceeding_spec.rb
@@ -86,6 +86,12 @@ RSpec.describe Proceeding, type: :model do
     end
   end
 
+  describe "#delegated_functions_scope_limitation_meaning" do # TEMP for coverage
+    subject(:delegated_functions_scope_limitation_meaning) { proceeding.delegated_functions_scope_limitation_meaning }
+
+    it { is_expected.not_to be_nil }
+  end
+
   describe "#proceeding_case_p_num" do
     it "prefixes the proceeding case id with P_" do
       legal_aid_application = create :legal_aid_application, :with_proceedings

--- a/spec/models/proceeding_spec.rb
+++ b/spec/models/proceeding_spec.rb
@@ -86,7 +86,11 @@ RSpec.describe Proceeding, type: :model do
     end
   end
 
-  describe "#delegated_functions_scope_limitation_meaning" do # TEMP for coverage
+  describe "#delegated_functions_scope_limitation_meaning" do
+    # TODO: This is TEMP for coverage
+    # This was not being explicitly tested and caused a code-coverage drop, it can be
+    # removed once the helper methods for single scope limitation values are removed from
+    # the proceeding object
     subject(:delegated_functions_scope_limitation_meaning) { proceeding.delegated_functions_scope_limitation_meaning }
 
     it { is_expected.not_to be_nil }

--- a/spec/models/scope_limitation_spec.rb
+++ b/spec/models/scope_limitation_spec.rb
@@ -1,0 +1,7 @@
+require "rails_helper"
+
+RSpec.describe ScopeLimitation do
+  subject { described_class.new }
+
+  it { is_expected.to define_enum_for(:scope_type).with_values(%i[substantive emergency]) }
+end

--- a/spec/services/legal_framework/add_proceeding_service_spec.rb
+++ b/spec/services/legal_framework/add_proceeding_service_spec.rb
@@ -44,13 +44,11 @@ module LegalFramework
           context "is on" do
             let(:enable_loop) { true }
 
+            it "does not create scope_limitations" do
+              expect(proceeding.reload.scope_limitations.count).to eq 0
+            end
+
             it "does not populate the scope_limitation_attrs" do
-              expect(proceeding.substantive_scope_limitation_code).to be_nil
-              expect(proceeding.substantive_scope_limitation_meaning).to be_nil
-              expect(proceeding.substantive_scope_limitation_description).to be_nil
-              expect(proceeding.delegated_functions_scope_limitation_code).to be_nil
-              expect(proceeding.delegated_functions_scope_limitation_meaning).to be_nil
-              expect(proceeding.delegated_functions_scope_limitation_description).to be_nil
               expect(proceeding.substantive_level_of_service).to be_nil
               expect(proceeding.substantive_level_of_service_name).to be_nil
               expect(proceeding.substantive_level_of_service_stage).to be_nil
@@ -63,13 +61,11 @@ module LegalFramework
           context "is off" do
             let(:enable_loop) { false }
 
+            it "creates scope_limitations" do
+              expect(proceeding.reload.scope_limitations.count).to eq 2
+            end
+
             it "populates the scope_limitation_attrs" do
-              expect(proceeding.substantive_scope_limitation_code).not_to be_nil
-              expect(proceeding.substantive_scope_limitation_meaning).not_to be_nil
-              expect(proceeding.substantive_scope_limitation_description).not_to be_nil
-              expect(proceeding.delegated_functions_scope_limitation_code).not_to be_nil
-              expect(proceeding.delegated_functions_scope_limitation_meaning).not_to be_nil
-              expect(proceeding.delegated_functions_scope_limitation_description).not_to be_nil
               expect(proceeding.substantive_level_of_service).to be 3
               expect(proceeding.substantive_level_of_service_name).to eql "Full Representation"
               expect(proceeding.substantive_level_of_service_stage).to be 8

--- a/spec/services/legal_framework/proceeding_types/defaults_spec.rb
+++ b/spec/services/legal_framework/proceeding_types/defaults_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe LegalFramework::ProceedingTypes::Defaults, :vcr do
   let(:uri) { "#{Rails.configuration.x.legal_framework_api_host}/proceeding_types_defaults" }
 
   describe ".call" do
-    subject(:call) { defaults.call(proceeding) }
+    subject(:call) { defaults.call(proceeding, false) }
 
     before { call }
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3495)

This creates a new ScopeLimitaton object and updates handlers to create new ScopeLimitation objects going forward.

It adds helper methods to read data from the proceedings table (current records) _or_ the ScopeLimitations table (new records) depending on what is available


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
