### PR TITLE
ap-3624: prevent duplicate scope limitations

### DIFF
--- a/app/forms/proceedings/emergency_defaults_form.rb
+++ b/app/forms/proceedings/emergency_defaults_form.rb
@@ -34,6 +34,7 @@ module Proceedings
     def save
       return false unless super
 
+      model.scope_limitations.where(scope_type: :emergency).destroy_all
       case accepted_emergency_defaults&.to_s
       when "true"
         new_scope = {

--- a/app/forms/proceedings/substantive_defaults_form.rb
+++ b/app/forms/proceedings/substantive_defaults_form.rb
@@ -32,6 +32,7 @@ module Proceedings
     end
 
     def save
+      model.scope_limitations.where(scope_type: :substantive).destroy_all
       case accepted_substantive_defaults&.to_s
       when "false"
         attributes[:substantive_level_of_service] = nil

--- a/spec/cassettes/Proceedings_SubstantiveDefaultsForm/_save/when_the_submission_is_valid/and_the_user_accepts_the_defaults/when_the_proceeding_already_has_scope_limitations/deletes_the_existing_substantive_scope_limitations_and_creates_one_new_substantive_scope_limitation.yml
+++ b/spec/cassettes/Proceedings_SubstantiveDefaultsForm/_save/when_the_submission_is_valid/and_the_user_accepts_the_defaults/when_the_proceeding_already_has_scope_limitations/deletes_the_existing_substantive_scope_limitations_and_creates_one_new_substantive_scope_limitation.yml
@@ -1,0 +1,66 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_type_defaults
+    body:
+      encoding: UTF-8
+      string: '{"proceeding_type_ccms_code":"DA001","delegated_functions_used":false,"client_involvement_type":"Z"}'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Faraday v1.10.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 17 Nov 2022 14:31:22 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Vary:
+      - Accept, Origin
+      Etag:
+      - W/"8352d3267c40ba3460c3693b3f8b034e"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - b1ae1adb3ee872fec4ccd92477effe75
+      X-Runtime:
+      - '0.016935'
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '{"success":true,"requested_params":{"proceeding_type_ccms_code":"DA001","delegated_functions_used":false,"client_involvement_type":"Z"},"default_level_of_service":{"level":3,"name":"Full
+        Representation","stage":8},"default_scope":{"code":"AA019","meaning":"Injunction
+        FLA-to final hearing","description":"As to proceedings under Part IV Family
+        Law Act 1996 limited to all steps up to and including obtaining and serving
+        a final order and in the event of breach leading to the exercise of a power
+        of arrest to representation on the consideration of the breach by the court
+        (but excluding applying for a warrant of arrest, if not attached, and representation
+        in contempt proceedings).","additional_params":[]}}'
+  recorded_at: Thu, 17 Nov 2022 14:31:22 GMT
+recorded_with: VCR 6.1.0

--- a/spec/forms/proceedings/emergency_defaults_form_spec.rb
+++ b/spec/forms/proceedings/emergency_defaults_form_spec.rb
@@ -182,6 +182,39 @@ RSpec.describe Proceedings::EmergencyDefaultsForm, type: :form, vcr: { cassette_
           end
         end
 
+        context "and the proceeding already has scope limitations" do
+          before do
+            proceeding.scope_limitations.create!(
+              scope_type: 1,
+              code: "CV118",
+              meaning: "Hearing",
+              description: "Limited to all steps up to and including the hearing on [see additional limitation notes]",
+            )
+          end
+
+          let(:skip_subject) { true }
+          let(:params) do
+            {
+              accepted_emergency_defaults: true,
+              emergency_level_of_service: 3,
+              emergency_level_of_service_name: "Full Representation",
+              emergency_level_of_service_stage: 8,
+              hearing_date_3i: Date.yesterday.day,
+              hearing_date_2i: Date.yesterday.month,
+              hearing_date_1i: Date.yesterday.year,
+            }
+          end
+
+          it "deletes the existing emergency scope limitations and creates one new emergency scope limitation" do
+            save_form
+            expect(proceeding.scope_limitations.where(scope_type: :emergency).count).to eq 1
+            expect(proceeding.scope_limitations.find_by(scope_type: :emergency)).to have_attributes(code: "CV117",
+                                                                                                    meaning: "Interim order inc. return date",
+                                                                                                    description: "Limited to all steps necessary to apply for an interim order; where application is made without notice to include representation on the return date.",
+                                                                                                    hearing_date: Date.yesterday)
+          end
+        end
+
         context "without calling the subject" do
           let(:skip_subject) { true }
 

--- a/spec/forms/proceedings/substantive_defaults_form_spec.rb
+++ b/spec/forms/proceedings/substantive_defaults_form_spec.rb
@@ -42,6 +42,27 @@ RSpec.describe Proceedings::SubstantiveDefaultsForm, :vcr, type: :form do
                                                                                                       description: "As to proceedings under Part IV Family Law Act 1996 limited to all steps up to and including obtaining and serving a final order and in the event of breach leading to the exercise of a power of arrest to representation on the consideration of the breach by the court (but excluding applying for a warrant of arrest, if not attached, and representation in contempt proceedings).")
           end
         end
+
+        context "when the proceeding already has scope limitations" do
+          before do
+            proceeding.scope_limitations.create!(
+              scope_type: 0,
+              code: "CV118",
+              meaning: "Hearing",
+              description: "Limited to all steps up to and including the hearing on [see additional limitation notes]",
+            )
+          end
+
+          let(:skip_subject) { true }
+
+          it "deletes the existing substantive scope limitations and creates one new substantive scope limitation" do
+            save_form
+            expect(proceeding.scope_limitations.where(scope_type: :substantive).count).to eq 1
+            expect(proceeding.scope_limitations.find_by(scope_type: :substantive)).to have_attributes(code: "AA019",
+                                                                                                      meaning: "Injunction FLA-to final hearing",
+                                                                                                      description: "As to proceedings under Part IV Family Law Act 1996 limited to all steps up to and including obtaining and serving a final order and in the event of breach leading to the exercise of a power of arrest to representation on the consideration of the breach by the court (but excluding applying for a warrant of arrest, if not attached, and representation in contempt proceedings).")
+          end
+        end
       end
 
       context "and the user rejects the defaults" do


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3624)

It is possible that the user has already entered non-default scope limitations when they arrive at the default scope limitation page (e.g. if they use the back button). The application was adding the default scope limitation in addition to any existing scope limitations. Instead, delete any existing scope limitations. This applies to both substantive and emergency scope limitations.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
