### PR TITLE
Bump test executor postgres version 10.18 to 11.16

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ executors:
           GITHUB_TEAM_NAME_SLUG: laa-apply-for-legal-aid
           CACHE_VERSION: v1
           NODE_OPTIONS: --openssl-legacy-provider
-      - image: cimg/postgres:10.18
+      - image: cimg/postgres:11.16
       - image: cimg/redis:5.0
       - image: ghcr.io/ministryofjustice/hmpps-clamav:latest
 


### PR DESCRIPTION
## What
Bump test executor postgres version 10.18 to 11.16

matching staging/production version.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
