### PR TITLE
Address Rubocop erblint failures in `app/views/shared/check_answers`

### DIFF
--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -11,7 +11,6 @@ linters:
     enabled: true
     exclude:
       - "**/app/views/providers/**/*"
-      - "**/app/views/shared/check_answers/*"
     rubocop_config:
       inherit_from:
         - .rubocop.yml

--- a/app/views/shared/check_answers/_assets.html.erb
+++ b/app/views/shared/check_answers/_assets.html.erb
@@ -1,89 +1,87 @@
-<%
-  read_only = false unless local_assigns.key?(:read_only)
-  online_savings_accounts = @legal_aid_application.online_savings_accounts_balance
-  online_current_accounts = @legal_aid_application.online_current_accounts_balance
-%>
+<% read_only = false unless local_assigns.key?(:read_only) %>
+<% online_savings_accounts = @legal_aid_application.online_savings_accounts_balance %>
+<% online_current_accounts = @legal_aid_application.online_current_accounts_balance %>
 
 <section class="print-no-break">
-  <%= render 'shared/check_answers/property', read_only: read_only %>
+  <%= render "shared/check_answers/property", read_only: %>
 </section>
 
 <section class="print-no-break">
-  <%= render 'shared/check_answers/vehicles', read_only: read_only %>
+  <%= render "shared/check_answers/vehicles", read_only: %>
 
   <% if @legal_aid_application.non_passported? && !@legal_aid_application.uploading_bank_statements? %>
     <!-- non-passported truelayer only -->
 
     <% if read_only %>
-      <h2 class="govuk-heading-m"><%= t('.assets.bank_accounts') %></h2>
+      <h2 class="govuk-heading-m"><%= t(".assets.bank_accounts") %></h2>
       <dl class="govuk-summary-list govuk-!-margin-bottom-9" data-test="applicant-bank-accounts">
 
         <%= check_answer_link(
               name: :online_current_accounts,
               url: check_answer_url_for(journey_type, :applicant_bank_accounts, @legal_aid_application),
-              question: t('.assets.current_account'),
-              answer: online_current_accounts.present? ? gds_number_to_currency(online_current_accounts) : t('generic.none_declared'),
-              read_only: read_only,
+              question: t(".assets.current_account"),
+              answer: online_current_accounts.present? ? gds_number_to_currency(online_current_accounts) : t("generic.none_declared"),
+              read_only:,
             ) %>
         <%= check_answer_link(
               name: :online_savings_accounts,
               url: check_answer_url_for(journey_type, :applicant_bank_accounts, @legal_aid_application),
-              question: t('.assets.savings_account'),
-              answer: online_savings_accounts.present? ? gds_number_to_currency(online_savings_accounts) : t('generic.none_declared'),
-              read_only: read_only,
+              question: t(".assets.savings_account"),
+              answer: online_savings_accounts.present? ? gds_number_to_currency(online_savings_accounts) : t("generic.none_declared"),
+              read_only:,
             ) %>
       </dl>
     <% end %>
 
-    <%= render 'shared/check_answers/offline_savings_accounts', read_only: read_only %>
+    <%= render "shared/check_answers/offline_savings_accounts", read_only: %>
   <% else %>
     <!-- passported and non-passported bank statement uploaded -->
 
     <%= check_answer_one_change_link(
           name: :bank_accounts,
           url: check_answer_url_for(journey_type, :offline_accounts, @legal_aid_application),
-          question: t('.assets.bank_accounts'),
+          question: t(".assets.bank_accounts"),
           answer_hash: capital_accounts_list(
             @legal_aid_application.savings_amount,
-            locale_namespace: "shared.forms.revealing_checkbox.attribute.#{journey_type}.savings_and_investments.check_box_"
+            locale_namespace: "shared.forms.revealing_checkbox.attribute.#{journey_type}.savings_and_investments.check_box_",
           ),
-          read_only: read_only
+          read_only:,
         ) %>
   <% end %>
 
   <%= check_answer_one_change_link(
         name: :savings_and_investments,
         url: check_answer_url_for(journey_type, :savings_and_investments, @legal_aid_application),
-        question: t('.assets.savings_and_investments'),
+        question: t(".assets.savings_and_investments"),
         answer_hash: capital_assets_list(
           @legal_aid_application.savings_amount,
-          locale_namespace: "shared.forms.revealing_checkbox.attribute.#{journey_type}.savings_and_investments.check_box_"
+          locale_namespace: "shared.forms.revealing_checkbox.attribute.#{journey_type}.savings_and_investments.check_box_",
         ),
-        read_only: read_only
+        read_only:,
       ) %>
 
   <%= check_answer_one_change_link(
         name: :other_assets,
         url: check_answer_url_for(journey_type, :other_assets, @legal_aid_application),
-        question: t('.assets.other_assets'),
+        question: t(".assets.other_assets"),
         answer_hash: capital_amounts_list(
           @legal_aid_application.other_assets_declaration,
           locale_namespace: "shared.forms.revealing_checkbox.attribute.#{journey_type}.other_assets.check_box_",
-          percentage_values: [:second_home_percentage]
+          percentage_values: [:second_home_percentage],
         ),
-        read_only: read_only
+        read_only:,
       ) %>
 
-  <%= render('shared/check_answers/restrictions', read_only: read_only) if @legal_aid_application.own_capital? %>
+  <%= render("shared/check_answers/restrictions", read_only:) if @legal_aid_application.own_capital? %>
 
   <section class="print-no-break">
     <% if @legal_aid_application.policy_disregards.present? %>
       <%= check_answer_one_change_link(
             name: :policy_disregards,
             url: check_answer_url_for(journey_type, :policy_disregards, @legal_aid_application),
-            question: t('.assets.policy_disregards'),
+            question: t(".assets.policy_disregards"),
             answer_hash: policy_disregards_list(@legal_aid_application.policy_disregards),
-            read_only: read_only
+            read_only:,
           ) %>
     <% end %>
   </section>

--- a/app/views/shared/check_answers/_bank_statements.html.erb
+++ b/app/views/shared/check_answers/_bank_statements.html.erb
@@ -1,13 +1,13 @@
-<h3 class="govuk-heading-m"><%= t('.section_heading') %></h3>
+<h3 class="govuk-heading-m"><%= t(".section_heading") %></h3>
 
 <% read_only = false unless local_assigns.key?(:read_only) %>
 
 <dl class="govuk-summary-list govuk-!-margin-bottom-9">
   <%= check_answer_link(
-    name: :bank_statements,
-    url: providers_legal_aid_application_bank_statements_path(@legal_aid_application),
-    question: t('.bank_statement_question'),
-    answer: attachments_with_size(bank_statements),
-    read_only: read_only
-  ) %>
+        name: :bank_statements,
+        url: providers_legal_aid_application_bank_statements_path(@legal_aid_application),
+        question: t(".bank_statement_question"),
+        answer: attachments_with_size(bank_statements),
+        read_only:,
+      ) %>
 </dl>

--- a/app/views/shared/check_answers/_bank_transaction_table.html.erb
+++ b/app/views/shared/check_answers/_bank_transaction_table.html.erb
@@ -1,17 +1,17 @@
 <table class="govuk-table" style="margin-bottom: 15px;">
   <caption class="govuk-table__caption" style="padding-bottom:10px;">
-    <%= t('date.date_period', from: date_from(@legal_aid_application), to: date_to(@legal_aid_application)) %>
+    <%= t("date.date_period", from: date_from(@legal_aid_application), to: date_to(@legal_aid_application)) %>
   </caption>
   <tbody class="govuk-table__body">
-   <% transaction_types.order(:name).each do |transaction_type| %>
-     <tr class="govuk-table__row">
-       <td class="govuk-table__cell">
-         <%= t('.total', text: transaction_type.label_name) %>
-       </td>
-       <td class="govuk-table__cell govuk-table__cell--numeric">
-         <%= gds_number_to_currency @legal_aid_application.transactions_total_by_category(transaction_type.id) %>
-       </td>
-     </tr>
-   <% end %>
+  <% transaction_types.order(:name).each do |transaction_type| %>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">
+        <%= t(".total", text: transaction_type.label_name) %>
+      </td>
+      <td class="govuk-table__cell govuk-table__cell--numeric">
+        <%= gds_number_to_currency @legal_aid_application.transactions_total_by_category(transaction_type.id) %>
+      </td>
+    </tr>
+  <% end %>
   </tbody>
 </table>

--- a/app/views/shared/check_answers/_capital_result.html.erb
+++ b/app/views/shared/check_answers/_capital_result.html.erb
@@ -3,29 +3,29 @@
 <dl id="capital-result-questions" class="govuk-summary-list govuk-!-margin-bottom-9">
   <%= check_answer_link(
         name: :total_capital_assessed,
-        question: t('.total'),
+        question: t(".total"),
         answer: gds_number_to_currency(@legal_aid_application.cfe_result.total_capital),
-        read_only: read_only
+        read_only:,
       ) %>
 
   <%= check_answer_link(
         name: :capital_lower_limit,
-        question: t('.lower_limit_label'),
+        question: t(".lower_limit_label"),
         answer: gds_number_to_currency(Rails.configuration.x.capital_result.lower_limit),
-        read_only: read_only
+        read_only:,
       ) %>
 
   <%= check_answer_link(
         name: :capital_upper_limit,
-        question: t('.upper_limit_label'),
+        question: t(".upper_limit_label"),
         answer: gds_number_to_currency(Rails.configuration.x.capital_result.upper_limit),
-        read_only: read_only
+        read_only:,
       ) %>
 
   <%= check_answer_link(
         name: :capital_contribution,
-        question: t('.contribution'),
+        question: t(".contribution"),
         answer: gds_number_to_currency(@legal_aid_application.cfe_result.capital_contribution),
-        read_only: read_only
+        read_only:,
       ) %>
 </dl>

--- a/app/views/shared/check_answers/_client_details.html.erb
+++ b/app/views/shared/check_answers/_client_details.html.erb
@@ -1,57 +1,70 @@
 <% read_only = false unless local_assigns.key?(:read_only) %>
 <dl id="client-details-questions" class="govuk-summary-list govuk-!-margin-bottom-9">
-  <%= check_answer_link(
-        name: :first_name,
-        url: providers_legal_aid_application_applicant_details_path(@legal_aid_application, anchor: :first_name),
-        question: t('.first_name'),
-        answer: applicant.first_name,
-        read_only: read_only,
-      ) if :first_name.in?(attributes) %>
+  <% if :first_name.in?(attributes) %>
+    <%= check_answer_link(
+          name: :first_name,
+          url: providers_legal_aid_application_applicant_details_path(@legal_aid_application, anchor: :first_name),
+          question: t(".first_name"),
+          answer: applicant.first_name,
+          read_only:,
+        ) %>
+  <% end %>
 
