### PR TITLE
[AP-3590] Bump sidekiq 6.5.7 --> 7.0.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ executors:
           CACHE_VERSION: v1
           NODE_OPTIONS: --openssl-legacy-provider
       - image: cimg/postgres:11.16
-      - image: cimg/redis:5.0
+      - image: cimg/redis:6.2
       - image: ghcr.io/ministryofjustice/hmpps-clamav:latest
 
 references:

--- a/Gemfile
+++ b/Gemfile
@@ -62,7 +62,6 @@ gem "jwt"
 # background processing
 gem "redis-namespace"
 gem "sidekiq", "~> 7.0"
-gem "sidekiq-status", "~> 2.1.3"
 
 # URL and path parsing
 gem "addressable"

--- a/Gemfile
+++ b/Gemfile
@@ -61,7 +61,7 @@ gem "jwt"
 
 # background processing
 gem "redis-namespace"
-gem "sidekiq", "~> 6.5.7"
+gem "sidekiq", "~> 7.0"
 gem "sidekiq-status", "~> 2.1.3"
 
 # URL and path parsing

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -153,8 +153,6 @@ GEM
     case_transform (0.2)
       activesupport
     childprocess (4.1.0)
-    chronic_duration (0.10.6)
-      numerizer (~> 0.1.1)
     coderay (1.1.3)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
@@ -429,7 +427,6 @@ GEM
       shellany (~> 0.0)
     notifications-ruby-client (5.4.0)
       jwt (>= 1.5, < 3)
-    numerizer (0.1.1)
     oauth (1.1.0)
       oauth-tty (~> 1.0, >= 1.0.1)
       snaky_hash (~> 2.0)
@@ -651,9 +648,6 @@ GEM
       connection_pool (>= 2.3.0)
       rack (>= 2.2.4)
       redis-client (>= 0.11.0)
-    sidekiq-status (2.1.3)
-      chronic_duration
-      sidekiq (>= 5.0)
     signet (0.17.0)
       addressable (~> 2.8)
       faraday (>= 0.17.5, < 3.a)
@@ -818,7 +812,6 @@ DEPENDENCIES
   sentry-sidekiq
   shoulda-matchers (~> 5.3)
   sidekiq (~> 7.0)
-  sidekiq-status (~> 2.1.3)
   simple_command
   simplecov
   simplecov-rcov

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -543,7 +543,10 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    redis (4.8.0)
+    redis (5.0.6)
+      redis-client (>= 0.9.0)
+    redis-client (0.12.1)
+      connection_pool
     redis-namespace (1.10.0)
       redis (>= 4)
     regexp_parser (2.6.2)
@@ -643,10 +646,11 @@ GEM
     shellany (0.0.1)
     shoulda-matchers (5.3.0)
       activesupport (>= 5.2.0)
-    sidekiq (6.5.7)
-      connection_pool (>= 2.2.5)
-      rack (~> 2.0)
-      redis (>= 4.5.0, < 5)
+    sidekiq (7.0.3)
+      concurrent-ruby (< 2)
+      connection_pool (>= 2.3.0)
+      rack (>= 2.2.4)
+      redis-client (>= 0.11.0)
     sidekiq-status (2.1.3)
       chronic_duration
       sidekiq (>= 5.0)
@@ -813,7 +817,7 @@ DEPENDENCIES
   sentry-ruby
   sentry-sidekiq
   shoulda-matchers (~> 5.3)
-  sidekiq (~> 6.5.7)
+  sidekiq (~> 7.0)
   sidekiq-status (~> 2.1.3)
   simple_command
   simplecov

--- a/app/jobs/reports_uploader_job.rb
+++ b/app/jobs/reports_uploader_job.rb
@@ -1,5 +1,4 @@
 class ReportsUploaderJob < ApplicationJob
-  include Sidekiq::Status::Worker
   def perform
     log "starting at #{Time.zone.now}"
     unless admin_report.application_details_report&.blob.nil?

--- a/app/workers/bank_holiday_update_worker.rb
+++ b/app/workers/bank_holiday_update_worker.rb
@@ -1,7 +1,6 @@
 class BankHolidayUpdateWorker
   DataRetrievalError = Class.new(StandardError)
   include Sidekiq::Worker
-  include Sidekiq::Status::Worker
 
   UPDATE_INTERVAL = 2.days
 

--- a/app/workers/ccms/submission_process_worker.rb
+++ b/app/workers/ccms/submission_process_worker.rb
@@ -5,7 +5,6 @@ module CCMS
 
   class SubmissionProcessWorker
     include Sidekiq::Worker
