### PR TITLE
Providers can submit housing benefit data

### DIFF
--- a/app/controllers/providers/means/housing_benefits_controller.rb
+++ b/app/controllers/providers/means/housing_benefits_controller.rb
@@ -1,0 +1,36 @@
+module Providers
+  module Means
+    class HousingBenefitsController < ProviderBaseController
+      before_action :redirect_unless_enhanced_bank_upload_enabled
+
+      def show
+        @form = HousingBenefitForm.new(legal_aid_application:)
+      end
+
+      def update
+        @form = HousingBenefitForm.new(housing_benefit_params)
+
+        if @form.save
+          go_forward
+        else
+          render :show, status: :unprocessable_entity
+        end
+      end
+
+    private
+
+      def housing_benefit_params
+        params
+          .require(:providers_means_housing_benefit_form)
+          .permit(:housing_benefit, :housing_benefit_amount, :housing_benefit_frequency)
+          .merge(legal_aid_application:)
+      end
+
+      def redirect_unless_enhanced_bank_upload_enabled
+        unless Setting.enhanced_bank_upload?
+          go_forward
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/providers/means/identify_types_of_incomes_controller.rb
+++ b/app/controllers/providers/means/identify_types_of_incomes_controller.rb
@@ -31,7 +31,7 @@ module Providers
       end
 
       def transaction_types
-        @transaction_types ||= TransactionType.credits.find_with_children(legal_aid_application_params[:transaction_type_ids])
+        @transaction_types ||= TransactionType.credits.where(id: legal_aid_application_params[:transaction_type_ids])
       end
 
       def transaction_types_selected?
@@ -43,10 +43,10 @@ module Providers
       end
 
       def synchronize_credit_transaction_types
-        existing_credit_tt_ids = legal_aid_application.legal_aid_application_transaction_types.credits.map(&:transaction_type_id)
+        existing_credit_transaction_type_ids = legal_aid_application.transaction_types.credits.not_children.pluck(:id)
 
         keep = transaction_types.each_with_object([]) do |form_tt, arr|
-          add_transaction_type(form_tt) if existing_credit_tt_ids.exclude?(form_tt.id)
+          add_transaction_type(form_tt) if existing_credit_transaction_type_ids.exclude?(form_tt.id)
           arr.append(form_tt.id)
         end
 

--- a/app/controllers/providers/means_summaries_controller.rb
+++ b/app/controllers/providers/means_summaries_controller.rb
@@ -1,5 +1,7 @@
 module Providers
   class MeansSummariesController < ProviderBaseController
+    before_action :set_transaction_types, only: :show
+
     def show
       legal_aid_application.set_transaction_period
       legal_aid_application.check_non_passported_means! unless legal_aid_application.checking_non_passported_means?
@@ -29,6 +31,16 @@ module Providers
 
     def check_financial_eligibility
       CFE::SubmissionManager.call(legal_aid_application.id)
+    end
+
+    def set_transaction_types
+      @credit_transaction_types = if legal_aid_application.uploading_bank_statements?
+                                    TransactionType.credits.without_disregarded_benefits
+                                  else
+                                    TransactionType.credits.without_housing_benefits
+                                  end
+
+      @debit_transaction_types = TransactionType.debits
     end
   end
 end

--- a/app/controllers/providers/transactions_controller.rb
+++ b/app/controllers/providers/transactions_controller.rb
@@ -1,7 +1,7 @@
 module Providers
   class TransactionsController < ProviderBaseController
     def show
-      if transaction_type.name == "excluded_benefits" && !disregarded_state_benefits_list
+      if transaction_type.disregarded_benefit? && !disregarded_state_benefits_list
         redirect_to(problem_index_path) && return
       end
 

--- a/app/forms/providers/means/housing_benefit_form.rb
+++ b/app/forms/providers/means/housing_benefit_form.rb
@@ -1,0 +1,117 @@
+module Providers
+  module Means
+    class HousingBenefitForm
+      include ActiveModel::Model
+
+      attr_accessor :housing_benefit,
+                    :housing_benefit_amount,
+                    :housing_benefit_frequency
+
+      attr_reader :legal_aid_application
+
+      validates :housing_benefit, inclusion: { in: %w[true false] }
+
+      validates :housing_benefit_amount,
+                currency: { greater_than: 0 },
+                if: :applicant_in_receipt_of_housing_benefit?
+
+      validates :housing_benefit_frequency,
+                inclusion: { in: ->(form) { form.frequency_options } },
+                if: :applicant_in_receipt_of_housing_benefit?
+
+      def initialize(params = {})
+        @legal_aid_application = params.delete(:legal_aid_application)
+
+        if params[:housing_benefit].nil?
+          assign_housing_benefit_attributes
+        end
+
+        super
+      end
+
+      def save
+        return false unless valid?
+
+        ApplicationRecord.transaction do
+          legal_aid_application.applicant_in_receipt_of_housing_benefit = housing_benefit
+
+          if applicant_in_receipt_of_housing_benefit?
+            build_housing_benefit_transaction_type
+            build_housing_benefit_regular_transaction
+          else
+            destroy_housing_benefit_transaction_type!
+            destroy_housing_benefit_regular_transaction!
+          end
+
+          legal_aid_application.save!
+        end
+
+        true
+      end
+
+      def frequency_options
+        RegularTransaction.frequencies_for(housing_benefit_transaction_type)
+      end
+
+    private
+
+      def applicant_in_receipt_of_housing_benefit?
+        housing_benefit == "true"
+      end
+
+      def assign_housing_benefit_attributes
+        @housing_benefit = @legal_aid_application.applicant_in_receipt_of_housing_benefit
+        @housing_benefit_amount = housing_benefit_regular_transaction&.amount
+        @housing_benefit_frequency = housing_benefit_regular_transaction&.frequency
+      end
+
+      def build_housing_benefit_transaction_type
+        legal_aid_application
+          .legal_aid_application_transaction_types
+          .find_or_initialize_by(
+            transaction_type: housing_benefit_transaction_type,
+          )
+      end
+
+      def build_housing_benefit_regular_transaction
+        housing_benefit_transaction = legal_aid_application
+          .regular_transactions
+          .find_or_initialize_by(
+            transaction_type: housing_benefit_transaction_type,
+          )
+        housing_benefit_transaction.assign_attributes(
+          amount: housing_benefit_amount,
+          frequency: housing_benefit_frequency,
+        )
+        housing_benefit_transaction.save!
+      end
+
+      def destroy_housing_benefit_transaction_type!
+        legal_aid_application
+          .legal_aid_application_transaction_types
+          .includes(:transaction_type)
+          .where(transaction_type: { name: "housing_benefit" })
+          .destroy_all
+      end
+
+      def destroy_housing_benefit_regular_transaction!
+        legal_aid_application
+          .regular_transactions
+          .includes(:transaction_type)
+          .where(transaction_type: { name: "housing_benefit" })
+          .destroy_all
+      end
+
+      def housing_benefit_regular_transaction
+        @legal_aid_application
+          .regular_transactions
+          .includes(:transaction_type)
+          .find_by(transaction_type: { name: "housing_benefit" })
+      end
+
+      def housing_benefit_transaction_type
+        TransactionType.find_by!(name: "housing_benefit")
+      end
+    end
+  end
+end

--- a/app/forms/providers/means/regular_income_form.rb
+++ b/app/forms/providers/means/regular_income_form.rb
@@ -31,7 +31,8 @@ module Providers
       def initialize(params = {})
         @none_selected = none_selected.in?(params["transaction_type_ids"] || [])
         @legal_aid_application = params.delete(:legal_aid_application)
-        @transaction_type_ids = params["transaction_type_ids"] || @legal_aid_application.transaction_type_ids
+        @transaction_type_ids = params["transaction_type_ids"] ||
+          @legal_aid_application.transaction_types.credits.not_children.pluck(:id)
 
         assign_regular_transaction_attributes
 

--- a/app/forms/providers/means/regular_outgoings_form.rb
+++ b/app/forms/providers/means/regular_outgoings_form.rb
@@ -3,12 +3,18 @@ module Providers
     class RegularOutgoingsForm
       include ActiveModel::Model
 
-      OUTGOING_TYPES = %w[rent_or_mortgage child_care maintenance_out legal_aid].freeze
+      OUTGOING_TYPES = %w[
+        rent_or_mortgage
+        child_care
+        maintenance_out
+        legal_aid
+      ].freeze
 
       attr_reader :transaction_type_ids, :legal_aid_application
 
       OUTGOING_TYPES.each do |outgoing_type|
-        attr_accessor "#{outgoing_type}_amount".to_sym, "#{outgoing_type}_frequency".to_sym
+        attr_accessor "#{outgoing_type}_amount".to_sym,
+                      "#{outgoing_type}_frequency".to_sym
       end
 
       validates :transaction_type_ids, presence: true, unless: :none_selected?
@@ -17,7 +23,8 @@ module Providers
       def initialize(params = {})
         @none_selected = none_selected.in?(params["transaction_type_ids"] || [])
         @legal_aid_application = params.delete(:legal_aid_application)
-        @transaction_type_ids = params["transaction_type_ids"] || @legal_aid_application.transaction_type_ids
+        @transaction_type_ids = params["transaction_type_ids"] ||
+          @legal_aid_application.transaction_types.debits.not_children.pluck(:id)
 
         assign_regular_transaction_attributes
 

--- a/app/helpers/user_transactions_helper.rb
+++ b/app/helpers/user_transactions_helper.rb
@@ -3,7 +3,7 @@ module UserTransactionsHelper
 
   def incomings_list(incomings, locale_namespace:)
     items = TransactionType.credits&.map do |income_type|
