### PR TITLE
Use `rails db:prepare` to prepare the database

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,7 @@ executors:
     docker:
       - image: ministryofjustice/apply-ci:latest-3.2.0
         environment:
+          RAILS_ENV: test
           GITHUB_TEAM_NAME_SLUG: laa-apply-for-legal-aid
           CACHE_VERSION: v1
           NODE_OPTIONS: --openssl-legacy-provider
@@ -121,13 +122,6 @@ references:
       paths:
         - node_modules
 
-  setup_database: &setup_database
-    run:
-      name: Database Setup
-      command: |
-        bundle exec rake db:create db:schema:load
-        bundle exec rake db:migrate db:seed
-
 jobs:
   lint_checks:
     executor: linting-executor
@@ -186,7 +180,7 @@ jobs:
         key: apply-repo-{{ .Environment.CIRCLE_SHA1 }}
         paths:
           - ~/project
-    - *setup_database
+    - run: bundle exec rails db:prepare
     - *restore_js_packages_cache
     - *install_js_packages
     - *save_js_packages_cache
@@ -243,7 +237,7 @@ jobs:
     - *restore_gems_cache
     - *install_gems
     - *save_gems_cache
-    - *setup_database
+    - run: bundle exec rails db:prepare
     - *restore_js_packages_cache
     - *install_js_packages
     - *save_js_packages_cache

--- a/docker/run
+++ b/docker/run
@@ -2,9 +2,14 @@
 
 set -e
 
+# Wait for postgres to be up and running
 ./docker/wait_for_pg
-./docker/setup_db
-# remove irb prompts from rails console
+
+# Prepare the database and always seed it
+bundle exec rails db:prepare db:seed
+
+# Remove irb prompts from rails console
 echo 'IRB.conf[:USE_AUTOCOMPLETE] = false' >> ~/.irbrc
 
+# Start the Puma server
 bundle exec puma -C config/puma.rb

--- a/docker/setup_db
+++ b/docker/setup_db
@@ -1,8 +1,0 @@
-#!/bin/sh
-# Usage: setup_db
-# Description:
-# Setup and migrate the database if it doesn't exist.
-
-echo "Setup Database"
-bundle exec rake db:create
-bundle exec rake db:migrate db:seed


### PR DESCRIPTION
Since Rails 6, the [`db:prepare` task][task] has provided a simple API for managing databases in Rails applications.

Running `bin/rails db:prepare` will prepare the database. This means

If the database does not exist:
  1. Create the database
  2. Load the schema if it exists, or run migrations
  3. Seed the database

If the database exists already, then only migrations are run.

[task]: https://github.com/rails/rails/blob/9fcfbe5306cf632f5f47fa8bb5dfa36545ab1be6/activerecord/lib/active_record/tasks/database_tasks.rb#L188