### PR TITLE
Fix: Update Check your answer actions handling

### DIFF
--- a/app/views/shared/check_answers/_client_details.html.erb
+++ b/app/views/shared/check_answers/_client_details.html.erb
@@ -1,4 +1,6 @@
-<%= govuk_summary_list(classes: "govuk-!-margin-bottom-9", html_attributes: { id: "client-details-questions" }) do |summary_list| %>
+<%= govuk_summary_list(classes: "govuk-!-margin-bottom-9",
+                       html_attributes: { id: "client-details-questions" },
+                       actions: !read_only) do |summary_list| %>
   <% if :first_name.in?(attributes) %>
     <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__first_name" }) do |row| %>
       <%= row.with_key(text: t(".first_name"), classes: "govuk-!-width-one-half") %>


### PR DESCRIPTION
## What

The new govuk style displays were displaying change links on the review and print applications page as well as the CYA page.  
This could allow providers to change data after submission

This update uses the read_only method to hide the actions column

### Before fix: 
<img src='https://user-images.githubusercontent.com/6757677/231680002-a33ad093-304c-4151-a4a2-c3b89dd2ebe2.png' width='250'>
<img src='https://user-images.githubusercontent.com/6757677/231680105-381714e6-ead5-4b6a-8f6c-33ada0cb9740.png' width='250'>

### After fix:
<img src='https://user-images.githubusercontent.com/6757677/231680218-cd68486e-2e77-448d-9bd1-b01aefc18e1a.png' width='250'>
<img src='https://user-images.githubusercontent.com/6757677/231680169-884538b3-aab1-49fb-8526-67cf27c7ec36.png' width='250'>

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
