### PR TITLE
Use `ActiveRecord::Encryption` for citizen URLs

### DIFF
--- a/db/migrate/20230217105228_add_citizen_url_id_to_legal_aid_applications.rb
+++ b/db/migrate/20230217105228_add_citizen_url_id_to_legal_aid_applications.rb
@@ -1,0 +1,5 @@
+class AddCitizenUrlIdToLegalAidApplications < ActiveRecord::Migration[7.0]
+  def change
+    add_column :legal_aid_applications, :citizen_url_id, :string, null: true
+  end
+end

--- a/db/migrate/20230217111318_add_citizen_url_expires_on_to_legal_aid_applications.rb
+++ b/db/migrate/20230217111318_add_citizen_url_expires_on_to_legal_aid_applications.rb
@@ -1,0 +1,5 @@
+class AddCitizenUrlExpiresOnToLegalAidApplications < ActiveRecord::Migration[7.0]
+  def change
+    add_column :legal_aid_applications, :citizen_url_expires_on, :date, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_15_161035) do
+ActiveRecord::Schema[7.0].define(version: 2023_02_17_111318) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -563,6 +563,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_15_161035) do
     t.decimal "substantive_cost_requested"
     t.string "substantive_cost_reasons"
     t.boolean "applicant_in_receipt_of_housing_benefit"
+    t.string "citizen_url_id"
+    t.date "citizen_url_expires_on"
     t.index ["applicant_id"], name: "index_legal_aid_applications_on_applicant_id"
     t.index ["application_ref"], name: "index_legal_aid_applications_on_application_ref", unique: true
     t.index ["discarded_at"], name: "index_legal_aid_applications_on_discarded_at"


### PR DESCRIPTION
Similarly to #4967, we can use this new API to encrypt citizen URLs rather than our bespoke `SecureData` pattern.

This begins deterministically encrypting a random UUID that is stored against the LegalAidApplication alongside an expiry date.

The UUID is encrypted deterministically (rather than non-deterministically) so that applications can be queried by the `citizen_url_id` when requests are made to the Citizen application page.

A new `CITIZEN_URL_EXPIRES_AFTER_IN_DAYS` constant is used to define the number of days the URL is valid for.

For example, if the URL is generated on 2023-01-01, it will be valid for 7 days, expiring on the 8th day (i.e 2023-01-09).

This is consistent with the existing behaviour, although the implementation differs slightly.

Currently, if a URL is generated at *any time* on 2023-01-01, it will be valid until the end of the day, 7 days later (i.e 2023-01-08 23:59.999999) —after which it will have expired.

Subsequent work will migrate previously generated URLs before removing `SecureData` code.