### PR TITLE
Send applicant employed status to CFE

### DIFF
--- a/app/services/cfe/create_applicant_service.rb
+++ b/app/services/cfe/create_applicant_service.rb
@@ -8,6 +8,7 @@ module CFE
       {
         applicant: {
           date_of_birth: applicant.date_of_birth.strftime("%Y-%m-%d"),
+          employed: applicant.employed,
           involvement_type: "applicant",
           has_partner_opponent: false,
           receives_qualifying_benefit: legal_aid_application.applicant_receives_benefit?,

--- a/spec/services/cfe/create_applicant_service_spec.rb
+++ b/spec/services/cfe/create_applicant_service_spec.rb
@@ -71,6 +71,7 @@ module CFE
       {
         applicant: {
           date_of_birth: applicant.date_of_birth.strftime("%Y-%m-%d"),
+          employed: applicant.employed,
           involvement_type: "applicant",
           has_partner_opponent: false,
           receives_qualifying_benefit: application.applicant_receives_benefit?,


### PR DESCRIPTION
In order for CFE to apportion child care cost allowance for an applicant, it needs to know whether an applicant is employed or not.

This adds `employed` to the `CreateApplicantService` payload, so that the data point can be persisted to the applicant in CFE.

[Changes have been made to CFE][cfe-changes] to take into account this new information when collating the childcare costs allowance for an assessment.

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3560)

[cfe-changes]: https://github.com/ministryofjustice/check-financial-eligibility/pull/1163