### PR TITLE
Fix: Update web deploy with shell sleep

### DIFF
--- a/helm_deploy/apply-for-legal-aid/templates/deployment_web.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/deployment_web.yaml
@@ -61,6 +61,10 @@ spec:
               port: http
             initialDelaySeconds: 60
             timeoutSeconds: 10
+          lifecycle:
+            preStop:
+              exec:
+                command: [ "sh", "-c", "sleep 30" ] # Workaround for occasional lost requests - see https://github.com/puma/puma/blob/master/docs/kubernetes.md#running-puma-in-kubernetes
           resources:
             limits:
               cpu: 1000m


### PR DESCRIPTION
## What

This is the workaround proposed for puma dropping requests while the K8s pod shuts down

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
