### PR TITLE
AP-3491: Add mini-loop merits client_denial_of_allegations question

### DIFF
--- a/app/controllers/providers/application_merits_task/client_denial_of_allegations_controller.rb
+++ b/app/controllers/providers/application_merits_task/client_denial_of_allegations_controller.rb
@@ -1,0 +1,26 @@
+module Providers
+  module ApplicationMeritsTask
+    class ClientDenialOfAllegationsController < ProviderBaseController
+      def show
+        @form = ApplicationMeritsTask::ClientDenialOfAllegationForm.new(model: allegation)
+      end
+
+      def update
+        @form = ApplicationMeritsTask::ClientDenialOfAllegationForm.new(form_params)
+        render :show unless update_task_save_continue_or_draft(:application, :client_denial_of_allegation)
+      end
+
+    private
+
+      def allegation
+        legal_aid_application.allegation || legal_aid_application.build_allegation
+      end
+
+      def form_params
+        merge_with_model(allegation) do
+          params.require(:application_merits_task_allegation).permit(:denies_all, :additional_information)
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/providers/capital_assessment_results_controller.rb
+++ b/app/controllers/providers/capital_assessment_results_controller.rb
@@ -10,7 +10,6 @@ module Providers
     end
 
     def update
-      LegalFramework::MeritsTasksService.call(legal_aid_application)
       continue_or_draft
     end
 

--- a/app/forms/providers/application_merits_task/client_denial_of_allegation_form.rb
+++ b/app/forms/providers/application_merits_task/client_denial_of_allegation_form.rb
@@ -1,0 +1,29 @@
+module Providers
+  module ApplicationMeritsTask
+    class ClientDenialOfAllegationForm < BaseForm
+      form_for ::ApplicationMeritsTask::Allegation
+
+      attr_accessor :denies_all, :additional_information
+
+      validate :denies_all_presence
+      validates :additional_information, presence: true, if: :requires_additional_information?
+
+      def denies_all_presence
+        errors.add(:denies_all, :blank) if denies_all.to_s.blank?
+      end
+
+      def denies_all?
+        denies_all.to_s == "true"
+      end
+
+      def requires_additional_information?
+        denies_all.to_s == "false"
+      end
+
+      def save
+        additional_information&.clear if denies_all?
+        super
+      end
+    end
+  end
+end

--- a/app/forms/providers/application_merits_task/client_denial_of_allegation_form.rb
+++ b/app/forms/providers/application_merits_task/client_denial_of_allegation_form.rb
@@ -8,6 +8,13 @@ module Providers
       validate :denies_all_presence
       validates :additional_information, presence: true, if: :requires_additional_information?
 
+      def save
+        additional_information&.clear if denies_all?
+        super
+      end
+
+    private
+
       def denies_all_presence
         errors.add(:denies_all, :blank) if denies_all.to_s.blank?
       end
@@ -18,11 +25,6 @@ module Providers
 
       def requires_additional_information?
         denies_all.to_s == "false"
-      end
-
-      def save
-        additional_information&.clear if denies_all?
-        super
       end
     end
   end

--- a/app/models/application_merits_task/allegation.rb
+++ b/app/models/application_merits_task/allegation.rb
@@ -1,0 +1,5 @@
+module ApplicationMeritsTask
+  class Allegation < ApplicationRecord
+    belongs_to :legal_aid_application
+  end
+end

--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -28,6 +28,7 @@ class LegalAidApplication < ApplicationRecord
   has_one :uploaded_evidence_collection, dependent: :destroy
   has_one :opponent, class_name: "ApplicationMeritsTask::Opponent", dependent: :destroy
   has_one :latest_incident, -> { order(occurred_on: :desc) }, class_name: "ApplicationMeritsTask::Incident", inverse_of: :legal_aid_application, dependent: :destroy
+  has_one :allegation, class_name: "ApplicationMeritsTask::Allegation", dependent: :destroy
   has_many :attempts_to_settles, class_name: "ProceedingMeritsTask::AttemptsToSettle", through: :proceedings
   has_many :legal_aid_application_transaction_types, dependent: :destroy
   has_many :transaction_types, through: :legal_aid_application_transaction_types

--- a/app/models/legal_framework/merits_task_list.rb
+++ b/app/models/legal_framework/merits_task_list.rb
@@ -12,11 +12,17 @@ module LegalFramework
       save!
     end
 
+    def mark_as_ignored!(group, task)
+      task_list.mark_as_ignored!(group, task)
+      self.serialized_data = task_list.to_yaml
+      save!
+    end
+
     def can_proceed?
       application_states = task_list.tasks[:application].map(&:state).flatten
       proceeding_states = task_list.tasks[:proceedings].map { |task| task[1][:tasks].map(&:state) }.flatten
       all_task_states = application_states + proceeding_states
