### PR TITLE
Add application instance var to path call

### DIFF
--- a/app/views/shared/check_answers/_merits.html.erb
+++ b/app/views/shared/check_answers/_merits.html.erb
@@ -124,7 +124,7 @@
     <dl class="govuk-summary-list govuk-!-margin-bottom-2">
       <%= check_answer_link(
             name: :allegation_denies_all,
-            url: providers_legal_aid_application_client_denial_of_allegation_path,
+            url: providers_legal_aid_application_client_denial_of_allegation_path(@legal_aid_application),
             question: t('.items.allegation_denies_all'),
             answer: yes_no(allegation.denies_all),
             no_border: true,
@@ -144,7 +144,7 @@
     <dl class="govuk-summary-list govuk-!-margin-bottom-2">
       <%= check_answer_link(
             name: :undertaking_offered,
-            url: providers_legal_aid_application_client_offered_undertakings_path,
+            url: providers_legal_aid_application_client_offered_undertakings_path(@legal_aid_application),
             question: t('.items.undertaking_offered'),
             answer: yes_no(undertaking.offered),
             no_border: true,
@@ -161,7 +161,7 @@
   <section class="print-no-break">
     <%= check_answer_change_link(
       name: :nature_of_urgency_heading,
-      url: providers_legal_aid_application_nature_of_urgencies_path,
+      url: providers_legal_aid_application_nature_of_urgencies_path(@legal_aid_application),
       question: t('.nature_of_urgency_heading'),
       read_only: read_only
     ) %>


### PR DESCRIPTION
Add explicit instance vars to route path helper calls.

## What

Fixes potential failed merits report caused by various new merits question renderings

Errors are raised - see Sidekiq/ReportsCreatorWorker errors such as below

```
ActionView::Template::Error: No route matches {:action=>"show", :controller=>"providers/application_merits_task/client_denial_of_allegations", :locale=>:en}, missing required keys: [:legal_aid_applicat...
While route helpers can deduce missing ke
```

This is because while path helpers can deduce a missing require route key when rendered in the rails
standard MVC way (via ActionDispatch cleverness) the way the MeritsReportCreator (and MeansReportCreator) work is to call `Controller.renderer.render` directly, which cannot deduce the missing route keys (I assume).

Solution: always be explicit with your route params

see https://thoughtbot.com/blog/avoid-making-path-helpers-guess#searching-for-missing-route-values
for more.



## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
