### PR TITLE
Fix: Opponent task errors while in progress

### DIFF
--- a/app/controllers/providers/merits_task_lists_controller.rb
+++ b/app/controllers/providers/merits_task_lists_controller.rb
@@ -25,6 +25,7 @@ module Providers
       if merits_task_list.nil?
         LegalFramework::MeritsTasksService.call(@legal_aid_application).tasks
       else
+        LegalFramework::OpponentTaskUpdateService.call(@legal_aid_application)
         merits_task_list.task_list.tasks
       end
     end

--- a/app/services/legal_framework/opponent_task_update_service.rb
+++ b/app/services/legal_framework/opponent_task_update_service.rb
@@ -24,6 +24,7 @@ module LegalFramework
       @merits_task_list.task_list.tasks[:application] = @application_tasks - [legacy_opponent_step]
       @merits_task_list.serialized_data = @merits_task_list.task_list.to_yaml
       @merits_task_list.save!
+      Rails.logger.info("OpponentTaskUpdateService - processed for #{@legal_aid_application.id}, original state was #{legacy_opponent_step.state}")
     end
 
   private

--- a/app/services/legal_framework/opponent_task_update_service.rb
+++ b/app/services/legal_framework/opponent_task_update_service.rb
@@ -1,0 +1,39 @@
+module LegalFramework
+  class OpponentTaskUpdateService
+    def initialize(legal_aid_application)
+      @legal_aid_application = legal_aid_application
+      @merits_task_list = @legal_aid_application.legal_framework_merits_task_list
+      @application_tasks = @merits_task_list.task_list.tasks[:application]
+    end
+
+    def self.call(legal_aid_application)
+      new(legal_aid_application).call
+    end
+
+    def call
+      return unless has_legacy_opponent_step?
+
+      @application_tasks << LegalFramework::SerializableMeritsTask.new(:opponent_name, dependencies: [])
+      @application_tasks << LegalFramework::SerializableMeritsTask.new(:opponent_mental_capacity, dependencies: [])
+      @application_tasks << LegalFramework::SerializableMeritsTask.new(:domestic_abuse_summary, dependencies: [])
+      if legacy_opponent_step.state == :complete
+        @merits_task_list.mark_as_complete!(:application, :opponent_name)
+        @merits_task_list.mark_as_complete!(:application, :opponent_mental_capacity)
+        @merits_task_list.mark_as_complete!(:application, :domestic_abuse_summary)
+      end
+      @merits_task_list.task_list.tasks[:application] = @application_tasks - [legacy_opponent_step]
+      @merits_task_list.serialized_data = @merits_task_list.task_list.to_yaml
+      @merits_task_list.save!
+    end
+
+  private
+
+    def legacy_opponent_step
+      @application_tasks.detect { |task| task.name == :opponent_details }
+    end
+
+    def has_legacy_opponent_step?
+      @has_legacy_opponent_step ||= legacy_opponent_step.present?
+    end
+  end
+end

--- a/spec/factories/legal_framework_merits_task_list.rb
+++ b/spec/factories/legal_framework_merits_task_list.rb
@@ -42,5 +42,9 @@ FactoryBot.define do
     trait :da001_da005_as_applicant do
       serialized_data { build(:legal_framework_serializable_merits_task_list, :da001_da005_as_applicant).to_yaml }
     end
+
+    trait :broken_opponent do
+      serialized_data { build(:legal_framework_serializable_merits_task_list, :broken_opponent).to_yaml }
+    end
   end
 end

--- a/spec/factories/legal_framework_serialized_merits_task_list.rb
+++ b/spec/factories/legal_framework_serialized_merits_task_list.rb
@@ -11,7 +11,6 @@ FactoryBot.define do
             opponent_name: [],
             opponent_mental_capacity: [],
             domestic_abuse_summary: [],
-            # opponent_details: [],
             children_application: [],
             statement_of_case: [],
             why_matter_opposed: [],
