### PR TITLE
[Security] Selectively bump loader-utils to v1.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "glob-parent": "^5.1.2",
     "is-svg": "^4.2.2",
     "kind-of": "^6.0.3",
+    "loader-utils": "^1.4.2",
     "minimist": "^1.2.2",
     "normalize-url": "^4.5.1",
     "nth-check": "^2.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6425,7 +6425,7 @@ loader-runner@^2.4.0:
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.4.0.tgz#ed47066bfe534d7e84c4c7b9998c2a75607d9357"
   integrity sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw==
 
-loader-utils@^1.1.0, loader-utils@^1.2.3, loader-utils@^1.4.0:
+loader-utils@^1.1.0, loader-utils@^1.2.3, loader-utils@^1.4.0, loader-utils@^1.4.2, loader-utils@^2.0.0:
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.4.2.tgz#29a957f3a63973883eb684f10ffd3d151fec01a3"
   integrity sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==
@@ -6433,15 +6433,6 @@ loader-utils@^1.1.0, loader-utils@^1.2.3, loader-utils@^1.4.0:
     big.js "^5.2.2"
     emojis-list "^3.0.0"
     json5 "^1.0.1"
-
-loader-utils@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-2.0.0.tgz#e4cace5b816d425a166b5f097e10cd12b36064b0"
-  integrity sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==
-  dependencies:
-    big.js "^5.2.2"
-    emojis-list "^3.0.0"
-    json5 "^2.1.2"
 
 locate-path@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## What

The loader-utils package <1.4.1 >=2.0.0 <2.0.3 are vulnerable to Regular Expression Denial of Service (ReDoS).

ReDos bug fixed in [v1.4.2](https://github.com/webpack/loader-utils/releases/tag/v1.4.2), [v2.0.4](https://github.com/webpack/loader-utils/releases/tag/v2.0.4) and [v3.2.1](https://github.com/webpack/loader-utils/releases/tag/v3.2.1)

The latest possible version that can be installed is 1.4.2 because of the following conflicting dependencies:

```
@rails/webpacker@5.4.3 requires loader-utils@^1.4.0 via a transitive dependency on babel-loader@8.2.2
@rails/webpacker@5.4.3 requires loader-utils@^1.2.3 via a transitive dependency on css-loader@3.6.0
@rails/webpacker@5.4.3 requires loader-utils@^1.1.0 via mini-css-extract-plugin@0.9.0
@rails/webpacker@5.4.3 requires loader-utils@^1.1.0 via postcss-loader@3.0.0
@rails/webpacker@5.4.3 requires loader-utils@^1.2.3 via a transitive dependency on webpack@4.46.0
@rails/webpacker@5.4.3 requires loader-utils@^1.4.0 via a transitive dependency on webpack-cli@3.3.12
```

References
https://security.snyk.io/vuln/SNYK-JS-LOADERUTILS-3043105
https://github.com/advisories/GHSA-76p3-8jx3-jpfq


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
