### PR TITLE
AP-3495: remove scope_limitation fields from Proceeding

### DIFF
--- a/db/migrate/20220915131126_remove_proceedings_scope_limitations.rb
+++ b/db/migrate/20220915131126_remove_proceedings_scope_limitations.rb
@@ -1,0 +1,34 @@
+class RemoveProceedingsScopeLimitations < ActiveRecord::Migration[7.0]
+  def up
+    raise StandardError, "Proceeding table has scope limitation data" if any_proceeding_data_present?
+
+    change_table :proceedings, bulk: true do |t|
+      t.remove :substantive_scope_limitation_code
+      t.remove :substantive_scope_limitation_meaning
+      t.remove :substantive_scope_limitation_description
+      t.remove :delegated_functions_scope_limitation_code
+      t.remove :delegated_functions_scope_limitation_meaning
+      t.remove :delegated_functions_scope_limitation_description
+    end
+  end
+
+  def down
+    change_table :proceedings, bulk: true do |t|
+      t.string :substantive_scope_limitation_code
+      t.string :substantive_scope_limitation_meaning
+      t.string :substantive_scope_limitation_description
+      t.string :delegated_functions_scope_limitation_code
+      t.string :delegated_functions_scope_limitation_meaning
+      t.string :delegated_functions_scope_limitation_description
+    end
+  end
+
+  def any_proceeding_data_present?
+    Proceeding.where.not(substantive_scope_limitation_code: nil,
+                         substantive_scope_limitation_meaning: nil,
+                         substantive_scope_limitation_description: nil,
+                         delegated_functions_scope_limitation_code: nil,
+                         delegated_functions_scope_limitation_meaning: nil,
+                         delegated_functions_scope_limitation_description: nil).count.positive?
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_09_15_124637) do
+ActiveRecord::Schema[7.0].define(version: 2022_09_15_131126) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -674,12 +674,6 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_15_124637) do
     t.string "description", null: false
     t.decimal "substantive_cost_limitation", null: false
     t.decimal "delegated_functions_cost_limitation", null: false
-    t.string "substantive_scope_limitation_code"
-    t.string "substantive_scope_limitation_meaning"
-    t.string "substantive_scope_limitation_description"
-    t.string "delegated_functions_scope_limitation_code"
-    t.string "delegated_functions_scope_limitation_meaning"
-    t.string "delegated_functions_scope_limitation_description"
     t.date "used_delegated_functions_on"
     t.date "used_delegated_functions_reported_on"
     t.datetime "created_at", null: false
@@ -913,6 +907,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_15_124637) do
   add_foreign_key "regular_transactions", "transaction_types"
   add_foreign_key "savings_amounts", "legal_aid_applications"
   add_foreign_key "scheduled_mailings", "legal_aid_applications", on_delete: :cascade
+  add_foreign_key "scope_limitations", "proceedings"
   add_foreign_key "statement_of_cases", "legal_aid_applications", on_delete: :cascade
   add_foreign_key "statement_of_cases", "providers", column: "provider_uploader_id"
   add_foreign_key "uploaded_evidence_collections", "legal_aid_applications"


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3495)

After the previous migration has been executed and the rake task, that moves data from the proceedings table to the new ScopeLimitation table, has been run - this can be merged to remove the original columns

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
