### PR TITLE
Use `govuk_accordion` ViewComponent helper

### DIFF
--- a/app/views/providers/capital_assessment_results/_result_details.html.erb
+++ b/app/views/providers/capital_assessment_results/_result_details.html.erb
@@ -1,23 +1,16 @@
 <div class="govuk-details govuk-!-margin-top-6" data-module="govuk-details">
-    <h1 class="govuk-heading-l">
-      <%= t('.client_eligibility_calculation') %>
-    </h1>
+  <h2 class="govuk-heading-l">
+    <%= t('.client_eligibility_calculation') %>
+  </h2>
 
-  <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-breakdown">
-    <div class="govuk-accordion__section">
-      <div class="govuk-accordion__section-header">
-        <h2 class="govuk-accordion__section-heading">
-        <span class="govuk-accordion__section-button" id="accordion-capital-calculation">
-          <%= t('.capital_calculation') %>
-        </span>
-        </h2>
-      </div>
-        <%= render 'shared/property_results' %>
-        <%= render 'shared/vehicle_results' %>
-        <%= render 'shared/savings_and_investments' %>
-        <%= render 'shared/other_assets' %>
-        <%= render 'shared/total_capital' %>
-        <%= render 'shared/restrictions' %>
-    </div>
-  </div>
+  <%= govuk_accordion do |accordion| %>
+    <% accordion.section(heading_text: t(".capital_calculation")) do %>
+      <%= render "shared/property_results" %>
+      <%= render "shared/vehicle_results" %>
+      <%= render "shared/savings_and_investments" %>
+      <%= render "shared/other_assets" %>
+      <%= render "shared/total_capital" %>
+      <%= render "shared/restrictions" %>
+    <% end %>
+  <% end %>
 </div>

--- a/app/views/providers/capital_assessment_results/show.html.erb
+++ b/app/views/providers/capital_assessment_results/show.html.erb
@@ -8,9 +8,7 @@
     <%= render @result_partial %>
   </div>
 
