### PR TITLE
Fix: Update test REGEXs for tasks

### DIFF
--- a/spec/models/legal_framework/merits_task_list_spec.rb
+++ b/spec/models/legal_framework/merits_task_list_spec.rb
@@ -34,8 +34,8 @@ module LegalFramework
 
       it "updates the task list" do
         # match pattern => key: :value, newline, any amount of spaces, repeat
-        expect(merits_task_list.serialized_data).to match(/name: :children_application\n\s+dependencies: \*\d\n\s+state: :complete/)
-        expect(merits_task_list.serialized_data).to match(/name: :children_proceeding\n\s+dependencies: \*\d\n\s+state: :not_started/)
+        expect(merits_task_list.serialized_data).to match(/name: :children_application\n\s+dependencies: \*\d+\n\s+state: :complete/)
+        expect(merits_task_list.serialized_data).to match(/name: :children_proceeding\n\s+dependencies: \*\d+\n\s+state: :not_started/)
       end
     end
 

--- a/spec/requests/providers/application_merits_task/client_denial_of_allegation_spec.rb
+++ b/spec/requests/providers/application_merits_task/client_denial_of_allegation_spec.rb
@@ -74,7 +74,7 @@ module Providers
 
         it "sets the task to complete" do
           post_client_denial
-          expect(legal_aid_application.legal_framework_merits_task_list.serialized_data).to match(/name: :client_denial_of_allegation\n\s+dependencies: \*\d\n\s+state: :complete/)
+          expect(legal_aid_application.legal_framework_merits_task_list.serialized_data).to match(/name: :client_denial_of_allegation\n\s+dependencies: \*\d+\n\s+state: :complete/)
         end
 
         context "when all previous tasks are completed" do
@@ -101,7 +101,7 @@ module Providers
         context "when incomplete" do
           let(:denies_all) { false }
           let(:additional_information) { "" }
-          let(:regex) { /name: :client_denial_of_allegation\n\s+dependencies: \*\d\n\s+state: :not_started/ }
+          let(:regex) { /name: :client_denial_of_allegation\n\s+dependencies: \*\d+\n\s+state: :not_started/ }
 
           it "renders show" do
             post_client_denial
@@ -124,7 +124,7 @@ module Providers
 
           it "does not set the task to complete" do
             post_client_denial
-            expect(legal_aid_application.legal_framework_merits_task_list.serialized_data).to match(/name: :client_denial_of_allegation\n\s+dependencies: \*\d\n\s+state: :not_started/)
+            expect(legal_aid_application.legal_framework_merits_task_list.serialized_data).to match(/name: :client_denial_of_allegation\n\s+dependencies: \*\d+\n\s+state: :not_started/)
           end
         end
       end

--- a/spec/requests/providers/application_merits_task/client_offered_undertakings_controller_spec.rb
+++ b/spec/requests/providers/application_merits_task/client_offered_undertakings_controller_spec.rb
@@ -60,7 +60,7 @@ module Providers
         let(:draft_button) { { draft_button: "Save as draft" } }
         let(:button_clicked) { {} }
         let(:undertaking) { legal_aid_application.reload.undertaking }
-        let(:not_started_regex) { /name: :client_offer_of_undertakings\n\s+dependencies: \*\d\n\s+state: :not_started/ }
+        let(:not_started_regex) { /name: :client_offer_of_undertakings\n\s+dependencies: \*\d+\n\s+state: :not_started/ }
 
         before do
           allow(LegalFramework::MeritsTasksService).to receive(:call).with(legal_aid_application).and_return(smtl)
@@ -75,7 +75,7 @@ module Providers
 
         it "sets the task to complete" do
           post_client_undertakings
-          expect(legal_aid_application.legal_framework_merits_task_list.serialized_data).to match(/name: :client_offer_of_undertakings\n\s+dependencies: \*\d\n\s+state: :complete/)
+          expect(legal_aid_application.legal_framework_merits_task_list.serialized_data).to match(/name: :client_offer_of_undertakings\n\s+dependencies: \*\d+\n\s+state: :complete/)
         end
 
         it "redirects to the next page" do

--- a/spec/requests/providers/application_merits_task/date_client_told_incidents_spec.rb
+++ b/spec/requests/providers/application_merits_task/date_client_told_incidents_spec.rb
@@ -89,7 +89,7 @@ module Providers
 
         it "sets the task to complete" do
           subject
