### PR TITLE
Address Rubocop erblint failures in app/views/admin

### DIFF
--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -10,7 +10,6 @@ linters:
   Rubocop:
     enabled: true
     exclude:
-      - "**/app/views/admin/**/*"
       - "**/app/views/citizens/**/*"
       - "**/app/views/providers/**/*"
       - "**/app/views/shared/**/*"

--- a/app/views/admin/feedback/_feedbacks.erb
+++ b/app/views/admin/feedback/_feedbacks.erb
@@ -3,21 +3,21 @@
       <table class="govuk-table">
         <thead class="govuk-table__head">
           <tr class="govuk-table__row">
-            <th class="govuk-table__header govuk-!-width-one-quarter" scope="col"><%= t('.done_eveything') %></th>
-            <th class="govuk-table__header" scope="col"><%= t('.satisfaction') %></th>
-            <th class="govuk-table__header" scope="col"><%= t('.suggestion') %></th>
-            <th class="govuk-table__header" scope="col"><%= t('.source') %></th>
+            <th class="govuk-table__header govuk-!-width-one-quarter" scope="col"><%= t(".done_eveything") %></th>
+            <th class="govuk-table__header" scope="col"><%= t(".satisfaction") %></th>
+            <th class="govuk-table__header" scope="col"><%= t(".suggestion") %></th>
+            <th class="govuk-table__header" scope="col"><%= t(".source") %></th>
           </tr>
         </thead>
         <tbody class="govuk-table__body">
           <% @feedback.each do |feedback| %>
             <tr class="govuk-table__row">
               <td class="govuk-table__cell feedback-done-all-needed">
-                <%= feedback.done_all_needed.nil? ? t('generic.not_completed') : feedback.done_all_needed.to_s %>
+                <%= feedback.done_all_needed.nil? ? t("generic.not_completed") : feedback.done_all_needed.to_s %>
               </td>
-              <td class="govuk-table__cell feedback-satisfaction"><%= feedback.satisfaction&.humanize || t('generic.not_completed') %></td>
+              <td class="govuk-table__cell feedback-satisfaction"><%= feedback.satisfaction&.humanize || t("generic.not_completed") %></td>
               <td class="govuk-table__cell feedback-improvement-suggestion">
-                <%= feedback.improvement_suggestion.present? ? feedback.improvement_suggestion : t('generic.not_completed') %>
+                <%= feedback.improvement_suggestion.presence || t("generic.not_completed") %>
               </td>
               <td class="govuk-table__cell feedback-satisfaction"><%= feedback.source %></td>
             </tr>

--- a/app/views/admin/feedback/show.html.erb
+++ b/app/views/admin/feedback/show.html.erb
@@ -1,11 +1,11 @@
 <%= page_template(
-      page_title: t('.heading_1'),
+      page_title: t(".heading_1"),
       column_width: :full,
-      back_link: :none
+      back_link: :none,
     ) do %>
   <% if @feedback.present? %>
-    <%= render 'feedbacks', pagy: @pagy %>
+    <%= render "feedbacks", pagy: @pagy %>
   <% else %>
-    <h2><%= t('.no_feedback') %></h2>
+    <h2><%= t(".no_feedback") %></h2>
   <% end %>
 <% end %>

--- a/app/views/admin/firms/index.html.erb
+++ b/app/views/admin/firms/index.html.erb
@@ -1,6 +1,6 @@
 <%= govuk_fieldset_header do %>
   <h1 class="govuk-fieldset__heading">
-    <%= label_tag(t('.heading_1'), page_title) %>
+    <%= label_tag(t(".heading_1"), page_title) %>
   </h1>
 <% end %>
 
@@ -9,10 +9,10 @@
     <table class="govuk-table">
       <thead class="govuk-table__head">
         <tr class="govuk-table__row">