-      next if income_type.excluded_benefit?
+      next if income_type.disregarded_benefit?
 
       TransactionItemStruct.new(t("#{locale_namespace}.#{income_type.name}"),
                                 income_type.name,

--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -522,6 +522,10 @@ class LegalAidApplication < ApplicationRecord
     Setting.enhanced_bank_upload? && uploading_bank_statements?
   end
 
+  def housing_payments?
+    transaction_types.for_outgoing_type?(:rent_or_mortgage)
+  end
+
 private
 
   def client_open_banking_consent?
@@ -552,7 +556,7 @@ private
   end
 
   def add_uncategorised_transaction_error(transaction_type)
-    return if transaction_type.name == "excluded_benefits"
+    return if transaction_type.disregarded_benefit?
 
     errors.add(transaction_type.name, I18n.t("activemodel.errors.models.legal_aid_application.attributes.uncategorised_bank_transactions.message"))
   end

--- a/app/models/regular_transaction.rb
+++ b/app/models/regular_transaction.rb
@@ -5,7 +5,7 @@ class RegularTransaction < ApplicationRecord
   belongs_to :transaction_type
 
   validates :amount, currency: { greater_than: 0 }
-  validates :frequency, inclusion: { in: FREQUENCIES }
+  validates :frequency, inclusion: { in: ->(transaction) { frequencies_for(transaction.transaction_type) } }
 
   def self.credits
     includes(:transaction_type).where(transaction_types: { operation: :credit })

--- a/app/models/transaction_type.rb
+++ b/app/models/transaction_type.rb
@@ -45,6 +45,8 @@ class TransactionType < ApplicationRecord
   scope :income_for, ->(transaction_type_name) { active.where(operation: :credit, name: transaction_type_name) }
   scope :outgoing_for, ->(transaction_type_name) { active.where(operation: :debit, name: transaction_type_name) }
   scope :not_children, -> { where(parent_id: nil) }
+  scope :without_disregarded_benefits, -> { not_children }
+  scope :without_housing_benefits, -> { where.not(name: "housing_benefit") }
 
   def self.for_income_type?(transaction_type_name)
     income_for(transaction_type_name).any?

--- a/app/models/transaction_type.rb
+++ b/app/models/transaction_type.rb
@@ -6,6 +6,7 @@ class TransactionType < ApplicationRecord
     credit: %i[
       benefits
       excluded_benefits
+      housing_benefit
       friends_or_family
       maintenance_in
       property_or_lodger
@@ -20,7 +21,10 @@ class TransactionType < ApplicationRecord
     ],
   }.freeze
 
-  EXCLUDED_BENEFITS = "excluded_benefits".freeze
+  DISREGARDED_BENEFITS = %w[
+    excluded_benefits
+    housing_benefit
+  ].freeze
 
   OTHER_INCOME_TYPES = %w[
     friends_or_family
@@ -32,6 +36,7 @@ class TransactionType < ApplicationRecord
 
   HIERARCHIES = {
     excluded_benefits: :benefits,
+    housing_benefit: :benefits,
   }.freeze
 
   scope :active, -> { where(archived_at: nil) }
@@ -45,55 +50,39 @@ class TransactionType < ApplicationRecord
     income_for(transaction_type_name).any?
   end
 
+  def self.for_outgoing_type?(transaction_type_name)
+    outgoing_for(transaction_type_name).any?
+  end
+
   def self.other_income
-    TransactionType.where(other_income: true)
+    where(other_income: true)
   end
 
   def label_name(journey: :citizens)
     I18n.t("transaction_types.names.#{journey}.#{name}")
   end
 
-  def self.for_outgoing_type?(transaction_type_name)
-    outgoing_for(transaction_type_name).any?
-  end
-
-  def self.find_with_children(*ids)
-    all_ids = (ids + TransactionType.where(parent_id: ids.compact).pluck(:id)).flatten
-    where(id: all_ids)
-  end
-
-  def self.any_type_of(name)
-    top_level_id = TransactionType.find_by(name:)&.id
-    return [] if top_level_id.nil?
-
-    find_with_children(top_level_id)
-  end
-
   def providers_label_name
     label_name(journey: :providers)
   end
 
-  def excluded_benefit?
-    name == EXCLUDED_BENEFITS
+  def disregarded_benefit?
+    name.in?(DISREGARDED_BENEFITS)
   end
 
   def child?
     parent_id.present?
   end
 
-  def parent?
-    TransactionType.where(parent_id: id).any?
-  end
-
-  def parent
-    TransactionType.find_by(id: parent_id)
-  end
-
   def children
-    TransactionType.where(parent_id: id)
+    self.class.where(parent_id: id)
   end
 
   def parent_or_self
-    parent_id.present? ? parent : self
+    if parent_id.present?
+      self.class.find(parent_id)
+    else
+      self
+    end
   end
 end

--- a/app/services/flow/flows/provider_capital.rb
+++ b/app/services/flow/flows/provider_capital.rb
@@ -76,13 +76,28 @@ module Flow
         regular_outgoings: {
           path: ->(application) { urls.providers_legal_aid_application_means_regular_outgoings_path(application) },
           forward: lambda do |application|
-            if application.outgoing_types?
+            if application.housing_payments?
+              :housing_benefits
+            elsif application.outgoing_types?
               :cash_outgoings
             else
               :has_dependants
             end
           end,
-          check_answers: ->(application) { application.outgoing_types? ? :cash_outgoings : :means_summaries },
+          check_answers: lambda do |application|
+            if application.housing_payments?
+              :housing_benefits
+            elsif application.outgoing_types?
+              :cash_outgoings
+            else
+              :means_summaries
+            end
+          end,
+        },
+        housing_benefits: {
+          path: ->(application) { urls.providers_legal_aid_application_means_housing_benefits_path(application) },
+          forward: :cash_outgoings,
+          check_answers: :cash_outgoings,
         },
         cash_outgoings: {
           path: ->(application) { urls.providers_legal_aid_application_means_cash_outgoing_path(application) },

--- a/app/views/providers/means/housing_benefits/show.html.erb
+++ b/app/views/providers/means/housing_benefits/show.html.erb
@@ -1,0 +1,20 @@
+<%= form_with model: @form,
+              url: providers_legal_aid_application_means_housing_benefits_path(@legal_aid_application),
+              method: :patch do |f| %>
+  <%= page_template page_title: page_title, template: :basic, form: f do %>
+    <%= f.govuk_radio_buttons_fieldset :housing_benefit, legend: {tag: "h1", size: "xl"} do %>
+      <%= f.govuk_radio_button :housing_benefit, "true", link_errors: true do %>
+        <%= f.govuk_text_field :housing_benefit_amount, width: "one-quarter", prefix_text: "£" %>
+        <%= f.govuk_collection_radio_buttons :housing_benefit_frequency,
+                                             @form.frequency_options,
+                                             :itself,
+                                             ->(option) { t("transaction_types.frequencies.#{option}") },
+                                             legend: {tag: "p", size: "s"} %>
+      <% end %>
+
+      <%= f.govuk_radio_button :housing_benefit, "false" %>
+    <% end %>
+
+    <%= f.govuk_submit t("generic.save_and_continue") %>
+  <% end %>
+<% end %>

--- a/app/views/providers/means_summaries/_income_assessment.html.erb
+++ b/app/views/providers/means_summaries/_income_assessment.html.erb
@@ -22,7 +22,7 @@
       'shared/check_answers/income_summary',
       income_type: t('.credits-section-heading'),
       url: @legal_aid_application.using_enhanced_bank_upload? ? :regular_incomes : :identify_types_of_incomes,
-      transaction_types: TransactionType.credits
+      transaction_types: @credit_transaction_types
     ) %>
 
 <%= render('income_cash_payments', read_only: false) if @legal_aid_application.uploading_bank_statements? %>
@@ -34,8 +34,8 @@
 <%= render(
       'shared/check_answers/income_summary',
       income_type: t('.debits-section-heading'),
-      url:  @legal_aid_application.using_enhanced_bank_upload? ? :regular_outgoings : :identify_types_of_outgoings,
-      transaction_types: TransactionType.debits
+      url: @legal_aid_application.using_enhanced_bank_upload? ? :regular_outgoings : :identify_types_of_outgoings,
+      transaction_types: @debit_transaction_types
     ) %>
 
 <%= render('outgoings_cash_payments', read_only: false) if @legal_aid_application.uploading_bank_statements? %>

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -497,6 +497,16 @@ en:
               file_virus: "%{file_name} contains a virus"
               no_file_chosen: Upload your client's bank statements
               system_down: There was a problem uploading your file - try again
+        providers/means/housing_benefit_form:
+          attributes:
+            housing_benefit:
+              inclusion: Select one of the options
+            housing_benefit_amount:
+              greater_than: Enter a number greater than 0
+              not_a_number: Enter the amount of housing benefit received
+              too_many_decimals: Enter a number with no more than 2 decimal places
+            housing_benefit_frequency:
+              inclusion: Select how often your client receives housing benefit
         providers/means/regular_income_form:
           attributes:
             benefits_amount:

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -32,6 +32,11 @@ en:
       legal_aid_application:
         own_vehicle:
           <<: *true_false
+      providers_means_housing_benefit_form:
+        housing_benefit_amount: Enter amount
+        housing_benefit_options:
+          "true": "Yes"
+          "false": "No"
       providers_means_regular_income_form:
         benefits_amount: Enter amount
         friends_or_family_amount: Enter amount
@@ -74,6 +79,9 @@ en:
         enhanced_bank_upload:
           <<: *true_false
     legend:
+      providers_means_housing_benefit_form:
+        housing_benefit: Does your client receive housing benefits?
+        housing_benefit_frequency: Select frequency
       providers_means_regular_income_form:
         benefits_frequency: Select frequency
         friends_or_family_frequency: Select frequency

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -126,6 +126,7 @@ Rails.application.routes.draw do
         resource :cash_income, only: %i[show update]
         resource :regular_incomes, only: %i[show update]
         resource :regular_outgoings, only: %i[show update]
+        resource :housing_benefits, only: %i[show update]
         resource :identify_types_of_income, only: %i[show update]
         resource :identify_types_of_outgoing, only: %i[show update]
         resource :has_dependants, only: %i[show update]

--- a/db/migrate/20220928154516_add_applicant_in_receipt_of_housing_benefit_to_legal_aid_applications.rb
+++ b/db/migrate/20220928154516_add_applicant_in_receipt_of_housing_benefit_to_legal_aid_applications.rb
@@ -1,0 +1,5 @@
+class AddApplicantInReceiptOfHousingBenefitToLegalAidApplications < ActiveRecord::Migration[7.0]
+  def change
+    add_column :legal_aid_applications, :applicant_in_receipt_of_housing_benefit, :boolean, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -553,6 +553,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_13_114916) do
     t.boolean "substantive_cost_override"
     t.decimal "substantive_cost_requested"
     t.string "substantive_cost_reasons"
