### PR TITLE
Prevent basic uploads navigating to truelayer `income_summary`

### DIFF
--- a/app/services/flow/flows/provider_capital.rb
+++ b/app/services/flow/flows/provider_capital.rb
@@ -57,7 +57,7 @@ module Flow
           forward: lambda do |application|
             if application.outgoing_types?
               :cash_outgoings
-            elsif application.income_types?
+            elsif application.income_types? && !application.uploading_bank_statements?
               :income_summary
             else
               :has_dependants

--- a/spec/requests/providers/means/identify_types_of_outgoings_controller_spec.rb
+++ b/spec/requests/providers/means/identify_types_of_outgoings_controller_spec.rb
@@ -89,6 +89,18 @@ RSpec.describe Providers::Means::IdentifyTypesOfOutgoingsController do
         request
         expect(response).to redirect_to(providers_legal_aid_application_means_cash_outgoing_path(legal_aid_application))
       end
+
+      context "with bank statement upload flow" do
+        before do
+          legal_aid_application.provider.permissions << Permission.find_or_create_by(role: "application.non_passported.bank_statement_upload.*")
+          legal_aid_application.update!(provider_received_citizen_consent: false)
+        end
+
+        it "redirects to the means cash outgoings page" do
+          request
+          expect(response).to redirect_to(providers_legal_aid_application_means_cash_outgoing_path(legal_aid_application))
+        end
+      end
     end
 
     context "when application has transaction types of other kind" do
@@ -177,6 +189,26 @@ RSpec.describe Providers::Means::IdentifyTypesOfOutgoingsController do
         it "redirects to the has dependants page" do
           request
           expect(response).to redirect_to(providers_legal_aid_application_means_has_dependants_path(legal_aid_application))
+        end
+      end
+
+      context "with bank statement upload flow" do
+        before do
+          legal_aid_application.provider.permissions << Permission.find_or_create_by(role: "application.non_passported.bank_statement_upload.*")
+          legal_aid_application.update!(provider_received_citizen_consent: false)
+        end
+
+        let(:maintenance_in) { create(:transaction_type, :maintenance_in) }
+
+        context "with existing credits and no debits selected" do
+          before do
+            legal_aid_application.transaction_types << maintenance_in
+          end
+
+          it "redirects to has_dependants" do
+            request
+            expect(response).to redirect_to(providers_legal_aid_application_means_has_dependants_path(legal_aid_application))
+          end
         end
       end
     end


### PR DESCRIPTION
Prevent basic uploads navigating to truelayer income_summary

## What
This is a live bug whereby if the provider does not add any
outgoings on the outgoings page but has provided incomes
on the earlier incomes page they will be take to the
income_summary page - this page is only for categorising
bank transactions and part of the truelayer path only.

ps: this would not effect the enhanced journey.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
