### PR TITLE
AP-3915: Add CCMS queue analysis to admin

### DIFF
--- a/app/controllers/admin/ccms_queues_controller.rb
+++ b/app/controllers/admin/ccms_queues_controller.rb
@@ -1,0 +1,46 @@
+module Admin
+  class CCMSQueuesController < AdminBaseController
+    before_action :authenticate_admin_user!
+
+    def index
+      @in_progress = CCMS::Submission.where.not(aasm_state: %w[completed abandoned]).order(created_at: :desc)
+    end
+
+    def show
+      submission
+      legal_aid_application
+    end
+
+    def reset_and_restart
+      result = submission.complete_restart! # return from service
+      status = result ? :notice : :error
+      core = "submission #{submission_id}"
+      message = status.eql?(:error) ? "Restarting #{core} failed" : "Reset and restarted #{core}"
+      flash[status] = message
+      redirect_to action: :show
+    end
+
+    def restart_current_submission
+      result = submission.restart_existing_submission!
+      status = result ? :notice : :error
+      core = "submission #{submission_id}"
+      message = status.eql?(:error) ? "Restarting #{core} failed" : "Restarted #{core}"
+      flash[status] = message
+      redirect_to action: :show
+    end
+
+  private
+
+    def submission
+      @submission ||= CCMS::Submission.find(submission_id)
+    end
+
+    def legal_aid_application
+      @legal_aid_application ||= submission.legal_aid_application
+    end
+
+    def submission_id
+      params.require(:id)
+    end
+  end
+end

--- a/app/controllers/admin/ccms_queues_controller.rb
+++ b/app/controllers/admin/ccms_queues_controller.rb
@@ -34,11 +34,8 @@ module Admin
     end
 
     def execute_submission_method(method)
-      result = submission.send(method)
-      status = result ? :notice : :error
-      message = status.eql?(:error) ? "Restarting submission #{submission_id} failed" : "#{method.to_s.humanize} submission #{submission_id}"
-      flash[status] = message
-      redirect_to action: :show
+      submission.public_send(method)
+      redirect_to admin_ccms_queue_path(submission.id), notice: "#{method.to_s.humanize.sub('!', '')} submission #{submission_id}"
     end
   end
 end

--- a/app/controllers/admin/ccms_queues_controller.rb
+++ b/app/controllers/admin/ccms_queues_controller.rb
@@ -12,21 +12,11 @@ module Admin
     end
 
     def reset_and_restart
-      result = submission.complete_restart! # return from service
-      status = result ? :notice : :error
-      core = "submission #{submission_id}"
-      message = status.eql?(:error) ? "Restarting #{core} failed" : "Reset and restarted #{core}"
-      flash[status] = message
-      redirect_to action: :show
+      execute_submission_method(:restart_from_beginning!)
     end
 
     def restart_current_submission
-      result = submission.restart_existing_submission!
-      status = result ? :notice : :error
-      core = "submission #{submission_id}"
-      message = status.eql?(:error) ? "Restarting #{core} failed" : "Restarted #{core}"
-      flash[status] = message
-      redirect_to action: :show
+      execute_submission_method(:restart_current_step!)
     end
 
   private
@@ -41,6 +31,14 @@ module Admin
 
     def submission_id
       params.require(:id)
+    end
+
+    def execute_submission_method(method)
+      result = submission.send(method)
+      status = result ? :notice : :error
+      message = status.eql?(:error) ? "Restarting submission #{submission_id} failed" : "#{method.to_s.humanize} submission #{submission_id}"
+      flash[status] = message
+      redirect_to action: :show
     end
   end
 end

--- a/app/models/ccms/submission.rb
+++ b/app/models/ccms/submission.rb
@@ -40,7 +40,7 @@ module CCMS
     def process_async!
       SubmissionProcessWorker.perform_async(id, aasm_state)
     end
-    alias_method :restart_existing_submission!, :process_async!
+    alias_method :restart_current_step!, :process_async!
 
     def sidekiq_running?
       return :running if Sidekiq::Workers.new.map(&:to_s).to_s.scan(id).count.positive?