-  <%= render 'result_details' %>
-
-  <br><br>
+  <%= render "result_details" %>
 
   <%= next_action_buttons_with_form(
           url: providers_legal_aid_application_capital_assessment_result_path(@legal_aid_application),

--- a/app/views/providers/capital_income_assessment_results/_bank_statements.html.erb
+++ b/app/views/providers/capital_income_assessment_results/_bank_statements.html.erb
@@ -1,12 +1,10 @@
-<div class="govuk-accordion__section-content">
-  <h3 class="govuk-heading-m"><%= t('.title') %></h3>
-  <dl class="govuk-summary-list">
-    <%= check_answer_link(
-          name: :bank_statements,
-          url: providers_legal_aid_application_bank_statements_path(@legal_aid_application),
-          question: t('.uploaded'),
-          answer: attachments_with_size(bank_statements),
-          read_only: true
-        ) %>
-  </dl>
-</div>
+<h3 class="govuk-heading-m"><%= t('.title') %></h3>
+<dl class="govuk-summary-list">
+  <%= check_answer_link(
+        name: :bank_statements,
+        url: providers_legal_aid_application_bank_statements_path(@legal_aid_application),
+        question: t('.uploaded'),
+        answer: attachments_with_size(bank_statements),
+        read_only: true
+      ) %>
+</dl>

--- a/app/views/providers/capital_income_assessment_results/_deductions.html.erb
+++ b/app/views/providers/capital_income_assessment_results/_deductions.html.erb
@@ -1,12 +1,10 @@
-<div class="govuk-accordion__section-content">
-  <h2 class="govuk-heading-m"><%= t('.title') %></h2>
-  <table class="govuk-table">
-    <tbody>
-    <%= render partial: 'shared/results_detail_row', locals: { caption: t('.dependants_allowance'), value: gds_number_to_currency(@cfe_result.dependants_allowance) } %>
-    <% unless @legal_aid_application.uploading_bank_statements? %>
-      <%= render partial: 'shared/results_detail_row', locals: { caption: t('.excluded_benefits'), value: gds_number_to_currency(@cfe_result.disregarded_state_benefits) } %>
-    <% end %>
-    <%= render partial: 'shared/results_total_row', locals: { caption: t('.total_deductions'), value: gds_number_to_currency(@cfe_result.total_deductions) } %>
-    </tbody>
-  </table>
-</div>
+<h2 class="govuk-heading-m"><%= t('.title') %></h2>
+<table class="govuk-table">
+  <tbody>
+  <%= render partial: 'shared/results_detail_row', locals: { caption: t('.dependants_allowance'), value: gds_number_to_currency(@cfe_result.dependants_allowance) } %>
+  <% unless @legal_aid_application.uploading_bank_statements? %>
+    <%= render partial: 'shared/results_detail_row', locals: { caption: t('.excluded_benefits'), value: gds_number_to_currency(@cfe_result.disregarded_state_benefits) } %>
+  <% end %>
+  <%= render partial: 'shared/results_total_row', locals: { caption: t('.total_deductions'), value: gds_number_to_currency(@cfe_result.total_deductions) } %>
+  </tbody>
+</table>

--- a/app/views/providers/capital_income_assessment_results/_disposable_income.html.erb
+++ b/app/views/providers/capital_income_assessment_results/_disposable_income.html.erb
@@ -1,11 +1,9 @@
-<div class="govuk-accordion__section-content">
-  <h2 class="govuk-heading-m"><%= t('.title') %></h2>
-  <table class="govuk-table">
-    <tbody>
-      <%= render partial: 'shared/results_detail_row', locals: { caption: t('.total_income'), value: gds_number_to_currency(@cfe_result.total_monthly_income_including_employment_income) } %>
-      <%= render partial: 'shared/results_detail_row', locals: { caption: t('.total_outgoings'), value: gds_number_to_currency(@cfe_result.total_monthly_outgoings_including_tax_and_ni) } %>
-      <%= render partial: 'shared/results_detail_row', locals: { caption: t('.total_deductions'), value: gds_number_to_currency(@cfe_result.total_deductions_including_fixed_employment_allowance) } %>
-      <%= render partial: 'shared/results_total_bold_row', locals: { caption: t('.total_disposable'), value: gds_number_to_currency(@cfe_result.total_disposable_income_assessed) } %>
-    <tbody>
-  </table>
-</div>
+<h2 class="govuk-heading-m"><%= t('.title') %></h2>
+<table class="govuk-table">
+  <tbody>
+    <%= render partial: 'shared/results_detail_row', locals: { caption: t('.total_income'), value: gds_number_to_currency(@cfe_result.total_monthly_income_including_employment_income) } %>
+    <%= render partial: 'shared/results_detail_row', locals: { caption: t('.total_outgoings'), value: gds_number_to_currency(@cfe_result.total_monthly_outgoings_including_tax_and_ni) } %>
+    <%= render partial: 'shared/results_detail_row', locals: { caption: t('.total_deductions'), value: gds_number_to_currency(@cfe_result.total_deductions_including_fixed_employment_allowance) } %>
+    <%= render partial: 'shared/results_total_bold_row', locals: { caption: t('.total_disposable'), value: gds_number_to_currency(@cfe_result.total_disposable_income_assessed) } %>
+  <tbody>
+</table>

--- a/app/views/providers/capital_income_assessment_results/_employment_income.html.erb
+++ b/app/views/providers/capital_income_assessment_results/_employment_income.html.erb
@@ -1,13 +1,11 @@
-<div class="govuk-accordion__section-content">
-  <h2 class="govuk-heading-m"><%= t('.title') %></h2>
-  <table class="govuk-table">
-    <tbody>
-    <%= render partial: 'shared/results_detail_row', locals: { caption: t('.monthly_income_before_tax'), value: gds_number_to_currency(@cfe_result.employment_income_gross_income) } %>
-    <%= render partial: 'shared/results_detail_row', locals: { caption: t('.benefits_in_kind'), value: gds_number_to_currency(@cfe_result.employment_income_benefits_in_kind) } %>
-    <%= render partial: 'shared/results_detail_row', locals: { caption: t('.tax'), value: gds_number_to_currency(@cfe_result.employment_income_tax) } %>
-    <%= render partial: 'shared/results_detail_row', locals: { caption: t('.national_insurance'), value: gds_number_to_currency(@cfe_result.employment_income_national_insurance) } %>
-    <%= render partial: 'shared/results_detail_row', locals: { caption: t('.fixed_employment_deduction'), value: gds_number_to_currency(@cfe_result.employment_income_fixed_employment_deduction) } %>
-    <%= render partial: 'shared/results_total_row', locals: { caption: t('.total'), value: gds_number_to_currency(@cfe_result.employment_income_net_employment_income) } %>
-    </tbody>
-  </table>
-</div>
+<h2 class="govuk-heading-m"><%= t('.title') %></h2>
+<table class="govuk-table">
+  <tbody>
+  <%= render partial: 'shared/results_detail_row', locals: { caption: t('.monthly_income_before_tax'), value: gds_number_to_currency(@cfe_result.employment_income_gross_income) } %>
+  <%= render partial: 'shared/results_detail_row', locals: { caption: t('.benefits_in_kind'), value: gds_number_to_currency(@cfe_result.employment_income_benefits_in_kind) } %>
+  <%= render partial: 'shared/results_detail_row', locals: { caption: t('.tax'), value: gds_number_to_currency(@cfe_result.employment_income_tax) } %>
+  <%= render partial: 'shared/results_detail_row', locals: { caption: t('.national_insurance'), value: gds_number_to_currency(@cfe_result.employment_income_national_insurance) } %>
+  <%= render partial: 'shared/results_detail_row', locals: { caption: t('.fixed_employment_deduction'), value: gds_number_to_currency(@cfe_result.employment_income_fixed_employment_deduction) } %>
+  <%= render partial: 'shared/results_total_row', locals: { caption: t('.total'), value: gds_number_to_currency(@cfe_result.employment_income_net_employment_income) } %>
+  </tbody>
+</table>

--- a/app/views/providers/capital_income_assessment_results/_other_income.html.erb
+++ b/app/views/providers/capital_income_assessment_results/_other_income.html.erb
@@ -1,16 +1,14 @@
-<div class="govuk-accordion__section-content">
-  <h2 class="govuk-heading-m">
-    <%= @legal_aid_application.provider.employment_permissions? && @cfe_result.jobs? ? t('.title') : t('.income') %>
-  </h2>
-  <table class="govuk-table">
-    <tbody>
-    <%= render partial: 'shared/results_detail_row', locals: { caption: t('.benefits'), value: gds_number_to_currency(@cfe_result.monthly_state_benefits) } %>
-    <%= render partial: 'shared/results_detail_row', locals: { caption: t('.friends_or_family'), value: gds_number_to_currency(@cfe_result.mei_friends_or_family) } %>
-    <%= render partial: 'shared/results_detail_row', locals: { caption: t('.maintenance'), value: gds_number_to_currency(@cfe_result.mei_maintenance_in) } %>
-    <%= render partial: 'shared/results_detail_row', locals: { caption: t('.property_or_lodger'), value: gds_number_to_currency(@cfe_result.mei_property_or_lodger) } %>
-    <%= render partial: 'shared/results_detail_row', locals: { caption: t('.student_loan_or_grant'), value: gds_number_to_currency(@cfe_result.mei_student_loan) } %>
-    <%= render partial: 'shared/results_detail_row', locals: { caption: t('.pension'), value: gds_number_to_currency(@cfe_result.mei_pension) } %>
-    <%= render partial: 'shared/results_total_row', locals: { caption: t('.total'), value: gds_number_to_currency(@cfe_result.total_gross_income) } %>
-    </tbody>
-  </table>
-</div>
+<h2 class="govuk-heading-m">
+  <%= @legal_aid_application.provider.employment_permissions? && @cfe_result.jobs? ? t('.title') : t('.income') %>
+</h2>
+<table class="govuk-table">
+  <tbody>
+  <%= render partial: 'shared/results_detail_row', locals: { caption: t('.benefits'), value: gds_number_to_currency(@cfe_result.monthly_state_benefits) } %>
+  <%= render partial: 'shared/results_detail_row', locals: { caption: t('.friends_or_family'), value: gds_number_to_currency(@cfe_result.mei_friends_or_family) } %>
+  <%= render partial: 'shared/results_detail_row', locals: { caption: t('.maintenance'), value: gds_number_to_currency(@cfe_result.mei_maintenance_in) } %>
+  <%= render partial: 'shared/results_detail_row', locals: { caption: t('.property_or_lodger'), value: gds_number_to_currency(@cfe_result.mei_property_or_lodger) } %>
+  <%= render partial: 'shared/results_detail_row', locals: { caption: t('.student_loan_or_grant'), value: gds_number_to_currency(@cfe_result.mei_student_loan) } %>
+  <%= render partial: 'shared/results_detail_row', locals: { caption: t('.pension'), value: gds_number_to_currency(@cfe_result.mei_pension) } %>
+  <%= render partial: 'shared/results_total_row', locals: { caption: t('.total'), value: gds_number_to_currency(@cfe_result.total_gross_income) } %>
+  </tbody>
+</table>

--- a/app/views/providers/capital_income_assessment_results/_outgoings.html.erb
+++ b/app/views/providers/capital_income_assessment_results/_outgoings.html.erb
@@ -1,12 +1,10 @@
-<div class="govuk-accordion__section-content">
-  <h2 class="govuk-heading-m"><%= t('.title') %></h2>
-  <table class="govuk-table">
-    <tbody>
-    <%= render partial: 'shared/results_detail_row', locals: { caption: t('.housing_costs'), value: gds_number_to_currency(@cfe_result.moe_housing) } %>
-    <%= render partial: 'shared/results_detail_row', locals: { caption: t('.childcare_costs'), value: gds_number_to_currency(@cfe_result.moe_childcare) } %>
-    <%= render partial: 'shared/results_detail_row', locals: { caption: t('.maintenance_out'), value: gds_number_to_currency(@cfe_result.moe_maintenance_out) } %>
-    <%= render partial: 'shared/results_detail_row', locals: { caption: t('.legal_aid'), value: gds_number_to_currency(@cfe_result.moe_legal_aid) } %>
-    <%= render partial: 'shared/results_total_row', locals: { caption: t('.total_outgoings'), value: gds_number_to_currency(@cfe_result.total_monthly_outgoings) } %>
-    </tbody>
-  </table>
-</div>
+<h2 class="govuk-heading-m"><%= t('.title') %></h2>
+<table class="govuk-table">
+  <tbody>
+  <%= render partial: 'shared/results_detail_row', locals: { caption: t('.housing_costs'), value: gds_number_to_currency(@cfe_result.moe_housing) } %>
+  <%= render partial: 'shared/results_detail_row', locals: { caption: t('.childcare_costs'), value: gds_number_to_currency(@cfe_result.moe_childcare) } %>
+  <%= render partial: 'shared/results_detail_row', locals: { caption: t('.maintenance_out'), value: gds_number_to_currency(@cfe_result.moe_maintenance_out) } %>
+  <%= render partial: 'shared/results_detail_row', locals: { caption: t('.legal_aid'), value: gds_number_to_currency(@cfe_result.moe_legal_aid) } %>
+  <%= render partial: 'shared/results_total_row', locals: { caption: t('.total_outgoings'), value: gds_number_to_currency(@cfe_result.total_monthly_outgoings) } %>
+  </tbody>
+</table>

--- a/app/views/providers/capital_income_assessment_results/_result_details.html.erb
+++ b/app/views/providers/capital_income_assessment_results/_result_details.html.erb
@@ -1,47 +1,33 @@
 <div class="govuk-details govuk-!-margin-top-6" data-module="govuk-details">
-    <h2 class="govuk-heading-l">
-      <%= t('.client_eligibility_calculation') %>
-    </h2>
+  <h2 class="govuk-heading-l">
+    <%= t('.client_eligibility_calculation') %>
+  </h2>
 
-  <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-breakdown">
+  <%= govuk_accordion do |accordion| %>
+    <% accordion.section(heading_text: t(".income_calculation")) do %>
+      <p class="govuk-hint"><%= t(".hint_text") %></p>
 
-    <div class="govuk-accordion__section ">
-      <div class="govuk-accordion__section-header">
-        <h2 class="govuk-accordion__section-heading">
-        <span class="govuk-accordion__section-button" id="accordion-income-calculation">
-          <%= t('.income_calculation') %>
-        </span>
-        </h2>
-      </div>
-      <div class="govuk-accordion__section-content">
-        <p class="govuk-hint"><%= t('.hint_text') %></p>
-      </div>
       <% if @legal_aid_application.uploading_bank_statements? %>
-        <%= render('bank_statements', bank_statements: @legal_aid_application.attachments.bank_statement_evidence, read_only: true) %>
+        <%= render("bank_statements", bank_statements: @legal_aid_application.attachments.bank_statement_evidence, read_only: true) %>
       <% end %>
-      <% if @legal_aid_application.provider.employment_permissions? && @cfe_result.jobs? %>
-        <%= render 'employment_income' %>
-      <% end %>
-      <%= render 'other_income' %>
-      <%= render 'outgoings' %>
-      <%= render 'deductions' %>
-      <%= render 'disposable_income' %>
-    </div>
 
-    <div class="govuk-accordion__section ">
-      <div class="govuk-accordion__section-header">
-        <h2 class="govuk-accordion__section-heading">
-        <span class="govuk-accordion__section-button" id="accordion-capital-calculation">
-          <%= t('.capital_calculation') %>
-        </span>
-        </h2>
-      </div>
-        <%= render 'shared/property_results' %>
-        <%= render 'shared/vehicle_results' %>
-        <%= render 'shared/savings_and_investments' %>
-        <%= render 'shared/other_assets' %>
-        <%= render 'shared/total_capital' %>
-        <%= render 'shared/restrictions' %>
-    </div>
-  </div>
+      <% if @legal_aid_application.provider.employment_permissions? && @cfe_result.jobs? %>
+        <%= render "employment_income" %>
+      <% end %>
+
+      <%= render "other_income" %>
+      <%= render "outgoings" %>
+      <%= render "deductions" %>
+      <%= render "disposable_income" %>
+    <% end %>
+
+    <%= accordion.section(heading_text: t(".capital_calculation")) do %>
+      <%= render "shared/property_results" %>
+      <%= render "shared/vehicle_results" %>
+      <%= render "shared/savings_and_investments" %>
+      <%= render "shared/other_assets" %>
+      <%= render "shared/total_capital" %>
+      <%= render "shared/restrictions" %>
+    <% end %>
+  <% end %>
 </div>

--- a/app/views/providers/capital_income_assessment_results/show.html.erb
+++ b/app/views/providers/capital_income_assessment_results/show.html.erb
@@ -9,9 +9,7 @@
     <%= render @result_partial %>
   </div>
 
-  <%= render 'result_details' %>
-
-  <div class="govuk-!-padding-bottom-6"></div>
+  <%= render "result_details" %>
 
   <%= next_action_buttons_with_form(
           url: providers_legal_aid_application_capital_income_assessment_result_path(@legal_aid_application),

--- a/app/views/shared/_other_assets.html.erb
+++ b/app/views/shared/_other_assets.html.erb
@@ -1,14 +1,12 @@
 <% if @cfe_result.liquid_capital_items.any? || @cfe_result.additional_property? %>
-  <div class="govuk-accordion__section-content">
-    <h2 class="govuk-heading-m"><%= t('.other_assets') %></h2>
-    <table class="govuk-table">
-      <tbody>
-        <% @cfe_result.non_liquid_capital_items.each do |item| %>
-          <%= render partial: 'shared/results_detail_row', locals: { caption: item[:description], value: gds_number_to_currency(item[:value]) } %>
-        <% end %>
+  <h2 class="govuk-heading-m"><%= t('.other_assets') %></h2>
+  <table class="govuk-table">
+    <tbody>
+      <% @cfe_result.non_liquid_capital_items.each do |item| %>
+        <%= render partial: 'shared/results_detail_row', locals: { caption: item[:description], value: gds_number_to_currency(item[:value]) } %>
+      <% end %>
 
-        <%= render partial: 'shared/results_total_row', locals: { caption: t('.assessed_amount'), value: gds_number_to_currency(@cfe_result.total_other_assets) } %>
-      </tbody>
-    </table>
-  </div>
+      <%= render partial: 'shared/results_total_row', locals: { caption: t('.assessed_amount'), value: gds_number_to_currency(@cfe_result.total_other_assets) } %>
+    </tbody>
+  </table>
 <% end %>

--- a/app/views/shared/_property_results.html.erb
+++ b/app/views/shared/_property_results.html.erb
@@ -1,22 +1,20 @@
-<div class="govuk-accordion__section-content">
-  <h2 class="govuk-heading-m"><%= t('.property') %></h2>
+<h2 class="govuk-heading-m"><%= t('.property') %></h2>
+<table class="govuk-table">
+  <tbody>
+    <%= render partial: 'shared/results_detail_row', locals: { caption: t('.value'), value: gds_number_to_currency(@cfe_result.main_home_value) } %>
+    <%= render partial: 'shared/results_detail_row', locals: { caption: t('.outstanding_mortgage'), value: gds_number_to_currency(@cfe_result.main_home_outstanding_mortgage) } %>
+    <%= render partial: 'shared/results_detail_row', locals: { caption: t('.disregards'), value: gds_number_to_currency(@cfe_result.main_home_equity_disregard) } %>
+    <%= render partial: 'shared/results_total_row', locals: { caption: t('.assessment_amount'), value: gds_number_to_currency(@cfe_result.main_home_assessed_equity) } %>
+  </tbody>
+</table>
+
+<% if @cfe_result.additional_property? %>
+  <h2 class="govuk-heading-m"><%= t('.additional_property') %></h2>
   <table class="govuk-table">
     <tbody>
-      <%= render partial: 'shared/results_detail_row', locals: { caption: t('.value'), value: gds_number_to_currency(@cfe_result.main_home_value) } %>
-      <%= render partial: 'shared/results_detail_row', locals: { caption: t('.outstanding_mortgage'), value: gds_number_to_currency(@cfe_result.main_home_outstanding_mortgage) } %>
-      <%= render partial: 'shared/results_detail_row', locals: { caption: t('.disregards'), value: gds_number_to_currency(@cfe_result.main_home_equity_disregard) } %>
-      <%= render partial: 'shared/results_total_row', locals: { caption: t('.assessment_amount'), value: gds_number_to_currency(@cfe_result.main_home_assessed_equity) } %>
+    <%= render partial: 'shared/results_detail_row', locals: { caption: t('.value'), value: gds_number_to_currency(@cfe_result.additional_property_value) } %>
+    <%= render partial: 'shared/results_detail_row', locals: { caption: t('.outstanding_mortgage'), value: gds_number_to_currency(@cfe_result.additional_property_mortgage) } %>
+    <%= render partial: 'shared/results_total_row', locals: { caption: t('.assessment_amount'), value: gds_number_to_currency(@cfe_result.additional_property_assessed_equity) } %>
     </tbody>
   </table>
-
-  <% if @cfe_result.additional_property? %>
-    <h2 class="govuk-heading-m"><%= t('.additional_property') %></h2>
-    <table class="govuk-table">
-      <tbody>
-      <%= render partial: 'shared/results_detail_row', locals: { caption: t('.value'), value: gds_number_to_currency(@cfe_result.additional_property_value) } %>
-      <%= render partial: 'shared/results_detail_row', locals: { caption: t('.outstanding_mortgage'), value: gds_number_to_currency(@cfe_result.additional_property_mortgage) } %>
-      <%= render partial: 'shared/results_total_row', locals: { caption: t('.assessment_amount'), value: gds_number_to_currency(@cfe_result.additional_property_assessed_equity) } %>
-      </tbody>
-    </table>
-    <% end %>
-</div>
+  <% end %>

--- a/app/views/shared/_restrictions.html.erb
+++ b/app/views/shared/_restrictions.html.erb
@@ -1,14 +1,12 @@
-<div class="govuk-accordion__section-content">
-  <h2 class="govuk-heading-m"><%= t('.restrictions') %></h2>
-    <tbody>
-      <tr>
-        <td class="govuk-table__cell govuk-table">
-          <% if @legal_aid_application.has_restrictions? %>
-            <%= @legal_aid_application.restrictions_details %>
-          <% else %>
-            <%= t('.none') %>
-          <% end %>
-        </td>
-      </tr>
-    </tbody>
-</div>
+<h2 class="govuk-heading-m"><%= t('.restrictions') %></h2>
+  <tbody>
+    <tr>
+      <td class="govuk-table__cell govuk-table">
+        <% if @legal_aid_application.has_restrictions? %>
+          <%= @legal_aid_application.restrictions_details %>
+        <% else %>
+          <%= t('.none') %>
+        <% end %>
+      </td>
+    </tr>
+  </tbody>

--- a/app/views/shared/_savings_and_investments.html.erb
+++ b/app/views/shared/_savings_and_investments.html.erb
@@ -1,15 +1,13 @@
 <% if @cfe_result.liquid_capital_items.any? %>
-  <div class="govuk-accordion__section-content">
-    <h2 class="govuk-heading-m"><%= t('.savings_and_investments') %></h2>
-    <table class="govuk-table">
-      <tbody>
-        <% @cfe_result.liquid_capital_items.each do |item| %>
-          <% if capital_items_to_display?(@legal_aid_application, item) %>
-            <%= render partial: 'shared/results_detail_row', locals: {caption:  item_description(@legal_aid_application, item), value: gds_number_to_currency(item[:value]) } %>
-          <% end %>
+  <h2 class="govuk-heading-m"><%= t('.savings_and_investments') %></h2>
+  <table class="govuk-table">
+    <tbody>
+      <% @cfe_result.liquid_capital_items.each do |item| %>
+        <% if capital_items_to_display?(@legal_aid_application, item) %>
+          <%= render partial: 'shared/results_detail_row', locals: {caption:  item_description(@legal_aid_application, item), value: gds_number_to_currency(item[:value]) } %>
         <% end %>
-      <%= render partial: 'shared/results_total_row', locals: { caption: t('.assessed_amount'), value: gds_number_to_currency(@cfe_result.total_savings) } %>
-      </tbody>
-    </table>
-  </div>
+      <% end %>
+    <%= render partial: 'shared/results_total_row', locals: { caption: t('.assessed_amount'), value: gds_number_to_currency(@cfe_result.total_savings) } %>
+    </tbody>
+  </table>
 <% end %>

--- a/app/views/shared/_total_capital.html.erb
+++ b/app/views/shared/_total_capital.html.erb
@@ -1,14 +1,12 @@
-<div class="govuk-accordion__section-content">
-  <h2 class="govuk-heading-m"><%= t('.total_assessed_capital') %></h2>
-  <table class="govuk-table">
-    <tbody>
-    <%= render partial: 'shared/results_detail_row', locals: { caption: t('.property'), value: gds_number_to_currency(@cfe_result.total_property) } %>
-    <%= render partial: 'shared/results_detail_row', locals: { caption: t('.vehicles'), value: gds_number_to_currency(@cfe_result.total_vehicles) } %>
-    <%= render partial: 'shared/results_detail_row', locals: { caption: t('.savings_and_investments'), value: gds_number_to_currency(@cfe_result.total_savings) } %>
-    <%= render partial: 'shared/results_detail_row', locals: { caption: t('.other_assets'), value: gds_number_to_currency(@cfe_result.total_other_assets) } %>
-    <%= render partial: 'shared/results_total_bold_row', locals: { caption: t('.total_capital'), value: gds_number_to_currency(@cfe_result.total_capital_before_pensioner_disregard) } %>
-    <%= render partial: 'shared/results_detail_row', locals: { caption: t('.pensioner_disregard'), value: gds_number_to_currency(@cfe_result.pensioner_capital_disregard) } %>
-    <%= render partial: 'shared/results_total_bold_row', locals: { caption: t('.disposable_capital'), value: gds_number_to_currency(@cfe_result.total_disposable_capital) } %>
-    </tbody>
-  </table>
-</div>
+<h2 class="govuk-heading-m"><%= t('.total_assessed_capital') %></h2>
+<table class="govuk-table">
+  <tbody>
+  <%= render partial: 'shared/results_detail_row', locals: { caption: t('.property'), value: gds_number_to_currency(@cfe_result.total_property) } %>
+  <%= render partial: 'shared/results_detail_row', locals: { caption: t('.vehicles'), value: gds_number_to_currency(@cfe_result.total_vehicles) } %>
+  <%= render partial: 'shared/results_detail_row', locals: { caption: t('.savings_and_investments'), value: gds_number_to_currency(@cfe_result.total_savings) } %>
+  <%= render partial: 'shared/results_detail_row', locals: { caption: t('.other_assets'), value: gds_number_to_currency(@cfe_result.total_other_assets) } %>
+  <%= render partial: 'shared/results_total_bold_row', locals: { caption: t('.total_capital'), value: gds_number_to_currency(@cfe_result.total_capital_before_pensioner_disregard) } %>
+  <%= render partial: 'shared/results_detail_row', locals: { caption: t('.pensioner_disregard'), value: gds_number_to_currency(@cfe_result.pensioner_capital_disregard) } %>
+  <%= render partial: 'shared/results_total_bold_row', locals: { caption: t('.disposable_capital'), value: gds_number_to_currency(@cfe_result.total_disposable_capital) } %>
+  </tbody>
+</table>

--- a/app/views/shared/_vehicle_results.erb
+++ b/app/views/shared/_vehicle_results.erb
@@ -1,13 +1,11 @@
 <% if @cfe_result.vehicles? %>
-  <div class="govuk-accordion__section-content">
-    <h2 class="govuk-heading-m"><%= t('.vehicles') %></h2>
-    <table class="govuk-table" >
-      <tbody>
-      <%= render partial: 'shared/results_detail_row', locals: { caption: t('.value'), value: gds_number_to_currency(@cfe_result.vehicle_value) } %>
-      <%= render partial: 'shared/results_detail_row', locals: { caption: t('.oustanding_payments'), value: gds_number_to_currency(@cfe_result.vehicle_loan_amount_outstanding) } %>
-      <%= render partial: 'shared/results_detail_row', locals: { caption: t('.disregards'), value: gds_number_to_currency(@cfe_result.vehicle_disregard) } %>
-      <%= render partial: 'shared/results_total_row', locals: { caption: t('.assessment_amount'), value: gds_number_to_currency(@cfe_result.total_vehicles) } %>
-      </tbody>
-    </table>
-  </div>
+  <h2 class="govuk-heading-m"><%= t('.vehicles') %></h2>
+  <table class="govuk-table" >
+    <tbody>
+    <%= render partial: 'shared/results_detail_row', locals: { caption: t('.value'), value: gds_number_to_currency(@cfe_result.vehicle_value) } %>
+    <%= render partial: 'shared/results_detail_row', locals: { caption: t('.oustanding_payments'), value: gds_number_to_currency(@cfe_result.vehicle_loan_amount_outstanding) } %>
+    <%= render partial: 'shared/results_detail_row', locals: { caption: t('.disregards'), value: gds_number_to_currency(@cfe_result.vehicle_disregard) } %>
+    <%= render partial: 'shared/results_total_row', locals: { caption: t('.assessment_amount'), value: gds_number_to_currency(@cfe_result.total_vehicles) } %>
+    </tbody>
+  </table>
 <% end %>


### PR DESCRIPTION
Before, accordion components were rendered adhoc by replicating and tweaking HTML examples from the GOV.UK Design System.

This replaces accordion components with their govuk-components counterparts.