-      all_task_states.all?(:complete)
+      (all_task_states.uniq - %i[complete ignored]).empty?
     end
   end
 end

--- a/app/models/legal_framework/serializable_merits_task.rb
+++ b/app/models/legal_framework/serializable_merits_task.rb
@@ -20,5 +20,11 @@ module LegalFramework
 
       @state = :complete
     end
+
+    def mark_as_ignored!
+      raise "Unmet dependency #{@dependencies.join(',')} for task #{@name}" if @dependencies.any?
+
+      @state = :ignored
+    end
   end
 end

--- a/app/models/legal_framework/serializable_merits_task_list.rb
+++ b/app/models/legal_framework/serializable_merits_task_list.rb
@@ -33,6 +33,11 @@ module LegalFramework
       unblock_dependant_tasks(task_name)
     end
 
+    def mark_as_ignored!(task_group, task_name)
+      task(task_group, task_name).mark_as_ignored!
+      unblock_dependant_tasks(task_name)
+    end
+
     def self.new_from_serialized(yaml_string)
       YAML.safe_load(yaml_string, permitted_classes: SAFE_SERIALIZABLE_CLASSES, aliases: true)
     end

--- a/app/models/legal_framework/serializable_merits_task_list.rb
+++ b/app/models/legal_framework/serializable_merits_task_list.rb
@@ -64,7 +64,7 @@ module LegalFramework
     end
 
     def serialize_proceeding_types_tasks
-      @lfa_response[:proceeding_types].each do |proceeding_type_hash|
+      loop_proceedings.each do |proceeding_type_hash|
         ccms_code = proceeding_type_hash[:ccms_code].to_sym
         proceeding_name = Proceeding.find_by(ccms_code:).meaning
         @tasks[:proceedings][ccms_code] = { name: proceeding_name, tasks: [] }
@@ -72,6 +72,10 @@ module LegalFramework
           @tasks[:proceedings][ccms_code][:tasks] << SerializableMeritsTask.new(task_name, dependencies:)
         end
       end
+    end
+
+    def loop_proceedings
+      Setting.enable_mini_loop? ? @lfa_response[:proceedings] : @lfa_response[:proceeding_types]
     end
   end
 end

--- a/app/services/flow/flows/provider_merits.rb
+++ b/app/services/flow/flows/provider_merits.rb
@@ -63,6 +63,11 @@ module Flow
           forward: ->(application) { application.section_8_proceedings? ? :start_involved_children_task : :merits_task_lists },
           check_answers: :check_merits_answers,
         },
+        client_denial_of_allegations: {
+          # path: ->(application) { urls.providers_legal_aid_application_client_denial_of_allegation_path(application) }, # not needed until flow handling updated
+          forward: :merits_task_lists,
+          check_answers: :check_merits_answers,
+        },
         chances_of_success: {
           path: lambda do |application|
             proceeding = application.proceedings.find(application.provider_step_params["merits_task_list_id"])

--- a/app/services/legal_framework/merits_tasks_retriever_service.rb
+++ b/app/services/legal_framework/merits_tasks_retriever_service.rb
@@ -1,22 +1,42 @@
 module LegalFramework
   class MeritsTasksRetrieverService < BaseService
     ENDPOINT = "/merits_tasks".freeze
+    NEW_ENDPOINT = "/civil_merits_questions".freeze
 
     def url_path
+      return NEW_ENDPOINT if Setting.enable_mini_loop?
+
       ENDPOINT
     end
 
     def request_body
-      {
-        request_id:,
-        proceeding_types: proceeding_types_codes,
-      }.to_json
+      if Setting.enable_mini_loop?
+        {
+          request_id:,
+          proceedings: proceedings_data,
+        }.to_json
+      else
+        {
+          request_id:,
+          proceeding_types: proceeding_types_codes,
+        }.to_json
+      end
     end
 
   private
 
     def proceeding_types_codes
       legal_aid_application.proceedings.map(&:ccms_code)
+    end
+
+    def proceedings_data
+      legal_aid_application.proceedings.map do |proceeding|
+        {
+          ccms_code: proceeding.ccms_code,
+          delegated_functions_used: proceeding.used_delegated_functions,
+          client_involvement_type: proceeding.client_involvement_type_ccms_code,
+        }
+      end
     end
   end
 end

--- a/app/views/providers/application_merits_task/client_denial_of_allegations/show.html.erb
+++ b/app/views/providers/application_merits_task/client_denial_of_allegations/show.html.erb
@@ -9,8 +9,8 @@
                     back_link: {},
                     form: form) do %>
     <%= form.govuk_radio_buttons_fieldset :denies_all, legend: {size: 'xl', tag: 'h1', text: page_title} do %>
