### PR TITLE
Fix: Update cloud-platform-tools-image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ executors:
           CACHE_VERSION: v1
   cloud-platform-executor:
     docker:
-      - image: ministryofjustice/cloud-platform-tools:2.1
+      - image: ministryofjustice/cloud-platform-tools:2.3.0
         environment:
           GITHUB_TEAM_NAME_SLUG: laa-apply-for-legal-aid
   notification-executor:
@@ -82,7 +82,7 @@ references:
         sudo apt-get update
         sudo apt-get install -y python3-pip
         sudo pip3 install awscli
-        $(aws ecr get-login --region eu-west-2 --no-include-email)
+        aws ecr get-login-password --region eu-west-2 | docker login --username AWS --password-stdin ${ECR_ENDPOINT}
 
   setup_uat_kubectl: &setup_uat_kubectl
     run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,7 @@ references:
     run:
       name: Kubectl deployment setup UAT
       command: |
-        $(aws ecr get-login --region eu-west-2 --no-include-email)
+        aws ecr get-login-password --region eu-west-2 | docker login --username AWS --password-stdin ${ECR_ENDPOINT}
         echo -n ${K8S_CLUSTER_CERT_LIVE} | base64 -d > ./ca.crt
         kubectl config set-cluster ${K8S_CLUSTER_NAME_LIVE} --certificate-authority=./ca.crt --server=https://${K8S_CLUSTER_NAME_LIVE}
         kubectl config set-credentials circleci --token=${K8S_TOKEN_LIVE}


### PR DESCRIPTION
## What

Update the cloud platform tool image to 2.3.0
Update the AWS login command to use the aws cli V2

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