-  <%= check_answer_link(
-        name: :last_name,
-        url: providers_legal_aid_application_applicant_details_path(@legal_aid_application, anchor: :last_name),
-        question: t('.last_name'),
-        answer: applicant.last_name,
-        read_only: read_only,
-      ) if :last_name.in?(attributes) %>
+  <% if :last_name.in?(attributes) %>
+    <%= check_answer_link(
+          name: :last_name,
+          url: providers_legal_aid_application_applicant_details_path(@legal_aid_application, anchor: :last_name),
+          question: t(".last_name"),
+          answer: applicant.last_name,
+          read_only:,
+        ) %>
+  <% end %>
 
-  <%= check_answer_link(
-        name: :date_of_birth,
-        url: providers_legal_aid_application_applicant_details_path(@legal_aid_application, anchor: :date_of_birth),
-        question: t('.dob'),
-        answer: applicant.date_of_birth,
-        read_only: read_only,
-      ) if :date_of_birth.in?(attributes) %>
+  <% if :date_of_birth.in?(attributes) %>
+    <%= check_answer_link(
+          name: :date_of_birth,
+          url: providers_legal_aid_application_applicant_details_path(@legal_aid_application, anchor: :date_of_birth),
+          question: t(".dob"),
+          answer: applicant.date_of_birth,
+          read_only:,
+        ) %>
+  <% end %>
 
-  <%= check_answer_link(
-        name: :age,
-        question: t('.age_question'),
-        answer: t('.age', years: applicant.age),
-      ) if :age.in?(attributes) %>
+  <% if :age.in?(attributes) %>
+    <%= check_answer_link(
+          name: :age,
+          question: t(".age_question"),
+          answer: t(".age", years: applicant.age),
+        ) %>
+  <% end %>
 
-  <%= check_answer_link(
-        name: :address,
-        url: change_address_link(applicant),
-        question: t('.address'),
-        answer: address_with_line_breaks(address),
-        read_only: read_only,
-      ) if :address.in?(attributes) %>
+  <% if :address.in?(attributes) %>
+    <%= check_answer_link(
+          name: :address,
+          url: change_address_link(applicant),
+          question: t(".address"),
+          answer: address_with_line_breaks(address),
+          read_only:,
+        ) %>
+  <% end %>
 
-  <%= check_answer_link(
-        name: :national_insurance_number,
-        url: providers_legal_aid_application_has_national_insurance_number_path(@legal_aid_application),
-        question: t('.nino'),
-        answer: applicant.national_insurance_number || t('generic.not_provided'),
-        read_only: read_only,
-      ) if :national_insurance_number.in?(attributes) %>
+  <% if :national_insurance_number.in?(attributes) %>
+    <%= check_answer_link(
+          name: :national_insurance_number,
+          url: providers_legal_aid_application_has_national_insurance_number_path(@legal_aid_application),
+          question: t(".nino"),
+          answer: applicant.national_insurance_number || t("generic.not_provided"),
+          read_only:,
+        ) %>
+  <% end %>
 
-  <%= check_answer_link(
-        name: :email,
-        url: providers_legal_aid_application_applicant_details_path(@legal_aid_application, anchor: :email),
-        question: t('.email'),
-        answer: applicant.email,
-        read_only: read_only,
-      ) if :email.in?(attributes) %>
-
+  <% if :email.in?(attributes) %>
+    <%= check_answer_link(
+          name: :email,
+          url: providers_legal_aid_application_applicant_details_path(@legal_aid_application, anchor: :email),
+          question: t(".email"),
+          answer: applicant.email,
+          read_only:,
+        ) %>
+  <% end %>
 </dl>

--- a/app/views/shared/check_answers/_client_involvement_type_details.html.erb
+++ b/app/views/shared/check_answers/_client_involvement_type_details.html.erb
@@ -2,7 +2,7 @@
 <%= check_answer_link(
       name: :"#{proceeding.name}_client_involvement_type",
       url: providers_legal_aid_application_client_involvement_type_path(@legal_aid_application, proceeding),
-      question: t('.question'),
+      question: t(".question"),
       answer: proceeding.client_involvement_type_description,
-      read_only: read_only
+      read_only:,
     ) %>

--- a/app/views/shared/check_answers/_deductions_details.html.erb
+++ b/app/views/shared/check_answers/_deductions_details.html.erb
@@ -1,9 +1,9 @@
 <section>
   <dl id="deductions-details-questions" class="govuk-summary-list govuk-!-margin-bottom-9">
     <% deductions_detail_items(@legal_aid_application).each do |item| %>
-      <%= render 'shared/means_report/item', item.to_h %>
+      <%= render "shared/means_report/item", item.to_h %>
     <% end %>
-    <%= render 'shared/means_report/total', name: 'total_deductions', value_method: :total_deductions %>
+    <%= render "shared/means_report/total", name: "total_deductions", value_method: :total_deductions %>
   </dl>
 
 </section>

--- a/app/views/shared/check_answers/_delegated_functions.html.erb
+++ b/app/views/shared/check_answers/_delegated_functions.html.erb
@@ -5,8 +5,8 @@
           name: :"#{proceeding_struct.name}_used_delegated_functions_on",
           url: :show_blank_action,
           question: proceeding_struct.meaning,
-          answer: proceeding_struct.proceeding.used_delegated_functions_on&.strftime('%-d %B %Y') || t(".not_used"),
-          read_only: read_only
+          answer: proceeding_struct.proceeding.used_delegated_functions_on&.strftime("%-d %B %Y") || t(".not_used"),
+          read_only:,
         ) %>
   <% end %>
 </dl>

--- a/app/views/shared/check_answers/_dependants.html.erb
+++ b/app/views/shared/check_answers/_dependants.html.erb
@@ -1,21 +1,21 @@
 <div class="govuk-summary-list govuk-!-margin-bottom-9">
   <dl class="govuk-summary-list govuk-summary-list--no-border">
     <%= check_answer_link(
-            name: "dependants",
-            url: providers_legal_aid_application_means_has_dependants_path,
-            question: t('providers.means_summaries.income_assessment.dependants.has_dependants'),
-            answer: yes_no(@legal_aid_application.has_dependants)
+          name: "dependants",
+          url: providers_legal_aid_application_means_has_dependants_path,
+          question: t("providers.means_summaries.income_assessment.dependants.has_dependants"),
+          answer: yes_no(@legal_aid_application.has_dependants),
         ) %>
   </dl>
 </div>
 <% if @legal_aid_application.dependants %>
   <% @legal_aid_application.dependants.each_with_index do |dependant, index| %>
     <%= check_answer_one_change_link(
-      name: "dependants_#{index + 1}",
-      url: providers_legal_aid_application_means_dependant_path(@legal_aid_application, dependant),
-      question: "Dependant #{index + 1}: #{dependant.name}",
-      answer_hash: dependant_hash(dependant),
-      read_only: false
-    ) %>
+          name: "dependants_#{index + 1}",
+          url: providers_legal_aid_application_means_dependant_path(@legal_aid_application, dependant),
+          question: "Dependant #{index + 1}: #{dependant.name}",
+          answer_hash: dependant_hash(dependant),
+          read_only: false,
+        ) %>
   <% end %>
 <% end %>

--- a/app/views/shared/check_answers/_emergency_costs.html.erb
+++ b/app/views/shared/check_answers/_emergency_costs.html.erb
@@ -1,19 +1,19 @@
 <dl class="govuk-summary-list govuk-!-margin-bottom-9">
   <%= check_answer_no_link(
         name: :emergency_cost_override,
-        question: t('.request_higher_limit'),
-        answer: yes_no(@legal_aid_application.emergency_cost_override)
+        question: t(".request_higher_limit"),
+        answer: yes_no(@legal_aid_application.emergency_cost_override),
       ) %>
   <% if @legal_aid_application.emergency_cost_override %>
     <%= check_answer_no_link(
           name: :emergency_cost_requested,
           question: t(".new_cost_limit"),
-          answer: gds_number_to_currency(@legal_aid_application.emergency_cost_requested,  precision: 2)
+          answer: gds_number_to_currency(@legal_aid_application.emergency_cost_requested, precision: 2),
         ) %>
     <%= check_answer_no_link(
           name: :emergency_cost_reasons,
           question: t(".new_limit_reasons"),
-          answer: @legal_aid_application.emergency_cost_reasons
+          answer: @legal_aid_application.emergency_cost_reasons,
         ) %>
   <% end %>
 </dl>

--- a/app/views/shared/check_answers/_emergency_limitations.html.erb
+++ b/app/views/shared/check_answers/_emergency_limitations.html.erb
@@ -1,17 +1,17 @@
 <dl class="govuk-summary-list govuk-!-margin-bottom-9">
   <%= check_answer_no_link(
         name: :form_of_service,
-        question: t('.form_of_service'),
-        answer: @legal_aid_application.lead_proceeding.substantive_level_of_service_name
+        question: t(".form_of_service"),
+        answer: @legal_aid_application.lead_proceeding.substantive_level_of_service_name,
       ) %>
   <%= check_answer_no_link(
         name: :incurrable_costs,
-        question: t('.costs'),
-        answer: gds_number_to_currency(@legal_aid_application.default_delegated_functions_cost_limitation, precision: 0)
+        question: t(".costs"),
+        answer: gds_number_to_currency(@legal_aid_application.default_delegated_functions_cost_limitation, precision: 0),
       ) %>
   <%= check_answer_no_link(
         name: :allowable_work,
-        question: t('.work'),
-        answer: @legal_aid_application.lead_proceeding.delegated_functions_scope_limitation_description
+        question: t(".work"),
+        answer: @legal_aid_application.lead_proceeding.delegated_functions_scope_limitation_description,
       ) %>
 </dl>

--- a/app/views/shared/check_answers/_employed_income.html.erb
+++ b/app/views/shared/check_answers/_employed_income.html.erb
@@ -1,12 +1,14 @@
 <div class="govuk-grid-row" id="app-check-your-answers__employment">
   <div class="govuk-grid-column-two-thirds">
-    <h3 class="govuk-heading-m"><%= t('.employment') %></h3>
+    <h3 class="govuk-heading-m"><%= t(".employment") %></h3>
   </div>
   <div class="govuk-grid-column-one-third govuk-summary-list--no-border align-text-right">
     <% unless read_only %>
       <p>
