### PR TITLE
AP-3561: Update merit question flow

### DIFF
--- a/app/controllers/providers/application_merits_task/statement_of_cases_controller.rb
+++ b/app/controllers/providers/application_merits_task/statement_of_cases_controller.rb
@@ -6,10 +6,10 @@ module Providers
       end
 
       def update
+        form
         if upload_button_pressed?
           perform_upload
-        elsif save_continue_or_draft(form)
-          update_task(:application, :statement_of_case)
+        elsif update_task_save_continue_or_draft(:application, :statement_of_case)
           convert_new_files_to_pdf
         else
           render :show

--- a/app/services/flow/flows/provider_merits.rb
+++ b/app/services/flow/flows/provider_merits.rb
@@ -37,7 +37,13 @@ module Flow
         },
         has_other_involved_children: {
           path: ->(application) { urls.providers_legal_aid_application_has_other_involved_children_path(application) },
-          forward: ->(_application, has_other_involved_child) { has_other_involved_child ? :involved_children : :merits_task_lists },
+          forward: lambda { |application, has_other_involved_child|
+            if has_other_involved_child
+              :involved_children
+            else
+              Flow::MeritsLoop.forward_flow(application, :application)
+            end
+          },
         },
         remove_involved_child: {
           forward: lambda { |application|

--- a/app/services/flow/flows/provider_merits.rb
+++ b/app/services/flow/flows/provider_merits.rb
@@ -56,27 +56,27 @@ module Flow
         },
         date_client_told_incidents: {
           path: ->(application) { urls.providers_legal_aid_application_date_client_told_incident_path(application) },
-          forward: :opponents,
+          forward: ->(application) { Flow::MeritsLoop.forward_flow(application, :application) },
           check_answers: :check_merits_answers,
         },
         opponents: {
           path: ->(application) { urls.providers_legal_aid_application_opponent_path(application) },
-          forward: :statement_of_cases,
+          forward: ->(application) { Flow::MeritsLoop.forward_flow(application, :application) },
           check_answers: :check_merits_answers,
         },
         statement_of_cases: {
           path: ->(application) { urls.providers_legal_aid_application_statement_of_case_path(application) },
-          forward: ->(application) { application.section_8_proceedings? ? :start_involved_children_task : :merits_task_lists },
+          forward: ->(application) { Flow::MeritsLoop.forward_flow(application, :application) },
           check_answers: :check_merits_answers,
         },
         client_denial_of_allegations: {
-          # path: ->(application) { urls.providers_legal_aid_application_client_denial_of_allegation_path(application) }, # not needed until flow handling updated
-          forward: :merits_task_lists,
+          path: ->(application) { urls.providers_legal_aid_application_client_denial_of_allegation_path(application) },
+          forward: ->(application) { Flow::MeritsLoop.forward_flow(application, :application) },
           check_answers: :check_merits_answers,
         },
         client_offered_undertakings: {
-          # path: ->(application) { urls.providers_legal_aid_application_client_offered_undertakings_path(application) }, # not needed until flow handling updated
-          forward: :merits_task_lists,
+          path: ->(application) { urls.providers_legal_aid_application_client_offered_undertakings_path(application) },
+          forward: ->(application) { Flow::MeritsLoop.forward_flow(application, :application) },
           check_answers: :check_merits_answers,
         },
         chances_of_success: {
@@ -87,7 +87,7 @@ module Flow
           forward: lambda do |application|
             proceeding = application.proceedings.find(application.provider_step_params["merits_task_list_id"])
             if proceeding.chances_of_success.success_likely?
-              :merits_task_lists
+              Flow::MeritsLoop.forward_flow(application, proceeding.ccms_code.to_sym)
             else
               :success_prospects
             end
@@ -102,11 +102,21 @@ module Flow
             proceeding = application.proceedings.find(application.provider_step_params["merits_task_list_id"])
             urls.providers_merits_task_list_success_prospects_path(proceeding)
           end,
-          forward: :merits_task_lists,
+          forward: lambda do |application|
+            proceeding = application.proceedings.find(application.provider_step_params["merits_task_list_id"])
+            Flow::MeritsLoop.forward_flow(application, proceeding.ccms_code.to_sym)
+          end,
           check_answers: :check_merits_answers,
         },
         attempts_to_settle: {
-          forward: :merits_task_lists,
+          path: lambda do |application|
+            proceeding = application.proceedings.find(application.provider_step_params["merits_task_list_id"])
+            urls.providers_merits_task_list_attempts_to_settle_path(proceeding)
+          end,
+          forward: lambda do |application|
+            proceeding = application.proceedings.find(application.provider_step_params["merits_task_list_id"])
+            Flow::MeritsLoop.forward_flow(application, proceeding.ccms_code.to_sym)
+          end,
           check_answers: :check_merits_answers,
         },
         linked_children: {
@@ -114,7 +124,10 @@ module Flow
             proceeding = application.proceedings.find(application.provider_step_params["merits_task_list_id"])
             urls.providers_merits_task_list_linked_children_path(proceeding)
           end,
-          forward: :merits_task_lists,
+          forward: lambda do |application|
+            proceeding = application.proceedings.find(application.provider_step_params["merits_task_list_id"])
+            Flow::MeritsLoop.forward_flow(application, proceeding.ccms_code.to_sym)
+          end,
           check_answers: :check_merits_answers,
         },
         merits_task_lists: {

--- a/app/services/flow/merits_loop.rb
+++ b/app/services/flow/merits_loop.rb
@@ -1,0 +1,65 @@
+module Flow
+  class MeritsLoop
+    def initialize(legal_aid_application, group)
+      @legal_aid_application = legal_aid_application
+      @group = group
+    end
+
+    def self.forward_flow(legal_aid_application, group)
+      new(legal_aid_application, group).forward_flow
+    end
+
+    def forward_flow
+      next_task
+    end
+
+  private
+
+    def next_task
+      return first_task_name if not_started_tasks.any?
+
+      :merits_task_lists
+    end
+
+    def first_task_name
+      not_started_tasks.first[:name]
+    end
+
+    def convert_task_to_flow_name(task)
+      {
+        latest_incident_details: :date_client_told_incidents,
+        opponent_details: :opponents,
+        statement_of_case: :statement_of_cases,
+        children_application: :start_involved_children_task,
+        children_proceeding: :linked_children,
+        attempts_to_settle: :attempts_to_settle,
+        chances_of_success: :chances_of_success,
+        client_denial_of_allegation: :client_denial_of_allegations,
+        client_offer_of_undertakings: :client_offered_undertakings,
+      }[task]
+    end
+
+    def not_started_tasks
+      @not_started_tasks ||= grouped_tasks.map { |task|
+        next unless task.state == :not_started
+
+        {
+          name: convert_task_to_flow_name(task.name),
+          task_name: task.name,
+          url: I18n.t(task.name, scope: "providers.merits_task_lists.task_list_item.urls"),
+          state: task.state,
+        }
+      }&.compact
+    end
+
+    def grouped_tasks
+      all_tasks = @legal_aid_application.reload.legal_framework_merits_task_list.task_list.tasks
+
+      if @group.to_sym == :application
+        all_tasks[:application]
+      else
+        all_tasks.dig(:proceedings, @group.to_sym)[:tasks]
+      end
+    end
+  end
+end

--- a/features/cassettes/mini-loop_additional_merits_questions/Clicking_the_merits_questions_out_of_sequence_allow_a_group_to_be_completed_regardless_of_start_point.yml
+++ b/features/cassettes/mini-loop_additional_merits_questions/Clicking_the_merits_questions_out_of_sequence_allow_a_group_to_be_completed_regardless_of_start_point.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/civil_merits_questions
+    body:
+      encoding: UTF-8
+      string: '{"request_id":"6a408691-aa40-4a3a-9e15-295c68bf07fe","proceedings":[{"ccms_code":"DA001","delegated_functions_used":false,"client_involvement_type":"D"},{"ccms_code":"SE013","delegated_functions_used":false,"client_involvement_type":"A"}]}'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Faraday v1.10.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 19 Oct 2022 14:10:54 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Vary:
+      - Accept, Origin
+      Etag:
+      - W/"0fdcfcf74543f1453fc3b4bb4c54acfc"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 9ba5455a2cbefea3c7400b46f60bf271
+      X-Runtime:
+      - '0.063554'
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '{"request_id":"6a408691-aa40-4a3a-9e15-295c68bf07fe","success":true,"application":{"tasks":{"latest_incident_details":[],"opponent_details":[],"statement_of_case":[],"client_denial_of_allegation":[],"client_offer_of_undertakings":[],"children_application":[]}},"proceedings":[{"ccms_code":"DA001","tasks":{"chances_of_success":[]}},{"ccms_code":"SE013","tasks":{"chances_of_success":[],"children_proceeding":["children_application"],"attempts_to_settle":[]}}]}'
+  recorded_at: Wed, 19 Oct 2022 14:10:54 GMT
+recorded_with: VCR 6.1.0

--- a/features/providers/merits_task_list.feature
+++ b/features/providers/merits_task_list.feature
@@ -21,15 +21,15 @@ Feature: Merits task list
     And I fill "Bail conditions set details" with "Foo bar"
     And I fill "Police notified details" with "Foo bar"
     When I click 'Save and continue'
-    Then I should be on a page showing "Provide a statement of case"
-    When I fill "Application merits task statement of case statement field" with "Statement of case"
-    And I click 'Save and continue'
     Then I should be on the 'involved_children/new' page showing 'Enter details of the children involved in this application'
     When I fill "Full Name" with "John Doe Jr"
     And I enter a 'date_of_birth' for a 14 year old
     When I click 'Save and continue'
     Then I should be on the 'has_other_involved_children' page showing 'You have added 1 child'
     When I choose 'No'
+    And I click 'Save and continue'
+    Then I should be on a page showing "Provide a statement of case"
+    When I fill "Application merits task statement of case statement field" with "Statement of case"
     And I click 'Save and continue'
     Then I should be on the 'merits_task_list' page showing 'Children involved in this application\nCOMPLETED'
     And I should see 'Children involved in this proceeding\nNOT STARTED'
@@ -42,13 +42,9 @@ Feature: Merits task list
     Then I should be on the 'chances_of_success' page showing 'Is the chance of a successful outcome 50% or better?'
     When I choose 'Yes'
     And I click 'Save and continue'
-    Then I should be on the 'merits_task_list' page showing 'Chances of success\nCOMPLETED'
-    When I click link 'Children involved in this proceeding'
     Then I should be on the 'linked_children' page showing 'Which children are covered under this proceeding?'
     When I select 'John Doe Jr'
     And I click 'Save and continue'
-    Then I should be on the 'merits_task_list' page showing 'Children involved in this proceeding\nCOMPLETED'
-    When I click link 'Attempts to settle'
     Then I should be on the 'attempts_to_settle' page showing 'What attempts have been made to settle the matter?'
     When I fill "Attempts made" with "A settlement attempt"
     And I click 'Save and continue'
@@ -84,9 +80,6 @@ Feature: Merits task list
     And I fill "Bail conditions set details" with "Foo bar"
     And I fill "Police notified details" with "Foo bar"
     When I click 'Save and continue'
-    Then I should be on a page showing "Provide a statement of case"
-    When I fill "Application merits task statement of case statement field" with "Statement of case"
-    And I click 'Save and continue'
     Then I should be on the 'involved_children/new' page showing 'Enter details of the children involved in this application'
     When I fill "Full Name" with "John Doe Jr"
     And I enter a 'date_of_birth' for a 14 year old
@@ -119,6 +112,13 @@ Feature: Merits task list
     And I fill "Bail conditions set details" with "Foo bar"
     And I fill "Police notified details" with "Foo bar"
     When I click 'Save and continue'
+    Then I should be on the 'involved_children/new' page showing 'Enter details of the children involved in this application'
+    When I fill "Full Name" with "John Doe Jr"
+    And I enter a 'date_of_birth' for a 14 year old
+    When I click 'Save and continue'
+    Then I should be on the 'has_other_involved_children' page showing 'You have added 1 child'
+    When I choose 'No'
+    And I click 'Save and continue'
     Then I should be on a page showing "Provide a statement of case"
     When I upload an evidence file named 'hello_world.pdf'
     Then I should see 'hello_world.pdf'
@@ -129,4 +129,4 @@ Feature: Merits task list
     Then I upload an evidence file named 'hello_world.pdf'
     And I should see 'UPLOADED'
     When I click 'Save and continue'
-    Then I should be on the 'involved_children/new' page showing 'Enter details of the children involved in this application'
+    Then I should be on the 'merits_task_list' page showing 'Statement of case\nCOMPLETED'

--- a/features/providers/mini-loop/merits_questions.feature
+++ b/features/providers/mini-loop/merits_questions.feature
@@ -1,0 +1,50 @@
+Feature: mini-loop additional merits questions
+  @javascript @vcr
+  Scenario: Clicking the merits questions out of sequence allow a group to be completed regardless of start point
+    # When the application has a domestic abuse proceeding where the client is not an applicant
+    # additional questions are included in the grouping
+    Given the feature flag for enable_mini_loop is enabled
+    And I have started an application where the client is a defendant on the domestic abuse proceeding
+    When I visit the merits question page
+    Then I should see "Latest incident details"
+    And I should see "Opponent details"
+    And I should see "Statement of case"
+    And I should see "Client denial of allegation"
+    And I should see "Children involved in this application"
+    When I click link "Statement of case"
+    Then I should be on a page showing "Provide a statement of case"
+    When I fill "Application merits task statement of case statement field" with "Statement of case"
+    And I click 'Save and continue'
+    Then I should be on a page showing 'When did your client contact you about the latest domestic abuse incident?'
+    When I enter the 'told' date of 2 days ago
+    And I enter the 'occurred' date of 2 days ago
+    When I click 'Save and continue'
+    Then I should be on a page showing "Opponent details"
+    When I fill "Full Name" with "John Doe"
+    And I choose option "Application merits task opponent understands terms of court order True field"
+    And I choose option "Application merits task opponent warning letter sent True field"
+    And I choose option "Application merits task opponent police notified True field"
+    And I choose option "Application merits task opponent bail conditions set True field"
+    And I fill "Bail conditions set details" with "Foo bar"
+    And I fill "Police notified details" with "Foo bar"
+    When I click 'Save and continue'
+    Then I should be on a page showing "Does the client wholly or substantially deny any allegations?"
+    When I choose "Yes"
+    And I click "Save and continue"
+    Then I should be on a page showing "Has the client offered undertakings?"
+    When I choose "Yes"
+    And I click "Save and continue"
+    Then I should be on the 'involved_children/new' page showing 'Enter details of the children involved in this application'
+    When I fill "Full Name" with "John Doe Jr"
+    And I enter a 'date_of_birth' for a 14 year old
+    When I click 'Save and continue'
+    Then I should be on the 'has_other_involved_children' page showing 'You have added 1 child'
+    When I choose 'No'
+    And I click 'Save and continue'
+    Then I should be on a page showing "Provide details of the case"
+    And I should see "Latest incident details\nCOMPLETED"
+    And I should see "Opponent details\nCOMPLETED"
+    And I should see "Statement of case\nCOMPLETED"
+    And I should see "Client denial of allegation\nCOMPLETED"
+    And I should see "Client offer of undertaking\nCOMPLETED"
+    And I should see "Children involved in this application\nCOMPLETED"

--- a/features/step_definitions/civil_journey_steps.rb
+++ b/features/step_definitions/civil_journey_steps.rb
@@ -463,6 +463,33 @@ Given("I have started an application with multiple proceedings") do
   steps %(Then I should be on a page showing 'Do you want to add another proceeding?')
 end
 
+Given("I have started an application where the client is a defendant on the domestic abuse proceeding") do
+  @legal_aid_application = create(
+    :legal_aid_application,
+    :with_applicant_and_address_lookup,
+    :with_proceedings,
+    explicit_proceedings: %i[da001 se013],
+    set_lead_proceeding: :da001,
+  )
+  login_as @legal_aid_application.provider
+  visit(providers_legal_aid_application_has_other_proceedings_path(@legal_aid_application))
+  steps %(Then I should be on a page showing 'Do you want to add another proceeding?')
+  proceeding = @legal_aid_application.proceedings.find_by(ccms_code: "DA001")
+  proceeding.update(
+    client_involvement_type_ccms_code: "D",
+    client_involvement_type_description: "Defendant/respondent",
+    used_delegated_functions: false,
+  )
+  proceeding = @legal_aid_application.proceedings.find_by(ccms_code: "SE013")
+  proceeding.update(
+    used_delegated_functions: false,
+  )
+end
+
+And("I visit the merits question page") do
+  visit(providers_legal_aid_application_merits_task_list_path(@legal_aid_application))
+end
+
 Given("I used delegated functions") do
   @legal_aid_application.proceedings.each do |proceeding|
     proceeding.update!(used_delegated_functions: true,

--- a/spec/factories/legal_framework_merits_task_list.rb
+++ b/spec/factories/legal_framework_merits_task_list.rb
@@ -10,5 +10,9 @@ FactoryBot.define do
     trait :da001_as_defendant do
       serialized_data { build(:legal_framework_serializable_merits_task_list, :da001_as_defendant).to_yaml }
     end
+
+    trait :da001_as_defendant_and_child_section_8 do
+      serialized_data { build(:legal_framework_serializable_merits_task_list, :da001_as_defendant_and_child_section_8).to_yaml }
+    end
   end
 end

--- a/spec/factories/legal_framework_serialized_merits_task_list.rb
+++ b/spec/factories/legal_framework_serialized_merits_task_list.rb
@@ -40,7 +40,6 @@ FactoryBot.define do
             tasks: {
               latest_incident_details: [],
               opponent_details: [],
-              children_application: [],
               statement_of_case: [],
             },
           },
@@ -64,7 +63,6 @@ FactoryBot.define do
             tasks: {
               latest_incident_details: [],
               opponent_details: [],
-              children_application: [],
               statement_of_case: [],
               client_denial_of_allegation: [],
               client_offer_of_undertakings: [],
@@ -75,6 +73,39 @@ FactoryBot.define do
               ccms_code: "DA001",
               tasks: {
                 chances_of_success: [],
+              },
+            },
+          ],
+        }
+      end
+    end
+    trait :da001_as_defendant_and_child_section_8 do
+      lfa_response do
+        {
+          request_id: SecureRandom.uuid,
+          application: {
+            tasks: {
+              latest_incident_details: [],
+              opponent_details: [],
+              statement_of_case: [],
+              client_denial_of_allegation: [],
+              client_offer_of_undertakings: [],
+              children_application: [],
+            },
+          },
+          proceeding_types: [
+            {
+              ccms_code: "DA001",
+              tasks: {
+                chances_of_success: [],
+              },
+            },
+            {
+              ccms_code: "SE014",
+              tasks: {
+                chances_of_success: [],
+                children_proceeding: [:children_application],
+                attempts_to_settle: [],
               },
             },
           ],

--- a/spec/requests/providers/application_merits_task/client_denial_of_allegation_spec.rb
+++ b/spec/requests/providers/application_merits_task/client_denial_of_allegation_spec.rb
@@ -77,9 +77,17 @@ module Providers
           expect(legal_aid_application.legal_framework_merits_task_list.serialized_data).to match(/name: :client_denial_of_allegation\n\s+dependencies: \*\d\n\s+state: :complete/)
         end
 
-        it "redirects to the next page" do
-          post_client_denial
-          expect(response).to redirect_to(flow_forward_path)
+        context "when all previous tasks are completed" do
+          before do
+            legal_aid_application.legal_framework_merits_task_list.mark_as_complete!(:application, :latest_incident_details)
+            legal_aid_application.legal_framework_merits_task_list.mark_as_complete!(:application, :opponent_details)
+            legal_aid_application.legal_framework_merits_task_list.mark_as_complete!(:application, :statement_of_case)
+          end
+
+          it "redirects to the next page" do
+            post_client_denial
+            expect(response).to redirect_to(providers_legal_aid_application_client_offered_undertakings_path(legal_aid_application))
+          end
         end
 
         context "when not authenticated" do

--- a/spec/requests/providers/application_merits_task/has_other_involved_children_spec.rb
+++ b/spec/requests/providers/application_merits_task/has_other_involved_children_spec.rb
@@ -9,8 +9,10 @@ module Providers
       let(:provider) { application.provider }
       let(:child1) { create :involved_child, legal_aid_application: application }
       let(:smtl) { create :legal_framework_merits_task_list, legal_aid_application: application }
+      let(:next_page) { :merits_task_lists }
 
       before do
+        allow(Flow::MeritsLoop).to receive(:forward_flow).and_return(next_page)
         allow(LegalFramework::MeritsTasksService).to receive(:call).with(application).and_return(smtl)
         login_as provider
       end

--- a/spec/requests/providers/application_merits_task/opponents_spec.rb
+++ b/spec/requests/providers/application_merits_task/opponents_spec.rb
@@ -96,9 +96,32 @@ module Providers
           expect(legal_aid_application.legal_framework_merits_task_list.serialized_data).to match(/name: :opponent_details\n\s+dependencies: \*\d\n\s+state: :complete/)
         end
 
-        it "redirects to the next page" do
-          subject
-          expect(response).to redirect_to(flow_forward_path)
+        context "when no other tasks are complete" do
+          it "redirects to the next incomplete question" do
+            subject
+            expect(response).to redirect_to(providers_legal_aid_application_date_client_told_incident_path(legal_aid_application))
+          end
+        end
+
+        context "when the first task is complete" do
+          before { legal_aid_application.legal_framework_merits_task_list.mark_as_complete!(:application, :latest_incident_details) }
+
+          it "redirects to the next incomplete question" do
+            subject
+            expect(response).to redirect_to(new_providers_legal_aid_application_involved_child_path(legal_aid_application))
+          end
+        end
+
+        context "when the all but one task is complete" do
+          before do
+            legal_aid_application.legal_framework_merits_task_list.mark_as_complete!(:application, :latest_incident_details)
+            legal_aid_application.legal_framework_merits_task_list.mark_as_complete!(:application, :children_application)
+          end
+
+          it "redirects to the final question" do
+            subject
+            expect(response).to redirect_to(providers_legal_aid_application_statement_of_case_path(legal_aid_application))
+          end
         end
 
         context "when attributes have trailing whitespaces" do

--- a/spec/requests/providers/merits_task_lists_controller_spec.rb
+++ b/spec/requests/providers/merits_task_lists_controller_spec.rb
@@ -89,7 +89,6 @@ RSpec.describe Providers::MeritsTaskListsController, type: :request do
       before do
         legal_aid_application.legal_framework_merits_task_list.mark_as_complete!(:application, :latest_incident_details)
         legal_aid_application.legal_framework_merits_task_list.mark_as_complete!(:application, :opponent_details)
-        legal_aid_application.legal_framework_merits_task_list.mark_as_complete!(:application, :children_application)
         legal_aid_application.legal_framework_merits_task_list.mark_as_complete!(:application, :statement_of_case)
         legal_aid_application.legal_framework_merits_task_list.mark_as_complete!(:DA001, :chances_of_success)
         patch providers_legal_aid_application_merits_task_list_path(legal_aid_application)

--- a/spec/requests/providers/proceeding_merits_task/attempts_to_settle_controller_spec.rb
+++ b/spec/requests/providers/proceeding_merits_task/attempts_to_settle_controller_spec.rb
@@ -5,6 +5,9 @@ RSpec.describe Providers::ProceedingMeritsTask::AttemptsToSettleController, type
   let(:smtl) { create :legal_framework_merits_task_list, legal_aid_application: }
   let(:provider) { legal_aid_application.provider }
   let(:proceeding) { legal_aid_application.proceedings.find_by(ccms_code: "SE014") }
+  let(:next_page) { :merits_task_lists }
+
+  before { allow(Flow::MeritsLoop).to receive(:forward_flow).and_return(next_page) }
 
   describe "GET /providers/applications/merits_task_list/:merits_task_list_id/attempts_to_settle" do
     subject { get providers_merits_task_list_attempts_to_settle_path(proceeding) }

--- a/spec/requests/providers/proceeding_merits_task/linked_children_spec.rb
+++ b/spec/requests/providers/proceeding_merits_task/linked_children_spec.rb
@@ -53,8 +53,15 @@ module Providers
         before { legal_aid_application&.legal_framework_merits_task_list&.mark_as_complete!(:application, :children_application) }
 
         context "with all selected" do
+          before { legal_aid_application.legal_framework_merits_task_list.mark_as_complete!(:SE014, :chances_of_success) }
+
           it "adds involved children to the proceeding" do
             expect { subject }.to change { proceeding.proceeding_linked_children.count }.by(3)
+          end
+
+          it "redirects to the next unanswered question" do
+            subject
+            expect(response).to redirect_to(providers_merits_task_list_attempts_to_settle_path(proceeding))
           end
         end
 

--- a/spec/requests/providers/proceeding_merits_task/success_prospects_spec.rb
+++ b/spec/requests/providers/proceeding_merits_task/success_prospects_spec.rb
@@ -3,11 +3,13 @@ require "rails_helper"
 module Providers
   module ProceedingMeritsTask
     RSpec.describe SuccessProspectsController, type: :request do
-      let!(:legal_aid_application) { create :legal_aid_application, :with_proceedings }
+      let!(:legal_aid_application) { create :legal_aid_application, :with_proceedings, explicit_proceedings: %i[da001 se014] }
+      let(:smtl) { create :legal_framework_merits_task_list, legal_aid_application: }
       let(:proceeding) { legal_aid_application.proceedings.find_by(ccms_code: "DA001") }
       let(:proceeding_two) { legal_aid_application.proceedings.find_by(ccms_code: "SE014") }
-
       let(:provider) { legal_aid_application.provider }
+
+      before { allow(LegalFramework::MeritsTasksService).to receive(:call).with(legal_aid_application).and_return(smtl) }
 
       describe "GET /providers/merits_task_list/:id/success_prospects" do
         subject { get providers_merits_task_list_success_prospects_path(proceeding) }

--- a/spec/services/flow/merits_loop_spec.rb
+++ b/spec/services/flow/merits_loop_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+
+RSpec.describe Flow::MeritsLoop do
+  subject(:merits_loop) { described_class.new(legal_aid_application, group) }
+
+  let(:legal_aid_application) { create :legal_aid_application, :with_multiple_proceedings_inc_section8 }
+  let(:merits_task_list) { create :legal_framework_merits_task_list, :da001_as_defendant_and_child_section_8, legal_aid_application: }
+
+  describe ".forward_flow" do
+    subject(:forward_flow) { merits_loop.forward_flow }
+
+    context "when called at application level" do
+      let(:group) { "application" }
+
+      context "when some tasks are complete" do
+        before { merits_task_list.mark_as_complete!(:application, :latest_incident_details) }
+
+        it "returns the first :not_started task" do
+          expect(forward_flow).to eq :opponents
+        end
+      end
+
+      context "when all tasks in group are complete" do
+        before { merits_task_list.task_list.tasks[:application].each { |t| merits_task_list.mark_as_complete!(:application, t.name) } }
+
+        it { expect(forward_flow).to eq :merits_task_lists }
+      end
+    end
+
+    context "when called at proceeding level" do
+      context "when some tasks are complete" do
+        let(:group) { :SE014 }
+
+        before { merits_task_list.mark_as_complete!(:SE014, :chances_of_success) }
+
+        it "returns the first :not_started task" do
+          expect(forward_flow).to eq :attempts_to_settle # this ignores :children_proceeding as it is still unable to be started
+        end
+      end
+
+      context "when all tasks in group are complete" do
+        let(:group) { "DA001" }
+
+        before { merits_task_list.task_list.tasks[:proceedings][:DA001][:tasks].each { |t| merits_task_list.mark_as_complete!(:DA001, t.name) } }
+
+        it { expect(forward_flow).to eq :merits_task_lists }
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3561)

Extract merits question logic to separate class that allows merits questions to be grouped by application or proceeding.ccms_code

This allows a user to answer a single question and be looped through the remaining questions without being bounced to the merits_task_list each time

![image](https://user-images.githubusercontent.com/6757677/197138569-b843c321-5118-4219-84db-1970eb46d251.png)

Clicking on Latest incident details, the user will be taken through each question in group 1 and then returned to the merits task list
If the user starts lower down the list, e.g. Statement of case, they will get taken to `Latest incident details,` then though each `Not started` until reaching `Client offer of undertaking`

If they start with Chances of Success for Child arrangements order before completing  Children involved in this application  in Group 1, they will be taken to Attempts to settle before returning to the task list

### test updates
This also involved updating a lot of tests as previously, with hard-coded flows, it would always transition to page X.
This involved ensuring that the controllers always had a merits task list created and, sometimes, marking other tests as complete so that we could test each of the 'usual' flows as well as some exceptional ones, just in case!


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