-      <%= form.govuk_radio_button :denies_all, true, label: {text: t('generic.yes')} %>
-      <%= form.govuk_radio_button :denies_all, false, link_errors: true, label: {text: t('generic.no')} do %>
+      <%= form.govuk_radio_button :denies_all, true, link_errors: true, label: {text: t('generic.yes')} %>
+      <%= form.govuk_radio_button :denies_all, false, label: {text: t('generic.no')} do %>
         <%= form.govuk_text_area :additional_information, label: {text: t('.no-hint')}, rows: 5 %>
       <% end %>
 

--- a/app/views/providers/application_merits_task/client_denial_of_allegations/show.html.erb
+++ b/app/views/providers/application_merits_task/client_denial_of_allegations/show.html.erb
@@ -1,0 +1,22 @@
+<%= form_with(
+      model: @form,
+      url: providers_legal_aid_application_client_denial_of_allegation_path,
+      method: :patch,
+      local: true
+    ) do |form| %>
+  <%= page_template(page_title: t('.h1-heading'),
+                    template: :basic,
+                    back_link: {},
+                    form: form) do %>
+    <%= form.govuk_radio_buttons_fieldset :denies_all, legend: {size: 'xl', tag: 'h1', text: page_title} do %>
+      <%= form.govuk_radio_button :denies_all, true, label: {text: t('generic.yes')} %>
+      <%= form.govuk_radio_button :denies_all, false, link_errors: true, label: {text: t('generic.no')} do %>
+        <%= form.govuk_text_area :additional_information, label: {text: t('.no-hint')}, rows: 5 %>
+      <% end %>
+
+    <% end %>
+    <div class="govuk-!-padding-bottom-4"></div>
+
+    <%= next_action_buttons(show_draft: true, form: form) %>
+  <% end %>
+<% end %>

--- a/app/views/providers/check_merits_answers/show.html.erb
+++ b/app/views/providers/check_merits_answers/show.html.erb
@@ -9,6 +9,7 @@
         statement_of_case: @legal_aid_application.statement_of_case,
         opponent: @legal_aid_application.opponent,
         gateway_evidence: @legal_aid_application&.gateway_evidence,
+        allegation: @legal_aid_application&.allegation,
         read_only: false
       ) %>
   <div class="govuk-!-padding-bottom-6"></div>

--- a/app/views/providers/merits_reports/show.html.erb
+++ b/app/views/providers/merits_reports/show.html.erb
@@ -55,6 +55,7 @@
         statement_of_case: @legal_aid_application.statement_of_case,
         opponent: @legal_aid_application.opponent,
         gateway_evidence: @legal_aid_application&.gateway_evidence,
+        allegation: @legal_aid_application&.allegation,
         read_only: true
       ) %>
 <% end %>

--- a/app/views/providers/merits_task_lists/_task_list_section.html.erb
+++ b/app/views/providers/merits_task_lists/_task_list_section.html.erb
@@ -5,6 +5,7 @@
   </h2>
   <ul class="app-task-list__items">
     <% tasks.each do |task| %>
+      <% next if task.state.eql?(:ignored) %>
       <%= task_list_item(
               name: task.name,
               status: task.state,

--- a/app/views/shared/_review_application.html.erb
+++ b/app/views/shared/_review_application.html.erb
@@ -152,6 +152,7 @@
     statement_of_case: @legal_aid_application.statement_of_case,
     gateway_evidence: @legal_aid_application&.gateway_evidence,
     opponent: @legal_aid_application.opponent,
+    allegation: @legal_aid_application&.allegation,
     read_only: true
   ) %>
 </section>

--- a/app/views/shared/check_answers/_merits.html.erb
+++ b/app/views/shared/check_answers/_merits.html.erb
@@ -118,7 +118,7 @@
 <% if @legal_aid_application.allegation %>
   <div class="govuk-!-padding-bottom-6"></div>
   <section class="print-no-break">
