### PR TITLE
[AP-3315] refactor and ensure provider/team only notified once

### DIFF
--- a/app/jobs/email_monitor_job.rb
+++ b/app/jobs/email_monitor_job.rb
@@ -4,13 +4,8 @@ class EmailMonitorJob < ApplicationJob
   DEFAULT_DELAY = 2.minutes.freeze
 
   def perform
-    ScheduledMailing.monitored.each { |mail| GovukEmails::Monitor.call(mail.id) }
-    reschedule unless JobQueue.enqueued?(self.class)
-  end
-
-private
-
-  def reschedule
-    self.class.set(wait: DEFAULT_DELAY).perform_later
+    ScheduledMailing.monitored.each do |mail|
+      GovukEmails::Monitor.call(mail.id)
+    end
   end
 end

--- a/app/mailers/undeliverable_email_alert_mailer.rb
+++ b/app/mailers/undeliverable_email_alert_mailer.rb
@@ -14,4 +14,15 @@ class UndeliverableEmailAlertMailer < BaseApplyMailer
 
     mail to: Rails.configuration.x.support_email_address
   end
+
+  def notify_provider(provider_email, application_ref, applicant_name, applicant_email)
+    template_name :client_email_failed_provider_alert
+    set_personalisation(
+      ref_number: application_ref,
+      applicant_name:,
+      applicant_email:,
+    )
+
+    mail to: provider_email
+  end
 end

--- a/app/services/govuk_emails/email.rb
+++ b/app/services/govuk_emails/email.rb
@@ -2,6 +2,8 @@ module GovukEmails
   class Email
     attr_reader :id
 
+    delegate :status, to: :response
+
     # states documentation:
     # https://docs.notifications.service.gov.uk/ruby.html#status-optional
     RESENDABLE_STATUS = %w[temporary-failure technical-failure].freeze
@@ -24,12 +26,10 @@ module GovukEmails
       status == PERMANENTLY_FAILED_STATUS
     end
 
-    delegate :status, to: :email
-
   private
 
-    def email
-      @email ||= govuk_notify_client.get_notification(id)
+    def response
+      @response ||= govuk_notify_client.get_notification(id)
     end
 
     def govuk_notify_client

--- a/app/services/govuk_emails/monitor.rb
+++ b/app/services/govuk_emails/monitor.rb
@@ -26,7 +26,7 @@ module GovukEmails
     end
 
     def send_undeliverable_alerts
-      return unless HostEnv.production?
+      # return unless HostEnv.production?
 
       AlertManager.capture_message("Unable to deliver mail to #{scheduled_mail.addressee} - ScheduledMailing record #{scheduled_mail.id}")
 

--- a/app/services/govuk_emails/monitor.rb
+++ b/app/services/govuk_emails/monitor.rb
@@ -22,9 +22,44 @@ module GovukEmails
       AlertManager.capture_message("Unable to deliver mail to #{@scheduled_mail.addressee} - ScheduledMailing record #{@scheduled_mail.id}")
       ScheduledMailing.send_now!(mailer_klass: UndeliverableEmailAlertMailer,
                                  mailer_method: :notify_apply_team,
-                                 legal_aid_application_id: @scheduled_mail.legal_aid_application_id,
+                                 legal_aid_application_id: legal_aid_application.id,
                                  addressee: Rails.configuration.x.support_email_address,
                                  arguments: [@scheduled_mail.id])
+
+      notify_provider_email_failed if @scheduled_mail.mailer_method == "citizen_start_email"
+    end
+
+    def notify_provider_email_failed
+      ScheduledMailing.send_now!(mailer_klass: UndeliverableEmailAlertMailer,
+                                 mailer_method: :notify_provider,
+                                 legal_aid_application_id: legal_aid_application.id,
+                                 addressee: provider_email_or_support,
+                                 arguments: mailer_args)
+    end
+
+    def mailer_args
+      [
+        provider.email,
+        legal_aid_application.application_ref,
+        applicant.full_name,
+        applicant.email,
+      ]
+    end
+
+    def provider_email_or_support
+      HostEnv.staging? ? Rails.configuration.x.support_email_address : provider.email
+    end
+
+    def legal_aid_application
+      @legal_aid_application = @scheduled_mail.legal_aid_application
+    end
+
+    def applicant
+      @applicant ||= legal_aid_application.applicant
+    end
+
+    def provider
+      @provider ||= legal_aid_application.provider
     end
   end
 end

