### PR TITLE
Update: Allow the bin/div to read $PORT from .env

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,4 +1,4 @@
-web: bin/rails server -p 3002
+web: bin/rails server -p ${PORT:-3002}
 worker: bundle exec sidekiq
 js: yarn build --watch
 css: yarn build:css --watch


### PR DESCRIPTION
## What

Rather than defaulting to 3002, read the PORT=xxxx value from a local `.env` file or use 3002 as a fallback

This ensures that generated emails and script will work if a dev uses 3000, 4050, etc in their local .env file

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
