### PR TITLE
Ignore soon to be deleted columns

### DIFF
--- a/app/models/proceeding_merits_task/attempts_to_settle.rb
+++ b/app/models/proceeding_merits_task/attempts_to_settle.rb
@@ -1,5 +1,7 @@
 module ProceedingMeritsTask
   class AttemptsToSettle < ApplicationRecord
+    self.ignored_columns += %w[application_proceeding_type_id]
+
     belongs_to :proceeding
   end
 end

--- a/app/models/proceeding_merits_task/chances_of_success.rb
+++ b/app/models/proceeding_merits_task/chances_of_success.rb
@@ -1,5 +1,7 @@
 module ProceedingMeritsTask
   class ChancesOfSuccess < ApplicationRecord
+    self.ignored_columns += %w[application_proceeding_type_id]
+
     belongs_to :proceeding
 
     PRETTY_SUCCESS_PROSPECTS = {


### PR DESCRIPTION
The `application_proceeding_types` table was dropped in #3427, but associated columns were not removed from the `chances_of_successes` and `attempts_to_settles` tables.

This ignores the column in both models, so that the columns can be safely removed in a subsequent change.