### PR TITLE
Bump Devise to v4.9.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ gem "webdack-uuid_migration", "~> 1.4.0"
 gem "bootsnap", ">= 1.1.0", require: false
 
 # Authentication
-gem "devise", ">= 4.8.0" # User authentication
+gem "devise" # User authentication
 gem "devise_saml_authenticatable", ">= 1.7.0"
 gem "omniauth", ">= 2.0.0"
 gem "omniauth-google-oauth2", ">= 0.8.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -211,7 +211,7 @@ GEM
     declarative (0.0.20)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
-    devise (4.8.1)
+    devise (4.9.0)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
       railties (>= 4.1.0)
@@ -723,7 +723,7 @@ DEPENDENCIES
   cucumber
   cucumber-rails (>= 2.4.0)
   database_cleaner
-  devise (>= 4.8.0)
+  devise
   devise_saml_authenticatable (>= 1.7.0)
   dibber
   discard (~> 1.2)


### PR DESCRIPTION
The new version of Devise includes support for Hotwire/Turbo.

We're not using Turbo, so we shouldn't need to change anything.

[Changelog](https://github.com/heartcombo/devise/blob/main/CHANGELOG.md#490---2023-02-17)