-          <th class="govuk-table__header govuk-!-width-one-quarter" scope="col"><%= t('.firm') %></th>
-          <th class="govuk-table__header" scope="col"><%= t('.num_users') %></th>
-          <th class="govuk-table__header govuk-!-width-one-half" scope="col"><%= t('.permissions') %></th>
-          <th class="govuk-table__header" scope="col"><%= t('.action') %></th>
+          <th class="govuk-table__header govuk-!-width-one-quarter" scope="col"><%= t(".firm") %></th>
+          <th class="govuk-table__header" scope="col"><%= t(".num_users") %></th>
+          <th class="govuk-table__header govuk-!-width-one-half" scope="col"><%= t(".permissions") %></th>
+          <th class="govuk-table__header" scope="col"><%= t(".action") %></th>
         </tr>
       </thead>
 
@@ -28,7 +28,14 @@
                 <% end %>
               </ul>
             </td>
-            <td class="govuk-table__cell"><%= link_to_accessible t('.view_users'), admin_firm_providers_path(firm), id: "firm-#{firm.id}", method: :get %></td>
+            <td class="govuk-table__cell">
+              <%= link_to_accessible(
+                    t(".view_users"),
+                    admin_firm_providers_path(firm),
+                    id: "firm-#{firm.id}",
+                    method: :get,
+                  ) %>
+            </td>
           </tr>
         <% end %>
       </tbody>

--- a/app/views/admin/legal_aid_applications/_legal_aid_applications.html.erb
+++ b/app/views/admin/legal_aid_applications/_legal_aid_applications.html.erb
@@ -1,14 +1,14 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <table class="govuk-table">
-      <caption class="govuk-table__caption"><%= t('.latest_applications') %></caption>
+      <caption class="govuk-table__caption"><%= t(".latest_applications") %></caption>
       <thead class="govuk-table__head">
         <tr class="govuk-table__row">
-          <th class="govuk-table__header" scope="col"><%= t('.applicant_name') %></th>
-          <th class="govuk-table__header" scope="col"><%= t('.created_at') %></th>
-          <th class="govuk-table__header" scope="col"><%= t('.application_ref') %></th>
-          <th class="govuk-table__header" scope="col"><%= t('.status') %></th>
-          <th class="govuk-table__header" scope="col"><%= t('.provider_username') %></th>
+          <th class="govuk-table__header" scope="col"><%= t(".applicant_name") %></th>
+          <th class="govuk-table__header" scope="col"><%= t(".created_at") %></th>
+          <th class="govuk-table__header" scope="col"><%= t(".application_ref") %></th>
+          <th class="govuk-table__header" scope="col"><%= t(".status") %></th>
+          <th class="govuk-table__header" scope="col"><%= t(".provider_username") %></th>
           <th class="govuk-table__header" scope="col"></th>
           <th class="govuk-table__header" scope="col"></th>
         </tr>
@@ -16,27 +16,29 @@
       <tbody class="govuk-table__body">
         <% @applications.each do |application| %>
           <tr class="govuk-table__row">
-            <td class="govuk-table__cell case-full-name"><%= application.applicant_full_name || t('generic.undefined') %></td>
+            <td class="govuk-table__cell case-full-name"><%= application.applicant_full_name || t("generic.undefined") %></td>
             <td class="govuk-table__cell"><%= l(application.created_at.to_date, format: :long_date) %></td>
             <td class="govuk-table__cell case-reference-number"><%= application.application_ref %></td>
             <td class="govuk-table__cell"><%= application.enum_t(:state) %></td>
             <td class="govuk-table__cell"><%= mail_to application.provider.email, application.provider.username %></td>
             <td class="govuk-table__cell">
