### PR TITLE
AP-3896: Remove bank statement upload restrictions

### DIFF
--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -494,8 +494,6 @@ class LegalAidApplication < ApplicationRecord
   end
 
   def uploading_bank_statements?
-    return false unless provider.bank_statement_upload_permissions?
-
     client_not_given_consent_to_open_banking? || attachments.bank_statement_evidence.exists?
   end
 

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -36,10 +36,6 @@ class Provider < ApplicationRecord
     firm.nil? ? [] : firm.permissions
   end
 
-  def bank_statement_upload_permissions?
-    user_permissions.map(&:role).include?("application.non_passported.bank_statement_upload.*")
-  end
-
   def full_section_8_permissions?
     user_permissions.map(&:role).include?("application.full_section_8.*")
   end

--- a/app/views/shared/check_answers/_student_finance.html.erb
+++ b/app/views/shared/check_answers/_student_finance.html.erb
@@ -1,39 +1,34 @@
-<% if @legal_aid_application.provider.bank_statement_upload_permissions? %>
-  <div class="govuk-grid-row" id="app-check-your-answers__student_finance">
-    <div class="govuk-grid-column-two-thirds">
-      <h3 class="govuk-heading-m"><%= t(".heading") %></h3>
-    </div>
-    <div class="govuk-grid-column-one-third govuk-summary-list--no-border align-text-right">
-      <% unless read_only %>
-        <p>
-          <%= link_to_accessible(
-                t("generic.change"),
-                providers_legal_aid_application_means_student_finance_path(@legal_aid_application),
-                class: "govuk-link change-link",
-                suffix: t(".heading"),
-              ) %>
-        </p>
-      <% end %>
-    </div>
+<div class="govuk-grid-row" id="app-check-your-answers__student_finance">
+  <div class="govuk-grid-column-two-thirds">
+    <h3 class="govuk-heading-m"><%= t(".heading") %></h3>
   </div>
