### PR TITLE
Fix flaky bank statement spec

### DIFF
--- a/features/providers/check_your_answers.feature
+++ b/features/providers/check_your_answers.feature
@@ -321,11 +321,11 @@ Feature: Checking answers backwards and forwards
     And I should not see 'Does your client have any savings accounts they cannot access online?'
 
     When I click Check Your Answers Change link for 'bank statements'
-    And I upload an evidence file named 'hello_world.pdf'
     Then I should see "hello_world.pdf UPLOADED"
+    And I upload an evidence file named 'hello_world1.pdf'
+    Then I should see "hello_world1.pdf UPLOADED"
     And I click 'Save and continue'
     Then I should be on the 'means_summary' page showing 'Check your answers'
-    And I should see 'hello_world.pdf'
 
     When I click Check Your Answers Change link for "What payments does your client receive?"
     And I check 'Benefits'


### PR DESCRIPTION
Before, this test was flaky because it would try to navigate to the next page while a document was being uploaded.

In #4375, that document upload spec expected to see "document.pdf UPLOADED" content before clicking "Save and continue". This ensured that the document had finished uploaded before navigating away.

This test appeared to work similarly, except it would fail sporadically.

On closer inspection, it turns out the "hello_world.pdf" file was already uploaded. This meant the test attempted to navigate away by clicking "Save and continue" straight away (rather than waiting for the upload to finish).

This updates the test to upload a different second file, and expect both files to be uploaded before navigating away from the page.

As in #4375, similar considerations should be made, but in the meantime this prevents the test from being flaky.