### PR TITLE
Fix: Flaky features

### DIFF
--- a/spec/factories/other_assets_declarations.rb
+++ b/spec/factories/other_assets_declarations.rb
@@ -14,7 +14,7 @@ FactoryBot.define do
       second_home_percentage { rand(1...99.0).round(2) }
       timeshare_property_value { rand(1...1_000_000.0).round(2) }
       land_value { rand(1...1_000_000.0).round(2) }
-      valuable_items_value { rand(1...1_000_000.0).round(2) }
+      valuable_items_value { rand(500...1_000_000.0).round(2) }
       inherited_assets_value { rand(1...1_000_000.0).round(2) }
       money_owed_value { rand(1...1_000_000.0).round(2) }
       trust_value { rand(1...1_000_000.0).round(2) }

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :provider do
     firm
     name { Faker::Name.name }
-    username { Faker::Internet.unique.username }
+    username { "#{Faker::Internet.username}_#{Random.rand(1...999).to_s.rjust(3, '0')}" }
     email { Faker::Internet.safe_email }
     portal_enabled { true }
 


### PR DESCRIPTION

## What

This PR address some recent feature flickers:
* The features/providers/check_single_employment.feature (and probably others) would intermittently fail becuase the seed would generate a value below 500 and cause the validation to fail and leave it on the previous page

  This updates the `other_assets_declaration` factory to ensure a valuable_items_value cannot be below the validation threshold

* We saw an instance where a test failed because faker randomly picked `rose` as a username but there is an existing provider in the seeded table that caused it to fail

  This adds a zero-padded three-digit suffix to the username field in the `provider` factory to ensure this does not recur, e.g. `rose_056`

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
