### PR TITLE
Revert "AP-3794: Update digest-exporter"

### DIFF
--- a/app/services/digest_exporter.rb
+++ b/app/services/digest_exporter.rb
@@ -9,16 +9,14 @@ class DigestExporter
     log_message "Initializing"
     secret_file = StringIO.new(google_secret.to_json)
     @session = GoogleDrive::Session.from_service_account_key(secret_file)
-    @spreadsheet = @session.spreadsheet_by_key(spreadsheet_key)
+    @worksheet = @session.spreadsheet_by_key(spreadsheet_key).worksheets[0]
+    @rows = []
+    reset_worksheet
   end
 
   def call
-    @rows = []
-    archive_previous
-    create_sheet1
-    build_rows_from_digest(digest_ids)
+    save_digest_to_rows(digest_ids)
     update_and_save_worksheet
-    clear_archive
   end
 
 private
@@ -29,36 +27,10 @@ private
     Rails.logger.info message
   end
 
-  def archive_previous
-    log_message "archive_previous"
-    @yesterday = @spreadsheet.worksheets[0]
-    archive_title = "Archive#{@yesterday.num_cols.positive? ? " #{@yesterday[1, @yesterday.num_cols]}".downcase : ''}"
-    log_message "Saving archived sheet as #{archive_title}"
-    @yesterday.title = archive_title
-    @yesterday.save
-  end
-
-  def create_sheet1
-    log_message "create_sheet1"
-    @worksheet = @spreadsheet.add_worksheet("Sheet1", digest_ids.count, column_headers.count, index: 0)
-  end
-
-  def build_rows_from_digest(digest_ids)
-    log_message "build_rows_from_digest"
-    log_message "Adding #{column_headers.count + 1} column headers, ApplicationDigest.column_headers + extraction date, to @rows"
-    @rows << [column_headers + extraction_date].flatten
-    log_message "#{digest_ids.size} records to be added to @rows"
-    digest_ids.each_with_index do |digest_id, _index|
-      digest = ApplicationDigest.find(digest_id)
-      @rows << digest.to_google_sheet_row
-    end
-    log_message "@row.count: #{@rows.size}"
-  end
-
   def update_and_save_worksheet
     log_message "update_and_save_worksheet"
     log_message "updating cells, @rows.count: #{@rows.count}"
-    @worksheet.update_cells(1, 1, @rows)
+    @worksheet.update_cells(2, 1, @rows)
     log_message "saving worksheet"
     @worksheet.save
     raise SpreadsheetEmpty, "Spreadsheet unexpectedly empty" if @worksheet.rows.count == 1
@@ -70,26 +42,41 @@ private
     raise
   end
 
-  def clear_archive
-    if @spreadsheet.worksheets.count < 2
-      log_message "skipping clear_archive, only #{@spreadsheet.worksheets.count} worksheets"
-    else
-      log_message "clear_archive"
-      @spreadsheet.worksheets[2..].each(&:delete)
-    end
-  end
-
   def digest_ids
     @digest_ids ||= initialize_digest_ids
   end
 
   def initialize_digest_ids
-    log_message "initialize_digest_ids"
+    log_message "Getting digest ids"
     ApplicationDigest.order(:created_at).pluck(:id)
   end
 
-  def column_headers
-    ApplicationDigest.column_headers
+  def save_digest_to_rows(digest_ids)
+    log_message "save_digest_to_rows"
+    log_message "#{digest_ids.size} records to be added to @rows"
+    digest_ids.each_with_index do |digest_id, _index|
+      digest = ApplicationDigest.find(digest_id)
+      @rows << digest.to_google_sheet_row
+    end
+    log_message "@row.count: #{@rows.size}"
+    log_message "@worksheet.rows.count: #{@worksheet.rows.count}"
+  end
+
+  def reset_worksheet
+    log_message "reset_worksheet"
+    # You can't delete all the rows in a worksheet, so we delete all but one, and we'll overwrite that
+    # with the column headers
+    @worksheet.delete_rows(1, @worksheet.max_rows - 1)
+    log_message "Existing data removed from spreadsheet"
+
+    log_message "Writing #{ApplicationDigest.column_headers.count} column headers + extraction date"
+    # Overwrite the 1 remaining row with column headers
+    @worksheet.update_cells(1, 1, [ApplicationDigest.column_headers + extraction_date])
+    @worksheet.save
+
+    # It turns out that you have to re-initialise the worksheet, otherwise the deleted rows haven't really gone.
+    @worksheet = @session.spreadsheet_by_key(spreadsheet_key).worksheets[0]
+    log_message "@worksheet.rows.count: #{@worksheet.rows.count}"
   end
 
   def extraction_date

--- a/spec/services/digest_exporter_spec.rb
+++ b/spec/services/digest_exporter_spec.rb
@@ -5,63 +5,46 @@ RSpec.describe DigestExporter do
   # expected methods are called
   describe ".call" do
     let(:google_session) { double GoogleDrive::Session }
