### PR TITLE
[AP-3536] Add current and saving account totals to bank statement uploads

### DIFF
--- a/app/helpers/capital_helper.rb
+++ b/app/helpers/capital_helper.rb
@@ -62,7 +62,7 @@ module CapitalHelper
   end
 
   def capital_amount_attributes(capital)
-    return capital&.amount_attributes if @legal_aid_application.passported?
+    return capital&.amount_attributes if @legal_aid_application.passported? || @legal_aid_application.uploading_bank_statements?
 
     capital&.amount_attributes&.reject { |c| c == "offline_savings_accounts" }
   end

--- a/app/services/flow/flows/provider_vehicle.rb
+++ b/app/services/flow/flows/provider_vehicle.rb
@@ -7,8 +7,8 @@ module Flow
           forward: lambda do |application|
             if application.own_vehicle?
               :vehicles_estimated_values
-            elsif application.non_passported?
-              application.uploading_bank_statements? ? :savings_and_investments : :applicant_bank_accounts
+            elsif application.non_passported? && !application.uploading_bank_statements?
+              :applicant_bank_accounts
             else
               :offline_accounts
             end
@@ -31,8 +31,8 @@ module Flow
         vehicles_regular_uses: {
           path: ->(application) { urls.providers_legal_aid_application_vehicles_regular_use_path(application) },
           forward: lambda do |application|
-            if application.non_passported?
-              application.uploading_bank_statements? ? :savings_and_investments : :applicant_bank_accounts
+            if application.non_passported? && !application.uploading_bank_statements?
+              :applicant_bank_accounts
             else
               :offline_accounts
             end

--- a/app/views/shared/check_answers/_assets.html.erb
+++ b/app/views/shared/check_answers/_assets.html.erb
@@ -11,42 +11,44 @@
 <section class="print-no-break">
   <%= render 'shared/check_answers/vehicles', read_only: read_only %>
 
-  <% unless @legal_aid_application.uploading_bank_statements? %>
-    <% if @legal_aid_application.non_passported? %>
-      <% if read_only %>
-        <h2 class="govuk-heading-m"><%= t('.assets.bank_accounts') %></h2>
-        <dl class="govuk-summary-list govuk-!-margin-bottom-9">
+  <% if @legal_aid_application.non_passported? && !@legal_aid_application.uploading_bank_statements? %>
+    <!-- non-passported truelayer only -->
 
-          <%= check_answer_link(
-                name: :online_current_accounts,
-                url: check_answer_url_for(journey_type, :applicant_bank_accounts, @legal_aid_application),
-                question: t('.assets.current_account'),
-                answer: online_current_accounts.present? ? gds_number_to_currency(online_current_accounts) : t('generic.none_declared'),
-                read_only: read_only,
-              ) %>
-          <%= check_answer_link(
-                name: :online_savings_accounts,
-                url: check_answer_url_for(journey_type, :applicant_bank_accounts, @legal_aid_application),
-                question: t('.assets.savings_account'),
-                answer: online_savings_accounts.present? ? gds_number_to_currency(online_savings_accounts) : t('generic.none_declared'),
-                read_only: read_only,
-              ) %>
-        </dl>
-      <% end %>
+    <% if read_only %>
+      <h2 class="govuk-heading-m"><%= t('.assets.bank_accounts') %></h2>
+      <dl class="govuk-summary-list govuk-!-margin-bottom-9">
 
-      <%= render 'shared/check_answers/offline_savings_accounts', read_only: read_only %>
-    <% else %>
-      <%= check_answer_one_change_link(
-            name: :bank_accounts,
-            url: check_answer_url_for(journey_type, :offline_accounts, @legal_aid_application),
-            question: t('.assets.bank_accounts'),
-            answer_hash: capital_accounts_list(
-              @legal_aid_application.savings_amount,
-              locale_namespace: "shared.forms.revealing_checkbox.attribute.#{journey_type}.savings_and_investments.check_box_"
-            ),
-            read_only: read_only
-          ) %>
+        <%= check_answer_link(
+              name: :online_current_accounts,
+              url: check_answer_url_for(journey_type, :applicant_bank_accounts, @legal_aid_application),
+              question: t('.assets.current_account'),
+              answer: online_current_accounts.present? ? gds_number_to_currency(online_current_accounts) : t('generic.none_declared'),
+              read_only: read_only,
+            ) %>
+        <%= check_answer_link(
+              name: :online_savings_accounts,
+              url: check_answer_url_for(journey_type, :applicant_bank_accounts, @legal_aid_application),
+              question: t('.assets.savings_account'),
+              answer: online_savings_accounts.present? ? gds_number_to_currency(online_savings_accounts) : t('generic.none_declared'),
+              read_only: read_only,
+            ) %>
+      </dl>
     <% end %>
+
+    <%= render 'shared/check_answers/offline_savings_accounts', read_only: read_only %>
+  <% else %>
+    <!-- passported and non-passported bank statement uploaded -->
+
+    <%= check_answer_one_change_link(
+          name: :bank_accounts,
+          url: check_answer_url_for(journey_type, :offline_accounts, @legal_aid_application),
+          question: t('.assets.bank_accounts'),
+          answer_hash: capital_accounts_list(
+            @legal_aid_application.savings_amount,
+            locale_namespace: "shared.forms.revealing_checkbox.attribute.#{journey_type}.savings_and_investments.check_box_"
+          ),
+          read_only: read_only
+        ) %>
   <% end %>
 
   <%= check_answer_one_change_link(

--- a/features/providers/bank_statement_flow.feature
+++ b/features/providers/bank_statement_flow.feature
@@ -55,6 +55,10 @@ Feature: Bank statement flow
 
     When I choose "No"
     And I click 'Save and continue'
+    Then I should be on a page with title "Which bank accounts does your client have?"
+
+    When I select 'None of these'
+    And I click 'Save and continue'
     Then I should be on a page with title "Which savings or investments does your client have?"
 
     When I select "Money not in a bank account"

--- a/features/providers/check_your_answers.feature
+++ b/features/providers/check_your_answers.feature
@@ -297,10 +297,29 @@ Feature: Checking answers backwards and forwards
     And I have completed a non-passported employed application with bank statement upload as far as the end of the means section
     Then I should be on the 'means_summary' page showing 'Check your answers'
 
+    And the following sections should exist:
+      | tag | section |
+      | h1  | Check your answers |
+      | h3  | Bank statements |
+      | h2  | Your client's income |
+      | h3  | Employment income |
+      | h3  | What payments does your client receive? |
+      | h3  | Student finance |
+      | h2  | Your client's outgoings |
+      | h3  | What payments does your client make? |
+      | h2  | Your client's capital |
+      | h3  | Property |
+      | h3  | Vehicles |
+      | h2  | Which bank accounts does your client have? |
+      | h2  | Which savings or investments does your client have? |
+      | h2  | Which assets does your client have? |
+      | h2  | Restrictions on your client's assets |
+      | h2  | Payments from scheme or charities |
+
     And I should see 'Uploaded bank statements'
     And I should see 'Does your client receive student finance?'
     And the answer for 'student finance question' should be 'No'
-    And I should not see 'Which bank accounts does your client have?'
+    And I should not see 'Does your client have any savings accounts they cannot access online?'
 
     When I click Check Your Answers Change link for 'bank statements'
     And I upload an evidence file named 'hello_world.pdf'

--- a/features/providers/check_your_answers.feature
+++ b/features/providers/check_your_answers.feature
@@ -318,7 +318,6 @@ Feature: Checking answers backwards and forwards
 
     And I should see 'Uploaded bank statements'
     And I should see 'Does your client receive student finance?'
-    And the answer for 'student finance question' should be 'No'
     And I should not see 'Does your client have any savings accounts they cannot access online?'
 
     When I click Check Your Answers Change link for 'bank statements'

--- a/features/providers/enhanced_bank_upload/check_your_answers.feature
+++ b/features/providers/enhanced_bank_upload/check_your_answers.feature
@@ -27,6 +27,7 @@ Feature: Enhanced bank upload check your answers
 
     And I should see "Uploaded bank statements"
     And I should see 'Does your client receive student finance?'
+    And I should not see 'Does your client have any savings accounts they cannot access online?'
 
     When I click Check Your Answers Change link for "bank statements"
     And I upload an evidence file named "hello_world.pdf"

--- a/features/providers/enhanced_bank_upload/check_your_answers.feature
+++ b/features/providers/enhanced_bank_upload/check_your_answers.feature
@@ -6,8 +6,27 @@ Feature: Enhanced bank upload check your answers
     And I have completed a non-passported employed application with enhanced bank upload as far as the end of the means section
     Then I should be on the "means_summary" page showing "Check your answers"
 
+    And the following sections should exist:
+      | tag | section |
+      | h1  | Check your answers |
+      | h3  | Bank statements |
+      | h2  | Your client's income |
+      | h3  | Employment income |
+      | h3  | What payments does your client receive? |
+      | h3  | Student finance |
+      | h2  | Your client's outgoings |
+      | h3  | What payments does your client make? |
+      | h2  | Your client's capital |
+      | h3  | Property |
+      | h3  | Vehicles |
+      | h2  | Which bank accounts does your client have? |
+      | h2  | Which savings or investments does your client have? |
+      | h2  | Which assets does your client have? |
+      | h2  | Restrictions on your client's assets |
+      | h2  | Payments from scheme or charities |
+
     And I should see "Uploaded bank statements"
-    And I should not see "Which bank accounts does your client have?"
+    And I should see 'Does your client receive student finance?'
 
     When I click Check Your Answers Change link for "bank statements"
     And I upload an evidence file named "hello_world.pdf"

--- a/features/providers/means_report.feature
+++ b/features/providers/means_report.feature
@@ -21,7 +21,7 @@ Feature: Means report
       | h2  | Property, savings and other assets |
       | h3  | Property |
       | h3  | Vehicles |
-      | h2  | Property, savings and other assets |
+      | h2  | Which bank accounts does your client have? |
       | h2  | Which savings or investments does your client have? |
       | h2  | Which assets does your client have? |
       | h2  | Restrictions on your client's assets |
@@ -127,6 +127,11 @@ Feature: Means report
       | Are there any payments left on the vehicle? |
       | The vehicle was bought more than three years ago? |
       | Is the vehicle in regular use? |
+
+    And the "Which banks accounts does your client have?" questions should exist:
+      | question |
+      | Current account |
+      | Savings account |
 
     And the "Which savings or investments does your client have?" questions should exist:
       | question |

--- a/features/step_definitions/bank_statement_uploaded_steps.rb
+++ b/features/step_definitions/bank_statement_uploaded_steps.rb
@@ -43,6 +43,7 @@ Given("I have completed a non-passported employed application with bank statemen
     :with_fixed_rent_or_mortage_cash_transactions,
     :with_maintenance_out_category,
     :with_own_home_mortgaged,
+    :with_savings_amount,
     :with_policy_disregards,
     :with_non_passported_state_machine,
     :checking_non_passported_means,

--- a/features/step_definitions/enhanced_bank_upload_steps.rb
+++ b/features/step_definitions/enhanced_bank_upload_steps.rb
@@ -25,6 +25,8 @@ Given "I have completed a non-passported employed application with enhanced bank
     :with_employed_applicant,
     :with_single_employment,
     :with_extra_employment_information,
+    :with_savings_amount,
+    :with_policy_disregards,
     :without_open_banking_consent,
     :checking_non_passported_means,
   )

--- a/features/step_definitions/means_report_steps.rb
+++ b/features/step_definitions/means_report_steps.rb
@@ -198,6 +198,10 @@ Then("the Vehicles questions should exist:") do |table|
   expect_questions_in(selector: "#vehicles-questions", expected: table)
 end
 
+Then("the \"Which banks accounts does your client have?\" questions should exist:") do |table|
+  expect_questions_in(selector: "#app-check-your-answers__bank_accounts_items", expected: table)
+end
+
 Then("the \"Which savings or investments does your client have?\" questions should exist:") do |table|
   expect_questions_in(selector: "#app-check-your-answers__savings_and_investments_items", expected: table)
 end


### PR DESCRIPTION
## What
Add "Which bank accounts does your client have?" step to bank statement upload

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3536)

This seems to have been missed from existing/basic bank 
statement upload flow and should be included in both the 
basic and enhanced flow.

- [x] add section into flow for basic and enhanced banks statement upload
- [x] add section into means summaries CYA page
- [x] add section into means report

NOTE: In the context of non-passported bank statement
uploads the name `offline_accounts` is wrong as well
as the field saving_amounts#offline_current_accounts
and saving_amounts#offline_saving_accounts. renaming
or adding new columns to reflect the new logic (to just
collect a flat amount for all current accounts whether
off or online) would require rejigging various other
classes.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
