### PR TITLE
AP-3315 alert provider when a client start email has failed

### DIFF
--- a/app/mailers/undeliverable_email_alert_mailer.rb
+++ b/app/mailers/undeliverable_email_alert_mailer.rb
@@ -14,4 +14,15 @@ class UndeliverableEmailAlertMailer < BaseApplyMailer
 
     mail to: Rails.configuration.x.support_email_address
   end
+
+  def notify_provider(provider_email, application_ref, applicant_name, applicant_email)
+    template_name :client_email_failed_provider_alert
+    set_personalisation(
+      ref_number: application_ref,
+      applicant_name:,
+      applicant_email:,
+    )
+
+    mail to: provider_email
+  end
 end

--- a/app/services/govuk_emails/monitor.rb
+++ b/app/services/govuk_emails/monitor.rb
@@ -22,9 +22,44 @@ module GovukEmails
       AlertManager.capture_message("Unable to deliver mail to #{@scheduled_mail.addressee} - ScheduledMailing record #{@scheduled_mail.id}")
       ScheduledMailing.send_now!(mailer_klass: UndeliverableEmailAlertMailer,
                                  mailer_method: :notify_apply_team,
-                                 legal_aid_application_id: @scheduled_mail.legal_aid_application_id,
+                                 legal_aid_application_id: legal_aid_application.id,
                                  addressee: Rails.configuration.x.support_email_address,
                                  arguments: [@scheduled_mail.id])
+
+      notify_provider_email_failed if @scheduled_mail.mailer_method == "citizen_start_email"
+    end
+
+    def notify_provider_email_failed
+      ScheduledMailing.send_now!(mailer_klass: UndeliverableEmailAlertMailer,
+                                 mailer_method: :notify_provider,
+                                 legal_aid_application_id: legal_aid_application.id,
+                                 addressee: provider_email_or_support,
+                                 arguments: mailer_args)
+    end
+
+    def mailer_args
+      [
+        provider.email,
+        legal_aid_application.application_ref,
+        applicant.full_name,
+        applicant.email,
+      ]
+    end
+
+    def provider_email_or_support
+      HostEnv.staging? ? Rails.configuration.x.support_email_address : provider.email
+    end
+
+    def legal_aid_application
+      @legal_aid_application = @scheduled_mail.legal_aid_application
+    end
+
+    def applicant
+      @applicant ||= legal_aid_application.applicant
+    end
+
+    def provider
+      @provider ||= legal_aid_application.provider
     end
   end
 end

--- a/config/govuk_notify_templates.yml
+++ b/config/govuk_notify_templates.yml
@@ -8,4 +8,5 @@ reminder_to_submit_financial_information_provider: 9843f667-8b11-41c0-9c11-622ff
 new_link_to_client: 1f360188-7046-4eb2-9c03-a8253bf663c1
 citizen_completed_application: 3b18efe5-7d09-4042-927c-7d1ae03fdd7e
 undeliverable_alert: 8977dba0-7f06-4180-8ae8-11f630be8849
+client_email_failed_provider_alert: f4a1139e-ac74-4a8b-8ecf-bfa3de272236
 exception_alert: 7cee1d9e-5ee9-406d-a28b-51ab16d675ef

--- a/spec/mailers/undeliverable_email_alert_mailer_spec.rb
+++ b/spec/mailers/undeliverable_email_alert_mailer_spec.rb
@@ -1,16 +1,22 @@
 require "rails_helper"
 
 RSpec.describe UndeliverableEmailAlertMailer do
-  let(:legal_aid_application) { create(:legal_aid_application) }
+  let(:applicant) { create(:applicant, first_name: "John", last_name: "Doe", email: "johndoe@email.com") }
+  let(:provider) { create(:provider) }
+  let(:legal_aid_application) { create(:legal_aid_application, applicant:) }
   let(:failure_reason) { "permanently-failed" }
   let(:mailer) { "NotifyMailer" }
   let(:mail_method) { "citizen_start_email" }
   let(:args) { [] }
   let(:app_id) { "L-H12-3XZ" }
   let(:url) { "http://localhost/start_my_application/some_secret_id" }
-  let(:applicant_name) { "John Doe" }
-  let(:provider_firm) { "Acme Solicitors" }
-  let(:scheduled_mailing) { create(:scheduled_mailing, :citizen_start_email, :failed, legal_aid_application_id: legal_aid_application.id) }
+  let(:scheduled_mailing) do
+    create(:scheduled_mailing,
+           :citizen_start_email,
+           :failed,
+           addressee: applicant.email,
+           legal_aid_application_id: legal_aid_application.id)
+  end
 
   describe "#notify_apply_team" do
     let(:mail) { described_class.notify_apply_team(scheduled_mailing.id) }
@@ -33,6 +39,38 @@ RSpec.describe UndeliverableEmailAlertMailer do
         failure_reason: scheduled_mailing.status,
         mailer_and_method: "NotifyMailer#citizen_start_email",
         mail_params: scheduled_mailing.arguments,