@@ -49,7 +49,7 @@ module CCMS
       false
     end
 
-    def complete_restart!
+    def restart_from_beginning!
       update!(aasm_state: "initialised", case_poll_count: 0, applicant_poll_count: 0)
       process_async!
     end

--- a/app/models/ccms/submission.rb
+++ b/app/models/ccms/submission.rb
@@ -44,7 +44,7 @@ module CCMS
 
     def sidekiq_running?
       return :running if Sidekiq::Workers.new.map(&:to_s).to_s.scan(id).count.positive?
-      return :in_retry if Sidekiq::RetrySet.new.map { |job| job.args.include?(id) }.any?(true)
+      return :in_retry if Sidekiq::RetrySet.new.any? { |job| job.args.include?(id) }
 
       false
     end

--- a/app/views/admin/ccms_queues/index.html.erb
+++ b/app/views/admin/ccms_queues/index.html.erb
@@ -12,7 +12,7 @@
           <th class="govuk-table__header" scope="col"><%= t(".references") %></th>
           <th class="govuk-table__header" scope="col"><%= t(".state") %></th>
           <th class="govuk-table__header" scope="col"><%= t(".created_at") %></th>
-          <th class="govuk-table__header" scope="col"><%= t(".running") %></th>
+          <th class="govuk-table__header" scope="col"><%= t(".state") %></th>
         </tr>
         </thead>
         <tbody class="govuk-table__body">

--- a/app/views/admin/ccms_queues/index.html.erb
+++ b/app/views/admin/ccms_queues/index.html.erb
@@ -1,0 +1,32 @@
+<h1 class="govuk-heading-xl"><%= t(".page_title") %></h1>
+
+<% if @in_progress.empty? %>
+  <h2 class="govuk-heading-m">Queue is empty</h2>
+<% else %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <table class="govuk-table">
+        <caption class="govuk-table__caption govuk-visually-hidden"><%= t(".page_title") %></caption>
+        <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th class="govuk-table__header" scope="col"><%= t(".references") %></th>
+          <th class="govuk-table__header" scope="col"><%= t(".state") %></th>
+          <th class="govuk-table__header" scope="col"><%= t(".created_at") %></th>
+          <th class="govuk-table__header" scope="col"><%= t(".running") %></th>
+        </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+        <% @in_progress.each do |submission| %>
+          <% application = submission.legal_aid_application %>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell case-reference-number"><%= link_to_accessible("#{submission.case_ccms_reference}, (#{application.application_ref})", admin_ccms_queue_path(submission.id)) %></td>
+            <td class="govuk-table__cell case-full-name"><%= submission.aasm_state %></td>
+            <td class="govuk-table__cell"><%= l(application.created_at, format: :long_date_time) %></td>
+            <td class="govuk-table__cell"><%= t(".sidekiq.#{submission.sidekiq_running?}") %></td>
+          </tr>
+        <% end %>
+        </tbody>
+      </table>
+    </div>
+  </div>
+<% end %>

--- a/app/views/admin/ccms_queues/show.html.erb
+++ b/app/views/admin/ccms_queues/show.html.erb
@@ -15,113 +15,92 @@
     <h2 class="govuk-summary-card__title"><%= @legal_aid_application.application_ref %> (<%= @submission.case_ccms_reference %>)</h2>
   </div>
   <div class="govuk-summary-card__content">
