### PR TITLE
AP-3794: Update digest-exporter

### DIFF
--- a/spec/services/digest_exporter_spec.rb
+++ b/spec/services/digest_exporter_spec.rb
@@ -5,46 +5,63 @@ RSpec.describe DigestExporter do
   # expected methods are called
   describe ".call" do
     let(:google_session) { double GoogleDrive::Session }
-    let(:spreadsheet) { double "Spreadsheet" }
-    let(:worksheet) { double "Worksheet", rows: {} }
-    let(:column_headings) { ApplicationDigest.column_headers + [extracted_at] }
+    let(:spreadsheet) { double "Spreadsheet", worksheets: {} }
+    # let(:archive) { double "Worksheet", rows: {} }
+    let(:worksheet) { double "Worksheet", rows: {}, delete: true }
+    let(:column_headings) { [ApplicationDigest.column_headers + [extracted_at]].flatten }
     let(:fixed_time) { Time.zone.now }
     let(:extracted_at) { "Extracted at: #{fixed_time.strftime('%Y-%m-%d %H:%M:%S %z')}" }
     let(:rows) { ApplicationDigest.order(:created_at).map(&:to_google_sheet_row) }
+    let(:expected_rows) { [column_headings] + rows }
 
     before do
+      allow(spreadsheet).to receive(:add_worksheet).and_return(worksheet)
       allow(worksheet.rows).to receive(:count).and_return(10)
+      allow(worksheet).to receive(:num_cols).and_return(2)
+      allow(worksheet).to receive(:[]).with(1, 2).and_return("Fake extraction date")
+      allow(worksheet).to receive(:title=).with("Archive fake extraction date").and_return("Archive fake extraction date")
       create_list(:application_digest, 4)
     end
 
     it "loads all the digest records" do
       travel_to fixed_time do
         expect(GoogleDrive::Session).to receive(:from_service_account_key).and_return(google_session)
-        expect(google_session).to receive(:spreadsheet_by_key).and_return(spreadsheet).exactly(2)
+        expect(google_session).to receive(:spreadsheet_by_key).and_return(spreadsheet).once
         expect(spreadsheet).to receive(:worksheets).and_return([worksheet]).at_least(2)
-        expect(worksheet).to receive(:max_rows).and_return(10)
-        expect(worksheet).to receive(:delete_rows).with(1, 9)
+        expect(worksheet).to receive(:num_cols).and_return(2)
         expect(worksheet).to receive(:save).twice
-        expect(worksheet).to receive(:update_cells).with(1, 1, [column_headings])
-        expect(worksheet).to receive(:update_cells).with(2, 1, rows)
+        expect(worksheet).to receive(:update_cells).once
 
         described_class.call
       end
     end
 
-    context "when saving records silently fails" do
+    context "when sheets need archiving" do
+      it "deletes the third worksheet" do
+        travel_to fixed_time do
+          expect(GoogleDrive::Session).to receive(:from_service_account_key).and_return(google_session)
+          expect(google_session).to receive(:spreadsheet_by_key).and_return(spreadsheet).once
+          expect(spreadsheet).to receive(:worksheets).and_return([worksheet, worksheet, worksheet]).at_least(2)
+          expect(worksheet).to receive(:num_cols).and_return(2)
+          expect(worksheet).to receive(:delete).once
+          expect(worksheet).to receive(:save).twice
+          expect(worksheet).to receive(:update_cells).once
+
+          described_class.call
+        end
+      end
+    end
+
+    context "when saving records fails" do
       before { allow(worksheet.rows).to receive(:count).and_return(1) }
 
       it "calls raises an error and calls AlertManager" do
         travel_to fixed_time do
           expect(GoogleDrive::Session).to receive(:from_service_account_key).and_return(google_session)
-          expect(google_session).to receive(:spreadsheet_by_key).and_return(spreadsheet).exactly(2)
-          expect(spreadsheet).to receive(:worksheets).and_return([worksheet]).at_least(2)
-          expect(worksheet).to receive(:max_rows).and_return(10)
-          expect(worksheet).to receive(:delete_rows).with(1, 9)
+          expect(google_session).to receive(:spreadsheet_by_key).and_return(spreadsheet).once
+          expect(spreadsheet).to receive(:worksheets).and_return([worksheet]).once
           expect(worksheet).to receive(:save).twice
-          expect(worksheet).to receive(:update_cells).with(1, 1, [column_headings])
-          expect(worksheet).to receive(:update_cells).with(2, 1, rows)
+          expect(worksheet).to receive(:update_cells).once
           expect(AlertManager).to receive(:capture_exception).with(message_contains("Spreadsheet unexpectedly empty"))
           expect { described_class.call }.to raise_error(DigestExporter::SpreadsheetEmpty)
         end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3794)

This PR updates the generation of the digest

As data-studio requires a static sheet name of `Sheet1`, previously
this would delete rows and re-create, this has started to cause errors
where the header row would get overwritten and cause the data-studio to break

This now renames the current Sheet1 to `Archive` and the date it was
originally generated and recreates Sheet1 from scratch

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
