### PR TITLE
Reenable manual_review_determiner spec

### DIFF
--- a/app/services/ccms/manual_review_determiner.rb
+++ b/app/services/ccms/manual_review_determiner.rb
@@ -21,11 +21,8 @@ module CCMS
     delegate :capital_contribution_required?, to: :cfe_result
 
     def initialize(legal_aid_application)
-      # TODO: this if/else needs tidying up in ap-3338 where we will create a blank cfe_result for these cases
       @legal_aid_application = legal_aid_application
-      if legal_aid_application.uploading_bank_statements?
-        nil
-      elsif legal_aid_application.cfe_result.nil?
+      if legal_aid_application.cfe_result.nil?
         raise "Unable to determine whether Manual review is required before means assessment"
       end
     end

--- a/spec/services/ccms/manual_review_determiner_spec.rb
+++ b/spec/services/ccms/manual_review_determiner_spec.rb
@@ -230,20 +230,16 @@ module CCMS
           end
         end
 
-        # TODO: This test needs to be re-enabled once the work on AP-3338 is complete
-        # or it may no longer be required at that stage and can be deleted
-        #
-        # context "with uploading_bank_statements" do
-        #   let(:provider) { create :provider, :with_bank_statement_upload_permissions }
-        #   let(:legal_aid_application) { create :legal_aid_application, attachments: [bank_statement], provider: }
-        #   let(:bank_statement) { create :attachment, :bank_statement }
-        #
-        #   let!(:cfe_result) { nil }
-        #
-        #   it "returns true" do
-        #     expect(subject).to be true
-        #   end
-        # end
+        context "with uploading_bank_statements" do
+          let(:provider) { create(:provider, :with_bank_statement_upload_permissions) }
+          let(:legal_aid_application) { create(:legal_aid_application, attachments: [bank_statement], provider:) }
+          let(:bank_statement) { create(:attachment, :bank_statement) }
+          let!(:cfe_result) { create(:cfe_v5_result, submission: cfe_submission) }
+
+          it "returns true" do
+            expect(subject).to be true
+          end
+        end
       end
     end
 


### PR DESCRIPTION
## What

Removed a couple of TODOs left over from [AP-3338](https://dsdmoj.atlassian.net/browse/AP-3338)

Re-enabled a spec for manual_review_required? for applications with bank statements uploaded in manaul_review_determiner_spec.

Also removed conditional if statement in manual_review_determiner testing if application has uploaded bank statements. I believe this is no longer required as applications with uploaded bank statements are now assessed by CFE and receive a CFE result in the same way as other applications.

Tested that the CFE result page is the same for applications with uploaded bank statements before and after the change.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.


[AP-3338]: https://dsdmoj.atlassian.net/browse/AP-3338?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