### PR TITLE
AP-3668: Update Client Undertaking question

### DIFF
--- a/app/controllers/providers/application_merits_task/client_offered_undertakings_controller.rb
+++ b/app/controllers/providers/application_merits_task/client_offered_undertakings_controller.rb
@@ -18,7 +18,7 @@ module Providers
 
       def form_params
         merge_with_model(undertaking) do
-          params.require(:application_merits_task_undertaking).permit(:offered, :additional_information)
+          params.require(:application_merits_task_undertaking).permit(:offered, :additional_information_true, :additional_information_false)
         end
       end
     end

--- a/app/forms/providers/application_merits_task/client_offered_undertakings_form.rb
+++ b/app/forms/providers/application_merits_task/client_offered_undertakings_form.rb
@@ -3,28 +3,43 @@ module Providers
     class ClientOfferedUndertakingsForm < BaseForm
       form_for ::ApplicationMeritsTask::Undertaking
 
-      attr_accessor :offered, :additional_information
+      attr_accessor :offered, :additional_information, :additional_information_true, :additional_information_false
 
-      validate :offered_presence
-      validates :additional_information, presence: true, if: :requires_additional_information?
+      validates :offered, inclusion: { in: %w[true false] }
+      validates :additional_information_true, presence: true, if: :requires_additional_information?
+      validates :additional_information_false, presence: true, unless: :requires_additional_information?
+
+      def initialize(*args)
+        super
+        extrapolate_additional_information
+      end
 
       def save
-        additional_information&.clear if offered?
+        attributes[:additional_information] = requires_additional_information? ? additional_information_true : additional_information_false
         super
       end
 
     private
 
-      def offered_presence
-        errors.add(:offered, :blank) if offered.to_s.blank?
-      end
-
-      def offered?
+      def requires_additional_information?
         offered.to_s == "true"
       end
 
-      def requires_additional_information?
-        offered.to_s == "false"
+      def extrapolate_additional_information
+        return unless %w[true false].include?(offered.to_s)
+        return unless additional_information_expandable?
+
+        field = "additional_information_#{offered}"
+        __send__("#{field}=", additional_information)
+        attributes[field] = additional_information
+      end
+
+      def additional_information_expandable?
+        additional_information.present? && __send__("additional_information_#{offered}").nil?
+      end
+
+      def exclude_from_model
+        %i[additional_information_true additional_information_false]
       end
     end
   end

--- a/app/forms/providers/application_merits_task/client_offered_undertakings_form.rb
+++ b/app/forms/providers/application_merits_task/client_offered_undertakings_form.rb
@@ -6,8 +6,8 @@ module Providers
       attr_accessor :offered, :additional_information, :additional_information_true, :additional_information_false
 
       validates :offered, inclusion: { in: %w[true false] }
-      validates :additional_information_true, presence: true, if: :requires_additional_information?
-      validates :additional_information_false, presence: true, unless: :requires_additional_information?
+      validates :additional_information_true, presence: true, if: :requires_yes_additional_information?
+      validates :additional_information_false, presence: true, if: :requires_no_additional_information?
 
       def initialize(*args)
         super
@@ -15,14 +15,18 @@ module Providers
       end
 
       def save
-        attributes[:additional_information] = requires_additional_information? ? additional_information_true : additional_information_false
+        attributes[:additional_information] = requires_yes_additional_information? ? additional_information_true : additional_information_false
         super
       end
 
     private
 
-      def requires_additional_information?
+      def requires_yes_additional_information?
         offered.to_s == "true"
+      end
+
+      def requires_no_additional_information?
+        offered.to_s == "false"
       end
 
       def extrapolate_additional_information

--- a/app/views/providers/application_merits_task/client_offered_undertakings/show.html.erb
+++ b/app/views/providers/application_merits_task/client_offered_undertakings/show.html.erb
@@ -9,11 +9,16 @@
                     back_link: {},
                     form: form) do %>
     <%= form.govuk_radio_buttons_fieldset :offered, legend: {size: 'xl', tag: 'h1', text: page_title} do %>
-      <%= form.govuk_radio_button :offered, true, link_errors: true, label: {text: t('generic.yes')} %>
-      <%= form.govuk_radio_button :offered, false, label: {text: t('generic.no')} do %>
-        <%= form.govuk_text_area :additional_information, label: {text: t('.no-hint')}, rows: 5 %>
+      <%= form.govuk_radio_button :offered, true, link_errors: true, label: {text: t('generic.yes')} do %>
+        <%= form.govuk_text_area :additional_information_true,
+                                 label: {text: t('.yes-hint')},
+                                 rows: 5 %>
       <% end %>
-
+      <%= form.govuk_radio_button :offered, false, label: {text: t('generic.no')} do %>
+        <%= form.govuk_text_area :additional_information_false,
+                                 label: {text: t('.no-hint')},
+                                 rows: 5 %>
+      <% end %>
     <% end %>
     <div class="govuk-!-padding-bottom-4"></div>
 

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -189,9 +189,12 @@ en:
         application_merits_task/undertaking:
           attributes:
             offered:
