### PR TITLE
Address Rubocop failures in `app/views/providers`

### DIFF
--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -9,8 +9,6 @@ linters:
     enabled: false
   Rubocop:
     enabled: true
-    exclude:
-      - "**/app/views/providers/**/*"
     rubocop_config:
       inherit_from:
         - .rubocop.yml

--- a/app/views/providers/about_the_financial_assessments/show.html.erb
+++ b/app/views/providers/about_the_financial_assessments/show.html.erb
@@ -1,11 +1,11 @@
-<%= page_template(page_title: t('.title')) do %>
+<%= page_template(page_title: t(".title")) do %>
 
   <p class="govuk-body">
-    <%= t('.activity') %>
+    <%= t(".activity") %>
   </p>
 
   <h2 class="govuk-heading-m">
-    <%= t '.section_2.heading' %>
+    <%= t(".section_2.heading") %>
   </h2>
 
   <dl class="govuk-summary-list">
@@ -15,10 +15,10 @@
       </dt>
       <dd class="govuk-summary-list__actions">
         <%= link_to_accessible(
-                t('generic.change'),
-                providers_legal_aid_application_email_address_path(anchor: :email),
-                class: 'govuk-link change-link',
-                suffix: 'email address'
+              t("generic.change"),
+              providers_legal_aid_application_email_address_path(anchor: :email),
+              class: "govuk-link change-link",
+              suffix: "email address",
             ) %>
       </dd>
     </div>
@@ -28,6 +28,6 @@
         url: providers_legal_aid_application_about_the_financial_assessment_path,
         method: :patch,
         show_draft: true,
-        continue_button_text: t('.send_client_link')
+        continue_button_text: t(".send_client_link"),
       ) %>
 <% end %>

--- a/app/views/providers/address_lookups/show.html.erb
+++ b/app/views/providers/address_lookups/show.html.erb
@@ -3,27 +3,27 @@
       scope: :address_lookup,
       url: providers_legal_aid_application_address_lookup_path(@legal_aid_application),
       method: :patch,
-      local: true
+      local: true,
     ) do |form| %>
 
   <%= page_template(
-        page_title: t('.heading'),
+        page_title: t(".heading"),
         template: :basic,
-        form: form,
-        ) do %>
+        form:,
+      ) do %>
 
-    <%= form.govuk_fieldset legend: { size: 'xl', tag: 'h1', text: t('.heading') }  do %>
+    <%= form.govuk_fieldset legend: { size: "xl", tag: "h1", text: t(".heading") }  do %>
       <div class="govuk-!-padding-2"></div>
-      <%= form.govuk_text_field :postcode, label: {text: t('.label'), tag: 'h2', size: 'm'}, width: 10 %>
+      <%= form.govuk_text_field :postcode, label: { text: t(".label"), tag: "h2", size: "m" }, width: 10 %>
     <% end %>
 
     <%= next_action_buttons(
-          form: form,
+          form:,
           show_draft: true,
-          continue_id: 'find-address',
-          continue_button_text: t('.submit_button')
+          continue_id: "find-address",
+          continue_button_text: t(".submit_button"),
         ) %>
 
-    <p><%= link_to_accessible t('.address_manual_link'), providers_legal_aid_application_address_path, class: 'govuk-link' %></p>
+    <p><%= link_to_accessible t(".address_manual_link"), providers_legal_aid_application_address_path, class: "govuk-link" %></p>
   <% end %>
 <% end %>

--- a/app/views/providers/address_selections/show.html.erb
+++ b/app/views/providers/address_selections/show.html.erb
@@ -3,33 +3,33 @@
       scope: :address_selection,
       url: providers_legal_aid_application_address_selection_path(@legal_aid_application),
       method: :patch,
-      local: true
+      local: true,
     ) do |form| %>
 
     <%= page_template(
-            page_title: t('.heading'),
-            template: :basic,
-            form: form,
+          page_title: t(".heading"),
+          template: :basic,
+          form:,
         ) do %>
 
-    <%= form.govuk_fieldset legend: {text: page_title, tag: 'h1', size: 'xl'} do %>
+    <%= form.govuk_fieldset legend: { text: page_title, tag: "h1", size: "xl" } do %>
 
       <p class="govuk-label">
-        <%= t('generic.address.postcode') %>
+        <%= t("generic.address.postcode") %>
       </p>
       <p class='govuk-body govuk-!-font-weight-bold' role='alert'>
         <%= @form.postcode.insert(-4, " ") %>
         <%= link_to_accessible(
-              t('generic.change'),
+              t("generic.change"),
               providers_legal_aid_application_address_lookup_path(@legal_aid_application),
-              class: 'govuk-body change-link change-postcode-link',
-              suffix: 'postcode'
+              class: "govuk-body change-link change-postcode-link",
+              suffix: "postcode",
             ) %>
       </p>
       <%= form.hidden_field :postcode %>
 
       <% @addresses.each_with_index do |address, index| %>
-        <%= hidden_field_tag 'address_selection[list][]', address.to_json, id: "address_selection_list_#{index}" %>
+        <%= hidden_field_tag "address_selection[list][]", address.to_json, id: "address_selection_list_#{index}" %>
       <% end %>
 
       <div class="govuk-!-padding-bottom-2"></div>
@@ -37,11 +37,11 @@
                                        @address_collection,
                                        :id,
                                        :address,
-                                       label: {text: t('.select_address_label')} %>
+                                       label: { text: t(".select_address_label") } %>
 
-      <p><%= link_to_accessible t('.link_text'), providers_legal_aid_application_address_path(@legal_aid_application), class: 'govuk-link' %></p>
+      <p><%= link_to_accessible t(".link_text"), providers_legal_aid_application_address_path(@legal_aid_application), class: "govuk-link" %></p>
 
     <% end %>
-    <%= next_action_buttons continue_id: 'select-address-button', show_draft: true, form: form %>
+    <%= next_action_buttons continue_id: "select-address-button", show_draft: true, form: %>
   <% end %>
 <% end %>

--- a/app/views/providers/addresses/show.html.erb
+++ b/app/views/providers/addresses/show.html.erb
@@ -4,25 +4,25 @@
       scope: :address,
       url: providers_legal_aid_application_address_path(@legal_aid_application),
       method: :patch,
-      local: true
+      local: true,
     ) do |form| %>
 
   <%= page_template(
-        page_title: t('.heading'),
-        form: form,
-        ) do %>
+        page_title: t(".heading"),
+        form:,
+      ) do %>
 
     <% if form.object.lookup_postcode.present? %>
       <%= form.hidden_field :lookup_postcode %>
       <div class='govuk-form-group'>
-        <%= label_tag t('.label_1'), class: 'govuk-label' do %>
-          <%= t('.postcode') %>
+        <%= label_tag t(".label_1"), class: "govuk-label" do %>
+          <%= t(".postcode") %>
           <p class='govuk-body govuk-!-font-weight-bold'>
             <%= form.object.lookup_postcode %>
             <%= link_to_accessible(
-                  t('generic.change'),
+                  t("generic.change"),
                   providers_legal_aid_application_address_lookup_path(@legal_aid_application),
-                  class: 'govuk-body change-link change-postcode-link'
+                  class: "govuk-body change-link change-postcode-link",
                 ) %>
           </p>
         <% end %>
@@ -36,17 +36,17 @@
 
     <div class="govuk-!-padding-bottom-2"></div>
 
-    <% group_error_class = @form.errors[:address_line_one].any? ? 'govuk-form-group--error' : '' %>
+    <% group_error_class = @form.errors[:address_line_one].any? ? "govuk-form-group--error" : "" %>
     <div class="govuk-form-group <%= group_error_class %>">
-      <%= form.govuk_text_field :address_line_one , label: {text: "Building and street"}, 'aria-label': 'Building and street line 1 of 2' %>
-      <%= form.govuk_text_field :address_line_two, label: {text: "Building and street", hidden: true},
-                                'aria-label': 'Building and street line 2 of 2', field_with_error: :address_line_one %>
+      <%= form.govuk_text_field :address_line_one, label: { text: "Building and street" }, "aria-label": "Building and street line 1 of 2" %>
+      <%= form.govuk_text_field :address_line_two, label: { text: "Building and street", hidden: true },
+                                                   "aria-label": "Building and street line 2 of 2", field_with_error: :address_line_one %>
     </div>
 
-    <%= form.govuk_text_field :city, width: 'two-thirds' %>
-    <%= form.govuk_text_field :county, width: 'two-thirds' %>
+    <%= form.govuk_text_field :city, width: "two-thirds" %>
+    <%= form.govuk_text_field :county, width: "two-thirds" %>
     <%= form.govuk_text_field :postcode, hint: nil, width: 10 %>
 
-    <%= next_action_buttons(show_draft: true, form: form) %>
+    <%= next_action_buttons(show_draft: true, form:) %>
   <% end %>
 <% end %>

--- a/app/views/providers/applicant_bank_accounts/show.html.erb
+++ b/app/views/providers/applicant_bank_accounts/show.html.erb
@@ -2,13 +2,13 @@
       url: providers_legal_aid_application_applicant_bank_account_path,
       model: @form,
       method: :patch,
-      local: true
+      local: true,
     ) do |form| %>
-  <%= page_template page_title: t('.heading'), template: :basic, form: form do %>
+  <%= page_template page_title: t(".heading"), template: :basic, form: do %>
 
     <%= govuk_fieldset_header page_title %>
 
-    <p class="govuk-body"><%= t('.previously_told') %></p>
+    <p class="govuk-body"><%= t(".previously_told") %></p>
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">
@@ -16,11 +16,11 @@
           <% applicant_account.bank_accounts.each do |bank_account| %>
             <ul class="govuk-list govuk-!-margin-bottom-4">
               <li>
-                <strong><%= t('.account') %>: </strong>
+                <strong><%= t(".account") %>: </strong>
                 <%= bank_account.bank_and_account_name %>
               </li>
               <li>
-                <strong><%= t('.balance') %>: </strong>
+                <strong><%= t(".balance") %>: </strong>
                 <%= value_with_currency_unit(bank_account.balance, bank_account.currency) %>
               </li>
             </ul>
@@ -32,30 +32,27 @@
     <div class="govuk-!-padding-bottom-4"></div>
 
     <%= form.govuk_radio_buttons_fieldset :applicant_bank_account,
-                                          legend: { size: 'm', tag: 'h2', text: t('.offline_savings_accounts') },
-                                          hint: {text: t('.hints.offline_savings_accounts')} do %>
+                                          legend: { size: "m", tag: "h2", text: t(".offline_savings_accounts") },
+                                          hint: { text: t(".hints.offline_savings_accounts") } do %>
       <%= form.govuk_radio_button :applicant_bank_account,
                                   true,
                                   link_errors: true,
-                                  label: {text: t('generic.yes')},
+                                  label: { text: t("generic.yes") },
                                   checked: (@form.offline_savings_accounts.present? || @form.errors.include?(:offline_savings_accounts)) do %>
         <%= form.govuk_text_field(
               :offline_savings_accounts,
-              label: {text: t('.offline_savings_amount_label')},
+              label: { text: t(".offline_savings_amount_label") },
               value: number_to_currency_or_original_string(@form.offline_savings_accounts),
-              prefix_text: t('currency.gbp'),
-              width: 5
+              prefix_text: t("currency.gbp"),
+              width: 5,
             ) %>
       <% end %>
       <%= form.govuk_radio_button :applicant_bank_account,
                                   false,
                                   checked: (@legal_aid_application.checking_answers? && @form.offline_savings_accounts.nil?),
-                                  label: {text: t('generic.no')} %>
+                                  label: { text: t("generic.no") } %>
     <% end %>
 
-    <%= next_action_buttons(
-            show_draft: true,
-            form: form
-        ) %>
+    <%= next_action_buttons(show_draft: true, form:) %>
   <% end %>
 <% end %>

--- a/app/views/providers/applicant_details/show.html.erb
+++ b/app/views/providers/applicant_details/show.html.erb
@@ -1,5 +1,5 @@
 <%= render(
-      'shared/forms/applicant_form',
+      "shared/forms/applicant_form",
       form_url: providers_legal_aid_application_applicant_details_path,
-      form_method: :patch
+      form_method: :patch,
     ) %>

--- a/app/views/providers/applicant_employed/index.html.erb
+++ b/app/views/providers/applicant_employed/index.html.erb
@@ -1,32 +1,32 @@
 <%= form_with(
-        model: @form,
-        url: providers_legal_aid_application_applicant_employed_index_path(@legal_aid_application),
-        method: :post,
-        local: true
+      model: @form,
+      url: providers_legal_aid_application_applicant_employed_index_path(@legal_aid_application),
+      method: :post,
+      local: true,
     ) do |form| %>
 
   <%= page_template(
-        page_title: t('.heading_1'),
+        page_title: t(".heading_1"),
         template: :basic,
-        form: form,
-        back_link: { text: t('generic.back') }
+        form:,
+        back_link: { text: t("generic.back") },
       ) do %>
 
     <%= form.govuk_check_boxes_fieldset :applicant,
-                                        legend: {text: page_title, size: 'xl', tag: 'h1'},
-                                        hint: {text: t('generic.select_all_that_apply')} do %>
+                                        legend: { text: page_title, size: "xl", tag: "h1" },
+                                        hint: { text: t("generic.select_all_that_apply") } do %>
       <div class="govuk-checkboxes" data-module="govuk-checkboxes">
         <div class="deselect-group" data-deselect-ctrl="#applicant-none-selected-true-field">
           <% Applicants::EmployedForm::EMPLOYMENT_TYPES.each do |employment_type| %>
-             <%= form.govuk_check_box employment_type, true, '', multiple: false, link_errors: true, label: {text: t(".#{employment_type}")} %>
+             <%= form.govuk_check_box employment_type, true, "", multiple: false, link_errors: true, label: { text: t(".#{employment_type}") } %>
            <% end %>
         </div>
       </div>
       <%= form.govuk_radio_divider %>
-      <%= form.govuk_check_box :none_selected, true, '', multiple: false, label: {text: t('.not_employed')} %>
+      <%= form.govuk_check_box :none_selected, true, "", multiple: false, label: { text: t(".not_employed") } %>
     <% end %>
 
-    <%= next_action_buttons(show_draft: true, form: form) %>
+    <%= next_action_buttons(show_draft: true, form:) %>
   <% end %>
 
 <% end %>

--- a/app/views/providers/applicants/new.html.erb
+++ b/app/views/providers/applicants/new.html.erb
@@ -1,5 +1,5 @@
 <%= render(
-      'shared/forms/applicant_form',
+      "shared/forms/applicant_form",
       form_url: providers_applicants_path,
-      form_method: :post
+      form_method: :post,
     ) %>

--- a/app/views/providers/application_confirmations/show.html.erb
+++ b/app/views/providers/application_confirmations/show.html.erb
@@ -1,27 +1,29 @@
-<%= page_template page_title: t('.h1_heading'), back_link: :none do %>
+<%= page_template page_title: t(".h1_heading"), back_link: :none do %>
 
-  <p class="govuk-heading-m govuk-!-margin-top-4"><%= t('.laa_reference') %>: <%= @legal_aid_application.application_ref %></p>
+  <p class="govuk-heading-m govuk-!-margin-top-4">
+    <%= t(".laa_reference") %>: <%= @legal_aid_application.application_ref %>
+  </p>
   <div class="govuk-!-padding-2"></div>
-  <p class="govuk-body"><%= t '.sent_email_text', email: @legal_aid_application.applicant.email %></p>
+  <p class="govuk-body"><%= t ".sent_email_text", email: @legal_aid_application.applicant.email %></p>
 
-  <%= link_to_accessible t('.change_email_button') ,
+  <%= link_to_accessible t(".change_email_button"),
                          providers_legal_aid_application_email_address_path,
-                         role: 'button',
-                         class: 'govuk-button govuk-button--secondary',
-                         id: 'change-email' %>
+                         role: "button",
+                         class: "govuk-button govuk-button--secondary",
+                         id: "change-email" %>
 
-  <h2 class="govuk-heading-m govuk-!-margin-top-4"><%= t '.happen_next_heading' %></h2>
+  <h2 class="govuk-heading-m govuk-!-margin-top-4"><%= t ".happen_next_heading" %></h2>
   <p class="govuk-body">
-   <%= t '.happen_next_text' %>
+   <%= t ".happen_next_text" %>
   </p>
   <p class="govuk-body">
-    <%= t '.let_you_know_text' %>
+    <%= t ".let_you_know_text" %>
   </p>
   <%= link_to_accessible(
-        t('.back_button'),
+        t(".back_button"),
         providers_legal_aid_applications_path,
-        class: 'govuk-button govuk-button',
-        id: 'continue',
-        role: 'button'
+        class: "govuk-button govuk-button",
+        id: "continue",
+        role: "button",
       ) %>
 <% end %>

--- a/app/views/providers/application_merits_task/client_denial_of_allegations/show.html.erb
+++ b/app/views/providers/application_merits_task/client_denial_of_allegations/show.html.erb
@@ -2,21 +2,21 @@
       model: @form,
       url: providers_legal_aid_application_client_denial_of_allegation_path,
       method: :patch,
-      local: true
+      local: true,
     ) do |form| %>
-  <%= page_template(page_title: t('.h1-heading'),
+  <%= page_template(page_title: t(".h1-heading"),
                     template: :basic,
                     back_link: {},
-                    form: form) do %>
-    <%= form.govuk_radio_buttons_fieldset :denies_all, legend: {size: 'xl', tag: 'h1', text: page_title} do %>
-      <%= form.govuk_radio_button :denies_all, true, link_errors: true, label: {text: t('generic.yes')} %>
-      <%= form.govuk_radio_button :denies_all, false, label: {text: t('generic.no')} do %>
-        <%= form.govuk_text_area :additional_information, label: {text: t('.no-hint')}, rows: 5 %>
+                    form:) do %>
+    <%= form.govuk_radio_buttons_fieldset :denies_all, legend: { size: "xl", tag: "h1", text: page_title } do %>
+      <%= form.govuk_radio_button :denies_all, true, link_errors: true, label: { text: t("generic.yes") } %>
+      <%= form.govuk_radio_button :denies_all, false, label: { text: t("generic.no") } do %>
+        <%= form.govuk_text_area :additional_information, label: { text: t(".no-hint") }, rows: 5 %>
       <% end %>
 
     <% end %>
     <div class="govuk-!-padding-bottom-4"></div>
 
-    <%= next_action_buttons(show_draft: true, form: form) %>
+    <%= next_action_buttons(show_draft: true, form:) %>
   <% end %>
 <% end %>

--- a/app/views/providers/application_merits_task/client_offered_undertakings/show.html.erb
+++ b/app/views/providers/application_merits_task/client_offered_undertakings/show.html.erb
@@ -2,26 +2,26 @@
       model: @form,
       url: providers_legal_aid_application_client_offered_undertakings_path,
       method: :patch,
-      local: true
+      local: true,
     ) do |form| %>
-  <%= page_template(page_title: t('.h1-heading'),
+  <%= page_template(page_title: t(".h1-heading"),
                     template: :basic,
                     back_link: {},
-                    form: form) do %>
-    <%= form.govuk_radio_buttons_fieldset :offered, legend: {size: 'xl', tag: 'h1', text: page_title} do %>
-      <%= form.govuk_radio_button :offered, true, link_errors: true, label: {text: t('generic.yes')} do %>
+                    form:) do %>
+    <%= form.govuk_radio_buttons_fieldset :offered, legend: { size: "xl", tag: "h1", text: page_title } do %>
+      <%= form.govuk_radio_button :offered, true, link_errors: true, label: { text: t("generic.yes") } do %>
         <%= form.govuk_text_area :additional_information_true,
-                                 label: {text: t('.yes-hint')},
+                                 label: { text: t(".yes-hint") },
                                  rows: 5 %>
       <% end %>
-      <%= form.govuk_radio_button :offered, false, label: {text: t('generic.no')} do %>
+      <%= form.govuk_radio_button :offered, false, label: { text: t("generic.no") } do %>
         <%= form.govuk_text_area :additional_information_false,
-                                 label: {text: t('.no-hint')},
+                                 label: { text: t(".no-hint") },
                                  rows: 5 %>
       <% end %>
     <% end %>
     <div class="govuk-!-padding-bottom-4"></div>
 
-    <%= next_action_buttons(show_draft: true, form: form) %>
+    <%= next_action_buttons(show_draft: true, form:) %>
   <% end %>
 <% end %>

--- a/app/views/providers/application_merits_task/date_client_told_incidents/show.html.erb
+++ b/app/views/providers/application_merits_task/date_client_told_incidents/show.html.erb
@@ -2,22 +2,22 @@
       model: @form,
       url: providers_legal_aid_application_date_client_told_incident_path,
       method: :patch,
-      local: true
+      local: true,
     ) do |form| %>
-    <%= page_template(page_title: t('.h1-heading'),
+    <%= page_template(page_title: t(".h1-heading"),
                       template: :basic,
                       back_link: {},
-                      form: form) do %>
+                      form:) do %>
 
-    <%= form.govuk_fieldset legend: {size: 'xl', tag: 'h1', text: page_title} do %>
+    <%= form.govuk_fieldset legend: { size: "xl", tag: "h1", text: page_title } do %>
       <%= form.govuk_date_field :told_on, legend: { text: t("shared.forms.date_input_fields.told_on_label") },
-                                hint: { text: t("shared.forms.date_input_fields.date_hint", options: number_of_days_ago(0))} %>
+                                          hint: { text: t("shared.forms.date_input_fields.date_hint", options: number_of_days_ago(0)) } %>
       <%= form.govuk_date_field :occurred_on, legend: { text: t("shared.forms.date_input_fields.occurred_on_label") },
-                                hint: { text: t("shared.forms.date_input_fields.date_hint", options: number_of_days_ago(0))} %>
+                                              hint: { text: t("shared.forms.date_input_fields.date_hint", options: number_of_days_ago(0)) } %>
     <% end %>
 
     <div class="govuk-!-padding-bottom-4"></div>
 
-    <%= next_action_buttons(show_draft: true, form: form) %>
+    <%= next_action_buttons(show_draft: true, form:) %>
   <% end %>
 <% end %>

--- a/app/views/providers/application_merits_task/domestic_abuse_summaries/show.html.erb
+++ b/app/views/providers/application_merits_task/domestic_abuse_summaries/show.html.erb
@@ -2,65 +2,36 @@
       model: @form,
       url: providers_legal_aid_application_domestic_abuse_summary_path,
       method: :patch,
-      local: true
+      local: true,
     ) do |form| %>
-  <%= page_template(
-        page_title: t('.h1-heading'),
-        back_link: {},
-        form: form) do %>
+  <%= page_template(page_title: t(".h1-heading"), back_link: {}, form:) do %>
 
-    <%
-      questions = %i[warning_letter_sent].map do |attr|
-        OpenStruct.new(
-          title: t(".#{attr}"),
-          attribute: attr,
-          attribute_details: "#{attr}_details".to_sym,
-          )
-      end
-      questions += %i[police_notified].map do |attr|
-        OpenStruct.new(
-          title: t(".#{attr}"),
-          attribute: attr,
-          attribute_details_true: "#{attr}_details_true".to_sym,
-          attribute_details_false: "#{attr}_details_false".to_sym
-        )
-      end
-      questions += %i[bail_conditions_set].map do |attr|
-        OpenStruct.new(
-          title: t(".#{attr}"),
-          attribute: attr,
-          attribute_details: "#{attr}_details".to_sym,
-          )
-      end
-      police_notified_titles = {
-        yes: t('.police_notified_yes'),
-        no: t('.police_notified_no'),
-      }
-    %>
+    <%= form.govuk_radio_buttons_fieldset :warning_letter_sent, legend: { text: t(".warning_letter_sent") } do %>
+      <%= form.govuk_radio_button :warning_letter_sent, true, link_errors: true, label: { text: t("generic.yes") } %>
 
-    <% questions.each do |question| %>
-      <%= form.govuk_radio_buttons_fieldset question.attribute, legend: {text: question.title} do %>
-        <% if question.attribute == :police_notified %>
-          <%= form.govuk_radio_button question.attribute, true, link_errors: true, label: {text: t('generic.yes')} do %>
-            <%= form.govuk_text_area question.attribute_details_true, label: {text: police_notified_titles[:yes]}, rows: 5 %>
-          <% end %>
-          <%= form.govuk_radio_button question.attribute, false, label: {text: t('generic.no')} do %>
-            <%= form.govuk_text_area question.attribute_details_false, label: {text: police_notified_titles[:no]}, rows: 5 %>
-          <% end %>
-        <% elsif question.attribute == :bail_conditions_set %>
-          <%= form.govuk_radio_button question.attribute, true, link_errors: true, label: {text: t('generic.yes')} do %>
-            <%= form.govuk_text_area question.attribute_details, rows: 5 %>
-          <% end %>
-          <%= form.govuk_radio_button question.attribute, false, label: {text: t('generic.no')} %>
-        <% else %>
-          <%= form.govuk_radio_button question.attribute, true, link_errors: true, label: {text: t('generic.yes')} %>
-          <%= form.govuk_radio_button question.attribute, false, label: {text: t('generic.no')} do %>
-            <%= form.govuk_text_area question.attribute_details, rows: 5 %>
-          <% end %>
-        <% end %>
+      <%= form.govuk_radio_button :warning_letter_sent, false, label: { text: t("generic.no") } do %>
+        <%= form.govuk_text_area :warning_letter_sent_details, rows: 5 %>
       <% end %>
     <% end %>
 
-    <%= next_action_buttons(show_draft: true, form: form) %>
+    <%= form.govuk_radio_buttons_fieldset :police_notified, legend: { text: t(".police_notified") } do %>
+      <%= form.govuk_radio_button :police_notified, true, link_errors: true, label: { text: t("generic.yes") } do %>
+        <%= form.govuk_text_area :police_notified_details_true, label: { text: t(".police_notified_yes") }, rows: 5 %>
+      <% end %>
+
+      <%= form.govuk_radio_button :police_notified, false, label: { text: t("generic.no") } do %>
+        <%= form.govuk_text_area :police_notified_details_false, label: { text: t(".police_notified_no") }, rows: 5 %>
+      <% end %>
+    <% end %>
+
+    <%= form.govuk_radio_buttons_fieldset :bail_conditions_set, legend: { text: t(".bail_conditions_set") } do %>
+      <%= form.govuk_radio_button :bail_conditions_set, true, link_errors: true, label: { text: t("generic.yes") } do %>
+        <%= form.govuk_text_area :bail_conditions_set_details, rows: 5 %>
+      <% end %>
+
+      <%= form.govuk_radio_button :bail_conditions_set, false, label: { text: t("generic.no") } %>
+    <% end %>
+
+    <%= next_action_buttons(show_draft: true, form:) %>
   <% end %>
 <% end %>

--- a/app/views/providers/application_merits_task/has_other_involved_children/show.html.erb
+++ b/app/views/providers/application_merits_task/has_other_involved_children/show.html.erb
@@ -1,17 +1,19 @@
 <%= form_with(
-        url: providers_legal_aid_application_has_other_involved_children_path,
-        model: @form,
-        method: :patch,
-        local: true
+      url: providers_legal_aid_application_has_other_involved_children_path,
+      model: @form,
+      method: :patch,
+      local: true,
     ) do |form| %>
-  <%= page_template page_title: t('.page_title', count: "#{pluralize(@legal_aid_application.involved_children.count, 'child')}"),
+  <%= page_template page_title: t(".page_title", count: pluralize(@legal_aid_application.involved_children.count, "child").to_s),
                     template: :basic,
-                    form: form do %>
+                    form: do %>
 
     <% if @legal_aid_application.involved_children.count > 0 %>
-    <h1 class="govuk-heading-xl"><%= t('.existing', count: "#{pluralize(@legal_aid_application.involved_children.count, 'child')}") %></h1>
+    <h1 class="govuk-heading-xl">
+      <%= t(".existing", count: pluralize(@legal_aid_application.involved_children.count, "child").to_s) %>
+    </h1>
     <table class="govuk-table">
-        <caption class="govuk-table__caption govuk-table__caption--m govuk-visually-hidden"><%= t('.table_caption') %></caption>
+        <caption class="govuk-table__caption govuk-table__caption--m govuk-visually-hidden"><%= t(".table_caption") %></caption>
         <thead class="govuk-table__head">
           <tr class="govuk-table__row">
             <th class="govuk-table__header">Name</th>
@@ -23,17 +25,22 @@
             <tr class="govuk-table__row">
               <td class="govuk-table__cell" id="involved_child<%= involved_child.id %>"><%= involved_child.full_name %></td>
               <td class="govuk-table__cell"><%= involved_child.date_of_birth %></td>
-              <td class="govuk-table__cell"><%= link_to_accessible(
-                        t('generic.change'),
-                        providers_legal_aid_application_involved_child_path(@legal_aid_application, involved_child),
-                        class: 'govuk-link change-link',
-                        suffix: involved_child.full_name
-                      ) %></td>
-              <td class="govuk-table__cell"><%= link_to_accessible(
-                        t('.remove'),
-                        providers_legal_aid_application_remove_involved_child_path(@legal_aid_application, involved_child),
-                        class: 'govuk-link change-link',
-                        suffix: involved_child.full_name) %></td>
+              <td class="govuk-table__cell">
+                <%= link_to_accessible(
+                      t("generic.change"),
+                      providers_legal_aid_application_involved_child_path(@legal_aid_application, involved_child),
+                      class: "govuk-link change-link",
+                      suffix: involved_child.full_name,
+                    ) %>
+              </td>
+              <td class="govuk-table__cell">
+                <%= link_to_accessible(
+                      t(".remove"),
+                      providers_legal_aid_application_remove_involved_child_path(@legal_aid_application, involved_child),
+                      class: "govuk-link change-link",
+                      suffix: involved_child.full_name,
+                    ) %>
+              </td>
             </tr>
           <% end %>
         </tbody>
@@ -44,10 +51,8 @@
                                             yes_no_options,
                                             :value,
                                             :label,
-                                            legend: {text: t(".add_another"), size: 'l', tag: 'h2'} %>
+                                            legend: { text: t(".add_another"), size: "l", tag: "h2" } %>
 
-      <%= next_action_buttons(
-            show_draft: true,
-            form: form) %>
+      <%= next_action_buttons(show_draft: true, form:) %>
   <% end %>
 <% end %>

--- a/app/views/providers/application_merits_task/in_scope_of_laspos/show.html.erb
+++ b/app/views/providers/application_merits_task/in_scope_of_laspos/show.html.erb
@@ -2,13 +2,13 @@
               url: providers_legal_aid_application_in_scope_of_laspo_path,
               method: :patch,
               local: true) do |form| %>
-  <%= page_template page_title: t('.page_title'), template: :basic, form: form do %>
+  <%= page_template page_title: t(".page_title"), template: :basic, form: do %>
     <%= form.govuk_collection_radio_buttons :in_scope_of_laspo,
                                             yes_no_options,
                                             :value,
                                             :label,
-                                            hint: { text: '' },
-                                            legend: { text: page_title, tag: 'h1', size: 'l' } %>
-    <%= next_action_buttons show_draft: true, form: form %>
+                                            hint: { text: "" },
+                                            legend: { text: page_title, tag: "h1", size: "l" } %>
+    <%= next_action_buttons show_draft: true, form: %>
   <% end %>
 <% end %>

--- a/app/views/providers/application_merits_task/involved_children/_form.html.erb
+++ b/app/views/providers/application_merits_task/involved_children/_form.html.erb
@@ -2,18 +2,15 @@
       model: @form,
       url: form_path,
       method: :patch,
-      local: true
+      local: true,
     ) do |form| %>
-  <div class="govuk-hint"><%= t('.hint') %></div>
+  <div class="govuk-hint"><%= t(".hint") %></div>
   <div class="govuk-!-padding-bottom-2"></div>
 
-  <%= form.govuk_text_field :full_name, width: 'three-quarters', label: { size: 'm', text: t('.name') } %>
+  <%= form.govuk_text_field :full_name, width: "three-quarters", label: { size: "m", text: t(".name") } %>
 
-  <%= form.govuk_date_field :date_of_birth, legend: {text: t('.date_of_birth')}, hint: {text: t('.dob_hint')} %>
+  <%= form.govuk_date_field :date_of_birth, legend: { text: t(".date_of_birth") }, hint: { text: t(".dob_hint") } %>
 
   <div class="govuk-!-padding-bottom-2"></div>
-  <%= next_action_buttons(
-        show_draft: true,
-        form: form
-      ) %>
+  <%= next_action_buttons(show_draft: true, form:) %>
 <% end %>

--- a/app/views/providers/application_merits_task/involved_children/new.html.erb
+++ b/app/views/providers/application_merits_task/involved_children/new.html.erb
@@ -1,10 +1,10 @@
 <%= page_template(
-      page_title: t('.page_title'),
+      page_title: t(".page_title"),
       page_heading_options: { margin_bottom: 3 },
-      show_errors_for: @form
+      show_errors_for: @form,
     ) do %>
 
-  <%= render 'providers/application_merits_task/involved_children/form',
+  <%= render "providers/application_merits_task/involved_children/form",
              form: @form,
              form_path: new_providers_legal_aid_application_involved_child_path(@legal_aid_application, @form.model) %>
 <% end %>

--- a/app/views/providers/application_merits_task/involved_children/show.html.erb
+++ b/app/views/providers/application_merits_task/involved_children/show.html.erb
@@ -1,10 +1,10 @@
 <%= page_template(
-      page_title: t('.page_title', name: @involved_child.full_name),
+      page_title: t(".page_title", name: @involved_child.full_name),
       page_heading_options: { margin_bottom: 3 },
-      show_errors_for: @form
+      show_errors_for: @form,
     ) do %>
 
-  <%= render 'providers/application_merits_task/involved_children/form',
+  <%= render "providers/application_merits_task/involved_children/form",
              form: @form,
              form_path: providers_legal_aid_application_involved_child_path(@legal_aid_application, @form.model) %>
 <% end %>

--- a/app/views/providers/application_merits_task/matter_opposed_reasons/show.html.erb
+++ b/app/views/providers/application_merits_task/matter_opposed_reasons/show.html.erb
@@ -1,14 +1,14 @@
 <%= form_with(
-  model: @form,
-  url: providers_legal_aid_application_matter_opposed_reason_path(@legal_aid_application),
-  method: :patch
-) do |f| %>
+      model: @form,
+      url: providers_legal_aid_application_matter_opposed_reason_path(@legal_aid_application),
+      method: :patch,
+    ) do |f| %>
   <%= page_template page_title: t(".page_heading"), template: :basic, form: f do %>
     <%= f.govuk_text_area(
-      :reason,
-      rows: 10,
-      label: { tag: "h1", size: "xl", text: t(".page_heading"), class: "govuk-label govuk-label--xl govuk-!-margin-bottom-8" }
-    ) %>
+          :reason,
+          rows: 10,
+          label: { tag: "h1", size: "xl", text: t(".page_heading"), class: "govuk-label govuk-label--xl govuk-!-margin-bottom-8" },
+        ) %>
 
     <%= next_action_buttons(show_draft: true, form: f) %>
   <% end %>

--- a/app/views/providers/application_merits_task/nature_of_urgencies/show.html.erb
+++ b/app/views/providers/application_merits_task/nature_of_urgencies/show.html.erb
@@ -2,23 +2,23 @@
       model: @form,
       url: providers_legal_aid_application_nature_of_urgencies_path,
       method: :patch,
-      local: true
+      local: true,
     ) do |form| %>
-  <%= page_template(page_title: t('.h1-heading'),
-                      template: :basic,
-                      back_link: {},
-                      form: form) do %>
-    <%= form.govuk_fieldset legend: {size: 'xl', tag: 'h1', text: page_title} do %>
-      <%= form.govuk_text_area :nature_of_urgency, label: {text: t('.no-hint')}, rows: 5 %>
-      <%= form.govuk_radio_buttons_fieldset :hearing_date_set, legend: {size: 'xl', tag: 'h1', text: t('.hearing-date-set')} do %>
-        <%= form.govuk_radio_button :hearing_date_set, true, link_errors: true, label: {text: t('generic.yes')} do %>
-          <%= form.govuk_date_field :hearing_date, legend: { text: t('.hearing-date') }, hint: { text: t('.hearing-date-hint') } %>
+  <%= page_template(page_title: t(".h1-heading"),
+                    template: :basic,
+                    back_link: {},
+                    form:) do %>
+    <%= form.govuk_fieldset legend: { size: "xl", tag: "h1", text: page_title } do %>
+      <%= form.govuk_text_area :nature_of_urgency, label: { text: t(".no-hint") }, rows: 5 %>
+      <%= form.govuk_radio_buttons_fieldset :hearing_date_set, legend: { size: "xl", tag: "h1", text: t(".hearing-date-set") } do %>
+        <%= form.govuk_radio_button :hearing_date_set, true, link_errors: true, label: { text: t("generic.yes") } do %>
+          <%= form.govuk_date_field :hearing_date, legend: { text: t(".hearing-date") }, hint: { text: t(".hearing-date-hint") } %>
         <% end %>
-        <%= form.govuk_radio_button :hearing_date_set, false, label: {text: t('generic.no')} %>
+        <%= form.govuk_radio_button :hearing_date_set, false, label: { text: t("generic.no") } %>
       <% end %>
     <% end %>
     <div class="govuk-!-padding-bottom-4"></div>
 
-    <%= next_action_buttons(show_draft: true, form: form) %>
+    <%= next_action_buttons(show_draft: true, form:) %>
   <% end %>
 <% end %>

--- a/app/views/providers/application_merits_task/opponents_mental_capacities/show.html.erb
+++ b/app/views/providers/application_merits_task/opponents_mental_capacities/show.html.erb
@@ -2,19 +2,20 @@
       model: @form,
       url: providers_legal_aid_application_opponents_mental_capacity_path,
       method: :patch,
-      local: true
+      local: true,
     ) do |form| %>
   <%= page_template(
-        page_title: t('.h1-heading'),
+        page_title: t(".h1-heading"),
         template: :basic,
         back_link: {},
-        form: form) do %>
-    <%= form.govuk_radio_buttons_fieldset :understands_terms_of_court_order, legend: {size: 'xl', tag: 'h1', text: page_title} do %>
-      <%= form.govuk_radio_button :understands_terms_of_court_order, true, link_errors: true, label: {text: t('generic.yes')} %>
-      <%= form.govuk_radio_button :understands_terms_of_court_order, false, label: {text: t('generic.no')} do %>
+        form:,
+      ) do %>
+    <%= form.govuk_radio_buttons_fieldset :understands_terms_of_court_order, legend: { size: "xl", tag: "h1", text: page_title } do %>
+      <%= form.govuk_radio_button :understands_terms_of_court_order, true, link_errors: true, label: { text: t("generic.yes") } %>
+      <%= form.govuk_radio_button :understands_terms_of_court_order, false, label: { text: t("generic.no") } do %>
         <%= form.govuk_text_area :understands_terms_of_court_order_details, rows: 5 %>
       <% end %>
     <% end %>
-    <%= next_action_buttons(show_draft: true, form: form) %>
+    <%= next_action_buttons(show_draft: true, form:) %>
   <% end %>
 <% end %>

--- a/app/views/providers/application_merits_task/opponents_names/show.html.erb
+++ b/app/views/providers/application_merits_task/opponents_names/show.html.erb
@@ -2,25 +2,26 @@
       model: @form,
       url: providers_legal_aid_application_opponents_name_path,
       method: :patch,
