### PR TITLE
Refactor regular transaction forms

### DIFF
--- a/app/controllers/providers/means/housing_benefits_controller.rb
+++ b/app/controllers/providers/means/housing_benefits_controller.rb
@@ -22,7 +22,7 @@ module Providers
       def housing_benefit_params
         params
           .require(:providers_means_housing_benefit_form)
-          .permit(:housing_benefit, :housing_benefit_amount, :housing_benefit_frequency)
+          .permit(:transaction_type_ids, :housing_benefit_amount, :housing_benefit_frequency)
           .merge(legal_aid_application:)
       end
 

--- a/app/forms/providers/means/housing_benefit_form.rb
+++ b/app/forms/providers/means/housing_benefit_form.rb
@@ -1,116 +1,30 @@
 module Providers
   module Means
-    class HousingBenefitForm
-      include ActiveModel::Model
+    class HousingBenefitForm < RegularTransactionForm
+      attr_accessor :housing_benefit_amount, :housing_benefit_frequency
 
-      attr_accessor :housing_benefit,
-                    :housing_benefit_amount,
-                    :housing_benefit_frequency
+      delegate :applicant_in_receipt_of_housing_benefit, to: :legal_aid_application
 
-      attr_reader :legal_aid_application
-
-      validates :housing_benefit, inclusion: { in: %w[true false] }
-
-      validates :housing_benefit_amount,
-                currency: { greater_than: 0 },
-                if: :applicant_in_receipt_of_housing_benefit?
-
-      validates :housing_benefit_frequency,
-                inclusion: { in: ->(form) { form.frequency_options } },
-                if: :applicant_in_receipt_of_housing_benefit?
-
-      def initialize(params = {})
-        @legal_aid_application = params.delete(:legal_aid_application)
-
-        if params[:housing_benefit].nil?
-          assign_housing_benefit_attributes
-        end
-
-        super
-      end
-
-      def save
-        return false unless valid?
-
-        ApplicationRecord.transaction do
-          legal_aid_application.applicant_in_receipt_of_housing_benefit = housing_benefit
-
-          if applicant_in_receipt_of_housing_benefit?
-            build_housing_benefit_transaction_type
-            build_housing_benefit_regular_transaction
-          else
-            destroy_housing_benefit_transaction_type!
-            destroy_housing_benefit_regular_transaction!
-          end
-
-          legal_aid_application.save!
-        end
-
-        true
+      def housing_benefit_transaction_type
+        TransactionType.find_by(name: "housing_benefit")
       end
 
       def frequency_options
         RegularTransaction.frequencies_for(housing_benefit_transaction_type)
       end
 
+      def housing_benefit_selected?
+        transaction_type_ids.include?(housing_benefit_transaction_type.id)
+      end
+
     private
 
-      def applicant_in_receipt_of_housing_benefit?
-        housing_benefit == "true"
+      def transaction_type_conditions
+        { name: "housing_benefit" }
       end
 
-      def assign_housing_benefit_attributes
-        @housing_benefit = @legal_aid_application.applicant_in_receipt_of_housing_benefit
-        @housing_benefit_amount = housing_benefit_regular_transaction&.amount
-        @housing_benefit_frequency = housing_benefit_regular_transaction&.frequency
-      end
-
-      def build_housing_benefit_transaction_type
-        legal_aid_application
-          .legal_aid_application_transaction_types
-          .find_or_initialize_by(
-            transaction_type: housing_benefit_transaction_type,
-          )
-      end
-
-      def build_housing_benefit_regular_transaction
-        housing_benefit_transaction = legal_aid_application
-          .regular_transactions
-          .find_or_initialize_by(
-            transaction_type: housing_benefit_transaction_type,
-          )
-        housing_benefit_transaction.assign_attributes(
-          amount: housing_benefit_amount,
-          frequency: housing_benefit_frequency,
-        )
-        housing_benefit_transaction.save!
-      end
-
-      def destroy_housing_benefit_transaction_type!
-        legal_aid_application
-          .legal_aid_application_transaction_types
-          .includes(:transaction_type)
-          .where(transaction_type: { name: "housing_benefit" })
-          .destroy_all
-      end
-
-      def destroy_housing_benefit_regular_transaction!
-        legal_aid_application
-          .regular_transactions
-          .includes(:transaction_type)
-          .where(transaction_type: { name: "housing_benefit" })
-          .destroy_all
-      end
-
-      def housing_benefit_regular_transaction
-        legal_aid_application
-          .regular_transactions
-          .includes(:transaction_type)
-          .find_by(transaction_type: { name: "housing_benefit" })
-      end
-
-      def housing_benefit_transaction_type
-        TransactionType.find_by!(name: "housing_benefit")
+      def legal_aid_application_attributes
+        { applicant_in_receipt_of_housing_benefit: housing_benefit_selected? }
       end
     end
   end

--- a/app/forms/providers/means/regular_income_form.rb
+++ b/app/forms/providers/means/regular_income_form.rb
@@ -1,8 +1,6 @@
 module Providers
   module Means
