### PR TITLE
AP-3800: Client has a partner question

### DIFF
--- a/app/controllers/providers/partner/client_has_partners_controller.rb
+++ b/app/controllers/providers/partner/client_has_partners_controller.rb
@@ -1,0 +1,28 @@
+module Providers
+  module Partner
+    class ClientHasPartnersController < ProviderBaseController
+      include PreDWPCheckVisible
+
+      def show
+        @form = Providers::Partners::ClientHasPartnerForm.new(model: applicant)
+      end
+
+      def update
+        @form = Providers::Partners::ClientHasPartnerForm.new(form_params)
+        render :show unless save_continue_or_draft(@form)
+      end
+
+    private
+
+      def applicant
+        legal_aid_application.applicant
+      end
+
+      def form_params
+        merge_with_model(applicant) do
+          params.require(:applicant).permit(:has_partner)
+        end
+      end
+    end
+  end
+end

--- a/app/forms/providers/partners/client_has_partner_form.rb
+++ b/app/forms/providers/partners/client_has_partner_form.rb
@@ -1,0 +1,11 @@
+module Providers
+  module Partners
+    class ClientHasPartnerForm < BaseForm
+      form_for Applicant
+
+      attr_accessor :has_partner
+
+      validates :has_partner, inclusion: %w[true false], unless: :draft?
+    end
+  end
+end

--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -4,7 +4,7 @@ require "omniauth"
 class Applicant < ApplicationRecord
   devise :rememberable
 
-  attribute :has_partner, default: -> { Setting.partner_means_assessment? ? nil : false }
+  attribute :has_partner, :boolean, default: -> { Setting.partner_means_assessment? ? nil : false }
 
   NINO_REGEXP = /\A[A-CEGHJ-PR-TW-Z]{1}[A-CEGHJ-NPR-TW-Z]{1}[0-9]{6}[A-DFM]{1}\z/
 

--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -4,6 +4,8 @@ require "omniauth"
 class Applicant < ApplicationRecord
   devise :rememberable
 
+  attribute :has_partner, default: -> { Setting.partner_means_assessment? ? nil : false }
+
   NINO_REGEXP = /\A[A-CEGHJ-PR-TW-Z]{1}[A-CEGHJ-NPR-TW-Z]{1}[0-9]{6}[A-DFM]{1}\z/
 
   has_one :legal_aid_application, dependent: :destroy

--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -73,7 +73,7 @@ class LegalAidApplication < ApplicationRecord
   validate :validate_document_categories
 
   delegate :bank_transactions, :under_18?, :under_16_blocked?, to: :applicant, allow_nil: true
-  delegate :full_name, to: :applicant, prefix: true, allow_nil: true
+  delegate :full_name, :has_partner, :has_partner?, to: :applicant, prefix: true, allow_nil: true
   delegate :case_ccms_reference, to: :ccms_submission, allow_nil: true
   delegate :applicant_enter_means!,
            :await_applicant!,

--- a/app/services/flow/flows/provider_partner.rb
+++ b/app/services/flow/flows/provider_partner.rb
@@ -1,0 +1,12 @@
+module Flow
+  module Flows
+    class ProviderPartner < FlowSteps
+      STEPS = {
+        client_has_partners: {
+          path: ->(application) { urls.providers_legal_aid_application_client_has_partner_path(application) },
+          forward: :check_provider_answers, # temp until next page is added and this flow is extended
+        },
+      }.freeze
+    end
+  end
+end

--- a/app/services/flow/flows/provider_start.rb
+++ b/app/services/flow/flows/provider_start.rb
@@ -59,8 +59,15 @@ module Flow
         },
         has_national_insurance_numbers: {
           path: ->(application) { urls.providers_legal_aid_application_has_national_insurance_number_path(application) },
-          forward: :check_provider_answers,
+          forward: lambda do |_application|
+            if Setting.partner_means_assessment?
+              :client_has_partners
+            else
+              :check_provider_answers
+            end
+          end,
         },