-        <%= link_to_accessible(t('generic.change'), providers_legal_aid_application_means_employment_income_path(@legal_aid_application),
-                             class: 'govuk-link change-link') %>
+        <%= link_to_accessible(
+              t("generic.change"), providers_legal_aid_application_means_employment_income_path(@legal_aid_application),
+              class: "govuk-link change-link"
+            ) %>
       </p>
     <% end %>
   </div>
@@ -15,15 +17,15 @@
 
   <%= check_answer_no_link(
         name: :extra_employment_information,
-        question: t('.employment_question'),
+        question: t(".employment_question"),
         answer: safe_yes_or_no(@legal_aid_application.extra_employment_information?),
-        read_only: read_only
+        read_only:,
       ) %>
 
   <% if @legal_aid_application.extra_employment_information? %>
     <%= check_long_question_no_link(
           name: :extra_employment_information_details,
-          question: t('.employment_details'),
+          question: t(".employment_details"),
           answer: @legal_aid_application.extra_employment_information_details,
         ) %>
   <% end %>

--- a/app/views/shared/check_answers/_final_hearing.html.erb
+++ b/app/views/shared/check_answers/_final_hearing.html.erb
@@ -7,14 +7,14 @@
           name: :"#{proceeding.name}_final_hearing",
           question: t(".date.question"),
           answer: final_hearing.date,
-          read_only: read_only
+          read_only:,
         ) %>
   <% else %>
     <%= check_answer_no_link(
           name: :"#{proceeding.name}_final_hearing",
           question: t(".details.question"),
           answer: final_hearing.details,
-          read_only: read_only
+          read_only:,
         ) %>
   <% end %>
 <% end %>

--- a/app/views/shared/check_answers/_full_employment_details.html.erb
+++ b/app/views/shared/check_answers/_full_employment_details.html.erb
@@ -1,12 +1,14 @@
 <div class="govuk-grid-row" id="app-check-your-answers__employment">
   <div class="govuk-grid-column-two-thirds">
-    <h3 class="govuk-heading-m"><%= t('.employment') %></h3>
+    <h3 class="govuk-heading-m"><%= t(".employment") %></h3>
   </div>
   <div class="govuk-grid-column-one-third govuk-summary-list--no-border align-text-right">
     <% unless read_only %>
       <p>
-        <%= link_to_accessible(t('generic.change'), providers_legal_aid_application_means_full_employment_details_path(@legal_aid_application),
-                               class: 'govuk-link change-link', suffix: t('.employment')) %>
+        <%= link_to_accessible(
+              t("generic.change"), providers_legal_aid_application_means_full_employment_details_path(@legal_aid_application),
+              class: "govuk-link change-link", suffix: t(".employment")
+            ) %>
       </p>
     <% end %>
   </div>
@@ -14,7 +16,7 @@
 <dl id="employment-income-questions" class="govuk-summary-list govuk-!-margin-bottom-9">
   <%= check_long_question_no_link(
         name: :full_employment_details,
-        question: t('.full_employment_details'),
-        answer: @legal_aid_application.full_employment_details
+        question: t(".full_employment_details"),
+        answer: @legal_aid_application.full_employment_details,
       ) %>
 </dl>

--- a/app/views/shared/check_answers/_housing_benefit.html.erb
+++ b/app/views/shared/check_answers/_housing_benefit.html.erb
@@ -1,34 +1,35 @@
 <div class="govuk-grid-row" id="app-check-your-answers__housing_benefit">
   <div class="govuk-grid-column-two-thirds">
-    <h3 class="govuk-heading-m"><%= t('.heading') %></h3>
+    <h3 class="govuk-heading-m"><%= t(".heading") %></h3>
   </div>
   <div class="govuk-grid-column-one-third govuk-summary-list--no-border align-text-right">
     <% unless read_only %>
       <p>
         <%= link_to_accessible(
-              t('generic.change'),
+              t("generic.change"),
               providers_legal_aid_application_means_housing_benefits_path(@legal_aid_application),
-              class: 'govuk-link change-link',
-              suffix: t('.heading')) %>
+              class: "govuk-link change-link",
+              suffix: t(".heading"),
+            ) %>
       </p>
     <% end %>
   </div>
 </div>
 
-<dl class="govuk-summary-list govuk-!-margin-bottom-9" data-check-your-answers-section="<%= t('.heading').parameterize %>">
+<dl class="govuk-summary-list govuk-!-margin-bottom-9" data-check-your-answers-section="<%= t(".heading").parameterize %>">
   <%= check_answer_no_link(
         name: :housing_benefit_question,
-        question: t('.does_your_client'),
+        question: t(".does_your_client"),
         answer: yes_no(@legal_aid_application.applicant_in_receipt_of_housing_benefit?),
         read_only: false,
-        ) %>
+      ) %>
 
   <% housing_benefit_type = TransactionType.find_by(name: "housing_benefit") %>
 
   <%= check_answer_for_regular_transactions(
         name: housing_benefit_type.label_name,
-        question: t('generic.amount'),
+        question: t("generic.amount"),
         legal_aid_application: @legal_aid_application,
-        transaction_type: housing_benefit_type
+        transaction_type: housing_benefit_type,
       ) %>
 </dl>

--- a/app/views/shared/check_answers/_income_cash_payments.html.erb
+++ b/app/views/shared/check_answers/_income_cash_payments.html.erb
@@ -2,33 +2,36 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-        <h3 class="govuk-heading-m"><%= t('.heading') %></h3>
+        <h3 class="govuk-heading-m"><%= t(".heading") %></h3>
     </div>
     <div class="govuk-grid-column-one-third govuk-summary-list--no-border align-text-right">
         <p>
           <% unless read_only %>
-            <%= link_to_accessible(t('generic.change'),
-                                   check_answer_url_for(:providers,
-                                                        :cash_incomes,
-                                                        @legal_aid_application),
-                                   class: 'govuk-link change-link', suffix: t('.heading')) %>
+            <%= link_to_accessible(
+                  t("generic.change"),
+                  check_answer_url_for(:providers, :cash_incomes, @legal_aid_application),
+                  class: "govuk-link change-link",
+                  suffix: t(".heading"),
+                ) %>
           <% end %>
         </p>
     </div>
 </div>
 
 <% if @legal_aid_application.transaction_types.credits.none? %>
- <div class="govuk-body>"> <%= t('generic.none') %> </div>
+  <div class="govuk-body>">
+    <%= t("generic.none") %>
+  </div>
 <% end %>
 
-<dl id="income-cash-payments-questions" class="govuk-summary-list govuk-!-margin-bottom-9" data-check-your-answers-section="<%= t('.heading').parameterize %>">
+<dl id="income-cash-payments-questions" class="govuk-summary-list govuk-!-margin-bottom-9" data-check-your-answers-section="<%= t(".heading").parameterize %>">
 
   <% TransactionType.credits.not_children.each do |category| %>
-     <%= check_answer_for_cash_transactions(
+    <%= check_answer_for_cash_transactions(
           name: "income_cash_payments_#{category.label_name}",
           question: category.label_name,
           legal_aid_application: @legal_aid_application,
-          transaction_type: category
-      ) %>
+          transaction_type: category,
+        ) %>
   <% end %>
 </dl>

--- a/app/views/shared/check_answers/_income_details.html.erb
+++ b/app/views/shared/check_answers/_income_details.html.erb
@@ -1,9 +1,9 @@
 <section>
   <dl id="income-details-questions" class="govuk-summary-list govuk-!-margin-bottom-9">
     <% income_detail_items(@legal_aid_application).each do |item| %>
-      <%= render 'shared/means_report/item', item.to_h %>
+      <%= render "shared/means_report/item", item.to_h %>
     <% end %>
-    <%= render 'shared/means_report/total', name: 'total_income', value_method: :total_gross_income_assessed %>
+    <%= render "shared/means_report/total", name: "total_income", value_method: :total_gross_income_assessed %>
   </dl>
 
 </section>

--- a/app/views/shared/check_answers/_income_result.html.erb
+++ b/app/views/shared/check_answers/_income_result.html.erb
@@ -3,46 +3,46 @@
 
   <dl id="income-result-questions" class="govuk-summary-list govuk-!-margin-bottom-9">
     <%= check_answer_link(
-            name: :total_gross_income_assessed,
-            question: t('.total_gross_income'),
-            answer: gds_number_to_currency(@legal_aid_application.cfe_result.total_gross_income_assessed),
-            read_only: read_only
+          name: :total_gross_income_assessed,
+          question: t(".total_gross_income"),
+          answer: gds_number_to_currency(@legal_aid_application.cfe_result.total_gross_income_assessed),
+          read_only:,
         ) %>
 
     <%= check_answer_link(
-            name: :total_disposable_income_assessed,
-            question: t('.total_disposable_income'),
-            answer: gds_number_to_currency(@legal_aid_application.cfe_result.total_disposable_income_assessed),
-            read_only: read_only
+          name: :total_disposable_income_assessed,
+          question: t(".total_disposable_income"),
+          answer: gds_number_to_currency(@legal_aid_application.cfe_result.total_disposable_income_assessed),
+          read_only:,
         ) %>
 
   <% if @legal_aid_application.using_enhanced_bank_upload? || !@legal_aid_application.uploading_bank_statements? %>
     <%= check_answer_link(
-            name: :gross_income_limit,
-            question: t('.gross_income_limit'),
-            answer: number_to_currency_or_na(@legal_aid_application.cfe_result.gross_income_upper_threshold),
-            read_only: read_only
+          name: :gross_income_limit,
+          question: t(".gross_income_limit"),
+          answer: number_to_currency_or_na(@legal_aid_application.cfe_result.gross_income_upper_threshold),
+          read_only:,
         ) %>
 
     <%= check_answer_link(
-            name: :disposable_income_lower_limit,
-            question: t('.disposable_income_lower_limit'),
-            answer: gds_number_to_currency(@legal_aid_application.cfe_result.disposable_income_lower_threshold),
-            read_only: read_only
+          name: :disposable_income_lower_limit,
+          question: t(".disposable_income_lower_limit"),
+          answer: gds_number_to_currency(@legal_aid_application.cfe_result.disposable_income_lower_threshold),
+          read_only:,
         ) %>
 
     <%= check_answer_link(
-            name: :disposable_income_upper_limit_limit,
-            question: t('.disposable_income_upper_limit'),
-            answer: number_to_currency_or_na(@legal_aid_application.cfe_result.disposable_income_upper_threshold),
-            read_only: read_only
+          name: :disposable_income_upper_limit_limit,
+          question: t(".disposable_income_upper_limit"),
+          answer: number_to_currency_or_na(@legal_aid_application.cfe_result.disposable_income_upper_threshold),
+          read_only:,
         ) %>
 
     <%= check_answer_link(
-            name: :disposable_income_contribution,
-            question: t('.disposable_income_contribution'),
-            answer: gds_number_to_currency(@legal_aid_application.cfe_result.income_contribution),
-            read_only: read_only
+          name: :disposable_income_contribution,
+          question: t(".disposable_income_contribution"),
+          answer: gds_number_to_currency(@legal_aid_application.cfe_result.income_contribution),
+          read_only:,
         ) %>
     <% end %>
   </dl>

