### PR TITLE
Chore: remove webhint ignored dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,28 +29,3 @@ updates:
   open-pull-requests-limit: 10
   reviewers:
   - "ministryofjustice/laa-apply-for-legal-aid"
-  ignore:
-  - dependency-name: hint
-    versions:
-    - "> 5.2.3"
-    - "< 5.3"
-  - dependency-name: "@hint/configuration-web-recommended"
-    versions:
-    - "> 7.1.0"
-    - "< 7.2"
-  - dependency-name: "@hint/configuration-web-recommended"
-    versions:
-    - ">= 7.a"
-    - "< 8"
-  - dependency-name: "@hint/connector-local"
-    versions:
-    - "> 3.1.5"
-    - "< 3.2"
-  - dependency-name: "@hint/formatter-json"
-    versions:
-    - "> 3.1.5"
-    - "< 3.2"
-  - dependency-name: "@hint/parser-javascript"
-    versions:
-    - "> 3.0.8"
-    - "< 3.1"


### PR DESCRIPTION
## What

Remove Webhint's ignored dependencies via dependabot.

Webhint and its dependencies were removed from the codebase, therefore, we no longer need to ignore these via dependabot

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
