### PR TITLE
[AP-3199] Add label to select component on evidence upload page

### DIFF
--- a/app/views/providers/uploaded_evidence_collections/_uploaded_files.html.erb
+++ b/app/views/providers/uploaded_evidence_collections/_uploaded_files.html.erb
@@ -40,7 +40,7 @@
                                                @attachment_type_options,
                                                :first,
                                                :last,
-                                               label: nil,
+                                               label: { text: t('.select_a_category_label', filename: attachment.document.filename), class: 'govuk-visually-hidden' },
                                                options: { selected: selected },
                                                class: [select_error] %>
             </div>

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -568,8 +568,8 @@ en:
         uploaded: Uploaded
         delete: Delete
         select_a_category: Select a category
+        select_a_category_label: "Select a category for %{filename}"
         update: Update
-        select_attachment_label: Select a label for the attachment
     gateway_evidences:
       show:
         h1-heading: Upload supporting evidence


### PR DESCRIPTION

## What

[Add label to select component on evidence upload page](https://dsdmoj.atlassian.net/browse/AP-3199)

The select component does not have a programmatically determined label. Whilst screen reading software may attempt to generate a label from the name attribute this cannot be relied upon; additionally, out of context the select component will present as unlabelled.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.


[AP-3199]: https://dsdmoj.atlassian.net/browse/AP-3199?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