### PR TITLE
Address Rubocop erblint failures in `app/views/shared/forms`

### DIFF
--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -12,8 +12,6 @@ linters:
     exclude:
       - "**/app/views/providers/**/*"
       - "**/app/views/shared/check_answers/*"
-      - "**/app/views/shared/forms/**/*"
-      - "**/app/views/shared/forms/*"
     rubocop_config:
       inherit_from:
         - .rubocop.yml

--- a/app/views/shared/forms/_applicant_form.html.erb
+++ b/app/views/shared/forms/_applicant_form.html.erb
@@ -1,30 +1,30 @@
 
 <%= form_with(
-        model: @form,
-        url: form_url,
-        method: form_method,
-        local: true
+      model: @form,
+      url: form_url,
+      method: form_method,
+      local: true,
     ) do |form| %>
 
   <%= page_template(
-        page_title: t('.page_title'),
-        back_link: { text: t('generic.back') },
+        page_title: t(".page_title"),
+        back_link: { text: t("generic.back") },
         page_heading_options: { margin_bottom: 3 },
-        form: form
+        form:,
       ) do %>
 
     <div class="govuk-!-padding-bottom-2"></div>
-    <%= form.govuk_fieldset legend: {text: t('.name')} do %>
-      <%= form.govuk_text_field :first_name, label: { text: 'First name' }, width: 'three-quarters' %>
-      <%= form.govuk_text_field :last_name, label: { text: 'Last name'}, width: 'three-quarters' %>
+    <%= form.govuk_fieldset legend: { text: t(".name") } do %>
+      <%= form.govuk_text_field :first_name, label: { text: "First name" }, width: "three-quarters" %>
+      <%= form.govuk_text_field :last_name, label: { text: "Last name" }, width: "three-quarters" %>
     <% end %>
 
     <div class="govuk-!-padding-bottom-4"></div>
     <%= form.govuk_date_field :date_of_birth, legend: { text: t("shared.forms.date_input_fields.date_of_birth_label") },
-                              hint: { text: t("shared.forms.date_input_fields.date_of_birth_hint")} %>
+                                              hint: { text: t("shared.forms.date_input_fields.date_of_birth_hint") } %>
 
     <div class="govuk-!-padding-bottom-2"></div>
 
-    <%= next_action_buttons(show_draft: true, form: form) %>
+    <%= next_action_buttons(show_draft: true, form:) %>
   <% end %>
 <% end %>

--- a/app/views/shared/forms/_cash_income_form.html.erb
+++ b/app/views/shared/forms/_cash_income_form.html.erb
@@ -2,34 +2,34 @@
       model: @aggregated_cash_income,
       url: form_path,
       method: :patch,
-      local: true
+      local: true,
     ) do |form| %>
 
-    <%= page_template page_title: page_title, template: :basic, form: form do %>
+    <%= page_template page_title:, template: :basic, form: do %>
 
-    <%= form.govuk_check_boxes_fieldset :cash_income, legend: {size: 'xl', tag: 'h1', text: page_title} do %>
-      <p><%= t('.info') %></p>
-      <div id="select-all-that-apply-hint" class="govuk-hint"><%= t('generic.select_all_that_apply') %></div>
+    <%= form.govuk_check_boxes_fieldset :cash_income, legend: { size: "xl", tag: "h1", text: page_title } do %>
+      <p><%= t(".info") %></p>
+      <div id="select-all-that-apply-hint" class="govuk-hint"><%= t("generic.select_all_that_apply") %></div>
       <div class="deselect-group" data-deselect-ctrl="#aggregated-cash-income-none-selected-true-field">
         <% @legal_aid_application.transaction_types.not_children.credits.each do |transaction_type| %>
           <%= render(
-                'shared/partials/revealing_checkbox',
+                "shared/partials/revealing_checkbox",
                 name: transaction_type.name,
-                form: form,
+                form:,
                 number_of_fields: AggregatedCashIncome::NUMBER_OF_FIELDS,
                 model: @aggregated_cash_income,
-                input_prefix: t('currency.gbp')
+                input_prefix: t("currency.gbp"),
               ) %>
         <% end %>
       </div>
 
       <%= form.govuk_radio_divider %>