-              blank: Select yes if the client has offered undertakings
-            additional_information:
-              blank: Enter information to explain the merit of this application
+              inclusion: Select yes if the client has offered undertakings
+            additional_information_blank: &additional_information_blank Enter information to explain the merit of this application
+            additional_information_true:
+              blank: *additional_information_blank
+            additional_information_false:
+              blank: *additional_information_blank
         application_merits_task/urgency:
           attributes:
             nature_of_urgency:

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -483,7 +483,8 @@ en:
       client_offered_undertakings:
         show:
           h1-heading: Has the client offered undertakings?
-          no-hint: Tell us why the client has not offered undertakings. This will help us assess the application
+          no-hint: Tell us why the client has not offered undertakings. This will help us assess the application.
+          yes-hint: Tell us what undertakings the client has offered and if they were accepted. This will help us assess the application.
       nature_of_urgencies:
         show:
           h1-heading: What is the nature of the urgency?

--- a/features/providers/mini-loop/merits_questions.feature
+++ b/features/providers/mini-loop/merits_questions.feature
@@ -40,6 +40,7 @@ Feature: mini-loop additional merits questions
     And I click "Save and continue"
     Then I should be on a page showing "Has the client offered undertakings?"
     When I choose "Yes"
+    And I fill "application merits task undertaking additional information true field" with "Yes answer"
     And I click "Save and continue"
     Then I should be on the 'involved_children/new' page showing 'Enter details of the children involved in this application'
     When I fill "Full Name" with "John Doe Jr"

--- a/spec/forms/providers/application_merits_task/client_offered_undertakings_form_spec.rb
+++ b/spec/forms/providers/application_merits_task/client_offered_undertakings_form_spec.rb
@@ -3,41 +3,72 @@ require "rails_helper"
 module Providers
   module ApplicationMeritsTask
     RSpec.describe ClientOfferedUndertakingsForm do
-      subject(:undertaking_form) { described_class.new(params) }
+      subject(:undertaking_form) { described_class.new(form_params) }
 
       let(:params) do
         {
           offered:,
-          additional_information:,
+          additional_information_true:,
+          additional_information_false:,
         }
       end
-      let(:offered) { true }
-      let(:additional_information) { nil }
+      let(:offered) { "true" }
+      let(:additional_information_true) { nil }
+      let(:additional_information_false) { nil }
+      let(:undertaking) { create(:undertaking) }
+      let(:form_params) { params.merge(model: undertaking) }
 
       describe "#valid?" do
-        context "when all fields are valid" do
-          it "returns true" do
-            expect(undertaking_form).to be_valid
-          end
-        end
-
         context "when offered is missing" do
           let(:offered) { nil }
 
           it { expect(undertaking_form).to be_invalid }
         end
 
+        context "when offered is true" do
+          context "and the additional information is missing" do
+            it { expect(undertaking_form).to be_invalid }
+          end
+
+          context "and the additional information is provided" do
+            let(:additional_information_true) { "some text input" }
+
+            it { expect(undertaking_form).to be_valid }
+          end
+        end
+
         context "when offered is false" do
-          let(:offered) { false }
+          let(:offered) { "false" }
 
           context "and the additional information is missing" do
             it { expect(undertaking_form).to be_invalid }
           end
 
           context "and the additional information is provided" do
-            let(:additional_information) { "some text input" }
+            let(:additional_information_false) { "some text input" }
 
             it { expect(undertaking_form).to be_valid }
+          end
+        end
+      end
+
+      describe "#save" do
+        subject(:save_form) { undertaking_form.save }
+
+        before { save_form }
+
+        context "when both additional information fields are populated" do
+          let(:additional_information_true) { "Yes Answer" }
+          let(:additional_information_false) { "No Answer" }
+
+          context "and the user answered 'yes'" do
+            it { expect(undertaking.reload.additional_information).to eq additional_information_true }
+          end
+
+          context "and the user answered 'no'" do
+            let(:offered) { "false" }
+
+            it { expect(undertaking.reload.additional_information).to eq additional_information_false }
           end
         end
       end

--- a/spec/requests/providers/application_merits_task/client_offered_undertakings_controller_spec.rb
+++ b/spec/requests/providers/application_merits_task/client_offered_undertakings_controller_spec.rb
@@ -47,13 +47,15 @@ module Providers
           )
         end
 
-        let(:offered) { true }
-        let(:additional_information) { "" }
+        let(:offered) { "true" }
+        let(:additional_information_true) { "yes answer" }
+        let(:additional_information_false) { "" }
         let(:params) do
           {
             application_merits_task_undertaking: {
               offered:,
-              additional_information:,
+              additional_information_true:,
+              additional_information_false:,
             },
           }
         end
@@ -69,7 +71,7 @@ module Providers
         it "creates a new undertaking with the values entered" do
           expect { post_client_undertakings }.to change(::ApplicationMeritsTask::Undertaking, :count).by(1)
           expect(undertaking.offered).to be_truthy
-          expect(undertaking.additional_information).to eq ""
+          expect(undertaking.additional_information).to eq "yes answer"
         end
 
         it "sets the task to complete" do
@@ -91,8 +93,9 @@ module Providers
         end
 
         context "when incomplete" do
-          let(:offered) { false }
-          let(:additional_information) { "" }
+          let(:offered) { "false" }
+          let(:additional_information_true) { "" }
+          let(:additional_information_false) { "" }
 
           it "renders show" do
             post_client_undertakings


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3668)

Ensure the providers enter a response for the client undertakings question regardless of whether they answer yes or no
This extrapolates and interpolates the values into split inputs on the page and merges into the single, additional_information, field in the database 

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
