### PR TITLE
Fix: Update default firm permissions

### DIFF
--- a/app/services/provider_details_creator.rb
+++ b/app/services/provider_details_creator.rb
@@ -9,6 +9,7 @@ class ProviderDetailsCreator
     @provider = provider
     @passported_permission = Permission.find_by(role: "application.passported.*")
     @non_passported_permission = Permission.find_by(role: "application.non_passported.*")
+    @employed_journey_permission = Permission.find_by(role: "application.non_passported.employment.*")
   end
 
   def call
@@ -38,6 +39,7 @@ private
     end
     current_firm.permissions << @passported_permission unless current_firm.permissions.include?(@passported_permission)
     current_firm.permissions << @non_passported_permission unless current_firm.permissions.include?(@non_passported_permission)
+    current_firm.permissions << @employed_journey_permission unless current_firm.permissions.include?(@employed_journey_permission)
     current_firm
   end
 

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -9,7 +9,9 @@ FactoryBot.define do
       passported = create(:permission, :passported) if passported.nil?
       non_passported = Permission.find_by(role: "application.non_passported.*")
       non_passported = create(:permission, :non_passported) if non_passported.nil?
-      [passported, non_passported]
+      non_passported_employed = Permission.find_by(role: "application.non_passported.employment.*")
+      non_passported_employed = create(:permission, :employed) if non_passported_employed.nil?
+      [passported, non_passported, non_passported_employed]
     end
     portal_enabled { true }
 

--- a/spec/services/provider_details_creator_spec.rb
+++ b/spec/services/provider_details_creator_spec.rb
@@ -58,9 +58,9 @@ RSpec.describe ProviderDetailsCreator do
       expect(firm.name).to eq(ccms_firm.name)
     end
 
-    it "adds non passported permission to the firm" do
+    it "adds standard permissions to the firm" do
       expect { subject }.to change(Firm, :count).by(1)
-      expect(firm.permissions.map(&:role)).to match_array(["application.passported.*", "application.non_passported.*"])
+      expect(firm.permissions.map(&:role)).to match_array(%w[application.passported.* application.non_passported.* application.non_passported.employment.*])
     end
 
     it "creates the right offices" do


### PR DESCRIPTION
## What

Following the release to all users of the employed journey, ensure that a newly created firm has the employed permissions

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