-      <%= form.govuk_check_box :none_selected, true, '', multiple: false, label: {text: t('.none_selected')}, checked: @legal_aid_application.no_cash_income? %>
+      <%= form.govuk_check_box :none_selected, true, "", multiple: false, label: { text: t(".none_selected") }, checked: @legal_aid_application.no_cash_income? %>
     <% end %>
 
     <%= next_action_buttons(
-          form: form,
-          show_draft: false
+          form:,
+          show_draft: false,
         ) %>
   <% end %>
 <% end %>

--- a/app/views/shared/forms/_cash_outgoings_form.html.erb
+++ b/app/views/shared/forms/_cash_outgoings_form.html.erb
@@ -2,35 +2,35 @@
       model: @aggregated_cash_outgoings,
       url: form_path,
       method: :patch,
-      local: true
+      local: true,
     ) do |form| %>
 
-  <%= page_template page_title: page_title, template: :basic, form: form do %>
+  <%= page_template page_title:, template: :basic, form: do %>
 
-    <%= form.govuk_check_boxes_fieldset :cash_outgoings, legend: {size: 'xl', tag: 'h1', text: page_title} do %>
-    <p><%= t('.info') %></p>
-    <div id="select-all-that-apply-hint" class="govuk-hint"><%= t('generic.select_all_that_apply') %></div>
+    <%= form.govuk_check_boxes_fieldset :cash_outgoings, legend: { size: "xl", tag: "h1", text: page_title } do %>
+    <p><%= t(".info") %></p>
+    <div id="select-all-that-apply-hint" class="govuk-hint"><%= t("generic.select_all_that_apply") %></div>
 
       <div class="deselect-group" data-deselect-ctrl="#aggregated-cash-outgoings-none-selected-true-field">
         <% @legal_aid_application.transaction_types.not_children.debits.each do |category| %>
           <%= render(
-                'shared/partials/revealing_checkbox',
+                "shared/partials/revealing_checkbox",
                 name: category.name,
-                form: form,
+                form:,
                 number_of_fields: AggregatedCashOutgoings::NUMBER_OF_FIELDS,
                 model: @aggregated_cash_outgoings,
-                input_prefix: t('currency.gbp')
+                input_prefix: t("currency.gbp"),
               ) %>
         <% end %>
       </div>
 
     <%= form.govuk_radio_divider %>
-    <%= form.govuk_check_box :none_selected, true, '', multiple: false, label: {text: t('.none_selected')}, checked: @legal_aid_application.no_cash_outgoings? %>
+    <%= form.govuk_check_box :none_selected, true, "", multiple: false, label: { text: t(".none_selected") }, checked: @legal_aid_application.no_cash_outgoings? %>
   <% end %>
 
   <%= next_action_buttons(
-        form: form,
-        show_draft: false
+        form:,
+        show_draft: false,
       ) %>
   <% end %>
 <% end %>

--- a/app/views/shared/forms/_date_input_fields.html.erb
+++ b/app/views/shared/forms/_date_input_fields.html.erb
@@ -1,11 +1,9 @@
-<%
-accessibility_error_notice = content_tag(:span, I18n.translate('helpers.accessibility.error'), class: 'govuk-visually-hidden')
-%>
+<% accessibility_error_notice = content_tag(:span, I18n.t("helpers.accessibility.error"), class: "govuk-visually-hidden") %>
 
 <div class="govuk-form-group">
   <div class="govuk-date-input__item <%= group_error_class %>">
 
-    <% hint = t(".#{field_name}_hint", default: '') %>
+    <% hint = t(".#{field_name}_hint", default: "") %>
     <% if hint.present? %>
       <fieldset class="govuk-fieldset" aria-describedby="<%= "#{field_name}-hint".dasherize %>" role="group">
     <% else %>
