### PR TITLE
Remove redundant regular incomes flow

### DIFF
--- a/app/services/flow/flows/provider_capital.rb
+++ b/app/services/flow/flows/provider_capital.rb
@@ -38,11 +38,7 @@ module Flow
           forward: lambda do |application|
             application.income_types? ? :cash_incomes : :student_finances
           end,
-          check_answers: lambda do |application|
-            return :cash_incomes if application.income_types?
-
-            application.uploading_bank_statements? ? :means_summaries : :income_summary
-          end,
+          check_answers: ->(application) { application.income_types? ? :cash_incomes : :means_summaries },
         },
         cash_incomes: {
           path: ->(application) { urls.providers_legal_aid_application_means_cash_income_path(application) },

--- a/spec/requests/providers/means/regular_incomes_controller_spec.rb
+++ b/spec/requests/providers/means/regular_incomes_controller_spec.rb
@@ -152,33 +152,8 @@ RSpec.describe Providers::Means::RegularIncomesController do
       end
     end
 
-    context "when checking answers for an application uploading bank statements and none is selected" do
+    context "when checking answers and none is selected" do
       it "updates the application and redirects to the means summaries page" do
-        Setting.setting.update!(enhanced_bank_upload: true)
-        non_passported_permission = create(:permission, :non_passported)
-        bank_statement_permission = create(:permission, :bank_statement_upload)
-        provider = create(:provider, permissions: [non_passported_permission, bank_statement_permission])
-        legal_aid_application = create(
-          :legal_aid_application,
-          :with_non_passported_state_machine,
-          :checking_non_passported_means,
-          provider_received_citizen_consent: false,
-          no_credit_transaction_types_selected: false,
-          provider:,
-        )
-        login_as provider
-        login_as provider
-        params = { providers_means_regular_income_form: { transaction_type_ids: ["", "none"] } }
-
-        patch providers_legal_aid_application_means_regular_incomes_path(legal_aid_application), params: params
-
-        expect(response).to redirect_to(providers_legal_aid_application_means_summary_path(legal_aid_application))
-        expect(legal_aid_application.reload.no_credit_transaction_types_selected).to be true
-      end
-    end
-
-    context "when checking answers for an application not uploading bank statements and none is selected" do
-      it "updates the application and redirects to the income summary page" do
         Setting.setting.update!(enhanced_bank_upload: true)
         legal_aid_application = create(
           :legal_aid_application,
@@ -192,7 +167,7 @@ RSpec.describe Providers::Means::RegularIncomesController do
 
         patch providers_legal_aid_application_means_regular_incomes_path(legal_aid_application), params: params
 
-        expect(response).to redirect_to(providers_legal_aid_application_income_summary_index_path(legal_aid_application))
+        expect(response).to redirect_to(providers_legal_aid_application_means_summary_path(legal_aid_application))
         expect(legal_aid_application.reload.no_credit_transaction_types_selected).to be true
       end
     end


### PR DESCRIPTION
Before, the `:regular_incomes` step, defined a `check_answers` flow that could never be reached in practice.

All applications that reach the `:regular_incomes` step are using the enhanced bank upload journey (and uploading bank statements) by design.

This removes that redundant `check_answers` flow and associated tests.