-    <h2 class="govuk-heading-l"><%= t('.client_denial_of_allegation_heading') %></h2>
+    <h2 class="govuk-heading-m"><%= t('.client_denial_of_allegation_heading') %></h2>
 
     <dl class="govuk-summary-list govuk-!-margin-bottom-2">
       <%= check_answer_link(

--- a/app/views/shared/check_answers/_merits.html.erb
+++ b/app/views/shared/check_answers/_merits.html.erb
@@ -115,6 +115,26 @@
   <%= render 'shared/check_answers/section_break' if statement_of_case&.statement %>
 </section>
 
+<% if @legal_aid_application.allegation %>
+  <div class="govuk-!-padding-bottom-6"></div>
+  <section class="print-no-break">
+    <h2 class="govuk-heading-l"><%= t('.client_denial_of_allegation_heading') %></h2>
+
+    <dl class="govuk-summary-list govuk-!-margin-bottom-2">
+      <%= check_answer_link(
+            name: :allegation_denies_all,
+            url: providers_legal_aid_application_client_denial_of_allegation_path,
+            question: t('.items.allegation_denies_all'),
+            answer: yes_no(allegation.denies_all),
+            no_border: true,
+            read_only: read_only
+          ) %>
+    </dl>
+    <div class='govuk-body'><%= allegation.additional_information %></div>
+    <%= render 'shared/check_answers/section_break' if allegation.additional_information %>
+  </section>
+<% end %>
+
 <% if @legal_aid_application.section_8_proceedings? %>
   <div class="govuk-!-padding-bottom-6"></div>
   <section class="print-no-break">

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -165,6 +165,12 @@ en:
               date_is_in_the_future: Date of birth must be in the past
             full_name:
               blank: Enter the child's full name
+        application_merits_task/allegation:
+          attributes:
+            denies_all:
+              blank: Select yes if the client wholly or substantially denies any allegations
+            additional_information:
+              blank: Enter information to explain the merit of this application
         application_merits_task/opponent:
           attributes:
             full_name:

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -430,6 +430,10 @@ en:
           status: Status
           uploaded: Uploaded
           title: Files added
+      client_denial_of_allegations:
+        show:
+          h1-heading: Does the client wholly or substantially deny any allegations?
+          no-hint: As the allegation has not been denied, give us more information to explain why you think there is merit in this application.
     has_other_involved_children:
       show:
         error: Select yes if you need to add another child
@@ -918,6 +922,7 @@ en:
         children_application: Children involved in this application
         children_proceeding: Children involved in this proceeding
         attempts_to_settle: Attempts to settle
+        client_denial_of_allegation: Client denial of allegation
         states:
           not_started: Not started
           waiting_for_dependency: Cannot start yet
@@ -931,6 +936,7 @@ en:
           has_other_involved_children: has_other_involved_children
           children_proceeding: linked_children
           attempts_to_settle: attempts_to_settle
+          client_denial_of_allegation: client_denial_of_allegation
     merits_reports:
       show:
         heading: Merits report

--- a/config/locales/en/shared.yml
+++ b/config/locales/en/shared.yml
@@ -267,6 +267,7 @@ en:
           notification_of_latest_incident: When did your client contact you about the latest domestic abuse incident?
           date_of_latest_incident: When did the incident occur?
           gateway_evidence: Upload supporting evidence
+          allegation_denies_all: Does the client wholly or substantially deny any allegations?
       full_employment_details:
         employment: Employment income
         full_employment_details: Your client's employment details

--- a/config/locales/en/shared.yml
+++ b/config/locales/en/shared.yml
@@ -248,6 +248,7 @@ en:
         statement-of-case-heading: Statement of case
         gateway-evidence-heading: Supporting evidence
         evidence_upload_heading: Supporting evidence
+        client_denial_of_allegation_heading: Client denial of allegation
         evidence_types:
           benefit_evidence: Benefit evidence
           employment_evidence: Employment evidence

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -189,6 +189,7 @@ Rails.application.routes.draw do
 
       resource :opponent, only: %i[show update], controller: "application_merits_task/opponents"
       resource :date_client_told_incident, only: %i[show update], controller: "application_merits_task/date_client_told_incidents"
+      resource :client_denial_of_allegation, only: %i[show update], controller: "application_merits_task/client_denial_of_allegations"
       resource :merits_task_list, only: %i[show update]
       resource :gateway_evidence, only: %i[show update destroy]
       resource :uploaded_evidence_collection, only: %i[show update destroy] do

--- a/db/anonymise/rules.rb
+++ b/db/anonymise/rules.rb
@@ -23,6 +23,9 @@ NINO_REGEXP = /^[A-CEGHJ-PR-TW-Z]{1}[A-CEGHJ-NPR-TW-Z]{1}[0-9]{6}[A-DFM]{1}$/
     submitted_applications_report: -> {},
     nonpassported_applications_report: -> {},
   },
+  allegations: {
+    additional_information: -> { Faker::Lorem.sentence },
+  },
   applicants: {
     first_name: -> { Faker::Name.first_name },
     last_name: -> { Faker::Name.last_name },

--- a/db/migrate/20221013114916_create_allegation.rb
+++ b/db/migrate/20221013114916_create_allegation.rb
@@ -1,0 +1,11 @@
+class CreateAllegation < ActiveRecord::Migration[7.0]
+  def change
+    create_table :allegations, id: :uuid do |t|
+      t.belongs_to :legal_aid_application, null: false, foreign_key: true, type: :uuid
+      t.boolean :denies_all
+      t.string :additional_information
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_09_15_131126) do
+ActiveRecord::Schema[7.0].define(version: 2022_10_13_114916) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -87,24 +87,33 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_15_131126) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "allegations", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "legal_aid_application_id", null: false
+    t.boolean "denies_all"
+    t.string "additional_information"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["legal_aid_application_id"], name: "index_allegations_on_legal_aid_application_id"
+  end
+
   create_table "applicants", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "first_name"
     t.date "date_of_birth"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.string "last_name"
     t.string "email"
     t.string "national_insurance_number"
     t.string "confirmation_token"