@@ -22,19 +20,19 @@ accessibility_error_notice = content_tag(:span, I18n.translate('helpers.accessib
       <% end %>
 
       <% if hint.present? %>
-        <%= content_tag(:div, t(".#{field_name}_hint", options: options), id: "#{field_name}-hint".dasherize, class: ['govuk-hint']) %>
+        <%= content_tag(:div, t(".#{field_name}_hint", options:), id: "#{field_name}-hint".dasherize, class: %w[govuk-hint]) %>
       <% end %>
 
       <% if form.object.errors[field_name].any? %>
-          <%= content_tag(:p, class: 'govuk-error-message', id: "#{field_name}-error".dasherize) do %>
+          <%= content_tag(:p, class: "govuk-error-message", id: "#{field_name}-error".dasherize) do %>
             <%= accessibility_error_notice + form.object.errors[field_name].first %>
           <% end %>
       <% end %>
 
       <div class="govuk-date-input">
-        <%= render 'shared/forms/date_part_input_fields', parent_field: field_name, field_name: :"#{prefix}_day", form: form, use_parent_as_id: true %>
-        <%= render 'shared/forms/date_part_input_fields', parent_field: field_name, field_name: :"#{prefix}_month", form: form %>
-        <%= render 'shared/forms/date_part_input_fields', parent_field: field_name, field_name: :"#{prefix}_year", form: form %>
+        <%= render "shared/forms/date_part_input_fields", parent_field: field_name, field_name: :"#{prefix}_day", form:, use_parent_as_id: true %>
+        <%= render "shared/forms/date_part_input_fields", parent_field: field_name, field_name: :"#{prefix}_month", form: %>
+        <%= render "shared/forms/date_part_input_fields", parent_field: field_name, field_name: :"#{prefix}_year", form: %>
       </div>
     </fieldset>
   </div>

--- a/app/views/shared/forms/_date_part_input_fields.html.erb
+++ b/app/views/shared/forms/_date_part_input_fields.html.erb
@@ -1,13 +1,11 @@
-<%
-  field_error_class = form.object.errors[field_name].present? || form.object.errors[parent_field].present? ? 'govuk-input--error' : ''
-  width = /_year\z/.match?(field_name.to_s) ? '4' : '2'
-  use_parent_as_id = false unless local_assigns[:use_parent_as_id]
-  input_id = use_parent_as_id ? parent_field : field_name
-%>
+<% field_error_class = form.object.errors[field_name].present? || form.object.errors[parent_field].present? ? "govuk-input--error" : "" %>
+<% width = field_name.to_s.end_with?("_year") ? "4" : "2" %>
+<% use_parent_as_id = false unless local_assigns[:use_parent_as_id] %>
+<% input_id = use_parent_as_id ? parent_field : field_name %>
 
 <div class="govuk-date-input__item">
   <div class="govuk-form-group">
-    <%= form.label field_name, class: ['govuk-date-input__label govuk-label'], for: input_id %>
+    <%= form.label field_name, class: ["govuk-date-input__label govuk-label"], for: input_id %>
     <%= form.text_field field_name, id: input_id, class: ["govuk-input govuk-date-input__input govuk-input--width-#{width} #{field_error_class}"], inputmode: "numeric" %>
   </div>
 </div>

--- a/app/views/shared/forms/_error_summary.html.erb
+++ b/app/views/shared/forms/_error_summary.html.erb
@@ -1,9 +1,9 @@
-<% attribute_prefix = local_assigns[:attribute_prefix] ? attribute_prefix : '' %>
+<% attribute_prefix = "" unless local_assigns[:attribute_prefix] %>
 <% if model.errors.any? %>
   <div class="govuk-error-summary" tabindex="-1" data-module="govuk-error-summary">
     <div role="alert">
       <h2 class="govuk-error-summary__title">
-        <%= t('generic.errors.problem_text') %>
+        <%= t("generic.errors.problem_text") %>
       </h2>
       <div class="govuk-error-summary__body">
         <ul class="govuk-list govuk-error-summary__list">

--- a/app/views/shared/forms/_error_summary_hidden.html.erb
+++ b/app/views/shared/forms/_error_summary_hidden.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-error-summary hidden" id="error-summary-hideable" tabindex="-1" data-module="govuk-error-summary">
   <div role="alert">
     <h2 class="govuk-error-summary__title" id="error-summary-title">
-      <%= t('generic.errors.problem_text') %>
+      <%= t("generic.errors.problem_text") %>
     </h2>
     <div class="govuk-error-summary__body">
       <ul class="govuk-list govuk-error-summary__list"></ul>

--- a/app/views/shared/forms/_next_action_buttons.html.erb
+++ b/app/views/shared/forms/_next_action_buttons.html.erb
@@ -1,19 +1,19 @@
 <% if show_continue %>
   <%= form.submit(
-      continue_button_text,
-      id: continue_id,
-      name: 'continue_button',
-      class: 'govuk-button form-button',
-      data: { module: 'govuk-button' }
-    ) %>
+        continue_button_text,
+        id: continue_id,
+        name: "continue_button",
+        class: "govuk-button form-button",
+        data: { module: "govuk-button" },
+      ) %>
 <% end %>
 <% if show_draft %>
-  <% left_margin = show_continue == true ? 'govuk-!-margin-left-3' : 'govuk-!-margin-left-0' %>
+  <% left_margin = show_continue == true ? "govuk-!-margin-left-3" : "govuk-!-margin-left-0" %>
   <%= form.submit(
-      draft_button_text,
-      name: 'draft_button',
-      id: 'draft_button',
-      class: "govuk-button form-button govuk-secondary-button #{left_margin}",
-      data: { module: 'govuk-button' }
-    ) %>
+        draft_button_text,
+        name: "draft_button",
+        id: "draft_button",
+        class: "govuk-button form-button govuk-secondary-button #{left_margin}",
+        data: { module: "govuk-button" },
+      ) %>
   <% end %>

