### PR TITLE
Ap 3497 multiple scope limitations ccms

### DIFF
--- a/app/services/ccms/attribute_value_generator.rb
+++ b/app/services/ccms/attribute_value_generator.rb
@@ -308,7 +308,12 @@ module CCMS
     end
 
     def multiple_scope_limitations?(proceeding)
-      proceeding.scope_limitations.where(scope_type: :emergency).count > 1 || proceeding.scope_limitations.where(scope_type: :substantive).count > 1
+      proceeding
+        .scope_limitations
+        .select(:scope_type)
+        .group(:scope_type)
+        .count
+        .any? { |_type, count| count > 1 }
     end
 
     def other_party_full_name(options)

--- a/app/services/ccms/attribute_value_generator.rb
+++ b/app/services/ccms/attribute_value_generator.rb
@@ -302,9 +302,13 @@ module CCMS
 
     def proceeding_cost_limitation(options)
       proceeding = options[:proceeding]
-      return "MULTIPLE" if proceeding.used_delegated_functions?
+      return "MULTIPLE" if proceeding.used_delegated_functions? || multiple_scope_limitations?(proceeding)
 
       proceeding.substantive_scope_limitation_code
+    end
+
+    def multiple_scope_limitations?(proceeding)
+      proceeding.scope_limitations.where(scope_type: :emergency).count > 1 || proceeding.scope_limitations.where(scope_type: :substantive).count > 1
     end
 
     def other_party_full_name(options)

--- a/app/services/ccms/requestors/case_add_requestor.rb
+++ b/app/services/ccms/requestors/case_add_requestor.rb
@@ -227,17 +227,21 @@ module CCMS
       end
 
       def generate_scope_limitations(xml, proceeding)
-        xml.__send__(:"casebio:ScopeLimitation") do
-          xml.__send__(:"casebio:ScopeLimitation", proceeding.substantive_scope_limitation_code)
-          xml.__send__(:"casebio:ScopeLimitationWording", proceeding.substantive_scope_limitation_description)
-          xml.__send__(:"casebio:DelegatedFunctionsApply", false)
+        proceeding.scope_limitations.where(scope_type: :substantive).each do |scope_limitation|
+          xml.__send__(:"casebio:ScopeLimitation") do
+            xml.__send__(:"casebio:ScopeLimitation", scope_limitation.code)
+            xml.__send__(:"casebio:ScopeLimitationWording", scope_limitation.description)
+            xml.__send__(:"casebio:DelegatedFunctionsApply", false)
+          end
         end
         return if proceeding.used_delegated_functions_on.nil?
 
-        xml.__send__(:"casebio:ScopeLimitation") do
-          xml.__send__(:"casebio:ScopeLimitation", proceeding.delegated_functions_scope_limitation_code)
-          xml.__send__(:"casebio:ScopeLimitationWording", proceeding.delegated_functions_scope_limitation_description)
-          xml.__send__(:"casebio:DelegatedFunctionsApply", true)
+        proceeding.scope_limitations.where(scope_type: :emergency).each do |scope_limitation|
+          xml.__send__(:"casebio:ScopeLimitation") do
+            xml.__send__(:"casebio:ScopeLimitation", scope_limitation.code)
+            xml.__send__(:"casebio:ScopeLimitationWording", scope_limitation.description)
+            xml.__send__(:"casebio:DelegatedFunctionsApply", true)
+          end
         end
       end
 

--- a/spec/services/ccms/requestors/case_add_requestor_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_spec.rb
@@ -164,7 +164,7 @@ module CCMS
             /<common:Attribute> <common:Attribute>REQUESTED_SCOPE<\/common:Attribute> <common:ResponseType>text<\/common:ResponseType> <common:ResponseValue>MULTIPLE<\/common:ResponseValue> <common:UserDefinedInd>true<\/common:UserDefinedInd> <\/common:Attribute>/
           end
 
-          context "when DF are present" do
+          context "when DF have not been used" do
             it "generates the expected scope limitations" do
               expect(CCMS::OpponentId).to receive(:next_serial_id).and_return(88_123_456, 88_123_457, 88_123_458)
               travel_to Time.zone.parse("2020-11-24T11:54:29.000") do
@@ -180,7 +180,7 @@ module CCMS
             end
           end
 
-          context "when DF are actually used" do
+          context "when DF are used" do
             let(:df_date) { Date.parse("2020-11-23") }
 
             before do

--- a/spec/services/ccms/requestors/case_add_requestor_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_spec.rb
@@ -127,6 +127,82 @@ module CCMS
             end
           end
         end
