### PR TITLE
Fix more flaky document upload tests

### DIFF
--- a/features/providers/bank_statement_upload.feature
+++ b/features/providers/bank_statement_upload.feature
@@ -28,9 +28,7 @@ Feature: Bank statement upload
     And I should see govuk error summary "Upload your client's bank statements"
 
     When I upload the fixture file named 'acceptable.pdf'
-    Then I should see 'acceptable.pdf UPLOADED'
-
-    When I click 'Save and continue'
+    And I click 'Save and continue'
     Then I should be on a page with title matching "Review .*'s employment income"
 
     When I click link "Back"
@@ -55,9 +53,6 @@ Feature: Bank statement upload
     Given I upload the fixture file named 'acceptable.pdf'
     And I upload an evidence file named 'hello_world.pdf'
     And I upload an evidence file named 'hello_world.docx'
-    Then I should see 'acceptable.pdf UPLOADED'
-    And I should see 'hello_world.pdf UPLOADED'
-    And I should see 'hello_world.docx UPLOADED'
 
     When I click delete for the file 'hello_world.pdf'
     Then I should see 'hello_world.pdf has been successfully deleted'

--- a/features/providers/check_multiple_employment.feature
+++ b/features/providers/check_multiple_employment.feature
@@ -131,7 +131,6 @@ Feature: Check multiple employment
     Then I should be on a page showing "Upload supporting evidence"
 
     When I upload an evidence file named 'hello_world.pdf'
-    And I sleep for 2 seconds
     Then I should be able to categorise 'hello_world.pdf' as 'Employment evidence'
 
     When I click 'Save and continue'
@@ -163,4 +162,3 @@ Feature: Check multiple employment
 
     When I click 'Continue'
     Then I should be on a page showing "HMRC found a record of your client's employment"
-

--- a/features/providers/check_pending_employment.feature
+++ b/features/providers/check_pending_employment.feature
@@ -123,7 +123,6 @@ Feature: Check pending employment
     Then I should be on a page showing "Upload supporting evidence"
 
     When I upload an evidence file named 'hello_world.pdf'
-    And I sleep for 2 seconds
     Then I should be able to categorise 'hello_world.pdf' as 'Employment evidence'
 
     And I click 'Save and continue'

--- a/features/providers/check_single_employment.feature
+++ b/features/providers/check_single_employment.feature
@@ -130,7 +130,6 @@ Feature: Check single employment
     Then I should be on a page showing "Upload supporting evidence"
 
     When I upload an evidence file named 'hello_world.pdf'
-    And I sleep for 2 seconds
     And I should be able to categorise 'hello_world.pdf' as 'Employment evidence'
     And I click 'Save and continue'
     Then I should be on a page showing "Check your answers"
@@ -147,7 +146,3 @@ Feature: Check single employment
 
     When I click 'View completed application'
     Then I should be on a page showing "Application for civil legal aid certificate"
-
-
-
-

--- a/features/providers/civil_application_journey.feature
+++ b/features/providers/civil_application_journey.feature
@@ -703,8 +703,6 @@ Feature: Civil application journeys
     Then I fill "Application merits task statement of case statement field" with "Statement of case"
     When I upload an evidence file named 'hello_world.pdf'
     Then I should not see "There was a problem uploading your file"
-    Then I should be on a page showing "hello_world.pdf"
-    Then I should be on a page showing "UPLOADED"
     Then I click 'Save and continue'
     Then I should be on the 'merits_task_list' page showing 'Chances of success\nNOT STARTED'
     When I click link 'Chances of success'

--- a/features/providers/enhanced_bank_upload/check_your_answers.feature
+++ b/features/providers/enhanced_bank_upload/check_your_answers.feature
@@ -11,9 +11,7 @@ Feature: Enhanced bank upload check your answers
 
     When I click Check Your Answers Change link for "bank statements"
     And I upload an evidence file named "hello_world.pdf"
-    Then I should see "hello_world.pdf UPLOADED"
-
-    When I click "Save and continue"
+    And I click "Save and continue"
     Then I should be on the "means_summary" page showing "Check your answers"
     And I should see "hello_world.pdf"
 

--- a/features/providers/enhanced_bank_upload/enhanced_bank_upload_flow.feature
+++ b/features/providers/enhanced_bank_upload/enhanced_bank_upload_flow.feature
@@ -13,10 +13,7 @@ Feature: Enhanced bank upload flow
 
     Given I upload the fixture file named "acceptable.pdf"
     And I upload an evidence file named "hello_world.pdf"
-    Then I should see "acceptable.pdf UPLOADED"
-    And I should see "hello_world.pdf UPLOADED"
-
-    When I click "Save and continue"
+    And I click "Save and continue"
     Then I should be on a page with title matching "Review .*'s employment income"
     And I should be on a page showing "Do you need to tell us anything else about your client's employment?"
     And the page is accessible

--- a/features/providers/merits_task_list.feature
+++ b/features/providers/merits_task_list.feature
@@ -121,12 +121,9 @@ Feature: Merits task list
     When I click 'Save and continue'
     Then I should be on a page showing "Provide a statement of case"
     When I upload an evidence file named 'hello_world.pdf'
-    Then I should see 'hello_world.pdf'
-    And I should see 'UPLOADED'
-    When I click 'Delete'
+    Then I click 'Delete'
     Then I should see 'hello_world.pdf has been successfully deleted'
     And I should not see 'UPLOADED'
     Then I upload an evidence file named 'hello_world.pdf'
-    And I should see 'UPLOADED'
     When I click 'Save and continue'
     Then I should be on the 'involved_children/new' page showing 'Enter details of the children involved in this application'

--- a/features/step_definitions/evidence_upload_steps.rb
+++ b/features/step_definitions/evidence_upload_steps.rb
@@ -30,10 +30,12 @@ end
 
 Then(/^I upload an evidence file named ['|"](.*?)['|"]/) do |filename|
   attach_file(Rails.root.join("spec/fixtures/files/documents/#{filename}"), class: "dz-hidden-input", make_visible: true, wait: 30)
+  expect(page).to have_content("#{filename} UPLOADED")
 end
 
 Then(/^I upload the fixture file named ['|"](.*?)['|"]/) do |filename|
   attach_file(Rails.root.join("spec/fixtures/files/#{filename}"), class: "dz-hidden-input", make_visible: true, wait: 30)
+  expect(page).to have_content("#{filename} UPLOADED")
 end
 
 Then(/^I should be able to categorise ['|"](.*?)['|"] as ['|"](.*?)['|"]$/) do |filename, category|


### PR DESCRIPTION
In #4338, some flaky tests were fixed by asserting that the 
document had been uploaded, rather than immediately 
continuing to the next page.

This updates the document upload Cucumber steps to ensure 
the expectation is met every time a document is uploaded in 
Cucumber tests.