### PR TITLE
Update schema to reflect migrations

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -693,8 +693,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_27_065931) do
     t.string "category_of_law", null: false
     t.string "category_law_code", null: false
     t.string "ccms_matter_code"
-    t.string "client_involvement_type_ccms_code", null: false
-    t.string "client_involvement_type_description", null: false
+    t.string "client_involvement_type_ccms_code"
+    t.string "client_involvement_type_description"
     t.boolean "used_delegated_functions"
     t.integer "emergency_level_of_service"
     t.string "emergency_level_of_service_name"


### PR DESCRIPTION
These colums need to be nullable and migration reflects this but
schema does not currently

To fix problems locally you can run this

```
rails db:migrate:down VERSION=20220708123323
```

```
rails db:migrate:up VERSION=20220708123323
```



## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-XXX)

Describe what you did and why.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
