### PR TITLE
Remove redundant `BenefitType` model

### DIFF
--- a/app/models/benefit_type.rb
+++ b/app/models/benefit_type.rb
@@ -1,4 +1,0 @@
-class BenefitType < ApplicationRecord
-  validates :label, uniqueness: true, presence: true
-  validates :description, presence: true
-end

--- a/config/locales/cy/activerecord.yml
+++ b/config/locales/cy/activerecord.yml
@@ -1,10 +1,6 @@
 ---
 cy:
   activerecord:
-    attributes:
-      benefit_type:
-        description: noitpircseD
-        exclude_from_gross_income: emocnI ssorG morf edulcxE
     errors:
       models:
         address:
@@ -19,13 +15,6 @@ cy:
               invalid: tamrof thgir eht ni ton si sserdda
             national_insurance_number:
               invalid: tamrof thgir eht ni ton si
-        benefit_type:
-          attributes:
-            label:
-              blank: tneserp eb tsum lebaL
-              taken: epyT tifeneB rehtona yb desu ydaerla si lebal ehT
-            description:
-              blank: tneserp eb tsum noitpircseD
         feedback:
           attributes:
             satisfaction:

--- a/config/locales/en/activerecord.yml
+++ b/config/locales/en/activerecord.yml
@@ -1,10 +1,6 @@
 ---
 en:
   activerecord:
-    attributes:
-      benefit_type:
-        description: Description
-        exclude_from_gross_income: Exclude from Gross Income
     errors:
       models:
         address:
@@ -23,13 +19,6 @@ en:
           attributes:
             lead_proceeding:
               multiple: Only one application proceeding type can be nominated as lead proceeding
-        benefit_type:
-          attributes:
-            label:
-              blank: Label must be present
-              taken: The label is already used by another Benefit Type
-            description:
-              blank: Description must be present
         feedback:
           attributes:
             satisfaction:


### PR DESCRIPTION
The `benefit_types` table was dropped in #1105, but this model got left behind :(