### PR TITLE
Remove redundant module

### DIFF
--- a/app/controllers/concerns/providers/pre_dwp_check_visible.rb
+++ b/app/controllers/concerns/providers/pre_dwp_check_visible.rb
@@ -1,7 +1,0 @@
-module Providers
-  module PreDWPCheckVisible
-    def pre_dwp_check?
-      true
-    end
-  end
-end

--- a/app/controllers/providers/address_lookups_controller.rb
+++ b/app/controllers/providers/address_lookups_controller.rb
@@ -1,7 +1,5 @@
 module Providers
   class AddressLookupsController < ProviderBaseController
-    include PreDWPCheckVisible
-
     def show
       @form = Addresses::AddressLookupForm.new(model: address)
     end

--- a/app/controllers/providers/address_selections_controller.rb
+++ b/app/controllers/providers/address_selections_controller.rb
@@ -1,6 +1,5 @@
 module Providers
   class AddressSelectionsController < ProviderBaseController
-    include PreDWPCheckVisible
     AddressCollectionItem = Struct.new(:id, :address)
 
     def show

--- a/app/controllers/providers/addresses_controller.rb
+++ b/app/controllers/providers/addresses_controller.rb
@@ -1,7 +1,5 @@
 module Providers
   class AddressesController < ProviderBaseController
-    include PreDWPCheckVisible
-
     def show
       @form = Addresses::AddressForm.new(model: address)
     end

--- a/app/controllers/providers/applicant_details_controller.rb
+++ b/app/controllers/providers/applicant_details_controller.rb
@@ -1,7 +1,5 @@
 module Providers
   class ApplicantDetailsController < ProviderBaseController
-    include PreDWPCheckVisible
-
     def show
       @form = Applicants::BasicDetailsForm.new(model: applicant)
     end

--- a/app/controllers/providers/check_benefits_controller.rb
+++ b/app/controllers/providers/check_benefits_controller.rb
@@ -1,6 +1,5 @@
 module Providers
   class CheckBenefitsController < ProviderBaseController
-    include PreDWPCheckVisible
     include ApplicantDetailsCheckable
     include BenefitCheckSkippable
 

--- a/app/controllers/providers/check_provider_answers_controller.rb
+++ b/app/controllers/providers/check_provider_answers_controller.rb
@@ -1,7 +1,5 @@
 module Providers
   class CheckProviderAnswersController < ProviderBaseController
-    include PreDWPCheckVisible
-
     def index
       return redirect_to_client_completed_means if legal_aid_application.provider_assessing_means?
 

--- a/app/controllers/providers/has_national_insurance_numbers_controller.rb
+++ b/app/controllers/providers/has_national_insurance_numbers_controller.rb
@@ -1,7 +1,5 @@
 module Providers
   class HasNationalInsuranceNumbersController < ProviderBaseController
-    include PreDWPCheckVisible
-
     def show
       @form = Applicants::HasNationalInsuranceNumberForm.new(model: applicant)
     end

--- a/app/controllers/providers/limitations_controller.rb
+++ b/app/controllers/providers/limitations_controller.rb
@@ -1,7 +1,5 @@
 module Providers
   class LimitationsController < ProviderBaseController
-    include PreDWPCheckVisible
-
     def show
       @form = LegalAidApplications::EmergencyCostOverrideForm.new(model: legal_aid_application)
       legal_aid_application.enter_applicant_details! unless no_state_change_required?

--- a/app/controllers/providers/partner/client_has_partners_controller.rb
+++ b/app/controllers/providers/partner/client_has_partners_controller.rb
@@ -1,8 +1,6 @@
 module Providers
   module Partner
     class ClientHasPartnersController < ProviderBaseController
-      include PreDWPCheckVisible
-
       def show
         @form = Providers::Partners::ClientHasPartnerForm.new(model: applicant)
       end

--- a/app/controllers/providers/proceeding_loop/client_involvement_type_controller.rb
+++ b/app/controllers/providers/proceeding_loop/client_involvement_type_controller.rb
@@ -1,7 +1,6 @@
 module Providers
   module ProceedingLoop
     class ClientInvolvementTypeController < ProviderBaseController
-      include PreDWPCheckVisible
       before_action :proceeding
 
       def show

--- a/app/controllers/providers/proceeding_loop/delegated_functions_controller.rb
+++ b/app/controllers/providers/proceeding_loop/delegated_functions_controller.rb
@@ -1,7 +1,6 @@
 module Providers
   module ProceedingLoop
     class DelegatedFunctionsController < ProviderBaseController
-      include PreDWPCheckVisible
       before_action :proceeding
 
       def show

--- a/app/controllers/providers/proceeding_loop/emergency_defaults_controller.rb
+++ b/app/controllers/providers/proceeding_loop/emergency_defaults_controller.rb
@@ -1,7 +1,6 @@
 module Providers
   module ProceedingLoop
     class EmergencyDefaultsController < ProviderBaseController
-      include PreDWPCheckVisible
       before_action :proceeding
 
       def show

--- a/app/controllers/providers/proceeding_loop/final_hearings_controller.rb
+++ b/app/controllers/providers/proceeding_loop/final_hearings_controller.rb
@@ -1,7 +1,6 @@
 module Providers
   module ProceedingLoop
     class FinalHearingsController < ProviderBaseController
-      include PreDWPCheckVisible
       before_action :proceeding
 
       def show