-    <dl class="govuk-summary-list">
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key"><%= t(".created_at") %></dt>
-        <dd class="govuk-summary-list__value"><%= l(@submission.created_at, format: :long_date_time) %></dd>
-      </div>
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key"><%= t(".updated_at") %></dt>
-        <dd class="govuk-summary-list__value"><%= l(@submission.updated_at, format: :long_date_time) %></dd>
-      </div>
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key"><%= t(".status") %></dt>
-        <dd class="govuk-summary-list__value"><%= @submission.aasm_state %></dd>
-      </div>
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key"><%= t(".applicant_poll_count") %></dt>
-        <dd class="govuk-summary-list__value"><%= @submission.applicant_poll_count %></dd>
-      </div>
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key"><%= t(".case_poll_count") %></dt>
-        <dd class="govuk-summary-list__value"><%= @submission.case_poll_count %></dd>
-      </div>
-    </dl>
+    <%= govuk_summary_list(actions: false) do |summary_list|
+          summary_list.with_row do |row|
+            row.with_key { t(".created_at") }
+            row.with_value { l(@submission.created_at, format: :long_date_time) }
+          end
+          summary_list.with_row do |row|
+            row.with_key { t(".updated_at") }
+            row.with_value { l(@submission.updated_at, format: :long_date_time) }
+          end
+          summary_list.with_row do |row|
+            row.with_key { t(".status") }
+            row.with_value { @submission.aasm_state }
+          end
+          summary_list.with_row do |row|
+            row.with_key { t(".applicant_poll_count") }
+            row.with_value { @submission.applicant_poll_count.to_s }
+          end
+          summary_list.with_row do |row|
+            row.with_key { t(".case_poll_count") }
+            row.with_value { @submission.case_poll_count.to_s }
+          end
+        end %>
   </div>
 </div>
 
-<h2 class="govuk-heading-l"><%= t(".actions") %></h2>
-<% if @submission.sidekiq_running? %>
-  <p>The original job is still pending in sidekiq</p>
-<% else %>
-  <div class="govuk-!-padding-bottom-6">
-    <details>
-      <summary class="govuk-heading-m govuk-details__summary">
-        <%= t(".restart") %>
-      </summary>
-      <section>
-        <p><%= t(".restart_details") %></p>
-        <p><%= link_to_accessible t(".restart"), restart_current_submission_admin_ccms_queue_path(@submission.id), class: "govuk-button govuk-!-margin-bottom-0" %></p>
-      </section>
-    </details>
-    <details>
-      <summary class="govuk-heading-m govuk-details__summary">
-        <%= t(".reset") %>
-      </summary>
-      <section>
-        <div class="govuk-!-padding-bottom-2">
-          <p><%= t(".reset_details") %></p>
-          <p><%= link_to_accessible t(".reset"), reset_and_restart_admin_ccms_queue_path(@submission.id), class: "govuk-button govuk-!-margin-bottom-0" %></p>
-        </div>
-      </section>
-    </details>
-  </div>
-<% end %>
+<div class="govuk-!-padding-bottom-6">
+  <h2 class="govuk-heading-l"><%= t(".actions") %></h2>
+  <% if @submission.sidekiq_running? %>
+    <p>The original job is still pending in sidekiq</p>
+  <% else %>
+    <%= govuk_details(summary_text: t(".restart")) do %>
+      <p><%= t(".restart_details") %></p>
+      <p><%= link_to_accessible t(".restart"), restart_current_submission_admin_ccms_queue_path(@submission.id), class: "govuk-button govuk-!-margin-bottom-0" %></p>
+    <% end %>
+    <%= govuk_details(summary_text: t(".reset")) do %>
+      <p><%= t(".reset_details") %></p>
+      <p><%= link_to_accessible t(".reset"), reset_and_restart_admin_ccms_queue_path(@submission.id), class: "govuk-button govuk-!-margin-bottom-0" %></p>
+    <% end %>
+  <% end %>
+</div>
+
 <h2 class="govuk-heading-l"><%= t(".submission_histories") %></h2>
 <% @submission.submission_history.order(:created_at).each do |history| %>
   <div class="govuk-summary-card">