--- a/app/views/shared/check_answers/_income_summary.html.erb
+++ b/app/views/shared/check_answers/_income_summary.html.erb
@@ -7,9 +7,12 @@
     <div class="govuk-grid-column-one-third govuk-summary-list--no-border align-text-right">
       <% unless read_only %>
         <p>
-            <%= link_to_accessible(t('generic.change'),
-                                   check_answer_url_for(:providers, url, @legal_aid_application),
-                                   class: 'govuk-link change-link', suffix: income_type) %>
+            <%= link_to_accessible(
+                  t("generic.change"),
+                  check_answer_url_for(:providers, url, @legal_aid_application),
+                  class: "govuk-link change-link",
+                  suffix: income_type,
+                ) %>
         </p>
       <% end %>
     </div>
@@ -22,7 +25,7 @@
             name: transaction_type.label_name,
             question: transaction_type.label_name,
             legal_aid_application: @legal_aid_application,
-            transaction_type: transaction_type
+            transaction_type:,
           ) %>
     <% end %>
   </dl>
@@ -33,7 +36,7 @@
               name: transaction_type.label_name,
               question: transaction_type.label_name,
               legal_aid_application: @legal_aid_application,
-              transaction_type: transaction_type
+              transaction_type:,
             ) %>
       <% end %>
   </dl>

--- a/app/views/shared/check_answers/_item.html.erb
+++ b/app/views/shared/check_answers/_item.html.erb
@@ -1,7 +1,5 @@
-<%
-  read_only = local_assigns[:read_only] ? read_only : false
-  no_border = no_border ? 'govuk-summary-list__row--no-border' : ''
-%>
+<% read_only = false unless local_assigns[:read_only] %>
+<% no_border = no_border ? "govuk-summary-list__row--no-border" : "" %>
 
 <div class="govuk-summary-list__row <%= no_border %> normal-word-break" id="app-check-your-answers__<%= name %>">
   <dt class="govuk-summary-list__key govuk-!-width-one-half">
@@ -28,7 +26,7 @@
   <% unless read_only %>
     <dd class="govuk-summary-list__actions">
       <% unless url == :show_blank_action %>
-        <%= link_to_accessible(t('generic.change'), url, class: 'govuk-link change-link', suffix: question) %>
+        <%= link_to_accessible(t("generic.change"), url, class: "govuk-link change-link", suffix: question) %>
       <% end %>
     </dd>
   <% end %>

--- a/app/views/shared/check_answers/_level_of_service.html.erb
+++ b/app/views/shared/check_answers/_level_of_service.html.erb
@@ -4,5 +4,5 @@
       # url: send("providers_legal_aid_application_#{level_of_service}_level_of_service_path", @legal_aid_application, proceeding),
       question: t(".#{level_of_service}.question"),
       answer: proceeding.send("#{level_of_service}_level_of_service_name"),
-      read_only: read_only
+      read_only:,
     ) %>

--- a/app/views/shared/check_answers/_merits.html.erb
+++ b/app/views/shared/check_answers/_merits.html.erb
@@ -1,102 +1,102 @@
-<h2 class="govuk-heading-l"><%= t('.case-details-heading') %></h2>
+<h2 class="govuk-heading-l"><%= t(".case-details-heading") %></h2>
 
 <% if @legal_aid_application.latest_incident %>
   <section class="print-no-break">
     <%= check_answer_change_link(
           name: :incident_details,
           url: providers_legal_aid_application_date_client_told_incident_path(@legal_aid_application),
-          question: t('.latest-incident-heading'),
-          read_only: read_only
+          question: t(".latest-incident-heading"),
+          read_only:,
         ) %>
 
     <dl class="govuk-summary-list govuk-!-margin-bottom-2">
       <%= check_answer_no_link(
             name: :notification_of_latest_incident,
-            question: t('.items.notification_of_latest_incident'),
+            question: t(".items.notification_of_latest_incident"),
             answer: incident&.told_on,
-            read_only: read_only
+            read_only:,
           ) %>
 
       <%= check_answer_no_link(
             name: :date_of_latest_incident,
-            question: t('.items.date_of_latest_incident'),
+            question: t(".items.date_of_latest_incident"),
             answer: incident&.occurred_on,
-            read_only: read_only
+            read_only:,
           ) %>
     </dl>
   </section>
 <% end %>
 
 <section class="print-no-break">
-  <h2 class="govuk-heading-m govuk-!-padding-top-6"><%= t '.opponent-heading' %></h2>
+  <h2 class="govuk-heading-m govuk-!-padding-top-6"><%= t ".opponent-heading" %></h2>
   <dl class="govuk-summary-list govuk-!-margin-bottom-2">
     <%= check_answer_link(
           name: :full_name,
-          question: t('.items.full_name'),
+          question: t(".items.full_name"),
           url: providers_legal_aid_application_opponents_name_path(@legal_aid_application),
           answer: opponent.full_name,
-          read_only: read_only
+          read_only:,
         ) %>
   </dl>
 
-  <%= render 'shared/check_answers/section_break' unless opponent.full_name %>
+  <%= render "shared/check_answers/section_break" unless opponent.full_name %>
 
   <dl class="govuk-summary-list govuk-!-margin-bottom-2">
     <%= check_answer_link(
           name: :understands_terms_of_court_order,
-          question: t('.items.understands_terms_of_court_order'),
+          question: t(".items.understands_terms_of_court_order"),
           url: providers_legal_aid_application_opponents_mental_capacity_path(@legal_aid_application),
           answer: yes_no(opponent.understands_terms_of_court_order),
           no_border: !opponent.understands_terms_of_court_order,
-          read_only: read_only
+          read_only:,
         ) %>
   </dl>
   <div class='govuk-body'><%= opponent.understands_terms_of_court_order_details %></div>
 
-  <%= render 'shared/check_answers/section_break' unless opponent.understands_terms_of_court_order %>
+  <%= render "shared/check_answers/section_break" unless opponent.understands_terms_of_court_order %>
 
   <% if task_list_includes?(@legal_aid_application, :domestic_abuse_summary) %>
     <dl class="govuk-summary-list govuk-!-margin-bottom-2">
       <%= check_answer_link(
             name: :warning_letter_sent,
-            question: t('.items.warning_letter_sent'),
+            question: t(".items.warning_letter_sent"),
             url: providers_legal_aid_application_domestic_abuse_summary_path(@legal_aid_application),
             answer: yes_no(opponent.warning_letter_sent),
             no_border: !opponent.warning_letter_sent,
-            read_only: read_only
+            read_only:,
           ) %>
     </dl>
     <div class='govuk-body'><%= opponent.warning_letter_sent_details %></div>
 
-    <%= render 'shared/check_answers/section_break' unless opponent.warning_letter_sent %>
+    <%= render "shared/check_answers/section_break" unless opponent.warning_letter_sent %>
 
     <dl class="govuk-summary-list govuk-!-margin-bottom-2">
       <%= check_answer_link(
             name: :police_notified,
-            question: t('.items.police_notified'),
+            question: t(".items.police_notified"),
             url: providers_legal_aid_application_domestic_abuse_summary_path(@legal_aid_application),
             answer: yes_no(opponent.police_notified),
             no_border: true,
-            read_only: read_only
+            read_only:,
           ) %>
     </dl>
     <div class='govuk-body'><%= opponent.police_notified_details %></div>
 
-    <%= render 'shared/check_answers/section_break' %>
+    <%= render "shared/check_answers/section_break" %>
 
     <dl class="govuk-summary-list govuk-!-margin-bottom-2">
       <%= check_answer_link(
             name: :bail_conditions_set,
-            question: t('.items.bail_conditions_set'),
+            question: t(".items.bail_conditions_set"),
             url: providers_legal_aid_application_domestic_abuse_summary_path(@legal_aid_application),
             answer: yes_no(opponent.bail_conditions_set),
             no_border: opponent.bail_conditions_set,
-            read_only: read_only
+            read_only:,
           ) %>
     </dl>
     <div class='govuk-body'><%= opponent.bail_conditions_set_details %></div>
 
-    <%= render 'shared/check_answers/section_break' if opponent.bail_conditions_set %>
+    <%= render "shared/check_answers/section_break" if opponent.bail_conditions_set %>
   <% end %>
 </section>
 <div class="govuk-!-padding-bottom-6"></div>
@@ -106,52 +106,52 @@
           name: :statement_of_case,
           url: providers_legal_aid_application_statement_of_case_path(@legal_aid_application),
           answer: attachments_with_size(statement_of_case&.original_attachments),
-          question: t('.statement-of-case-heading'),
-          read_only: read_only,
-          no_border: true
+          question: t(".statement-of-case-heading"),
+          read_only:,
+          no_border: true,
         ) %>
   </dl>
   <div class="govuk-body"><%= statement_of_case&.statement %></div>
-  <%= render 'shared/check_answers/section_break' if statement_of_case&.statement %>
+  <%= render "shared/check_answers/section_break" if statement_of_case&.statement %>
 </section>
 
 <% if @legal_aid_application.allegation %>
   <div class="govuk-!-padding-bottom-6"></div>
   <section class="print-no-break">
-    <h2 class="govuk-heading-m"><%= t('.client_denial_of_allegation_heading') %></h2>
+    <h2 class="govuk-heading-m"><%= t(".client_denial_of_allegation_heading") %></h2>
 
     <dl class="govuk-summary-list govuk-!-margin-bottom-2">
       <%= check_answer_link(
             name: :allegation_denies_all,
             url: providers_legal_aid_application_client_denial_of_allegation_path(@legal_aid_application),
-            question: t('.items.allegation_denies_all'),
+            question: t(".items.allegation_denies_all"),
             answer: yes_no(allegation.denies_all),
             no_border: true,
-            read_only: read_only
+            read_only:,
           ) %>
     </dl>
     <div class='govuk-body'><%= allegation.additional_information %></div>
