### PR TITLE
AP-3534: Update default firm permissions

### DIFF
--- a/app/controllers/providers/confirm_dwp_non_passported_applications_controller.rb
+++ b/app/controllers/providers/confirm_dwp_non_passported_applications_controller.rb
@@ -59,12 +59,8 @@ module Providers
       Rails.configuration.x.collect_hmrc_data
     end
 
-    def user_has_employment_permissions?
-      legal_aid_application.provider.employment_permissions?
-    end
-
     def make_hmrc_call?
-      hmrc_call_enabled? && user_has_employment_permissions?
+      hmrc_call_enabled?
     end
 
     alias_method :display_hmrc_inset_text?, :make_hmrc_call?

--- a/app/services/hmrc/status_analyzer.rb
+++ b/app/services/hmrc/status_analyzer.rb
@@ -18,8 +18,6 @@ module HMRC
     end
 
     def call
-      return :provider_not_enabled_for_employed_journey unless provider.employment_permissions?
-
       return :applicant_not_employed if applicant_not_employed && no_employment_payments
 
       return :unexpected_employment_data if applicant_not_employed && eligible_employment_payments.any?

--- a/app/services/provider_details_creator.rb
+++ b/app/services/provider_details_creator.rb
@@ -9,6 +9,7 @@ class ProviderDetailsCreator
     @provider = provider
     @passported_permission = Permission.find_by(role: "application.passported.*")
     @non_passported_permission = Permission.find_by(role: "application.non_passported.*")
+    @employed_journey_permission = Permission.find_by(role: "application.non_passported.employment.*")
   end
 
   def call
@@ -38,6 +39,7 @@ private
     end
     current_firm.permissions << @passported_permission unless current_firm.permissions.include?(@passported_permission)
     current_firm.permissions << @non_passported_permission unless current_firm.permissions.include?(@non_passported_permission)
+    current_firm.permissions << @employed_journey_permission unless current_firm.permissions.include?(@employed_journey_permission)
     current_firm
   end
 

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -9,7 +9,9 @@ FactoryBot.define do
       passported = create(:permission, :passported) if passported.nil?
       non_passported = Permission.find_by(role: "application.non_passported.*")
       non_passported = create(:permission, :non_passported) if non_passported.nil?
-      [passported, non_passported]
+      non_passported_employed = Permission.find_by(role: "application.non_passported.employment.*")
+      non_passported_employed = create(:permission, :employed) if non_passported_employed.nil?
+      [passported, non_passported, non_passported_employed]
     end
     portal_enabled { true }
 

--- a/spec/requests/providers/applicant_employed_spec.rb
+++ b/spec/requests/providers/applicant_employed_spec.rb
@@ -82,7 +82,6 @@ RSpec.describe Providers::ApplicantEmployedController, type: :request do
         applicant = create(:applicant, self_employed: true)
         legal_aid_application = create(:legal_aid_application, applicant:)
         provider = legal_aid_application.provider
-        grant_employment_journey_permissions(provider)
         login_as provider
 
         post providers_legal_aid_application_applicant_employed_index_path(legal_aid_application),
@@ -101,7 +100,6 @@ RSpec.describe Providers::ApplicantEmployedController, type: :request do
           df_options: { DA001: [Date.yesterday, Date.current] },
         )
         provider = legal_aid_application.provider
-        grant_employment_journey_permissions(provider)
         login_as provider
 
         post providers_legal_aid_application_applicant_employed_index_path(legal_aid_application),
@@ -113,26 +111,12 @@ RSpec.describe Providers::ApplicantEmployedController, type: :request do
       it "redirects to the open banking consent page for applications that have not used delegated functions" do
         legal_aid_application = create(:legal_aid_application)
         provider = legal_aid_application.provider
-        grant_employment_journey_permissions(provider)
         login_as provider
 
         post providers_legal_aid_application_applicant_employed_index_path(legal_aid_application),
              params: { applicant: { employed: "true" } }
 
         expect(response).to redirect_to(providers_legal_aid_application_open_banking_consents_path(legal_aid_application))