-  <div class="govuk-summary-card__title-wrapper">
-    <h2 class="govuk-summary-card__title"><%= history.id %> (<%= history.from_state %> > <%= history.to_state %>)</h2>
+    <div class="govuk-summary-card__title-wrapper">
+      <h2 class="govuk-summary-card__title"><%= history.id %> (<%= history.from_state %> > <%= history.to_state %>)</h2>
+    </div>
+    <div class="govuk-summary-card__content">
+      <%= govuk_summary_list(actions: false) do |summary_list|
+            summary_list.with_row do |row|
+              row.with_key { t(".from_state") }
+              row.with_value { history.from_state }
+            end
+            summary_list.with_row do |row|
+              row.with_key { t(".to_state") }
+              row.with_value { history.to_state }
+            end
+            summary_list.with_row do |row|
+              row.with_key { t("generic.success") }
+              row.with_value { history.success.to_s }
+            end
+            summary_list.with_row do |row|
+              row.with_key { t(".request") }
+              row.with_value do
+                if history.request.nil?
+                  t(".request_is_nil")
+                else
+                  govuk_details(summary_text: t(".expand")) do
+                    history.request
+                  end
+                end
+              end
+            end
+            summary_list.with_row do |row|
+              row.with_key { t(".response") }
+              row.with_value do
+                if history.response.nil?
+                  t(".response_is_nil")
+                else
+                  govuk_details(summary_text: t(".expand")) do
+                    history.response
+                  end
+                end
+              end
+            end
+          end %>
+    </div>
   </div>
-  <div class="govuk-summary-card__content">
-    <dl class="govuk-summary-list">
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">from_state</dt>
-        <dd class="govuk-summary-list__value"><%= history.from_state %></dd>
-      </div>
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key"> to_state</dt>
-        <dd class="govuk-summary-list__value"><%= history.to_state %></dd>
-      </div>
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key"><%= t("generic.success") %></dt>
-        <dd class="govuk-summary-list__value"><%= history.success %></dd>
-      </div>
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key"><%= t(".request") %></dt>
-        <dd class="govuk-summary-list__value">
-          <% if history.request.nil? %>
-            Request is nil
-          <% else %>
-            <details>
-              <summary class="govuk-heading-m govuk-details__summary">
-                <%= t(".expand") %>
-              </summary>
-              <section>
-                <%= history.request %>
-              </section>
-            </details>
-          <% end %>
-        </dd>
-      </div>
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key"><%= t(".response") %></dt>
-        <dd class="govuk-summary-list__value">
-          <% if history.response.nil? %>
-              response is nil
-          <% else %>
-            <details>
-              <summary class="govuk-heading-m govuk-details__summary">
-                <%= t(".expand") %>
-              </summary>
-              <section>
-                <%= history.response %>
-              </section>
-            </details>
-          <% end %>
-        </dd>
-      </div>
-    </dl>
-  </div>
-</div>
 <% end %>

