### PR TITLE
Remove `enhanced_bank_upload` column from settings

### DIFF
--- a/db/migrate/20221201085138_remove_enhanced_bank_upload_from_settings.rb
+++ b/db/migrate/20221201085138_remove_enhanced_bank_upload_from_settings.rb
@@ -1,0 +1,7 @@
+class RemoveEnhancedBankUploadFromSettings < ActiveRecord::Migration[7.0]
+  def change
+    safety_assured do
+      remove_column :settings, :enhanced_bank_upload, :boolean, null: false, default: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_11_28_150745) do
+ActiveRecord::Schema[7.0].define(version: 2022_12_01_085138) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -854,7 +854,6 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_28_150745) do
     t.datetime "digest_extracted_at", precision: nil, default: "1970-01-01 00:00:01"
     t.boolean "enable_mini_loop", default: false, null: false
     t.boolean "enable_loop", default: false, null: false
-    t.boolean "enhanced_bank_upload", default: false, null: false
     t.boolean "means_test_review_phase_one", default: false, null: false
   end
 


### PR DESCRIPTION
In #4638 the `enhanced_bank_upload` column in the `Setting` model was ignored, and `Setting.enhanced_bank_upload?` always returns `true`.

This safely removes the `enhanced_bank_upload` column from the `settings` table.