### PR TITLE
Move client declaration information to component

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -94,8 +94,9 @@ gem "grover"
 # DFE formbuilder
 gem "govuk_design_system_formbuilder"
 
-# DFE ViewComponent library
+# ViewComponent
 gem "govuk-components"
+gem "view_component"
 
 # Catching unsafe migrations in development
 gem "strong_migrations"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -823,6 +823,7 @@ DEPENDENCIES
   super_diff
   tzinfo-data
   vcr
+  view_component
   webdack-uuid_migration (~> 1.4.0)
   webdrivers (~> 5.2)
   webmock

--- a/app/components/providers/confirm_client_declaration/information.rb
+++ b/app/components/providers/confirm_client_declaration/information.rb
@@ -1,0 +1,33 @@
+module Providers
+  module ConfirmClientDeclaration
+    class Information < ViewComponent::Base
+      def initialize(legal_aid_application:)
+        @legal_aid_application = legal_aid_application
+        super
+      end
+
+    private
+
+      attr_reader :legal_aid_application
+
+      delegate :applicant_full_name, to: :legal_aid_application
+
+      def provider_firm_name
+        legal_aid_application.provider.firm_name
+      end
+
+      def t(key, **options)
+        key = ".#{i18n_prefix}.#{key}"
+        super(key, **options)
+      end
+
+      def i18n_prefix
+        if legal_aid_application.non_means_tested?
+          :non_means_tested
+        else
+          :means_tested
+        end
+      end
+    end
+  end
+end

--- a/app/components/providers/confirm_client_declaration/information/information.html.erb
+++ b/app/components/providers/confirm_client_declaration/information/information.html.erb
@@ -1,0 +1,21 @@
+<p class="govuk-body">
+  <%= t(".intro", applicant_full_name:) %>
+</p>
+
+<ul class="govuk-list govuk-list--bullet">
+  <% t(".bullets", provider_firm_name:).each do |bullet| %>
+    <li><%== bullet %></li>
+  <% end %>
+</ul>
+
+<%= govuk_warning_text do %>
+  <%= t(".warning.text", applicant_full_name:) %>
+
+  <ul class="govuk-list govuk-list--bullet govuk-!-margin-top-2">
+    <% t(".warning.bullets").each do |bullet| %>
+      <li class="govuk-!-font-weight-bold">
+        <%= bullet %>
+      </li>
+    <% end %>
+  </ul>
+<% end %>

--- a/app/components/providers/confirm_client_declaration/information/information.yml
+++ b/app/components/providers/confirm_client_declaration/information/information.yml
@@ -1,0 +1,47 @@
+en:
+  means_tested:
+    intro: "%{applicant_full_name} agrees that:"
+    bullets:
+      - they've instructed %{provider_firm_name} to represent them
+      - they've read the <a href="/privacy_policy">LAA privacy policy</a>
+      - we can share their information with other government departments like
+        DWP and HMRC
+      - we can check their details with bank and credit reference agencies
+      - they may have to pay towards legal aid
+      - they may have to repay the legal costs if they keep or gain property or
+        money at the end of the case (the 'statutory charge')
+      - the information they've given is complete and correct
+      - they'll report any changes to their financial situation immediately
+    warning:
+      text: >-
+        If they give wrong or incomplete information, do not report changes, or
+        are found to have committed benefit fraud, they may:
+      bullets:
+        - be prosecuted
+        - need to pay a financial penalty
+        - have their legal aid stopped and have to pay back the costs
+  non_means_tested:
+    intro: "You agree for %{applicant_full_name} that:"
+    bullets:
+      - they are under 18
+      - they've instructed %{provider_firm_name} to represent them
+      - they've read the <a href="/privacy_policy">LAA privacy policy</a>
+      - we can share their information with other government departments like
+        DWP and HMRC
+      - we can check their details with bank and credit reference agencies
+      - they may have to pay towards legal aid
+      - they may have to repay the legal costs if they keep or gain
+        property or money at the end of the case (the 'statutory charge')
+      - if the case continues after their 18th birthday, we may reassess
+        their income and capital to check if they should contribute
+        towards legal costs
+      - the information they've given is complete and correct
+      - they'll report any changes to their financial situation immediately
+    warning:
+      text: >-
+        If you have given wrong or incomplete information, or do not report
+        changes for %{applicant_full_name}, they may:
+      bullets:
+        - be prosecuted
+        - need to pay a financial penalty
+        - have their legal aid stopped and have to pay back the costs

--- a/app/controllers/providers/confirm_client_declarations_controller.rb
+++ b/app/controllers/providers/confirm_client_declarations_controller.rb
@@ -5,14 +5,10 @@ module Providers
     end
 
     def update
-      return continue_or_draft if draft_selected?
-
       @form = LegalAidApplications::ConfirmClientDeclarationForm.new(form_params)
