### PR TITLE
[AP-3549] Add Google Analytics 4 subdomain to our content security policy

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -1,19 +1,21 @@
+GOOGLE_ANALYTICS_DOMAIN = "https://*.google-analytics.com".freeze
+
 Rails.application.config.content_security_policy do |policy|
   policy.default_src :self
   policy.font_src :self, :data
   policy.img_src :self,
                  :data,
-                 "https://www.google-analytics.com",
+                 GOOGLE_ANALYTICS_DOMAIN,
                  "www.googletagmanager.com",
                  "https://truelayer-client-logos.s3-eu-west-1.amazonaws.com",
                  "https://truelayer-provider-assets.s3.amazonaws.com"
   policy.object_src :none
   policy.style_src :self, :unsafe_inline
   policy.script_src :self,
-                    "https://www.google-analytics.com",
+                    GOOGLE_ANALYTICS_DOMAIN,
                     "https://www.googletagmanager.com"
   policy.connect_src :self,
-                     "https://www.google-analytics.com",
+                     GOOGLE_ANALYTICS_DOMAIN,
                      "https://*.justice.gov.uk"
 end
 Rails.application.config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }


### PR DESCRIPTION
## What

[Upgrade to Google Analytics 4](https://dsdmoj.atlassian.net/browse/AP-3549)

Update the google analytics glob to allow Google Analytics 4 subdomain to our content security policy in order to load GA4
GA4 is loaded via new subdomains of `regionx.google-analytics.com` Therefore GA4 connections are refused because it violates the Content Security Policy directives.

![GA-CSP](https://user-images.githubusercontent.com/8057224/219047470-3f03f702-8e12-45e4-adc2-34ba0c2fe6d4.png)

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