+    t.boolean "applicant_in_receipt_of_housing_benefit"
     t.index ["applicant_id"], name: "index_legal_aid_applications_on_applicant_id"
     t.index ["application_ref"], name: "index_legal_aid_applications_on_application_ref", unique: true
     t.index ["discarded_at"], name: "index_legal_aid_applications_on_discarded_at"

--- a/features/providers/check_your_answers.feature
+++ b/features/providers/check_your_answers.feature
@@ -378,7 +378,6 @@ Feature: Checking answers backwards and forwards
       | h2  | Your client's capital |
       | h3  | Property |
       | h3  | Vehicles |
-    # | h3  | Which bank accounts does your client have? |
       | h3  | Does your client have any savings accounts they cannot access online? |
       | h2  | Which savings or investments does your client have? |
       | h2  | Which assets does your client have? |
@@ -388,15 +387,16 @@ Feature: Checking answers backwards and forwards
     And I should not see "Payments your client receives in cash"
     And I should not see "Payments your client makes in cash"
 
-    And the "What payments does your client receive?" section's questions and answers should exist:
+    And the "What payments does your client receive?" section's questions and answers should match:
       | question | answer |
       | Benefits | £666.00 |
+      | Disregarded benefits | None |
       | Financial help from friends or family | None |
       | Maintenance payments from a former partner | Yes, but none specified |
       | Income from a property or lodger | None |
       | Pension | None |
 
-    And the "What payments does your client make?" section's questions and answers should exist:
+    And the "What payments does your client make?" section's questions and answers should match:
       | question | answer |
       | Housing payments | £999.00 |
       | Childcare payments | None |
@@ -433,7 +433,7 @@ Feature: Checking answers backwards and forwards
       | question |
       | Uploaded bank statements |
 
-    And the "What payments does your client receive?" section's questions and answers should exist:
+    And the "What payments does your client receive?" section's questions and answers should match:
       | question | answer |
       | Benefits | Yes |
       | Financial help from friends or family | None |
@@ -445,7 +445,7 @@ Feature: Checking answers backwards and forwards
       | question |
       | Benefits |
 
-    And the "What payments does your client make?" section's questions and answers should exist:
+    And the "What payments does your client make?" section's questions and answers should match:
       | question | answer |
       | Housing payments | Yes |
       | Childcare payments | None |

--- a/features/providers/enhanced_bank_upload/check_your_answers.feature
+++ b/features/providers/enhanced_bank_upload/check_your_answers.feature
@@ -86,6 +86,27 @@ Feature: Enhanced bank upload check your answers
     And I should see "Monthly"
 
     When I click Check Your Answers Change link for "What payments does your client make?"
+    Then I should be on the "regular_outgoings" page showing "Which of the following payments does your client make?"
+    And I check "Housing payments"
+    And I fill "Rent or mortgage amount" with "500"
+    And I choose "providers-means-regular-outgoings-form-rent-or-mortgage-frequency-monthly-field"
+
+    When I click "Save and continue"
+    Then I should be on the "housing_benefits" page showing "Does your client receive housing benefits?"
+
+    When I choose "Yes"
+    And I enter amount "100"
+    And I choose "Every week"
+
+    And I click "Save and continue"
+    Then I should be on a page with title "Select payments your client makes in cash"
+
+    When I check "None of the above"
+    And I click "Save and continue"
+    Then I should be on the "means_summary" page showing "Check your answers"
+
+    When I click Check Your Answers Change link for "What payments does your client make?"
+    Then I should be on the "regular_outgoings" page showing "Which of the following payments does your client make?"
     And I check "My client makes none of these payments"
     And I click "Save and continue"
     Then I should be on the "means_summary" page showing "Check your answers"

--- a/features/providers/enhanced_bank_upload/check_your_answers.feature
+++ b/features/providers/enhanced_bank_upload/check_your_answers.feature
@@ -16,6 +16,7 @@ Feature: Enhanced bank upload check your answers
       | h3  | Student finance |
       | h2  | Your client's outgoings |
       | h3  | What payments does your client make? |
+      # | h2  | Housing benefit | # TODO:
       | h2  | Your client's capital |
       | h3  | Property |
       | h3  | Vehicles |
@@ -28,6 +29,14 @@ Feature: Enhanced bank upload check your answers
     And I should see "Uploaded bank statements"
     And I should see 'Does your client receive student finance?'
     And I should not see 'Does your client have any savings accounts they cannot access online?'
+
+    And the "What payments does your client receive?" section's questions and answers should match:
+      | question | answer |
+      | Benefits | None |
+      | Financial help from friends or family | None |
+      | Maintenance payments from a former partner | None |
+      | Income from a property or lodger | None |
+      | Pension | None |
 
     When I click Check Your Answers Change link for "bank statements"
     And I upload an evidence file named "hello_world.pdf"

--- a/features/providers/enhanced_bank_upload/enhanced_bank_upload_flow.feature
+++ b/features/providers/enhanced_bank_upload/enhanced_bank_upload_flow.feature
@@ -23,7 +23,7 @@ Feature: Enhanced bank upload flow
 
     When I click "Save and continue"
     Then I should be on the "regular_incomes" page showing "Which of the following payments does your client receive?"
-    And I should see 'Disregarded benefits'
+    And I should see govuk-details 'Disregarded benefits'
     And the page is accessible
 
     When I open the section 'Disregarded benefits'

--- a/features/providers/enhanced_bank_upload/enhanced_bank_upload_flow.feature
+++ b/features/providers/enhanced_bank_upload/enhanced_bank_upload_flow.feature
@@ -60,7 +60,7 @@ Feature: Enhanced bank upload flow
     Then I should be on the "regular_outgoings" page showing "Which of the following payments does your client make?"
     And the page is accessible
 
-    When I select "Housing"
+    When I select "Housing payments"
     And I fill "Rent or mortgage amount" with "500"
     And I choose "providers-means-regular-outgoings-form-rent-or-mortgage-frequency-three-monthly-field"
 
@@ -69,6 +69,16 @@ Feature: Enhanced bank upload flow
     And I choose "providers-means-regular-outgoings-form-child-care-frequency-four-weekly-field"
 
     When I click "Save and continue"
+    Then I should be on the "housing_benefits" page showing "Does your client receive housing benefits?"
+    And the page is accessible
+
+    When I choose "Yes"
+    And I enter amount "100"
+    And I choose "Every week"
+    And I click "Save and continue"
+    Then I should be on a page with title "Select payments your client makes in cash"
+    And the page is accessible
+
     Then I should be on a page with title "Select payments your client makes in cash"
     And I should see "Housing"
     And I should see "Childcare"

--- a/features/providers/means_report.feature
+++ b/features/providers/means_report.feature
@@ -235,31 +235,33 @@ Feature: Means report
       | Disposable income upper limit |
       | Income contribution |
 
-    And the Income questions should exist:
-      | question |
-      | Gross employment income |
-      | Income tax |
-      | National insurance |
-      | Fixed employment deduction |
-      | Benefits |
-      | Financial help from friends or family |
-      | Maintenance payments |
-      | Income from property or lodger |
-      | Student loan or grant |
-      | Pension |
-      | Total income |
+    And the Income questions and answers should match:
+      | question | answer |
+      | Gross employment income | £2,143.97 |
+      | Income tax | -£204.15 |
+      | National insurance | -£161.64 |
+      | Fixed employment deduction | -£45 |
+      | Benefits | £75 |
+      | Financial help from friends or family | £0 |
+      | Maintenance payments | £0 |
+      | Income from property or lodger | £0 |
+      | Student loan or grant | £0 |
+      | Pension | £0 |
+
+    And I should see "Total income"
 
     And the Employment notes questions should exist:
       | Do you need to tell us anything else about your client's employment? |
       | Details |
 
