### PR TITLE
AP-3873: Opponent clear up

### DIFF
--- a/db/anonymise/rules.rb
+++ b/db/anonymise/rules.rb
@@ -138,13 +138,8 @@ NINO_REGEXP = /^[A-CEGHJ-PR-TW-Z]{1}[A-CEGHJ-NPR-TW-Z]{1}[0-9]{6}[A-DFM]{1}$/
   },
   offices_providers: {},
   opponents: {
-    full_name: -> { Faker::Name.name },
     first_name: -> { Faker::Name.first_name },
     last_name: -> { Faker::Name.last_name },
-    understands_terms_of_court_order_details: -> { Faker::Lorem.sentence },
-    warning_letter_sent_details: -> { Faker::Lorem.sentence },
-    police_notified_details: -> { Faker::Lorem.sentence },
-    bail_conditions_set_details: -> { Faker::Lorem.sentence },
   },
   opponents_applications: {
     reason_for_applying: -> { Faker::Lorem.sentence },

--- a/db/migrate/20230228132829_update_opponent_fields.rb
+++ b/db/migrate/20230228132829_update_opponent_fields.rb
@@ -1,0 +1,8 @@
+class UpdateOpponentFields < ActiveRecord::Migration[7.0]
+  def change
+    safety_assured do
+      remove_columns :opponents, :understands_terms_of_court_order_details, :warning_letter_sent_details, :police_notified_details, :bail_conditions_set_details, type: :string
+      remove_columns :opponents, :understands_terms_of_court_order, :warning_letter_sent, :police_notified, :bail_conditions_set, type: :boolean
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_28_112837) do
+ActiveRecord::Schema[7.0].define(version: 2023_02_28_132829) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -661,14 +661,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_28_112837) do
 
   create_table "opponents", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "legal_aid_application_id", null: false
-    t.boolean "understands_terms_of_court_order"
-    t.text "understands_terms_of_court_order_details"
-    t.boolean "warning_letter_sent"
-    t.text "warning_letter_sent_details"
-    t.boolean "police_notified"
-    t.text "police_notified_details"
-    t.boolean "bail_conditions_set"
-    t.text "bail_conditions_set_details"
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.integer "ccms_opponent_id"


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3873)

PR 2 of 2

This clears up after the first PR, it:
* removes the database columns from the opponent table
* removes some anonymisation rules that were no longer needed
* updates the migration script after some edge cases were found on production 

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
