### PR TITLE
Remove duplicate delegated functions method

### DIFF
--- a/app/models/concerns/delegated_functions.rb
+++ b/app/models/concerns/delegated_functions.rb
@@ -3,12 +3,6 @@ module DelegatedFunctions
     proceedings.any?(&:used_delegated_functions?)
   end
 
-  # TODO: move the logic from the method below into used_delegated_functions? method above
-  # and remove the associated tests for this method on legal_aid_application
-  def proceedings_used_delegated_functions?
-    proceedings.any?(&:used_delegated_functions?)
-  end
-
   def used_delegated_functions_on
     earliest_delegated_functions_date
   end

--- a/app/services/ccms/attribute_value_generator.rb
+++ b/app/services/ccms/attribute_value_generator.rb
@@ -103,7 +103,7 @@ module CCMS
     end
 
     def app_amendment_type(_options)
-      legal_aid_application.proceedings_used_delegated_functions? ? "SUBDP" : "SUB"
+      legal_aid_application.used_delegated_functions? ? "SUBDP" : "SUB"
     end
 
     def provider_firm_id(_options)
@@ -218,11 +218,11 @@ module CCMS
     end
 
     def application_substantive?(_options)
-      !legal_aid_application.proceedings_used_delegated_functions?
+      !legal_aid_application.used_delegated_functions?
     end
 
     def proceeding_proceeding_application_type(_options)
-      legal_aid_application.proceedings_used_delegated_functions? ? "Both" : "Substantive"
+      legal_aid_application.used_delegated_functions? ? "Both" : "Substantive"
     end
 
     def no_warning_letter_sent?(_options)

--- a/spec/models/legal_aid_application_spec.rb
+++ b/spec/models/legal_aid_application_spec.rb
@@ -660,24 +660,6 @@ RSpec.describe LegalAidApplication do
     end
   end
 
-  describe "#proceedings_used_delegated_functions?" do
-    context "when application uses df" do
-      let(:legal_aid_application) { create(:legal_aid_application, :with_proceedings, explicit_proceedings: [:da004], set_lead_proceeding: :da004) }
-
-      it "returns true" do
-        expect(legal_aid_application.proceedings_used_delegated_functions?).to be(true)
-      end
-    end
-
-    context "when application does not use df" do
-      let(:legal_aid_application) { create(:legal_aid_application, :with_proceedings) }
-
-      it "returns false" do
-        expect(legal_aid_application.proceedings_used_delegated_functions?).to be(false)
-      end
-    end
-  end
-
   describe "#read_only?" do
     context "when provider application not submitted" do
       let(:legal_aid_application) { create(:legal_aid_application, :with_non_passported_state_machine) }


### PR DESCRIPTION
## What
Remove duplicate delegated functions method

[Link to story](https://dsdmoj.atlassian.net/browse/AP-6329)

`#proceedings_used_delegated_functions?` and `#used_delegated_functions?`
 do the same thing. Keep the shorter one as more succint while still
 sufficiently desccribing its function.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