-      local: true
+      local: true,
     ) do |form| %>
   <%= page_template(
-        page_title: t('.h1-heading'),
+        page_title: t(".h1-heading"),
         back_link: {},
-        form: form) do %>
+        form:,
+      ) do %>
 
     <%= form.govuk_text_field(
           :first_name,
-          label: { text: t('.first_name'), size: 'm' },
-          class: 'govuk-input govuk-input--width-20'
+          label: { text: t(".first_name"), size: "m" },
+          class: "govuk-input govuk-input--width-20",
         ) %>
 
     <%= form.govuk_text_field(
           :last_name,
-          label: { text: t('.last_name'), size: 'm' },
-          class: 'govuk-input govuk-input--width-20'
+          label: { text: t(".last_name"), size: "m" },
+          class: "govuk-input govuk-input--width-20",
         ) %>
 
-    <%= next_action_buttons(show_draft: true, form: form) %>
+    <%= next_action_buttons(show_draft: true, form:) %>
   <% end %>
 <% end %>

--- a/app/views/providers/application_merits_task/remove_involved_child/show.html.erb
+++ b/app/views/providers/application_merits_task/remove_involved_child/show.html.erb
@@ -1,18 +1,18 @@
-<%= page_template page_title: t('.page_title', name: @involved_child.full_name), template: :basic do %>
+<%= page_template page_title: t(".page_title", name: @involved_child.full_name), template: :basic do %>
 
   <%= form_with(
         url: providers_legal_aid_application_remove_involved_child_path,
         model: @form,
         method: :patch,
-        local: true
+        local: true,
       ) do |form| %>
 
     <%= form.govuk_collection_radio_buttons :remove_involved_child,
                                             yes_no_options,
                                             :value,
                                             :label,
-                                            legend: {text: content_for(:page_title), tag: 'h1', size: 'xl'} %>
+                                            legend: { text: content_for(:page_title), tag: "h1", size: "xl" } %>
 
-    <%= next_action_buttons(form: form) %>
+    <%= next_action_buttons(form:) %>
   <% end %>
 <% end %>

--- a/app/views/providers/application_merits_task/statement_of_cases/_uploaded_files.html.erb
+++ b/app/views/providers/application_merits_task/statement_of_cases/_uploaded_files.html.erb
@@ -1,9 +1,9 @@
-<table class="govuk-table <%= 'hidden' if attachments.empty? %>">
-  <caption class="govuk-table__caption govuk-visually-hidden"><%= t('.title') %></caption>
+<table class="govuk-table <%= "hidden" if attachments.empty? %>">
+  <caption class="govuk-table__caption govuk-visually-hidden"><%= t(".title") %></caption>
   <thead class="govuk-table__head">
   <tr class="govuk-table__row">
-    <th class="govuk-table__header" scope="col"><%= t('.filename') %></th>
-    <th class="govuk-table__header" scope="col"><%= t('.status') %></th>
+    <th class="govuk-table__header" scope="col"><%= t(".filename") %></th>
+    <th class="govuk-table__header" scope="col"><%= t(".status") %></th>
     <td class="govuk-table__header" scope="col"></td>
   </tr>
   </thead>
@@ -15,12 +15,12 @@
       <td class="govuk-table__cell"><%= govuk_tag(text: t(".uploaded")) %></td>
       <td class="govuk-table__cell">
         <%= button_to_accessible(
-              t('.delete'),
+              t(".delete"),
               providers_legal_aid_application_statement_of_case_path(@legal_aid_application),
               method: :delete,
-              class: 'button-as-link',
+              class: "button-as-link",
               params: { attachment_id: attachment.id },
-              suffix: attachment.document.filename
+              suffix: attachment.document.filename,
             ) %>
       </td>
     </tr>

--- a/app/views/providers/application_merits_task/statement_of_cases/show.html.erb
+++ b/app/views/providers/application_merits_task/statement_of_cases/show.html.erb
@@ -4,13 +4,13 @@
                     elsif @error_message || @successful_upload
                       "#{@successful_upload} #{@error_message}"
                     else
-                      t('.h1-heading')
+                      t(".h1-heading")
                     end %>
 <%= page_template(
-      page_title: t('.h1-heading'),
+      page_title: t(".h1-heading"),
       head_title: new_head_title,
       template: :basic,
-      back_link: {}
+      back_link: {},
     ) do %>
 
   <% if @successfully_deleted %>
@@ -20,20 +20,20 @@
   <% end %>
 
   <%= form_with(
-          model: @form,
-          url: providers_legal_aid_application_statement_of_case_path,
-          method: :patch,
-          local: true,
-          html: { id: 'file-upload-form' }
+        model: @form,
+        url: providers_legal_aid_application_statement_of_case_path,
+        method: :patch,
+        local: true,
+        html: { id: "file-upload-form" },
       ) do |form| %>
 
     <%= form.govuk_error_summary %>
 
-    <%= render partial: 'shared/forms/error_summary_hidden' %>
+    <%= render partial: "shared/forms/error_summary_hidden" %>
 
-    <%= form.govuk_fieldset legend: {text: page_title, tag: 'h1', size: 'xl'} do %>
+    <%= form.govuk_fieldset legend: { text: page_title, tag: "h1", size: "xl" } do %>
 
-      <p class="govuk-body"><%= t('generic.tell_us') %></p>
+      <p class="govuk-body"><%= t("generic.tell_us") %></p>
       <ul class="govuk-list govuk-list--bullet govuk-!-padding-bottom-2">
         <% (1..5).each do |bullet_number| %>
           <li><%= t(".bullet-#{bullet_number}") %></li>
@@ -45,9 +45,9 @@
       <div class="dropzone__upload">
         <div class="govuk-form-group script hidden" id="dropzone-form-group" aria-labelledby="dropzone-label">
             <label class="govuk-label govuk-label--m" id="dropzone-label">
-              <%= t('.upload_file') %>
+              <%= t(".upload_file") %>
             </label>
-            <div class="govuk-hint"><%= t('.size_hint') %></div>
+            <div class="govuk-hint"><%= t(".size_hint") %></div>
 
             <span class="hidden" aria-hidden="true" id="application-id"><%= @form.model.legal_aid_application_id %></span>
             <span class="hidden" aria-hidden="true" id="dropzone-url" data-url="/v1/statement_of_cases"></span>
@@ -56,31 +56,31 @@
             </p>
             <div class="dropzone" id="dropzone-form">
               <div class="dz-message" data-dz-message>
-                <p class="govuk-body govuk-!-padding-top-2 script"><%= t('.dropzone_message') %></p>
-                <button id="dz-upload-button" class="govuk-button govuk-button--secondary script" tabindex="0"><%= t('.choose_files_btn') %></button>
+                <p class="govuk-body govuk-!-padding-top-2 script"><%= t(".dropzone_message") %></p>
+                <button id="dz-upload-button" class="govuk-button govuk-button--secondary script" tabindex="0"><%= t(".choose_files_btn") %></button>
               </div>
             </div>
         </div>
 
         <div class="fallback no-script">
-          <%= form.govuk_file_field :original_file, label: {text: t('generic.attach_file'), size: 'm'},
-                                    hint: {text: t('.size_hint')},
-                                    classes: ['govuk-file-upload moj-multi-file-upload__input'] %>
+          <%= form.govuk_file_field :original_file, label: { text: t("generic.attach_file"), size: "m" },
+                                                    hint: { text: t(".size_hint") },
+                                                    classes: ["govuk-file-upload moj-multi-file-upload__input"] %>
           <%= form.submit(
-                t('generic.upload'),
-                id: 'upload',
-                name: 'upload_button',
-                class: 'govuk-button govuk-button--secondary form-button moj-multi-file-upload__button'
+                t("generic.upload"),
+                id: "upload",
+                name: "upload_button",
+                class: "govuk-button govuk-button--secondary form-button moj-multi-file-upload__button",
               ) %>
 
         </div>
 
-        <h2 class="govuk-heading-m"><%= t('.h2-heading') %></h2>
+        <h2 class="govuk-heading-m"><%= t(".h2-heading") %></h2>
         <div id="uploaded-files-table-container">
-          <%= render partial: 'uploaded_files', locals: { attachments: @form.model.original_attachments } %>
+          <%= render partial: "uploaded_files", locals: { attachments: @form.model.original_attachments } %>
           <% if @form.model.original_attachments.empty? %>
             <p class="govuk-body">
-              <%= t('.no_files') %>
+              <%= t(".no_files") %>
             </p>
           <% end %>
         </div>
@@ -102,25 +102,25 @@
         model: @form,
         url: providers_legal_aid_application_statement_of_case_path,
         method: :patch,
-        local: true
-    ) do |form| %>
+        local: true,
+      ) do |form| %>
 
     <%= form.govuk_radio_divider %>
 
     <%= form.govuk_text_area :statement, rows: 15 %>
 
-    <%= next_action_buttons(show_draft: true, form: form) %>
+    <%= next_action_buttons(show_draft: true, form:) %>
   <% end %>
 <% end %>
 
 <script nonce="<%= request.content_security_policy_nonce %>">
   window.LAA_VARS = {
     images: {
-      loading_small: <%= asset_pack_path('media/images/loading-small.gif').to_json.html_safe %>
+      loading_small: <%= asset_pack_path("media/images/loading-small.gif").to_json.html_safe %>
     },
     locales: {
       generic: {
-        uploading: <%= t('generic.uploading').to_json.html_safe %>
+        uploading: <%= t("generic.uploading").to_json.html_safe %>
       }
     }
   };

--- a/app/views/providers/bank_statements/_uploaded_files.html.erb
+++ b/app/views/providers/bank_statements/_uploaded_files.html.erb
@@ -1,22 +1,22 @@
 <% if attachments.empty? %>
   <p class="govuk-body govuk-!-padding-bottom-4">
-     <%= t('.no_files') %>
+     <%= t(".no_files") %>
   </p>
 <% else %>
   <%= form_with(
-          model: @form,
-          url: providers_legal_aid_application_bank_statements_path,
-          method: :delete,
-          local: true,
-          html: { id: 'file-delete-form' }
+        model: @form,
+        url: providers_legal_aid_application_bank_statements_path,
+        method: :delete,
+        local: true,
+        html: { id: "file-delete-form" },
       ) do |form| %>
 
-    <table class="govuk-table <%= 'hidden' if attachments.empty? %>">
-      <caption class="govuk-table__caption govuk-visually-hidden"><%= t('.title') %></caption>
+    <table class="govuk-table <%= "hidden" if attachments.empty? %>">
+      <caption class="govuk-table__caption govuk-visually-hidden"><%= t(".title") %></caption>
       <thead class="govuk-table__head">
       <tr class="govuk-table__row">
-        <th class="govuk-table__header" scope="col"><%= t('.filename') %></th>
-        <th class="govuk-table__header" scope="col"><%= t('.status') %></th>
+        <th class="govuk-table__header" scope="col"><%= t(".filename") %></th>
+        <th class="govuk-table__header" scope="col"><%= t(".status") %></th>
         <td class="govuk-table__header" scope="col"></td>
       </tr>
       </thead>
@@ -28,12 +28,12 @@
           <td class="govuk-table__cell"><%= govuk_tag(text: t(".uploaded")) %></td>
           <td class="govuk-table__cell">
             <%= button_to_accessible(
-                  t('.delete'),
+                  t(".delete"),
                   providers_legal_aid_application_bank_statements_path(@legal_aid_application),
                   method: :delete,
-                  class: 'button-as-link',
+                  class: "button-as-link",
                   params: { attachment_id: attachment.id },
-                  suffix: attachment.document.filename
+                  suffix: attachment.document.filename,
                 ) %>
           </td>
         </tr>

--- a/app/views/providers/bank_statements/show.html.erb
+++ b/app/views/providers/bank_statements/show.html.erb
@@ -4,14 +4,14 @@
                     elsif @error_message || @successful_upload
                       "#{@successful_upload} #{@error_message}"
                     else
-                      t('.h1-heading')
+                      t(".h1-heading")
                     end
-   form_error_class = @form.errors.any? ? 'govuk-form-group--error' : '' %>
+   form_error_class = @form.errors.any? ? "govuk-form-group--error" : "" %>
 <%= page_template(
-      page_title: t('.h1-heading'),
+      page_title: t(".h1-heading"),
       head_title: new_head_title,
       template: :basic,
-      back_link: {}
+      back_link: {},
     ) do %>
 
   <% if @successfully_deleted %>
@@ -21,31 +21,31 @@
   <% end %>
 
   <%= form_with(
-          model: @form,
-          url: providers_legal_aid_application_bank_statements_path,
-          method: :patch,
-          local: true,
-          html: { id: 'file-upload-form' }
+        model: @form,
+        url: providers_legal_aid_application_bank_statements_path,
+        method: :patch,
+        local: true,
+        html: { id: "file-upload-form" },
       ) do |form| %>
 
     <%= form.govuk_error_summary %>
 
-    <%= render partial: 'shared/forms/error_summary_hidden' %>
+    <%= render partial: "shared/forms/error_summary_hidden" %>
 
-    <%= form.govuk_fieldset legend: {text: page_title, tag: 'h1', size: 'xl'} do %>
+    <%= form.govuk_fieldset legend: { text: page_title, tag: "h1", size: "xl" } do %>
 
         <p class="govuk-body govuk-!-padding-top-4">
-          <%= t('.info') %>
+          <%= t(".info") %>
         </p>
 
-      <%= govuk_warning_text(text: t('.warning')) %>
+      <%= govuk_warning_text(text: t(".warning")) %>
 
       <div class="dropzone__upload">
         <div class="govuk-form-group script hidden <%= form_error_class %>" id="dropzone-form-group" aria-labelledby="dropzone-label">
             <label class="govuk-label govuk-label--m" id="dropzone-label">
-              <%= t('.upload_file') %>
+              <%= t(".upload_file") %>
             </label>
-            <div class="govuk-hint"><%= t('.size_hint') %></div>
+            <div class="govuk-hint"><%= t(".size_hint") %></div>
           <% if @form.errors %>
             <p id="dropzone-mandatory-error" class='govuk-error-message dropzone-error govuk-!-margin-bottom-1'>
               <% @form.errors.errors.each do |error| %>
@@ -62,21 +62,21 @@
             </p>
             <div class="dropzone" id="dropzone-form">
               <div class="dz-message" data-dz-message>
-                <p class="govuk-body govuk-!-padding-top-2 script"><%= t('.dropzone_message') %></p>
-                <button id="dz-upload-button" class="govuk-button govuk-button--secondary script" tabindex="0"><%= t('.choose_files_btn') %></button>
+                <p class="govuk-body govuk-!-padding-top-2 script"><%= t(".dropzone_message") %></p>
+                <button id="dz-upload-button" class="govuk-button govuk-button--secondary script" tabindex="0"><%= t(".choose_files_btn") %></button>
               </div>
             </div>
         </div>
 
         <div class="fallback no-script">
-          <%= form.govuk_file_field :original_file, name: :original_file, label: {text: t('generic.attach_file'), size: 'm'},
-                                    hint: {text: t('.size_hint')},
-                                    classes: ['govuk-file-upload moj-multi-file-upload__input'] %>
+          <%= form.govuk_file_field :original_file, name: :original_file, label: { text: t("generic.attach_file"), size: "m" },
+                                                    hint: { text: t(".size_hint") },
+                                                    classes: ["govuk-file-upload moj-multi-file-upload__input"] %>
           <%= form.submit(
-                t('generic.upload'),
-                id: 'upload',
-                name: 'upload_button',
-                class: 'govuk-button govuk-button--secondary form-button moj-multi-file-upload__button'
+                t("generic.upload"),
+                id: "upload",
+                name: "upload_button",
+                class: "govuk-button govuk-button--secondary form-button moj-multi-file-upload__button",
               ) %>
         </div>
       </div>
@@ -93,30 +93,30 @@
     <% end %>
   <% end %>
 
-  <h2 class="govuk-heading-m"><%= t('.h2-heading') %></h2>
+  <h2 class="govuk-heading-m"><%= t(".h2-heading") %></h2>
   <div id="uploaded-files-table-container">
-    <%= render partial: 'uploaded_files', locals: { attachments: @form.legal_aid_application.attachments.bank_statement_evidence } %>
+    <%= render partial: "uploaded_files", locals: { attachments: @form.legal_aid_application.attachments.bank_statement_evidence } %>
   </div>
 
   <%= form_with(
         model: @form,
         url: providers_legal_aid_application_bank_statements_path,
         method: :patch,
-        local: true
-    ) do |form| %>
+        local: true,
+      ) do |form| %>
 
-    <%= next_action_buttons(show_draft: true, form: form) %>
+    <%= next_action_buttons(show_draft: true, form:) %>
   <% end %>
 <% end %>
 
 <script nonce="<%= request.content_security_policy_nonce %>">
   window.LAA_VARS = {
     images: {
-      loading_small: <%= asset_pack_path('media/images/loading-small.gif').to_json.html_safe %>
+      loading_small: <%= asset_pack_path("media/images/loading-small.gif").to_json.html_safe %>
     },
     locales: {
       generic: {
-        uploading: <%= t('generic.uploading').to_json.html_safe %>
+        uploading: <%= t("generic.uploading").to_json.html_safe %>
       }
     }
   };

--- a/app/views/providers/bank_transactions/_list_selected.html.erb
+++ b/app/views/providers/bank_transactions/_list_selected.html.erb
@@ -1,11 +1,11 @@
 <table class="govuk-table">
-  <caption class="govuk-table__caption govuk-table__caption--m govuk-visually-hidden"><%= t('.caption', category: category) %></caption>
+  <caption class="govuk-table__caption govuk-table__caption--m govuk-visually-hidden"><%= t(".caption", category:) %></caption>
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
-      <th class="govuk-table__header" scope="col"><%= t('.col_date') %></th>
-      <th class="govuk-table__header" scope="col"><%= t('.col_description') %></th>
-      <th class="govuk-table__header" scope="col"><%= t('.col_amount') %></th>
-      <th class="govuk-table__header" scope="col"><p class="govuk-visually-hidden"><%= t('.col_remove') %></p></th>
+      <th class="govuk-table__header" scope="col"><%= t(".col_date") %></th>
+      <th class="govuk-table__header" scope="col"><%= t(".col_description") %></th>
+      <th class="govuk-table__header" scope="col"><%= t(".col_amount") %></th>
+      <th class="govuk-table__header" scope="col"><p class="govuk-visually-hidden"><%= t(".col_remove") %></p></th>
     </tr>
   </thead>
   <tbody class="govuk-table__body">
@@ -22,13 +22,13 @@
         </td>
         <td class="govuk-table__cell">
           <%= button_to_accessible(
-                t('.remove_link'),
+                t(".remove_link"),
                 remove_transaction_type_providers_legal_aid_application_bank_transaction_path(@legal_aid_application, bank_transaction),
                 method: :patch,
-                class: 'button-as-link',
-                form_class: 'remote-remove-transaction',
-                suffix: bank_transaction.description + " " + value_with_currency_unit(bank_transaction.amount, bank_transaction.currency) + " " + l(bank_transaction.happened_at.to_date, format: :short_date),
-                remote: true
+                class: "button-as-link",
+                form_class: "remote-remove-transaction",
+                suffix: "#{bank_transaction.description} #{value_with_currency_unit(bank_transaction.amount, bank_transaction.currency)} #{l(bank_transaction.happened_at.to_date, format: :short_date)}",
+                remote: true,
               ) %>
         </td>
       </tr>

--- a/app/views/providers/capital_assessment_results/_result_details.html.erb
+++ b/app/views/providers/capital_assessment_results/_result_details.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-details govuk-!-margin-top-6" data-module="govuk-details">
   <h2 class="govuk-heading-l">
-    <%= t('.client_eligibility_calculation') %>
+    <%= t(".client_eligibility_calculation") %>
   </h2>
 
   <%= govuk_accordion do |accordion| %>

--- a/app/views/providers/capital_assessment_results/show.html.erb
+++ b/app/views/providers/capital_assessment_results/show.html.erb
@@ -1,7 +1,7 @@
 <%= page_template(
-      page_title: t(".page_title", result: t(".result.#{@cfe_result.assessment_result}") ),
+      page_title: t(".page_title", result: t(".result.#{@cfe_result.assessment_result}")),
       template: :basic,
-      column_width: :full
+      column_width: :full,
     ) do %>
 
   <div class="interruption-panel">
@@ -11,8 +11,8 @@
   <%= render "result_details" %>
 
   <%= next_action_buttons_with_form(
-          url: providers_legal_aid_application_capital_assessment_result_path(@legal_aid_application),
-          method: :patch,
-          show_draft: true
+        url: providers_legal_aid_application_capital_assessment_result_path(@legal_aid_application),
+        method: :patch,
+        show_draft: true,
       ) %>
 <% end %>

--- a/app/views/providers/capital_income_assessment_results/_bank_statements.html.erb
+++ b/app/views/providers/capital_income_assessment_results/_bank_statements.html.erb
@@ -1,10 +1,10 @@
-<h3 class="govuk-heading-m"><%= t('.title') %></h3>
+<h3 class="govuk-heading-m"><%= t(".title") %></h3>
 <dl class="govuk-summary-list">
   <%= check_answer_link(
         name: :bank_statements,
         url: providers_legal_aid_application_bank_statements_path(@legal_aid_application),
-        question: t('.uploaded'),
+        question: t(".uploaded"),
         answer: attachments_with_size(bank_statements),
-        read_only: true
+        read_only: true,
       ) %>
 </dl>

--- a/app/views/providers/capital_income_assessment_results/_deductions.html.erb
+++ b/app/views/providers/capital_income_assessment_results/_deductions.html.erb
@@ -1,10 +1,10 @@
-<h2 class="govuk-heading-m"><%= t('.title') %></h2>
+<h2 class="govuk-heading-m"><%= t(".title") %></h2>
 <table class="govuk-table">
   <tbody>
-  <%= render partial: 'shared/results_detail_row', locals: { caption: t('.dependants_allowance'), value: gds_number_to_currency(@cfe_result.dependants_allowance) } %>
+  <%= render partial: "shared/results_detail_row", locals: { caption: t(".dependants_allowance"), value: gds_number_to_currency(@cfe_result.dependants_allowance) } %>
   <% unless @legal_aid_application.uploading_bank_statements? %>
-    <%= render partial: 'shared/results_detail_row', locals: { caption: t('.excluded_benefits'), value: gds_number_to_currency(@cfe_result.disregarded_state_benefits) } %>
+    <%= render partial: "shared/results_detail_row", locals: { caption: t(".excluded_benefits"), value: gds_number_to_currency(@cfe_result.disregarded_state_benefits) } %>
   <% end %>
-  <%= render partial: 'shared/results_total_row', locals: { caption: t('.total_deductions'), value: gds_number_to_currency(@cfe_result.total_deductions) } %>
+  <%= render partial: "shared/results_total_row", locals: { caption: t(".total_deductions"), value: gds_number_to_currency(@cfe_result.total_deductions) } %>
   </tbody>
 </table>

--- a/app/views/providers/capital_income_assessment_results/_disposable_income.html.erb
+++ b/app/views/providers/capital_income_assessment_results/_disposable_income.html.erb
@@ -1,9 +1,9 @@
-<h2 class="govuk-heading-m"><%= t('.title') %></h2>
+<h2 class="govuk-heading-m"><%= t(".title") %></h2>
 <table class="govuk-table">
   <tbody>
-    <%= render partial: 'shared/results_detail_row', locals: { caption: t('.total_income'), value: gds_number_to_currency(@cfe_result.total_monthly_income_including_employment_income) } %>
-    <%= render partial: 'shared/results_detail_row', locals: { caption: t('.total_outgoings'), value: gds_number_to_currency(@cfe_result.total_monthly_outgoings_including_tax_and_ni) } %>
-    <%= render partial: 'shared/results_detail_row', locals: { caption: t('.total_deductions'), value: gds_number_to_currency(@cfe_result.total_deductions_including_fixed_employment_allowance) } %>
-    <%= render partial: 'shared/results_total_bold_row', locals: { caption: t('.total_disposable'), value: gds_number_to_currency(@cfe_result.total_disposable_income_assessed) } %>
+    <%= render partial: "shared/results_detail_row", locals: { caption: t(".total_income"), value: gds_number_to_currency(@cfe_result.total_monthly_income_including_employment_income) } %>
+    <%= render partial: "shared/results_detail_row", locals: { caption: t(".total_outgoings"), value: gds_number_to_currency(@cfe_result.total_monthly_outgoings_including_tax_and_ni) } %>
+    <%= render partial: "shared/results_detail_row", locals: { caption: t(".total_deductions"), value: gds_number_to_currency(@cfe_result.total_deductions_including_fixed_employment_allowance) } %>
+    <%= render partial: "shared/results_total_bold_row", locals: { caption: t(".total_disposable"), value: gds_number_to_currency(@cfe_result.total_disposable_income_assessed) } %>
   <tbody>
 </table>

--- a/app/views/providers/capital_income_assessment_results/_employment_income.html.erb
+++ b/app/views/providers/capital_income_assessment_results/_employment_income.html.erb
@@ -1,11 +1,11 @@
-<h2 class="govuk-heading-m"><%= t('.title') %></h2>
+<h2 class="govuk-heading-m"><%= t(".title") %></h2>
 <table class="govuk-table">
   <tbody>
-  <%= render partial: 'shared/results_detail_row', locals: { caption: t('.monthly_income_before_tax'), value: gds_number_to_currency(@cfe_result.employment_income_gross_income) } %>
-  <%= render partial: 'shared/results_detail_row', locals: { caption: t('.benefits_in_kind'), value: gds_number_to_currency(@cfe_result.employment_income_benefits_in_kind) } %>
-  <%= render partial: 'shared/results_detail_row', locals: { caption: t('.tax'), value: gds_number_to_currency(@cfe_result.employment_income_tax) } %>
-  <%= render partial: 'shared/results_detail_row', locals: { caption: t('.national_insurance'), value: gds_number_to_currency(@cfe_result.employment_income_national_insurance) } %>
-  <%= render partial: 'shared/results_detail_row', locals: { caption: t('.fixed_employment_deduction'), value: gds_number_to_currency(@cfe_result.employment_income_fixed_employment_deduction) } %>
-  <%= render partial: 'shared/results_total_row', locals: { caption: t('.total'), value: gds_number_to_currency(@cfe_result.employment_income_net_employment_income) } %>
+  <%= render partial: "shared/results_detail_row", locals: { caption: t(".monthly_income_before_tax"), value: gds_number_to_currency(@cfe_result.employment_income_gross_income) } %>
+  <%= render partial: "shared/results_detail_row", locals: { caption: t(".benefits_in_kind"), value: gds_number_to_currency(@cfe_result.employment_income_benefits_in_kind) } %>
+  <%= render partial: "shared/results_detail_row", locals: { caption: t(".tax"), value: gds_number_to_currency(@cfe_result.employment_income_tax) } %>
+  <%= render partial: "shared/results_detail_row", locals: { caption: t(".national_insurance"), value: gds_number_to_currency(@cfe_result.employment_income_national_insurance) } %>
+  <%= render partial: "shared/results_detail_row", locals: { caption: t(".fixed_employment_deduction"), value: gds_number_to_currency(@cfe_result.employment_income_fixed_employment_deduction) } %>
+  <%= render partial: "shared/results_total_row", locals: { caption: t(".total"), value: gds_number_to_currency(@cfe_result.employment_income_net_employment_income) } %>
   </tbody>
 </table>

--- a/app/views/providers/capital_income_assessment_results/_other_income.html.erb
+++ b/app/views/providers/capital_income_assessment_results/_other_income.html.erb
@@ -1,14 +1,14 @@
 <h2 class="govuk-heading-m">
-  <%= @cfe_result.jobs? ? t('.title') : t('.income') %>
+  <%= @cfe_result.jobs? ? t(".title") : t(".income") %>
 </h2>
 <table class="govuk-table">
   <tbody>
-  <%= render partial: 'shared/results_detail_row', locals: { caption: t('.benefits'), value: gds_number_to_currency(@cfe_result.monthly_state_benefits) } %>
-  <%= render partial: 'shared/results_detail_row', locals: { caption: t('.friends_or_family'), value: gds_number_to_currency(@cfe_result.mei_friends_or_family) } %>
-  <%= render partial: 'shared/results_detail_row', locals: { caption: t('.maintenance'), value: gds_number_to_currency(@cfe_result.mei_maintenance_in) } %>
-  <%= render partial: 'shared/results_detail_row', locals: { caption: t('.property_or_lodger'), value: gds_number_to_currency(@cfe_result.mei_property_or_lodger) } %>
-  <%= render partial: 'shared/results_detail_row', locals: { caption: t('.student_loan_or_grant'), value: gds_number_to_currency(@cfe_result.mei_student_loan) } %>
-  <%= render partial: 'shared/results_detail_row', locals: { caption: t('.pension'), value: gds_number_to_currency(@cfe_result.mei_pension) } %>
-  <%= render partial: 'shared/results_total_row', locals: { caption: t('.total'), value: gds_number_to_currency(@cfe_result.total_gross_income) } %>
+  <%= render partial: "shared/results_detail_row", locals: { caption: t(".benefits"), value: gds_number_to_currency(@cfe_result.monthly_state_benefits) } %>
+  <%= render partial: "shared/results_detail_row", locals: { caption: t(".friends_or_family"), value: gds_number_to_currency(@cfe_result.mei_friends_or_family) } %>
+  <%= render partial: "shared/results_detail_row", locals: { caption: t(".maintenance"), value: gds_number_to_currency(@cfe_result.mei_maintenance_in) } %>
+  <%= render partial: "shared/results_detail_row", locals: { caption: t(".property_or_lodger"), value: gds_number_to_currency(@cfe_result.mei_property_or_lodger) } %>
+  <%= render partial: "shared/results_detail_row", locals: { caption: t(".student_loan_or_grant"), value: gds_number_to_currency(@cfe_result.mei_student_loan) } %>
+  <%= render partial: "shared/results_detail_row", locals: { caption: t(".pension"), value: gds_number_to_currency(@cfe_result.mei_pension) } %>
+  <%= render partial: "shared/results_total_row", locals: { caption: t(".total"), value: gds_number_to_currency(@cfe_result.total_gross_income) } %>
   </tbody>
 </table>

--- a/app/views/providers/capital_income_assessment_results/_outgoings.html.erb
+++ b/app/views/providers/capital_income_assessment_results/_outgoings.html.erb
@@ -1,10 +1,10 @@
-<h2 class="govuk-heading-m"><%= t('.title') %></h2>
+<h2 class="govuk-heading-m"><%= t(".title") %></h2>
 <table class="govuk-table">
   <tbody>
-  <%= render partial: 'shared/results_detail_row', locals: { caption: t('.housing_costs'), value: gds_number_to_currency(@cfe_result.moe_housing) } %>
-  <%= render partial: 'shared/results_detail_row', locals: { caption: t('.childcare_costs'), value: gds_number_to_currency(@cfe_result.moe_childcare) } %>
-  <%= render partial: 'shared/results_detail_row', locals: { caption: t('.maintenance_out'), value: gds_number_to_currency(@cfe_result.moe_maintenance_out) } %>
-  <%= render partial: 'shared/results_detail_row', locals: { caption: t('.legal_aid'), value: gds_number_to_currency(@cfe_result.moe_legal_aid) } %>
-  <%= render partial: 'shared/results_total_row', locals: { caption: t('.total_outgoings'), value: gds_number_to_currency(@cfe_result.total_monthly_outgoings) } %>
+  <%= render partial: "shared/results_detail_row", locals: { caption: t(".housing_costs"), value: gds_number_to_currency(@cfe_result.moe_housing) } %>
+  <%= render partial: "shared/results_detail_row", locals: { caption: t(".childcare_costs"), value: gds_number_to_currency(@cfe_result.moe_childcare) } %>
+  <%= render partial: "shared/results_detail_row", locals: { caption: t(".maintenance_out"), value: gds_number_to_currency(@cfe_result.moe_maintenance_out) } %>
+  <%= render partial: "shared/results_detail_row", locals: { caption: t(".legal_aid"), value: gds_number_to_currency(@cfe_result.moe_legal_aid) } %>
+  <%= render partial: "shared/results_total_row", locals: { caption: t(".total_outgoings"), value: gds_number_to_currency(@cfe_result.total_monthly_outgoings) } %>
   </tbody>
 </table>

--- a/app/views/providers/capital_income_assessment_results/_result_details.html.erb
+++ b/app/views/providers/capital_income_assessment_results/_result_details.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-details govuk-!-margin-top-6" data-module="govuk-details">
   <h2 class="govuk-heading-l">
-    <%= t('.client_eligibility_calculation') %>
+    <%= t(".client_eligibility_calculation") %>
   </h2>
 
   <%= govuk_accordion do |accordion| %>

--- a/app/views/providers/capital_income_assessment_results/show.html.erb
+++ b/app/views/providers/capital_income_assessment_results/show.html.erb
@@ -1,8 +1,8 @@
 <%= page_template(
-        page_title: t(".page_title", result: t(".result.#{@cfe_result.assessment_result}") ),
-        head_title: t(".tab_title.#{@cfe_result.assessment_result}" ),
-        template: :basic,
-        column_width: :full
+      page_title: t(".page_title", result: t(".result.#{@cfe_result.assessment_result}")),
+      head_title: t(".tab_title.#{@cfe_result.assessment_result}"),
+      template: :basic,
+      column_width: :full,
     ) do %>
 
   <div class="interruption-panel">
@@ -12,8 +12,8 @@
   <%= render "result_details" %>
 
   <%= next_action_buttons_with_form(
-          url: providers_legal_aid_application_capital_income_assessment_result_path(@legal_aid_application),
-          method: :patch,
-          show_draft: true
+        url: providers_legal_aid_application_capital_income_assessment_result_path(@legal_aid_application),
+        method: :patch,
+        show_draft: true,
       ) %>
 <% end %>

--- a/app/views/providers/capital_introductions/show.html.erb
+++ b/app/views/providers/capital_introductions/show.html.erb
@@ -1,16 +1,16 @@
-<%= page_template page_title: t('.h1-heading') do %>
+<%= page_template page_title: t(".h1-heading") do %>
   <ol class="govuk-list govuk-list--number govuk-heading-m">
-    <li><%= t('.capital_list_heading') %></li>
-    <p class="govuk-body govuk-!-margin-top-4"><%= t('.capital_text') %></p>
-    <%= list_from_translation_path '.capital_introductions.show.capital_items' %>
+    <li><%= t(".capital_list_heading") %></li>
+    <p class="govuk-body govuk-!-margin-top-4"><%= t(".capital_text") %></p>
+    <%= list_from_translation_path ".capital_introductions.show.capital_items" %>
 
-    <li><%= t('.merits_list_heading') %></li>
-    <p class="govuk-body govuk-!-margin-top-4"><%= t('.merits_text') %></p>
-    <%= list_from_translation_path '.capital_introductions.show.merits_items' %>
+    <li><%= t(".merits_list_heading") %></li>
+    <p class="govuk-body govuk-!-margin-top-4"><%= t(".merits_text") %></p>
+    <%= list_from_translation_path ".capital_introductions.show.merits_items" %>
 
     <% if @legal_aid_application.section_8_proceedings? %>
       <div style="margin-top: -0.5em">
-        <%= list_from_translation_path '.capital_introductions.show.section_8_items' %>
+        <%= list_from_translation_path ".capital_introductions.show.section_8_items" %>
       </div>
     <% end %>
 
@@ -21,8 +21,8 @@
   <%= next_action_buttons_with_form(
         url: providers_legal_aid_application_capital_introduction_path,
         method: :patch,
-        continue_button_text: t('generic.continue'),
-        show_draft: true
+        continue_button_text: t("generic.continue"),
+        show_draft: true,
       ) %>
 
 <% end %>

--- a/app/views/providers/check_benefits/_check_benefits_result.html.erb
+++ b/app/views/providers/check_benefits/_check_benefits_result.html.erb
@@ -7,7 +7,7 @@
           url: providers_legal_aid_application_check_benefit_path,
           method: :patch,
           show_draft: true,
-          continue_button_text: t('generic.continue')
+          continue_button_text: t("generic.continue"),
         ) %>
   <% end %>
 </div>

--- a/app/views/providers/check_benefits/index.html.erb
+++ b/app/views/providers/check_benefits/index.html.erb
@@ -7,7 +7,7 @@
           url: providers_legal_aid_application_check_benefit_path,
           method: :patch,
           show_draft: true,
-          continue_button_text: t('generic.continue')
+          continue_button_text: t("generic.continue"),
         ) %>
   <% end %>
 </div>

--- a/app/views/providers/check_client_details/show.html.erb
+++ b/app/views/providers/check_client_details/show.html.erb
@@ -1,47 +1,41 @@
-<%= page_template page_title: t('.title'), template: :basic do %>
+<%= page_template page_title: t(".title"), template: :basic do %>
   <%= form_with(
         model: @form,
         url: providers_legal_aid_application_check_client_details_path(@legal_aid_application),
         method: :patch,
-        local: true
+        local: true,
       ) do |form| %>
 
     <%= govuk_fieldset_header page_title %>
 
     <table class="govuk-table">
-      <caption class="govuk-table__caption govuk-table__caption--m govuk-visually-hidden"><%= t('.table_caption') %></caption>
+      <caption class="govuk-table__caption govuk-table__caption--m govuk-visually-hidden"><%= t(".table_caption") %></caption>
       <thead class="govuk-table__head">
       </thead>
       <tbody class="govuk-table__body">
       <tr class="govuk-table__row">
-        <th scope="row" class="govuk-table__header"><%= t('.name') %></th>
+        <th scope="row" class="govuk-table__header"><%= t(".name") %></th>
         <td class="govuk-table__cell"><%= "#{@applicant.first_name} #{@applicant.last_name}" %></td>
       </tr>
       <tr class="govuk-table__row">
-        <th scope="row" class="govuk-table__header"><%= t('.date_of_birth') %></th>
-        <td class="govuk-table__cell"><%= @applicant.date_of_birth.strftime('%e %B %Y') %></td>
+        <th scope="row" class="govuk-table__header"><%= t(".date_of_birth") %></th>
+        <td class="govuk-table__cell"><%= @applicant.date_of_birth.strftime("%e %B %Y") %></td>
       </tr>
       <tr class="govuk-table__row">
-        <th scope="row" class="govuk-table__header"><%= t('.national_insurance_number') %></th>
+        <th scope="row" class="govuk-table__header"><%= t(".national_insurance_number") %></th>
         <td class="govuk-table__cell"><%= @applicant.national_insurance_number.gsub(/(.{2})(?=.)/, '\1 \2') %></td>
       </tr>
       </tbody>
     </table>
 
-    <% options = [
-                  OpenStruct.new(value: true, label: t('.details_correct')),
-                  OpenStruct.new(value: false, label: t('.details_incorrect'))
-                 ] %>
+    <% options = [[true, t(".details_correct")], [false, t(".details_incorrect")]] %>
 
     <%= form.govuk_collection_radio_buttons :check_client_details,
                                             options,
-                                            :value,
-                                            :label,
+                                            :first,
+                                            :second,
                                             legend: nil %>
 
-    <%= next_action_buttons(
-          show_draft: true,
-          form: form
-        ) %>
+    <%= next_action_buttons(show_draft: true, form:) %>
   <% end %>
 <% end %>

--- a/app/views/providers/check_merits_answers/show.html.erb
+++ b/app/views/providers/check_merits_answers/show.html.erb
@@ -1,6 +1,6 @@
 <%= page_template(
-      page_title: t('.h1-heading'),
-      back_link: { path: reset_providers_legal_aid_application_check_merits_answers_path(@legal_aid_application), method: :patch }
+      page_title: t(".h1-heading"),
+      back_link: { path: reset_providers_legal_aid_application_check_merits_answers_path(@legal_aid_application), method: :patch },
     ) do %>
 
   <%= render(
@@ -12,14 +12,14 @@
         allegation: @legal_aid_application&.allegation,
         undertaking: @legal_aid_application&.undertaking,
         urgency: @legal_aid_application&.urgency,
-        read_only: false
+        read_only: false,
       ) %>
   <div class="govuk-!-padding-bottom-6"></div>
 
   <%= next_action_buttons_with_form(
-          url: continue_providers_legal_aid_application_check_merits_answers_path(@legal_aid_application),
-          method: :patch,
-          show_draft: true
+        url: continue_providers_legal_aid_application_check_merits_answers_path(@legal_aid_application),
+        method: :patch,
+        show_draft: true,
       ) %>
 
 <% end %>