+        # partner_flow called here
         check_provider_answers: {
           path: ->(application) { urls.providers_legal_aid_application_check_provider_answers_path(application) },
           forward: lambda do |application|

--- a/app/services/flow/provider_flow_service.rb
+++ b/app/services/flow/provider_flow_service.rb
@@ -1,6 +1,7 @@
 module Flow
   class ProviderFlowService < BaseFlowService
     steps = {}.deep_merge(Flows::ProviderStart::STEPS)
+              .deep_merge(Flows::ProviderPartner::STEPS)
               .deep_merge(Flows::ProviderProceedingLoop::STEPS)
               .deep_merge(Flows::ProviderDWPOverride::STEPS)
               .deep_merge(Flows::ProviderCapital::STEPS)

--- a/app/views/providers/partner/client_has_partners/show.html.erb
+++ b/app/views/providers/partner/client_has_partners/show.html.erb
@@ -1,0 +1,33 @@
+<%= form_with(
+      url: providers_legal_aid_application_client_has_partner_path,
+      model: @form,
+      method: :patch,
+      local: true,
+    ) do |form| %>
+  <%= page_template page_title: t(".page_title", count: pluralize(@legal_aid_application.opponents.count, "opponent").to_s),
+                    template: :basic,
+                    form: do %>
+    <%= form.govuk_collection_radio_buttons :has_partner,
+                                            yes_no_options,
+                                            :value,
+                                            :label,
+                                            inline: true,
+                                            legend: { text: t(".page_title"), size: "xl", tag: "h1" } do %>
+
+        <p class="govuk-body"><%= t(".details_content_para_one") %></p>
+        <ul class="govuk-list govuk-list--bullet">
+          <% t(".details.list_one").split("\n").each do |bullet| %>
+            <li><%= bullet %></li>
+          <% end %>
+        </ul>
+        <p class="govuk-body"><%= t(".details_content_para_two") %></p>
+        <ul class="govuk-list govuk-list--bullet">
+          <% t(".details.list_two").split("\n").each do |bullet| %>
+            <li><%= bullet %></li>
+          <% end %>
+        </ul>
+    <% end %>
+
+    <%= next_action_buttons(show_draft: true, form:) %>
+  <% end %>
+<% end %>

--- a/app/views/providers/partner/client_has_partners/show.html.erb
+++ b/app/views/providers/partner/client_has_partners/show.html.erb
@@ -16,13 +16,13 @@
 
         <p class="govuk-body"><%= t(".details_content_para_one") %></p>
         <ul class="govuk-list govuk-list--bullet">
-          <% t(".details.list_one").split("\n").each do |bullet| %>
+          <% t(".details.list_one").each do |bullet| %>
             <li><%= bullet %></li>
           <% end %>
         </ul>
         <p class="govuk-body"><%= t(".details_content_para_two") %></p>
         <ul class="govuk-list govuk-list--bullet">
-          <% t(".details.list_two").split("\n").each do |bullet| %>
+          <% t(".details.list_two").each do |bullet| %>
             <li><%= bullet %></li>
           <% end %>
         </ul>

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -115,6 +115,8 @@ en:
               blank: Select yes if your client is employed
             base:
               none_selected: Select one or more employment types or None of the above if not employed
+            has_partner:
+              inclusion: Select yes if the client has a partner
         aggregated_cash_income:
           credits:
             attributes:

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -501,14 +501,14 @@ en:
           details_content_para_one: "A partner is someone your client is:"
           details_content_para_two: "Do not include anyone who:"
           details:
-            list_one: |
-              married to
-              in a civil partnership with
-              living with as if they were married or in a civil partnership
-            list_two: |
-              your client is permanently separated from
-              is an opponent in the case
-              has 'contrary interest' in the case - this means they want a different outcome to your client
+            list_one:
+              - married to
+              - in a civil partnership with
+              - living with as if they were married or in a civil partnership
+            list_two:
+              - your client is permanently separated from
+              - is an opponent in the case
+              - has 'contrary interest' in the case - this means they want a different outcome to your client
           error: Select yes if your client has a partner
     has_national_insurance_numbers:
       show:

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -349,6 +349,9 @@ en:
         dependants_text: Provide details of your client's dependants (if they have any).
         capital_heading: Tell us about their capital
         capital_text: Provide details of your client's savings, investments and other assets
+    client_has_partners:
+      show:
+        error: Select yes if your client has a partner
     confirm_offices:
       show:
         h1-heading: Is %{office_code} your office account number?
@@ -490,6 +493,23 @@ en:
           hearing-date-set: Has a date been set for the hearing?
           hearing-date: Enter the date
           hearing-date-hint: For example, 12 11 2007
+    partner:
+      client_has_partners:
+        show:
+          page_title: Does your client have a partner?
+          client_has_a_partner: Does your client have a partner?
+          details_content_para_one: "A partner is someone your client is:"
+          details_content_para_two: "Do not include anyone who:"
+          details:
+            list_one: |
+              married to
+              in a civil partnership with
+              living with as if they were married or in a civil partnership
+            list_two: |
+              your client is permanently separated from
+              is an opponent in the case
+              has 'contrary interest' in the case - this means they want a different outcome to your client
+          error: Select yes if your client has a partner
     has_national_insurance_numbers:
       show:
         page_title: Does the client have a National Insurance number?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -262,6 +262,10 @@ Rails.application.routes.draw do
         end
       end
 
+      scope module: :partner do
+        resource :client_has_partner, only: %i[show update]
+      end
+
       scope module: :application_merits_task do
         resources :involved_children, only: %i[new show update]
         resources :remove_involved_child, only: %i[show update]

--- a/db/migrate/20230320094303_add_has_partner_to_applicant.rb
+++ b/db/migrate/20230320094303_add_has_partner_to_applicant.rb
@@ -1,0 +1,7 @@
+class AddHasPartnerToApplicant < ActiveRecord::Migration[7.0]
+  def change
+    add_column :applicants, :has_partner, :boolean
+
+    Applicant.update_all(has_partner: false)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_28_132829) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_20_094303) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -118,6 +118,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_28_132829) do
     t.boolean "has_national_insurance_number"
     t.integer "age_for_means_test_purposes"
     t.jsonb "encrypted_true_layer_token"
