### PR TITLE
Fix: Remove sidekiq-alive queue

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -2,6 +2,5 @@
 :queues:
   - default
   - mailers
-  - sidekiq_alive
   - active_storage_analysis
   - active_storage_purge

--- a/spec/services/metrics/sidekiq_queue_sizes_spec.rb
+++ b/spec/services/metrics/sidekiq_queue_sizes_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Metrics::SidekiqQueueSizes do
   describe "#call" do
     subject { described_class.call(prometheus_client) }
 
-    let(:queues) { %w[default mailers sidekiq_alive active_storage_analysis active_storage_purge] }
+    let(:queues) { %w[default mailers active_storage_analysis active_storage_purge] }
     let(:prometheus_client) { spy(PrometheusExporter::Client) }
     let(:collector_type) { PrometheusCollectors::SidekiqQueueCollector::COLLECTOR_TYPE }
 


### PR DESCRIPTION
## What

We removed the sidekiq-alive gem in Nov 2021 #2823 This should have been removed at the same time!

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
