### PR TITLE
Means test review declaration content changes

### DIFF
--- a/app/controllers/providers/confirm_client_declarations_controller.rb
+++ b/app/controllers/providers/confirm_client_declarations_controller.rb
@@ -5,14 +5,10 @@ module Providers
     end
 
     def update
-      return continue_or_draft if draft_selected?
-
       @form = LegalAidApplications::ConfirmClientDeclarationForm.new(form_params)
-      if @form.valid?
-        legal_aid_application.update!(client_declaration_confirmed_at: Time.zone.now)
-        go_forward
-      else
-        render :show
+
+      unless save_continue_or_draft(@form)
+        render :show, status: :unprocessable_entity
       end
     end
 

--- a/app/forms/legal_aid_applications/confirm_client_declaration_form.rb
+++ b/app/forms/legal_aid_applications/confirm_client_declaration_form.rb
@@ -1,17 +1,20 @@
 module LegalAidApplications
   class ConfirmClientDeclarationForm < BaseForm
+    include ActiveModel::Attributes
+
     form_for LegalAidApplication
 
-    attr_accessor :client_declaration_confirmed
+    attribute :client_declaration_confirmed, :boolean
 
-    validate :confirm_client_declaration_presence
+    validates :client_declaration_confirmed,
+              acceptance: true, allow_nil: false, unless: :draft?
 
-  private
+    def save
+      return false unless valid?
 
-    def confirm_client_declaration_presence
-      return if draft? || client_declaration_confirmed.present?
-
-      errors.add(:client_declaration_confirmed, I18n.t("activemodel.errors.models.legal_aid_application.attributes.client_declaration_confirmed.blank"))
+      model.update!(client_declaration_confirmed_at: Time.current)
     end
+
+    alias_method :save!, :save
   end
 end

--- a/app/views/providers/confirm_client_declarations/show.html.erb
+++ b/app/views/providers/confirm_client_declarations/show.html.erb
@@ -1,27 +1,45 @@
-<%= form_with(model: @form,
-              url: providers_legal_aid_application_confirm_client_declaration_path(@legal_aid_application),
-              method: :patch,
-              local: true) do |form| %>
+<%= form_with(
+      model: @form,
+      url: providers_legal_aid_application_confirm_client_declaration_path(@legal_aid_application),
+      method: :patch,
+      local: true
+    ) do |form| %>
 
-  <%= page_template page_title: t('.h1-heading'), form: form do %>
-
-    <p class="govuk-body"><%= t('.text', applicant_name: @legal_aid_application.applicant_full_name) %></p>
+  <%= page_template page_title: t(".h1-heading"), form: form do %>
 
     <% params = { provider_firm_name: @legal_aid_application.provider.firm.name } %>
-    <%= bullet_list_from_translation_array('providers.confirm_client_declarations.show.list', params: params) %>
+
+    <% if @legal_aid_application.non_means_tested? %>
+      <% i18n_prefix = "non_means_tested" %>
+    <% else %>
+      <% i18n_prefix = "means_tested" %>
+    <% end %>
+
+    <p class="govuk-body">
+      <%= t(".#{i18n_prefix}.text", applicant_name: @legal_aid_application.applicant_full_name) %>
+    </p>
+
+    <%= bullet_list_from_translation_array(
+          "providers.confirm_client_declarations.show.#{i18n_prefix}.list",
+          params: params
+        ) %>
 
     <%= govuk_warning_text do %>
-      <%= t(".sign_app_text") %>
+      <%= t(".#{i18n_prefix}.sign_app_text", applicant_name: @legal_aid_application.applicant_full_name) %>
       <%= list_from_translation_path ".confirm_client_declarations.show.warning" %>
     <% end %>
 
     <%= form.govuk_check_boxes_fieldset :client_declaration_confirmed, legend: nil do %>
-      <p><%= form.govuk_check_box :client_declaration_confirmed, true, '', link_errors: true, multiple: false, label: { text: t('.confirmation_checkbox') } %></p>
+      <%= form.govuk_check_box(
+            :client_declaration_confirmed,
+            true,
+            "",
+            link_errors: true,
+            multiple: false,
+            label: { text: t(".confirmation_checkbox") }
+          ) %>
     <% end %>
 
-    <%= next_action_buttons(
-            form: form,
-            show_draft: true
-        ) %>
+    <%= next_action_buttons(form: form, show_draft: true) %>
   <% end %>
 <% end %>

--- a/app/views/providers/confirm_client_declarations/show.html.erb
+++ b/app/views/providers/confirm_client_declarations/show.html.erb
@@ -16,7 +16,7 @@
     <% end %>
 
     <%= form.govuk_check_boxes_fieldset :client_declaration_confirmed, legend: nil do %>
