### PR TITLE
fix review page housing benefit

### DIFF
--- a/app/views/shared/_review_application.html.erb
+++ b/app/views/shared/_review_application.html.erb
@@ -124,7 +124,7 @@
     <% else %>
       <%= render(
           'shared/check_answers/bank_transaction_table',
-          transaction_types: TransactionType.credits,
+          transaction_types: TransactionType.credits.without_housing_benefits,
           read_only: true
         ) %>
     <% end %>

--- a/app/views/shared/_review_application.html.erb
+++ b/app/views/shared/_review_application.html.erb
@@ -1,191 +1,190 @@
 <div class="print-header-wrapper">
-<dl class="govuk-list inline-list print-header">
-  <dt>
-    <strong><%= t('.client_name') %>:</strong>
-  </dt>
-  <dd><%= @legal_aid_application.applicant_full_name %></dd>
+  <dl class="govuk-list inline-list print-header">
+    <dt>
+      <strong><%= t('.client_name') %>:</strong>
+    </dt>
+    <dd><%= @legal_aid_application.applicant_full_name %></dd>
 
-  <dt>
-    <strong><%= t('.case_reference_html') %>:</strong>
-  </dt>
-  <dd><%= @legal_aid_application.application_ref %></dd>
+    <dt>
+      <strong><%= t('.case_reference_html') %>:</strong>
+    </dt>
+    <dd><%= @legal_aid_application.application_ref %></dd>
 
-  <dt>
-    <strong><%= t('.ccms_reference_html') %>:</strong>
-  </dt>
-  <dd><%= @legal_aid_application.case_ccms_reference %></dd>
-
-</dl>
+    <dt>
+      <strong><%= t('.ccms_reference_html') %>:</strong>
+    </dt>
+    <dd><%= @legal_aid_application.case_ccms_reference %></dd>
+  </dl>
 </div>
 
 <div class="print-position-correction">
-<section class="client_details print-no-break">
-  <h2 class="govuk-heading-l"><%= t('.client_details_heading') %></h2>
-  <%= render(
-        'shared/check_answers/client_details',
-        attributes: %i[first_name last_name date_of_birth national_insurance_number email address],
-        applicant: @legal_aid_application.applicant,
-        address: @legal_aid_application.applicant.address,
-        read_only: true
-      ) %>
-</section>
-
-<section class="proceeding_details print-no-break">
-  <h2 class="govuk-heading-m"><%= t('.proceedings_details_heading') %></h2>
-  <%= render(
-        'shared/check_answers/proceedings_details',
-        proceeding_types: @legal_aid_application.proceedings,
-        legal_aid_application: @legal_aid_application,
-        read_only: true
-      ) %>
-</section>
-
-<% if Setting.enable_mini_loop? %>
-  <% @legal_aid_application.proceedings.each do |proceeding| %>
+  <section class="client_details print-no-break">
+    <h2 class="govuk-heading-l"><%= t('.client_details_heading') %></h2>
     <%= render(
-      'shared/check_answers/proceeding_details_section',
-      proceeding: proceeding,
-      read_only: true
-    ) %>
-  <% end %>
+          'shared/check_answers/client_details',
+          attributes: %i[first_name last_name date_of_birth national_insurance_number email address],
+          applicant: @legal_aid_application.applicant,
+          address: @legal_aid_application.applicant.address,
+          read_only: true
+        ) %>
+  </section>
 
-<% else %>
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <h2 class="govuk-heading-m"><%= t '.section_delegated.heading' %></h2>
+  <section class="proceeding_details print-no-break">
+    <h2 class="govuk-heading-m"><%= t('.proceedings_details_heading') %></h2>
+    <%= render(
+          'shared/check_answers/proceedings_details',
+          proceeding_types: @legal_aid_application.proceedings,
+          legal_aid_application: @legal_aid_application,
+          read_only: true
+        ) %>
+  </section>
+
+  <% if Setting.enable_mini_loop? %>
+    <% @legal_aid_application.proceedings.each do |proceeding| %>
+      <%= render(
+        'shared/check_answers/proceeding_details_section',
+        proceeding: proceeding,
+        read_only: true
+      ) %>
+    <% end %>
+
+  <% else %>
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <h2 class="govuk-heading-m"><%= t '.section_delegated.heading' %></h2>
+      </div>
     </div>
-  </div>
 
