### PR TITLE
Use govuk_warning_text component

### DIFF
--- a/app/views/providers/application_merits_task/statement_of_cases/show.html.erb
+++ b/app/views/providers/application_merits_task/statement_of_cases/show.html.erb
@@ -39,13 +39,7 @@
         <% end %>
       </ul>
 
-      <div class="govuk-warning-text">
-        <span class="govuk-warning-text__icon govuk_two_line_warning" aria-hidden="true">!</span>
-        <strong class="govuk-warning-text__text">
-          <span class="govuk-warning-text__assistive"><%= t('.warning_text') %></span>
-          <%= t('.warning_text') %>
-        </strong>
-      </div>
+      <%= govuk_warning_text(text: t(".warning_text")) %>
 
       <div class="dropzone__upload">
         <div class="govuk-form-group script hidden" id="dropzone-form-group" aria-labelledby="dropzone-label">

--- a/app/views/providers/confirm_client_declarations/show.html.erb
+++ b/app/views/providers/confirm_client_declarations/show.html.erb
@@ -10,16 +10,10 @@
     <% params = { provider_firm_name: @legal_aid_application.provider.firm.name } %>
     <%= bullet_list_from_translation_array('providers.confirm_client_declarations.show.list', params: params) %>
 
-    <div class="govuk-warning-text">
-      <span class="govuk-warning-text__icon govuk_two_line_warning" aria-hidden="true">!</span>
-      <strong class="govuk-warning-text__text">
-        <span class="govuk-warning-text__assistive"><%= t('.sign_app_text') %></span>
-        <%= t('.sign_app_text') %>
-      </strong>
-      <strong class="govuk-warning-text__text">
-        <%= list_from_translation_path '.confirm_client_declarations.show.warning' %>
-      </strong>
-    </div>
+    <%= govuk_warning_text do %>
+      <%= t(".sign_app_text") %>
+      <%= list_from_translation_path ".confirm_client_declarations.show.warning" %>
+    <% end %>
 
     <%= form.govuk_check_boxes_fieldset :client_declaration_confirmed, legend: nil do %>
       <p><%= form.govuk_check_box :client_declaration_confirmed, true, '', multiple: false, label: { text: t('.confirmation_checkbox') } %></p>

--- a/app/webpack/stylesheets/application.scss
+++ b/app/webpack/stylesheets/application.scss
@@ -33,7 +33,6 @@
 @import 'task-list';
 @import 'tickbox-divider';
 @import 'width-style-correction';
-@import 'citizens/declarations';
 @import 'citizens/spinner';
 @import 'forms/revealing_checkboxes';
 @import 'providers/legal_aid_applications';

--- a/app/webpack/stylesheets/citizens/declarations.scss
+++ b/app/webpack/stylesheets/citizens/declarations.scss
@@ -1,3 +1,0 @@
-.declaration-warning.govuk-warning-text {
-  padding-left: 60px;
-}

--- a/app/webpack/stylesheets/govuk-mods.scss
+++ b/app/webpack/stylesheets/govuk-mods.scss
@@ -22,7 +22,3 @@ dl.govuk-list.inline-list {
 .govuk-button__start-icon {
   width:15.5px;
 }
-
-.govuk_two_line_warning {
-  margin-top: 7px !important;
-}


### PR DESCRIPTION
Before, custom markup was used to render two instances 
of the [GOV.UK Warning text component][component].

Rather than maintaining custom HTML, we can make use 
of the `govuk_warning_text` ViewComponent instead.

This adopts that component and removes some styles that 
are no longer in use.

[component]: https://design-system.service.gov.uk/components/warning-text/