-      <p><%= form.govuk_check_box :client_declaration_confirmed, true, '', multiple: false, label: { text: t('.confirmation_checkbox') } %></p>
+      <p><%= form.govuk_check_box :client_declaration_confirmed, true, '', link_errors: true, multiple: false, label: { text: t('.confirmation_checkbox') } %></p>
     <% end %>
 
     <%= next_action_buttons(

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -447,7 +447,7 @@ en:
               blank: Enter the date you used delegated functions
               date_not_in_range: "The date you used delegated functions cannot be before %{months}"
             client_declaration_confirmed:
-              blank: You MUST confirm that you will obtain the necessary signed declarations/signatures and will retain them upon the client's file.
+              blank: Confirm this information is correct and that you'll get a signed declaration from your client
         other_assets_declaration:
           attributes:
             valuable_items_value:

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -447,7 +447,7 @@ en:
               blank: Enter the date you used delegated functions
               date_not_in_range: "The date you used delegated functions cannot be before %{months}"
             client_declaration_confirmed:
-              blank: Confirm this information is correct and that you'll get a signed declaration from your client
+              accepted: Confirm this information is correct and that you'll get a signed declaration from your client
         other_assets_declaration:
           attributes:
             valuable_items_value:

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -243,17 +243,37 @@ en:
     confirm_client_declarations:
       show:
         h1-heading: Confirm the following
-        text: "%{applicant_name} agrees that:"
-        list:
-          a: they've instructed %{provider_firm_name} to represent them
-          b_html: they've read the <a href="/privacy_policy">LAA privacy policy</a>
-          c: we can share their information with other government departments like DWP and HMRC
-          d: we can check their details with bank and credit reference agencies
-          e: they may have to pay towards legal aid
-          f: they may have to repay the legal costs if they keep or gain property or money at the end of the case (the 'statutory charge')
-          g: the information they’ve given is complete and correct
-          h: they’ll report any changes to their financial situation immediately
-        sign_app_text: "If they give wrong or incomplete information, do not report changes, or are found to have committed benefit fraud, they may:"
+        means_tested:
+          text: "%{applicant_name} agrees that:"
+          list:
+            a: they've instructed %{provider_firm_name} to represent them
+            b_html: they've read the <a href="/privacy_policy">LAA privacy policy</a>
+            c: we can share their information with other government departments like DWP and HMRC
+            d: we can check their details with bank and credit reference agencies
+            e: they may have to pay towards legal aid
+            f: they may have to repay the legal costs if they keep or gain property or money at the end of the case (the 'statutory charge')
+            g: the information they’ve given is complete and correct
+            h: they’ll report any changes to their financial situation immediately
+          sign_app_text: "If they give wrong or incomplete information, do not report changes, or are found to have committed benefit fraud, they may:"
+        non_means_tested:
+          text: "You agree for %{applicant_name} that:"
+          list:
+            a: they are under 18
+            b: they've instructed %{provider_firm_name} to represent them
+            c_html: they've read the <a href="/privacy_policy">LAA privacy policy</a>
+            d: we can share their information with other government departments like DWP and HMRC
+            e: we can check their details with bank and credit reference agencies
+            f: they may have to pay towards legal aid
+            g: |
+              they may have to repay the legal costs if they keep or gain
+              property or money at the end of the case (the 'statutory charge')
+            h: |
+              if the case continues after their 18th birthday, we may reassess
+              their income and capital to check if they should contribute
+              towards legal costs
+            i: the information they’ve given is complete and correct
+            j: they’ll report any changes to their financial situation immediately
+          sign_app_text: "If you have given wrong or incomplete information, or do not report changes for %{applicant_name}, they may:"
         warning:
           list: |
             be prosecuted

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -247,7 +247,7 @@ en:
         list:
           a: they've instructed %{provider_firm_name} to represent them
           b_html: they've read the <a href="/privacy_policy">LAA privacy policy</a>
-          c: we can share their information with other government departments like the DWP and HMRC
+          c: we can share their information with other government departments like DWP and HMRC
           d: we can check their details with bank and credit reference agencies
           e: they may have to pay towards legal aid
           f: they may have to repay the legal costs if they keep or gain property or money at the end of the case (the 'statutory charge')
@@ -259,7 +259,7 @@ en:
             be prosecuted
             need to pay a financial penalty
             have their legal aid stopped and have to pay back the costs
-        confirmation_checkbox: I confirm the above is correct and that I'll obtain a signed declaration from my client.
+        confirmation_checkbox: I confirm the above is correct and that I'll get a signed declaration from my client
     check_passported_answers:
       show:
         h1-heading: Check your answers

--- a/features/accessibility/provider.feature
+++ b/features/accessibility/provider.feature
@@ -274,7 +274,7 @@ Feature: Provider accessibility
     Then I click 'Save and continue'
     Then I should be on a page showing "Confirm the following"
     And the page is accessible
-    Then I select the first checkbox
+    Then I check "I confirm the above is correct and that I'll get a signed declaration from my client"
     Then I click 'Save and continue'
     Then I should be on a page showing "Review and print your application"
     And the page is accessible

--- a/features/providers/check_ccms_autogrant.feature
+++ b/features/providers/check_ccms_autogrant.feature
@@ -63,7 +63,7 @@ Feature: Checking ccms means does NOT auto grant
     Then I should be on a page showing "Check your answers"
     Then I click 'Save and continue'
     Then I should be on a page showing "Confirm the following"
-    Then I select the first checkbox
+    Then I check "I confirm the above is correct and that I'll get a signed declaration from my client"
     Then I click 'Save and continue'
     Then I should be on a page showing "Review and print your application"
     Then I click 'Submit and continue'
@@ -128,7 +128,7 @@ Feature: Checking ccms means does NOT auto grant
     Then I should be on a page showing "Check your answers"
     Then I click 'Save and continue'
     Then I should be on a page showing "Confirm the following"
-    Then I select the first checkbox
+    Then I check "I confirm the above is correct and that I'll get a signed declaration from my client"
     Then I click 'Save and continue'
     Then I should be on a page showing "Review and print your application"
     Then I click 'Submit and continue'

--- a/features/providers/check_multiple_employment.feature
+++ b/features/providers/check_multiple_employment.feature
@@ -146,7 +146,7 @@ Feature: Check multiple employment
     When I click 'Save and continue'
     Then I should be on a page showing "Confirm the following"
 
-    When I check "I confirm the above is correct and that I'll obtain a signed declaration from my client."
+    When I check "I confirm the above is correct and that I'll get a signed declaration from my client"
     And I click 'Save and continue'
     Then I should be on a page showing "Review and print your application"
 

--- a/features/providers/check_nonpassport_autogrant.feature
+++ b/features/providers/check_nonpassport_autogrant.feature
@@ -111,7 +111,7 @@ Feature: Checking ccms means does NOT auto grant for non passported applications
     Then I should be on a page showing "Check your answers"
     Then I click 'Save and continue'
     Then I should be on a page showing "Confirm the following"
-    Then I select the first checkbox
+    Then I check "I confirm the above is correct and that I'll get a signed declaration from my client"
     Then I click 'Save and continue'
     Then I should be on a page showing "Review and print your application"
     Then I click 'Submit and continue'
@@ -230,7 +230,7 @@ Feature: Checking ccms means does NOT auto grant for non passported applications
     Then I should be on a page showing "Check your answers"
     Then I click 'Save and continue'
     Then I should be on a page showing "Confirm the following"
-    Then I select the first checkbox
+    Then I check "I confirm the above is correct and that I'll get a signed declaration from my client"
     Then I click 'Save and continue'
     Then I should be on a page showing "Review and print your application"
     Then I click 'Submit and continue'

--- a/features/providers/check_pending_employment.feature
+++ b/features/providers/check_pending_employment.feature
@@ -138,7 +138,7 @@ Feature: Check pending employment
     When I click 'Save and continue'
     Then I should be on a page showing "Confirm the following"
 
-    When I check "I confirm the above is correct and that I'll obtain a signed declaration from my client."
+    When I check "I confirm the above is correct and that I'll get a signed declaration from my client"
     And I click 'Save and continue'
     Then I should be on a page showing "Review and print your application"
 

--- a/features/providers/check_single_employment.feature
+++ b/features/providers/check_single_employment.feature
@@ -141,7 +141,7 @@ Feature: Check single employment
     When I click 'Save and continue'
     Then I should be on a page showing "Confirm the following"
 
-    When I check "I confirm the above is correct and that I'll obtain a signed declaration from my client."
+    When I check "I confirm the above is correct and that I'll get a signed declaration from my client"
     And I click 'Save and continue'
     Then I should be on a page showing "Review and print your application"
 
@@ -150,7 +150,3 @@ Feature: Check single employment
 
     When I click 'View completed application'
     Then I should be on a page showing "Application for civil legal aid certificate"
-
-
-
-

--- a/features/providers/merits_task_list.feature
+++ b/features/providers/merits_task_list.feature
@@ -200,7 +200,7 @@ Feature: Merits task list
     Then I should be on a page showing "Check your answers"
     Then I click 'Save and continue'
     Then I should be on a page showing "Confirm the following"
-    Then I select the first checkbox
+    Then I check "I confirm the above is correct and that I'll get a signed declaration from my client"
     Then I click 'Save and continue'
     Then I should be on a page showing "Review and print your application"
     Then I click 'Submit and continue'

--- a/features/providers/non_means_tested_journey/without_delegated_functions.feature
+++ b/features/providers/non_means_tested_journey/without_delegated_functions.feature
@@ -107,7 +107,7 @@ Feature: Non-means-tested applicant journey without use of delegation functions
 
     When I click 'Save and continue'
     Then I should be on a page showing "Confirm the following"
-    And I select the first checkbox
+    And I check "I confirm the above is correct and that I'll get a signed declaration from my client"
 
     When I click 'Save and continue'
     Then I should be on a page showing "Review and print your application"

--- a/features/providers/passported_journey.feature
+++ b/features/providers/passported_journey.feature
@@ -97,7 +97,7 @@ Feature: passported_journey completes application
     And the answer for 'Statement of case' should be 'This is some test data for the statement of case'
     Then I click 'Save and continue'
     And I should be on a page showing "Confirm the following"
-    Then I select the first checkbox
+    Then I check "I confirm the above is correct and that I'll get a signed declaration from my client"
     Then I click 'Save and continue'
     Then I should be on a page showing "Review and print your application"
     Then I click 'Submit and continue'

--- a/spec/forms/legal_aid_applications/confirm_client_declaration_form_spec.rb
+++ b/spec/forms/legal_aid_applications/confirm_client_declaration_form_spec.rb
@@ -3,23 +3,51 @@ require "rails_helper"
 RSpec.describe LegalAidApplications::ConfirmClientDeclarationForm do
   subject(:form) { described_class.new(params) }
 
-  let(:client_declaration_confirmed) { true }
-  let(:params) do
-    {
-      client_declaration_confirmed:,
-    }
-  end
+  describe "#validates" do
+    context "when the client declaration is confirmed" do
+      let(:params) { { client_declaration_confirmed: true } }
 
-  describe "valid?" do
-    it "returns true when validations pass" do
-      expect(form).to be_valid
+      it { is_expected.to be_valid }
     end
 
-    context "when invalid" do
-      let(:client_declaration_confirmed) { nil }
+    context "when the client declaration is not confirmed" do
+      let(:params) { { client_declaration_confirmed: "" } }
 
-      it "returns false when validations fail" do
-        expect(form).not_to be_valid
+      it "is invalid" do
+        expect(form).to be_invalid
+        expect(form.errors).to be_added(:client_declaration_confirmed, :accepted)
+      end
+    end
+  end
+
+  describe "#save" do
+    let(:legal_aid_application) do
+      create(:legal_aid_application, client_declaration_confirmed_at: nil)
+    end
+
+    before do
+      freeze_time
+      form.save!
+    end
+
+    context "when the client declaration is confirmed" do
+      let(:params) do
+        { client_declaration_confirmed: true, model: legal_aid_application }
+      end
+
+      it "updates the application" do
+        expect(legal_aid_application.client_declaration_confirmed_at)
+          .to eq Time.current
+      end
+    end
+
+    context "when the client declaration is not confirmed" do
+      let(:params) do
+        { client_declaration_confirmed: "", model: legal_aid_application }
+      end
+
+      it "does not update the application" do
+        expect(legal_aid_application.client_declaration_confirmed_at).to be_nil
       end
     end
   end


### PR DESCRIPTION
Once the means test review work has been completed, providers 
will be able to apply for legal aid on the behalf of clients under the
age of 18.

This change means the wording of the declaration needs to be
different depending on whether the applicant is under the age of
18 or not.

Currently, the concept of a `non_means_tested?` legal aid 
application is synonymous with an applicant being under the age
of 18 for the purposes of the means test (i.e 
`age_for_means_test_purposes < 18`).

I'm not convinced this coupling is particularly future-proof though
since there will likely be future scenarios where an application is 
not means tested, but the applicant is 18 or over.

I think it would be worthwhile the team thinking about whether this
is a problem worth solving now, or whether we should address it
when the issue arises.

<details>
<summary>Screenshots</summary>


### Before
<img width="1024" alt="Before" src="https://user-images.githubusercontent.com/25187547/211818011-707ba87c-37d1-493a-9e6f-db7930939ebe.png">


### Means tested
<img width="1016" alt="Means tested" src="https://user-images.githubusercontent.com/25187547/211819022-160f0d46-4935-4f22-8e99-0dfe943c2d45.png">


### Non-means tested
<img width="1019" alt="Non-means tested" src="https://user-images.githubusercontent.com/25187547/211819545-e8ffee0d-9625-4ede-a84d-68ec36580167.png">


</details>

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3712)