### PR TITLE
Update schema.rb to reflect production

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -111,9 +111,9 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_13_212453) do
     t.string "unlock_token"
     t.datetime "locked_at", precision: nil
     t.string "true_layer_secure_data_id"
+    t.boolean "employed"
     t.datetime "remember_created_at", precision: nil
     t.string "remember_token"
-    t.boolean "employed"
     t.boolean "self_employed", default: false
     t.boolean "armed_forces", default: false
     t.boolean "has_national_insurance_number"
@@ -558,9 +558,9 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_13_212453) do
     t.boolean "no_cash_income"
     t.boolean "no_cash_outgoings"
     t.date "purgeable_on"
+    t.string "required_document_categories", default: [], null: false, array: true
     t.boolean "extra_employment_information"
     t.string "extra_employment_information_details"
-    t.string "required_document_categories", default: [], null: false, array: true
     t.string "full_employment_details"
     t.datetime "client_declaration_confirmed_at", precision: nil
     t.boolean "substantive_cost_override"
@@ -614,7 +614,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_13_212453) do
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.boolean "scanner_working"
-    t.index ["uploader_type", "uploader_id"], name: "index_malware_scan_results_on_uploader"
+    t.index ["uploader_type", "uploader_id"], name: "index_malware_scan_results_on_uploader_type_and_uploader_id"
   end
 
   create_table "matter_oppositions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -723,6 +723,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_13_212453) do
     t.string "category_of_law", null: false
     t.string "category_law_code", null: false
     t.string "ccms_matter_code"
+    t.string "client_involvement_type_ccms_code"
+    t.string "client_involvement_type_description"
     t.boolean "used_delegated_functions"
     t.integer "emergency_level_of_service"
     t.string "emergency_level_of_service_name"
@@ -732,8 +734,6 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_13_212453) do
     t.integer "substantive_level_of_service_stage"
     t.boolean "accepted_emergency_defaults"
     t.boolean "accepted_substantive_defaults"
-    t.string "client_involvement_type_ccms_code"
-    t.string "client_involvement_type_description"
     t.index ["legal_aid_application_id"], name: "index_proceedings_on_legal_aid_application_id"
     t.index ["proceeding_case_id"], name: "index_proceedings_on_proceeding_case_id", unique: true
   end


### PR DESCRIPTION
1. Timestamp precision

This was originally addressed in 22fe6852d095d7d096d1de790af58413e0187bd0 but
the changes were since merged in a different change inadvertently.

Since Rails 7.0, datetime column precision is set to 6 by default.

This means `t.datetime "partied_at"` would generate a column in postgres of
`timestamp(6) without time zone` type.

Before Rails 7.0, datatime column precision was set to nil by default.

This meant `t.datetime "partied_at"` would have generated a column in postgres
of `timestamp without time zone` type.

It seems that we always used the default, which means any datetime columns added
to the database **before** Rails 7.0 have a type without any precision, but any
datetime columns added to the database **after** Rails 7.0 have a type with
precision (6).

Currently our schema suggests that all datetime columns in the database have
precision (6), but this isn't the case.

This updates the datetime columns in the schema to reflect that some columns
have a type without precision (nil) while others have a type with precision (6).

2. Nullable columns

This was originally addressed in ebdf9e8522ab65cbee8881ab0a2fed6131ebe452 but
the changes were since merged in a different change inadvertently.

These columns were added as nullable string columns in #4048, but for some
reason the schema did not reflect this until #4530.

Since then, #4529 undid the change in #4530, so this redoes the change again.

Before, the columns were nullable but specified as `null: false` in the schema.

Now, they are still nullable, and the schema reflects that.

3. Column ordering

Less significant, but discrepancies between production and the schema make
conflicts more likely and make it harder to ensure the correct changes are added
to the schema after running migrations.

4. Misnamed index

The index is named unconventionally in the schema. It has been updated to
reflect the naming in production.