### PR TITLE
Use `govuk_inset_text` ViewComponent helper

### DIFF
--- a/app/views/admin/legal_aid_applications/index.html.erb
+++ b/app/views/admin/legal_aid_applications/index.html.erb
@@ -13,9 +13,9 @@
       <p id="delete-case-name"></p>
       <p id="delete-case-ref"></p>
     </div>
-    <div class="govuk-error-summary__body govuk-inset-text">
-      <%= t('.warning.delete_consequence') %>
-    </div>
+
+    <%= govuk_inset_text(text: t(".warning.delete_consequence")) %>
+
     <%= button_to_accessible(
           t('.confirm_delete'),
           nil,

--- a/app/views/citizens/consents/show.html.erb
+++ b/app/views/citizens/consents/show.html.erb
@@ -7,9 +7,10 @@
 
     <%= page_template page_title: t('.title_html'),  head_title: t('.head_title'), form: form do %>
 
-      <div class="govuk-inset-text">
+      <%= govuk_inset_text do %>
         <p class="govuk-body govuk-!-padding-bottom-2"><%= t('.inset_text') %></p>
-      </div>
+      <% end %>
+
       <details class="govuk-details govuk-!-margin-top-4" data-module="govuk-details">
         <summary class="govuk-details__summary">
           <span class="govuk-details__summary-text"

--- a/app/views/citizens/means_test_results/show.html.erb
+++ b/app/views/citizens/means_test_results/show.html.erb
@@ -24,6 +24,6 @@
   <p class="govuk-body"><%= t('.what-happens-next') %></p>
 <% end %>
 
-<div class="govuk-inset-text">
+<%= govuk_inset_text do %>
   <p class="govuk-body govuk-!-padding-bottom-2"><%= link_to_accessible t('.feedback_prefix'), new_feedback_path %><%= t('.feedback_suffix') %></p>
-</div>
+<% end %>

--- a/app/views/providers/addresses/show.html.erb
+++ b/app/views/providers/addresses/show.html.erb
@@ -31,9 +31,7 @@
 
     <% if form.object.lookup_error.present? %>
       <%= form.hidden_field :lookup_error %>
-      <div class='govuk-inset-text'>
-        <%= t("errors.address.#{form.object.lookup_error}") %>
-      </div>
+      <%= govuk_inset_text(text: t("errors.address.#{form.object.lookup_error}")) %>
     <% end %>
 
     <div class="govuk-!-padding-bottom-2"></div>

--- a/app/views/providers/confirm_dwp_non_passported_applications/show.html.erb
+++ b/app/views/providers/confirm_dwp_non_passported_applications/show.html.erb
@@ -17,9 +17,7 @@
                                               classes: ['govuk-!-margin-top-4'] %>
 
       <% if display_hmrc_inset_text? %>
-        <div class="govuk-inset-text">
-          <%= t('.hmrc_inset_text') %>
-        </div>
+        <%= govuk_inset_text(text: t(".hmrc_inset_text")) %>
       <% end %>
 
       <% if @form.errors.any? %>

--- a/app/views/providers/end_of_applications/show.html.erb
+++ b/app/views/providers/end_of_applications/show.html.erb
@@ -25,9 +25,10 @@
 
   <p class="govuk-body"><%= t('.application_to_be_checked') %></p>
   <p class="govuk-body"><%= t('.decision_in_ccms_html') %></p>
-  <div class="govuk-inset-text">
-  <p class="govuk-body govuk-!-padding-bottom-2"><%= link_to_accessible t('.feedback_prefix'), new_feedback_path %><%= t('.feedback_suffix') %></p>
-  </div>
+
+  <%= govuk_inset_text do %>
+    <p class="govuk-body govuk-!-padding-bottom-2"><%= link_to_accessible t('.feedback_prefix'), new_feedback_path %><%= t('.feedback_suffix') %></p>
+  <% end %>
 
   <%= next_action_buttons_with_form(
       url: providers_legal_aid_application_end_of_application_path,

--- a/app/views/providers/gateway_evidences/show.html.erb
+++ b/app/views/providers/gateway_evidences/show.html.erb
@@ -24,7 +24,7 @@
 
     <%= form.govuk_fieldset legend: {text: page_title, tag: 'h1', size: 'xl'} do %>
 
-      <div class="govuk-inset-text"><%= t('.hint_text') %></div>
+      <%= govuk_inset_text(text: t(".hint_text")) %>
 
       <%= form.govuk_file_field :original_file, label: {text: t('generic.upload_file'), size: 'm'},
                                 hint: {text: t('.size_hint')} %>

--- a/app/views/providers/means/has_dependants/show.html.erb
+++ b/app/views/providers/means/has_dependants/show.html.erb
@@ -26,11 +26,11 @@
           <% end %>
         </ul>
 
-        <div class="govuk-inset-text">
+        <%= govuk_inset_text do %>
           <p class="govuk-body">
             <%= t('.extra_info') %>
           </p>
-        </div>
+        <% end %>
 
     <% end %>
 

--- a/app/views/providers/start/index.html.erb
+++ b/app/views/providers/start/index.html.erb
@@ -2,9 +2,9 @@
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-xl"><%= t('.apply_for_legal_aid_heading') %></h1>
 
-    <div class="govuk-inset-text">
+    <%= govuk_inset_text do %>
       <p class="govuk-body"><%= t('.must_be_provider') %></p>
-    </div>
+    <% end %>
 
     <p class="govuk-body"><%= t('.domestic_violence_or_abuse_only') %></p>
 

--- a/app/views/providers/transactions/show.html.erb
+++ b/app/views/providers/transactions/show.html.erb
@@ -1,6 +1,6 @@
 <%= page_template page_title: t("transaction_types.page_titles.#{@transaction_type.name}"), column_width: 'full', template: :default do %>
 
-  <div class="govuk-inset-text"><%= t("transaction_types.#{@transaction_type.name}.inset_text") %></div>
+  <%= govuk_inset_text(text: t("transaction_types.#{@transaction_type.name}.inset_text")) %>
 
   <% if @transaction_type.name == 'excluded_benefits' %>
     <%= render 'disregarded_list' %>


### PR DESCRIPTION
Before, inset text components were rendered adhoc by replicating and tweaking HTML examples from the GOV.UK Design System.

This replaces all usages of the inset text component with its `govuk-components` counterpart.