--- a/app/views/providers/check_passported_answers/show.html.erb
+++ b/app/views/providers/check_passported_answers/show.html.erb
@@ -1,19 +1,19 @@
 <%= page_template(
-      page_title: t('.h1-heading'),
-      back_link: { path: reset_providers_legal_aid_application_check_passported_answers_path(@legal_aid_application), method: :patch }
+      page_title: t(".h1-heading"),
+      back_link: { path: reset_providers_legal_aid_application_check_passported_answers_path(@legal_aid_application), method: :patch },
     ) do %>
 
-  <h2 class="govuk-heading-l"><%= t('.h2-heading') %></h2>
+  <h2 class="govuk-heading-l"><%= t(".h2-heading") %></h2>
 
-  <%= render 'shared/check_answers/assets' %>
+  <%= render "shared/check_answers/assets" %>
 
-  <h2 class="govuk-heading-m"><%= t('.chances_of_success_h2') %></h2>
+  <h2 class="govuk-heading-m"><%= t(".chances_of_success_h2") %></h2>
 
-  <p class="govuk-body"><%= t('.chances_of_success_body') %></p>
+  <p class="govuk-body"><%= t(".chances_of_success_body") %></p>
 
   <%= next_action_buttons_with_form(
         url: continue_providers_legal_aid_application_check_passported_answers_path(@legal_aid_application),
         method: :patch,
-        show_draft: true
+        show_draft: true,
       ) %>
 <% end %>

--- a/app/views/providers/check_provider_answers/_read_only.html.erb
+++ b/app/views/providers/check_provider_answers/_read_only.html.erb
@@ -2,31 +2,31 @@
   <% notification_banner.heading(text: t(".banner.your_client_needs_to")) %>
 <% end %>
 
-  <p class="govuk-body"><%= t '.sent_email_text', email: @legal_aid_application.applicant.email %></p>
+  <p class="govuk-body"><%= t ".sent_email_text", email: @legal_aid_application.applicant.email %></p>
 
-  <%= link_to_accessible t('.change_email_button') ,
+  <%= link_to_accessible t(".change_email_button"),
                          providers_legal_aid_application_email_address_path,
-                         role: 'button',
-                         class: 'govuk-button govuk-button--secondary',
-                         id: 'change-email' %>
+                         role: "button",
+                         class: "govuk-button govuk-button--secondary",
+                         id: "change-email" %>
 
   <%= page_template(
-          page_title: t('.title'),
-          back_link: {
-              path: providers_legal_aid_applications_path,
-              text: t('generic.home'),
-              method: :get
-          }
+        page_title: t(".title"),
+        back_link: {
+          path: providers_legal_aid_applications_path,
+          text: t("generic.home"),
+          method: :get,
+        },
       ) do %>
 
-    <%= render('providers/check_provider_answers/shared',
+    <%= render("providers/check_provider_answers/shared",
                applicant: @applicant,
                address: @address,
                read_only: @read_only) %>
     <%= next_action_buttons_with_form(
-            url: providers_legal_aid_applications_path,
-            method: :get,
-            show_draft: false,
-            continue_button_text: t('generic.back_to_your_applications')
+          url: providers_legal_aid_applications_path,
+          method: :get,
+          show_draft: false,
+          continue_button_text: t("generic.back_to_your_applications"),
         ) %>
 <% end %>

--- a/app/views/providers/check_provider_answers/_shared.html.erb
+++ b/app/views/providers/check_provider_answers/_shared.html.erb
@@ -1,61 +1,61 @@
-  <h2 class="govuk-heading-m"><%= t '.section_client.heading' %></h2>
+  <h2 class="govuk-heading-m"><%= t ".section_client.heading" %></h2>
 
   <%= render(
-          'shared/check_answers/client_details',
-          attributes: %i[first_name last_name date_of_birth national_insurance_number address],
-          applicant: @applicant,
-          address: @address,
-          read_only: @read_only
+        "shared/check_answers/client_details",
+        attributes: %i[first_name last_name date_of_birth national_insurance_number address],
+        applicant: @applicant,
+        address: @address,
+        read_only: @read_only,
       ) %>
     <div class="govuk-grid-row" id="app-check-your-answers__proceedings">
       <div class="govuk-grid-column-two-thirds">
-        <h2 class="govuk-heading-m"><%= t '.section_proceeding.heading' %></h2>
+        <h2 class="govuk-heading-m"><%= t ".section_proceeding.heading" %></h2>
       </div>
       <div class="govuk-grid-column-one-third">
-        <p><%= link_to_accessible t('.change'), providers_legal_aid_application_has_other_proceedings_path(@legal_aid_application), class: 'govuk-link govuk-link-right' %></p>
+        <p><%= link_to_accessible t(".change"), providers_legal_aid_application_has_other_proceedings_path(@legal_aid_application), class: "govuk-link govuk-link-right" %></p>
       </div>
     </div>
     <%= render(
-          'shared/check_answers/proceedings_details',
+          "shared/check_answers/proceedings_details",
           legal_aid_application: @legal_aid_application,
-          read_only: @read_only
+          read_only: @read_only,
         ) %>
     <% @legal_aid_application.proceedings.in_order_of_addition.each do |proceeding| %>
       <%= render(
-            'shared/check_answers/proceeding_details',
-            proceeding: proceeding,
-            read_only: @read_only
+            "shared/check_answers/proceeding_details",
+            proceeding:,
+            read_only: @read_only,
           ) %>
     <% end %>
 
   <% if @legal_aid_application.used_delegated_functions? %>
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <h2 class="govuk-heading-m"><%= t '.emergency_cost_limit' %></h2>
+        <h2 class="govuk-heading-m"><%= t ".emergency_cost_limit" %></h2>
       </div>
       <div class="govuk-grid-column-one-third">
-        <p><%= link_to_accessible t('.change'), providers_legal_aid_application_limitations_path(@legal_aid_application), class: 'govuk-link govuk-link-right' %></p>
+        <p><%= link_to_accessible t(".change"), providers_legal_aid_application_limitations_path(@legal_aid_application), class: "govuk-link govuk-link-right" %></p>
       </div>
     </div>
     <%= render(
-          'shared/check_answers/emergency_costs',
+          "shared/check_answers/emergency_costs",
           legal_aid_application: @legal_aid_application,
-          read_only: @read_only
+          read_only: @read_only,
         ) %>
   <% end %>
 
   <% if @legal_aid_application.substantive_cost_overridable? %>
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <h2 class="govuk-heading-m"><%= t '.substantive_cost_limit' %></h2>
+        <h2 class="govuk-heading-m"><%= t ".substantive_cost_limit" %></h2>
       </div>
       <div class="govuk-grid-column-one-third">
-        <p><%= link_to_accessible t('.change'), providers_legal_aid_application_limitations_path(@legal_aid_application), class: 'govuk-link govuk-link-right' %></p>
+        <p><%= link_to_accessible t(".change"), providers_legal_aid_application_limitations_path(@legal_aid_application), class: "govuk-link govuk-link-right" %></p>
       </div>
     </div>
     <%= render(
-          'shared/check_answers/substantive_costs',
+          "shared/check_answers/substantive_costs",
           legal_aid_application: @legal_aid_application,
-          read_only: @read_only
+          read_only: @read_only,
         ) %>
   <% end %>

--- a/app/views/providers/check_provider_answers/_standard.html.erb
+++ b/app/views/providers/check_provider_answers/_standard.html.erb
@@ -1,27 +1,27 @@
 <%= page_template(
-        page_title: t('.title'),
-        back_link: {
-            path: reset_providers_legal_aid_application_check_provider_answers_path,
-            text: t('generic.back'),
-            method: :post
-        }
+      page_title: t(".title"),
+      back_link: {
+        path: reset_providers_legal_aid_application_check_provider_answers_path,
+        text: t("generic.back"),
+        method: :post,
+      },
     ) do %>
-  <%= render('providers/check_provider_answers/shared',
+  <%= render("providers/check_provider_answers/shared",
              applicant: @applicant,
              address: @address,
              read_only: @read_only) %>
 
   <% if @applicant.national_insurance_number? %>
-    <h2 class="govuk-heading-m"><%= t '.section_next.heading' %></h2>
+    <h2 class="govuk-heading-m"><%= t ".section_next.heading" %></h2>
 
     <p class="govuk-body govuk-!-margin-bottom-9">
-      <%= t '.section_next.content' %>
+      <%= t ".section_next.content" %>
     </p>
   <% end %>
 
   <%= next_action_buttons_with_form(
-          url: continue_providers_legal_aid_application_check_provider_answers_path,
-          method: :patch,
-          show_draft: true
+        url: continue_providers_legal_aid_application_check_provider_answers_path,
+        method: :patch,
+        show_draft: true,
       ) %>
 <% end %>

--- a/app/views/providers/check_provider_answers/index.html.erb
+++ b/app/views/providers/check_provider_answers/index.html.erb
@@ -1,10 +1,10 @@
 <% pass_through = {
-                    applicant: @applicant,
-                    address: @address,
-                    read_only: @read_only
-                  } %>
+     applicant: @applicant,
+     address: @address,
+     read_only: @read_only,
+   } %>
 <% if @read_only %>
-  <%= render 'providers/check_provider_answers/read_only', pass_through %>
+  <%= render "providers/check_provider_answers/read_only", pass_through %>
 <% else %>
-  <%= render 'providers/check_provider_answers/standard', pass_through %>
+  <%= render "providers/check_provider_answers/standard", pass_through %>
 <% end %>

--- a/app/views/providers/client_completed_means/show.html.erb
+++ b/app/views/providers/client_completed_means/show.html.erb
@@ -1,6 +1,6 @@
-<%= page_template page_title: t('.h1-heading', client_name: @legal_aid_application.applicant.full_name) do %>
+<%= page_template page_title: t(".h1-heading", client_name: @legal_aid_application.applicant.full_name) do %>
 
-  <p class="govuk-body-l"><%= t('.what_to_do') %></p>
+  <p class="govuk-body-l"><%= t(".what_to_do") %></p>
 
   <% @action_list.each_with_index do |action, index| %>
 
@@ -16,6 +16,6 @@
   <%= next_action_buttons_with_form(
         url: providers_legal_aid_application_client_completed_means_path,
         method: :patch,
-        continue_button_text: t('generic.continue')
+        continue_button_text: t("generic.continue"),
       ) %>
 <% end %>

--- a/app/views/providers/confirm_client_declarations/show.html.erb
+++ b/app/views/providers/confirm_client_declarations/show.html.erb
@@ -2,10 +2,10 @@
       model: @form,
       url: providers_legal_aid_application_confirm_client_declaration_path(@legal_aid_application),
       method: :patch,
-      local: true
+      local: true,
     ) do |form| %>
 
-  <%= page_template page_title: t(".h1-heading"), form: form do %>
+  <%= page_template page_title: t(".h1-heading"), form: do %>
 
     <% params = { provider_firm_name: @legal_aid_application.provider.firm.name } %>
 
@@ -21,7 +21,7 @@
 
     <%= bullet_list_from_translation_array(
           "providers.confirm_client_declarations.show.#{i18n_prefix}.list",
-          params: params
+          params:,
         ) %>
 
     <%= govuk_warning_text do %>
@@ -36,10 +36,10 @@
             "",
             link_errors: true,
             multiple: false,
-            label: { text: t(".confirmation_checkbox") }
+            label: { text: t(".confirmation_checkbox") },
           ) %>
     <% end %>
 
-    <%= next_action_buttons(form: form, show_draft: true) %>
+    <%= next_action_buttons(form:, show_draft: true) %>
   <% end %>
 <% end %>

--- a/app/views/providers/confirm_dwp_non_passported_applications/show.html.erb
+++ b/app/views/providers/confirm_dwp_non_passported_applications/show.html.erb
@@ -1,27 +1,28 @@
 <div class="interruption-panel">
-  <%= page_template(page_title: t('.tab_title'), column_width: :full, template: :basic) do %>
+  <%= page_template(page_title: t(".tab_title"), column_width: :full, template: :basic) do %>
 
     <%= form_with(
           model: @form,
           url: providers_legal_aid_application_confirm_dwp_non_passported_applications_path,
           method: :patch,
-          local: true
+          local: true,
         ) do |form| %>
 
+      <% options = [[true, t("generic.yes")], [false, t(".no")]] %>
+
       <%= form.govuk_collection_radio_buttons :correct_dwp_result,
-                                              [OpenStruct.new(value: true, label: t('generic.yes')),
-                                               OpenStruct.new(value: false, label: t('.no'))],
-                                              :value,
-                                              :label,
-                                              legend: {text: t('.title_html'), tag: 'h1', size: 'l'},
-                                              classes: ['govuk-!-margin-top-4'] %>
+                                              options,
+                                              :first,
+                                              :second,
+                                              legend: { text: t(".title_html"), tag: "h1", size: "l" },
+                                              classes: ["govuk-!-margin-top-4"] %>
 
       <% if display_hmrc_inset_text? %>
         <%= govuk_inset_text(text: t(".hmrc_inset_text")) %>
       <% end %>
 
       <% if @form.errors.any? %>
-        <%= link_to_accessible @form.errors.map { |error| error.message }.first, "#correct_dwp_result-true-field", class: 'govuk-heading-s' %>
+        <%= link_to_accessible @form.errors.map(&:message).first, "#correct_dwp_result-true-field", class: "govuk-heading-s" %>
       <% end %>
 
       <div class="govuk-!-padding-bottom-4"></div>
@@ -30,7 +31,7 @@
             url: providers_legal_aid_application_confirm_dwp_non_passported_applications_path,
             method: :patch,
             show_draft: true,
-            continue_button_text: t('generic.save_and_continue')
+            continue_button_text: t("generic.save_and_continue"),
           ) %>
     <% end %>
   <% end %>

--- a/app/views/providers/confirm_non_means_tested_applications/show.html.erb
+++ b/app/views/providers/confirm_non_means_tested_applications/show.html.erb
@@ -12,7 +12,7 @@
           url: providers_legal_aid_application_confirm_non_means_tested_applications_path,
           method: :patch,
           show_draft: true,
-          continue_button_text: t('generic.continue')
+          continue_button_text: t("generic.continue"),
         ) %>
   <% end %>
 </div>

--- a/app/views/providers/confirm_offices/show.html.erb
+++ b/app/views/providers/confirm_offices/show.html.erb
@@ -3,16 +3,17 @@
               method: :patch,
               local: true) do |form| %>
 
-  <%= page_template page_title: t('.h1-heading', office_code: current_provider.selected_office.code), form: form, template: :basic do %>
+  <%= page_template page_title: t(".h1-heading", office_code: current_provider.selected_office.code), form:, template: :basic do %>
+
+    <% options = [[true, t("generic.yes")], [false, t(".no_another_office")]] %>
 
     <%= form.govuk_collection_radio_buttons :confirm_office,
-                                            [OpenStruct.new(value: true, label: t('generic.yes')),
-                                             OpenStruct.new(value: false, label: t('.no_another_office'))],
-                                            :value,
-                                            :label,
-                                            legend: {text: content_for(:page_title), tag: 'h1', size: 'xl'} %>
+                                            options,
+                                            :first,
+                                            :second,
+                                            legend: { text: content_for(:page_title), tag: "h1", size: "xl" } %>
 
     <div class="govuk-!-padding-bottom-2"></div>
-    <%= next_action_buttons(form: form) %>
+    <%= next_action_buttons(form:) %>
   <% end %>
 <% end %>

--- a/app/views/providers/cookies/show.html.erb
+++ b/app/views/providers/cookies/show.html.erb
@@ -1,53 +1,52 @@
 <% new_head_title = if @successfully_saved
-                      t('.success_message')
+                      t(".success_message")
                     else
-                      t('.page_title')
+                      t(".page_title")
                     end %>
 <%= form_with(model: @form,
               url: providers_cooky_path,
               method: :patch,
               local: true) do |form| %>
 
-  <%= page_template page_title: t('.page_title'), head_title: new_head_title, template: :basic, form: form do %>
+  <%= page_template page_title: t(".page_title"), head_title: new_head_title, template: :basic, form: do %>
 
     <% if @successfully_saved %>
       <%= govuk_notification_banner(title_text: t("generic.success"), success: true) do |notification_banner| %>
-        <% notification_banner.heading(text: t('.success_message')) %>
+        <% notification_banner.heading(text: t(".success_message")) %>
         <%= link_to t(".go_back_link"), back_path %>
       <% end %>
     <% end %>
 
-    <h1 class="govuk-heading-l"><%= t('.page_title') %></h1>
+    <h1 class="govuk-heading-l"><%= t(".page_title") %></h1>
 
-    <p class="govuk-body"><%= t('.cookies_are_files') %></p>
-    <p class="govuk-body"><%= t('.we_use_cookies') %></p>
+    <p class="govuk-body"><%= t(".cookies_are_files") %></p>
+    <p class="govuk-body"><%= t(".we_use_cookies") %></p>
 
-    <h2 class="govuk-heading-m"><%= t('.heading_2') %></h2>
-    <p class="govuk-body"><%= t('.we_use_ga') %></p>
-    <p class="govuk-body"><%= t('.we_do_not_allow') %></p>
-    <p class="govuk-body"><%= t('.google_analytics') %></p>
+    <h2 class="govuk-heading-m"><%= t(".heading_2") %></h2>
+    <p class="govuk-body"><%= t(".we_use_ga") %></p>
+    <p class="govuk-body"><%= t(".we_do_not_allow") %></p>
+    <p class="govuk-body"><%= t(".google_analytics") %></p>
 
-    <%= list_from_translation_path('.cookies.show') %>
+    <%= list_from_translation_path(".cookies.show") %>
 
     <div class="govuk-!-padding-2"></div>
 
     <%= form.govuk_radio_buttons_fieldset :cookies_enabled,
-                                          legend: { size: 'm', tag: 'h2', text: t('.heading_2'), hidden: true } do %>
-      <%= form.govuk_radio_button :cookies_enabled, true, link_errors: true, label: {text: t('.use_this_cookie')} %>
-      <%= form.govuk_radio_button :cookies_enabled, false, label: {text: t('.do_not_use')} %>
+                                          legend: { size: "m", tag: "h2", text: t(".heading_2"), hidden: true } do %>
+      <%= form.govuk_radio_button :cookies_enabled, true, link_errors: true, label: { text: t(".use_this_cookie") } %>
+      <%= form.govuk_radio_button :cookies_enabled, false, label: { text: t(".do_not_use") } %>
     <% end %>
 
     <div class="govuk-!-padding-2"></div>
 
-    <h2 class="govuk-heading-m"><%= t('.heading_3') %></h2>
-    <p class="govuk-body"><%= t('.these_essential_cookies') %></p>
-    <p class="govuk-body"><%= t('.they_always_need') %></p>
+    <h2 class="govuk-heading-m"><%= t(".heading_3") %></h2>
+    <p class="govuk-body"><%= t(".these_essential_cookies") %></p>
+    <p class="govuk-body"><%= t(".they_always_need") %></p>
 
-    <%= link_to_accessible(t('.find_out_more_link'), 'https://www.gov.uk/help/cookie-details', class: 'govuk-link govuk-body') %>
+    <%= link_to_accessible(t(".find_out_more_link"), "https://www.gov.uk/help/cookie-details", class: "govuk-link govuk-body") %>
 
     <div class="govuk-!-padding-2"></div>
 
-    <%= form.submit(t('.save_changes_btn'), class: 'govuk-button form-button') %>
-
+    <%= form.submit(t(".save_changes_btn"), class: "govuk-button form-button") %>
   <% end %>
 <% end %>

--- a/app/views/providers/declarations/show.html.erb
+++ b/app/views/providers/declarations/show.html.erb
@@ -1,14 +1,14 @@
-<%= page_template(page_title: t('.h1-heading')) do %>
-  <p class="govuk-body"><%= t('.statement') %></p>
+<%= page_template(page_title: t(".h1-heading")) do %>
+  <p class="govuk-body"><%= t(".statement") %></p>
   <ul class="govuk-list govuk-list--bullet print-add-bullet">
-    <%- t('.statement-bullets').each do |bullet| %>
+    <%- t(".statement-bullets").each do |bullet| %>
       <li><%= bullet %></li>
     <% end %>
   </ul>
   <%= next_action_buttons_with_form(
-          url: providers_legal_aid_applications_path,
-          method: :post,
-          show_draft: false,
-          continue_button_text: t('.continue_button')
+        url: providers_legal_aid_applications_path,
+        method: :post,
+        show_draft: false,
+        continue_button_text: t(".continue_button"),
       ) %>
 <% end %>

--- a/app/views/providers/delegated_confirmation/index.html.erb
+++ b/app/views/providers/delegated_confirmation/index.html.erb
@@ -1,24 +1,24 @@
 <% content_for(:panel) do %>
   <div class="govuk-panel govuk-panel--confirmation">
     <h1 class="govuk-panel__title">
-      <%= t '.page-heading' %>
+      <%= t ".page-heading" %>
     </h1>
     <div class="govuk-panel__body">
-    <%= t '.sub_title' %>
+    <%= t ".sub_title" %>
     <br>
     <strong><%= @legal_aid_application.application_ref %></strong>
     </div>
   </div>
 <% end %>
 
-<%= page_template page_title: t('.what_happens_next'), back_link: :none do %>
+<%= page_template page_title: t(".what_happens_next"), back_link: :none do %>
   <p class="govuk-body">
-    <%= t('.warning.application_deadline_date') %><%= @legal_aid_application.substantive_application_deadline_on %>.
+    <%= t(".warning.application_deadline_date") %><%= @legal_aid_application.substantive_application_deadline_on %>.
   </p>
   <%= link_to_accessible(
-        t('.back_home'),
+        t(".back_home"),
         providers_legal_aid_applications_path,
-        class: 'govuk-button govuk-button',
-        id: 'continue'
+        class: "govuk-button govuk-button",
+        id: "continue",
       ) %>
 <% end %>

--- a/app/views/providers/delete/show.html.erb
+++ b/app/views/providers/delete/show.html.erb
@@ -1,24 +1,24 @@
-<h1 class="govuk-heading-xl"><%= t('.page_title') %></h1>
+<h1 class="govuk-heading-xl"><%= t(".page_title") %></h1>
 <div class="govuk-panel__body">
   <dl class="govuk-list inline-list">
     <dt>
-      <strong><%= t('.applicant') %>:</strong>
+      <strong><%= t(".applicant") %>:</strong>
     </dt>
     <dd><%= @legal_aid_application.applicant.full_name %></dd>
 
     <dt>
-      <strong><%= t('.reference') %>:</strong>
+      <strong><%= t(".reference") %>:</strong>
     </dt>
     <dd><%= @legal_aid_application.application_ref %></dd>
   </dl>
 </div>
 
-<%= govuk_warning_text(text: t('.warning')) %>
+<%= govuk_warning_text(text: t(".warning")) %>
 
 <%= form_for(@legal_aid_application, url: providers_legal_aid_application_delete_path, method: :delete) do |form| %>
   <%= form.submit(
-          t('.yes_button'),
-          class: 'govuk-button govuk-button--warning',
+        t(".yes_button"),
+        class: "govuk-button govuk-button--warning",
       ) %>
-  <%= link_to_accessible t('.no_button'), providers_legal_aid_applications_path, class: 'govuk-button' %>
+  <%= link_to_accessible t(".no_button"), providers_legal_aid_applications_path, class: "govuk-button" %>
 <% end %>

--- a/app/views/providers/email_addresses/show.html.erb
+++ b/app/views/providers/email_addresses/show.html.erb
@@ -1,27 +1,27 @@
 <%= form_with(
-        model: @form,
-        url: providers_legal_aid_application_email_address_path,
-        method: :patch,
-        local: true
+      model: @form,
+      url: providers_legal_aid_application_email_address_path,
+      method: :patch,
+      local: true,
     ) do |form| %>
 
     <%= page_template(
-        page_title: t('.page_title'),
-        page_heading_options: { margin_bottom: 3 },
-        form: form
-      ) do %>
+          page_title: t(".page_title"),
+          page_heading_options: { margin_bottom: 3 },
+          form:,
+        ) do %>
 
     <div class="govuk-!-padding-bottom-6"></div>
 
     <%= form.govuk_text_field(
           :email,
-          width: 'three-quarters',
-          hint: {text: t('.hint')},
-          label: {text: t('.label')}
+          width: "three-quarters",
+          hint: { text: t(".hint") },
+          label: { text: t(".label") },
         ) %>
 
     <div class="govuk-!-padding-bottom-2"></div>
 
-    <%= next_action_buttons(show_draft: true, form: form) %>
+    <%= next_action_buttons(show_draft: true, form:) %>
   <% end %>
 <% end %>

--- a/app/views/providers/end_of_applications/show.html.erb
+++ b/app/views/providers/end_of_applications/show.html.erb
@@ -1,40 +1,40 @@
-<%= page_template page_title: t('.heading'), template: :basic, back_link: :none do %>
+<%= page_template page_title: t(".heading"), template: :basic, back_link: :none do %>
   <div class="govuk-panel govuk-panel--confirmation">
     <h1 class="govuk-panel__title govuk-!-padding-top-4">
       <%= page_title %>
     </h1>
     <div class="govuk-panel__body">
-      <%= t('.your_case_reference_number') %><br>
+      <%= t(".your_case_reference_number") %><br>
       <strong><%= @legal_aid_application.application_ref %></strong>
     </div>
   </div>
 
-  <p class="govuk-body govuk-!-padding-top-4"><%= t('.confirmation_email_sent') %></p>
+  <p class="govuk-body govuk-!-padding-top-4"><%= t(".confirmation_email_sent") %></p>
 
-  <h2 class="govuk-heading-m"><%= t('.need_to_do') %></h2>
-  <p class="govuk-body"><%= t('.print_application') %></p>
-  <p class="govuk-body"><%= t('.keep_file') %></p>
+  <h2 class="govuk-heading-m"><%= t(".need_to_do") %></h2>
+  <p class="govuk-body"><%= t(".print_application") %></p>
+  <p class="govuk-body"><%= t(".keep_file") %></p>
   <ul class="govuk-list govuk-list--bullet">
-    <li><%= t('.copy_application') %></li>
-    <li><%= t('.financial_evidence') %></li>
-    <li><%= t('.client_sign') %></li>
+    <li><%= t(".copy_application") %></li>
+    <li><%= t(".financial_evidence") %></li>
+    <li><%= t(".client_sign") %></li>
   </ul>
-  <p class="govuk-body"><%= t('.audit') %></p>
+  <p class="govuk-body"><%= t(".audit") %></p>
 
-  <h2 class="govuk-heading-m"><%= t('.what_next') %></h2>
+  <h2 class="govuk-heading-m"><%= t(".what_next") %></h2>
 
-  <p class="govuk-body"><%= t('.application_to_be_checked') %></p>
-  <p class="govuk-body"><%= t('.decision_in_ccms_html') %></p>
+  <p class="govuk-body"><%= t(".application_to_be_checked") %></p>
+  <p class="govuk-body"><%= t(".decision_in_ccms_html") %></p>
 
   <%= govuk_inset_text do %>
-    <p class="govuk-body govuk-!-padding-bottom-2"><%= link_to_accessible t('.feedback_prefix'), new_feedback_path %><%= t('.feedback_suffix') %></p>
+    <p class="govuk-body govuk-!-padding-bottom-2"><%= link_to_accessible t(".feedback_prefix"), new_feedback_path %><%= t(".feedback_suffix") %></p>
   <% end %>
 
   <%= next_action_buttons_with_form(
-      url: providers_legal_aid_application_end_of_application_path,
-      method: :patch,
-      show_draft: true,
-      continue_button_text: t('.view_completed_application'),
-      draft_button_text: t('.back_to_your_applications')
-    ) %>
+        url: providers_legal_aid_application_end_of_application_path,
+        method: :patch,
+        show_draft: true,
+        continue_button_text: t(".view_completed_application"),
+        draft_button_text: t(".back_to_your_applications"),
+      ) %>
 <% end %>

--- a/app/views/providers/gateway_evidences/_uploaded_files.html.erb
+++ b/app/views/providers/gateway_evidences/_uploaded_files.html.erb
@@ -1,10 +1,10 @@
-<table class="govuk-table <%= 'hidden' if attachments.empty? %>">
-  <caption class="govuk-table__caption"><%= t('.title') %></caption>
+<table class="govuk-table <%= "hidden" if attachments.empty? %>">
+  <caption class="govuk-table__caption"><%= t(".title") %></caption>
   <thead class="govuk-table__head">
   <tr class="govuk-table__row">
-    <th class="govuk-table__header" scope="col"><%= t('.filename') %></th>
-    <th class="govuk-table__header" scope="col"><%= t('.size') %></th>
-    <th class="govuk-table__header" scope="col"><%= t('.status') %></th>
+    <th class="govuk-table__header" scope="col"><%= t(".filename") %></th>
+    <th class="govuk-table__header" scope="col"><%= t(".size") %></th>
+    <th class="govuk-table__header" scope="col"><%= t(".status") %></th>
     <th class="govuk-table__header" scope="col"></th>
   </tr>
   </thead>
@@ -17,12 +17,12 @@
       <td class="govuk-table__cell"><%= govuk_tag(text: t(".uploaded")) %></td>
       <td class="govuk-table__cell">
         <%= button_to_accessible(
-              t('.delete'),
+              t(".delete"),
               providers_legal_aid_application_gateway_evidence_path(@legal_aid_application),
               method: :delete,
-              class: 'button-as-link',
+              class: "button-as-link",
               params: { attachment_id: attachment.id },
-              suffix: attachment.document.filename
+              suffix: attachment.document.filename,
             ) %>
       </td>
     </tr>

--- a/app/views/providers/gateway_evidences/show.html.erb
+++ b/app/views/providers/gateway_evidences/show.html.erb
@@ -4,36 +4,36 @@
                     elsif @error_message || @successful_upload
                       "#{@successful_upload} #{@error_message}"
                     else
-                      t('.h1-heading')
+                      t(".h1-heading")
                     end %>
 <%= page_template(
       page_title: "Upload supporting evidence",
       head_title: new_head_title,
       template: :basic,
-      back_link: { path: providers_legal_aid_application_merits_task_list_path(@legal_aid_application) }
+      back_link: { path: providers_legal_aid_application_merits_task_list_path(@legal_aid_application) },
     ) do %>
 
   <%= form_with(
-          model: @form,
-          url: providers_legal_aid_application_gateway_evidence_path,
-          method: :patch,
-          local: true
+        model: @form,
+        url: providers_legal_aid_application_gateway_evidence_path,
+        method: :patch,
+        local: true,
       ) do |form| %>
 
     <%= form.govuk_error_summary %>
 
-    <%= form.govuk_fieldset legend: {text: page_title, tag: 'h1', size: 'xl'} do %>
+    <%= form.govuk_fieldset legend: { text: page_title, tag: "h1", size: "xl" } do %>
 
       <%= govuk_inset_text(text: t(".hint_text")) %>
 
-      <%= form.govuk_file_field :original_file, label: {text: t('generic.upload_file'), size: 'm'},
-                                hint: {text: t('.size_hint')} %>
+      <%= form.govuk_file_field :original_file, label: { text: t("generic.upload_file"), size: "m" },
+                                                hint: { text: t(".size_hint") } %>
 
       <%= form.submit(
-              t('generic.upload'),
-              id: 'upload',
-              name: 'upload_button',
-              class: 'govuk-button govuk-button--secondary'
+            t("generic.upload"),
+            id: "upload",
+            name: "upload_button",
+            class: "govuk-button govuk-button--secondary",
           ) %>
 
       <%#  Customised accessibility alerts within this span below %>
@@ -47,30 +47,30 @@
   <% end %>
 
   <div id="uploaded-files-table-container">
-    <%= render partial: 'uploaded_files', locals: { attachments: @form.model.original_attachments } %>
+    <%= render partial: "uploaded_files", locals: { attachments: @form.model.original_attachments } %>
   </div>
 
     <%= form_with(
           model: @form,
           url: providers_legal_aid_application_gateway_evidence_path,
           method: :patch,
-          local: true
-      ) do |form| %>
+          local: true,
+        ) do |form| %>
 
     <div class="govuk-!-padding-bottom-6"></div>
 
-    <%= next_action_buttons(show_draft: true, form: form) %>
+    <%= next_action_buttons(show_draft: true, form:) %>
   <% end %>
 <% end %>
 
 <script nonce="<%= request.content_security_policy_nonce %>">
   window.LAA_VARS = {
     images: {
-      loading_small: <%= asset_pack_path('media/images/loading-small.gif').to_json.html_safe %>
+      loading_small: <%= asset_pack_path("media/images/loading-small.gif").to_json.html_safe %>
     },
     locales: {
       generic: {
-        uploading: <%= t('generic.uploading').to_json.html_safe %>
+        uploading: <%= t("generic.uploading").to_json.html_safe %>
       }
     }
   };

--- a/app/views/providers/has_evidence_of_benefits/show.html.erb
+++ b/app/views/providers/has_evidence_of_benefits/show.html.erb
@@ -1,22 +1,20 @@
-<%= page_template page_title: t('.page_title', passporting_benefit: @passporting_benefit), template: :basic do %>
+<%= page_template page_title: t(".page_title", passporting_benefit: @passporting_benefit), template: :basic do %>
     <%= form_with(
           model: @form,
           url: providers_legal_aid_application_has_evidence_of_benefit_path,
           method: :patch,
-          local: true
-      ) do |form| %>
+          local: true,
+        ) do |form| %>
 
     <%= form.govuk_collection_radio_buttons :has_evidence_of_benefit, # attribute name
-                                            yes_no_options(yes: t('.radio_hint_yes')), # collection
+                                            yes_no_options(yes: t(".radio_hint_yes")), # collection
                                             :value, # value method
                                             :label, # text method
-                                            :radio_hint, #hint method,
+                                            :radio_hint, # hint method,
                                             bold_labels: false,
-                                            legend: { text: content_for(:page_title), tag: 'h1', size: 'xl' },
-                                            hint: { text: t('.evidence_hint') } %>
-    <%= next_action_buttons(
-            show_draft: true,
-            form: form
-        ) %>
+                                            legend: { text: content_for(:page_title), tag: "h1", size: "xl" },
+                                            hint: { text: t(".evidence_hint") } %>
+
+    <%= next_action_buttons(show_draft: true, form:) %>
   <% end %>
 <% end %>

--- a/app/views/providers/has_national_insurance_numbers/show.html.erb
+++ b/app/views/providers/has_national_insurance_numbers/show.html.erb
@@ -2,38 +2,38 @@
       model: @form,
       url: providers_legal_aid_application_has_national_insurance_number_path(@legal_aid_application),
       method: :patch,
-      local: true
-  ) do |form| %>
+      local: true,
+    ) do |form| %>
 
-  <%= page_template page_title: t('.page_title'), template: :basic, form: form do %>
+  <%= page_template page_title: t(".page_title"), template: :basic, form: do %>
 
     <%= form.govuk_radio_buttons_fieldset(:has_national_insurance_number,
-                                          legend: { text: page_title, size: 'xl', tag: 'h1' }) do %>
+                                          legend: { text: page_title, size: "xl", tag: "h1" }) do %>
 
       <p class="govuk-body govuk-!-margin-top-3 govuk-!-margin-bottom-6">
-        <%= t('.hint') %>
+        <%= t(".hint") %>
       </p>
 
       <%= form.govuk_radio_button(
-              :has_national_insurance_number,
-              true,
-              link_errors: true,
-              label: {text: t('generic.yes')},
+            :has_national_insurance_number,
+            true,
+            link_errors: true,
+            label: { text: t("generic.yes") },
           ) do %>
         <%= form.govuk_text_field(
               :national_insurance_number,
-              label: { text: t('.nino_label') },
-              width: 10
+              label: { text: t(".nino_label") },
+              width: 10,
             ) %>
       <% end %>
 
       <%= form.govuk_radio_button(
-              :has_national_insurance_number,
-              false,
-              label: {text: t('generic.no')}
+            :has_national_insurance_number,
+            false,
+            label: { text: t("generic.no") },
           ) %>
     <% end %>
 
-    <%= next_action_buttons(show_draft: true, form: form) %>
+    <%= next_action_buttons(show_draft: true, form:) %>
   <% end %>
 <% end %>

--- a/app/views/providers/has_other_proceedings/show.html.erb
+++ b/app/views/providers/has_other_proceedings/show.html.erb
@@ -2,21 +2,21 @@
               url: providers_legal_aid_application_has_other_proceedings_path,
               method: :patch,
               local: true) do |form| %>
-  <%= page_template page_title: t('.page_title'), template: :basic, form: form do %>
+  <%= page_template page_title: t(".page_title"), template: :basic, form: do %>
 
     <% if @legal_aid_application.proceedings.any? %>
-      <h1 class="govuk-heading-xl"><%= t('.existing', count: "#{pluralize(@legal_aid_application.proceedings.count, 'proceeding')}") %></h1>
+      <h1 class="govuk-heading-xl"><%= t(".existing", count: pluralize(@legal_aid_application.proceedings.count, "proceeding").to_s) %></h1>
       <div class="govuk-summary-list">
         <% @legal_aid_application.proceedings.order(:created_at).each do |proceeding| %>
           <dl class="govuk-summary-list__row" id="proceeding_type_<%= proceeding.ccms_code %>">
             <dt class="govuk-summary-list__value"><%= proceeding.meaning %></dt>
             <dd class="govuk-summary-list__actions">
               <%= link_to_accessible(
-                    t('.remove'),
+                    t(".remove"),
                     providers_legal_aid_application_has_other_proceedings_path(@legal_aid_application, ccms_code: proceeding.ccms_code),
-                    class: 'govuk-link change-link',
+                    class: "govuk-link change-link",
                     method: :delete,
-                    suffix: proceeding.meaning
+                    suffix: proceeding.meaning,
                   ) %>
             </dd>
           </dl>
@@ -25,11 +25,8 @@
     <% end %>
 
     <%= form.govuk_collection_radio_buttons :has_other_proceeding, yes_no_options, :value, :label,
-                                            legend: {text: content_for(:page_title), tag: 'h2', size: 'm'} %>
+                                            legend: { text: content_for(:page_title), tag: "h2", size: "m" } %>
 
-    <%= next_action_buttons(
-            form: form,
-            show_draft: true
-        ) %>
+    <%= next_action_buttons(form:, show_draft: true) %>
   <% end %>
 <% end %>

--- a/app/views/providers/income_summary/_add_other_income.html.erb
+++ b/app/views/providers/income_summary/_add_other_income.html.erb
@@ -1,12 +1,12 @@
 <li>
   <div class="app-task-list__section">
     <span class="app-task-list__section-number">
-      <%= image_pack_tag('plus_icon.svg', alt: '') %>
+      <%= image_pack_tag("plus_icon.svg", alt: "") %>
     </span>
     <%= link_to_accessible(
-          t('.add_other_income'),
+          t(".add_other_income"),
           providers_legal_aid_application_means_identify_types_of_income_path(@legal_aid_application),
-          class: 'govuk-body'
+          class: "govuk-body",
         ) %>
   </div>
 </li>