+      )
+    end
+  end
+
+  describe "#notify_provider" do
+    let(:mailer_args) do
+      [
+        provider.email,
+        legal_aid_application.application_ref,
+        applicant.full_name,
+        applicant.email,
+      ]
+    end
+    let(:mail) { described_class.notify_provider(*mailer_args) }
+
+    it "sends an email to the correct provider email address" do
+      expect(mail.to).to eq([provider.email])
+    end
+
+    it "is a govuk_notify delivery" do
+      expect(mail.delivery_method).to be_a(GovukNotifyRails::Delivery)
+    end
+
+    it "sets the correct template" do
+      expect(mail.govuk_notify_template).to eq("f4a1139e-ac74-4a8b-8ecf-bfa3de272236")
+    end
+
+    it "has the right personalisation" do
+      expect(mail.govuk_notify_personalisation).to eq(
+        ref_number: legal_aid_application.application_ref,
+        applicant_name: applicant.full_name,
+        applicant_email: applicant.email,
       )
     end
   end

--- a/spec/services/govuk_emails/monitor_spec.rb
+++ b/spec/services/govuk_emails/monitor_spec.rb
@@ -42,26 +42,65 @@ RSpec.describe GovukEmails::Monitor do
 
         it "schedules an undeliverable alert email" do
           expect { subject }.to change(ScheduledMailing, :count).by(1)
-          undeliverable_mail = ScheduledMailing.order(:created_at).last
+          undeliverable_alert_mail = ScheduledMailing.order(:created_at).last
 
-          expect(undeliverable_mail.legal_aid_application_id).to eq scheduled_mailing.legal_aid_application_id
-          expect(undeliverable_mail.mailer_klass).to eq "UndeliverableEmailAlertMailer"
-          expect(undeliverable_mail.mailer_method).to eq "notify_apply_team"
-          expect(undeliverable_mail.arguments).to eq [scheduled_mailing.id]
-          expect(undeliverable_mail.scheduled_at).to have_been_in_the_past
-          expect(undeliverable_mail.addressee).to eq Rails.configuration.x.support_email_address
+          expect(undeliverable_alert_mail.legal_aid_application_id).to eq scheduled_mailing.legal_aid_application_id
+          expect(undeliverable_alert_mail.mailer_klass).to eq "UndeliverableEmailAlertMailer"
+          expect(undeliverable_alert_mail.mailer_method).to eq "notify_apply_team"
+          expect(undeliverable_alert_mail.arguments).to eq [scheduled_mailing.id]
+          expect(undeliverable_alert_mail.scheduled_at).to have_been_in_the_past
+          expect(undeliverable_alert_mail.addressee).to eq Rails.configuration.x.support_email_address
+        end
+      end
+
+      context "when the failed email is a citizen start email" do
+        let(:applicant) { create(:applicant, email: "johndoe@example.net") }
+        let(:provider) { create(:provider) }
+        let(:legal_aid_application) { create(:legal_aid_application, applicant:, provider:) }
+        let(:scheduled_mailing) do
+          create(:scheduled_mailing,
+                 :citizen_start_email,
+                 :processing,
+                 addressee: applicant.email,
+                 legal_aid_application_id: legal_aid_application.id)
+        end
+        let(:mailer_args) do
+          [
+            provider.email,
+            legal_aid_application.application_ref,
+            applicant.full_name,
+            applicant.email,
+          ]
+        end
+
+        before { allow(HostEnv).to receive(:production?).and_return(true) }
+
+        it "schedules an email to notify the provider of the failure" do
+          expect { subject }.to change(ScheduledMailing, :count).by(2)
+        end
+
+        it "uses the undeliverable email alert mailer and the notify_provider method with the right args" do
+          subject
+          provider_alert_mail = ScheduledMailing.order(:created_at).last
+
+          expect(provider_alert_mail.legal_aid_application_id).to eq scheduled_mailing.legal_aid_application_id
+          expect(provider_alert_mail.mailer_klass).to eq "UndeliverableEmailAlertMailer"
+          expect(provider_alert_mail.mailer_method).to eq "notify_provider"
+          expect(provider_alert_mail.addressee).to eq provider.email
+          expect(provider_alert_mail.arguments).to eq mailer_args
+          expect(provider_alert_mail.scheduled_at).to have_been_in_the_past
         end
       end
 
       context "not on production host" do
         before { allow(HostEnv).to receive(:production?).and_return(false) }
 
-        it "does not captures raven message" do
+        it "does not capture raven message" do
           expect(AlertManager).not_to receive(:capture_message)
           subject
         end
 
-        it "does not schedules an undeliverable alert email" do
+        it "does not schedule an undeliverable alert email" do
           expect { subject }.not_to change(ScheduledMailing, :count)
         end
       end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3315)

Add new method to undeliverable email alerts mailer
Add rspecs

NB: this hasn't been fully manually tested although rspecs are passing


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