-    <%= render 'shared/check_answers/section_break' if allegation.additional_information %>
+    <%= render "shared/check_answers/section_break" if allegation.additional_information %>
   </section>
 <% end %>
 
 <% if @legal_aid_application.undertaking %>
   <div class="govuk-!-padding-bottom-6"></div>
   <section class="print-no-break">
-    <h2 class="govuk-heading-m"><%= t('.client_offer_of_undertakings_heading') %></h2>
+    <h2 class="govuk-heading-m"><%= t(".client_offer_of_undertakings_heading") %></h2>
 
     <dl class="govuk-summary-list govuk-!-margin-bottom-2">
       <%= check_answer_link(
             name: :undertaking_offered,
             url: providers_legal_aid_application_client_offered_undertakings_path(@legal_aid_application),
-            question: t('.items.undertaking_offered'),
+            question: t(".items.undertaking_offered"),
             answer: yes_no(undertaking.offered),
             no_border: true,
-            read_only: read_only
+            read_only:,
           ) %>
     </dl>
     <div class='govuk-body'><%= undertaking.additional_information %></div>
-    <%= render 'shared/check_answers/section_break' if undertaking.additional_information %>
+    <%= render "shared/check_answers/section_break" if undertaking.additional_information %>
   </section>
 <% end %>
 
@@ -159,28 +159,28 @@
   <div class="govuk-!-padding-bottom-6"></div>
   <section class="print-no-break">
     <%= check_answer_change_link(
-      name: :nature_of_urgency_heading,
-      url: providers_legal_aid_application_nature_of_urgencies_path(@legal_aid_application),
-      question: t('.nature_of_urgency_heading'),
-      read_only: read_only
-    ) %>
+          name: :nature_of_urgency_heading,
+          url: providers_legal_aid_application_nature_of_urgencies_path(@legal_aid_application),
+          question: t(".nature_of_urgency_heading"),
+          read_only:,
+        ) %>
 
     <dl class="govuk-summary-list govuk-!-margin-bottom-2">
       <%= check_answer_no_link(
-        name: :nature_of_urgency,
-        question: t('.items.nature_of_urgency'),
-        answer: urgency.nature_of_urgency,
-        read_only: read_only
-      ) %>
+            name: :nature_of_urgency,
+            question: t(".items.nature_of_urgency"),
+            answer: urgency.nature_of_urgency,
+            read_only:,
+          ) %>
     </dl>
 
     <dl class="govuk-summary-list govuk-!-margin-bottom-2">
       <%= check_answer_no_link(
-        name: :hearing_date_set,
-        question: t('.items.hearing_date_set'),
-        answer: sanitize("#{yes_no(urgency.hearing_date_set)}<br>#{urgency.hearing_date}#{urgency.additional_information}"),
-        read_only: read_only
-      ) %>
+            name: :hearing_date_set,
+            question: t(".items.hearing_date_set"),
+            answer: sanitize("#{yes_no(urgency.hearing_date_set)}<br>#{urgency.hearing_date}#{urgency.additional_information}"),
+            read_only:,
+          ) %>
     </dl>
   </section>
 <% end %>
@@ -188,30 +188,30 @@
 <% if @legal_aid_application.section_8_proceedings? %>
   <section class="print-no-break govuk-!-padding-top-6">
     <%= check_answer_change_link(
-        name: :involved_children,
-        url: providers_legal_aid_application_has_other_involved_children_path(@legal_aid_application),
-        question: t('.involved-children-heading'),
-        read_only: read_only
-      ) %>
+          name: :involved_children,
+          url: providers_legal_aid_application_has_other_involved_children_path(@legal_aid_application),
+          question: t(".involved-children-heading"),
+          read_only:,
+        ) %>
     <% @legal_aid_application.involved_children.each_with_index do |child, i| %>
       <dl class="govuk-summary-list govuk-!-margin-bottom-2 ">
         <%= check_answer_no_link(
-              name: "involved_child_#{i+1}".to_sym,
-              question: "#{t('.items.child')} #{i+1}",
+              name: "involved_child_#{i + 1}".to_sym,
+              question: "#{t('.items.child')} #{i + 1}",
               answer: "#{child.full_name} born on #{child.date_of_birth.strftime('%e %B %Y')}",
               no_border: false,
-              read_only: read_only
+              read_only:,
             ) %>
       </dl>
     <% end %>
-    <h2 class="govuk-heading-m govuk-!-padding-top-6"><%= t '.laspo.heading' %></h2>
+    <h2 class="govuk-heading-m govuk-!-padding-top-6"><%= t ".laspo.heading" %></h2>
     <dl class="govuk-summary-list govuk-!-margin-bottom-9">
       <%= check_answer_link(
             name: :in_scope_of_laspo,
             url: providers_legal_aid_application_in_scope_of_laspo_path(@legal_aid_application),
-            question: t('.laspo.question'),
+            question: t(".laspo.question"),
             answer: yes_no(@legal_aid_application.in_scope_of_laspo),
-            read_only: read_only
+            read_only:,
           ) %>
     </dl>
   </section>
@@ -220,19 +220,19 @@
 <% if @legal_aid_application.matter_opposition %>
   <section class="print-no-break govuk-!-padding-top-6">
     <%= check_answer_change_link(
-      name: :matter_opposed_reason_heading,
-      url: providers_legal_aid_application_matter_opposed_reason_path(@legal_aid_application),
-      question: t(".matter_opposed_reason_heading"),
-      read_only: read_only
-    ) %>
+          name: :matter_opposed_reason_heading,
+          url: providers_legal_aid_application_matter_opposed_reason_path(@legal_aid_application),
+          question: t(".matter_opposed_reason_heading"),
+          read_only:,
+        ) %>
 
     <dl class="govuk-summary-list govuk-!-margin-bottom-2">
       <%= check_answer_no_link(
-        name: :matter_opposed_reason,
-        question: t(".items.matter_opposed_reason"),
-        answer: @legal_aid_application.matter_opposition.reason,
-        read_only: read_only
-      ) %>
+            name: :matter_opposed_reason,
+            question: t(".items.matter_opposed_reason"),
+            answer: @legal_aid_application.matter_opposition.reason,
+            read_only:,
+          ) %>
     </dl>
   </section>
 <% end %>
@@ -243,15 +243,15 @@
 
   <section class="print-no-break">
     <h2 class="govuk-heading-m">
-      <%= t '.gateway-evidence-heading' %>
+      <%= t ".gateway-evidence-heading" %>
     </h2>
     <dl class="govuk-summary-list govuk-!-margin-bottom-2 print-remove-border">
     <%= check_answer_link(
           name: :gateway_evidence,
           url: providers_legal_aid_application_gateway_evidence_path(@legal_aid_application),
-          question: t('.items.gateway_evidence'),
+          question: t(".items.gateway_evidence"),
           answer: attachments_with_size(gateway_evidence&.original_attachments),
-          read_only: read_only
+          read_only:,
         ) %>
     </dl>
   </section>
@@ -266,17 +266,20 @@
       <%= check_answer_link(
             name: "#{proceeding.id}_success_likely".to_sym,
             url: providers_merits_task_list_chances_of_success_index_path(proceeding),
-            question: t('.items.prospects_of_success'),
+            question: t(".items.prospects_of_success"),
             answer: yes_no(proceeding.chances_of_success.success_likely),
-            read_only: read_only
+            read_only:,
           ) %>
+
+      <% unless proceeding.chances_of_success.success_likely? %>
         <%= check_answer_link(
               name: "#{proceeding.id}_success_prospect".to_sym,
               url: providers_merits_task_list_success_prospects_path(proceeding),
-              question: t('.items.success_prospect'),
+              question: t(".items.success_prospect"),
               answer: t("shared.forms.success_prospect.#{proceeding.chances_of_success.success_prospect}"),
-              read_only: read_only
-            ) unless proceeding.chances_of_success.success_likely? %>
+              read_only:,
+            ) %>
+      <% end %>
     </dl>
 
     <% if proceeding.chances_of_success.success_prospect_details %>
@@ -289,9 +292,9 @@
         <%= check_answer_link(
               name: "#{proceeding.id}_attempts_to_settle".to_sym,
               url: providers_merits_task_list_attempts_to_settle_path(proceeding),
-              question: t('.items.attempts_to_settle'),
+              question: t(".items.attempts_to_settle"),
               answer: proceeding.attempts_to_settle.attempts_made,
-              read_only: read_only
+              read_only:,
             ) %>
       </dl>
     <% end %>
@@ -300,9 +303,9 @@
         <%= check_answer_link(
               name: "#{proceeding.id}_linked_children".to_sym,
               url: providers_merits_task_list_linked_children_path(proceeding),
-              question: t('.items.linked_children'),
+              question: t(".items.linked_children"),
               answer: linked_children_names(proceeding),
-              read_only: read_only
+              read_only:,
             ) %>
       </dl>
     <% end %>
@@ -311,9 +314,9 @@
         <%= check_answer_link(
               name: "#{proceeding.id}_specific_issue".to_sym,
               url: providers_merits_task_list_specific_issue_path(proceeding),
-              question: t('.items.specific_issue'),
+              question: t(".items.specific_issue"),
               answer: proceeding.specific_issue.details,
-              read_only: read_only
+              read_only:,
             ) %>
       </dl>
     <% end %>
@@ -322,25 +325,25 @@
         <%= check_answer_link(
               name: "#{proceeding.id}_prohibited_steps".to_sym,
               url: providers_merits_task_list_prohibited_steps_path(proceeding),
-              question: t('.items.prohibited_steps'),
+              question: t(".items.prohibited_steps"),
               answer: yes_no(proceeding.prohibited_steps.uk_removal),
-              read_only: read_only,
-              no_border: true
+              read_only:,
+              no_border: true,
             ) %>
       </dl>
       <% unless proceeding.prohibited_steps.uk_removal %>
         <div class="govuk-body"><%= proceeding.prohibited_steps.details %></div>
       <% end %>
-      <%= render 'shared/check_answers/section_break' %>
+      <%= render "shared/check_answers/section_break" %>
     <% end %>
     <% if proceeding.vary_order %>
       <dl class="govuk-summary-list govuk-!-margin-bottom-2">
         <%= check_answer_link(
               name: "#{proceeding.id}_vary_order".to_sym,
               url: providers_merits_task_list_vary_order_path(proceeding),
-              question: t('.items.vary_order'),
+              question: t(".items.vary_order"),
               answer: proceeding.vary_order.details,
-              read_only: read_only
+              read_only:,
             ) %>
       </dl>
     <% end %>
