### PR TITLE
Introduce encrypted Citizen access tokens 

### DIFF
--- a/app/models/citizen/access_token.rb
+++ b/app/models/citizen/access_token.rb
@@ -1,0 +1,21 @@
+module Citizen
+  class AccessToken < ApplicationRecord
+    EXPIRES_AFTER_IN_DAYS = 8
+
+    self.table_name = "citizen_access_tokens"
+
+    belongs_to :legal_aid_application
+
+    encrypts :token, deterministic: true
+
+    validates :expires_on, comparison: { greater_than: ->(_record) { Date.current } }
+
+    def self.generate_for(legal_aid_application:)
+      create!(
+        token: SecureRandom.uuid,
+        expires_on: EXPIRES_AFTER_IN_DAYS.days.from_now,
+        legal_aid_application:,
+      )
+    end
+  end
+end

--- a/db/anonymise/rules.rb
+++ b/db/anonymise/rules.rb
@@ -86,6 +86,7 @@ NINO_REGEXP = /^[A-CEGHJ-PR-TW-Z]{1}[A-CEGHJ-NPR-TW-Z]{1}[0-9]{6}[A-DFM]{1}$/
     cfe_result: nil,
   },
   chances_of_successes: {},
+  citizen_access_tokens: {},
   debugs: {},
   dependants: {
     name: -> { Faker::Name.name },

--- a/db/migrate/20230221174503_create_citizen_access_tokens.rb
+++ b/db/migrate/20230221174503_create_citizen_access_tokens.rb
@@ -1,0 +1,11 @@
+class CreateCitizenAccessTokens < ActiveRecord::Migration[7.0]
+  def change
+    create_table :citizen_access_tokens, id: :uuid do |t|
+      t.references :legal_aid_application, type: :uuid, foreign_key: { on_delete: :cascade }, null: false
+      t.string :token, null: false, default: ""
+      t.date :expires_on, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_17_111318) do
+ActiveRecord::Schema[7.0].define(version: 2023_02_21_174503) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -347,6 +347,15 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_17_111318) do
     t.boolean "success_likely"
     t.uuid "proceeding_id", null: false
     t.index ["proceeding_id"], name: "index_chances_of_successes_on_proceeding_id"
+  end
+
+  create_table "citizen_access_tokens", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "legal_aid_application_id", null: false
+    t.string "token", default: "", null: false
+    t.date "expires_on", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["legal_aid_application_id"], name: "index_citizen_access_tokens_on_legal_aid_application_id"
   end
 
   create_table "debugs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -967,6 +976,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_17_111318) do
   add_foreign_key "ccms_submissions", "legal_aid_applications", on_delete: :cascade
   add_foreign_key "cfe_submissions", "legal_aid_applications"
   add_foreign_key "chances_of_successes", "proceedings"
+  add_foreign_key "citizen_access_tokens", "legal_aid_applications", on_delete: :cascade
   add_foreign_key "dependants", "legal_aid_applications"
   add_foreign_key "dwp_overrides", "legal_aid_applications"
   add_foreign_key "employment_payments", "employments"

