### PR TITLE
Migrate applicant SecureData true layer tokens

### DIFF
--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -34,11 +34,19 @@ class Applicant < ApplicationRecord
   end
 
   def true_layer_token
-    true_layer_token_data[:token]
+    if encrypted_true_layer_token && encrypted_true_layer_token["token"]
+      encrypted_true_layer_token["token"]
+    else
+      true_layer_token_data[:token]
+    end
   end
 
   def true_layer_token_expires_at
-    Time.zone.parse(true_layer_token_data[:expires]) if true_layer_token_data[:expires]
+    if encrypted_true_layer_token && encrypted_true_layer_token["expires_at"]
+      Time.zone.parse(encrypted_true_layer_token["expires_at"])
+    elsif true_layer_token_data[:expires]
+      Time.zone.parse(true_layer_token_data[:expires])
+    end
   end
 
   def true_layer_token_data

--- a/lib/tasks/secure_data_migration.rake
+++ b/lib/tasks/secure_data_migration.rake
@@ -1,0 +1,40 @@
+namespace :secure_data_migration do
+  desc "Temporary task to migrate SecureData TrueLayer tokens to encrypted attributes"
+  task :true_layer_tokens, %i[commit sample] => :environment do |_task, args|
+    args = args.with_defaults(commit: "false", sample: nil)
+
+    # `true_layer_secure_data_id` is a string rather than a UUID, so we can't use `joins`
+    applicants = if args[:sample]
+                   Applicant.where.not(true_layer_secure_data_id: [nil, ""]).limit(args[:sample].to_i)
+                 else
+                   Applicant.where.not(true_layer_secure_data_id: [nil, ""])
+                 end
+
+    puts "Found #{applicants.count} Applicants with TrueLayer token data to migrate"
+    puts "Migrating SecureData TrueLayer tokens in batches of 50..."
+
+    applicants.in_batches(of: 50).each_with_index do |batch, batch_index|
+      batch.each do |applicant|
+        token_data = applicant.true_layer_secure_data.retrieve
+
+        puts "Found Applicant #{applicant.id} with token ...#{token_data[:token].last(5)}"
+
+        next unless args[:commit] == "true"
+
+        data_to_encrypt = {
+          token: token_data[:token],
+          expires_at: token_data[:expires],
+        }
+
+        applicant.update!(encrypted_true_layer_token: data_to_encrypt)
+
+        puts "Updated Applicant #{applicant.id}"
+      end
+
+      next unless args[:commit] == "true"
+
+      updated = [(batch_index + 1) * 50, applicants.count].min
+      puts "Updated #{updated} of #{applicants.count} Applicants"
+    end
+  end
+end

--- a/spec/models/applicant_spec.rb
+++ b/spec/models/applicant_spec.rb
@@ -84,6 +84,68 @@ RSpec.describe Applicant do
     end
   end
 
+  describe "#true_layer_token" do
+    subject(:true_layer_token) { applicant.true_layer_token }
+
+    let(:applicant) do
+      create(
+        :applicant,
+        encrypted_true_layer_token:,
+        true_layer_secure_data_id: secure_data_id,
+      )
+    end
+
+    context "when there is encrypted data" do
+      let(:encrypted_true_layer_token) { { token: "encrypted-token" } }
+      let(:secure_data_id) { nil }
+
+      it "returns the token" do
+        expect(true_layer_token).to eq("encrypted-token")
+      end
+    end
+
+    context "when there is only SecureData" do
+      let(:encrypted_true_layer_token) { nil }
+      let(:secure_data_id) { SecureData.create_and_store!(token: "secure-token") }
+
+      it "returns the token" do
+        expect(true_layer_token).to eq("secure-token")
+      end
+    end
+  end
+
+  describe "#true_layer_token_expires_at" do
+    subject(:true_layer_token_expires_at) { applicant.true_layer_token_expires_at }
+
+    let(:applicant) do
+      create(
+        :applicant,
+        encrypted_true_layer_token:,
+        true_layer_secure_data_id: secure_data_id,
+      )
+    end
+
+    before { freeze_time }
+
+    context "when there is encrypted data" do
+      let(:encrypted_true_layer_token) { { expires_at: 1.year.ago } }
+      let(:secure_data_id) { nil }
+
+      it "returns the expiry time" do
+        expect(true_layer_token_expires_at).to eq(1.year.ago)
+      end
+    end
+
+    context "when there is only SecureData" do
+      let(:encrypted_true_layer_token) { nil }
+      let(:secure_data_id) { SecureData.create_and_store!(expires: 1.day.ago) }
+
+      it "returns the expiry time" do
+        expect(true_layer_token_expires_at).to eq(1.day.ago)
+      end
+    end
+  end
+
   context "with True Layer Token" do
     subject { applicant.store_true_layer_token token:, expires: token_expires_at }
 


### PR DESCRIPTION
Before, the bespoke `SecureData` pattern was used to store applicant TrueLayer tokens.

In #4967, a new `encrypted_true_layer_token` encrypted attribute was introduced, and data was written to it as part of the TrueLayer flow.

This adds a temporary idempotent task to copy encrypted token data to the new attribute, and updates existing methods to read from the new attribute if it is present.

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3743)