@@ -349,17 +352,17 @@
         <%= check_answer_link(
               name: "#{proceeding.id}_opponents_application".to_sym,
               url: providers_merits_task_list_opponents_application_path(proceeding),
-              question: t('.items.opponents_application_question'),
+              question: t(".items.opponents_application_question"),
               answer: yes_no(proceeding.opponents_application.has_opponents_application),
-              read_only: read_only
+              read_only:,
             ) %>
         <% if proceeding.opponents_application.reason_for_applying %>
           <%= check_answer_link(
                 name: "#{proceeding.id}_opponents_application".to_sym,
                 url: providers_merits_task_list_opponents_application_path(proceeding),
-                question: t('.items.opponents_application_reason'),
+                question: t(".items.opponents_application_reason"),
                 answer: proceeding.opponents_application.reason_for_applying,
-                read_only: read_only
+                read_only:,
               ) %>
         <% end %>
       </dl>
@@ -373,17 +376,17 @@
     <%= check_answer_change_link(
           name: :supporting_evidence,
           url: providers_legal_aid_application_uploaded_evidence_collection_path(@legal_aid_application),
-          question: t('.evidence_upload_heading'),
-          read_only: read_only
+          question: t(".evidence_upload_heading"),
+          read_only:,
         ) %>
 
     <dl class="govuk-summary-list govuk-!-margin-bottom-2">
       <% @legal_aid_application.uploaded_evidence_by_category.each do | category, attachments| %>
       <%= check_answer_no_link(
-              name: category,
-              question: t(".evidence_types.#{category}"),
-              answer: attachments,
-              read_only: read_only
+            name: category,
+            question: t(".evidence_types.#{category}"),
+            answer: attachments,
+            read_only:,
           ) %>
       <% end %>
     </dl>

--- a/app/views/shared/check_answers/_no_link_cash_transaction_item.html.erb
+++ b/app/views/shared/check_answers/_no_link_cash_transaction_item.html.erb
@@ -5,10 +5,10 @@
   <dd class="govuk-summary-list__value">
     <% if legal_aid_application.cash_transactions.for_transaction_type(transaction_type.id).any? %>
       <% legal_aid_application.cash_transactions.for_transaction_type(transaction_type.id).each do |ctx| %>
-        <strong><%= ctx.transaction_date.strftime('%B') %></strong>: <%= gds_number_to_currency(ctx.amount, precision: 2) %><br>
+        <strong><%= ctx.transaction_date.strftime("%B") %></strong>: <%= gds_number_to_currency(ctx.amount, precision: 2) %><br>
       <% end %>
     <% else %>
-      <%= t('generic.none') %>
+      <%= t("generic.none") %>
     <% end %>
   </dd>
 </div>

--- a/app/views/shared/check_answers/_no_link_item.html.erb
+++ b/app/views/shared/check_answers/_no_link_item.html.erb
@@ -1,7 +1,5 @@
-<%
-  no_border = no_border ? 'govuk-summary-list--no-border' : ''
-  read_only = local_assigns[:read_only] ? read_only : false
-%>
+<% no_border = no_border ? "govuk-summary-list--no-border" : "" %>
+<% read_only = false unless local_assigns[:read_only] %>
 <div class="govuk-summary-list__row <%= no_border %> normal-word-break" id="app-check-your-answers__<%= name %>">
   <dt class="govuk-summary-list__key govuk-!-width-one-half">
     <%= question %>

--- a/app/views/shared/check_answers/_no_link_long_item.html.erb
+++ b/app/views/shared/check_answers/_no_link_long_item.html.erb
@@ -1,9 +1,9 @@
-<% no_border = no_border ? 'govuk-summary-list--no-border' : '' %>
+<% no_border = no_border ? "govuk-summary-list--no-border" : "" %>
 <div class="govuk-summary-list__row <%= no_border %>" id="app-check-your-answers__<%= name %>">
   <dt class="govuk-summary-list__key">
     <%= question %>
   </dd>
   <dd class="govuk-summary-list__value">
-    <%= answer.present? ? answer : '-' %>
+    <%= answer.presence || "-" %>
   </dd>
 </div>

--- a/app/views/shared/check_answers/_no_link_transaction_type_item.html.erb
+++ b/app/views/shared/check_answers/_no_link_transaction_type_item.html.erb
@@ -3,6 +3,6 @@
     <%= question %>
   </dt>
   <dd class="govuk-summary-list__value">
-    <%= answer_for_transaction_type(legal_aid_application: legal_aid_application, transaction_type: transaction_type) %>
+    <%= answer_for_transaction_type(legal_aid_application:, transaction_type:) %>
   </dd>
 </div>

--- a/app/views/shared/check_answers/_offline_savings_accounts.html.erb
+++ b/app/views/shared/check_answers/_offline_savings_accounts.html.erb
@@ -1,15 +1,19 @@
-<% read_only = local_assigns[:read_only] ? read_only : false %>
+<% read_only = false unless local_assigns[:read_only] %>
 <% if @legal_aid_application.offline_savings? %>
   <div class="govuk-grid-row" id="app-check-your-answers__offline_savings_accounts">
     <div class="govuk-grid-column-two-thirds">
-      <h3 class="govuk-heading-m"><%= t('.heading') %></h3>
+      <h3 class="govuk-heading-m"><%= t(".heading") %></h3>
     </div>
     <div class="govuk-grid-column-one-third govuk-summary-list--no-border align-text-right">
 
       <p>
         <% if read_only == false %>
-          <%= link_to_accessible(t('generic.change'), check_answer_url_for(journey_type, :applicant_bank_accounts, @legal_aid_application),
-                                 class: 'govuk-link change-link', suffix: :offline_savings_accounts) %>
+          <%= link_to_accessible(
+                t("generic.change"),
+                check_answer_url_for(journey_type, :applicant_bank_accounts, @legal_aid_application),
+                class: "govuk-link change-link",
+                suffix: :offline_savings_accounts,
+              ) %>
         <% end %>
       </p>
     </div>
@@ -17,26 +21,26 @@
   <dl class="govuk-summary-list govuk-!-margin-bottom-9" data-test="offline-savings-accounts">
     <%= check_answer_no_link(
           name: :has_offline_savings,
-          question: t('.offline_savings_accounts'),
+          question: t(".offline_savings_accounts"),
           answer: safe_yes_or_no(@legal_aid_application.offline_savings?),
-          read_only: read_only
+          read_only:,
         ) %>
     <%= check_answer_no_link(
           name: :offline_savings_amount,
-          question: t('.offline_savings_amount'),
+          question: t(".offline_savings_amount"),
           answer: gds_number_to_currency(@legal_aid_application.offline_savings_value),
-          read_only: read_only
+          read_only:,
         ) %>
   </dl>
 <% else %>
-  <h3 class="govuk-heading-m"><%= t('.heading') %></h3>
+  <h3 class="govuk-heading-m"><%= t(".heading") %></h3>
   <dl class="govuk-summary-list govuk-!-margin-bottom-9">
     <%= check_answer_link(
           name: :has_offline_savings,
           url: check_answer_url_for(journey_type, :applicant_bank_accounts, @legal_aid_application),
-          question: t('.offline_savings_accounts'),
+          question: t(".offline_savings_accounts"),
           answer: safe_yes_or_no(@legal_aid_application.offline_savings?),
-          read_only: read_only
+          read_only:,
         ) %>
   </dl>
 <% end %>

--- a/app/views/shared/check_answers/_one_link_section.html.erb
+++ b/app/views/shared/check_answers/_one_link_section.html.erb
@@ -1,13 +1,13 @@
-<% read_only = local_assigns[:read_only] ? read_only : false %>
+<% read_only = false unless local_assigns[:read_only] %>
 
-<div class="govuk-grid-row" id="app-check-your-answers__<%= name %><%= answer_hash.present? ? '' : '_header' %>">
+<div class="govuk-grid-row" id="app-check-your-answers__<%= name %><%= answer_hash.present? ? "" : "_header" %>">
   <div class="govuk-grid-column-two-thirds">
     <h2 class="govuk-heading-m"><%= question %></h2>
   </div>
   <% if answer_hash.present? && !read_only %>
     <div class="govuk-grid-column-one-third govuk-summary-list--no-border align-text-right">
       <p>
-        <%= link_to_accessible(t('generic.change'), url, class: 'govuk-link change-link', suffix: question) %>
+        <%= link_to_accessible(t("generic.change"), url, class: "govuk-link change-link", suffix: question) %>
       </p>
     </div>
   <% end %>
@@ -21,17 +21,17 @@
               name: item.name || "#{name}_#{index}",
               question: item.label,
               answer: safe_yes_or_no(item.amount_text),
-              read_only: read_only
+              read_only:,
             ) %>
       <% end %>
 
   <% else %>
     <%= check_answer_link(
-          name: name,
-          url: url,
-          question: question,
-          answer: t('generic.none_declared'),
-          read_only: read_only
+          name:,
+          url:,
+          question:,
+          answer: t("generic.none_declared"),
+          read_only:,
         ) %>
   <% end %>
 </dl>

--- a/app/views/shared/check_answers/_only_link_section.html.erb
+++ b/app/views/shared/check_answers/_only_link_section.html.erb
@@ -5,7 +5,7 @@
   <% unless read_only %>
       <div class="govuk-grid-column-one-third govuk-summary-list--no-border align-text-right">
         <p>
-          <%= link_to_accessible(t('generic.change'), url, class: 'govuk-link change-link', suffix: question) %>
+          <%= link_to_accessible(t("generic.change"), url, class: "govuk-link change-link", suffix: question) %>
         </p>
       </div>
   <% end %>

--- a/app/views/shared/check_answers/_outgoings_cash_payments.html.erb
+++ b/app/views/shared/check_answers/_outgoings_cash_payments.html.erb
@@ -2,32 +2,33 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-        <h3 class="govuk-heading-m"><%= t('.heading') %></h3>
+        <h3 class="govuk-heading-m"><%= t(".heading") %></h3>
     </div>
     <div class="govuk-grid-column-one-third govuk-summary-list--no-border align-text-right">
         <p>
           <% unless read_only %>
-            <%= link_to_accessible(t('generic.change'),
-                                   check_answer_url_for(:providers,
-                                                        :cash_outgoings,
-                                                        @legal_aid_application),
-                                   class: 'govuk-link change-link', suffix: t('.heading')) %>
+            <%= link_to_accessible(
+                  t("generic.change"),
+                  check_answer_url_for(:providers, :cash_outgoings, @legal_aid_application),
+                  class: "govuk-link change-link",
+                  suffix: t(".heading"),
+                ) %>
           <% end %>
         </p>
     </div>
 </div>
 
 <% if !@legal_aid_application.transaction_types.debits.exists? %>