-    class RegularIncomeForm
-      include ActiveModel::Model
-
+    class RegularIncomeForm < RegularTransactionForm
       INCOME_TYPES = %w[
         benefits
         friends_or_family
@@ -18,164 +16,23 @@ module Providers
         other
       ].freeze
 
-      attr_reader :transaction_type_ids, :legal_aid_application
-
       INCOME_TYPES.each do |income_type|
         attr_accessor "#{income_type}_amount".to_sym,
                       "#{income_type}_frequency".to_sym
-      end
-
-      validates :transaction_type_ids, presence: true, unless: :none_selected?
-      validate :all_regular_transactions_valid
-
-      def initialize(params = {})
-        @none_selected = none_selected.in?(params["transaction_type_ids"] || [])
-        @legal_aid_application = params.delete(:legal_aid_application)
-        @transaction_type_ids = params["transaction_type_ids"] ||
-          @legal_aid_application.transaction_types.credits.not_children.pluck(:id)
-
-        assign_regular_transaction_attributes
-
-        super
-      end
-
-      def save
-        return false unless valid?
-
-        ApplicationRecord.transaction do
-          destroy_transactions!
-
-          build_legal_aid_application_transaction_types
-          legal_aid_application.assign_attributes(
-            no_credit_transaction_types_selected: none_selected?,
-          )
-          legal_aid_application.save!
-
-          regular_transactions.each(&:save!)
-        end
-
-        true
-      end
-
-      def transaction_type_ids=(ids)
-        @transaction_type_ids = if none_selected?
-                                  []
-                                else
-                                  ids.compact_blank
-                                end
-      end
-
-      def transaction_type_options
-        TransactionType.not_children.credits
       end
 
       def disregarded_benefit_categories
         DISREGARDED_BENEFIT_CATEGORIES
       end
 
-      def none_selected
-        "none"
-      end
-
     private
 
-      def assign_regular_transaction_attributes
-        regular_transactions.each do |transaction|
-          transaction_type = transaction.transaction_type
-          public_send("#{transaction_type.name}_amount=", transaction.amount)
-          public_send("#{transaction_type.name}_frequency=", transaction.frequency)
-        end
+      def transaction_type_conditions
+        { operation: "credit", parent_id: nil }
       end
 
-      def none_selected?
-        @none_selected
-      end
-
-      def transaction_types
-        transaction_type_options.where(id: transaction_type_ids)
-      end
-
-      def destroy_transactions!
-        destroy_legal_aid_application_transaction_types!
-        destroy_regular_income_transactions!
-        destroy_cash_income_transactions!
-      end
-
-      def destroy_legal_aid_application_transaction_types!
-        legal_aid_application
-          .legal_aid_application_transaction_types
-          .credits
-          .where.not(transaction_type_id: transaction_type_ids_to_keep)
-          .destroy_all
-      end
-
-      def destroy_regular_income_transactions!
-        legal_aid_application
-          .regular_incomes
-          .where.not(transaction_type_id: transaction_type_ids_to_keep)
-          .destroy_all
-      end
-
-      def destroy_cash_income_transactions!
-        legal_aid_application
-          .cash_transactions
-          .credits
-          .where.not(transaction_type_id: transaction_type_ids_to_keep)
-          .destroy_all
-      end
-
-      def transaction_type_ids_to_keep
-        @transaction_type_ids_to_keep ||= transaction_type_ids + [housing_benefit_id]
-      end
-
-      def housing_benefit_id
-        @housing_benefit_id ||= TransactionType.find_by!(name: "housing_benefit").id
-      end
-
-      def build_legal_aid_application_transaction_types
-        transaction_type_ids.each do |transaction_type_id|
-          next if transaction_type_id.in?(legal_aid_application.transaction_type_ids)
-
-          legal_aid_application.legal_aid_application_transaction_types.build(
-            transaction_type_id:,
-          )
-        end
-      end
-
-      def regular_transactions
-        @regular_transactions ||= transaction_types.map do |transaction_type|
-          RegularTransaction.find_or_initialize_by(
-            legal_aid_application:,
-            transaction_type:,
-          )
-        end
-      end
-
-      def all_regular_transactions_valid
-        regular_transactions.each do |transaction|
-          transaction_type = transaction.transaction_type
-          transaction.amount = public_send("#{transaction_type.name}_amount")
-          transaction.frequency = public_send("#{transaction_type.name}_frequency")
-
-          next if transaction.valid?
-
-          transaction.errors.each do |error|
-            add_regular_transaction_error_to_form(
-              transaction.transaction_type.name,
-              error,
-            )
-          end
-        end
-      end
-
-      def add_regular_transaction_error_to_form(transaction_type, error)
-        attribute = if error.attribute.in?(%i[amount frequency])
-                      "#{transaction_type}_#{error.attribute}".to_sym
-                    else
-                      :base
-                    end
-
-        errors.add(attribute, error.type, **error.options)
+      def legal_aid_application_attributes
+        { no_credit_transaction_types_selected: none_selected? }
       end
     end
   end