--- a/app/views/providers/income_summary/_income_type_item.html.erb
+++ b/app/views/providers/income_summary/_income_type_item.html.erb
@@ -1,20 +1,18 @@
-<%
-  transaction_link = link_to_accessible(
-    link_text,
-    providers_legal_aid_application_incoming_transactions_path(transaction_type: name),
-    class: 'govuk-body transaction-type-link',
-    suffix: "for #{t "transaction_types.names.providers.#{name}"}"
-  )
-  form_group_error_class = error.present? ? 'govuk-form-group--error' : ''
-  error_message = error.present? ? error.first : ''
-%>
+<% transaction_link = link_to_accessible(
+     link_text,
+     providers_legal_aid_application_incoming_transactions_path(transaction_type: name),
+     class: "govuk-body transaction-type-link",
+     suffix: "for #{t "transaction_types.names.providers.#{name}"}",
+   ) %>
+<% form_group_error_class = error.present? ? "govuk-form-group--error" : "" %>
+<% error_message = error.present? ? error.first : "" %>
 
-<li id="<%= "#{name}" %>" class="<%= form_group_error_class %>">
+<li id="<%= name.to_s %>" class="<%= form_group_error_class %>">
   <h2 class="app-task-list__section">
     <% if display_number %>
       <span class="app-task-list__section-number"><%= number %>. </span>
     <% else %>
-      <span class="app-task-list__section-number"><%= '' %> </span>
+      <span class="app-task-list__section-number"><%= "" %> </span>
     <% end %>
 
     <%= t("transaction_types.names.providers.#{name}") %>
@@ -27,9 +25,9 @@
       <p id='<%= "error-#{name}" %>' class="govuk-error-message"><%= error_message %></p>
     <% end %>
   </h2>
-  <%= content_tag(:div, class: 'app-task-list__items', id: "list-item-#{name}") do %>
+  <%= content_tag(:div, class: "app-task-list__items", id: "list-item-#{name}") do %>
     <% if bank_transactions.present? %>
-      <%= render 'providers/bank_transactions/list_selected', category: name, bank_transactions: bank_transactions %>
+      <%= render "providers/bank_transactions/list_selected", category: name, bank_transactions: %>
       <%= transaction_link %>
     <% else %>
       <p class="app-task-list__item">

--- a/app/views/providers/income_summary/index.html.erb
+++ b/app/views/providers/income_summary/index.html.erb
@@ -1,30 +1,28 @@
-<%= page_template page_title: t('.page_heading'), show_errors_for: @legal_aid_application do %>
+<%= page_template page_title: t(".page_heading"), show_errors_for: @legal_aid_application do %>
 
-<%
-  errors = @legal_aid_application.errors.messages
-%>
+  <% errors = @legal_aid_application.errors.messages %>
 
-  <p class="gov-body"><%= t('.subheading') %></p>
+  <p class="gov-body"><%= t(".subheading") %></p>
 
-  <p class="gov-body"><%= t('.you_need_to.text') %></p>
-  <%= list_from_translation_path('.income_summary.index.you_need_to') %>
+  <p class="gov-body"><%= t(".you_need_to.text") %></p>
+  <%= list_from_translation_path(".income_summary.index.you_need_to") %>
 
   <ol class="app-task-list">
     <% index = 0 %>
     <% @legal_aid_application.transaction_types.credits.each do |transaction_type| %>
       <% index += 1 unless transaction_type.child? %>
       <%= render(
-            'income_type_item',
+            "income_type_item",
             name: transaction_type.name,
             number: index,
             display_number: !transaction_type.child?,
             link_text: t(".select"),
             bank_transactions: @bank_transactions[transaction_type],
-            error: errors[transaction_type.name.to_sym]
+            error: errors[transaction_type.name.to_sym],
           ) %>
     <% end %>
       <% if @legal_aid_application.transaction_types.credits.count < TransactionType.credits.count %>
-        <%= render partial: 'add_other_income' %>
+        <%= render partial: "add_other_income" %>
       <% end %>
   </ol>
 
@@ -32,6 +30,6 @@
 
   <%= next_action_buttons_with_form(
         url: providers_legal_aid_application_income_summary_index_path,
-        show_draft: true
+        show_draft: true,
       ) %>
 <% end %>

--- a/app/views/providers/invalid_logins/show.html.erb
+++ b/app/views/providers/invalid_logins/show.html.erb
@@ -1,5 +1,5 @@
-<% page_title = @provider.provider_details_api_error? ? '.error_title' : '.permission_title' %>
-<% error_translation = @provider.invalid_login_details || 'api_details_user_not_found' %>
+<% page_title = @provider.provider_details_api_error? ? ".error_title" : ".permission_title" %>
+<% error_translation = @provider.invalid_login_details || "api_details_user_not_found" %>
 
 <%= page_template page_title: t(page_title), back_link: :none do %>
   <p><%= t(".#{error_translation}.html", team_email: Rails.configuration.x.support_email_address) %></p>
@@ -7,4 +7,4 @@
 
 <p /><p />
 
-<%= link_to_accessible t('generic.return_to_portal'), @portal_url, class: 'govuk-link' %>
+<%= link_to_accessible t("generic.return_to_portal"), @portal_url, class: "govuk-link" %>

--- a/app/views/providers/legal_aid_applications/_legal_aid_applications.html.erb
+++ b/app/views/providers/legal_aid_applications/_legal_aid_applications.html.erb
@@ -1,48 +1,48 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <table class="govuk-table sortable table-merge_columns">
-      <caption class="govuk-visually-hidden"><%= t('.table_description') %></caption>
+      <caption class="govuk-visually-hidden"><%= t(".table_description") %></caption>
       <thead class="govuk-table__head">
         <tr class="govuk-table__row">
-          <%= sort_column_th type: :alphabetic, content: t('.applicant_name'), currently_sorted: @initial_sort[:applicant_name] %>
-          <%= sort_column_th type: :date, content: t('.created_at'), currently_sorted: @initial_sort[:created_at], combine_right: { at: 555, append: t('.col_and_ref') } %>
-          <%= sort_column_th type: :alphabetic, content: t('.application_ref_html'), currently_sorted: @initial_sort[:applicant_ref] %>
+          <%= sort_column_th type: :alphabetic, content: t(".applicant_name"), currently_sorted: @initial_sort[:applicant_name] %>
+          <%= sort_column_th type: :date, content: t(".created_at"), currently_sorted: @initial_sort[:created_at], combine_right: { at: 555, append: t(".col_and_ref") } %>
+          <%= sort_column_th type: :alphabetic, content: t(".application_ref_html"), currently_sorted: @initial_sort[:applicant_ref] %>
           <th class="nullcell" aria-hidden="true"></th>
-          <%= sort_column_th type: :alphabetic, content: t('.certificate_type'), currently_sorted: @initial_sort[:certificate_type], combine_right: { at: 555, append: t('.col_and_state') } %>
-          <%= sort_column_th type: :alphabetic, content: t('.status'), currently_sorted: @initial_sort[:status] %>
-          <th class='govuk-table__header clear-all' scope='col'><%= t('.action') %></th>
+          <%= sort_column_th type: :alphabetic, content: t(".certificate_type"), currently_sorted: @initial_sort[:certificate_type], combine_right: { at: 555, append: t(".col_and_state") } %>
+          <%= sort_column_th type: :alphabetic, content: t(".status"), currently_sorted: @initial_sort[:status] %>
+          <th class='govuk-table__header clear-all' scope='col'><%= t(".action") %></th>
         </tr>
       </thead>
       <tbody class="govuk-table__body">
         <% legal_aid_applications.each do |application| %>
           <% ref = application.application_ref %>
-          <%= render 'shared/partials/modal_dialogue', application: application %>
+          <%= render "shared/partials/modal_dialogue", application: %>
           <tr class="govuk-table__row">
-              <% link_text = application.applicant_full_name || t('generic.undefined') %>
+              <% link_text = application.applicant_full_name || t("generic.undefined") %>
               <%= sort_column_cell(
                     content: link_to_application(link_text, application),
-                    sort_by: link_text
+                    sort_by: link_text,
                   ) %>
 
               <%= sort_column_cell(
                     content: l(application.created_at.to_date, format: :short_date),
                     sort_by: application.created_at.to_i,
-                    combine_right: 555
+                    combine_right: 555,
                   ) %>
 
               <%= sort_column_cell(content: ref) %>
               <td class="nullcell" aria-hidden="true"></td>
               <%= sort_column_cell(sort_by: application.used_delegated_functions?.to_s, combine_right: 555) do %>
                 <% if application.used_delegated_functions? %>
-                  <%= t('.emergency') %>
+                  <%= t(".emergency") %>
                   <% if application.substantive_application_deadline_on? &&  application.summary_state == :in_progress %>
                     <br>
                     <span class="govuk-body-s">
-                      <%= t('.substantive_due', date: l(application.substantive_application_deadline_on, format: :short_date)) %>
+                      <%= t(".substantive_due", date: l(application.substantive_application_deadline_on, format: :short_date)) %>
                     </span>
                   <% end %>
                 <% else %>
-                  <%= t('.substantive') %>
+                  <%= t(".substantive") %>
                 <% end %>
               <% end %>
 
@@ -52,16 +52,16 @@
               <td>
                 <% unless application.summary_state == :submitted %>
                 <%= link_to_accessible(
-                    t('.delete'),
-                    providers_legal_aid_application_delete_path(application),
-                    class: 'govuk-button govuk-button--secondary govuk-!-margin-1 no-script',
-                    suffix: t('.delete_suffix', reference: ref, applicant: application.applicant_full_name)
+                      t(".delete"),
+                      providers_legal_aid_application_delete_path(application),
+                      class: "govuk-button govuk-button--secondary govuk-!-margin-1 no-script",
+                      suffix: t(".delete_suffix", reference: ref, applicant: application.applicant_full_name),
                     ) %>
                   <button class="govuk-button govuk-button--secondary govuk-!-margin-1 script hidden"
                           id="<%= ref %>-modal-btn"
                           data-toggle="modal"
                           data-target="<%= ref %>_modal">
-                    <%= t('.delete') %> <span class="govuk-visually-hidden"><%= t('.delete_label', reference: application.application_ref, applicant_name: application.applicant.full_name) %></span></button>
+                    <%= t(".delete") %> <span class="govuk-visually-hidden"><%= t(".delete_label", reference: application.application_ref, applicant_name: application.applicant.full_name) %></span></button>
               <% end %>
               </td>
             </tr>

--- a/app/views/providers/legal_aid_applications/index.html.erb
+++ b/app/views/providers/legal_aid_applications/index.html.erb
@@ -1,27 +1,23 @@
-<%= page_template(
-      page_title: t('.heading_1'),
-      back_link: :none
-    ) do %>
+<%= page_template(page_title: t(".heading_1"), back_link: :none) do %>
 
   <%= link_to_accessible(start_button_label(:new_app),
-              providers_declaration_path,
-              class: 'govuk-button govuk-button--start',
-              role: 'button',
-              id: 'start',
-              method: :get
-      ) %>
+                         providers_declaration_path,
+                         class: "govuk-button govuk-button--start",
+                         role: "button",
+                         id: "start",
+                         method: :get) %>
 
 <% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h2 class="govuk-heading-m">
-      <%= t('.current_applications') %>
-      <%= link_to_accessible t('.search_applications'),
-                  search_providers_legal_aid_applications_path,
-                  class: 'govuk-button govuk-button--secondary govuk-!-margin-bottom-1' %>
+      <%= t(".current_applications") %>
+      <%= link_to_accessible t(".search_applications"),
+                             search_providers_legal_aid_applications_path,
+                             class: "govuk-button govuk-button--secondary govuk-!-margin-bottom-1" %>
     </h2>
   </div>
 </div>
 
-<%= render 'legal_aid_applications', legal_aid_applications: @legal_aid_applications, pagy: @pagy %>
+<%= render "legal_aid_applications", legal_aid_applications: @legal_aid_applications, pagy: @pagy %>

--- a/app/views/providers/legal_aid_applications/search.html.erb
+++ b/app/views/providers/legal_aid_applications/search.html.erb
@@ -1,27 +1,27 @@
-<%= page_template page_title: t('.title'), template: :basic do %>
+<%= page_template page_title: t(".title"), template: :basic do %>
 
   <%= form_with(method: :get, local: true) do |form| %>
 
-    <%= render partial: 'shared/error' if @error %>
+    <%= render partial: "shared/error" if @error %>
 
-    <%= form.govuk_fieldset legend: {text: page_title, tag: 'h1', size: 'xl'} do %>
+    <%= form.govuk_fieldset legend: { text: page_title, tag: "h1", size: "xl" } do %>
       <div class="govuk-!-padding-bottom-4"></div>
       <%= form.govuk_text_field(
             :search_term,
-            label: {text: :search_term, hidden: true},
-            caption: {text: t('.hint')},
-            width: 'two-thirds',
-            value: @search_term
+            label: { text: :search_term, hidden: true },
+            caption: { text: t(".hint") },
+            width: "two-thirds",
+            value: @search_term,
           ) %>
     <% end %>
 
-    <%= form.govuk_submit t('.search_button') %>
+    <%= form.govuk_submit t(".search_button") %>
   <% end %>
 <% end %>
 
 <% if @legal_aid_applications && @legal_aid_applications.any? %>
-  <h3 class="govuk-heading-m"><%= t('.search_results') %></h3>
-  <%= render 'legal_aid_applications', legal_aid_applications: @legal_aid_applications, pagy: @pagy %>
+  <h3 class="govuk-heading-m"><%= t(".search_results") %></h3>
+  <%= render "legal_aid_applications", legal_aid_applications: @legal_aid_applications, pagy: @pagy %>
 <% elsif @search_term.present? %>
-  <h3 class="govuk-heading-m"><%= t('.empty_result') %></h3>
+  <h3 class="govuk-heading-m"><%= t(".empty_result") %></h3>
 <% end %>

--- a/app/views/providers/limitations/_cost_limits.html.erb
+++ b/app/views/providers/limitations/_cost_limits.html.erb
@@ -2,25 +2,25 @@
   <%= t(title_translation_path) %>
 </h3>
 
-<p><%= t('.default_substantive_limit_is') %> <strong><%= gds_number_to_currency(@legal_aid_application.default_substantive_cost_limitation,  precision: 0) %></strong></p>
+<p><%= t(".default_substantive_limit_is") %> <strong><%= gds_number_to_currency(@legal_aid_application.default_substantive_cost_limitation, precision: 0) %></strong></p>
 
 <% if @legal_aid_application.substantive_cost_overridable? %>
   <%= form.govuk_radio_buttons_fieldset(:substantive_cost_override,
-                                        legend: { size: 's', tag: 'h3', text: t('.substantive_cost_override_question') }) do %>
-    <%= form.govuk_radio_button(:substantive_cost_override, true, link_errors: true, label: {text: t('generic.yes')} ) do %>
+                                        legend: { size: "s", tag: "h3", text: t(".substantive_cost_override_question") }) do %>
+    <%= form.govuk_radio_button(:substantive_cost_override, true, link_errors: true, label: { text: t("generic.yes") }) do %>
       <%= form.govuk_text_field(
             :substantive_cost_requested,
-            label: {text: t('.enter_substantive_cost_limit')},
+            label: { text: t(".enter_substantive_cost_limit") },
             value: number_to_currency_or_original_string(@form.substantive_cost_requested),
-            prefix_text: t('currency.gbp'),
-            width: 'one-third',
-            ) %>
+            prefix_text: t("currency.gbp"),
+            width: "one-third",
+          ) %>
 
       <%= form.govuk_text_area(
             :substantive_cost_reasons,
-            label: {text: t('.enter_substantive_cost_reasons')}
+            label: { text: t(".enter_substantive_cost_reasons") },
           ) %>
     <% end %>
-    <%= form.govuk_radio_button(:substantive_cost_override, false, label: {text:  t('generic.no')}) %>
+    <%= form.govuk_radio_button(:substantive_cost_override, false, label: { text: t("generic.no") }) %>
   <% end %>
 <% end %>

--- a/app/views/providers/limitations/_proceeding_type.html.erb
+++ b/app/views/providers/limitations/_proceeding_type.html.erb
@@ -3,15 +3,15 @@
     <h3 class="govuk-heading-m"><%= proceeding.meaning %></h3>
   </dd>
   <dd class="govuk-summary-list__actions">
-    <%= link_to_accessible(t('generic.change'),
-                          providers_legal_aid_application_has_other_proceedings_path(legal_aid_application_id: @legal_aid_application),
-                          class: 'govuk-link change-link',
-                          suffix: proceeding.meaning) %>
+    <%= link_to_accessible(t("generic.change"),
+                           providers_legal_aid_application_has_other_proceedings_path(legal_aid_application_id: @legal_aid_application),
+                           class: "govuk-link change-link",
+                           suffix: proceeding.meaning) %>
   </dd>
 </div>
 <div class="govuk-summary-list__row--no-border">
   <dd class="govuk-summary-list__key govuk-!-padding-bottom-0">
-    <h3 class="govuk-heading-s"><%= t('.client_role') %><span class="govuk-!-font-weight-regular"><%= proceeding.client_involvement_type_description %></span></h3>
+    <h3 class="govuk-heading-s"><%= t(".client_role") %><span class="govuk-!-font-weight-regular"><%= proceeding.client_involvement_type_description %></span></h3>
   </dd>
 </div>
 <div class="govuk-summary-list__row">
@@ -19,27 +19,27 @@
     <details class="govuk-details" data-module="govuk-details">
       <summary class="govuk-details__summary">
       <span class="govuk-details__summary-text"
-            title="<%= t('.details_heading') %>"
-            aria-label="<%= t('.details_heading') %>">
-        <%= t('.details_heading') %>
+            title="<%= t(".details_heading") %>"
+            aria-label="<%= t(".details_heading") %>">
+        <%= t(".details_heading") %>
       </span>
       </summary>
 
       <div class="govuk-details__text">
         <% if proceeding.used_delegated_functions_on %>
-          <h4 class="govuk-heading-m"><%= t('.emergency_certificate') %></h4>
-          <p><strong><%= t('.form_of_service') %></strong>
+          <h4 class="govuk-heading-m"><%= t(".emergency_certificate") %></h4>
+          <p><strong><%= t(".form_of_service") %></strong>
             <%= proceeding.emergency_level_of_service_name %>
           </p>
-          <p><strong><%= t('.allowable_work') %></strong>
+          <p><strong><%= t(".allowable_work") %></strong>
             <%= scope_limits(proceeding, "emergency") %>
           </p>
         <% end %>
-        <h4 class="govuk-heading-m"><%= t('.substantive_certificate') %></h4>
-        <p><strong><%= t('.form_of_service') %></strong>
+        <h4 class="govuk-heading-m"><%= t(".substantive_certificate") %></h4>
+        <p><strong><%= t(".form_of_service") %></strong>
           <%= proceeding.substantive_level_of_service_name %>
         </p>
-        <p><strong><%= t('.allowable_work') %></strong>
+        <p><strong><%= t(".allowable_work") %></strong>
           <%= scope_limits(proceeding, "substantive") %>
         </p>
       </div>

--- a/app/views/providers/limitations/_proceeding_types.html.erb
+++ b/app/views/providers/limitations/_proceeding_types.html.erb
@@ -2,25 +2,22 @@
               url: providers_legal_aid_application_limitations_path(@legal_aid_application),
               method: :patch,
               local: true) do |form| %>
-  <%= page_template(page_title: t('.h1-heading'), template: :basic, form: form) do %>
-  <h1 class="govuk-heading-xl"><%= t('.h1-heading') %></h1>
+  <%= page_template(page_title: t(".h1-heading"), template: :basic, form:) do %>
+  <h1 class="govuk-heading-xl"><%= t(".h1-heading") %></h1>
   <h2 class="govuk-heading-l">
-    <%= t('.proceedings_heading') %>
+    <%= t(".proceedings_heading") %>
   </h2>
 
   <dl class="govuk-summary-list govuk-!-padding-bottom-4">
-    <%= render partial: 'providers/limitations/proceeding_type',
+    <%= render partial: "providers/limitations/proceeding_type",
                collection: @legal_aid_application.proceedings.in_order_of_addition, as: :proceeding,
-               locals: {translation_path: 'providers.limitations.show'} %>
+               locals: { translation_path: "providers.limitations.show" } %>
   </dl>
 
-    <%= render partial: 'providers/limitations/cost_limits',
-               locals: { title_translation_path: '.cost_heading', form: form } %>
+    <%= render partial: "providers/limitations/cost_limits",
+               locals: { title_translation_path: ".cost_heading", form: } %>
     <div class="govuk-!-padding-bottom-6"></div>
 
-    <%= next_action_buttons(
-          show_draft: true,
-          form: form
-        ) %>
+    <%= next_action_buttons(show_draft: true, form:) %>
   <% end %>
 <% end %>

--- a/app/views/providers/limitations/_proceeding_types_with_df.html.erb
+++ b/app/views/providers/limitations/_proceeding_types_with_df.html.erb
@@ -2,56 +2,53 @@
               url: providers_legal_aid_application_limitations_path(@legal_aid_application),
               method: :patch,
               local: true) do |form| %>
-  <%= page_template page_title: t('.h1-heading'), template: :basic, form: form do %>
+  <%= page_template page_title: t(".h1-heading"), template: :basic, form: do %>
 
-    <h1 class="govuk-heading-xl"><%= t('.h1-heading') %></h1>
+    <h1 class="govuk-heading-xl"><%= t(".h1-heading") %></h1>
     <h2 class="govuk-heading-l">
-      <%= t('.proceedings_heading') %>
+      <%= t(".proceedings_heading") %>
     </h2>
 
     <dl class="govuk-summary-list govuk-!-padding-bottom-4">
-      <%= render partial: 'providers/limitations/proceeding_type',
+      <%= render partial: "providers/limitations/proceeding_type",
                  collection: @legal_aid_application.proceedings.in_order_of_addition, as: :proceeding,
-                 locals: {translation_path: 'providers.limitations.show'} %>
+                 locals: { translation_path: "providers.limitations.show" } %>
     </dl>
 
     <h2 class="govuk-heading-l">
-      <%= t('.cost_heading') %>
+      <%= t(".cost_heading") %>
     </h2>
 
     <h3 class="govuk-heading-m">
-      <%= t('.emergency_certificate') %>
+      <%= t(".emergency_certificate") %>
     </h3>
 
     <p class="govuk-body">
-      <p><%= t('.default_limit_is') %> <strong><%= gds_number_to_currency(@legal_aid_application.default_delegated_functions_cost_limitation,  precision: 0) %></strong></p>
+      <p><%= t(".default_limit_is") %> <strong><%= gds_number_to_currency(@legal_aid_application.default_delegated_functions_cost_limitation, precision: 0) %></strong></p>
       <%= form.govuk_radio_buttons_fieldset(:emergency_cost_override,
-                                            legend: { size: 's', tag: 'h2', text: t('.cost_override_question') }) do %>
-        <%= form.govuk_radio_button(:emergency_cost_override, true, link_errors: true, label: {text: t('generic.yes')} ) do %>
+                                            legend: { size: "s", tag: "h2", text: t(".cost_override_question") }) do %>
+        <%= form.govuk_radio_button(:emergency_cost_override, true, link_errors: true, label: { text: t("generic.yes") }) do %>
           <%= form.govuk_text_field(
                 :emergency_cost_requested,
-                label: {text: t('.enter_cost_limit')},
+                label: { text: t(".enter_cost_limit") },
                 value: number_to_currency_or_original_string(@form.emergency_cost_requested),
-                prefix_text: t('currency.gbp'),
-                width: 'one-third',
-                ) %>
+                prefix_text: t("currency.gbp"),
+                width: "one-third",
+              ) %>
 
         <%= form.govuk_text_area(
               :emergency_cost_reasons,
-              label: {text: t('.enter_cost_reasons')}
-              ) %>
+              label: { text: t(".enter_cost_reasons") },
+            ) %>
       <% end %>
-      <%= form.govuk_radio_button(:emergency_cost_override, false, label: {text:  t('generic.no')}) %>
+      <%= form.govuk_radio_button(:emergency_cost_override, false, label: { text: t("generic.no") }) %>
     <% end %>
 
-    <%= render partial: 'providers/limitations/cost_limits',
-               locals: { title_translation_path: '.substantive_certificate', form: form } %>
+    <%= render partial: "providers/limitations/cost_limits",
+               locals: { title_translation_path: ".substantive_certificate", form: } %>
 
     <div class="govuk-!-padding-bottom-6"></div>
 
-    <%= next_action_buttons(
-          show_draft: true,
-          form: form
-        ) %>
+    <%= next_action_buttons(show_draft: true, form:) %>
   <% end %>
 <% end %>

--- a/app/views/providers/limitations/show.html.erb
+++ b/app/views/providers/limitations/show.html.erb
@@ -1,5 +1,5 @@
 <% if @legal_aid_application.used_delegated_functions? %>
-    <%= render partial: 'providers/limitations/proceeding_types_with_df' %>
+  <%= render partial: "providers/limitations/proceeding_types_with_df" %>
 <% else %>
-  <%= render partial: 'providers/limitations/proceeding_types' %>
+  <%= render partial: "providers/limitations/proceeding_types" %>
 <% end %>

--- a/app/views/providers/means/cash_incomes/show.html.erb
+++ b/app/views/providers/means/cash_incomes/show.html.erb
@@ -1,5 +1,5 @@
 <%= render(
-      'shared/forms/cash_income_form',
-      page_title: t('.page_heading'),
-      form_path: providers_legal_aid_application_means_cash_income_path
+      "shared/forms/cash_income_form",
+      page_title: t(".page_heading"),
+      form_path: providers_legal_aid_application_means_cash_income_path,
     ) %>

--- a/app/views/providers/means/cash_outgoings/show.html.erb
+++ b/app/views/providers/means/cash_outgoings/show.html.erb
@@ -1,5 +1,5 @@
 <%= render(
-      'shared/forms/cash_outgoings_form',
-      page_title: t('.page_heading'),
-      form_path: providers_legal_aid_application_means_cash_outgoing_path
+      "shared/forms/cash_outgoings_form",
+      page_title: t(".page_heading"),
+      form_path: providers_legal_aid_application_means_cash_outgoing_path,
     ) %>

--- a/app/views/providers/means/dependants/_form.html.erb
+++ b/app/views/providers/means/dependants/_form.html.erb
@@ -2,90 +2,87 @@
       model: @form,
       url: form_path,
       method: :patch,
-      local: true
-  ) do |form| %>
+      local: true,
+    ) do |form| %>
 
-  <%= page_template page_title: page_title, page_heading_options: { margin_bottom: 3 }, form: form do %>
+  <%= page_template page_title:, page_heading_options: { margin_bottom: 3 }, form: do %>
 
     <div class="govuk-!-padding-bottom-2"></div>
 
-    <%= form.govuk_text_field :name, width: 'three-quarters', label: { size: 'm', text: t('.name') } %>
+    <%= form.govuk_text_field :name, width: "three-quarters", label: { size: "m", text: t(".name") } %>
 
-    <%= form.govuk_date_field :date_of_birth, legend: { text: t('.date_of_birth') }, hint: { text: t('.dob_hint') } %>
+    <%= form.govuk_date_field :date_of_birth, legend: { text: t(".date_of_birth") }, hint: { text: t(".dob_hint") } %>
 
-    <%= form.govuk_radio_buttons_fieldset :relationship, legend: {text: t('.relationship')} do %>
+    <%= form.govuk_radio_buttons_fieldset :relationship, legend: { text: t(".relationship") } do %>
       <% Dependant.relationships.keys.each do |relationship_type| %>
         <%= form.govuk_radio_button(
-                :relationship,
-                relationship_type,
-                link_errors: true,
-                label: {text: t(".option.#{relationship_type}")},
-                hint: {text: t(".option.hint.#{relationship_type}")},
+              :relationship,
+              relationship_type,
+              link_errors: true,
+              label: { text: t(".option.#{relationship_type}") },
+              hint: { text: t(".option.hint.#{relationship_type}") },
             ) %>
       <% end %>
     <% end %>
 
     <div class="govuk-!-padding-bottom-4"></div>
     <%= form.govuk_collection_radio_buttons(
-            :in_full_time_education,
-            yes_no_options,
-            :value,
-            :label,
-            legend: { text: t('.in_full_time_education'), size: 'm', tag: 'h2' }
+          :in_full_time_education,
+          yes_no_options,
+          :value,
+          :label,
+          legend: { text: t(".in_full_time_education"), size: "m", tag: "h2" },
         ) %>
 
     <%= form.govuk_radio_buttons_fieldset :has_income,
-                                          hint: {text: t('.has_income.hint')},
-                                          legend: { text: t('.has_income.question'), size: 'm'} do %>
+                                          hint: { text: t(".has_income.hint") },
+                                          legend: { text: t(".has_income.question"), size: "m" } do %>
       <%= form.govuk_radio_button(
-              :has_income,
-              true,
-              link_errors: true,
-              label: {text: t('generic.yes')},
+            :has_income,
+            true,
+            link_errors: true,
+            label: { text: t("generic.yes") },
           ) do %>
           <%= form.govuk_text_field(
-                  :monthly_income,
-                  label: {text: t('.has_income.enter_monthly_income')},
-                  value: number_to_currency_or_original_string(@form.monthly_income),
-                  prefix_text: t('currency.gbp'),
-                  width: 'one-third'
+                :monthly_income,
+                label: { text: t(".has_income.enter_monthly_income") },
+                value: number_to_currency_or_original_string(@form.monthly_income),
+                prefix_text: t("currency.gbp"),
+                width: "one-third",
               ) %>
       <% end %>
       <%= form.govuk_radio_button(
-              :has_income,
-              false,
-              label: {text: t('generic.no')}
+            :has_income,
+            false,
+            label: { text: t("generic.no") },
           ) %>
     <% end %>
 
     <%= form.govuk_radio_buttons_fieldset :has_assets_more_than_threshold,
-                                          hint: {text: t('.has_assets_more_than_threshold.hint')},
-                                          legend: {text: t('.has_assets_more_than_threshold.question'), size: 'm'} do %>
+                                          hint: { text: t(".has_assets_more_than_threshold.hint") },
+                                          legend: { text: t(".has_assets_more_than_threshold.question"), size: "m" } do %>
       <%= form.govuk_radio_button(
-              :has_assets_more_than_threshold,
-              true,
-              link_errors: true,
-              label: {text: t('generic.yes')},
+            :has_assets_more_than_threshold,
+            true,
+            link_errors: true,
+            label: { text: t("generic.yes") },
           ) do %>
         <%= form.govuk_text_field(
-                :assets_value,
-                label: {text: t('.has_assets_more_than_threshold.enter_assets_value')},
-                value: number_to_currency_or_original_string(@form.assets_value),
-                prefix_text: t('currency.gbp'),
-                width: 'one-third'
+              :assets_value,
+              label: { text: t(".has_assets_more_than_threshold.enter_assets_value") },
+              value: number_to_currency_or_original_string(@form.assets_value),
+              prefix_text: t("currency.gbp"),
+              width: "one-third",
             ) %>
       <% end %>
       <%= form.govuk_radio_button(
-              :has_assets_more_than_threshold,
-              false,
-              label: {text: t('generic.no')},
+            :has_assets_more_than_threshold,
+            false,
+            label: { text: t("generic.no") },
           ) %>
       <% end %>
 
     <div class="govuk-!-padding-bottom-2"></div>
-    <%= next_action_buttons(
-            show_draft: true,
-            form: form
-        ) %>
+    <%= next_action_buttons(show_draft: true, form:) %>
   <% end %>
 <% end %>

--- a/app/views/providers/means/dependants/new.html.erb
+++ b/app/views/providers/means/dependants/new.html.erb
@@ -1,4 +1,4 @@
-<%= render 'providers/means/dependants/form',
+<%= render "providers/means/dependants/form",
            form: @form,
-           page_title: t('.page_title'),
+           page_title: t(".page_title"),
            form_path: new_providers_legal_aid_application_means_dependant_path(@legal_aid_application, @form.model) %>

--- a/app/views/providers/means/dependants/show.html.erb
+++ b/app/views/providers/means/dependants/show.html.erb
@@ -1,4 +1,4 @@
-<%= render 'providers/means/dependants/form',
+<%= render "providers/means/dependants/form",
            form: @form,
-           page_title: t('.page_title'),
+           page_title: t(".page_title"),
            form_path: providers_legal_aid_application_means_dependant_path(@legal_aid_application, @form.model) %>

--- a/app/views/providers/means/employment_incomes/show.html.erb
+++ b/app/views/providers/means/employment_incomes/show.html.erb
@@ -5,35 +5,35 @@
 
   <div class="moj-banner">
     <div class="moj-banner__message">
-      <h2 class="govuk-heading-m"><%= t('.hmrc-information') %></h2>
+      <h2 class="govuk-heading-m"><%= t(".hmrc-information") %></h2>
     </div>
   </div>
 
   <% if @eligible_employment_payments.any? && @applicant.not_employed? %>
-    <% page_heading = 'not_employed' %>
+    <% page_heading = "not_employed" %>
   <% else %>
-    <% page_heading = 'employed' %>
+    <% page_heading = "employed" %>
   <% end %>
 
-  <%= page_template page_title: t(".#{page_heading}", name: @applicant.full_name), template: :basic, form: form do %>
+  <%= page_template page_title: t(".#{page_heading}", name: @applicant.full_name), template: :basic, form: do %>
 
     <%= form.govuk_radio_buttons_fieldset(:has_extra_employment_information,
-                                          legend: { size: 'xl', tag: 'h1', text: page_title}) do %>
+                                          legend: { size: "xl", tag: "h1", text: page_title }) do %>
 
     <% if @eligible_employment_payments.any? && @applicant.not_employed? %>
         <div class="govuk-!-padding-bottom-6"></div>
-        <p class="govuk-body-l"> <%= t('.hmrc_not_employed') %> </p>
+        <p class="govuk-body-l"> <%= t(".hmrc_not_employed") %> </p>
     <% end %>
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <table class="govuk-table">
-        <caption class="govuk-table__caption govuk-table__caption--m govuk-visually-hidden"><%= t('.table_caption') %></caption>
+        <caption class="govuk-table__caption govuk-table__caption--m govuk-visually-hidden"><%= t(".table_caption") %></caption>
         <thead class="govuk-table__head">
         <tr class="govuk-table__row">
-          <th class="govuk-table__header" style="width: 25%;" scope="col"><%= t('.date') %></th>
-          <th class="govuk-table__header" style="width: 10%;" scope="col" colspan="2"><%= t('.income') %></th>
-          <th class="govuk-table__header" style="width: 35%;" scope="col" colspan="2"><%= t('.deductions') %></th>
+          <th class="govuk-table__header" style="width: 25%;" scope="col"><%= t(".date") %></th>
+          <th class="govuk-table__header" style="width: 10%;" scope="col" colspan="2"><%= t(".income") %></th>
+          <th class="govuk-table__header" style="width: 35%;" scope="col" colspan="2"><%= t(".deductions") %></th>
         </tr>
         </thead>
 
@@ -42,11 +42,11 @@
           <% employment.employment_payments.each do |payment| %>
           <tr class="govuk-table__row">
             <td class="govuk-table__cell" style="width: 25%;"><%= l(payment.date, format: :short_date) %></td>
-            <td class="govuk-table__cell" style="width: 10%;"><strong><%= t('.gross') %></strong></td>
+            <td class="govuk-table__cell" style="width: 10%;"><strong><%= t(".gross") %></strong></td>
             <td class="govuk-table__cell govuk-table__cell--numeric" style="width: 10%;"><strong></strong><%= gds_number_to_currency(payment.gross) %></td>
-            <td class="govuk-table__cell" style="width: 35%;"><strong><%= t('.tax') %></strong>
+            <td class="govuk-table__cell" style="width: 35%;"><strong><%= t(".tax") %></strong>
             <br>
-            <strong><%= t('.ni') %></strong>
+            <strong><%= t(".ni") %></strong>
             </td>
             <td class="govuk-table__cell govuk-table__cell--numeric" style="width: 20%;">
               <%= gds_number_to_currency(payment.tax) %>
@@ -60,20 +60,17 @@
       </table>
     </div>
   </div>
-      <%= form.govuk_radio_buttons_fieldset :extra_employment_information, legend: {text: t('.supplementary_question')}, hint: {text: t('.employment_hint')} do %>
-        <%= form.govuk_radio_button :extra_employment_information, true, link_errors: true, label: { text: t('generic.yes') } do %>
+      <%= form.govuk_radio_buttons_fieldset :extra_employment_information, legend: { text: t(".supplementary_question") }, hint: { text: t(".employment_hint") } do %>
+        <%= form.govuk_radio_button :extra_employment_information, true, link_errors: true, label: { text: t("generic.yes") } do %>
         <%= form.govuk_text_area :extra_employment_information_details,
-                                 label: {text: t('.enter_details')},
-                                 hint: {text: t('.details_hint')},
+                                 label: { text: t(".enter_details") },
+                                 hint: { text: t(".details_hint") },
                                  rows: 5 %>
         <% end %>
-        <%= form.govuk_radio_button :extra_employment_information, false, label: { text: t('generic.no') } %>
+        <%= form.govuk_radio_button :extra_employment_information, false, label: { text: t("generic.no") } %>
       <% end %>
     <% end %>
 
-    <%= next_action_buttons(
-          show_draft: true,
-          form: form
-        ) %>
+    <%= next_action_buttons(show_draft: true, form:) %>
   <% end %>
 <% end %>

--- a/app/views/providers/means/full_employment_details/show.html.erb
+++ b/app/views/providers/means/full_employment_details/show.html.erb
@@ -2,31 +2,28 @@
               url: providers_legal_aid_application_means_full_employment_details_path(@legal_aid_application),
               method: :patch,
               local: true) do |form| %>
-  <% page_heading = @legal_aid_application.has_multiple_employments? ? t('.page_heading_multi_jobs') : t('.page_heading_no_info') %>
+  <% page_heading = @legal_aid_application.has_multiple_employments? ? t(".page_heading_multi_jobs") : t(".page_heading_no_info") %>
 
-  <%= page_template page_title: page_heading, form: form do %>
+  <%= page_template page_title: page_heading, form: do %>
       <div class="govuk-!-padding-bottom-1"></div>
       <% if @legal_aid_application.has_multiple_employments? %>
-        <h2 class="govuk-body-l"><%= t('.mutiple_employment_info') %></h2>
+        <h2 class="govuk-body-l"><%= t(".mutiple_employment_info") %></h2>
       <% else %>
-        <h2 class="govuk-body-l"><%= t('.no_employment_info') %></h2>
+        <h2 class="govuk-body-l"><%= t(".no_employment_info") %></h2>
       <% end %>
-      <p class="govuk-body"><%= t('.enter_details') %></p>
+      <p class="govuk-body"><%= t(".enter_details") %></p>
       <ul class="govuk-list govuk-list--bullet">
-        <li><%= t '.details_1' %></li>
-        <li><%= t '.details_2' %></li>
-        <li><%= t '.details_3' %></li>
-        <li><%= t '.details_4' %></li>
+        <li><%= t ".details_1" %></li>
+        <li><%= t ".details_2" %></li>
+        <li><%= t ".details_3" %></li>
+        <li><%= t ".details_4" %></li>
       </ul>
 
       <%= form.govuk_text_area :full_employment_details,
-                                label: { text: t('.employment_details_header'), tag: 'h2', size: 'm' },
-                                hint: { text: t('.employment_details_hint') },
-                                rows: 10 %>
+                               label: { text: t(".employment_details_header"), tag: "h2", size: "m" },
+                               hint: { text: t(".employment_details_hint") },
+                               rows: 10 %>
 
-    <%= next_action_buttons(
-          show_draft: true,
-          form: form
-        ) %>
+    <%= next_action_buttons(show_draft: true, form:) %>
   <% end %>
 <% end %>

--- a/app/views/providers/means/has_dependants/show.html.erb
+++ b/app/views/providers/means/has_dependants/show.html.erb
@@ -2,41 +2,41 @@
       model: @form,
       url: providers_legal_aid_application_means_has_dependants_path(@legal_aid_application),
       method: :patch,
