### PR TITLE
Remove IE conditional comments

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -26,13 +26,6 @@
     <link rel="apple-touch-icon" sizes="167x167" href="<%= asset_pack_path("media/images/govuk-apple-touch-icon-167x167.png") %>">
     <link rel="apple-touch-icon" sizes="152x152" href="<%= asset_pack_path("media/images/govuk-apple-touch-icon-152x152.png") %>">
     <link rel="apple-touch-icon" href="<%= asset_pack_path("media/images/govuk-apple-touch-icon.png") %>">
-
-    <!--[if !IE 8]> <link href="/govuk-frontend/all.css" rel="stylesheet"/> <![endif]-->
-
-    <!--[if IE 8]> <link href="/govuk-frontend/all-ie8.css" rel="stylesheet" /> <![endif]-->
-
-    <!--[if lt IE 9]> <script src="/html5-shiv/html5shiv.js"></script> <![endif]-->
-
     <meta property="og:image" content="<%= asset_pack_path("media/images/govuk-opengraph-image.png") %>">
   </head>
 


### PR DESCRIPTION
## What
Remove IE conditional comments

Conditional comments are conditional statements interpreted by Microsoft Internet Explorer versions 5 through 9 in HTML source code.
Browser viersions that are no longer support by MS nor us.
In addition, these source paths do not exist, therefore would return a 404 if browsing on the relevant browsers.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
