### PR TITLE
Fix missing disregarded benefits from truelayer

### DIFF
--- a/app/controllers/providers/means/identify_types_of_incomes_controller.rb
+++ b/app/controllers/providers/means/identify_types_of_incomes_controller.rb
@@ -31,7 +31,8 @@ module Providers
       end
 
       def transaction_types
-        @transaction_types ||= TransactionType.credits.where(id: legal_aid_application_params[:transaction_type_ids])
+        @transaction_types ||= TransactionType.credits.find_with_children(legal_aid_application_params[:transaction_type_ids])
+        # @transaction_types ||= TransactionType.credits.where(id: legal_aid_application_params[:transaction_type_ids])
       end
 
       def transaction_types_selected?

--- a/app/models/transaction_type.rb
+++ b/app/models/transaction_type.rb
@@ -48,6 +48,11 @@ class TransactionType < ApplicationRecord
   scope :without_disregarded_benefits, -> { not_children }
   scope :without_housing_benefits, -> { where.not(name: "housing_benefit") }
 
+  def self.find_with_children(*ids)
+    all_ids = (ids + TransactionType.where(parent_id: ids.compact).without_housing_benefits.pluck(:id)).flatten
+    where(id: all_ids)
+  end
+
   def self.for_income_type?(transaction_type_name)
     income_for(transaction_type_name).any?
   end

--- a/spec/requests/providers/means/identify_types_of_incomes_controller_spec.rb
+++ b/spec/requests/providers/means/identify_types_of_incomes_controller_spec.rb
@@ -211,6 +211,20 @@ RSpec.describe Providers::Means::IdentifyTypesOfIncomesController do
       end
     end
 
+    context "when benefits selected" do
+      let(:transaction_type_ids) { [benefits.id] }
+      let(:benefits) { create(:transaction_type, :benefits) }
+
+      before do
+        create(:transaction_type, :excluded_benefits, parent_id: benefits.id)
+      end
+
+      it "adds excluded_benefits transaction type as well as benefits" do
+        expect { request }.to change(LegalAidApplicationTransactionType, :count).by(2)
+        expect(legal_aid_application.reload.transaction_types.pluck(:name)).to match_array(%w[benefits excluded_benefits])
+      end
+    end
+
     context "when checking answers" do
       subject(:request) { patch providers_legal_aid_application_means_identify_types_of_income_path(legal_aid_application), params: params.merge(submit_button) }
 


### PR DESCRIPTION
## What
Fix missing disregarded benefits from truelayer

Truelayer journey was missing excluded benefit transaction type
from the income summary/bank transaction selection/categorisation
summary page.

ATTENTION check this is ok for Enhanced bank statement upload flow


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