+    t.boolean "has_partner"
     t.index ["confirmation_token"], name: "index_applicants_on_confirmation_token", unique: true
     t.index ["email"], name: "index_applicants_on_email"
     t.index ["unlock_token"], name: "index_applicants_on_unlock_token", unique: true

--- a/spec/forms/providers/partners/client_has_partner_form_spec.rb
+++ b/spec/forms/providers/partners/client_has_partner_form_spec.rb
@@ -1,0 +1,115 @@
+require "rails_helper"
+
+RSpec.describe Providers::Partners::ClientHasPartnerForm, type: :form do
+  subject(:instance) { described_class.new(params) }
+
+  let(:applicant) { create(:applicant, has_partner: nil) }
+  let(:legal_aid_application) { create(:legal_aid_application, applicant:) }
+
+  let(:params) do
+    {
+      has_partner:,
+      model: applicant,
+    }
+  end
+
+  describe ".model_name" do
+    it 'is "Applicant"' do
+      expect(described_class.model_name).to eq("Applicant")
+    end
+  end
+
+  describe "#save" do
+    subject(:call_save) { instance.save }
+
+    context "with yes chosen and valid national insurance number provided" do
+      let(:params) { { model: applicant, has_partner: "true" } }
+
+      it "updates has_partner" do
+        expect { call_save }.to change { applicant.attributes.symbolize_keys }
+                                  .from(hash_including(has_partner: nil))
+                                  .to(hash_including(has_partner: true))
+      end
+    end
+
+    context "with no chosen" do
+      let(:params) { { model: applicant, has_partner: "false" } }
+
+      context "when no answer previously chosen" do
+        before { applicant.update!(has_partner: nil) }
+
+        it "updates has_partner" do
+          expect { call_save }.to change { applicant.attributes.symbolize_keys }
+                                    .from(hash_including(has_partner: nil))
+                                    .to(hash_including(has_partner: false))
+        end
+      end
+
+      context "when yes previously chosen" do
+        before { applicant.update!(has_partner: true) }
+
+        it "updates has_national_insurance_number to false" do
+          expect { call_save }.to change(applicant, :has_partner).from(true).to(false)
+        end
+      end
+    end
+
+    context "with no answer chosen" do
+      let(:params) { { has_partner: "", model: applicant } }
+
+      it "is invalid" do
+        call_save
+        expect(instance).to be_invalid
+      end
+
+      it "adds custom blank error message" do
+        call_save
+        error_messages = instance.errors.messages.values.flatten
+        expect(error_messages).to include("Select yes if the client has a partner")
+      end
+    end
+  end
+
+  describe "#save_as_draft" do
+    subject(:save_as_draft) { instance.save_as_draft }
+
+    context "with yes chosen" do
+      let(:params) { { model: applicant, has_partner: "true" } }
+
+      it "updates has_partner" do
+        expect { save_as_draft }.to change { applicant.attributes.symbolize_keys }
+                                      .from(hash_including(has_partner: nil))
+                                      .to(hash_including(has_partner: true))
+      end
+
+      it "is valid" do
+        save_as_draft
+        expect(instance).to be_valid
+      end
+    end
+
+    context "with no chosen" do
+      let(:params) { { model: applicant, has_partner: "false" } }
+
+      it "updates has_partner" do
+        expect { save_as_draft }.to change { applicant.attributes.symbolize_keys }
+                                      .from(hash_including(has_partner: nil))
+                                      .to(hash_including(has_partner: false))
+      end
+
+      it "is valid" do
+        save_as_draft
+        expect(instance).to be_valid
+      end
+    end
+
+    context "with no answer chosen" do
+      let(:params) { { model: applicant, has_partner: "" } }
+
+      it "is valid" do
+        save_as_draft
+        expect(instance).to be_valid
+      end
+    end
+  end
+end

