### PR TITLE
Fix: Error with bank uploads

### DIFF
--- a/app/models/concerns/non_passported_state_machine.rb
+++ b/app/models/concerns/non_passported_state_machine.rb
@@ -15,6 +15,7 @@ class NonPassportedStateMachine < BaseStateMachine
                     delegated_functions_used
                     provider_confirming_applicant_eligibility
                     provider_assessing_means
+                    checking_applicant_details
                   ],
                   to: :provider_confirming_applicant_eligibility
     end


### PR DESCRIPTION
## What

A state machine transition error was found on _all_ of the employed page when a user selected employed or none of the above

It could be bypassed by selecting self employed and returning but this allows the application to transition from `checking_applicant_details` to provider_confirm_applicant_eligibility` with no error

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