-      local: true
-  ) do |form| %>
+      local: true,
+    ) do |form| %>
 
-  <%= page_template page_title: t('.page_title'), form: form, template: :basic do %>
+  <%= page_template page_title: t(".page_title"), form:, template: :basic do %>
 
     <%= form.govuk_collection_radio_buttons :has_dependants,
                                             yes_no_options,
                                             :value,
                                             :label,
                                             legend: {
-                                                text: t('.page_title'),
-                                                tag: 'h1',
-                                                size: 'xl'
+                                              text: t(".page_title"),
+                                              tag: "h1",
+                                              size: "xl",
                                             } do %>
         <p class="govuk-body govuk-!-margin-top-4">
-          <%= t('.info') %>
+          <%= t(".info") %>
         </p>
 
         <ul class="govuk-list govuk-list--bullet">
-          <% t('.list').each_line do |item| %>
+          <% t(".list").each_line do |item| %>
             <li><%= item %></li>
           <% end %>
         </ul>
 
         <%= govuk_inset_text do %>
           <p class="govuk-body">
-            <%= t('.extra_info') %>
+            <%= t(".extra_info") %>
           </p>
         <% end %>
 
     <% end %>
 
     <%= next_action_buttons(
-            show_draft: local_assigns.key?(:show_draft) ? show_draft : false,
-            form: form
+          show_draft: local_assigns.key?(:show_draft) ? show_draft : false,
+          form:,
         ) %>
   <% end %>
 <% end %>

--- a/app/views/providers/means/has_other_dependants/show.html.erb
+++ b/app/views/providers/means/has_other_dependants/show.html.erb
@@ -1,33 +1,33 @@
 <%= form_with(
-        url: providers_legal_aid_application_means_has_other_dependants_path,
-        model: @form,
-        method: :patch,
-        local: true
+      url: providers_legal_aid_application_means_has_other_dependants_path,
+      model: @form,
+      method: :patch,
+      local: true,
     ) do |form| %>
 
-  <%= page_template page_title: t('.page_title'), head_title: t('.existing', count: "#{pluralize(@legal_aid_application.dependants.count, 'dependant')}"), form: form, template: :basic do %>
+  <%= page_template page_title: t(".page_title"), head_title: t(".existing", count: pluralize(@legal_aid_application.dependants.count, "dependant").to_s), form:, template: :basic do %>
 
   <% if @legal_aid_application.has_dependants? %>
-    <h1 class="govuk-heading-xl"><%= t('.existing', count: "#{pluralize(@legal_aid_application.dependants.count, 'dependant')}") %></h1>
+    <h1 class="govuk-heading-xl"><%= t(".existing", count: pluralize(@legal_aid_application.dependants.count, "dependant").to_s) %></h1>
     <div class="govuk-summary-list">
       <% @legal_aid_application.dependants.order(:created_at, :number).each do |dependant| %>
         <dl class="govuk-summary-list__row" id="dependant_<%= dependant.number %>">
           <dt class="govuk-summary-list__value"><%= dependant.name %></dt>
           <dt class="govuk-summary-list__actions">
             <%= link_to_accessible(
-                  t('generic.change'),
+                  t("generic.change"),
                   providers_legal_aid_application_means_dependant_path(@legal_aid_application, dependant),
-                  class: 'govuk-link change-link',
-                  suffix: dependant.name
+                  class: "govuk-link change-link",
+                  suffix: dependant.name,
                 ) %>
           </dt>
           <dt class="govuk-summary-list__actions">
             <dd class="govuk-summary-list__actions">
               <%= link_to_accessible(
-                      t('.remove'),
-                      providers_legal_aid_application_means_remove_dependant_path(@legal_aid_application, dependant),
-                      class: 'govuk-link change-link',
-                      suffix: dependant.name
+                    t(".remove"),
+                    providers_legal_aid_application_means_remove_dependant_path(@legal_aid_application, dependant),
+                    class: "govuk-link change-link",
+                    suffix: dependant.name,
                   ) %>
             </dd>
           </dt>
@@ -40,8 +40,8 @@
                                           yes_no_options,
                                           :value,
                                           :label,
-                                          legend: {text: content_for(:page_title), size: 'm', tag: 'h2'} %>
+                                          legend: { text: content_for(:page_title), size: "m", tag: "h2" } %>
 
-  <%= next_action_buttons(form: form) %>
+  <%= next_action_buttons(form:) %>
   <% end %>
 <% end %>

--- a/app/views/providers/means/housing_benefits/show.html.erb
+++ b/app/views/providers/means/housing_benefits/show.html.erb
@@ -3,7 +3,7 @@
               method: :patch do |f| %>
   <%= page_template page_title: t(".page_heading"), template: :basic, form: f do %>
 
-    <%= f.govuk_radio_buttons_fieldset :transaction_type_ids, legend: {tag: "h1", size: "xl"} do %>
+    <%= f.govuk_radio_buttons_fieldset :transaction_type_ids, legend: { tag: "h1", size: "xl" } do %>
 
       <%= f.govuk_radio_button :transaction_type_ids,
                                @form.housing_benefit_transaction_type.id,
@@ -15,7 +15,7 @@
                                              @form.frequency_options,
                                              :itself,
                                              ->(option) { t("transaction_types.frequencies.#{option}") },
-                                             legend: {tag: "h2", size: "s"} %>
+                                             legend: { tag: "h2", size: "s" } %>
       <% end %>
 
       <%= f.govuk_radio_button :transaction_type_ids,

--- a/app/views/providers/means/identify_types_of_incomes/show.html.erb
+++ b/app/views/providers/means/identify_types_of_incomes/show.html.erb
@@ -1,7 +1,7 @@
   <%= render(
-        'shared/forms/types_of_income_form',
+        "shared/forms/types_of_income_form",
         journey: :provider,
-        page_title: t('.page_heading'),
+        page_title: t(".page_heading"),
         form_path: providers_legal_aid_application_means_identify_types_of_income_path(@legal_aid_application),
-        show_draft: true
+        show_draft: true,
       ) %>

--- a/app/views/providers/means/identify_types_of_outgoings/show.html.erb
+++ b/app/views/providers/means/identify_types_of_outgoings/show.html.erb
@@ -1,7 +1,7 @@
 <%= render(
-      'shared/forms/types_of_outgoings_form',
-      page_title: t('.page_heading'),
+      "shared/forms/types_of_outgoings_form",
+      page_title: t(".page_heading"),
       journey: :provider,
       form_path: providers_legal_aid_application_means_identify_types_of_outgoing_path(@legal_aid_application),
-      show_draft: true
+      show_draft: true,
     ) %>

--- a/app/views/providers/means/other_assets/_second_home_conditional_checkbox.html.erb
+++ b/app/views/providers/means/other_assets/_second_home_conditional_checkbox.html.erb
@@ -1,25 +1,23 @@
-<%
-  check_box_attribute = 'check_box_second_home'
-  hint = I18n.t("helpers.hint.#{check_box_attribute}", default: nil)
-  @form.__send__("#{check_box_attribute}=", model.send(check_box_attribute).present? || model.any_second_home_value_present?)
-%>
+<% check_box_attribute = "check_box_second_home" %>
+<% hint = I18n.t("helpers.hint.#{check_box_attribute}", default: nil) %>
+<% @form.__send__("#{check_box_attribute}=", model.send(check_box_attribute).present? || model.any_second_home_value_present?) %>
 
 <%= form.govuk_check_box check_box_attribute, true, multiple: false, link_errors: true,
-                         label: {text: t('providers.other_assets.second_home_conditional_checkbox.check_box_second_home')},
-                         hint: {text: hint} do %>
+                                                    label: { text: t("providers.other_assets.second_home_conditional_checkbox.check_box_second_home") },
+                                                    hint: { text: hint } do %>
   <%= form.govuk_text_field :second_home_value,
-                            prefix_text: t('currency.gbp'),
-                            label: {text: t('providers.other_assets.second_home_conditional_checkbox.second_home_value')},
+                            prefix_text: t("currency.gbp"),
+                            label: { text: t("providers.other_assets.second_home_conditional_checkbox.second_home_value") },
                             value: number_to_currency_or_original_string(model.second_home_value),
-                            width: 'one-third' %>
+                            width: "one-third" %>
   <%= form.govuk_text_field :second_home_mortgage,
-                            label: {text: t('providers.other_assets.second_home_conditional_checkbox.second_home_mortgage')},
-                            prefix_text: t('currency.gbp'),
+                            label: { text: t("providers.other_assets.second_home_conditional_checkbox.second_home_mortgage") },
+                            prefix_text: t("currency.gbp"),
                             value: number_to_currency_or_original_string(model.second_home_mortgage),
-                            width: 'one-third' %>
+                            width: "one-third" %>
   <%= form.govuk_text_field :second_home_percentage,
-                            label: {text: t('providers.other_assets.second_home_conditional_checkbox.second_home_percentage')},
+                            label: { text: t("providers.other_assets.second_home_conditional_checkbox.second_home_percentage") },
                             value: model.second_home_percentage,
                             width: 4,
-                            suffix_text: '%' %>
+                            suffix_text: "%" %>
 <% end %>

--- a/app/views/providers/means/other_assets/show.html.erb
+++ b/app/views/providers/means/other_assets/show.html.erb
@@ -2,34 +2,31 @@
               url: providers_legal_aid_application_means_other_assets_path(@legal_aid_application),
               method: :patch,
               local: true) do |form| %>
-  <%= page_template page_title: t('.h1-heading'), template: :basic, form: form do %>
+  <%= page_template page_title: t(".h1-heading"), template: :basic, form: do %>
 
     <%= form.govuk_check_boxes_fieldset :other_assets,
-                                        legend: { text: page_title, size: "xl", tag: 'h1'},
-                                        hint: { text: t('.hint')} do %>
-      <%= render 'shared/means/cost_of_living_details' %>
+                                        legend: { text: page_title, size: "xl", tag: "h1" },
+                                        hint: { text: t(".hint") } do %>
+      <%= render "shared/means/cost_of_living_details" %>
       <div class="govuk-checkboxes" data-module="govuk-checkboxes">
         <div class="deselect-group" data-deselect-ctrl="#other-assets-declaration-none-selected-true-field">
-          <%= render partial: '/shared/forms/revealing_checkbox/attribute',
+          <%= render partial: "/shared/forms/revealing_checkbox/attribute",
                      collection: Citizens::OtherAssetsForm::VALUABLE_ITEMS_VALUE_ATTRIBUTE,
-                     locals: { model: @form, form: form } %>
-          <%= render partial: '/providers/means/other_assets/second_home_conditional_checkbox', locals: { model: @form, form: form } %>
-          <%= render partial: '/shared/forms/revealing_checkbox/attribute',
+                     locals: { model: @form, form: } %>
+          <%= render partial: "/providers/means/other_assets/second_home_conditional_checkbox", locals: { model: @form, form: } %>
+          <%= render partial: "/shared/forms/revealing_checkbox/attribute",
                      collection: Citizens::OtherAssetsForm::SINGLE_VALUE_ATTRIBUTES,
-                     locals: { model: @form, form: form } %>
+                     locals: { model: @form, form: } %>
         </div>
       </div>
 
       <%= form.govuk_radio_divider %>
-      <%= form.govuk_check_box :none_selected, true, '', multiple: false, label: {text: t('.none_of_these')} %>
+      <%= form.govuk_check_box :none_selected, true, "", multiple: false, label: { text: t(".none_of_these") } %>
 
     <% end %>
 
     <div class="govuk-!-padding-bottom-4"></div>
 
-    <%= next_action_buttons(
-            show_draft: true,
-            form: form
-        ) %>
+    <%= next_action_buttons(show_draft: true, form:) %>
   <% end %>
 <% end %>

--- a/app/views/providers/means/outstanding_mortgages/show.html.erb
+++ b/app/views/providers/means/outstanding_mortgages/show.html.erb
@@ -1,25 +1,23 @@
 <%= form_with(
-        model: @form,
-        scope: :legal_aid_application,
-        url: providers_legal_aid_application_means_outstanding_mortgage_path,
-        method: :patch,
-        local: true) do |form| %>
-    <%= page_template(page_title: t('.h1-heading'), template: :basic, form: form) do %>
+      model: @form,
+      scope: :legal_aid_application,
+      url: providers_legal_aid_application_means_outstanding_mortgage_path,
+      method: :patch,
+      local: true,
+    ) do |form| %>
+    <%= page_template(page_title: t(".h1-heading"), template: :basic, form:) do %>
 
-      <%= form.govuk_fieldset legend: { size: 'xl', tag: 'h1', text: t('.field_set_header') }  do %>
+      <%= form.govuk_fieldset legend: { size: "xl", tag: "h1", text: t(".field_set_header") }  do %>
       <%= form.govuk_text_field(
-              :outstanding_mortgage_amount,
-              label: {text: :property_value, hidden: true},
-              value: number_to_currency_or_original_string(@form.outstanding_mortgage_amount),
-              prefix_text: t('currency.gbp'),
-              width: 'one-third',
-              ) %>
+            :outstanding_mortgage_amount,
+            label: { text: :property_value, hidden: true },
+            value: number_to_currency_or_original_string(@form.outstanding_mortgage_amount),
+            prefix_text: t("currency.gbp"),
+            width: "one-third",
+          ) %>
     <% end %>
 
-    <%= next_action_buttons(
-            show_draft: true,
-            form: form
-        ) %>
+    <%= next_action_buttons(show_draft: true, form:) %>
 
   <% end %>
 <% end %>

--- a/app/views/providers/means/own_homes/show.html.erb
+++ b/app/views/providers/means/own_homes/show.html.erb
@@ -1,25 +1,21 @@
 <%= form_with(
-        model: @form,
-        url: providers_legal_aid_application_means_own_home_path(@legal_aid_application),
-        method: :patch,
-        local: true) do |form| %>
-    <%= page_template page_title: t('.h1-heading'), form: form, template: :basic do %>
+      model: @form,
+      url: providers_legal_aid_application_means_own_home_path(@legal_aid_application),
+      method: :patch,
+      local: true,
+    ) do |form| %>
+    <%= page_template page_title: t(".h1-heading"), form:, template: :basic do %>
 
-    <%
-      options = [
-          OpenStruct.new( value: :mortgage, label: t('.mortgage')),
-          OpenStruct.new(value: :owned_outright, label: t('.owned_outright')),
-          OpenStruct.new(value: :no, label: t('.no'))
-      ]
-    %>
+    <% options = [
+        [:mortgage, t(".mortgage")],
+        [:owned_outright, t(".owned_outright")],
+        [:no, t(".no")]
+      ] %>
 
-    <%= form.govuk_collection_radio_buttons(:own_home, options, :value, :label,
-                                            legend: {size: 'xl', tag: 'h1', text: content_for(:page_title)}) %>
+    <%= form.govuk_collection_radio_buttons(:own_home, options, :first, :second,
+                                            legend: { size: "xl", tag: "h1", text: content_for(:page_title) }) %>
 
-    <%= next_action_buttons(
-            show_draft: true,
-            form: form
-        ) %>
+    <%= next_action_buttons(show_draft: true, form:) %>
 
   <% end %>
 <% end %>

--- a/app/views/providers/means/own_homes/show.html.erb
+++ b/app/views/providers/means/own_homes/show.html.erb
@@ -7,10 +7,10 @@
     <%= page_template page_title: t(".h1-heading"), form:, template: :basic do %>
 
     <% options = [
-        [:mortgage, t(".mortgage")],
-        [:owned_outright, t(".owned_outright")],
-        [:no, t(".no")]
-      ] %>
+         [:mortgage, t(".mortgage")],
+         [:owned_outright, t(".owned_outright")],
+         [:no, t(".no")],
+       ] %>
 
     <%= form.govuk_collection_radio_buttons(:own_home, options, :first, :second,
                                             legend: { size: "xl", tag: "h1", text: content_for(:page_title) }) %>

--- a/app/views/providers/means/percentage_homes/show.html.erb
+++ b/app/views/providers/means/percentage_homes/show.html.erb
@@ -3,21 +3,18 @@
               url: providers_legal_aid_application_means_percentage_home_path(@legal_aid_application),
               method: :patch,
               local: true) do |form| %>
-  <%= page_template page_title: t('.h1-heading'), template: :basic, form: form do %>
+  <%= page_template page_title: t(".h1-heading"), template: :basic, form: do %>
 
     <%= form.govuk_text_field(
           :percentage_home,
           value: @form.percentage_home,
-          label: { size: 'xl', tag: 'h1', text: page_title },
-          hint: {text: t('.percentage_home')},
+          label: { size: "xl", tag: "h1", text: page_title },
+          hint: { text: t(".percentage_home") },
           width: 5,
-          suffix_text: '%'
+          suffix_text: "%",
         ) %>
 
     <div class="govuk-!-padding-bottom-4"></div>
-    <%= next_action_buttons(
-            show_draft: true,
-            form: form
-        ) %>
+    <%= next_action_buttons(show_draft: true, form:) %>
   <% end %>
 <% end %>

--- a/app/views/providers/means/policy_disregards/show.html.erb
+++ b/app/views/providers/means/policy_disregards/show.html.erb
@@ -2,26 +2,23 @@
               url: providers_legal_aid_application_means_policy_disregards_path(@legal_aid_application),
               method: :patch,
               local: true) do |form| %>
-  <%= page_template page_title: t('.h1-heading'), template: :basic, form: form do %>
+  <%= page_template page_title: t(".h1-heading"), template: :basic, form: do %>
 
     <%= form.govuk_check_boxes_fieldset :policy_disregards,
-                                        legend: {text: page_title, size: 'xl', tag: 'h1'},
-                                        hint: {text: t('generic.select_all_that_apply')} do %>
+                                        legend: { text: page_title, size: "xl", tag: "h1" },
+                                        hint: { text: t("generic.select_all_that_apply") } do %>
 
-     <div class="deselect-group" data-deselect-ctrl="#policy-disregards-none-selected-true-field">
-       <% Providers::PolicyDisregardsForm::SINGLE_VALUE_ATTRIBUTES.each do |checkbox| %>
-         <%= form.govuk_check_box checkbox, true, '', multiple: false, link_errors: true, label: {text: t(".#{checkbox}")} %>
-       <% end %>
-     </div>
+    <div class="deselect-group" data-deselect-ctrl="#policy-disregards-none-selected-true-field">
+      <% Providers::PolicyDisregardsForm::SINGLE_VALUE_ATTRIBUTES.each do |checkbox| %>
+        <%= form.govuk_check_box checkbox, true, "", multiple: false, link_errors: true, label: { text: t(".#{checkbox}") } %>
+      <% end %>
+    </div>
 
-     <%= form.govuk_radio_divider %>
-     <%= form.govuk_check_box :none_selected, true, '', multiple: false, label: {text: t('.none_of_these')} %>
+    <%= form.govuk_radio_divider %>
+    <%= form.govuk_check_box :none_selected, true, "", multiple: false, label: { text: t(".none_of_these") } %>
 
-   <% end %>
-
-   <%= next_action_buttons(
-           show_draft: true,
-           form: form
-       ) %>
   <% end %>
- <% end %>
+
+  <%= next_action_buttons(show_draft: true, form:) %>
+  <% end %>
+<% end %>

--- a/app/views/providers/means/property_values/show.html.erb
+++ b/app/views/providers/means/property_values/show.html.erb
@@ -1,24 +1,22 @@
 <%= form_with(
-        model: @form,
-        scope: :legal_aid_application,
-        url: providers_legal_aid_application_means_property_value_path,
-        method: :patch,
-        local: true) do |form| %>
-  <%= page_template page_title: t('.h1-heading'), form: form, template: :basic do %>
+      model: @form,
+      scope: :legal_aid_application,
+      url: providers_legal_aid_application_means_property_value_path,
+      method: :patch,
+      local: true,
+    ) do |form| %>
+  <%= page_template page_title: t(".h1-heading"), form:, template: :basic do %>
 
     <%= form.govuk_text_field(
           :property_value,
-          label: {text: page_title, size: 'xl', tag: 'h1'},
-          hint: {text: t('.hint')},
+          label: { text: page_title, size: "xl", tag: "h1" },
+          hint: { text: t(".hint") },
           value: number_to_currency_or_original_string(@form.property_value),
-          prefix_text: t('currency.gbp'),
-          width: 'one-third',
-          ) %>
-
-    <%= next_action_buttons(
-            show_draft: true,
-            form: form
+          prefix_text: t("currency.gbp"),
+          width: "one-third",
         ) %>
+
+    <%= next_action_buttons(show_draft: true, form:) %>
 
   <% end %>
 <% end %>

--- a/app/views/providers/means/regular_incomes/_cost_of_living_and_disregarded_benefits.html.erb
+++ b/app/views/providers/means/regular_incomes/_cost_of_living_and_disregarded_benefits.html.erb
@@ -1,5 +1,5 @@
-<%= govuk_details(summary_text: t('.title')) do %>
+<%= govuk_details(summary_text: t(".title")) do %>
   <h2 class="govuk-heading-s"><%= t("shared.cost_of_living.header") %></h2>
-  <%= render 'shared/means/cost_of_living_section' %>
-  <%= render 'shared/means/disregarded_benefits_section' %>
+  <%= render "shared/means/cost_of_living_section" %>
+  <%= render "shared/means/disregarded_benefits_section" %>
 <% end %>

--- a/app/views/providers/means/regular_incomes/show.html.erb
+++ b/app/views/providers/means/regular_incomes/show.html.erb
@@ -1,18 +1,18 @@
 <%= form_with model: @form,
               url: providers_legal_aid_application_means_regular_incomes_path(@legal_aid_application),
               method: :patch do |f| %>
-  <%= page_template page_title: page_title, template: :basic, form: f do %>
+  <%= page_template page_title:, template: :basic, form: f do %>
 
-    <%= f.govuk_check_boxes_fieldset :transaction_type_ids, legend: {tag: "h1", size: "xl"} do %>
+    <%= f.govuk_check_boxes_fieldset :transaction_type_ids, legend: { tag: "h1", size: "xl" } do %>
 
-      <%= render 'cost_of_living_and_disregarded_benefits' %>
+      <%= render "cost_of_living_and_disregarded_benefits" %>
 
       <% @form.transaction_type_options.each_with_index do |transaction_type, index| %>
         <%= f.govuk_check_box :transaction_type_ids,
                               transaction_type.id,
-                              link_errors: index == 0,
+                              link_errors: index.zero?,
                               label: { text: t(".labels.#{transaction_type.name}") },
-                              hint: {text: t(".hints.#{transaction_type.name}") } do %>
+                              hint: { text: t(".hints.#{transaction_type.name}") } do %>
           <%= f.govuk_text_field "#{transaction_type.name}_amount".to_sym,
                                  width: "one-quarter",
                                  prefix_text: "£" %>
@@ -20,7 +20,7 @@
                                                RegularTransaction.frequencies_for(transaction_type),
                                                :itself,
                                                ->(option) { t("transaction_types.frequencies.#{option}") },
-                                               legend: {tag: "h2", size: "s"} %>
+                                               legend: { tag: "h2", size: "s" } %>
         <% end %>
       <% end %>
 
@@ -29,7 +29,7 @@
       <%= f.govuk_check_box :transaction_type_ids,
                             @form.none_selected,
                             exclusive: true,
-                            label: {text: t(".labels.none")} %>
+                            label: { text: t(".labels.none") } %>
     <% end %>
 
     <%= f.govuk_submit t("generic.save_and_continue") %>

--- a/app/views/providers/means/regular_outgoings/show.html.erb
+++ b/app/views/providers/means/regular_outgoings/show.html.erb
@@ -1,23 +1,23 @@
 <%= form_with model: @form,
               url: providers_legal_aid_application_means_regular_outgoings_path(@legal_aid_application),
               method: :patch do |f| %>
-  <%= page_template page_title: page_title, template: :basic, form: f do %>
+  <%= page_template page_title:, template: :basic, form: f do %>
 
-    <%= f.govuk_check_boxes_fieldset :transaction_type_ids, legend: {tag: "h1", size: "xl"} do %>
+    <%= f.govuk_check_boxes_fieldset :transaction_type_ids, legend: { tag: "h1", size: "xl" } do %>
 
       <% @form.transaction_type_options.each_with_index do |transaction_type, index| %>
         <%= f.govuk_check_box :transaction_type_ids,
                               transaction_type.id,
-                              link_errors: index == 0,
+                              link_errors: index.zero?,
                               label: { text: t(".labels.#{transaction_type.name}") },
-                              hint: {text: t(".hints.#{transaction_type.name}") } do %>
+                              hint: { text: t(".hints.#{transaction_type.name}") } do %>
           <%= f.govuk_text_field "#{transaction_type.name}_amount".to_sym,
                                  width: "one-quarter",
                                  prefix_text: "£" %>
           <%= f.govuk_collection_radio_buttons "#{transaction_type.name}_frequency".to_sym,
                                                RegularTransaction.frequencies_for(transaction_type),
                                                :itself, ->(option) { t("transaction_types.frequencies.#{option}") },
-                                               legend: {tag: "h2", size: "s"} %>
+                                               legend: { tag: "h2", size: "s" } %>
         <% end %>
       <% end %>
 
@@ -26,7 +26,7 @@
       <%= f.govuk_check_box :transaction_type_ids,
                             @form.none_selected,
                             exclusive: true,
-                            label: {text: t(".labels.none")} %>
+                            label: { text: t(".labels.none") } %>
     <% end %>
 
     <%= f.govuk_submit t("generic.save_and_continue") %>

--- a/app/views/providers/means/remove_dependants/show.html.erb
+++ b/app/views/providers/means/remove_dependants/show.html.erb
@@ -1,17 +1,17 @@
 <%= form_with(
-        url: providers_legal_aid_application_means_remove_dependant_path,
-        model: @form,
-        method: :patch,
-        local: true
+      url: providers_legal_aid_application_means_remove_dependant_path,
+      model: @form,
+      method: :patch,
+      local: true,
     ) do |form| %>
-    <%= page_template page_title: t('.page_title', name: @dependant.name), form: form,  template: :basic do %>
+    <%= page_template page_title: t(".page_title", name: @dependant.name), form:, template: :basic do %>
 
     <%= form.govuk_collection_radio_buttons :remove_dependant,
                                             yes_no_options,
                                             :value,
                                             :label,
-                                            legend: {text: content_for(:page_title), tag: 'h1', size: 'xl'} %>
+                                            legend: { text: content_for(:page_title), tag: "h1", size: "xl" } %>
 
-    <%= next_action_buttons(form: form) %>
+    <%= next_action_buttons(form:) %>
   <% end %>
 <% end %>

--- a/app/views/providers/means/restrictions/show.html.erb
+++ b/app/views/providers/means/restrictions/show.html.erb
@@ -2,23 +2,20 @@
               url: providers_legal_aid_application_means_restrictions_path(@legal_aid_application),
               method: :patch,
               local: true) do |form| %>
-  <%= page_template page_title: t('.h1-heading'), template: :basic, form: form do %>
+  <%= page_template page_title: t(".h1-heading"), template: :basic, form: do %>
 
     <%= form.govuk_radio_buttons_fieldset(:has_restrictions,
-                                          legend: { size: 'xl', tag: 'h1', text: page_title}) do %>
-      <p class="govuk-body"><%= t('.for_example') %></p>
+                                          legend: { size: "xl", tag: "h1", text: page_title }) do %>
+      <p class="govuk-body"><%= t(".for_example") %></p>
       <%= list_from_translation_path(".means.restrictions.show.examples") %>
-      <%= render 'shared/means/cost_of_living_details' %>
-      <%= form.govuk_radio_button :has_restrictions, true, link_errors: true, label: { text: t('generic.yes') } do %>
+      <%= render "shared/means/cost_of_living_details" %>
+      <%= form.govuk_radio_button :has_restrictions, true, link_errors: true, label: { text: t("generic.yes") } do %>
         <%= form.govuk_text_area :restrictions_details,
-                                 label: { text: t('.restrictions_details') }, rows: 5 %>
+                                 label: { text: t(".restrictions_details") }, rows: 5 %>
       <% end %>
-      <%= form.govuk_radio_button :has_restrictions, false, label: { text: t('generic.no') } %>
+      <%= form.govuk_radio_button :has_restrictions, false, label: { text: t("generic.no") } %>
     <% end %>
 
-    <%= next_action_buttons(
-            show_draft: true,
-            form: form
-        ) %>
+    <%= next_action_buttons(show_draft: true, form:) %>
   <% end %>
 <% end %>

--- a/app/views/providers/means/savings_and_investments/show.html.erb
+++ b/app/views/providers/means/savings_and_investments/show.html.erb
@@ -2,25 +2,22 @@
               url: providers_legal_aid_application_means_savings_and_investment_path(@legal_aid_application),
               method: :patch,
               local: true) do |form| %>
-  <%= page_template page_title: t('.h1-heading'), template: :basic, form: form do %>
+  <%= page_template page_title: t(".h1-heading"), template: :basic, form: do %>
 
   <%= form.govuk_check_boxes_fieldset :bank_accounts,
-                                      legend: { text: page_title, size: "xl", tag: 'h1'},
-                                      hint: { text: t('generic.select_all_that_apply')} do %>
+                                      legend: { text: page_title, size: "xl", tag: "h1" },
+                                      hint: { text: t("generic.select_all_that_apply") } do %>
     <div class="govuk-checkboxes" data-module="govuk-checkboxes">
       <div class="deselect-group" data-deselect-ctrl="#savings-amount-none-selected-true-field">
-        <%= render partial: 'shared/forms/revealing_checkbox/attribute',
+        <%= render partial: "shared/forms/revealing_checkbox/attribute",
                    collection: attributes,
-                   locals: { model: @form, form: form } %>
+                   locals: { model: @form, form: } %>
       </div>
     </div>
     <%= form.govuk_radio_divider %>
-    <%= form.govuk_check_box :none_selected, true, '', multiple: false, label: {text: t('.none_selected')} %>
+    <%= form.govuk_check_box :none_selected, true, "", multiple: false, label: { text: t(".none_selected") } %>
   <% end %>
 
-  <%= next_action_buttons(
-          show_draft: true,
-          form: form
-      ) %>
+  <%= next_action_buttons(show_draft: true, form:) %>
   <% end %>
 <% end %>

--- a/app/views/providers/means/shared_ownerships/show.html.erb
+++ b/app/views/providers/means/shared_ownerships/show.html.erb
@@ -1,12 +1,13 @@
 <%= form_with(
-        model: @form,
-        scope: :legal_aid_application,
-        url: providers_legal_aid_application_means_shared_ownership_path(@legal_aid_application),
-        method: :patch,
-        local: true) do |form| %>
-  <%= page_template page_title: t('.heading_1'), template: :basic, form: form do %>
+      model: @form,
+      scope: :legal_aid_application,
+      url: providers_legal_aid_application_means_shared_ownership_path(@legal_aid_application),
+      method: :patch,
+      local: true,
+    ) do |form| %>
+  <%= page_template page_title: t(".heading_1"), template: :basic, form: do %>
 
-    <%= form.govuk_radio_buttons_fieldset(:shared_ownership, legend: { size: 'xl', tag: 'h1', text: page_title }) do %>
+    <%= form.govuk_radio_buttons_fieldset(:shared_ownership, legend: { size: "xl", tag: "h1", text: page_title }) do %>
       <% LegalAidApplication::SHARED_OWNERSHIP_REASONS.each do |reason| %>
         <% if reason == 'no_sole_owner' %>
           <%= form.govuk_radio_divider %>
@@ -15,9 +16,6 @@
       <% end %>
     <% end %>
 
-    <%= next_action_buttons(
-            show_draft: true,
-            form: form
-        ) %>
+    <%= next_action_buttons(show_draft: true, form:) %>
   <% end %>
 <% end %>

--- a/app/views/providers/means/student_finances/show.html.erb
+++ b/app/views/providers/means/student_finances/show.html.erb
@@ -1,5 +1,5 @@
 <%= form_with(model: @form,
               url: providers_legal_aid_application_means_student_finance_path,
               method: :patch, local: true) do |form| %>
-  <%= render 'shared/means/student_finances', form: form %>
+  <%= render "shared/means/student_finances", form: %>
 <% end %>

--- a/app/views/providers/means/vehicles/show.html.erb
+++ b/app/views/providers/means/vehicles/show.html.erb
@@ -2,20 +2,20 @@
               url: providers_legal_aid_application_means_vehicle_path,
               method: :patch,
               local: true) do |form| %>
-  <%= page_template page_title: t('.heading'), template: :basic, form: form do %>
+  <%= page_template page_title: t(".heading"), template: :basic, form: do %>
 
     <%= form.govuk_collection_radio_buttons(
-            :own_vehicle,
-            yes_no_options,
-            :value,
-            :label,
-            legend: {size: 'xl', tag: 'h1', text: t('.heading')},
-            hint: {text: t('.hint') }
+          :own_vehicle,
+          yes_no_options,
+          :value,
+          :label,
+          legend: { size: "xl", tag: "h1", text: t(".heading") },
+          hint: { text: t(".hint") },
         ) %>
 
     <%= next_action_buttons(
-            show_draft: true,
-            form: form
+          show_draft: true,
+          form:,
         ) %>
   <% end %>
 <% end %>

--- a/app/views/providers/means_reports/_caseworker_review.html.erb
+++ b/app/views/providers/means_reports/_caseworker_review.html.erb
@@ -1,5 +1,5 @@
   <section class="print-no-break">
-    <h2 class="govuk-heading-l"><%= t('providers.means_reports.caseworker_review_section_heading') %></h2>
+    <h2 class="govuk-heading-l"><%= t("providers.means_reports.caseworker_review_section_heading") %></h2>
 
     <section>
       <dl id="caseworker-review-questions" class="govuk-summary-list govuk-!-margin-bottom-9">

--- a/app/views/providers/means_reports/_dependants.html.erb
+++ b/app/views/providers/means_reports/_dependants.html.erb
@@ -1,29 +1,29 @@
-<h2 class="govuk-heading-m"><%= t('providers.means_reports.dependants_heading') %></h2>
+<h2 class="govuk-heading-m"><%= t("providers.means_reports.dependants_heading") %></h2>
 
 <dl id="dependants-questions" class="govuk-summary-list govuk-!-margin-bottom-9">
   <%= check_answer_link(
-          name: "child_dependants",
-          question: t('providers.means_reports.child_dependants'),
-          answer: @legal_aid_application.dependants.child_relative.count,
-          read_only: read_only
+        name: "child_dependants",
+        question: t("providers.means_reports.child_dependants"),
+        answer: @legal_aid_application.dependants.child_relative.count,
+        read_only:,
       ) %>
 
   <%= check_answer_link(
-          name: "adult_dependants",
-          question: t('providers.means_reports.adult_dependants'),
-          answer: @legal_aid_application.dependants.adult_relative.count,
-          read_only: read_only
+        name: "adult_dependants",
+        question: t("providers.means_reports.adult_dependants"),
+        answer: @legal_aid_application.dependants.adult_relative.count,
+        read_only:,
       ) %>
 </dl>
 
 <% if @legal_aid_application.dependants %>
   <% @legal_aid_application.dependants.each_with_index do |dependant, index| %>
     <%= check_answer_one_change_link(
-      name: "dependants_#{index + 1}",
-      url: providers_legal_aid_application_means_dependant_path(@legal_aid_application, dependant),
-      question: "Dependant #{index + 1}: #{dependant.name}",
-      answer_hash: dependant_hash(dependant),
-      read_only: read_only
-    ) %>
+          name: "dependants_#{index + 1}",
+          url: providers_legal_aid_application_means_dependant_path(@legal_aid_application, dependant),
+          question: "Dependant #{index + 1}: #{dependant.name}",
+          answer_hash: dependant_hash(dependant),
+          read_only:,
+        ) %>
   <% end %>
 <% end %>

--- a/app/views/providers/means_reports/_income_cash_payments.html.erb
+++ b/app/views/providers/means_reports/_income_cash_payments.html.erb
@@ -1,40 +1,35 @@
-<h2 class="govuk-heading-m"><%= t('providers.means_reports.income_cash_payments_heading') %></h2>
+<h2 class="govuk-heading-m"><%= t("providers.means_reports.income_cash_payments_heading") %></h2>
 
-<%
-credits = @legal_aid_application.legal_aid_application_transaction_types.credits
-cash_credits = @legal_aid_application.cash_transactions.credits.order(:transaction_date)
-credit_categories = TransactionType.credits.not_children
-%>
+<% credits = @legal_aid_application.legal_aid_application_transaction_types.credits %>
+<% cash_credits = @legal_aid_application.cash_transactions.credits.order(:transaction_date) %>
+<% credit_categories = TransactionType.credits.not_children %>
 
 <% if !@legal_aid_application.transaction_types.credits.exists? %>
- <div class="govuk-body>"> <%= t('generic.none') %> </div>
+  <div class="govuk-body>"><%= t("generic.none") %></div>
 <% end %>
 
 <dl id="income-cash-payments-questions" class="govuk-summary-list govuk-!-margin-bottom-9">
   <% credit_categories.each do |category| %>
     <% if credits.pluck(:transaction_type_id).include?(category.id) %>
       <% if cash_credits.pluck(:transaction_type_id).include?(category.id) %>
-        <%
-        cash_payments = cash_credits.where(transaction_type_id: category.id)
+        <% cash_payments = cash_credits.where(transaction_type_id: category.id) %>
 
-        cash_payment_list = cash_payments.each_with_object([]) do |payment, list|
-          list << "#{payment.transaction_date.strftime("%B %Y")} #{gds_number_to_currency(payment.amount, precision: 2)}"
-        end
-        %>
-
+        <% cash_payment_list = cash_payments.each_with_object([]) do |payment, list|
+             list << "#{payment.transaction_date.strftime('%B %Y')} #{gds_number_to_currency(payment.amount, precision: 2)}"
+           end %>
         <%= check_answer_link(
-            name: category.label_name,
-            question: category.label_name,
-            answer: cash_payment_list,
-            read_only: true) %>
-
+              name: category.label_name,
+              question: category.label_name,
+              answer: cash_payment_list,
+              read_only: true,
+            ) %>
       <% else %>
         <%= check_answer_link(
-            name: category.label_name,
-            question: category.label_name,
-            answer: "None",
-            read_only: true) %>
+              name: category.label_name,
+              question: category.label_name,
+              answer: "None",
+              read_only: true,
+            ) %>
       <% end %>
     <% end %>
-  <% end %>
-</dl>
+  <% end %>>

--- a/app/views/providers/means_reports/_income_categories.html.erb
+++ b/app/views/providers/means_reports/_income_categories.html.erb
@@ -1,18 +1,17 @@
-<h2 class="govuk-heading-m"><%= t('providers.means_reports.income_categories_heading') %></h2>
+<h2 class="govuk-heading-m"><%= t("providers.means_reports.income_categories_heading") %></h2>
 
-<%
-credits = @legal_aid_application.legal_aid_application_transaction_types.credits
-credit_categories = TransactionType.credits.not_children
-%>
+<% credits = @legal_aid_application.legal_aid_application_transaction_types.credits %>
+<% credit_categories = TransactionType.credits.not_children %>
 
 <dl id="income-category-questions" class="govuk-summary-list govuk-!-margin-bottom-9">
   <% credit_categories.each do |category| %>
     <% answer = credits.pluck(:transaction_type_id).include?(category.id) %>
 
     <%= check_answer_link(
-        name: category.label_name,
-        question: category.label_name,
-        answer: safe_yes_or_no(answer),
-        read_only: true) %>
+          name: category.label_name,
+          question: category.label_name,
+          answer: safe_yes_or_no(answer),
+          read_only: true,
+        ) %>
   <% end %>
 </dl>

