### PR TITLE
Use default Docker version in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,8 +133,7 @@ jobs:
     executor: linting-executor
     steps:
     - checkout
-    - setup_remote_docker:
-        version: 20.10.7
+    - setup_remote_docker
     - *update_packages
     - run: sudo apt-get install -y git-crypt
     - *decrypt_secrets
@@ -262,8 +261,7 @@ jobs:
     executor: basic-executor
     steps:
     - checkout
-    - setup_remote_docker:
-        version: 20.10.7
+    - setup_remote_docker
     - *update_packages
     - run: sudo apt-get install -y git-crypt
     - *decrypt_secrets


### PR DESCRIPTION
This change was [recommended] by the operations team ahead of 
some changes to CircleCI.

[recommended]: https://mojdt.slack.com/archives/C02D2NEF9CJ/p1665061637638169

We were already using the default version in most places, however 
this removes the version flag from the two remaining places it was used.