### PR TITLE
Simplify `LegalAidApplications::HasOtherProceedingsForm`

### DIFF
--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -314,6 +314,9 @@ en:
               blank: Confirm the date you used delegated functions
             has_dependants:
               blank: Select yes if your client has any dependants
+            has_other_proceeding:
+              blank: Select yes if you want to add another proceeding
+              must_add_domestic_abuse: You must add at least one domestic abuse proceeding
             has_restrictions:
               citizens:
                 blank: Select yes if there are restrictions that prevent you from selling or borrowing against your assets

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -1193,8 +1193,6 @@ en:
         page_title: Do you want to add another proceeding?
         existing: You have added %{count}
         remove: Remove
-        error: Select yes if you want to add another proceeding
-        must_add_domestic_abuse: You must add at least one domestic abuse proceeding
     providers:
       show:
         account_number: Account number

--- a/spec/requests/providers/has_other_proceedings_controller_spec.rb
+++ b/spec/requests/providers/has_other_proceedings_controller_spec.rb
@@ -62,8 +62,9 @@ RSpec.describe Providers::HasOtherProceedingsController do
       let(:legal_aid_application) { create(:legal_aid_application, :at_checking_applicant_details, :with_proceedings, explicit_proceedings: [:se014], set_lead_proceeding: false) }
       let(:params) { { legal_aid_application: { has_other_proceeding: "false" } } }
 
-      it "redirects to the page to add another proceeding type" do
-        expect(response.body).to include(I18n.t("providers.has_other_proceedings.show.must_add_domestic_abuse"))
+      it "stays on the page and displays an error" do
+        expect(response).to have_http_status(:ok)
+        expect(page).to have_error_message("has_other_proceeding.must_add_domestic_abuse")
       end
     end
 
@@ -72,7 +73,7 @@ RSpec.describe Providers::HasOtherProceedingsController do
 
       it "stays on the page if there is a validation error" do
         expect(response).to have_http_status(:ok)
-        expect(response.body).to include(I18n.t("providers.has_other_proceedings.show.error"))
+        expect(page).to have_error_message("has_other_proceeding.blank")
       end
     end
 
@@ -84,7 +85,7 @@ RSpec.describe Providers::HasOtherProceedingsController do
 
         it "stays on the page and displays an error" do
           expect(response).to have_http_status(:ok)
-          expect(response.body).to include(I18n.t("providers.has_other_proceedings.show.must_add_domestic_abuse"))
+          expect(page).to have_error_message("has_other_proceeding.must_add_domestic_abuse")
         end
       end
 
@@ -118,6 +119,13 @@ RSpec.describe Providers::HasOtherProceedingsController do
           expect(response).to redirect_to(providers_legal_aid_application_client_involvement_type_path(legal_aid_application.id, proceeding_id))
         end
       end
+    end
+
+    def have_error_message(key)
+      have_css(
+        ".govuk-error-summary__list > li",
+        text: I18n.t(key, scope: "activemodel.errors.models.legal_aid_application.attributes"),
+      )
     end
   end
 


### PR DESCRIPTION
This prefers default Rails validations to custom validation, 
reduces the external API of the form model, and prefers 
default error message lookups to custom ones.