-  <div class="govuk-body>"> <%= t('generic.none') %> </div>
+  <div class="govuk-body>"> <%= t("generic.none") %> </div>
 <% end %>
 
-<dl id="outgoings-cash-payments-questions" class="govuk-summary-list govuk-!-margin-bottom-9" data-check-your-answers-section="<%= t('.heading').parameterize %>">
+<dl id="outgoings-cash-payments-questions" class="govuk-summary-list govuk-!-margin-bottom-9" data-check-your-answers-section="<%= t(".heading").parameterize %>">
   <% TransactionType.debits.each do |category| %>
-     <%= check_answer_for_cash_transactions(
+    <%= check_answer_for_cash_transactions(
           name: "outgoings_cash_payments_#{category.label_name}",
           question: category.label_name,
           legal_aid_application: @legal_aid_application,
-          transaction_type: category
-      ) %>
+          transaction_type: category,
+        ) %>
   <% end %>
 </dl>

--- a/app/views/shared/check_answers/_outgoings_details.html.erb
+++ b/app/views/shared/check_answers/_outgoings_details.html.erb
@@ -1,9 +1,9 @@
 <section>
   <dl id="outgoings-details-questions" class="govuk-summary-list govuk-!-margin-bottom-9">
     <% outgoings_detail_items(@legal_aid_application).each do |item| %>
-      <%= render 'shared/means_report/item', item.to_h %>
+      <%= render "shared/means_report/item", item.to_h %>
     <% end %>
-    <%= render 'shared/means_report/total', name: 'total_outgoings', value_method: :total_monthly_outgoings %>
+    <%= render "shared/means_report/total", name: "total_outgoings", value_method: :total_monthly_outgoings %>
   </dl>
 
 </section>

--- a/app/views/shared/check_answers/_proceeding_details_section.html.erb
+++ b/app/views/shared/check_answers/_proceeding_details_section.html.erb
@@ -2,35 +2,35 @@
 <h2 class="govuk-heading-m"><%= proceeding.meaning %></h2>
 <dl class="govuk-summary-list govuk-!-margin-bottom-9">
   <%= check_answer_no_link(
-    name: :client_role,
-    question: t('.client_role'),
-    answer: proceeding.client_involvement_type_description
-  ) %>
+        name: :client_role,
+        question: t(".client_role"),
+        answer: proceeding.client_involvement_type_description,
+      ) %>
   <% if proceeding.used_delegated_functions %>
     <%= check_answer_no_link(
-      name: :delegated_functions_date,
-      question: t('.delegated_functions'),
-      answer: proceeding.used_delegated_functions_on&.strftime('%-d %B %Y')
-    ) %>
+          name: :delegated_functions_date,
+          question: t(".delegated_functions"),
+          answer: proceeding.used_delegated_functions_on&.strftime("%-d %B %Y"),
+        ) %>
     <%= check_answer_no_link(
-      name: :emergency_level_of_service,
-      question: t('.emergency_level_of_service'),
-      answer: proceeding.emergency_level_of_service_name
-    ) %>
+          name: :emergency_level_of_service,
+          question: t(".emergency_level_of_service"),
+          answer: proceeding.emergency_level_of_service_name,
+        ) %>
     <%= check_answer_no_link(
-      name: :emergency_scope_limits,
-      question: t('.emergency_scope_limits'),
-      answer: scope_limits(proceeding, "emergency")
-    ) %>
+          name: :emergency_scope_limits,
+          question: t(".emergency_scope_limits"),
+          answer: scope_limits(proceeding, "emergency"),
+        ) %>
   <% end %>
   <%= check_answer_no_link(
-    name: :substantive_level_of_service,
-    question: t('.substantive_level_of_service'),
-    answer: proceeding.substantive_level_of_service_name
-  ) %>
+        name: :substantive_level_of_service,
+        question: t(".substantive_level_of_service"),
+        answer: proceeding.substantive_level_of_service_name,
+      ) %>
   <%= check_answer_no_link(
-    name: :substantive_scope_limits,
-    question: t('.substantive_scope_limits'),
-    answer: scope_limits(proceeding, "substantive")
-  ) %>
+        name: :substantive_scope_limits,
+        question: t(".substantive_scope_limits"),
+        answer: scope_limits(proceeding, "substantive"),
+      ) %>
 </dl>

--- a/app/views/shared/check_answers/_proceedings_details.html.erb
+++ b/app/views/shared/check_answers/_proceedings_details.html.erb
@@ -4,25 +4,27 @@
   <% if Setting.enable_loop? %>
     <% @legal_aid_application.proceedings.in_order_of_addition.each do |proceeding| %>
       <%= render(
-            'shared/check_answers/proceeding_details',
-            proceeding: proceeding,
-            read_only: read_only
+            "shared/check_answers/proceeding_details",
+            proceeding:,
+            read_only:,
           ) %>
     <% end %>
   <% else %>
-    <%= check_answer_link(
-          name: :proceeding_type,
-          question: t('.section_proceeding.client_involvement_type'),
-          answer: t('.section_proceeding.client_involvement_type_applicant')
-        ) if show_client_involvment_type %>
+    <% if show_client_involvment_type %>
+      <%= check_answer_link(
+            name: :proceeding_type,
+            question: t(".section_proceeding.client_involvement_type"),
+            answer: t(".section_proceeding.client_involvement_type_applicant"),
+          ) %>
+    <% end %>
 
     <% @legal_aid_application.proceedings_by_name.each_with_index do |proceeding, i| %>
       <%= check_answer_link(
             name: :"#{proceeding.name}_proceeding",
             url: :show_blank_action,
-            question: "#{t(".proceeding")} #{i + 1}",
+            question: "#{t('.proceeding')} #{i + 1}",
             answer: proceeding.meaning,
-            read_only: read_only
+            read_only:,
           ) %>
     <% end %>
 <% end %>

--- a/app/views/shared/check_answers/_property.html.erb
+++ b/app/views/shared/check_answers/_property.html.erb
@@ -1,44 +1,51 @@
 <% read_only = false unless local_assigns.key?(:read_only) %>
-<h3 class="govuk-heading-m"><%= t('shared.check_answers.assets.property.heading') %></h3>
+<h3 class="govuk-heading-m"><%= t("shared.check_answers.assets.property.heading") %></h3>
 <dl id="property-questions" class="govuk-summary-list govuk-!-margin-bottom-9">
   <%= check_answer_link(
-          name: :own_home,
-          url: check_answer_url_for(journey_type, :own_homes, @legal_aid_application),
-          question: t('shared.check_answers.assets.property.own_home'),
-          answer: @legal_aid_application.own_home.blank? ? '' : t("shared.forms.own_home_form.#{@legal_aid_application.own_home}"),
-          read_only: read_only
-          ) %>
+        name: :own_home,
+        url: check_answer_url_for(journey_type, :own_homes, @legal_aid_application),
+        question: t("shared.check_answers.assets.property.own_home"),
+        answer: @legal_aid_application.own_home.blank? ? "" : t("shared.forms.own_home_form.#{@legal_aid_application.own_home}"),
+        read_only:,
+      ) %>
 
-  <%= check_answer_link(
+  <% if @legal_aid_application.own_home? %>
+    <%= check_answer_link(
           name: :property_value,
           url: check_answer_url_for(journey_type, :property_values, @legal_aid_application),
-          question: t('shared.check_answers.assets.property.property_value'),
+          question: t("shared.check_answers.assets.property.property_value"),
           answer: gds_number_to_currency(@legal_aid_application.property_value),
-          read_only: read_only
-          ) if @legal_aid_application.own_home? %>
+          read_only:,
+        ) %>
+  <% end %>
 
-  <%= check_answer_link(
+  <% if @legal_aid_application.own_home_mortgage? %>
+    <%= check_answer_link(
           name: :outstanding_mortgage,
           url: check_answer_url_for(journey_type, :outstanding_mortgages, @legal_aid_application),
-          question: t('shared.check_answers.assets.property.outstanding_mortgage'),
+          question: t("shared.check_answers.assets.property.outstanding_mortgage"),
           answer: gds_number_to_currency(@legal_aid_application.outstanding_mortgage_amount),
-          read_only: read_only
-          ) if @legal_aid_application.own_home_mortgage? %>
+          read_only:,
+        ) %>
+  <% end %>
 
-  <%= check_answer_link(
+  <% if @legal_aid_application.own_home? %>
+    <%= check_answer_link(
           name: :shared_ownership,
           url: check_answer_url_for(journey_type, :shared_ownerships, @legal_aid_application),
-          question: t('shared.check_answers.assets.property.shared_ownership'),
-          answer: @legal_aid_application.shared_ownership.blank? ? '' : t("shared.forms.shared_ownership_form.#{@legal_aid_application.shared_ownership}"),
-          read_only: read_only
-          ) if @legal_aid_application.own_home? %>
+          question: t("shared.check_answers.assets.property.shared_ownership"),
+          answer: @legal_aid_application.shared_ownership.blank? ? "" : t("shared.forms.shared_ownership_form.#{@legal_aid_application.shared_ownership}"),
+          read_only:,
+        ) %>
+  <% end %>
 
-  <%= check_answer_link(
+  <% if @legal_aid_application.shared_ownership? && @legal_aid_application.own_home? %>
+    <%= check_answer_link(
           name: :percentage_home,
           url: check_answer_url_for(journey_type, :percentage_homes, @legal_aid_application),
-          question: t('shared.check_answers.assets.property.percentage_home'),
+          question: t("shared.check_answers.assets.property.percentage_home"),
           answer: number_to_percentage(@legal_aid_application.percentage_home, precision: 2),
-          read_only: read_only
-          ) if @legal_aid_application.shared_ownership? && @legal_aid_application.own_home? %>
-
+          read_only:,
+        ) %>
+  <% end %>
 </dl>

--- a/app/views/shared/check_answers/_regular_transaction_item.html.erb
+++ b/app/views/shared/check_answers/_regular_transaction_item.html.erb
@@ -1,4 +1,4 @@
-<% regular_transaction_amount, regular_transaction_frequency = regular_transaction_answer_by_type(legal_aid_application: legal_aid_application, transaction_type: transaction_type) %>
+<% regular_transaction_amount, regular_transaction_frequency = regular_transaction_answer_by_type(legal_aid_application:, transaction_type:) %>
 <div class="govuk-summary-list__row normal-word-break" id="app-check-your-answers__<%= name.parameterize %>">
   <dt class="govuk-summary-list__key">
     <%= question %>

