### PR TITLE
Fix flaky test

### DIFF
--- a/app/models/concerns/translatable_model_attribute.rb
+++ b/app/models/concerns/translatable_model_attribute.rb
@@ -14,37 +14,8 @@
 module TranslatableModelAttribute
   extend ActiveSupport::Concern
 
-  RadioButtonStruct = Struct.new(:name, :label)
-
   def enum_t(attribute)
     model = model_name.i18n_key
     I18n.t(__send__(attribute), scope: [:model_enum_translations, model, attribute])
-  end
-
-  class_methods do
-    # This method generates a radio button for each option in an enum
-    # For example, if the form object is a `Feedback` instance which has the
-    # `satisfaction` enum attribute:
-    #     <%= Feedback.enum_radio_buttons(form, :satisfaction) %>
-    # To reverse the order:
-    #     <%= Feedback.enum_radio_buttons(form, :satisfaction, order: :reverse) %>
-    def enum_radio_buttons(form, attribute, order: :normal, args: nil)
-      collection = enum_ts(attribute).map do |option, translation|
-        RadioButtonStruct.new(option.to_s, translation)
-      end
-      collection.reverse! if order == :reverse
-      form.govuk_collection_radio_buttons(attribute, collection, :name, :label, **args)
-    end
-
-    def enum_ts(attribute)
-      enums = __send__(attribute.to_s.pluralize)
-      enum_ts_cache[attribute.to_sym] ||= enums.keys.each_with_object({}) do |value, hash|
-        hash[value.to_sym] = I18n.t(value, scope: [:model_enum_translations, model_name.i18n_key, attribute])
-      end
-    end
-
-    def enum_ts_cache
-      @enum_ts_cache ||= {}
-    end
   end
 end

--- a/app/views/feedback/new.html.erb
+++ b/app/views/feedback/new.html.erb
@@ -12,24 +12,20 @@
           },
         ) %>
 
-    <%= Feedback.enum_radio_buttons(
-          form, :difficulty,
-          order: :reverse,
-          args: {
-            legend: {
-              text: t(".difficulty"),
-            },
-          }
+    <%= form.govuk_collection_radio_buttons(
+          :difficulty,
+          Feedback.difficulties.keys.reverse,
+          ->(option) { option },
+          ->(option) { t("model_enum_translations.feedback.difficulty.#{option}") },
+          legend: { text: t(".difficulty") },
         ) %>
 
-    <%= Feedback.enum_radio_buttons(
-          form, :satisfaction,
-          order: :reverse,
-          args: {
-            legend: {
-              text: t(".satisfaction"),
-            },
-          }
+    <%= form.govuk_collection_radio_buttons(
+          :satisfaction,
+          Feedback.satisfactions.keys.reverse,
+          ->(option) { option },
+          ->(option) { t("model_enum_translations.feedback.satisfaction.#{option}") },
+          legend: { text: t(".satisfaction") },
         ) %>
 
     <%= form.govuk_text_area(

--- a/spec/models/concerns/translatable_model_attribute_spec.rb
+++ b/spec/models/concerns/translatable_model_attribute_spec.rb
@@ -18,22 +18,4 @@ RSpec.describe TranslatableModelAttribute do
       end
     end
   end
-
-  describe ".enum_ts" do
-    subject { klass.enum_ts(:satisfaction) }
-
-    let(:klass) { Feedback }
-    let(:satisfactions) { klass.satisfactions }
-    let(:instance) { klass.new }
-
-    it "returns a hash with an entry for each state" do
-      expect(subject.keys).to match_array satisfactions.keys.map(&:to_sym)
-    end
-
-    it "has values that match the translations" do
-      key = subject.keys.sample
-      instance.satisfaction = key
-      expect(subject[key]).to eq(instance.enum_t(:satisfaction))
-    end
-  end
 end


### PR DESCRIPTION
Before, the feedback page used the `.enum_radio_buttons` class method from the `TranslatableModelAttribute` concern to build options for the difficulty and satisfaction feedback questions.

While these provided a nice API for building the options, it added unnecessary complexity and opened cache-sized door of opportunity for bugs.

This was highlighted by the [flaky test] which started failing intermittently (but with very high frequency) since tests were broken down in #4852.

When the feedback form was completed in Welsh, the translations were cached and subsequent tests of the feedback form in English would fail because the "Easy" option was missing (it was "ysaE" instead).

This fixes the flaky test by replacing the use of `.enum_radio_buttons` with an inline translation lookup —removing the cache and source of the leak.

[flaky test]: https://app.circleci.com/pipelines/github/ministryofjustice/laa-apply-for-legal-aid/20171/workflows/ba644a60-8077-42db-97fe-f1d733948eb1/jobs/104965