### PR TITLE
Bump delete-uat-release from v1.0.0 to v1.0.1

### DIFF
--- a/.github/workflows/delete-uat-release.yml
+++ b/.github/workflows/delete-uat-release.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Delete UAT release action
         id: delete_uat
-        uses: ministryofjustice/laa-civil-apply-delete-uat-release@v1.0.0
+        uses: ministryofjustice/laa-civil-apply-delete-uat-release@v1.0.1
         with:
           release_name_prefix: "apply-"
           k8s_cluster: ${{ secrets.K8S_GHA_UAT_CLUSTER_NAME }}


### PR DESCRIPTION
## What
Bump github action for delete-uat-release from v1.0.0 to use v1.0.1

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3669)

handles deprecated set-output command
[delete uat release GHA v1.0.1](https://github.com/ministryofjustice/laa-civil-apply-delete-uat-release/releases/tag/v1.0.1)

see [github action bump PR](https://github.com/ministryofjustice/laa-civil-apply-delete-uat-release/pull/2) for more details.
see [successful test deletion with no deprecation warnings](https://github.com/ministryofjustice/legal-framework-api/actions/runs/3582656827/jobs/6027140022)

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