-    let(:spreadsheet) { double "Spreadsheet", worksheets: {} }
-    # let(:archive) { double "Worksheet", rows: {} }
-    let(:worksheet) { double "Worksheet", rows: {}, delete: true }
-    let(:column_headings) { [ApplicationDigest.column_headers + [extracted_at]].flatten }
+    let(:spreadsheet) { double "Spreadsheet" }
+    let(:worksheet) { double "Worksheet", rows: {} }
+    let(:column_headings) { ApplicationDigest.column_headers + [extracted_at] }
     let(:fixed_time) { Time.zone.now }
     let(:extracted_at) { "Extracted at: #{fixed_time.strftime('%Y-%m-%d %H:%M:%S %z')}" }
     let(:rows) { ApplicationDigest.order(:created_at).map(&:to_google_sheet_row) }
-    let(:expected_rows) { [column_headings] + rows }
 
     before do
-      allow(spreadsheet).to receive(:add_worksheet).and_return(worksheet)
       allow(worksheet.rows).to receive(:count).and_return(10)
-      allow(worksheet).to receive(:num_cols).and_return(2)
-      allow(worksheet).to receive(:[]).with(1, 2).and_return("Fake extraction date")
-      allow(worksheet).to receive(:title=).with("Archive fake extraction date").and_return("Archive fake extraction date")
       create_list(:application_digest, 4)
     end
 
     it "loads all the digest records" do
       travel_to fixed_time do
         expect(GoogleDrive::Session).to receive(:from_service_account_key).and_return(google_session)
-        expect(google_session).to receive(:spreadsheet_by_key).and_return(spreadsheet).once
+        expect(google_session).to receive(:spreadsheet_by_key).and_return(spreadsheet).exactly(2)
         expect(spreadsheet).to receive(:worksheets).and_return([worksheet]).at_least(2)
-        expect(worksheet).to receive(:num_cols).and_return(2)
+        expect(worksheet).to receive(:max_rows).and_return(10)
+        expect(worksheet).to receive(:delete_rows).with(1, 9)
         expect(worksheet).to receive(:save).twice
-        expect(worksheet).to receive(:update_cells).once
+        expect(worksheet).to receive(:update_cells).with(1, 1, [column_headings])
+        expect(worksheet).to receive(:update_cells).with(2, 1, rows)
 
         described_class.call
       end
     end
 
-    context "when sheets need archiving" do
-      it "deletes the third worksheet" do
-        travel_to fixed_time do
-          expect(GoogleDrive::Session).to receive(:from_service_account_key).and_return(google_session)
-          expect(google_session).to receive(:spreadsheet_by_key).and_return(spreadsheet).once
-          expect(spreadsheet).to receive(:worksheets).and_return([worksheet, worksheet, worksheet]).at_least(2)
-          expect(worksheet).to receive(:num_cols).and_return(2)
-          expect(worksheet).to receive(:delete).once
-          expect(worksheet).to receive(:save).twice
-          expect(worksheet).to receive(:update_cells).once
-
-          described_class.call
-        end
-      end
-    end
-
-    context "when saving records fails" do
+    context "when saving records silently fails" do
       before { allow(worksheet.rows).to receive(:count).and_return(1) }
 
       it "calls raises an error and calls AlertManager" do
         travel_to fixed_time do
           expect(GoogleDrive::Session).to receive(:from_service_account_key).and_return(google_session)
-          expect(google_session).to receive(:spreadsheet_by_key).and_return(spreadsheet).once
-          expect(spreadsheet).to receive(:worksheets).and_return([worksheet]).once
+          expect(google_session).to receive(:spreadsheet_by_key).and_return(spreadsheet).exactly(2)
+          expect(spreadsheet).to receive(:worksheets).and_return([worksheet]).at_least(2)
+          expect(worksheet).to receive(:max_rows).and_return(10)
+          expect(worksheet).to receive(:delete_rows).with(1, 9)
           expect(worksheet).to receive(:save).twice
-          expect(worksheet).to receive(:update_cells).once
+          expect(worksheet).to receive(:update_cells).with(1, 1, [column_headings])
+          expect(worksheet).to receive(:update_cells).with(2, 1, rows)
           expect(AlertManager).to receive(:capture_exception).with(message_contains("Spreadsheet unexpectedly empty"))
           expect { described_class.call }.to raise_error(DigestExporter::SpreadsheetEmpty)
         end


### PR DESCRIPTION
Reverts ministryofjustice/laa-apply-for-legal-aid#4951

The new code worked perfectly - a new sheet was created and populated 🎉 

Regrettably, the data-studio link is to an explicit worksheet, not the name as the config implies.

Therefore another approach is needed to replace this data each night 😞 