-              <%= t('.discarded', date: application.discarded_at.strftime('%d-%m-%Y')) if application.discarded? %>
-              <%= button_to_accessible(
-                t('.delete'),
-                admin_legal_aid_application_path(application.id),
-                method: :delete,
-                class: 'govuk-button govuk-button--warning request-delete-button',
-                "data-application-id": application.id,
-                "data-original-text": t('.delete'),
-                "data-delete-name": "#{t('.applicant_name')}: #{application.applicant_full_name || t('generic.undefined')}",
-                "data-delete-ref": "#{t('.application_ref')}: #{application.application_ref}",
-                "data-delete-message": t('.warning.delete')
-              ) if destroy_enabled? %>
+              <%= t(".discarded", date: application.discarded_at.strftime("%d-%m-%Y")) if application.discarded? %>
+              <%= if destroy_enabled?
+                    button_to_accessible(
+                      t(".delete"),
+                      admin_legal_aid_application_path(application.id),
+                      method: :delete,
+                      class: "govuk-button govuk-button--warning request-delete-button",
+                      "data-application-id": application.id,
+                      "data-original-text": t(".delete"),
+                      "data-delete-name": "#{t('.applicant_name')}: #{application.applicant_full_name || t('generic.undefined')}",
+                      "data-delete-ref": "#{t('.application_ref')}: #{application.application_ref}",
+                      "data-delete-message": t(".warning.delete"),
+                    )
+                  end %>
              </td>
             <td class="govuk-table__cell">
-              <%= link_to_accessible t('.data_view'), admin_legal_aid_applications_submission_path(application), class: 'govuk-button govuk-!-margin-bottom-0' %>
+              <%= link_to_accessible t(".data_view"), admin_legal_aid_applications_submission_path(application), class: "govuk-button govuk-!-margin-bottom-0" %>
             </td>
           </tr>
         <% end %>

--- a/app/views/admin/legal_aid_applications/index.html.erb
+++ b/app/views/admin/legal_aid_applications/index.html.erb
@@ -1,11 +1,11 @@
 <%= page_template(
-      page_title: t('.heading_1'),
+      page_title: t(".heading_1"),
       column_width: :full,
-      back_link: :none
+      back_link: :none,
     ) do %>
-  <%= render partial: 'shared/error' if @error %>
+  <%= render partial: "shared/error" if @error %>
 
-  <div id="confirm-delete" class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary" data-cancel-text="<%= t('.cancel_delete') %>" hidden>
+  <div id="confirm-delete" class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary" data-cancel-text="<%= t(".cancel_delete") %>" hidden>
     <h2 class="govuk-error-summary__title" id="error-summary-title">
       <span id="delete-message"></span>
     </h2>
@@ -16,50 +16,56 @@
 
     <%= govuk_inset_text(text: t(".warning.delete_consequence")) %>
 
-    <%= button_to_accessible(
-          t('.confirm_delete'),
-          nil,
-          method: :delete,
-          class: 'govuk-button govuk-button--warning govuk-!-margin-bottom-1 govuk-!-margin-top-4',
-          id: 'confirm-delete-button',
-          disabled: 'true'
-        ) if destroy_enabled? %>
+    <%= if destroy_enabled?
+          button_to_accessible(
+            t(".confirm_delete"),
+            nil,
+            method: :delete,
+            class: "govuk-button govuk-button--warning govuk-!-margin-bottom-1 govuk-!-margin-top-4",
+            id: "confirm-delete-button",
+            disabled: "true",
+          )
+        end %>
   </div>
 
-  <%= button_to_accessible(
-        t('generic.create_test_applications'),
-        create_test_applications_admin_legal_aid_applications_path,
-        method: :post,
-        class: 'govuk-button'
-      ) if create_test_applications_enabled? %>
+  <%= if create_test_applications_enabled?
+        button_to_accessible(
+          t("generic.create_test_applications"),
+          create_test_applications_admin_legal_aid_applications_path,
+          method: :post,
+          class: "govuk-button",
+        )
+      end %>
 
