### PR TITLE
Remove redundant rubocop_todo config

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -704,43 +704,6 @@ RSpec/NamedSubject:
     - 'spec/workers/import_bank_data_worker_spec.rb'
     - 'spec/workers/true_layer_banks_update_worker_spec.rb'
 
-# Offense count: 63
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: not_to, to_not
-RSpec/NotToNot:
-  Exclude:
-    - 'spec/forms/applicants/basic_details_form_spec.rb'
-    - 'spec/forms/legal_aid_applications/restrictions_form_spec.rb'
-    - 'spec/forms/providers/proceeding_merits_task/linked_children_form_spec.rb'
-    - 'spec/helpers/policy_disregards_helper_spec.rb'
-    - 'spec/models/address_spec.rb'
-    - 'spec/models/applicant_spec.rb'
-    - 'spec/models/cfe/v4/result_spec.rb'
-    - 'spec/models/legal_framework/merits_task_list_spec.rb'
-    - 'spec/requests/citizens/gather_transactions_spec.rb'
-    - 'spec/requests/providers/address_selections_spec.rb'
-    - 'spec/requests/providers/addresses_spec.rb'
-    - 'spec/requests/providers/bank_transactions_spec.rb'
-    - 'spec/requests/providers/check_benefits_spec.rb'
-    - 'spec/requests/providers/confirm_dwp_non_passported_applications_spec.rb'
-    - 'spec/requests/providers/employed_incomes_spec.rb'
-    - 'spec/requests/providers/limitations_spec.rb'
-    - 'spec/requests/providers/proceeding_merits_task/attempts_to_settle_controller_spec.rb'
-    - 'spec/requests/providers/proceeding_merits_task/chances_of_success_spec.rb'
-    - 'spec/requests/providers/proceeding_merits_task/linked_children_spec.rb'
-    - 'spec/requests/providers/means/restrictions_spec.rb'
-    - 'spec/requests/providers/submitted_applications_spec.rb'
-    - 'spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_variable_attributes_spec.rb'
-    - 'spec/services/ccms/submitters/check_case_status_service_spec.rb'
-    - 'spec/services/ccms/submitters/obtain_document_id_service_spec.rb'
-    - 'spec/services/dashboard_event_handler_spec.rb'
-    - 'spec/services/govuk_emails/delivery_man_spec.rb'
-    - 'spec/services/hmrc/create_responses_service_spec.rb'
-    - 'spec/services/malware_scanner_spec.rb'
-    - 'spec/services/populators/transaction_type_populator_spec.rb'
-    - 'spec/services/reports/reports_creator_spec.rb'
-
 # Offense count: 8
 RSpec/OverwritingSetup:
   Exclude:


### PR DESCRIPTION
These infractions were resolved in #4439, but never removed 
from the `.rubocop_todo.yml` configuration.

This removes the redundant configuration.