### PR TITLE
AP-3442: Monitor banking path usage

### DIFF
--- a/app/models/application_digest.rb
+++ b/app/models/application_digest.rb
@@ -42,6 +42,9 @@ class ApplicationDigest < ApplicationRecord
         employed: laa.applicant.employed?,
         hmrc_data_used: determine_hmrc_data_used?(laa),
         referred_to_caseworker: determine_caseworker_review?(laa),
+        true_layer_path: laa.truelayer_path?,
+        bank_statements_path: laa.bank_statement_upload_path?,
+        true_layer_data: laa.bank_transactions.any?,
       }
     end
 

--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -509,6 +509,14 @@ class LegalAidApplication < ApplicationRecord
     uploading_bank_statements? && housing_payments?
   end
 
+  def truelayer_path?
+    provider_received_citizen_consent == true
+  end
+
+  def bank_statement_upload_path?
+    client_not_given_consent_to_open_banking?
+  end
+
 private
 
   def client_not_given_consent_to_open_banking?

--- a/app/services/reports/mis/application_detail_csv_line.rb
+++ b/app/services/reports/mis/application_detail_csv_line.rb
@@ -166,6 +166,9 @@ module Reports
           "Free text required",
           "Free text optional",
           "Multi Employment",
+          "Bank statements path",
+          "Truelayer path",
+          "Truelayer data",
         ]
       end
 
@@ -196,6 +199,7 @@ module Reports
         opponent_details
         merits
         hmrc_data
+        banking_data
         sanitise
       end
 
@@ -384,6 +388,12 @@ module Reports
         @line << yesno(laa.full_employment_details.present?) # "Free text required",
         @line << yesno(laa.extra_employment_information_details.present?) # "Free text optional",
         @line << yesno(laa.has_multiple_employments?) # "Multi Employment",
+      end
+
+      def banking_data
+        @line << yesno(laa.bank_statement_upload_path?) # "Bank statements path",
+        @line << yesno(laa.truelayer_path?) # "Truelayer path",
+        @line << yesno(laa.bank_transactions.any?) # Truelayer data""
       end
 
       def yesno(value)

--- a/db/migrate/20230131084513_add_banking_paths_to_application_digest.rb
+++ b/db/migrate/20230131084513_add_banking_paths_to_application_digest.rb
@@ -1,0 +1,11 @@
+class AddBankingPathsToApplicationDigest < ActiveRecord::Migration[7.0]
+  def change
+    safety_assured do
+      change_table :application_digests, bulk: true do |t|
+        t.boolean :true_layer_path, null: true
+        t.boolean :bank_statements_path, null: true
+        t.boolean :true_layer_data, null: true
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_12_19_133711) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_31_084513) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -144,6 +144,9 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_19_133711) do
     t.boolean "employed", default: false, null: false
     t.boolean "hmrc_data_used", default: false, null: false
     t.boolean "referred_to_caseworker", default: false, null: false
+    t.boolean "true_layer_path"
+    t.boolean "bank_statements_path"
+    t.boolean "true_layer_data"
     t.index ["legal_aid_application_id"], name: "index_application_digests_on_legal_aid_application_id", unique: true
   end
 

--- a/spec/services/digest_exporter_spec.rb
+++ b/spec/services/digest_exporter_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe DigestExporter do
         expect(spreadsheet).to receive(:worksheets).and_return([worksheet]).at_least(2)
         expect(worksheet).to receive(:max_rows).and_return(10)
         expect(worksheet).to receive(:delete_rows).with(1, 9)
-        expect(worksheet).to receive(:save).exactly(3).times
+        expect(worksheet).to receive(:save).twice
         expect(worksheet).to receive(:update_cells).with(1, 1, [column_headings])
         expect(worksheet).to receive(:update_cells).with(2, 1, rows)
 
@@ -42,7 +42,7 @@ RSpec.describe DigestExporter do
           expect(spreadsheet).to receive(:worksheets).and_return([worksheet]).at_least(2)
           expect(worksheet).to receive(:max_rows).and_return(10)
           expect(worksheet).to receive(:delete_rows).with(1, 9)
-          expect(worksheet).to receive(:save).exactly(3).times
+          expect(worksheet).to receive(:save).twice
           expect(worksheet).to receive(:update_cells).with(1, 1, [column_headings])
           expect(worksheet).to receive(:update_cells).with(2, 1, rows)
           expect(AlertManager).to receive(:capture_exception).with(message_contains("Spreadsheet unexpectedly empty"))


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3442)

In order for the team to monitor and track the different banking journey paths we need to record whether a non passported application has started the bank statement uploads or Truelayer journey

This PR adds field to the digest, for datastudio tracking, and admin report output for excel analysis

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