-  <%= button_to_accessible(
-        t('.delete_all'),
-        destroy_all_admin_legal_aid_applications_path,
-        method: :delete,
-        class: 'govuk-button govuk-button--warning request-delete-button',
-        "data-original-text": t('.delete_all'),
-        "data-application-id": 'destroy_all',
-        "data-delete-message": t('.warning.delete_all')
-      ) if @applications.present? && destroy_enabled? %>
+  <%= if @applications.present? && destroy_enabled?
+        button_to_accessible(
+          t(".delete_all"),
+          destroy_all_admin_legal_aid_applications_path,
+          method: :delete,
+          class: "govuk-button govuk-button--warning request-delete-button",
+          "data-original-text": t(".delete_all"),
+          "data-application-id": "destroy_all",
+          "data-delete-message": t(".warning.delete_all"),
+        )
+      end %>
 <% end %>
 
 <%= form_with(
       url: admin_application_search_path,
       method: :post,
-      local: true
+      local: true,
     ) do |form| %>
 
     <%= form.govuk_text_field :search,
-                              label: {text: t('.search.label')},
-                              hint: {text: t('.search.hint')},
+                              label: { text: t(".search.label") },
+                              hint: { text: t(".search.hint") },
                               width: 20,
-                              value: params['search'] || '' %>
-    <%= form.govuk_submit t('generic.search') %>
+                              value: params["search"] || "" %>
+    <%= form.govuk_submit t("generic.search") %>
 <% end %>
 
 <% if @applications.present? %>
-  <%= render 'legal_aid_applications', pagy: @pagy %>
+  <%= render "legal_aid_applications", pagy: @pagy %>
 <% else %>
-  <h2 class="govuk-heading-m"><%= t('.no_applications') %></h2>
+  <h2 class="govuk-heading-m"><%= t(".no_applications") %></h2>
 <% end %>

--- a/app/views/admin/legal_aid_applications/submissions/show.html.erb
+++ b/app/views/admin/legal_aid_applications/submissions/show.html.erb
@@ -1,4 +1,4 @@
-<%= back_link() %>
+<%= back_link %>
 <div class='govuk-body'>
   <h1 class="govuk-heading-l">Legal Aid Application</h1>
   <dl class="govuk-body kvp">
@@ -11,11 +11,11 @@
   <dl class="govuk-body kvp">
     <% if @legal_aid_application&.means_report&.document.present? %>
       <dt>Means report</dt>
-      <dd><%= link_to_accessible('Download means report', download_means_report_admin_legal_aid_applications_submission_path(@legal_aid_application)) %></dd>
+      <dd><%= link_to_accessible("Download means report", download_means_report_admin_legal_aid_applications_submission_path(@legal_aid_application)) %></dd>
     <% end %>
     <% if @legal_aid_application&.merits_report&.document.present? %>
       <dt>Merits report</dt>
-      <dd><%= link_to_accessible('Download merits report', download_merits_report_admin_legal_aid_applications_submission_path(@legal_aid_application)) %>
+      <dd><%= link_to_accessible("Download merits report", download_merits_report_admin_legal_aid_applications_submission_path(@legal_aid_application)) %>
     <% end %>
     <% if @legal_aid_application&.hmrc_responses.any? %>
       <% @legal_aid_application.hmrc_responses.each do |hmrc_response| %>
@@ -28,8 +28,8 @@
           <section>
             <% if hmrc_response.response.present? %>
                 <% if hmrc_response&.response['data'].present? %>
-                <% hmrc_response.response['data'].each do |hrr_hash| %>
-                  <% next if hrr_hash.keys.eql?(['individuals/matching/individual']) %>
+                <% hmrc_response.response["data"].each do |hrr_hash| %>
+                  <% next if hrr_hash.keys.eql?(["individuals/matching/individual"]) %>
                   <%= format_hash(hrr_hash) %>
                 <% end %>
               <% else %>
@@ -52,7 +52,7 @@
         <dt>assessment_id</dt>
         <dd><%= cfe_submission.assessment_id %></dd>
         <dt>error message</dt>
-        <dd><%= cfe_submission.error_message ||= 'N/A' %></dd>
+        <dd><%= cfe_submission.error_message ||= "N/A" %></dd>
       </dl>
       <details>
         <section>
@@ -83,16 +83,16 @@
         <dt>Applicant CCMS reference</dt>
         <dd><%= @legal_aid_application.ccms_submission.applicant_ccms_reference %></dd>
         <dt>Applicant poll count</dt>
