### PR TITLE
Use clamav in tests when explicitly tagged

### DIFF
--- a/features/providers/bank_statement_upload.feature
+++ b/features/providers/bank_statement_upload.feature
@@ -1,6 +1,6 @@
+@javascript @clamav
 Feature: Bank statement upload
 
-  @javascript
   Scenario: Uploading a file
     Given csrf is enabled
     And I have completed a non-passported employed application and reached the open banking consent with bank statement upload enabled
@@ -40,7 +40,6 @@ Feature: Bank statement upload
     When I click 'Save and come back later'
     Then I should be on a page with title "Applications"
 
-  @javascript
   Scenario: Deleting a file
 
     Given csrf is enabled

--- a/features/providers/evidence_upload.feature
+++ b/features/providers/evidence_upload.feature
@@ -1,6 +1,6 @@
+@javascript @clamav
 Feature: Evidence upload
 
-  @javascript @vcr
   Scenario: Uploading a file
     Given csrf is enabled
     When I have completed a non-passported application and reached the evidence upload page
@@ -8,7 +8,6 @@ Feature: Evidence upload
     Then I upload an evidence file named 'hello_world.docx'
     Then I should see 4 uploaded files
 
-  @javascript @vcr
   Scenario: Categorising a file and validating that categorising a file is required to proceed
     When I have completed a non-passported application and reached the evidence upload page
     Then I should be on a page showing 'Uncategorised'
@@ -18,7 +17,6 @@ Feature: Evidence upload
     Then I should see 'Upload supporting evidence'
     And I should see 'Select a category for each uploaded file'
 
-  @javascript @vcr
   Scenario: Deleting a file
     When I have completed a non-passported application and reached the evidence upload page
     Then I should be on a page showing 'Upload supporting evidence'

--- a/features/providers/merits_task_list.feature
+++ b/features/providers/merits_task_list.feature
@@ -100,7 +100,7 @@ Feature: Merits task list
     When I click 'Save and come back later'
     Then I should be on the 'applications' page showing 'Applications'
 
-  @javascript
+  @javascript @clamav
   Scenario: Uploading a file for statement of case
     Given csrf is enabled
     Given I have completed a non-passported application and reached the merits task_list

--- a/features/providers/statement_of_case_upload.feature
+++ b/features/providers/statement_of_case_upload.feature
@@ -1,4 +1,4 @@
-@javascript @vcr
+@javascript @vcr @clamav
 Feature: Statement of case upload
 
   Background:

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -7,3 +7,14 @@ end
 After("@hmrc_use_dev_mock") do
   allow(Rails.configuration.x).to receive(:hmrc_use_dev_mock).and_call_original
 end
+
+Before("not @clamav") do
+  stdout = "/some/file/path.pdf: OK"
+  stderr = ""
+  status = instance_double(Process::Status, success?: true, exitstatus: 0)
+  allow(Open3).to receive(:capture3).and_call_original
+  allow(Open3)
+    .to receive(:capture3)
+    .with(/clamdscan/, any_args)
+    .and_return([stdout, stderr, status])
+end

--- a/spec/requests/providers/application_merits_task/statement_of_case_spec.rb
+++ b/spec/requests/providers/application_merits_task/statement_of_case_spec.rb
@@ -335,7 +335,7 @@ module Providers
                 expect(response.body).to match 'id="application-merits-task-statement-of-case-original-file-error"'
               end
 
-              context "when file contains a malware" do
+              context "when file contains a malware", clamav: true do
                 let(:original_file) { uploaded_file("spec/fixtures/files/malware.doc") }
 
                 it "does not save the object and raise an error" do

--- a/spec/requests/providers/bank_statements_spec.rb
+++ b/spec/requests/providers/bank_statements_spec.rb
@@ -258,7 +258,7 @@ RSpec.describe "Providers::BankStatementsController", type: :request do
         end
       end
 
-      context "when file contains a virus" do
+      context "when file contains a virus", clamav: true do
         let(:file) { uploaded_file("spec/fixtures/files/malware.doc") }
 
         it "does not add attachment object" do

