### PR TITLE
Remove redundant dependabot ignore rule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,10 +13,6 @@ updates:
   - dependency-name: prometheus_exporter
     versions:
     - "> 0.4.17"
-  - dependency-name: sprockets
-    versions:
-    - ">= 4.0.a"
-    - "< 4.1"
   reviewers:
   - "ministryofjustice/laa-apply-for-legal-aid"
 - package-ecosystem: npm


### PR DESCRIPTION
We don't use the `sprockets` gem anymore, so we don't need to ignore it anymore.
