### PR TITLE
[AP-3767] bump sidekiq 6.5.7 to 7.0.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,8 +76,7 @@ gem "libreconv"
 gem "business"
 
 # Monitoring
-gem "prometheus_exporter", "=0.4.17"
-gem "webrick"
+gem "prometheus_exporter"
 
 # Generating Fake applications for tests and admin user
 gem "factory_bot_rails", ">= 6.2.0"

--- a/Gemfile
+++ b/Gemfile
@@ -59,6 +59,7 @@ gem "ruby-saml-idp", github: "dev-develop/ruby-saml-idp", branch: "master"
 gem "jwt"
 
 # background processing
+gem "redis"
 gem "redis-namespace"
 gem "sidekiq", "~> 7.0"
 gem "sidekiq-status", "~> 3.0.0"

--- a/Gemfile
+++ b/Gemfile
@@ -60,7 +60,7 @@ gem "jwt"
 
 # background processing
 gem "redis-namespace"
-gem "sidekiq", "~> 6.5.7"
+gem "sidekiq", "~> 7.0"
 gem "sidekiq-status", "~> 3.0.0"
 
 # URL and path parsing

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -520,7 +520,10 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    redis (4.8.1)
+    redis (5.0.6)
+      redis-client (>= 0.9.0)
+    redis-client (0.12.1)
+      connection_pool
     redis-namespace (1.10.0)
       redis (>= 4)
     regexp_parser (2.7.0)
@@ -622,10 +625,12 @@ GEM
     shellany (0.0.1)
     shoulda-matchers (5.3.0)
       activesupport (>= 5.2.0)
-    sidekiq (6.5.7)
-      connection_pool (>= 2.2.5)
-      rack (~> 2.0)
-      redis (>= 4.5.0, < 5)
+
+    sidekiq (7.0.3)
+      concurrent-ruby (< 2)
+      connection_pool (>= 2.3.0)
+      rack (>= 2.2.4)
+      redis-client (>= 0.11.0)
     sidekiq-status (3.0.0)
       chronic_duration
       sidekiq (>= 6.0, < 8)
@@ -789,7 +794,7 @@ DEPENDENCIES
   sentry-ruby
   sentry-sidekiq
   shoulda-matchers (~> 5.3)
-  sidekiq (~> 6.5.7)
+  sidekiq (~> 7.0)
   sidekiq-status (~> 3.0.0)
   simple_command
   simplecov

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -448,7 +448,8 @@ GEM
       optimist (~> 3.0)
     pg (1.4.5)
     pg_dump_anonymize (0.1.2)
-    prometheus_exporter (0.4.17)
+    prometheus_exporter (2.0.8)
+      webrick
     propshaft (0.6.4)
       actionpack (>= 7.0.0)
       activesupport (>= 7.0.0)
@@ -769,7 +770,7 @@ DEPENDENCIES
   pagy
   pg
   pg_dump_anonymize
-  prometheus_exporter (= 0.4.17)
+  prometheus_exporter
   propshaft
   pry-byebug
   pry-rescue

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -781,6 +781,7 @@ DEPENDENCIES
   rack-pjax
   rails
   rails-controller-testing
+  redis
   redis-namespace
   rexml
   rspec-rails (~> 6.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -626,7 +626,6 @@ GEM
     shellany (0.0.1)
     shoulda-matchers (5.3.0)
       activesupport (>= 5.2.0)
-
     sidekiq (7.0.3)
       concurrent-ruby (< 2)
       connection_pool (>= 2.3.0)
@@ -809,7 +808,6 @@ DEPENDENCIES
   webdack-uuid_migration (~> 1.4.0)
   webdrivers (~> 5.2)
   webmock
-  webrick
 
 RUBY VERSION
    ruby 3.2.0p0

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -14,17 +14,17 @@ Sidekiq.configure_client do |config|
   config.redis = { url: redis_url, namespace: } if redis_url
 
   # accepts :expiration (optional)
-  Sidekiq::Status.configure_client_middleware config, expiration: 30.minutes
+  Sidekiq::Status.configure_client_middleware config, expiration: 30.minutes.to_i
 end
 
 Sidekiq.configure_server do |config|
   config.redis = { url: redis_url, namespace: } if redis_url
 
   # accepts :expiration (optional)
-  Sidekiq::Status.configure_server_middleware config, expiration: 30.minutes
+  Sidekiq::Status.configure_server_middleware config, expiration: 30.minutes.to_i
 
   # accepts :expiration (optional)
-  Sidekiq::Status.configure_client_middleware config, expiration: 30.minutes
+  Sidekiq::Status.configure_client_middleware config, expiration: 30.minutes.to_i
 
   if Rails.env.production? && Rails.configuration.x.kubernetes_deployment
     config.server_middleware do |chain|

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -9,6 +9,8 @@ namespace = ENV.fetch("HOST", "laa-apply")
 module Dashboard; end
 
 Sidekiq.configure_client do |config|
+  config.logger = Rails.logger
+  config.logger.level = Logger::WARN
   config.redis = { url: redis_url, namespace: } if redis_url
 
   # accepts :expiration (optional)


### PR DESCRIPTION
Bump sidekiq 6.5.7 --> 7.0.3

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3767)

Test branch:

- [ ] ensure prometheus exporter still working
- [ ] redis-namespace removal

## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-XXX)

Describe what you did and why.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