@@ -368,6 +367,40 @@ FactoryBot.define do
               tasks: {
                 chances_of_success: [],
                 vary_order: [],
+              },
+            },
+          ],
+        }
+      end
+    end
+
+    trait :broken_opponent do
+      lfa_response do
+        {
+          request_id: SecureRandom.uuid,
+          application: {
+            tasks: {
+              latest_incident_details: [],
+              opponent_details: [],
+              children_application: [],
+              statement_of_case: [],
+              why_matter_opposed: [],
+              laspo: [],
+            },
+          },
+          proceeding_types: [
+            {
+              ccms_code: "DA001",
+              tasks: {
+                chances_of_success: [],
+              },
+            },
+            {
+              ccms_code: "SE014",
+              tasks: {
+                chances_of_success: [],
+                children_proceeding: [:children_application],
+                attempts_to_settle: [],
               },
             },
           ],

--- a/spec/requests/providers/merits_task_lists_controller_spec.rb
+++ b/spec/requests/providers/merits_task_lists_controller_spec.rb
@@ -56,6 +56,21 @@ RSpec.describe Providers::MeritsTaskListsController do
         proceeding_names.each { |name| expect(response.body).to include(name) }
       end
     end
+
+    context "the task list was started before the opponent split was implemented" do
+      let(:task_list) { create(:legal_framework_merits_task_list, :broken_opponent, legal_aid_application:) }
+
+      before do
+        subject
+      end
+
+      it "calls the OpponentTaskUpdateService and replaces the opponent_details task and returns http success" do
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("Opponent&#39;s name")
+        expect(response.body).to include("Opponent&#39;s mental capacity")
+        expect(response.body).to include("Domestic abuse summary")
+      end
+    end
   end
 
   describe "PATCH /providers/merits_task_list" do

--- a/spec/services/legal_framework/opponent_task_update_service_spec.rb
+++ b/spec/services/legal_framework/opponent_task_update_service_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+module LegalFramework
+  RSpec.describe OpponentTaskUpdateService do
+    subject(:call_service) { described_class.call(legal_aid_application) }
+
+    let(:legal_aid_application) { create(:legal_aid_application, :with_multiple_proceedings_inc_section8) }
+
+    context "when the task list predates the switch" do
+      let!(:task_list) { create(:legal_framework_merits_task_list, :broken_opponent, legal_aid_application:) }
+
+      it "replaces the tasks with the new version" do
+        call_service
+        expect(legal_aid_application.legal_framework_merits_task_list.reload.serialized_data).not_to eql task_list.serialized_data
+      end
+
+      context "and the opponent_details task is complete" do
+        before do
+          legal_aid_application.legal_framework_merits_task_list.mark_as_complete!(:application, :opponent_details)
+        end
+
+        it "marks the new values as completed too" do
+          call_service
+          expect(legal_aid_application.legal_framework_merits_task_list.reload).to have_task_in_state(:application, :opponent_name, :complete)
+          expect(legal_aid_application.legal_framework_merits_task_list.reload).to have_task_in_state(:application, :opponent_mental_capacity, :complete)
+          expect(legal_aid_application.legal_framework_merits_task_list.reload).to have_task_in_state(:application, :domestic_abuse_summary, :complete)
+        end
+      end
+    end
+
+    context "when the task list is in the new style" do
+      let!(:task_list) { create(:legal_framework_merits_task_list, legal_aid_application:) }
+
+      it "does nothing" do
+        call_service
+        expect(legal_aid_application.legal_framework_merits_task_list.reload.serialized_data).to eql task_list.serialized_data
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What

When the opponent split was deployed, more applications than expected were in progress
This handles the display and generation of the task list.  If an application has a task list with the original, single, opponents_detail task it was failing.

When displaying the task list, this now replaces it with the three new questions and marks them as complete

This should be short-lived and removable soon

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