-        <dd><%= @legal_aid_application.ccms_submission.applicant_poll_count ||= 'N/A' %></dd>
+        <dd><%= @legal_aid_application.ccms_submission.applicant_poll_count ||= "N/A" %></dd>
         <dt>Case poll count</dt>
-        <dd><%= @legal_aid_application.ccms_submission.case_poll_count ||= 'N/A' %></dd>
+        <dd><%= @legal_aid_application.ccms_submission.case_poll_count ||= "N/A" %></dd>
       </dl>
     </section>
     <% if @legal_aid_application.ccms_submission.submission_history.present? %>
       <h2 class="govuk-heading-m">CCMS Submission histories</h2>
         <dl class="govuk-body kvp">
           <% @legal_aid_application.ccms_submission.submission_history.order(:created_at).each do |submission_history| %>
-            <dt>Created <%= submission_history.created_at.strftime('%d %B %Y at %H:%M:%S') %></dt>
+            <dt>Created <%= submission_history.created_at.strftime("%d %B %Y at %H:%M:%S") %></dt>
             <dd><%= submission_history.id %></dd>
             <dt>From state</dt>
             <dd><%= submission_history.from_state %></dd>
@@ -107,11 +107,11 @@
             <dt class="govuk-!-margin-bottom-5"></dt>
             <dd>
               <% if submission_history.request.present? %>
-                <%= link_to_accessible 'Download XML Request', download_xml_request_admin_legal_aid_applications_submission_path(submission_history) %>
+                <%= link_to_accessible "Download XML Request", download_xml_request_admin_legal_aid_applications_submission_path(submission_history) %>
               <% end %>
               <br>
               <% if submission_history.response.present? %>
-                <%= link_to_accessible 'Download XML Response', download_xml_response_admin_legal_aid_applications_submission_path(submission_history) %>
+                <%= link_to_accessible "Download XML Response", download_xml_response_admin_legal_aid_applications_submission_path(submission_history) %>
               <% end %>
             </dd>
         <% end %>

--- a/app/views/admin/providers/index.html.erb
+++ b/app/views/admin/providers/index.html.erb
@@ -1,6 +1,6 @@
 <%= govuk_fieldset_header do %>
   <h1 class="govuk-fieldset__heading">
-    <% title = @firm.present? ? t('.heading_1', firm_name: @firm.name) : t('.all_firms_heading_1') %>
+    <% title = @firm.present? ? t(".heading_1", firm_name: @firm.name) : t(".all_firms_heading_1") %>
     <label for="#{title.downcase}">
       <%= title %>
     </label>
@@ -12,8 +12,8 @@
     <table class="govuk-table">
       <thead class="govuk-table__head">
       <tr class="govuk-table__row">
-        <th class="govuk-table__header" scope="col"><%= t('.username') %></th>
-        <th class="govuk-table__header" scope="col"><%= t('.email_address') %></th>
+        <th class="govuk-table__header" scope="col"><%= t(".username") %></th>
+        <th class="govuk-table__header" scope="col"><%= t(".email_address") %></th>
       </tr>
       </thead>
 

--- a/app/views/admin/reports/index.html.erb
+++ b/app/views/admin/reports/index.html.erb
@@ -1,8 +1,8 @@
 <%= page_template(
-  page_title: t('.heading_1'),
-  column_width: :full,
-  back_link: :none
-  ) do %>
+      page_title: t(".heading_1"),
+      column_width: :full,
+      back_link: :none,
+    ) do %>
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">

--- a/app/views/admin/roles/_form.html.erb
+++ b/app/views/admin/roles/_form.html.erb
@@ -5,11 +5,11 @@
 
   <div class="govuk-grid-column-one-third control-column">
     <%= button_to_accessible(
-            t('generic.select_and_continue'),
-            admin_roles_permission_path(provider_firm.id),
-            method: :get,
-            tabindex: '-1',
-            class: 'govuk-button govuk-!-margin-top-4'
+          t("generic.select_and_continue"),
+          admin_roles_permission_path(provider_firm.id),
+          method: :get,
+          tabindex: "-1",
+          class: "govuk-button govuk-!-margin-top-4",
         ) %>
   </div>
 

