### PR TITLE
Use `<h2>` tag for nested fieldset headings

### DIFF
--- a/app/views/providers/means/housing_benefits/show.html.erb
+++ b/app/views/providers/means/housing_benefits/show.html.erb
@@ -9,7 +9,7 @@
                                              @form.frequency_options,
                                              :itself,
                                              ->(option) { t("transaction_types.frequencies.#{option}") },
-                                             legend: {tag: "p", size: "s"} %>
+                                             legend: {tag: "h2", size: "s"} %>
       <% end %>
 
       <%= f.govuk_radio_button :housing_benefit, "false" %>

--- a/app/views/providers/means/regular_incomes/show.html.erb
+++ b/app/views/providers/means/regular_incomes/show.html.erb
@@ -20,7 +20,7 @@
                                                RegularTransaction.frequencies_for(transaction_type),
                                                :itself,
                                                ->(option) { t("transaction_types.frequencies.#{option}") },
-                                               legend: {tag: "p", size: "s"} %>
+                                               legend: {tag: "h2", size: "s"} %>
         <% end %>
       <% end %>
 

--- a/app/views/providers/means/regular_outgoings/show.html.erb
+++ b/app/views/providers/means/regular_outgoings/show.html.erb
@@ -17,7 +17,7 @@
           <%= f.govuk_collection_radio_buttons "#{transaction_type.name}_frequency".to_sym,
                                                RegularTransaction.frequencies_for(transaction_type),
                                                :itself, ->(option) { t("transaction_types.frequencies.#{option}") },
-                                               legend: {tag: "p", size: "s"} %>
+                                               legend: {tag: "h2", size: "s"} %>
         <% end %>
       <% end %>
 


### PR DESCRIPTION
Before, these nested fieldsets in the regular transaction forms were using a `<p>` tag.

This was an accessibility issue, so the fieldset headings have been updated to use `<h2>` tags.