### PR TITLE
Address Rubocop erblint failures in app/views/shared

### DIFF
--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -11,8 +11,9 @@ linters:
     enabled: true
     exclude:
       - "**/app/views/providers/**/*"
-      - "**/app/views/shared/**/*"
-      - "**/app/views/shared/*"
+      - "**/app/views/shared/check_answers/*"
+      - "**/app/views/shared/forms/**/*"
+      - "**/app/views/shared/forms/*"
     rubocop_config:
       inherit_from:
         - .rubocop.yml

--- a/app/views/shared/_applicant_declaration.html.erb
+++ b/app/views/shared/_applicant_declaration.html.erb
@@ -1,20 +1,20 @@
-<h2 class="govuk-heading-l"><%= t('.confirm_following') %></h2>
+<h2 class="govuk-heading-l"><%= t(".confirm_following") %></h2>
 
-<p class="govuk-body"><%= t('.submission_list_summary') %>:</p>
+<p class="govuk-body"><%= t(".submission_list_summary") %>:</p>
 
 <ul class="govuk-list govuk-list--bullet print-add-bullet">
-  <% t('.submission_list', firm: @legal_aid_application.provider.firm_name).each_line do |submission| %>
+  <% t(".submission_list", firm: @legal_aid_application.provider.firm_name).each_line do |submission| %>
     <li><%= submission %></li>
   <% end %>
 </ul>
 
 <%= govuk_warning_text do %>
   <p class="govuk-body">
-    <strong><%= t('.warning_list_summary') %>:</strong>
+    <strong><%= t(".warning_list_summary") %>:</strong>
   </p>
 
   <ul class="govuk-list govuk-list--bullet">
-    <% t('.warning_list').each_line do |warning| %>
+    <% t(".warning_list").each_line do |warning| %>
       <li><strong><%= warning %></strong></li>
     <% end %>
   </ul>

--- a/app/views/shared/_application_ref.html.erb
+++ b/app/views/shared/_application_ref.html.erb
@@ -1,7 +1,7 @@
 <dl class="govuk-summary-list govuk-summary-list--no-border">
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">
-      <%= t('.apply_ref') %>
+      <%= t(".apply_ref") %>
     </dt>
     <dd class="govuk-summary-list__value">
       <%= legal_aid_application.application_ref %>
@@ -9,7 +9,7 @@
   </div>
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">
-      <%= t('.ccms_ref_html') %>
+      <%= t(".ccms_ref_html") %>
     </dt>
     <dd class="govuk-summary-list__value">
       <%= legal_aid_application.case_ccms_reference %>

--- a/app/views/shared/_cash_transactions.html.erb
+++ b/app/views/shared/_cash_transactions.html.erb
@@ -3,27 +3,27 @@
 
   <div class="govuk-!-padding-bottom-4"></div>
 
-  <h2 class="govuk-heading-m"><%= t('.cash_heading') %> <%= t(".#{type}").downcase %></h2>
+  <h2 class="govuk-heading-m"><%= t(".cash_heading") %> <%= t(".#{type}").downcase %></h2>
 
-  <div class="govuk-hint"><% t('.cash_hint') %></div>
+  <div class="govuk-hint"><% t(".cash_hint") %></div>
 
   <table class="govuk-table" style="margin-bottom:0px;">
     <thead class="govuk-table__head">
     <tr class="govuk-table__row">
-      <th class="govuk-table__header" scope="col"><%= t('.month') %></th>
-      <th class="govuk-table__header govuk-table__cell--numeric govuk-!-font-weight-bold" scope="col"><%= t('.amount') %></th>
+      <th class="govuk-table__header" scope="col"><%= t(".month") %></th>
+      <th class="govuk-table__header govuk-table__cell--numeric govuk-!-font-weight-bold" scope="col"><%= t(".amount") %></th>
     </tr>
     </thead>
 
     <tbody class="govuk-table__body">
-    <% @cash_transactions.select {|i| i.transaction_type.name == type}.each do |transaction| %>
+    <% @cash_transactions.select { |i| i.transaction_type.name == type }.each do |transaction| %>
       <tr class="govuk-table__row">
-        <td class="govuk-table__cell"><%= l(transaction.transaction_date, format: '%B %Y') %></td>
+        <td class="govuk-table__cell"><%= l(transaction.transaction_date, format: "%B %Y") %></td>
         <td class="govuk-table__cell govuk-table__cell--numeric"><%= gds_number_to_currency(transaction.amount) %></td>
       </tr>
     <% end %>
     <tr class="govuk-table__row">
-      <td class="govuk-table__cell"><strong><%= t('.total') %></strong></td>
+      <td class="govuk-table__cell"><strong><%= t(".total") %></strong></td>
       <td class="govuk-table__cell govuk-table__cell--numeric"><strong>
         <%= gds_number_to_currency CashTransaction.amounts_for_application(@legal_aid_application.id).fetch(type, 0) %>
       </strong></td>

--- a/app/views/shared/_employment_income_table.html.erb
+++ b/app/views/shared/_employment_income_table.html.erb
@@ -1,13 +1,13 @@
 <section class="print-no-break">
-  <h3 class="govuk-heading-m"><%= t('.heading') %></h3>
+  <h3 class="govuk-heading-m"><%= t(".heading") %></h3>
   <table class="govuk-table govuk-!-margin-bottom-3">
     <caption class="govuk-table__caption govuk-!-padding-bottom-2">
-      <%= t('date.date_period', from: date_from(@legal_aid_application), to: date_to(@legal_aid_application)) %>
+      <%= t("date.date_period", from: date_from(@legal_aid_application), to: date_to(@legal_aid_application)) %>
     </caption>
     <tbody class="govuk-table__body">
         <tr class="govuk-table__row">
           <td class="govuk-table__cell">
-            <%= t('.monthly_income_before_tax') %>
+            <%= t(".monthly_income_before_tax") %>
           </td>
           <td class="govuk-table__cell govuk-table__cell--numeric">
             <%= gds_number_to_currency @legal_aid_application.cfe_result.employment_income_gross_income %>
@@ -15,7 +15,7 @@
         </tr>
         <tr class="govuk-table__row">
           <td class="govuk-table__cell">
-            <%= t('.benefits_in_kind') %>
+            <%= t(".benefits_in_kind") %>
           </td>
           <td class="govuk-table__cell govuk-table__cell--numeric">
             <%= gds_number_to_currency @legal_aid_application.cfe_result.employment_income_benefits_in_kind %>
@@ -23,7 +23,7 @@
         </tr>
         <tr class="govuk-table__row">
           <td class="govuk-table__cell">
-            <%= t('.tax') %>
+            <%= t(".tax") %>
           </td>
           <td class="govuk-table__cell govuk-table__cell--numeric">
             <%= gds_number_to_currency @legal_aid_application.cfe_result.employment_income_tax %>
@@ -31,7 +31,7 @@
         </tr>
         <tr class="govuk-table__row">
           <td class="govuk-table__cell">