--- a/app/controllers/providers/proceeding_loop/substantive_defaults_controller.rb
+++ b/app/controllers/providers/proceeding_loop/substantive_defaults_controller.rb
@@ -1,7 +1,6 @@
 module Providers
   module ProceedingLoop
     class SubstantiveDefaultsController < ProviderBaseController
-      include PreDWPCheckVisible
       before_action :proceeding
 
       def show

--- a/app/controllers/providers/proceedings_types_controller.rb
+++ b/app/controllers/providers/proceedings_types_controller.rb
@@ -1,7 +1,5 @@
 module Providers
   class ProceedingsTypesController < ProviderBaseController
-    include PreDWPCheckVisible
-
     # GET /provider/applications/:legal_aid_application_id/proceedings_types
     def index
       proceeding_types

--- a/spec/requests/providers/address_lookups_spec.rb
+++ b/spec/requests/providers/address_lookups_spec.rb
@@ -25,12 +25,6 @@ RSpec.describe Providers::AddressLookupsController do
         expect(unescaped_response_body).to include(I18n.t("providers.address_lookups.show.heading"))
       end
     end
-
-    describe "#pre_dwp_check?" do
-      it "returns true" do
-        expect(described_class.new.pre_dwp_check?).to be true
-      end
-    end
   end
 
   describe "PATCH/providers/applications/:legal_aid_application_id/address_lookup" do

--- a/spec/requests/providers/address_selections_spec.rb
+++ b/spec/requests/providers/address_selections_spec.rb
@@ -62,12 +62,6 @@ RSpec.describe Providers::AddressSelectionsController do
         end
       end
     end
-
-    describe "#pre_dwp_check?" do
-      it "returns true" do
-        expect(described_class.new.pre_dwp_check?).to be true
-      end
-    end
   end
 
   describe "PATCH /providers/applications/:legal_aid_application_id/address_selections" do

--- a/spec/requests/providers/applicant_details_spec.rb
+++ b/spec/requests/providers/applicant_details_spec.rb
@@ -33,12 +33,6 @@ RSpec.describe Providers::ApplicantDetailsController do
           expect(unescaped_response_body).to include(applicant.first_name)
         end
       end
-
-      describe "#pre_dwp_check?" do
-        it "returns true" do
-          expect(described_class.new.pre_dwp_check?).to be true
-        end
-      end
     end
   end
 

--- a/spec/requests/providers/check_benefits_spec.rb
+++ b/spec/requests/providers/check_benefits_spec.rb
@@ -23,12 +23,6 @@ RSpec.describe Providers::CheckBenefitsController do
       expect(response).to have_http_status(:ok)
     end
 
-    describe "#pre_dwp_check?" do
-      it "returns true" do
-        expect(described_class.new.pre_dwp_check?).to be true
-      end
-    end
-
     it "generates a new check_benefit_result" do
       expect { subject }.to change(BenefitCheckResult, :count).by(1)
     end

--- a/spec/requests/providers/check_provider_answers_spec.rb
+++ b/spec/requests/providers/check_provider_answers_spec.rb
@@ -37,12 +37,6 @@ RSpec.describe Providers::CheckProviderAnswersController do
         expect(response).to be_successful
       end
 
-      describe "#pre_dwp_check?" do
-        it "returns true" do
-          expect(described_class.new.pre_dwp_check?).to be true
-        end
-      end
-
       it "displays the correct page" do
         expect(unescaped_response_body).to include("Check your answers")
       end

--- a/spec/requests/providers/has_national_insurance_numbers_controller_spec.rb
+++ b/spec/requests/providers/has_national_insurance_numbers_controller_spec.rb
@@ -7,10 +7,6 @@ RSpec.describe Providers::HasNationalInsuranceNumbersController do
 
   before { login_as provider }
 
-  describe "#pre_dwp_check?" do
-    it { expect(described_class.new.pre_dwp_check?).to be true }
-  end
-
   describe "GET /providers/applications/:legal_aid_application_id/has_national_insurance_number" do
     subject! do
       get providers_legal_aid_application_has_national_insurance_number_path(legal_aid_application)

--- a/spec/requests/providers/limitations_spec.rb
+++ b/spec/requests/providers/limitations_spec.rb
@@ -42,12 +42,6 @@ RSpec.describe Providers::LimitationsController do
         end
       end
     end
-
-    describe "#pre_dwp_check?" do
-      it "returns true" do
-        expect(described_class.new.pre_dwp_check?).to be true
-      end
-    end
   end
 
   describe "PATCH /providers/applications/:id/limitations" do

--- a/spec/requests/providers/proceedings_types_spec.rb
+++ b/spec/requests/providers/proceedings_types_spec.rb
@@ -61,12 +61,6 @@ RSpec.describe Providers::ProceedingsTypesController, :vcr do
         end
       end
     end
-
-    describe "#pre_dwp_check?" do
-      it "returns true" do
-        expect(described_class.new.pre_dwp_check?).to be true
-      end
-    end
   end
 
   describe "create: POST /providers/applications/:legal_aid_application_id/proceedings_types" do


### PR DESCRIPTION
This module was included in lots of controllers, but the method it includes isn't used anywhere.

The module was introduced in #1583, but the last remaining usage of the `pre_dwp_check?` method was removed as part of #4699.

This removes the module and associated tests.