-  <dl class="govuk-summary-list govuk-!-margin-bottom-9">
-    <%= check_answer_no_link(
-          name: :student_finance_question,
-          question: t(".does_your_client"),
-          answer: yes_no(@legal_aid_application.receives_student_finance?),
-          read_only: false,
-        ) %>
-
-    <% if @legal_aid_application.receives_student_finance? %>
-        <%= check_answer_no_link(
-              name: :student_finance_annual_amount,
-              question: t(".how_much"),
-              answer: gds_number_to_currency(@legal_aid_application.value_of_student_finance),
-              read_only: false,
+  <div class="govuk-grid-column-one-third govuk-summary-list--no-border align-text-right">
+    <% unless read_only %>
+      <p>
+        <%= link_to_accessible(
+              t("generic.change"),
+              providers_legal_aid_application_means_student_finance_path(@legal_aid_application),
+              class: "govuk-link change-link",
+              suffix: t(".heading"),
             ) %>
+      </p>
     <% end %>
-  </dl>
-<% else %>
-  <h3 class="govuk-heading-m"><%= t(".heading") %></h3>
-  <p><%= t(".info_html", student_finance: value_with_currency_unit(@legal_aid_application.value_of_student_finance, t("currency.gbp"))) %></p>
-<% end %>
+  </div>
+</div>
+<dl class="govuk-summary-list govuk-!-margin-bottom-9">
+  <%= check_answer_no_link(
+        name: :student_finance_question,
+        question: t(".does_your_client"),
+        answer: yes_no(@legal_aid_application.receives_student_finance?),
+        read_only: false,
+      ) %>
+
+  <% if @legal_aid_application.receives_student_finance? %>
+      <%= check_answer_no_link(
+            name: :student_finance_annual_amount,
+            question: t(".how_much"),
+            answer: gds_number_to_currency(@legal_aid_application.value_of_student_finance),
+            read_only: false,
+          ) %>
+  <% end %>
+</dl>

--- a/db/migrate/20200708102815_create_permissions_table.rb
+++ b/db/migrate/20200708102815_create_permissions_table.rb
@@ -6,8 +6,5 @@ class CreatePermissionsTable < ActiveRecord::Migration[6.0]
     end
 
     add_index :permissions, :role, unique: true
-
-    require Rails.root.join("db/seeds/permissions")
-    PermissionsPopulator.run
   end
 end

--- a/db/seeds/permissions.rb
+++ b/db/seeds/permissions.rb
@@ -16,6 +16,13 @@ class PermissionsPopulator
       Rails.logger.info "Removing #{permission.role} permission from database"
       permission.destroy!
     end
+    ActorPermission.group(:permission_id).count.each do |permission_id, count|
+      next if Permission.find(permission_id)
+
+    rescue ActiveRecord::RecordNotFound
+      Rails.logger.info "Delete #{count} ActorPermissions for #{permission_id}"
+      ActorPermission.where(permission_id:).delete_all
+    end
   end
 end
 

--- a/db/seeds/permissions.rb
+++ b/db/seeds/permissions.rb
@@ -1,6 +1,5 @@
 class PermissionsPopulator
   ROLES = {
-    "application.non_passported.bank_statement_upload.*" => "Can upload bank statements",
     "application.full_section_8.*" => "Can use full set of section 8 proceedings",
   }.freeze
 

--- a/features/providers/applicant_details.feature
+++ b/features/providers/applicant_details.feature
@@ -354,20 +354,6 @@ Feature: Applicant details
     Then I should be on a page showing "DWP records show that your client does not receive a passporting benefit"
 
   @javascript @vcr
-  Scenario: I am instructed to use CCMS when the applicant is not eligible
-    Given I start the application with a negative benefit check result
-    Then I should be on a page showing "DWP records show that your client does not receive a passporting benefit"
-    Then I choose 'Yes'
-    Then I click 'Save and continue'
-    And I should be on a page showing "What is your client's employment status?"
-    And I select "None of the above"
-    When I click 'Save and continue'
-    Then I should be on a page with title "We need your client's bank statements from the last 3 months"
-    Then I choose 'No'
-    Then I click 'Save and continue'
-    Then I should be on a page showing "You need to apply using CCMS"
-
-  @javascript @vcr
   Scenario: I want to change client details after a failed benefit check
     Given I start the application with a negative benefit check result
     Then I should be on a page showing "DWP records show that your client does not receive a passporting benefit"

--- a/features/step_definitions/bank_statement_upload_steps.rb
+++ b/features/step_definitions/bank_statement_upload_steps.rb
@@ -9,9 +9,6 @@ Given "I have completed a non-passported employed application with bank statemen
     :provider_confirming_applicant_eligibility,
   )
 
-  @legal_aid_application.provider.permissions << Permission.find_by(role: "application.non_passported.bank_statement_upload.*")
-  @legal_aid_application.provider.save!
-
   login_as @legal_aid_application.provider
 
   visit(providers_legal_aid_application_open_banking_consents_path(@legal_aid_application))
@@ -33,9 +30,6 @@ Given "I have completed a non-passported employed application with bank statemen
 
   create :attachment, :bank_statement, legal_aid_application: @legal_aid_application
 
-  @legal_aid_application.provider.permissions << Permission.find_by(role: "application.non_passported.bank_statement_upload.*")
-  @legal_aid_application.provider.save!
-
   login_as @legal_aid_application.provider
 
   visit(providers_legal_aid_application_means_check_income_answers_path(@legal_aid_application))
@@ -51,9 +45,6 @@ Given "I have completed a non-passported non-employed application with bank stat
   )
 
   create :attachment, :bank_statement, legal_aid_application: @legal_aid_application
-
-  @legal_aid_application.provider.permissions << Permission.find_by(role: "application.non_passported.bank_statement_upload.*")
-  @legal_aid_application.provider.save!
 
   login_as @legal_aid_application.provider
 

--- a/features/step_definitions/check_your_answers_steps.rb
+++ b/features/step_definitions/check_your_answers_steps.rb
@@ -25,9 +25,6 @@ Given("I have completed the income section of a non-passported application with 
     set_lead_proceeding: :da002,
   )
 