-            <%= t('.national_insurance') %>
+            <%= t(".national_insurance") %>
           </td>
           <td class="govuk-table__cell govuk-table__cell--numeric">
             <%= gds_number_to_currency @legal_aid_application.cfe_result.employment_income_national_insurance %>
@@ -40,7 +40,7 @@
         <% if @legal_aid_application.extra_employment_information %>
           <tr class="govuk-table__row">
             <td class="govuk-table__cell">
-              <%= t('.employment_details') %>
+              <%= t(".employment_details") %>
             </td>
             <td class="govuk-table__cell govuk-table__cell--numeric">
               <%= gds_number_to_currency @legal_aid_application.extra_employment_information_details %>

--- a/app/views/shared/_error.html.erb
+++ b/app/views/shared/_error.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-error-summary" id="error_explanation" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
   <h2 class="govuk-error-summary__title" id="error-summary-title">
-    <%= t('generic.errors.problem_text') %>
+    <%= t("generic.errors.problem_text") %>
   </h2>
   <div class="govuk-error-summary__body">
     <ul class="govuk-list govuk-error-summary__list">

--- a/app/views/shared/_irregular_incomes_table.html.erb
+++ b/app/views/shared/_irregular_incomes_table.html.erb
@@ -4,7 +4,7 @@
     <section class="print-no-break">
       <table class="govuk-table govuk-!-margin-bottom-3">
         <caption class="govuk-table__caption govuk-!-padding-bottom-2">
-          <%= t('date.date_period', from: period.first, to: period.last) %>
+          <%= t("date.date_period", from: period.first, to: period.last) %>
         </caption>
         <tbody class="govuk-table__body">
           <% irregular_incomes.each do |irregular_income| %>

--- a/app/views/shared/_other_assets.html.erb
+++ b/app/views/shared/_other_assets.html.erb
@@ -1,12 +1,12 @@
 <% if @cfe_result.liquid_capital_items.any? || @cfe_result.additional_property? %>
-  <h2 class="govuk-heading-m"><%= t('.other_assets') %></h2>
+  <h2 class="govuk-heading-m"><%= t(".other_assets") %></h2>
   <table class="govuk-table">
     <tbody>
       <% @cfe_result.non_liquid_capital_items.each do |item| %>
-        <%= render partial: 'shared/results_detail_row', locals: { caption: item[:description], value: gds_number_to_currency(item[:value]) } %>
+        <%= render partial: "shared/results_detail_row", locals: { caption: item[:description], value: gds_number_to_currency(item[:value]) } %>
       <% end %>
 
-      <%= render partial: 'shared/results_total_row', locals: { caption: t('.assessed_amount'), value: gds_number_to_currency(@cfe_result.total_other_assets) } %>
+      <%= render partial: "shared/results_total_row", locals: { caption: t(".assessed_amount"), value: gds_number_to_currency(@cfe_result.total_other_assets) } %>
     </tbody>
   </table>
 <% end %>

--- a/app/views/shared/_property_results.html.erb
+++ b/app/views/shared/_property_results.html.erb
@@ -1,20 +1,20 @@
-<h2 class="govuk-heading-m"><%= t('.property') %></h2>
+<h2 class="govuk-heading-m"><%= t(".property") %></h2>
 <table class="govuk-table">
   <tbody>
-    <%= render partial: 'shared/results_detail_row', locals: { caption: t('.value'), value: gds_number_to_currency(@cfe_result.main_home_value) } %>
-    <%= render partial: 'shared/results_detail_row', locals: { caption: t('.outstanding_mortgage'), value: gds_number_to_currency(@cfe_result.main_home_outstanding_mortgage) } %>
-    <%= render partial: 'shared/results_detail_row', locals: { caption: t('.disregards'), value: gds_number_to_currency(@cfe_result.main_home_equity_disregard) } %>
-    <%= render partial: 'shared/results_total_row', locals: { caption: t('.assessment_amount'), value: gds_number_to_currency(@cfe_result.main_home_assessed_equity) } %>
+    <%= render partial: "shared/results_detail_row", locals: { caption: t(".value"), value: gds_number_to_currency(@cfe_result.main_home_value) } %>
+    <%= render partial: "shared/results_detail_row", locals: { caption: t(".outstanding_mortgage"), value: gds_number_to_currency(@cfe_result.main_home_outstanding_mortgage) } %>
+    <%= render partial: "shared/results_detail_row", locals: { caption: t(".disregards"), value: gds_number_to_currency(@cfe_result.main_home_equity_disregard) } %>
+    <%= render partial: "shared/results_total_row", locals: { caption: t(".assessment_amount"), value: gds_number_to_currency(@cfe_result.main_home_assessed_equity) } %>
   </tbody>
 </table>
 
 <% if @cfe_result.additional_property? %>
-  <h2 class="govuk-heading-m"><%= t('.additional_property') %></h2>
+  <h2 class="govuk-heading-m"><%= t(".additional_property") %></h2>
   <table class="govuk-table">
     <tbody>
-    <%= render partial: 'shared/results_detail_row', locals: { caption: t('.value'), value: gds_number_to_currency(@cfe_result.additional_property_value) } %>
-    <%= render partial: 'shared/results_detail_row', locals: { caption: t('.outstanding_mortgage'), value: gds_number_to_currency(@cfe_result.additional_property_mortgage) } %>
-    <%= render partial: 'shared/results_total_row', locals: { caption: t('.assessment_amount'), value: gds_number_to_currency(@cfe_result.additional_property_assessed_equity) } %>
+    <%= render partial: "shared/results_detail_row", locals: { caption: t(".value"), value: gds_number_to_currency(@cfe_result.additional_property_value) } %>
+    <%= render partial: "shared/results_detail_row", locals: { caption: t(".outstanding_mortgage"), value: gds_number_to_currency(@cfe_result.additional_property_mortgage) } %>
+    <%= render partial: "shared/results_total_row", locals: { caption: t(".assessment_amount"), value: gds_number_to_currency(@cfe_result.additional_property_assessed_equity) } %>
     </tbody>
   </table>
   <% end %>

--- a/app/views/shared/_provider_header_link.html.erb
+++ b/app/views/shared/_provider_header_link.html.erb
@@ -1,14 +1,14 @@
 <%= menu_button %>
 <ul id="navigation" class="govuk-header__navigation" aria-label="Top Level Navigation">
   <li class="govuk-header__navigation-item">
-    <%= link_to_accessible(current_provider.username, providers_provider_path, class: 'govuk-header__link') %>
+    <%= link_to_accessible(current_provider.username, providers_provider_path, class: "govuk-header__link") %>
   </li>
   <li class="govuk-header__navigation-item">
     <%= button = button_to_accessible(
-          t('layouts.logout.provider'),
+          t("layouts.logout.provider"),
           destroy_provider_session_path,
           method: :delete,
-          class: 'button-as-link govuk-header__link'
+          class: "button-as-link govuk-header__link",
         ) %>
   </li>
 </ul>

