### PR TITLE
Fix: Faker safe_email deprecation warnings

### DIFF
--- a/spec/factories/applicants.rb
+++ b/spec/factories/applicants.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     first_name { Faker::Name.first_name }
     last_name { Faker::Name.last_name }
     date_of_birth { Faker::Date.birthday }
-    email { Faker::Internet.safe_email }
+    email { Faker::Internet.email }
     has_national_insurance_number { true }
     national_insurance_number { "JA123456D" }
     employed { false }
@@ -68,7 +68,7 @@ FactoryBot.define do
       first_name { "Langley" }
       last_name { "Yorke" }
       date_of_birth { Date.new(1992, 7, 22) }
-      email { Faker::Internet.safe_email }
+      email { Faker::Internet.email }
       national_insurance_number { "MN212451D" }
     end
 
@@ -76,7 +76,7 @@ FactoryBot.define do
       first_name { "Ida" }
       last_name { "Paisley" }
       date_of_birth { Date.new(1987, 11, 24) }
-      email { Faker::Internet.safe_email }
+      email { Faker::Internet.email }
       national_insurance_number { "OE726113A" }
     end
 
@@ -84,7 +84,7 @@ FactoryBot.define do
       first_name { "John" }
       last_name { "Pending" }
       date_of_birth { Date.new(2002, 9, 1) }
-      email { Faker::Internet.safe_email }
+      email { Faker::Internet.email }
       national_insurance_number { "KY123456D" }
     end
 
@@ -93,7 +93,7 @@ FactoryBot.define do
       first_name { "John" }
       last_name { "Jobseeker" }
       date_of_birth { Date.new(2005, 5, 5) }
-      email { Faker::Internet.safe_email }
+      email { Faker::Internet.email }
       national_insurance_number { "BB123456B" }
     end
 

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     firm
     name { Faker::Name.name }
     username { "#{Faker::Internet.username}_#{Random.rand(1...999).to_s.rjust(3, '0')}" }
-    email { Faker::Internet.safe_email }
+    email { Faker::Internet.email }
     portal_enabled { true }
 
     trait :without_portal_enabled do

--- a/spec/factories/scheduled_mailings.rb
+++ b/spec/factories/scheduled_mailings.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     mailer_klass { "SubmitApplicationReminderMailer" }
     mailer_method { "notify_provider" }
     status { "processing" }
-    addressee { Faker::Internet.safe_email }
+    addressee { Faker::Internet.email }
     arguments { [legal_aid_application.id, "Bob Marley", "bob@wailing.jm"] }
     scheduled_at { Faker::Time.between(from: 1.minute.from_now, to: 2.months.from_now) }
     govuk_message_id { SecureRandom.uuid }

--- a/spec/forms/applicants/email_form_spec.rb
+++ b/spec/forms/applicants/email_form_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Applicants::EmailForm, type: :form do
   end
   let(:legal_aid_application) { create(:legal_aid_application, applicant:) }
   let(:applicant) { create(:applicant, email: nil) }
-  let(:email) { Faker::Internet.safe_email }
+  let(:email) { Faker::Internet.email }
 
   describe ".model_name" do
     it 'is "Applicant"' do
@@ -42,7 +42,7 @@ RSpec.describe Applicants::EmailForm, type: :form do
     end
 
     context "when stripping whitespace" do
-      let(:fake_email_address) { Faker::Internet.safe_email }
+      let(:fake_email_address) { Faker::Internet.email }
       let(:email) { "  #{fake_email_address}  " }
 
       it "updates the applicant email with the email address without whitespace" do

--- a/spec/mailers/citizen_completed_means_mailer_spec.rb
+++ b/spec/mailers/citizen_completed_means_mailer_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe CitizenCompletedMeansMailer do
   let(:application) { create(:legal_aid_application, :with_everything) }
-  let(:email) { Faker::Internet.safe_email }
+  let(:email) { Faker::Internet.email }
   let(:provider_name) { Faker::Name.name }
   let(:applicant_name) { Faker::Name.name }
   let(:application_url) { "/provider/legal_aid_applications/" }

--- a/spec/mailers/citizen_confirmation_mailer_spec.rb
+++ b/spec/mailers/citizen_confirmation_mailer_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe CitizenConfirmationMailer do
   let(:app_id) { SecureRandom.uuid }
-  let(:email) { Faker::Internet.safe_email }
+  let(:email) { Faker::Internet.email }
   let(:client_name) { Faker::Name.name }
   let(:citizen_completed_application_template) { Rails.configuration.govuk_notify_templates[:citizen_completed_application] }
 