-    And the Outgoings questions should exist:
-      | question |
-      | Housing payments (any declared housing benefits have been deducted from this total) |
-      | Childcare payments |
-      | Maintenance payments to a former partner |
-      | Payments towards legal aid in a criminal cas |
-      | Total outgoings |
+    And the Outgoings questions and answers should match:
+      | question | answer |
+      | Housing payments (any declared housing benefits have been deducted from this total) | £125 |
+      | Childcare payments | £0 |
+      | Maintenance payments to a former partner | £0 |
+      | Payments towards legal aid in a criminal case | £0 |
+
+    And I should see "Total outgoings"
 
     And the Deductions questions should exist:
       | question |
@@ -399,33 +401,33 @@ Feature: Means report
       | Disposable income upper limit |
       | Income contribution |
 
-    And the Income questions should exist:
-      | question |
-      | Gross employment income |
-      | Income tax |
-      | National insurance |
-      | Fixed employment deduction |
-      | Benefits |
-      | Financial help from friends or family |
-      | Maintenance payments |
-      | Income from property or lodger |
-      | Student loan or grant |
-      | Pension |
-      | Total income |
+    And the Income questions and answers should match:
+      | question | answer |
+      | Gross employment income | £2,143.97 |
+      | Income tax | -£204.15 |
+      | National insurance | -£161.64 |
+      | Fixed employment deduction | -£45 |
+      | Benefits | £75 |
+      | Financial help from friends or family | £0 |
+      | Maintenance payments | £0 |
+      | Income from property or lodger | £0 |
+      | Student loan or grant | £0 |
+      | Pension | £0 |
+
+    And I should see "Total income"
 
     And the Employment notes questions should exist:
       | Do you need to tell us anything else about your client's employment? |
       | Details |
 
-    And the Outgoings questions should exist:
-      | question |
-      | Housing payments |
-      | Childcare payments |
-      | Maintenance payments to a former partner |
-      | Payments towards legal aid in a criminal cas |
-      | Total outgoings |
+    And the Outgoings questions and answers should match:
+      | question | answer |
+      | Housing payments | £125 |
+      | Childcare payments | £0 |
+      | Maintenance payments to a former partner | £0 |
+      | Payments towards legal aid in a criminal case | £0 |
 
-    And I should not see "housing benefits have been deducted"
+    And I should see "Total outgoings"
 
     And the Deductions questions should exist:
       | question |

--- a/features/step_definitions/check_your_answers_steps.rb
+++ b/features/step_definitions/check_your_answers_steps.rb
@@ -48,18 +48,16 @@ Then("the {string} section's questions should exist:") do |section, table|
   expect_questions_in(selector: "[data-check-your-answers-section=\"#{section}\"]", expected: table)
 end
 
-Then("the {string} section's questions and answers should exist:") do |section, table|
+Then("the {string} section's questions and answers should match:") do |section, table|
   section = section.parameterize
-  expect_questions_and_anwsers_in(selector: "[data-check-your-answers-section=\"#{section}\"]", expected: table)
+  expect_matching_questions_and_answers(actual_selector: "[data-check-your-answers-section=\"#{section}\"]", expected_table: table)
 end
 
-def expect_questions_and_anwsers_in(expected:, selector:)
-  expected = expected.hashes.map(&:symbolize_keys)
-  actual = actual_questions_and_anwsers_in(selector:)
+def expect_matching_questions_and_answers(actual_selector:, expected_table:)
+  expected = expected_table.hashes.map(&:symbolize_keys)
+  actual = actual_questions_and_anwsers_in(selector: actual_selector)
 
-  expected.each do |row|
-    expect(actual).to include(row), "expected to find question with \"dt\" tag including \"#{row[:question]}\" and answer with tag \"dd\" including text: \"#{row[:answer]}\""
-  end
+  expect(actual).to match_array(expected)
 end
 
 def actual_questions_and_anwsers_in(selector:)

--- a/features/step_definitions/generic_steps.rb
+++ b/features/step_definitions/generic_steps.rb
@@ -11,3 +11,7 @@ Then("I should see govuk error summary {string}") do |error_text|
   expect(summary).to have_selector("#error-summary-title", text: "There is a problem")
   expect(summary).to have_link(error_text)
 end
+
+Then("I should see govuk-details {string}") do |text|
+  expect(page).to have_selector(".govuk-details", text:)
+end

--- a/features/step_definitions/means_report_steps.rb
+++ b/features/step_definitions/means_report_steps.rb
@@ -164,8 +164,8 @@ Then("the Income result questions should exist:") do |table|
   expect_questions_in(selector: "#income-result-questions", expected: table)
 end
 
-Then("the Income questions should exist:") do |table|
-  expect_questions_in(selector: "#income-details-questions", expected: table)
+Then("the Income questions and answers should match:") do |table|
+  expect_matching_questions_and_answers(actual_selector: "#income-details-questions", expected_table: table)
 end
 
 Then("the Deductions questions should exist:") do |table|
@@ -180,8 +180,8 @@ Then("the Capital result questions should exist:") do |table|
   expect_questions_in(selector: "#capital-result-questions", expected: table)
 end
 
-Then("the Outgoings questions should exist:") do |table|
-  expect_questions_in(selector: "#outgoings-details-questions", expected: table)
+Then("the Outgoings questions and answers should match:") do |table|
+  expect_matching_questions_and_answers(actual_selector: "#outgoings-details-questions", expected_table: table)
 end
 
 Then("the Declared income categories questions should exist:") do |table|

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -1,3 +1,5 @@
+require "super_diff/rspec-rails"
+
 # before and after hooks for feature tests
 #
 Before("@hmrc_use_dev_mock") do

--- a/spec/factories/regular_transactions.rb
+++ b/spec/factories/regular_transactions.rb
@@ -16,5 +16,9 @@ FactoryBot.define do
     trait :maintenance_out do
       association :transaction_type, :maintenance_out
     end
+
+    trait :housing_benefit do
+      association :transaction_type, :housing_benefit
+    end
   end
 end

--- a/spec/factories/transaction_types.rb
+++ b/spec/factories/transaction_types.rb
@@ -12,16 +12,17 @@ end
 
 FactoryBot.define do
   factory :transaction_type do
-    name { TransactionType::NAMES.values.flatten.sample }
-    operation { TransactionType::NAMES.keys.sample }
+    name { "pension" }
+    operation { "credit" }
 
     trait :debit do
-      name { TransactionType::NAMES[:debit].sample }
-      operation { :debit }
+      name { "maintenance_out" }
+      operation { "debit" }
     end
+
     trait :credit do
-      TransactionType::NAMES[:credit].sample
-      operation { :credit }
+      name { "maintenance_in" }
+      operation { "credit" }
     end
 
     trait :credit_with_standard_name do
@@ -31,7 +32,7 @@ FactoryBot.define do
       operation { :credit }
 
       after(:create) do |record|
-        if record.name == "excluded_benefits"
+        if record.disregarded_benefit?
           parent = TransactionType.find_or_create_by(name: "benefits", operation: "credit")
           record.update!(parent_id: parent.id)
         end
@@ -79,6 +80,12 @@ FactoryBot.define do
       name { "excluded_benefits" }
       operation { "credit" }
       sort_order { 40 }
+    end
+
+    trait :housing_benefit do
+      name { "housing_benefit" }
+      operation { "credit" }
+      sort_order { 50 }
     end
 
     trait :rent_or_mortgage do

--- a/spec/factories/transaction_types.rb
+++ b/spec/factories/transaction_types.rb
@@ -51,12 +51,6 @@ FactoryBot.define do
       sort_order { 20 }
     end
 
-    trait :salary do
-      name { "salary" }
-      operation { "credit" }
-      sort_order { 10 }
-    end
-
     trait :maintenance_in do
       name { "maintenance_in" }
       operation { "credit" }