--- a/app/views/admin/roles/index.html.erb
+++ b/app/views/admin/roles/index.html.erb
@@ -1,8 +1,8 @@
 <%= page_template(
-  page_title: t('.heading_1'),
-  column_width: :full,
-  back_link: :none
-  ) do %>
+      page_title: t(".heading_1"),
+      column_width: :full,
+      back_link: :none,
+    ) do %>
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
@@ -11,13 +11,13 @@
           <%= form_tag(admin_roles_path, method: :get, name: "firm-search-input") do %>
             <%= text_field_tag(:search, params[:search], class: "govuk-input", autocomplete: "off") %>
         </div>
-            <%= submit_tag ("Search"), name: nil, class: 'govuk-button' %>
-      </div>
+            <%= submit_tag "Search", name: nil, class: "govuk-button" %>
           <% end %>
+      </div>
 
       <div class="govuk-grid-row govuk-!-margin-top-0">
         <ul id="firms-list" class="govuk-grid-column-full govuk-list govuk-!-margin-bottom-0">
-          <%= render partial: 'form', collection: @provider_firms, as: :provider_firm %>
+          <%= render partial: "form", collection: @provider_firms, as: :provider_firm %>
         </ul>
       </div>
     </div>

--- a/app/views/admin/roles/permissions/show.html.erb
+++ b/app/views/admin/roles/permissions/show.html.erb
@@ -1,14 +1,14 @@
 <%= page_template(
-  page_title: t('.heading_1', firm_name: @firm.name),
-  column_width: :full,
-  back_link: :none
-  ) do %>
+      page_title: t(".heading_1", firm_name: @firm.name),
+      column_width: :full,
+      back_link: :none,
+    ) do %>
 
   <%= form_with(
-          model: @firm,
-          url: admin_roles_permission_path,
-          method: :patch,
-          local: true
+        model: @firm,
+        url: admin_roles_permission_path,
+        method: :patch,
+        local: true,
       ) do |form| %>
 
     <div class="govuk-!-margin-top-0govuk-!-padding-bottom-2">
@@ -19,8 +19,8 @@
               <% for perm in @permissions %>
                   <div class="govuk-checkboxes">
                     <div class="govuk-checkboxes__item">
-                      <%= check_box_tag  "firm[permission_ids][]", perm.id, @firm.permissions.include?(perm), class: 'govuk-checkboxes__input' %>
-                      <%= label_tag perm.role, perm.description, class: 'govuk-label govuk-checkboxes__label' %>
+                      <%= check_box_tag "firm[permission_ids][]", perm.id, @firm.permissions.include?(perm), class: "govuk-checkboxes__input" %>
+                      <%= label_tag perm.role, perm.description, class: "govuk-label govuk-checkboxes__label" %>
                     </div>
                   </div>
                 <br>
@@ -34,8 +34,8 @@
     <div class="govuk-!-padding-bottom-4"></div>
 
     <%= next_action_buttons(
-            form: form,
-            show_draft: false
+          form:,
+          show_draft: false,
         ) %>
   <% end %>
 <% end %>

