### PR TITLE
Fix: Improve task list test handling

### DIFF
--- a/spec/requests/providers/application_merits_task/client_denial_of_allegation_spec.rb
+++ b/spec/requests/providers/application_merits_task/client_denial_of_allegation_spec.rb
@@ -74,7 +74,7 @@ module Providers
 
         it "sets the task to complete" do
           post_client_denial
-          expect(legal_aid_application.legal_framework_merits_task_list.serialized_data).to match(/name: :client_denial_of_allegation\n\s+dependencies: \*\d\n\s+state: :complete/)
+          expect(legal_aid_application.legal_framework_merits_task_list).to have_completed_task(:application, :client_denial_of_allegation)
         end
 
         context "when all previous tasks are completed" do
@@ -101,7 +101,6 @@ module Providers
         context "when incomplete" do
           let(:denies_all) { false }
           let(:additional_information) { "" }
-          let(:regex) { /name: :client_denial_of_allegation\n\s+dependencies: \*\d\n\s+state: :not_started/ }
 
           it "renders show" do
             post_client_denial
@@ -110,7 +109,7 @@ module Providers
 
           it "does not set the task to complete" do
             post_client_denial
-            expect(legal_aid_application.legal_framework_merits_task_list.serialized_data).to match(regex)
+            expect(legal_aid_application.legal_framework_merits_task_list).to have_not_started_task(:application, :client_denial_of_allegation)
           end
         end
 
@@ -124,7 +123,7 @@ module Providers
 
           it "does not set the task to complete" do
             post_client_denial
-            expect(legal_aid_application.legal_framework_merits_task_list.serialized_data).to match(/name: :client_denial_of_allegation\n\s+dependencies: \*\d\n\s+state: :not_started/)
+            expect(legal_aid_application.legal_framework_merits_task_list).to have_not_started_task(:application, :client_denial_of_allegation)
           end
         end
       end

--- a/spec/requests/providers/application_merits_task/client_offered_undertakings_controller_spec.rb
+++ b/spec/requests/providers/application_merits_task/client_offered_undertakings_controller_spec.rb
@@ -60,7 +60,6 @@ module Providers
         let(:draft_button) { { draft_button: "Save as draft" } }
         let(:button_clicked) { {} }
         let(:undertaking) { legal_aid_application.reload.undertaking }
-        let(:not_started_regex) { /name: :client_offer_of_undertakings\n\s+dependencies: \*\d\n\s+state: :not_started/ }
 
         before do
           allow(LegalFramework::MeritsTasksService).to receive(:call).with(legal_aid_application).and_return(smtl)
@@ -75,7 +74,7 @@ module Providers
 
         it "sets the task to complete" do
           post_client_undertakings
-          expect(legal_aid_application.legal_framework_merits_task_list.serialized_data).to match(/name: :client_offer_of_undertakings\n\s+dependencies: \*\d\n\s+state: :complete/)
+          expect(legal_aid_application.legal_framework_merits_task_list).to have_completed_task(:application, :client_offer_of_undertakings)
         end
 
         it "redirects to the next page" do
@@ -102,7 +101,7 @@ module Providers
 
           it "does not set the task to complete" do
             post_client_undertakings
-            expect(legal_aid_application.legal_framework_merits_task_list.serialized_data).to match(not_started_regex)
+            expect(legal_aid_application.legal_framework_merits_task_list).to have_not_started_task(:application, :client_offer_of_undertakings)
           end
         end
 
@@ -116,7 +115,7 @@ module Providers
 
           it "does not set the task to complete" do
             post_client_undertakings
-            expect(legal_aid_application.legal_framework_merits_task_list.serialized_data).to match(not_started_regex)
+            expect(legal_aid_application.legal_framework_merits_task_list).to have_not_started_task(:application, :client_offer_of_undertakings)
           end
         end
       end

--- a/spec/requests/providers/application_merits_task/date_client_told_incidents_spec.rb
+++ b/spec/requests/providers/application_merits_task/date_client_told_incidents_spec.rb
@@ -89,7 +89,7 @@ module Providers
 
         it "sets the task to complete" do
           subject
-          expect(legal_aid_application.legal_framework_merits_task_list.serialized_data).to match(/name: :latest_incident_details\n\s+dependencies: \*\d\n\s+state: :complete/)
+          expect(legal_aid_application.legal_framework_merits_task_list).to have_completed_task(:application, :latest_incident_details)
         end
 
         it "redirects to the next page" do