--- a/spec/mailers/notify_mailer_spec.rb
+++ b/spec/mailers/notify_mailer_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe NotifyMailer do
   let(:app_id) { SecureRandom.uuid }
-  let(:email) { Faker::Internet.safe_email }
+  let(:email) { Faker::Internet.email }
   let(:client_name) { Faker::Name.name }
   let(:provider_firm) { Faker::Name.name }
   let(:application_url) { "/applications/#{app_id}/citizen/start" }

--- a/spec/mailers/submit_application_reminder_mailer_spec.rb
+++ b/spec/mailers/submit_application_reminder_mailer_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe SubmitApplicationReminderMailer do
            df_options: { DA001: 10.days.ago },
            substantive_application_deadline_on: 10.days.from_now)
   end
-  let(:email) { Faker::Internet.safe_email }
+  let(:email) { Faker::Internet.email }
   let(:provider_name) { Faker::Name.name }
 
   describe "#notify_provider" do

--- a/spec/mailers/submit_citizen_financial_reminder_mailer_spec.rb
+++ b/spec/mailers/submit_citizen_financial_reminder_mailer_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe SubmitCitizenFinancialReminderMailer do
   let(:application) { create(:legal_aid_application, :with_applicant, :with_everything, :with_non_passported_state_machine) }
-  let(:email) { Faker::Internet.safe_email }
+  let(:email) { Faker::Internet.email }
   let(:provider_name) { Faker::Name.name }
   let(:application_url) { "http://test.com" }
   let(:url_expiry_date) { (Time.zone.today + 7.days).strftime("%-d %B %Y") }

--- a/spec/mailers/submit_provider_financial_reminder_mailer_spec.rb
+++ b/spec/mailers/submit_provider_financial_reminder_mailer_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe SubmitProviderFinancialReminderMailer do
   let(:application) { create(:legal_aid_application, :with_applicant) }
-  let(:email) { Faker::Internet.safe_email }
+  let(:email) { Faker::Internet.email }
   let(:provider_name) { Faker::Name.name }
   let(:application_url) { "test" }
 

--- a/spec/models/scheduled_mailing_spec.rb
+++ b/spec/models/scheduled_mailing_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe ScheduledMailing do
   let(:mailer_klass) { "NotifyMailer" }
   let(:mailer_method) { "notify" }
   let(:legal_aid_application) { create(:legal_aid_application) }
-  let(:addressee) { Faker::Internet.safe_email }
+  let(:addressee) { Faker::Internet.email }
   let(:mailer_args) { [:one, :two, "three"] }
   let(:frozen_time) { Time.zone.now }
   let(:future_time) { 2.hours.from_now }

--- a/spec/requests/providers/applicant_details_spec.rb
+++ b/spec/requests/providers/applicant_details_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Providers::ApplicantDetailsController do
           "date_of_birth(1i)": "1981",
           "date_of_birth(2i)": "07",
           "date_of_birth(3i)": "11",
-          email: Faker::Internet.safe_email,
+          email: Faker::Internet.email,
         },
       }
     end
@@ -89,7 +89,7 @@ RSpec.describe Providers::ApplicantDetailsController do
                 "date_of_birth(1i)": "1999",
                 "date_of_birth(2i)": "07",
                 "date_of_birth(3i)": "11",
-                email: Faker::Internet.safe_email,
+                email: Faker::Internet.email,
               },
             }
           end
@@ -137,7 +137,7 @@ RSpec.describe Providers::ApplicantDetailsController do
                 "date_of_birth(1i)": "1981",
                 "date_of_birth(2i)": "07",
                 "date_of_birth(3i)": "11",
-                email: Faker::Internet.safe_email,
+                email: Faker::Internet.email,
               },
             }
           end
@@ -182,7 +182,7 @@ RSpec.describe Providers::ApplicantDetailsController do
               "date_of_birth(1i)": "1981",
               "date_of_birth(2i)": "6s",
               "date_of_birth(3i)": "11sa",
-              email: Faker::Internet.safe_email,
+              email: Faker::Internet.email,
             },
           }
         end

--- a/spec/requests/providers/email_addresses_spec.rb
+++ b/spec/requests/providers/email_addresses_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe "update client email address before application confirmation" do
     let(:params) do
       {
         applicant: {
-          email: Faker::Internet.safe_email,
+          email: Faker::Internet.email,
         },
       }
     end


### PR DESCRIPTION
## What

After the Faker 3.2.0 update we were seeing a lot of:
```NOTE: Faker::Internet.safe_email is deprecated; use email instead. It will be removed on or after 2023-10.```
warnings

This PR should remove them

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
