### PR TITLE
Small content fixes on the privacy policy page

### DIFF
--- a/app/views/privacy_policy/index.html.erb
+++ b/app/views/privacy_policy/index.html.erb
@@ -75,6 +75,7 @@
 
   <h2 class="govuk-heading-l"><%= t('.complaints.header') %></h2>
   <p class="govuk-body"><%= t('.complaints.info_1') %></p>
+  <p class="govuk-body"><%= t('.complaints.info_2') %></p>
   <p class="govuk-body">
     <% t('.complaints.address').each do |address_lines| %>
       <%= address_lines[-1] %><br>

--- a/config/locales/en/privacy_policy.yml
+++ b/config/locales/en/privacy_policy.yml
@@ -49,7 +49,7 @@ en:
         info_2: Any personal data shared with a data processor for this purpose will be governed by model contract clauses under data protection law.
       details_of_transfer:
         header: Details of transfers to third country and safeguards
-        info_1: "It may sometimes be necessary to transfer personal information overseas. When this is needed, information may be transferred to the European Economic Area (EEA)"
+        info_1: "It may sometimes be necessary to transfer personal information overseas. When this is needed, information may be transferred to the European Economic Area (EEA)."
         info_2: Any transfers made will be in full compliance with all aspects of the data protection law.
       retention_period:
         header: Retention period for information collected
@@ -89,7 +89,7 @@ en:
             withdraw consent at any time where relevant
             lodge a complaint with the supervisory authority
       more_details:
-        header: "The Data Protection Officer:"
+        header: "The Data Protection Officer"
         info_1: "The Data Protection Officer can provide details on:"
         list: |
           agreements we have with other organisations for sharing information


### PR DESCRIPTION

## What

Crime Apply have stolen our privacy policy and noticed some small issues on the page - a missing full stop, an unnecessary colon and a missing header. This is just a small PR to fix these.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