@@ -107,7 +107,6 @@ module Providers
 
         context "when incomplete" do
           let(:told_on_3i) { "" }
-          let(:regex) { /name: :latest_incident_details\n\s+dependencies: \*\d\n\s+state: :not_started/ }
 
           it "renders show" do
             subject
@@ -116,7 +115,7 @@ module Providers
 
           it "does not set the task to complete" do
             subject
-            expect(legal_aid_application.legal_framework_merits_task_list.serialized_data).to match(regex)
+            expect(legal_aid_application.legal_framework_merits_task_list).to have_not_started_task(:application, :latest_incident_details)
           end
         end
 
@@ -154,7 +153,7 @@ module Providers
 
           it "does not set the task to complete" do
             subject
-            expect(legal_aid_application.legal_framework_merits_task_list.serialized_data).to match(/name: :latest_incident_details\n\s+dependencies: \*\d\n\s+state: :not_started/)
+            expect(legal_aid_application.legal_framework_merits_task_list).to have_not_started_task(:application, :latest_incident_details)
           end
         end
       end

--- a/spec/requests/providers/application_merits_task/has_other_involved_children_spec.rb
+++ b/spec/requests/providers/application_merits_task/has_other_involved_children_spec.rb
@@ -53,7 +53,7 @@ module Providers
 
           it "does not set the task to complete" do
             subject
-            expect(application.legal_framework_merits_task_list.serialized_data).to match(/name: :children_application\n\s+dependencies: \*\d\n\s+state: :not_started/)
+            expect(application.legal_framework_merits_task_list).to have_not_started_task(:application, :children_application)
           end
         end
 
@@ -73,7 +73,7 @@ module Providers
 
           it "sets the task to complete" do
             subject
-            expect(application.reload.legal_framework_merits_task_list.serialized_data).to match(/name: :children_application\n\s+dependencies: \*\d\n\s+state: :complete/)
+            expect(application.reload.legal_framework_merits_task_list).to have_completed_task(:application, :children_application)
           end
         end
 
@@ -93,7 +93,7 @@ module Providers
 
           it "does not set the task to complete" do
             subject
-            expect(application.legal_framework_merits_task_list.serialized_data).to match(/name: :children_application\n\s+dependencies: \*\d\n\s+state: :not_started/)
+            expect(application.legal_framework_merits_task_list).to have_not_started_task(:application, :children_application)
           end
         end
       end

--- a/spec/requests/providers/application_merits_task/nature_of_urgencies_controller_spec.rb
+++ b/spec/requests/providers/application_merits_task/nature_of_urgencies_controller_spec.rb
@@ -55,7 +55,6 @@ module Providers
         let(:draft_button) { { draft_button: "Save as draft" } }
         let(:button_clicked) { {} }
         let(:urgency) { legal_aid_application.reload.urgency }
-        let(:not_started_regex) { /name: :nature_of_urgency\n\s+dependencies: \*\d\n\s+state: :not_started/ }
 
         before do
           allow(LegalFramework::MeritsTasksService).to receive(:call).with(legal_aid_application).and_return(smtl)
@@ -112,7 +111,7 @@ module Providers
 
           it "does not set the task to complete" do
             post_nature_of_urgencies
-            expect(legal_aid_application.legal_framework_merits_task_list.serialized_data).to match(not_started_regex)
+            expect(legal_aid_application.legal_framework_merits_task_list).to have_not_started_task(:application, :nature_of_urgency)
           end
         end
       end

--- a/spec/requests/providers/application_merits_task/opponents_spec.rb
+++ b/spec/requests/providers/application_merits_task/opponents_spec.rb
@@ -93,7 +93,7 @@ module Providers
 
         it "sets the task to complete" do
           subject
-          expect(legal_aid_application.legal_framework_merits_task_list.serialized_data).to match(/name: :opponent_details\n\s+dependencies: \*\d\n\s+state: :complete/)
+          expect(legal_aid_application.legal_framework_merits_task_list).to have_completed_task(:application, :opponent_details)
         end
 
         context "when no other tasks are complete" do
@@ -161,7 +161,7 @@ module Providers
 
           it "does not set the task to complete" do
             subject