-  @legal_aid_application.provider.permissions << Permission.find_by(role: "application.non_passported.bank_statement_upload.*")
-  @legal_aid_application.provider.save!
-
   login_as @legal_aid_application.provider
 end
 
@@ -62,9 +59,6 @@ Given("I have completed the income and capital sections of a non-passported appl
     explicit_proceedings: %i[da002 da006],
     set_lead_proceeding: :da002,
   )
-
-  @legal_aid_application.provider.permissions << Permission.find_by(role: "application.non_passported.bank_statement_upload.*")
-  @legal_aid_application.provider.save!
 
   login_as @legal_aid_application.provider
 end

--- a/features/step_definitions/means_report_steps.rb
+++ b/features/step_definitions/means_report_steps.rb
@@ -29,9 +29,6 @@ Given("I have completed a non-passported employed application with bank statemen
     attachments: [build(:attachment, :bank_statement)],
   )
 
-  @legal_aid_application.provider.permissions << Permission.find_by(role: "application.non_passported.bank_statement_upload.*")
-  @legal_aid_application.provider.save!
-
   login_as @legal_aid_application.provider
 end
 
@@ -66,9 +63,6 @@ Given("I have completed a non-passported application with truelayer") do
     set_lead_proceeding: :da002,
   )
 
-  @legal_aid_application.provider.permissions << Permission.find_by(role: "application.non_passported.bank_statement_upload.*")
-  @legal_aid_application.provider.save!
-
   login_as @legal_aid_application.provider
 end
 
@@ -100,9 +94,6 @@ Given("I have completed a passported application") do
     explicit_proceedings: %i[da002 da006],
     set_lead_proceeding: :da002,
   )
-
-  @legal_aid_application.provider.permissions << Permission.find_by(role: "application.non_passported.bank_statement_upload.*")
-  @legal_aid_application.provider.save!
 
   login_as @legal_aid_application.provider
 end

--- a/features/step_definitions/review_and_print_steps.rb
+++ b/features/step_definitions/review_and_print_steps.rb
@@ -31,8 +31,6 @@ Given("I have completed a bank statement upload application with merits") do
     attachments: [build(:attachment, :bank_statement)],
   )
 
-  @legal_aid_application.provider.permissions << Permission.find_by(role: "application.non_passported.bank_statement_upload.*")
-  @legal_aid_application.provider.save!
   create :legal_framework_merits_task_list, :da002_da006_as_applicant, legal_aid_application: @legal_aid_application
 
   login_as @legal_aid_application.provider
@@ -71,8 +69,6 @@ Given("I have completed truelayer application with merits") do
     set_lead_proceeding: :da002,
   )
 
-  @legal_aid_application.provider.permissions << Permission.find_by(role: "application.non_passported.bank_statement_upload.*")
-  @legal_aid_application.provider.save!
   create :legal_framework_merits_task_list, :da002_da006_as_applicant, legal_aid_application: @legal_aid_application
 
   login_as @legal_aid_application.provider
@@ -111,8 +107,6 @@ Given("I have completed truelayer application with merits and no student finance
     student_finance: false,
   )
   create :legal_framework_merits_task_list, :da002_da006_as_applicant, legal_aid_application: @legal_aid_application
-  @legal_aid_application.provider.permissions << Permission.find_by(role: "application.non_passported.bank_statement_upload.*")
-  @legal_aid_application.provider.save!
 
   login_as @legal_aid_application.provider
 end
@@ -146,8 +140,6 @@ Given("I have completed a passported application with merits") do
     set_lead_proceeding: :da002,
   )
 
-  @legal_aid_application.provider.permissions << Permission.find_by(role: "application.non_passported.bank_statement_upload.*")
-  @legal_aid_application.provider.save!
   create :legal_framework_merits_task_list, :da002_da006_as_applicant, legal_aid_application: @legal_aid_application
 
   login_as @legal_aid_application.provider

--- a/spec/factories/permissions.rb
+++ b/spec/factories/permissions.rb
@@ -3,11 +3,6 @@ FactoryBot.define do
     sequence(:role) { |n| "role_#{n}" }
     sequence(:description) { |n| "The description for role_#{n}" }
 
