### PR TITLE
Use `https` protocol in mailer urls in Production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -88,6 +88,7 @@ Rails.application.configure do
   config.x.logs_faraday_response = false
 
   Rails.application.routes.default_url_options[:host] = ENV.fetch("HOST", nil)
+  Rails.application.routes.default_url_options[:protocol] = Rails.env.production? ? "https" : "http"
 
   config.active_storage.service = :amazon
   config.x.application.host_url = "https://#{config.x.application.host}"


### PR DESCRIPTION
Before, urls passed to the mailer used the `http` protocol in all environments.

While these are canonically redirected to `https`, it is possible email clients might flag links as potentially unsafe or insecure.

Ideally we would update `config.action_mailer.default_url_options`, but we can't since we use a "Service object" pattern to send mail rather than leaning on ActionMailer.