### PR TITLE
Stop ignoring columns

### DIFF
--- a/app/models/proceeding_merits_task/attempts_to_settle.rb
+++ b/app/models/proceeding_merits_task/attempts_to_settle.rb
@@ -1,7 +1,5 @@
 module ProceedingMeritsTask
   class AttemptsToSettle < ApplicationRecord
-    self.ignored_columns += %w[application_proceeding_type_id]
-
     belongs_to :proceeding
   end
 end

--- a/app/models/proceeding_merits_task/chances_of_success.rb
+++ b/app/models/proceeding_merits_task/chances_of_success.rb
@@ -1,7 +1,5 @@
 module ProceedingMeritsTask
   class ChancesOfSuccess < ApplicationRecord
-    self.ignored_columns += %w[application_proceeding_type_id]
-
     belongs_to :proceeding
 
     PRETTY_SUCCESS_PROSPECTS = {


### PR DESCRIPTION
These columns were ignored so they could be removed safely.

They have since been removed in #4595, so we can stop ignoring the columns.