-    trait :bank_statement_upload do
-      role { "application.non_passported.bank_statement_upload.*" }
-      description { "Can upload bank statements" }
-    end
-
     trait :full_section_8 do
       role { "application.full_section_8.*" }
       description { "Can use full set of section 8 proceedings" }

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -14,14 +14,6 @@ FactoryBot.define do
       username { "NEETADESOR" }
     end
 
-    trait :with_bank_statement_upload_permissions do
-      permissions do
-        bank_statement_upload = Permission.find_by(role: "application.non_passported.bank_statement_upload.*")
-        bank_statement_upload = create(:permission, :bank_statement_upload) if bank_statement_upload.nil?
-        [bank_statement_upload]
-      end
-    end
-
     trait :with_full_section_8_permissions do
       permissions do
         full_section_8 = Permission.find_by(role: "application.full_section_8.*")

--- a/spec/models/legal_aid_application_spec.rb
+++ b/spec/models/legal_aid_application_spec.rb
@@ -1722,42 +1722,29 @@ RSpec.describe LegalAidApplication do
   end
 
   describe "#uploading_bank_statements?" do
-    let(:laa) { create(:legal_aid_application, provider:, provider_received_citizen_consent: consent) }
+    let(:laa) { create(:legal_aid_application, provider_received_citizen_consent: consent) }
 
-    context "when provider does not have bank statement upload role" do
-      let(:provider) { create(:provider) }
-      let(:consent) { nil }
+    context "when client permission to use true layer received" do
+      let(:consent) { true }
 
       it "returns false" do
         expect(laa.uploading_bank_statements?).to be false
       end
     end
 
-    context "when provider has bank statement upload role" do
-      let(:provider) { create(:provider, :with_bank_statement_upload_permissions) }
+    context "when client permission to use true layer not received" do
+      let(:consent) { false }
 
-      context "when client permission to use true layer received" do
-        let(:consent) { true }
-
-        it "returns false" do
-          expect(laa.uploading_bank_statements?).to be false
-        end
+      it "returns true" do
+        expect(laa.uploading_bank_statements?).to be true
       end
+    end
 
-      context "when client permission to use true layer not received" do
-        let(:consent) { false }
+    context "when client permission to use true layer not specified" do
+      let(:consent) { nil }
 
-        it "returns true" do
-          expect(laa.uploading_bank_statements?).to be true
-        end
-      end
-
-      context "when client permission to use true layer not specified" do
-        let(:consent) { nil }
-
-        it "returns false" do
-          expect(laa.uploading_bank_statements?).to be false
-        end
+      it "returns false" do
+        expect(laa.uploading_bank_statements?).to be false
       end
     end
   end

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -119,24 +119,6 @@ RSpec.describe Provider do
     end
   end
 
-  describe "#bank_statement_upload_permissions?" do
-    context "when provider does not have bank statement upload permissions" do
-      let(:provider) { create(:provider, :with_no_permissions) }
-
-      it "returns false" do
-        expect(provider.bank_statement_upload_permissions?).to be false
-      end
-    end
-
-    context "when provider has bank statement upload permissions" do
-      let(:provider) { create(:provider, :with_bank_statement_upload_permissions) }
-
-      it "returns true" do
-        expect(provider.bank_statement_upload_permissions?).to be true
-      end
-    end
-  end
-
   describe "#full_section_8_permissions?" do
     context "when provider does not have full section 8 permissions" do
       let(:provider) { create(:provider, :with_no_permissions) }

--- a/spec/requests/providers/bank_statements_spec.rb
+++ b/spec/requests/providers/bank_statements_spec.rb
@@ -333,18 +333,6 @@ RSpec.describe "Providers::BankStatementsController" do
         end
 
         context "when HMRC response status is applicant_not_employed, " \