--- a/lib/tasks/migrate_citizen_urls.rake
+++ b/lib/tasks/migrate_citizen_urls.rake
@@ -1,0 +1,79 @@
+namespace :secure_data_migration do
+  desc "Temporary task to migrate SecureData citizen url IDs to access tokens"
+  task :citizen_urls, %i[commit sample] => :environment do |_task, args|
+    args = args.with_defaults(commit: "false", sample: nil)
+
+    secure_data = if args[:sample]
+                    SecureData.limit(args[:sample].to_i)
+                  else
+                    SecureData.all
+                  end
+
+    puts "There are #{Citizen::AccessToken.count} access tokens"
+    puts "--------------------------------------------------"
+
+    puts "Migrating SecureData citizen url IDs to access tokens"
+    puts "--------------------------------------------------"
+
+    access_token_count = 0
+    not_found_application_count = 0
+
+    secure_data.in_batches(of: 100) do |batch|
+      batch_token_count = 0
+
+      # Decrypt the data
+      decrypted_data = batch.map { { id: _1.id, data: _1.retrieve } }
+
+      # Select only the citizen url data
+      decrypted_data.select! { _1.fetch(:data).key?(:legal_aid_application) }
+
+      puts "Found #{decrypted_data.count} citizen url IDs out of #{batch.count} SecureData records"
+      puts "--------------------------------------------------"
+
+      decrypted_data.each do |citizen_url_data|
+        secure_data_id = citizen_url_data[:id]
+        secure_data_expired_at = Date.parse(citizen_url_data[:data][:expired_at])
+        legal_aid_application_id = citizen_url_data[:data][:legal_aid_application]["id"]
+
+        begin
+          legal_aid_application = LegalAidApplication.find(legal_aid_application_id)
+
+          next unless args[:commit] == "true"
+
+          # Only create a new access token if one doesn't already exist
+          access_token = Citizen::AccessToken.find_or_initialize_by(token: secure_data_id)
+
+          unless access_token.persisted?
+            access_token.assign_attributes(
+              # Citizen access tokens expire on a date, SecureData tokens expired after 23:59:59 on a given day
+              expires_on: secure_data_expired_at.days_since(1),
+              legal_aid_application:,
+            )
+            access_token.save!(validate: false)
+            access_token_count += 1
+            batch_token_count += 1
+          end
+        rescue ActiveRecord::RecordNotFound
+          puts "Could not find legal aid application #{legal_aid_application_id} for SecureData #{secure_data_id}"
+          puts "--------------------------------------------------"
+          not_found_application_count += 1
+        end
+      end
+
+      puts "Migrated #{batch_token_count} citizen url IDs to access tokens"
+      puts "--------------------------------------------------"
+    end
+
+    puts "Migrated #{access_token_count} citizen url IDs to access tokens"
+    puts "--------------------------------------------------"
+
+    puts "Finished migrating SecureData citizen url IDs to access tokens"
+    puts "--------------------------------------------------"
+
+    puts "Could not find #{not_found_application_count} legal aid applications"
+    puts "--------------------------------------------------"
+
+    puts "There are #{Citizen::AccessToken.count} access tokens"
+    puts "--------------------------------------------------"
+  end
+end

--- a/spec/factories/citizen/access_tokens.rb
+++ b/spec/factories/citizen/access_tokens.rb
@@ -1,0 +1,10 @@
+module Citizen
+  FactoryBot.define do
+    factory :citizen_access_token, class: "Citizen::AccessToken" do
+      legal_aid_application
+
+      token { SecureRandom.uuid }
+      expires_on { 8.days.from_now }
+    end
+  end
+end

--- a/spec/models/citizen/access_token_spec.rb
+++ b/spec/models/citizen/access_token_spec.rb
@@ -1,0 +1,55 @@
+require "rails_helper"
+
+RSpec.describe Citizen::AccessToken do
+  describe ".find_by_token" do
+    subject(:find_by_token) { described_class.find_by_token(token) }
+
+    let(:access_token) { create(:citizen_access_token, token:) }
+    let(:token) { "find-this-token" }
+
+    it "queries by deteministically encrypted token" do
+      expect(access_token).to eq(find_by_token)
+    end
+  end
+
+  describe ".generate_for" do
+    subject(:generate_token) { described_class.generate_for(legal_aid_application:) }
+
+    let(:legal_aid_application) { build(:legal_aid_application) }
+
+    before do
+      travel_to Date.new(2024, 1, 1)
+      allow(SecureRandom).to receive(:uuid).and_return("test-uuid")
+    end
+
+    it "encrypts a unique access token that expires in 8 days" do
+      expect(generate_token).to have_attributes(
+        token: "test-uuid",
+        expires_on: Date.new(2024, 1, 9),
+        legal_aid_application:,
+      )
+    end
+  end
+
+  describe "#validate" do
+    subject(:access_token) { build(:citizen_access_token, expires_on:) }
+
+    context "when expires_on is in the past" do
+      let(:expires_on) { 1.day.ago }
+
+      it { is_expected.to be_invalid }
+    end
+
+    context "when expires_on is today" do
+      let(:expires_on) { Date.current }
+
+      it { is_expected.to be_invalid }
+    end
+
+    context "when expires_on is in the future" do
+      let(:expires_on) { 1.day.from_now }
+
+      it { is_expected.to be_valid }
+    end
+  end
+end

