### PR TITLE
Revert "AP-3331 save vehicles remaining payments answer"

### DIFF
--- a/app/forms/vehicle_form/remaining_payment_form.rb
+++ b/app/forms/vehicle_form/remaining_payment_form.rb
@@ -17,7 +17,7 @@ module VehicleForm
     end
 
     def save
-      attributes[:payment_remaining] = nil if valid? && !payments_remain?
+      attributes[:payment_remaining] = 0 if valid? && !payments_remain?
       super
     end
 

--- a/app/views/providers/vehicles/remaining_payments/show.html.erb
+++ b/app/views/providers/vehicles/remaining_payments/show.html.erb
@@ -9,10 +9,7 @@
     <%= form.govuk_radio_buttons_fieldset(:payments_remain,
                                         legend: { size: 'xl', tag: 'h1', text: page_title },
                                         hint: {text: t('.detail_of_payments_to_include')}) do %>
-    <%= form.govuk_radio_button(:payments_remain, true,
-                                link_errors: true,
-                                label: {text: t('generic.yes')},
-                                checked: (@form.payment_remaining.present?)) do %>
+    <%= form.govuk_radio_button(:payments_remain, true, link_errors: true, label: {text: t('generic.yes')} ) do %>
       <%= form.govuk_text_field(
               :payment_remaining,
               label: {text: t('.enter_amount_left_to_pay')},
@@ -21,9 +18,7 @@
               width: 'one-third',
               ) %>
     <% end %>
-    <%= form.govuk_radio_button(:payments_remain, false,
-                                label: {text:  t('generic.no')},
-                                checked: (@legal_aid_application.checking_answers? && @form.payment_remaining.nil?)) %>
+    <%= form.govuk_radio_button(:payments_remain, false, label: {text:  t('generic.no')}) %>
 
   <% end %>
 

--- a/app/views/shared/check_answers/_vehicles.html.erb
+++ b/app/views/shared/check_answers/_vehicles.html.erb
@@ -25,7 +25,7 @@
           name: :vehicles_remaining_payments,
           url: check_answer_url_for(journey_type, :vehicles_remaining_payments, @legal_aid_application),
           question: t(".#{journey_type}.payment_remaining"),
-          answer: @legal_aid_application.vehicle.payment_remaining.nil? ? t("generic.no") : gds_number_to_currency(@legal_aid_application.vehicle.payment_remaining),
+          answer: gds_number_to_currency(@legal_aid_application.vehicle.payment_remaining),
           read_only:,
         ) %>
 

--- a/features/providers/check_your_answers.feature
+++ b/features/providers/check_your_answers.feature
@@ -281,20 +281,6 @@ Feature: Checking answers backwards and forwards
       Then I choose "Yes"
       And I click "Save and continue"
       Then I should be on a page showing 'Check your answers'
-      And the answer for "vehicles remaining payments" should be "£2,000"
-
-      When I click Check Your Answers Change link for 'vehicles remaining payments'
-      Then I should be on a page showing "Are there any payments left on the vehicle?"
-      Then the radio button response for "Vehicle payments remain" should be "Yes"
-      When I choose "No"
-      And I click "Save and continue"
-      And I click "Save and continue"
-      And I click "Save and continue"
-      Then I should be on a page showing 'Check your answers'
-      And the answer for "vehicles remaining payments" should be "No"
-      When I click Check Your Answers Change link for 'vehicles remaining payments'
-      Then I should be on a page showing "Are there any payments left on the vehicle?"
-      And the radio button response for "Vehicle payments remain" should be "No"
 
     @javascript
     Scenario: I submit the application and view the check_your_answers page

--- a/features/step_definitions/check_your_answers_steps.rb
+++ b/features/step_definitions/check_your_answers_steps.rb
@@ -52,23 +52,14 @@ Then("the {string} section's questions and answers should match:") do |section, 
   expect_matching_questions_and_answers(actual_selector: "[data-check-your-answers-section=\"#{section}\"]", expected_table: table)
 end
 
-Then("the radio button response for {string} should be {string}") do |question, answer|
-  question.downcase!
-  question.gsub!(/\s+/, "-")
-  value = answer == "Yes" ? "-true" : ""
-  label = find("label[for='#{question}#{value}-field']")
-  input = label.sibling("input", visible: false)
-  expect(input).to be_checked
-end
-
 def expect_matching_questions_and_answers(actual_selector:, expected_table:)
   expected = expected_table.hashes.map(&:symbolize_keys)
-  actual = actual_questions_and_answers_in(selector: actual_selector)
+  actual = actual_questions_and_anwsers_in(selector: actual_selector)
 
   expect(actual).to match_array(expected)
 end
 
-def actual_questions_and_answers_in(selector:)
+def actual_questions_and_anwsers_in(selector:)
   actual = []
 
   within(selector) do

--- a/spec/requests/providers/vehicles/remaining_payments_spec.rb
+++ b/spec/requests/providers/vehicles/remaining_payments_spec.rb
@@ -60,9 +60,9 @@ RSpec.describe Providers::Vehicles::RemainingPaymentsController do
     context "with payments remaining false" do
       let(:payments_remain) { "false" }
 
-      it "sets vehicle payment remaining to nil" do
+      it "sets vehicle payment remaining to zero" do
         subject
-        expect(vehicle.reload.payment_remaining).to be_nil
+        expect(vehicle.reload.payment_remaining).to be_zero
       end
     end
 


### PR DESCRIPTION
Reverts ministryofjustice/laa-apply-for-legal-aid#4786

Since this was deployed yesterday, we have seen a number (11)
of `CFE::Submission` errors in production.

```
CFE::SubmissionError
Message: Unprocessable entity: URL: http://check-financial-eligibility.check-financial-eligibility-production.svc.cluster.local/assessments/5938f952-355d-49a9-8ab1-3e42908d5d7d/vehicles, details: The property ‘#/vehicles/0/loan_amount_outstanding’ of type null matched the disallowed schema in schema file:///myapp/public/schemas/common/currency
```

It looks like the schema in CFE does not allow `null` for the `loan_amount_outstanding` attribute.

This reverts the change.  