--- a/app/views/shared/forms/_offline_accounts_form.html.erb
+++ b/app/views/shared/forms/_offline_accounts_form.html.erb
@@ -1,23 +1,24 @@
-<%= render 'accounts_summary', bank_accounts: bank_accounts if bank_accounts.any? %>
+<%= render "accounts_summary", bank_accounts: bank_accounts if bank_accounts.any? %>
 
 <%= form_with(
-        model: @form,
-        url: form_path,
-        method: :patch,
-        local: true) do |form| %>
+      model: @form,
+      url: form_path,
+      method: :patch,
+      local: true,
+    ) do |form| %>
 
   <%= form.govuk_check_boxes_fieldset :savings_amount,
-                                   legend: { text: page_title, size: "xl", tag: 'h1'},
-                                   hint: { text: t('generic.select_all_that_apply')} do %>
+                                      legend: { text: page_title, size: "xl", tag: "h1" },
+                                      hint: { text: t("generic.select_all_that_apply") } do %>
     <div class="govuk-checkboxes" data-module="govuk-checkboxes">
       <div class="deselect-group" data-deselect-ctrl="#savings-amount-no-account-selected-true-field">
-        <%= render partial: 'shared/forms/revealing_checkbox/attribute',
+        <%= render partial: "shared/forms/revealing_checkbox/attribute",
                    collection: attributes,
-                   locals: { model: @form, form: form } %>
+                   locals: { model: @form, form: } %>
       </div>
     </div>
     <%= form.govuk_radio_divider %>
-    <%= form.govuk_check_box :no_account_selected, true, '', multiple: false, label: {text: no_account_selected} %>
+    <%= form.govuk_check_box :no_account_selected, true, "", multiple: false, label: { text: no_account_selected } %>
 
   <% end %>
 
@@ -25,6 +26,6 @@
 
   <%= next_action_buttons(
         show_draft: local_assigns.key?(:show_draft) ? show_draft : false,
-        form: form
+        form:,
       ) %>
 <% end %>

--- a/app/views/shared/forms/_radio_inputs.html.erb
+++ b/app/views/shared/forms/_radio_inputs.html.erb
@@ -5,9 +5,9 @@
             field_name,
             value,
             (selected == value),
-            class: 'govuk-radios__input'
+            class: "govuk-radios__input",
           ) %>
-      <%= label_tag "#{field_name}_#{value}", label, class: 'govuk-label govuk-radios__label' %>
+      <%= label_tag "#{field_name}_#{value}", label, class: "govuk-label govuk-radios__label" %>
     </div>
   <% end %>
 </div>

--- a/app/views/shared/forms/_text_fields.html.erb
+++ b/app/views/shared/forms/_text_fields.html.erb
@@ -1,17 +1,17 @@
-<% field_with_error = local_assigns[:field_with_error] ? field_with_error : field_name %>
-<% group_error_class = form.object.errors[field_with_error].any? ? 'govuk-form-group--error' : '' %>
+<% field_with_error = field_name unless local_assigns[:field_with_error] %>
+<% group_error_class = form.object.errors[field_with_error].any? ? "govuk-form-group--error" : "" %>
 
-<% custom_classes = local_assigns[:class].nil? ? '' : local_assigns[:class] %>
+<% custom_classes = local_assigns[:class].nil? ? "" : local_assigns[:class] %>
 
 <div class="govuk-form-group <%= group_error_class %>">
