### PR TITLE
[AP-3685] Modify applicant#age to apply non means tested logic

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,5 @@
+# Run this command to always ignore formatting commits in `git blame`
+# git config blame.ignoreRevsFile .git-blame-ignore-revs
+
+# Changing single-quote to double-quote
+90a8f3c03106bc66d6ea777f615a944e8d6f7ac2

--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -41,6 +41,8 @@ class Applicant < ApplicationRecord
   end
 
   def age
+    return age_for_means_test_purposes if no_means_test_required?
+
     AgeCalculator.call(date_of_birth, legal_aid_application.calculation_date)
   end
 

--- a/features/providers/means_report.feature
+++ b/features/providers/means_report.feature
@@ -370,3 +370,16 @@ Feature: Means report
       | h2  | Declared outgoings categories |
       | h2  | Declared cash outgoings |
       | h3  | Bank statements |
+
+  Scenario: For a non means tested journey
+    Given the feature flag for means_test_review_phase_one is enabled
+    And I have completed a non means tested application
+    When I view the means report
+
+    Then the following sections should exist:
+      | tag | section |
+      | h2  | Client details |
+
+   And the "Client details" check your answers section should contain:
+    | question | answer |
+    | Age at computation date | 17 years old |

--- a/features/step_definitions/means_report_steps.rb
+++ b/features/step_definitions/means_report_steps.rb
@@ -110,6 +110,24 @@ Given("I have completed a passported application") do
   login_as @legal_aid_application.provider
 end
 
+Given("I have completed a non means tested application") do
+  @legal_aid_application = create(
+    :legal_aid_application,
+    :with_proceedings,
+    :with_under_18_applicant,
+    :with_skipped_benefit_check_result,
+    :with_non_means_tested_state_machine,
+    :with_cfe_empty_result,
+    :with_merits_statement_of_case,
+    :with_opponent,
+    :with_incident,
+    :with_chances_of_success,
+    :assessment_submitted,
+  )
+
+  login_as @legal_aid_application.provider
+end
+
 When("I view the means report") do
   visit(providers_legal_aid_application_means_report_path(@legal_aid_application, debug: true))
 end

--- a/spec/factories/legal_aid_applications.rb
+++ b/spec/factories/legal_aid_applications.rb
@@ -47,7 +47,7 @@ FactoryBot.define do
     end
 
     trait :with_under_18_applicant do
-      applicant { build(:applicant, :with_address, date_of_birth: Date.current - 16.years, age_for_means_test_purposes: 16) }
+      applicant { build(:applicant, :with_address, date_of_birth: 18.years.ago + 1.day, age_for_means_test_purposes: 17) }
     end
 
     #######################################################
@@ -560,6 +560,10 @@ FactoryBot.define do
 
     trait :with_undetermined_benefit_check_result do
       benefit_check_result { build(:benefit_check_result, :undetermined) }
+    end
+
+    trait :with_skipped_benefit_check_result do
+      benefit_check_result { build(:benefit_check_result, :skipped) }
     end
 
     trait :passported do


### PR DESCRIPTION
## What
Modify applicant#age to address non means tested application logic

[Link to story](https://dsdmoj.atlassian.net/browse/AP-XXX)

Ensure means and merits reports can be generated for 
Non-means-tested (NMT) applications

For NMT applications the age should be based on the value
stored in the db. This is set at the relevant point which
for NMT is when providers continue past the first check 
your answers page.


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