-  <%= render(
-        'shared/check_answers/delegated_functions',
-        legal_aid_application: @legal_aid_application,
-        read_only: true
-      ) %>
-
-  <% if @legal_aid_application.used_delegated_functions? %>
-    <h2 class="govuk-heading-m"><%= t '.section_emergency.heading' %></h2>
     <%= render(
-          'shared/check_answers/emergency_limitations',
+          'shared/check_answers/delegated_functions',
+          legal_aid_application: @legal_aid_application,
+          read_only: true
+        ) %>
+
+    <% if @legal_aid_application.used_delegated_functions? %>
+      <h2 class="govuk-heading-m"><%= t '.section_emergency.heading' %></h2>
+      <%= render(
+            'shared/check_answers/emergency_limitations',
+            legal_aid_application: @legal_aid_application
+          ) %>
+    <% end %>
+
+    <h2 class="govuk-heading-m"><%= t('.section_substantive.heading') %></h2>
+    <%= render(
+          'shared/check_answers/substantive_limitations',
           legal_aid_application: @legal_aid_application
         ) %>
   <% end %>
 
-  <h2 class="govuk-heading-m"><%= t('.section_substantive.heading') %></h2>
-  <%= render(
-        'shared/check_answers/substantive_limitations',
-        legal_aid_application: @legal_aid_application
-      ) %>
-<% end %>
-
-<% if @legal_aid_application.used_delegated_functions? %>
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <h2 class="govuk-heading-m"><%= t '.emergency_cost_limit' %></h2>
+  <% if @legal_aid_application.used_delegated_functions? %>
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <h2 class="govuk-heading-m"><%= t '.emergency_cost_limit' %></h2>
+      </div>
     </div>