--- a/app/forms/providers/means/regular_transaction_form.rb
+++ b/app/forms/providers/means/regular_transaction_form.rb
@@ -1,0 +1,158 @@
+module Providers
+  module Means
+    class RegularTransactionForm
+      include ActiveModel::Model
+
+      attr_reader :transaction_type_ids, :legal_aid_application
+
+      validates :transaction_type_ids, presence: true, unless: :none_selected?
+      validate :all_regular_transactions_valid
+
+      def initialize(params = {})
+        @none_selected = none_selected.in?(params["transaction_type_ids"] || [])
+        @legal_aid_application = params.delete(:legal_aid_application)
+        @transaction_type_ids = params["transaction_type_ids"] || existing_transaction_type_ids
+
+        assign_regular_transaction_attributes
+
+        super
+      end
+
+      def save
+        return false unless valid?
+
+        ApplicationRecord.transaction do
+          destroy_transactions!
+
+          build_legal_aid_application_transaction_types
+          legal_aid_application.assign_attributes(legal_aid_application_attributes)
+          legal_aid_application.save!
+
+          regular_transactions.each(&:save!)
+        end
+
+        true
+      end
+
+      def transaction_type_ids=(ids)
+        @transaction_type_ids = if none_selected?
+                                  []
+                                else
+                                  [ids].flatten.compact_blank
+                                end
+      end
+
+      def transaction_type_options
+        TransactionType.active.where(transaction_type_conditions)
+      end
+
+      def none_selected
+        "none"
+      end
+
+    private
+
+      def transaction_type_conditions
+        raise(
+          NotImplementedError,
+          "#transaction_type_conditions must be implemented in the subclass",
+        )
+      end
+
+      def legal_aid_application_attributes
+        raise(
+          NotImplementedError,
+          "#legal_aid_application_attributes must be implemented in the subclass",
+        )
+      end
+
+      def none_selected?
+        @none_selected
+      end
+
+      def existing_transaction_type_ids
+        legal_aid_application
+          .transaction_types
+          .where(transaction_type_conditions)
+          .pluck(:id)
+      end
+
+      def assign_regular_transaction_attributes
+        regular_transactions.each do |transaction|
+          transaction_type = transaction.transaction_type
+          public_send("#{transaction_type.name}_amount=", transaction.amount)
+          public_send("#{transaction_type.name}_frequency=", transaction.frequency)
+        end
+      end
+
+      def build_legal_aid_application_transaction_types
+        transaction_type_ids.each do |transaction_type_id|
+          next if transaction_type_id.in?(legal_aid_application.transaction_type_ids)
+
+          legal_aid_application.legal_aid_application_transaction_types.build(
+            transaction_type_id:,
+          )
+        end
+      end
+
+      def destroy_transactions!
+        dependent_transaction_models.each do |model|
+          legal_aid_application
+            .public_send(model)
+            .includes(:transaction_type)
+            .where(transaction_type: transaction_type_conditions)
+            .where.not(transaction_type_id: transaction_type_ids)
+            .destroy_all
+        end
+      end
+
+      def dependent_transaction_models
+        %i[
+          legal_aid_application_transaction_types
+          regular_transactions
+          cash_transactions
+        ]
+      end
+
+      def regular_transactions
+        @regular_transactions ||= transaction_types.map do |transaction_type|
+          RegularTransaction.find_or_initialize_by(
+            legal_aid_application:,
+            transaction_type:,
+          )
+        end
+      end
+
+      def transaction_types
+        transaction_type_options.where(id: transaction_type_ids)
+      end
+
+      def all_regular_transactions_valid
+        regular_transactions.each do |transaction|
+          transaction_type = transaction.transaction_type
+          transaction.amount = public_send("#{transaction_type.name}_amount")
+          transaction.frequency = public_send("#{transaction_type.name}_frequency")
+
+          next if transaction.valid?
+
+          transaction.errors.each do |error|
+            add_regular_transaction_error_to_form(
+              transaction.transaction_type.name,
+              error,
+            )
+          end
+        end
+      end
+
+      def add_regular_transaction_error_to_form(transaction_type, error)
+        attribute = if error.attribute.in?(%i[amount frequency])
+                      "#{transaction_type}_#{error.attribute}".to_sym
+                    else
+                      :base
+                    end
+
+        errors.add(attribute, error.type, **error.options)
+      end
+    end
+  end
+end

--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -53,8 +53,6 @@ class LegalAidApplication < ApplicationRecord
   has_many :hmrc_responses, class_name: "HMRC::Response", dependent: :destroy, inverse_of: :legal_aid_application
   has_many :employments, dependent: :destroy
   has_many :regular_transactions, dependent: :destroy
-  has_many :regular_incomes, -> { credits }, class_name: "RegularTransaction"
-  has_many :regular_outgoings, -> { debits }, class_name: "RegularTransaction"
 
   before_save :set_open_banking_consent_choice_at
   before_create :create_app_ref