-      end
-    end
-
-    context "when the provider does not have employment permissions and the applicant is employed" do
-      it "redirects to the use ccms employed page" do
-        legal_aid_application = create(:legal_aid_application)
-        provider = legal_aid_application.provider
-        login_as provider
-
-        post providers_legal_aid_application_applicant_employed_index_path(legal_aid_application),
-             params: { applicant: { employed: "true" } }
-
-        expect(response).to redirect_to(providers_legal_aid_application_use_ccms_employed_index_path(legal_aid_application))
       end
     end
 
@@ -164,11 +148,5 @@ RSpec.describe Providers::ApplicantEmployedController, type: :request do
         expect(response).to redirect_to(providers_legal_aid_application_open_banking_consents_path(legal_aid_application))
       end
     end
-  end
-
-  def grant_employment_journey_permissions(provider)
-    permission = create(:permission, :employed)
-    provider.permissions << permission
-    provider.save!
   end
 end

--- a/spec/requests/providers/bank_statements_spec.rb
+++ b/spec/requests/providers/bank_statements_spec.rb
@@ -303,6 +303,7 @@ RSpec.describe "Providers::BankStatementsController", type: :request do
 
       context "with files already attached" do
         before do
+          create(:applicant, :employed, legal_aid_application:)
           patch(providers_legal_aid_application_bank_statements_path(legal_aid_application),
                 params: { upload_button: "Upload",
                           original_file: uploaded_file("spec/fixtures/files/acceptable.pdf", "application/pdf") })
@@ -352,7 +353,6 @@ RSpec.describe "Providers::BankStatementsController", type: :request do
             allow(HMRC::StatusAnalyzer).to receive(:call).and_return :applicant_not_employed
             Setting.setting.update!(enhanced_bank_upload: true)
             permissions = [
-              create(:permission, :employed),
               create(:permission, :bank_statement_upload),
             ]
             provider.permissions << permissions

--- a/spec/requests/providers/client_completed_means_spec.rb
+++ b/spec/requests/providers/client_completed_means_spec.rb
@@ -55,14 +55,6 @@ RSpec.describe Providers::ClientCompletedMeansController, type: :request do
         login_as provider
       end
 
-      context "Continue button pressed" do
-        let(:submit_button) { { continue_button: "Continue" } }
-
-        it "redirects to next page" do
-          expect(subject).to redirect_to(providers_legal_aid_application_means_identify_types_of_income_path(legal_aid_application))
-        end
-      end
-
       context "Save as draft button pressed" do
         let(:submit_button) { { draft_button: "Save as draft" } }
 
@@ -77,9 +69,7 @@ RSpec.describe Providers::ClientCompletedMeansController, type: :request do
         end
       end
 
-      context "the user has employed permissions" do
-        before { allow_any_instance_of(Provider).to receive(:employment_permissions?).and_return(true) }
-
+      context "Continue button pressed" do
         let(:submit_button) { { continue_button: "Continue" } }
 
         context "employment income data was received from HMRC" do

--- a/spec/requests/providers/confirm_dwp_non_passported_applications_spec.rb
+++ b/spec/requests/providers/confirm_dwp_non_passported_applications_spec.rb
@@ -44,18 +44,9 @@ RSpec.describe Providers::ConfirmDWPNonPassportedApplicationsController, type: :
       before { login_as application.provider }
 
       context "the user has employed permissions" do
-        before { allow_any_instance_of(Provider).to receive(:employment_permissions?).and_return(true) }
-
         it "displays the HMRC inset text" do
           subject
           expect(unescaped_response_body).to include(I18n.t(".providers.confirm_dwp_non_passported_applications.show.hmrc_inset_text"))
-        end
-      end
-
-      context "the user does not have employed permissions" do
-        it "does not display the HMRC inset text" do
-          subject
-          expect(unescaped_response_body).not_to include(I18n.t(".providers.confirm_dwp_non_passported_applications.show.hmrc_inset_text"))
         end
       end
     end
@@ -106,20 +97,9 @@ RSpec.describe Providers::ConfirmDWPNonPassportedApplicationsController, type: :
           expect(application.reload.state_machine_proxy.type).to eq "NonPassportedStateMachine"
         end
 