-                "but application is not using bank upload journey" do
-          before do
-            allow(HMRC::StatusAnalyzer).to receive(:call).and_return :applicant_not_employed
-          end
-
-          it "redirects to identify types of income page" do
-            request
-            expect(response).to redirect_to(providers_legal_aid_application_means_identify_types_of_income_path(legal_aid_application))
-          end
-        end
-
-        context "when HMRC response status is applicant_not_employed, " \
                 "and application is using bank upload journey" do
           before do
             allow(HMRC::StatusAnalyzer).to receive(:call).and_return :applicant_not_employed

--- a/spec/requests/providers/bank_statements_spec.rb
+++ b/spec/requests/providers/bank_statements_spec.rb
@@ -332,15 +332,9 @@ RSpec.describe "Providers::BankStatementsController" do
           end
         end
 
-        context "when HMRC response status is applicant_not_employed, " \
-                "and application is using bank upload journey" do
+        context "when HMRC response status is applicant_not_employed" do
           before do
             allow(HMRC::StatusAnalyzer).to receive(:call).and_return :applicant_not_employed
-            permissions = [
-              create(:permission, :bank_statement_upload),
-            ]
-            provider.permissions << permissions
-            provider.save!
           end
 
           it "redirects to regular income page" do

--- a/spec/requests/providers/means/employed_incomes_spec.rb
+++ b/spec/requests/providers/means/employed_incomes_spec.rb
@@ -86,12 +86,6 @@ RSpec.describe "employed incomes request" do
         context "when the application is using the bank upload journey" do
           let(:application) { create(:legal_aid_application, provider_received_citizen_consent: false) }
 
-          before do
-            permission = create(:permission, :bank_statement_upload)
-            provider.permissions << permission
-            provider.save!
-          end
-
           it "redirects to the regular income page" do
             request
             expect(response).to redirect_to(providers_legal_aid_application_means_regular_incomes_path(application))

--- a/spec/requests/providers/means/full_employment_details_controller_spec.rb
+++ b/spec/requests/providers/means/full_employment_details_controller_spec.rb
@@ -104,12 +104,6 @@ RSpec.describe Providers::Means::FullEmploymentDetailsController do
         context "when the application is using the bank upload journey" do
           let(:application) { create(:legal_aid_application, provider_received_citizen_consent: false) }
 
-          before do
-            permission = create(:permission, :bank_statement_upload)
-            provider.permissions << permission
-            provider.save!
-          end
-
           it "redirects to the regular incomes page" do
             request
             expect(response).to redirect_to(providers_legal_aid_application_means_regular_incomes_path(application))

--- a/spec/requests/providers/means/student_finances_controller_spec.rb
+++ b/spec/requests/providers/means/student_finances_controller_spec.rb
@@ -120,17 +120,11 @@ RSpec.describe Providers::Means::StudentFinancesController do
         end
       end
 
-      context "when the provider has bank statement upload permissions" do
+      context "when the application is using the bank upload journey" do
         let(:legal_aid_application) { create(:legal_aid_application, provider_received_citizen_consent: false) }
 
         let(:next_page) do
           providers_legal_aid_application_means_regular_outgoings_path(legal_aid_application)
-        end
-
-        before do
-          permission = create(:permission, :bank_statement_upload)
-          provider.permissions << permission
-          provider.save!
         end
 
         it "redirects to the regular outgoings page" do
@@ -142,7 +136,7 @@ RSpec.describe Providers::Means::StudentFinancesController do
         end
       end
 
-      context "when the provider does not have bank statement upload permissions" do
+      context "when the application is not using the bank upload journey" do
         let(:next_page) do
           providers_legal_aid_application_means_identify_types_of_outgoing_path(legal_aid_application)
         end

--- a/spec/requests/providers/open_banking_consents_spec.rb
+++ b/spec/requests/providers/open_banking_consents_spec.rb
@@ -88,17 +88,6 @@ RSpec.describe "does client use online banking requests" do
             expect(response).to redirect_to(providers_legal_aid_application_bank_statements_path(application))
           end
         end