--- a/app/views/shared/_restrictions.html.erb
+++ b/app/views/shared/_restrictions.html.erb
@@ -1,11 +1,11 @@
-<h2 class="govuk-heading-m"><%= t('.restrictions') %></h2>
+<h2 class="govuk-heading-m"><%= t(".restrictions") %></h2>
   <tbody>
     <tr>
       <td class="govuk-table__cell govuk-table">
         <% if @legal_aid_application.has_restrictions? %>
           <%= @legal_aid_application.restrictions_details %>
         <% else %>
-          <%= t('.none') %>
+          <%= t(".none") %>
         <% end %>
       </td>
     </tr>

--- a/app/views/shared/_savings_and_investments.html.erb
+++ b/app/views/shared/_savings_and_investments.html.erb
@@ -1,13 +1,13 @@
 <% if @cfe_result.liquid_capital_items.any? %>
-  <h2 class="govuk-heading-m"><%= t('.savings_and_investments') %></h2>
+  <h2 class="govuk-heading-m"><%= t(".savings_and_investments") %></h2>
   <table class="govuk-table">
     <tbody>
       <% @cfe_result.liquid_capital_items.each do |item| %>
         <% if capital_items_to_display?(@legal_aid_application, item) %>
-          <%= render partial: 'shared/results_detail_row', locals: {caption:  item_description(@legal_aid_application, item), value: gds_number_to_currency(item[:value]) } %>
+          <%= render partial: "shared/results_detail_row", locals: { caption: item_description(@legal_aid_application, item), value: gds_number_to_currency(item[:value]) } %>
         <% end %>
       <% end %>
-    <%= render partial: 'shared/results_total_row', locals: { caption: t('.assessed_amount'), value: gds_number_to_currency(@cfe_result.total_savings) } %>
+    <%= render partial: "shared/results_total_row", locals: { caption: t(".assessed_amount"), value: gds_number_to_currency(@cfe_result.total_savings) } %>
     </tbody>
   </table>
 <% end %>

--- a/app/views/shared/_signed_out_header_link.html.erb
+++ b/app/views/shared/_signed_out_header_link.html.erb
@@ -1,9 +1,9 @@
 <ul id="navigation" class="govuk-header__navigation" aria-label="Top Level Navigation">
   <li class="govuk-header__navigation-item">
     <%= button = button_to_accessible(
-        t('layouts.login'),
-        providers_legal_aid_applications_path,
-        class: 'button-as-link govuk-header__link'
-    ) %>
+          t("layouts.login"),
+          providers_legal_aid_applications_path,
+          class: "button-as-link govuk-header__link",
+        ) %>
   </li>
 </ul>

--- a/app/views/shared/_total_capital.html.erb
+++ b/app/views/shared/_total_capital.html.erb
@@ -1,12 +1,12 @@
-<h2 class="govuk-heading-m"><%= t('.total_assessed_capital') %></h2>
+<h2 class="govuk-heading-m"><%= t(".total_assessed_capital") %></h2>
 <table class="govuk-table">
   <tbody>
-  <%= render partial: 'shared/results_detail_row', locals: { caption: t('.property'), value: gds_number_to_currency(@cfe_result.total_property) } %>
-  <%= render partial: 'shared/results_detail_row', locals: { caption: t('.vehicles'), value: gds_number_to_currency(@cfe_result.total_vehicles) } %>
-  <%= render partial: 'shared/results_detail_row', locals: { caption: t('.savings_and_investments'), value: gds_number_to_currency(@cfe_result.total_savings) } %>
-  <%= render partial: 'shared/results_detail_row', locals: { caption: t('.other_assets'), value: gds_number_to_currency(@cfe_result.total_other_assets) } %>
-  <%= render partial: 'shared/results_total_bold_row', locals: { caption: t('.total_capital'), value: gds_number_to_currency(@cfe_result.total_capital_before_pensioner_disregard) } %>
-  <%= render partial: 'shared/results_detail_row', locals: { caption: t('.pensioner_disregard'), value: gds_number_to_currency(@cfe_result.pensioner_capital_disregard) } %>
-  <%= render partial: 'shared/results_total_bold_row', locals: { caption: t('.disposable_capital'), value: gds_number_to_currency(@cfe_result.total_disposable_capital) } %>
+  <%= render partial: "shared/results_detail_row", locals: { caption: t(".property"), value: gds_number_to_currency(@cfe_result.total_property) } %>
+  <%= render partial: "shared/results_detail_row", locals: { caption: t(".vehicles"), value: gds_number_to_currency(@cfe_result.total_vehicles) } %>
+  <%= render partial: "shared/results_detail_row", locals: { caption: t(".savings_and_investments"), value: gds_number_to_currency(@cfe_result.total_savings) } %>
+  <%= render partial: "shared/results_detail_row", locals: { caption: t(".other_assets"), value: gds_number_to_currency(@cfe_result.total_other_assets) } %>
+  <%= render partial: "shared/results_total_bold_row", locals: { caption: t(".total_capital"), value: gds_number_to_currency(@cfe_result.total_capital_before_pensioner_disregard) } %>
+  <%= render partial: "shared/results_detail_row", locals: { caption: t(".pensioner_disregard"), value: gds_number_to_currency(@cfe_result.pensioner_capital_disregard) } %>
+  <%= render partial: "shared/results_total_bold_row", locals: { caption: t(".disposable_capital"), value: gds_number_to_currency(@cfe_result.total_disposable_capital) } %>
   </tbody>
 </table>

--- a/app/views/shared/_worker_complete.html.erb
+++ b/app/views/shared/_worker_complete.html.erb
@@ -1,9 +1,7 @@
-<%
-heading = locals[:heading] || nil
-intro_text = locals[:intro_text] || nil
-balance_text = locals[:balance_text] || nil
-continue_text = locals[:continue_text] || nil
-%>
+<% heading = locals[:heading] || nil %>
+<% intro_text = locals[:intro_text] || nil %>
+<% balance_text = locals[:balance_text] || nil %>
+<% continue_text = locals[:continue_text] || nil %>
 
 <%= page_template page_title: heading do %>
   <p>
@@ -13,7 +11,7 @@ continue_text = locals[:continue_text] || nil
     <%= balance_text %>
   </p>
   <div class="govuk-!-padding-top-3">
-    <%= next_action_link(continue_text: continue_text) %>
+    <%= next_action_link(continue_text:) %>
   </div>
   <span role="status" id="complete"></span>
 <% end %>

--- a/app/views/shared/_worker_failed.html.erb
+++ b/app/views/shared/_worker_failed.html.erb
@@ -1,7 +1,5 @@
-<%
-failed_transactions_retrieval = locals[:failed_transactions_retrieval] || nil
-error_description = locals[:error_description] || nil
-%>
+<% failed_transactions_retrieval = locals[:failed_transactions_retrieval] || nil %>
+<% error_description = locals[:error_description] || nil %>
 
 <%= page_template page_title: failed_transactions_retrieval, column_width: :full do %>
   <div class="govuk-error-summary" role="alert" tabindex="-1" data-module="govuk-error-summary">