-    t.datetime "confirmed_at"
-    t.datetime "confirmation_sent_at"
+    t.datetime "confirmed_at", precision: nil
+    t.datetime "confirmation_sent_at", precision: nil
     t.integer "failed_attempts", default: 0, null: false
     t.string "unlock_token"
-    t.datetime "locked_at"
+    t.datetime "locked_at", precision: nil
     t.string "true_layer_secure_data_id"
-    t.boolean "employed"
-    t.datetime "remember_created_at"
+    t.datetime "remember_created_at", precision: nil
     t.string "remember_token"
+    t.boolean "employed"
     t.boolean "self_employed", default: false
     t.boolean "armed_forces", default: false
     t.index ["confirmation_token"], name: "index_applicants_on_confirmation_token", unique: true
@@ -871,6 +880,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_15_131126) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "addresses", "applicants"
+  add_foreign_key "allegations", "legal_aid_applications"
   add_foreign_key "attempts_to_settles", "proceedings"
   add_foreign_key "bank_account_holders", "bank_providers"
   add_foreign_key "bank_accounts", "bank_providers"

--- a/spec/factories/allegations.rb
+++ b/spec/factories/allegations.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :allegation, class: "ApplicationMeritsTask::Allegation" do
+    denies_all { true }
+    legal_aid_application
+
+    trait :with_data do
+      denies_all { false }
+      additional_information { "extenuating circumstances" }
+    end
+  end
+end

--- a/spec/factories/legal_framework_merits_task_list.rb
+++ b/spec/factories/legal_framework_merits_task_list.rb
@@ -6,5 +6,9 @@ FactoryBot.define do
     trait :da001 do
       serialized_data { build(:legal_framework_serializable_merits_task_list, :da001).to_yaml }
     end
+
+    trait :da001_as_defendant do
+      serialized_data { build(:legal_framework_serializable_merits_task_list, :da001_as_defendant).to_yaml }
+    end
   end
 end

--- a/spec/factories/legal_framework_serialized_merits_task_list.rb
+++ b/spec/factories/legal_framework_serialized_merits_task_list.rb
@@ -55,5 +55,31 @@ FactoryBot.define do
         }
       end
     end
+
+    trait :da001_as_defendant do
+      lfa_response do
+        {
+          request_id: SecureRandom.uuid,
+          application: {
+            tasks: {
+              latest_incident_details: [],
+              opponent_details: [],
+              children_application: [],
+              statement_of_case: [],
+              client_denial_of_allegation: [],
+              client_offer_of_undertakings: [],
+            },
+          },
+          proceeding_types: [
+            {
+              ccms_code: "DA001",
+              tasks: {
+                chances_of_success: [],
+              },
+            },
+          ],
+        }
+      end
+    end
   end
 end

--- a/spec/forms/providers/application_merits_task/client_denial_of_allegation_form_spec.rb
+++ b/spec/forms/providers/application_merits_task/client_denial_of_allegation_form_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+module Providers
+  module ApplicationMeritsTask
+    RSpec.describe ClientDenialOfAllegationForm do
+      subject(:denial_form) { described_class.new(params) }
+
+      let(:params) do
+        {
+          denies_all:,
+          additional_information:,
+        }
+      end
+      let(:denies_all) { true }
+      let(:additional_information) { nil }
+
+      describe "#valid?" do
+        context "when all fields are valid" do
+          it "returns true" do
+            expect(denial_form).to be_valid
+          end
+        end
+
+        context "when denies_all is missing" do
+          let(:denies_all) { nil }
+
+          it { expect(denial_form).to be_invalid }
+        end
+
+        context "when denies_all is false" do
+          let(:denies_all) { false }
+
+          context "and the additional information is missing" do
+            it { expect(denial_form).to be_invalid }
+          end
+
+          context "and the additional information is provided" do
+            let(:additional_information) { "some text input" }
+
+            it { expect(denial_form).to be_valid }
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/models/legal_framework/merits_task_list_spec.rb
+++ b/spec/models/legal_framework/merits_task_list_spec.rb
@@ -65,6 +65,21 @@ module LegalFramework
 
         it { is_expected.to be true }
       end
+
+      context "when all tasks are complete or ignored" do
+        before do
+          merits_task_list.mark_as_complete!(:application, :latest_incident_details)
+          merits_task_list.mark_as_complete!(:application, :opponent_details)
+          merits_task_list.mark_as_complete!(:application, :children_application)
+          merits_task_list.mark_as_ignored!(:application, :statement_of_case)
+          merits_task_list.mark_as_complete!(:DA001, :chances_of_success)
+          merits_task_list.mark_as_complete!(:SE014, :chances_of_success)
+          merits_task_list.mark_as_complete!(:SE014, :children_proceeding)
+          merits_task_list.mark_as_complete!(:SE014, :attempts_to_settle)
+        end
+
+        it { is_expected.to be true }
+      end
     end
 
     def dummy_serialized_merits_task_list

