### PR TITLE
AP-3864: Enable multiple opponents

### DIFF
--- a/app/controllers/providers/application_merits_task/has_other_opponents_controller.rb
+++ b/app/controllers/providers/application_merits_task/has_other_opponents_controller.rb
@@ -1,0 +1,37 @@
+module Providers
+  module ApplicationMeritsTask
+    class HasOtherOpponentsController < ProviderBaseController
+      def show
+        form
+      end
+
+      def update
+        update_task(:application, :opponent_name)
+        return continue_or_draft if draft_selected?
+        return go_forward(form.has_other_opponents?) if form.valid?
+
+        render :show
+      end
+
+    private
+
+      def task_list_should_update?
+        application_has_task_list? && form.valid? && !draft_selected? && !form.has_other_opponents?
+      end
+
+      def form
+        @form ||= BinaryChoiceForm.call(
+          journey: :provider,
+          radio_buttons_input_name: :has_other_opponents,
+          form_params:,
+        )
+      end
+
+      def form_params
+        return {} unless params[:binary_choice_form]
+
+        params.require(:binary_choice_form).permit(:has_other_opponents)
+      end
+    end
+  end
+end

--- a/app/controllers/providers/application_merits_task/opponents_names_controller.rb
+++ b/app/controllers/providers/application_merits_task/opponents_names_controller.rb
@@ -5,6 +5,10 @@ module Providers
         @form = Opponents::NameForm.new(model: opponent)
       end
 
+      def new
+        @form = Opponents::NameForm.new(model: opponent)
+      end
+
       def update
         @form = Opponents::NameForm.new(form_params)
         render :show unless update_task_save_continue_or_draft(:application, :opponent_name)
@@ -13,7 +17,17 @@ module Providers
     private
 
       def opponent
-        @opponent ||= legal_aid_application.opponent || legal_aid_application.build_opponent
+        @opponent ||= opponent_exists? || build_new_opponent
+      end
+
+      def opponent_exists?
+        legal_aid_application.opponents.find(params[:id])
+      rescue ActiveRecord::RecordNotFound
+        false
+      end
+
+      def build_new_opponent
+        ::ApplicationMeritsTask::Opponent.new(legal_aid_application:)
       end
 
       def form_params

--- a/app/controllers/providers/application_merits_task/remove_opponent_controller.rb
+++ b/app/controllers/providers/application_merits_task/remove_opponent_controller.rb
@@ -1,0 +1,40 @@
+module Providers
+  module ApplicationMeritsTask
+    class RemoveOpponentController < ProviderBaseController
+      def show
+        form
+        opponent
+      end
+
+      def update
+        if form.valid?
+          opponent&.destroy! if form.remove_opponent?
+          return go_forward
+        end
+
+        opponent
+        render :show
+      end
+
+    private
+
+      def form
+        @form ||= BinaryChoiceForm.call(
+          journey: :provider,
+          radio_buttons_input_name: :remove_opponent,
+          form_params:,
+        )
+      end
+
+      def opponent
+        @opponent ||= legal_aid_application.opponents.find(params[:id])
+      end
+
+      def form_params
+        return {} unless params[:binary_choice_form]
+
+        params.require(:binary_choice_form).permit(:remove_opponent)
+      end
+    end
+  end
+end

--- a/app/controllers/providers/check_merits_answers_controller.rb
+++ b/app/controllers/providers/check_merits_answers_controller.rb
@@ -1,7 +1,6 @@
 module Providers
   class CheckMeritsAnswersController < ProviderBaseController
     def show
-      legal_aid_application.create_opponent! unless legal_aid_application.opponent
       legal_aid_application.check_merits_answers! unless legal_aid_application.checking_merits_answers?
     end
 

--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -27,7 +27,7 @@ class LegalAidApplication < ApplicationRecord
   has_one :statement_of_case, class_name: "ApplicationMeritsTask::StatementOfCase", dependent: :destroy
   has_one :gateway_evidence, dependent: :destroy
   has_one :uploaded_evidence_collection, dependent: :destroy
-  has_one :opponent, class_name: "ApplicationMeritsTask::Opponent", dependent: :destroy
+  has_many :opponents, class_name: "ApplicationMeritsTask::Opponent", dependent: :destroy
   has_one :domestic_abuse_summary, class_name: "ApplicationMeritsTask::DomesticAbuseSummary", dependent: :destroy
   has_one :parties_mental_capacity, class_name: "ApplicationMeritsTask::PartiesMentalCapacity", dependent: :destroy
   has_one :latest_incident, -> { order(occurred_on: :desc) }, class_name: "ApplicationMeritsTask::Incident", inverse_of: :legal_aid_application, dependent: :destroy

--- a/app/services/ccms/requestors/case_add_requestor.rb
+++ b/app/services/ccms/requestors/case_add_requestor.rb
@@ -123,7 +123,9 @@ module CCMS
       end
 
       def generate_other_parties(xml)
-        generate_opponent(xml, @legal_aid_application.opponents.first)
+        @legal_aid_application.opponents.order(:created_at).each do |opponent|
+          generate_opponent(xml, opponent)
+        end
 
         @legal_aid_application.involved_children.order(:date_of_birth).each do |child|
           generate_involved_child(xml, child)
@@ -291,7 +293,6 @@ module CCMS
       end
 
       def other_parties
-        # [opponent] + involved_children
         opponents.all + involved_children
       end
 

--- a/app/services/ccms/requestors/case_add_requestor.rb
+++ b/app/services/ccms/requestors/case_add_requestor.rb
@@ -8,7 +8,7 @@ module CCMS
       attr_reader :ccms_attribute_keys, :submission
 
       delegate :involved_children,
-               :opponent, to: :legal_aid_application
+               :opponents, to: :legal_aid_application
 
       attr_accessor :legal_aid_application
 
@@ -123,7 +123,7 @@ module CCMS
       end
 
       def generate_other_parties(xml)
-        generate_opponent(xml, @legal_aid_application.opponent)
+        generate_opponent(xml, @legal_aid_application.opponents.first)
 
         @legal_aid_application.involved_children.order(:date_of_birth).each do |child|
           generate_involved_child(xml, child)
@@ -291,7 +291,8 @@ module CCMS
       end
 
       def other_parties
-        [opponent] + involved_children
+        # [opponent] + involved_children
+        opponents.all + involved_children
       end
 
       def predicate_true?(config)
@@ -429,7 +430,7 @@ module CCMS
                                            xml,
                                            :proceeding_merits,
                                            proceeding:,
-                                           opponent: @legal_aid_application.opponent,
+                                           opponent: @legal_aid_application.opponents.first,
                                            chances_of_success: proceeding.chances_of_success)
           end
         end