--- a/app/views/shared/_worker_working.html.erb
+++ b/app/views/shared/_worker_working.html.erb
@@ -1,8 +1,6 @@
-<%
-retrieving_transactions = locals[:retrieving_transactions] || nil
-worker_id = locals[:worker_id] || nil
-page_loading = locals[:page_loading] || nil
-%>
+<% retrieving_transactions = locals[:retrieving_transactions] || nil %>
+<% worker_id = locals[:worker_id] || nil %>
+<% page_loading = locals[:page_loading] || nil %>
 
 <%= page_template page_title: retrieving_transactions  do %>
   <div class="worker-waiter" data-worker-id="<%= worker_id %>" align="center">

--- a/app/views/shared/assessment_results/_capital_and_income_contribution_required.html.erb
+++ b/app/views/shared/assessment_results/_capital_and_income_contribution_required.html.erb
@@ -5,15 +5,14 @@
 </header>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds"></p>
-    <p class="govuk-body"><%= t('.line_1') %></p>
+    <p class="govuk-body"><%= t(".line_1") %></p>
     <ul class="govuk-list govuk-list--bullet">
         <% t(".details",
-         capital_contribution: gds_number_to_currency(@cfe_result.capital_contribution),
-         income_contribution: gds_number_to_currency(@cfe_result.income_contribution)
-        ).each do |detail| %>
+             capital_contribution: gds_number_to_currency(@cfe_result.capital_contribution),
+             income_contribution: gds_number_to_currency(@cfe_result.income_contribution)).each do |detail| %>
         <li style="color: #fff;"><%= detail %></li>
       <% end %>
     </ul>
-    <p class="govuk-body"><%= t('.line_2') %></p>
+    <p class="govuk-body"><%= t(".line_2") %></p>
   </div>
 </div>

--- a/app/views/shared/assessment_results/_ineligible.html.erb
+++ b/app/views/shared/assessment_results/_ineligible.html.erb
@@ -1,9 +1,9 @@
 <h1 class="govuk-heading-l">
-  <%= t('.heading', name: @legal_aid_application.applicant_full_name) %>
+  <%= t(".heading", name: @legal_aid_application.applicant_full_name) %>
 </h1>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <p class="govuk-body"><%= t('.detail') %></p>
+    <p class="govuk-body"><%= t(".detail") %></p>
   </div>
 </div>

--- a/app/views/shared/assessment_results/_manual_check_required.html.erb
+++ b/app/views/shared/assessment_results/_manual_check_required.html.erb
@@ -1,20 +1,20 @@
 <h1 class="govuk-heading-l">
-  <%= t('.heading', name: @legal_aid_application.applicant_full_name) %>
+  <%= t(".heading", name: @legal_aid_application.applicant_full_name) %>
 </h1>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <% if @legal_aid_application.cfe_result.assessment_result == 'eligible' %>
-      <p class="govuk-body"><%= t('.line1_eligible') %></p>
+      <p class="govuk-body"><%= t(".line1_eligible") %></p>
     <% elsif @details.length > 1 %>
-      <p class="govuk-body"><%= t('.line1_multi') %></p>
+      <p class="govuk-body"><%= t(".line1_multi") %></p>
       <% @details.each do |detail| %>
-        <p class="govuk-body"><%= t('.detail', detail: detail) %></p>
+        <p class="govuk-body"><%= t(".detail", detail:) %></p>
       <% end %>
     <% else %>
-      <p class="govuk-body"><%= t('.line1', detail: @details[0]) %></p>
+      <p class="govuk-body"><%= t(".line1", detail: @details[0]) %></p>
     <% end %>
-    <p class="govuk-body"><%= t('.line2') %></p>
-    <p class="govuk-body"><%= t('.line3') %></p>
+    <p class="govuk-body"><%= t(".line2") %></p>
+    <p class="govuk-body"><%= t(".line3") %></p>
   </div>
 </div>

--- a/app/views/shared/assessment_results/_no_cfe_result.html.erb
+++ b/app/views/shared/assessment_results/_no_cfe_result.html.erb
@@ -1,11 +1,11 @@
 <h1 class="govuk-heading-l">
-  <%= t('.heading') %>
+  <%= t(".heading") %>
 </h1>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <p class="govuk-body"><%= t('.cannot_calculate') %></p>
-    <p class="govuk-body"><%= t('.caseworker_check') %></p>
-    <p class="govuk-body"><%= t('.continue') %></p>
+    <p class="govuk-body"><%= t(".cannot_calculate") %></p>
+    <p class="govuk-body"><%= t(".caseworker_check") %></p>
+    <p class="govuk-body"><%= t(".continue") %></p>
   </div>
 </div>

--- a/app/views/shared/assessment_results/_partially_eligible_capital_income.html.erb
+++ b/app/views/shared/assessment_results/_partially_eligible_capital_income.html.erb
@@ -5,16 +5,15 @@
 </header>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds"></p>
-    <p class="govuk-body"><%= t('.line_1') %></p>
+    <p class="govuk-body"><%= t(".line_1") %></p>
     <ul class="govuk-list govuk-list--bullet">
         <% t(".details",
-         capital_contribution: gds_number_to_currency(@cfe_result.capital_contribution),
-         income_contribution: gds_number_to_currency(@cfe_result.income_contribution)
-        ).each do |detail| %>
+             capital_contribution: gds_number_to_currency(@cfe_result.capital_contribution),
+             income_contribution: gds_number_to_currency(@cfe_result.income_contribution)).each do |detail| %>
         <li style="color: #fff;"><%= detail %></li>
       <% end %>
     </ul>
-    <p class="govuk-body"><%= t('.line_2') %></p>
-    <p class="govuk-body"><%= t('.line_3') %></p>
+    <p class="govuk-body"><%= t(".line_2") %></p>
+    <p class="govuk-body"><%= t(".line_3") %></p>
   </div>
 </div>

--- a/app/views/shared/means/_student_finances.html.erb
+++ b/app/views/shared/means/_student_finances.html.erb
@@ -1,20 +1,20 @@
-<% page_title = journey_type == :providers ? t('.field_set_header_provider') : t('.field_set_header') %>
-<% amount = journey_type == :providers ? t('.amount_provider') : t('.amount') %>
-<% amount_hint = journey_type == :providers ? t('.amount_hint_provider') : t('.amount_hint') %>
-<%= page_template page_title: page_title, form: form, template: :basic do %>
+<% page_title = journey_type == :providers ? t(".field_set_header_provider") : t(".field_set_header") %>
+<% amount = journey_type == :providers ? t(".amount_provider") : t(".amount") %>
+<% amount_hint = journey_type == :providers ? t(".amount_hint_provider") : t(".amount_hint") %>
+<%= page_template page_title:, form:, template: :basic do %>
   <%= form.govuk_radio_buttons_fieldset :student_finance,