--- a/spec/models/legal_framework/serializable_merits_task_spec.rb
+++ b/spec/models/legal_framework/serializable_merits_task_spec.rb
@@ -62,5 +62,24 @@ module LegalFramework
         end
       end
     end
+
+    describe "#mark_as_ignored!" do
+      context "with dependencies" do
+        it "raises an exception" do
+          expect {
+            serialized_merits_task.mark_as_ignored!
+          }.to raise_error RuntimeError, /Unmet dependency/
+        end
+      end
+
+      context "when successful" do
+        let(:serialized_merits_task) { described_class.new(:proceeding_children, dependencies: []) }
+
+        it "marks the task as ignored" do
+          serialized_merits_task.mark_as_ignored!
+          expect(serialized_merits_task.state).to eq :ignored
+        end
+      end
+    end
   end
 end

--- a/spec/requests/providers/application_merits_task/client_denial_of_allegation_spec.rb
+++ b/spec/requests/providers/application_merits_task/client_denial_of_allegation_spec.rb
@@ -1,0 +1,125 @@
+require "rails_helper"
+
+module Providers
+  module ApplicationMeritsTask
+    RSpec.describe ClientDenialOfAllegationsController, type: :request do
+      let(:legal_aid_application) { create :legal_aid_application, :with_multiple_proceedings_inc_section8 }
+      let(:login_provider) { login_as legal_aid_application.provider }
+      let(:smtl) { create :legal_framework_merits_task_list, :da001_as_defendant, legal_aid_application: }
+
+      describe "GET /providers/applications/:legal_aid_application_id/client_denial_of_allegation" do
+        subject(:client_denial) { get providers_legal_aid_application_client_denial_of_allegation_path(legal_aid_application) }
+
+        before do
+          login_provider
+          client_denial
+        end
+
+        it "renders successfully" do
+          expect(response).to have_http_status(:ok)
+        end
+
+        context "when not authenticated" do
+          let(:login_provider) { nil }
+
+          it_behaves_like "a provider not authenticated"
+        end
+
+        context "with an existing allegation" do
+          let(:allegation) { create :allegation, :with_data }
+          let(:legal_aid_application) { create :legal_aid_application, :with_multiple_proceedings_inc_section8, allegation: }
+
+          it "renders successfully" do
+            expect(response).to have_http_status(:ok)
+          end
+
+          it "displays additional information" do
+            expect(response.body).to include("extenuating circumstances")
+          end
+        end
+      end
+
+      describe "PATCH /providers/applications/:legal_aid_application_id/client_denial_of_allegation" do
+        subject(:post_client_denial) do
+          patch(
+            providers_legal_aid_application_client_denial_of_allegation_path(legal_aid_application),
+            params: params.merge(button_clicked),
+          )
+        end
+
+        let(:denies_all) { true }
+        let(:additional_information) { "" }
+        let(:params) do
+          {
+            application_merits_task_allegation: {
+              denies_all:,
+              additional_information:,
+            },
+          }
+        end
+        let(:draft_button) { { draft_button: "Save as draft" } }
+        let(:button_clicked) { {} }
+        let(:allegation) { legal_aid_application.reload.allegation }
+
+        before do
+          allow(LegalFramework::MeritsTasksService).to receive(:call).with(legal_aid_application).and_return(smtl)
+          login_provider
+        end
+
+        it "creates a new allegation with the values entered" do
+          expect { post_client_denial }.to change(::ApplicationMeritsTask::Allegation, :count).by(1)
+          expect(allegation.denies_all).to be_truthy
+          expect(allegation.additional_information).to eq ""
+        end
+
+        it "sets the task to complete" do
+          post_client_denial
+          expect(legal_aid_application.legal_framework_merits_task_list.serialized_data).to match(/name: :client_denial_of_allegation\n\s+dependencies: \*\d\n\s+state: :complete/)
+        end
+
+        it "redirects to the next page" do
+          post_client_denial
+          expect(response).to redirect_to(flow_forward_path)
+        end
+
+        context "when not authenticated" do
+          let(:login_provider) { nil }
+
+          before { post_client_denial }
+
+          it_behaves_like "a provider not authenticated"
+        end
+
+        context "when incomplete" do
+          let(:denies_all) { false }
+          let(:additional_information) { "" }
+          let(:regex) { /name: :client_denial_of_allegation\n\s+dependencies: \*\d\n\s+state: :not_started/ }
+
+          it "renders show" do
+            post_client_denial
+            expect(response).to have_http_status(:ok)
+          end
+
+          it "does not set the task to complete" do
+            post_client_denial
+            expect(legal_aid_application.legal_framework_merits_task_list.serialized_data).to match(regex)
+          end
+        end
+
+        context "when save as draft selected" do
+          let(:button_clicked) { draft_button }
+
+          it "redirects to provider draft endpoint" do
+            post_client_denial
+            expect(response).to redirect_to provider_draft_endpoint
+          end
+
+          it "does not set the task to complete" do
+            post_client_denial
+            expect(legal_aid_application.legal_framework_merits_task_list.serialized_data).to match(/name: :client_denial_of_allegation\n\s+dependencies: \*\d\n\s+state: :not_started/)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/providers/application_merits_task/statement_of_case_spec.rb
+++ b/spec/requests/providers/application_merits_task/statement_of_case_spec.rb
@@ -102,6 +102,16 @@ module Providers
         end
 
         describe "redirect on success" do
