### PR TITLE
Enable RSpec/ExampleLength cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,6 +25,11 @@ AllCops:
   - 'tmp/**/*'
   - 'log/**/*'
 
+RSpec/ExampleLength:
+  Enabled: true
+  CountAsOne: ['array', 'hash', 'heredoc']
+  Max: 10
+
 Lint/AmbiguousBlockAssociation:
   Exclude:
   - 'spec/**/*'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -303,6 +303,48 @@ RSpec/ContextWording:
     - 'spec/services/submit_provider_reminder_service_spec.rb'
     - 'spec/services/substantive_application_deadline_calculator_spec.rb'
 
+
+RSpec/ExampleLength:
+  Exclude:
+    - 'spec/forms/citizens/other_assets_form_spec.rb'
+    - 'spec/forms/providers/means/housing_benefit_form_spec.rb'
+    - 'spec/forms/providers/means/regular_income_form_spec.rb'
+    - 'spec/forms/providers/means/regular_outgoings_form_spec.rb'
+    - 'spec/models/aggregated_cash_income_spec.rb'
+    - 'spec/models/aggregated_cash_outgoings_spec.rb'
+    - 'spec/models/applicant_spec.rb'
+    - 'spec/models/legal_aid_application_spec.rb'
+    - 'spec/models/proceeding_spec.rb'
+    - 'spec/models/scheduled_mailing_spec.rb'
+    - 'spec/requests/providers/applicant_employed_spec.rb'
+    - 'spec/requests/providers/check_passported_answers_spec.rb'
+    - 'spec/requests/providers/means/housing_benefits_controller_spec.rb'
+    - 'spec/requests/providers/means/regular_incomes_controller_spec.rb'
+    - 'spec/requests/providers/means_reports_spec.rb'
+    - 'spec/services/ccms/requestors/case_add_requestor_xml_blocks.rb'
+    - 'spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_additional_property_attributes_spec.rb'
+    - 'spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_dependant_child_attributes_spec.rb'
+    - 'spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_variable_attributes_spec.rb'
+    - 'spec/services/cfe/create_applicant_service_spec.rb'
+    - 'spec/services/cfe/create_assessment_service_spec.rb'
+    - 'spec/services/cfe/create_capitals_service_spec.rb'
+    - 'spec/services/cfe/create_cash_transactions_service_spec.rb'
+    - 'spec/services/cfe/create_dependants_service_spec.rb'
+    - 'spec/services/cfe/create_employments_service_spec.rb'
+    - 'spec/services/cfe/create_other_income_service_spec.rb'
+    - 'spec/services/cfe/create_outgoings_service_spec.rb'
+    - 'spec/services/cfe/create_proceeding_types_service_spec.rb'
+    - 'spec/services/cfe/create_state_benefits_service_spec.rb'
+    - 'spec/services/cfe/create_vehicles_service_spec.rb'
+    - 'spec/services/cfe/obtain_assessment_result_service_spec.rb'
+    - 'spec/services/digest_exporter_spec.rb'
+    - 'spec/services/provider_details_creator_spec.rb'
+    - 'spec/services/reports/mis/application_detail_csv_line_spec.rb'
+    - 'spec/services/reports/mis/non_passported_application_csv_line_spec.rb'
+    - 'spec/services/true_layer/importers/import_transactions_service_spec.rb'
+    - 'spec/support/shared_examples/cfe_failures_shared_examples.rb'
+    - 'spec/support/shared_examples/legal_framework_failures_shared_examples.rb'
+
 # Offense count: 1
 # Cop supports --auto-correct.
 RSpec/ExpectActual:


### PR DESCRIPTION
## What
Enable RSpec/ExampleLength

Do we want to enable this cop to

1. prevent further high block lengths
2. enable us to whittle some down

Have configured to allow certain structures over multiple
lines and increased default of 5 lines to 10 lines. This
reduces violations from 384 to 73.

We can exclude for now and work on them via the usual `rubocop_todo.yml`
but wanted to show them failing to start with.

https://docs.rubocop.org/rubocop-rspec/cops_rspec.html#rspecexamplelength


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
