### PR TITLE
Remove `simulated_email_address` config

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -71,7 +71,6 @@ module LaaApplyForLegalAid
     config.govuk_notify_templates = YAML.load_file(Rails.root.join("config/govuk_notify_templates.yml")).symbolize_keys
 
     config.x.support_email_address = "apply-for-civil-legal-aid@digital.justice.gov.uk".freeze
-    config.x.simulated_email_address = "simulate-delivered@notifications.service.gov.uk".freeze
     config.x.govuk_notify_api_key = ENV.fetch("GOVUK_NOTIFY_API_KEY", nil)
 
     config.x.admin_portal.allow_reset = ENV["ADMIN_ALLOW_RESET"] == "true"

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -58,8 +58,6 @@ Rails.application.configure do
   config.x.application.host = "test"
   config.x.application.host_url = "http://#{config.x.application.host}"
 
-  config.x.support_email_address = config.x.simulated_email_address
-
   config.x.email_domain.suffix = "@test.test"
 
   unless ENV["RAILS_ENABLE_TEST_LOG"]

--- a/spec/services/citizen_email_service_spec.rb
+++ b/spec/services/citizen_email_service_spec.rb
@@ -4,8 +4,7 @@ require "sidekiq/testing"
 RSpec.describe CitizenEmailService do
   subject { described_class.new(application) }
 
-  let(:simulated_email_address) { Rails.configuration.x.simulated_email_address }
-  let(:applicant) { create(:applicant, first_name: "John", last_name: "Doe", email: simulated_email_address) }
+  let(:applicant) { create(:applicant, first_name: "John", last_name: "Doe", email: "test@example.com") }
   let(:firm) { create(:firm) }
   let(:provider) { create(:provider, firm:) }
   let(:application) { create(:application, applicant:, provider:) }

--- a/spec/services/provider_email_service_spec.rb
+++ b/spec/services/provider_email_service_spec.rb
@@ -4,9 +4,8 @@ require "sidekiq/testing"
 RSpec.describe ProviderEmailService do
   subject { described_class.new(application) }
 
-  let(:simulated_email_address) { Rails.configuration.x.simulated_email_address }
   let(:applicant) { create(:applicant, first_name: "John", last_name: "Doe") }
-  let(:provider) { create(:provider, email: simulated_email_address) }
+  let(:provider) { create(:provider, email: "test@example.com") }
   let(:application) { create(:application, applicant:, provider:) }
   let(:application_url) { "http://www.example.com/providers/applications/#{application.id}/client_completed_means?locale=en" }
 

--- a/spec/services/submit_application_reminder_service_spec.rb
+++ b/spec/services/submit_application_reminder_service_spec.rb
@@ -4,8 +4,7 @@ require "sidekiq/testing"
 RSpec.describe SubmitApplicationReminderService, :vcr do
   subject { described_class.new(application) }
 
-  let(:simulated_email_address) { Rails.configuration.x.simulated_email_address }
-  let(:provider) { create(:provider, email: simulated_email_address) }
+  let(:provider) { create(:provider, email: "test@example.com") }
   let(:application) do
     create(:application,
            :with_applicant,

--- a/spec/services/submit_citizen_reminder_service_spec.rb
+++ b/spec/services/submit_citizen_reminder_service_spec.rb
@@ -4,8 +4,7 @@ require "sidekiq/testing"
 RSpec.describe SubmitCitizenReminderService, :vcr do
   subject { described_class.new(application) }
 
-  let(:simulated_email_address) { Rails.configuration.x.simulated_email_address }
-  let(:provider) { create(:provider, email: simulated_email_address) }
+  let(:provider) { create(:provider, email: "test@example.com") }
   let(:application) { create(:application, :with_applicant, provider:) }
   let(:application_url) { "http://test.com" }
   let(:url_expiry_date) { (Time.zone.today + 7.days).strftime("%-d %B %Y") }
@@ -16,7 +15,7 @@ RSpec.describe SubmitCitizenReminderService, :vcr do
     end
 
     context "sending the email" do
-      let(:mail) { SubmitCitizenFinancialReminderMailer.notify_citizen(application.id, simulated_email_address, application_url, application.applicant.full_name, url_expiry_date) }
+      let(:mail) { SubmitCitizenFinancialReminderMailer.notify_citizen(application.id, "test@example.com", application_url, application.applicant.full_name, url_expiry_date) }
 
       it "sends an email with the right parameters" do
         expect(mail.govuk_notify_personalisation).to eq(

--- a/spec/services/submit_provider_reminder_service_spec.rb
+++ b/spec/services/submit_provider_reminder_service_spec.rb
@@ -4,8 +4,7 @@ require "sidekiq/testing"
 RSpec.describe SubmitProviderReminderService, :vcr do
   subject { described_class.new(application) }
 
-  let(:simulated_email_address) { Rails.configuration.x.simulated_email_address }
-  let(:provider) { create(:provider, email: simulated_email_address) }
+  let(:provider) { create(:provider, email: "test@example.com") }
   let(:application) { create(:application, :with_applicant, provider:) }
   let(:application_url) { "http://test.com" }
 


### PR DESCRIPTION
This config variable was added initially in #573 when we added smoke tests, and renamed in #2033 when those smoke tests were disabled.

The only reference to this config in application was removed in #2302, but the config was never removed.

This removes the config and updates references to it in tests.