### PR TITLE
Update default firm permissions

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -18,7 +18,6 @@ Seeder.monitor DocumentCategory
 Dir[Rails.root.join("db/seeds/*.rb")].each do |seed|
   load seed
 end
-Rake::Task["employ"].invoke if Rails.env.development?
 
 Rails.logger.info Seeder.report.join("\n")
 Rails.logger.info "Seeding completed"

--- a/db/seeds/test_provider_populator.rb
+++ b/db/seeds/test_provider_populator.rb
@@ -44,17 +44,20 @@ class TestProviderPopulator
     return if HostEnv.production?
 
     TEST_PROVIDERS.each { |username, details| populate_provider(username, details) }
-    populate_firm_permissions
+    populate_all_firm_permissions
   end
 
 private
 
-  def populate_firm_permissions
+  def populate_all_firm_permissions
     passported_permission = Permission.find_by(role: "application.passported.*")
     non_passported_permission = Permission.find_by(role: "application.non_passported.*")
+    employment_permission = Permission.find_by(role: "application.non_passported.employment.*")
+
     Firm.all.each do |firm|
-      firm.permissions << passported_permission unless firm.permissions.map(&:role).include?("application.passported.*")
-      firm.permissions << non_passported_permission unless firm.permissions.map(&:role).include?("application.non_passported.*")
+      firm.permissions << passported_permission unless firm.permissions.include?(passported_permission)
+      firm.permissions << non_passported_permission unless firm.permissions.include?(non_passported_permission)
+      firm.permissions << employment_permission unless firm.permissions.include?(employment_permission)
       firm.save!
     end
   end


### PR DESCRIPTION
Add employment permission to all firms by default

## What

Add employment permission to all firms inline
with production.

This will primarily mean we do not have to set
the permission on UAT environments.

_QUESTION: this script updates ALL firms permissions as part
seeding, but surely it should be just the test providers
we update here?!_


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
