### PR TITLE
Fix flaky document upload spec

### DIFF
--- a/features/providers/bank_statement_flow.feature
+++ b/features/providers/bank_statement_flow.feature
@@ -13,6 +13,9 @@ Feature: Bank statement flow
 
     Given I upload the fixture file named 'acceptable.pdf'
     And I upload an evidence file named 'hello_world.pdf'
+    Then I should see "acceptable.pdf UPLOADED"
+    And I should see "hello_world.pdf UPLOADED"
+
     When I click 'Save and continue'
     Then I should be on a page with title matching "Review .*'s employment income"
     And I should be on a page showing "Do you need to tell us anything else about your client's employment?"


### PR DESCRIPTION
If the request to upload the document hasn't completed (and subsequently updated the DOM), the "Save and continue" button will be clicked before the document has uploaded. This means the form returns an error and the user does not navigate to the "Review employment income" page as expected by the test.

This adds an assertions against the rendered content to ensure that the document has been uploaded before submitting the form. This prevents the test being flaky, but it doesn't resolve the underlying issue.

Here are some UX/testing considerations that might improve the user experience and the robustness of the test:

- Prevent form submissions while documents are being uploaded.
- Offer a visual affordance to the user that the document is being uploaded (e.g a spinning progress icon).
- Wait for JavaScript-driven requests (i.e uploading the document) to finish in tests before continuing. Cuprite is a Selenium alternative that offers this kind of functionality out of the box.