-
-        context "when provider is not bank statement upload enabled" do
-          before do
-            application.provider.permissions.find_by(role: "application.non_passported.bank_statement_upload.*")&.destroy!
-          end
-
-          it "redirects to the use ccms page" do
-            request
-            expect(response).to redirect_to(providers_legal_aid_application_use_ccms_path(application))
-          end
-        end
       end
 
       context "when no option is chosen" do

--- a/spec/requests/providers/open_banking_consents_spec.rb
+++ b/spec/requests/providers/open_banking_consents_spec.rb
@@ -77,16 +77,9 @@ RSpec.describe "does client use online banking requests" do
       context "when provider_received_citizen_consent is false" do
         let(:provider_received_citizen_consent) { "false" }
 
-        context "when provider is bank statement upload enabled" do
-          before do
-            permission = build(:permission, :bank_statement_upload)
-            application.provider.permissions << permission
-          end
-
-          it "redirects to the bank statement upload page" do
-            request
-            expect(response).to redirect_to(providers_legal_aid_application_bank_statements_path(application))
-          end
+        it "redirects to the bank statement upload page" do
+          request
+          expect(response).to redirect_to(providers_legal_aid_application_bank_statements_path(application))
         end
       end
 

--- a/spec/requests/providers/open_banking_guidances_controller_spec.rb
+++ b/spec/requests/providers/open_banking_guidances_controller_spec.rb
@@ -81,28 +81,9 @@ RSpec.describe Providers::OpenBankingGuidancesController do
       context "when no is selected" do
         let(:can_client_use_truelayer) { "false" }
 
-        context "when provider has bank upload permissions" do
-          before do
-            permission = build(:permission, :bank_statement_upload)
-            legal_aid_application.provider.permissions << permission
-            request
-          end
-
-          it "redirects to the bank statement upload page" do
-            request
-            expect(response).to redirect_to providers_legal_aid_application_bank_statements_path
-          end
-        end
-
-        context "when provider does not have bank upload permissions" do
-          before do
-            legal_aid_application.provider.permissions.find_by(role: "application.non_passported.bank_statement_upload.*")&.destroy!
-          end
-
-          it "redirects to the use ccms page" do
-            request
-            expect(response).to redirect_to providers_legal_aid_application_use_ccms_path
-          end
+        it "redirects to the bank statement upload page" do
+          request
+          expect(response).to redirect_to providers_legal_aid_application_bank_statements_path
         end
       end
     end

--- a/spec/services/ccms/manual_review_determiner_spec.rb
+++ b/spec/services/ccms/manual_review_determiner_spec.rb
@@ -230,8 +230,8 @@ module CCMS
           end
         end
 
-        context "with uploading_bank_statements" do
-          let(:provider) { create(:provider, :with_bank_statement_upload_permissions) }
+        context "with uploaded bank_statements" do
+          let(:provider) { create(:provider) }
           let(:legal_aid_application) { create(:legal_aid_application, attachments: [bank_statement], provider:) }
           let(:bank_statement) { create(:attachment, :bank_statement) }
           let!(:cfe_result) { create(:cfe_v5_result, submission: cfe_submission) }

--- a/spec/services/cfe/submission_manager_spec.rb
+++ b/spec/services/cfe/submission_manager_spec.rb
@@ -58,7 +58,6 @@ module CFE
                  :applicant_entering_means,
                  :with_regular_transactions,
                  vehicle:,
-                 provider: build(:provider, :with_bank_statement_upload_permissions),
                  attachments: [build(:attachment, :bank_statement)])
         end
 
@@ -194,7 +193,6 @@ module CFE
                  :with_everything,
                  :with_negative_benefit_check_result,
                  :applicant_entering_means,
-                 provider: build(:provider, :with_bank_statement_upload_permissions),
                  attachments: [build(:attachment, :bank_statement)])
         end
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3896)

As part of a phased rollout a set of permissions was created, `application.non_passported.bank_statement_upload.*`, and granted to certain firms.

We now want everyone to be able to use this feature so we are removing the permissions completely so that all users will have access

This PR removes the permissions, factory traits, and code references.  When it is merged, _all_ providers will be able to upload bank statements for their clients

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