--- a/spec/forms/providers/partners/client_has_partner_form_spec.rb
+++ b/spec/forms/providers/partners/client_has_partner_form_spec.rb
@@ -1,10 +1,10 @@
 require "rails_helper"
 
 RSpec.describe Providers::Partners::ClientHasPartnerForm, type: :form do
-  subject(:instance) { described_class.new(params) }
+  subject(:client_partner_form) { described_class.new(params) }
 
-  let(:applicant) { create(:applicant, has_partner: nil) }
-  let(:legal_aid_application) { create(:legal_aid_application, applicant:) }
+  let(:applicant) { create(:applicant, has_partner: applicant_has_partner) }
+  let(:applicant_has_partner) { nil }
 
   let(:params) do
     {
@@ -13,14 +13,43 @@ RSpec.describe Providers::Partners::ClientHasPartnerForm, type: :form do
     }
   end
 
-  describe ".model_name" do
-    it 'is "Applicant"' do
-      expect(described_class.model_name).to eq("Applicant")
+  describe "#validate" do
+    subject(:validate_form) { client_partner_form.valid? }
+
+    before { validate_form }
+
+    context "with yes chosen" do
+      let(:has_partner) { "true" }
+
+      it "is valid" do
+        expect(client_partner_form).to be_valid
+      end
+    end
+
+    context "with no chosen" do
+      let(:has_partner) { "false" }
+
+      it "is valid" do
+        expect(client_partner_form).to be_valid
+      end
+    end
+
+    context "when no answer chosen" do
+      let(:params) { { has_partner: "", model: applicant } }
+
+      it "is invalid" do
+        expect(client_partner_form).to be_invalid
+      end
+
+      it "adds custom blank error message" do
+        error_messages = client_partner_form.errors.messages.values.flatten
+        expect(error_messages).to include("Select yes if the client has a partner")
+      end
     end
   end
 
   describe "#save" do
-    subject(:call_save) { instance.save }
+    subject(:call_save) { client_partner_form.save }
 
     context "with yes chosen and valid national insurance number provided" do
       let(:params) { { model: applicant, has_partner: "true" } }
@@ -53,62 +82,29 @@ RSpec.describe Providers::Partners::ClientHasPartnerForm, type: :form do
         end
       end
     end