--- a/spec/requests/providers/gateway_evidence_spec.rb
+++ b/spec/requests/providers/gateway_evidence_spec.rb
@@ -239,7 +239,7 @@ module Providers
             end
           end
 
-          context "file contains a malware" do
+          context "file contains a malware", clamav: true do
             let(:original_file) { uploaded_file("spec/fixtures/files/malware.doc") }
 
             it "does not save the object and raise an error" do

--- a/spec/requests/providers/uploaded_evidence_collection_spec.rb
+++ b/spec/requests/providers/uploaded_evidence_collection_spec.rb
@@ -192,7 +192,7 @@ module Providers
           end
         end
 
-        context "with a file that contains malware" do
+        context "with a file that contains malware", clamav: true do
           let(:original_file) { uploaded_file("spec/fixtures/files/malware.doc") }
 
           it "does not save the object and raises an error" do

--- a/spec/requests/status_spec.rb
+++ b/spec/requests/status_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe StatusController, type: :request do
+RSpec.describe StatusController, type: :request, clamav: true do
   describe "#healthcheck" do
     before do
       allow(Sidekiq::ProcessSet).to receive(:new).and_return(instance_double(Sidekiq::ProcessSet, size: 1))

--- a/spec/requests/v1/bank_statements_spec.rb
+++ b/spec/requests/v1/bank_statements_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe "POST /v1/bank_statements", type: :request do
         end
       end
 
-      context "when the file contains malware" do
+      context "when the file contains malware", clamav: true do
         let(:file) { uploaded_file("spec/fixtures/files/malware.doc", "application/pdf") }
 
         it "does not save the object and raises a 400 error with text" do

--- a/spec/requests/v1/statement_of_cases_spec.rb
+++ b/spec/requests/v1/statement_of_cases_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe "POST /v1/statement_of_case", type: :request do
         end
       end
 
-      context "file contains a malware" do
+      context "file contains a malware", clamav: true do
         let(:file) { uploaded_file("spec/fixtures/files/malware.doc", "application/pdf") }
         let(:i18n_error_message) { I18n.t("activemodel.errors.models.application_merits_task/statement_of_case.attributes.original_file.file_virus", file_name: "malware.doc") }
 

--- a/spec/requests/v1/uploaded_evidence_collections_spec.rb
+++ b/spec/requests/v1/uploaded_evidence_collections_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe "POST /v1/uploaded_evidence_collections", type: :request do
         end
       end
 
-      context "file contains a malware" do
+      context "file contains a malware", clamav: true do
         let(:file) { uploaded_file("spec/fixtures/files/malware.doc") }
 
         it "does not save the object and raises an error" do

--- a/spec/services/malware_scanner_spec.rb
+++ b/spec/services/malware_scanner_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe MalwareScanner do
+RSpec.describe MalwareScanner, clamav: true do
   subject do
     described_class.call(
       file_path:,

--- a/spec/support/malware_scanner.rb
+++ b/spec/support/malware_scanner.rb
@@ -1,0 +1,14 @@
+RSpec.configure do |config|
+  config.before do |example|
+    unless example.metadata[:clamav] == true
+      stdout = "/some/file/path.pdf: OK"
+      stderr = ""
+      status = instance_double(Process::Status, success?: true, exitstatus: 0)
+      allow(Open3).to receive(:capture3).and_call_original
+      allow(Open3)
+        .to receive(:capture3)
+        .with(/clamdscan/, any_args)
+        .and_return([stdout, stderr, status])
+    end
+  end
+end


### PR DESCRIPTION
Before, clamav was used for malware scanning in all tests that interacted with the `MalwareScanner` class (either directly or indirectly).

While it is important and useful to test the entire stack in integration tests, clamav is a source of repeated flakiness across the test suite due to the latency it introduces (especially in CI).

This updates RSpec specs and Cucumber tests to mock a successful clamav response
unless they are explicitly tagged with `clamav: true` or `@clamav`.