--- a/app/views/admin/ccms_queues/show.html.erb
+++ b/app/views/admin/ccms_queues/show.html.erb
@@ -1,0 +1,127 @@
+<div class="govuk-breadcrumbs">
+  <ol class="govuk-breadcrumbs__list">
+    <li class="govuk-breadcrumbs__list-item">
+      <%= link_to_accessible("CCMS Queue", admin_ccms_queues_path, class: "govuk-breadcrumbs__link") %>
+    </li>
+    <li class="govuk-breadcrumbs__list-item">
+      <%= @legal_aid_application.application_ref %>
+    </li>
+  </ol>
+</div>
+
+<h2 class="govuk-heading-l"><%= t(".submission") %></h2>
+<div class="govuk-summary-card">
+  <div class="govuk-summary-card__title-wrapper">
+    <h2 class="govuk-summary-card__title"><%= @legal_aid_application.application_ref %> (<%= @submission.case_ccms_reference %>)</h2>
+  </div>
+  <div class="govuk-summary-card__content">
+    <dl class="govuk-summary-list">
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key"><%= t(".created_at") %></dt>
+        <dd class="govuk-summary-list__value"><%= l(@submission.created_at, format: :long_date_time) %></dd>
+      </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key"><%= t(".updated_at") %></dt>
+        <dd class="govuk-summary-list__value"><%= l(@submission.updated_at, format: :long_date_time) %></dd>
+      </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key"><%= t(".status") %></dt>
+        <dd class="govuk-summary-list__value"><%= @submission.aasm_state %></dd>
+      </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key"><%= t(".applicant_poll_count") %></dt>
+        <dd class="govuk-summary-list__value"><%= @submission.applicant_poll_count %></dd>
+      </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key"><%= t(".case_poll_count") %></dt>
+        <dd class="govuk-summary-list__value"><%= @submission.case_poll_count %></dd>
+      </div>
+    </dl>
+  </div>
+</div>
+
+<h2 class="govuk-heading-l"><%= t(".actions") %></h2>
+<% if @submission.sidekiq_running? %>
+  <p>The original job is still pending in sidekiq</p>
+<% else %>
+  <div class="govuk-!-padding-bottom-6">
+    <details>
+      <summary class="govuk-heading-m govuk-details__summary">
+        <%= t(".restart") %>
+      </summary>
+      <section>
+        <p><%= t(".restart_details") %></p>
+        <p><%= link_to_accessible t(".restart"), restart_current_submission_admin_ccms_queue_path(@submission.id), class: "govuk-button govuk-!-margin-bottom-0" %></p>
+      </section>
+    </details>
+    <details>
+      <summary class="govuk-heading-m govuk-details__summary">
+        <%= t(".reset") %>
+      </summary>
+      <section>
+        <div class="govuk-!-padding-bottom-2">
+          <p><%= t(".reset_details") %></p>
+          <p><%= link_to_accessible t(".reset"), reset_and_restart_admin_ccms_queue_path(@submission.id), class: "govuk-button govuk-!-margin-bottom-0" %></p>
+        </div>
+      </section>
+    </details>
+  </div>
+<% end %>
+<h2 class="govuk-heading-l"><%= t(".submission_histories") %></h2>
+<% @submission.submission_history.order(:created_at).each do |history| %>
+  <div class="govuk-summary-card">
+  <div class="govuk-summary-card__title-wrapper">
+    <h2 class="govuk-summary-card__title"><%= history.id %> (<%= history.from_state %> > <%= history.to_state %>)</h2>
+  </div>
+  <div class="govuk-summary-card__content">
+    <dl class="govuk-summary-list">
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">from_state</dt>
+        <dd class="govuk-summary-list__value"><%= history.from_state %></dd>
+      </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key"> to_state</dt>
+        <dd class="govuk-summary-list__value"><%= history.to_state %></dd>
+      </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key"><%= t("generic.success") %></dt>
+        <dd class="govuk-summary-list__value"><%= history.success %></dd>
+      </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key"><%= t(".request") %></dt>
+        <dd class="govuk-summary-list__value">
+          <% if history.request.nil? %>
+            Request is nil
+          <% else %>
+            <details>
+              <summary class="govuk-heading-m govuk-details__summary">
+                <%= t(".expand") %>
+              </summary>
+              <section>
+                <%= history.request %>
+              </section>
+            </details>
+          <% end %>
+        </dd>
+      </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key"><%= t(".response") %></dt>
+        <dd class="govuk-summary-list__value">
+          <% if history.response.nil? %>
+              response is nil
+          <% else %>
+            <details>
+              <summary class="govuk-heading-m govuk-details__summary">
+                <%= t(".expand") %>
+              </summary>
+              <section>
+                <%= history.response %>
+              </section>
+            </details>
+          <% end %>
+        </dd>
+      </div>
+    </dl>
+  </div>
+</div>
+<% end %>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -3,6 +3,7 @@
     <ul class="app-navigation__list govuk-width-container">
       <%= admin_nav_to t(".applications"), admin_root_path %>
       <%= admin_nav_to t(".edit_settings"), admin_settings_path %>
+      <%= admin_nav_to t(".ccms_queue"), admin_ccms_queues_path %>
       <%= admin_nav_to t(".submitted_applications_report"), admin_submitted_applications_report_path %>
       <%= admin_nav_to t(".feedback"), admin_feedback_path %>
       <%= admin_nav_to t(".reports"), admin_reports_path %>

