### PR TITLE
Use encrypted `citizen_url_id` to retrieve applications

### DIFF
--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -217,19 +217,11 @@ class LegalAidApplication < ApplicationRecord
   end
 
   def generate_secure_id
-    transaction do
-      update!(
-        citizen_url_id: SecureRandom.uuid,
-        citizen_url_expires_on: CITIZEN_URL_EXPIRES_AFTER_IN_DAYS.days.from_now,
-      )
-
-      SecureData.create_and_store!(
-        legal_aid_application: { id: },
-        expired_at: (Time.current + SECURE_ID_DAYS_TO_EXPIRE.days).end_of_day,
-        # So each secure data payload is unique
-        token: SecureRandom.hex,
-      )
-    end
+    update!(
+      citizen_url_id: SecureRandom.uuid,
+      citizen_url_expires_on: CITIZEN_URL_EXPIRES_AFTER_IN_DAYS.days.from_now,
+    )
+    citizen_url_id
   end
 
   def set_transaction_period

--- a/app/services/secure_application_finder.rb
+++ b/app/services/secure_application_finder.rb
@@ -10,6 +10,8 @@ class SecureApplicationFinder
   end
 
   def legal_aid_application
+    LegalAidApplication.find_by!(citizen_url_id: secure_id)
+  rescue ActiveRecord::RecordNotFound
     LegalAidApplication.find_by! secure_data[:legal_aid_application]
   end
 
@@ -24,6 +26,10 @@ private
   end
 
   def expired?
-    secure_data[:expired_at] && secure_data[:expired_at] < Time.current
+    expires_on && expires_on < Time.current
+  end
+
+  def expires_on
+    legal_aid_application.citizen_url_expires_on.presence || secure_data[:expired_at]
   end
 end

--- a/spec/models/legal_aid_application_spec.rb
+++ b/spec/models/legal_aid_application_spec.rb
@@ -373,31 +373,11 @@ RSpec.describe LegalAidApplication do
   describe "#generate_secure_id" do
     subject(:generate_secure_id) { legal_aid_application.generate_secure_id }
 
-    let(:legal_aid_application) { create(:legal_aid_application) }
-    let(:secure_data) { SecureData.last }
+    let(:legal_aid_application) { build(:legal_aid_application) }
 
-    it "generates a new secure data object" do
-      expect { generate_secure_id }.to change(SecureData, :count).by(1)
-    end
-
-    it "returns the generated id" do
-      expect(generate_secure_id).to eq(secure_data.id)
-    end
-
-    it "generates data that can be used to find legal_aid_application" do
-      data = SecureData.for(generate_secure_id)[:legal_aid_application]
-      expect(described_class.find_by(data)).to eq(legal_aid_application)
-    end
-
-    it "generates data that contains a date which is in 8 days" do
-      freeze_time
-      data = SecureData.for(generate_secure_id)
-      expires_at = LegalAidApplication::SECURE_ID_DAYS_TO_EXPIRE.days.from_now.end_of_day
-      expect(data[:expired_at]).to eq(expires_at.to_s)
-    end
+    before { allow(SecureRandom).to receive(:uuid).and_return("test-uuid") }
 
     it "saves citizen url data" do
-      allow(SecureRandom).to receive(:uuid).and_return("test-uuid")
       freeze_time
 
       generate_secure_id
@@ -413,12 +393,14 @@ RSpec.describe LegalAidApplication do
     end
 
     it "saves a citizen url that can be queried" do
-      allow(SecureRandom).to receive(:uuid).and_return("test-uuid")
-
       generate_secure_id
       queried_record = described_class.find_by(citizen_url_id: "test-uuid")
 
       expect(queried_record).to eq(legal_aid_application)
+    end
+
+    it "returns the generated citizen url id" do
+      expect(generate_secure_id).to eq("test-uuid")
     end
   end
 

--- a/spec/services/secure_application_finder_spec.rb
+++ b/spec/services/secure_application_finder_spec.rb
@@ -31,4 +31,51 @@ RSpec.describe SecureApplicationFinder do
       expect(subject.error).to eq(:expired)
     end
   end
+
+  context "when the application has a citizen url id" do
+    let!(:legal_aid_application) do
+      create(
+        :legal_aid_application,
+        citizen_url_id: "test-citizen-url-id",
+        citizen_url_expires_on: 8.days.from_now,
+      )
+    end
+
+    describe "#legal_aid_application" do
+      subject(:found_application) do
+        described_class.new(citizen_url_id).legal_aid_application
+      end
+
+      context "when a matching application exists" do
+        let(:citizen_url_id) { "test-citizen-url-id" }
+
+        it "finds the application" do
+          expect(found_application).to eq(legal_aid_application)
+        end
+      end
+
+      context "when no matching application exists" do
+        let(:citizen_url_id) { "non-matching-citizen-url-id" }
+
+        it "raises an error" do
+          expect { found_application }
+            .to raise_error(ActiveRecord::RecordNotFound)
+        end
+      end
+    end
+
+    describe "#error" do
+      subject(:error) { described_class.new("test-citizen-url-id").error }
+
+      context "when the link has expired" do
+        before { travel_to 8.days.from_now }
+
+        it { is_expected.to eq(:expired) }
+      end
+
+      context "when the link has not expired" do
+        it { is_expected.to be_nil }
+      end
+    end
+  end
 end


### PR DESCRIPTION
In #5010, unique encrypted citizen URL IDs were generated alongside `SecureData` records and stored on the LegalAidApplication.

This uses the new column to generate unique citizen URLs and updates the `SecureApplicationFinder` service so that it can retrieve applications by citizen URL id *and* by SecureData id.