--- a/app/services/govuk_emails/monitor.rb
+++ b/app/services/govuk_emails/monitor.rb
@@ -1,5 +1,10 @@
 module GovukEmails
   class Monitor
+    attr_reader :scheduled_mail
+
+    delegate :legal_aid_application, to: :scheduled_mail
+    delegate :applicant, :provider, to: :legal_aid_application
+
     def self.call(scheduled_mail_id)
       new(scheduled_mail_id).call
     end
@@ -9,32 +14,49 @@ module GovukEmails
     end
 
     def call
-      status = GovukEmails::Email.new(@scheduled_mail.govuk_message_id).status
-      @scheduled_mail.update!(status:)
-      send_undeliverable_alerts if status.in?(ScheduledMailing::FAILURE_STATUSES)
+      scheduled_mail.update!(status: response.status)
+
+      send_undeliverable_alerts if scheduled_mail.status.in?(ScheduledMailing::FAILURE_STATUSES)
     end
 
   private
 
+    def response
+      @response ||= GovukEmails::Email.new(scheduled_mail.govuk_message_id)
+    end
+
     def send_undeliverable_alerts
       return unless HostEnv.production?
 
-      AlertManager.capture_message("Unable to deliver mail to #{@scheduled_mail.addressee} - ScheduledMailing record #{@scheduled_mail.id}")
+      AlertManager.capture_message("Unable to deliver mail to #{scheduled_mail.addressee} - ScheduledMailing record #{scheduled_mail.id}")
+
+      send_undeliverable_to_apply_team!
+      send_undeliverable_citizen_start_email_to_provider!
+    end
+
+    def send_undeliverable_to_apply_team!
       ScheduledMailing.send_now!(mailer_klass: UndeliverableEmailAlertMailer,
                                  mailer_method: :notify_apply_team,
                                  legal_aid_application_id: legal_aid_application.id,
                                  addressee: Rails.configuration.x.support_email_address,
-                                 arguments: [@scheduled_mail.id])
-
-      notify_provider_email_failed if @scheduled_mail.mailer_method == "citizen_start_email"
+                                 arguments: [scheduled_mail.id])
     end
 
-    def notify_provider_email_failed
+    def send_undeliverable_citizen_start_email_to_provider!
+      return unless scheduled_mail.mailer_method == "citizen_start_email" && scheduled_mail.status == "permanent-failure"
+
       ScheduledMailing.send_now!(mailer_klass: UndeliverableEmailAlertMailer,
                                  mailer_method: :notify_provider,
                                  legal_aid_application_id: legal_aid_application.id,
                                  addressee: provider_email_or_support,
                                  arguments: mailer_args)
+
+      cancel_citizen_start_email_and_reminders!
+    end
+
+    def cancel_citizen_start_email_and_reminders!
+      scheduled_mail.cancel!
+      legal_aid_application.scheduled_mailings.where(mailer_klass: "SubmitCitizenFinancialReminderMailer").each(&:cancel!)
     end
 
     def mailer_args
@@ -48,18 +70,6 @@ module GovukEmails
 
     def provider_email_or_support
       HostEnv.staging? ? Rails.configuration.x.support_email_address : provider.email
-    end
-
-    def legal_aid_application
-      @legal_aid_application = @scheduled_mail.legal_aid_application
-    end
-
-    def applicant
-      @applicant ||= legal_aid_application.applicant
-    end
-
-    def provider
-      @provider ||= legal_aid_application.provider
     end
   end
 end

--- a/config/govuk_notify_templates.yml
+++ b/config/govuk_notify_templates.yml
@@ -8,4 +8,5 @@ reminder_to_submit_financial_information_provider: 9843f667-8b11-41c0-9c11-622ff
 new_link_to_client: 1f360188-7046-4eb2-9c03-a8253bf663c1
 citizen_completed_application: 3b18efe5-7d09-4042-927c-7d1ae03fdd7e
 undeliverable_alert: 8977dba0-7f06-4180-8ae8-11f630be8849
+client_email_failed_provider_alert: f4a1139e-ac74-4a8b-8ecf-bfa3de272236
 exception_alert: 7cee1d9e-5ee9-406d-a28b-51ab16d675ef