--- a/spec/models/legal_aid_application_spec.rb
+++ b/spec/models/legal_aid_application_spec.rb
@@ -396,29 +396,15 @@ RSpec.describe LegalAidApplication do
       expect(data[:expired_at]).to eq(expires_at.to_s)
     end
 
-    it "saves citizen url data" do
-      allow(SecureRandom).to receive(:uuid).and_return("test-uuid")
-      freeze_time
-
-      generate_secure_id
-
-      expires_on = Date.current.days_since(
-        LegalAidApplication::CITIZEN_URL_EXPIRES_AFTER_IN_DAYS,
-      )
-
-      expect(legal_aid_application).to have_attributes(
-        citizen_url_id: "test-uuid",
-        citizen_url_expires_on: expires_on,
-      )
-    end
-
-    it "saves a citizen url that can be queried" do
+    it "generates a citizen URL access token" do
       allow(SecureRandom).to receive(:uuid).and_return("test-uuid")
 
       generate_secure_id
-      queried_record = described_class.find_by(citizen_url_id: "test-uuid")
 
-      expect(queried_record).to eq(legal_aid_application)
+      expect(Citizen::AccessToken.last).to have_attributes(
+        token: "test-uuid",
+        legal_aid_application:,
+      )
     end
   end
 


### PR DESCRIPTION
In https://github.com/ministryofjustice/laa-apply-for-legal-aid/pull/5010 we started encrypting a `citizen_url_id` and storing it alongside the
date the corresponding Citizen application link would expire on the
`LegalAidApplication` model.

As work to migrate from the `SecureData` approach continued in https://github.com/ministryofjustice/laa-apply-for-legal-aid/pull/5018, a bug was
discovered in manual testing.

Rather than generating a token for the Citizen URL once and passing that around,
tokens are generated multiple times for an application in the process of sending
an email to the client.

This means there could be X different `SecureData` records in the database for
an application, and we don't know which correspond to links sent in emails to
Citizens.

In order to accommodate this behaviour, and to migrate existing data so we can
continue to handle existing links appropriately -a new approach was needed.

This introduces the concept of a Citizen access token, that can be sent to
Citizens in emails, expire, and used to retrieve a client's legal aid
application.

This approach will also us to accommodate existing links (including expired
links), however we might later decide that initial requirements laid out in
the [initial ticket] and [discussion] or decisions taken in https://github.com/ministryofjustice/laa-apply-for-legal-aid/pull/73 are no longer
appropriate.

[initial ticket]: https://dsdmoj.atlassian.net/browse/AP-148
[discussion]: https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/1106608346/2018-09-17+Securing+Citizen+access+to+the+service

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3867)

---

A temporary task can be used to migrate existing SecureData records to
Citizen access tokens so that the application can continue to handle existing
links gracefully.

This migrates data that looks like this:

```
SecureData
----------
- id <uuid>
- data <encrypted JWT token>
```

where the JWT data looks like:

```
{
  legal_aid_application: {
    "id": <uuid>
  },
  expired_at: <timestamp> (2020-01-01 23:59:59 +0000),
  token: <hex>
}
```

into data that looks like this:

```
Citizen::AccessToken
---------
- id <uuid>
- token <encrypted uuid string>
- expires_on <date> (2020-01-02)
- legal_aid_application_id <uuid>
```

Links are currently valid for 7 days, but Citizens can request new links if they
try to access an application using an expired link.

This migration will allows us to continue to retrieve applications from valid
and expired links.