### PR TITLE
Ensure correct flows use enhanced bank upload journey

### DIFF
--- a/app/controllers/providers/means/identify_types_of_incomes_controller.rb
+++ b/app/controllers/providers/means/identify_types_of_incomes_controller.rb
@@ -1,8 +1,6 @@
 module Providers
   module Means
     class IdentifyTypesOfIncomesController < ProviderBaseController
-      before_action :redirect_if_enhanced_bank_upload_enabled
-
       def show
         @none_selected = legal_aid_application.no_credit_transaction_types_selected?
       end
@@ -66,12 +64,6 @@ module Providers
             .credits
             .where.not(transaction_type_id: except)
             .destroy_all
-        end
-      end
-
-      def redirect_if_enhanced_bank_upload_enabled
-        if Setting.enhanced_bank_upload?
-          redirect_to providers_legal_aid_application_means_regular_incomes_path(legal_aid_application)
         end
       end
     end

--- a/app/services/flow/flows/provider_capital.rb
+++ b/app/services/flow/flows/provider_capital.rb
@@ -12,7 +12,7 @@ module Flow
             when :hmrc_single_employment, :unexpected_employment_data
               :employment_incomes
             when :employed_journey_not_enabled, :provider_not_enabled_for_employed_journey, :applicant_not_employed
-              if Setting.enhanced_bank_upload?
+              if application.using_enhanced_bank_upload?
                 :regular_incomes
               else
                 :identify_types_of_incomes