-                                        hint: {text: t('.hint')},
-                                        legend: {text: content_for(:page_title), tag: 'h1', size: 'xl'} do %>
-    <%= form.govuk_radio_button(:student_finance, true, label: { text: t('generic.yes') }, checked: @legal_aid_application.student_finance?) do %>
+                                        hint: { text: t(".hint") },
+                                        legend: { text: content_for(:page_title), tag: "h1", size: "xl" } do %>
+    <%= form.govuk_radio_button(:student_finance, true, label: { text: t("generic.yes") }, checked: @legal_aid_application.student_finance?) do %>
       <%= form.govuk_text_field(
-          :amount,
-          hint: {text: amount_hint},
-          label: {text: amount},
-          prefix_text: t('currency.gbp'),
-          width: 'one-quarter'
-      ) %>
+            :amount,
+            hint: { text: amount_hint },
+            label: { text: amount },
+            prefix_text: t("currency.gbp"),
+            width: "one-quarter",
+          ) %>
     <% end %>
-    <%= form.govuk_radio_button(:student_finance, false, label: { text: t('generic.no') } , checked: @legal_aid_application.student_finance == false) %>
+    <%= form.govuk_radio_button(:student_finance, false, label: { text: t("generic.no") }, checked: @legal_aid_application.student_finance == false) %>
   <% end %>
-  <%= next_action_buttons(form: form) %>
+  <%= next_action_buttons(form:) %>
 <% end %>

--- a/app/views/shared/means_report/_item.html.erb
+++ b/app/views/shared/means_report/_item.html.erb
@@ -1,11 +1,9 @@
-<%
-  addendum = local_assigns[:addendum] || nil
-  suppress_border = suppress_border || false
-  css_border_klass = suppress_border ? 'govuk-summary-list__row--no-border' : ''
-%>
+<% addendum = local_assigns[:addendum] || nil %>
+<% suppress_border ||= false %>
+<% css_border_klass = suppress_border ? "govuk-summary-list__row--no-border" : "" %>
 <div class="<%= "govuk-summary-list__row  normal-word-break #{css_border_klass}" %>" id="<%= "means-merits-report__#{name}" %>">
   <dt class="<%= "govuk-summary-list__key govuk-!-width-one-half" %>">
-    <%= t(".#{scope}.#{name}", addendum: addendum) %>
+    <%= t(".#{scope}.#{name}", addendum:) %>
   </dt>
   <!--  in-line styling due to issues around pdf generation in our production envs -->
   <dd class="govuk-summary-list__value govuk-!-text-align-right">

--- a/app/views/shared/page_templates/_basic_page_template.html.erb
+++ b/app/views/shared/page_templates/_basic_page_template.html.erb
@@ -1,4 +1,4 @@
-<%= render(partial: 'shared/forms/error_summary', locals: { model: show_errors_for }) if show_errors_for %>
+<%= render(partial: "shared/forms/error_summary", locals: { model: show_errors_for }) if show_errors_for %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-<%= column_width %>">
     <%= form.govuk_error_summary if form %>

--- a/app/views/shared/page_templates/_default_page_template.html.erb
+++ b/app/views/shared/page_templates/_default_page_template.html.erb
@@ -1,5 +1,5 @@
-<%= render(partial: 'shared/forms/error_summary', locals: { model: show_errors_for }) if show_errors_for %>
-<%= render(partial: 'shared/forms/success_message', locals: { success_message: success_message }) if success_message.present? %>
+<%= render(partial: "shared/forms/error_summary", locals: { model: show_errors_for }) if show_errors_for %>
+<%= render(partial: "shared/forms/success_message", locals: { success_message: }) if success_message.present? %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-<%= column_width %>">
     <%= form.govuk_error_summary if form %>
@@ -12,7 +12,7 @@
         </h2>
       <% end %>
     <% else %>
-      <%= page_heading **page_heading_options %>
+      <%= page_heading(**page_heading_options) %>
     <% end %>
     <%= content %>
   </div>

--- a/app/views/shared/partials/_cookie_banner.html.erb
+++ b/app/views/shared/partials/_cookie_banner.html.erb
@@ -4,23 +4,23 @@
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <h2 class="govuk-cookie-banner__heading govuk-heading-m"><%= t('.title') %></h2>
+        <h2 class="govuk-cookie-banner__heading govuk-heading-m"><%= t(".title") %></h2>
 
         <div class="govuk-cookie-banner__content">
-          <p class="govuk-body"><%= t('.we_use_some') %></p>
-          <p class="govuk-body"><%= t('.wed_also_lie') %></p>
+          <p class="govuk-body"><%= t(".we_use_some") %></p>
+          <p class="govuk-body"><%= t(".wed_also_lie") %></p>
         </div>
       </div>
     </div>
 
     <div class="govuk-button-group">
       <button value="accept" type="button" name="cookies" class="govuk-button" data-module="govuk-button">
-        <%= t('.accept') %>
+        <%= t(".accept") %>
       </button>
       <button value="reject" type="button" name="cookies" class="govuk-button" data-module="govuk-button">
-        <%= t('.reject') %>
+        <%= t(".reject") %>
       </button>
-      <%= link_to_accessible t('.view'), providers_cooky_path(current_provider), class: 'govuk-link' %>
+      <%= link_to_accessible t(".view"), providers_cooky_path(current_provider), class: "govuk-link" %>
     </div>
   </div>
 
@@ -31,9 +31,9 @@
 
         <div class="govuk-cookie-banner__content">
           <p class="govuk-body">
-            <%= t('.accepted') %>
-            <%= link_to_accessible t('.link_text'), providers_cooky_path(current_provider), class: 'govuk-link' %>
-            <%= t('.any_time') %>
+            <%= t(".accepted") %>
+            <%= link_to_accessible t(".link_text"), providers_cooky_path(current_provider), class: "govuk-link" %>
+            <%= t(".any_time") %>
           </p>
         </div>
       </div>
@@ -41,7 +41,7 @@
 
     <div class="govuk-button-group">
       <button value="hide" class="govuk-button" data-module="govuk-button">
-        <%= t('.hide') %>
+        <%= t(".hide") %>
       </button>
     </div>
   </div>
@@ -53,16 +53,16 @@
 
         <div class="govuk-cookie-banner__content">
           <p class="govuk-body">
-            <%= t('.rejected') %>
-            <%= link_to_accessible t('.link_text'), providers_cooky_path(current_provider), class: 'govuk-link' %>
-            <%= t('.any_time') %>
+            <%= t(".rejected") %>
+            <%= link_to_accessible t(".link_text"), providers_cooky_path(current_provider), class: "govuk-link" %>
+            <%= t(".any_time") %>
         </div>
       </div>
     </div>
 
     <div class="govuk-button-group">
       <button value="hide" class="govuk-button" data-module="govuk-button">
-        <%= t('.hide') %>
+        <%= t(".hide") %>
       </button>
     </div>
   </div>