-  <%= form.label field_name, class: ['govuk-label'] %>
-  <% hint = t(".#{field_name}_hint", default: '') %>
+  <%= form.label field_name, class: %w[govuk-label] %>
+  <% hint = t(".#{field_name}_hint", default: "") %>
   <% if !local_assigns[:hide_hint?] && hint.present? %>
-    <%= content_tag(:div, hint, id: "#{field_name}-hint".dasherize, class: ['govuk-hint']) %>
+    <%= content_tag(:div, hint, id: "#{field_name}-hint".dasherize, class: %w[govuk-hint]) %>
   <% end %>
   <% if form.object.errors[field_with_error].any? %>
-    <%= content_tag(:p, form.object.errors[field_name].first, class: ['govuk-error-message']) %>
+    <%= content_tag(:p, form.object.errors[field_name].first, class: %w[govuk-error-message]) %>
   <% end %>
-  <% input_error_class = form.object.errors[field_with_error].any? ? 'govuk-input--error' : '' %>
+  <% input_error_class = form.object.errors[field_with_error].any? ? "govuk-input--error" : "" %>
   <%= form.text_field field_name, id: field_name, class: "govuk-input #{custom_classes} #{input_error_class}" %>
 </div>

--- a/app/views/shared/forms/_types_of_income_form.html.erb
+++ b/app/views/shared/forms/_types_of_income_form.html.erb
@@ -2,37 +2,46 @@
       model: @legal_aid_application,
       url: form_path,
       method: :patch,
-      local: true
+      local: true,
     ) do |form| %>
 
-  <%= page_template page_title: page_title, template: :basic, form: form do %>
+  <%= page_template page_title:, template: :basic, form: do %>
 
-    <%= form.govuk_check_boxes_fieldset :transaction_type_ids, legend: {size: 'xl', tag: 'h1', text: page_title},
-                                         hint: {text: t('generic.select_all_that_apply')} do %>
+    <%= form.govuk_check_boxes_fieldset :transaction_type_ids, legend: { size: "xl", tag: "h1", text: page_title },
+                                                               hint: { text: t("generic.select_all_that_apply") } do %>
       <div class="deselect-group govuk-!-padding-bottom-1" data-deselect-ctrl="#legal-aid-application-none-selected-true-field">
         <% TransactionType.credits.not_children.each do |transaction_type| %>
-          <%= form.govuk_check_box :transaction_type_ids, transaction_type.id, link_errors: true,
-                                   label: {text: t("transaction_types.names.#{journey_type}.#{transaction_type.name}")},
-                                   hint: {text: t(".hints.#{journey_type}.#{transaction_type.name}", default: '')} %>
+          <%= form.govuk_check_box(
+                :transaction_type_ids,
+                transaction_type.id,
+                link_errors: true,
+                label: { text: t("transaction_types.names.#{journey_type}.#{transaction_type.name}") },
+                hint: { text: t(".hints.#{journey_type}.#{transaction_type.name}", default: "") },
+              ) %>
         <% end %>
       </div>
       <%= form.govuk_radio_divider %>
-      <%= form.govuk_check_box :none_selected, true, '', multiple: false,
-                             label: {text: t(".#{journey_type}.none_of_these")} %>
+      <%= form.govuk_check_box(
+            :none_selected,
+            true,
+            "",
+            multiple: false,
+            label: { text: t(".#{journey_type}.none_of_these") },
+          ) %>
     <% end %>
 
     <% if journey == :citizen %>
       <details class="govuk-details govuk-!-margin-top-4" data-module="govuk-details">
         <summary class="govuk-details__summary">
           <span class="govuk-details__summary-text"
-            title="<%= t('.expanded_explanation.heading') %>"
-            aria-label="<%= t('.expanded_explanation.heading') %>">
-            <%= t('.expanded_explanation.heading') %>
+            title="<%= t(".expanded_explanation.heading") %>"
+            aria-label="<%= t(".expanded_explanation.heading") %>">
+            <%= t(".expanded_explanation.heading") %>
           </span>
         </summary>
 
         <div class="govuk-details__text">
-          <% t('.expanded_explanation.list').each_line do |para| %>
+          <% t(".expanded_explanation.list").each_line do |para| %>
             <p>
             <%= para %>
           <% end %>