--- a/app/views/providers/means_reports/_outgoings_cash_payments.html.erb
+++ b/app/views/providers/means_reports/_outgoings_cash_payments.html.erb
@@ -1,40 +1,36 @@
-<h2 class="govuk-heading-m"><%= t('providers.means_reports.outgoings_cash_payments_heading') %></h2>
+<h2 class="govuk-heading-m"><%= t("providers.means_reports.outgoings_cash_payments_heading") %></h2>
 
-<%
-debits = @legal_aid_application.legal_aid_application_transaction_types.debits
-cash_debits = @legal_aid_application.cash_transactions.debits.order(:transaction_date)
-debit_categories = TransactionType.debits
-%>
+<% debits = @legal_aid_application.legal_aid_application_transaction_types.debits %>
+<% cash_debits = @legal_aid_application.cash_transactions.debits.order(:transaction_date) %>
+<% debit_categories = TransactionType.debits %>
 
 <% if !@legal_aid_application.transaction_types.debits.exists? %>
-  <div class="govuk-body>"> <%= t('generic.none') %> </div>
+  <div class="govuk-body>"> <%= t("generic.none") %> </div>
 <% end %>
 
 <dl id="outgoings-cash-payments-questions" class="govuk-summary-list govuk-!-margin-bottom-9">
   <% debit_categories.each do |category| %>
     <% if debits.pluck(:transaction_type_id).include?(category.id) %>
       <% if cash_debits.pluck(:transaction_type_id).include?(category.id) %>
-        <%
-        cash_payments = cash_debits.where(transaction_type_id: category.id)
+        <% cash_payments = cash_debits.where(transaction_type_id: category.id) %>
 
-        cash_payment_list = cash_payments.each_with_object([]) do |payment, list|
-          list << "#{payment.transaction_date.strftime("%B %Y")} #{gds_number_to_currency(payment.amount, precision: 2)}"
-        end
-        %>
+        <% cash_payment_list = cash_payments.each_with_object([]) do |payment, list|
+             list << "#{payment.transaction_date.strftime('%B %Y')} #{gds_number_to_currency(payment.amount, precision: 2)}"
+           end %>
 
         <%= check_answer_link(
-            name: category.label_name,
-            question: category.label_name,
-            answer: cash_payment_list,
-            read_only: true) %>
-
+              name: category.label_name,
+              question: category.label_name,
+              answer: cash_payment_list,
+              read_only: true,
+            ) %>
       <% else %>
         <%= check_answer_link(
-            name: category.label_name,
-            question: category.label_name,
-            answer: t('generic.none'),
-            read_only: true) %>
+              name: category.label_name,
+              question: category.label_name,
+              answer: t("generic.none"),
+              read_only: true,
+            ) %>
       <% end %>
     <% end %>
-  <% end %>
-</dl>
+  <% end %>>

--- a/app/views/providers/means_reports/_outgoings_categories.html.erb
+++ b/app/views/providers/means_reports/_outgoings_categories.html.erb
@@ -1,10 +1,8 @@
-<h2 class="govuk-heading-m"><%= t('providers.means_reports.outgoings_categories_heading') %></h2>
+<h2 class="govuk-heading-m"><%= t("providers.means_reports.outgoings_categories_heading") %></h2>
 
 <!-- TODO: move ruby to controller or presenter?! -->
-<%
-debits = @legal_aid_application.legal_aid_application_transaction_types.debits
-debit_categories = TransactionType.debits
-%>
+<% debits = @legal_aid_application.legal_aid_application_transaction_types.debits %>
+<% debit_categories = TransactionType.debits %>
 
 <dl id="outgoings-category-questions" class="govuk-summary-list govuk-!-margin-bottom-9">
   <% debit_categories.each do |category| %>
@@ -14,6 +12,7 @@ debit_categories = TransactionType.debits
           name: category.label_name,
           question: category.label_name,
           answer: safe_yes_or_no(answer),
-          read_only: true) %>
+          read_only: true,
+        ) %>
   <% end %>
 </dl>

--- a/app/views/providers/means_reports/_proceeding_eligibility.html.erb
+++ b/app/views/providers/means_reports/_proceeding_eligibility.html.erb
@@ -1,4 +1,4 @@
-<h2 class="govuk-heading-m"><%= t('providers.means_reports.proceeding_eligibility') %></h2>
+<h2 class="govuk-heading-m"><%= t("providers.means_reports.proceeding_eligibility") %></h2>
 
 <dl id="proceeding-eligibility-questions" class="govuk-summary-list govuk-!-margin-bottom-9">
   <% results.each do |proceeding_type, result| %>
@@ -7,6 +7,7 @@
           question: proceeding_type,
           answer: result,
           url: nil,
-          read_only: true) %>
+          read_only: true,
+        ) %>
   <% end %>
 </dl>

--- a/app/views/providers/means_reports/_receives_benefits.html.erb
+++ b/app/views/providers/means_reports/_receives_benefits.html.erb
@@ -1,12 +1,12 @@
 <h2 class="govuk-heading-m">
-  <%= t('providers.means_reports.benefit_check_heading') %>
+  <%= t("providers.means_reports.benefit_check_heading") %>
 </h2>
 
 <dl class="govuk-summary-list govuk-!-margin-bottom-9">
   <%= check_answer_link(
         name: :receives_benefit,
-        question: t('providers.means_reports.benefit_check_question'),
+        question: t("providers.means_reports.benefit_check_question"),
         answer: yes_no(@legal_aid_application.applicant_receives_benefit?),
-        read_only: true
+        read_only: true,
       ) %>
 </dl>

--- a/app/views/providers/means_reports/_student_finance.html.erb
+++ b/app/views/providers/means_reports/_student_finance.html.erb
@@ -1,9 +1,10 @@
-<h2 class="govuk-heading-m"><%= t('providers.means_reports.student_finance_heading') %></h2>
+<h2 class="govuk-heading-m"><%= t("providers.means_reports.student_finance_heading") %></h2>
 
 <dl id="student-finance-questions" class="govuk-summary-list govuk-!-margin-bottom-9">
   <%= check_answer_no_link(
-      name: :student_finance_annual_amount,
-      question: "Student loan or grant (per year)",
-      answer: gds_number_to_currency(@legal_aid_application.value_of_student_finance.to_f),
-      read_only: read_only) %>
+        name: :student_finance_annual_amount,
+        question: "Student loan or grant (per year)",
+        answer: gds_number_to_currency(@legal_aid_application.value_of_student_finance.to_f),
+        read_only:,
+      ) %>
 </dl>

--- a/app/views/providers/means_reports/_with_bank_statement_uploads.html.erb
+++ b/app/views/providers/means_reports/_with_bank_statement_uploads.html.erb
@@ -1,65 +1,65 @@
-<%= render 'receives_benefits' %>
+<%= render "receives_benefits" %>
 
 <% if @legal_aid_application.non_passported? %>
   <section class="print-no-break">
-    <%= render('income_categories', read_only: true) %>
+    <%= render("income_categories", read_only: true) %>
   </section>
 
   <section class="print-no-break">
-    <%= render('student_finance', read_only: true) %>
+    <%= render("student_finance", read_only: true) %>
   </section>
 
   <section class="print-no-break">
-    <%= render('income_cash_payments', read_only: true) %>
+    <%= render("income_cash_payments", read_only: true) %>
   </section>
 
   <section class="print-no-break">
-    <%= render('dependants', read_only: true) %>
+    <%= render("dependants", read_only: true) %>
   </section>
 
   <section class="print-no-break">
-    <%= render('outgoings_categories', read_only: true) %>
+    <%= render("outgoings_categories", read_only: true) %>
   </section>
 
   <section class="print-no-break">
-    <%= render('outgoings_cash_payments', read_only: true) %>
+    <%= render("outgoings_cash_payments", read_only: true) %>
   </section>
 
   <section class="print-no-break">
     <% if @legal_aid_application.extra_employment_information? %>
-      <%= render 'shared/check_answers/employed_income', read_only: true %>
+      <%= render "shared/check_answers/employed_income", read_only: true %>
     <% end %>
   </section>
 
   <h2 class="govuk-heading-m">
-    <%= t('.income_result_heading') %>
+    <%= t(".income_result_heading") %>
   </h2>
 
   <section class="print-no-break">
-    <%= render 'shared/check_answers/income_result', read_only: true %>
+    <%= render "shared/check_answers/income_result", read_only: true %>
   </section>
 
   <section class="print-no-break">
     <% if @legal_aid_application.full_employment_details? %>
-      <%= render 'shared/check_answers/full_employment_details', read_only: true %>
+      <%= render "shared/check_answers/full_employment_details", read_only: true %>
     <% end %>
   </section>
 
   <div class="govuk-!-padding-bottom-8"></div>
 
-  <%= render 'caseworker_review' %>
+  <%= render "caseworker_review" %>
 <% end %>
 
 <h2 class="govuk-heading-m">
-  <%= t('.assets_heading') %>
+  <%= t(".assets_heading") %>
 </h2>
 
-<%= render 'shared/check_answers/assets', read_only: true %>
+<%= render "shared/check_answers/assets", read_only: true %>
 
 <% if @legal_aid_application.passported? && @manual_review_determiner.manual_review_required? %>
-    <%= render 'caseworker_review' %>
+    <%= render "caseworker_review" %>
 <% end %>
 
 <section class="print-no-break">
-  <%= render('shared/check_answers/bank_statements', bank_statements: @legal_aid_application.attachments.bank_statement_evidence, read_only: true) %>
+  <%= render("shared/check_answers/bank_statements", bank_statements: @legal_aid_application.attachments.bank_statement_evidence, read_only: true) %>
 </section>

--- a/app/views/providers/means_reports/_with_cfe_result_details.html.erb
+++ b/app/views/providers/means_reports/_with_cfe_result_details.html.erb
@@ -1,76 +1,76 @@
 <% if @legal_aid_application.cfe_result.version >= 4 %>
-  <%= render 'proceeding_eligibility', results: @legal_aid_application.cfe_result.results_by_proceeding_type %>
+  <%= render "proceeding_eligibility", results: @legal_aid_application.cfe_result.results_by_proceeding_type %>
 <% end %>
 
-<%= render 'receives_benefits' %>
+<%= render "receives_benefits" %>
 
 <% if @legal_aid_application.non_passported? %>
   <h2 class="govuk-heading-m">
-    <%= t('.income_result_heading') %>
+    <%= t(".income_result_heading") %>
   </h2>
 
-  <%= render 'shared/check_answers/income_result', read_only: true %>
+  <%= render "shared/check_answers/income_result", read_only: true %>
 
   <section class="print-no-break">
     <h2 class="govuk-heading-m">
-      <%= t('.income_details_heading') %>
+      <%= t(".income_details_heading") %>
     </h2>
-    <%= render 'shared/check_answers/income_details' %>
+    <%= render "shared/check_answers/income_details" %>
   </section>
 
   <section class="print-no-break">
     <% if @legal_aid_application.extra_employment_information? %>
-      <%= render 'shared/check_answers/employed_income', read_only: true %>
+      <%= render "shared/check_answers/employed_income", read_only: true %>
     <% end %>
   </section>
 
   <section class="print-no-break">
     <% if @legal_aid_application.full_employment_details? %>
-      <%= render 'shared/check_answers/full_employment_details', read_only: true %>
+      <%= render "shared/check_answers/full_employment_details", read_only: true %>
     <% end %>
   </section>
 
   <div class="govuk-!-padding-bottom-8"></div>
 
   <section class="print-no-break">
-    <h2 class="govuk-heading-l"><%= t('.debits-section-heading') %></h2>
-    <%= render 'shared/check_answers/outgoings_details' %>
+    <h2 class="govuk-heading-l"><%= t(".debits-section-heading") %></h2>
+    <%= render "shared/check_answers/outgoings_details" %>
   </section>
 
   <div class="govuk-!-padding-bottom-8"></div>
 
   <section class="print-no-break">
-    <h2 class="govuk-heading-l"><%= t('.deductions-section-heading') %></h2>
-    <%= render 'shared/check_answers/deductions_details' %>
+    <h2 class="govuk-heading-l"><%= t(".deductions-section-heading") %></h2>
+    <%= render "shared/check_answers/deductions_details" %>
   </section>
 
   <div class="govuk-!-padding-bottom-8"></div>
 
-  <%= render 'caseworker_review' %>
+  <%= render "caseworker_review" %>
 <% end %>
 
 <section class="print-no-break">
   <h2 class="govuk-heading-m">
-    <%= t('.capital_result_heading') %>
+    <%= t(".capital_result_heading") %>
   </h2>
 
-  <%= render 'shared/check_answers/capital_result', read_only: true %>
+  <%= render "shared/check_answers/capital_result", read_only: true %>
 </section>
 
 <h2 class="govuk-heading-m">
-  <%= t('.assets_heading') %>
+  <%= t(".assets_heading") %>
 </h2>
 
-<%= render 'shared/check_answers/assets', read_only: true %>
+<%= render "shared/check_answers/assets", read_only: true %>
 
 <% if @legal_aid_application.passported? && @manual_review_determiner.manual_review_required? %>
-    <%= render 'caseworker_review' %>
+    <%= render "caseworker_review" %>
 <% end %>
 
 <% if @legal_aid_application.uploading_bank_statements? %>
 <div class="govuk-!-padding-bottom-8"></div>
 
 <section class="print-no-break">
-  <%= render('shared/check_answers/bank_statements', bank_statements: @legal_aid_application.attachments.bank_statement_evidence, read_only: true) %>
+  <%= render("shared/check_answers/bank_statements", bank_statements: @legal_aid_application.attachments.bank_statement_evidence, read_only: true) %>
 </section>
 <% end %>

--- a/app/views/providers/means_reports/show.html.erb
+++ b/app/views/providers/means_reports/show.html.erb
@@ -1,17 +1,18 @@
-<%= page_template page_title: t('.heading'), back_link: :none do %>
+<%= page_template page_title: t(".heading"), back_link: :none do %>
   <% @legal_aid_application = legal_aid_application if @legal_aid_application.nil? %>
   <% @cfe_result = cfe_result if @cfe_result.nil? %>
   <% @manual_review_determiner = manual_review_determiner if @manual_review_determiner.nil? %>
 
-  <%= render 'shared/application_ref', legal_aid_application: @legal_aid_application %>
+  <%= render "shared/application_ref", legal_aid_application: @legal_aid_application %>
 
-  <h2 class="govuk-heading-m"><%= t('.client_details_heading') %></h2>
+  <h2 class="govuk-heading-m"><%= t(".client_details_heading") %></h2>
 
   <%= render(
-        'shared/check_answers/client_details',
+        "shared/check_answers/client_details",
         attributes: %i[first_name last_name date_of_birth age means_test national_insurance_number],
         applicant: @legal_aid_application.applicant,
-        read_only: true) %>
+        read_only: true,
+      ) %>
 
   <%= render "with_cfe_result_details" unless @legal_aid_application.non_means_tested? %>
 

--- a/app/views/providers/means_summaries/_income_assessment.html.erb
+++ b/app/views/providers/means_summaries/_income_assessment.html.erb
@@ -1,45 +1,45 @@
 <% bank_statement_upload = @legal_aid_application.uploading_bank_statements? %>
 
-<h2 class="govuk-heading-l"><%= t('.income-heading') %></h2>
+<h2 class="govuk-heading-l"><%= t(".income-heading") %></h2>
 
 <% if bank_statement_upload %>
-  <%= render('shared/check_answers/bank_statements', bank_statements: @legal_aid_application.attachments.bank_statement_evidence, read_only: false) %>
+  <%= render("shared/check_answers/bank_statements", bank_statements: @legal_aid_application.attachments.bank_statement_evidence, read_only: false) %>
 <% end %>
 
 <% if @legal_aid_application.hmrc_employment_income? %>
   <% if @legal_aid_application.has_multiple_employments? %>
-    <%= render 'shared/check_answers/full_employment_details', read_only: false %>
+    <%= render "shared/check_answers/full_employment_details", read_only: false %>
   <% else %>
-    <%= render 'shared/check_answers/employed_income', read_only: false %>
+    <%= render "shared/check_answers/employed_income", read_only: false %>
   <% end %>
 <% elsif @legal_aid_application.applicant_employed? %>
-  <%= render 'shared/check_answers/full_employment_details', read_only: false %>
+  <%= render "shared/check_answers/full_employment_details", read_only: false %>
 <% end %>
 
 <%= render(
-      'shared/check_answers/income_summary',
-      income_type: t('.credits-section-heading'),
+      "shared/check_answers/income_summary",
+      income_type: t(".credits-section-heading"),
       url: @legal_aid_application.uploading_bank_statements? ? :regular_incomes : :identify_types_of_incomes,
-      transaction_types: @credit_transaction_types
+      transaction_types: @credit_transaction_types,
     ) %>
 
-<%= render('shared/check_answers/income_cash_payments', read_only: false) if @legal_aid_application.uploading_bank_statements? %>
+<%= render("shared/check_answers/income_cash_payments", read_only: false) if @legal_aid_application.uploading_bank_statements? %>
 
-<%= render 'shared/check_answers/student_finance', read_only: false %>
+<%= render "shared/check_answers/student_finance", read_only: false %>
 
-<h2 class="govuk-heading-l"><%= t('.outgoings-heading') %></h2>
+<h2 class="govuk-heading-l"><%= t(".outgoings-heading") %></h2>
 
 <%= render(
-      'shared/check_answers/income_summary',
-      income_type: t('.debits-section-heading'),
+      "shared/check_answers/income_summary",
+      income_type: t(".debits-section-heading"),
       url: @legal_aid_application.uploading_bank_statements? ? :regular_outgoings : :identify_types_of_outgoings,
-      transaction_types: @debit_transaction_types
+      transaction_types: @debit_transaction_types,
     ) %>
 
-<%= render('shared/check_answers/housing_benefit', read_only: false) if @legal_aid_application.housing_benefit_regular_transaction_applicable? %>
+<%= render("shared/check_answers/housing_benefit", read_only: false) if @legal_aid_application.housing_benefit_regular_transaction_applicable? %>
 
-<%= render('shared/check_answers/outgoings_cash_payments', read_only: false) if @legal_aid_application.uploading_bank_statements? %>
+<%= render("shared/check_answers/outgoings_cash_payments", read_only: false) if @legal_aid_application.uploading_bank_statements? %>
 
-<h2 class="govuk-heading-l"><%= t('.dependants.heading') %></h2>
+<h2 class="govuk-heading-l"><%= t(".dependants.heading") %></h2>
 
-<%= render 'shared/check_answers/dependants' %>
+<%= render "shared/check_answers/dependants" %>

--- a/app/views/providers/means_summaries/show.html.erb
+++ b/app/views/providers/means_summaries/show.html.erb
@@ -1,18 +1,18 @@
-<%= page_template(page_title: t('.h1-heading')) do %>
+<%= page_template(page_title: t(".h1-heading")) do %>
 
-  <%= render 'providers/means_summaries/income_assessment' %>
+  <%= render "providers/means_summaries/income_assessment" %>
 
-  <h2 class="govuk-heading-l"><%= t('.capital-section-heading') %></h2>
+  <h2 class="govuk-heading-l"><%= t(".capital-section-heading") %></h2>
 
-  <%= render 'shared/check_answers/assets' %>
+  <%= render "shared/check_answers/assets" %>
 
-  <h3 class="govuk-heading-m"><%= t('.what_happens_next.heading') %></h3>
-  <p class="govuk-body govuk-!-margin-bottom-7"><%= t('.what_happens_next.text') %></p>
+  <h3 class="govuk-heading-m"><%= t(".what_happens_next.heading") %></h3>
+  <p class="govuk-body govuk-!-margin-bottom-7"><%= t(".what_happens_next.text") %></p>
 
   <%= next_action_buttons_with_form(
         url: providers_legal_aid_application_means_summary_path,
         method: :patch,
-        show_draft: true
+        show_draft: true,
       ) %>
 
 <% end %>

--- a/app/views/providers/merits_reports/show.html.erb
+++ b/app/views/providers/merits_reports/show.html.erb
@@ -1,52 +1,52 @@
-<%= page_template page_title: t('.heading'), back_link: :none do %>
+<%= page_template page_title: t(".heading"), back_link: :none do %>
   <% @legal_aid_application = legal_aid_application if @legal_aid_application.nil? %>
 
-  <%= render 'shared/application_ref', legal_aid_application: @legal_aid_application %>
+  <%= render "shared/application_ref", legal_aid_application: @legal_aid_application %>
 
-  <h2 class="govuk-heading-m"><%= t('.client_details_heading') %></h2>
+  <h2 class="govuk-heading-m"><%= t(".client_details_heading") %></h2>
 
   <%= render(
-        'shared/check_answers/client_details',
+        "shared/check_answers/client_details",
         attributes: %i[first_name last_name date_of_birth age means_test national_insurance_number],
         applicant: @legal_aid_application.applicant,
-        read_only: true
+        read_only: true,
       ) %>
 
-  <h2 class="govuk-heading-m"><%= t('.applying_for') %></h2>
+  <h2 class="govuk-heading-m"><%= t(".applying_for") %></h2>
 
   <%= render(
-        'shared/check_answers/proceedings_details',
+        "shared/check_answers/proceedings_details",
         legal_aid_application: @legal_aid_application,
         read_only: true,
-        show_client_involvment_type: true
+        show_client_involvment_type: true,
       ) %>
 
-  <h2 class="govuk-heading-m"><%= t '.delegated_functions' %></h2>
+  <h2 class="govuk-heading-m"><%= t ".delegated_functions" %></h2>
 
   <%= render(
-          'shared/check_answers/delegated_functions',
-          legal_aid_application: @legal_aid_application,
-          read_only: true,
+        "shared/check_answers/delegated_functions",
+        legal_aid_application: @legal_aid_application,
+        read_only: true,
       ) %>
 
   <% if @legal_aid_application.used_delegated_functions? %>
-    <h2 class="govuk-heading-m"><%= t '.emergency_cost_limit' %></h2>
+    <h2 class="govuk-heading-m"><%= t ".emergency_cost_limit" %></h2>
 
     <%= render(
-          'shared/check_answers/emergency_costs',
+          "shared/check_answers/emergency_costs",
           legal_aid_application: @legal_aid_application,
           read_only: true,
-          ) %>
+        ) %>
   <% end %>
 
   <% if @legal_aid_application.substantive_cost_overridable? %>
-    <h2 class="govuk-heading-m"><%= t '.substantive_cost_limit' %></h2>
+    <h2 class="govuk-heading-m"><%= t ".substantive_cost_limit" %></h2>
 
     <%= render(
-          'shared/check_answers/substantive_costs',
+          "shared/check_answers/substantive_costs",
           legal_aid_application: @legal_aid_application,
           read_only: true,
-          ) %>
+        ) %>
   <% end %>
 
   <%= render(
@@ -58,6 +58,6 @@
         allegation: @legal_aid_application&.allegation,
         undertaking: @legal_aid_application&.undertaking,
         urgency: @legal_aid_application&.urgency,
-        read_only: true
+        read_only: true,
       ) %>
 <% end %>

--- a/app/views/providers/merits_task_lists/_task_list_item.html.erb
+++ b/app/views/providers/merits_task_lists/_task_list_item.html.erb
@@ -8,9 +8,9 @@
     <% end %>
   </span>
   <%= govuk_tag(
-      text: t(".states.#{status}"),
-      colour: tag_colour,
-      classes: "app-task-list__tag",
-      html_attributes: { id: "#{name}_status" }
-    ) %>
+        text: t(".states.#{status}"),
+        colour: tag_colour,
+        classes: "app-task-list__tag",
+        html_attributes: { id: "#{name}_status" },
+      ) %>
 </li>

--- a/app/views/providers/merits_task_lists/_task_list_section.html.erb
+++ b/app/views/providers/merits_task_lists/_task_list_section.html.erb
@@ -7,10 +7,10 @@
     <% tasks.each do |task| %>
       <% next if task.state.eql?(:ignored) %>
       <%= task_list_item(
-              name: task.name,
-              status: task.state,
-              legal_aid_application: @legal_aid_application,
-              ccms_code: ccms_code
+            name: task.name,
+            status: task.state,
+            legal_aid_application: @legal_aid_application,
+            ccms_code:,
           ) %>
     <% end %>
   </ul>

--- a/app/views/providers/merits_task_lists/show.html.erb
+++ b/app/views/providers/merits_task_lists/show.html.erb
@@ -1,24 +1,24 @@
 <%= page_template(
-    page_title: t('.page_heading'),
-    back_link: { path: back_path },
-    show_errors_for: @merits_task_list
+      page_title: t(".page_heading"),
+      back_link: { path: back_path },
+      show_errors_for: @merits_task_list,
     ) do %>
 
-  <div id='task_list' class="<%= 'govuk-form-group--error' if @merits_task_list&.errors&.any? && @merits_task_list.errors[:task_list].present? %>">
-    <h2 class="govuk-heading-l"><%= t('.application_heading') %></h2>
+  <div id='task_list' class="<%= "govuk-form-group--error" if @merits_task_list&.errors&.any? && @merits_task_list.errors[:task_list].present? %>">
+    <h2 class="govuk-heading-l"><%= t(".application_heading") %></h2>
 
     <% if @merits_task_list&.errors&.any? && @merits_task_list.errors[:task_list].present? %>
       <p class="govuk-error-message" id="task-list-error">
         <span class="govuk-visually-hidden">Error: </span>
-        <%= @merits_task_list&.errors[:task_list]&.first %>
+        <%= @merits_task_list.errors[:task_list].first %>
       </p>
     <% end %>
     <ol class="app-task-list">
-      <%= render 'task_list_section', name: t('.application_section_heading'), ccms_code: nil, tasks: @merits_tasks[:application], section_number: 1 %>
+      <%= render "task_list_section", name: t(".application_section_heading"), ccms_code: nil, tasks: @merits_tasks[:application], section_number: 1 %>
 
-      <h2 class="govuk-heading-l govuk-!-margin-top-4"><%= t('.proceeding_heading') %></h2>
+      <h2 class="govuk-heading-l govuk-!-margin-top-4"><%= t(".proceeding_heading") %></h2>
       <% @merits_tasks[:proceedings].each_with_index do |(_, proceeding), index| %>
-        <%= render 'task_list_section', name: proceeding[:name], tasks: proceeding[:tasks], ccms_code: @merits_tasks[:proceedings].keys[index], section_number: index + 2 %>
+        <%= render "task_list_section", name: proceeding[:name], tasks: proceeding[:tasks], ccms_code: @merits_tasks[:proceedings].keys[index], section_number: index + 2 %>
       <% end %>
     </ol>
   </div>
@@ -27,6 +27,6 @@
   <%= next_action_buttons_with_form(
         url: providers_legal_aid_application_merits_task_list_path,
         method: :patch,
-        show_draft: true
+        show_draft: true,
       ) %>
 <% end %>

--- a/app/views/providers/no_eligibility_assessments/show.html.erb
+++ b/app/views/providers/no_eligibility_assessments/show.html.erb
@@ -1,8 +1,8 @@
 <%= page_template(
       page_title: t(".page_title"),
-      head_title: t('.no_cfe_assessment'),
+      head_title: t(".no_cfe_assessment"),
       template: :basic,
-      column_width: :full
+      column_width: :full,
     ) do %>
 
   <div class="interruption-panel">
@@ -15,6 +15,6 @@
         url: providers_legal_aid_application_no_eligibility_assessment_path(@legal_aid_application),
         method: :patch,
         show_draft: true,
-        continue_button_text: t('.continue_button')
+        continue_button_text: t(".continue_button"),
       ) %>
 <% end %>

--- a/app/views/providers/no_national_insurance_numbers/show.html.erb
+++ b/app/views/providers/no_national_insurance_numbers/show.html.erb
@@ -8,7 +8,7 @@
           url: providers_legal_aid_application_no_national_insurance_number_path,
           method: :patch,
           show_draft: true,
-          continue_button_text: t('generic.continue')
+          continue_button_text: t("generic.continue"),
         ) %>
   <% end %>
 </div>

--- a/app/views/providers/offline_accounts/show.html.erb
+++ b/app/views/providers/offline_accounts/show.html.erb
@@ -1,9 +1,9 @@
-<%= page_template page_title: t('.h1-heading'), template: :basic, show_errors_for: @form do %>
-    <%= render  'shared/forms/offline_accounts_form',
+<%= page_template page_title: t(".h1-heading"), template: :basic, show_errors_for: @form do %>
+    <%= render  "shared/forms/offline_accounts_form",
                 model: @form,
                 show_draft: true,
                 bank_accounts: [],
-                or_break: t('generic.or'),
-                no_account_selected: t('.no_account_selected'),
+                or_break: t("generic.or"),
+                no_account_selected: t(".no_account_selected"),
                 form_path: providers_legal_aid_application_offline_account_path(@legal_aid_application) %>
 <% end %>

--- a/app/views/providers/open_banking_consents/show.html.erb
+++ b/app/views/providers/open_banking_consents/show.html.erb
@@ -2,27 +2,24 @@
       model: @form,
       url: providers_legal_aid_application_open_banking_consents_path(@legal_aid_application),
       method: :patch,
-      local: true
+      local: true,
     ) do |form| %>
 
-    <%= page_template page_title: t('.heading'), form: form, template: :basic do %>
+    <%= page_template page_title: t(".heading"), form:, template: :basic do %>
 
-      <h1 class="govuk-heading-xl"><%= t('.heading') %></h1>
+      <h1 class="govuk-heading-xl"><%= t(".heading") %></h1>
 
       <%= form.govuk_radio_buttons_fieldset(:provider_received_citizen_consent,
-                                            legend: { size: 'm', tag: 'h2', text:t('.online_banking_question') }) do %>
+                                            legend: { size: "m", tag: "h2", text: t(".online_banking_question") }) do %>
 
         <div class="govuk-!-padding-bottom-1"></div>
 
-        <%= form.govuk_radio_button(:provider_received_citizen_consent, true, link_errors: true, label: {text: t('generic.yes')} ) %>
-        <%= form.govuk_radio_button(:provider_received_citizen_consent, false, label: {text:  t('generic.no')}) %>
+        <%= form.govuk_radio_button(:provider_received_citizen_consent, true, link_errors: true, label: { text: t("generic.yes") }) %>
+        <%= form.govuk_radio_button(:provider_received_citizen_consent, false, label: { text: t("generic.no") }) %>
       <% end %>
     <% end %>
 
   <div class="govuk-!-padding-bottom-5"></div>
 
-  <%= next_action_buttons(
-        show_draft: true,
-        form: form
-      ) %>
+  <%= next_action_buttons(show_draft: true, form:) %>
 <% end %>

--- a/app/views/providers/open_banking_guidances/show.html.erb
+++ b/app/views/providers/open_banking_guidances/show.html.erb
@@ -2,74 +2,74 @@
       model: @form,
       url: providers_legal_aid_application_open_banking_guidance_path(@legal_aid_application),
       method: :patch,
-      local: true
+      local: true,
     ) do |form| %>
 
-  <%= page_template page_title: t('.heading_h1'), form: form, template: :basic do %>
+  <%= page_template page_title: t(".heading_h1"), form:, template: :basic do %>
 
-    <h1 class="govuk-heading-xl"><%= t('.heading_h1') %></h1>
+    <h1 class="govuk-heading-xl"><%= t(".heading_h1") %></h1>
 
-    <p class="govuk-body"><%= t('.your_client_can') %></p>
-    <p class="govuk-body"><%= t('.its_a_fast') %></p>
+    <p class="govuk-body"><%= t(".your_client_can") %></p>
+    <p class="govuk-body"><%= t(".its_a_fast") %></p>
 
     <details class="govuk-details govuk-!-display-none-print" data-module="govuk-details">
       <summary class="govuk-details__summary">
           <span class="govuk-details__summary-text">
-            <%= t('.details_summary') %>
+            <%= t(".details_summary") %>
           </span>
       </summary>
       <div class="govuk-details__text govuk-!-padding-bottom-1">
-        <%= t('.details_content_html') %>
-        <%= list_from_translation_path('.open_banking_consents.show.details') %>
+        <%= t(".details_content_html") %>
+        <%= list_from_translation_path(".open_banking_consents.show.details") %>
       </div>
     </details>
 
     <div class="govuk-!-padding-bottom-4 only-print">
-      <h3 class="govuk-heading-m"><%= t('.details_summary') %></h3>
-      <p class="govuk-body"><%= t('.details_content_para_one') %></p>
-      <p class="govuk-body"><%= t('.details_content_para_two') %></p>
-      <p class="govuk-body"><%= t('.details_content_para_three') %></p>
+      <h3 class="govuk-heading-m"><%= t(".details_summary") %></h3>
+      <p class="govuk-body"><%= t(".details_content_para_one") %></p>
+      <p class="govuk-body"><%= t(".details_content_para_two") %></p>
+      <p class="govuk-body"><%= t(".details_content_para_three") %></p>
       <ul class="govuk-list govuk-list--bullet print-add-bullet">
-        <% t('.details.list').split("\n").each do |bullet| %>
+        <% t(".details.list").split("\n").each do |bullet| %>
           <li><%= bullet %></li>
         <% end %>
       </ul>
     </div>
 
-    <h2 class="govuk-heading-l"><%= t('.heading_h2') %></h2>
+    <h2 class="govuk-heading-l"><%= t(".heading_h2") %></h2>
 
-    <h3 class="govuk-heading-m"><%= t('.list_heading_one') %></h3>
-    <p class="govuk-body"><%= t('.your_client_will') %></p>
-    <p class="govuk-body"><%= t('.theres_a_link') %></p>
+    <h3 class="govuk-heading-m"><%= t(".list_heading_one") %></h3>
+    <p class="govuk-body"><%= t(".your_client_will") %></p>
+    <p class="govuk-body"><%= t(".theres_a_link") %></p>
 
     <div class="govuk-!-padding-bottom-4 page_break_before">
-      <h3 class="govuk-heading-m"><%= t('.list_heading_two') %></h3>
-      <p class="govuk-body"><%= t('.your_client_selects') %></p>
-      <img src="<%= asset_pack_path 'media/images/open_banking/select_bank.png' %>" alt="<%= t('.image_alt_1') %>" class="govuk-!-display-none-print">
-      <img src="<%= asset_pack_path 'media/images/open_banking/select_bank.png' %>" alt="<%= t('.image_alt_1') %>" class="only-print open-banking-guidance-img">
+      <h3 class="govuk-heading-m"><%= t(".list_heading_two") %></h3>
+      <p class="govuk-body"><%= t(".your_client_selects") %></p>
+      <img src="<%= asset_pack_path "media/images/open_banking/select_bank.png" %>" alt="<%= t(".image_alt_1") %>" class="govuk-!-display-none-print">
+      <img src="<%= asset_pack_path "media/images/open_banking/select_bank.png" %>" alt="<%= t(".image_alt_1") %>" class="only-print open-banking-guidance-img">
     </div>
 
     <div class="govuk-!-padding-bottom-4">
-      <h3 class="govuk-heading-m"><%= t('.list_heading_three') %></h3>
-      <p class="govuk-body"><%= t('.your_client_chooses') %></p>
-      <img src="<%= asset_pack_path 'media/images/open_banking/sharing.png' %>" alt="<%= t('.image_alt_2') %>" class="govuk-!-display-none-print">
-      <img src="<%= asset_pack_path 'media/images/open_banking/sharing.png' %>" alt="<%= t('.image_alt_2') %>" class="only-print open-banking-guidance-img">
+      <h3 class="govuk-heading-m"><%= t(".list_heading_three") %></h3>
+      <p class="govuk-body"><%= t(".your_client_chooses") %></p>
+      <img src="<%= asset_pack_path "media/images/open_banking/sharing.png" %>" alt="<%= t(".image_alt_2") %>" class="govuk-!-display-none-print">
+      <img src="<%= asset_pack_path "media/images/open_banking/sharing.png" %>" alt="<%= t(".image_alt_2") %>" class="only-print open-banking-guidance-img">
     </div>
 
     <div class="govuk-!-padding-bottom-4 page_break_before">
-      <h3 class="govuk-heading-m"><%= t('.list_heading_four') %></h3>
-      <p class="govuk-body"><%= t('.your_client_will_see') %></p>
-      <img src="<%= asset_pack_path 'media/images/open_banking/success.png' %>" alt="<%= t('.image_alt_3') %>" class="govuk-!-display-none-print">
-      <img src="<%= asset_pack_path 'media/images/open_banking/success.png' %>" alt="<%= t('.image_alt_3') %>" class="only-print open-banking-guidance-img">
+      <h3 class="govuk-heading-m"><%= t(".list_heading_four") %></h3>
+      <p class="govuk-body"><%= t(".your_client_will_see") %></p>
+      <img src="<%= asset_pack_path "media/images/open_banking/success.png" %>" alt="<%= t(".image_alt_3") %>" class="govuk-!-display-none-print">
+      <img src="<%= asset_pack_path "media/images/open_banking/success.png" %>" alt="<%= t(".image_alt_3") %>" class="only-print open-banking-guidance-img">
     </div>
 
     <div class="govuk-!-padding-bottom-4">
-      <h3 class="govuk-heading-m"><%= t('.list_heading_five') %></h3>
-      <p class="govuk-body"><%= t('.you_need_to') %></p>
+      <h3 class="govuk-heading-m"><%= t(".list_heading_five") %></h3>
+      <p class="govuk-body"><%= t(".you_need_to") %></p>
     </div>
 
     <div class="govuk-!-padding-bottom-2">
-      <%= print_button t('.print_guidance_button') %>
+      <%= print_button t(".print_guidance_button") %>
     </div>
 
     <div class="govuk-!-padding-bottom-2 govuk-!-display-none-print">
@@ -77,12 +77,10 @@
                                               yes_no_options,
                                               :value,
                                               :label,
-                                              legend: {text: t(".can_your_client_share"), size: 'm', tag: 'h2'} %>
+                                              legend: { text: t(".can_your_client_share"), size: "m", tag: "h2" } %>
     </div>
 
-    <%= next_action_buttons(
-          show_draft: true,
-          form: form) %>
+    <%= next_action_buttons(show_draft: true, form:) %>
 
   <% end %>
 <% end %>

--- a/app/views/providers/outgoings_summary/_outgoing_type_item.html.erb
+++ b/app/views/providers/outgoings_summary/_outgoing_type_item.html.erb
@@ -1,14 +1,13 @@
-<%
-  transaction_link = link_to_accessible(
-    link_text,
-    providers_legal_aid_application_outgoing_transactions_path(transaction_type: name),
-    class: 'govuk-body transaction-type-link',
-    suffix: "for #{t "transaction_types.names.providers.#{name}"}"
-  )
-  form_group_error_class = error.present? ? 'govuk-form-group--error' : ''
-  error_message = error.present? ? error.first : ''
-%>
-<li id="<%= "#{name}" %>" class="<%= form_group_error_class %>">
+<% transaction_link = link_to_accessible(
+     link_text,
+     providers_legal_aid_application_outgoing_transactions_path(transaction_type: name),
+     class: "govuk-body transaction-type-link",
+     suffix: "for #{t "transaction_types.names.providers.#{name}"}",
+   ) %>
+<% form_group_error_class = error.present? ? "govuk-form-group--error" : "" %>
+<% error_message = error.present? ? error.first : "" %>
+
+<li id="<%= name.to_s %>" class="<%= form_group_error_class %>">
   <h2 class="app-task-list__section">
     <span class="app-task-list__section-number"><%= number %>. </span>
     <%= t("transaction_types.names.providers.#{name}") %>
@@ -21,9 +20,9 @@
       <p id='<%= "error-#{name}" %>' class="govuk-error-message"><%= error_message %></p>
     <% end %>
   </h2>
-  <%= content_tag(:div, class: 'app-task-list__items', id: "list-item-#{name}") do %>
+  <%= content_tag(:div, class: "app-task-list__items", id: "list-item-#{name}") do %>
     <% if bank_transactions.present? %>