--- a/app/views/admin/settings/show.html.erb
+++ b/app/views/admin/settings/show.html.erb
@@ -1,9 +1,9 @@
-<%= page_template page_title: t('.heading_1'), back_link: :none do %>
+<%= page_template page_title: t(".heading_1"), back_link: :none do %>
   <%= form_with(
         model: @form,
         url: admin_settings_path,
         method: :patch,
-        local: true
+        local: true,
       ) do |form| %>
 
     <%= form.govuk_collection_radio_buttons(
@@ -12,39 +12,39 @@
           :value,
           :label,
           inline: true,
-          hint: { text: t('.hints.mock_true_layer_data', bank_transaction_filename: Setting.bank_transaction_filename)},
-          legend: { text: t('.labels.mock_true_layer_data') }
+          hint: { text: t(".hints.mock_true_layer_data", bank_transaction_filename: Setting.bank_transaction_filename) },
+          legend: { text: t(".labels.mock_true_layer_data") },
         ) %>
 
     <%= form.govuk_collection_radio_buttons(
-      :manually_review_all_cases,
-      yes_no_options,
-      :value,
-      :label,
-      inline: true,
-      hint: { text: t('.hints.manually_review_all_cases')},
-      legend: { text: t('.labels.manually_review_all_cases') }
-    ) %>
+          :manually_review_all_cases,
+          yes_no_options,
+          :value,
+          :label,
+          inline: true,
+          hint: { text: t(".hints.manually_review_all_cases") },
+          legend: { text: t(".labels.manually_review_all_cases") },
+        ) %>
 
     <%= form.govuk_collection_radio_buttons(
-      :allow_welsh_translation,
-      yes_no_options,
-      :value,
-      :label,
-      inline: true,
-      hint: { text: t('.hints.allow_welsh_translation')},
-      legend: { text: t('.labels.allow_welsh_translation') }
-    ) %>
+          :allow_welsh_translation,
+          yes_no_options,
+          :value,
+          :label,
+          inline: true,
+          hint: { text: t(".hints.allow_welsh_translation") },
+          legend: { text: t(".labels.allow_welsh_translation") },
+        ) %>
 
     <%= form.govuk_collection_radio_buttons(
-        :enable_ccms_submission,
-        yes_no_options,
-        :value,
-        :label,
-        inline: true,
-        hint: { text: t('.hints.enable_ccms_submission')},
-        legend: { text: t('.labels.enable_ccms_submission') }
-    ) %>
+          :enable_ccms_submission,
+          yes_no_options,
+          :value,
+          :label,
+          inline: true,
+          hint: { text: t(".hints.enable_ccms_submission") },
+          legend: { text: t(".labels.enable_ccms_submission") },
+        ) %>
 
     <%= form.govuk_collection_radio_buttons(
           :enable_mini_loop,
@@ -52,8 +52,8 @@
           :value,
           :label,
           inline: true,
-          hint: { text: t('.hints.enable_mini_loop')},
-          legend: { text: t('.labels.enable_mini_loop') }
+          hint: { text: t(".hints.enable_mini_loop") },
+          legend: { text: t(".labels.enable_mini_loop") },
         ) %>
 
     <%= form.govuk_collection_radio_buttons(
@@ -62,8 +62,8 @@
           :value,
           :label,
           inline: true,
-          hint: { text: t('.hints.enable_loop')},
-          legend: { text: t('.labels.enable_loop') }
+          hint: { text: t(".hints.enable_loop") },
+          legend: { text: t(".labels.enable_loop") },
         ) %>
 
     <%= form.govuk_collection_radio_buttons(
@@ -72,8 +72,8 @@
           :value,
           :label,
           inline: true,
-          hint: { text: t('.hints.enhanced_bank_upload')},
-          legend: { text: t('.labels.enhanced_bank_upload') }
+          hint: { text: t(".hints.enhanced_bank_upload") },
+          legend: { text: t(".labels.enhanced_bank_upload") },
         ) %>
 
     <%= form.govuk_collection_radio_buttons(
@@ -82,10 +82,10 @@
           :value,
           :label,
           inline: true,
-          hint: { text: t('.hints.means_test_review_phase_one')},
-          legend: { text: t('.labels.means_test_review_phase_one') }
+          hint: { text: t(".hints.means_test_review_phase_one") },
+          legend: { text: t(".labels.means_test_review_phase_one") },
         ) %>
 
-    <%= form.submit(t('generic.submit'), class: 'govuk-button form-button') %>
+    <%= form.submit(t("generic.submit"), class: "govuk-button form-button") %>
   <% end %>
 <% end %>