--- a/spec/mailers/undeliverable_email_alert_mailer_spec.rb
+++ b/spec/mailers/undeliverable_email_alert_mailer_spec.rb
@@ -1,16 +1,22 @@
 require "rails_helper"
 
 RSpec.describe UndeliverableEmailAlertMailer do
-  let(:legal_aid_application) { create(:legal_aid_application) }
+  let(:applicant) { create(:applicant, first_name: "John", last_name: "Doe", email: "johndoe@email.com") }
+  let(:provider) { create(:provider) }
+  let(:legal_aid_application) { create(:legal_aid_application, applicant:) }
   let(:failure_reason) { "permanently-failed" }
   let(:mailer) { "NotifyMailer" }
   let(:mail_method) { "citizen_start_email" }
   let(:args) { [] }
   let(:app_id) { "L-H12-3XZ" }
   let(:url) { "http://localhost/start_my_application/some_secret_id" }
-  let(:applicant_name) { "John Doe" }
-  let(:provider_firm) { "Acme Solicitors" }
-  let(:scheduled_mailing) { create(:scheduled_mailing, :citizen_start_email, :failed, legal_aid_application_id: legal_aid_application.id) }
+  let(:scheduled_mailing) do
+    create(:scheduled_mailing,
+           :citizen_start_email,
+           :failed,
+           addressee: applicant.email,
+           legal_aid_application_id: legal_aid_application.id)
+  end
 
   describe "#notify_apply_team" do
     let(:mail) { described_class.notify_apply_team(scheduled_mailing.id) }
@@ -33,6 +39,38 @@ RSpec.describe UndeliverableEmailAlertMailer do
         failure_reason: scheduled_mailing.status,
         mailer_and_method: "NotifyMailer#citizen_start_email",
         mail_params: scheduled_mailing.arguments,
+      )
+    end
+  end
+
+  describe "#notify_provider" do
+    let(:mailer_args) do
+      [
+        provider.email,
+        legal_aid_application.application_ref,
+        applicant.full_name,
+        applicant.email,
+      ]
+    end
+    let(:mail) { described_class.notify_provider(*mailer_args) }
+
+    it "sends an email to the correct provider email address" do
+      expect(mail.to).to eq([provider.email])
+    end
+
+    it "is a govuk_notify delivery" do
+      expect(mail.delivery_method).to be_a(GovukNotifyRails::Delivery)
+    end
+
+    it "sets the correct template" do
+      expect(mail.govuk_notify_template).to eq("f4a1139e-ac74-4a8b-8ecf-bfa3de272236")
+    end
+
+    it "has the right personalisation" do
+      expect(mail.govuk_notify_personalisation).to eq(
+        ref_number: legal_aid_application.application_ref,
+        applicant_name: applicant.full_name,
+        applicant_email: applicant.email,
       )
     end
   end

--- a/spec/services/govuk_emails/monitor_spec.rb
+++ b/spec/services/govuk_emails/monitor_spec.rb
@@ -1,108 +1,181 @@
 require "rails_helper"
 
 RSpec.describe GovukEmails::Monitor do
-  let(:scheduled_mailing) { create(:scheduled_mailing, :processing) }
-  let(:response) { double GovukEmails::Email, status: }
-
   before do
     allow(GovukEmails::Email).to receive(:new).with(scheduled_mailing.govuk_message_id).and_return(response)
     Setting.setting.update(alert_via_sentry: true)
   end
 
+  let(:response) { double GovukEmails::Email, status: }
+
   describe ".call" do
-    subject { described_class.call(scheduled_mailing.id) }
+    subject(:call) { described_class.call(scheduled_mailing.id) }
 
-    context "non-failure response" do
-      let(:status) { "delivered" }
+    shared_examples "non-failure handling job" do
+      it "does not capture an alert message" do
+        expect(AlertManager).not_to receive(:capture_message)
+        call
+      end
 
-      it "updates the scheduled_mailing record" do
-        subject
-        expect(scheduled_mailing.reload.status).to eq "delivered"
+      it "does not schedule an undeliverable alert email" do
+        expect { call }.not_to change(ScheduledMailing, :count)
+      end
+
+      it "does not enqueue a job to send email" do
+        ActiveJob::Base.queue_adapter = :test
+        expect { call }.not_to have_enqueued_job
       end
     end
 