-  </div>
-  <%= render(
-        'shared/check_answers/emergency_costs',
-        legal_aid_application: @legal_aid_application,
-        read_only: true
-      ) %>
-<% end %>
-
-<% if @legal_aid_application.substantive_cost_overridable? %>
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <h2 class="govuk-heading-m"><%= t '.substantive_cost_limit' %></h2>
-    </div>
-  </div>
-  <%= render(
-        'shared/check_answers/substantive_costs',
-        legal_aid_application: @legal_aid_application,
-        read_only: true
-      ) %>
-<% end %>
-
-<section class="income_payments_and_assets page_break_before">
-  <div class="govuk-!-padding-bottom-6"></div>
-  <h2 class="govuk-heading-l"><%= t('.income_payments_and_assets_heading') %></h2>
-
-  <% if @legal_aid_application.uploading_bank_statements? %>
-    <%= render('shared/check_answers/bank_statements', bank_statements: @legal_aid_application.attachments.bank_statement_evidence, read_only: true) %>
-  <% end %>
-
-  <% if display_employment_income? %>
-    <%= render 'shared/employment_income_table' %>
-  <% end %>
-
-  <section class="print-no-break">
-    <h3 class="govuk-heading-m govuk-!-padding-top-8"><%= display_employment_income? ? t('.other_income') : t('.income') %></h3>
-    <% if @legal_aid_application.applicant_receives_benefit? %>
-      <strong class="govuk-tag app-tag--capitalize">
-        <%= t('.passported') %>
-      </strong>
-    <% else %>
-      <%= render(
-          'shared/check_answers/bank_transaction_table',
-          transaction_types: TransactionType.credits.without_housing_benefits,
+    <%= render(
+          'shared/check_answers/emergency_costs',
+          legal_aid_application: @legal_aid_application,
           read_only: true
         ) %>
-    <% end %>
-  </section>
-
-  <% if @legal_aid_application.irregular_incomes.any? %>
-    <%= render 'shared/irregular_incomes_table',
-               irregular_incomes: @legal_aid_application.irregular_incomes,
-               period: @legal_aid_application.year_to_calculation_date %>
   <% end %>
 
-  <section class="print-no-break">
-    <h3 class="govuk-heading-m govuk-!-padding-top-8"><%= t('.payments') %></h3>
-    <% if @legal_aid_application.applicant_receives_benefit? %>
-      <strong class="govuk-tag app-tag--capitalize">
-        <%= t('.passported') %>
-      </strong>
-    <% else %>
-      <%= render(
+  <% if @legal_aid_application.substantive_cost_overridable? %>
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <h2 class="govuk-heading-m"><%= t '.substantive_cost_limit' %></h2>
+      </div>
+    </div>
+    <%= render(
+          'shared/check_answers/substantive_costs',
+          legal_aid_application: @legal_aid_application,
+          read_only: true
+        ) %>
+  <% end %>
+
+  <section class="income_payments_and_assets page_break_before">
+    <div class="govuk-!-padding-bottom-6"></div>
+    <h2 class="govuk-heading-l"><%= t('.income_payments_and_assets_heading') %></h2>
+
+    <% if @legal_aid_application.uploading_bank_statements? %>
+      <%= render('shared/check_answers/bank_statements', bank_statements: @legal_aid_application.attachments.bank_statement_evidence, read_only: true) %>
+    <% end %>
+
+    <% if display_employment_income? %>
+      <%= render 'shared/employment_income_table' %>
+    <% end %>
+
+    <section class="print-no-break">
+      <h3 class="govuk-heading-m govuk-!-padding-top-8"><%= display_employment_income? ? t('.other_income') : t('.income') %></h3>
+      <% if @legal_aid_application.applicant_receives_benefit? %>
+        <strong class="govuk-tag app-tag--capitalize">
+          <%= t('.passported') %>
+        </strong>
+      <% else %>
+        <%= render(
             'shared/check_answers/bank_transaction_table',
-            transaction_types: TransactionType.debits,
+            transaction_types: TransactionType.credits.without_housing_benefits,
             read_only: true
           ) %>
+      <% end %>
+    </section>
+
+    <% if @legal_aid_application.irregular_incomes.any? %>
+      <%= render 'shared/irregular_incomes_table',
+                 irregular_incomes: @legal_aid_application.irregular_incomes,
+                 period: @legal_aid_application.year_to_calculation_date %>
     <% end %>
+
+    <section class="print-no-break">
+      <h3 class="govuk-heading-m govuk-!-padding-top-8"><%= t('.payments') %></h3>
+      <% if @legal_aid_application.applicant_receives_benefit? %>
+        <strong class="govuk-tag app-tag--capitalize">
+          <%= t('.passported') %>
+        </strong>
+      <% else %>
+        <%= render(
+              'shared/check_answers/bank_transaction_table',
+              transaction_types: TransactionType.debits,
+              read_only: true
+            ) %>
+      <% end %>
+    </section>
+
+    <section class="print-no-break govuk-!-padding-top-8">
+      <%= render 'shared/check_answers/assets', read_only: true %>
+    </section>
   </section>
 
-  <section class="print-no-break govuk-!-padding-top-8">
-    <%= render 'shared/check_answers/assets', read_only: true %>
+  <section class="merits page_break_before">
+    <%= render(
+      "shared/check_answers/merits",
+      incident: @legal_aid_application.latest_incident,
+      statement_of_case: @legal_aid_application.statement_of_case,
+      gateway_evidence: @legal_aid_application&.gateway_evidence,
+      opponent: @legal_aid_application.opponent,
+      allegation: @legal_aid_application&.allegation,
+      undertaking: @legal_aid_application&.undertaking,
+      read_only: true
+    ) %>
   </section>
-</section>
 
-<section class="merits page_break_before">
-  <%= render(
-    "shared/check_answers/merits",
-    incident: @legal_aid_application.latest_incident,
-    statement_of_case: @legal_aid_application.statement_of_case,
-    gateway_evidence: @legal_aid_application&.gateway_evidence,
-    opponent: @legal_aid_application.opponent,
-    allegation: @legal_aid_application&.allegation,
-    undertaking: @legal_aid_application&.undertaking,
-    read_only: true
-  ) %>
-</section>
+  <section id="client-declaration" class="only-print print-no-break page_break_before">
+    <div class="govuk-!-padding-bottom-6"></div>
+    <h2 class="govuk-heading-l"><%= t('.client_declaration.heading') %></h2>
 
-<section id="client-declaration" class="only-print print-no-break page_break_before">
-  <div class="govuk-!-padding-bottom-6"></div>
-  <h2 class="govuk-heading-l"><%= t('.client_declaration.heading') %></h2>
+    <%= render 'shared/applicant_declaration' %>
 
-  <%= render 'shared/applicant_declaration' %>
-
-  <dl class="govuk-summary-list govuk-summary-list--no-border">
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key print-bottom-gap">
-        <%= t('.client_declaration.signature') %>
-      </dt>
-    </div>
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        <%= t('.client_declaration.date') %>
-      </dt>
-    </div>
-  </dl>
-</section>
+    <dl class="govuk-summary-list govuk-summary-list--no-border">
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key print-bottom-gap">
+          <%= t('.client_declaration.signature') %>
+        </dt>
+      </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          <%= t('.client_declaration.date') %>
+        </dt>
+      </div>
+    </dl>
+  </section>
 </div>


### PR DESCRIPTION
## What
Remove "housing benefit total" from income section

![Screenshot 2022-10-25 at 08 02 30](https://user-images.githubusercontent.com/7016425/197704959-5a70d01b-61e2-435c-8eb6-6edec4b11521.png)


[Link to story](https://dsdmoj.atlassian.net/browse/AP-3558)

The income section of the review and print page
is only to be used by truelayer applications
for which the housing benefit transaction type
is not applicable.

The enhanced bank statement journey will replace the
the entire "income, regular payments and assets" section
and show housing benefit in in a separate section according
to designs.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
