### PR TITLE
AP-3781: Update client truelayer notify email

### DIFF
--- a/config/govuk_notify_templates.yml
+++ b/config/govuk_notify_templates.yml
@@ -1,4 +1,4 @@
-citizen_start_application: 1ad50d58-ab76-4583-8c31-258d7c8304a4
+citizen_start_application: 6cfe6265-c465-4379-bafc-81c44d412ac6
 feedback_notification: abb5932d-24a3-49fe-a103-907d367dd75f
 submission_confirmation: 5472b10b-bc11-432a-a18d-9f20de5b2854
 reminder_to_submit_an_application: 96e58b6c-83e2-4ae8-be67-028803e98398


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3781)

Update the template ID for the citizen_start_application mailer

We are not using the ref_number field but sending it will not cause notify to break so retaining it, in case we change back to using it in the future

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
