### PR TITLE
Update GOVUK dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -94,10 +94,10 @@ gem "wdm", ">= 0.1.0" if Gem.win_platform?
 gem "grover"
 
 # DFE formbuilder
-gem "govuk_design_system_formbuilder"
+gem "govuk_design_system_formbuilder", "4.0.0a1"
 
 # ViewComponent
-gem "govuk-components"
+gem "govuk-components", "4.0.0a1"
 gem "view_component"
 
 # Catching unsafe migrations in development

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -276,15 +276,15 @@ GEM
       multi_json (~> 1.11)
       os (>= 0.9, < 2.0)
       signet (>= 0.16, < 2.a)
-    govuk-components (3.3.0)
-      html-attributes-utils (~> 0.9, >= 0.9.2)
-      pagy (~> 5.10.1)
-      view_component (~> 2.74.1)
-    govuk_design_system_formbuilder (3.3.0)
+    govuk-components (4.0.0a1)
+      html-attributes-utils (~> 1.0.0, >= 1.0.0)
+      pagy (~> 6.0)
+      view_component (~> 2)
+    govuk_design_system_formbuilder (4.0.0a1)
       actionview (>= 6.1)
       activemodel (>= 6.1)
       activesupport (>= 6.1)
-      html-attributes-utils (~> 0.9, >= 0.9.2)
+      html-attributes-utils (~> 1)
     govuk_notify_rails (2.2.0)
       notifications-ruby-client (~> 5.1)
       rails (>= 4.1.0)
@@ -323,7 +323,7 @@ GEM
     hashie (5.0.0)
     highline (2.1.0)
     hirb (0.7.3)
-    html-attributes-utils (0.9.2)
+    html-attributes-utils (1.0.0)
       activesupport (>= 6.1.4.4)
     htmlentities (4.3.4)
     http_parser.rb (0.8.0)
@@ -439,8 +439,7 @@ GEM
       childprocess (>= 0.6.3, < 5)
       iniparse (~> 1.4)
       rexml (~> 3.2)
-    pagy (5.10.1)
-      activesupport
+    pagy (6.0.2)
     parallel (1.22.1)
     parser (3.2.1.1)
       ast (~> 2.4.1)
@@ -670,8 +669,8 @@ GEM
     unicode-display_width (2.4.2)
     vcr (6.1.0)
     version_gem (1.1.2)
-    view_component (2.74.1)
-      activesupport (>= 5.0.0, < 8.0)
+    view_component (2.82.0)
+      activesupport (>= 5.2.0, < 8.0)
       concurrent-ruby (~> 1.0)
       method_source (~> 1.0)
     virtus (2.0.0)
@@ -733,8 +732,8 @@ DEPENDENCIES
   faker (>= 1.9.1)
   geckoboard-ruby
   google-apis-sheets_v4
-  govuk-components
-  govuk_design_system_formbuilder
+  govuk-components (= 4.0.0a1)
+  govuk_design_system_formbuilder (= 4.0.0a1)
   govuk_notify_rails (~> 2.2.0)
   grover
   guard-cucumber

--- a/app/views/providers/application_merits_task/statement_of_cases/show.html.erb
+++ b/app/views/providers/application_merits_task/statement_of_cases/show.html.erb
@@ -15,7 +15,7 @@
 
   <% if @successfully_deleted %>
     <%= govuk_notification_banner(title_text: t("generic.success"), success: true) do |notification_banner| %>
-      <% notification_banner.heading(text: @successfully_deleted) %>
+      <% notification_banner.with_heading(text: @successfully_deleted) %>
     <% end %>
   <% end %>
 

--- a/app/views/providers/bank_statements/show.html.erb
+++ b/app/views/providers/bank_statements/show.html.erb
@@ -16,7 +16,7 @@
 
   <% if @successfully_deleted %>
     <%= govuk_notification_banner(title_text: t("generic.success"), success: true) do |notification_banner| %>
-      <% notification_banner.heading(text: @successfully_deleted) %>
+      <% notification_banner.with_heading(text: @successfully_deleted) %>
     <% end %>
   <% end %>
 

--- a/app/views/providers/capital_assessment_results/_result_details.html.erb
+++ b/app/views/providers/capital_assessment_results/_result_details.html.erb
@@ -4,7 +4,7 @@
   </h2>
 
   <%= govuk_accordion do |accordion| %>
-    <% accordion.section(heading_text: t(".capital_calculation")) do %>
+    <% accordion.with_section(heading_text: t(".capital_calculation")) do %>
       <%= render "shared/property_results" %>
       <%= render "shared/vehicle_results" %>
       <%= render "shared/savings_and_investments" %>

--- a/app/views/providers/capital_income_assessment_results/_result_details.html.erb
+++ b/app/views/providers/capital_income_assessment_results/_result_details.html.erb
@@ -4,7 +4,7 @@
   </h2>
 
   <%= govuk_accordion do |accordion| %>
-    <% accordion.section(heading_text: t(".income_calculation")) do %>
+    <% accordion.with_section(heading_text: t(".income_calculation")) do %>
       <p class="govuk-hint"><%= t(".hint_text") %></p>
 
       <% if @legal_aid_application.uploading_bank_statements? %>
@@ -21,7 +21,7 @@
       <%= render "disposable_income" %>
     <% end %>
 
-    <%= accordion.section(heading_text: t(".capital_calculation")) do %>
+    <%= accordion.with_section(heading_text: t(".capital_calculation")) do %>
       <%= render "shared/property_results" %>
       <%= render "shared/vehicle_results" %>
       <%= render "shared/savings_and_investments" %>

--- a/app/views/providers/check_provider_answers/_read_only.html.erb
+++ b/app/views/providers/check_provider_answers/_read_only.html.erb
@@ -1,5 +1,5 @@
 <%= govuk_notification_banner(title_text: t("generic.important")) do |notification_banner| %>
-  <% notification_banner.heading(text: t(".banner.your_client_needs_to")) %>
+  <% notification_banner.with_heading(text: t(".banner.your_client_needs_to")) %>
 <% end %>
 
   <p class="govuk-body"><%= t ".sent_email_text", email: @legal_aid_application.applicant.email %></p>

--- a/app/views/providers/cookies/show.html.erb
+++ b/app/views/providers/cookies/show.html.erb
@@ -12,7 +12,7 @@
 
     <% if @successfully_saved %>
       <%= govuk_notification_banner(title_text: t("generic.success"), success: true) do |notification_banner| %>
-        <% notification_banner.heading(text: t(".success_message")) %>
+        <% notification_banner.with_heading(text: t(".success_message")) %>
         <%= link_to t(".go_back_link"), back_path %>
       <% end %>
     <% end %>

--- a/app/views/providers/uploaded_evidence_collections/show.html.erb
+++ b/app/views/providers/uploaded_evidence_collections/show.html.erb
@@ -17,7 +17,7 @@
 
   <% if @successfully_deleted %>
     <%= govuk_notification_banner(title_text: t("generic.success"), success: true) do |notification_banner| %>
-      <% notification_banner.heading(text: @successfully_deleted) %>
+      <% notification_banner.with_heading(text: @successfully_deleted) %>
     <% end %>
   <% end %>
 


### PR DESCRIPTION
This updates `govuk-components` and `govuk-formbuilder` to the latest release
candidate versions, which unblocks the `pagy` upgrade.