### PR TITLE
Remove ignored true layer columns

### DIFF
--- a/db/migrate/20230215160839_remove_true_layer_secure_data_id_from_applicants.rb
+++ b/db/migrate/20230215160839_remove_true_layer_secure_data_id_from_applicants.rb
@@ -1,0 +1,5 @@
+class RemoveTrueLayerSecureDataIdFromApplicants < ActiveRecord::Migration[7.0]
+  def change
+    safety_assured { remove_column :applicants, :true_layer_secure_data_id, :string, null: true }
+  end
+end

--- a/db/migrate/20230215161023_remove_token_from_bank_providers.rb
+++ b/db/migrate/20230215161023_remove_token_from_bank_providers.rb
@@ -1,0 +1,5 @@
+class RemoveTokenFromBankProviders < ActiveRecord::Migration[7.0]
+  def change
+    safety_assured { remove_column :bank_providers, :token, :string, null: true }
+  end
+end

--- a/db/migrate/20230215161035_remove_token_expires_at_from_bank_providers.rb
+++ b/db/migrate/20230215161035_remove_token_expires_at_from_bank_providers.rb
@@ -1,0 +1,5 @@
+class RemoveTokenExpiresAtFromBankProviders < ActiveRecord::Migration[7.0]
+  def change
+    safety_assured { remove_column :bank_providers, :token_expires_at, :datetime, null: true }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_13_141824) do
+ActiveRecord::Schema[7.0].define(version: 2023_02_15_161035) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -110,7 +110,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_13_141824) do
     t.integer "failed_attempts", default: 0, null: false
     t.string "unlock_token"
     t.datetime "locked_at", precision: nil
-    t.string "true_layer_secure_data_id"
     t.boolean "employed"
     t.datetime "remember_created_at", precision: nil
     t.string "remember_token"
@@ -215,8 +214,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_13_141824) do
     t.uuid "applicant_id", null: false
     t.json "true_layer_response"
     t.string "credentials_id"
-    t.string "token"
-    t.datetime "token_expires_at", precision: nil
     t.string "name"
     t.string "true_layer_provider_id"
     t.datetime "created_at", precision: nil, null: false


### PR DESCRIPTION
In #4991, some TrueLayer related columns were ignored in the Applicant and BankProvider models.

Now that those columns are ignored, they can be safely removed from their respective tables.