--- a/app/views/providers/means/housing_benefits/show.html.erb
+++ b/app/views/providers/means/housing_benefits/show.html.erb
@@ -1,9 +1,15 @@
 <%= form_with model: @form,
               url: providers_legal_aid_application_means_housing_benefits_path(@legal_aid_application),
               method: :patch do |f| %>
-  <%= page_template page_title: t('.page_heading'), template: :basic, form: f do %>
-    <%= f.govuk_radio_buttons_fieldset :housing_benefit, legend: {tag: "h1", size: "xl"} do %>
-      <%= f.govuk_radio_button :housing_benefit, "true", link_errors: true do %>
+  <%= page_template page_title: t(".page_heading"), template: :basic, form: f do %>
+
+    <%= f.govuk_radio_buttons_fieldset :transaction_type_ids, legend: {tag: "h1", size: "xl"} do %>
+
+      <%= f.govuk_radio_button :transaction_type_ids,
+                               @form.housing_benefit_transaction_type.id,
+                               link_errors: true,
+                               label: { text: t(".labels.housing_benefit.yes") },
+                               checked: @form.housing_benefit_selected? do %>
         <%= f.govuk_text_field :housing_benefit_amount, width: "one-quarter", prefix_text: "£" %>
         <%= f.govuk_collection_radio_buttons :housing_benefit_frequency,
                                              @form.frequency_options,
@@ -12,7 +18,10 @@
                                              legend: {tag: "p", size: "s"} %>
       <% end %>
 
-      <%= f.govuk_radio_button :housing_benefit, "false" %>
+      <%= f.govuk_radio_button :transaction_type_ids,
+                               @form.none_selected,
+                               label: { text: t(".labels.housing_benefit.no") },
+                               checked: @form.applicant_in_receipt_of_housing_benefit == false && !@form.housing_benefit_selected? %>
     <% end %>
 
     <%= f.govuk_submit t("generic.save_and_continue") %>

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -505,8 +505,8 @@ en:
               system_down: There was a problem uploading your file - try again
         providers/means/housing_benefit_form:
           attributes:
-            housing_benefit:
-              inclusion: Select one of the options
+            transaction_type_ids:
+              blank: Select whether your client receives housing benefit
             housing_benefit_amount:
               greater_than: Enter a number greater than 0
               not_a_number: Enter the amount of housing benefit received

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -506,13 +506,13 @@ en:
         providers/means/housing_benefit_form:
           attributes:
             transaction_type_ids:
-              blank: Select whether your client receives housing benefit
+              blank: Select yes if your client receives Housing Benefit
             housing_benefit_amount:
               greater_than: Enter a number greater than 0
-              not_a_number: Enter the amount of housing benefit received
+              not_a_number: Enter the amount of Housing Benefit received
               too_many_decimals: Enter a number with no more than 2 decimal places
             housing_benefit_frequency:
-              inclusion: Select how often your client receives housing benefit
+              inclusion: Select how often your client receives Housing Benefit
         providers/means/regular_income_form:
           attributes:
             benefits_amount:

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -34,9 +34,6 @@ en:
           <<: *true_false
       providers_means_housing_benefit_form:
         housing_benefit_amount: Enter amount
-        housing_benefit_options:
-          "true": "Yes"
-          "false": "No"
       providers_means_regular_income_form:
         benefits_amount: Enter amount
         friends_or_family_amount: Enter amount
@@ -80,7 +77,7 @@ en:
           <<: *true_false
     legend:
       providers_means_housing_benefit_form:
-        housing_benefit: Does your client receive housing benefits?
+        transaction_type_ids: Does your client receive housing benefits?
         housing_benefit_frequency: Select frequency
       providers_means_regular_income_form:
         benefits_frequency: Select frequency

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -702,6 +702,10 @@ en:
           page_heading: Select payments your client receives in cash
       housing_benefits:
         show:
+          labels:
+            housing_benefit:
+              "yes": "Yes"
+              "no": "No"
           page_heading: Does your client receive housing benefits?
       identify_types_of_incomes:
         show:

--- a/spec/forms/providers/means/housing_benefit_form_spec.rb
+++ b/spec/forms/providers/means/housing_benefit_form_spec.rb
@@ -10,6 +10,11 @@ RSpec.describe Providers::Means::HousingBenefitForm do
           applicant_in_receipt_of_housing_benefit: true,
         )
         transaction_type = create(:transaction_type, :housing_benefit)
