### PR TITLE
Remove `enhanced_bank_upload?` methods

### DIFF
--- a/app/helpers/means_report_helper.rb
+++ b/app/helpers/means_report_helper.rb
@@ -18,7 +18,7 @@ module MeansReportHelper
 
   def deductions_detail_items(legal_aid_application)
     items = [TransactionTypeItem.new(:dependants_allowance, :dependants_allowance, "deductions", false)]
-    items.append(TransactionTypeItem.new(:disregarded_state_benefits, :disregarded_state_benefits, "deductions", true)) unless legal_aid_application.using_enhanced_bank_upload?
+    items.append(TransactionTypeItem.new(:disregarded_state_benefits, :disregarded_state_benefits, "deductions", true)) unless legal_aid_application.uploading_bank_statements?
     items
   end
 
@@ -45,6 +45,6 @@ private
   end
 
   def housing_payment_addendum(legal_aid_application)
-    t("shared.means_report.item.outgoing.housing_addendum") if legal_aid_application.using_enhanced_bank_upload?
+    t("shared.means_report.item.outgoing.housing_addendum") if legal_aid_application.uploading_bank_statements?
   end
 end

--- a/app/models/cfe/submission.rb
+++ b/app/models/cfe/submission.rb
@@ -6,6 +6,6 @@ module CFE
     has_many :submission_histories, -> { order(created_at: :asc) }, inverse_of: :submission
     has_one :result, class_name: "BaseResult"
 
-    delegate :passported?, :non_passported?, :using_enhanced_bank_upload?, to: :legal_aid_application
+    delegate :passported?, :non_passported?, :uploading_bank_statements?, to: :legal_aid_application
   end
 end

--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -514,16 +514,12 @@ class LegalAidApplication < ApplicationRecord
     legal_aid_application_transaction_types.map(&:transaction_type_id).include?(transaction_type.id)
   end
 
-  def using_enhanced_bank_upload?
-    Setting.enhanced_bank_upload? && uploading_bank_statements?
-  end
-
   def housing_payments?
     transaction_types.for_outgoing_type?(:rent_or_mortgage)
   end
 
   def housing_benefit_regular_transaction_applicable?
-    using_enhanced_bank_upload? && housing_payments?
+    uploading_bank_statements? && housing_payments?
   end
 
 private

--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -507,7 +507,7 @@ class LegalAidApplication < ApplicationRecord
   def uploading_bank_statements?
     return false unless provider.bank_statement_upload_permissions?
 
-    !client_open_banking_consent? || attachments.bank_statement_evidence.exists?
+    client_not_given_consent_to_open_banking? || attachments.bank_statement_evidence.exists?
   end
 
   def has_transaction_type?(transaction_type)
@@ -524,10 +524,8 @@ class LegalAidApplication < ApplicationRecord
 
 private
 
-  def client_open_banking_consent?
-    return true if provider_received_citizen_consent.nil?
-
-    provider_received_citizen_consent?
+  def client_not_given_consent_to_open_banking?
+    provider_received_citizen_consent == false
   end
 
   def bank_transactions_by_type(type)

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -1,6 +1,4 @@
 class Setting < ApplicationRecord
-  self.ignored_columns += %w[enhanced_bank_upload]
-
   def self.mock_true_layer_data?
     setting.mock_true_layer_data?
   end
@@ -31,10 +29,6 @@ class Setting < ApplicationRecord
 
   def self.enable_loop?
     setting.enable_loop?
-  end
-
-  def self.enhanced_bank_upload?
-    true
   end
 
   def self.means_test_review_phase_one?

--- a/app/services/cfe/service_set.rb
+++ b/app/services/cfe/service_set.rb
@@ -64,7 +64,7 @@ module CFE
     def service_set
       if object.passported?
         PASSPORTED_SERVICES
-      elsif object.non_passported? && object.using_enhanced_bank_upload?
+      elsif object.non_passported? && object.uploading_bank_statements?
         NON_PASSPORTED_WITH_REGULAR_TRANSACTIONS_SERVICES
       elsif object.non_passported?
         NON_PASSPORTED_WITH_BANK_TRANSACTIONS_SERVICES

--- a/app/services/flow/flows/provider_capital.rb
+++ b/app/services/flow/flows/provider_capital.rb
@@ -12,7 +12,7 @@ module Flow
             when :hmrc_single_employment, :unexpected_employment_data
               :employment_incomes
             when :employed_journey_not_enabled, :provider_not_enabled_for_employed_journey, :applicant_not_employed
