### PR TITLE
Replace `.to_not` expectations with `.not_to`

### DIFF
--- a/features/step_definitions/civil_journey_steps.rb
+++ b/features/step_definitions/civil_journey_steps.rb
@@ -756,7 +756,7 @@ Then(/^proceeding search field is empty$/) do
 end
 
 Then(/^the results section is empty$/) do
-  expect(page).to_not have_css("#proceeding-list .proceeding-item")
+  expect(page).not_to have_css("#proceeding-list .proceeding-item")
 end
 
 Then(/^proceeding suggestions has (results|no results)$/) do |results|
@@ -765,7 +765,7 @@ Then(/^proceeding suggestions has (results|no results)$/) do |results|
   when "results"
     expect(page).to have_css("#proceeding-list .proceeding-item")
   when "no results"
-    expect(page).to_not have_css("#proceeding-list .proceeding-item")
+    expect(page).not_to have_css("#proceeding-list .proceeding-item")
   end
 end
 
@@ -825,7 +825,7 @@ Then("the answer for all {string} categories should be {string}") do |field_name
   wrong_answer = expected_answer == "No" ? "Yes" : "No"
   within "#app-check-your-answers__#{field_name}_items" do # search within the section to check that all answers are yes/no
     expect(page).to have_text(expected_answer)
-    expect(page).to_not have_text(wrong_answer)
+    expect(page).not_to have_text(wrong_answer)
   end
 end
 
@@ -838,7 +838,7 @@ Then("I click the close button for the modal") do
 end
 
 Then("the delete modal should not be visible") do
-  expect(page).to_not have_css("modal-dialog")
+  expect(page).not_to have_css("modal-dialog")
 end
 
 Then("I select a proceeding type and continue") do