-            expect(legal_aid_application.legal_framework_merits_task_list.serialized_data).to match(/name: :opponent_details\n\s+dependencies: \*\d\n\s+state: :not_started/)
+            expect(legal_aid_application.legal_framework_merits_task_list).to have_not_started_task(:application, :opponent_details)
           end
         end
 
@@ -175,7 +175,7 @@ module Providers
 
           it "does not set the task to complete" do
             subject
-            expect(legal_aid_application.legal_framework_merits_task_list.serialized_data).to match(/name: :opponent_details\n\s+dependencies: \*\d\n\s+state: :not_started/)
+            expect(legal_aid_application.legal_framework_merits_task_list).to have_not_started_task(:application, :opponent_details)
           end
         end
       end

--- a/spec/requests/providers/application_merits_task/statement_of_case_spec.rb
+++ b/spec/requests/providers/application_merits_task/statement_of_case_spec.rb
@@ -166,7 +166,7 @@ module Providers
 
               it "sets the task to complete" do
                 subject
-                expect(legal_aid_application.reload.legal_framework_merits_task_list.serialized_data).to match(/name: :statement_of_case\n\s+dependencies: \*\d\n\s+state: :complete/)
+                expect(legal_aid_application.reload.legal_framework_merits_task_list).to have_completed_task(:application, :statement_of_case)
               end
             end
 
@@ -451,7 +451,7 @@ module Providers
 
           it "does not set the task to complete" do
             subject
-            expect(legal_aid_application.legal_framework_merits_task_list.serialized_data).to match(/name: :statement_of_case\n\s+dependencies: \*\d\n\s+state: :not_started/)
+            expect(legal_aid_application.legal_framework_merits_task_list).to have_not_started_task(:application, :statement_of_case)
           end
 
           it "redirects to provider draft endpoint" do

--- a/spec/requests/providers/proceeding_merits_task/attempts_to_settle_controller_spec.rb
+++ b/spec/requests/providers/proceeding_merits_task/attempts_to_settle_controller_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe Providers::ProceedingMeritsTask::AttemptsToSettleController do
 
         it "updates the task list" do
           subject
-          expect(legal_aid_application.legal_framework_merits_task_list.serialized_data).to match(/name: :attempts_to_settle\n\s+dependencies: \*\d+\n\s+state: :complete/)
+          expect(legal_aid_application.legal_framework_merits_task_list).to have_completed_task(:SE014, :attempts_to_settle)
         end
 
         context "when the params are not valid" do
@@ -134,7 +134,7 @@ RSpec.describe Providers::ProceedingMeritsTask::AttemptsToSettleController do
 
         it "does not set the task to complete" do
           subject
-          expect(legal_aid_application.legal_framework_merits_task_list.serialized_data).not_to match(/name: :attempts_to_settle\n\s+dependencies: \*\d+\n\s+state: :complete/)
+          expect(legal_aid_application.legal_framework_merits_task_list).to have_not_started_task(:SE014, :attempts_to_settle)
         end
       end
     end

--- a/spec/requests/providers/proceeding_merits_task/chances_of_success_spec.rb
+++ b/spec/requests/providers/proceeding_merits_task/chances_of_success_spec.rb
@@ -69,7 +69,7 @@ module Providers
 
         it "updates the task list" do
           subject
-          expect(legal_aid_application.legal_framework_merits_task_list.serialized_data).to match(/name: :chances_of_success\n\s+dependencies: \*\d\n\s+state: :complete/)
+          expect(legal_aid_application.legal_framework_merits_task_list).to have_completed_task(:DA001, :chances_of_success)
         end
 
         context "when false is selected" do
@@ -89,8 +89,7 @@ module Providers
 
           it "does not set the task to complete" do
             subject
-            serialized_merits_task_list = legal_aid_application.legal_framework_merits_task_list.reload.serialized_data
-            expect(serialized_merits_task_list).not_to match(/name: :chances_of_success\n\s+dependencies: \*\d\n\s+state: :complete/)
+            expect(legal_aid_application.legal_framework_merits_task_list).to have_not_started_task(:DA001, :chances_of_success)
           end
 
           it "redirects to next page" do
@@ -158,7 +157,7 @@ module Providers
 
           it "does not set the task to complete" do
             subject
