### PR TITLE
Fix: Update overcommit rule for DB anonymisation

### DIFF
--- a/.overcommit.yml
+++ b/.overcommit.yml
@@ -32,3 +32,5 @@ PreCommit:
   DBAnonymizer:
     enabled: true
     command: ['ruby', './scripts/migration_hook.rb']
+    requires_files: true
+    include: 'db/migrate/*.rb'


### PR DESCRIPTION
## What

It was running (slowly) on each commit this changes it so that it only runs when files in the db/migrate folder are in the commit, this retains the speed of not tripping the github action with a speed increase on every other commit!

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