--- a/app/views/shared/partials/_modal_dialogue.html.erb
+++ b/app/views/shared/partials/_modal_dialogue.html.erb
@@ -1,24 +1,24 @@
 <div class="modal modal-dialog" id="<%= application.application_ref %>-modal" tabindex="0">
   <div class="modal-content" aria-modal="true" aria-hidden="true" role="dialog" aria-label="Confirm delete application">
     <span class="close close-modal" aria-label="Close modal">&times;</span>
-    <h1 class="govuk-heading-l modal-dialog" id="modal-title"><%= t('.page_title') %></h1>
+    <h1 class="govuk-heading-l modal-dialog" id="modal-title"><%= t(".page_title") %></h1>
     <div class="govuk-panel__body">
       <ul class="govuk-list govuk-!-margin-bottom-4">
         <li>
-          <strong><%= t('.applicant') %>: </strong>
+          <strong><%= t(".applicant") %>: </strong>
           <%= application.applicant_full_name %>
         </li>
         <li>
-          <strong><%= t('.reference') %>: </strong>
+          <strong><%= t(".reference") %>: </strong>
           <%= application.application_ref %>
         </li>
       </ul>
     </div>
 
-    <%= govuk_warning_text(text: t('.warning')) %>
+    <%= govuk_warning_text(text: t(".warning")) %>
 
     <span class="hidden" aria-hidden="true" id="<%= application.application_ref %>-id"><%= application.id %></span>
-    <button class="govuk-button form-button govuk-button--warning confirm-delete-btn modal-dialog"><%= t('.yes_button') %></button>
-    <button class="govuk-button form-button govuk-!-margin-left-3 close-modal modal-dialog"><%= t('.no_button') %></button>
+    <button class="govuk-button form-button govuk-button--warning confirm-delete-btn modal-dialog"><%= t(".yes_button") %></button>
+    <button class="govuk-button form-button govuk-!-margin-left-3 close-modal modal-dialog"><%= t(".no_button") %></button>
   </div>
 </div>

--- a/app/views/shared/partials/_notification_banner.html.erb
+++ b/app/views/shared/partials/_notification_banner.html.erb
@@ -1,6 +1,6 @@
-<% success_class = local_assigns[:success] ? 'govuk-notification-banner--success' : ''
-   header = local_assigns[:success] ? t('generic.success') : t('generic.important')
-   link_to = false unless local_assigns.has_key?(:link_to) %>
+<% success_class = local_assigns[:success] ? "govuk-notification-banner--success" : ""
+   header = local_assigns[:success] ? t("generic.success") : t("generic.important")
+   link_to = false unless local_assigns.key?(:link_to) %>
 <div class="govuk-notification-banner <%= success_class %>" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
   <div class="govuk-notification-banner__header">
     <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">

--- a/app/views/shared/partials/_revealing_checkbox.html.erb
+++ b/app/views/shared/partials/_revealing_checkbox.html.erb
@@ -1,21 +1,21 @@
-<% field_name="check_box_#{name}"
+<% field_name = "check_box_#{name}"
    model.__send__("#{field_name}=", model.send(field_name).present?)
-   error_class=nil %>
+   error_class = nil %>
 
-<%= form.govuk_check_box field_name, true, '', link_errors: true, multiple: false, label: {text: controller_t("check_box_#{name}")} do %>
+<%= form.govuk_check_box field_name, true, "", link_errors: true, multiple: false, label: { text: controller_t("check_box_#{name}") } do %>
   <div class="govuk-hint"><% t(".#{journey_type}.#{controller_name}.hint") %></div>
   <% (1..number_of_fields).each do |number| %>
-    <% error=model.errors.messages["#{name}#{number}".to_sym][0] %>
+    <% error = model.errors.messages["#{name}#{number}".to_sym][0] %>
     <% if error %>
-      <% error_class='govuk-form-group--error'
+      <% error_class = "govuk-form-group--error"
          error_id = "#{model.model_name.to_s.underscore.dasherize}-#{name.dasherize}#{number}" %>
       <p class='govuk-error-message' id="<%= error_id %>"><%= error %></p>
     <% end %>
     <%= form.govuk_text_field "#{name}#{number}",
-      label: {text: model.period(number)},
-      value: gds_number_to_currency(model.__send__("#{name}#{number}"), unit: ''),
-      prefix_text: defined?(input_prefix) ? input_prefix : nil,
-      form_group: {classes: error_class},
-      width: 'one-third' %>
+                              label: { text: model.period(number) },
+                              value: gds_number_to_currency(model.__send__("#{name}#{number}"), unit: ""),
+                              prefix_text: defined?(input_prefix) ? input_prefix : nil,
+                              form_group: { classes: error_class },
+                              width: "one-third" %>
   <% end %>
 <% end %>

--- a/app/views/shared/review_application/_income_payments_and_assets.html.erb
+++ b/app/views/shared/review_application/_income_payments_and_assets.html.erb
@@ -1,59 +1,59 @@
 <section class="income_payments_and_assets page_break_before">
   <div class="govuk-!-padding-bottom-6"></div>
-  <h2 class="govuk-heading-l"><%= t('.heading') %></h2>
+  <h2 class="govuk-heading-l"><%= t(".heading") %></h2>
 
   <% if display_employment_income? %>
-    <%= render 'shared/employment_income_table' %>
+    <%= render "shared/employment_income_table" %>
   <% end %>
 
   <section class="print-no-break">
-    <h3 class="govuk-heading-m govuk-!-padding-top-8"><%= display_employment_income? ? t('.other_income') : t('.income') %></h3>
+    <h3 class="govuk-heading-m govuk-!-padding-top-8"><%= display_employment_income? ? t(".other_income") : t(".income") %></h3>
     <% if @legal_aid_application.applicant_receives_benefit? %>
       <strong class="govuk-tag app-tag--capitalize">
-        <%= t('.passported') %>
+        <%= t(".passported") %>
       </strong>
     <% else %>
       <%= render(
-          'shared/check_answers/bank_transaction_table',
-          transaction_types: TransactionType.credits.without_housing_benefits,
-          read_only: true
-        ) %>
+            "shared/check_answers/bank_transaction_table",
+            transaction_types: TransactionType.credits.without_housing_benefits,
+            read_only: true,
+          ) %>
     <% end %>
   </section>
 
   <% if @legal_aid_application.irregular_incomes.any? %>
-    <%= render 'shared/irregular_incomes_table',
+    <%= render "shared/irregular_incomes_table",
                irregular_incomes: @legal_aid_application.irregular_incomes,
                period: @legal_aid_application.year_to_calculation_date %>
   <% else %>
     <section>
       <dl class="govuk-summary-list govuk-!-margin-top-6">
         <%= check_answer_no_link(
-            name: :student_finance_question,
-            question: t("shared.check_answers.student_finance.does_your_client"),
-            answer: yes_no(@legal_aid_application.receives_student_finance?),
-            read_only: true,
-          ) %>
+              name: :student_finance_question,
+              question: t("shared.check_answers.student_finance.does_your_client"),
+              answer: yes_no(@legal_aid_application.receives_student_finance?),
+              read_only: true,
+            ) %>
       </dl>
     </section>
   <% end %>
 
   <section class="print-no-break">