-            expect(legal_aid_application.legal_framework_merits_task_list.serialized_data).not_to match(/name: :chances_of_success\n\s+dependencies: \*\d\n\s+state: :complete/)
+            expect(legal_aid_application.legal_framework_merits_task_list).to have_not_started_task(:DA001, :chances_of_success)
           end
 
           it "updates the model" do

--- a/spec/requests/providers/proceeding_merits_task/linked_children_spec.rb
+++ b/spec/requests/providers/proceeding_merits_task/linked_children_spec.rb
@@ -165,7 +165,7 @@ module Providers
 
           it "does not set the task to complete" do
             subject
-            expect(legal_aid_application.legal_framework_merits_task_list.serialized_data).not_to match(/name: :children_proceeding\n\s+dependencies: \*\d\n\s+state: :complete/)
+            expect(legal_aid_application.legal_framework_merits_task_list).to have_not_started_task(:SE014, :children_proceeding)
           end
         end
       end

--- a/spec/requests/providers/proceeding_merits_task/opponents_application_controller_spec.rb
+++ b/spec/requests/providers/proceeding_merits_task/opponents_application_controller_spec.rb
@@ -68,7 +68,7 @@ module Providers
 
         it "sets the task to complete" do
           request
-          expect(legal_aid_application.legal_framework_merits_task_list.serialized_data).to match(/name: :opponents_application\n\s+dependencies: \*\d+\n\s+state: :complete/)
+          expect(legal_aid_application.legal_framework_merits_task_list).to have_completed_task(:DA001, :opponents_application)
         end
 
         it "redirects to the next page" do
@@ -87,7 +87,6 @@ module Providers
         context "when incomplete" do
           let(:has_opponents_application) { "false" }
           let(:reason_for_applying) { "" }
-          let(:regex) { /name: :opponents_application\n\s+dependencies: \*\d+\n\s+state: :not_started/ }
 
           it "renders show" do
             request
@@ -96,7 +95,7 @@ module Providers
 
           it "does not set the task to complete" do
             request
-            expect(legal_aid_application.legal_framework_merits_task_list.serialized_data).to match(regex)
+            expect(legal_aid_application.legal_framework_merits_task_list).to have_not_started_task(:DA001, :opponents_application)
           end
         end
 
@@ -122,7 +121,7 @@ module Providers
 
           it "does not set the task to complete" do
             request
-            expect(legal_aid_application.legal_framework_merits_task_list.serialized_data).to match(/name: :opponents_application\n\s+dependencies: \*\d+\n\s+state: :not_started/)
+            expect(legal_aid_application.legal_framework_merits_task_list).to have_not_started_task(:DA001, :opponents_application)
           end
         end
       end

--- a/spec/requests/providers/proceeding_merits_task/prohibited_steps_controller_spec.rb
+++ b/spec/requests/providers/proceeding_merits_task/prohibited_steps_controller_spec.rb
@@ -68,7 +68,7 @@ module Providers
 
         it "sets the task to complete" do
           post_prohibited_steps
-          expect(legal_aid_application.legal_framework_merits_task_list.serialized_data).to match(/name: :prohibited_steps\n\s+dependencies: \*\d+\n\s+state: :complete/)
+          expect(legal_aid_application.legal_framework_merits_task_list).to have_completed_task(:SE003, :prohibited_steps)
         end
 
         context "when all previous tasks are completed" do
@@ -95,7 +95,6 @@ module Providers
         context "when incomplete" do
           let(:uk_removal) { "false" }
           let(:details) { "" }
-          let(:regex) { /name: :prohibited_steps\n\s+dependencies: \*\d+\n\s+state: :not_started/ }
 
           it "renders show" do
             post_prohibited_steps
@@ -104,7 +103,7 @@ module Providers
 
           it "does not set the task to complete" do
             post_prohibited_steps
-            expect(legal_aid_application.legal_framework_merits_task_list.serialized_data).to match(regex)
+            expect(legal_aid_application.legal_framework_merits_task_list).to have_not_started_task(:SE003, :prohibited_steps)
           end
         end
 
@@ -130,7 +129,7 @@ module Providers
 
           it "does not set the task to complete" do
             post_prohibited_steps
-            expect(legal_aid_application.legal_framework_merits_task_list.serialized_data).to match(/name: :prohibited_steps\n\s+dependencies: \*\d+\n\s+state: :not_started/)
+            expect(legal_aid_application.legal_framework_merits_task_list).to have_not_started_task(:SE003, :prohibited_steps)
           end
         end
       end

