### PR TITLE
Remove unused method

### DIFF
--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -28,11 +28,6 @@ class Applicant < ApplicationRecord
     encrypted_true_layer_token&.fetch("token", nil)
   end
 
-  def true_layer_token_expires_at
-    expires_at = encrypted_true_layer_token&.fetch("expires_at", nil)
-    Time.zone.parse(expires_at) if expires_at
-  end
-
   def age
     return age_for_means_test_purposes if no_means_test_required? || under_16_blocked?
 

--- a/spec/models/applicant_spec.rb
+++ b/spec/models/applicant_spec.rb
@@ -114,32 +114,6 @@ RSpec.describe Applicant do
     end
   end
 
-  describe "#true_layer_token_expires_at" do
-    subject(:true_layer_token_expires_at) { applicant.true_layer_token_expires_at }
-
-    let(:applicant) { build(:applicant, encrypted_true_layer_token:) }
-
-    context "when the encrypted token is nil" do
-      let(:encrypted_true_layer_token) { nil }
-
-      it { is_expected.to be_nil }
-    end
-
-    context "when the encrypted token does not contain an expiry time" do
-      let(:encrypted_true_layer_token) { { token: "test-token" } }
-
-      it { is_expected.to be_nil }
-    end
-
-    context "when the encrypted token contains an expiry time" do
-      let(:encrypted_true_layer_token) { { expires_at: 1.year.ago } }
-
-      before { freeze_time }
-
-      it { is_expected.to eq(1.year.ago) }
-    end
-  end
-
   describe "#age" do
     subject(:age) { legal_aid_application.applicant.age }
 

--- a/spec/requests/applicants/omniauth_callbacks_spec.rb
+++ b/spec/requests/applicants/omniauth_callbacks_spec.rb
@@ -54,7 +54,9 @@ RSpec.describe "applicants omniauth call back" do
 
       it "persists expires_at" do
         subject
-        expect(applicant.reload.true_layer_token_expires_at.utc.to_s).to eq(expires_at.utc.to_s)
+        token = applicant.reload.encrypted_true_layer_token
+        token_expires_at = Time.zone.parse(token.fetch("expires_at"))
+        expect(token_expires_at).to eq(expires_at)
       end
     end
 
@@ -63,7 +65,8 @@ RSpec.describe "applicants omniauth call back" do
 
       it "does not persist expires_at" do
         subject
-        expect(applicant.reload.true_layer_token_expires_at).to be_nil
+        token = applicant.reload.encrypted_true_layer_token
+        expect(token.fetch("expires_at")).to be_nil
       end
     end
 


### PR DESCRIPTION
The `Applicant#true_layer_token_expires_at` method isn't called anywhere in the application.

We continue to capture this information in the `jsonb` token, but this removes the method that exposes it.

Perhaps we don't need to capture that data in the first place?