### PR TITLE
Omit asset sourcemaps from prod env

### DIFF
--- a/config/webpack/production.js
+++ b/config/webpack/production.js
@@ -2,4 +2,8 @@ process.env.NODE_ENV = process.env.NODE_ENV || 'production'
 
 const environment = require('./environment')
 
+environment.config.merge({
+  devtool: 'none'
+})
+
 module.exports = environment.toWebpackConfig()


### PR DESCRIPTION

## What

Omit asset source maps from the production environment, as to reduce the number of 500 http requests to said assets.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
