### PR TITLE
Add hint text when a new substantive cost limit is requested

### DIFF
--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -11,6 +11,10 @@ en:
         postcode: This must be a UK postcode, for example SW1A 2AA.
       applicant:
         national_insurance_number: For example, QQ 12 34 56 C
+      legal_aid_application:
+        substantive_cost_requested: >-
+          The maximum you can request is currently £25,000. You can request
+          more after a caseworker has processed your application.
       providers_means_regular_income_form:
         transaction_type_ids: Select all that apply. Do not include Housing Benefit, government Cost of Living Payments, or any other disregarded benefits.
       providers_means_regular_outgoings_form:


### PR DESCRIPTION
This adds some clarifying hint text to the substantive cost limit request question when a provider selects "Yes" to request a higher substantive cost limit.

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3227)