### PR TITLE
Add backoffLimit to all cronjob job specs

### DIFF
--- a/helm_deploy/apply-for-legal-aid/templates/cronjob-admin-report.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/cronjob-admin-report.yaml
@@ -14,6 +14,7 @@ spec:
   failedJobsHistoryLimit: 1
   jobTemplate:
     spec:
+      backoffLimit: 1
       template:
         metadata:
           labels:

--- a/helm_deploy/apply-for-legal-aid/templates/cronjob-db-backup-cleanup.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/cronjob-db-backup-cleanup.yaml
@@ -15,6 +15,7 @@ spec:
   failedJobsHistoryLimit: 0
   jobTemplate:
     spec:
+      backoffLimit: 1
       template:
         spec:
           containers:

--- a/helm_deploy/apply-for-legal-aid/templates/cronjob-deliver-scheduled-mail.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/cronjob-deliver-scheduled-mail.yaml
@@ -14,6 +14,7 @@ spec:
   failedJobsHistoryLimit: 0
   jobTemplate:
     spec:
+      backoffLimit: 1
       template:
         spec:
           containers:

--- a/helm_deploy/apply-for-legal-aid/templates/cronjob-destroy-purgeable.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/cronjob-destroy-purgeable.yaml
@@ -14,6 +14,7 @@ spec:
   failedJobsHistoryLimit: 1
   jobTemplate:
     spec:
+      backoffLimit: 1
       template:
         metadata:
           labels:

--- a/helm_deploy/apply-for-legal-aid/templates/cronjob-export-digest.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/cronjob-export-digest.yaml
@@ -14,6 +14,7 @@ spec:
   failedJobsHistoryLimit: 1
   jobTemplate:
     spec:
+      backoffLimit: 1
       template:
         metadata:
           labels:

--- a/helm_deploy/apply-for-legal-aid/templates/cronjob-extract-digest.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/cronjob-extract-digest.yaml
@@ -14,6 +14,7 @@ spec:
   failedJobsHistoryLimit: 1
   jobTemplate:
     spec:
+      backoffLimit: 1
       template:
         metadata:
           labels:

--- a/helm_deploy/apply-for-legal-aid/templates/cronjob-hourly-db-backup.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/cronjob-hourly-db-backup.yaml
@@ -15,6 +15,7 @@ spec:
   failedJobsHistoryLimit: 0
   jobTemplate:
     spec:
+      backoffLimit: 1
       template:
         spec:
           containers:

--- a/helm_deploy/apply-for-legal-aid/templates/cronjob-mark-purgeable.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/cronjob-mark-purgeable.yaml
@@ -14,6 +14,7 @@ spec:
   failedJobsHistoryLimit: 1
   jobTemplate:
     spec:
+      backoffLimit: 1
       template:
         metadata:
           labels:

--- a/helm_deploy/apply-for-legal-aid/templates/cronjob-metrics.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/cronjob-metrics.yaml
@@ -15,6 +15,7 @@ spec:
   failedJobsHistoryLimit: 0
   jobTemplate:
     spec:
+      backoffLimit: 1
       template:
         spec:
           containers:

--- a/helm_deploy/apply-for-legal-aid/templates/cronjob-reset-dashboard-overnight.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/cronjob-reset-dashboard-overnight.yaml
@@ -14,6 +14,7 @@ spec:
   failedJobsHistoryLimit: 0
   jobTemplate:
     spec:
+      backoffLimit: 1
       template:
         spec:
           containers:


### PR DESCRIPTION
Add backoffLimit for all cronjob Jobs on all environments

UAT environments are erroring when performing many of the jobs
due to database pods being recycled and not migrated/seeded.

The large numbers of errored job pods were persisting in the UAT
namespace eating up pods unnecessarily and could, in-extremis,
cause deployment failures due to pod limits?!

 ## backoffLimit

Failure of a cronjob's Job pod is usually configuration related
and is not likely to succeed on subsequent attempts. Combined
with the current cronjob `failedJobsHistoryLimit` of 0 or 1 a
`backofLimit` of 1 means failed or errored pods will remain
around for debugging purposes on any environment in any event.

The [backoffLimit](https://kubernetes.io/docs/concepts/workloads/controllers/job/#pod-backoff-failure-policy) setting allows
erroring pods to be retried only that many times.

Combined with a restartPolicy of "Never" this will only allow
2 pods to error (quite why it is 2 is unclear but I surmise it is
one initial attempt plus one retry) before it marks it as failed
and does not retry.


## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-XXX)

Describe what you did and why.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