-    <h3 class="govuk-heading-m govuk-!-padding-top-8"><%= t('.payments') %></h3>
+    <h3 class="govuk-heading-m govuk-!-padding-top-8"><%= t(".payments") %></h3>
     <% if @legal_aid_application.applicant_receives_benefit? %>
       <strong class="govuk-tag app-tag--capitalize">
-        <%= t('.passported') %>
+        <%= t(".passported") %>
       </strong>
     <% else %>
       <%= render(
-            'shared/check_answers/bank_transaction_table',
+            "shared/check_answers/bank_transaction_table",
             transaction_types: TransactionType.debits,
-            read_only: true
+            read_only: true,
           ) %>
     <% end %>
   </section>
 
   <section class="print-no-break govuk-!-padding-top-8">
-    <%= render 'shared/check_answers/assets', read_only: true %>
+    <%= render "shared/check_answers/assets", read_only: true %>
   </section>
 </section>

--- a/app/views/shared/review_application/_income_payments_and_assets_for_bank_statement_upload.html.erb
+++ b/app/views/shared/review_application/_income_payments_and_assets_for_bank_statement_upload.html.erb
@@ -1,62 +1,62 @@
 <section class="income_payments_and_assets page_break_before">
   <div class="govuk-!-padding-bottom-6"></div>
-  <h2 class="govuk-heading-l"><%= t('.income-heading') %></h2>
+  <h2 class="govuk-heading-l"><%= t(".income-heading") %></h2>
 
-  <%= render('shared/check_answers/bank_statements', bank_statements: @legal_aid_application.attachments.bank_statement_evidence, read_only: true) %>
+  <%= render("shared/check_answers/bank_statements", bank_statements: @legal_aid_application.attachments.bank_statement_evidence, read_only: true) %>
 
   <section class="print-no-break">
     <% if @legal_aid_application.provider.employment_permissions? %>
       <% if @legal_aid_application.hmrc_employment_income? %>
         <% if @legal_aid_application.has_multiple_employments? %>
-          <%= render 'shared/check_answers/full_employment_details', read_only: true %>
+          <%= render "shared/check_answers/full_employment_details", read_only: true %>
         <% else %>
-          <%= render 'shared/check_answers/employed_income', read_only: true %>
+          <%= render "shared/check_answers/employed_income", read_only: true %>
         <% end %>
       <% elsif @legal_aid_application.applicant_employed? %>
-        <%= render 'shared/check_answers/full_employment_details', read_only: true %>
+        <%= render "shared/check_answers/full_employment_details", read_only: true %>
       <% end %>
     <% end %>
   </section>
 
   <section class="print-no-break">
     <%= render(
-        'shared/check_answers/income_summary',
-        income_type: t('.credits-section-heading'),
-        url: @legal_aid_application.using_enhanced_bank_upload? ? :regular_incomes : :identify_types_of_incomes,
-        transaction_types: TransactionType.credits.without_disregarded_benefits,
-        read_only: true
-      ) %>
+          "shared/check_answers/income_summary",
+          income_type: t(".credits-section-heading"),
+          url: @legal_aid_application.using_enhanced_bank_upload? ? :regular_incomes : :identify_types_of_incomes,
+          transaction_types: TransactionType.credits.without_disregarded_benefits,
+          read_only: true,
+        ) %>
   </section>
 
   <section class="print-no-break">
-    <%= render('shared/check_answers/housing_benefit', read_only: true) if @legal_aid_application.housing_benefit_regular_transaction_applicable? %>
+    <%= render("shared/check_answers/housing_benefit", read_only: true) if @legal_aid_application.housing_benefit_regular_transaction_applicable? %>
   </section>
 
   <section class="print-no-break">
-    <%= render('shared/check_answers/income_cash_payments', read_only: true) %>
+    <%= render("shared/check_answers/income_cash_payments", read_only: true) %>
   </section>
 
-  <%= render 'shared/check_answers/student_finance', read_only: true %>
+  <%= render "shared/check_answers/student_finance", read_only: true %>
 
   <section class="print-no-break">
-    <h2 class="govuk-heading-l"><%= t('.outgoings-heading') %></h2>
+    <h2 class="govuk-heading-l"><%= t(".outgoings-heading") %></h2>
 
     <%= render(
-        'shared/check_answers/income_summary',
-        income_type: t('.debits-section-heading'),
-        url: @legal_aid_application.using_enhanced_bank_upload? ? :regular_outgoings : :identify_types_of_outgoings,
-        transaction_types: TransactionType.debits,
-        read_only: true
-      ) %>
+          "shared/check_answers/income_summary",
+          income_type: t(".debits-section-heading"),
+          url: @legal_aid_application.using_enhanced_bank_upload? ? :regular_outgoings : :identify_types_of_outgoings,
+          transaction_types: TransactionType.debits,
+          read_only: true,
+        ) %>
   </section>
 
   <section class="print-no-break">
-    <%= render('shared/check_answers/outgoings_cash_payments', read_only: true) %>
+    <%= render("shared/check_answers/outgoings_cash_payments", read_only: true) %>
   </section>
 
   <section class="print-no-break govuk-!-padding-top-8">
-    <h2 class="govuk-heading-l"><%= t('.capital-heading') %></h2>
+    <h2 class="govuk-heading-l"><%= t(".capital-heading") %></h2>
 
-    <%= render 'shared/check_answers/assets', read_only: true %>
+    <%= render "shared/check_answers/assets", read_only: true %>
   </section>
 </section>

--- a/app/views/shared/review_application/_questions_and_answers.html.erb
+++ b/app/views/shared/review_application/_questions_and_answers.html.erb
@@ -1,17 +1,17 @@
 <div class="print-header-wrapper">
   <dl class="govuk-list inline-list print-header">
     <dt>
-      <strong><%= t('.client_name') %>:</strong>
+      <strong><%= t(".client_name") %>:</strong>
     </dt>
     <dd><%= @legal_aid_application.applicant_full_name %></dd>
 
     <dt>
-      <strong><%= t('.case_reference_html') %>:</strong>
+      <strong><%= t(".case_reference_html") %>:</strong>
     </dt>
     <dd><%= @legal_aid_application.application_ref %></dd>
 
     <dt>
-      <strong><%= t('.ccms_reference_html') %>:</strong>
+      <strong><%= t(".ccms_reference_html") %>:</strong>
     </dt>
     <dd><%= @legal_aid_application.case_ccms_reference %></dd>
   </dl>
@@ -19,59 +19,59 @@
 
 <div class="print-position-correction">
   <section class="client_details print-no-break">