-      <%= render 'providers/bank_transactions/list_selected', category: name, bank_transactions: bank_transactions %>
+      <%= render "providers/bank_transactions/list_selected", category: name, bank_transactions: %>
       <%= transaction_link %>
     <% else %>
       <p class="app-task-list__item">

--- a/app/views/providers/outgoings_summary/index.html.erb
+++ b/app/views/providers/outgoings_summary/index.html.erb
@@ -1,35 +1,33 @@
-<%= page_template page_title: t('.page_heading'), show_errors_for: @legal_aid_application do %>
+<%= page_template page_title: t(".page_heading"), show_errors_for: @legal_aid_application do %>
 
-<%
-  errors = @legal_aid_application.errors.messages
-%>
+  <% errors = @legal_aid_application.errors.messages %>
 
   <p class="govuk-body">
-    <%= t('.payment_types') %>
+    <%= t(".payment_types") %>
   </p>
 
   <p class="govuk-body">
-    <%= t('.you_need_to') %>
+    <%= t(".you_need_to") %>
   </p>
 
   <p class="govuk-body">
-    <%= list_from_translation_path '.outgoings_summary.index' %>
+    <%= list_from_translation_path ".outgoings_summary.index" %>
   </p>
 
   <ol class="app-task-list">
     <% @legal_aid_application.transaction_types.debits.each_with_index do |transaction_type, index| %>
       <%= render(
-            'outgoing_type_item',
+            "outgoing_type_item",
             name: transaction_type.name,
             number: index + 1,
             link_text: t(".select.#{transaction_type.name}"),
             bank_transactions: @bank_transactions[transaction_type],
-            error: errors[transaction_type.name.to_sym]
+            error: errors[transaction_type.name.to_sym],
           ) %>
     <% end %>
 
     <% if @legal_aid_application.transaction_types.debits.count < TransactionType.debits.count %>
-      <%= render partial: 'add_other_outgoings' %>
+      <%= render partial: "add_other_outgoings" %>
     <% end %>
   </ol>
 
@@ -37,6 +35,6 @@
 
   <%= next_action_buttons_with_form(
         url: providers_legal_aid_application_outgoings_summary_index_path,
-        show_draft: true
+        show_draft: true,
       ) %>
 <% end %>

--- a/app/views/providers/proceeding_loop/client_involvement_type/show.html.erb
+++ b/app/views/providers/proceeding_loop/client_involvement_type/show.html.erb
@@ -2,20 +2,17 @@
       model: @form,
       url: providers_legal_aid_application_client_involvement_type_path,
       method: :patch,
-      local: true
+      local: true,
     ) do |form| %>
-  <%= page_template page_title: @proceeding.meaning, template: :basic, form: form do %>
+  <%= page_template page_title: @proceeding.meaning, template: :basic, form: do %>
     <span class="govuk-caption-l"><%= position_in_array(@proceeding) %></span>
     <h1 class="govuk-heading-xl"><%= page_title %></h1>
     <%= form.govuk_collection_radio_buttons(:client_involvement_type_ccms_code,
                                             @form.client_involvement_types,
                                             :ccms_code,
                                             :description,
-                                            legend: {size: 'm', tag: 'h2', text: t('.question')}) %>
+                                            legend: { size: "m", tag: "h2", text: t(".question") }) %>
 
-    <%= next_action_buttons(
-          form: form,
-          show_draft: true
-        ) %>
+    <%= next_action_buttons(form:, show_draft: true) %>
   <% end %>
 <% end %>

--- a/app/views/providers/proceeding_loop/confirm_delegated_functions_date/show.html.erb
+++ b/app/views/providers/proceeding_loop/confirm_delegated_functions_date/show.html.erb
@@ -2,22 +2,22 @@
       model: @form,
       url: providers_legal_aid_application_confirm_delegated_functions_date_path,
       method: :patch,
-      local: true
+      local: true,
     ) do |form| %>
 
-  <%= page_template page_title: @proceeding.meaning, template: :basic, form: form do %>
+  <%= page_template page_title: @proceeding.meaning, template: :basic, form: do %>
     <span class="govuk-caption-l"><%= position_in_array(@proceeding) %></span>
     <h1 class="govuk-heading-xl govuk-!-margin-top-2"><%= page_title %></h1>
 
     <%= govuk_warning_text(text: t(".warning_text")) %>
 
     <%= form.govuk_radio_buttons_fieldset :confirm_delegated_functions_date,
-                                          legend: { size: 'm', tag: 'h2', text: t('.question', date: @proceeding.used_delegated_functions_on.strftime('%-d %B %Y')) } do %>
-      <%= form.govuk_radio_button :confirm_delegated_functions_date, true, label: { text: t('generic.yes')}, link_errors: true %>
-      <%= form.govuk_radio_button :confirm_delegated_functions_date, false, label: { text: t(".details_incorrect")} %>
+                                          legend: { size: "m", tag: "h2", text: t(".question", date: @proceeding.used_delegated_functions_on.strftime("%-d %B %Y")) } do %>
+      <%= form.govuk_radio_button :confirm_delegated_functions_date, true, label: { text: t("generic.yes") }, link_errors: true %>
+      <%= form.govuk_radio_button :confirm_delegated_functions_date, false, label: { text: t(".details_incorrect") } %>
     <% end %>
 
     <div class="govuk-!-padding-bottom-4"></div>
-    <%= next_action_buttons(show_draft: true, form: form) %>
+    <%= next_action_buttons(show_draft: true, form:) %>
   <% end %>
 <% end %>

--- a/app/views/providers/proceeding_loop/delegated_functions/show.html.erb
+++ b/app/views/providers/proceeding_loop/delegated_functions/show.html.erb
@@ -2,24 +2,21 @@
       model: @form,
       url: providers_legal_aid_application_delegated_function_path,
       method: :patch,
-      local: true
+      local: true,
     ) do |form| %>
-  <%= page_template page_title: @proceeding.meaning, template: :basic, form: form do %>
+  <%= page_template page_title: @proceeding.meaning, template: :basic, form: do %>
     <span class="govuk-caption-l"><%= position_in_array(@proceeding) %></span>
     <h1 class="govuk-heading-xl govuk-!-margin-top-2"><%= page_title %></h1>
     <%= form.govuk_radio_buttons_fieldset(:used_delegated_functions,
-                                          legend: { size: 'm', tag: 'h2', text: t('.question')}) do %>
-      <%= form.govuk_radio_button :used_delegated_functions, true, label: { text: t('generic.yes') } do %>
+                                          legend: { size: "m", tag: "h2", text: t(".question") }) do %>
+      <%= form.govuk_radio_button :used_delegated_functions, true, label: { text: t("generic.yes") } do %>
          <%= form.govuk_date_field :used_delegated_functions_on,
-                                    legend: { text: t("shared.forms.date_input_fields.used_delegated_functions_on_label"), class: 'govuk-label govuk-date-input__label' },
-                                    hint: { text: t("shared.forms.date_input_fields.used_delegated_functions_on_hint", options: number_of_days_ago(5))} %>
+                                   legend: { text: t("shared.forms.date_input_fields.used_delegated_functions_on_label"), class: "govuk-label govuk-date-input__label" },
+                                   hint: { text: t("shared.forms.date_input_fields.used_delegated_functions_on_hint", options: number_of_days_ago(5)) } %>
         <% end %>
-      <%= form.govuk_radio_button :used_delegated_functions, false, label: { text: t('generic.no') } %>
+      <%= form.govuk_radio_button :used_delegated_functions, false, label: { text: t("generic.no") } %>
     <% end %>
 
-    <%= next_action_buttons(
-          form: form,
-          show_draft: true
-        ) %>
+    <%= next_action_buttons(form:, show_draft: true) %>
   <% end %>
 <% end %>

--- a/app/views/providers/proceeding_loop/emergency_defaults/show.html.erb
+++ b/app/views/providers/proceeding_loop/emergency_defaults/show.html.erb
@@ -2,25 +2,25 @@
       model: @form,
       url: providers_legal_aid_application_emergency_default_path,
       method: :patch,
-      local: true
+      local: true,
     ) do |form| %>
-  <%= page_template template: :basic, form: form do %>
+  <%= page_template template: :basic, form: do %>
     <span class="govuk-caption-l"><%= position_in_array(@proceeding) %></span>
     <h1 class="govuk-heading-xl govuk-!-margin-bottom-4"><%= @proceeding.meaning %></h1>
 
-    <h2 class="govuk-heading-m"><%= t('.h2_header') %></h2>
+    <h2 class="govuk-heading-m"><%= t(".h2_header") %></h2>
 
     <div class="govuk-!-padding-1"></div>
 
-    <p><strong><%= t('.los_header') %></strong> <%= form.object.emergency_level_of_service_name %></p>
-    <p><strong><%= t('.scope_header') %></strong> <%= form.object.delegated_functions_scope_limitation_meaning %></p>
-    <p><strong><%= t('.scope_description_header') %></strong> <%= form.object.delegated_functions_scope_limitation_description %></p>
+    <p><strong><%= t(".los_header") %></strong> <%= form.object.emergency_level_of_service_name %></p>
+    <p><strong><%= t(".scope_header") %></strong> <%= form.object.delegated_functions_scope_limitation_meaning %></p>
+    <p><strong><%= t(".scope_description_header") %></strong> <%= form.object.delegated_functions_scope_limitation_description %></p>
 
     <div class="govuk-!-padding-2"></div>
 
     <%= form.govuk_radio_buttons_fieldset :accepted_emergency_defaults,
                                           inline: false,
-                                          legend: { size: 'm', tag: 'h2', text: t('.question') } do %>
+                                          legend: { size: "m", tag: "h2", text: t(".question") } do %>
 
       <%= form.hidden_field :emergency_level_of_service %>
       <%= form.hidden_field :emergency_level_of_service_name %>
@@ -29,13 +29,13 @@
       <%= form.hidden_field :delegated_functions_scope_limitation_description %>
       <%= form.hidden_field :delegated_functions_scope_limitation_code %>
 
-      <%= form.govuk_radio_button :accepted_emergency_defaults, true, label: { text: t('generic.yes')}, link_errors: true do %>
+      <%= form.govuk_radio_button :accepted_emergency_defaults, true, label: { text: t("generic.yes") }, link_errors: true do %>
         <% if form.object.additional_params.present? %>
-          <%= render partial: "shared/scope_limitations/#{form.object.additional_params.first.dig("name")}", locals: { form: form, field_name: :hearing_date } %>
+          <%= render partial: "shared/scope_limitations/#{form.object.additional_params.first['name']}", locals: { form:, field_name: :hearing_date } %>
         <% end %>
       <% end %>
-      <%= form.govuk_radio_button :accepted_emergency_defaults, false, label: { text: t("generic.no")} %>
+      <%= form.govuk_radio_button :accepted_emergency_defaults, false, label: { text: t("generic.no") } %>
     <% end %>
-    <%= next_action_buttons(show_draft: true, form: form) %>
+    <%= next_action_buttons(show_draft: true, form:) %>
   <% end %>
 <% end %>

--- a/app/views/providers/proceeding_loop/emergency_level_of_service/show.html.erb
+++ b/app/views/providers/proceeding_loop/emergency_level_of_service/show.html.erb
@@ -2,15 +2,15 @@
       model: @form,
       url: providers_legal_aid_application_emergency_level_of_service_path,
       method: :patch,
-      local: true
+      local: true,
     ) do |form| %>
-  <%= page_template template: :basic, form: form do %>
+  <%= page_template template: :basic, form: do %>
     <span class="govuk-caption-l"><%= position_in_array(@proceeding) %></span>
     <h1 class="govuk-heading-xl"><%= @proceeding.meaning %></h1>
     <% if form.object.levels_of_service.length > 1 %>
-      <%= form.govuk_radio_buttons_fieldset(:emergency_level_of_service, legend: { text: t('.instruction'), tag: 'h2', size: 'm'} ) do %>
+      <%= form.govuk_radio_buttons_fieldset(:emergency_level_of_service, legend: { text: t(".instruction"), tag: "h2", size: "m" }) do %>
         <% form.object.levels_of_service.each do |level| %>
-          <% hint = level["name"] == "Full Representation" ? t('.hint_text') : '' %>
+          <% hint = level["name"] == "Full Representation" ? t(".hint_text") : "" %>
           <%= form.govuk_radio_button :emergency_level_of_service, level["level"],
                                       link_errors: true,
                                       label: { text: level["name"] },
@@ -20,12 +20,12 @@
     <% else %>
       <%= form.hidden_field :emergency_level_of_service, value: form.object.levels_of_service[0]["level"] %>
       <p>
-        <%= t('.cannot_change_default') %>
+        <%= t(".cannot_change_default") %>
       </p>
       <p>
-        <%= t('.continue_to_change_scope') %>
+        <%= t(".continue_to_change_scope") %>
       </p>
     <% end %>
-    <%= next_action_buttons(show_draft: true, form: form) %>
+    <%= next_action_buttons(show_draft: true, form:) %>
   <% end %>
 <% end %>

--- a/app/views/providers/proceeding_loop/emergency_scope_limitations/show.html.erb
+++ b/app/views/providers/proceeding_loop/emergency_scope_limitations/show.html.erb
@@ -2,29 +2,29 @@
       model: @form,
       url: providers_legal_aid_application_emergency_scope_limitation_path,
       method: :patch,
-      local: true
+      local: true,
     ) do |form| %>
-  <%= page_template template: :basic, form: form do %>
+  <%= page_template template: :basic, form: do %>
     <span class="govuk-caption-l"><%= position_in_array(@proceeding) %></span>
     <h1 class="govuk-heading-xl"><%= @proceeding.meaning %></h1>
-    <%= form.govuk_check_boxes_fieldset :scope_codes, legend: {size: 'm', tag: 'h2', text: t('.select_emergency_scope')},
-                                         hint: {text: t('generic.select_all_that_apply')} do %>
+    <%= form.govuk_check_boxes_fieldset :scope_codes, legend: { size: "m", tag: "h2", text: t(".select_emergency_scope") },
+                                                      hint: { text: t("generic.select_all_that_apply") } do %>
       <div class="deselect-group" data-deselect-ctrl="#emergency-scope-none-selected-true-field">
         <% @form.scopes.each_with_index do |scope| %>
           <%= form.hidden_field :"meaning_#{scope["code"]}", value: scope["meaning"] %>
           <%= form.hidden_field :"description_#{scope["code"]}", value: scope["description"] %>
-          <%= form.govuk_check_box :scope_codes, scope["code"], label: {text: scope["meaning"]} do %>
+          <%= form.govuk_check_box :scope_codes, scope["code"], label: { text: scope["meaning"] } do %>
             <% scope["additional_params"].each do |ap| %>
               <% if ap["name"] == "hearing_date" %>
-                <%= render partial: "shared/scope_limitations/hearing_date", locals: { form: form, field_name: :"hearing_date_#{scope["code"]}" } %>
+                <%= render partial: "shared/scope_limitations/hearing_date", locals: { form:, field_name: :"hearing_date_#{scope["code"]}" } %>
               <% elsif ap["name"] == "limitation_note" %>
-                <%= render partial: "shared/scope_limitations/limitation_note", locals: { form: form, scope: scope } %>
+                <%= render partial: "shared/scope_limitations/limitation_note", locals: { form:, scope: } %>
               <% end %>
             <% end %>
           <% end %>
         <% end %>
       </div>
     <% end %>
-    <%= next_action_buttons(show_draft: true, form: form) %>
+    <%= next_action_buttons(show_draft: true, form:) %>
   <% end %>
 <% end %>

--- a/app/views/providers/proceeding_loop/final_hearings/show.html.erb
+++ b/app/views/providers/proceeding_loop/final_hearings/show.html.erb
@@ -2,25 +2,22 @@
       model: @form,
       url: providers_legal_aid_application_final_hearings_path(@legal_aid_application, @proceeding, params[:work_type]),
       method: :patch,
-      local: true
+      local: true,
     ) do |form| %>
-  <%= page_template page_title: @proceeding.meaning, template: :basic, form: form do %>
+  <%= page_template page_title: @proceeding.meaning, template: :basic, form: do %>
     <span class="govuk-caption-l"><%= position_in_array(@proceeding) %></span>
     <h1 class="govuk-heading-xl"><%= page_title %></h1>
     <%= form.govuk_radio_buttons_fieldset(:listed,
-                                          legend: { size: 'm', tag: 'h2', text: t('.question')}) do %>
-      <%= form.govuk_radio_button :listed, true, link_errors: true, label: { text: t('generic.yes') } do %>
+                                          legend: { size: "m", tag: "h2", text: t(".question") }) do %>
+      <%= form.govuk_radio_button :listed, true, link_errors: true, label: { text: t("generic.yes") } do %>
         <%= form.govuk_date_field :date,
-                                  legend: { text: t(".hearing"), class: 'govuk-label govuk-date-input__label' },
-                                  hint: { text: t("shared.forms.date_input_fields.used_delegated_functions_on_hint", options: number_of_days_ago(5))} %>
+                                  legend: { text: t(".hearing"), class: "govuk-label govuk-date-input__label" },
+                                  hint: { text: t("shared.forms.date_input_fields.used_delegated_functions_on_hint", options: number_of_days_ago(5)) } %>
       <% end %>
-      <%= form.govuk_radio_button :listed, false, label: { text: t('generic.no') } do %>
-        <%= form.govuk_text_area :details, label: {text: t('.details')}, rows: 5 %>
+      <%= form.govuk_radio_button :listed, false, label: { text: t("generic.no") } do %>
+        <%= form.govuk_text_area :details, label: { text: t(".details") }, rows: 5 %>
       <% end %>
     <% end %>
-    <%= next_action_buttons(
-          form: form,
-          show_draft: true
-        ) %>
+    <%= next_action_buttons(form:, show_draft: true) %>
   <% end %>
 <% end %>

--- a/app/views/providers/proceeding_loop/substantive_defaults/show.html.erb
+++ b/app/views/providers/proceeding_loop/substantive_defaults/show.html.erb
@@ -2,25 +2,25 @@
       model: @form,
       url: providers_legal_aid_application_substantive_default_path,
       method: :patch,
-      local: true
+      local: true,
     ) do |form| %>
-  <%= page_template template: :basic, form: form do %>
+  <%= page_template template: :basic, form: do %>
     <span class="govuk-caption-l"><%= position_in_array(@proceeding) %></span>
     <h1 class="govuk-heading-xl govuk-!-margin-bottom-4"><%= @proceeding.meaning %></h1>
 
-    <h2 class="govuk-heading-m"><%= t('.h2_header') %></h2>
+    <h2 class="govuk-heading-m"><%= t(".h2_header") %></h2>
 
     <div class="govuk-!-padding-1"></div>
 
-    <p><strong><%= t('.los_header') %></strong> <%= form.object.substantive_level_of_service_name %></p>
-    <p><strong><%= t('.scope_header') %></strong> <%= form.object.substantive_scope_limitation_meaning %></p>
-    <p><strong><%= t('.scope_description_header') %></strong> <%= form.object.substantive_scope_limitation_description %></p>
+    <p><strong><%= t(".los_header") %></strong> <%= form.object.substantive_level_of_service_name %></p>
+    <p><strong><%= t(".scope_header") %></strong> <%= form.object.substantive_scope_limitation_meaning %></p>
+    <p><strong><%= t(".scope_description_header") %></strong> <%= form.object.substantive_scope_limitation_description %></p>
 
     <div class="govuk-!-padding-2"></div>
 
     <%= form.govuk_radio_buttons_fieldset :accepted_substantive_defaults,
                                           inline: false,
-                                          legend: { size: 'm', tag: 'h2', text: t('.question') } do %>
+                                          legend: { size: "m", tag: "h2", text: t(".question") } do %>
 
       <%= form.hidden_field :substantive_level_of_service %>
       <%= form.hidden_field :substantive_level_of_service_name %>
@@ -29,13 +29,13 @@
       <%= form.hidden_field :substantive_scope_limitation_description %>
       <%= form.hidden_field :substantive_scope_limitation_code %>
 
-      <%= form.govuk_radio_button :accepted_substantive_defaults, true, label: { text: t('generic.yes')}, link_errors: true do %>
+      <%= form.govuk_radio_button :accepted_substantive_defaults, true, label: { text: t("generic.yes") }, link_errors: true do %>
         <% if form.object.additional_params.present? %>
           <%= pp form.object.additional_params %>
         <% end %>
       <% end %>
-      <%= form.govuk_radio_button :accepted_substantive_defaults, false, label: { text: t("generic.no")} %>
+      <%= form.govuk_radio_button :accepted_substantive_defaults, false, label: { text: t("generic.no") } %>
     <% end %>
-    <%= next_action_buttons(show_draft: true, form: form) %>
+    <%= next_action_buttons(show_draft: true, form:) %>
   <% end %>
 <% end %>

--- a/app/views/providers/proceeding_loop/substantive_level_of_service/show.html.erb
+++ b/app/views/providers/proceeding_loop/substantive_level_of_service/show.html.erb
@@ -2,15 +2,15 @@
       model: @form,
       url: providers_legal_aid_application_substantive_level_of_service_path,
       method: :patch,
-      local: true
+      local: true,
     ) do |form| %>
-  <%= page_template template: :basic, form: form do %>
+  <%= page_template template: :basic, form: do %>
     <span class="govuk-caption-l"><%= position_in_array(@proceeding) %></span>
     <h1 class="govuk-heading-xl"><%= @proceeding.meaning %></h1>
     <% if form.object.levels_of_service.length > 1 %>
-      <%= form.govuk_radio_buttons_fieldset(:substantive_level_of_service, legend: { text: t('.instruction'), tag: 'h2', size: 'm'} ) do %>
+      <%= form.govuk_radio_buttons_fieldset(:substantive_level_of_service, legend: { text: t(".instruction"), tag: "h2", size: "m" }) do %>
         <% form.object.levels_of_service.each do |level| %>
-          <% hint = level["name"] == "Full Representation" ? t('.hint_text') : '' %>
+          <% hint = level["name"] == "Full Representation" ? t(".hint_text") : "" %>
           <%= form.govuk_radio_button :substantive_level_of_service, level["level"],
                                       link_errors: true,
                                       label: { text: level["name"] },
@@ -20,12 +20,12 @@
     <% else %>
       <%= form.hidden_field :substantive_level_of_service, value: form.object.levels_of_service[0]["level"] %>
       <p>
-        <%= t('.cannot_change_default') %>
+        <%= t(".cannot_change_default") %>
       </p>
       <p>
-        <%= t('.continue_to_change_scope') %>
+        <%= t(".continue_to_change_scope") %>
       </p>
     <% end %>
-    <%= next_action_buttons(show_draft: true, form: form) %>
+    <%= next_action_buttons(show_draft: true, form:) %>
   <% end %>
 <% end %>

--- a/app/views/providers/proceeding_loop/substantive_scope_limitations/show.html.erb
+++ b/app/views/providers/proceeding_loop/substantive_scope_limitations/show.html.erb
@@ -2,30 +2,30 @@
       model: @form,
       url: providers_legal_aid_application_substantive_scope_limitation_path,
       method: :patch,
-      local: true
+      local: true,
     ) do |form| %>
-  <%= page_template template: :basic, form: form do %>
+  <%= page_template template: :basic, form: do %>
     <span class="govuk-caption-l"><%= position_in_array(@proceeding) %></span>
     <h1 class="govuk-heading-xl"><%= @proceeding.meaning %></h1>
-    <%= form.govuk_check_boxes_fieldset :scope_codes, legend: {size: 'm', tag: 'h2', text: t('.select_substantive_scope')},
-                                         hint: {text: t('generic.select_all_that_apply')} do %>
+    <%= form.govuk_check_boxes_fieldset :scope_codes, legend: { size: "m", tag: "h2", text: t(".select_substantive_scope") },
+                                                      hint: { text: t("generic.select_all_that_apply") } do %>
       <div class="deselect-group" data-deselect-ctrl="#substantive-scope-none-selected-true-field">
         <% @form.scopes.each_with_index do |scope, index| %>
           <%= form.hidden_field :"meaning_#{scope["code"]}", value: scope["meaning"] %>
           <%= form.hidden_field :"description_#{scope["code"]}", value: scope["description"] %>
           <%= form.govuk_check_box :scope_codes, scope["code"], link_errors: true,
-                                   label: {text: scope["meaning"]} do %>
+                                                                label: { text: scope["meaning"] } do %>
             <% scope["additional_params"].each do |ap| %>
               <% if ap["name"] == "hearing_date" %>
-                <%= render partial: "shared/scope_limitations/hearing_date", locals: { form: form, field_name: :"hearing_date_#{scope["code"]}" } %>
+                <%= render partial: "shared/scope_limitations/hearing_date", locals: { form:, field_name: :"hearing_date_#{scope["code"]}" } %>
               <% elsif ap["name"] == "limitation_note" %>
-                <%= render partial: "shared/scope_limitations/limitation_note", locals: { form: form, scope: scope } %>
+                <%= render partial: "shared/scope_limitations/limitation_note", locals: { form:, scope: } %>
               <% end %>
             <% end %>
           <% end %>
         <% end %>
       </div>
     <% end %>
-    <%= next_action_buttons(show_draft: true, form: form) %>
+    <%= next_action_buttons(show_draft: true, form:) %>
   <% end %>
 <% end %>

--- a/app/views/providers/proceeding_merits_task/attempts_to_settle/show.html.erb
+++ b/app/views/providers/proceeding_merits_task/attempts_to_settle/show.html.erb
@@ -2,26 +2,26 @@
       model: @form,
       url: providers_merits_task_list_attempts_to_settle_path(@proceeding),
       method: :patch,
-      local: true
+      local: true,
     ) do |form| %>
     <%= page_template(
-            page_title: t('.h1-heading'),
-            head_title: "#{@proceeding.meaning} - "+ t('.h1-heading'),
-            template: :basic,
-            form: form
+          page_title: t(".h1-heading"),
+          head_title: "#{@proceeding.meaning} - " + t(".h1-heading"),
+          template: :basic,
+          form:,
         ) do %>
 
     <%= form.govuk_text_area(
           :attempts_made,
-          label: { size: 'xl', tag: 'h1', text: page_title },
-          caption: { text: @proceeding.meaning, size: 'xl' },
-          hint: { text: t('.hint-text') },
-          legend: {text: content_for(:page_title), tag: 'h1', size: 'xl'},
-          rows: 8
+          label: { size: "xl", tag: "h1", text: page_title },
+          caption: { text: @proceeding.meaning, size: "xl" },
+          hint: { text: t(".hint-text") },
+          legend: { text: content_for(:page_title), tag: "h1", size: "xl" },
+          rows: 8,
         ) %>
 
     <div class="govuk-!-padding-bottom-2"></div>
 
-    <%= next_action_buttons(show_draft: true, form: form) %>
+    <%= next_action_buttons(show_draft: true, form:) %>
   <% end %>
 <% end %>

--- a/app/views/providers/proceeding_merits_task/chances_of_success/index.html.erb
+++ b/app/views/providers/proceeding_merits_task/chances_of_success/index.html.erb
@@ -2,14 +2,14 @@
       model: @form,
       url: providers_merits_task_list_chances_of_success_index_path,
       method: :post,
-      local: true
+      local: true,
     ) do |form| %>
     <%= page_template(
-            page_title: t('.h1-heading'),
-            head_title: "#{@proceeding.meaning} - "+ t('.h1-heading'),
-            template: :basic,
-            form: form,
-            back_link: {}
+          page_title: t(".h1-heading"),
+          head_title: "#{@proceeding.meaning} - " + t(".h1-heading"),
+          template: :basic,
+          form:,
+          back_link: {},
         ) do %>
 
     <%= form.govuk_collection_radio_buttons(
@@ -17,10 +17,10 @@
           yes_no_options,
           :value,
           :label,
-          legend: {size: 'xl', tag: 'h1', text: content_for(:page_title)},
-          caption: { text: @proceeding.meaning, size: 'xl' }
+          legend: { size: "xl", tag: "h1", text: content_for(:page_title) },
+          caption: { text: @proceeding.meaning, size: "xl" },
         ) %>
 
-    <%= next_action_buttons(show_draft: true, form: form) %>
+    <%= next_action_buttons(show_draft: true, form:) %>
   <% end %>
 <% end %>

--- a/app/views/providers/proceeding_merits_task/linked_children/show.html.erb
+++ b/app/views/providers/proceeding_merits_task/linked_children/show.html.erb
@@ -2,27 +2,27 @@
       model: @form,
       url: providers_merits_task_list_linked_children_path(@proceeding),
       method: :patch,
-      local: true
+      local: true,
     ) do |form| %>
     <%= page_template(
-          page_title: t('.h1-heading'),
-          head_title: "#{@proceeding.meaning} - "+ t('.h1-heading'),
+          page_title: t(".h1-heading"),
+          head_title: "#{@proceeding.meaning} - " + t(".h1-heading"),
           template: :basic,
-          form: form
+          form:,
         ) do %>
 
       <%= form.govuk_check_boxes_fieldset :linked_children,
-                                          legend: {size: 'xl', tag: 'h1', text: page_title},
-                                          caption: { text: @proceeding.meaning, size: 'xl' } do %>
-        <div id="select-all-that-apply-hint" class="govuk-hint"><%= t('generic.select_all_that_apply') %></div>
+                                          legend: { size: "xl", tag: "h1", text: page_title },
+                                          caption: { text: @proceeding.meaning, size: "xl" } do %>
+        <div id="select-all-that-apply-hint" class="govuk-hint"><%= t("generic.select_all_that_apply") %></div>
 
         <% @form.value_list.each do |child| %>
-          <%= form.govuk_check_box :linked_children, child[:id], '', multiple: true, link_errors: true, label: {text: child[:name]}, checked: child[:is_checked] %>
+          <%= form.govuk_check_box :linked_children, child[:id], "", multiple: true, link_errors: true, label: { text: child[:name] }, checked: child[:is_checked] %>
         <% end %>
       <% end %>
 
       <div class="govuk-!-padding-bottom-2"></div>
 
-      <%= next_action_buttons(show_draft: true, form: form) %>
+      <%= next_action_buttons(show_draft: true, form:) %>
     <% end %>
 <% end %>

--- a/app/views/providers/proceeding_merits_task/opponents_application/show.html.erb
+++ b/app/views/providers/proceeding_merits_task/opponents_application/show.html.erb
@@ -2,26 +2,26 @@
       model: @form,
       url: providers_merits_task_list_opponents_application_path(@proceeding),
       method: :patch,
-      local: true
+      local: true,
     ) do |form| %>
-  <%= page_template(page_title: t('.h1_heading'),
-                    head_title: "#{@proceeding.meaning} - "+ t('.h1_heading'),
+  <%= page_template(page_title: t(".h1_heading"),
+                    head_title: "#{@proceeding.meaning} - " + t(".h1_heading"),
                     template: :basic,
                     back_link: {},
-                    form: form) do %>
+                    form:) do %>
 
     <%= form.govuk_radio_buttons_fieldset :has_opponents_application,
-                                          legend: {size: 'xl', tag: 'h1', text: page_title},
-                                          caption: { text: @proceeding.meaning, size: 'xl' },
+                                          legend: { size: "xl", tag: "h1", text: page_title },
+                                          caption: { text: @proceeding.meaning, size: "xl" },
                                           classes: "govuk-!-padding-bottom-4" do %>
 
       <%= form.govuk_radio_button :has_opponents_application, true, link_errors: true,
-                                  label: {text: t('generic.yes')}, hint: { text: t('.hint_text')} %>
-      <%= form.govuk_radio_button :has_opponents_application, false, label: {text: t('generic.no')} do %>
-        <%= form.govuk_text_area :reason_for_applying, label: {text: t('.reason_question')}, rows: 5 %>
+                                                                    label: { text: t("generic.yes") }, hint: { text: t(".hint_text") } %>
+      <%= form.govuk_radio_button :has_opponents_application, false, label: { text: t("generic.no") } do %>
+        <%= form.govuk_text_area :reason_for_applying, label: { text: t(".reason_question") }, rows: 5 %>
       <% end %>
     <% end %>
 
-    <%= next_action_buttons(show_draft: true, form: form) %>
+    <%= next_action_buttons(show_draft: true, form:) %>
   <% end %>
 <% end %>

--- a/app/views/providers/proceeding_merits_task/prohibited_steps/show.html.erb
+++ b/app/views/providers/proceeding_merits_task/prohibited_steps/show.html.erb
@@ -2,20 +2,20 @@
       model: @form,
       url: providers_merits_task_list_prohibited_steps_path(@proceeding),
       method: :patch,
-      local: true
+      local: true,
     ) do |form| %>
-  <%= page_template(page_title: t('.h1-heading'),
-                    head_title: "#{@proceeding.meaning} - "+ t('.h1-heading'),
+  <%= page_template(page_title: t(".h1-heading"),
+                    head_title: "#{@proceeding.meaning} - " + t(".h1-heading"),
                     template: :basic,
                     back_link: {},
-                    form: form) do %>
-    <%= form.govuk_radio_buttons_fieldset :uk_removal, legend: {size: 'xl', tag: 'h1', text: page_title}, classes: "govuk-!-padding-bottom-4" do %>
-      <%= form.govuk_radio_button :uk_removal, true, link_errors: true, label: {text: t('generic.yes')} %>
-      <%= form.govuk_radio_button :uk_removal, false, label: {text: t('generic.no')} do %>
-        <%= form.govuk_text_area :details, label: {text: t('.no-hint')}, rows: 5 %>
+                    form:) do %>
+    <%= form.govuk_radio_buttons_fieldset :uk_removal, legend: { size: "xl", tag: "h1", text: page_title }, classes: "govuk-!-padding-bottom-4" do %>
+      <%= form.govuk_radio_button :uk_removal, true, link_errors: true, label: { text: t("generic.yes") } %>
+      <%= form.govuk_radio_button :uk_removal, false, label: { text: t("generic.no") } do %>
+        <%= form.govuk_text_area :details, label: { text: t(".no-hint") }, rows: 5 %>
       <% end %>
     <% end %>
 
-    <%= next_action_buttons(show_draft: true, form: form) %>
+    <%= next_action_buttons(show_draft: true, form:) %>
   <% end %>
 <% end %>

--- a/app/views/providers/proceeding_merits_task/specific_issue/show.html.erb
+++ b/app/views/providers/proceeding_merits_task/specific_issue/show.html.erb
@@ -2,32 +2,32 @@
       model: @form,
       url: providers_merits_task_list_specific_issue_path(@proceeding),
       method: :patch,
-      local: true
+      local: true,
     ) do |form| %>
-  <%
-    page_title_locale = if @proceeding.client_involvement_type_ccms_code == "A"
-                   ".h1-heading.applicant"
-                 else
-                   ".h1-heading.non-applicant"
-                 end
-  %>
+
+  <% page_title_locale = if @proceeding.client_involvement_type_ccms_code == "A"
+                           ".h1-heading.applicant"
+                         else
+                           ".h1-heading.non-applicant"
+                         end %>
+
   <%= page_template(
         page_title: t(page_title_locale),
         head_title: "#{@proceeding.meaning} - #{t(page_title_locale)}",
         template: :basic,
-        form: form
+        form:,
       ) do %>
     <%= form.govuk_text_area(
           :details,
-          label: {size: 'xl', tag: 'h1', text: page_title},
-          caption: { text: @proceeding.meaning, size: 'xl' },
-          hint: { text: t('.hint-text') },
-          legend: {text: content_for(:page_title), tag: 'h1', size: 'xl'},
-          rows: 8
+          label: { size: "xl", tag: "h1", text: page_title },
+          caption: { text: @proceeding.meaning, size: "xl" },
+          hint: { text: t(".hint-text") },
+          legend: { text: content_for(:page_title), tag: "h1", size: "xl" },
+          rows: 8,
         ) %>
     <%= form.govuk_check_boxes_fieldset :confirmed, legend: nil do %>
-      <p><%= form.govuk_check_box :confirmed, true, '', multiple: false, link_errors: true, label: { text: t('.confirmed') } %></p>
+      <p><%= form.govuk_check_box :confirmed, true, "", multiple: false, link_errors: true, label: { text: t(".confirmed") } %></p>
     <% end %>
-    <%= next_action_buttons(show_draft: true, form: form) %>
+    <%= next_action_buttons(show_draft: true, form:) %>
   <% end %>
 <% end %>

--- a/app/views/providers/proceeding_merits_task/success_prospects/show.html.erb
+++ b/app/views/providers/proceeding_merits_task/success_prospects/show.html.erb
@@ -1,28 +1,28 @@
 <%= form_with(
-        model: @form,
-        url: providers_merits_task_list_success_prospects_path(@proceeding),
-        method: :patch,
-        local: true
+      model: @form,
+      url: providers_merits_task_list_success_prospects_path(@proceeding),
+      method: :patch,
+      local: true,
     ) do |form| %>
   <%= page_template(
-          page_title: t('.h1-heading'),
-          head_title: "#{@proceeding.meaning} - "+ t('.h1-heading'),
-          template: :basic,
-          form: form,
-          back_link: {}
+        page_title: t(".h1-heading"),
+        head_title: "#{@proceeding.meaning} - " + t(".h1-heading"),
+        template: :basic,
+        form:,
+        back_link: {},
       ) do %>
 
-    <%= form.govuk_radio_buttons_fieldset(:success_prospect, legend: {size: 'xl', tag: 'h1', text: content_for(:page_title)}) do %>
+    <%= form.govuk_radio_buttons_fieldset(:success_prospect, legend: { size: "xl", tag: "h1", text: content_for(:page_title) }) do %>
       <% ProceedingMeritsTask::ChancesOfSuccess.prospects_unlikely_to_succeed.each do |prospect| %>
         <%= form.govuk_radio_button :success_prospect, prospect,
                                     link_errors: true,
-                                    label: {text: t("shared.forms.success_prospect.#{prospect}")},
-                                    hint: {text: t("shared.forms.success_prospect.hint.#{prospect}")} do %>
+                                    label: { text: t("shared.forms.success_prospect.#{prospect}") },
+                                    hint: { text: t("shared.forms.success_prospect.hint.#{prospect}") } do %>
           <%= form.govuk_text_area "success_prospect_details_#{prospect}".to_sym,
-                                   label: {text: 'Tell us why legal aid should be granted'}, rows: 5 %>
+                                   label: { text: "Tell us why legal aid should be granted" }, rows: 5 %>
         <% end %>
       <% end %>
     <% end %>
-    <%= next_action_buttons(show_draft: true, form: form) %>
+    <%= next_action_buttons(show_draft: true, form:) %>
   <% end %>
 <% end %>

--- a/app/views/providers/proceeding_merits_task/vary_order/show.html.erb
+++ b/app/views/providers/proceeding_merits_task/vary_order/show.html.erb
@@ -2,20 +2,20 @@
       model: @form,
       url: providers_merits_task_list_vary_order_path(@proceeding),
       method: :patch,
-      local: true
+      local: true,
     ) do |form| %>
-  <%= page_template(page_title: t('.h1-heading'),
-                    head_title: t('.h1-heading'),
+  <%= page_template(page_title: t(".h1-heading"),
+                    head_title: t(".h1-heading"),
                     template: :basic,
                     back_link: {},
-                    form: form) do %>
+                    form:) do %>
     <%= form.govuk_text_area(
           :details,
-          label: {size: 'xl', tag: 'h1', text: page_title},
-          caption: { text: @proceeding.meaning, size: 'xl' },
-          hint: { text: t('.hint-text') },
-          rows: 8
+          label: { size: "xl", tag: "h1", text: page_title },
+          caption: { text: @proceeding.meaning, size: "xl" },
+          hint: { text: t(".hint-text") },
+          rows: 8,
         ) %>
-    <%= next_action_buttons(show_draft: true, form: form) %>
+    <%= next_action_buttons(show_draft: true, form:) %>
   <% end %>
 <% end %>

