### PR TITLE
AP-3559 means summary page employment details section display logic

### DIFF
--- a/app/views/providers/means_summaries/_income_assessment.html.erb
+++ b/app/views/providers/means_summaries/_income_assessment.html.erb
@@ -13,7 +13,7 @@
     <% else %>
       <%= render 'shared/check_answers/employed_income', read_only: false %>
     <% end %>
-  <% else %>
+  <% elsif @legal_aid_application.applicant_employed? %>
     <%= render 'shared/check_answers/full_employment_details', read_only: false %>
   <% end %>
 <% end %>

--- a/features/providers/check_your_answers.feature
+++ b/features/providers/check_your_answers.feature
@@ -364,7 +364,7 @@ Feature: Checking answers backwards and forwards
   @javascript
   Scenario: I am able to see all necessary sections for a non-passported open banking flow
     Given I have completed a non-passported application with open banking transactions
-    And I am viewing the means summary check your anwsers page
+    And I am viewing the means summary check your answers page
 
     Then the following sections should exist:
       | tag | section |
@@ -378,7 +378,6 @@ Feature: Checking answers backwards and forwards
       | h2  | Your client's capital |
       | h3  | Property |
       | h3  | Vehicles |
-    # | h3  | Which bank accounts does your client have? |
       | h3  | Does your client have any savings accounts they cannot access online? |
       | h2  | Which savings or investments does your client have? |
       | h2  | Which assets does your client have? |

--- a/features/providers/enhanced_bank_upload/check_your_answers.feature
+++ b/features/providers/enhanced_bank_upload/check_your_answers.feature
@@ -1,6 +1,6 @@
 Feature: Enhanced bank upload check your answers
   @javascript
-  Scenario: I am able to view and amend provider means answers for enhanced bank upload flow
+  Scenario: I am able to view and amend provider means answers for enhanced bank upload flow for an employed applicant
     Given csrf is enabled
     And the feature flag for enhanced_bank_upload is enabled
     And I have completed a non-passported employed application with enhanced bank upload as far as the end of the means section
@@ -89,3 +89,30 @@ Feature: Enhanced bank upload check your answers
     And I check "My client makes none of these payments"
     And I click "Save and continue"
     Then I should be on the "means_summary" page showing "Check your answers"
+
+  @javascript
+  Scenario: On the enhanced bank upload journey, the provider has employment permissions but the applicant is unemployed
+    Given csrf is enabled
+    And the feature flag for enhanced_bank_upload is enabled
+    And I have completed a non-passported non-employed application with enhanced bank upload as far as the end of the means section
+    Then I should be on the "means_summary" page showing "Check your answers"
+    And I should not see 'Employment income'
+    And the following sections should exist:
+      | tag | section |
+      | h1  | Check your answers |
+      | h3  | Bank statements |
+      | h2  | Your client's income |
+      | h3  | What payments does your client receive? |
+      | h3  | Student finance |
+      | h2  | Your client's outgoings |
+      | h3  | What payments does your client make? |
+      | h2  | Your client's capital |
+      | h3  | Property |
+      | h3  | Vehicles |
+      | h2  | Which bank accounts does your client have? |
+      | h2  | Which savings or investments does your client have? |
+      | h2  | Which assets does your client have? |
+      | h2  | Restrictions on your client's assets |
+      | h2  | Payments from scheme or charities |
+
+

--- a/features/step_definitions/check_your_answers_steps.rb
+++ b/features/step_definitions/check_your_answers_steps.rb
@@ -39,7 +39,7 @@ Given("I have completed a non-passported application with open banking transacti
   login_as @legal_aid_application.provider
 end
 
-And("I am viewing the means summary check your anwsers page") do
+And("I am viewing the means summary check your answers page") do
   visit(providers_legal_aid_application_means_summary_path(@legal_aid_application))
 end
 

--- a/features/step_definitions/enhanced_bank_upload_steps.rb
+++ b/features/step_definitions/enhanced_bank_upload_steps.rb
@@ -41,3 +41,25 @@ Given "I have completed a non-passported employed application with enhanced bank
 
   visit(providers_legal_aid_application_means_summary_path(@legal_aid_application))
 end
+
+Given "I have completed a non-passported non-employed application with enhanced bank upload as far as the end of the means section" do
+  @legal_aid_application = create(
+    :legal_aid_application,
+    :with_proceedings,
+    :with_applicant,
+    :with_savings_amount,
+    :with_policy_disregards,
+    :without_open_banking_consent,
+    :checking_non_passported_means,
+  )
+
+  create :attachment, :bank_statement, legal_aid_application: @legal_aid_application
+
+  @legal_aid_application.provider.permissions << Permission.find_by(role: "application.non_passported.employment.*")
+  @legal_aid_application.provider.permissions << Permission.find_by(role: "application.non_passported.bank_statement_upload.*")
+  @legal_aid_application.provider.save!
+
+  login_as @legal_aid_application.provider
+
+  visit(providers_legal_aid_application_means_summary_path(@legal_aid_application))
+end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3559)

Fix logic for displaying the employment income details section on the means summary page.

The following scenarios should now work as expected, for all three non-passported journeys (Truelayer journey, open banking journey, enhanced bank upload journey):

**Scenario 1:** Provider has selected employed and HMRC returns data - **show employment details section**
**Scenario 2:** Provider has selected unemployed and HMRC returns data - **show employment details section**
**Scenario 3:** Provider has selected unemployed and HMRC does NOT return data - **DON'T show employment details section**

- Added a feature test to test Scenario 3 on the enhanced bank upload journey
- I have not added a feature test to test the open banking scenario as there are already a lot of feature tests and it's a small change, plus the logic is the same for both journeys anyway, however I have tested manually and all looks good

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