-
-    context "with no answer chosen" do
-      let(:params) { { has_partner: "", model: applicant } }
-
-      it "is invalid" do
-        call_save
-        expect(instance).to be_invalid
-      end
-
-      it "adds custom blank error message" do
-        call_save
-        error_messages = instance.errors.messages.values.flatten
-        expect(error_messages).to include("Select yes if the client has a partner")
-      end
-    end
   end
 
   describe "#save_as_draft" do
-    subject(:save_as_draft) { instance.save_as_draft }
+    subject(:save_as_draft) { client_partner_form.save_as_draft }
 
     context "with yes chosen" do
-      let(:params) { { model: applicant, has_partner: "true" } }
+      let(:has_partner) { "true" }
 
       it "updates has_partner" do
         expect { save_as_draft }.to change { applicant.attributes.symbolize_keys }
                                       .from(hash_including(has_partner: nil))
                                       .to(hash_including(has_partner: true))
       end
-
-      it "is valid" do
-        save_as_draft
-        expect(instance).to be_valid
-      end
     end
 
     context "with no chosen" do
-      let(:params) { { model: applicant, has_partner: "false" } }
+      let(:applicant_has_partner) { nil }
+      let(:has_partner) { "false" }
 
       it "updates has_partner" do
         expect { save_as_draft }.to change { applicant.attributes.symbolize_keys }
                                       .from(hash_including(has_partner: nil))
                                       .to(hash_including(has_partner: false))
-      end
-
-      it "is valid" do
-        save_as_draft
-        expect(instance).to be_valid
-      end
-    end
-
-    context "with no answer chosen" do
-      let(:params) { { model: applicant, has_partner: "" } }
-
-      it "is valid" do
-        save_as_draft
-        expect(instance).to be_valid
       end
     end
   end

--- a/spec/models/applicant_spec.rb
+++ b/spec/models/applicant_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Applicant do
       end
     end
 
-    context "and the partner means test feature flag isoff" do
+    context "and the partner means test feature flag is off" do
       before { allow(Setting).to receive(:partner_means_assessment?).and_return(false) }
 
       it "pre-populates the has_partner field with false" do

--- a/spec/models/applicant_spec.rb
+++ b/spec/models/applicant_spec.rb
@@ -1,6 +1,26 @@
 require "rails_helper"
 
 RSpec.describe Applicant do
+  describe "when creating an applicant record" do
+    subject(:created_applicant) { described_class.create }
+
+    context "and the partner means test feature flag is on" do
+      before { allow(Setting).to receive(:partner_means_assessment?).and_return(true) }
+
+      it "leaves the has_partner field as nil" do
+        expect(created_applicant.has_partner).to be_nil
+      end
+    end
+
+    context "and the partner means test feature flag isoff" do
+      before { allow(Setting).to receive(:partner_means_assessment?).and_return(false) }
+
+      it "pre-populates the has_partner field with false" do
+        expect(created_applicant.has_partner).to be false
+      end
+    end
+  end
+
   describe "on validation" do
     subject { described_class.new }
 

--- a/spec/requests/providers/has_national_insurance_numbers_controller_spec.rb
+++ b/spec/requests/providers/has_national_insurance_numbers_controller_spec.rb
@@ -26,7 +26,14 @@ RSpec.describe Providers::HasNationalInsuranceNumbersController do
   end
 
   describe "PATCH /providers/:application_id/has_national_insurance_number" do
-    subject! { patch providers_legal_aid_application_has_national_insurance_number_path(legal_aid_application), params: }
+    subject(:patch_has_nino) { patch providers_legal_aid_application_has_national_insurance_number_path(legal_aid_application), params: }
+
+    before do
+      allow(Setting).to receive(:partner_means_assessment?).and_return(enable_pma)
+      patch_has_nino
+    end
+
+    let(:enable_pma) { false }
 
     context "when form submitted with Save as draft button" do
       let(:params) { { applicant: { has_national_insurance_number: "" }, draft_button: "Save and come back later" } }
@@ -42,6 +49,14 @@ RSpec.describe Providers::HasNationalInsuranceNumbersController do
       it "redirects to the check your answers page for the applicant" do
         expect(response).to redirect_to(providers_legal_aid_application_check_provider_answers_path(legal_aid_application))
       end