--- a/app/views/providers/proceedings_types/index.html.erb
+++ b/app/views/providers/proceedings_types/index.html.erb
@@ -1,20 +1,19 @@
 <%= page_template(
-      page_title: t('.heading_1'),
+      page_title: t(".heading_1"),
       show_errors_for: @legal_aid_application,
-      back_link: @legal_aid_application.proceedings.empty? && @legal_aid_application.checking_answers? ? :none : {}
+      back_link: @legal_aid_application.proceedings.empty? && @legal_aid_application.checking_answers? ? :none : {},
     ) %>
 
-<%
-  error_message = @legal_aid_application.errors[:'proceeding-search-input']&.to_sentence
-  form_group_error_class = error_message.present? ? 'govuk-form-group--error' : ''
-  input_error_class = error_message.present? ? 'govuk-input--error' : ''
-%>
+<% error_message = @legal_aid_application.errors[:"proceeding-search-input"]&.to_sentence %>
+<% form_group_error_class = error_message.present? ? "govuk-form-group--error" : "" %>
+<% input_error_class = error_message.present? ? "govuk-input--error" : "" %>
+
 <div id="search-field" class="govuk-form-group govuk-!-margin-top-0 govuk-!-margin-bottom-0 <%= form_group_error_class %>">
   <h2 class="govuk-heading-m govuk-!-margin-bottom-0">
     <label class="govuk-heading-m govuk-!-margin-bottom-0" for="proceeding-search-input">
-      <%= t '.heading_2' %>
+      <%= t ".heading_2" %>
       <div class="govuk-hint govuk-!-margin-top-0 govuk-!-width-two-thirds">
-        <%= @legal_aid_application.provider.full_section_8_permissions? ? t('.search_help_example_with_s8_permission') : t('.search_help_example') %>
+        <%= @legal_aid_application.provider.full_section_8_permissions? ? t(".search_help_example_with_s8_permission") : t(".search_help_example") %>
         <span class="govuk-visually-hidden">Enter search term, results will automatically return</span>
       </div>
     </label>
@@ -27,7 +26,7 @@
     </div>
 
     <div class="govuk-grid-column-one-third govuk-!-margin-top-2 clear-search">
-      <p><%= link_to_accessible t('.clear_search'), '#', class: 'govuk-link govuk-!-font-size-19', id: 'clear-proceeding-search' %></p>
+      <p><%= link_to_accessible t(".clear_search"), "#", class: "govuk-link govuk-!-font-size-19", id: "clear-proceeding-search" %></p>
     </div>
   </div>
 </div>
@@ -37,20 +36,21 @@
        data-uri="<%= Rails.configuration.x.legal_framework_api_host %>"
        value="<%= @excluded_codes %>">
 <%= form_with(
-  model: nil,
-  url: providers_legal_aid_application_proceedings_types_path,
-  local: true) do |form| %>
+      model: nil,
+      url: providers_legal_aid_application_proceedings_types_path,
+      local: true,
+    ) do |form| %>
   <div class="govuk-grid-row govuk-!-margin-top-0">
     <div id="proceeding-list" class="govuk-grid-column-two-thirds govuk-list govuk-!-margin-bottom-0">
-        <%= form.govuk_radio_buttons_fieldset :id, legend: {text: nil, hidden: true} do %>
+        <%= form.govuk_radio_buttons_fieldset :id, legend: { text: nil, hidden: true } do %>
           <% @proceeding_types.each do |proceeding_type| %>
             <div id="<%= proceeding_type.ccms_code %>" class="govuk-grid-row proceeding-item">
               <%= form.govuk_radio_button(
-                      :id,
-                      proceeding_type.ccms_code,
-                      label: {text: proceeding_type.meaning},
-                      hint: {text: "#{proceeding_type.ccms_category_law} (#{proceeding_type.ccms_matter})"}
-                    ) %>
+                    :id,
+                    proceeding_type.ccms_code,
+                    label: { text: proceeding_type.meaning },
+                    hint: { text: "#{proceeding_type.ccms_category_law} (#{proceeding_type.ccms_matter})" },
+                  ) %>
             </div>
           <% end %>
         <% end %>
@@ -58,15 +58,12 @@
   </div>
   <div class="govuk-grid-row no-proceeding-items" style="display: none;">
     <div class="govuk-grid-column-two-thirds">
-      <span class="govuk-body"><%= t '.no_results' %></span>
+      <span class="govuk-body"><%= t ".no_results" %></span>
     </div>
   </div>
   <div class="govuk-grid-row govuk-!-margin-top-5">
     <div class="govuk-grid-column-two-thirds">
-      <%= next_action_buttons(
-            form: form,
-            show_draft: true
-          ) %>
+      <%= next_action_buttons(form:, show_draft: true) %>
     </div>
   </div>
 <% end %>

--- a/app/views/providers/providers/show.html.erb
+++ b/app/views/providers/providers/show.html.erb
@@ -1,23 +1,20 @@
-<%= page_template(
-      page_title: t('.page_title'),
-      column_width: 'full'
-    ) do %>
+<%= page_template(page_title: t(".page_title"), column_width: "full") do %>
   <table class="govuk-table">
     <tbody class="govuk-table__body">
       <tr class="govuk-table__row">
-        <th class="govuk-table__header" scope="row"><%= t('.name') %></th>
+        <th class="govuk-table__header" scope="row"><%= t(".name") %></th>
         <td class="govuk-table__cell"><%= @provider.name %></td>
       </tr>
       <tr class="govuk-table__row">
-        <th class="govuk-table__header" scope="row"><%= t('.username') %></th>
+        <th class="govuk-table__header" scope="row"><%= t(".username") %></th>
         <td class="govuk-table__cell"><%= @provider.username %></td>
       </tr>
       <tr class="govuk-table__row">
-        <th class="govuk-table__header" scope="row"><%= t('.email') %></th>
+        <th class="govuk-table__header" scope="row"><%= t(".email") %></th>
         <td class="govuk-table__cell"><%= @provider.email %></td>
       </tr>
       <tr class="govuk-table__row">
-        <th class="govuk-table__header" scope="row"><%= t('.account_number') %></th>
+        <th class="govuk-table__header" scope="row"><%= t(".account_number") %></th>
         <td class="govuk-table__cell"></td>
       </tr>
     </tbody>

--- a/app/views/providers/received_benefit_confirmations/show.html.erb
+++ b/app/views/providers/received_benefit_confirmations/show.html.erb
@@ -1,8 +1,8 @@
- <%= page_template page_title: t('.h1-heading'), template: :basic, show_errors_for: @form do %>
-    <%= render partial: '/shared/forms/received_benefit_confirmation/form',
+ <%= page_template page_title: t(".h1-heading"), template: :basic, show_errors_for: @form do %>
+    <%= render partial: "/shared/forms/received_benefit_confirmation/form",
                locals: {
                  model: @form,
                  show_draft: true,
-                 url: providers_legal_aid_application_received_benefit_confirmation_path(@legal_aid_application)
+                 url: providers_legal_aid_application_received_benefit_confirmation_path(@legal_aid_application),
                } %>
  <% end %>

--- a/app/views/providers/review_and_print_applications/show.html.erb
+++ b/app/views/providers/review_and_print_applications/show.html.erb
@@ -1,33 +1,33 @@
 <%= page_template page_title: nil do %>
   <h1 class="no-print govuk-heading-xl">
-    <%= t('.heading') %>
+    <%= t(".heading") %>
   </h1>
 
   <h1 class="only-print govuk-heading-xl">
-    <%= t('.print_heading') %>
+    <%= t(".print_heading") %>
   </h1>
 
-  <%= render 'shared/review_application/questions_and_answers' %>
+  <%= render "shared/review_application/questions_and_answers" %>
 
   <div class="no-print govuk-!-padding-top-6">
-    <h1 class="govuk-heading-l"><%= t('.print_your_application') %></h1>
+    <h1 class="govuk-heading-l"><%= t(".print_your_application") %></h1>
 
-    <p class="govuk-body"><%= t('.print_the_application') %></p>
+    <p class="govuk-body"><%= t(".print_the_application") %></p>
 
-    <p class="govuk-body"><%= t('.keep_a_copy') %></p>
+    <p class="govuk-body"><%= t(".keep_a_copy") %></p>
 
-   <p class="govuk-body"><%= t('.audit') %></p>
+    <p class="govuk-body"><%= t(".audit") %></p>
 
     <br>
 
-    <%= print_button t('.print_button') %>
+    <%= print_button t(".print_button") %>
 
     <%= next_action_buttons_with_form(
-      url: continue_providers_legal_aid_application_review_and_print_application_path(@legal_aid_application),
-      method: :patch,
-      show_draft: true,
-      continue_button_text: t('generic.submit_and_continue')
-    ) %>
+          url: continue_providers_legal_aid_application_review_and_print_application_path(@legal_aid_application),
+          method: :patch,
+          show_draft: true,
+          continue_button_text: t("generic.submit_and_continue"),
+        ) %>
   </div>
 
 <% end %>

--- a/app/views/providers/select_offices/show.html.erb
+++ b/app/views/providers/select_offices/show.html.erb
@@ -1,4 +1,4 @@
-<%= page_template page_title: t('.h1-heading', firm: firm.name), template: :basic do %>
+<%= page_template page_title: t(".h1-heading", firm: firm.name), template: :basic do %>
   <%= form_with(model: @form, url: providers_select_office_path, method: :patch, local: true) do |form| %>
 
     <%= form.govuk_collection_radio_buttons(:selected_office_id,
@@ -6,11 +6,11 @@
                                             :id,
                                             :code,
                                             legend: {
-                                                text: content_for(:page_title),
-                                                tag: 'h1',
-                                                size: 'xl'
+                                              text: content_for(:page_title),
+                                              tag: "h1",
+                                              size: "xl",
                                             }) %>
 
-    <%= next_action_buttons(form: form) %>
+    <%= next_action_buttons(form:) %>
   <% end %>
 <% end %>

--- a/app/views/providers/start/index.html.erb
+++ b/app/views/providers/start/index.html.erb
@@ -1,25 +1,25 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <h1 class="govuk-heading-xl"><%= t('.apply_for_legal_aid_heading') %></h1>
+    <h1 class="govuk-heading-xl"><%= t(".apply_for_legal_aid_heading") %></h1>
 
     <%= govuk_inset_text do %>
-      <p class="govuk-body"><%= t('.must_be_provider') %></p>
+      <p class="govuk-body"><%= t(".must_be_provider") %></p>
     <% end %>
 
-    <p class="govuk-body"><%= t('.domestic_violence_or_abuse_only') %></p>
+    <p class="govuk-body"><%= t(".domestic_violence_or_abuse_only") %></p>
 
-    <p class="govuk-body"><%= t('.use_ccms_para_html') %></p>
+    <p class="govuk-body"><%= t(".use_ccms_para_html") %></p>
 
-    <h2 class="govuk-heading-m"><%= t('.before_you_start.heading') %></h2>
+    <h2 class="govuk-heading-m"><%= t(".before_you_start.heading") %></h2>
 
     <p class="govuk-body">
-      <%= t('.before_you_start.conditions') %>
+      <%= t(".before_you_start.conditions") %>
     </p>
 
     <%= link_to_accessible start_button_label(:start_now),
-                providers_legal_aid_applications_path,
-                role: 'button',
-                class: 'govuk-button govuk-button--start',
-                id: 'start' %>
+                           providers_legal_aid_applications_path,
+                           role: "button",
+                           class: "govuk-button govuk-button--start",
+                           id: "start" %>
   </div>
 </div>

--- a/app/views/providers/submitted_applications/show.html.erb
+++ b/app/views/providers/submitted_applications/show.html.erb
@@ -1,8 +1,8 @@
-<%= page_template page_title: t('.heading'), back_link: :none do %>
-  <%= print_button t('.print_button') %>
+<%= page_template page_title: t(".heading"), back_link: :none do %>
+  <%= print_button t(".print_button") %>
 
-  <%= render 'shared/review_application/questions_and_answers' %>
+  <%= render "shared/review_application/questions_and_answers" %>
 
-  <%= next_action_link continue_text: t('.back_home'), html_class: 'govuk-button--secondary no-print' %>
+  <%= next_action_link continue_text: t(".back_home"), html_class: "govuk-button--secondary no-print" %>
 
 <% end %>

--- a/app/views/providers/substantive_applications/show.html.erb
+++ b/app/views/providers/substantive_applications/show.html.erb
@@ -1,24 +1,24 @@
 <%= form_with(
-        model: @form,
-        url: providers_legal_aid_application_substantive_application_path,
-        method: :patch,
-        local: true
+      model: @form,
+      url: providers_legal_aid_application_substantive_application_path,
+      method: :patch,
+      local: true,
     ) do |form| %>
-  <%= page_template page_title: t('.heading'), template: :basic, form: form do %>
+  <%= page_template page_title: t(".heading"), template: :basic, form: do %>
 
     <%= form.govuk_radio_buttons_fieldset(:substantive_application,
-                                            legend: { size: 'xl', tag: 'h1', text: page_title}) do %>
+                                          legend: { size: "xl", tag: "h1", text: page_title }) do %>
 
       <p class="govuk-body govuk-body govuk-!-padding-top-6 govuk-!-padding-bottom-4">
-        <%= t '.information_on_next_actions' %>
+        <%= t ".information_on_next_actions" %>
       </p>
 
-      <%= form.govuk_radio_button :substantive_application, true, label: { text: t('generic.yes') } %>
-      <%= form.govuk_radio_button :substantive_application, false, label: { text: t('.no_start_later') } %>
+      <%= form.govuk_radio_button :substantive_application, true, label: { text: t("generic.yes") } %>
+      <%= form.govuk_radio_button :substantive_application, false, label: { text: t(".no_start_later") } %>
     <% end %>
 
-    <%= govuk_warning_text(text: t('.must_submit_by', deadline: @form.substantive_application_deadline_on) ) %>
+    <%= govuk_warning_text(text: t(".must_submit_by", deadline: @form.substantive_application_deadline_on)) %>
 
-    <%= next_action_buttons(show_draft: true, form: form) %>
+    <%= next_action_buttons(show_draft: true, form:) %>
   <% end %>
 <% end %>

--- a/app/views/providers/transactions/show.html.erb
+++ b/app/views/providers/transactions/show.html.erb
@@ -1,9 +1,9 @@
-<%= page_template page_title: t("transaction_types.page_titles.#{@transaction_type.name}"), column_width: 'full', template: :default do %>
+<%= page_template page_title: t("transaction_types.page_titles.#{@transaction_type.name}"), column_width: "full", template: :default do %>
 
   <div class="govuk-body"><%= t("transaction_types.#{@transaction_type.name}.inset_text") %></div>
 
   <% if %w[benefits excluded_benefits].include?(@transaction_type.name) %>
-    <%= render 'providers/means/regular_incomes/cost_of_living_and_disregarded_benefits' %>
+    <%= render "providers/means/regular_incomes/cost_of_living_and_disregarded_benefits" %>
   <% end %>
 
   <% if I18n.exists?("transaction_types.#{@transaction_type.name}.details_summary_heading") %>
@@ -37,36 +37,36 @@
     <div id="screen-reader-messages" class="govuk-visually-hidden" role="alert" aria-live="assertive"></div>
     <table class="govuk-table sortable table-merge_columns">
       <caption class="govuk-table__caption">
-        <%= content_tag(:span, t('.table_description', from: date_from(@legal_aid_application), to: date_to(@legal_aid_application)), class: 'govuk-visually-hidden') if @bank_transactions.any? %>
-        <%= content_tag(:h2, t('date.date_period', from: date_from(@legal_aid_application), to: date_to(@legal_aid_application)), aria: { hidden: 'true'}, class: 'govuk-heading-s') if @bank_transactions.any? %>
+        <%= content_tag(:span, t(".table_description", from: date_from(@legal_aid_application), to: date_to(@legal_aid_application)), class: "govuk-visually-hidden") if @bank_transactions.any? %>
+        <%= content_tag(:h2, t("date.date_period", from: date_from(@legal_aid_application), to: date_to(@legal_aid_application)), aria: { hidden: "true" }, class: "govuk-heading-s") if @bank_transactions.any? %>
       </caption>
       <thead class="govuk-table__head">
         <tr class="govuk-table__row">
           <th
             class="govuk-table__header select-clear-all"
             scope="col"
-            data-copy-select="<%= t '.col_select_all' %>"
-            data-copy-clear="<%= t '.col_clear_all' %>">
+            data-copy-select="<%= t ".col_select_all" %>"
+            data-copy-clear="<%= t ".col_clear_all" %>">
           </th>
 
           <%= sort_column_th(
                 type: :date,
-                content: t('.col_date'),
-                combine_right: { at: 555, append: t('.col_and_description') },
-                currently_sorted: :desc
+                content: t(".col_date"),
+                combine_right: { at: 555, append: t(".col_and_description") },
+                currently_sorted: :desc,
               ) %>
 
-          <%= sort_column_th type: :alphabetic, content: t('.col_description') %>
+          <%= sort_column_th type: :alphabetic, content: t(".col_description") %>
 
           <th class="nullcell" aria-hidden="true"></th>
 
           <%= sort_column_th(
                 type: :numeric,
-                content: t('.col_amount'),
-                combine_right: { at: 470, append: t('.col_and_category') }
+                content: t(".col_amount"),
+                combine_right: { at: 470, append: t(".col_and_category") },
               ) %>
 
-          <%= sort_column_th type: :alphabetic, content: t('.col_category') %>
+          <%= sort_column_th type: :alphabetic, content: t(".col_category") %>
         </tr>
       </thead>
       <tbody class="govuk-table__body">
@@ -76,7 +76,7 @@
               <% if builder.object.transaction_type_id == nil %>
                 <div class="govuk-checkboxes__item">
                   <% checked = builder.object.transaction_type_id == @transaction_type.id %>
-                  <%= builder.check_box(class: 'govuk-checkboxes__input', checked: checked, 'aria-labelledby' => 'Date-' + builder.object.id + ' Description-' + builder.object.id + ' Amount-' + builder.object.id) %>
+                  <%= builder.check_box(class: "govuk-checkboxes__input", checked:, "aria-labelledby" => "Date-#{builder.object.id} Description-#{builder.object.id} Amount-#{builder.object.id}") %>
                   <label for="transaction_ids_<%= builder.object.id %>" class="govuk-label govuk-checkboxes__label table-checkbox_label"><span class="govuk-visually-hidden"><%= builder.object.description %>, <%= value_with_currency_unit(builder.object.amount, builder.object.currency) %> on <%= l(builder.object.happened_at.to_date, format: :long_date) %></span></label>
                 </div>
               <% end %>
@@ -86,12 +86,12 @@
                   id: "Date-#{builder.object.id}",
                   content: l(builder.object.happened_at.to_date, format: :short_date),
                   combine_right: 555,
-                  sort_by: [builder.object.happened_at.to_i, builder.object.description]
+                  sort_by: [builder.object.happened_at.to_i, builder.object.description],
                 ) %>
 
             <%= sort_column_cell(
                   id: "Description-#{builder.object.id}",
-                  content: builder.object.description
+                  content: builder.object.description,
                 ) %>
 
             <td class="nullcell" aria-hidden="true"></td>
@@ -101,7 +101,7 @@
                   content: value_with_currency_unit(builder.object.amount, builder.object.currency),
                   combine_right: 470,
                   sort_by: builder.object.amount,
-                  numeric: true
+                  numeric: true,
                 ) %>
 
             <%= sort_category_column_cell builder.object, @transaction_type %>
@@ -111,6 +111,6 @@
       </tbody>
     </table>
 
-    <%= next_action_buttons(show_draft: true, form: form) %>
+    <%= next_action_buttons(show_draft: true, form:) %>
   <% end %>
 <% end %>

--- a/app/views/providers/uploaded_evidence_collections/_upload_evidence.html.erb
+++ b/app/views/providers/uploaded_evidence_collections/_upload_evidence.html.erb
@@ -1,31 +1,30 @@
-<%
-  form_group_error_class = @mandatory_evidence_errors.present? ? 'govuk-form-group--error' : ''
-%>
+<% form_group_error_class = @mandatory_evidence_errors.present? ? "govuk-form-group--error" : "" %>
+
 <%= form_with(
       model: @upload_form,
       url: providers_legal_aid_application_uploaded_evidence_collection_path,
       method: :patch,
-      local: true
+      local: true,
     ) do |form| %>
 
   <%= form.govuk_error_summary %>
 
-  <%= render partial: 'shared/forms/error_summary_hidden', locals: { field_id: 'uploaded-evidence-collection-original-file-field' } %>
+  <%= render partial: "shared/forms/error_summary_hidden", locals: { field_id: "uploaded-evidence-collection-original-file-field" } %>
 
-  <%= form.govuk_fieldset legend: {text: page_title, tag: 'h1', size: 'xl'} do %>
+  <%= form.govuk_fieldset legend: { text: page_title, tag: "h1", size: "xl" } do %>
 
     <div class="govuk-!-padding-bottom-6"></div>
 
       <% if @required_documents.size == 1 %>
         <% if  @legal_aid_application.section_8_proceedings? %>
-          <div class="govuk-body"><%= t('.section_8_evidence') %></div>
+          <div class="govuk-body"><%= t(".section_8_evidence") %></div>
         <% elsif @evidence_type_translation.present? %>
-          <div class="govuk-body"><%= t('.single_item', evidence_type: @evidence_type_translation) %></div>
+          <div class="govuk-body"><%= t(".single_item", evidence_type: @evidence_type_translation) %></div>
         <% else %>
-          <div class="govuk-body"><%= t('.single_non_specific_item', item: t(".#{@required_documents.first}")) %></div>
+          <div class="govuk-body"><%= t(".single_non_specific_item", item: t(".#{@required_documents.first}")) %></div>
         <% end %>
       <% else %>
-        <div class="govuk-body"><%= t('.list_text') %></div>
+        <div class="govuk-body"><%= t(".list_text") %></div>
         <ul class="govuk-list govuk-list--bullet govuk-!-padding-bottom-2">
           <% @required_documents.each do |evidence| %>
             <li><%= t(".#{evidence}", benefit: @legal_aid_application&.dwp_override&.passporting_benefit&.titleize) %></li>
@@ -38,9 +37,9 @@
     <div class="dropzone__upload">
       <div class="govuk-form-group script hidden <%= form_group_error_class %>" id="dropzone-form-group" aria-labelledby="dropzone-label">
         <label class="govuk-label govuk-label--m" id="dropzone-label">
-          <%= t('.upload_file') %>
+          <%= t(".upload_file") %>
         </label>
-        <div class="govuk-hint"><%= t('.size_hint') %></div>
+        <div class="govuk-hint"><%= t(".size_hint") %></div>
         <% if @mandatory_evidence_errors %>
             <p id="dropzone-mandatory-error" class='govuk-error-message dropzone-error govuk-!-margin-bottom-1'>
               <% @mandatory_evidence_errors.each do |error| %>
@@ -57,8 +56,8 @@
         </p>
         <div class="dropzone" id="dropzone-form">
           <div class="dz-message" data-dz-message>
-            <p class="govuk-body govuk-!-padding-top-2 script"><%= t('.dropzone_message') %></p>
-            <button id="dz-upload-button" class="govuk-button govuk-button--secondary script" tabindex="0"><%= t('.choose_files_btn') %></button>
+            <p class="govuk-body govuk-!-padding-top-2 script"><%= t(".dropzone_message") %></p>
+            <button id="dz-upload-button" class="govuk-button govuk-button--secondary script" tabindex="0"><%= t(".choose_files_btn") %></button>
           </div>
         </div>
       </div>
@@ -69,14 +68,14 @@
             <p class='govuk-error-message govuk-!-margin-top-1'><%= error.message %></p>
           <% end %>
         <% end %>
-        <%= form.govuk_file_field :original_file, label: {text: t('generic.attach_file'), size: 'm'},
-                                  hint: {text: t('.size_hint')},
-                                  classes: ['govuk-file-upload ' + form_group_error_class] %>
+        <%= form.govuk_file_field :original_file, label: { text: t("generic.attach_file"), size: "m" },
+                                                  hint: { text: t(".size_hint") },
+                                                  classes: ["govuk-file-upload #{form_group_error_class}"] %>
         <%= form.submit(
-              t('generic.upload'),
-              id: 'upload',
-              name: 'upload_button',
-              class: 'govuk-button govuk-button--secondary form-button moj-multi-file-upload__button'
+              t("generic.upload"),
+              id: "upload",
+              name: "upload_button",
+              class: "govuk-button govuk-button--secondary form-button moj-multi-file-upload__button",
             ) %>
       </div>
     </div>

--- a/app/views/providers/uploaded_evidence_collections/_uploaded_files.html.erb
+++ b/app/views/providers/uploaded_evidence_collections/_uploaded_files.html.erb
@@ -1,10 +1,10 @@
-<% form_group_error_class = @categorisation_errors.present? ? 'govuk-form-group--error' : '' %>
-<% select_error = '' %>
+<% form_group_error_class = @categorisation_errors.present? ? "govuk-form-group--error" : "" %>
+<% select_error = "" %>
 
 <div class="<%= form_group_error_class %>">
-  <table class="govuk-table <%= 'hidden' if attachments.empty? %>">
+  <table class="govuk-table <%= "hidden" if attachments.empty? %>">
     <caption class="govuk-table__caption govuk-heading-m">
-      <%= t('.title') %>
+      <%= t(".title") %>
       <% if @categorisation_errors %>
         <% @categorisation_errors.each do |error| %>
           <p class='govuk-error-message govuk-!-margin-bottom-0'><%= error.message %></p>
@@ -13,8 +13,8 @@
     </caption>
     <thead class="govuk-table__head">
     <tr class="govuk-table__row">
-      <th class="govuk-table__header" scope="col"><%= t('.filename') %></th>
-      <th class="govuk-table__header" scope="col"><%= t('.select_a_category') %></th>
+      <th class="govuk-table__header" scope="col"><%= t(".filename") %></th>
+      <th class="govuk-table__header" scope="col"><%= t(".select_a_category") %></th>
       <th class="govuk-table__header" scope="col"></th>
     </tr>
     </thead>
@@ -29,26 +29,26 @@
           <td class="govuk-table__cell no-wrap">
             <div class="govuk-form-group govuk">
               <% if @categorisation_errors.present? %>
-                <% select_error = attachment.attachment_type == 'uncategorised' ? 'govuk-select--error' : '' %>
+                <% select_error = attachment.attachment_type == "uncategorised" ? "govuk-select--error" : "" %>
               <% end %>
               <%= form.govuk_collection_select attachment.id,
                                                @attachment_type_options,
                                                :first,
                                                :last,
-                                               label: { text: t('.select_a_category_label', filename: attachment.document.filename), class: 'govuk-visually-hidden' },
-                                               options: { selected: selected },
+                                               label: { text: t(".select_a_category_label", filename: attachment.document.filename), class: "govuk-visually-hidden" },
+                                               options: { selected: },
                                                class: [select_error] %>
             </div>
           </td>
           <td class="govuk-table__cell">
             <%= button_to_accessible(
-                  t('.delete'),
+                  t(".delete"),
                   providers_legal_aid_application_uploaded_evidence_collection_path(@legal_aid_application),
                   method: :patch,
-                  name: 'delete_button',
-                  class: 'button-as-link',
+                  name: "delete_button",
+                  class: "button-as-link",
                   params: { attachment_id: attachment.id },
-                  suffix: attachment.document.filename
+                  suffix: attachment.document.filename,
                 ) %>
           </td>
         </tr>

--- a/app/views/providers/uploaded_evidence_collections/show.html.erb
+++ b/app/views/providers/uploaded_evidence_collections/show.html.erb
@@ -4,15 +4,15 @@
                     elsif @error_message || @successful_upload
                       "#{@successful_upload} #{@error_message}"
                     else
-                      t('.h1-heading')
+                      t(".h1-heading")
                     end %>
 
 <%= page_template(
-      page_title: t('.h1-heading'),
+      page_title: t(".h1-heading"),
       head_title: new_head_title,
       template: :basic,
       show_errors_for: @submission_form&.model,
-      back_link: { path: providers_legal_aid_application_merits_task_list_path(@legal_aid_application) }
+      back_link: { path: providers_legal_aid_application_merits_task_list_path(@legal_aid_application) },
     ) do %>
 
   <% if @successfully_deleted %>
@@ -21,31 +21,31 @@
     <% end %>
   <% end %>
 
-  <%= render partial: 'upload_evidence' %>
+  <%= render partial: "upload_evidence" %>
 
   <%= form_with(
         model: @submission_form,
         url: providers_legal_aid_application_uploaded_evidence_collection_path,
         method: :patch,
-        local: true
+        local: true,
       ) do |form| %>
 
     <div id="uploaded-files-table-container">
-      <%= render partial: 'uploaded_files', locals: { attachments: @legal_aid_application.uploaded_evidence_collection.original_attachments } %>
+      <%= render partial: "uploaded_files", locals: { attachments: @legal_aid_application.uploaded_evidence_collection.original_attachments } %>
     </div>
     <div aria-live="assertive" class="govuk-visually-hidden" id="file-upload-status-message"></div>
-    <%= next_action_buttons(show_draft: true, form: form) %>
+    <%= next_action_buttons(show_draft: true, form:) %>
   <% end %>
 <% end %>
 
 <script nonce="<%= request.content_security_policy_nonce %>">
   window.LAA_VARS = {
     images: {
-      loading_small: <%= asset_pack_path('media/images/loading-small.gif').to_json.html_safe %>
+      loading_small: <%= asset_pack_path("media/images/loading-small.gif").to_json.html_safe %>
     },
     locales: {
       generic: {
-        uploading: <%= t('generic.uploading').to_json.html_safe %>
+        uploading: <%= t("generic.uploading").to_json.html_safe %>
       }
     }
   };

--- a/app/views/providers/use_ccms/show.html.erb
+++ b/app/views/providers/use_ccms/show.html.erb
@@ -1,14 +1,14 @@
 <div class="interruption-panel">
-  <%= page_template(page_title: t('.title_html'), head_title: t('.head_title'), column_width: 'full', template: :basic) do %>
-    <%= page_heading(size: 'l') %>
+  <%= page_template(page_title: t(".title_html"), head_title: t(".head_title"), column_width: "full", template: :basic) do %>
+    <%= page_heading(size: "l") %>
     <div class="maximize-text-width">
-      <p class="govuk-body"><%= t '.sub_heading' %></p>
-      <%= list_from_translation_path '.use_ccms.show.online_banking_consent' %>
+      <p class="govuk-body"><%= t ".sub_heading" %></p>
+      <%= list_from_translation_path ".use_ccms.show.online_banking_consent" %>
     </div>
 
     <div>
-      <%= link_to_accessible t('.continue_in_ccms_html'), 'https://portal.legalservices.gov.uk', class: 'govuk-button white-button', role: 'button' %>
+      <%= link_to_accessible t(".continue_in_ccms_html"), "https://portal.legalservices.gov.uk", class: "govuk-button white-button", role: "button" %>
     </div>
-    <%= link_to_accessible t('.back_to_applications'), providers_legal_aid_applications_path, class: 'govuk-body black_text_on_focus' %>
+    <%= link_to_accessible t(".back_to_applications"), providers_legal_aid_applications_path, class: "govuk-body black_text_on_focus" %>
   <% end %>
 </div>

--- a/app/views/providers/use_ccms_employed/index.html.erb
+++ b/app/views/providers/use_ccms_employed/index.html.erb
@@ -1,21 +1,21 @@
 <div class="interruption-panel">
-  <%= page_template(page_title: t('.title_html'), head_title: t('.head_title'), column_width: 'full', template: :basic) do %>
-    <%= page_heading(size: 'l') %>
+  <%= page_template(page_title: t(".title_html"), head_title: t(".head_title"), column_width: "full", template: :basic) do %>
+    <%= page_heading(size: "l") %>
 
     <% if @legal_aid_application.employment_journey_ineligible? %>
       <div class="maximize-text-width">
-        <p class="govuk-body"><%= t '.warning_list_title' %></p>
-        <%= list_from_translation_path '.use_ccms_employed.index.ineligible_employed' %>
+        <p class="govuk-body"><%= t ".warning_list_title" %></p>
+        <%= list_from_translation_path ".use_ccms_employed.index.ineligible_employed" %>
       </div>
     <% else %>
       <div class="maximize-text-width">
-        <p class="govuk-body"><%= t '.warning' %></p>
+        <p class="govuk-body"><%= t ".warning" %></p>
       </div>
     <% end %>
 
     <div>
-      <%= link_to_accessible t('.continue_in_ccms_html'), 'https://portal.legalservices.gov.uk', class: 'govuk-button white-button', role: 'button' %>
+      <%= link_to_accessible t(".continue_in_ccms_html"), "https://portal.legalservices.gov.uk", class: "govuk-button white-button", role: "button" %>
     </div>
-    <%= link_to_accessible t('.back_to_applications'), providers_legal_aid_applications_path, class: 'govuk-body black_text_on_focus' %>
+    <%= link_to_accessible t(".back_to_applications"), providers_legal_aid_applications_path, class: "govuk-body black_text_on_focus" %>
   <% end %>
 </div>

--- a/app/views/providers/vehicles/ages/show.html.erb
+++ b/app/views/providers/vehicles/ages/show.html.erb
@@ -1,23 +1,23 @@
 <%= form_with(
-        model: @form,
-        url: providers_legal_aid_application_vehicles_age_path,
-        method: :patch,
-        local: true
+      model: @form,
+      url: providers_legal_aid_application_vehicles_age_path,
+      method: :patch,
+      local: true,
     ) do |form| %>
-  <%= page_template page_title: t('.heading'), template: :basic, form: form do %>
+  <%= page_template page_title: t(".heading"), template: :basic, form: do %>
 
     <%= form.govuk_collection_radio_buttons(
-            :more_than_three_years_old,
-            yes_no_options,
-            :value,
-            :label,
-            legend: {size: 'xl', tag: 'h1', text: page_title},
-            ) %>
+          :more_than_three_years_old,
+          yes_no_options,
+          :value,
+          :label,
+          legend: { size: "xl", tag: "h1", text: page_title },
+        ) %>
 
     <div class="govuk-!-padding-bottom-4"></div>
     <%= next_action_buttons(
-            show_draft: true,
-            form: form
+          show_draft: true,
+          form:,
         ) %>
   <% end %>
 <% end %>

--- a/app/views/providers/vehicles/estimated_values/show.html.erb
+++ b/app/views/providers/vehicles/estimated_values/show.html.erb
@@ -1,27 +1,27 @@
 <%= form_with(
-        model: @form,
-        url: providers_legal_aid_application_vehicles_estimated_value_path,
-        method: :patch,
-        local: true
+      model: @form,
+      url: providers_legal_aid_application_vehicles_estimated_value_path,
+      method: :patch,
+      local: true,
     ) do |form| %>
-  <%= page_template page_title: t('.heading'), template: :basic, form: form do %>
+  <%= page_template page_title: t(".heading"), template: :basic, form: do %>
 
-    <%= form.govuk_fieldset legend: { size: 'xl', tag: 'h1', text: page_title }  do %>
+    <%= form.govuk_fieldset legend: { size: "xl", tag: "h1", text: page_title }  do %>
       <%= form.govuk_text_field(
-              :estimated_value,
-              value: number_to_currency_or_original_string(@form.model.estimated_value),
-              label: {text: :estimated_value, hidden: true},
-              hint: {text: t('.use_car_valuation_sites')},
-              width: 'one-third',
-              prefix_text: '£'
+            :estimated_value,
+            value: number_to_currency_or_original_string(@form.model.estimated_value),
+            label: { text: :estimated_value, hidden: true },
+            hint: { text: t(".use_car_valuation_sites") },
+            width: "one-third",
+            prefix_text: "£",
           ) %>
     <% end %>
 
     <div class="govuk-!-padding-bottom-4"></div>
 
     <%= next_action_buttons(
-            show_draft: true,
-            form: form
+          show_draft: true,
+          form:,
         ) %>
   <% end %>
 <% end %>

--- a/app/views/providers/vehicles/regular_uses/show.html.erb
+++ b/app/views/providers/vehicles/regular_uses/show.html.erb
@@ -1,24 +1,24 @@
 <%= form_with(
-        model: @form,
-        url: providers_legal_aid_application_vehicles_regular_use_path,
-        method: :patch,
-        local: true
+      model: @form,
+      url: providers_legal_aid_application_vehicles_regular_use_path,
+      method: :patch,
+      local: true,
     ) do |form| %>
-  <%= page_template page_title: t('.heading'), template: :basic, form: form do %>
+  <%= page_template page_title: t(".heading"), template: :basic, form: do %>
 
     <%= form.govuk_collection_radio_buttons(
-            :used_regularly,
-            yes_no_options,
-            :value,
-            :label,
-            legend: {size: 'xl', tag: 'h1', text: page_title},
-            hint: {text: t('.include_partner_use')}
+          :used_regularly,
+          yes_no_options,
+          :value,
+          :label,
+          legend: { size: "xl", tag: "h1", text: page_title },
+          hint: { text: t(".include_partner_use") },
         ) %>
 
     <div class="govuk-!-padding-bottom-4"></div>
     <%= next_action_buttons(
-            show_draft: true,
-            form: form
+          show_draft: true,
+          form:,
         ) %>
   <% end %>
 <% end %>

--- a/app/views/providers/vehicles/remaining_payments/show.html.erb
+++ b/app/views/providers/vehicles/remaining_payments/show.html.erb
@@ -1,31 +1,31 @@
 <%= form_with(
-        model: @form,
-        url: providers_legal_aid_application_vehicles_remaining_payment_path,
-        method: :patch,
-        local: true
+      model: @form,
+      url: providers_legal_aid_application_vehicles_remaining_payment_path,
+      method: :patch,
+      local: true,
     ) do |form| %>
-  <%= page_template page_title: t('.heading'), template: :basic, form: form do %>
+  <%= page_template page_title: t(".heading"), template: :basic, form: do %>
 
     <%= form.govuk_radio_buttons_fieldset(:payments_remain,
-                                        legend: { size: 'xl', tag: 'h1', text: page_title },
-                                        hint: {text: t('.detail_of_payments_to_include')}) do %>
-    <%= form.govuk_radio_button(:payments_remain, true, link_errors: true, label: {text: t('generic.yes')} ) do %>
+                                          legend: { size: "xl", tag: "h1", text: page_title },
+                                          hint: { text: t(".detail_of_payments_to_include") }) do %>
+    <%= form.govuk_radio_button(:payments_remain, true, link_errors: true, label: { text: t("generic.yes") }) do %>
       <%= form.govuk_text_field(
-              :payment_remaining,
-              label: {text: t('.enter_amount_left_to_pay')},
-              value: number_to_currency_or_original_string(@form.payment_remaining),
-              prefix_text: t('currency.gbp'),
-              width: 'one-third',
-              ) %>
+            :payment_remaining,
+            label: { text: t(".enter_amount_left_to_pay") },
+            value: number_to_currency_or_original_string(@form.payment_remaining),
+            prefix_text: t("currency.gbp"),
+            width: "one-third",
+          ) %>
     <% end %>
-    <%= form.govuk_radio_button(:payments_remain, false, label: {text:  t('generic.no')}) %>
+    <%= form.govuk_radio_button(:payments_remain, false, label: { text: t("generic.no") }) %>
 
   <% end %>
 
   <div class="govuk-!-padding-bottom-4"></div>
   <%= next_action_buttons(
-          show_draft: true,
-          form: form
+        show_draft: true,
+        form:,
       ) %>
   <% end %>
 <% end %>


### PR DESCRIPTION
1. Stop excluding `app/views/providers/**/*` from Rubocop erb-lint and autocorrect most issues
2. Address `OpenStruct` usage
3. Manually resolve multi-line assignment issues