### PR TITLE
Remove CCMS testing section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,23 +224,6 @@ VCR is used to record interactions with external services and play back these st
 
 see [VCR Recording](docs/vcr_recording.md) for setup and recommended approaches to rerecording of cassettes.
 
-#### CCMS tests
-
-As of August 2021, rspec will ignore the CCMS tests. There are 600+ of them and they were taking >6 minutes to run.
-Removing them halved the time taken to run the entire test suite.  A full overnight run is now scheduled in CircleCI and, on failure, it will alert via the apply-dev channel in slack
-
-If you are working on the CCMS tests and need to run them locally, you can run the tests locally with
-```shell
-INC_CCMS=true bundle exec rspec
-```
-This will run the entire test suite and monitor code coverage.
-
-If you don't care about code coverage, you could run
-```ruby
-bundle exec rspec --tag ccms
-```
-and it will only run the CCMS tests, but complain about coverage
-
 #### Guard
 
 The repo also includes a Guardfile, this can be run in a terminal window


### PR DESCRIPTION
Before, tests tagged with `ccms` were only run if explictly included in the test command.

In #3466, this was changed so that `ccms` tests ran as part of the test suite by default.

This updates the README to reflect that change.