### PR TITLE
[AP-3767] Bump sidekiq 6 to 7 with forked status

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -78,8 +78,7 @@ gem "libreconv"
 gem "business"
 
 # Monitoring
-gem "prometheus_exporter", "=0.4.17"
-gem "webrick"
+gem "prometheus_exporter"
 
 # Generating Fake applications for tests and admin user
 gem "factory_bot_rails", ">= 6.2.0"

--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,7 @@ gem "ruby-saml-idp", github: "dev-develop/ruby-saml-idp", branch: "master"
 gem "jwt"
 
 # background processing
+gem "redis"
 gem "redis-namespace"
 gem "sidekiq", "~> 7.0"
 gem "sidekiq-status", git: "https://github.com/anedot/sidekiq-status.git", ref: "6ffd4c9"

--- a/Gemfile
+++ b/Gemfile
@@ -62,7 +62,8 @@ gem "jwt"
 # background processing
 gem "redis-namespace"
 gem "sidekiq", "~> 7.0"
-gem "sidekiq-status", "~> 2.1.3"
+gem "sidekiq-status", git: "https://github.com/anedot/sidekiq-status.git", ref: "6ffd4c9"
+# gem "sidekiq-status", git: "https://github.com/anedot/sidekiq-status.git", branch: "sidekiq-7"
 
 # URL and path parsing
 gem "addressable"

--- a/Gemfile
+++ b/Gemfile
@@ -61,7 +61,7 @@ gem "jwt"
 
 # background processing
 gem "redis-namespace"
-gem "sidekiq", "~> 6.5.7"
+gem "sidekiq", "~> 7.0"
 gem "sidekiq-status", "~> 2.1.3"
 
 # URL and path parsing

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -543,7 +543,10 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    redis (4.8.0)
+    redis (5.0.6)
+      redis-client (>= 0.9.0)
+    redis-client (0.12.1)
+      connection_pool
     redis-namespace (1.10.0)
       redis (>= 4)
     regexp_parser (2.6.2)
@@ -646,10 +649,11 @@ GEM
     shellany (0.0.1)
     shoulda-matchers (5.3.0)
       activesupport (>= 5.2.0)
-    sidekiq (6.5.7)
-      connection_pool (>= 2.2.5)
-      rack (~> 2.0)
-      redis (>= 4.5.0, < 5)
+    sidekiq (7.0.3)
+      concurrent-ruby (< 2)
+      connection_pool (>= 2.3.0)
+      rack (>= 2.2.4)
+      redis-client (>= 0.11.0)
     sidekiq-status (2.1.3)
       chronic_duration
       sidekiq (>= 5.0)
@@ -816,7 +820,7 @@ DEPENDENCIES
   sentry-ruby
   sentry-sidekiq
   shoulda-matchers (~> 5.3)
-  sidekiq (~> 6.5.7)
+  sidekiq (~> 7.0)
   sidekiq-status (~> 2.1.3)
   simple_command
   simplecov

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -813,6 +813,7 @@ DEPENDENCIES
   rack-pjax
   rails
   rails-controller-testing
+  redis
   redis-namespace
   rexml
   rspec-rails (~> 6.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,13 @@
 GIT
+  remote: https://github.com/anedot/sidekiq-status.git
+  revision: 6ffd4c96f9bd4d52d8c304ee5de60d4ec2b5685b
+  ref: 6ffd4c9
+  specs:
+    sidekiq-status (2.1.3)
+      chronic_duration
+      sidekiq (>= 5.0, < 8.0)
+
+GIT
   remote: https://github.com/dev-develop/ruby-saml-idp.git
   revision: e8c9ba90a0f868e03d033133df1d2b035b9b65a9
   branch: master
@@ -654,9 +663,6 @@ GEM
       connection_pool (>= 2.3.0)
       rack (>= 2.2.4)
       redis-client (>= 0.11.0)
-    sidekiq-status (2.1.3)
-      chronic_duration
-      sidekiq (>= 5.0)
     signet (0.17.0)
       addressable (~> 2.8)
       faraday (>= 0.17.5, < 3.a)
@@ -821,7 +827,7 @@ DEPENDENCIES
   sentry-sidekiq
   shoulda-matchers (~> 5.3)
   sidekiq (~> 7.0)
-  sidekiq-status (~> 2.1.3)
+  sidekiq-status!
   simple_command
   simplecov
   simplecov-rcov

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -483,7 +483,8 @@ GEM
       optimist (~> 3.0)
     pg (1.4.5)
     pg_dump_anonymize (0.1.2)
-    prometheus_exporter (0.4.17)
+    prometheus_exporter (2.0.8)
+      webrick
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -802,7 +803,7 @@ DEPENDENCIES
   pagy
   pg
   pg_dump_anonymize
-  prometheus_exporter (= 0.4.17)
+  prometheus_exporter
   pry-byebug
   pry-rescue
   pry-stack_explorer
@@ -840,7 +841,6 @@ DEPENDENCIES
   webdrivers (~> 5.2)
   webmock
   webpacker (~> 5)
-  webrick
 
 RUBY VERSION
    ruby 3.2.0p0

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -14,17 +14,17 @@ Sidekiq.configure_client do |config|
   config.redis = { url: redis_url, namespace: } if redis_url
 
   # accepts :expiration (optional)
-  Sidekiq::Status.configure_client_middleware config, expiration: 30.minutes
+  Sidekiq::Status.configure_client_middleware config, expiration: 30.minutes.to_i
 end
 
 Sidekiq.configure_server do |config|
   config.redis = { url: redis_url, namespace: } if redis_url
 
   # accepts :expiration (optional)
-  Sidekiq::Status.configure_server_middleware config, expiration: 30.minutes
+  Sidekiq::Status.configure_server_middleware config, expiration: 30.minutes.to_i
 
   # accepts :expiration (optional)
-  Sidekiq::Status.configure_client_middleware config, expiration: 30.minutes
+  Sidekiq::Status.configure_client_middleware config, expiration: 30.minutes.to_i
 
   if Rails.env.production? && Rails.configuration.x.kubernetes_deployment
     config.server_middleware do |chain|

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -9,6 +9,8 @@ namespace = ENV.fetch("HOST", "laa-apply")
 module Dashboard; end
 
 Sidekiq.configure_client do |config|
+  config.logger = Rails.logger
+  config.logger.level = Logger::WARN
   config.redis = { url: redis_url, namespace: } if redis_url
 
   # accepts :expiration (optional)


### PR DESCRIPTION
## What
Use forked version of sidekiq-status against sidekiq 7.

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3767)

The fork is aimed at supporting sidekiq 7

[Use forked sidekiq-status](https://github.com/anedot/sidekiq-status) 

remote: https://github.com/anedot/sidekiq-status
revision: `6ffd4c9`
branch: `sidekiq-7`

see [comment](https://github.com/kenaniah/sidekiq-status/pull/23#issuecomment-1351755924)

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