-      if @form.valid?
-        legal_aid_application.update!(client_declaration_confirmed_at: Time.zone.now)
-        go_forward
-      else
-        render :show
+
+      unless save_continue_or_draft(@form)
+        render :show, status: :unprocessable_entity
       end
     end
 

--- a/app/forms/legal_aid_applications/confirm_client_declaration_form.rb
+++ b/app/forms/legal_aid_applications/confirm_client_declaration_form.rb
@@ -1,17 +1,20 @@
 module LegalAidApplications
   class ConfirmClientDeclarationForm < BaseForm
+    include ActiveModel::Attributes
+
     form_for LegalAidApplication
 
-    attr_accessor :client_declaration_confirmed
+    attribute :client_declaration_confirmed, :boolean
 
-    validate :confirm_client_declaration_presence
+    validates :client_declaration_confirmed,
+              acceptance: true, allow_nil: false, unless: :draft?
 
-  private
+    def save
+      return false unless valid?
 
-    def confirm_client_declaration_presence
-      return if draft? || client_declaration_confirmed.present?
-
-      errors.add(:client_declaration_confirmed, I18n.t("activemodel.errors.models.legal_aid_application.attributes.client_declaration_confirmed.blank"))
+      model.update!(client_declaration_confirmed_at: Time.current)
     end
+
+    alias_method :save!, :save
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -75,11 +75,6 @@ module ApplicationHelper
     render "shared/forms/list_items", translation_path: prefix + translation_path, bullet_list:, params:
   end
 
-  def bullet_list_from_translation_array(locale_path, params: {})
-    keys = [I18n.locale, locale_path.split(".").map(&:to_sym)].flatten
-    render "shared/forms/list_with_items", locale_path:, items: I18n.backend.send(:translations).dig(*keys), params:
-  end
-
   def yes_no(boolean)
     boolean ? t("generic.yes") : t("generic.no")
   end

--- a/app/views/providers/confirm_client_declarations/show.html.erb
+++ b/app/views/providers/confirm_client_declarations/show.html.erb
@@ -7,27 +7,9 @@
 
   <%= page_template page_title: t(".h1-heading"), form: form do %>
 
