### PR TITLE
Clean up factory associations

### DIFF
--- a/spec/factories/cfe_results.rb
+++ b/spec/factories/cfe_results.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :cfe_v1_result, class: CFE::V1::Result do
-    submission { create(:cfe_submission) }
+    submission factory: :cfe_submission
     legal_aid_application { submission.legal_aid_application }
     result { CFEResults::V1::MockResults.eligible.to_json }
 
@@ -30,7 +30,7 @@ FactoryBot.define do
   end
 
   factory :cfe_v2_result, class: CFE::V2::Result do
-    submission { create(:cfe_submission) }
+    submission factory: :cfe_submission
     legal_aid_application { submission.legal_aid_application }
     result { CFEResults::V2::MockResults.eligible.to_json }
 

--- a/spec/factories/cfe_results/empty/results.rb
+++ b/spec/factories/cfe_results/empty/results.rb
@@ -2,7 +2,7 @@ module CFEResults
   module Empty
     FactoryBot.define do
       factory :cfe_empty_result, class: "CFE::Empty::Result" do
-        submission { create(:cfe_submission) }
+        submission factory: :cfe_submission
         legal_aid_application { submission.legal_aid_application }
         result { CFEResults::Empty::MockResults.no_assessment.to_json }
         type { "CFE::Empty::Result" }

--- a/spec/factories/cfe_results/v3/results.rb
+++ b/spec/factories/cfe_results/v3/results.rb
@@ -2,7 +2,7 @@ module CFEResults
   module V3
     FactoryBot.define do
       factory :cfe_v3_result, class: CFE::V3::Result do
-        submission { create(:cfe_submission) }
+        submission factory: :cfe_submission
         legal_aid_application { submission.legal_aid_application }
         result { CFEResults::V3::MockResults.eligible.to_json }
         type { "CFE::V3::Result" }

--- a/spec/factories/cfe_results/v4/results.rb
+++ b/spec/factories/cfe_results/v4/results.rb
@@ -2,7 +2,7 @@ module CFEResults
   module V4
     FactoryBot.define do
       factory :cfe_v4_result, class: CFE::V4::Result do
-        submission { create(:cfe_submission) }
+        submission factory: :cfe_submission
         legal_aid_application { submission.legal_aid_application }
         result { CFEResults::V4::MockResults.eligible.to_json }
         type { "CFE::V4::Result" }

--- a/spec/factories/cfe_results/v5/results.rb
+++ b/spec/factories/cfe_results/v5/results.rb
@@ -2,7 +2,7 @@ module CFEResults
   module V5
     FactoryBot.define do
       factory :cfe_v5_result, class: "CFE::V5::Result" do
-        submission { create(:cfe_submission) }
+        submission factory: :cfe_submission
         legal_aid_application { submission.legal_aid_application }
         result { CFEResults::V5::MockResults.eligible.to_json }
         type { "CFE::V5::Result" }

--- a/spec/factories/cfe_submissions.rb
+++ b/spec/factories/cfe_submissions.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :cfe_submission, class: CFE::Submission do
-    legal_aid_application { create(:legal_aid_application) }
+    legal_aid_application
     assessment_id { SecureRandom.uuid }
   end
 end

--- a/spec/factories/legal_framework_submissions.rb
+++ b/spec/factories/legal_framework_submissions.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :legal_framework_submission, class: LegalFramework::Submission do
-    legal_aid_application { create(:legal_aid_application) }
+    legal_aid_application
     request_id { SecureRandom.uuid }
   end
 end

--- a/spec/factories/scope_limitations.rb
+++ b/spec/factories/scope_limitations.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :scope_limitation do
-    proceeding { create(:proceeding, :da001) }
+    association :proceeding, :da001
 
     trait :emergency do
       scope_type { 1 }

--- a/spec/factories/submissions.rb
+++ b/spec/factories/submissions.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :submission, class: CCMS::Submission do
-    legal_aid_application { create(:legal_aid_application) }
+    legal_aid_application
+
     sequence(:case_ccms_reference) { |n| sprintf("300000%<number>06d", number: n) }
 
     trait :case_ref_obtained do


### PR DESCRIPTION
Before, some factory associations were _always_ created, even 
when the parent record was not.

This behaviour was unexpected (to me at least), and I suspect 
unintentional.

Now, factory associations are not explicitly created, and instead 
defer to the parent object strategy (e.g if a `cfe_result` is built 
rather than created, its associated `submission` will also be built).