-        context "the user has employed permissions" do
-          before { allow_any_instance_of(Provider).to receive(:employment_permissions?).and_return(true) }
-
-          it "calls the HMRC::CreateResponsesService" do
-            subject
-            expect(HMRC::CreateResponsesService).to have_received(:call).once
-          end
-        end
-
-        context "the user does not have employed permissions" do
-          it "does not call the HMRC::CreateResponsesService" do
-            subject
-            expect(HMRC::CreateResponsesService).not_to have_received(:call)
-          end
+        it "calls the HMRC::CreateResponsesService" do
+          subject
+          expect(HMRC::CreateResponsesService).to have_received(:call).once
         end
       end
 
@@ -148,20 +128,9 @@ RSpec.describe Providers::ConfirmDWPNonPassportedApplicationsController, type: :
           expect(application.reload.state_machine_proxy.type).to eq "PassportedStateMachine"
         end
 
-        context "the user has employed permissions" do
-          before { allow_any_instance_of(Provider).to receive(:employment_permissions?).and_return(true) }
-
-          it "calls the HMRC::CreateResponsesService" do
-            subject
-            expect(HMRC::CreateResponsesService).to have_received(:call)
-          end
-        end
-
-        context "the user has does not have employed permissions" do
-          it "does not call the HMRC::CreateResponsesService" do
-            subject
-            expect(HMRC::CreateResponsesService).to_not have_received(:call)
-          end
+        it "calls the HMRC::CreateResponsesService" do
+          subject
+          expect(HMRC::CreateResponsesService).to have_received(:call)
         end
       end
 
@@ -197,20 +166,9 @@ RSpec.describe Providers::ConfirmDWPNonPassportedApplicationsController, type: :
         expect(application.reload).to be_draft
       end
 
-      context "the user has employed permissions" do
-        before { allow_any_instance_of(Provider).to receive(:employment_permissions?).and_return(true) }
-
-        it "does not call the HMRC::CreateResponsesService" do
-          subject
-          expect(HMRC::CreateResponsesService).to_not have_received(:call)
-        end
-      end
-
-      context "the user has does not have employed permissions" do
-        it "does not call the HMRC::CreateResponsesService" do
-          subject
-          expect(HMRC::CreateResponsesService).to_not have_received(:call)
-        end
+      it "does not call the HMRC::CreateResponsesService" do
+        subject
+        expect(HMRC::CreateResponsesService).to_not have_received(:call)
       end
     end
   end

--- a/spec/requests/providers/review_and_print_applications_controller_spec.rb
+++ b/spec/requests/providers/review_and_print_applications_controller_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Providers::ReviewAndPrintApplicationsController, type: :request d
            :with_chances_of_success,
            :with_attempts_to_settle,
            :with_involved_children,
+           :with_cfe_v4_result,
            :provider_entering_merits,
            proceeding_count: 3
   end

--- a/spec/requests/providers/submitted_applications_spec.rb
+++ b/spec/requests/providers/submitted_applications_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Providers::SubmittedApplicationsController, type: :request do
            :with_everything,
            :with_proceedings,
            :assessment_submitted,
+           :with_cfe_v4_result,
            set_lead_proceeding: :da001,
            provider:
   end

--- a/spec/requests/saml_sessions_spec.rb
+++ b/spec/requests/saml_sessions_spec.rb
@@ -60,6 +60,7 @@ RSpec.describe "SamlSessionsController", type: :request do
     before do
       create :permission, :passported
       create :permission, :non_passported
+      create :permission, :employed
       allow_any_instance_of(Warden::Proxy).to receive(:authenticate!).and_return(provider)
       stub_request(:get, provider_details_api_url).to_return(body: provider_details_api_reponse, status:)
     end

--- a/spec/services/hmrc/status_analyzer_spec.rb
+++ b/spec/services/hmrc/status_analyzer_spec.rb
@@ -5,76 +5,60 @@ module HMRC
     describe ".call" do
       subject(:service_call) { described_class.call(laa) }
       before do
-        if provider_employed_permissions
-          permission = create :permission, :employed
-          laa.provider.firm.permissions << permission
-          laa.provider.permissions << permission
-        end
         laa.applicant.update!(employed: true) if applicant_employed
       end
 
       let(:feature_flag) { true }
       let(:laa) { create :legal_aid_application, :with_applicant, :with_transaction_period }
