### PR TITLE
Update schema.rb to reflect nullable columns

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -710,8 +710,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_10_161139) do
     t.string "category_of_law", null: false
     t.string "category_law_code", null: false
     t.string "ccms_matter_code"
-    t.string "client_involvement_type_ccms_code", null: false
-    t.string "client_involvement_type_description", null: false
+    t.string "client_involvement_type_ccms_code"
+    t.string "client_involvement_type_description"
     t.boolean "used_delegated_functions"
     t.integer "emergency_level_of_service"
     t.string "emergency_level_of_service_name"


### PR DESCRIPTION
These columns were added as nullable string columns in #4048, but for some reason the schema did not reflect this until #4530.

Since then, #4529 undid the change in #4530, so this redoes the change again.

Before, the columns were nullable but specified as `null: false` in the schema.

Now, they are still nullable, and the schema reflects that.