--- a/config/locales/cy/layouts.yml
+++ b/config/locales/cy/layouts.yml
@@ -4,6 +4,7 @@ cy:
     admin:
       applications: snoitacilppA
       edit_settings: sgnitteS
+      ccms_queue: SMCC
       submitted_applications_report: snoitacilppA dettimbuS
       feedback: kcabdeeF
       reports: stropeR

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -37,10 +37,9 @@ en:
         references: CCMS & case reference
         created_at: Date started
         state: State
-        running: Expired
         sidekiq:
           in_retry: on retry queue
-          false: ""
+          false: Expired
           running: Running
       show:
         submission: CCMS submission

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -54,8 +54,12 @@ en:
         reset: Reset submission
         reset_details: This will reset the submission to `initialized` and restart it.  This will generate a new CCMS reference so you should alert the provider and caseworkers
         submission_histories: Submission histories
+        from_state: From state
+        to_state: To state
         request: Request
+        request_is_nil: Request is nil
         response: Response
+        response_is_nil: Response is nil
         expand: Expand
     settings:
       show:

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -30,6 +30,34 @@ en:
         data_view: Submission details
       search:
         error: Please enter a search criteria
+    ccms_queues:
+      index:
+        page_title: Incomplete CCMS Submissions
+        applicant_name: Client's name
+        references: CCMS & case reference
+        created_at: Date started
+        state: State
+        running: Expired
+        sidekiq:
+          in_retry: on retry queue
+          false: ""
+          running: Running
+      show:
+        submission: CCMS submission
+        created_at: Created at
+        updated_at: Updated at
+        status: Status
+        applicant_poll_count: Applicant poll count
+        case_poll_count: Case poll count
+        actions: Actions
+        restart: Restart at current step
+        restart_details: This will restart the submission at the current step and attempt to complete it another 10 times
+        reset: Reset submission
+        reset_details: This will reset the submission to `initialized` and restart it.  This will generate a new CCMS reference so you should alert the provider and caseworkers
+        submission_histories: Submission histories
+        request: Request
+        response: Response
+        expand: Expand
     settings:
       show:
         heading_1: Settings

--- a/config/locales/en/dates.yml
+++ b/config/locales/en/dates.yml
@@ -1,5 +1,8 @@
 ---
 en:
+  time:
+    formats:
+      long_date_time: "%-d %B %Y @ %l:%M%p"
   date:
     formats:
       default: "%Y-%m-%d"

--- a/config/locales/en/layouts.yml
+++ b/config/locales/en/layouts.yml
@@ -2,9 +2,10 @@
 en:
   layouts:
     admin:
-      applications: Applications
+      applications: Apps
       edit_settings: Settings
-      submitted_applications_report: Submitted Applications
+      ccms_queue: CCMS
+      submitted_applications_report: Submitted
       feedback: Feedback
       reports: Reports
       user_admin: User admin

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -65,6 +65,12 @@ Rails.application.routes.draw do
       delete :destroy_all, on: :collection
     end
     resource :settings, only: %i[show update]
+    resources :ccms_queues, only: %i[index show] do
+      member do
+        get "reset_and_restart"
+        get "restart_current_submission"
+      end
+    end
     resource :submitted_applications_report, only: %i[show]
     resource :feedback, controller: :feedback, only: %i[show]
     resources :reports, only: %i[index create]

--- a/spec/models/ccms/submission_spec.rb
+++ b/spec/models/ccms/submission_spec.rb
@@ -176,14 +176,14 @@ module CCMS
       end
     end
 
-    describe "#restart_existing_submission!" do
+    describe "#restart_current_step!" do
       it "is an alias of process_async!" do
-        expect(submission.method(:restart_existing_submission!)).to eql(submission.method(:process_async!))
+        expect(submission.method(:restart_current_step!)).to eql(submission.method(:process_async!))
       end
     end
 