@@ -43,8 +52,8 @@
     <div class="govuk-!-padding-bottom-4"></div>
 
     <%= next_action_buttons(
-          form: form,
-          show_draft: local_assigns.key?(:show_draft) ? show_draft : false
+          form:,
+          show_draft: local_assigns.key?(:show_draft) ? show_draft : false,
         ) %>
   <% end %>
 <% end %>

--- a/app/views/shared/forms/_types_of_outgoings_form.html.erb
+++ b/app/views/shared/forms/_types_of_outgoings_form.html.erb
@@ -2,36 +2,40 @@
       model: @legal_aid_application,
       url: form_path,
       method: :patch,
-      local: true
+      local: true,
     ) do |form| %>
 
-  <%= page_template page_title: page_title, template: :basic, form: form do %>
+  <%= page_template page_title:, template: :basic, form: do %>
 
-    <%= form.govuk_check_boxes_fieldset :transaction_type_ids, legend: {size: 'xl', tag: 'h1', text: page_title},
-                                        hint: {text: t('generic.select_all_that_apply')} do %>
+    <%= form.govuk_check_boxes_fieldset :transaction_type_ids, legend: { size: "xl", tag: "h1", text: page_title },
+                                                               hint: { text: t("generic.select_all_that_apply") } do %>
       <div class="deselect-group govuk-!-padding-bottom-1" data-deselect-ctrl="#legal-aid-application-none-selected-true-field">
         <% TransactionType.debits.each do |transaction_type| %>
-          <%= form.govuk_check_box :transaction_type_ids, transaction_type.id, link_errors: true,
-                                   label: {text: t("transaction_types.names.#{journey_type}.#{transaction_type.name}")},
-                                   hint: {text: t(".hints.#{transaction_type.name}", default: '')} %>
+          <%= form.govuk_check_box(
+                :transaction_type_ids,
+                transaction_type.id,
+                link_errors: true,
+                label: { text: t("transaction_types.names.#{journey_type}.#{transaction_type.name}") },
+                hint: { text: t(".hints.#{transaction_type.name}", default: "") },
+              ) %>
         <% end %>
       </div>
       <%= form.govuk_radio_divider %>
-      <%= form.govuk_check_box :none_selected, true, '', multiple: false, label: {text: t(".#{journey_type}.none_of_these")} %>
+      <%= form.govuk_check_box :none_selected, true, "", multiple: false, label: { text: t(".#{journey_type}.none_of_these") } %>
     <% end %>
 
     <% if journey == :citizen %>
       <details class="govuk-details govuk-!-margin-top-4" data-module="govuk-details">
         <summary class="govuk-details__summary">
           <span class="govuk-details__summary-text"
-            title="<%= t('.expanded_explanation.heading') %>"
-            aria-label="<%= t('.expanded_explanation.heading') %>">
-            <%= t('.expanded_explanation.heading') %>
+            title="<%= t(".expanded_explanation.heading") %>"
+            aria-label="<%= t(".expanded_explanation.heading") %>">
+            <%= t(".expanded_explanation.heading") %>
           </span>
         </summary>
 
         <div class="govuk-details__text">
-          <% t('.expanded_explanation.list').each_line do |para| %>
+          <% t(".expanded_explanation.list").each_line do |para| %>
             <p>
               <%= para %>
           <% end %>
@@ -41,7 +45,7 @@
 
     <%= next_action_buttons(
           show_draft: local_assigns.key?(:show_draft) ? show_draft : false,
-          form: form
+          form:,
         ) %>
   <% end %>
 <% end %>

--- a/app/views/shared/forms/proceedings_types/_legacy_proceeding_type_form.html.erb
+++ b/app/views/shared/forms/proceedings_types/_legacy_proceeding_type_form.html.erb
@@ -8,15 +8,15 @@
 
   <div class="govuk-grid-column-one-third control-column">
     <%= button_to_accessible(
-          t('generic.select_and_continue'),
+          t("generic.select_and_continue"),
           providers_legal_aid_application_proceedings_type_path(
             legal_aid_application_id: @legal_aid_application,
-            id: proceeding_type
+            id: proceeding_type,
           ),
           method: :patch,
-          tabindex: '-1',
-          class: 'govuk-button proceeding-link govuk-!-margin-top-4',
-          "aria-label"=>"Select #{proceeding_type.meaning.gsub(/[^0-9a-z ]/i, '')} and continue"
+          tabindex: "-1",
+          class: "govuk-button proceeding-link govuk-!-margin-top-4",
+          "aria-label" => "Select #{proceeding_type.meaning.gsub(/[^0-9a-z ]/i, '')} and continue",
         ) %>
   </div>
   <div class="govuk-grid-row">

