### PR TITLE
Fix: Update ScheduledMailingsDeliveryJob

### DIFF
--- a/app/jobs/scheduled_mailings_delivery_job.rb
+++ b/app/jobs/scheduled_mailings_delivery_job.rb
@@ -9,6 +9,8 @@ class ScheduledMailingsDeliveryJob < ApplicationJob
     end
     reschedule unless JobQueue.enqueued?(ScheduledMailingsDeliveryJob)
     EmailMonitorJob.perform_later unless JobQueue.enqueued?(EmailMonitorJob)
+  rescue ActiveRecord::StatementInvalid
+    Sentry.capture_message("Database for #{ENV.fetch('APP_BRANCH', 'unknown branch')} not available to send scheduled mailings")
   end
 
   def reschedule


### PR DESCRIPTION
## What

Currently, the scheduled mailer runs each morning on each UAT instance.  If K8s has deleted the postgres pod sidekiq will try multiple times to connect and send mails.  This results in thousands of sentry errors
![image](https://user-images.githubusercontent.com/6757677/203514745-f81bb4c1-f0de-425c-b650-d9260179287c.png)
This job runs every 30 minutes, so when the DB has been recycled there are a _lot_ of errors


This PR attempts to allow the job to fail politely.  If it cannot find the DB it will send a single Sentry message and then allow the job to exit, this should mean that sidekiq won't keep retrying as the job has not 'failed'

We can monitor this by tracking the sentry stats for the UAT instance - I think there will still be many alerts but fewer than there are now

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