-    context "failure response" do
-      let(:status) { ScheduledMailing::FAILURE_STATUSES.sample }
-      let(:addressee) { scheduled_mailing.addressee }
-      let(:id) { scheduled_mailing.id }
-      let(:raven_message) { "Unable to deliver mail to #{addressee} - ScheduledMailing record #{id}" }
+    context "when on production host" do
+      before { allow(HostEnv).to receive(:production?).and_return(true) }
 
-      it "updates the scheduled_mailing record" do
-        subject
-        expect(scheduled_mailing.reload.status).to eq status
-      end
+      context "with a provider financial reminder with a \"delivered\" response from govuk notify" do
+        let(:scheduled_mailing) { create(:scheduled_mailing, :provider_financial_reminder, :processing) }
+        let(:status) { "delivered" }
 
-      context "on production host" do
-        before { allow(HostEnv).to receive(:production?).and_return(true) }
+        it_behaves_like "non-failure handling job"
 
-        it "captures raven message" do
-          expect(AlertManager).to receive(:capture_message).with(raven_message)
-          subject
-        end
-
-        it "schedules an undeliverable alert email" do
-          expect { subject }.to change(ScheduledMailing, :count).by(1)
-          undeliverable_alert_mail = ScheduledMailing.order(:created_at).last
-
-          expect(undeliverable_alert_mail.legal_aid_application_id).to eq scheduled_mailing.legal_aid_application_id
-          expect(undeliverable_alert_mail.mailer_klass).to eq "UndeliverableEmailAlertMailer"
-          expect(undeliverable_alert_mail.mailer_method).to eq "notify_apply_team"
-          expect(undeliverable_alert_mail.arguments).to eq [scheduled_mailing.id]
-          expect(undeliverable_alert_mail.scheduled_at).to have_been_in_the_past
-          expect(undeliverable_alert_mail.addressee).to eq Rails.configuration.x.support_email_address
+        it "updates the scheduled_mailing record" do
+          expect { call }.to change { scheduled_mailing.reload.status }.from("processing").to("delivered")
         end
       end
 
-      context "when the failed email is a citizen start email" do
-        let(:applicant) { create(:applicant, email: "johndoe@example.net") }
-        let(:provider) { create(:provider) }
-        let(:legal_aid_application) { create(:legal_aid_application, applicant:, provider:) }
+      context "with a provider financial reminder with a \"permanent-failure\" response from govuk notify" do
+        let(:scheduled_mailing) { create(:scheduled_mailing, :provider_financial_reminder, :processing) }
+
+        let(:status) { "permanent-failure" }
+        let(:addressee) { scheduled_mailing.addressee }
+        let(:id) { scheduled_mailing.id }
+
+        it "updates the scheduled_mailing record" do
+          expect { call }.to change { scheduled_mailing.reload.status }.from("processing").to("permanent-failure")
+        end
+
+        it "captures alert message" do
+          expect(AlertManager).to receive(:capture_message).with("Unable to deliver mail to #{addressee} - ScheduledMailing record #{id}")
+          call
+        end
+
+        it "creates 1 scheduled_mailing to send alert email to the apply team", :aggregate_failures do
+          expect { call }.to change(ScheduledMailing, :count).by(1)
+
+          undelivered_mailing = ScheduledMailing.find_by(mailer_klass: "UndeliverableEmailAlertMailer")
+
+          expect(undelivered_mailing)
+            .to have_attributes(
+              legal_aid_application_id: scheduled_mailing.legal_aid_application_id,
+              mailer_klass: "UndeliverableEmailAlertMailer",
+              mailer_method: "notify_apply_team",
+              addressee: Rails.configuration.x.support_email_address,
+              arguments: [scheduled_mailing.id],
+            )
+
+          expect(undelivered_mailing.scheduled_at).to have_been_in_the_past
+        end
+
+        it "enqueues job to send email" do
+          ActiveJob::Base.queue_adapter = :test
+          expect { call }.to have_enqueued_job(ScheduledMailingsDeliveryJob)
+                              .on_queue("default")
+                              .at(:no_wait)
+        end
+      end
+
+      context "with a citizen start email with a \"permanent-failure\" response from govuk notify" do
+        let(:legal_aid_application) do
+          create(:legal_aid_application,
+                 applicant: build(:applicant, email: "johndoe@example.net"),
+                 provider: build(:provider, email: "johndoes-provider@example.net"))
+        end
+
+        let(:status) { "permanent-failure" }
+
         let(:scheduled_mailing) do
           create(:scheduled_mailing,
                  :citizen_start_email,
                  :processing,
-                 addressee: applicant.email,
+                 addressee: legal_aid_application.applicant.email,
                  legal_aid_application_id: legal_aid_application.id)
         end
