### PR TITLE
Ap 3659 remove domestic abuse proceeding limitation

### DIFF
--- a/app/forms/legal_aid_applications/has_other_proceedings_form.rb
+++ b/app/forms/legal_aid_applications/has_other_proceedings_form.rb
@@ -5,7 +5,7 @@ module LegalAidApplications
     attr_accessor :has_other_proceeding
 
     validates :has_other_proceeding, presence: true, unless: :draft?
-    validate :at_least_one_domestic_abuse, unless: -> { draft? || has_other_proceeding? }
+    validate :at_least_one_domestic_abuse, unless: -> { draft? || has_other_proceeding? || model.provider.full_section_8_permissions? }
 
     delegate :proceedings, to: :model
 

--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -144,15 +144,6 @@ class LegalAidApplication < ApplicationRecord
     proceedings.find_by(lead_proceeding: true)
   end
 
-  def find_or_set_lead_proceeding
-    lead_proc = lead_proceeding
-    if lead_proc.nil?
-      lead_proc = proceedings.detect { |p| p.ccms_code =~ /^DA/ }
-      lead_proc.update! lead_proceeding: true
-    end
-    lead_proc
-  end
-
   def proceedings_by_name
     # returns an array of ProceedingStruct containing:
     # - name of the proceeding type

--- a/app/services/legal_framework/lead_proceeding_assignment_service.rb
+++ b/app/services/legal_framework/lead_proceeding_assignment_service.rb
@@ -21,7 +21,7 @@ module LegalFramework
   private
 
     def assign_new_lead
-      new_lead_proceeding = @legal_aid_application.proceedings.detect(&:domestic_abuse?)
+      new_lead_proceeding = @legal_aid_application.proceedings.in_order_of_addition.first
       return if new_lead_proceeding.nil?
 
       new_lead_proceeding.update!(lead_proceeding: true)

--- a/spec/models/legal_aid_application_spec.rb
+++ b/spec/models/legal_aid_application_spec.rb
@@ -1179,32 +1179,6 @@ RSpec.describe LegalAidApplication do
     end
   end
 
-  describe "#find or set lead proceeding" do
-    context "with lead proceeding already set" do
-      let(:laa) { create(:legal_aid_application, :with_proceedings, proceeding_count: 4, set_lead_proceeding: :da004) }
-      let(:da004) { laa.proceedings.find_by(ccms_code: "DA004") }
-
-      it "returns the lead proceeding" do
-        expect(laa.find_or_set_lead_proceeding).to eq da004
-      end
-    end
-
-    context "with no lead proceeding set" do
-      let(:laa) { create(:legal_aid_application, :with_proceedings, proceeding_count: 4, set_lead_proceeding: false) }
-
-      it "returns one of the domestic abuse proceedings" do
-        expect(laa.lead_proceeding).to be_nil
-        lead_proc = laa.find_or_set_lead_proceeding
-        expect(lead_proc.ccms_code).to match(/^DA/)
-      end
-
-      it "has set the lead proceeding to true" do
-        lead_proc = laa.find_or_set_lead_proceeding
-        expect(lead_proc.lead_proceeding).to be true
-      end
-    end
-  end
-
   describe "#proceedings_by_name" do
     subject { laa.proceedings_by_name }
 

--- a/spec/requests/providers/has_other_proceedings_controller_spec.rb
+++ b/spec/requests/providers/has_other_proceedings_controller_spec.rb
@@ -10,9 +10,14 @@ RSpec.describe Providers::HasOtherProceedingsController do
   let(:provider) { legal_aid_application.provider }
   let(:next_flow_step) { flow_forward_path }
   let(:mini_loop?) { false }
+  let(:permission) { create(:permission, :full_section_8) }
+  let(:full_section_8?) { false }
 
   before do
     allow(Setting).to receive(:enable_mini_loop?).and_return(mini_loop?)
+    if full_section_8?
+      legal_aid_application.provider.permissions << permission
+    end
     login_as provider
   end
 
@@ -62,9 +67,28 @@ RSpec.describe Providers::HasOtherProceedingsController do
       let(:legal_aid_application) { create(:legal_aid_application, :at_checking_applicant_details, :with_proceedings, explicit_proceedings: [:se014], set_lead_proceeding: false) }
       let(:params) { { legal_aid_application: { has_other_proceeding: "false" } } }
 