-          expect(legal_aid_application.legal_framework_merits_task_list.serialized_data).to match(/name: :latest_incident_details\n\s+dependencies: \*\d\n\s+state: :complete/)
+          expect(legal_aid_application.legal_framework_merits_task_list.serialized_data).to match(/name: :latest_incident_details\n\s+dependencies: \*\d+\n\s+state: :complete/)
         end
 
         it "redirects to the next page" do
@@ -107,7 +107,7 @@ module Providers
 
         context "when incomplete" do
           let(:told_on_3i) { "" }
-          let(:regex) { /name: :latest_incident_details\n\s+dependencies: \*\d\n\s+state: :not_started/ }
+          let(:regex) { /name: :latest_incident_details\n\s+dependencies: \*\d+\n\s+state: :not_started/ }
 
           it "renders show" do
             subject
@@ -154,7 +154,7 @@ module Providers
 
           it "does not set the task to complete" do
             subject
-            expect(legal_aid_application.legal_framework_merits_task_list.serialized_data).to match(/name: :latest_incident_details\n\s+dependencies: \*\d\n\s+state: :not_started/)
+            expect(legal_aid_application.legal_framework_merits_task_list.serialized_data).to match(/name: :latest_incident_details\n\s+dependencies: \*\d+\n\s+state: :not_started/)
           end
         end
       end

--- a/spec/requests/providers/application_merits_task/has_other_involved_children_spec.rb
+++ b/spec/requests/providers/application_merits_task/has_other_involved_children_spec.rb
@@ -53,7 +53,7 @@ module Providers
 
           it "does not set the task to complete" do
             subject
-            expect(application.legal_framework_merits_task_list.serialized_data).to match(/name: :children_application\n\s+dependencies: \*\d\n\s+state: :not_started/)
+            expect(application.legal_framework_merits_task_list.serialized_data).to match(/name: :children_application\n\s+dependencies: \*\d+\n\s+state: :not_started/)
           end
         end
 
@@ -73,7 +73,7 @@ module Providers
 
           it "sets the task to complete" do
             subject
-            expect(application.reload.legal_framework_merits_task_list.serialized_data).to match(/name: :children_application\n\s+dependencies: \*\d\n\s+state: :complete/)
+            expect(application.reload.legal_framework_merits_task_list.serialized_data).to match(/name: :children_application\n\s+dependencies: \*\d+\n\s+state: :complete/)
           end
         end
 
@@ -93,7 +93,7 @@ module Providers
 
           it "does not set the task to complete" do
             subject
-            expect(application.legal_framework_merits_task_list.serialized_data).to match(/name: :children_application\n\s+dependencies: \*\d\n\s+state: :not_started/)
+            expect(application.legal_framework_merits_task_list.serialized_data).to match(/name: :children_application\n\s+dependencies: \*\d+\n\s+state: :not_started/)
           end
         end
       end

--- a/spec/requests/providers/application_merits_task/nature_of_urgencies_controller_spec.rb
+++ b/spec/requests/providers/application_merits_task/nature_of_urgencies_controller_spec.rb
@@ -55,7 +55,7 @@ module Providers
         let(:draft_button) { { draft_button: "Save as draft" } }
         let(:button_clicked) { {} }
         let(:urgency) { legal_aid_application.reload.urgency }
-        let(:not_started_regex) { /name: :nature_of_urgency\n\s+dependencies: \*\d\n\s+state: :not_started/ }
+        let(:not_started_regex) { /name: :nature_of_urgency\n\s+dependencies: \*\d+\n\s+state: :not_started/ }
 
         before do
           allow(LegalFramework::MeritsTasksService).to receive(:call).with(legal_aid_application).and_return(smtl)

--- a/spec/requests/providers/application_merits_task/opponents_spec.rb
+++ b/spec/requests/providers/application_merits_task/opponents_spec.rb
@@ -93,7 +93,7 @@ module Providers
 
         it "sets the task to complete" do
           subject
-          expect(legal_aid_application.legal_framework_merits_task_list.serialized_data).to match(/name: :opponent_details\n\s+dependencies: \*\d\n\s+state: :complete/)
+          expect(legal_aid_application.legal_framework_merits_task_list.serialized_data).to match(/name: :opponent_details\n\s+dependencies: \*\d+\n\s+state: :complete/)
         end
 
         context "when no other tasks are complete" do
@@ -161,7 +161,7 @@ module Providers
 
           it "does not set the task to complete" do
             subject
-            expect(legal_aid_application.legal_framework_merits_task_list.serialized_data).to match(/name: :opponent_details\n\s+dependencies: \*\d\n\s+state: :not_started/)
+            expect(legal_aid_application.legal_framework_merits_task_list.serialized_data).to match(/name: :opponent_details\n\s+dependencies: \*\d+\n\s+state: :not_started/)
           end
         end
 