+          context "when the application only has domestic abuse proceedings" do
+            let(:legal_aid_application) { create :legal_aid_application, :with_proceedings }
+            let(:smtl) { create :legal_framework_merits_task_list, :da001, legal_aid_application: }
+
+            it "redirects to the next page" do
+              subject
+              expect(response).to redirect_to providers_legal_aid_application_merits_task_list_path(legal_aid_application)
+            end
+          end
+
           context "when the application has a section 8 proceeding" do
             let(:legal_aid_application) { create :legal_aid_application, :with_proceedings, :with_multiple_proceedings_inc_section8 }
 

--- a/spec/requests/providers/capital_assessment_results_spec.rb
+++ b/spec/requests/providers/capital_assessment_results_spec.rb
@@ -284,11 +284,6 @@ RSpec.describe Providers::CapitalAssessmentResultsController, type: :request do
         it "redirects to the merits task list" do
           expect(subject).to redirect_to(providers_legal_aid_application_merits_task_list_path)
         end
-
-        it "creates a task list" do
-          subject
-          expect(LegalFramework::MeritsTasksService).to have_received(:call).with(legal_aid_application)
-        end
       end
 
       context "when save as draft button is pressed" do

--- a/spec/requests/providers/proceeding_merits_task/chances_of_success_spec.rb
+++ b/spec/requests/providers/proceeding_merits_task/chances_of_success_spec.rb
@@ -114,6 +114,15 @@ module Providers
             subject
             expect(response).to redirect_to(providers_legal_aid_application_check_merits_answers_path(legal_aid_application))
           end
+
+          context "when the user updates to say no" do
+            let(:success_likely) { "false" }
+
+            it "redirects back to the answers page" do
+              subject
+              expect(response).to redirect_to(providers_merits_task_list_success_prospects_path(proceeding))
+            end
+          end
         end
 
         context "when nothing is selected" do

--- a/spec/services/legal_framework/merits_tasks_retriever_service_spec.rb
+++ b/spec/services/legal_framework/merits_tasks_retriever_service_spec.rb
@@ -2,81 +2,167 @@ require "rails_helper"
 
 module LegalFramework
   RSpec.describe MeritsTasksRetrieverService do
+    before { allow(Setting).to receive(:enable_mini_loop?).and_return(enable_mini_loop) } # TODO: Remove when the mini-loop feature flag is removed
+
     let(:application) { create :legal_aid_application, :with_proceedings }
     let(:submission) { create :legal_framework_submission, legal_aid_application: application }
     let(:dummy_response) { dummy_response_hash.to_json }
     let(:service) { described_class.new(submission) }
-    let(:api_url) { "#{Rails.configuration.x.legal_framework_api_host}/merits_tasks" }
+    let(:orig_api_url) { "#{Rails.configuration.x.legal_framework_api_host}/merits_tasks" }
+    let(:loop_api_url) { "#{Rails.configuration.x.legal_framework_api_host}/civil_merits_questions" }
+    let(:enable_mini_loop) { false }
 
-    describe "#url" do
-      it "contains correct url" do
-        expect(service.legal_framework_url).to eq api_url
+    context "when then mini-loop flag is off" do
+      let(:expected_payload_hash) do
+        {
+          request_id: submission.id,
+          proceeding_types: [application.proceedings.first.ccms_code],
+        }
       end
-    end
-
-    describe "#request_body" do
-      it "creates the expected payload from the application proceeding types" do
-        expect(service.request_body).to eq expected_payload_hash.to_json
+      let(:dummy_response_hash) do
+        {
+          request_id: submission.id,
+          application: {
+            tasks: {
+              incident_details: [],
+              opponent_details: [],
+              application_children: [],
+            },
+          },
+          proceeding_types: [
+            {
+              ccms_code: application.proceedings.first.ccms_code,
+              tasks: {
+                chances_of_success: [], # the merits tasks for this one proceeding type, and any dependencies
+              },
+            },
+          ],
+        }
       end
-    end
 
