### PR TITLE
Stop ignoring Citizen URL columns

### DIFF
--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -1,6 +1,4 @@
 class LegalAidApplication < ApplicationRecord
-  self.ignored_columns += %w[citizen_url_id citizen_url_expires_on]
-
   include Discard::Model
   include DelegatedFunctions
 


### PR DESCRIPTION
This columns were removed in #5032, so we can safely stop ignoring them now.