### PR TITLE
Confirm prohibited steps is not for change of name

### DIFF
--- a/app/controllers/providers/proceeding_merits_task/prohibited_steps_controller.rb
+++ b/app/controllers/providers/proceeding_merits_task/prohibited_steps_controller.rb
@@ -26,7 +26,13 @@ module Providers
 
       def form_params
         merge_with_model(prohibited_steps) do
-          params.require(:proceeding_merits_task_prohibited_steps).permit(:uk_removal, :details)
+          params
+            .require(:proceeding_merits_task_prohibited_steps)
+            .permit(
+              :uk_removal,
+              :details,
+              :confirmed_not_change_of_name,
+            )
         end
       end
     end

--- a/app/forms/providers/proceeding_merits_task/prohibited_steps_form.rb
+++ b/app/forms/providers/proceeding_merits_task/prohibited_steps_form.rb
@@ -3,11 +3,14 @@ module Providers
     class ProhibitedStepsForm < BaseForm
       form_for ::ProceedingMeritsTask::ProhibitedSteps
 
-      attr_accessor :uk_removal, :details, :proceeding_id
+      attr_accessor :uk_removal, :details, :proceeding_id, :confirmed_not_change_of_name
+
+      before_validation :clear_details, if: :uk_removal?
 
       validates :uk_removal, inclusion: { in: %w[true false] }
       validates :details, presence: true, if: :requires_details?
-      before_validation :clear_details, if: :uk_removal?
+      validates :confirmed_not_change_of_name, inclusion: { in: %w[true] },
+                                               if: :requires_details?
 
     private
 

--- a/app/views/providers/proceeding_merits_task/prohibited_steps/show.html.erb
+++ b/app/views/providers/proceeding_merits_task/prohibited_steps/show.html.erb
@@ -13,6 +13,17 @@
       <%= form.govuk_radio_button :uk_removal, true, link_errors: true, label: { text: t("generic.yes") } %>
       <%= form.govuk_radio_button :uk_removal, false, label: { text: t("generic.no") } do %>
         <%= form.govuk_text_area :details, label: { text: t(".no-hint") }, rows: 5 %>
+
+        <%= form.govuk_check_boxes_fieldset :confirmed_not_change_of_name, multiple: false, legend: nil do %>
+          <%= form.govuk_check_box(
+                :confirmed_not_change_of_name,
+                true,
+                "",
+                multiple: false,
+                link_errors: true,
+                label: { text: t(".confirmed_not_change_of_name") },
+              ) %>
+        <% end %>
       <% end %>
     <% end %>
 

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -260,6 +260,8 @@ en:
               inclusion: Select yes if the prohibited step is to remove your client from the UK
             details:
               blank: Enter information to explain what you would like prohibited
+            confirmed_not_change_of_name:
+              inclusion: You must confirm this prohibited steps proceeding is not for a change of name application
         proceeding_merits_task/opponents_application:
           attributes:
             has_opponents_application:

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -380,6 +380,7 @@ en:
         show:
           h1-heading: Is the prohibited step to prevent removal from the UK?
           no-hint: What are you asking to be prohibited?
+          confirmed_not_change_of_name: I confirm this prohibited steps proceeding is not for a change of name application
       success_prospects:
         show:
           h1-heading: What is the chance of a successful outcome?

--- a/db/migrate/20230330155942_add_confirmed_not_change_of_name_to_prohibited_steps.rb
+++ b/db/migrate/20230330155942_add_confirmed_not_change_of_name_to_prohibited_steps.rb
@@ -1,0 +1,5 @@
+class AddConfirmedNotChangeOfNameToProhibitedSteps < ActiveRecord::Migration[7.0]
+  def change
+    add_column :prohibited_steps, :confirmed_not_change_of_name, :boolean, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_21_081156) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_30_155942) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -786,6 +786,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_21_081156) do
     t.string "details"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "confirmed_not_change_of_name"
     t.index ["proceeding_id"], name: "index_prohibited_steps_on_proceeding_id"
   end
 

--- a/spec/forms/providers/proceeding_merits_task/prohibited_steps_form_spec.rb
+++ b/spec/forms/providers/proceeding_merits_task/prohibited_steps_form_spec.rb
@@ -9,10 +9,13 @@ module Providers
         {
           uk_removal:,
           details:,
+          confirmed_not_change_of_name:,
         }
       end
+
       let(:uk_removal) { "true" }
-      let(:details) { nil }
+      let(:details) { "" }
+      let(:confirmed_not_change_of_name) { "" }
 
       describe "#valid?" do
         context "when all fields are valid" do
@@ -22,7 +25,7 @@ module Providers
         end
 
         context "when uk_removal is missing" do
-          let(:uk_removal) { nil }
+          let(:uk_removal) { "" }
 
           it { expect(prohibited_steps_form).to be_invalid }
         end
@@ -30,12 +33,21 @@ module Providers
         context "when uk_removal is false" do
           let(:uk_removal) { "false" }
 
-          context "and the additional information is missing" do
-            it { expect(prohibited_steps_form).to be_invalid }
+          context "and fields are missing", :aggregate_failures do
+            it "is invalid" do
+              expect(prohibited_steps_form).to be_invalid
+              expect(prohibited_steps_form.errors).to be_added(:details, :blank)
+              expect(prohibited_steps_form.errors).to be_added(
+                :confirmed_not_change_of_name,
+                :inclusion,
+                value: "",
+              )
+            end
           end
 
-          context "and the additional information is provided" do
+          context "and required fields are provided" do
             let(:details) { "some text input" }
+            let(:confirmed_not_change_of_name) { "true" }
 
             it { expect(prohibited_steps_form).to be_valid }
           end

--- a/spec/requests/providers/proceeding_merits_task/prohibited_steps_controller_spec.rb
+++ b/spec/requests/providers/proceeding_merits_task/prohibited_steps_controller_spec.rb
@@ -43,11 +43,13 @@ module Providers
 
         let(:uk_removal) { "true" }
         let(:details) { "" }
+        let(:confirmed_not_change_of_name) { "" }
         let(:params) do
           {
             proceeding_merits_task_prohibited_steps: {
               uk_removal:,
               details:,
+              confirmed_not_change_of_name:,
             },
           }
         end


### PR DESCRIPTION
This adds a confirmation checkbox to the prohibited steps step of the proceeding task list, similarly to the specific issue question.

This should act as a speedbump for providers when submitting an application, to ensure that they do not try to submit an application for a prohibited steps proceeding when they are trying to submit a change of name application.

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3911)