--- a/spec/forms/providers/means/housing_benefit_form_spec.rb
+++ b/spec/forms/providers/means/housing_benefit_form_spec.rb
@@ -1,0 +1,492 @@
+require "rails_helper"
+
+# rubocop:disable Rails/SaveBang
+RSpec.describe Providers::Means::HousingBenefitForm do
+  describe "#new" do
+    context "when the applicant is receiving housing benefit" do
+      it "assigns housing benefit attributes" do
+        legal_aid_application = create(
+          :legal_aid_application,
+          applicant_in_receipt_of_housing_benefit: true,
+        )
+        transaction_type = create(:transaction_type, :housing_benefit)
+        _housing_benefit = create(
+          :regular_transaction,
+          legal_aid_application:,
+          transaction_type:,
+          amount: 500,
+          frequency: "weekly",
+        )
+        params = { legal_aid_application: }
+
+        form = described_class.new(params)
+
+        expect(form).to have_attributes(
+          housing_benefit: true,
+          housing_benefit_amount: 500,
+          housing_benefit_frequency: "weekly",
+        )
+      end
+    end
+
+    context "when the applicant is not receiving housing benefit" do
+      it "assigns housing benefit attributes" do
+        legal_aid_application = build_stubbed(
+          :legal_aid_application,
+          applicant_in_receipt_of_housing_benefit: false,
+        )
+        params = { legal_aid_application: }
+
+        form = described_class.new(params)
+
+        expect(form).to have_attributes(
+          housing_benefit: false,
+          housing_benefit_amount: nil,
+          housing_benefit_frequency: nil,
+        )
+      end
+    end
+
+    context "when the applicant has not answered the question" do
+      it "does not assign housing benefit attributes" do
+        legal_aid_application = build_stubbed(
+          :legal_aid_application,
+          applicant_in_receipt_of_housing_benefit: nil,
+        )
+        params = { legal_aid_application: }
+
+        form = described_class.new(params)
+
+        expect(form).to have_attributes(
+          housing_benefit: nil,
+          housing_benefit_amount: nil,
+          housing_benefit_frequency: nil,
+        )
+      end
+    end
+  end
+
+  describe "#validate" do
+    context "when neither true or false is selected" do
+      it "is invalid" do
+        legal_aid_application = build_stubbed(:legal_aid_application)
+        params = {
+          "housing_benefit_amount" => "",
+          "housing_benefit_frequency" => "",
+          legal_aid_application:,
+        }
+
+        form = described_class.new(params)
+
+        expect(form).to be_invalid
+        expect(form.errors).to be_added(:housing_benefit, :inclusion, value: nil)
+      end
+    end
+
+    context "when housing benefit is false" do
+      it "is valid" do
+        legal_aid_application = build_stubbed(:legal_aid_application)
+        params = {
+          "housing_benefit" => "false",
+          "housing_benefit_amount" => "",
+          "housing_benefit_frequency" => "",
+          legal_aid_application:,
+        }
+
+        form = described_class.new(params)
+
+        expect(form).to be_valid
+      end
+    end
+
+    context "when housing benefit is true, but amount is blank" do
+      it "is invalid" do
+        _housing_benefit = create(:transaction_type, :housing_benefit)
+        legal_aid_application = build_stubbed(:legal_aid_application)
+        params = {
+          "housing_benefit" => "true",
+          "housing_benefit_amount" => "",
+          "housing_benefit_frequency" => "weekly",
+          legal_aid_application:,
+        }
+
+        form = described_class.new(params)
+
+        expect(form).to be_invalid
+        expect(form.errors).to be_added(
+          :housing_benefit_amount,
+          :not_a_number,
+          value: "",
+        )
+      end
+    end
+
+    context "when housing benefit is true, but amount is invalid" do
+      it "is invalid" do
+        _housing_benefit = create(:transaction_type, :housing_benefit)
+        legal_aid_application = build_stubbed(:legal_aid_application)
+        params = {
+          "housing_benefit" => "true",
+          "housing_benefit_amount" => "-100",
+          "housing_benefit_frequency" => "weekly",
+          legal_aid_application:,
+        }
+
+        form = described_class.new(params)
+
+        expect(form).to be_invalid
+        expect(form.errors).to be_added(
+          :housing_benefit_amount,
+          :greater_than,
+          value: -100,
+          count: 0,
+        )
+      end
+    end
+
+    context "when housing benefit is true, but frequency is blank" do
+      it "is invalid" do
+        _housing_benefit = create(:transaction_type, :housing_benefit)
+        legal_aid_application = build_stubbed(:legal_aid_application)
+        params = {
+          "housing_benefit" => "true",
+          "housing_benefit_amount" => "100",
+          "housing_benefit_frequency" => "",
+          legal_aid_application:,
+        }
+
+        form = described_class.new(params)
+
+        expect(form).to be_invalid
+        expect(form.errors).to be_added(
+          :housing_benefit_frequency,
+          :inclusion,
+          value: "",
+        )
+      end
+    end
+
+    context "when housing benefit is true, but frequency is invalid" do
+      it "is invalid" do
+        _housing_benefit = create(:transaction_type, :housing_benefit)
+        legal_aid_application = build_stubbed(:legal_aid_application)
+        params = {
+          "housing_benefit" => "true",
+          "housing_benefit_amount" => "100",
+          "housing_benefit_frequency" => "invalid",
+          legal_aid_application:,
+        }
+
+        form = described_class.new(params)
+
+        expect(form).to be_invalid
+        expect(form.errors).to be_added(
+          :housing_benefit_frequency,
+          :inclusion,
+          value: "invalid",
+        )
+      end
+    end
+
+    context "when housing benefit is true, and amount and frequency are valid" do
+      it "is valid" do
+        _housing_benefit = create(:transaction_type, :housing_benefit)
+        legal_aid_application = build_stubbed(:legal_aid_application)
+        params = {
+          "housing_benefit" => "true",
+          "housing_benefit_amount" => "100",
+          "housing_benefit_frequency" => "weekly",
+          legal_aid_application:,
+        }
+
+        form = described_class.new(params)
+
+        expect(form).to be_valid
+      end
+    end
+  end
+
+  describe "#save" do
+    context "when the form is invalid" do
+      it "returns false" do
+        legal_aid_application = build_stubbed(:legal_aid_application)
+        params = {
+          "housing_benefit_amount" => "",
+          "housing_benefit_frequency" => "",
+          legal_aid_application:,
+        }
+        form = described_class.new(params)
+
+        result = form.save
+
+        expect(result).to be false
+      end
+
+      it "does not update the applicant_in_receipt_of_housing_benefit attribute" do
+        legal_aid_application = build_stubbed(
+          :legal_aid_application,
+          applicant_in_receipt_of_housing_benefit: false,
+        )
+        params = {
+          "housing_benefit_amount" => "",
+          "housing_benefit_frequency" => "",
+          legal_aid_application:,
+        }
+        form = described_class.new(params)
+
+        form.save
+
+        expect(legal_aid_application.applicant_in_receipt_of_housing_benefit)
+          .to be false
+      end
+
+      it "does not update an application's transaction types" do
+        _housing_benefit = create(:transaction_type, :housing_benefit)
+        legal_aid_application = create(:legal_aid_application)
+        params = {
+          "housing_benefit" => "true",
+          "housing_benefit_amount" => "",
+          "housing_benefit_frequency" => "",
+          legal_aid_application:,
+        }
+        form = described_class.new(params)
+
+        form.save
+
+        expect(legal_aid_application.transaction_types).to be_empty
+      end
+
+      it "does not update an application's regular transactions" do
+        _housing_benefit = create(:transaction_type, :housing_benefit)
+        legal_aid_application = create(:legal_aid_application)
+        params = {
+          "housing_benefit" => "true",
+          "housing_benefit_amount" => "",
+          "housing_benefit_frequency" => "",
+          legal_aid_application:,
+        }
+        form = described_class.new(params)
+
+        form.save
+
+        expect(legal_aid_application.regular_transactions).to be_empty
+      end
+    end
+
+    context "when housing benefit is false" do
+      it "returns true" do
+        legal_aid_application = create(:legal_aid_application)
+        params = {
+          "housing_benefit" => "false",
+          "housing_benefit_amount" => "",
+          "housing_benefit_frequency" => "",
+          legal_aid_application:,
+        }
+        form = described_class.new(params)
+
+        result = form.save
+
+        expect(result).to be true
+      end
+
+      it "updates the applicant_in_receipt_of_housing_benefit attribute" do
+        legal_aid_application = create(
+          :legal_aid_application,
+          applicant_in_receipt_of_housing_benefit: true,
+        )
+        params = {
+          "housing_benefit" => "false",
+          "housing_benefit_amount" => "",
+          "housing_benefit_frequency" => "",
+          legal_aid_application:,
+        }
+        form = described_class.new(params)
+
+        form.save
+
+        expect(legal_aid_application.applicant_in_receipt_of_housing_benefit)
+          .to be false
+      end
+
+      it "destroys any existing housing benefit transaction types" do
+        legal_aid_application = create(:legal_aid_application)
+        transaction_type = create(:transaction_type, :housing_benefit)
+        _housing_benefit = create(
+          :legal_aid_application_transaction_type,
+          legal_aid_application:,
+          transaction_type:,
+        )
+        params = {
+          "housing_benefit" => "false",
+          "housing_benefit_amount" => "",
+          "housing_benefit_frequency" => "",
+          legal_aid_application:,
+        }
+        form = described_class.new(params)
+
+        form.save
+
+        expect(legal_aid_application.transaction_types).to be_empty
+      end
+
+      it "destroys any existing housing benefit regular transactions" do
+        legal_aid_application = create(:legal_aid_application)
+        transaction_type = create(:transaction_type, :housing_benefit)
+        _housing_benefit = create(
+          :regular_transaction,
+          legal_aid_application:,
+          transaction_type:,
+        )
+        params = {
+          "housing_benefit" => "false",
+          "housing_benefit_amount" => "",
+          "housing_benefit_frequency" => "",
+          legal_aid_application:,
+        }
+        form = described_class.new(params)
+
+        form.save
+
+        expect(legal_aid_application.regular_transactions).to be_empty
+      end
+    end
+
+    context "when housing benefit is true" do
+      it "returns true" do
+        legal_aid_application = create(:legal_aid_application)
+        _housing_benefit = create(:transaction_type, :housing_benefit)
+        params = {
+          "housing_benefit" => "true",
+          "housing_benefit_amount" => "100",
+          "housing_benefit_frequency" => "weekly",
+          legal_aid_application:,
+        }
+        form = described_class.new(params)
+
+        result = form.save
+
+        expect(result).to be true
+      end
+
+      it "updates the applicant_in_receipt_of_housing_benefit attribute" do
+        legal_aid_application = create(
+          :legal_aid_application,
+          applicant_in_receipt_of_housing_benefit: true,
+        )
+        _housing_benefit = create(:transaction_type, :housing_benefit)
+        params = {
+          "housing_benefit" => "true",
+          "housing_benefit_amount" => "100",
+          "housing_benefit_frequency" => "weekly",
+          legal_aid_application:,
+        }
+        form = described_class.new(params)
+
+        form.save
+
+        expect(legal_aid_application.applicant_in_receipt_of_housing_benefit)
+          .to be true
+      end
+
+      it "updates the application's transaction types" do
+        legal_aid_application = create(:legal_aid_application)
+        housing_benefit = create(:transaction_type, :housing_benefit)
+        params = {
+          "housing_benefit" => "true",
+          "housing_benefit_amount" => "100",
+          "housing_benefit_frequency" => "weekly",
+          legal_aid_application:,
+        }
+        form = described_class.new(params)
+
+        form.save
+
+        expect(legal_aid_application.transaction_types)
+          .to contain_exactly(housing_benefit)
+      end
+
+      it "updates the application's regular transactions" do
+        legal_aid_application = create(:legal_aid_application)
+        housing_benefit = create(:transaction_type, :housing_benefit)
+        params = {
+          "housing_benefit" => "true",
+          "housing_benefit_amount" => "100",
+          "housing_benefit_frequency" => "weekly",
+          legal_aid_application:,
+        }
+        form = described_class.new(params)
+
+        form.save
+
+        regular_transactions = legal_aid_application.regular_transactions
+        expect(regular_transactions.count).to eq 1
+        expect(regular_transactions.first).to have_attributes(
+          legal_aid_application:,
+          transaction_type: housing_benefit,
+          amount: 100,
+          frequency: "weekly",
+        )
+      end
+
+      context "when a housing benefit regular transaction already exists" do
+        it "does not create another legal aid application transaction type" do
+          legal_aid_application = create(:legal_aid_application)
+          transaction_type = create(:transaction_type, :housing_benefit)
+          legal_aid_application_transaction_type = create(
+            :legal_aid_application_transaction_type,
+            legal_aid_application:,
+            transaction_type:,
+          )
+          _housing_benefit = create(
+            :regular_transaction,
+            legal_aid_application:,
+            transaction_type:,
+          )
+          params = {
+            "housing_benefit" => "true",
+            "housing_benefit_amount" => "200",
+            "housing_benefit_frequency" => "monthly",
+            legal_aid_application:,
+          }
+          form = described_class.new(params)
+
+          form.save
+
+          expect(legal_aid_application.legal_aid_application_transaction_types)
+            .to contain_exactly(legal_aid_application_transaction_type)
+        end
+
+        it "updates the existing regular transaction" do
+          legal_aid_application = create(:legal_aid_application)
+          transaction_type = create(:transaction_type, :housing_benefit)
+          housing_benefit = create(
+            :regular_transaction,
+            legal_aid_application:,
+            transaction_type:,
+            amount: 100,
+            frequency: "weekly",
+          )
+          params = {
+            "housing_benefit" => "true",
+            "housing_benefit_amount" => "200",
+            "housing_benefit_frequency" => "monthly",
+            legal_aid_application:,
+          }
+          form = described_class.new(params)
+
+          form.save
+
+          expect(legal_aid_application.regular_transactions)
+            .to contain_exactly(housing_benefit)
+          expect(housing_benefit.reload).to have_attributes(
+            legal_aid_application:,
+            transaction_type:,
+            amount: 200,
+            frequency: "monthly",
+          )
+        end
+      end
+    end
+  end
+end
+# rubocop:enable Rails/SaveBang

