### PR TITLE
Remove explicit builder arguments.

### DIFF
--- a/app/views/providers/applicant_bank_accounts/show.html.erb
+++ b/app/views/providers/applicant_bank_accounts/show.html.erb
@@ -1,5 +1,4 @@
 <%= form_with(
-      builder: GOVUKDesignSystemFormBuilder::FormBuilder,
       url: providers_legal_aid_application_applicant_bank_account_path,
       model: @form,
       method: :patch,

--- a/app/views/providers/has_evidence_of_benefits/show.html.erb
+++ b/app/views/providers/has_evidence_of_benefits/show.html.erb
@@ -1,6 +1,5 @@
 <%= page_template page_title: t('.page_title', passporting_benefit: @passporting_benefit), template: :basic do %>
     <%= form_with(
-          builder: GOVUKDesignSystemFormBuilder::FormBuilder,
           model: @form,
           url: providers_legal_aid_application_has_evidence_of_benefit_path,
           method: :patch,

--- a/app/views/providers/proceeding_merits_task/attempts_to_settle/show.html.erb
+++ b/app/views/providers/proceeding_merits_task/attempts_to_settle/show.html.erb
@@ -1,5 +1,4 @@
 <%= form_with(
-      builder: GOVUKDesignSystemFormBuilder::FormBuilder,
       model: @form,
       url: providers_merits_task_list_attempts_to_settle_path(@proceeding),
       method: :patch,

--- a/app/views/providers/proceeding_merits_task/linked_children/show.html.erb
+++ b/app/views/providers/proceeding_merits_task/linked_children/show.html.erb
@@ -1,5 +1,4 @@
 <%= form_with(
-      builder: GOVUKDesignSystemFormBuilder::FormBuilder,
       model: @form,
       url: providers_merits_task_list_linked_children_path(@proceeding),
       method: :patch,

--- a/app/views/providers/proceeding_merits_task/specific_issue/show.html.erb
+++ b/app/views/providers/proceeding_merits_task/specific_issue/show.html.erb
@@ -1,5 +1,4 @@
 <%= form_with(
-      builder: GOVUKDesignSystemFormBuilder::FormBuilder,
       model: @form,
       url: providers_merits_task_list_specific_issue_path(@proceeding),
       method: :patch,


### PR DESCRIPTION



## What
Remove explicit builder arguments

It is set to be this by default 
```
# config/application.rb
ActionView::Base.default_form_builder = GOVUKDesignSystemFormBuilder::FormBuilder
```

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