-    describe "#complete_restart!" do
-      subject(:complete_restart) { submission.complete_restart! }
+    describe "#restart_from_beginning!" do
+      subject(:complete_restart) { submission.restart_from_beginning! }
 
       let(:state) { :document_ids_obtained }
       let(:applicant_poll_count) { 1 }

--- a/spec/requests/admin/ccms_queues_controller_spec.rb
+++ b/spec/requests/admin/ccms_queues_controller_spec.rb
@@ -1,0 +1,83 @@
+require "rails_helper"
+
+RSpec.describe Admin::CCMSQueuesController do
+  let(:admin_user) { create(:admin_user) }
+
+  describe "GET index" do
+    subject(:get_index) { get admin_ccms_queues_path }
+
+    before do
+      sign_in admin_user
+    end
+
+    it "renders successfully" do
+      get_index
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "displays page title" do
+      get_index
+      expect(response.body).to include("Incomplete CCMS Submissions")
+    end
+
+    context "when there are no applications on the queue" do
+      it "has a link to the download csv path" do
+        get_index
+        expect(response.body).to include("Queue is empty")
+      end
+    end
+
+    context "when an application is on the queue" do
+      let!(:ccms_submission) { create(:ccms_submission, :case_ref_obtained) }
+
+      it "has a link to the application" do
+        get_index
+        expect(response.body).to include(admin_ccms_queue_path(ccms_submission.id))
+      end
+    end
+  end
+
+  describe "GET show" do
+    subject(:get_show) { get admin_ccms_queue_path(ccms_submission.id) }
+
+    let!(:ccms_submission) { create(:ccms_submission, :case_ref_obtained) }
+
+    before do
+      sign_in admin_user
+      get_show
+    end
+
+    it "renders successfully" do
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "displays ccms case reference" do
+      expect(response.body).to include(ccms_submission.case_ccms_reference)
+    end
+  end
+
+  describe "GET reset_and_restart" do
+    subject(:get_reset_and_restart) { get reset_and_restart_admin_ccms_queue_path(ccms_submission.id) }
+
+    before { sign_in admin_user }
+
+    let!(:ccms_submission) { create(:ccms_submission, :case_ref_obtained) }
+
+    it "calls submission.complete_restart!" do
+      expect(get_reset_and_restart).to redirect_to(admin_ccms_queue_path(ccms_submission.id))
+    end
+  end
+
+  describe "GET restart_current_submission" do
+    subject(:get_restart_current_submission) { get restart_current_submission_admin_ccms_queue_path(ccms_submission.id) }
+
+    let!(:ccms_submission) { create(:ccms_submission, :case_ref_obtained) }
+
+    before { sign_in admin_user }
+
+    it "calls submission.restart_current_submission" do
+      expect(get_restart_current_submission).to redirect_to(admin_ccms_queue_path(ccms_submission.id))
+      expect(flash[:notice]).to match(ccms_submission.id)
+    end
+  end
+end

--- a/spec/requests/admin/ccms_queues_controller_spec.rb
+++ b/spec/requests/admin/ccms_queues_controller_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Admin::CCMSQueuesController do
     end
 
     context "when there are no applications on the queue" do
-      it "has a link to the download csv path" do
+      it "displays a warning message" do
         get_index
         expect(response.body).to include("Queue is empty")
       end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3915)

This proof of concept will, in its current form, allow admin users to assess the CCMS queue 

Currently, a developer has to access the console to monitor the steps that have been taken and then assess the next best steps 

The hope is that this is the first step in allowing a non-dev admin to see the current state and then re-start submissions
Index page
![image](https://user-images.githubusercontent.com/6757677/224013981-f529ed23-9f47-45e4-ad1a-17a1e9008d49.png)

Individual submission page with both options expanded
![image](https://user-images.githubusercontent.com/6757677/223662274-29a678d3-63fd-4dcf-b05c-7ce41f4a1b7f.png)

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