--- a/app/views/admin/submitted_applications_reports/_submitted_applications.html.erb
+++ b/app/views/admin/submitted_applications_reports/_submitted_applications.html.erb
@@ -3,18 +3,18 @@
       <table class="govuk-table">
         <thead class="govuk-table__head">
           <tr class="govuk-table__row">
-            <th class="govuk-table__header" scope="col"><%= t('.applicant_name') %></th>
-            <th class="govuk-table__header" scope="col"><%= t('.application_ref') %></th>
-            <th class="govuk-table__header" scope="col"><%= t('.ccms_ref_html') %></th>
-            <th class="govuk-table__header" scope="col"><%= t('.provider_firm') %></th>
-            <th class="govuk-table__header" scope="col"><%= t('.provider_username') %></th>
-            <th class="govuk-table__header" scope="col"><%= t('.submission_date') %></th>
+            <th class="govuk-table__header" scope="col"><%= t(".applicant_name") %></th>
+            <th class="govuk-table__header" scope="col"><%= t(".application_ref") %></th>
+            <th class="govuk-table__header" scope="col"><%= t(".ccms_ref_html") %></th>
+            <th class="govuk-table__header" scope="col"><%= t(".provider_firm") %></th>
+            <th class="govuk-table__header" scope="col"><%= t(".provider_username") %></th>
+            <th class="govuk-table__header" scope="col"><%= t(".submission_date") %></th>
           </tr>
         </thead>
         <tbody class="govuk-table__body">
           <% @applications.each do |application| %>
             <tr class="govuk-table__row">
-              <td class="govuk-table__cell case-full-name"><%= application.applicant_full_name || t('generic.undefined') %></td>
+              <td class="govuk-table__cell case-full-name"><%= application.applicant_full_name || t("generic.undefined") %></td>
               <td class="govuk-table__cell case-reference-number"><%= application.application_ref %></td>
               <td class="govuk-table__cell case-reference-number"><%= application.ccms_submission.case_ccms_reference %></td>
               <td class="govuk-table__cell case-reference-number"><%= application.provider.firm.name %></td>

--- a/app/views/admin/submitted_applications_reports/show.html.erb
+++ b/app/views/admin/submitted_applications_reports/show.html.erb
@@ -1,11 +1,11 @@
 <%= page_template(
-      page_title: t('.heading_1'),
+      page_title: t(".heading_1"),
       column_width: :full,
-      back_link: :none
+      back_link: :none,
     ) do %>
   <% if @applications.present? %>
-    <%= render 'submitted_applications', pagy: @pagy %>
+    <%= render "submitted_applications", pagy: @pagy %>
   <% else %>
-    <h2><%= t('.no_applications') %></h2>
+    <h2><%= t(".no_applications") %></h2>
   <% end %>
 <% end %>

--- a/app/views/admin/user_dashboard/index.html.erb
+++ b/app/views/admin/user_dashboard/index.html.erb
@@ -1,10 +1,10 @@
 <%= govuk_fieldset_header do %>
   <h1 class="govuk-fieldset__heading">
-    <%= label_tag(t('.heading_1'), page_title) %>
+    <%= label_tag(t(".heading_1"), page_title) %>
   </h1>
 <% end %>
 
 <br>
 
-<%= link_to_accessible t('.firm_permissions'), admin_roles_path, class: 'govuk-heading-m', id: 'firm_permissions', method: :get %>
-<%= link_to_accessible t('.firms'), admin_firms_path,  class: 'govuk-heading-m', id: 'firm_permissions', method: :get %>
+<%= link_to_accessible t(".firm_permissions"), admin_roles_path, class: "govuk-heading-m", id: "firm_permissions", method: :get %>
+<%= link_to_accessible t(".firms"), admin_firms_path, class: "govuk-heading-m", id: "firm_permissions", method: :get %>


### PR DESCRIPTION
Before, all templates in `app/views/admin` were excluded from Rubocop linting.

This removes that rule, and resolves all failures.

All failures were resolved with the `--autocorrect` flag, and are all trivial.