### PR TITLE
AP-3235: Update HMRC response alerting

### DIFF
--- a/app/models/hmrc/response.rb
+++ b/app/models/hmrc/response.rb
@@ -2,7 +2,7 @@ module HMRC
   class Response < ApplicationRecord
     self.table_name = "hmrc_responses"
 
-    after_update :persist_employment_records
+    after_update :persist_employment_records, unless: :submission_started?
 
     USE_CASES = %w[one two].freeze
     belongs_to :legal_aid_application, inverse_of: :hmrc_responses
@@ -36,6 +36,10 @@ module HMRC
       return unless saved_changes?
 
       HMRC::ParsedResponse::Persistor.call(self)
+    end
+
+    def submission_started?
+      saved_change_to_url? && saved_change_to_submission_id?
     end
   end
 end

--- a/spec/workers/hmrc/result_worker_spec.rb
+++ b/spec/workers/hmrc/result_worker_spec.rb
@@ -45,11 +45,13 @@ RSpec.describe HMRC::ResultWorker do
 
       before do
         allow(HMRC::Interface::ResultService).to receive(:call).with(hmrc_response).and_return(good_response)
+        allow(HMRC::ParsedResponse::Persistor).to receive(:call).with(hmrc_response).and_return(true)
       end
 
       it "returns the expected payload" do
         perform
         expect(hmrc_response.reload.response).to eq good_response
+        expect(HMRC::ParsedResponse::Persistor).to have_received(:call)
       end
     end
 

--- a/spec/workers/hmrc/submission_worker_spec.rb
+++ b/spec/workers/hmrc/submission_worker_spec.rb
@@ -25,12 +25,14 @@ RSpec.describe HMRC::SubmissionWorker do
 
       before do
         allow(HMRC::Interface::SubmissionService).to receive(:call).with(hmrc_response).and_return(good_response)
+        allow(HMRC::ParsedResponse::Persistor).to receive(:call).with(hmrc_response).and_return(false)
       end
 
       it "updates the hmrc_response" do
         perform
         expect(hmrc_response.reload.url).to eq good_response[:_links][0][:href]
         expect(hmrc_response.reload.submission_id).to eq good_response[:id]
+        expect(HMRC::ParsedResponse::Persistor).not_to have_received(:call)
       end
 
       it "starts a new check job" do

--- a/spec/workers/hmrc/submission_worker_spec.rb
+++ b/spec/workers/hmrc/submission_worker_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe HMRC::SubmissionWorker do
   subject(:worker) { described_class.new }
 
   let(:application) { create(:legal_aid_application, :with_applicant, :with_transaction_period) }
-  let(:hmrc_response) { create(:hmrc_response, :use_case_one, legal_aid_application: application) }
+  let(:hmrc_response) { create(:hmrc_response, :use_case_two, legal_aid_application: application) }
 
   it { is_expected.to be_a described_class }
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3235)

This PR addresses the multiple `HMRC Response is unacceptable` errors from Sidekiq/HMRC::SubmissionWorker that are seen each day
It is caused by the implementation of the HMRC::ParsedResponse::Persistor being called from an after_update hook in the HMRC::Response model

### Life cycle of an HMRC::Response object
- New hmrc_response is created and passed to an HMRC::SubmissionWorker job
- HMRC::SubmissionWorker requests an ID from the HMRC Interface,
- HMRC::SubmissionWorker updates the hmrc_response with a url and id
  <-- persistor trying to validate response here and raising error -->
- HMRC::SubmissionWorker creates an HMRC::ResultWorker job
- HMRC::ResultWorker queries the HMRC Interface until a result is available
- HMRC::ResultWorker updates the hmrc_response with response data
  <-- persistor should validate response here and extract employment data -->

This skips calling the persistor if the URL and ID were changed as part of the call

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