-              if application.using_enhanced_bank_upload?
+              if application.uploading_bank_statements?
                 :regular_incomes
               else
                 :identify_types_of_incomes
@@ -48,7 +48,7 @@ module Flow
         student_finances: {
           path: ->(application) { urls.providers_legal_aid_application_means_student_finance_path(application) },
           forward: lambda do |application|
-            application.using_enhanced_bank_upload? ? :regular_outgoings : :identify_types_of_outgoings
+            application.uploading_bank_statements? ? :regular_outgoings : :identify_types_of_outgoings
           end,
           check_answers: :means_summaries,
         },
@@ -198,7 +198,7 @@ module Flow
         employment_incomes: {
           path: ->(application) { urls.providers_legal_aid_application_means_employment_income_path(application) },
           forward: lambda do |application|
-            if application.using_enhanced_bank_upload?
+            if application.uploading_bank_statements?
               :regular_incomes
             else
               :identify_types_of_incomes
@@ -209,7 +209,7 @@ module Flow
         full_employment_details: {
           path: ->(application) { urls.providers_legal_aid_application_means_full_employment_details_path(application) },
           forward: lambda do |application|
-            if application.using_enhanced_bank_upload?
+            if application.uploading_bank_statements?
               :regular_incomes
             else
               :identify_types_of_incomes

--- a/app/services/flow/flows/provider_start.rb
+++ b/app/services/flow/flows/provider_start.rb
@@ -165,7 +165,7 @@ module Flow
             when :hmrc_single_employment, :unexpected_employment_data
               :employment_incomes
             when :employed_journey_not_enabled, :provider_not_enabled_for_employed_journey, :applicant_not_employed
-              if application.using_enhanced_bank_upload?
+              if application.uploading_bank_statements?
                 :regular_incomes
               else
                 :identify_types_of_incomes

--- a/app/views/providers/means_summaries/_income_assessment.html.erb
+++ b/app/views/providers/means_summaries/_income_assessment.html.erb
@@ -21,7 +21,7 @@
 <%= render(
       'shared/check_answers/income_summary',
       income_type: t('.credits-section-heading'),
-      url: @legal_aid_application.using_enhanced_bank_upload? ? :regular_incomes : :identify_types_of_incomes,
+      url: @legal_aid_application.uploading_bank_statements? ? :regular_incomes : :identify_types_of_incomes,
       transaction_types: @credit_transaction_types
     ) %>
 
@@ -34,7 +34,7 @@
 <%= render(
       'shared/check_answers/income_summary',
       income_type: t('.debits-section-heading'),
-      url: @legal_aid_application.using_enhanced_bank_upload? ? :regular_outgoings : :identify_types_of_outgoings,
+      url: @legal_aid_application.uploading_bank_statements? ? :regular_outgoings : :identify_types_of_outgoings,
       transaction_types: @debit_transaction_types
     ) %>
 

--- a/app/views/shared/check_answers/_income_result.html.erb
+++ b/app/views/shared/check_answers/_income_result.html.erb
@@ -16,7 +16,6 @@
           read_only:,
         ) %>
 
-  <% if @legal_aid_application.using_enhanced_bank_upload? || !@legal_aid_application.uploading_bank_statements? %>
     <%= check_answer_link(
           name: :gross_income_limit,
           question: t(".gross_income_limit"),
@@ -44,6 +43,5 @@
           answer: gds_number_to_currency(@legal_aid_application.cfe_result.income_contribution),
           read_only:,
         ) %>
-    <% end %>
   </dl>
 </section>

--- a/app/views/shared/check_answers/_income_summary.html.erb
+++ b/app/views/shared/check_answers/_income_summary.html.erb
@@ -18,7 +18,7 @@
     </div>
 </div>
 
-<% if @legal_aid_application.using_enhanced_bank_upload? %>
+<% if @legal_aid_application.uploading_bank_statements? %>
   <dl class="govuk-summary-list govuk-!-margin-bottom-9" data-check-your-answers-section="<%= income_type.parameterize %>">
     <% transaction_types.each do |transaction_type| %>
       <%= check_answer_for_regular_transactions(

--- a/app/views/shared/review_application/_income_payments_and_assets_for_bank_statement_upload.html.erb
+++ b/app/views/shared/review_application/_income_payments_and_assets_for_bank_statement_upload.html.erb
@@ -22,7 +22,7 @@
     <%= render(
           "shared/check_answers/income_summary",
           income_type: t(".credits-section-heading"),
-          url: @legal_aid_application.using_enhanced_bank_upload? ? :regular_incomes : :identify_types_of_incomes,
+          url: @legal_aid_application.uploading_bank_statements? ? :regular_incomes : :identify_types_of_incomes,
           transaction_types: TransactionType.credits.without_disregarded_benefits,
           read_only: true,
         ) %>
@@ -44,7 +44,7 @@
     <%= render(
           "shared/check_answers/income_summary",
           income_type: t(".debits-section-heading"),
-          url: @legal_aid_application.using_enhanced_bank_upload? ? :regular_outgoings : :identify_types_of_outgoings,
+          url: @legal_aid_application.uploading_bank_statements? ? :regular_outgoings : :identify_types_of_outgoings,
           transaction_types: TransactionType.debits,
           read_only: true,
         ) %>

--- a/spec/helpers/means_report_helper_spec.rb
+++ b/spec/helpers/means_report_helper_spec.rb
@@ -20,9 +20,9 @@ RSpec.describe MeansReportHelper do
     context "with housing item" do
       subject(:housing_item) { items.first }
 
-      context "when an application is using_enhanced_bank_upload?" do
+      context "when an application is uploading_bank_statements?" do
         before do
-          allow(legal_aid_application).to receive(:using_enhanced_bank_upload?).and_return(true)
+          allow(legal_aid_application).to receive(:uploading_bank_statements?).and_return(true)
         end
 
         it "addendum matches expected text" do
@@ -30,9 +30,9 @@ RSpec.describe MeansReportHelper do
         end
       end
 
-      context "when an application is not using_enhanced_bank_upload?" do
+      context "when an application is not uploading_bank_statements?" do
         before do
-          allow(legal_aid_application).to receive(:using_enhanced_bank_upload?).and_return(false)
+          allow(legal_aid_application).to receive(:uploading_bank_statements?).and_return(false)
         end
 
         it "addendum is nil" do
@@ -82,16 +82,16 @@ RSpec.describe MeansReportHelper do
 
     it_behaves_like "transaction type item list"
 
-    context "when application is not using_enhanced_bank_upload?" do
-      before { allow(legal_aid_application).to receive(:using_enhanced_bank_upload?).and_return(false) }
+    context "when application is not uploading_bank_statements?" do
+      before { allow(legal_aid_application).to receive(:uploading_bank_statements?).and_return(false) }
 
       it "has expected items" do
         expect(items.map(&:name)).to eql(%i[dependants_allowance disregarded_state_benefits])
       end
     end
 
-    context "when application is using_enhanced_bank_upload?" do
-      before { allow(legal_aid_application).to receive(:using_enhanced_bank_upload?).and_return(true) }
+    context "when application is uploading_bank_statements?" do
+      before { allow(legal_aid_application).to receive(:uploading_bank_statements?).and_return(true) }
 
       it "has expected items" do
         expect(items.map(&:name)).to eql(%i[dependants_allowance])

--- a/spec/models/cfe/submission_spec.rb
+++ b/spec/models/cfe/submission_spec.rb
@@ -5,5 +5,5 @@ RSpec.describe CFE::Submission do
 
   it { expect(instance).to delegate_method(:passported?).to(:legal_aid_application) }
   it { expect(instance).to delegate_method(:non_passported?).to(:legal_aid_application) }
-  it { expect(instance).to delegate_method(:using_enhanced_bank_upload?).to(:legal_aid_application) }
+  it { expect(instance).to delegate_method(:uploading_bank_statements?).to(:legal_aid_application) }
 end

--- a/spec/models/legal_aid_application_spec.rb
+++ b/spec/models/legal_aid_application_spec.rb
@@ -1728,36 +1728,6 @@ RSpec.describe LegalAidApplication do
     end
   end
 
-  describe "#using_enhanced_bank_upload?" do
-    context "when the `enhanced_bank_upload` setting is enabled, and the " \
-            "application is uploading bank statements" do
-      it "returns true" do
-        legal_aid_application = build_stubbed(:legal_aid_application)
-        allow(legal_aid_application)
-          .to receive(:uploading_bank_statements?)
-          .and_return(true)
-
-        result = legal_aid_application.using_enhanced_bank_upload?
-
-        expect(result).to be true
-      end
-    end
-
-    context "when the `enhanced_bank_upload` setting is enabled, but the " \
-            "application is not uploading bank statements" do
-      it "returns false" do
-        legal_aid_application = build_stubbed(:legal_aid_application)
-        allow(legal_aid_application)
-          .to receive(:uploading_bank_statements?)
-          .and_return(false)
-
-        result = legal_aid_application.using_enhanced_bank_upload?
-
-        expect(result).to be false
-      end
-    end
-  end
-
   describe "#housing_payments?" do
     context "when the application has a rent_or_mortgage transaction type" do
       it "returns true" do

--- a/spec/models/setting_spec.rb
+++ b/spec/models/setting_spec.rb
@@ -57,7 +57,6 @@ RSpec.describe Setting do
       expect(described_class.alert_via_sentry?).to be true
       expect(described_class.enable_mini_loop?).to be false
       expect(described_class.enable_loop?).to be false
-      expect(described_class.enhanced_bank_upload?).to be true
       expect(described_class.means_test_review_phase_one?).to be false
     end
   end

--- a/spec/requests/providers/client_completed_means_spec.rb
+++ b/spec/requests/providers/client_completed_means_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe Providers::ClientCompletedMeansController do
           end
 
           context "when application is using bank upload journey" do
-            before { allow_any_instance_of(LegalAidApplication).to receive(:using_enhanced_bank_upload?).and_return(true) }
+            before { allow_any_instance_of(LegalAidApplication).to receive(:uploading_bank_statements?).and_return(true) }
 
             it "redirects to the regular incomes page" do
               expect(subject).to redirect_to(providers_legal_aid_application_means_regular_incomes_path(legal_aid_application))

--- a/spec/services/cfe/service_set_spec.rb
+++ b/spec/services/cfe/service_set_spec.rb
@@ -22,8 +22,8 @@ RSpec.describe CFE::ServiceSet do
       end
     end
 
-    context "when object is non_passported? but not using_enhanced_bank_upload?" do
-      let(:object) { double(Object, passported?: false, non_passported?: true, using_enhanced_bank_upload?: false) }
+    context "when object is non_passported? but not uploading_bank_statements?" do
+      let(:object) { double(Object, passported?: false, non_passported?: true, uploading_bank_statements?: false) }
 
       it "returns set of non passported CFE::Service classes" do
         expect(call).to match([
@@ -46,8 +46,8 @@ RSpec.describe CFE::ServiceSet do
       end
     end
 
-    context "when object is non_passported? and using_enhanced_bank_upload?" do
-      let(:object) { double(Object, passported?: false, non_passported?: true, using_enhanced_bank_upload?: true) }
+    context "when object is non_passported? and uploading_bank_statements?" do
+      let(:object) { double(Object, passported?: false, non_passported?: true, uploading_bank_statements?: true) }
 
       it "returns set of non passported CFE::Service classes" do
         expect(call).to match([

--- a/spec/services/reports/means_report_creator_spec.rb
+++ b/spec/services/reports/means_report_creator_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Reports::MeansReportCreator do
           allow(legal_aid_application).to receive(:passported?).and_return(true)
           allow(legal_aid_application).to receive(:non_passported?).and_return(false)
           allow(legal_aid_application).to receive(:uploading_bank_statements?).and_return(false)
-          allow(legal_aid_application).to receive(:using_enhanced_bank_upload?).and_return(false)
+          allow(legal_aid_application).to receive(:uploading_bank_statements?).and_return(false)
         end
 
         it_behaves_like "successful means_report creator"
@@ -45,7 +45,7 @@ RSpec.describe Reports::MeansReportCreator do
         before do
           allow(legal_aid_application).to receive(:non_passported?).and_return(true)
           allow(legal_aid_application).to receive(:uploading_bank_statements?).and_return(false)
-          allow(legal_aid_application).to receive(:using_enhanced_bank_upload?).and_return(false)
+          allow(legal_aid_application).to receive(:uploading_bank_statements?).and_return(false)
         end
 
         it_behaves_like "successful means_report creator"
@@ -55,7 +55,7 @@ RSpec.describe Reports::MeansReportCreator do
         before do
           allow(legal_aid_application).to receive(:non_passported?).and_return(true)
           allow(legal_aid_application).to receive(:uploading_bank_statements?).and_return(true)
-          allow(legal_aid_application).to receive(:using_enhanced_bank_upload?).and_return(true)
+          allow(legal_aid_application).to receive(:uploading_bank_statements?).and_return(true)
         end
 
         it_behaves_like "successful means_report creator"


### PR DESCRIPTION
Now that the enhanced bank upload functionality has been released to all
providers with bank statement upload permissions and the flag always returns
`true`, the `enhanced_bank_upload?` method no longer means anything.

This replaces its usage with calls to `uploading_bank_statements?`.

While there are some applications that have not been completed that used the
original, non-enhanced bank statement upload journey, these are nominal.

Any issues that arise will be dealt with manually, although it is likely the
small number of affected applications (~ 5) will remain inactive.