-    <h2 class="govuk-heading-l"><%= t('.client_details_heading') %></h2>
+    <h2 class="govuk-heading-l"><%= t(".client_details_heading") %></h2>
     <%= render(
-          'shared/check_answers/client_details',
+          "shared/check_answers/client_details",
           attributes: %i[first_name last_name date_of_birth national_insurance_number email address],
           applicant: @legal_aid_application.applicant,
           address: @legal_aid_application.applicant.address,
-          read_only: true
+          read_only: true,
         ) %>
   </section>
 
   <section class="proceeding_details print-no-break">
-    <h2 class="govuk-heading-m"><%= t('.proceedings_details_heading') %></h2>
+    <h2 class="govuk-heading-m"><%= t(".proceedings_details_heading") %></h2>
     <% if Setting.enable_mini_loop? %>
     <% @legal_aid_application.proceedings.each do |proceeding| %>
       <%= render(
-        'shared/check_answers/proceeding_details_section',
-        proceeding: proceeding,
-        read_only: true
-      ) %>
+            "shared/check_answers/proceeding_details_section",
+            proceeding:,
+            read_only: true,
+          ) %>
     <% end %>
   <% else %>
 
     <%= render(
-          'shared/check_answers/proceedings_details',
+          "shared/check_answers/proceedings_details",
           proceeding_types: @legal_aid_application.proceedings,
           legal_aid_application: @legal_aid_application,
-          read_only: true
+          read_only: true,
         ) %>
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <h2 class="govuk-heading-m"><%= t '.section_delegated.heading' %></h2>
+        <h2 class="govuk-heading-m"><%= t ".section_delegated.heading" %></h2>
       </div>
     </div>
 
     <%= render(
-          'shared/check_answers/delegated_functions',
+          "shared/check_answers/delegated_functions",
           legal_aid_application: @legal_aid_application,
-          read_only: true
+          read_only: true,
         ) %>
 
     <% if @legal_aid_application.used_delegated_functions? %>
-      <h2 class="govuk-heading-m"><%= t '.section_emergency.heading' %></h2>
+      <h2 class="govuk-heading-m"><%= t ".section_emergency.heading" %></h2>
       <%= render(
-            'shared/check_answers/emergency_limitations',
-            legal_aid_application: @legal_aid_application
+            "shared/check_answers/emergency_limitations",
+            legal_aid_application: @legal_aid_application,
           ) %>
     <% end %>
 
-    <h2 class="govuk-heading-m"><%= t('.section_substantive.heading') %></h2>
+    <h2 class="govuk-heading-m"><%= t(".section_substantive.heading") %></h2>
     <%= render(
-          'shared/check_answers/substantive_limitations',
-          legal_aid_application: @legal_aid_application
+          "shared/check_answers/substantive_limitations",
+          legal_aid_application: @legal_aid_application,
         ) %>
 
   <% end %>
@@ -80,26 +80,26 @@
   <% if @legal_aid_application.used_delegated_functions? %>
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <h2 class="govuk-heading-m"><%= t '.emergency_cost_limit' %></h2>
+        <h2 class="govuk-heading-m"><%= t ".emergency_cost_limit" %></h2>
       </div>
     </div>
     <%= render(
-          'shared/check_answers/emergency_costs',
+          "shared/check_answers/emergency_costs",
           legal_aid_application: @legal_aid_application,
-          read_only: true
+          read_only: true,
         ) %>
   <% end %>
 
   <% if @legal_aid_application.substantive_cost_overridable? %>
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <h2 class="govuk-heading-m"><%= t '.substantive_cost_limit' %></h2>
+        <h2 class="govuk-heading-m"><%= t ".substantive_cost_limit" %></h2>
       </div>
     </div>
     <%= render(
-          'shared/check_answers/substantive_costs',
+          "shared/check_answers/substantive_costs",
           legal_aid_application: @legal_aid_application,
-          read_only: true
+          read_only: true,
         ) %>
   <% end %>
 
@@ -111,33 +111,33 @@
 
   <section class="merits page_break_before">
     <%= render(
-      "shared/check_answers/merits",
-      incident: @legal_aid_application.latest_incident,
-      statement_of_case: @legal_aid_application.statement_of_case,
-      gateway_evidence: @legal_aid_application&.gateway_evidence,
-      opponent: @legal_aid_application.opponent,
-      allegation: @legal_aid_application&.allegation,
-      undertaking: @legal_aid_application&.undertaking,
-      urgency: @legal_aid_application&.urgency,
-      read_only: true
-    ) %>
+          "shared/check_answers/merits",
+          incident: @legal_aid_application.latest_incident,
+          statement_of_case: @legal_aid_application.statement_of_case,
+          gateway_evidence: @legal_aid_application&.gateway_evidence,
+          opponent: @legal_aid_application.opponent,
+          allegation: @legal_aid_application&.allegation,
+          undertaking: @legal_aid_application&.undertaking,
+          urgency: @legal_aid_application&.urgency,
+          read_only: true,
+        ) %>
   </section>
 
   <section id="client-declaration" class="only-print print-no-break page_break_before">
     <div class="govuk-!-padding-bottom-6"></div>
-    <h2 class="govuk-heading-l"><%= t('.client_declaration.heading') %></h2>
+    <h2 class="govuk-heading-l"><%= t(".client_declaration.heading") %></h2>
 
-    <%= render 'shared/applicant_declaration' %>
+    <%= render "shared/applicant_declaration" %>
 
     <dl class="govuk-summary-list govuk-summary-list--no-border">
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key print-bottom-gap">
-          <%= t('.client_declaration.signature') %>
+          <%= t(".client_declaration.signature") %>
         </dt>
       </div>
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
-          <%= t('.client_declaration.date') %>
+          <%= t(".client_declaration.date") %>
         </dt>
       </div>
     </dl>

--- a/app/views/shared/scope_limitations/_hearing_date.html.erb
+++ b/app/views/shared/scope_limitations/_hearing_date.html.erb
@@ -1,2 +1,2 @@
 <%= form.govuk_date_field field_name, legend: { text: t("shared.forms.date_input_fields.scope_limitations_label") },
-                          hint: { text: t("shared.forms.date_input_fields.scope_limitations_hint", options: number_of_days_ago(0))} %>
+                                      hint: { text: t("shared.forms.date_input_fields.scope_limitations_hint", options: number_of_days_ago(0)) } %>

--- a/app/views/shared/scope_limitations/_limitation_note.html.erb
+++ b/app/views/shared/scope_limitations/_limitation_note.html.erb
@@ -1,5 +1,5 @@
 <%= form.govuk_text_area(
-                  field_name,
-                  label: { text: t('.details'), size: 's' },
-                  rows: 5
-                ) %>
+      field_name,
+      label: { text: t(".details"), size: "s" },
+      rows: 5,
+    ) %>


### PR DESCRIPTION
Before, all non-nested templates in `app/views/shared` were excluded from Rubocop linting.

This removes that rule, and resolves all failures.

All failures were resolved with the `--autocorrect` flag, and are all trivial

One caveat is that when assigning local variables in partials inside a multiline block, Rubocop thinks the first line is empty. This is a limitation of using Rubocop in erblint, since each line is parsed in isolation.