### PR TITLE
AP-3943: Fix for citizens locked out of applications

### DIFF
--- a/app/controllers/citizens/legal_aid_applications_controller.rb
+++ b/app/controllers/citizens/legal_aid_applications_controller.rb
@@ -11,8 +11,12 @@ module Citizens
       return expired if application_error == :expired
 
       legal_aid_application.applicant.remember_me!
-      legal_aid_application.applicant_enter_means!
-      start_applicant_flow
+      if legal_aid_application.checking_citizen_answers?
+        continue_applicant_flow
+      else
+        legal_aid_application.applicant_enter_means!
+        start_applicant_flow
+      end
     end
 
   private
@@ -30,6 +34,13 @@ module Citizens
       refresh_session
       sign_applicant_in_via_devise(legal_aid_application.applicant)
       redirect_to citizens_legal_aid_applications_path
+    end
+
+    def continue_applicant_flow
+      sign_out current_provider if provider_signed_in?
+      refresh_session
+      sign_applicant_in_via_devise(legal_aid_application.applicant)
+      redirect_to citizens_check_answers_path
     end
 
     def sign_applicant_in_via_devise(applicant)

--- a/spec/requests/citizens/legal_aid_applications_controller_spec.rb
+++ b/spec/requests/citizens/legal_aid_applications_controller_spec.rb
@@ -38,6 +38,25 @@ RSpec.describe Citizens::LegalAidApplicationsController do
       expect(session["page_history_id"]).not_to be_nil
     end
 
+    context "when the applicant has reached the check your answers page" do
+      let(:legal_aid_application) do
+        create(
+          :application,
+          :with_applicant,
+          :with_non_passported_state_machine,
+          :checking_citizen_answers,
+          completed_at:,
+          applicant: build(:applicant, first_name: "Test", last_name: "Applicant"),
+          provider: build(:provider, firm: build(:firm, name: "Test Firm")),
+        )
+      end
+
+      it "redirects back there" do
+        request
+        expect(response).to redirect_to(citizens_check_answers_path)
+      end
+    end
+
     context "when no matching legal aid application exists" do
       let(:token) { SecureRandom.uuid }
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3943)

When a citizen reaches the CYA page, the state of the application changes. If they close the browser and return later, the application tries to run the same starting code that involves resetting the state.  The state machine does not allow this and, even if it did, would mean they update their bank statements twice.

This checks for the change of state and routes them back to the CYA page

A ticket to investigate a proper save and return function for citizens will investigate a better long term solution 🤞

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