@@ -173,12 +173,24 @@ module Flow
         },
         employment_incomes: {
           path: ->(application) { urls.providers_legal_aid_application_means_employment_income_path(application) },
-          forward: :identify_types_of_incomes,
+          forward: lambda do |application|
+            if application.using_enhanced_bank_upload?
+              :regular_incomes
+            else
+              :identify_types_of_incomes
+            end
+          end,
           check_answers: :means_summaries,
         },
         full_employment_details: {
           path: ->(application) { urls.providers_legal_aid_application_means_full_employment_details_path(application) },
-          forward: :identify_types_of_incomes,
+          forward: lambda do |application|
+            if application.using_enhanced_bank_upload?
+              :regular_incomes
+            else
+              :identify_types_of_incomes
+            end
+          end,
           check_answers: :means_summaries,
         },
         capital_introductions: {

--- a/app/services/flow/flows/provider_start.rb
+++ b/app/services/flow/flows/provider_start.rb
@@ -150,7 +150,11 @@ module Flow
             when :hmrc_single_employment, :unexpected_employment_data
               :employment_incomes
             when :employed_journey_not_enabled, :provider_not_enabled_for_employed_journey, :applicant_not_employed
-              :identify_types_of_incomes
+              if application.using_enhanced_bank_upload?
+                :regular_incomes
+              else
+                :identify_types_of_incomes
+              end
             else
               raise "Unexpected hmrc status #{status.inspect}"
             end

--- a/app/views/providers/means_summaries/_income_assessment.html.erb
+++ b/app/views/providers/means_summaries/_income_assessment.html.erb
@@ -21,7 +21,7 @@
 <%= render(
       'shared/check_answers/income_summary',
       income_type: t('.credits-section-heading'),
-      url: :identify_types_of_incomes,
+      url: @legal_aid_application.using_enhanced_bank_upload? ? :regular_incomes : :identify_types_of_incomes,
       transaction_types: TransactionType.credits
     ) %>
 

--- a/features/providers/check_your_answers.feature
+++ b/features/providers/check_your_answers.feature
@@ -343,60 +343,6 @@ Feature: Checking answers backwards and forwards
     Then I should be on the 'means_summary' page showing 'Check your answers'
 
   @javascript
-  Scenario: I am able to view and amend provider means answers for enhanced bank upload flow
-    Given csrf is enabled
-    And the feature flag for enhanced_bank_upload is enabled
-    And I have completed a non-passported employed application with enhanced bank upload as far as the end of the means section
-    Then I should be on the "means_summary" page showing "Check your answers"
-
-    And I should see "Uploaded bank statements"
-    And I should see "Does your client receive student finance?"
-    And the answer for "student finance question" should be "No"
-    And I should not see "Which bank accounts does your client have?"
-
-    When I click Check Your Answers Change link for "bank statements"
-    And I upload an evidence file named "hello_world.pdf"
-    And I click "Save and continue"
-    Then I should be on the "means_summary" page showing "Check your answers"
-    And I should see "hello_world.pdf"
-
-    When I click Check Your Answers Change link for "What payments does your client receive?"
-    And I check "Benefits"
-    Then I fill "Benefits amount" with "1000"
-    Then I choose "providers-means-regular-income-form-benefits-frequency-monthly-field"
-    And I click "Save and continue"
-    Then I should be on a page with title "Select payments your client receives in cash"
-    When I check "None of the above"
-    And I click "Save and continue"
-    Then I should be on the "means_summary" page showing "Check your answers"
-
-    When I click Check Your Answers Change link for "What payments does your client receive?"
-    And I check "My client receives none of these payments"
-    And I click "Save and continue"
-    Then I should be on the "means_summary" page showing "Check your answers"
-
-    When I click Check Your Answers Change link for "student finance"
-    And I choose "Yes"
-    And I enter amount "5000"
-    And I click "Save and continue"
-    Then I should be on the "means_summary" page showing "Check your answers"
-    And the answer for "student finance question" should be "Yes"
-    And the answer for "student finance annual amount" should be "£5,000"
-
-    When I click Check Your Answers Change link for "What payments does your client make?"
-    And I check "Maintenance payments to a former partner"
-    And I click "Save and continue"
-    Then I should be on a page with title "Select payments your client makes in cash"
-    When I check "None of the above"
-    And I click "Save and continue"
-    Then I should be on the "means_summary" page showing "Check your answers"
-
-    When I click Check Your Answers Change link for "What payments does your client make?"
-    And I check "My client makes none of these payments"
-    And I click "Save and continue"
-    Then I should be on the "means_summary" page showing "Check your answers"
-
-  @javascript
   Scenario: I am able to see all necessary sections for a non-passported open banking flow
     Given I have completed a non-passported application with open banking transactions
     And I am viewing the means summary check your anwsers page

--- a/features/providers/enhanced_bank_upload/check_your_answers.feature
+++ b/features/providers/enhanced_bank_upload/check_your_answers.feature
@@ -1,0 +1,61 @@
+Feature: Enhanced bank upload check your answers
+  @javascript
+  Scenario: I am able to view and amend provider means answers for enhanced bank upload flow
+    Given csrf is enabled
+    And the feature flag for enhanced_bank_upload is enabled
+    And I have completed a non-passported employed application with enhanced bank upload as far as the end of the means section
+    Then I should be on the "means_summary" page showing "Check your answers"
+
+    And I should see "Uploaded bank statements"
+    And I should not see "Which bank accounts does your client have?"
+
+    When I click Check Your Answers Change link for "bank statements"
+    And I upload an evidence file named "hello_world.pdf"
+    And I click "Save and continue"
+    Then I should be on the "means_summary" page showing "Check your answers"
+    And I should see "hello_world.pdf"
+
+    When I click Check Your Answers Change link for "What payments does your client receive?"
+    Then I should be on the "regular_incomes" page showing "Which of the following payments does your client receive?"
+
+    When I check "Benefits"
+    And I fill "Benefits amount" with "1000"
+    And I choose "providers-means-regular-income-form-benefits-frequency-monthly-field"
+
+    When I click "Save and continue"
+    Then I should be on a page with title "Select payments your client receives in cash"
+
+    When I check "None of the above"
+    And I click "Save and continue"
+    Then I should be on the "means_summary" page showing "Check your answers"
+
+    When I click Check Your Answers Change link for "What payments does your client receive?"
+    Then I should be on the "regular_incomes" page showing "Which of the following payments does your client receive?"
+
+    When I check "My client receives none of these payments"
+    And I click "Save and continue"
+    Then I should be on the "means_summary" page showing "Check your answers"
+
+    When I click Check Your Answers Change link for "student finance"
+    And I choose "Yes"
+    And I enter amount "5000"
+
+    When I click "Save and continue"
+    Then I should be on the "means_summary" page showing "Check your answers"
+    And the answer for "student finance question" should be "Yes"
+    And the answer for "student finance annual amount" should be "£5,000"
+
+    When I click Check Your Answers Change link for "What payments does your client make?"
+    And I check "Maintenance payments to a former partner"
+
+    And I click "Save and continue"
+    Then I should be on a page with title "Select payments your client makes in cash"
+
+    When I check "None of the above"
+    And I click "Save and continue"
+    Then I should be on the "means_summary" page showing "Check your answers"
+
+    When I click Check Your Answers Change link for "What payments does your client make?"
+    And I check "My client makes none of these payments"
+    And I click "Save and continue"
+    Then I should be on the "means_summary" page showing "Check your answers"

--- a/features/providers/enhanced_bank_upload/enhanced_bank_upload_flow.feature
+++ b/features/providers/enhanced_bank_upload/enhanced_bank_upload_flow.feature
@@ -1,0 +1,46 @@
+Feature: Enhanced bank upload flow
+  @javascript
+  Scenario: Enhanced bank statement upload journey
+    Given csrf is enabled
+    And the feature flag for enhanced_bank_upload is enabled
+    And I have completed a non-passported employed application with enhanced bank upload as far as the open banking consent page
+    Then I should be on a page showing "Does your client use online banking?"
+
+    When I choose "No"
+    And I click "Save and continue"
+    Then I should be on a page with title "Upload bank statements"
+    And the page is accessible
+
+    Given I upload the fixture file named "acceptable.pdf"
+    And I upload an evidence file named "hello_world.pdf"
+    When I click "Save and continue"
+    Then I should be on a page with title matching "Review .*'s employment income"
+    And I should be on a page showing "Do you need to tell us anything else about your client's employment?"
+    And the page is accessible
+
+    When I click "Save and continue"
+    Then I should be on the "regular_incomes" page showing "Which of the following payments does your client receive?"
+    And the page is accessible
+
+    When I check "Benefits"
+    And I fill "Benefits amount" with "500"
+    And I choose "providers-means-regular-income-form-benefits-frequency-weekly-field"
+
+    Then I check "Pension"
+    And I fill "Pension amount" with "100"
+    And I choose "providers-means-regular-income-form-pension-frequency-monthly-field"
+
+    When I click "Save and continue"
+    Then I should be on a page with title "Select payments your client receives in cash"
+    And the page is accessible
+
+    When I select "None of the above"
+    And I click "Save and continue"
+    Then I should be on a page with title "Does your client receive student finance?"
+    And the page is accessible
+
+    When I choose "Yes"
+    And I enter amount "2000"
+    And I click "Save and continue"
+    Then I should be on a page with title "Which payments does your client make?"
+    And the page is accessible

--- a/features/providers/non_passported_journey.feature
+++ b/features/providers/non_passported_journey.feature
@@ -78,26 +78,6 @@ Feature: Non-passported applicant journeys
     Then I click 'Save and continue'
     Then I should be on the 'has_dependants' page showing "Does your client have any dependants?"
 
-  @javascript @vcr
-  Scenario: Selects and categorises bank transactions with enhanced bank upload setting enabled
-    Given I start the merits application with bank transactions with no transaction type category
-    And the feature flag for enhanced_bank_upload is enabled
-    Then I should be on the "client_completed_means" page showing "Your client has shared their financial information"
-    Then I click "Continue"
-
-    Then I should be on the "regular_incomes" page showing "Which of the following payments does your client receive?"
-
-    Then I select "Benefits"
-    Then I fill "Benefits amount" with "500"
-    Then I choose "providers-means-regular-income-form-benefits-frequency-weekly-field"
-
-    Then I select "Pension"
-    Then I fill "Pension amount" with "100"
-    Then I choose "providers-means-regular-income-form-pension-frequency-monthly-field"
-
-    And I click "Save and continue"
-    Then I should be on a page with title "Select payments your client receives in cash"
-
   @javascript
   Scenario: Complete an application for an applicant that does not receive benefits with dependants
     Given I start the means application

--- a/features/step_definitions/bank_statement_uploaded_steps.rb
+++ b/features/step_definitions/bank_statement_uploaded_steps.rb
@@ -60,25 +60,3 @@ Given("I have completed a non-passported employed application with bank statemen
 
   visit(providers_legal_aid_application_means_summary_path(@legal_aid_application))
 end
-
-Given "I have completed a non-passported employed application with enhanced bank upload as far as the end of the means section" do
-  @legal_aid_application = create(
-    :legal_aid_application,
-    :with_proceedings,
-    :with_employed_applicant,
-    :with_single_employment,
-    :with_extra_employment_information,
-    :without_open_banking_consent,
-    :checking_non_passported_means,
-  )
-
-  create :attachment, :bank_statement, legal_aid_application: @legal_aid_application
-
-  @legal_aid_application.provider.permissions << Permission.find_by(role: "application.non_passported.employment.*")
-  @legal_aid_application.provider.permissions << Permission.find_by(role: "application.non_passported.bank_statement_upload.*")
-  @legal_aid_application.provider.save!
-
-  login_as @legal_aid_application.provider
-
-  visit(providers_legal_aid_application_means_summary_path(@legal_aid_application))
-end

--- a/features/step_definitions/enhanced_bank_upload_steps.rb
+++ b/features/step_definitions/enhanced_bank_upload_steps.rb
@@ -1,0 +1,41 @@
+Given "I have completed a non-passported employed application with enhanced bank upload as far as the open banking consent page" do
+  @legal_aid_application = create(
+    :legal_aid_application,
+    :with_proceedings,
+    :with_employed_applicant,
+    :with_single_employment,
+    :with_extra_employment_information,
+    :with_non_passported_state_machine,
+    :provider_confirming_applicant_eligibility,
+  )
+
+  @legal_aid_application.provider.permissions << Permission.find_by(role: "application.non_passported.employment.*")
+  @legal_aid_application.provider.permissions << Permission.find_by(role: "application.non_passported.bank_statement_upload.*")
+  @legal_aid_application.provider.save!
+
+  login_as @legal_aid_application.provider
+
+  visit(providers_legal_aid_application_open_banking_consents_path(@legal_aid_application))
+end
+
+Given "I have completed a non-passported employed application with enhanced bank upload as far as the end of the means section" do
+  @legal_aid_application = create(
+    :legal_aid_application,
+    :with_proceedings,
+    :with_employed_applicant,
+    :with_single_employment,
+    :with_extra_employment_information,
+    :without_open_banking_consent,
+    :checking_non_passported_means,
+  )
+
+  create :attachment, :bank_statement, legal_aid_application: @legal_aid_application
+
+  @legal_aid_application.provider.permissions << Permission.find_by(role: "application.non_passported.employment.*")
+  @legal_aid_application.provider.permissions << Permission.find_by(role: "application.non_passported.bank_statement_upload.*")
+  @legal_aid_application.provider.save!
+
+  login_as @legal_aid_application.provider
+
+  visit(providers_legal_aid_application_means_summary_path(@legal_aid_application))
+end

--- a/spec/models/legal_aid_application_spec.rb
+++ b/spec/models/legal_aid_application_spec.rb
@@ -1575,6 +1575,68 @@ RSpec.describe LegalAidApplication, type: :model do
     end
   end
 
+  describe "#using_enhanced_bank_upload?" do
+    context "when the `enhanced_bank_upload` setting is enabled, and the " \
+            "application is uploading bank statements" do
+      it "returns true" do
+        Setting.setting.update!(enhanced_bank_upload: true)
+        legal_aid_application = build_stubbed(:legal_aid_application)
+        allow(legal_aid_application)
+          .to receive(:uploading_bank_statements?)
+          .and_return(true)
+
+        result = legal_aid_application.using_enhanced_bank_upload?
+
+        expect(result).to be true
+      end
+    end
+
+    context "when the `enhanced_bank_upload` setting is enabled, but the " \
+            "application is not uploading bank statements" do
+      it "returns false" do
+        Setting.setting.update!(enhanced_bank_upload: true)
+        legal_aid_application = build_stubbed(:legal_aid_application)
+        allow(legal_aid_application)
+          .to receive(:uploading_bank_statements?)
+          .and_return(false)
+
+        result = legal_aid_application.using_enhanced_bank_upload?
+
+        expect(result).to be false
+      end
+    end
+
+    context "when the `enhanced_bank_upload` setting is disabled, and the " \
+            "application is uploading bank statements" do
+      it "returns false" do
+        Setting.setting.update!(enhanced_bank_upload: false)
+        legal_aid_application = build_stubbed(:legal_aid_application)
+        allow(legal_aid_application)
+          .to receive(:uploading_bank_statements?)
+          .and_return(true)
+
+        result = legal_aid_application.using_enhanced_bank_upload?
+
+        expect(result).to be false
+      end
+    end
+
+    context "when the `enhanced_bank_upload` setting is disabled, and the " \
+            "application is not uploading bank statements" do
+      it "returns false" do
+        Setting.setting.update!(enhanced_bank_upload: false)
+        legal_aid_application = build_stubbed(:legal_aid_application)
+        allow(legal_aid_application)
+          .to receive(:uploading_bank_statements?)
+          .and_return(false)
+
+        result = legal_aid_application.using_enhanced_bank_upload?
+
+        expect(result).to be false
+      end
+    end
+  end
+
 private
 
   def uploaded_evidence_output

--- a/spec/requests/providers/client_completed_means_spec.rb
+++ b/spec/requests/providers/client_completed_means_spec.rb
@@ -137,8 +137,8 @@ RSpec.describe Providers::ClientCompletedMeansController, type: :request do
             expect(subject).to redirect_to(providers_legal_aid_application_means_identify_types_of_income_path(legal_aid_application))
           end
 
-          context "when enhanced_bank_upload is enabled" do
-            before { Setting.setting.update!(enhanced_bank_upload: true) }
+          context "when application is using enhanced bank upload journey" do
+            before { allow_any_instance_of(LegalAidApplication).to receive(:using_enhanced_bank_upload?).and_return(true) }
 
             it "redirects to the identify incomes page" do
               expect(subject).to redirect_to(providers_legal_aid_application_means_regular_incomes_path(legal_aid_application))

--- a/spec/requests/providers/means/full_employment_details_controller_spec.rb
+++ b/spec/requests/providers/means/full_employment_details_controller_spec.rb
@@ -101,9 +101,27 @@ RSpec.describe Providers::Means::FullEmploymentDetailsController, type: :request
           expect(application.reload.full_employment_details).to eq full_employment_details
         end
 
-        it "redirects to identify_types_of_income page" do
-          request
-          expect(response).to redirect_to(providers_legal_aid_application_means_identify_types_of_income_path(application))
+        context "when the application is using the enhanced bank upload journey" do
+          let(:application) { create(:legal_aid_application, provider_received_citizen_consent: false) }
+
+          before do
+            Setting.setting.update!(enhanced_bank_upload: true)
+            permission = create(:permission, :bank_statement_upload)
+            provider.permissions << permission
+            provider.save!
+          end
+
+          it "redirects to the regular incomes page" do
+            request
+            expect(response).to redirect_to(providers_legal_aid_application_means_regular_incomes_path(application))
+          end
+        end
+
+        context "when the application is not using the enhanced bank upload journey" do
+          it "redirects to identify_types_of_income page" do
+            request
+            expect(response).to redirect_to(providers_legal_aid_application_means_identify_types_of_income_path(application))
+          end
         end
 
         context "when params are invalid" do

--- a/spec/requests/providers/means/identify_types_of_incomes_controller_spec.rb
+++ b/spec/requests/providers/means/identify_types_of_incomes_controller_spec.rb
@@ -38,19 +38,6 @@ RSpec.describe Providers::Means::IdentifyTypesOfIncomesController do
 
       it_behaves_like "a provider not authenticated"
     end
-
-    context "when the enhanced_bank_upload setting is enabled" do
-      it "redirects to the identify income types page" do
-        Setting.setting.update!(enhanced_bank_upload: true)
-        legal_aid_application = create(:legal_aid_application)
-        provider = legal_aid_application.provider
-        login_as provider
-
-        get providers_legal_aid_application_means_identify_types_of_income_path(legal_aid_application)
-
-        expect(response).to redirect_to(providers_legal_aid_application_means_regular_incomes_path(legal_aid_application))
-      end
-    end
   end
 
   describe "PATCH /providers/applications/:legal_aid_application_id/means/identify_types_of_income" do
@@ -297,19 +284,6 @@ RSpec.describe Providers::Means::IdentifyTypesOfIncomesController do
       before { request }
 
       it_behaves_like "a provider not authenticated"
-    end
-
-    context "when the enhanced_bank_upload setting is enabled" do
-      it "redirects to the identify income types page" do
-        Setting.setting.update!(enhanced_bank_upload: true)
-        legal_aid_application = create(:legal_aid_application)
-        provider = legal_aid_application.provider
-        login_as provider
-
-        patch providers_legal_aid_application_means_identify_types_of_income_path(legal_aid_application)
-
-        expect(response).to redirect_to(providers_legal_aid_application_means_regular_incomes_path(legal_aid_application))
-      end
     end
 
     context "when submitted with Save as draft" do


### PR DESCRIPTION
Before, the `Providers::Means::IdentifyTypesofIncomesController` redirected all
requests to the new `Providers::Means::RegularIncomesController` if the enhanced
bank upload setting was enabled.

Initially this seemed reasonable, however it was based on some incorrect
assumptions.

When the enhanced bank upload setting is enabled, only applications that are
using the bank upload journey should use the new flow.

This change seeks to redress the incorrect flows and ensure that only
non-passported applications that are using the bank statement upload journey use
the new how much, how often (enhanced bank upload) flow.

### User scenarios that should lead to the enhanced bank upload journey

_Note: In each scenario the setting is enabled and the application is uploading bank_ 
_statements. If either of those conditions aren't met, the user will be directed to the_
_existing `:identify_types_of_income` route._

1. Provider uploads bank statements, applicant is not employed
2. Client has completed means, applicant is not employed
3. Provider enters employment incomes
4. Provider enters full employment details