### PR TITLE
Replace multiline anchors with start and end of string anchors

### DIFF
--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -4,7 +4,7 @@ require "omniauth"
 class Applicant < ApplicationRecord
   devise :rememberable
 
-  NINO_REGEXP = /^[A-CEGHJ-PR-TW-Z]{1}[A-CEGHJ-NPR-TW-Z]{1}[0-9]{6}[A-DFM]{1}$/
+  NINO_REGEXP = /\A[A-CEGHJ-PR-TW-Z]{1}[A-CEGHJ-NPR-TW-Z]{1}[0-9]{6}[A-DFM]{1}\z/
 
   has_one :legal_aid_application, dependent: :destroy
   has_many :addresses, dependent: :destroy

--- a/spec/factories/applicants.rb
+++ b/spec/factories/applicants.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
     last_name { Faker::Name.last_name }
     date_of_birth { Faker::Date.birthday }
     email { Faker::Internet.safe_email }
-    national_insurance_number { Faker::Base.regexify(Applicant::NINO_REGEXP) }
+    national_insurance_number { "JA123456D" }
     employed { false }
 
     trait :with_address do

--- a/spec/forms/applicants/basic_details_form_spec.rb
+++ b/spec/forms/applicants/basic_details_form_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe Applicants::BasicDetailsForm, type: :form do
     context "with test national insurance numbers" do
       let(:test_nino) { "JS130161E" }
       let(:invalid_nino) { "QQ12AS23RR" }
-      let(:valid_nino) { Faker::Base.regexify(Applicant::NINO_REGEXP) }
+      let(:valid_nino) { "JA123456D" }
 
       before do
         allow(Rails.configuration.x.laa_portal).to receive(:mock_saml).and_return(in_test_mode)


### PR DESCRIPTION
## What
Replace multiline anchors with start and end of string anchors

[came out of story](https://dsdmoj.atlassian.net/browse/AP-3608)

Nino validation uses the multiline anchors but should
use start and end instead. I noticed this raises error
when spiking use of `validate :blah, :format: { with: regex }`
rails valiadaion

```
The provided regular expression is using multiline anchors (^ or $), which may present a security risk. Did you mean to use \A and \z, or forgot to add the :multiline => true option?
```

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