--- a/app/views/shared/check_answers/_restrictions.html.erb
+++ b/app/views/shared/check_answers/_restrictions.html.erb
@@ -6,7 +6,7 @@
         question: t(".#{journey_type}.question"),
         answer: yes_no(@legal_aid_application.has_restrictions),
         no_border: @legal_aid_application.has_restrictions?,
-        read_only: read_only
+        read_only:,
       ) %>
 
   <% if @legal_aid_application.has_restrictions %>
@@ -16,7 +16,7 @@
             question: "Details of restrictions",
             answer: @legal_aid_application.restrictions_details,
             no_border: @legal_aid_application.has_restrictions?,
-            read_only: read_only
+            read_only:,
           ) %>
 <% end %>
 </dl>

--- a/app/views/shared/check_answers/_scope_limits.html.erb
+++ b/app/views/shared/check_answers/_scope_limits.html.erb
@@ -4,5 +4,5 @@
       # url: send("providers_legal_aid_application_#{level_of_service}_level_of_service_path", @legal_aid_application, proceeding),
       question: t(".#{level_of_service}.question"),
       answer: scope_limits(proceeding, level_of_service),
-      read_only: read_only
+      read_only:,
     ) %>

--- a/app/views/shared/check_answers/_student_finance.html.erb
+++ b/app/views/shared/check_answers/_student_finance.html.erb
@@ -1,13 +1,17 @@
 <% if @legal_aid_application.provider.bank_statement_upload_permissions? %>
   <div class="govuk-grid-row" id="app-check-your-answers__student_finance">
     <div class="govuk-grid-column-two-thirds">
-      <h3 class="govuk-heading-m"><%= t('.heading') %></h3>
+      <h3 class="govuk-heading-m"><%= t(".heading") %></h3>
     </div>
     <div class="govuk-grid-column-one-third govuk-summary-list--no-border align-text-right">
       <% unless read_only %>
         <p>
-          <%= link_to_accessible(t('generic.change'), providers_legal_aid_application_means_student_finance_path(@legal_aid_application),
-                                 class: 'govuk-link change-link', suffix: t('.heading')) %>
+          <%= link_to_accessible(
+                t("generic.change"),
+                providers_legal_aid_application_means_student_finance_path(@legal_aid_application),
+                class: "govuk-link change-link",
+                suffix: t(".heading"),
+              ) %>
         </p>
       <% end %>
     </div>
@@ -15,19 +19,21 @@
   <dl class="govuk-summary-list govuk-!-margin-bottom-9">
     <%= check_answer_no_link(
           name: :student_finance_question,
-          question: t('.does_your_client'),
+          question: t(".does_your_client"),
           answer: yes_no(@legal_aid_application.receives_student_finance?),
           read_only: false,
-          ) %>
+        ) %>
 
-    <%= check_answer_no_link(
-        name: :student_finance_annual_amount,
-        question: t('.how_much'),
-        answer: gds_number_to_currency(@legal_aid_application.value_of_student_finance),
-        read_only: false,
-        ) if @legal_aid_application.receives_student_finance? %>
+    <% if @legal_aid_application.receives_student_finance? %>
+        <%= check_answer_no_link(
+              name: :student_finance_annual_amount,
+              question: t(".how_much"),
+              answer: gds_number_to_currency(@legal_aid_application.value_of_student_finance),
+              read_only: false,
+            ) %>
+    <% end %>
   </dl>
 <% else %>
-  <h3 class="govuk-heading-m"><%= t('.heading') %></h3>
-  <p><%= t('.info_html', student_finance: value_with_currency_unit(@legal_aid_application.value_of_student_finance, t('currency.gbp'))) %></p>
+  <h3 class="govuk-heading-m"><%= t(".heading") %></h3>
+  <p><%= t(".info_html", student_finance: value_with_currency_unit(@legal_aid_application.value_of_student_finance, t("currency.gbp"))) %></p>
 <% end %>

--- a/app/views/shared/check_answers/_substantive_costs.html.erb
+++ b/app/views/shared/check_answers/_substantive_costs.html.erb
@@ -1,19 +1,19 @@
 <dl class="govuk-summary-list govuk-!-margin-bottom-9">
   <%= check_answer_no_link(
         name: :emergency_cost_override,
-        question: t('.request_higher_limit'),
-        answer: yes_no(@legal_aid_application.substantive_cost_override)
+        question: t(".request_higher_limit"),
+        answer: yes_no(@legal_aid_application.substantive_cost_override),
       ) %>
   <% if @legal_aid_application.substantive_cost_override %>
     <%= check_answer_no_link(
           name: :cost_requested,
           question: t(".new_cost_limit"),
-          answer: gds_number_to_currency(@legal_aid_application.substantive_cost_requested,  precision: 2)
+          answer: gds_number_to_currency(@legal_aid_application.substantive_cost_requested, precision: 2),
         ) %>
     <%= check_answer_no_link(
           name: :cost_reasons,
           question: t(".new_limit_reasons"),
-          answer: @legal_aid_application.substantive_cost_reasons
+          answer: @legal_aid_application.substantive_cost_reasons,
         ) %>
   <% end %>
 </dl>

--- a/app/views/shared/check_answers/_substantive_limitations.html.erb
+++ b/app/views/shared/check_answers/_substantive_limitations.html.erb
@@ -1,17 +1,17 @@
 <dl class="govuk-summary-list govuk-!-margin-bottom-9">
   <%= check_answer_no_link(
         name: :form_of_service,
-        question: t('.form_of_service'),
-        answer: @legal_aid_application.lead_proceeding.substantive_level_of_service_name
+        question: t(".form_of_service"),
+        answer: @legal_aid_application.lead_proceeding.substantive_level_of_service_name,
       ) %>
   <%= check_answer_no_link(
         name: :incurrable_costs,
-        question: t('.costs'),
-        answer: gds_number_to_currency(@legal_aid_application.default_substantive_cost_limitation,  precision: 0)
+        question: t(".costs"),
+        answer: gds_number_to_currency(@legal_aid_application.default_substantive_cost_limitation, precision: 0),
       ) %>
   <%= check_answer_no_link(
         name: :allowable_work,
-        question: t('.work'),
-        answer: @legal_aid_application.lead_proceeding.substantive_scope_limitation_description
+        question: t(".work"),
+        answer: @legal_aid_application.lead_proceeding.substantive_scope_limitation_description,
       ) %>
 </dl>

--- a/app/views/shared/check_answers/_vehicles.html.erb
+++ b/app/views/shared/check_answers/_vehicles.html.erb
@@ -1,4 +1,4 @@
-<% read_only = local_assigns[:read_only] ? read_only : false %>
+<% read_only = false unless local_assigns[:read_only] %>
 <h3 class="govuk-heading-m">
   <%= t(".#{journey_type}.heading") %>
 </h3>
@@ -9,38 +9,40 @@
         url: check_answer_url_for(journey_type, :vehicles, @legal_aid_application),
         question: t(".#{journey_type}.own"),
         answer: yes_no(@legal_aid_application.own_vehicle?),
-        read_only: read_only,
+        read_only:,
       ) %>
 
-  <%= check_answer_link(
-        name: :vehicles_estimated_values,
-        url: check_answer_url_for(journey_type, :vehicles_estimated_values, @legal_aid_application),
-        question: t(".#{journey_type}.estimated_value"),
-        answer: gds_number_to_currency(@legal_aid_application.vehicle.estimated_value),
-        read_only: read_only,
-      ) if @legal_aid_application.own_vehicle? %>
+  <% if @legal_aid_application.own_vehicle? %>
+    <%= check_answer_link(
+          name: :vehicles_estimated_values,
+          url: check_answer_url_for(journey_type, :vehicles_estimated_values, @legal_aid_application),
+          question: t(".#{journey_type}.estimated_value"),
+          answer: gds_number_to_currency(@legal_aid_application.vehicle.estimated_value),
+          read_only:,
+        ) %>
 
-  <%= check_answer_link(
-        name: :vehicles_remaining_payments,
-        url: check_answer_url_for(journey_type, :vehicles_remaining_payments, @legal_aid_application),
-        question: t(".#{journey_type}.payment_remaining"),
-        answer: gds_number_to_currency(@legal_aid_application.vehicle.payment_remaining),
-        read_only: read_only,
-      ) if @legal_aid_application.own_vehicle? %>
+    <%= check_answer_link(
+          name: :vehicles_remaining_payments,
+          url: check_answer_url_for(journey_type, :vehicles_remaining_payments, @legal_aid_application),
+          question: t(".#{journey_type}.payment_remaining"),
+          answer: gds_number_to_currency(@legal_aid_application.vehicle.payment_remaining),
+          read_only:,
+        ) %>
 
-  <%= check_answer_link(
-        name: :vehicles_ages,
-        url: check_answer_url_for(journey_type, :vehicles_ages, @legal_aid_application),
-        question: t(".#{journey_type}.more_than_three_years_old"),
-        answer: yes_no(@legal_aid_application.vehicle.more_than_three_years_old?),
-        read_only: read_only,
-      ) if @legal_aid_application.own_vehicle? %>
+    <%= check_answer_link(
+          name: :vehicles_ages,
+          url: check_answer_url_for(journey_type, :vehicles_ages, @legal_aid_application),
+          question: t(".#{journey_type}.more_than_three_years_old"),
+          answer: yes_no(@legal_aid_application.vehicle.more_than_three_years_old?),
+          read_only:,
+        ) %>
 
-  <%= check_answer_link(
-        name: :vehicles_regular_uses,
-        url: check_answer_url_for(journey_type, :vehicles_regular_uses, @legal_aid_application),
-        question: t(".#{journey_type}.used_regularly"),
-        answer: yes_no(@legal_aid_application.vehicle.used_regularly),
-        read_only: read_only,
-      ) if @legal_aid_application.own_vehicle? %>
+    <%= check_answer_link(
+          name: :vehicles_regular_uses,
+          url: check_answer_url_for(journey_type, :vehicles_regular_uses, @legal_aid_application),
+          question: t(".#{journey_type}.used_regularly"),
+          answer: yes_no(@legal_aid_application.vehicle.used_regularly),
+          read_only:,
+        ) %>
+  <% end %>
 </dl>


### PR DESCRIPTION
Before, all templates in `app/views/shared/check_answers` were excluded from Rubocop linting.

This removes that rule, and resolves all failures.

All failures were resolved with the `--autocorrect` flag and are trivial.