@@ -175,7 +175,7 @@ module Providers
 
           it "does not set the task to complete" do
             subject
-            expect(legal_aid_application.legal_framework_merits_task_list.serialized_data).to match(/name: :opponent_details\n\s+dependencies: \*\d\n\s+state: :not_started/)
+            expect(legal_aid_application.legal_framework_merits_task_list.serialized_data).to match(/name: :opponent_details\n\s+dependencies: \*\d+\n\s+state: :not_started/)
           end
         end
       end

--- a/spec/requests/providers/application_merits_task/statement_of_case_spec.rb
+++ b/spec/requests/providers/application_merits_task/statement_of_case_spec.rb
@@ -166,7 +166,7 @@ module Providers
 
               it "sets the task to complete" do
                 subject
-                expect(legal_aid_application.reload.legal_framework_merits_task_list.serialized_data).to match(/name: :statement_of_case\n\s+dependencies: \*\d\n\s+state: :complete/)
+                expect(legal_aid_application.reload.legal_framework_merits_task_list.serialized_data).to match(/name: :statement_of_case\n\s+dependencies: \*\d+\n\s+state: :complete/)
               end
             end
 
@@ -451,7 +451,7 @@ module Providers
 
           it "does not set the task to complete" do
             subject
-            expect(legal_aid_application.legal_framework_merits_task_list.serialized_data).to match(/name: :statement_of_case\n\s+dependencies: \*\d\n\s+state: :not_started/)
+            expect(legal_aid_application.legal_framework_merits_task_list.serialized_data).to match(/name: :statement_of_case\n\s+dependencies: \*\d+\n\s+state: :not_started/)
           end
 
           it "redirects to provider draft endpoint" do

--- a/spec/requests/providers/proceeding_merits_task/chances_of_success_spec.rb
+++ b/spec/requests/providers/proceeding_merits_task/chances_of_success_spec.rb
@@ -69,7 +69,7 @@ module Providers
 
         it "updates the task list" do
           subject
-          expect(legal_aid_application.legal_framework_merits_task_list.serialized_data).to match(/name: :chances_of_success\n\s+dependencies: \*\d\n\s+state: :complete/)
+          expect(legal_aid_application.legal_framework_merits_task_list.serialized_data).to match(/name: :chances_of_success\n\s+dependencies: \*\d+\n\s+state: :complete/)
         end
 
         context "when false is selected" do
@@ -90,7 +90,7 @@ module Providers
           it "does not set the task to complete" do
             subject
             serialized_merits_task_list = legal_aid_application.legal_framework_merits_task_list.reload.serialized_data
-            expect(serialized_merits_task_list).not_to match(/name: :chances_of_success\n\s+dependencies: \*\d\n\s+state: :complete/)
+            expect(serialized_merits_task_list).not_to match(/name: :chances_of_success\n\s+dependencies: \*\d+\n\s+state: :complete/)
           end
 
           it "redirects to next page" do
@@ -158,7 +158,7 @@ module Providers
 
           it "does not set the task to complete" do
             subject
-            expect(legal_aid_application.legal_framework_merits_task_list.serialized_data).not_to match(/name: :chances_of_success\n\s+dependencies: \*\d\n\s+state: :complete/)
+            expect(legal_aid_application.legal_framework_merits_task_list.serialized_data).not_to match(/name: :chances_of_success\n\s+dependencies: \*\d+\n\s+state: :complete/)
           end
 
           it "updates the model" do

--- a/spec/requests/providers/proceeding_merits_task/linked_children_spec.rb
+++ b/spec/requests/providers/proceeding_merits_task/linked_children_spec.rb
@@ -165,7 +165,7 @@ module Providers
 
           it "does not set the task to complete" do
             subject
-            expect(legal_aid_application.legal_framework_merits_task_list.serialized_data).not_to match(/name: :children_proceeding\n\s+dependencies: \*\d\n\s+state: :complete/)
+            expect(legal_aid_application.legal_framework_merits_task_list.serialized_data).not_to match(/name: :children_proceeding\n\s+dependencies: \*\d+\n\s+state: :complete/)
           end
         end
       end


### PR DESCRIPTION
## What

When these were first written we only had a maximum of 8 tasks as we start increasing, more and more often we hit errors when the regex fails to match as it moves from 9 to 11.  

Some have been updated to fix these errors as they've occurred, this PR globally replaces all of them so the tasks will be matched whether they are dependency 1 or 10

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
