### PR TITLE
Update statement of case textarea label

### DIFF
--- a/app/views/providers/application_merits_task/statement_of_cases/show.html.erb
+++ b/app/views/providers/application_merits_task/statement_of_cases/show.html.erb
@@ -107,7 +107,7 @@
 
     <%= form.govuk_radio_divider %>
 
-    <%= form.govuk_text_area :statement, label: {text: t('generic.enter_text')}, rows: 15 %>
+    <%= form.govuk_text_area :statement, rows: 15 %>
 
     <%= next_action_buttons(show_draft: true, form: form) %>
   <% end %>

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -60,6 +60,8 @@ en:
           <<: *true_false
       application_merits_task_opponent:
         <<: *opponent
+      application_merits_task_statement_of_case:
+        statement: Enter your client's statement of case
       setting:
         mock_true_layer_data:
           <<: *true_false


### PR DESCRIPTION
Before, the label for the statement of case textarea input was generic. The accessibility audit highlighted that this could be confusing out of context, so this updates the label.

Now, the label is more descriptive and explicitly refers to the information that should be entered in the input.

<details>
<summary>Screenshot</summary>

<img width="1240" alt="image" src="https://user-images.githubusercontent.com/25187547/211069392-40929ef8-71a7-4e4f-b1a7-0de7ec02c819.png">

</details>

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3202)