+        _legal_aid_application_transaction_type = create(
+          :legal_aid_application_transaction_type,
+          legal_aid_application:,
+          transaction_type:,
+        )
         _housing_benefit = create(
           :regular_transaction,
           legal_aid_application:,
@@ -22,7 +27,7 @@ RSpec.describe Providers::Means::HousingBenefitForm do
         form = described_class.new(params)
 
         expect(form).to have_attributes(
-          housing_benefit: true,
+          applicant_in_receipt_of_housing_benefit: true,
           housing_benefit_amount: 500,
           housing_benefit_frequency: "weekly",
         )
@@ -40,7 +45,7 @@ RSpec.describe Providers::Means::HousingBenefitForm do
         form = described_class.new(params)
 
         expect(form).to have_attributes(
-          housing_benefit: false,
+          applicant_in_receipt_of_housing_benefit: false,
           housing_benefit_amount: nil,
           housing_benefit_frequency: nil,
         )
@@ -58,7 +63,7 @@ RSpec.describe Providers::Means::HousingBenefitForm do
         form = described_class.new(params)
 
         expect(form).to have_attributes(
-          housing_benefit: nil,
+          applicant_in_receipt_of_housing_benefit: nil,
           housing_benefit_amount: nil,
           housing_benefit_frequency: nil,
         )
@@ -67,10 +72,11 @@ RSpec.describe Providers::Means::HousingBenefitForm do
   end
 
   describe "#validate" do
-    context "when neither true or false is selected" do
+    context "when no housing benefit option is selected" do
       it "is invalid" do
         legal_aid_application = build_stubbed(:legal_aid_application)
         params = {
+          "transaction_type_ids" => "",
           "housing_benefit_amount" => "",
           "housing_benefit_frequency" => "",
           legal_aid_application:,
@@ -79,15 +85,15 @@ RSpec.describe Providers::Means::HousingBenefitForm do
         form = described_class.new(params)
 
         expect(form).to be_invalid
-        expect(form.errors).to be_added(:housing_benefit, :inclusion, value: nil)
+        expect(form.errors).to be_added(:transaction_type_ids, :blank)
       end
     end
 
-    context "when housing benefit is false" do
+    context "when the applicant does not receive housing benefit" do
       it "is valid" do
         legal_aid_application = build_stubbed(:legal_aid_application)
         params = {
-          "housing_benefit" => "false",
+          "transaction_type_ids" => "none",
           "housing_benefit_amount" => "",
           "housing_benefit_frequency" => "",
           legal_aid_application:,
@@ -99,12 +105,13 @@ RSpec.describe Providers::Means::HousingBenefitForm do
       end
     end
 
-    context "when housing benefit is true, but amount is blank" do
+    context "when the applicant receives housing benefit, but amount is blank" do
       it "is invalid" do
         _housing_benefit = create(:transaction_type, :housing_benefit)
         legal_aid_application = build_stubbed(:legal_aid_application)
+        transaction_type = create(:transaction_type, :housing_benefit)
         params = {
-          "housing_benefit" => "true",
+          "transaction_type_ids" => transaction_type.id,
           "housing_benefit_amount" => "",
           "housing_benefit_frequency" => "weekly",
           legal_aid_application:,
@@ -121,12 +128,13 @@ RSpec.describe Providers::Means::HousingBenefitForm do
       end
     end
 
-    context "when housing benefit is true, but amount is invalid" do
+    context "when the applicant receives housing benefit, but amount is invalid" do
       it "is invalid" do
         _housing_benefit = create(:transaction_type, :housing_benefit)
         legal_aid_application = build_stubbed(:legal_aid_application)
+        transaction_type = create(:transaction_type, :housing_benefit)
         params = {
-          "housing_benefit" => "true",
+          "transaction_type_ids" => transaction_type.id,
           "housing_benefit_amount" => "-100",
           "housing_benefit_frequency" => "weekly",
           legal_aid_application:,
@@ -144,12 +152,13 @@ RSpec.describe Providers::Means::HousingBenefitForm do
       end
     end
 
-    context "when housing benefit is true, but frequency is blank" do
+    context "when the applicant receives housing benefit, but frequency is blank" do
       it "is invalid" do
         _housing_benefit = create(:transaction_type, :housing_benefit)
         legal_aid_application = build_stubbed(:legal_aid_application)
+        transaction_type = create(:transaction_type, :housing_benefit)
         params = {
-          "housing_benefit" => "true",
+          "transaction_type_ids" => transaction_type.id,
           "housing_benefit_amount" => "100",
           "housing_benefit_frequency" => "",
           legal_aid_application:,
@@ -166,12 +175,13 @@ RSpec.describe Providers::Means::HousingBenefitForm do
       end
     end
 
-    context "when housing benefit is true, but frequency is invalid" do
+    context "when the applicant receives housing benefit, but frequency is invalid" do
       it "is invalid" do
         _housing_benefit = create(:transaction_type, :housing_benefit)
         legal_aid_application = build_stubbed(:legal_aid_application)
+        transaction_type = create(:transaction_type, :housing_benefit)
         params = {
-          "housing_benefit" => "true",
+          "transaction_type_ids" => transaction_type.id,
           "housing_benefit_amount" => "100",
           "housing_benefit_frequency" => "invalid",
           legal_aid_application:,
@@ -192,8 +202,9 @@ RSpec.describe Providers::Means::HousingBenefitForm do
       it "is valid" do
         _housing_benefit = create(:transaction_type, :housing_benefit)
         legal_aid_application = build_stubbed(:legal_aid_application)
+        transaction_type = create(:transaction_type, :housing_benefit)
         params = {
-          "housing_benefit" => "true",
+          "transaction_type_ids" => transaction_type.id,
           "housing_benefit_amount" => "100",
           "housing_benefit_frequency" => "weekly",
           legal_aid_application:,
@@ -243,8 +254,9 @@ RSpec.describe Providers::Means::HousingBenefitForm do
       it "does not update an application's transaction types" do
         _housing_benefit = create(:transaction_type, :housing_benefit)
         legal_aid_application = create(:legal_aid_application)
+        transaction_type = create(:transaction_type, :housing_benefit)
         params = {
-          "housing_benefit" => "true",
+          "transaction_type_ids" => transaction_type.id,
           "housing_benefit_amount" => "",
           "housing_benefit_frequency" => "",
           legal_aid_application:,
@@ -259,8 +271,9 @@ RSpec.describe Providers::Means::HousingBenefitForm do
       it "does not update an application's regular transactions" do
         _housing_benefit = create(:transaction_type, :housing_benefit)
         legal_aid_application = create(:legal_aid_application)
+        transaction_type = create(:transaction_type, :housing_benefit)
         params = {
-          "housing_benefit" => "true",
+          "transaction_type_ids" => transaction_type.id,
           "housing_benefit_amount" => "",
           "housing_benefit_frequency" => "",
           legal_aid_application:,
@@ -276,8 +289,9 @@ RSpec.describe Providers::Means::HousingBenefitForm do
     context "when housing benefit is false" do
       it "returns true" do
         legal_aid_application = create(:legal_aid_application)
+        _transaction_type = create(:transaction_type, :housing_benefit)
         params = {
-          "housing_benefit" => "false",
+          "transaction_type_ids" => "none",
           "housing_benefit_amount" => "",
           "housing_benefit_frequency" => "",
           legal_aid_application:,
@@ -294,8 +308,9 @@ RSpec.describe Providers::Means::HousingBenefitForm do
           :legal_aid_application,
           applicant_in_receipt_of_housing_benefit: true,
         )
+        _transaction_type = create(:transaction_type, :housing_benefit)
         params = {
-          "housing_benefit" => "false",
+          "transaction_type_ids" => "none",
           "housing_benefit_amount" => "",
           "housing_benefit_frequency" => "",
           legal_aid_application:,
@@ -317,7 +332,7 @@ RSpec.describe Providers::Means::HousingBenefitForm do
           transaction_type:,
         )
         params = {
-          "housing_benefit" => "false",
+          "transaction_type_ids" => "none",
           "housing_benefit_amount" => "",
           "housing_benefit_frequency" => "",
           legal_aid_application:,
@@ -338,7 +353,7 @@ RSpec.describe Providers::Means::HousingBenefitForm do
           transaction_type:,
         )
         params = {
-          "housing_benefit" => "false",
+          "transaction_type_ids" => "none",
           "housing_benefit_amount" => "",
           "housing_benefit_frequency" => "",
           legal_aid_application:,
@@ -354,9 +369,9 @@ RSpec.describe Providers::Means::HousingBenefitForm do
     context "when housing benefit is true" do
       it "returns true" do
         legal_aid_application = create(:legal_aid_application)
-        _housing_benefit = create(:transaction_type, :housing_benefit)
+        transaction_type = create(:transaction_type, :housing_benefit)
         params = {
-          "housing_benefit" => "true",
+          "transaction_type_ids" => transaction_type.id,
           "housing_benefit_amount" => "100",
           "housing_benefit_frequency" => "weekly",
           legal_aid_application:,
@@ -373,9 +388,9 @@ RSpec.describe Providers::Means::HousingBenefitForm do
           :legal_aid_application,
           applicant_in_receipt_of_housing_benefit: true,
         )
-        _housing_benefit = create(:transaction_type, :housing_benefit)
+        transaction_type = create(:transaction_type, :housing_benefit)
         params = {
-          "housing_benefit" => "true",
+          "transaction_type_ids" => transaction_type.id,
           "housing_benefit_amount" => "100",
           "housing_benefit_frequency" => "weekly",
           legal_aid_application:,
@@ -390,9 +405,9 @@ RSpec.describe Providers::Means::HousingBenefitForm do
 
       it "updates the application's transaction types" do
         legal_aid_application = create(:legal_aid_application)
-        housing_benefit = create(:transaction_type, :housing_benefit)
+        transaction_type = create(:transaction_type, :housing_benefit)
         params = {
-          "housing_benefit" => "true",
+          "transaction_type_ids" => transaction_type.id,
           "housing_benefit_amount" => "100",
           "housing_benefit_frequency" => "weekly",
           legal_aid_application:,
@@ -402,14 +417,14 @@ RSpec.describe Providers::Means::HousingBenefitForm do
         form.save
 
         expect(legal_aid_application.transaction_types)
-          .to contain_exactly(housing_benefit)
+          .to contain_exactly(transaction_type)
       end
 
       it "updates the application's regular transactions" do
         legal_aid_application = create(:legal_aid_application)
-        housing_benefit = create(:transaction_type, :housing_benefit)
+        transaction_type = create(:transaction_type, :housing_benefit)
         params = {
-          "housing_benefit" => "true",
+          "transaction_type_ids" => transaction_type.id,
           "housing_benefit_amount" => "100",
           "housing_benefit_frequency" => "weekly",
           legal_aid_application:,
@@ -422,7 +437,7 @@ RSpec.describe Providers::Means::HousingBenefitForm do
         expect(regular_transactions.count).to eq 1
         expect(regular_transactions.first).to have_attributes(
           legal_aid_application:,
-          transaction_type: housing_benefit,
+          transaction_type:,
           amount: 100,
           frequency: "weekly",
         )
@@ -443,7 +458,7 @@ RSpec.describe Providers::Means::HousingBenefitForm do
             transaction_type:,
           )
           params = {
-            "housing_benefit" => "true",
+            "transaction_type_ids" => transaction_type.id,
             "housing_benefit_amount" => "200",
             "housing_benefit_frequency" => "monthly",
             legal_aid_application:,
@@ -467,7 +482,7 @@ RSpec.describe Providers::Means::HousingBenefitForm do
             frequency: "weekly",
           )
           params = {
-            "housing_benefit" => "true",
+            "transaction_type_ids" => transaction_type.id,
             "housing_benefit_amount" => "200",
             "housing_benefit_frequency" => "monthly",
             legal_aid_application:,

--- a/spec/forms/providers/means/regular_transaction_form_spec.rb
+++ b/spec/forms/providers/means/regular_transaction_form_spec.rb
@@ -1,0 +1,98 @@
+require "rails_helper"
+
+RSpec.describe Providers::Means::RegularTransactionForm do
+  describe "#transaction_type_conditions" do
+    context "when the method is not implemented" do
+      let(:conditions_not_implemented_form) do
+        Class.new(described_class) do
+        private
+
+          def legal_aid_application_attributes
+            {}
+          end
+        end
+      end
+
+      it "raises an error" do
+        params = { "transaction_type_ids" => ["", "none"] }
+
+        expect { conditions_not_implemented_form.new(params) }
+          .to raise_error(NotImplementedError)
+      end
+    end
+
+    context "when the method is implemented" do
+      let(:conditions_implemented_form) do
+        Class.new(described_class) do
+        private
+
+          def transaction_type_conditions
+            { operation: :credit, parent_id: nil }
+          end
+
+          def legal_aid_application_attributes
+            {}
+          end
+        end
+      end
+
+      it "does not raise an error" do
+        params = { "transaction_type_ids" => ["", "none"] }
+
+        expect { conditions_implemented_form.new(params) }.not_to raise_error
+      end
+    end
+  end
+
+  describe "#legal_aid_application_attributes" do
+    context "when the method is not implemented" do
+      let(:attributes_not_implemented_form) do
+        Class.new(described_class) do
+        private
+
+          def transaction_type_conditions
+            { operation: :credit, parent_id: nil }
+          end
+        end
+      end
+
+      it "raises an error" do
+        legal_aid_application = create(:legal_aid_application)
+        params = {
+          "transaction_type_ids" => ["", "none"],
+          legal_aid_application:,
+        }
+        form = attributes_not_implemented_form.new(params)
+
+        expect { form.save }.to raise_error(NotImplementedError)
+      end
+    end
+
+    context "when the method is implemented" do
+      let(:attributes_implemented_form) do
+        Class.new(described_class) do
+        private
+
+          def transaction_type_conditions
+            { operation: :credit, parent_id: nil }
+          end
+
+          def legal_aid_application_attributes
+            {}
+          end
+        end
+      end
+
+      it "does not raise an error" do
+        legal_aid_application = create(:legal_aid_application)
+        params = {
+          "transaction_type_ids" => ["", "none"],
+          legal_aid_application:,
+        }
+        form = attributes_implemented_form.new(params)
+
+        expect { form.save }.not_to raise_error
+      end
+    end
+  end
+end

--- a/spec/requests/providers/means/housing_benefits_controller_spec.rb
+++ b/spec/requests/providers/means/housing_benefits_controller_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Providers::Means::HousingBenefitsController, type: :request do
     it "returns ok" do
       _housing_benefit = create(:transaction_type, :housing_benefit)
       legal_aid_application = create(:legal_aid_application)
+      _transaction_type = create(:transaction_type, :housing_benefit)
       provider = legal_aid_application.provider
       login_as provider
 
@@ -21,12 +22,18 @@ RSpec.describe Providers::Means::HousingBenefitsController, type: :request do
           :legal_aid_application,
           applicant_in_receipt_of_housing_benefit: true,
         )
+        transaction_type = create(:transaction_type, :housing_benefit)
+        _legal_aid_application_transaction_type = create(
+          :legal_aid_application_transaction_type,
+          legal_aid_application:,
+          transaction_type:,
+        )
         housing_benefit = create(
           :regular_transaction,
-          :housing_benefit,
           amount: 100,
           frequency: "weekly",
           legal_aid_application:,
+          transaction_type:,
         )
         provider = legal_aid_application.provider
         login_as provider
@@ -34,7 +41,7 @@ RSpec.describe Providers::Means::HousingBenefitsController, type: :request do
         get providers_legal_aid_application_means_housing_benefits_path(legal_aid_application)
 
         expect(page).to have_checked_field(
-          "providers_means_housing_benefit_form[housing_benefit]",
+          "providers_means_housing_benefit_form[transaction_type_ids]",
         )
         expect(page).to have_field(
           "providers_means_housing_benefit_form[housing_benefit_amount]",
@@ -89,11 +96,12 @@ RSpec.describe Providers::Means::HousingBenefitsController, type: :request do
         :legal_aid_application,
         applicant_in_receipt_of_housing_benefit: nil,
       )
+      _transaction_type = create(:transaction_type, :housing_benefit)
       provider = legal_aid_application.provider
       login_as provider
       params = {
         "providers_means_housing_benefit_form" => {
-          "housing_benefit" => "false",
+          "transaction_type_ids" => "none",
           "housing_benefit_amount" => "",
           "housing_benefit_frequency" => "",
         },
@@ -112,11 +120,12 @@ RSpec.describe Providers::Means::HousingBenefitsController, type: :request do
           :legal_aid_application,
           applicant_in_receipt_of_housing_benefit: nil,
         )
+        _transaction_type = create(:transaction_type, :housing_benefit)
         provider = legal_aid_application.provider
         login_as provider
         params = {
           "providers_means_housing_benefit_form" => {
-            "housing_benefit" => "",
+            "transaction_type_ids" => "",
             "housing_benefit_amount" => "",
             "housing_benefit_frequency" => "",
           },
@@ -125,7 +134,7 @@ RSpec.describe Providers::Means::HousingBenefitsController, type: :request do
         patch providers_legal_aid_application_means_housing_benefits_path(legal_aid_application), params: params
 
         expect(response).to have_http_status(:unprocessable_entity)
-        expect(page).to have_css("p", class: "govuk-error-message", text: "Select one of the options")
+        expect(page).to have_css("p", class: "govuk-error-message", text: "Select whether your client receives housing benefit")
         expect(legal_aid_application.reload.applicant_in_receipt_of_housing_benefit).to be_nil
       end
     end

--- a/spec/requests/providers/means/housing_benefits_controller_spec.rb
+++ b/spec/requests/providers/means/housing_benefits_controller_spec.rb
@@ -134,7 +134,7 @@ RSpec.describe Providers::Means::HousingBenefitsController, type: :request do
         patch providers_legal_aid_application_means_housing_benefits_path(legal_aid_application), params: params
 
         expect(response).to have_http_status(:unprocessable_entity)
-        expect(page).to have_css("p", class: "govuk-error-message", text: "Select whether your client receives housing benefit")
+        expect(page).to have_css("p", class: "govuk-error-message", text: "Select yes if your client receives Housing Benefit")
         expect(legal_aid_application.reload.applicant_in_receipt_of_housing_benefit).to be_nil
       end
     end


### PR DESCRIPTION
This introduces a new `RegularTransactionForm` model for persisting regular
transaction data for an application (and destroying dependent records).

Each of `RegularIncome`, `RegularOutgoings` and `HousingBenefit` forms make
use of this new abstract form.

The basic premise of this refactor is that each of the forms exhibit the same
characteristic behaviour:

1. They validate user input (i.e an option is selected, inputs are valid).

2. They facilitate validation and creation of regular transaction records that
   belong to a given legal aid application.

3. They persist some data on the legal aid application record itself.

4. They destroy the correct combination of associated records. This is currently
   complicated by several factors:
    - The relationship between LegalAidApplication <> TransactionType <>
      Transaction (regular/cash) is indirect.
    - Housing payments (rent_or_mortgage outgoings) are coupled to housing
      benefit. This means housing benefit transactions can only exist if there is
      a rent or mortgage transaction. This also impacts user flow.
    - Housing benefit is also an income (i.e credit) transaction (although it is
      a child transaction type), but it is not handled by the income form and
      income form changes should not affect housing benefit transactions.

5. They assign regular transaction data from the legal aid application if it
   exists (i.e so correct data is displayed when changing answers).

Each form subclass defines a `transaction_type_conditions` private method that
sets out the conditions with which associated transactions should be scoped.
This means the `RegularIncomeForm` is only interested in transactions where the
transaction type has a "credit" operation and "nil" parent_id, for example.

Each form subclass also defines a `legal_aid_application_attributes` private
method that outlines the attributes to be updated for a given form.

This change also highlights further areas for refactoring -in particular the
relationship between a legal aid application, transaction types, and types of
transaction (i.e regular, cash, bank).

Subsequent work will be done to explore the feasibility of simplifying those
relationships. Essentially all types of transaction should be joined to an
application through the existing `LegalAidApplicationTransactionType` join
table.