### PR TITLE
Fix: Update the github action versions

### DIFF
--- a/.github/workflows/anonymise_check.yml
+++ b/.github/workflows/anonymise_check.yml
@@ -10,7 +10,7 @@ jobs:
     name: Check anonymise rules
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
       - name: Setup Faker
         run: gem install faker

--- a/.github/workflows/base-docker-image.yml
+++ b/.github/workflows/base-docker-image.yml
@@ -12,7 +12,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_PAT }}
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Build the Docker image
         run: |
           docker build . --file ./docker/apply_base.dockerfile --tag ministryofjustice/apply-base:latest --tag ministryofjustice/apply-base:latest-$(cat .ruby-version)

--- a/.github/workflows/ci-docker-image.yml
+++ b/.github/workflows/ci-docker-image.yml
@@ -12,7 +12,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_PAT }}
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Build the Docker image
         run: |
           docker build . --file ./docker/apply_ci.dockerfile --tag ministryofjustice/apply-ci:latest --tag ministryofjustice/apply-ci:latest-$(cat .ruby-version)

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -36,13 +36,13 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
## What

This PR:

* Updates all CodeQL actions to v2 as v1 is due to be deprecated on Jan 18th 2023
* Updates all checkout actions to v3 as v2 uses node12 which has also been deprecated

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