--- a/spec/requests/providers/proceeding_merits_task/specific_issue_controller_spec.rb
+++ b/spec/requests/providers/proceeding_merits_task/specific_issue_controller_spec.rb
@@ -65,7 +65,7 @@ module Providers
             end
 
             it "sets the task to complete" do
-              expect(legal_aid_application.reload.legal_framework_merits_task_list.serialized_data).to match(/name: :specific_issue\n\s+dependencies: \*\d+\n\s+state: :complete/)
+              expect(legal_aid_application.legal_framework_merits_task_list).to have_completed_task(:SE004, :specific_issue)
             end
 
             it "redirects to the next page" do

--- a/spec/requests/providers/proceeding_merits_task/vary_order_controller_spec.rb
+++ b/spec/requests/providers/proceeding_merits_task/vary_order_controller_spec.rb
@@ -63,8 +63,7 @@ RSpec.describe Providers::ProceedingMeritsTask::VaryOrderController do
 
       it "sets the vary_order task to complete" do
         patch_vary_order
-        deserialized_da002_tasks = legal_aid_application.legal_framework_merits_task_list.task_list.tasks.dig(:proceedings, :DA002, :tasks)
-        expect(deserialized_da002_tasks).to include(an_object_having_attributes(name: :vary_order, state: :complete))
+        expect(legal_aid_application.legal_framework_merits_task_list).to have_completed_task(:DA002, :vary_order)
       end
 
       it "redirects" do
@@ -83,8 +82,7 @@ RSpec.describe Providers::ProceedingMeritsTask::VaryOrderController do
 
       it "does not set the vary_order task to complete" do
         patch_vary_order
-        deserialized_da002_tasks = legal_aid_application.legal_framework_merits_task_list.task_list.tasks.dig(:proceedings, :DA002, :tasks)
-        expect(deserialized_da002_tasks).to include(an_object_having_attributes(name: :vary_order, state: :not_started))
+        expect(legal_aid_application.legal_framework_merits_task_list).to have_not_started_task(:DA002, :vary_order)
       end
     end
 
@@ -141,8 +139,7 @@ RSpec.describe Providers::ProceedingMeritsTask::VaryOrderController do
 
       it "does not set the task to complete" do
         patch_vary_order
-        deserialized_da002_tasks = legal_aid_application.legal_framework_merits_task_list.task_list.tasks.dig(:proceedings, :DA002, :tasks)
-        expect(deserialized_da002_tasks).to include(an_object_having_attributes(name: :vary_order, state: :not_started))
+        expect(legal_aid_application.legal_framework_merits_task_list).to have_not_started_task(:DA002, :vary_order)
       end
     end
   end

--- a/spec/support/task_list_matcher.rb
+++ b/spec/support/task_list_matcher.rb
@@ -1,0 +1,33 @@
+RSpec::Matchers.define :have_completed_task do |group, task_name|
+  match do |actual|
+    expect(actual).to have_task_in_state(group, task_name, :complete)
+  end
+end
+
+RSpec::Matchers.define :have_not_started_task do |group, task_name|
+  match do |actual|
+    expect(actual).to have_task_in_state(group, task_name, :not_started)
+  end
+end
+
+RSpec::Matchers.define :have_task_in_state do |group, task_name, expected_state|
+  match do |actual|
+    possible_tasks = actual.task_list.tasks[group.to_sym] || actual.task_list.tasks.dig(:proceedings, group.to_sym, :tasks)
+    if possible_tasks.nil?
+      @error_message = "No group named ':#{group}' exists"
+      break
+    end
+
+    @found_task = possible_tasks.detect { |task| task.name == task_name.to_sym }
+    if @found_task.nil?
+      @error_message = "No task named '#{task_name}' exists in group named ':#{group}'"
+      break
+    end
+
+    @found_task.state == expected_state
+  end
+
+  failure_message do
+    @error_message ||= "The [:#{group}][:#{task_name}] task is set to :#{@found_task.state}, not :#{expected_state}'"
+  end
+end


### PR DESCRIPTION

## What

Add a new set of rspec matchers that can be passed a group, task, and optionally, a state to determine
the current state of the task list.

`have_completed_task(:group, :task_name)`
`have_not_started_task(:group, :task_name)`
and, underlying them,
`have_task_in_state((:group, :task_name, :state)`


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
