### PR TITLE
Fix flaky cucumber upload tests

### DIFF
--- a/features/providers/enhanced_bank_upload/check_your_answers.feature
+++ b/features/providers/enhanced_bank_upload/check_your_answers.feature
@@ -11,7 +11,9 @@ Feature: Enhanced bank upload check your answers
 
     When I click Check Your Answers Change link for "bank statements"
     And I upload an evidence file named "hello_world.pdf"
-    And I click "Save and continue"
+    Then I should see "hello_world.pdf UPLOADED"
+
+    When I click "Save and continue"
     Then I should be on the "means_summary" page showing "Check your answers"
     And I should see "hello_world.pdf"
 

--- a/features/providers/enhanced_bank_upload/enhanced_bank_upload_flow.feature
+++ b/features/providers/enhanced_bank_upload/enhanced_bank_upload_flow.feature
@@ -13,6 +13,9 @@ Feature: Enhanced bank upload flow
 
     Given I upload the fixture file named "acceptable.pdf"
     And I upload an evidence file named "hello_world.pdf"
+    Then I should see "acceptable.pdf UPLOADED"
+    And I should see "hello_world.pdf UPLOADED"
+
     When I click "Save and continue"
     Then I should be on a page with title matching "Review .*'s employment income"
     And I should be on a page showing "Do you need to tell us anything else about your client's employment?"


### PR DESCRIPTION
Several cucumber tests that rely on uploading files are flaky, and have been failing at a higher rate recently.

They seem to fail because validations that ensure supporting evidence has been uploaded have not been met. This is likely due to latency in the system.

This adds assertions that the files have been uploaded before attempting to navigate to the next step of the user journey in two of these tests.

The intention of this change is to ensure that the file has been uploaded, but it also ensures we are testing more realistic and appropriate user behaviour (i.e we care that the user knows the file has been uploaded too).

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3505)