### PR TITLE
ap-3472: add employment status to your application

### DIFF
--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -98,4 +98,8 @@ class Applicant < ApplicationRecord
 
     sprintf("%<amount>.2f", amount: cfe_result.mortgage_per_month || 0)
   end
+
+  def employment_status
+    employed? ? "Employed" : "Not employed"
+  end
 end

--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -100,6 +100,6 @@ class Applicant < ApplicationRecord
   end
 
   def employment_status
-    employed? ? "Employed" : "Not employed"
+    employed? ? I18n.t("activemodel.attributes.applicant.employed") : I18n.t("activemodel.attributes.applicant.not_employed")
   end
 end

--- a/app/views/providers/check_provider_answers/_shared.html.erb
+++ b/app/views/providers/check_provider_answers/_shared.html.erb
@@ -2,7 +2,7 @@
 
   <%= render(
         "shared/check_answers/client_details",
-        attributes: %i[first_name last_name date_of_birth national_insurance_number address],
+        attributes: %i[first_name last_name date_of_birth national_insurance_number employment_status address],
         applicant: @applicant,
         address: @address,
         read_only: @read_only,

--- a/app/views/shared/check_answers/_client_details.html.erb
+++ b/app/views/shared/check_answers/_client_details.html.erb
@@ -61,7 +61,6 @@
   <% if :employment_status.in?(attributes) && !applicant.employed.nil? %>
     <%= check_answer_link(
           name: :employment_status,
-          url: nil,
           question: t(".employment_status"),
           answer: applicant.employment_status,
           read_only:,

--- a/app/views/shared/check_answers/_client_details.html.erb
+++ b/app/views/shared/check_answers/_client_details.html.erb
@@ -58,6 +58,16 @@
         ) %>
   <% end %>
 
+  <% if :employment_status.in?(attributes) && !applicant.employed.nil? %>
+    <%= check_answer_link(
+          name: :employment_status,
+          url: nil,
+          question: t(".employment_status"),
+          answer: applicant.employment_status,
+          read_only:,
+        ) %>
+  <% end %>
+
   <% if :national_insurance_number.in?(attributes) %>
     <%= check_answer_link(
           name: :national_insurance_number,

--- a/config/locales/cy/activemodel.yml
+++ b/config/locales/cy/activemodel.yml
@@ -18,6 +18,8 @@ cy:
         first_name: eman tsriF
         last_name: eman tsaL
         national_insurance_number: rebmun ecnarusnI lanoitaN
+        employed: deyolpmE
+        not_employed: deyolpme toN
       applicants/address_form:
         address_line_one: teerts dna gnidliuB
         address_line_two: ''

--- a/config/locales/cy/shared.yml
+++ b/config/locales/cy/shared.yml
@@ -133,6 +133,7 @@ cy:
         total: dessessa latipac latoT
       client_details:
         address: sserdda ecnednopserroC
+        employment_status: sutats tnemyolpmE
         age: dlo sraey %{years}
         age_question: etad noitatupmoc ta egA
         means_tested: ?detset-snaem tneilc eht saW

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -18,6 +18,8 @@ en:
         first_name: First name
         last_name: Last name
         national_insurance_number: National Insurance number
+        employed: Employed
+        not_employed: Not employed
       applicants/address_form:
         address_line_one: Building and street
         address_line_two: ''

--- a/config/locales/en/shared.yml
+++ b/config/locales/en/shared.yml
@@ -244,6 +244,7 @@ en:
         total: Total capital assessed
       client_details:
         address: Correspondence address
+        employment_status: Employment status
         age: "%{years} years old"
         age_question: Age at computation date
         means_tested: Was the client means-tested?

--- a/features/providers/non_passported_journey/waiting_for_applicant.feature
+++ b/features/providers/non_passported_journey/waiting_for_applicant.feature
@@ -25,3 +25,9 @@ Feature: non_passported_journey waiting for applicant
     Then I should be on the 'check_provider_answers' page showing 'Your application'
     And I should not see 'What happens next'
     But I should see 'Your client needs to complete their part of the application before you can continue.'
+    Then the following sections should exist:
+      | tag | section |
+      | h2  | Client details |
+
+    And the "Client details" check your answers section should contain:
+      | Employment status | Not employed |

--- a/spec/models/applicant_spec.rb
+++ b/spec/models/applicant_spec.rb
@@ -402,4 +402,20 @@ RSpec.describe Applicant do
       end
     end
   end
+
+  describe "#employment_status" do
+    context "when employed" do
+      it "returns Employed" do
+        applicant = build(:applicant, :employed)
+        expect(applicant.employment_status).to eq "Employed"
+      end
+    end
+
+    context "when not employed" do
+      it "returns Not employed" do
+        applicant = build(:applicant, :not_employed)
+        expect(applicant.employment_status).to eq "Not employed"
+      end
+    end
+  end
 end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/jira/software/c/projects/AP/boards/233?modal=detail&selectedIssue=AP-3472)

Added Employment status to the "Your application" page (the page the provider sees when clicking into the application while waiting for the client to finish their part). 

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
