### PR TITLE
Sass: silence deprecation warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "stylelint": "stylelint app/assets/stylesheets",
     "test": "jest",
     "build": "esbuild app/javascript/*.* --bundle --sourcemap --minify --outdir=app/assets/builds --public-path=assets --target=es6",
-    "build:css": "sass ./app/assets/stylesheets/application.scss:./app/assets/builds/application.css --style=compressed --load-path=node_modules"
+    "build:css": "sass ./app/assets/stylesheets/application.scss:./app/assets/builds/application.css --style=compressed --load-path=node_modules --quiet-deps"
   },
   "dependencies": {
     "@rails/ujs": "^7.0.4",


### PR DESCRIPTION
## What

Silence 29 repetitive deprecation warnings

Example:

Deprecation Warning: Using / for division outside of calc() is deprecated.
More info: https://sass-lang.com/d/slash-div

Deprecation Warning: $weight: Passing a number without unit % (60) is deprecated.
More info: https://sass-lang.com/d/function-units

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
