### PR TITLE
Add a base_state_machine spec

### DIFF
--- a/app/models/concerns/base_state_machine.rb
+++ b/app/models/concerns/base_state_machine.rb
@@ -122,7 +122,6 @@ class BaseStateMachine < ApplicationRecord
       transitions from: %i[
                     provider_entering_merits
                     checked_merits_answers
-                    provider_entering_merits
                     submitting_assessment
                     assessment_submitted
                   ],

--- a/spec/concerns/base_state_machine_spec.rb
+++ b/spec/concerns/base_state_machine_spec.rb
@@ -1,0 +1,90 @@
+require "rails_helper"
+require "aasm/rspec"
+
+RSpec.describe BaseStateMachine do
+  subject { legal_aid_application.state_machine }
+
+  let(:legal_aid_application) { create(:legal_aid_application, :with_base_state_machine) }
+
+  describe "#check_applicant_details" do
+    let(:event) { :check_applicant_details }
+
+    it { is_expected.to transition_from(:entering_applicant_details).to(:checking_applicant_details).on_event(event) }
+    it { is_expected.to transition_from(:applicant_details_checked).to(:checking_applicant_details).on_event(event) }
+    it { is_expected.to transition_from(:use_ccms).to(:checking_applicant_details).on_event(event) }
+
+    context "when application requires mean testing" do
+      before { allow(legal_aid_application).to receive(:non_means_tested?).and_return(false) }
+
+      it { is_expected.not_to transition_from(:provider_entering_merits).to(:checking_applicant_details).on_event(event) }
+    end
+
+    context "when application is non_means_tested" do
+      before { allow(legal_aid_application).to receive(:non_means_tested?).and_return(true) }
+
+      it { is_expected.to transition_from(:provider_entering_merits).to(:checking_applicant_details).on_event(event) }
+    end
+  end
+
+  describe "#applicant_details_checked" do
+    let(:event) { :applicant_details_checked }
+
+    context "without guard" do
+      before do
+        allow(CleanupCapitalAttributes).to receive(:call)
+      end
+
+      it { is_expected.to transition_from(:checking_applicant_details).to(:applicant_details_checked).on_event(event) }
+      it { is_expected.to transition_from(:use_ccms).to(:applicant_details_checked).on_event(event) }
+      it { is_expected.to transition_from(:delegated_functions_used).to(:applicant_details_checked).on_event(event) }
+    end
+
+    context "when application requires mean testing" do
+      before { allow(legal_aid_application).to receive(:non_means_tested?).and_return(false) }
+
+      it { is_expected.not_to transition_from(:provider_entering_merits).to(:applicant_details_checked).on_event(event) }
+    end
+
+    context "when application is non_means_tested" do
+      before { allow(legal_aid_application).to receive(:non_means_tested?).and_return(true) }
+
+      it { is_expected.to transition_from(:provider_entering_merits).to(:applicant_details_checked).on_event(event) }
+    end
+  end
+
+  describe "#provider_enter_merits" do
+    let(:event) { :provider_enter_merits }
+
+    context "when application requires mean testing" do
+      before { allow(legal_aid_application).to receive(:non_means_tested?).and_return(false) }
+
+      it { is_expected.not_to transition_from(:applicant_details_checked).to(:provider_entering_merits).on_event(event) }
+    end
+
+    context "when application is non_means_tested" do
+      before { allow(legal_aid_application).to receive(:non_means_tested?).and_return(true) }
+
+      it { is_expected.to transition_from(:applicant_details_checked).to(:provider_entering_merits).on_event(event) }
+    end
+  end
+
+  describe "#check_merits_answers" do
+    let(:event) { :check_merits_answers }
+
+    it { is_expected.to transition_from(:provider_entering_merits).to(:checking_merits_answers).on_event(event) }
+    it { is_expected.to transition_from(:submitting_assessment).to(:checking_merits_answers).on_event(event) }
+    it { is_expected.to transition_from(:assessment_submitted).to(:checking_merits_answers).on_event(event) }
+
+    context "when application requires mean testing" do
+      before { allow(legal_aid_application).to receive(:non_means_tested?).and_return(false) }
+
+      it { is_expected.not_to transition_from(:applicant_details_checked).to(:checking_merits_answers).on_event(event) }
+    end
+
+    context "when application is non_means_tested" do
+      before { allow(legal_aid_application).to receive(:non_means_tested?).and_return(true) }
+
+      it { is_expected.to transition_from(:applicant_details_checked).to(:checking_merits_answers).on_event(event) }
+    end
+  end
+end

--- a/spec/factories/base_state_machines.rb
+++ b/spec/factories/base_state_machines.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :base_state_machine do
+    legal_aid_application
+  end
+end

--- a/spec/factories/legal_aid_applications.rb
+++ b/spec/factories/legal_aid_applications.rb
@@ -76,6 +76,10 @@ FactoryBot.define do
       state_machine factory: :non_means_tested_state_machine
     end
 
+    trait :with_base_state_machine do
+      state_machine factory: :base_state_machine
+    end
+
     trait :initiated do
       before(:create) do |application|
         application.state_machine_proxy.update!(aasm_state: :initiated)


### PR DESCRIPTION
## What
Add a base state machine spec

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3629)

Was missing and there is quite a bit of logic that relies on this base state
machine. Some logic is tested in other state machine specs, some on over-riden
methods such as `legal_aid_application.applicant_details_checked!` or 
elsewhere(?). 

I have also added because it is otherwise possible to have faulty
code such as typos that is simply not exercised.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.


[AP-3629]: https://dsdmoj.atlassian.net/browse/AP-3629?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