-    include Sidekiq::Status::Worker
     attr_accessor :retry_count, :submission
 
     MAX_RETRIES = 10

--- a/app/workers/hmrc/base_worker.rb
+++ b/app/workers/hmrc/base_worker.rb
@@ -1,7 +1,6 @@
 module HMRC
   class BaseWorker
     include Sidekiq::Worker
-    include Sidekiq::Status::Worker
     attr_accessor :retry_count
 
     MAX_RETRIES = 10

--- a/app/workers/import_bank_data_worker.rb
+++ b/app/workers/import_bank_data_worker.rb
@@ -1,6 +1,5 @@
 class ImportBankDataWorker
   include Sidekiq::Worker
-  include Sidekiq::Status::Worker
   sidekiq_options retry: false
 
   attr_reader :legal_aid_application_id

--- a/app/workers/pdf_converter_worker.rb
+++ b/app/workers/pdf_converter_worker.rb
@@ -1,6 +1,5 @@
 class PdfConverterWorker
   include Sidekiq::Worker
-  include Sidekiq::Status::Worker
   attr_accessor :retry_count
 
   ALERT_ON_RETRY_COUNT = 3

--- a/app/workers/provider_details_creator_worker.rb
+++ b/app/workers/provider_details_creator_worker.rb
@@ -1,6 +1,5 @@
 class ProviderDetailsCreatorWorker
   include Sidekiq::Worker
-  include Sidekiq::Status::Worker
 
   def perform(provider_id)
     Provider.find(provider_id).update_details_directly

--- a/app/workers/reports_creator_worker.rb
+++ b/app/workers/reports_creator_worker.rb
@@ -1,6 +1,5 @@
 class ReportsCreatorWorker
   include Sidekiq::Worker
-  include Sidekiq::Status::Worker
 
   def perform(legal_aid_application_id)
     legal_aid_application = LegalAidApplication.find(legal_aid_application_id)

--- a/app/workers/true_layer_banks_update_worker.rb
+++ b/app/workers/true_layer_banks_update_worker.rb
@@ -1,7 +1,6 @@
 class TrueLayerBanksUpdateWorker
   DataRetrievalError = Class.new(StandardError)
   include Sidekiq::Worker
-  include Sidekiq::Status::Worker
 
   UPDATE_INTERVAL = 1.hour
 

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,5 +1,4 @@
 require "sidekiq"
-require "sidekiq-status"
 require "prometheus_exporter/client"
 require "prometheus_exporter/instrumentation"
 
@@ -10,19 +9,10 @@ module Dashboard; end
 
 Sidekiq.configure_client do |config|
   config.redis = { url: redis_url, namespace: } if redis_url
-
-  # accepts :expiration (optional)
-  Sidekiq::Status.configure_client_middleware config, expiration: 30.minutes
 end
 
 Sidekiq.configure_server do |config|
   config.redis = { url: redis_url, namespace: } if redis_url
-
-  # accepts :expiration (optional)
-  Sidekiq::Status.configure_server_middleware config, expiration: 30.minutes
-
-  # accepts :expiration (optional)
-  Sidekiq::Status.configure_client_middleware config, expiration: 30.minutes
 
   if Rails.env.production? && Rails.configuration.x.kubernetes_deployment
     config.server_middleware do |chain|

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -8,6 +8,8 @@ namespace = ENV.fetch("HOST", "laa-apply")
 module Dashboard; end
 
 Sidekiq.configure_client do |config|
+  config.logger = Rails.logger
+  config.logger.level = Logger::WARN
   config.redis = { url: redis_url, namespace: } if redis_url
 end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,6 @@ Rails.application.routes.draw do
   root to: "providers/start#index"
 
   require "sidekiq/web"
-  require "sidekiq-status/web"
   mount Sidekiq::Web => "/sidekiq"
 
   Sidekiq::Web.use Rack::Auth::Basic do |username, password|


### PR DESCRIPTION
## What
bump sidekiq 6.5.7 to 7.0.3

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3590)

Following redis migration from 4.0.10 to 6.2.6 we can now update to
latest version of sidekiq.

see https://github.com/mperham/sidekiq/blob/main/docs/7.0-API-Migration.md
and https://github.com/mperham/sidekiq/blob/main/docs/7.0-Upgrade.md

### Blockers
- [ ] sidekiq-status gem 
- [ ] redis-namespace gem - [see ticket](https://dsdmoj.atlassian.net/browse/AP-3767)

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