+
+        context "when multiple scope limitations are present" do
+          before do
+            proceeding.scope_limitations.create!(
+              scope_type: 1,
+              code: "FM062",
+              meaning: "Final hearing",
+              description: "Limited to all steps up to and including final hearing and any action necessary to implement (but not enforce) the order.",
+            )
+            proceeding.scope_limitations.create!(
+              scope_type: 0,
+              code: "CV118",
+              meaning: "Hearing",
+              description: "Limited to all steps up to and including the hearing on [see additional limitation notes]",
+            )
+          end
+
+          let(:substantive_scope_limitation_one_xml) do
+            /<casebio:ScopeLimitation> <casebio:ScopeLimitation>CV118<\/casebio:ScopeLimitation> <casebio:ScopeLimitationWording>Limited to all steps up to and including the hearing on \[see additional limitation notes\]<\/casebio:ScopeLimitationWording> <casebio:DelegatedFunctionsApply>false<\/casebio:DelegatedFunctionsApply> <\/casebio:ScopeLimitation>/
+          end
+
+          let(:substantive_scope_limitation_two_xml) do
+            /<casebio:ScopeLimitation> <casebio:ScopeLimitation>FM062<\/casebio:ScopeLimitation> <casebio:ScopeLimitationWording>Limited to all steps up to and including final hearing and any action necessary to implement \(but not enforce\) the order\.<\/casebio:ScopeLimitationWording> <casebio:DelegatedFunctionsApply>false<\/casebio:DelegatedFunctionsApply> <\/casebio:ScopeLimitation>/
+          end
+
+          let(:emergency_scope_limitation_one_xml) do
+            /<casebio:ScopeLimitation> <casebio:ScopeLimitation>CV117<\/casebio:ScopeLimitation> <casebio:ScopeLimitationWording>Limited to Family Help \(Higher\) and to all steps necessary to negotiate and conclude a settlement\. To include the issue of proceedings and representation in those proceedings save in relation to or at a contested final hearing\.<\/casebio:ScopeLimitationWording> <casebio:DelegatedFunctionsApply>true<\/casebio:DelegatedFunctionsApply> <\/casebio:ScopeLimitation>/
+          end
+
+          let(:emergency_scope_limitation_two_xml) do
+            /<casebio:ScopeLimitation> <casebio:ScopeLimitation>FM062<\/casebio:ScopeLimitation> <casebio:ScopeLimitationWording>Limited to all steps up to and including final hearing and any action necessary to implement \(but not enforce\) the order\.<\/casebio:ScopeLimitationWording> <casebio:DelegatedFunctionsApply>true<\/casebio:DelegatedFunctionsApply> <\/casebio:ScopeLimitation>/
+          end
+
+          let(:requested_scope_xml) do
+            /<common:Attribute> <common:Attribute>REQUESTED_SCOPE<\/common:Attribute> <common:ResponseType>text<\/common:ResponseType> <common:ResponseValue>MULTIPLE<\/common:ResponseValue> <common:UserDefinedInd>true<\/common:UserDefinedInd> <\/common:Attribute>/
+          end
+
+          context "when DF are present" do
+            it "generates the expected scope limitations" do
+              expect(CCMS::OpponentId).to receive(:next_serial_id).and_return(88_123_456, 88_123_457, 88_123_458)
+              travel_to Time.zone.parse("2020-11-24T11:54:29.000") do
+                expect(expected_xml.squish).to match substantive_scope_limitation_one_xml
+                expect(expected_xml.squish).to match substantive_scope_limitation_two_xml
+                expect(expected_xml.squish).not_to match emergency_scope_limitation_one_xml
+                expect(expected_xml.squish).not_to match emergency_scope_limitation_two_xml
+              end
+            end
+
+            it "specifies MULTIPLE for requested scope" do
+              expect(expected_xml.squish).to match requested_scope_xml
+            end
+          end
+
+          context "when DF are actually used" do
+            let(:df_date) { Date.parse("2020-11-23") }
+
+            before do
+              proceeding.update!(used_delegated_functions: true, used_delegated_functions_on: df_date, used_delegated_functions_reported_on: df_date)
+              legal_aid_application.reload
+            end
+
+            it "generates the expected scope limitations" do
+              expect(CCMS::OpponentId).to receive(:next_serial_id).and_return(88_123_456, 88_123_457, 88_123_458)
+              travel_to Time.zone.parse("2020-11-24T11:54:29.000") do
+                expect(expected_xml.squish).to match substantive_scope_limitation_one_xml
+                expect(expected_xml.squish).to match substantive_scope_limitation_two_xml
+                expect(expected_xml.squish).to match emergency_scope_limitation_one_xml
+                expect(expected_xml.squish).to match emergency_scope_limitation_two_xml
+              end
+            end
+
+            it "specifies MULTIPLE for requested scope" do
+              expect(expected_xml.squish).to match requested_scope_xml
+            end
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3497)

- Modified CCMS payload to send multiple emergency/substantive scope limitations for each proceeding where these exist.
- Specify "MULTUPLE" as requested scope where there exist multiple emergency or substantive scope limitations for a proceeding, or where delegated functions have been used.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