--- a/features/step_definitions/merits_task_steps.rb
+++ b/features/step_definitions/merits_task_steps.rb
@@ -23,6 +23,6 @@ Then(/^I should (see|not see) regex (.*?)$/) do |visible, text|
   if visible.eql?("see")
     expect(page).to have_content(/#{text}/)
   else
-    expect(page).to_not have_content(/#{text}/)
+    expect(page).not_to have_content(/#{text}/)
   end
 end

--- a/spec/forms/applicants/basic_details_form_spec.rb
+++ b/spec/forms/applicants/basic_details_form_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe Applicants::BasicDetailsForm, type: :form do
 
         it "invalid NINO is still invalid" do
           subject.national_insurance_number = invalid_nino
-          expect(subject).to_not be_valid
+          expect(subject).not_to be_valid
         end
 
         it "valid NINO is still valid" do
@@ -107,7 +107,7 @@ RSpec.describe Applicants::BasicDetailsForm, type: :form do
 
         it "invalid NINO is still invalid" do
           subject.national_insurance_number = invalid_nino
-          expect(subject).to_not be_valid
+          expect(subject).not_to be_valid
         end
 
         it "valid NINO is still valid" do

--- a/spec/forms/legal_aid_applications/restrictions_form_spec.rb
+++ b/spec/forms/legal_aid_applications/restrictions_form_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe LegalAidApplications::RestrictionsForm, type: :form do
 
       it "updates the legal_aid_application restrictions information" do
         expect(application.has_restrictions).to be true
-        expect(application.restrictions_details).to_not be_empty
+        expect(application.restrictions_details).not_to be_empty
       end
     end
   end

--- a/spec/forms/providers/proceeding_merits_task/linked_children_form_spec.rb
+++ b/spec/forms/providers/proceeding_merits_task/linked_children_form_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe Providers::ProceedingMeritsTask::LinkedChildrenForm, type: :form 
       context "when an error occurs" do
         let(:linked_children_params) { ["guid-for-non-existent-child", "", ""] }
 
-        it { expect { subject }.to_not change { proceeding.proceeding_linked_children.count } }
+        it { expect { subject }.not_to change { proceeding.proceeding_linked_children.count } }
 
         it "rolls back all changes" do
           expect(subject).to be false

--- a/spec/helpers/policy_disregards_helper_spec.rb
+++ b/spec/helpers/policy_disregards_helper_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe PolicyDisregardsHelper, type: :helper do
       let(:policy_disregards) { create :policy_disregards, none_selected: true }
 
       it "does not return nil" do
-        expect(policy_disregards_list(policy_disregards)).to_not be_nil
+        expect(policy_disregards_list(policy_disregards)).not_to be_nil
       end
 
       it "returns the correct hash" do

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Address, type: :model do
   it "is not valid without a building name and street address" do
     subject.address_line_one = ""
     subject.address_line_two = ""
-    expect(subject).to_not be_valid
+    expect(subject).not_to be_valid
     expect(subject.errors[:address_line_one]).to include("can't be blank")
   end
 
@@ -26,19 +26,19 @@ RSpec.describe Address, type: :model do
 
   it "is not valid without a town or city" do
     subject.city = nil
-    expect(subject).to_not be_valid
+    expect(subject).not_to be_valid
     expect(subject.errors[:city]).to include("can't be blank")
   end
 
   it "is not valid when a postcode is not provided" do
     subject.postcode = nil
-    expect(subject).to_not be_valid
+    expect(subject).not_to be_valid
     expect(subject.errors[:postcode]).to include("can't be blank")
   end
 
   it "is not valid if the postcode entered is not in the correct format" do
     subject.postcode = "1GIR00A"
-    expect(subject).to_not be_valid
+    expect(subject).not_to be_valid
     expect(subject.errors[:postcode]).to include("is not in the right format")
   end
 

--- a/spec/models/applicant_spec.rb
+++ b/spec/models/applicant_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Applicant, type: :model do
     end
 
     it "does not include model values we are not concerned with" do
-      expect(json_for_hmrc.keys).to_not include %i[id status created_at updated_at email employed true_layer_secure_data_id]
+      expect(json_for_hmrc.keys).not_to include %i[id status created_at updated_at email employed true_layer_secure_data_id]
     end
   end
 

--- a/spec/models/cfe/v4/result_spec.rb
+++ b/spec/models/cfe/v4/result_spec.rb
@@ -712,7 +712,7 @@ module CFE
             subject(:jobs) { with_employments.jobs }
 
             it { is_expected.to be_kind_of(Array) }
-            it { is_expected.to_not be_empty }
+            it { is_expected.not_to be_empty }
 
             it "has a name" do
               expect(subject[0][:name]).to eq "Job 1"

--- a/spec/models/legal_framework/merits_task_list_spec.rb
+++ b/spec/models/legal_framework/merits_task_list_spec.rb
@@ -17,11 +17,11 @@ module LegalFramework
       end
 
       it "is not empty" do
-        expect(merits_task_list.task_list).to_not be_empty
+        expect(merits_task_list.task_list).not_to be_empty
       end
 
       it "has no complete states" do
-        expect(merits_task_list.serialized_data).to_not include("state: :complete")
+        expect(merits_task_list.serialized_data).not_to include("state: :complete")
       end
     end
 

--- a/spec/requests/citizens/gather_transactions_spec.rb
+++ b/spec/requests/citizens/gather_transactions_spec.rb
@@ -67,8 +67,8 @@ RSpec.describe "citizen accounts request", type: :request do
       end
 
       it "does not display account information" do
-        expect(unescaped_response_body).to_not include(applicant_bank_account_holder.full_name)
-        expect(unescaped_response_body).to_not include("Account")
+        expect(unescaped_response_body).not_to include(applicant_bank_account_holder.full_name)
+        expect(unescaped_response_body).not_to include("Account")
       end
 
       it "displays a loading message" do

--- a/spec/requests/providers/address_selections_spec.rb
+++ b/spec/requests/providers/address_selections_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe Providers::AddressSelectionsController, type: :request do
         before { create :address, applicant: }
 
         it "does not create a new address record" do
-          expect { subject }.to_not change { applicant.addresses.count }
+          expect { subject }.not_to change { applicant.addresses.count }
         end
 
         it "updates the current address" do

--- a/spec/requests/providers/addresses_spec.rb
+++ b/spec/requests/providers/addresses_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe "address requests", type: :request do
         before { create :address, applicant: }
 
         it "does not create a new address record" do
-          expect { subject }.to_not change { applicant.addresses.count }
+          expect { subject }.not_to change { applicant.addresses.count }
         end
 
         it "updates the current address" do

--- a/spec/requests/providers/bank_transactions_spec.rb
+++ b/spec/requests/providers/bank_transactions_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Providers::BankTransactionsController, type: :request do
       let(:bank_account) { create :bank_account }
 
       it "does not remove the assocation with the transaction type" do
-        expect { subject }.to_not change { bank_transaction.reload.transaction_type }
+        expect { subject }.not_to change { bank_transaction.reload.transaction_type }
       end
 
       it "redirects to page_not_found" do

--- a/spec/requests/providers/check_benefits_spec.rb
+++ b/spec/requests/providers/check_benefits_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Providers::CheckBenefitsController, type: :request do
 
       it "does not generate a new one" do
         expect(BenefitCheckService).not_to receive(:call)
-        expect { subject }.to_not change(BenefitCheckResult, :count)
+        expect { subject }.not_to change(BenefitCheckResult, :count)
       end
 
       context "and the applicant has since been modified" do

--- a/spec/requests/providers/confirm_dwp_non_passported_applications_spec.rb
+++ b/spec/requests/providers/confirm_dwp_non_passported_applications_spec.rb
@@ -160,7 +160,7 @@ RSpec.describe Providers::ConfirmDWPNonPassportedApplicationsController, type: :
         context "the user has does not have employed permissions" do
           it "does not call the HMRC::CreateResponsesService" do
             subject
-            expect(HMRC::CreateResponsesService).to_not have_received(:call)
+            expect(HMRC::CreateResponsesService).not_to have_received(:call)
           end
         end
       end
@@ -202,14 +202,14 @@ RSpec.describe Providers::ConfirmDWPNonPassportedApplicationsController, type: :
 
         it "does not call the HMRC::CreateResponsesService" do
           subject
-          expect(HMRC::CreateResponsesService).to_not have_received(:call)
+          expect(HMRC::CreateResponsesService).not_to have_received(:call)
         end
       end
 
       context "the user has does not have employed permissions" do
         it "does not call the HMRC::CreateResponsesService" do
           subject
-          expect(HMRC::CreateResponsesService).to_not have_received(:call)
+          expect(HMRC::CreateResponsesService).not_to have_received(:call)
         end
       end
     end

--- a/spec/requests/providers/limitations_spec.rb
+++ b/spec/requests/providers/limitations_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Providers::LimitationsController, type: :request do
 
       it "puts scope limitations in a details section" do
         expect(parsed_response_body.css("details").text).to include(I18n.t("providers.limitations.proceeding_types.substantive_certificate"))
-        expect(unescaped_response_body).to_not include(I18n.t("providers.limitations.proceeding_types_with_df.cost_override_question"))
+        expect(unescaped_response_body).not_to include(I18n.t("providers.limitations.proceeding_types_with_df.cost_override_question"))
       end
 
       context "when delegated functions have been used" do

--- a/spec/requests/providers/proceeding_merits_task/attempts_to_settle_controller_spec.rb
+++ b/spec/requests/providers/proceeding_merits_task/attempts_to_settle_controller_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe Providers::ProceedingMeritsTask::AttemptsToSettleController, type
 
         it "does not set the task to complete" do
           subject
-          expect(legal_aid_application.legal_framework_merits_task_list.serialized_data).to_not match(/name: :attempts_to_settle\n\s+dependencies: \*\d\n\s+state: :complete/)
+          expect(legal_aid_application.legal_framework_merits_task_list.serialized_data).not_to match(/name: :attempts_to_settle\n\s+dependencies: \*\d\n\s+state: :complete/)
         end
       end
     end

--- a/spec/requests/providers/proceeding_merits_task/chances_of_success_spec.rb
+++ b/spec/requests/providers/proceeding_merits_task/chances_of_success_spec.rb
@@ -90,7 +90,7 @@ module Providers
           it "does not set the task to complete" do
             subject
             serialized_merits_task_list = legal_aid_application.legal_framework_merits_task_list.reload.serialized_data
-            expect(serialized_merits_task_list).to_not match(/name: :chances_of_success\n\s+dependencies: \*\d\n\s+state: :complete/)
+            expect(serialized_merits_task_list).not_to match(/name: :chances_of_success\n\s+dependencies: \*\d\n\s+state: :complete/)
           end
 
           it "redirects to next page" do
@@ -158,7 +158,7 @@ module Providers
 
           it "does not set the task to complete" do
             subject
-            expect(legal_aid_application.legal_framework_merits_task_list.serialized_data).to_not match(/name: :chances_of_success\n\s+dependencies: \*\d\n\s+state: :complete/)
+            expect(legal_aid_application.legal_framework_merits_task_list.serialized_data).not_to match(/name: :chances_of_success\n\s+dependencies: \*\d\n\s+state: :complete/)
           end
 
           it "updates the model" do

--- a/spec/requests/providers/proceeding_merits_task/linked_children_spec.rb
+++ b/spec/requests/providers/proceeding_merits_task/linked_children_spec.rb
@@ -138,7 +138,7 @@ module Providers
 
           it "does not set the task to complete" do
             subject
-            expect(legal_aid_application.legal_framework_merits_task_list.serialized_data).to_not match(/name: :children_proceeding\n\s+dependencies: \*\d\n\s+state: :complete/)
+            expect(legal_aid_application.legal_framework_merits_task_list.serialized_data).not_to match(/name: :children_proceeding\n\s+dependencies: \*\d\n\s+state: :complete/)
           end
         end
       end

--- a/spec/requests/providers/submitted_applications_spec.rb
+++ b/spec/requests/providers/submitted_applications_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Providers::SubmittedApplicationsController, type: :request do
 
     it "hides print buttons when printing the page" do
       print_buttons.each do |print_button|
-        expect(print_button.ancestors.at_css(".no-print")).to_not be_nil
+        expect(print_button.ancestors.at_css(".no-print")).not_to be_nil
       end
     end
 

--- a/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_variable_attributes_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_variable_attributes_spec.rb
@@ -619,7 +619,7 @@ module CCMS
               attrs.each do |attr_name|
                 block = XmlExtractor.call(xml, :global_means, attr_name)
                 expect(block).to have_boolean_response true
-                expect(block).to_not be_user_defined
+                expect(block).not_to be_user_defined
               end
             end
 
@@ -638,7 +638,7 @@ module CCMS
                 attrs.each do |attr_name|
                   block = XmlExtractor.call(xml, :global_means, attr_name)
                   expect(block).to have_boolean_response false
-                  expect(block).to_not be_user_defined
+                  expect(block).not_to be_user_defined
                 end
               end
             end
@@ -748,7 +748,7 @@ module CCMS
             let(:land_value) { 0.0 }
 
             it "does not generate the block" do
-              expect(block).to_not be_present
+              expect(block).not_to be_present
             end
           end
         end
@@ -771,7 +771,7 @@ module CCMS
             let(:money_owed) { 0.0 }
 
             it "does not generate the block" do
-              expect(block).to_not be_present
+              expect(block).not_to be_present
             end
           end
         end
@@ -792,7 +792,7 @@ module CCMS
               before { chances_of_success.update! success_prospect: test[:input] }
 
               it { is_expected.to have_text_response test[:result] }
-              it { is_expected.to_not be_user_defined }
+              it { is_expected.not_to be_user_defined }
             end
           end
         end
@@ -815,7 +815,7 @@ module CCMS
             let(:money_owed) { 0.0 }
 
             it "does not generate the block" do
-              expect(block).to_not be_present
+              expect(block).not_to be_present
             end
           end
         end
@@ -858,7 +858,7 @@ module CCMS
 
                   it "returns #{test[:result]} when percentage_home is set to #{test[:input]}" do
                     if test[:omit_block]
-                      expect(block).to_not be_present
+                      expect(block).not_to be_present
                     elsif true_false.include? test[:result]
                       expect(block).to have_boolean_response test[:result]
                     else
@@ -934,7 +934,7 @@ module CCMS
               let(:ownership) { "no" }
 
               it "does not generate the block" do
-                expect(block).to_not be_present
+                expect(block).not_to be_present
               end
             end
           end
@@ -949,7 +949,7 @@ module CCMS
                 let(:ownership) { "owned_outright" }
 
                 it "does not generate the block" do
-                  expect(block).to_not be_present
+                  expect(block).not_to be_present
                 end
               end
 
@@ -967,7 +967,7 @@ module CCMS
               let(:ownership) { "no" }
 
               it "does not generate the block" do
-                expect(block).to_not be_present
+                expect(block).not_to be_present
               end
             end
           end

--- a/spec/services/ccms/submitters/check_case_status_service_spec.rb
+++ b/spec/services/ccms/submitters/check_case_status_service_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe CCMS::Submitters::CheckCaseStatusService, :ccms do
           expect(history.from_state).to eq "case_submitted"
           expect(history.to_state).to eq "case_created"
           expect(history.request).to eq case_add_status_request
-          expect(history.request).to_not be_nil
+          expect(history.request).not_to be_nil
           expect(history.success).to be true
           expect(history.details).to be_nil
         end
@@ -154,7 +154,7 @@ RSpec.describe CCMS::Submitters::CheckCaseStatusService, :ccms do
         expect(history.from_state).to eq "case_submitted"
         expect(history.to_state).to eq "failed"
         expect(history.request).to eq case_add_status_request
-        expect(history.request).to_not be_nil
+        expect(history.request).not_to be_nil
         expect(history.success).to be false
         expect(history.details).to match(/#{error}/)
         expect(history.details).to match(/oops/)

--- a/spec/services/ccms/submitters/obtain_document_id_service_spec.rb
+++ b/spec/services/ccms/submitters/obtain_document_id_service_spec.rb
@@ -91,7 +91,7 @@ module CCMS
             it "populates the ccms_document_id for each document" do
               subject.call
               submission.submission_documents.each do |document|
-                expect(document.ccms_document_id).to_not be_nil
+                expect(document.ccms_document_id).not_to be_nil
               end
             end
 

--- a/spec/services/dashboard_event_handler_spec.rb
+++ b/spec/services/dashboard_event_handler_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe DashboardEventHandler do
       end
 
       it "does not fire a PendingCCMSSubmissions job" do
-        expect { subject }.to_not have_enqueued_job(Dashboard::UpdaterJob).with("PendingCCMSSubmissions")
+        expect { subject }.not_to have_enqueued_job(Dashboard::UpdaterJob).with("PendingCCMSSubmissions")
       end
     end
   end

--- a/spec/services/govuk_emails/delivery_man_spec.rb
+++ b/spec/services/govuk_emails/delivery_man_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe GovukEmails::DeliveryMan do
         end
 
         it "is does not get sent to Sentry" do
-          expect(Sentry).to_not receive(:capture_exception)
+          expect(Sentry).not_to receive(:capture_exception)
           subject
         end
       end

--- a/spec/services/hmrc/create_responses_service_spec.rb
+++ b/spec/services/hmrc/create_responses_service_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe HMRC::CreateResponsesService do
       context "when HMRC_USE_DEV_MOCK is set to false" do
         it "creates two jobs to request the data and does not invoke the MockInterfaceResponseService" do
           expect { call }.to change(HMRC::SubmissionWorker.jobs, :size).by(2)
-          expect(HMRC::MockInterfaceResponseService).to_not have_received(:call)
+          expect(HMRC::MockInterfaceResponseService).not_to have_received(:call)
         end
       end
 
@@ -37,7 +37,7 @@ RSpec.describe HMRC::CreateResponsesService do
 
             it "creates two jobs to request the data and does not invoke the MockInterfaceResponseService" do
               expect { call }.to change(HMRC::SubmissionWorker.jobs, :size).by(2)
-              expect(HMRC::MockInterfaceResponseService).to_not have_received(:call)
+              expect(HMRC::MockInterfaceResponseService).not_to have_received(:call)
             end
           end
 
@@ -45,7 +45,7 @@ RSpec.describe HMRC::CreateResponsesService do
             let(:host) { :staging }
 
             it "calls the MockInterfaceResponseService and creates no SubmissionWorker jobs" do
-              expect { call }.to_not change(HMRC::SubmissionWorker.jobs, :size)
+              expect { call }.not_to change(HMRC::SubmissionWorker.jobs, :size)
               expect(HMRC::MockInterfaceResponseService).to have_received(:call).twice
             end
           end
@@ -54,7 +54,7 @@ RSpec.describe HMRC::CreateResponsesService do
             let(:host) { :uat }
 
             it "calls the MockInterfaceResponseService and creates no SubmissionWorker jobs" do
-              expect { call }.to_not change(HMRC::SubmissionWorker.jobs, :size)
+              expect { call }.not_to change(HMRC::SubmissionWorker.jobs, :size)
               expect(HMRC::MockInterfaceResponseService).to have_received(:call).twice
             end
           end

--- a/spec/services/malware_scanner_spec.rb
+++ b/spec/services/malware_scanner_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe MalwareScanner, clamav: true do
       subject { described_class.call(file_path:, save_result: false) }
 
       it "does not create a MalwareScanResult record" do
-        expect { subject }.to_not change(MalwareScanResult, :count)
+        expect { subject }.not_to change(MalwareScanResult, :count)
       end
 
       it "returns a MalwareScanResult object" do

--- a/spec/services/populators/transaction_type_populator_spec.rb
+++ b/spec/services/populators/transaction_type_populator_spec.rb
@@ -46,7 +46,7 @@ module Populators
 
         it "sets the archived_at date in the database" do
           subject
-          expect(TransactionType.find_by(name: "council_tax").archived_at).to_not be_nil
+          expect(TransactionType.find_by(name: "council_tax").archived_at).not_to be_nil
         end
 
         it "does not set the archived_at date in the database for active transaction types" do

--- a/spec/services/reports/reports_creator_spec.rb
+++ b/spec/services/reports/reports_creator_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Reports::ReportsCreator do
     it "creates reports and update state" do
       expect(Reports::MeritsReportCreator).to receive(:call).with(legal_aid_application)
       expect(Reports::MeansReportCreator).to receive(:call).with(legal_aid_application)
-      expect(Reports::BankTransactions::BankTransactionReportCreator).to_not receive(:call).with(legal_aid_application)
+      expect(Reports::BankTransactions::BankTransactionReportCreator).not_to receive(:call).with(legal_aid_application)
       subject
       legal_aid_application.reload
       expect(legal_aid_application.state).to eq("submitting_assessment")


### PR DESCRIPTION
As Hamlet almost once said:

> ".to_not or .not_to be"

This replaces the former with the later in our tests, in the interests of consistency and correctness.