### PR TITLE
Use prosopite to detect N+1 queries

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -118,6 +118,10 @@ group :development, :test do
   gem "rubocop-govuk", require: false
   gem "rubocop-performance"
 
+  # Detecting N+1 queries
+  gem "pg_query"
+  gem "prosopite"
+
   # Available in dev env for generators
   gem "rspec-rails", "~> 5.1"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -293,6 +293,7 @@ GEM
       google-apis-core (>= 0.9.0, < 2.a)
     google-apis-sheets_v4 (0.18.0)
       google-apis-core (>= 0.9.0, < 2.a)
+    google-protobuf (3.21.7)
     google_drive (3.0.7)
       google-apis-drive_v3 (>= 0.5.0, < 1.0.0)
       google-apis-sheets_v4 (>= 0.4.0, < 1.0.0)
@@ -472,7 +473,10 @@ GEM
       optimist (~> 3.0)
     pg (1.4.3)
     pg_dump_anonymize (0.1.2)
+    pg_query (2.1.4)
+      google-protobuf (>= 3.19.2)
     prometheus_exporter (0.4.17)
+    prosopite (1.1.3)
     pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -789,7 +793,9 @@ DEPENDENCIES
   pagy
   pg
   pg_dump_anonymize
+  pg_query
   prometheus_exporter (= 0.4.17)
+  prosopite
   pry-byebug
   pry-rescue
   pry-stack_explorer

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,6 +7,8 @@ class ApplicationController < ActionController::Base
   # See also catch all route at end of config/routes.rb
   rescue_from ActiveRecord::RecordNotFound, with: :page_not_found
 
+  around_action :n_plus_one_detection, unless: -> { Rails.env.production? }
+
 private
 
   def page_not_found
@@ -25,5 +27,12 @@ private
   def convert_date_params(params)
     # gsub finds ([digit]i) and replaces with _[digit]i
     params.transform_keys! { |key| key.gsub(/\((\di)\)/, '_\\1') }
+  end
+
+  def n_plus_one_detection
+    Prosopite.scan
+    yield
+  ensure
+    Prosopite.finish
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -72,4 +72,8 @@ Rails.application.configure do
 
   # Switch to determine whether or not o collect HMRC data
   config.x.collect_hmrc_data = true
+
+  config.after_initialize do
+    Prosopite.rails_logger = true
+  end
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -78,4 +78,9 @@ Rails.application.configure do
 
   # Switch to determine whether or not o collect HMRC data
   config.x.collect_hmrc_data = true
+
+  config.after_initialize do
+    Prosopite.rails_logger = true
+    Prosopite.raise = true
+  end
 end

--- a/spec/support/prosopite.rb
+++ b/spec/support/prosopite.rb
@@ -1,0 +1,9 @@
+RSpec.configure do |config|
+  config.before do
+    Prosopite.scan
+  end
+
+  config.after do
+    Prosopite.finish
+  end
+end


### PR DESCRIPTION
This adds the prosopite gem to detect N+1 queries.

Default configuration has been applied.

This means N+1 queries raise errors in test environments and log in development environments.

Prosopite does not run in production.