### PR TITLE
Eager load the application in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,7 @@ executors:
         environment:
           - RAILS_ENV=test
           - TZ: "Europe/London"
+          - CI: true
   cloud-platform-executor:
     docker:
       - image: ministryofjustice/cloud-platform-tools:2.1
@@ -32,6 +33,7 @@ executors:
       - image: ministryofjustice/apply-ci:latest-3.1.2
         environment:
           GITHUB_TEAM_NAME_SLUG: laa-apply-for-legal-aid
+          CI: true
       - image: cimg/postgres:10.18
       - image: cimg/redis:5.0
       - image: ghcr.io/ministryofjustice/hmpps-clamav:latest

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -7,10 +7,10 @@ Rails.application.configure do
   # and recreated between test runs. Don't rely on the data there!
   config.cache_classes = false
 
-  # Do not eager load code on boot. This avoids loading your whole application
-  # just for the purpose of running a single test. If you are using a tool that
-  # preloads Rails for running tests, you may have to set it to true.
-  config.eager_load = false
+  # Eager loading loads your whole application. When running a single test locally,
+  # this probably isn't necessary. It's a good idea to do in a continuous integration
+  # system, or in some way before deploying your code.
+  config.eager_load = ENV["CI"].present?
 
   # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true


### PR DESCRIPTION
This ensures the application is eager loaded when running tests in CI.

This is the default behaviour since Rails 7+, and can help catch certain errors before deployment.

It also ensures all application code is checked by simplecov when doing performaing coverage checks.