+
+      context "when the MTR feature flag is on" do
+        let(:enable_pma) { true }
+
+        it "redirects to the client_has_partner page" do
+          expect(response).to redirect_to(providers_legal_aid_application_client_has_partner_path(legal_aid_application))
+        end
+      end
     end
 
     context "when no chosen" do
@@ -49,6 +64,14 @@ RSpec.describe Providers::HasNationalInsuranceNumbersController do
 
       it "redirects to the check your answers page for the applicant" do
         expect(response).to redirect_to(providers_legal_aid_application_check_provider_answers_path(legal_aid_application))
+      end
+
+      context "when the MTR feature flag is on" do
+        let(:enable_pma) { true }
+
+        it "redirects to the client_has_partner page" do
+          expect(response).to redirect_to(providers_legal_aid_application_client_has_partner_path(legal_aid_application))
+        end
       end
     end
 

--- a/spec/requests/providers/partner/client_has_partners_controller_spec.rb
+++ b/spec/requests/providers/partner/client_has_partners_controller_spec.rb
@@ -1,0 +1,65 @@
+require "rails_helper"
+
+RSpec.describe Providers::Partner::ClientHasPartnersController do
+  let(:legal_aid_application) { create(:legal_aid_application) }
+  let(:provider) { legal_aid_application.provider }
+
+  before { login_as provider }
+
+  describe "GET /providers/applications/:legal_aid_application_id/client_has_partner" do
+    subject! do
+      get providers_legal_aid_application_client_has_partner_path(legal_aid_application)
+    end
+
+    it "renders page with expected heading" do
+      expect(response).to have_http_status(:ok)
+      expect(page).to have_css(
+        "h1",
+        text: "Does your client have a partner?",
+      )
+    end
+  end
+
+  describe "PATCH /providers/:application_id/client_has_partner" do
+    subject(:patch_has_partner) { patch providers_legal_aid_application_client_has_partner_path(legal_aid_application), params: }
+
+    before { patch_has_partner }
+
+    context "when form submitted with Save as draft button" do
+      let(:params) { { applicant: { has_partner: "" }, draft_button: "Save and come back later" } }
+
+      it "redirects to the list of applications" do
+        expect(response).to redirect_to providers_legal_aid_applications_path
+      end
+    end
+
+    context "when yes chosen" do
+      let(:params) { { applicant: { has_partner: "true" } } }
+
+      it "redirects to the check your answers page for the applicant" do
+        expect(response).to redirect_to(providers_legal_aid_application_check_provider_answers_path(legal_aid_application))
+      end
+    end
+
+    context "when no chosen" do
+      let(:params) { { applicant: { has_partner: "false" } } }
+
+      it "redirects to the check your answers page for the applicant" do
+        expect(response).to redirect_to(providers_legal_aid_application_check_provider_answers_path(legal_aid_application))
+      end
+    end
+
+    context "when no answer chosen" do
+      let(:params) { { applicant: { has_partner: "" }, continue_button: "Save and continue" } }
+
+      it "stays on the page if there is a validation error" do
+        expect(response).to have_http_status(:ok)
+        expect(page).to have_error_message("Select yes if the client has a partner")
+      end
+    end
+
+    def have_error_message(text)
+      have_css(".govuk-error-summary__list > li", text:)
+    end
+  end
+end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3800)

This is the first step page in the partner means assessment flow

It adds a new page that follows the Does your client have a NINO question

A new value has been added to the applicant object (`has_partner`) that stores the response ti the question.  It is expected that this will be used later in flows and assessments as a quick check of the application (and applicant) status

Because we won't store a `has_partner` value until the flag is turned on a default attribute is set using 
```ruby
attribute :has_partner, default: -> { Setting.partner_means_assessment? ? nil : false }
```
rather than a default value at the DB level that will pre-populate the page when testing the new page
The pattern was taken from the [Andy Croll](https://andycroll.com/ruby/assign-a-default-to-an-attribute-active-record/) blog and seemed the simplest to remove when the feature flag is eventually removed

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
