### PR TITLE
[AP-3590] Bump redis iamge used for test suite excecutor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ executors:
           CACHE_VERSION: v1
           NODE_OPTIONS: --openssl-legacy-provider
       - image: cimg/postgres:11.16
-      - image: cimg/redis:5.0
+      - image: cimg/redis:6.2
       - image: ghcr.io/ministryofjustice/hmpps-clamav:latest
 
 references:


### PR DESCRIPTION
## What

Bump redis image used for test suite executor

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3590)

Inline with production version of 6.2.6

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
