### PR TITLE
Use strong_migrations gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -102,6 +102,9 @@ gem "govuk_design_system_formbuilder", ">= 3.0.1"
 # DFE ViewComponent library
 gem "govuk-components"
 
+# Catching unsafe migrations in development
+gem "strong_migrations"
+
 group :development, :test do
   gem "awesome_print", "~> 1.9.2"
   gem "byebug", platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -663,6 +663,8 @@ GEM
       hashie
       version_gem (~> 1.1)
     spring (4.1.0)
+    strong_migrations (1.3.1)
+      activerecord (>= 5.2)
     super_diff (0.9.0)
       attr_extras (>= 6.2.4)
       diff-lcs
@@ -815,6 +817,7 @@ DEPENDENCIES
   simplecov
   simplecov-rcov
   spring
+  strong_migrations
   super_diff
   tzinfo-data
   vcr

--- a/config/initializers/strong_migrations.rb
+++ b/config/initializers/strong_migrations.rb
@@ -1,0 +1,28 @@
+# Mark existing migrations as safe
+# rubocop:disable Style/NumericLiterals
+StrongMigrations.start_after = 20221017093914
+# rubocop:enable Style/NumericLiterals
+
+# Set timeouts for migrations
+# If you use PgBouncer in transaction mode, delete these lines and set timeouts on the database user
+StrongMigrations.lock_timeout = 10.seconds
+StrongMigrations.statement_timeout = 1.hour
+
+# Analyze tables after indexes are added
+# Outdated statistics can sometimes hurt performance
+StrongMigrations.auto_analyze = true
+
+# Set the version of the production database
+# so the right checks are run in development
+StrongMigrations.target_version = 11
+
+# Add custom checks
+# StrongMigrations.add_check do |method, args|
+#   if method == :add_index && args[0].to_s == "users"
+#     stop! "No more indexes on the users table"
+#   end
+# end
+
+# Make some operations safe by default
+# See https://github.com/ankane/strong_migrations#safe-by-default
+# StrongMigrations.safe_by_default = true


### PR DESCRIPTION
As the application continues to scale, we will need to think more 
about how we do safe migrations.

This gem reduces some of that cognitive load by catching unsafe 
migrations in development and giving developers insight on how 
to mitigate problematic migrations.

Default configuration has been applied, except the targeted 
database version has been set to 10.