-    <% params = { provider_firm_name: @legal_aid_application.provider.firm.name } %>
-
-    <% if @legal_aid_application.non_means_tested? %>
-      <% i18n_prefix = "non_means_tested" %>
-    <% else %>
-      <% i18n_prefix = "means_tested" %>
-    <% end %>
-
-    <p class="govuk-body">
-      <%= t(".#{i18n_prefix}.text", applicant_name: @legal_aid_application.applicant_full_name) %>
-    </p>
-
-    <%= bullet_list_from_translation_array(
-          "providers.confirm_client_declarations.show.#{i18n_prefix}.list",
-          params: params
+    <%= render Providers::ConfirmClientDeclaration::Information.new(
+          legal_aid_application: @legal_aid_application
         ) %>
-
-    <%= govuk_warning_text do %>
-      <%= t(".#{i18n_prefix}.sign_app_text", applicant_name: @legal_aid_application.applicant_full_name) %>
-      <%= list_from_translation_path ".confirm_client_declarations.show.warning" %>
-    <% end %>
 
     <%= form.govuk_check_boxes_fieldset :client_declaration_confirmed, legend: nil do %>
       <%= form.govuk_check_box(

--- a/app/views/providers/confirm_client_declarations/show.html.erb
+++ b/app/views/providers/confirm_client_declarations/show.html.erb
@@ -1,27 +1,45 @@
-<%= form_with(model: @form,
-              url: providers_legal_aid_application_confirm_client_declaration_path(@legal_aid_application),
-              method: :patch,
-              local: true) do |form| %>
+<%= form_with(
+      model: @form,
+      url: providers_legal_aid_application_confirm_client_declaration_path(@legal_aid_application),
+      method: :patch,
+      local: true
+    ) do |form| %>
 
-  <%= page_template page_title: t('.h1-heading'), form: form do %>
-
-    <p class="govuk-body"><%= t('.text', applicant_name: @legal_aid_application.applicant_full_name) %></p>
+  <%= page_template page_title: t(".h1-heading"), form: form do %>
 
     <% params = { provider_firm_name: @legal_aid_application.provider.firm.name } %>
-    <%= bullet_list_from_translation_array('providers.confirm_client_declarations.show.list', params: params) %>
+
+    <% if @legal_aid_application.non_means_tested? %>
+      <% i18n_prefix = "non_means_tested" %>
+    <% else %>
+      <% i18n_prefix = "means_tested" %>
+    <% end %>
+
+    <p class="govuk-body">
+      <%= t(".#{i18n_prefix}.text", applicant_name: @legal_aid_application.applicant_full_name) %>
+    </p>
+
+    <%= bullet_list_from_translation_array(
+          "providers.confirm_client_declarations.show.#{i18n_prefix}.list",
+          params: params
+        ) %>
 
     <%= govuk_warning_text do %>
-      <%= t(".sign_app_text") %>
+      <%= t(".#{i18n_prefix}.sign_app_text", applicant_name: @legal_aid_application.applicant_full_name) %>
       <%= list_from_translation_path ".confirm_client_declarations.show.warning" %>
     <% end %>
 
     <%= form.govuk_check_boxes_fieldset :client_declaration_confirmed, legend: nil do %>
-      <p><%= form.govuk_check_box :client_declaration_confirmed, true, '', link_errors: true, multiple: false, label: { text: t('.confirmation_checkbox') } %></p>
+      <%= form.govuk_check_box(
+            :client_declaration_confirmed,
+            true,
+            "",
+            link_errors: true,
+            multiple: false,
+            label: { text: t(".confirmation_checkbox") }
+          ) %>
     <% end %>
 
-    <%= next_action_buttons(
-            form: form,
-            show_draft: true
-        ) %>
+    <%= next_action_buttons(form: form, show_draft: true) %>
   <% end %>
 <% end %>

--- a/app/views/providers/confirm_client_declarations/show.html.erb
+++ b/app/views/providers/confirm_client_declarations/show.html.erb
@@ -16,7 +16,7 @@
     <% end %>
 
     <%= form.govuk_check_boxes_fieldset :client_declaration_confirmed, legend: nil do %>
-      <p><%= form.govuk_check_box :client_declaration_confirmed, true, '', multiple: false, label: { text: t('.confirmation_checkbox') } %></p>
+      <p><%= form.govuk_check_box :client_declaration_confirmed, true, '', link_errors: true, multiple: false, label: { text: t('.confirmation_checkbox') } %></p>
     <% end %>
 
     <%= next_action_buttons(

--- a/app/views/shared/forms/_list_with_items.html.erb
+++ b/app/views/shared/forms/_list_with_items.html.erb
@@ -1,7 +1,0 @@
-<div class="govuk-list">
-  <ul class="govuk-list govuk-list--bullet">
-    <% items.each do |key, _v| %>
-      <li><%= t(key, scope: locale_path, **params) %></li>
-    <% end %>
-  </ul>
-</div>

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -57,12 +57,13 @@ search:
   #  - app/
 
   ## Root directories for relative keys resolution.
-  # relative_roots:
-  #   - app/controllers
-  #   - app/helpers
-  #   - app/mailers
-  #   - app/presenters
-  #   - app/views
+  relative_roots:
+    - app/controllers
+    - app/helpers
+    - app/mailers
+    - app/presenters
+    - app/views
+    - app/components
 
   ## Files or `File.fnmatch` patterns to exclude from search. Some files are always excluded regardless of this setting:
   ##   %w(*.jpg *.png *.gif *.svg *.ico *.eot *.otf *.ttf *.woff *.woff2 *.pdf *.css *.sass *.scss *.less *.yml *.json)
@@ -70,6 +71,7 @@ search:
     - app/assets/images
     - app/assets/fonts
     - app/assets/videos
+    - app/components/**/*
 
   ## Alternatively, the only files or `File.fnmatch patterns` to search in `paths`:
   ## If specified, this settings takes priority over `exclude`, but `exclude` still applies.

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -447,7 +447,7 @@ en:
               blank: Enter the date you used delegated functions
               date_not_in_range: "The date you used delegated functions cannot be before %{months}"
             client_declaration_confirmed:
-              blank: You MUST confirm that you will obtain the necessary signed declarations/signatures and will retain them upon the client's file.
+              blank: Confirm the above is correct and that you'll get a signed declaration from your client
         other_assets_declaration:
           attributes:
             valuable_items_value:

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -447,7 +447,7 @@ en:
               blank: Enter the date you used delegated functions
               date_not_in_range: "The date you used delegated functions cannot be before %{months}"
             client_declaration_confirmed:
-              blank: Confirm the above is correct and that you'll get a signed declaration from your client
+              accepted: Confirm the above is correct and that you'll get a signed declaration from your client
         other_assets_declaration:
           attributes:
             valuable_items_value:

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -243,17 +243,37 @@ en:
     confirm_client_declarations:
       show:
         h1-heading: Confirm the following
-        text: "%{applicant_name} agrees that:"
-        list:
-          a: they've instructed %{provider_firm_name} to represent them
-          b_html: they've read the <a href="/privacy_policy">LAA privacy policy</a>
-          c: we can share their information with other government departments like DWP and HMRC
-          d: we can check their details with bank and credit reference agencies
-          e: they may have to pay towards legal aid
-          f: they may have to repay the legal costs if they keep or gain property or money at the end of the case (the 'statutory charge')
-          g: the information they’ve given is complete and correct
-          h: they’ll report any changes to their financial situation immediately
-        sign_app_text: "If they give wrong or incomplete information, do not report changes, or are found to have committed benefit fraud, they may:"
+        means_tested:
+          text: "%{applicant_name} agrees that:"
+          list:
+            a: they've instructed %{provider_firm_name} to represent them
+            b_html: they've read the <a href="/privacy_policy">LAA privacy policy</a>
+            c: we can share their information with other government departments like DWP and HMRC
+            d: we can check their details with bank and credit reference agencies
+            e: they may have to pay towards legal aid
+            f: they may have to repay the legal costs if they keep or gain property or money at the end of the case (the 'statutory charge')
+            g: the information they’ve given is complete and correct
+            h: they’ll report any changes to their financial situation immediately
+          sign_app_text: "If they give wrong or incomplete information, do not report changes, or are found to have committed benefit fraud, they may:"
+        non_means_tested:
+          text: "You agree for %{applicant_name} that:"
+          list:
+            a: they are under 18
+            b: they've instructed %{provider_firm_name} to represent them
+            c_html: they've read the <a href="/privacy_policy">LAA privacy policy</a>
+            d: we can share their information with other government departments like DWP and HMRC
+            e: we can check their details with bank and credit reference agencies
+            f: they may have to pay towards legal aid
+            g: |
+              they may have to repay the legal costs if they keep or gain
+              property or money at the end of the case (the 'statutory charge')
+            h: |
+              if the case continues after their 18th birthday, we may reassess
+              their income and capital to check if they should contribute
+              towards legal costs
+            i: the information they’ve given is complete and correct
+            j: they’ll report any changes to their financial situation immediately
+          sign_app_text: "If you have given wrong or incomplete information, or do not report changes for %{applicant_name}, they may:"
         warning:
           list: |
             be prosecuted

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -247,7 +247,7 @@ en:
         list:
           a: they've instructed %{provider_firm_name} to represent them
           b_html: they've read the <a href="/privacy_policy">LAA privacy policy</a>
-          c: we can share their information with other government departments like the DWP and HMRC
+          c: we can share their information with other government departments like DWP and HMRC
           d: we can check their details with bank and credit reference agencies
           e: they may have to pay towards legal aid
           f: they may have to repay the legal costs if they keep or gain property or money at the end of the case (the 'statutory charge')
@@ -259,7 +259,7 @@ en:
             be prosecuted
             need to pay a financial penalty
             have their legal aid stopped and have to pay back the costs
-        confirmation_checkbox: I confirm the above is correct and that I'll obtain a signed declaration from my client.
+        confirmation_checkbox: I confirm the above is correct and that I'll get a signed declaration from my client
     check_passported_answers:
       show:
         h1-heading: Check your answers

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -243,42 +243,6 @@ en:
     confirm_client_declarations:
       show:
         h1-heading: Confirm the following
-        means_tested:
-          text: "%{applicant_name} agrees that:"
-          list:
-            a: they've instructed %{provider_firm_name} to represent them
-            b_html: they've read the <a href="/privacy_policy">LAA privacy policy</a>
-            c: we can share their information with other government departments like DWP and HMRC
-            d: we can check their details with bank and credit reference agencies
-            e: they may have to pay towards legal aid
-            f: they may have to repay the legal costs if they keep or gain property or money at the end of the case (the 'statutory charge')
-            g: the information they’ve given is complete and correct
-            h: they’ll report any changes to their financial situation immediately
-          sign_app_text: "If they give wrong or incomplete information, do not report changes, or are found to have committed benefit fraud, they may:"
-        non_means_tested:
-          text: "You agree for %{applicant_name} that:"
-          list:
-            a: they are under 18
-            b: they've instructed %{provider_firm_name} to represent them
-            c_html: they've read the <a href="/privacy_policy">LAA privacy policy</a>
-            d: we can share their information with other government departments like DWP and HMRC
-            e: we can check their details with bank and credit reference agencies
-            f: they may have to pay towards legal aid
-            g: |
-              they may have to repay the legal costs if they keep or gain
-              property or money at the end of the case (the 'statutory charge')
-            h: |
-              if the case continues after their 18th birthday, we may reassess
-              their income and capital to check if they should contribute
-              towards legal costs
-            i: the information they’ve given is complete and correct
-            j: they’ll report any changes to their financial situation immediately
-          sign_app_text: "If you have given wrong or incomplete information, or do not report changes for %{applicant_name}, they may:"
-        warning:
-          list: |
-            be prosecuted
-            need to pay a financial penalty
-            have their legal aid stopped and have to pay back the costs
         confirmation_checkbox: I confirm the above is correct and that I'll get a signed declaration from my client
     check_passported_answers:
       show:

--- a/features/accessibility/provider.feature
+++ b/features/accessibility/provider.feature
@@ -274,7 +274,7 @@ Feature: Provider accessibility
     Then I click 'Save and continue'
     Then I should be on a page showing "Confirm the following"
     And the page is accessible
-    Then I select the first checkbox
+    Then I check "I confirm the above is correct and that I'll get a signed declaration from my client"
     Then I click 'Save and continue'
     Then I should be on a page showing "Review and print your application"
     And the page is accessible

--- a/features/providers/check_ccms_autogrant.feature
+++ b/features/providers/check_ccms_autogrant.feature
@@ -63,7 +63,7 @@ Feature: Checking ccms means does NOT auto grant
     Then I should be on a page showing "Check your answers"
     Then I click 'Save and continue'
     Then I should be on a page showing "Confirm the following"
-    Then I select the first checkbox
+    Then I check "I confirm the above is correct and that I'll get a signed declaration from my client"
     Then I click 'Save and continue'
     Then I should be on a page showing "Review and print your application"
     Then I click 'Submit and continue'
@@ -128,7 +128,7 @@ Feature: Checking ccms means does NOT auto grant
     Then I should be on a page showing "Check your answers"
     Then I click 'Save and continue'
     Then I should be on a page showing "Confirm the following"
-    Then I select the first checkbox
+    Then I check "I confirm the above is correct and that I'll get a signed declaration from my client"
     Then I click 'Save and continue'
     Then I should be on a page showing "Review and print your application"
     Then I click 'Submit and continue'

--- a/features/providers/check_multiple_employment.feature
+++ b/features/providers/check_multiple_employment.feature
@@ -146,7 +146,7 @@ Feature: Check multiple employment
     When I click 'Save and continue'
     Then I should be on a page showing "Confirm the following"
 
-    When I check "I confirm the above is correct and that I'll obtain a signed declaration from my client."
+    When I check "I confirm the above is correct and that I'll get a signed declaration from my client"
     And I click 'Save and continue'
     Then I should be on a page showing "Review and print your application"
 

--- a/features/providers/check_nonpassport_autogrant.feature
+++ b/features/providers/check_nonpassport_autogrant.feature
@@ -111,7 +111,7 @@ Feature: Checking ccms means does NOT auto grant for non passported applications
     Then I should be on a page showing "Check your answers"
     Then I click 'Save and continue'
     Then I should be on a page showing "Confirm the following"
-    Then I select the first checkbox
+    Then I check "I confirm the above is correct and that I'll get a signed declaration from my client"
     Then I click 'Save and continue'
     Then I should be on a page showing "Review and print your application"
     Then I click 'Submit and continue'
@@ -230,7 +230,7 @@ Feature: Checking ccms means does NOT auto grant for non passported applications
     Then I should be on a page showing "Check your answers"
     Then I click 'Save and continue'
     Then I should be on a page showing "Confirm the following"
-    Then I select the first checkbox
+    Then I check "I confirm the above is correct and that I'll get a signed declaration from my client"
     Then I click 'Save and continue'
     Then I should be on a page showing "Review and print your application"
     Then I click 'Submit and continue'

--- a/features/providers/check_pending_employment.feature
+++ b/features/providers/check_pending_employment.feature
@@ -138,7 +138,7 @@ Feature: Check pending employment
     When I click 'Save and continue'
     Then I should be on a page showing "Confirm the following"
 
-    When I check "I confirm the above is correct and that I'll obtain a signed declaration from my client."
+    When I check "I confirm the above is correct and that I'll get a signed declaration from my client"
     And I click 'Save and continue'
     Then I should be on a page showing "Review and print your application"
 

--- a/features/providers/check_single_employment.feature
+++ b/features/providers/check_single_employment.feature
@@ -141,7 +141,7 @@ Feature: Check single employment
     When I click 'Save and continue'
     Then I should be on a page showing "Confirm the following"
 
-    When I check "I confirm the above is correct and that I'll obtain a signed declaration from my client."
+    When I check "I confirm the above is correct and that I'll get a signed declaration from my client"
     And I click 'Save and continue'
     Then I should be on a page showing "Review and print your application"
 
@@ -150,7 +150,3 @@ Feature: Check single employment
 
     When I click 'View completed application'
     Then I should be on a page showing "Application for civil legal aid certificate"
-
-
-
-

--- a/features/providers/civil_application_journey.feature
+++ b/features/providers/civil_application_journey.feature
@@ -684,7 +684,7 @@ Feature: Civil application journeys
     Then I should be on a page showing "Check your answers"
     Then I click 'Save and continue'
     Then I should be on a page showing "Confirm the following"
-    Then I select the first checkbox
+    Then I check "I confirm the above is correct and that I'll get a signed declaration from my client"
     Then I click 'Save and continue'
     Then I should be on a page showing "Review and print your application"
     Then I click 'Submit and continue'
@@ -791,7 +791,7 @@ Feature: Civil application journeys
     And the answer for 'Statement of case' should be 'This is some test data for the statement of case'
     Then I click 'Save and continue'
     And I should be on a page showing "Confirm the following"
-    Then I select the first checkbox
+    Then I check "I confirm the above is correct and that I'll get a signed declaration from my client"
     Then I click 'Save and continue'
     Then I should be on a page showing "Review and print your application"
     Then I click 'Submit and continue'

--- a/features/providers/non_means_tested_journey/without_delegated_functions.feature
+++ b/features/providers/non_means_tested_journey/without_delegated_functions.feature
@@ -107,7 +107,7 @@ Feature: Non-means-tested applicant journey without use of delegation functions
 
     When I click 'Save and continue'
     Then I should be on a page showing "Confirm the following"
-    And I select the first checkbox
+    And I check "I confirm the above is correct and that I'll get a signed declaration from my client"
 
     When I click 'Save and continue'
     Then I should be on a page showing "Review and print your application"

--- a/lib/tasks/erblint.rake
+++ b/lib/tasks/erblint.rake
@@ -1,5 +1,5 @@
 desc "Run ERB lint"
 task erblint: :environment do
-  path = "app/views"
+  path = "app/views app/components"
   sh("erblint #{path}")
 end

--- a/spec/components/providers/confirm_client_declaration/information_spec.rb
+++ b/spec/components/providers/confirm_client_declaration/information_spec.rb
@@ -1,0 +1,139 @@
+require "rails_helper"
+
+RSpec.describe Providers::ConfirmClientDeclaration::Information, type: :component do
+  subject(:component) { described_class.new(legal_aid_application:) }
+
+  let(:legal_aid_application) do
+    build_stubbed(
+      :legal_aid_application,
+      :with_applicant,
+      applicant:,
+      provider:,
+    )
+  end
+
+  let(:applicant) do
+    build_stubbed(:applicant, first_name: "Test", last_name: "Applicant")
+  end
+
+  let(:provider) do
+    build_stubbed(:provider, firm: build_stubbed(:firm, name: "Testing Firm"))
+  end
+
+  before do
+    allow(legal_aid_application)
+      .to receive(:non_means_tested?)
+      .and_return(non_means_tested?)
+
+    render_inline(component)
+  end
+
+  context "when the legal aid application is means tested" do
+    let(:non_means_tested?) { false }
+
+    it "renders the means tested intro" do
+      expect(page).to have_content("Test Applicant agrees that:")
+    end
+
+    it "renders only the means tested bullet points", :aggregate_failures do
+      expected_bullet_points = [
+        "they've instructed Testing Firm to represent them",
+        "they've read the LAA privacy policy",
+        "we can share their information with other government departments like " \
+        "DWP and HMRC",
+        "we can check their details with bank and credit reference agencies",
+        "they may have to pay towards legal aid",
+        "they may have to repay the legal costs if they keep or gain property " \
+        "or money at the end of the case (the 'statutory charge')",
+        "the information they've given is complete and correct",
+        "they'll report any changes to their financial situation immediately",
+      ]
+
+      expected_bullet_points.each do |bullet|
+        expect(page).to have_bullet_point(bullet)
+      end
+
+      expect(page).to have_link("LAA privacy policy")
+      expect(page).not_to have_bullet_point("they are under 18")
+    end
+
+    it "renders the means tested warning", :aggregate_failures do
+      expect(page).to have_warning_text(
+        "If they give wrong or incomplete information, do not report " \
+        "changes, or are found to have committed benefit fraud, they may:",
+      )
+
+      expected_bullet_points = [
+        "be prosecuted",
+        "need to pay a financial penalty",
+        "have their legal aid stopped and have to pay back the costs",
+      ]
+
+      expected_bullet_points.each do |bullet|
+        expect(page).to have_warning_bullet_point(bullet)
+      end
+    end
+  end
+
+  context "when the legal aid application is not means tested" do
+    let(:non_means_tested?) { true }
+
+    it "renders the non-means tested intro" do
+      expect(page).to have_content("You agree for Test Applicant that:")
+    end
+
+    it "renders the non-means tested bullet points", :aggregate_failures do
+      expected_bullet_points = [
+        "they are under 18",
+        "they've instructed Testing Firm to represent them",
+        "they've read the LAA privacy policy",
+        "we can share their information with other government departments like " \
+        "DWP and HMRC",
+        "we can check their details with bank and credit reference agencies",
+        "they may have to pay towards legal aid",
+        "they may have to repay the legal costs if they keep or gain property " \
+        "or money at the end of the case (the 'statutory charge')",
+        "if the case continues after their 18th birthday, we may reassess " \
+        "their income and capital to check if they should contribute towards " \
+        "legal costs",
+        "the information they've given is complete and correct",
+        "they'll report any changes to their financial situation immediately",
+      ]
+
+      expected_bullet_points.each do |bullet|
+        expect(page).to have_bullet_point(bullet)
+      end
+
+      expect(page).to have_link("LAA privacy policy")
+    end
+
+    it "renders the non-means tested warning" do
+      expect(page).to have_warning_text(
+        "If you have given wrong or incomplete information, or do not report " \
+        "changes for Test Applicant, they may:",
+      )
+
+      expected_bullet_points = [
+        "be prosecuted",
+        "need to pay a financial penalty",
+        "have their legal aid stopped and have to pay back the costs",
+      ]
+
+      expected_bullet_points.each do |bullet|
+        expect(page).to have_warning_bullet_point(bullet)
+      end
+    end
+  end
+
+  def have_bullet_point(text)
+    have_css("ul.govuk-list--bullet > li", text:)
+  end
+
+  def have_warning_text(text)
+    have_css(".govuk-warning-text", text:)
+  end
+
+  def have_warning_bullet_point(text)
+    have_css(".govuk-warning-text__text > ul.govuk-list--bullet > li", text:)
+  end
+end

--- a/spec/forms/legal_aid_applications/confirm_client_declaration_form_spec.rb
+++ b/spec/forms/legal_aid_applications/confirm_client_declaration_form_spec.rb
@@ -3,23 +3,51 @@ require "rails_helper"
 RSpec.describe LegalAidApplications::ConfirmClientDeclarationForm do
   subject(:form) { described_class.new(params) }
 
-  let(:client_declaration_confirmed) { true }
-  let(:params) do
-    {
-      client_declaration_confirmed:,
-    }
-  end
+  describe "#validates" do
+    context "when the client declaration is confirmed" do
+      let(:params) { { client_declaration_confirmed: true } }
 
-  describe "valid?" do
-    it "returns true when validations pass" do
-      expect(form).to be_valid
+      it { is_expected.to be_valid }
     end
 
-    context "when invalid" do
-      let(:client_declaration_confirmed) { nil }
+    context "when the client declaration is not confirmed" do
+      let(:params) { { client_declaration_confirmed: "" } }
 
-      it "returns false when validations fail" do
-        expect(form).not_to be_valid
+      it "is invalid" do
+        expect(form).to be_invalid
+        expect(form.errors).to be_added(:client_declaration_confirmed, :accepted)
+      end
+    end
+  end
+
+  describe "#save" do
+    let(:legal_aid_application) do
+      create(:legal_aid_application, client_declaration_confirmed_at: nil)
+    end
+
+    before do
+      freeze_time
+      form.save!
+    end
+
+    context "when the client declaration is confirmed" do
+      let(:params) do
+        { client_declaration_confirmed: true, model: legal_aid_application }
+      end
+
+      it "updates the application" do
+        expect(legal_aid_application.client_declaration_confirmed_at)
+          .to eq Time.current
+      end
+    end
+
+    context "when the client declaration is not confirmed" do
+      let(:params) do
+        { client_declaration_confirmed: "", model: legal_aid_application }
+      end
+
+      it "does not update the application" do
+        expect(legal_aid_application.client_declaration_confirmed_at).to be_nil
       end
     end
   end

--- a/spec/requests/providers/confirm_client_declarations_controller_spec.rb
+++ b/spec/requests/providers/confirm_client_declarations_controller_spec.rb
@@ -1,95 +1,91 @@
 require "rails_helper"
 
 RSpec.describe Providers::ConfirmClientDeclarationsController do
-  let(:application) { create(:legal_aid_application) }
-  let(:provider) { application.provider }
+  let(:legal_aid_application) { create(:legal_aid_application) }
+
+  before do
+    freeze_time
+    login
+    request
+  end
 
   describe "GET /providers/applications/:id/confirm_client_declaration" do
-    subject(:request) { get providers_legal_aid_application_confirm_client_declaration_path(application) }
-
-    context "when the provider is not authenticated" do
-      before { request }
-
-      it_behaves_like "a provider not authenticated"
+    subject(:request) do
+      get providers_legal_aid_application_confirm_client_declaration_path(legal_aid_application)
     end
 
     context "when the provider is authenticated" do
-      before do
-        login_as provider
-        request
-      end
+      let(:login) { login_as legal_aid_application.provider }
 
-      it "returns http success" do
+      it "displays the declaration confirmation page", :aggregate_failures do
         expect(response).to have_http_status(:ok)
+        expect(page).to have_content("Confirm the following")
       end
+    end
 
-      it "displays the confirm client declaration page" do
-        expect(unescaped_response_body).to include(I18n.t("providers.confirm_client_declarations.show.h1-heading"))
-      end
+    context "when the provider is not authenticated" do
+      let(:login) { nil }
+
+      it_behaves_like "a provider not authenticated"
     end
   end
 
   describe "PATCH /providers/applications/:id/confirm_client_declaration" do
-    subject(:request) { patch providers_legal_aid_application_confirm_client_declaration_path(application), params: }
-
-    let(:params) do
-      {
-        legal_aid_application: { client_declaration_confirmed: },
-      }
+    subject(:request) do
+      patch providers_legal_aid_application_confirm_client_declaration_path(legal_aid_application),
+            params: params.merge(submit_button)
     end
+
+    let(:params) { { legal_aid_application: { client_declaration_confirmed: } } }
     let(:client_declaration_confirmed) { true }
+    let(:submit_button) { { continue_button: "Continue" } }
 
     context "when the provider is authenticated" do
-      before do
-        login_as provider
-        request
+      let(:login) { login_as legal_aid_application.provider }
+
+      context "when the provider confirms the declaration" do
+        it "updates the application and redirects to the next page", :aggregate_failures do
+          expect(legal_aid_application.reload.client_declaration_confirmed_at)
+            .to eq Time.current
+          expect(response).to redirect_to(
+            providers_legal_aid_application_review_and_print_application_path(legal_aid_application),
+          )
+        end
       end
 
-      context "when form submitted with continue button" do
-        let(:submit_button) do
-          {
-            continue_button: "Continue",
-          }
+      context "when the provider does not confirm the declaration" do
+        let(:client_declaration_confirmed) { "" }
+
+        it "doesn't update the application and displays an error", :aggregate_failures do
+          expect(legal_aid_application.reload.client_declaration_confirmed_at)
+            .to be_nil
+          expect(page).to have_error_message(
+            "Confirm the above is correct and that you'll get a signed " \
+            "declaration from your client",
+          )
         end
+      end
 
-        context "when client_declaration_confirmed checkbox checked" do
-          it "updates legal aid application client_declaration_confirmed" do
-            expect(application.reload.client_declaration_confirmed_at >= 2.seconds.ago).to be true
-          end
-        end
+      context "when the provider saves as draft" do
+        let(:client_declaration_confirmed) { "" }
+        let(:submit_button) { { draft_button: "Save as draft" } }
 
-        context "when client_declaration_confirmed checkbox unchecked" do
-          let(:client_declaration_confirmed) { nil }
-
-          it "does not update legal aid application client_declaration_confirmed" do
-            expect(application.reload.client_declaration_confirmed_at).to be_nil
-          end
-
-          it "displays an error" do
-            expect(unescaped_response_body).to include(I18n.t("activemodel.errors.models.legal_aid_application.attributes.client_declaration_confirmed.blank"))
-          end
-        end
-
-        context "when form submitted using Save as draft button" do
-          let(:params) { { draft_button: "Save as draft" } }
-
-          it "redirect provider to provider's applications page" do
-            request
-            expect(response).to redirect_to(providers_legal_aid_applications_path)
-          end
-
-          it "sets the application as draft" do
-            request
-            expect(application.reload).to be_draft
-          end
+        it "sets the application as draft and redirects to the dashboard", :aggregate_failures do
+          expect(legal_aid_application.reload).to be_draft
+          expect(response).to redirect_to(providers_legal_aid_applications_path)
         end
       end
     end
 
-    context "when unauthenticated" do
-      before { request }
+    context "when the provider is not authenticated" do
+      let(:login) { nil }
+      let(:submit_button) { { continue_button: "Continue" } }
 
       it_behaves_like "a provider not authenticated"
     end
+  end
+
+  def have_error_message(text)
+    have_css(".govuk-error-summary__list > li", text:)
   end
 end

--- a/spec/support/view_component.rb
+++ b/spec/support/view_component.rb
@@ -1,0 +1,7 @@
+require "view_component/test_helpers"
+require "capybara/rspec"
+
+RSpec.configure do |config|
+  config.include ViewComponent::TestHelpers, type: :component
+  config.include Capybara::RSpecMatchers, type: :component
+end


### PR DESCRIPTION
Before, conditional logic that determined which set of content was rendered for
a given application (i.e means-tested vs non-means-tested) resided in the view.

This made it difficult to test in isolation. While it is possible to write view
specs, their use is not widespread (and we have none in our test suite).

Currently we lean on integration tests (e.g request specs or cucumber features)
to assert that given content is rendered. This is useful, but they are
expensive —which prohibits unit style testing.

This introduces `view_component` as an explicit dependency (we use it implicitly
already through the `govuk-components` gem), and refactors the provider client
declaration confirmation page so that it renders a component.

This component encapsulates the logic for rendering means-tested and
non-means-tested specific content.

For now, `i18n-tasks.yml` excludes components files. I spent a couple of hours
trying to piece together a pattern mapper so that `i18n-tasks` didn't categorise
the keys as missing, but it was turning into a time-sink.

Given we have `config.raise_on_missing_translations = true` in development and
test, and the components are thoroughly unit-tested, I don't think this is a
major issue.