-      let(:provider_employed_permissions) { true }
       let(:applicant_employed) { true }
 
-      context "when provider not enabled for employment journey" do
-        let(:provider_employed_permissions) { false }
+      context "and applicant not employed and no eligible payments" do
+        let(:applicant_employed) { false }
 
-        it "returns provider_not_enabled_for_employed_journey" do
-          expect(service_call).to eq :provider_not_enabled_for_employed_journey
+        it "returns not employed" do
+          expect(service_call).to eq :applicant_not_employed
         end
       end
 
-      context "when provider_enabled_for_employment journey" do
-        context "and applicant not employed and no eligible payments" do
-          let(:applicant_employed) { false }
+      context "with applicant not employed but eligible employment payments exist" do
+        let(:applicant_employed) { false }
 
-          it "returns not employed" do
-            expect(service_call).to eq :applicant_not_employed
-          end
+        before { create :employment, :with_payments_in_transaction_period, legal_aid_application: laa }
+
+        it "returns :unexpected_employment_data" do
+          expect(service_call).to eq :unexpected_employment_data
         end
+      end
 
-        context "with applicant not employed but eligible employment payments exist" do
-          let(:applicant_employed) { false }
+      context "with applicant not employed and non-eligible employment payments exist" do
+        let(:applicant_employed) { false }
 
-          before { create :employment, :with_payments_in_transaction_period, legal_aid_application: laa }
+        before { create :employment, :with_payments_before_transaction_period, legal_aid_application: laa }
 
-          it "returns :unexpected_employment_data" do
-            expect(service_call).to eq :unexpected_employment_data
-          end
+        it "returns :unexpected_employment_data" do
+          expect(service_call).to eq :applicant_not_employed
         end
+      end
 
-        context "with applicant not employed and non-eligible employment payments exist" do
-          let(:applicant_employed) { false }
+      context "and applicant has multiple employments" do
+        before { create_list :employment, 2, legal_aid_application: laa }
 
-          before { create :employment, :with_payments_before_transaction_period, legal_aid_application: laa }
-
-          it "returns :unexpected_employment_data" do
-            expect(service_call).to eq :applicant_not_employed
-          end
+        it "returns hmrc_multiple_employments" do
+          expect(service_call).to eq :hmrc_multiple_employments
         end
+      end
 
-        context "and applicant has multiple employments" do
-          before { create_list :employment, 2, legal_aid_application: laa }
+      context "and applicant has single employment" do
+        before { create :employment, legal_aid_application: laa }
 
-          it "returns hmrc_multiple_employments" do
-            expect(service_call).to eq :hmrc_multiple_employments
-          end
+        it "returns hmrc_single_employment" do
+          expect(service_call).to eq :hmrc_single_employment
         end
+      end
 
-        context "and applicant has single employment" do
-          before { create :employment, legal_aid_application: laa }
-
-          it "returns hmrc_single_employment" do
-            expect(service_call).to eq :hmrc_single_employment
-          end
-        end
-
-        context "but applicant has no hmrc data" do
-          it "returns no_hmrc_data" do
-            expect(service_call).to eq :no_hmrc_data
-          end
+      context "but applicant has no hmrc data" do
+        it "returns no_hmrc_data" do
+          expect(service_call).to eq :no_hmrc_data
         end
       end
     end

--- a/spec/services/provider_details_creator_spec.rb
+++ b/spec/services/provider_details_creator_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe ProviderDetailsCreator do
 
     it "adds non passported permission to the firm" do
       expect { subject }.to change(Firm, :count).by(1)
-      expect(firm.permissions.map(&:role)).to match_array(["application.passported.*", "application.non_passported.*"])
+      expect(firm.permissions.map(&:role)).to match_array(["application.passported.*", "application.non_passported.*", "application.non_passported.employment.*"])
     end
 
     it "creates the right offices" do


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3534)

After the release of the employed journey to all Providers, this was implemented to to ensure a new joiner would automatically be assigned the employed permission.

It then snowballed to fix the tests that broke, then remove code branches that required the permissions on and off.

It is a work in progress - 5 Oct 2022

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