-    describe ".call" do
-      around do |example|
-        VCR.turn_off!
-        example.run
-        VCR.turn_on!
-      end
-
-      context "response received from Legal Framework API" do
-        describe "successful post" do
-          before do
-            stub_request(:post, service.legal_framework_url)
-              .with(body: service.request_body)
-              .to_return(body: dummy_response)
-          end
-
-          it "returns a list of merits tasks" do
-            outcome = service.call
-            expect(outcome).to eq dummy_response_hash
-          end
-
-          it "stores a submission history record" do
-            expect { service.call }.to change(LegalFramework::SubmissionHistory, :count)
-          end
+      describe "#url" do
+        it "contains correct url" do
+          expect(service.legal_framework_url).to eq orig_api_url
         end
       end
 
-      context "unsuccessful_response_from_LegalFrameworkAPI" do
-        it_behaves_like "a failed call to LegalFrameworkAPI"
+      describe "#request_body" do
+        it "creates the expected payload from the application proceeding types" do
+          expect(service.request_body).to eq expected_payload_hash.to_json
+        end
+      end
+
+      describe ".call" do
+        around do |example|
+          VCR.turn_off!
+          example.run
+          VCR.turn_on!
+        end
+
+        context "response received from Legal Framework API" do
+          describe "successful post" do
+            before do
+              stub_request(:post, service.legal_framework_url)
+                .with(body: service.request_body)
+                .to_return(body: dummy_response)
+            end
+
+            it "returns a list of merits tasks" do
+              outcome = service.call
+              expect(outcome).to eq dummy_response_hash
+            end
+
+            it "stores a submission history record" do
+              expect { service.call }.to change(LegalFramework::SubmissionHistory, :count)
+            end
+          end
+        end
+
+        context "unsuccessful_response_from_LegalFrameworkAPI" do
+          it_behaves_like "a failed call to LegalFrameworkAPI"
+        end
       end
     end
 
-    def expected_payload_hash
-      {
-        request_id: submission.id,
-        proceeding_types: [application.proceedings.first.ccms_code],
-      }
-    end
-
-    def dummy_response_hash
-      {
-        request_id: submission.id,
-        application: {
-          tasks: {
-            incident_details: [],
-            opponent_details: [],
-            application_children: [],
-          },
-        },
-        proceeding_types: [
-          {
-            ccms_code: application.proceedings.first.ccms_code,
+    context "when then mini-loop flag is on" do
+      let(:enable_mini_loop) { true }
+      let(:expected_payload_hash) do
+        {
+          request_id: submission.id,
+          proceedings: [
+            {
+              ccms_code: application.proceedings.first.ccms_code,
+              delegated_functions_used: application.proceedings.first.used_delegated_functions,
+              client_involvement_type: application.proceedings.first.client_involvement_type_ccms_code,
+            },
+          ],
+        }
+      end
+      let(:dummy_response_hash) do
+        {
+          request_id: submission.id,
+          application: {
             tasks: {
-              chances_of_success: [], # the merits tasks for this one proceeding type, and any dependencies
+              incident_details: [],
+              opponent_details: [],
+              application_children: [],
+              client_denial_of_allegation: [],
+              client_offer_of_undertakings: [],
             },
           },
-        ],
-      }
+          proceeding_types: [
+            {
+              ccms_code: application.proceedings.first.ccms_code,
+              tasks: {
+                chances_of_success: [], # the merits tasks for this one proceeding type, and any dependencies
+              },
+            },
+          ],
+        }
+      end
+
+      describe "#url" do
+        it "contains correct url" do
+          expect(service.legal_framework_url).to eq loop_api_url
+        end
+      end
+
+      describe "#request_body" do
+        it "creates the expected payload from the application proceeding types" do
+          expect(service.request_body).to eq expected_payload_hash.to_json
+        end
+      end
+
+      describe ".call" do
+        around do |example|
+          VCR.turn_off!
+          example.run
+          VCR.turn_on!
+        end
+
+        context "response received from Legal Framework API" do
+          describe "successful post" do
+            before do
+              stub_request(:post, service.legal_framework_url)
+                .with(body: service.request_body)
+                .to_return(body: dummy_response)
+            end
+
+            it "returns a list of merits tasks" do
+              outcome = service.call
+              expect(outcome).to eq dummy_response_hash
+            end
+
+            it "stores a submission history record" do
+              expect { service.call }.to change(LegalFramework::SubmissionHistory, :count)
+            end
+          end
+        end
+
+        context "unsuccessful_response_from_LegalFrameworkAPI" do
+          it_behaves_like "a failed call to LegalFrameworkAPI"
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3491)

There are two parts to this PR:
1. Update the Apply handling of questions, allow LFA to return something that we can ignore until we handle it.  This should reduce the need for carefully timed releases to LFA and Apply, by adding new questions to LFA before we add the relevant routes, controllers, DB handling etc
2. Adding the those parts for merits question 7, client denies allegations

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