--- a/app/views/shared/forms/proceedings_types/_proceeding_type.html.erb
+++ b/app/views/shared/forms/proceedings_types/_proceeding_type.html.erb
@@ -8,10 +8,10 @@
   <div class="govuk-grid-column-one-third control-column">
     <p class="govuk-body govuk-!-margin-bottom-1 govuk-!-margin-top-4">
       <%= link_to_accessible(
-            t('generic.change'),
+            t("generic.change"),
             providers_legal_aid_application_has_other_proceedings_path(legal_aid_application_id: @legal_aid_application),
-            class: 'govuk-link change-link',
-            suffix: 'proceeding'
+            class: "govuk-link change-link",
+            suffix: "proceeding",
           ) %>
     </p>
   </div>

--- a/app/views/shared/forms/received_benefit_confirmation/_form.html.erb
+++ b/app/views/shared/forms/received_benefit_confirmation/_form.html.erb
@@ -1,16 +1,16 @@
-<%= form_with(model: model, url: url, method: :patch, local: true) do |form| %>
+<%= form_with(model:, url:, method: :patch, local: true) do |form| %>
 
   <%= form.govuk_collection_radio_buttons(:passporting_benefit, Providers::ReceivedBenefitConfirmationForm.radio_options, :value, :label,
-                                          legend: {size: 'xl', tag: 'h1', text: content_for(:page_title)}) %>
+                                          legend: { size: "xl", tag: "h1", text: content_for(:page_title) }) %>
 
     <%= form.govuk_radio_divider %>
-    <%= form.govuk_radio_button(:passporting_benefit, :none_selected, label: {text:  t('generic.none_selected')}) %>
+    <%= form.govuk_radio_button(:passporting_benefit, :none_selected, label: { text: t("generic.none_selected") }) %>
 
   <div class="govuk-!-padding-bottom-3"></div>
 
   <%= next_action_buttons(
         show_draft: local_assigns.key?(:show_draft) ? show_draft : false,
-        form: form
+        form:,
       ) %>
 
 <% end %>

--- a/app/views/shared/forms/revealing_checkbox/_attribute.html.erb
+++ b/app/views/shared/forms/revealing_checkbox/_attribute.html.erb
@@ -1,17 +1,16 @@
-<%
-  check_box_attribute = "check_box_#{attribute}"
-  hint = controller_t "hint.#{check_box_attribute}", default: ''
-  revealing_hint = controller_t "hint.revealing_#{check_box_attribute}", default: ''
-  value = model.send(attribute)
-  @form.__send__("#{check_box_attribute}=", model.send(check_box_attribute).present? || value.present?)
-%>
+<% check_box_attribute = "check_box_#{attribute}" %>
+<% hint = controller_t "hint.#{check_box_attribute}", default: "" %>
+<% revealing_hint = controller_t "hint.revealing_#{check_box_attribute}", default: "" %>
+<% value = model.send(attribute) %>
+<% @form.__send__("#{check_box_attribute}=", model.send(check_box_attribute).present? || value.present?) %>
+
 <%= form.govuk_check_box check_box_attribute, true, multiple: false, link_errors: true,
-                         label: {text: controller_t(check_box_attribute)},
-                         hint: {text: hint} do %>
+                                                    label: { text: controller_t(check_box_attribute) },
+                                                    hint: { text: hint } do %>
   <%= form.govuk_text_field attribute, multiple: false,
-                            value: number_to_currency_or_original_string(value),
-                            label: {text: controller_t(attribute)},
-                            hint: {text: revealing_hint},
-                            prefix_text: t('currency.gbp'),
-                            width: 'one-third' %>
+                                       value: number_to_currency_or_original_string(value),
+                                       label: { text: controller_t(attribute) },
+                                       hint: { text: revealing_hint },
+                                       prefix_text: t("currency.gbp"),
+                                       width: "one-third" %>
 <% end %>


### PR DESCRIPTION
Before, all templates in `app/views/shared/forms` were excluded from Rubocop linting.

This removes that rule, and resolves all failures.

All failures were resolved with the `--autocorrect` flag, and are all trivial.