--- a/spec/forms/providers/means/regular_income_form_spec.rb
+++ b/spec/forms/providers/means/regular_income_form_spec.rb
@@ -122,15 +122,32 @@ RSpec.describe Providers::Means::RegularIncomeForm do
 
   describe "#new" do
     context "when the application has regular transactions" do
-      it "assigns the correct attributes" do
+      it "assigns attributes for the non-children credit transactions" do
         legal_aid_application = create(:legal_aid_application)
         benefits = create(:transaction_type, :benefits)
-        _transaction_type = create(
+        excluded_benefits = create(
+          :transaction_type,
+          :excluded_benefits,
+          parent_id: benefits.id,
+        )
+        _excluded_benefits_transaction_type = create(
+          :legal_aid_application_transaction_type,
+          legal_aid_application:,
+          transaction_type: excluded_benefits,
+        )
+        _benefits_transaction_type = create(
           :legal_aid_application_transaction_type,
           legal_aid_application:,
           transaction_type: benefits,
         )
-        _regular_transaction = create(
+        _excluded_benefits_transaction = create(
+          :regular_transaction,
+          legal_aid_application:,
+          transaction_type: excluded_benefits,
+          amount: 100,
+          frequency: "weekly",
+        )
+        _benefits_transaction = create(
           :regular_transaction,
           legal_aid_application:,
           transaction_type: benefits,

--- a/spec/helpers/providers_helper_spec.rb
+++ b/spec/helpers/providers_helper_spec.rb
@@ -28,14 +28,14 @@ RSpec.describe ProvidersHelper, type: :helper do
 
     it "incoming_transactions should return the right URL with param" do
       legal_aid_application.provider_step = "incoming_transactions"
-      legal_aid_application.provider_step_params = { transaction_type: :salary }
-      expect(url_for_application(legal_aid_application)).to eq("/providers/applications/#{legal_aid_application.id}/incoming_transactions/salary?locale=en")
+      legal_aid_application.provider_step_params = { transaction_type: :pension }
+      expect(url_for_application(legal_aid_application)).to eq("/providers/applications/#{legal_aid_application.id}/incoming_transactions/pension?locale=en")
     end
 
     it "outgoing_transactions should return the right URL with param" do
       legal_aid_application.provider_step = "outgoing_transactions"
-      legal_aid_application.provider_step_params = { transaction_type: :salary }
-      expect(url_for_application(legal_aid_application)).to eq("/providers/applications/#{legal_aid_application.id}/outgoing_transactions/salary?locale=en")
+      legal_aid_application.provider_step_params = { transaction_type: :pension }
+      expect(url_for_application(legal_aid_application)).to eq("/providers/applications/#{legal_aid_application.id}/outgoing_transactions/pension?locale=en")
     end
 
     context "when saved as draft and amending involved child" do

--- a/spec/helpers/user_transactions_helper_spec.rb
+++ b/spec/helpers/user_transactions_helper_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe UserTransactionsHelper, type: :helper do
-  let(:transaction_type) { create :transaction_type, :salary }
+  let(:transaction_type) { create :transaction_type, :pension }
   let(:legal_aid_application) do
     create :legal_aid_application, :with_applicant, transaction_types: [transaction_type]
   end

--- a/spec/models/legal_aid_application_spec.rb
+++ b/spec/models/legal_aid_application_spec.rb
@@ -1656,6 +1656,30 @@ RSpec.describe LegalAidApplication, type: :model do
     end
   end
 
+  describe "#housing_payments?" do
+    context "when the application has a rent_or_mortgage transaction type" do
+      it "returns true" do
+        legal_aid_application = create(:legal_aid_application)
+        transaction_type = create(:transaction_type, :rent_or_mortgage)
+        _rent_or_mortgage = create(
+          :legal_aid_application_transaction_type,
+          legal_aid_application:,
+          transaction_type:,
+        )
+
+        expect(legal_aid_application.housing_payments?).to be true
+      end
+    end
+
+    context "when the application does not have a rent_or_mortgage transaction type" do
+      it "returns false" do
+        legal_aid_application = build_stubbed(:legal_aid_application)
+
+        expect(legal_aid_application.housing_payments?).to be false
+      end
+    end
+  end
+
 private
 
   def uploaded_evidence_output

--- a/spec/models/legal_aid_application_spec.rb
+++ b/spec/models/legal_aid_application_spec.rb
@@ -1049,7 +1049,6 @@ RSpec.describe LegalAidApplication, type: :model do
   describe "#transaction_types" do
     let(:legal_aid_application) { create :legal_aid_application }
     let!(:ff) { create :transaction_type, :friends_or_family }
-    let!(:salary) { create :transaction_type, :salary }
     let!(:maintenance) { create :transaction_type, :maintenance_out }
     let!(:child_care) { create :transaction_type, :child_care }
     let!(:ff_tt) { create :legal_aid_application_transaction_type, transaction_type: ff, legal_aid_application: }

--- a/spec/models/regular_transaction_spec.rb
+++ b/spec/models/regular_transaction_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe RegularTransaction, type: :model do
           legal_aid_application:,
           transaction_type: benefits,
           amount: "1500.50",
-          frequency: "monthly",
+          frequency: "weekly",
         )
 
         expect(record).to be_valid

--- a/spec/models/transaction_type_spec.rb
+++ b/spec/models/transaction_type_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe TransactionType, type: :model do
     end
   end
 
-  describe "#for_income_type?" do
+  describe ".for_income_type?" do
     context "when checks that a boolean response is returned" do
       let!(:credit_transaction) { create :transaction_type, :credit_with_standard_name }
 
@@ -59,7 +59,7 @@ RSpec.describe TransactionType, type: :model do
     end
   end
 
-  describe "#for_outgoing_type?" do
+  describe ".for_outgoing_type?" do
     before { create :transaction_type, :child_care }
 
     context "when no such outgoing types exist" do
@@ -90,6 +90,7 @@ RSpec.describe TransactionType, type: :model do
 
     let(:benefits) { described_class.find_by(name: "benefits") }
     let(:excluded_benefits) { described_class.find_by(name: "excluded_benefits") }
+    let(:housing_benefit) { described_class.find_by(name: "housing_benefit") }
     let(:pension) { described_class.find_by(name: "pension") }
 
     describe "not_children scope" do
@@ -112,34 +113,6 @@ RSpec.describe TransactionType, type: :model do
       end
     end
 
-    describe "#parent?" do
-      context "when is a parent" do
-        it "returns true" do
-          expect(benefits.parent?).to be true
-        end
-      end
-
-      context "when is not a parent" do
-        it "returns true" do
-          expect(pension.parent?).to be false
-        end
-      end
-    end
-
-    describe "#parent" do
-      context "when is not a child" do
-        it "returns nil" do
-          expect(pension.parent).to be_nil
-        end
-      end
-
-      context "when is a child" do
-        it "returns the parent record" do
-          expect(excluded_benefits.parent).to eq benefits
-        end
-      end
-    end
-
     describe "parent_or_self" do
       context "when is not a child" do
         it "returns self" do
@@ -154,16 +127,16 @@ RSpec.describe TransactionType, type: :model do
       end
     end
 
-    describe "#excluded_benefit?" do
-      context "when a excluded benefit type" do
+    describe "#disregarded_benefit?" do
+      context "when a disregarded benefit type" do
         it "returns true" do
-          expect(excluded_benefits.excluded_benefit?).to be true
+          expect(excluded_benefits.disregarded_benefit?).to be true
         end
       end
 
-      context "when not an excluded benefit type" do
+      context "when not a disregarded benefit type" do
         it "returns false" do
-          expect(pension.excluded_benefit?).to be false
+          expect(pension.disregarded_benefit?).to be false
         end
       end
     end
@@ -177,59 +150,7 @@ RSpec.describe TransactionType, type: :model do
 
       context "with record with children" do
         it "returns an array of children" do
-          expect(benefits.children).to eq [excluded_benefits]
-        end
-      end
-    end
-
-    describe ".find_with_children" do
-      context "with one id with no children" do
-        it "return the one record" do
-          expect(described_class.find_with_children(pension.id)).to eq [pension]
-        end
-      end
-
-      context "with one id with children" do
-        it "returns the parent and child" do
-          expect(described_class.find_with_children(benefits.id)).to match_array([benefits, excluded_benefits])
-        end
-      end
-
-      context "with multiple ids all without children" do
-        it "returns just the records" do
-          expect(described_class.find_with_children(pension.id, excluded_benefits.id)).to match_array([pension, excluded_benefits])
-        end
-      end
-
-      context "with multiple ids with and without children" do
-        it "returns the records and the children" do
-          expect(described_class.find_with_children(pension.id, benefits.id)).to match_array([pension, benefits, excluded_benefits])
-        end
-      end
-
-      context "with nil" do
-        it "returns empty array" do
-          expect(described_class.find_with_children(nil)).to match_array([])
-        end
-      end
-    end
-
-    describe ".any_type_of" do
-      context "with name of record with children" do
-        it "returns record and its children" do
-          expect(described_class.any_type_of("benefits")).to match_array([benefits, excluded_benefits])
-        end
-      end
-
-      context "with name of record with no children" do
-        it "returns just that record in an array" do
-          expect(described_class.any_type_of("pension")).to eq [pension]
-        end
-      end
-
-      context "with name that does not exist" do
-        it "returns an empty collection" do
-          expect(described_class.any_type_of("xxx")).to be_empty
+          expect(benefits.children).to contain_exactly(excluded_benefits, housing_benefit)
         end
       end
     end

--- a/spec/requests/providers/client_completed_means_spec.rb
+++ b/spec/requests/providers/client_completed_means_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe Providers::ClientCompletedMeansController, type: :request do
 
         context "transactions exist, and applicant is not employed" do
           let(:submit_button) { { continue_button: "Continue" } }
-          let(:transaction_type) { create :transaction_type, :salary }
+          let(:transaction_type) { create :transaction_type, :pension }
           let(:applicant) { create :applicant, :not_employed }
           let(:legal_aid_application) do
             create :legal_aid_application, applicant:, transaction_types: [transaction_type]

--- a/spec/requests/providers/income_summary_spec.rb
+++ b/spec/requests/providers/income_summary_spec.rb
@@ -1,11 +1,10 @@
 require "rails_helper"
 
 RSpec.describe Providers::IncomeSummaryController do
-  let!(:salary) { create :transaction_type, :credit, name: "salary" }
   let!(:benefits) { create :transaction_type, :credit, name: "benefits" }
   let!(:maintenance) { create :transaction_type, :credit, name: "maintenance_in" }
   let!(:pension) { create :transaction_type, :credit, name: "pension" }
-  let(:legal_aid_application) { create :legal_aid_application, :with_applicant, :with_non_passported_state_machine, transaction_types: [salary, benefits] }
+  let(:legal_aid_application) { create :legal_aid_application, :with_applicant, :with_non_passported_state_machine, transaction_types: [pension, benefits] }
   let(:provider) { legal_aid_application.provider }
   let(:login) { login_as provider }
 
@@ -23,7 +22,7 @@ RSpec.describe Providers::IncomeSummaryController do
 
     it "displays a section for all transaction types linked to this application" do
       subject
-      [salary, benefits].pluck(:name).each do |name|
+      [pension, benefits].pluck(:name).each do |name|
         legend = I18n.t("transaction_types.names.providers.#{name}")
         expect(parsed_response_body.css("ol li##{name} h2").text).to match(/#{legend}/)
       end
@@ -67,8 +66,8 @@ RSpec.describe Providers::IncomeSummaryController do
       let(:applicant) { create :applicant }
       let(:bank_provider) { create :bank_provider, applicant: }
       let(:bank_account) { create :bank_account, bank_provider: }
-      let!(:bank_transaction) { create :bank_transaction, :credit, transaction_type: salary, bank_account: }
-      let(:legal_aid_application) { create :legal_aid_application, :with_non_passported_state_machine, applicant:, transaction_types: [salary] }
+      let!(:bank_transaction) { create :bank_transaction, :credit, transaction_type: pension, bank_account: }
+      let(:legal_aid_application) { create :legal_aid_application, :with_non_passported_state_machine, applicant:, transaction_types: [pension] }
 
       it "displays bank transaction" do
         subject
@@ -84,8 +83,8 @@ RSpec.describe Providers::IncomeSummaryController do
     let(:applicant) { create :applicant }
     let(:bank_provider) { create :bank_provider, applicant: }
     let(:bank_account) { create :bank_account, bank_provider: }
-    let!(:bank_transaction) { create :bank_transaction, :credit, transaction_type: salary, bank_account: }
-    let(:legal_aid_application) { create :legal_aid_application, :with_non_passported_state_machine, applicant:, transaction_types: [salary] }
+    let!(:bank_transaction) { create :bank_transaction, :credit, transaction_type: pension, bank_account: }
+    let(:legal_aid_application) { create :legal_aid_application, :with_non_passported_state_machine, applicant:, transaction_types: [pension] }
 
     let(:submit_button) { { continue_button: "Continue" } }
 
@@ -142,7 +141,7 @@ RSpec.describe Providers::IncomeSummaryController do
       let(:bank_provider) { create :bank_provider, applicant: }
       let(:bank_account) { create :bank_account, bank_provider: }
       let!(:bank_transaction) { create :bank_transaction, :credit, transaction_type: nil, bank_account: }
-      let(:legal_aid_application) { create :legal_aid_application, :with_non_passported_state_machine, applicant:, transaction_types: [salary] }
+      let(:legal_aid_application) { create :legal_aid_application, :with_non_passported_state_machine, applicant:, transaction_types: [pension] }
 
       let(:submit_button) { { continue_button: "Continue" } }
 

--- a/spec/requests/providers/means/housing_benefits_controller_spec.rb
+++ b/spec/requests/providers/means/housing_benefits_controller_spec.rb
@@ -1,0 +1,168 @@
+require "rails_helper"
+
+RSpec.describe Providers::Means::HousingBenefitsController, type: :request do
+  before { Setting.setting.update!(enhanced_bank_upload: true) }
+
+  describe "GET /providers/applications/:legal_aid_application_id/means/housing_benefits" do
+    it "returns ok" do
+      _housing_benefit = create(:transaction_type, :housing_benefit)
+      legal_aid_application = create(:legal_aid_application)
+      provider = legal_aid_application.provider
+      login_as provider
+
+      get providers_legal_aid_application_means_housing_benefits_path(legal_aid_application)
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    context "when the application has a housing benefit transaction" do
+      it "renders the housing benefit data" do
+        legal_aid_application = create(
+          :legal_aid_application,
+          applicant_in_receipt_of_housing_benefit: true,
+        )
+        housing_benefit = create(
+          :regular_transaction,
+          :housing_benefit,
+          amount: 100,
+          frequency: "weekly",
+          legal_aid_application:,
+        )
+        provider = legal_aid_application.provider
+        login_as provider
+
+        get providers_legal_aid_application_means_housing_benefits_path(legal_aid_application)
+
+        expect(page).to have_checked_field(
+          "providers_means_housing_benefit_form[housing_benefit]",
+        )
+        expect(page).to have_field(
+          "providers_means_housing_benefit_form[housing_benefit_amount]",
+          with: housing_benefit.amount,
+        )
+        expect(page).to have_field(
+          "providers_means_housing_benefit_form[housing_benefit_frequency]",
+          with: housing_benefit.frequency,
+        )
+      end
+    end
+
+    context "when the enhanced_bank_upload setting is not enabled" do
+      it "redirects to the next page" do
+        Setting.setting.update!(enhanced_bank_upload: false)
+        legal_aid_application = create(:legal_aid_application)
+        provider = legal_aid_application.provider
+        login_as provider
+
+        get providers_legal_aid_application_means_housing_benefits_path(legal_aid_application)
+
+        expect(response).to redirect_to(providers_legal_aid_application_means_cash_outgoing_path(legal_aid_application))
+      end
+    end
+
+    context "when the provider is not authenticated" do
+      it "redirects to the provider login page" do
+        legal_aid_application = create(:legal_aid_application)
+
+        get providers_legal_aid_application_means_housing_benefits_path(legal_aid_application)
+
+        expect(response).to redirect_to(new_provider_session_path)
+      end
+    end
+
+    context "when the provider is not authorised" do
+      it "redirects to the access denied page" do
+        legal_aid_application = create(:legal_aid_application)
+        provider = create(:provider)
+        login_as provider
+
+        get providers_legal_aid_application_means_housing_benefits_path(legal_aid_application)
+
+        expect(response).to redirect_to(error_path(:access_denied))
+      end
+    end
+  end
+
+  describe "PATCH /providers/applications/:legal_aid_application_id/means/housing_benefits" do
+    it "updates the application and redirects to the cash outgoings page" do
+      legal_aid_application = create(
+        :legal_aid_application,
+        applicant_in_receipt_of_housing_benefit: nil,
+      )
+      provider = legal_aid_application.provider
+      login_as provider
+      params = {
+        "providers_means_housing_benefit_form" => {
+          "housing_benefit" => "false",
+          "housing_benefit_amount" => "",
+          "housing_benefit_frequency" => "",
+        },
+      }
+
+      patch providers_legal_aid_application_means_housing_benefits_path(legal_aid_application), params: params
+
+      expect(legal_aid_application.reload.applicant_in_receipt_of_housing_benefit).to be false
+      expect(response).to redirect_to(providers_legal_aid_application_means_cash_outgoing_path(legal_aid_application))
+    end
+
+    context "when the form is invalid" do
+      it "returns unprocessable entity, renders errors, and does not update the application" do
+        _housing_benefit = create(:transaction_type, :housing_benefit)
+        legal_aid_application = create(
+          :legal_aid_application,
+          applicant_in_receipt_of_housing_benefit: nil,
+        )
+        provider = legal_aid_application.provider
+        login_as provider
+        params = {
+          "providers_means_housing_benefit_form" => {
+            "housing_benefit" => "",
+            "housing_benefit_amount" => "",
+            "housing_benefit_frequency" => "",
+          },
+        }
+
+        patch providers_legal_aid_application_means_housing_benefits_path(legal_aid_application), params: params
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(page).to have_css("p", class: "govuk-error-message", text: "Select one of the options")
+        expect(legal_aid_application.reload.applicant_in_receipt_of_housing_benefit).to be_nil
+      end
+    end
+
+    context "when the enhanced_bank_upload setting is not enabled" do
+      it "redirects to the next page" do
+        Setting.setting.update!(enhanced_bank_upload: false)
+        legal_aid_application = create(:legal_aid_application)
+        provider = legal_aid_application.provider
+        login_as provider
+
+        patch providers_legal_aid_application_means_housing_benefits_path(legal_aid_application)
+
+        expect(response).to redirect_to(providers_legal_aid_application_means_cash_outgoing_path(legal_aid_application))
+      end
+    end
+
+    context "when the provider is not authenticated" do
+      it "redirects to the provider login page" do
+        legal_aid_application = create(:legal_aid_application)
+
+        patch providers_legal_aid_application_means_housing_benefits_path(legal_aid_application)
+
+        expect(response).to redirect_to(new_provider_session_path)
+      end
+    end
+
+    context "when the provider is not authorised" do
+      it "redirects to the access denied page" do
+        legal_aid_application = create(:legal_aid_application)
+        provider = create(:provider)
+        login_as provider
+
+        patch providers_legal_aid_application_means_housing_benefits_path(legal_aid_application)
+
+        expect(response).to redirect_to(error_path(:access_denied))
+      end
+    end
+  end
+end

--- a/spec/requests/providers/means/regular_outgoings_controller_spec.rb
+++ b/spec/requests/providers/means/regular_outgoings_controller_spec.rb
@@ -84,14 +84,11 @@ RSpec.describe Providers::Means::RegularOutgoingsController do
     end
 
     context "when regular transactions are selected" do
-      let(:rent_or_mortgage) { create(:transaction_type, :rent_or_mortgage) }
       let(:child_care) { create(:transaction_type, :child_care) }
       let(:params) do
         {
           providers_means_regular_outgoings_form: {
-            transaction_type_ids: [rent_or_mortgage.id, child_care.id],
-            rent_or_mortgage_amount: 250,
-            rent_or_mortgage_frequency: "weekly",
+            transaction_type_ids: [child_care.id],
             child_care_amount: 100,
             child_care_frequency: "monthly",
           },
@@ -112,7 +109,25 @@ RSpec.describe Providers::Means::RegularOutgoingsController do
         request
         outgoing_transaction_types = legal_aid_application.regular_transactions.debits
         expect(outgoing_transaction_types.pluck(:transaction_type_id, :amount, :frequency))
-          .to contain_exactly([rent_or_mortgage.id, 250, "weekly"], [child_care.id, 100, "monthly"])
+          .to contain_exactly([child_care.id, 100, "monthly"])
+      end
+    end
+
+    context "when housing payments are selected" do
+      let(:rent_or_mortgage) { create(:transaction_type, :rent_or_mortgage) }
+      let(:params) do
+        {
+          providers_means_regular_outgoings_form: {
+            transaction_type_ids: [rent_or_mortgage.id],
+            rent_or_mortgage_amount: 100,
+            rent_or_mortgage_frequency: "monthly",
+          },
+        }
+      end
+
+      it "redirects to the housing payments page" do
+        request
+        expect(response).to redirect_to(providers_legal_aid_application_means_housing_benefits_path(legal_aid_application))
       end
     end
 
@@ -182,14 +197,11 @@ RSpec.describe Providers::Means::RegularOutgoingsController do
           no_debit_transaction_types_selected: false,
         )
       end
-      let(:rent_or_mortgage) { create(:transaction_type, :rent_or_mortgage) }
       let(:child_care) { create(:transaction_type, :child_care) }
       let(:params) do
         {
           providers_means_regular_outgoings_form: {
-            transaction_type_ids: [rent_or_mortgage.id, child_care.id],
-            rent_or_mortgage_amount: 250,
-            rent_or_mortgage_frequency: "weekly",
+            transaction_type_ids: [child_care.id],
             child_care_amount: 100,
             child_care_frequency: "monthly",
           },
@@ -200,12 +212,38 @@ RSpec.describe Providers::Means::RegularOutgoingsController do
         request
         identified_outgoing = legal_aid_application.regular_transactions.debits
         expect(identified_outgoing.pluck(:transaction_type_id, :amount, :frequency))
-          .to contain_exactly([rent_or_mortgage.id, 250, "weekly"], [child_care.id, 100, "monthly"])
+          .to contain_exactly([child_care.id, 100, "monthly"])
       end
 
       it "redirects to the cash outgoing page" do
         request
         expect(response).to redirect_to(providers_legal_aid_application_means_cash_outgoing_path(legal_aid_application))
+      end
+    end
+
+    context "when checking answers and housing payments are selected" do
+      let(:legal_aid_application) do
+        create(
+          :legal_aid_application,
+          :with_non_passported_state_machine,
+          :checking_non_passported_means,
+          no_debit_transaction_types_selected: false,
+        )
+      end
+      let(:rent_or_mortgage) { create(:transaction_type, :rent_or_mortgage) }
+      let(:params) do
+        {
+          providers_means_regular_outgoings_form: {
+            transaction_type_ids: [rent_or_mortgage.id],
+            rent_or_mortgage_amount: 100,
+            rent_or_mortgage_frequency: "monthly",
+          },
+        }
+      end
+
+      it "redirects to the housing benefit page" do
+        request
+        expect(response).to redirect_to(providers_legal_aid_application_means_housing_benefits_path(legal_aid_application))
       end
     end
   end

--- a/spec/requests/providers/transactions_spec.rb
+++ b/spec/requests/providers/transactions_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Providers::TransactionsController, type: :request do
   let(:legal_aid_application) { create :legal_aid_application, :with_applicant, :with_transaction_period }
   let(:applicant) { legal_aid_application.applicant }
   let(:provider) { legal_aid_application.provider }
-  let(:transaction_type) { create :transaction_type }
+  let(:transaction_type) { create :transaction_type, :maintenance_in }
   let(:bank_provider) { create :bank_provider, applicant: }
   let(:bank_account) { create :bank_account, bank_provider: }
   let(:cfe_state_benefits_url) { "#{Rails.configuration.x.check_financial_eligibility_host}/state_benefit_type" }
@@ -30,7 +30,7 @@ RSpec.describe Providers::TransactionsController, type: :request do
 
     context "When there are transactions" do
       let(:not_matching_operation) { (TransactionType::NAMES.keys.map(&:to_s) - [transaction_type.operation.to_s]).first }
-      let(:other_transaction_type) { create :transaction_type, name: (TransactionType::NAMES[transaction_type.operation.to_sym] - [transaction_type.name.to_sym]).sample }
+      let(:other_transaction_type) { create :transaction_type, :pension }
       let!(:bank_transaction_matching) { create :bank_transaction, bank_account:, operation: transaction_type.operation }
       let!(:bank_transaction_selected) { create :bank_transaction, bank_account:, operation: transaction_type.operation, transaction_type: }
       let!(:bank_transaction_not_matching) { create :bank_transaction, bank_account:, operation: not_matching_operation }


### PR DESCRIPTION
As part of the enhanced bank upload journey, providers need to tell us if their client is in receipt of housing benefit or not. If they do receive housing benefit, then they need to tell us how much, and how often.

If providers tell us that their client makes housing payments, then they are asked whether the client receives housing benefit.

If they do, the information is used to create a regular transaction that can be submitted to the CFE API to give an eligbility assessment result.

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3462)


https://user-images.githubusercontent.com/25187547/193324168-e225cf09-4d18-485a-bf7e-2153415959ed.mp4


