### PR TITLE
Refactor Settings

### DIFF
--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -18,12 +18,7 @@ module Admin
   private
 
     def form_params
-      params.require(:setting).permit(:mock_true_layer_data,
-                                      :manually_review_all_cases,
-                                      :allow_welsh_translation,
-                                      :enable_ccms_submission,
-                                      :means_test_review_phase_one,
-                                      :partner_means_assessment)
+      params.require(:setting).permit(*Setting::ATTRIBUTES)
     end
 
     def setting

--- a/app/forms/settings/setting_form.rb
+++ b/app/forms/settings/setting_form.rb
@@ -2,19 +2,8 @@ module Settings
   class SettingForm < BaseForm
     form_for Setting
 
-    attr_accessor :mock_true_layer_data,
-                  :manually_review_all_cases,
-                  :allow_welsh_translation,
-                  :enable_ccms_submission,
-                  :means_test_review_phase_one,
-                  :partner_means_assessment
+    attr_accessor(*::Setting::ATTRIBUTES)
 
-    validates :mock_true_layer_data,
-              :manually_review_all_cases,
-              :allow_welsh_translation,
-              :enable_ccms_submission,
-              :means_test_review_phase_one,
-              :partner_means_assessment,
-              presence: true
+    validates_presence_of(*::Setting::ATTRIBUTES)
   end
 end

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -1,37 +1,33 @@
 class Setting < ApplicationRecord
-  def self.mock_true_layer_data?
-    setting.mock_true_layer_data?
+  ATTRIBUTES = %i[
+    mock_true_layer_data
+    manually_review_all_cases
+    allow_welsh_translation
+    enable_ccms_submission
+    means_test_review_phase_one
+    partner_means_assessment
+  ].freeze
+
+  def self.method_missing(method_name, *args, &)
+    attribute_or_predicate = method_name.to_s.tr("?", "").to_sym
+
+    if attribute_or_predicate.in?(ATTRIBUTES)
+      setting.public_send(method_name, *args, &)
+    else
+      super
+    end
   end
 
-  def self.bank_transaction_filename
-    setting.bank_transaction_filename
-  end
-
-  def self.manually_review_all_cases?
-    setting.manually_review_all_cases
-  end
-
-  def self.allow_welsh_translation?
-    setting.allow_welsh_translation
-  end
-
-  def self.enable_ccms_submission?
-    setting.enable_ccms_submission
-  end
-
-  def self.alert_via_sentry?
-    setting.alert_via_sentry
-  end
-
-  def self.means_test_review_phase_one?
-    setting.means_test_review_phase_one
-  end
-
-  def self.partner_means_assessment?
-    setting.partner_means_assessment
+  def self.respond_to_missing?(method_name, include_private = false)
+    attribute_or_predicate = method_name.to_s.tr("?", "").to_sym
+    attribute_or_predicate.in?(ATTRIBUTES) || super
   end
 
   def self.setting
     Setting.first || Setting.create!
+  end
+
+  def self.bank_transaction_filename
+    setting.bank_transaction_filename
   end
 end

--- a/app/views/admin/settings/show.html.erb
+++ b/app/views/admin/settings/show.html.erb
@@ -6,66 +6,18 @@
         local: true,
       ) do |form| %>
 
-    <%= form.govuk_collection_radio_buttons(
-          :mock_true_layer_data,
-          yes_no_options,
-          :value,
-          :label,
-          inline: true,
-          hint: { text: t(".hints.mock_true_layer_data", bank_transaction_filename: Setting.bank_transaction_filename) },
-          legend: { text: t(".labels.mock_true_layer_data") },
-        ) %>
+      <% Setting::ATTRIBUTES.each do |attribute| %>
+        <%= form.govuk_collection_radio_buttons(
+              attribute,
+              yes_no_options,
+              :value,
+              :label,
+              inline: true,
+              hint: { text: t(".hints.#{attribute}") },
+              legend: { text: t(".labels.#{attribute}") },
+            ) %>
+      <% end %>
 
-    <%= form.govuk_collection_radio_buttons(
-          :manually_review_all_cases,
-          yes_no_options,
-          :value,
-          :label,
-          inline: true,
-          hint: { text: t(".hints.manually_review_all_cases") },
-          legend: { text: t(".labels.manually_review_all_cases") },
-        ) %>
-
-    <%= form.govuk_collection_radio_buttons(
-          :allow_welsh_translation,
-          yes_no_options,
-          :value,
-          :label,
-          inline: true,
-          hint: { text: t(".hints.allow_welsh_translation") },
-          legend: { text: t(".labels.allow_welsh_translation") },
-        ) %>
-
-    <%= form.govuk_collection_radio_buttons(
-          :enable_ccms_submission,
-          yes_no_options,
-          :value,
-          :label,
-          inline: true,
-          hint: { text: t(".hints.enable_ccms_submission") },
-          legend: { text: t(".labels.enable_ccms_submission") },
-        ) %>
-
-    <%= form.govuk_collection_radio_buttons(
-          :means_test_review_phase_one,
-          yes_no_options,
-          :value,
-          :label,
-          inline: true,
-          hint: { text: t(".hints.means_test_review_phase_one") },
-          legend: { text: t(".labels.means_test_review_phase_one") },
-        ) %>
-
-    <%= form.govuk_collection_radio_buttons(
-          :partner_means_assessment,
-          yes_no_options,
-          :value,
-          :label,
-          inline: true,
-          hint: { text: t(".hints.partner_means_assessment") },
-          legend: { text: t(".labels.partner_means_assessment") },
-        ) %>
-
-    <%= form.submit(t("generic.submit"), class: "govuk-button form-button") %>
+    <%= form.submit t("generic.submit"), class: "govuk-button" %>
   <% end %>
 <% end %>

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -42,7 +42,10 @@ en:
           means_test_review_phase_one: Enable changes for MTR Phase 1
           partner_means_assessment: Enable Partner Means Assessment
         hints:
-          mock_true_layer_data: Select Yes and TrueLayer data will be replaced by mock data from %{bank_transaction_filename}
+          mock_true_layer_data: >
+            Select Yes and TrueLayer data will be replaced by mock data from
+            db/sample_data/bank_transactions.csv. This path is configured with
+            the bank_transaction_filename setting.
           manually_review_all_cases: |
             All applications with capital contributions AND restrictions on assets will be routed to caseworker for review.
             Select Yes to additionally route all non-passported applications to caseworker for review.


### PR DESCRIPTION
Before, new methods needed to be defined each time a new Setting was added to the application.

This leans on `method_missing` to delegate to the Setting record.

Adding a new Setting now only involves adding the attribute to `Setting::ATTRIBUTES`, defining labels and hint text, and running a migration to add the new field to the Settings table.

Compare #5081 to #5044 or #4577 to see how it might make your life easier.