### PR TITLE
Fix flaky document upload spec

### DIFF
--- a/features/providers/check_your_answers.feature
+++ b/features/providers/check_your_answers.feature
@@ -322,6 +322,7 @@ Feature: Checking answers backwards and forwards
 
     When I click Check Your Answers Change link for 'bank statements'
     And I upload an evidence file named 'hello_world.pdf'
+    Then I should see "hello_world.pdf UPLOADED"
     And I click 'Save and continue'
     Then I should be on the 'means_summary' page showing 'Check your answers'
     And I should see 'hello_world.pdf'


### PR DESCRIPTION
This feature test would fail intermittently if the "Save and continue" 
button was clicked before the document had finished uploading.

Similarly to #4375, this adds an assertion that the document has 
been uploaded in order to make the test more predictably reliable 
(and better reflect the user experience).