-      it "stays on the page and displays an error" do
-        expect(response).to have_http_status(:ok)
-        expect(page).to have_error_message("has_other_proceeding.must_add_domestic_abuse")
+      context "when the provider does not have full section 8 permissions" do
+        it "stays on the page and displays an error" do
+          expect(response).to have_http_status(:ok)
+          expect(page).to have_error_message("has_other_proceeding.must_add_domestic_abuse")
+        end
+      end
+
+      context "when the provider has full section 8 permissions" do
+        let(:full_section_8?) { true }
+
+        it "redirects to multiple delegated functions" do
+          expect(response).to redirect_to(providers_legal_aid_application_used_multiple_delegated_functions_path(legal_aid_application))
+        end
+
+        context "when the mini-loop is on" do
+          let(:mini_loop?) { true }
+
+          it "redirects to the first incomplete proceedings client involvement type page" do
+            proceeding_id = legal_aid_application.proceedings.in_order_of_addition.incomplete.first.id
+            expect(response).to redirect_to(providers_legal_aid_application_client_involvement_type_path(legal_aid_application.id, proceeding_id))
+          end
+        end
       end
     end
 
@@ -78,14 +102,32 @@ RSpec.describe Providers::HasOtherProceedingsController do
     end
 
     context "with only Section 8 proceedings selected" do
-      let(:legal_aid_application) { create(:legal_aid_application, :with_proceedings, assign_lead_proceeding: false, explicit_proceedings: [:se013]) }
-
       context "choose no" do
+        let(:legal_aid_application) { create(:legal_aid_application, :with_proceedings, assign_lead_proceeding: false, explicit_proceedings: [:se013]) }
         let(:params) { { legal_aid_application: { has_other_proceeding: "false" } } }
 
-        it "stays on the page and displays an error" do
-          expect(response).to have_http_status(:ok)
-          expect(page).to have_error_message("has_other_proceeding.must_add_domestic_abuse")
+        context "when the provider does not have full section 8 permissions" do
+          it "stays on the page and displays an error" do
+            expect(response).to have_http_status(:ok)
+            expect(page).to have_error_message("has_other_proceeding.must_add_domestic_abuse")
+          end
+        end
+
+        context "when the provider has full section 8 permissions" do
+          let(:full_section_8?) { true }
+
+          it "redirects to multiple delegated functions" do
+            expect(response).to redirect_to(providers_legal_aid_application_used_multiple_delegated_functions_path(legal_aid_application))
+          end
+
+          context "when the mini-loop is on" do
+            let(:mini_loop?) { true }
+
+            it "redirects to the first incomplete proceedings client involvement type page" do
+              proceeding_id = legal_aid_application.proceedings.in_order_of_addition.incomplete.first.id
+              expect(response).to redirect_to(providers_legal_aid_application_client_involvement_type_path(legal_aid_application.id, proceeding_id))
+            end
+          end
         end
       end
 

--- a/spec/services/legal_framework/lead_proceeding_assignment_service_spec.rb
+++ b/spec/services/legal_framework/lead_proceeding_assignment_service_spec.rb
@@ -26,20 +26,23 @@ module LegalFramework
 
     context "when there are no lead proceedings" do
       let(:explicit_proceedings) { %i[se013 se014 da001] }
+      let(:first_proceeding) { laa.proceedings.in_order_of_addition.first }
 
-      it "sets the domestic abuse proceeding as lead" do
+      it "sets the proceeding added first as the lead proceeding" do
         subject
-        expect(p_s81.lead_proceeding?).to be false
-        expect(p_s82.lead_proceeding?).to be false
-        expect(p_da1.lead_proceeding?).to be true
+        expect(first_proceeding.lead_proceeding?).to be true
+        laa.proceedings.in_order_of_addition[1..].each do |proceeding|
+          expect(proceeding.lead_proceeding?).to be false
+        end
       end
     end
 
     context "when there are no domestic abuse proceedings" do
       let(:explicit_proceedings) { %i[se013 se014] }
 
-      it "changes nothing" do
-        expect(p_s81.lead_proceeding?).to be false
+      it "sets the proceeding added first as the lead proceeding" do
+        subject
+        expect(p_s81.lead_proceeding?).to be true
         expect(p_s82.lead_proceeding?).to be false
       end
     end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3659)

-Remove validation that there is a domestic abuse proceeding (where the provider has full_section_8 permission)
-Make first proceeding added the lead_proceeding (currently it is the first domestic abuse proceeding)
-Remove redundant find_or_set_lead_proceeding method

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
