### PR TITLE
Fix flaky proceeding helper spec

### DIFF
--- a/app/helpers/proceeding_helper.rb
+++ b/app/helpers/proceeding_helper.rb
@@ -11,11 +11,10 @@ module ProceedingHelper
   end
 
   def scope_limits(proceeding, scope_type)
-    scope_limits = []
-    proceeding.scope_limitations.where(scope_type:).each do |scope_limitation|
-      scope_limits << scope_limitation_meaning(scope_limitation)
-    end
-    scope_limits
+    proceeding
+      .scope_limitations
+      .where(scope_type:)
+      .map { |scope_limitation| scope_limitation_meaning(scope_limitation) }
   end
 
 private

--- a/spec/helpers/proceeding_helper_spec.rb
+++ b/spec/helpers/proceeding_helper_spec.rb
@@ -34,22 +34,67 @@ RSpec.describe ProceedingHelper, type: :helper do
   describe "#scope_limits" do
     subject(:scope_limitations) { scope_limits(proceeding, scope_type) }
 
-    let(:proceeding) { create :proceeding, :se013, no_scope_limitations: true, scope_limitations: [scope_limitation1, scope_limitation2, scope_limitation3, scope_limitation4] }
-    let(:scope_limitation1) { create :scope_limitation, :emergency_cv118, hearing_date: Date.yesterday }
-    let(:scope_limitation2) { create :scope_limitation, :emergency }
-    let(:scope_limitation3) { create :scope_limitation, :substantive }
-    let(:scope_limitation4) { create :scope_limitation, :substantive_CV119, limitation_note: "a handwriting expert" }
+    let(:emergency_scope_limitations) do
+      [
+        create(
+          :scope_limitation,
+          :emergency,
+          meaning: "Special hearing",
+          hearing_date: Date.new(2022, 12, 25),
+        ),
+        create(
+          :scope_limitation,
+          :emergency_cv118,
+          meaning: "Interim order",
+        ),
+      ]
+    end
+
+    let(:substantive_scope_limitations) do
+      [
+        create(
+          :scope_limitation,
+          :substantive,
+          meaning: "Final heading",
+        ),
+        create(
+          :scope_limitation,
+          :substantive,
+          meaning: "General report",
+          limitation_note: "This is a note",
+        ),
+      ]
+    end
+
+    let(:proceeding) do
+      create(
+        :proceeding,
+        :se013,
+        no_scope_limitations: true,
+        scope_limitations: emergency_scope_limitations + substantive_scope_limitations,
+      )
+    end
 
     context "when scope type is emergency" do
       let(:scope_type) { "emergency" }
 
-      it { is_expected.to eq ["Hearing<br>Date: #{Date.yesterday.strftime('%e %B %Y')}", "Interim order inc. return date"] }
+      it "returns only the emergency scope limitation meanings" do
+        expect(scope_limitations).to contain_exactly(
+          "Special hearing<br>Date: 25 December 2022",
+          "Interim order",
+        )
+      end
     end
 
     context "when scope type is substantive" do
       let(:scope_type) { "substantive" }
 
-      it { is_expected.to eq ["Final hearing", "General Report<br>Note: a handwriting expert"] }
+      it "returns only the substantive scope limitation meanings" do
+        expect(scope_limitations).to contain_exactly(
+          "Final heading",
+          "General report<br>Note: This is a note",
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
The tests for the `#scope_limits` helper method introduced recently were [flaky] 
because they expected scope limitations for a given proceeding to be returned in 
a particular order.

[flaky]: https://app.circleci.com/pipelines/github/ministryofjustice/laa-apply-for-legal-aid/18383/workflows/ce9fab1b-fdf1-46c5-855a-a0684d15e294/jobs/96235

This updates the tests to prefer the less specific `contain_exactly` helper over `eq`.

The tests have also been refactored with the aim of telling more of a story, since 
at first it wasn't clear to me what the tests were doing, or where the data was 
coming from.

The `#scope_limits` method itself has also been simplified.