### PR TITLE
AP-3506 Convert v5 CFE response to V5 models

### DIFF
--- a/app/models/cfe/v5/result.rb
+++ b/app/models/cfe/v5/result.rb
@@ -1,0 +1,6 @@
+module CFE
+  module V5
+    class Result < CFE::V4::Result
+    end
+  end
+end

--- a/app/services/cfe/obtain_assessment_result_service.rb
+++ b/app/services/cfe/obtain_assessment_result_service.rb
@@ -40,11 +40,11 @@ module CFE
     end
 
     def write_cfe_result
-      CFE::V4::Result.create!(
+      CFE::V5::Result.create!(
         legal_aid_application_id: legal_aid_application.id,
         submission_id: @submission.id,
         result: @response.body,
-        type: "CFE::V4::Result",
+        type: "CFE::V5::Result",
       )
     end
   end

--- a/features/providers/enhanced_bank_upload/check_your_answers.feature
+++ b/features/providers/enhanced_bank_upload/check_your_answers.feature
@@ -14,6 +14,7 @@ Feature: Enhanced bank upload check your answers
     Then I should see "hello_world.pdf UPLOADED"
 
     When I click "Save and continue"
+
     Then I should be on the "means_summary" page showing "Check your answers"
     And I should see "hello_world.pdf"
 

--- a/features/support/steps_helper.rb
+++ b/features/support/steps_helper.rb
@@ -5,6 +5,12 @@ Then("I debug the response body") do
   puts ">>>>>>>>>>>> #{__FILE__}:#{__LINE__} <<<<<<<<<<<<".yellow
 end
 
+Then("I print the response body html") do
+  puts ">>>>>>>>>>>>  #{__FILE__}:#{__LINE__} <<<<<<<<<<<<".yellow
+  puts page.body
+  puts ">>>>>>>>>>>>  #{__FILE__}:#{__LINE__} <<<<<<<<<<<<".yellow
+end
+
 Then("I should be on a page showing {string}") do |title|
   expect(page).to have_content(title)
 end

--- a/lib/tasks/cfe_result_v42v5.rake
+++ b/lib/tasks/cfe_result_v42v5.rake
@@ -1,0 +1,15 @@
+namespace :cfe do
+  namespace :v5 do
+    desc "Convert all CFE::V4:Result records that are really V5 to CFE::V5::Result"
+    task convert: :environment do
+      results = CFE::V4::Result.where.not(result: nil)
+      results.each do |rec|
+        hash = JSON.parse(rec.result)
+        if hash["version"] == "5"
+          rec.type = "CFE::V5::Result"
+          rec.save!
+        end
+      end
+    end
+  end
+end

--- a/spec/cassettes/EmergencyLevelOfServiceController/GET_/providers/applications/_legal_aid_application_id/emergency_level_of_service/_proceeding_id/when_the_provider_is_authenticated/when_the_proceeding_has_more_than_one_possible_level_of_service/asks_the_user_to_select_a_level_of_service.yml
+++ b/spec/cassettes/EmergencyLevelOfServiceController/GET_/providers/applications/_legal_aid_application_id/emergency_level_of_service/_proceeding_id/when_the_provider_is_authenticated/when_the_proceeding_has_more_than_one_possible_level_of_service/asks_the_user_to_select_a_level_of_service.yml
@@ -1,0 +1,72 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/SE013
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Faraday v1.10.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 26 Sep 2022 10:57:02 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Vary:
+      - Accept, Origin
+      Etag:
+      - W/"fe69693a4b975af261ae9d9aeaa36bd4"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 5a9d822b2f6bc0b8d7767a608639af6c
+      X-Runtime:
+      - '0.066030'
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '{"success":true,"ccms_code":"SE013","meaning":"Child arrangements order
+        (contact)","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","name":"child_arrangements_order_contact","description":"to
+        be represented on an application for a child arrangements order-who the child(ren)
+        spend time with.","full_s8_only":false,"ccms_category_law":"Family","ccms_matter":"Children
+        - section 8","cost_limitations":{"substantive":{"start_date":"1970-01-01","value":"25000.0"},"delegated_functions":{"start_date":"2021-09-13","value":"2250.0"}},"default_scope_limitations":{"substantive":{"code":"FM059","meaning":"FHH
+        Children","description":"Limited to Family Help (Higher) and to all steps
+        necessary to negotiate and conclude a settlement. To include the issue of
+        proceedings and representation in those proceedings save in relation to or
+        at a contested final hearing."},"delegated_functions":{"code":"CV117","meaning":"Interim
+        order inc. return date","description":"Limited to all steps necessary to apply
+        for an interim order; where application is made without notice to include
+        representation on the return date."}},"service_levels":[{"level":1,"name":"Family
+        Help (Higher)","stage":1,"proceeding_default":true},{"level":3,"name":"Full
+        Representation","stage":8,"proceeding_default":false}]}'
+  recorded_at: Mon, 26 Sep 2022 10:57:02 GMT
+recorded_with: VCR 6.1.0

--- a/spec/cassettes/Proceedings_EmergencyLevelOfServiceForm/_save/when_the_user_doesn_t_answer_the_question/generates_the_expected_error_message.yml
+++ b/spec/cassettes/Proceedings_EmergencyLevelOfServiceForm/_save/when_the_user_doesn_t_answer_the_question/generates_the_expected_error_message.yml
@@ -1,0 +1,60 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/SE014
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Faraday v1.10.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 26 Sep 2022 10:46:56 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Vary:
+      - Accept, Origin
+      Etag:
+      - W/"0628cdb3a0d7f056459a0eb5a468514c"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 30dcbe531557cf8278eb8ecef05c28fe
+      X-Runtime:
+      - '0.076077'
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJzdWNjZXNzIjp0cnVlLCJjY21zX2NvZGUiOiJTRTAxNCIsIm1lYW5pbmciOiJDaGlsZCBhcnJhbmdlbWVudHMgb3JkZXIgKHJlc2lkZW5jZSkiLCJjY21zX2NhdGVnb3J5X2xhd19jb2RlIjoiTUFUIiwiY2Ntc19tYXR0ZXJfY29kZSI6IktTRUM4IiwibmFtZSI6ImNoaWxkX2FycmFuZ2VtZW50c19vcmRlcl9yZXNpZGVuY2UiLCJkZXNjcmlwdGlvbiI6InRvIGJlIHJlcHJlc2VudGVkIG9uIGFuIGFwcGxpY2F0aW9uIGZvciBhIGNoaWxkIGFycmFuZ2VtZW50cyBvcmRlciDigJN3aGVyZSB0aGUgY2hpbGQocmVuKSB3aWxsIGxpdmUiLCJmdWxsX3M4X29ubHkiOmZhbHNlLCJjY21zX2NhdGVnb3J5X2xhdyI6IkZhbWlseSIsImNjbXNfbWF0dGVyIjoiQ2hpbGRyZW4gLSBzZWN0aW9uIDgiLCJjb3N0X2xpbWl0YXRpb25zIjp7InN1YnN0YW50aXZlIjp7InN0YXJ0X2RhdGUiOiIxOTcwLTAxLTAxIiwidmFsdWUiOiIyNTAwMC4wIn0sImRlbGVnYXRlZF9mdW5jdGlvbnMiOnsic3RhcnRfZGF0ZSI6IjIwMjEtMDktMTMiLCJ2YWx1ZSI6IjIyNTAuMCJ9fSwiZGVmYXVsdF9zY29wZV9saW1pdGF0aW9ucyI6eyJzdWJzdGFudGl2ZSI6eyJjb2RlIjoiRk0wNTkiLCJtZWFuaW5nIjoiRkhIIENoaWxkcmVuIiwiZGVzY3JpcHRpb24iOiJMaW1pdGVkIHRvIEZhbWlseSBIZWxwIChIaWdoZXIpIGFuZCB0byBhbGwgc3RlcHMgbmVjZXNzYXJ5IHRvIG5lZ290aWF0ZSBhbmQgY29uY2x1ZGUgYSBzZXR0bGVtZW50LiBUbyBpbmNsdWRlIHRoZSBpc3N1ZSBvZiBwcm9jZWVkaW5ncyBhbmQgcmVwcmVzZW50YXRpb24gaW4gdGhvc2UgcHJvY2VlZGluZ3Mgc2F2ZSBpbiByZWxhdGlvbiB0byBvciBhdCBhIGNvbnRlc3RlZCBmaW5hbCBoZWFyaW5nLiJ9LCJkZWxlZ2F0ZWRfZnVuY3Rpb25zIjp7ImNvZGUiOiJDVjExNyIsIm1lYW5pbmciOiJJbnRlcmltIG9yZGVyIGluYy4gcmV0dXJuIGRhdGUiLCJkZXNjcmlwdGlvbiI6IkxpbWl0ZWQgdG8gYWxsIHN0ZXBzIG5lY2Vzc2FyeSB0byBhcHBseSBmb3IgYW4gaW50ZXJpbSBvcmRlcjsgd2hlcmUgYXBwbGljYXRpb24gaXMgbWFkZSB3aXRob3V0IG5vdGljZSB0byBpbmNsdWRlIHJlcHJlc2VudGF0aW9uIG9uIHRoZSByZXR1cm4gZGF0ZS4ifX0sInNlcnZpY2VfbGV2ZWxzIjpbeyJsZXZlbCI6MSwibmFtZSI6IkZhbWlseSBIZWxwIChIaWdoZXIpIiwic3RhZ2UiOjEsInByb2NlZWRpbmdfZGVmYXVsdCI6dHJ1ZX0seyJsZXZlbCI6MywibmFtZSI6IkZ1bGwgUmVwcmVzZW50YXRpb24iLCJzdGFnZSI6OCwicHJvY2VlZGluZ19kZWZhdWx0IjpmYWxzZX1dfQ==
+  recorded_at: Mon, 26 Sep 2022 10:46:56 GMT
+recorded_with: VCR 6.1.0

--- a/spec/cassettes/SubstantiveLevelOfServiceController/GET_/providers/applications/_legal_aid_application_id/substantive_level_of_service/_proceeding_id/when_the_provider_is_authenticated/when_the_proceeding_has_more_than_one_possible_level_of_service/asks_the_user_to_select_a_level_of_service.yml
+++ b/spec/cassettes/SubstantiveLevelOfServiceController/GET_/providers/applications/_legal_aid_application_id/substantive_level_of_service/_proceeding_id/when_the_provider_is_authenticated/when_the_proceeding_has_more_than_one_possible_level_of_service/asks_the_user_to_select_a_level_of_service.yml
@@ -1,0 +1,72 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/SE013
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Faraday v1.10.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 26 Sep 2022 10:56:57 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Vary:
+      - Accept, Origin
+      Etag:
+      - W/"fe69693a4b975af261ae9d9aeaa36bd4"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - ef9e4489d04f0f6cf7bfe8eb55a37757
+      X-Runtime:
+      - '0.064076'
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '{"success":true,"ccms_code":"SE013","meaning":"Child arrangements order
+        (contact)","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","name":"child_arrangements_order_contact","description":"to
+        be represented on an application for a child arrangements order-who the child(ren)
+        spend time with.","full_s8_only":false,"ccms_category_law":"Family","ccms_matter":"Children
+        - section 8","cost_limitations":{"substantive":{"start_date":"1970-01-01","value":"25000.0"},"delegated_functions":{"start_date":"2021-09-13","value":"2250.0"}},"default_scope_limitations":{"substantive":{"code":"FM059","meaning":"FHH
+        Children","description":"Limited to Family Help (Higher) and to all steps
+        necessary to negotiate and conclude a settlement. To include the issue of
+        proceedings and representation in those proceedings save in relation to or
+        at a contested final hearing."},"delegated_functions":{"code":"CV117","meaning":"Interim
+        order inc. return date","description":"Limited to all steps necessary to apply
+        for an interim order; where application is made without notice to include
+        representation on the return date."}},"service_levels":[{"level":1,"name":"Family
+        Help (Higher)","stage":1,"proceeding_default":true},{"level":3,"name":"Full
+        Representation","stage":8,"proceeding_default":false}]}'
+  recorded_at: Mon, 26 Sep 2022 10:56:57 GMT
+recorded_with: VCR 6.1.0


### PR DESCRIPTION
## Convert v5 CFE response to V5 models

Existing V5 responses were being stored in the database as CFE::V4::Result (there being no difference in the result layout between v4 and v5).

This PR creates a CFE::V5::Result class, identical to CFE::V4::result, and ensures exising CFE responses are written as the new class.

A rake task  `cfe:v5:convert` has been provided to convert existing v5 results to the new model.


[Link to story](https://dsdmoj.atlassian.net/browse/AP-3506)

Describe what you did and why.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