--- a/app/services/flow/flows/provider_merits.rb
+++ b/app/services/flow/flows/provider_merits.rb
@@ -60,9 +60,39 @@ module Flow
           check_answers: :check_merits_answers,
         },
         opponents_names: {
-          path: ->(application) { urls.providers_legal_aid_application_opponents_name_path(application) },
-          forward: ->(application) { Flow::MeritsLoop.forward_flow(application, :application) },
+          path: ->(application) { urls.new_providers_legal_aid_application_opponents_name_path(application) },
+          forward: :has_other_opponents,
           check_answers: :check_merits_answers,
+        },
+        start_opponent_task: {
+          # This allows the task list to check for opponents and route to has_other_opponents
+          # if they exist or show the new page if they do not
+          path: lambda do |application|
+            if application.opponents.any?
+              urls.providers_legal_aid_application_has_other_opponent_path(application)
+            else
+              urls.new_providers_legal_aid_application_opponents_name_path(application)
+            end
+          end,
+        },
+        has_other_opponents: {
+          path: ->(application) { urls.providers_legal_aid_application_has_other_opponent_path(application) },
+          forward: lambda { |application, has_other_opponent|
+            if has_other_opponent
+              :opponents_names
+            else
+              Flow::MeritsLoop.forward_flow(application, :application)
+            end
+          },
+        },
+        remove_opponent: {
+          forward: lambda { |application|
+            if application.opponents.count.positive?
+              :has_other_opponents
+            else
+              :opponents_names
+            end
+          },
         },
         opponents_mental_capacities: {
           path: ->(application) { urls.providers_legal_aid_application_opponents_mental_capacity_path(application) },

--- a/app/services/flow/merits_loop.rb
+++ b/app/services/flow/merits_loop.rb
@@ -28,7 +28,7 @@ module Flow
     def convert_task_to_flow_name(task)
       {
         latest_incident_details: :date_client_told_incidents,
-        opponent_name: :opponents_names,
+        opponent_name: :start_opponent_task,
         opponent_mental_capacity: :opponents_mental_capacities,
         domestic_abuse_summary: :domestic_abuse_summaries,
         statement_of_case: :statement_of_cases,

--- a/app/services/reports/mis/application_detail_csv_line.rb
+++ b/app/services/reports/mis/application_detail_csv_line.rb
@@ -28,7 +28,6 @@ module Reports
                :proceedings,
                :property_value,
                :provider,
-               :opponent,
                :parties_mental_capacity,
                :domestic_abuse_summary,
                :savings_amount,

--- a/app/views/providers/application_merits_task/has_other_opponents/show.html.erb
+++ b/app/views/providers/application_merits_task/has_other_opponents/show.html.erb
@@ -1,0 +1,56 @@
+<%= form_with(
+      url: providers_legal_aid_application_has_other_opponent_path,
+      model: @form,
+      method: :patch,
+      local: true,
+    ) do |form| %>
+  <%= page_template page_title: t(".page_title", count: pluralize(@legal_aid_application.opponents.count, "opponent").to_s),
+                    template: :basic,
+                    form: do %>
+    <% if @legal_aid_application.opponents.count > 0 %>
+      <h1 class="govuk-heading-xl">
+        <%= t(".existing", count: pluralize(@legal_aid_application.opponents.count, "opponent").to_s) %>
+      </h1>
+      <table class="govuk-table">
+        <caption class="govuk-table__caption govuk-table__caption--m govuk-visually-hidden"><%= t(".table_caption") %></caption>
+        <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th class="govuk-table__header">Name</th>
+          <th class="govuk-table__header" colspan="3">Type</th>
+        </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+        <% @legal_aid_application.opponents.order(:created_at).each do |opponent| %>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell" id="opponent<%= opponent.id %>"><%= opponent.full_name %></td>
+            <td class="govuk-table__cell">Individual<%#= opponent.type %></td>
+            <td class="govuk-table__cell">
+              <%= link_to_accessible(
+                    t("generic.change"),
+                    providers_legal_aid_application_opponents_name_path(@legal_aid_application, opponent),
+                    class: "govuk-link change-link",
+                    suffix: opponent.full_name,
+                  ) %>
+            </td>
+            <td class="govuk-table__cell">
+              <%= link_to_accessible(
+                    t(".remove"),
+                    providers_legal_aid_application_remove_opponent_path(@legal_aid_application, opponent),
+                    class: "govuk-link change-link",
+                    suffix: opponent.full_name,
+                  ) %>
+            </td>
+          </tr>
+        <% end %>
+        </tbody>
+      </table>
+    <% end %>
+    <%= form.govuk_collection_radio_buttons :has_other_opponents,
+                                            yes_no_options,
+                                            :value,
+                                            :label,
+                                            legend: { text: t(".add_another"), size: "l", tag: "h2" } %>
+
+  <%= next_action_buttons(show_draft: true, form:) %>
+  <% end %>
+<% end %>

--- a/app/views/providers/application_merits_task/opponents_names/_form.html.erb
+++ b/app/views/providers/application_merits_task/opponents_names/_form.html.erb
@@ -1,0 +1,20 @@
+<%= form_with(
+      model: @form,
+      url: form_path,
+      method: :patch,
+      local: true,
+    ) do |form| %>
+  <%= form.govuk_text_field(
+        :first_name,
+        label: { text: t(".first_name"), size: "m" },
+        class: "govuk-input govuk-input--width-20",
+      ) %>
+
+  <%= form.govuk_text_field(
+        :last_name,
+        label: { text: t(".last_name"), size: "m" },
+        class: "govuk-input govuk-input--width-20",
+      ) %>
+
+  <%= next_action_buttons(show_draft: true, form:) %>
+<% end %>

--- a/app/views/providers/application_merits_task/opponents_names/new.html.erb
+++ b/app/views/providers/application_merits_task/opponents_names/new.html.erb
@@ -3,7 +3,8 @@
       page_heading_options: { margin_bottom: 3 },
       show_errors_for: @form,
     ) do %>
+
   <%= render "form",
              form: @form,
-             form_path: providers_legal_aid_application_opponents_name_path %>
+             form_path: new_providers_legal_aid_application_opponents_name_path(@legal_aid_application, @form.model) %>
 <% end %>

--- a/app/views/providers/application_merits_task/remove_opponent/show.html.erb
+++ b/app/views/providers/application_merits_task/remove_opponent/show.html.erb
@@ -1,0 +1,18 @@
+<%= page_template page_title: t(".page_title", name: @opponent.full_name), template: :basic do %>
+
+  <%= form_with(
+        url: providers_legal_aid_application_remove_opponent_path,
+        model: @form,
+        method: :patch,
+        local: true,
+      ) do |form| %>
+
+    <%= form.govuk_collection_radio_buttons :remove_opponent,
+                                            yes_no_options,
+                                            :value,
+                                            :label,
+                                            legend: { text: content_for(:page_title), tag: "h1", size: "xl" } %>
+
+    <%= next_action_buttons(form:) %>
+  <% end %>
+<% end %>

--- a/app/views/providers/check_merits_answers/show.html.erb
+++ b/app/views/providers/check_merits_answers/show.html.erb
@@ -7,7 +7,7 @@
         "shared/check_answers/merits",
         incident: @legal_aid_application.latest_incident,
         statement_of_case: @legal_aid_application.statement_of_case,
-        opponent: @legal_aid_application.opponent,
+        opponents: @legal_aid_application.opponents,
         parties_mental_capacity: @legal_aid_application.parties_mental_capacity,
         domestic_abuse_summary: @legal_aid_application.domestic_abuse_summary,
         gateway_evidence: @legal_aid_application&.gateway_evidence,

--- a/app/views/providers/merits_reports/show.html.erb
+++ b/app/views/providers/merits_reports/show.html.erb
@@ -53,7 +53,7 @@
         "shared/check_answers/merits",
         incident: @legal_aid_application.latest_incident,
         statement_of_case: @legal_aid_application.statement_of_case,
-        opponent: @legal_aid_application.opponent,
+        opponents: @legal_aid_application.opponents,
         parties_mental_capacity: @legal_aid_application.parties_mental_capacity,
         domestic_abuse_summary: @legal_aid_application.domestic_abuse_summary,
         gateway_evidence: @legal_aid_application&.gateway_evidence,

--- a/app/views/shared/check_answers/_merits.html.erb
+++ b/app/views/shared/check_answers/_merits.html.erb
@@ -27,19 +27,25 @@
   </section>
 <% end %>
 
-<section class="print-no-break">
-  <h2 class="govuk-heading-m govuk-!-padding-top-6"><%= t ".opponent-heading" %></h2>
-  <dl class="govuk-summary-list govuk-!-margin-bottom-2">
-    <%= check_answer_link(
-          name: :full_name,
-          question: t(".items.full_name"),
-          url: providers_legal_aid_application_opponents_name_path(@legal_aid_application),
-          answer: opponent.full_name,
-          read_only:,
-        ) %>
-  </dl>
-
-  <%= render "shared/check_answers/section_break" unless opponent.full_name %>
+<section class="print-no-break govuk-!-padding-top-6">
+  <%= check_answer_change_link(
+        name: :opponents,
+        url: providers_legal_aid_application_has_other_opponent_path(@legal_aid_application),
+        question: t(".opponent-heading"),
+        read_only:,
+      ) %>
+  <% opponents.order(:created_at).each_with_index do |opponent, i| %>
+    <dl class="govuk-summary-list govuk-!-margin-bottom-2 ">
+      <%= check_answer_no_link(
+            name: "opponent_#{i + 1}".to_sym,
+            question: "#{t('.items.opponent')} #{i + 1}",
+            answer: opponent.full_name,
+            no_border: false,
+            read_only:,
+          ) %>
+    </dl>
+  <% end %>
+</section>
 
   <dl class="govuk-summary-list govuk-!-margin-bottom-2">
     <%= check_answer_link(

--- a/app/views/shared/review_application/_questions_and_answers.html.erb
+++ b/app/views/shared/review_application/_questions_and_answers.html.erb
@@ -85,7 +85,7 @@
           incident: @legal_aid_application.latest_incident,
           statement_of_case: @legal_aid_application.statement_of_case,
           gateway_evidence: @legal_aid_application&.gateway_evidence,
-          opponent: @legal_aid_application.opponent,
+          opponents: @legal_aid_application.opponents,
           parties_mental_capacity: @legal_aid_application.parties_mental_capacity,
           domestic_abuse_summary: @legal_aid_application.domestic_abuse_summary,
           allegation: @legal_aid_application&.allegation,

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -410,8 +410,10 @@ en:
           remove: Remove
           add_another: Do you need to add another child?
       remove_involved_child:
-        show:
+        show: &remove_show
           page_title: Do you want to remove %{name} from the application?
+      remove_opponent:
+        show: *remove_show
       date_client_told_incidents:
         show:
           h1-heading: Latest incident details
@@ -422,10 +424,19 @@ en:
         show:
           page_heading: Why is the Section 8 matter opposed by your client or the other party?
       opponents_names:
-        show:
-          h1-heading: Opponent's name
+        show: &new
+          page_title: Opponent's name
+        new: *new
+        form:
           first_name: First name
           last_name: Last name
+      has_other_opponents:
+        show:
+          page_title: You have added %{count}
+          existing: You have added %{count}
+          table_caption: Opponents added
+          remove: Remove
+          add_another: Do you need to add another opponent?
       opponents_mental_capacities:
         show:
           h1-heading: Do all parties have the mental capacity to understand the terms of a court order?
@@ -490,6 +501,9 @@ en:
     has_other_involved_children:
       show:
         error: Select yes if you need to add another child
+    has_other_opponents:
+      show:
+        error: Select yes if you need to add another opponent
     declarations:
       show:
         h1-heading: Declaration
@@ -992,7 +1006,7 @@ en:
         proceeding_heading: Enter details for each proceeding
       task_list_item:
         latest_incident_details: Latest incident details
-        opponent_name: "Opponent's name"
+        opponent_name: "Opponents"
         opponent_mental_capacity: Mental capacity of all parties
         domestic_abuse_summary: Domestic abuse summary
         statement_of_case: Statement of case
@@ -1016,6 +1030,7 @@ en:
         urls:
           latest_incident_details: date_client_told_incident
           opponent_name: opponents_name
+          has_other_opponent: has_other_opponent
           opponent_mental_capacity: opponents_mental_capacity
           domestic_abuse_summary: domestic_abuse_summary
           statement_of_case: statement_of_case

--- a/config/locales/en/shared.yml
+++ b/config/locales/en/shared.yml
@@ -343,6 +343,7 @@ en:
           statement_of_case: Statement of case
           full_name: Name
           child: Child
+          opponent: Opponent
           linked_children: Which children are covered under this proceeding?
           attempts_to_settle: What attempts have been made to settle the matter?
           specific_issue: What specific issue do you want to determine at court?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -260,17 +260,19 @@ Rails.application.routes.draw do
         resources :involved_children, only: %i[new show update]
         resources :remove_involved_child, only: %i[show update]
 
+        resources :opponents_names, only: %i[new show update]
+        resources :remove_opponent, only: %i[show update]
+
         resource :client_denial_of_allegation, only: %i[show update]
         resource :client_offered_undertakings, only: %i[show update]
         resource :date_client_told_incident, only: %i[show update]
         resource :has_other_involved_children, only: %i[show update]
         resource :in_scope_of_laspo, only: %i[show update]
-        resource :opponents_name, only: %i[show update]
+        resource :has_other_opponent, only: %i[new show update]
         resource :opponents_mental_capacity, only: %i[show update]
         resource :domestic_abuse_summary, only: %i[show update]
         resource :matter_opposed_reason, only: %i[show update]
         resource :nature_of_urgencies, only: %i[show update]
-        resource :opponent, only: %i[show update]
         resource :statement_of_case, only: %i[show update destroy] do
           get "/list", to: "statement_of_cases#list"
         end

--- a/features/accessibility/provider.feature
+++ b/features/accessibility/provider.feature
@@ -253,6 +253,10 @@ Feature: Provider accessibility
     When I fill "First Name" with "John"
     And I fill "Last Name" with "Doe"
     When I click 'Save and continue'
+    Then I should be on a page showing "You have added 1 opponent"
+    And the page is accessible
+    When I choose "No"
+    And I click 'Save and continue'
     Then I should be on a page showing "Do all parties have the mental capacity to understand the terms of a court order?"
     And the page is accessible
     When I choose "Yes"

--- a/features/providers/check_ccms_autogrant.feature
+++ b/features/providers/check_ccms_autogrant.feature
@@ -40,6 +40,9 @@ Feature: Checking ccms means does NOT auto grant
     When I fill "First Name" with "John"
     And I fill "Last Name" with "Doe"
     When I click 'Save and continue'
+    Then I should be on a page showing "You have added 1 opponent"
+    When I choose "No"
+    And I click 'Save and continue'
     Then I should be on a page showing "Do all parties have the mental capacity to understand the terms of a court order?"
     When I choose "Yes"
     And I click 'Save and continue'
@@ -106,6 +109,9 @@ Feature: Checking ccms means does NOT auto grant
     When I fill "First Name" with "John"
     And I fill "Last Name" with "Doe"
     When I click 'Save and continue'
+    Then I should be on a page showing "You have added 1 opponent"
+    When I choose "No"
+    And I click 'Save and continue'
     Then I should be on a page showing "Do all parties have the mental capacity to understand the terms of a court order?"
     When I choose "Yes"
     And I click 'Save and continue'

--- a/features/providers/check_multiple_employment.feature
+++ b/features/providers/check_multiple_employment.feature
@@ -111,10 +111,10 @@ Feature: Check multiple employment
     And I fill "application_merits_task_incident_occurred_on_1i" with "21"
     And I click 'Save and continue'
 
-    Then I should be on a page showing "Opponent's name"
-    When I fill "First Name" with "John"
-    And I fill "Last Name" with "Doe"
-    When I click 'Save and continue'
+    # already an opponent added by the setup
+    Then I should be on a page showing "You have added 1 opponent"
+    When I choose "No"
+    And I click 'Save and continue'
 
     Then I should be on a page showing "Do all parties have the mental capacity to understand the terms of a court order?"
     When I choose "Yes"

--- a/features/providers/check_nonpassport_autogrant.feature
+++ b/features/providers/check_nonpassport_autogrant.feature
@@ -87,6 +87,9 @@ Feature: Checking ccms means does NOT auto grant for non passported applications
     When I fill "First Name" with "John"
     And I fill "Last Name" with "Doe"
     When I click 'Save and continue'
+    Then I should be on a page showing "You have added 1 opponent"
+    When I choose "No"
+    And I click 'Save and continue'
     Then I should be on a page showing "Do all parties have the mental capacity to understand the terms of a court order?"
     When I choose "Yes"
     And I click 'Save and continue'
@@ -209,6 +212,9 @@ Feature: Checking ccms means does NOT auto grant for non passported applications
     When I fill "First Name" with "John"
     And I fill "Last Name" with "Doe"
     When I click 'Save and continue'
+    Then I should be on a page showing "You have added 1 opponent"
+    When I choose "No"
+    And I click 'Save and continue'
     Then I should be on a page showing "Do all parties have the mental capacity to understand the terms of a court order?"
     When I choose "Yes"
     And I click 'Save and continue'

--- a/features/providers/check_pending_employment.feature
+++ b/features/providers/check_pending_employment.feature
@@ -102,10 +102,10 @@ Feature: Check pending employment
     And I fill "application_merits_task_incident_occurred_on_1i" with "21"
     And I click 'Save and continue'
 
-    Then I should be on a page showing "Opponent's name"
-    When I fill "First Name" with "John"
-    And I fill "Last Name" with "Doe"
-    When I click 'Save and continue'
+    # already an opponent added by the setup
+    Then I should be on a page showing "You have added 1 opponent"
+    When I choose "No"
+    And I click 'Save and continue'
 
     Then I should be on a page showing "Do all parties have the mental capacity to understand the terms of a court order?"
     When I choose "Yes"

--- a/features/providers/check_single_employment.feature
+++ b/features/providers/check_single_employment.feature
@@ -106,10 +106,10 @@ Feature: Check single employment
     And I fill "application_merits_task_incident_occurred_on_2i" with "4"
     And I fill "application_merits_task_incident_occurred_on_1i" with "21"
     And I click 'Save and continue'
-    Then I should be on a page showing "Opponent's name"
-    When I fill "First Name" with "John"
-    And I fill "Last Name" with "Doe"
-    When I click 'Save and continue'
+    # already an opponent added by the setup
+    Then I should be on a page showing "You have added 1 opponent"
+    When I choose "No"
+    And I click 'Save and continue'
     Then I should be on a page showing "Do all parties have the mental capacity to understand the terms of a court order?"
     When I choose "Yes"
     And I click 'Save and continue'

--- a/features/providers/merits_task_list.feature
+++ b/features/providers/merits_task_list.feature
@@ -16,6 +16,9 @@ Feature: Merits task list
     When I fill "First Name" with "John"
     And I fill "Last Name" with "Doe"
     When I click 'Save and continue'
+    Then I should be on a page showing "You have added 1 opponent"
+    When I choose "No"
+    And I click 'Save and continue'
     Then I should be on a page showing "Do all parties have the mental capacity to understand the terms of a court order?"
     When I choose "Yes"
     And I click 'Save and continue'
@@ -86,6 +89,16 @@ Feature: Merits task list
     When I fill "First Name" with "John"
     And I fill "Last Name" with "Doe"
     When I click 'Save and continue'
+    Then I should be on a page showing "You have added 1 opponent"
+    When I choose "Yes"
+    And I click 'Save and continue'
+    Then I should be on a page showing "Opponent's name"
+    When I fill "First Name" with "Jane"
+    And I fill "Last Name" with "Doe"
+    When I click 'Save and continue'
+    Then I should be on a page showing "You have added 2 opponents"
+    When I choose "No"
+    And I click 'Save and continue'
     Then I should be on a page showing "Do all parties have the mental capacity to understand the terms of a court order?"
     When I choose "Yes"
     And I click 'Save and continue'
@@ -123,6 +136,9 @@ Feature: Merits task list
     When I fill "First Name" with "John"
     And I fill "Last Name" with "Doe"
     When I click 'Save and continue'
+    Then I should be on a page showing "You have added 1 opponent"
+    When I choose "No"
+    And I click 'Save and continue'
     Then I should be on a page showing "Do all parties have the mental capacity to understand the terms of a court order?"
     When I choose "Yes"
     And I click 'Save and continue'
@@ -171,6 +187,9 @@ Feature: Merits task list
     When I fill "First Name" with "John"
     And I fill "Last Name" with "Doe"
     When I click 'Save and continue'
+    Then I should be on a page showing "You have added 1 opponent"
+    When I choose "No"
+    And I click 'Save and continue'
     Then I should be on a page showing "Do all parties have the mental capacity to understand the terms of a court order?"
     When I choose "Yes"
     And I click 'Save and continue'

--- a/features/providers/non_means_tested_journey/without_delegated_functions.feature
+++ b/features/providers/non_means_tested_journey/without_delegated_functions.feature
@@ -75,6 +75,10 @@ Feature: Non-means-tested applicant journey without use of delegation functions
     And I fill "Last Name" with "Doe"
 
     When I click 'Save and continue'
+    Then I should be on a page showing "You have added 1 opponent"
+    When I choose "No"
+    And I click 'Save and continue'
+
     Then I should be on a page showing "Do all parties have the mental capacity to understand the terms of a court order?"
     And I choose "Yes"
 

--- a/features/providers/passported_journey.feature
+++ b/features/providers/passported_journey.feature
@@ -59,6 +59,9 @@ Feature: passported_journey completes application
     When I fill "First Name" with "John"
     And I fill "Last Name" with "Doe"
     When I click 'Save and continue'
+    Then I should be on a page showing "You have added 1 opponent"
+    When I choose "No"
+    And I click 'Save and continue'
     Then I should be on a page showing "Do all parties have the mental capacity to understand the terms of a court order?"
     When I choose "Yes"
     And I click 'Save and continue'

--- a/spec/factories/legal_aid_applications.rb
+++ b/spec/factories/legal_aid_applications.rb
@@ -483,7 +483,9 @@ FactoryBot.define do
     end
 
     trait :with_opponent do
-      opponent { build(:opponent) }
+      after(:create) do |application|
+        create_list(:opponent, 1, legal_aid_application: application)
+      end
     end
 
     trait :with_parties_mental_capacity do

--- a/spec/requests/providers/application_merits_task/domestic_abuse_summaries_controller_spec.rb
+++ b/spec/requests/providers/application_merits_task/domestic_abuse_summaries_controller_spec.rb
@@ -100,7 +100,7 @@ module Providers
 
           it "redirects to the next incomplete question" do
             patch_das
-            expect(response).to redirect_to(providers_legal_aid_application_opponents_name_path(legal_aid_application))
+            expect(response).to redirect_to(new_providers_legal_aid_application_opponents_name_path(legal_aid_application))
           end
         end
 

--- a/spec/requests/providers/application_merits_task/has_other_opponents_controller_spec.rb
+++ b/spec/requests/providers/application_merits_task/has_other_opponents_controller_spec.rb
@@ -1,0 +1,105 @@
+require "rails_helper"
+
+module Providers
+  module ApplicationMeritsTask
+    RSpec.describe HasOtherOpponentsController do
+      let(:application) { create(:legal_aid_application, :with_multiple_proceedings_inc_section8) }
+      let(:provider) { application.provider }
+      let(:opponent) { create(:opponent, legal_aid_application: application) }
+      let(:smtl) { create(:legal_framework_merits_task_list, legal_aid_application: application) }
+
+      before do
+        allow(LegalFramework::MeritsTasksService).to receive(:call).with(application).and_return(smtl)
+        login_as provider
+      end
+
+      describe "show: GET /providers/applications/:legal_aid_application_id/has_other_opponents" do
+        subject(:get_has_other) { get providers_legal_aid_application_has_other_opponent_path(application) }
+
+        before { create(:opponent, legal_aid_application: application) }
+
+        it "returns success" do
+          get_has_other
+          expect(response).to have_http_status(:ok)
+        end
+
+        it "displays the do you want to add more page" do
+          get_has_other
+          expect(response.body).to include("You have added 1 opponent")
+          expect(response.body).to include("Do you need to add another opponent?")
+        end
+      end
+
+      describe "update: PATCH /providers/applications/:legal_aid_application_id/has_other_opponents" do
+        subject(:patch_has_other) { patch providers_legal_aid_application_has_other_opponent_path(application), params: params.merge(button_clicked) }
+
+        let(:params) do
+          {
+            binary_choice_form: {
+              has_other_opponents: radio_button,
+            },
+            legal_aid_application_id: application.id,
+          }
+        end
+        let(:draft_button) { { draft_button: "Save as draft" } }
+        let(:button_clicked) { {} }
+
+        context "when adding another opponent" do
+          let(:radio_button) { "true" }
+
+          it "redirects to new opponent" do
+            patch_has_other
+            expect(response).to redirect_to(new_providers_legal_aid_application_opponents_name_path(application))
+          end
+
+          it "does not set the task to complete" do
+            patch_has_other
+            expect(application.legal_framework_merits_task_list).to have_not_started_task(:application, :opponent_name)
+          end
+        end
+
+        context "when not adding another opponent" do
+          let(:radio_button) { "false" }
+
+          before do
+            application.legal_framework_merits_task_list.mark_as_complete!(:application, :latest_incident_details)
+            application.legal_framework_merits_task_list.mark_as_complete!(:application, :children_application)
+            application.legal_framework_merits_task_list.mark_as_complete!(:application, :opponent_mental_capacity)
+            application.legal_framework_merits_task_list.mark_as_complete!(:application, :domestic_abuse_summary)
+            application.legal_framework_merits_task_list.mark_as_complete!(:application, :statement_of_case)
+          end
+
+          it "redirects to why matter opposed page" do
+            patch_has_other
+            expect(response).to redirect_to(providers_legal_aid_application_matter_opposed_reason_path(application))
+          end
+
+          it "sets the task to complete" do
+            patch_has_other
+            expect(application.reload.legal_framework_merits_task_list).to have_completed_task(:application, :opponent_name)
+          end
+        end
+
+        context "with neither yes nor no selected" do
+          let(:radio_button) { "" }
+
+          it "re-renders the show page" do
+            patch_has_other
+            expect(response.body).to include("Do you need to add another opponent?")
+          end
+
+          it "displays the correct error message" do
+            patch_has_other
+            expect(unescaped_response_body).to include("There is a problem")
+            expect(unescaped_response_body).to include("Select yes if you need to add another opponent")
+          end
+
+          it "does not set the task to complete" do
+            patch_has_other
+            expect(application.legal_framework_merits_task_list).to have_not_started_task(:application, :opponent_name)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/providers/application_merits_task/opponents_names_controller_spec.rb
+++ b/spec/requests/providers/application_merits_task/opponents_names_controller_spec.rb
@@ -8,50 +8,70 @@ module Providers
       let(:smtl) { create(:legal_framework_merits_task_list, legal_aid_application:) }
       let(:proceeding) { laa.proceedings.detect { |p| p.ccms_code == "SE014" } }
 
-      describe "GET /providers/applications/:legal_aid_application_id/opponent_names" do
-        subject(:get_name) { get providers_legal_aid_application_opponents_name_path(legal_aid_application) }
+      describe "new: GET /providers/applications/:legal_aid_application_id/opponents_names/new" do
+        subject(:get_new_opponent) { get new_providers_legal_aid_application_opponents_name_path(legal_aid_application) }
 
-        before do
-          allow(LegalFramework::MeritsTasksService).to receive(:call).with(legal_aid_application).and_return(smtl)
-          login_provider
-          get_name
-        end
+        context "when authenticated" do
+          before do
+            login_provider
+            get_new_opponent
+          end
 
-        it "renders successfully" do
-          expect(response).to have_http_status(:ok)
-        end
-
-        context "when not authenticated" do
-          let(:login_provider) { nil }
-
-          it_behaves_like "a provider not authenticated"
-        end
-
-        context "with an existing opponent" do
-          let(:opponent) { create(:opponent) }
-          let(:legal_aid_application) { create(:legal_aid_application, :with_proceedings, explicit_proceedings: %i[da001 se014], opponent:) }
-
-          it "renders successfully" do
+          it "returns success" do
             expect(response).to have_http_status(:ok)
           end
 
-          it "displays opponent data" do
-            expect(response.body).to include(html_compare(opponent.first_name))
-            expect(response.body).to include(html_compare(opponent.last_name))
+          it "displays the form to add new children" do
+            expect(response.body).to include(html_compare("Opponent's name"))
+            expect(response.body).to include("First name")
+            expect(response.body).to include("Last name")
           end
+        end
+
+        context "when unauthenticated" do
+          before { get_new_opponent }
+
+          it_behaves_like "a provider not authenticated"
         end
       end
 
-      describe "PATCH /providers/applications/:legal_aid_application_id/opponent_name" do
+      describe "show: GET /providers/applications/:legal_aid_application_id/opponents_names/:opponent_id" do
+        subject(:get_existing_opponent) { get providers_legal_aid_application_opponents_name_path(legal_aid_application, opponent) }
+
+        let(:opponent) { create(:opponent, legal_aid_application:) }
+
+        context "when authenticated" do
+          before do
+            login_provider
+            get_existing_opponent
+          end
+
+          it "returns success" do
+            expect(response).to have_http_status(:ok)
+          end
+
+          it "displays opponent's name" do
+            expect(response.body).to include(html_compare(opponent.first_name))
+          end
+        end
+
+        context "when unauthenticated" do
+          before { get_existing_opponent }
+
+          it_behaves_like "a provider not authenticated"
+        end
+      end
+
+      describe "update: PATCH /providers/applications/:legal_aid_application_id/opponents_names/:opponent_id" do
         subject(:patch_name) do
           patch(
-            providers_legal_aid_application_opponents_name_path(legal_aid_application),
+            providers_legal_aid_application_opponents_name_path(legal_aid_application, opponent),
             params: params.merge(button_clicked),
           )
         end
-
-        let(:first_name) { Faker::Name.first_name }
-        let(:last_name) { Faker::Name.last_name }
+        let!(:opponent) { create(:opponent, legal_aid_application:, first_name: "Should", last_name: "Change") }
+        let(:first_name) { opponent.first_name }
+        let(:last_name) { "#{opponent.last_name} Junior" }
         let(:params) do
           {
             application_merits_task_opponent: {
@@ -62,15 +82,16 @@ module Providers
         end
         let(:draft_button) { { draft_button: "Save as draft" } }
         let(:button_clicked) { {} }
-        let(:opponent) { legal_aid_application.reload.opponent }
 
         before do
           allow(LegalFramework::MeritsTasksService).to receive(:call).with(legal_aid_application).and_return(smtl)
+          create(:opponent, legal_aid_application:, first_name: "Does", last_name: "Not-Change")
           login_provider
         end
 
-        it "creates a new opponent with the values entered" do
-          expect { patch_name }.to change(::ApplicationMeritsTask::Opponent, :count).by(1)
+        it "amends the opponent with the values entered" do
+          expect { patch_name }.not_to change(::ApplicationMeritsTask::Opponent, :count)
+          expect(opponent.reload.full_name).to eql "Should Change Junior"
         end
 
         it "sets the task to complete" do
@@ -78,34 +99,9 @@ module Providers
           expect(legal_aid_application.legal_framework_merits_task_list.serialized_data).to match(/name: :opponent_name\n\s+dependencies: \*\d+\n\s+state: :complete/)
         end
 
-        context "when no other tasks are complete" do
-          it "redirects to the next incomplete question" do
-            patch_name
-            expect(response).to redirect_to(providers_legal_aid_application_date_client_told_incident_path(legal_aid_application))
-          end
-        end
-
-        context "when the first task is complete" do
-          before { legal_aid_application.legal_framework_merits_task_list.mark_as_complete!(:application, :latest_incident_details) }
-
-          it "redirects to the next incomplete question" do
-            patch_name
-            expect(response).to redirect_to(providers_legal_aid_application_opponents_mental_capacity_path(legal_aid_application))
-          end
-        end
-
-        context "when the all but one task is complete" do
-          before do
-            legal_aid_application.legal_framework_merits_task_list.mark_as_complete!(:application, :latest_incident_details)
-            legal_aid_application.legal_framework_merits_task_list.mark_as_complete!(:application, :opponent_mental_capacity)
-            legal_aid_application.legal_framework_merits_task_list.mark_as_complete!(:application, :domestic_abuse_summary)
-            legal_aid_application.legal_framework_merits_task_list.mark_as_complete!(:application, :children_application)
-          end
-
-          it "redirects to the final question" do
-            patch_name
-            expect(response).to redirect_to(providers_legal_aid_application_statement_of_case_path(legal_aid_application))
-          end
+        it "redirects to the has another opponent question" do
+          patch_name
+          expect(response).to redirect_to(providers_legal_aid_application_has_other_opponent_path(legal_aid_application))
         end
 
         context "when not authenticated" do

--- a/spec/requests/providers/application_merits_task/remove_opponent_controller_spec.rb
+++ b/spec/requests/providers/application_merits_task/remove_opponent_controller_spec.rb
@@ -1,0 +1,80 @@
+require "rails_helper"
+
+module Providers
+  module ApplicationMeritsTask
+    RSpec.describe RemoveOpponentController do
+      let(:application) { create(:legal_aid_application) }
+      let(:provider) { application.provider }
+      let!(:opponent2) { create(:opponent, legal_aid_application: application) }
+
+      before { login_as provider }
+
+      describe "show GET /providers/applications/:legal_aid_application_id/remove_opponent/:id" do
+        subject(:get_remove) { get providers_legal_aid_application_remove_opponent_path(application, opponent2) }
+
+        it "displays the opponents details" do
+          get_remove
+          expect(response.body).to include(html_compare(opponent2.full_name))
+        end
+      end
+
+      describe "update PATCH /providers/applications/:legal_aid_application_id/remove_opponent/:id" do
+        subject(:submit_remove) { patch providers_legal_aid_application_remove_opponent_path(application, opponent2), params: }
+
+        let(:params) do
+          {
+            binary_choice_form: {
+              remove_opponent: radio_button,
+            },
+            legal_aid_application_id: application.id,
+          }
+        end
+
+        context "when opponent is removed" do
+          let(:radio_button) { "true" }
+
+          it "deletes the opponent record" do
+            expect { submit_remove }.to change { application.opponents.count }.by(-1)
+          end
+
+          context "and it is the only opponent on the application" do
+            it "redirects to the add new opponent page" do
+              submit_remove
+              expect(response).to redirect_to(new_providers_legal_aid_application_opponents_name_path(application))
+            end
+          end
+
+          context "and another opponent exists" do
+            before { create(:opponent, legal_aid_application: application) }
+
+            it "redirects back to the has_other_involved_children page" do
+              submit_remove
+              expect(response).to redirect_to(providers_legal_aid_application_has_other_opponent_path(application))
+            end
+          end
+        end
+
+        context "when opponent is not removed" do
+          let(:radio_button) { "false" }
+
+          it "does not delete a record" do
+            expect { submit_remove }.not_to change { application.opponents.count }
+          end
+
+          it "redirects back to the has_other_opponents page" do
+            submit_remove
+            expect(response).to redirect_to(providers_legal_aid_application_has_other_opponent_path(application))
+          end
+        end
+
+        context "with neither yes nor no specified" do
+          let(:radio_button) { "" }
+
+          it "does not delete a record" do
+            expect { submit_remove }.not_to change { application.opponents.count }
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/providers/check_merits_answers_spec.rb
+++ b/spec/requests/providers/check_merits_answers_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe "check merits answers requests" do
 
       it "displays the correct URLs for changing values" do
         expect(response.body).to have_change_link(:incident_details, providers_legal_aid_application_date_client_told_incident_path)
-        expect(response.body).to have_change_link(:full_name, providers_legal_aid_application_opponents_name_path(application))
+        expect(response.body).to have_change_link(:opponents, providers_legal_aid_application_has_other_opponent_path(application))
         expect(response.body).to have_change_link(:statement_of_case, providers_legal_aid_application_statement_of_case_path(application))
         application.proceedings.each do |proceeding|
           expect(response.body).to have_change_link(:success_likely,

--- a/spec/requests/providers/merits_task_lists_controller_spec.rb
+++ b/spec/requests/providers/merits_task_lists_controller_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe Providers::MeritsTaskListsController do
 
       it "calls the OpponentTaskUpdateService and replaces the opponent_details task and returns http success" do
         expect(response).to have_http_status(:ok)
-        expect(response.body).to include("Opponent&#39;s name")
+        expect(response.body).to include("Opponents")
         expect(response.body).to include("Mental capacity of all parties")
         expect(response.body).to include("Domestic abuse summary")
       end

--- a/spec/services/ccms/requestors/case_add_requestor_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_spec.rb
@@ -17,7 +17,7 @@ module CCMS
                  other_assets_declaration:,
                  savings_amount:,
                  provider:,
-                 opponent:,
+                 opponents:,
                  domestic_abuse_summary:,
                  office:)
         end
@@ -49,7 +49,7 @@ module CCMS
         let(:address) { create(:address, postcode: "GH08NY") }
         let(:provider) { create(:provider, username: "saturnina", firm:, email: "patrick_rath@example.net") }
         let(:firm) { create(:firm, ccms_id: 169) }
-        let(:opponent) { create(:opponent, first_name: "Joffrey", last_name: "Test-Opponent") }
+        let(:opponents) { create_list(:opponent, 1, first_name: "Joffrey", last_name: "Test-Opponent") }
         let(:submission) { create(:submission, :case_ref_obtained, case_ccms_reference: "300000000001", legal_aid_application:) }
         let(:cfe_submission) { create(:cfe_submission, legal_aid_application:) }
         let!(:cfe_result) { create(:cfe_v3_result, submission: cfe_submission) }
@@ -64,6 +64,7 @@ module CCMS
 
         before do
           legal_aid_application.reload
+          legal_aid_application.update!(opponents:)
           allow(Rails.configuration.x.ccms_soa).to receive(:client_username).and_return("FakeUser")
           allow(Rails.configuration.x.ccms_soa).to receive(:client_password).and_return("FakePassword")
           allow(Rails.configuration.x.ccms_soa).to receive(:client_password_type).and_return("password_type")

--- a/spec/services/ccms/requestors/case_add_requestor_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_spec.rb
@@ -206,6 +206,22 @@ module CCMS
             end
           end
         end
+
+        context "when multiple opponents are added" do
+          let(:opponent_one) { create(:opponent, first_name: "Joffrey", last_name: "Test-Opponent") }
+          let(:opponent_two) { create(:opponent, first_name: "Sansa", last_name: "Opponent-Test") }
+          let(:opponents) { [opponent_one, opponent_two] }
+
+          before do
+            allow(opponent_one).to receive(:generate_ccms_opponent_id).and_return("123456")
+            allow(opponent_two).to receive(:generate_ccms_opponent_id).and_return("654321")
+          end
+
+          it "generates expected xml with multiple opponents" do
+            expect(expected_xml).to match(/Joffrey Test-Opponent/)
+            expect(expected_xml).to match(/Sansa Opponent-Test/)
+          end
+        end
       end
     end
   end

--- a/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_means_tested_attributes_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_means_tested_attributes_spec.rb
@@ -45,7 +45,7 @@ module CCMS
 
         let(:expected_tx_id) { "201904011604570390059770666" }
         let(:proceeding) { legal_aid_application.proceedings.detect { |p| p.ccms_code == "DA001" } }
-        let(:opponent) { legal_aid_application.opponent }
+        let(:opponent) { legal_aid_application.opponents.first }
         let(:parties_mental_capacity) { legal_aid_application.parties_mental_capacity }
         let(:domestic_abuse_summary) { legal_aid_application.domestic_abuse_summary }
         let(:ccms_reference) { "300000054005" }

--- a/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_means_tested_attributes_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_means_tested_attributes_spec.rb
@@ -1074,86 +1074,178 @@ module CCMS
           end
         end
 
-        context "with means OPPONENT_OTHER_PARTIES entity" do
-          let(:entity) { :opponent_means }
+        context "with a single opponent" do
+          context "with means OPPONENT_OTHER_PARTIES entity" do
+            let(:entity) { :opponent_means }
 
-          it "generates OTHER_PARTY_ID" do
-            block = XmlExtractor.call(xml, entity, "OTHER_PARTY_ID")
-            expect(block).to have_text_response "OPPONENT_88000001"
+            it "generates OTHER_PARTY_ID" do
+              block = XmlExtractor.call(xml, entity, "OTHER_PARTY_ID")
+              expect(block).to have_text_response "OPPONENT_88000001"
+            end
+
+            it "adds OTHER_PARTY_NAME with value of full name of other party" do
+              block = XmlExtractor.call(xml, entity, "OTHER_PARTY_NAME")
+              expect(block).to have_text_response opponent.full_name
+            end
+
+            it "hard-codes OTHER_PARTY_TYPE" do
+              block = XmlExtractor.call(xml, entity, "OTHER_PARTY_TYPE")
+              expect(block).to have_text_response "PERSON"
+            end
+
+            it "hard-codes RELATIONSHIP_TO_CASE" do
+              block = XmlExtractor.call(xml, entity, "RELATIONSHIP_TO_CASE")
+              expect(block).to have_text_response "OPP"
+            end
+
+            it "hard-codes RELATIONSHIP_TO_CLIENT" do
+              block = XmlExtractor.call(xml, entity, "RELATIONSHIP_TO_CLIENT")
+              expect(block).to have_text_response "UNKNOWN"
+            end
           end
 
-          it "adds OTHER_PARTY_NAME with value of full name of other party" do
-            block = XmlExtractor.call(xml, entity, "OTHER_PARTY_NAME")
-            expect(block).to have_text_response opponent.full_name
-          end
+          context "with merits OPPONENT_OTHER_PARTIES entity" do
+            let(:entity) { :opponent_merits }
 
-          it "hard-codes OTHER_PARTY_TYPE" do
-            block = XmlExtractor.call(xml, entity, "OTHER_PARTY_TYPE")
-            expect(block).to have_text_response "PERSON"
-          end
+            it "hard-codes OPP_RELATIONSHIP_TO_CASE" do
+              block = XmlExtractor.call(xml, entity, "OPP_RELATIONSHIP_TO_CASE")
+              expect(block).to have_text_response "Opponent"
+            end
 
-          it "hard-codes RELATIONSHIP_TO_CASE" do
-            block = XmlExtractor.call(xml, entity, "RELATIONSHIP_TO_CASE")
-            expect(block).to have_text_response "OPP"
-          end
+            it "hard-codes OPP_RELATIONSHIP_TO_CLIENT" do
+              block = XmlExtractor.call(xml, entity, "OPP_RELATIONSHIP_TO_CLIENT")
+              expect(block).to have_text_response "Unknown"
+            end
 
-          it "hard-codes RELATIONSHIP_TO_CLIENT" do
-            block = XmlExtractor.call(xml, entity, "RELATIONSHIP_TO_CLIENT")
-            expect(block).to have_text_response "UNKNOWN"
+            it "generates OTHER_PARTY_ID" do
+              block = XmlExtractor.call(xml, entity, "OTHER_PARTY_ID")
+              expect(block).to have_text_response "OPPONENT_88000001"
+            end
+
+            it "adds OTHER_PARTY_NAME with value of full name of other party" do
+              block = XmlExtractor.call(xml, entity, "OTHER_PARTY_NAME")
+              expect(block).to have_text_response opponent.full_name
+            end
+
+            it "adds OTHER_PARTY_NAME_MERITS with value of full name of other party" do
+              block = XmlExtractor.call(xml, entity, "OTHER_PARTY_NAME_MERITS")
+              expect(block).to have_text_response opponent.full_name
+            end
+
+            it "hard-codes OTHER_PARTY_TYPE" do
+              block = XmlExtractor.call(xml, entity, "OTHER_PARTY_TYPE")
+              expect(block).to have_text_response "PERSON"
+            end
+
+            it "hard-codes OTHER_PARTY_PERSON" do
+              block = XmlExtractor.call(xml, entity, "OTHER_PARTY_PERSON")
+              expect(block).to have_boolean_response true
+            end
+
+            it "adds RELATIONSHIP_CASE_OPPONENT with derived value" do
+              block = XmlExtractor.call(xml, entity, "RELATIONSHIP_CASE_OPPONENT")
+              expect(block).to have_boolean_response true
+            end
+
+            it "adds RELATIONSHIP_TO_CASE with derived value" do
+              block = XmlExtractor.call(xml, entity, "RELATIONSHIP_TO_CASE")
+              expect(block).to have_text_response "OPP"
+            end
+
+            it "hard-codes RELATIONSHIP_TO_CLIENT" do
+              block = XmlExtractor.call(xml, entity, "RELATIONSHIP_TO_CLIENT")
+              expect(block).to have_text_response "UNKNOWN"
+            end
           end
         end
 
-        context "with merits OPPONENT_OTHER_PARTIES entity" do
-          let(:entity) { :opponent_merits }
+        context "with multiple opponents" do
+          let(:opponent_one) { create(:opponent, first_name: "Joffrey", last_name: "Test-Opponent") }
+          let(:opponent_two) { create(:opponent, first_name: "Sansa", last_name: "Opponent-Test") }
 
-          it "hard-codes OPP_RELATIONSHIP_TO_CASE" do
-            block = XmlExtractor.call(xml, entity, "OPP_RELATIONSHIP_TO_CASE")
-            expect(block).to have_text_response "Opponent"
+          before { legal_aid_application.update!(opponents: [opponent_one, opponent_two]) }
+
+          context "with means OPPONENT_OTHER_PARTIES entity" do
+            let(:entity) { :opponent_means }
+
+            it "generates OTHER_PARTY_ID" do
+              block = XmlExtractor.call(xml, entity, "OTHER_PARTY_ID")
+              expect(block).to have_text_response %w[OPPONENT_88000001 OPPONENT_88000002]
+            end
+
+            it "adds OTHER_PARTY_NAME with value of full name of other party" do
+              block = XmlExtractor.call(xml, entity, "OTHER_PARTY_NAME")
+              expect(block).to have_text_response [opponent_one.full_name, opponent_two.full_name]
+            end
+
+            it "hard-codes OTHER_PARTY_TYPE" do
+              block = XmlExtractor.call(xml, entity, "OTHER_PARTY_TYPE")
+              expect(block).to have_text_response %w[PERSON PERSON]
+            end
+
+            it "hard-codes RELATIONSHIP_TO_CASE" do
+              block = XmlExtractor.call(xml, entity, "RELATIONSHIP_TO_CASE")
+              expect(block).to have_text_response %w[OPP OPP]
+            end
+
+            it "hard-codes RELATIONSHIP_TO_CLIENT" do
+              block = XmlExtractor.call(xml, entity, "RELATIONSHIP_TO_CLIENT")
+              expect(block).to have_text_response %w[UNKNOWN UNKNOWN]
+            end
           end
 
-          it "hard-codes OPP_RELATIONSHIP_TO_CLIENT" do
-            block = XmlExtractor.call(xml, entity, "OPP_RELATIONSHIP_TO_CLIENT")
-            expect(block).to have_text_response "Unknown"
-          end
+          context "with merits OPPONENT_OTHER_PARTIES entity" do
+            let(:entity) { :opponent_merits }
 
-          it "generates OTHER_PARTY_ID" do
-            block = XmlExtractor.call(xml, entity, "OTHER_PARTY_ID")
-            expect(block).to have_text_response "OPPONENT_88000001"
-          end
+            it "hard-codes OPP_RELATIONSHIP_TO_CASE" do
+              block = XmlExtractor.call(xml, entity, "OPP_RELATIONSHIP_TO_CASE")
+              expect(block).to have_text_response %w[Opponent Opponent]
+            end
 
-          it "adds OTHER_PARTY_NAME with value of full name of other party" do
-            block = XmlExtractor.call(xml, entity, "OTHER_PARTY_NAME")
-            expect(block).to have_text_response opponent.full_name
-          end
+            it "hard-codes OPP_RELATIONSHIP_TO_CLIENT" do
+              block = XmlExtractor.call(xml, entity, "OPP_RELATIONSHIP_TO_CLIENT")
+              expect(block).to have_text_response %w[Unknown Unknown]
+            end
 
-          it "adds OTHER_PARTY_NAME_MERITS with value of full name of other party" do
-            block = XmlExtractor.call(xml, entity, "OTHER_PARTY_NAME_MERITS")
-            expect(block).to have_text_response opponent.full_name
-          end
+            it "generates OTHER_PARTY_ID" do
+              block = XmlExtractor.call(xml, entity, "OTHER_PARTY_ID")
+              expect(block).to have_text_response %w[OPPONENT_88000001 OPPONENT_88000002]
+            end
 
-          it "hard-codes OTHER_PARTY_TYPE" do
-            block = XmlExtractor.call(xml, entity, "OTHER_PARTY_TYPE")
-            expect(block).to have_text_response "PERSON"
-          end
+            it "adds OTHER_PARTY_NAME with value of full name of other party" do
+              block = XmlExtractor.call(xml, entity, "OTHER_PARTY_NAME")
+              expect(block).to have_text_response [opponent_one.full_name, opponent_two.full_name]
+            end
 
-          it "hard-codes OTHER_PARTY_PERSON" do
-            block = XmlExtractor.call(xml, entity, "OTHER_PARTY_PERSON")
-            expect(block).to have_boolean_response true
-          end
+            it "adds OTHER_PARTY_NAME_MERITS with value of full name of other party" do
+              block = XmlExtractor.call(xml, entity, "OTHER_PARTY_NAME_MERITS")
+              expect(block).to have_text_response [opponent_one.full_name, opponent_two.full_name]
+            end
 
-          it "adds RELATIONSHIP_CASE_OPPONENT with derived value" do
-            block = XmlExtractor.call(xml, entity, "RELATIONSHIP_CASE_OPPONENT")
-            expect(block).to have_boolean_response true
-          end
+            it "hard-codes OTHER_PARTY_TYPE" do
+              block = XmlExtractor.call(xml, entity, "OTHER_PARTY_TYPE")
+              expect(block).to have_text_response %w[PERSON PERSON]
+            end
 
-          it "adds RELATIONSHIP_TO_CASE with derived value" do
-            block = XmlExtractor.call(xml, entity, "RELATIONSHIP_TO_CASE")
-            expect(block).to have_text_response "OPP"
-          end
+            it "hard-codes OTHER_PARTY_PERSON" do
+              block = XmlExtractor.call(xml, entity, "OTHER_PARTY_PERSON")
+              expect(block).to have_boolean_response [true, true]
+            end
 
-          it "hard-codes RELATIONSHIP_TO_CLIENT" do
-            block = XmlExtractor.call(xml, entity, "RELATIONSHIP_TO_CLIENT")
-            expect(block).to have_text_response "UNKNOWN"
+            it "adds RELATIONSHIP_CASE_OPPONENT with derived value" do
+              block = XmlExtractor.call(xml, entity, "RELATIONSHIP_CASE_OPPONENT")
+              expect(block).to have_boolean_response [true, true]
+            end
+
+            it "adds RELATIONSHIP_TO_CASE with derived value" do
+              block = XmlExtractor.call(xml, entity, "RELATIONSHIP_TO_CASE")
+              expect(block).to have_text_response %w[OPP OPP]
+            end
+
+            it "hard-codes RELATIONSHIP_TO_CLIENT" do
+              block = XmlExtractor.call(xml, entity, "RELATIONSHIP_TO_CLIENT")
+              expect(block).to have_text_response %w[UNKNOWN UNKNOWN]
+            end
           end
         end
 

--- a/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_entities_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_entities_spec.rb
@@ -33,7 +33,6 @@ module CCMS
         let!(:chances_of_success) do
           create(:chances_of_success, :with_optional_text, proceeding:)
         end
-        let(:opponent) { legal_aid_application.opponent }
         let(:ccms_reference) { "300000054005" }
         let(:submission) { create(:submission, :case_ref_obtained, legal_aid_application:, case_ccms_reference: ccms_reference) }
         let(:cfe_submission) { create(:cfe_submission, legal_aid_application:) }

--- a/spec/services/ccms/requestors/case_add_requestor_xml_blocks/passported_attributes_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_xml_blocks/passported_attributes_spec.rb
@@ -27,7 +27,7 @@ module CCMS
                  office:)
         end
         let(:proceeding) { legal_aid_application.proceedings.detect { |p| p.ccms_code == "DA001" } }
-        let(:opponent) { legal_aid_application.opponent }
+        let(:opponent) { legal_aid_application.opponents.first }
         let(:domestic_abuse_summary) { legal_aid_application.domestic_abuse_summary }
         let(:parties_mental_capacity) { legal_aid_application.parties_mental_capacity }
         let(:ccms_reference) { "300000054005" }

--- a/spec/services/flow/merits_loop_spec.rb
+++ b/spec/services/flow/merits_loop_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Flow::MeritsLoop do
         before { merits_task_list.mark_as_complete!(:application, :latest_incident_details) }
 
         it "returns the first :not_started task" do
-          expect(forward_flow).to eq :opponents_names
+          expect(forward_flow).to eq :start_opponent_task
         end
       end
 

--- a/spec/services/reports/mis/application_detail_csv_line_spec.rb
+++ b/spec/services/reports/mis/application_detail_csv_line_spec.rb
@@ -22,7 +22,7 @@ module Reports
                benefit_check_result:,
                savings_amount:,
                other_assets_declaration:,
-               opponent:,
+               opponents:,
                parties_mental_capacity:,
                domestic_abuse_summary:,
                ccms_submission:,
@@ -51,7 +51,7 @@ module Reports
                benefit_check_result:,
                savings_amount:,
                other_assets_declaration:,
-               opponent:,
+               opponents:,
                parties_mental_capacity:,
                domestic_abuse_summary:,
                ccms_submission:,
@@ -74,7 +74,7 @@ module Reports
                benefit_check_result:,
                savings_amount:,
                other_assets_declaration:,
-               opponent:,
+               opponents:,
                parties_mental_capacity:,
                domestic_abuse_summary:,
                ccms_submission:,
@@ -140,8 +140,8 @@ module Reports
                none_selected:)
       end
 
-      let(:opponent) do
-        create(:opponent)
+      let(:opponents) do
+        create_list(:opponent, 1)
       end
 
       let(:parties_mental_capacity) do


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3864)

This PR updates the application -> opponent relationship from has_one to has_many
It then implements the `has-another` pattern for the application merits task opponents' name page

This required a re-write of the ccms/xml matchers to allow multiple values to be matched.  
Currently these only work in to assure all values are present, not their sequence, this may cause an issue in future with boolean values if they are dissimilar. e.g. expecting `[true, false]` it will ensure that one of each is present, but not necessarily that they are assigned to the expected linked blocks

Future work will expand the opponent to allow differentiation between individuals and organisations 

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