-        let(:mailer_args) do
+
+        let(:expected_provider_args) do
           [
-            provider.email,
+            legal_aid_application.provider.email,
             legal_aid_application.application_ref,
-            applicant.full_name,
-            applicant.email,
+            legal_aid_application.applicant.full_name,
+            legal_aid_application.applicant.email,
           ]
         end
 
-        before { allow(HostEnv).to receive(:production?).and_return(true) }
-
-        it "schedules an email to notify the provider of the failure" do
-          expect { subject }.to change(ScheduledMailing, :count).by(2)
+        it "cancels the scheduled_mailing record" do
+          expect { call }.to change { scheduled_mailing.reload.status }.from("processing").to("cancelled")
         end
 
-        it "uses the undeliverable email alert mailer and the notify_provider method with the right args" do
-          subject
-          provider_alert_mail = ScheduledMailing.order(:created_at).last
+        it "captures alert message" do
+          expect(AlertManager).to receive(:capture_message).with("Unable to deliver mail to #{legal_aid_application.applicant.email} - ScheduledMailing record #{scheduled_mailing.id}")
+          call
+        end
 
-          expect(provider_alert_mail.legal_aid_application_id).to eq scheduled_mailing.legal_aid_application_id
-          expect(provider_alert_mail.mailer_klass).to eq "UndeliverableEmailAlertMailer"
-          expect(provider_alert_mail.mailer_method).to eq "notify_provider"
-          expect(provider_alert_mail.addressee).to eq provider.email
-          expect(provider_alert_mail.arguments).to eq mailer_args
-          expect(provider_alert_mail.scheduled_at).to have_been_in_the_past
+        it "creates 2 more scheduled_mailings to send alert emails to the provider and apply team", :aggregate_failures do
+          expect { call }.to change(ScheduledMailing, :count).by(2)
+
+          undelivered_mailings = ScheduledMailing.where(mailer_klass: "UndeliverableEmailAlertMailer")
+
+          expect(undelivered_mailings)
+            .to match_array([
+              have_attributes(
+                legal_aid_application_id: scheduled_mailing.legal_aid_application_id,
+                mailer_klass: "UndeliverableEmailAlertMailer",
+                mailer_method: "notify_apply_team",
+                addressee: Rails.configuration.x.support_email_address,
+                arguments: [scheduled_mailing.id],
+              ),
+              have_attributes(
+                legal_aid_application_id: scheduled_mailing.legal_aid_application_id,
+                mailer_klass: "UndeliverableEmailAlertMailer",
+                mailer_method: "notify_provider",
+                addressee: legal_aid_application.provider.email,
+                arguments: expected_provider_args,
+              ),
+            ])
+
+          expect(undelivered_mailings.map(&:scheduled_at)).to all(have_been_in_the_past)
+        end
+
+        it "enqueues 2 jobs to send emails" do
+          ActiveJob::Base.queue_adapter = :test
+          expect { call }.to have_enqueued_job(ScheduledMailingsDeliveryJob)
+                              .on_queue("default")
+                              .at(:no_wait)
+                              .twice
         end
       end
+    end
 
-      context "not on production host" do
-        before { allow(HostEnv).to receive(:production?).and_return(false) }
+    context "when not on production host with a non-failure" do
+      before { allow(HostEnv).to receive(:production?).and_return(false) }
 
-        it "does not capture raven message" do
-          expect(AlertManager).not_to receive(:capture_message)
-          subject
-        end
+      let(:status) { "sending" }
+      let(:scheduled_mailing) { create(:scheduled_mailing, :citizen_start_email, :processing) }
 
-        it "does not schedule an undeliverable alert email" do
-          expect { subject }.not_to change(ScheduledMailing, :count)
-        end
+      it_behaves_like "non-failure handling job"
+
+      it "updates the scheduled_mailing record" do
+        expect { call }.to change { scheduled_mailing.reload.status }.from("processing").to("sending")
+      end
+    end
+
+    context "when not on production host with a permanent-failure for a citizen start email" do
+      before { allow(HostEnv).to receive(:production?).and_return(false) }
+
+      let(:status) { "permanent-failure" }
+      let(:scheduled_mailing) { create(:scheduled_mailing, :citizen_start_email, :processing) }
+
+      it_behaves_like "non-failure handling job"
+
+      it "updates the scheduled_mailing record" do
+        expect { call }.to change { scheduled_mailing.reload.status }.from("processing").to("permanent-failure")
       end
     end
   end

--- a/spec/services/govuk_emails/monitor_spec.rb
+++ b/spec/services/govuk_emails/monitor_spec.rb
@@ -42,26 +42,65 @@ RSpec.describe GovukEmails::Monitor do
 
         it "schedules an undeliverable alert email" do
           expect { subject }.to change(ScheduledMailing, :count).by(1)
-          undeliverable_mail = ScheduledMailing.order(:created_at).last
+          undeliverable_alert_mail = ScheduledMailing.order(:created_at).last
 
-          expect(undeliverable_mail.legal_aid_application_id).to eq scheduled_mailing.legal_aid_application_id
-          expect(undeliverable_mail.mailer_klass).to eq "UndeliverableEmailAlertMailer"
-          expect(undeliverable_mail.mailer_method).to eq "notify_apply_team"
-          expect(undeliverable_mail.arguments).to eq [scheduled_mailing.id]
-          expect(undeliverable_mail.scheduled_at).to have_been_in_the_past
-          expect(undeliverable_mail.addressee).to eq Rails.configuration.x.support_email_address
+          expect(undeliverable_alert_mail.legal_aid_application_id).to eq scheduled_mailing.legal_aid_application_id
+          expect(undeliverable_alert_mail.mailer_klass).to eq "UndeliverableEmailAlertMailer"
+          expect(undeliverable_alert_mail.mailer_method).to eq "notify_apply_team"
+          expect(undeliverable_alert_mail.arguments).to eq [scheduled_mailing.id]
+          expect(undeliverable_alert_mail.scheduled_at).to have_been_in_the_past
+          expect(undeliverable_alert_mail.addressee).to eq Rails.configuration.x.support_email_address
+        end
+      end
+
+      context "when the failed email is a citizen start email" do
+        let(:applicant) { create(:applicant, email: "johndoe@example.net") }
+        let(:provider) { create(:provider) }
+        let(:legal_aid_application) { create(:legal_aid_application, applicant:, provider:) }
+        let(:scheduled_mailing) do
+          create(:scheduled_mailing,
+                 :citizen_start_email,
+                 :processing,
+                 addressee: applicant.email,
+                 legal_aid_application_id: legal_aid_application.id)
+        end
+        let(:mailer_args) do
+          [
+            provider.email,
+            legal_aid_application.application_ref,
+            applicant.full_name,
+            applicant.email,
+          ]
+        end
+
+        before { allow(HostEnv).to receive(:production?).and_return(true) }
+
+        it "schedules an email to notify the provider of the failure" do
+          expect { subject }.to change(ScheduledMailing, :count).by(2)
+        end
+
+        it "uses the undeliverable email alert mailer and the notify_provider method with the right args" do
+          subject
+          provider_alert_mail = ScheduledMailing.order(:created_at).last
+
+          expect(provider_alert_mail.legal_aid_application_id).to eq scheduled_mailing.legal_aid_application_id
+          expect(provider_alert_mail.mailer_klass).to eq "UndeliverableEmailAlertMailer"
+          expect(provider_alert_mail.mailer_method).to eq "notify_provider"
+          expect(provider_alert_mail.addressee).to eq provider.email
+          expect(provider_alert_mail.arguments).to eq mailer_args
+          expect(provider_alert_mail.scheduled_at).to have_been_in_the_past
         end
       end
 
       context "not on production host" do
         before { allow(HostEnv).to receive(:production?).and_return(false) }
 
-        it "does not captures raven message" do
+        it "does not capture raven message" do
           expect(AlertManager).not_to receive(:capture_message)
           subject
         end
 
-        it "does not schedules an undeliverable alert email" do
+        it "does not schedule an undeliverable alert email" do
           expect { subject }.not_to change(ScheduledMailing, :count)
         end
       end


### PR DESCRIPTION
## What
Handle duplicate mail sending and refactor

Multiple emails were being sent (upto 4/5 times) to
the apply team inbox and, in this PR, to the
provider, for undeliverable emails.

This appears to have been the result of a race condition
whereby caused by the EmailMonitorJob being enqueued
both by an initiating `ScheduledMailingsDeliveryJob` and by
itself (`EmailMonitorJob`)

