### PR TITLE
AP-3642 details component

### DIFF
--- a/app/views/citizens/consents/show.html.erb
+++ b/app/views/citizens/consents/show.html.erb
@@ -11,33 +11,23 @@
         <p class="govuk-body govuk-!-padding-bottom-2"><%= t(".inset_text") %></p>
       <% end %>
 
-      <details class="govuk-details govuk-!-margin-top-4" data-module="govuk-details">
-        <summary class="govuk-details__summary">
-          <span class="govuk-details__summary-text"
-            title="<%= t(".summary_heading") %>"
-            aria-label="<%= t(".summary_heading") %>">
-            <%= t(".summary_heading") %>
-          </span>
-        </summary>
+      <%= govuk_details(summary_text: t(".summary_heading")) do %>
+        <p><%= t(".able_to_see.heading") %></p>
 
-        <div class="govuk-details__text">
-          <p><%= t(".able_to_see.heading") %></p>
+        <ul class="govuk-list govuk-list--bullet">
+          <% t(".able_to_see.list").each_line do |item| %>
+            <li><%= item %></li>
+          <% end %>
+        </ul>
 
-          <ul class="govuk-list govuk-list--bullet">
-            <% t(".able_to_see.list").each_line do |item| %>
-              <li><%= item %></li>
-            <% end %>
-          </ul>
+        <p><%= t(".unable_to_see.heading") %></p>
 
-          <p><%= t(".unable_to_see.heading") %></p>
-
-          <ul class="govuk-list govuk-list--bullet">
-            <% t(".unable_to_see.list").each_line do |item| %>
-              <li><%= item %></li>
-            <% end %>
-          </ul>
-        </div>
-      </details>
+        <ul class="govuk-list govuk-list--bullet">
+          <% t(".unable_to_see.list").each_line do |item| %>
+            <li><%= item %></li>
+          <% end %>
+        </ul>
+      <% end %>
 
       <%= form.govuk_collection_radio_buttons(
             :open_banking_consent,

--- a/app/views/providers/limitations/_proceeding_type.html.erb
+++ b/app/views/providers/limitations/_proceeding_type.html.erb
@@ -16,7 +16,7 @@
         <%= proceeding.client_involvement_type_description %>
       </span>
     </h3>
-    <%= govuk_details(summary_text: t(".details_heading"), html_attributes: { "data-module": "govuk-details" }) do %>
+    <%= govuk_details(summary_text: t(".details_heading")) do %>
       <% if proceeding.used_delegated_functions_on %>
         <h4 class="govuk-heading-m"><%= t(".emergency_certificate") %></h4>
         <p><strong><%= t(".form_of_service") %></strong>

--- a/app/views/providers/open_banking_guidances/show.html.erb
+++ b/app/views/providers/open_banking_guidances/show.html.erb
@@ -12,17 +12,10 @@
     <p class="govuk-body"><%= t(".your_client_can") %></p>
     <p class="govuk-body"><%= t(".its_a_fast") %></p>
 
-    <details class="govuk-details govuk-!-display-none-print" data-module="govuk-details">
-      <summary class="govuk-details__summary">
-          <span class="govuk-details__summary-text">
-            <%= t(".details_summary") %>
-          </span>
-      </summary>
-      <div class="govuk-details__text govuk-!-padding-bottom-1">
-        <%= t(".details_content_html") %>
-        <%= list_from_translation_path(".open_banking_consents.show.details") %>
-      </div>
-    </details>
+    <%= govuk_details(summary_text: t(".details_summary")) do %>
+      <%= t(".details_content_html") %>
+      <%= list_from_translation_path(".open_banking_consents.show.details") %>
+    <% end %>
 
     <div class="govuk-!-padding-bottom-4 only-print">
       <h3 class="govuk-heading-m"><%= t(".details_summary") %></h3>

--- a/app/views/providers/open_banking_guidances/show.html.erb
+++ b/app/views/providers/open_banking_guidances/show.html.erb
@@ -12,7 +12,7 @@
     <p class="govuk-body"><%= t(".your_client_can") %></p>
     <p class="govuk-body"><%= t(".its_a_fast") %></p>
 
-    <%= govuk_details(summary_text: t(".details_summary")) do %>
+    <%= govuk_details(summary_text: t(".details_summary"), classes: "govuk-!-display-none-print") do %>
       <%= t(".details_content_html") %>
       <%= list_from_translation_path(".open_banking_consents.show.details") %>
     <% end %>

--- a/app/views/shared/forms/_types_of_income_form.html.erb
+++ b/app/views/shared/forms/_types_of_income_form.html.erb
@@ -30,25 +30,6 @@
           ) %>
     <% end %>
 
-    <% if journey == :citizen %>
-      <details class="govuk-details govuk-!-margin-top-4" data-module="govuk-details">
-        <summary class="govuk-details__summary">
-          <span class="govuk-details__summary-text"
-            title="<%= t(".expanded_explanation.heading") %>"
-            aria-label="<%= t(".expanded_explanation.heading") %>">
-            <%= t(".expanded_explanation.heading") %>
-          </span>
-        </summary>
-
-        <div class="govuk-details__text">
-          <% t(".expanded_explanation.list").each_line do |para| %>
-            <p>
-            <%= para %>
-          <% end %>
-        </div>
-    </details>
-    <% end %>
-
     <div class="govuk-!-padding-bottom-4"></div>
 
     <%= next_action_buttons(

--- a/app/views/shared/forms/_types_of_outgoings_form.html.erb
+++ b/app/views/shared/forms/_types_of_outgoings_form.html.erb
@@ -24,25 +24,6 @@
       <%= form.govuk_check_box :none_selected, true, "", multiple: false, label: { text: t(".#{journey_type}.none_of_these") } %>
     <% end %>
 
-    <% if journey == :citizen %>
-      <details class="govuk-details govuk-!-margin-top-4" data-module="govuk-details">
-        <summary class="govuk-details__summary">
-          <span class="govuk-details__summary-text"
-            title="<%= t(".expanded_explanation.heading") %>"
-            aria-label="<%= t(".expanded_explanation.heading") %>">
-            <%= t(".expanded_explanation.heading") %>
-          </span>
-        </summary>
-
-        <div class="govuk-details__text">
-          <% t(".expanded_explanation.list").each_line do |para| %>
-            <p>
-              <%= para %>
-          <% end %>
-        </div>
-      </details>
-    <% end %>
-
     <%= next_action_buttons(
           show_draft: local_assigns.key?(:show_draft) ? show_draft : false,
           form:,

--- a/config/locales/cy/shared.yml
+++ b/config/locales/cy/shared.yml
@@ -341,15 +341,7 @@ cy:
           not_known: .sseccus fo doohilekil eht enimreted ot enod eb ot sdeen llits
             kroW
       types_of_income_form:
-        citizens:
-          none_of_these: stnemyap eseht fo enon eviecer I
         hints:
-          citizens:
-            friends_or_family: ".stnemyap ffo-eno edulcni ton oD .stsoc gnivil htiw
-              pleh ot yenom uoy sevig ylraluger evitaler ro dneirf a fi tceleS"
-            benefits: ".stiderc xat ro tifeneB dlihC ,elpmaxe roF"
-            maintenance_in: ".ecnanetniam dlihc sedulcni sihT"
-            pension: ".snoisnep lanosrep dna ecalpkrow ,etatS edulcnI"
           providers:
             friends_or_family: ".sllib ro tner rof rebmem ylimaf a morf yenom ,elpmaxe
               roF"
@@ -363,18 +355,10 @@ cy:
             .dia lagel rof yllaicnanif yfilauq uoy fi kcehc ot noitamrofni siht deen eW
             .tceles uoy seirogetac eht otni snoitcasnart ruoy tup dna stnemetats knab ruoy ta kool lliw roticilos ruoY
       types_of_outgoings_form:
-        citizens:
-          none_of_these: stnemyap eseht fo enon ekam I
         hints:
           rent_or_mortgage: ".gnigdol dna draob ro egagtrom ,tner ,elpmaxe roF"
           child_care: ".yresrun ro ynnan ,rednimdlihc a ot ,elpmaxe roF"
           maintenance_out: ".ecnanetniam dlihc sedulcni sihT"
-        expanded_explanation:
-          heading: "?siht deksa gnieb I ma yhW"
-          list: |2-
-
-            .dia lagel rof yllaicnanif yfilauq uoy fi kcehc ot noitamrofni siht deen eW
-            .tceles uoy seirogetac eht otni snoitcasnart ruoy tup dna stnemetats knab ruoy ta kool lliw roticilos ruoY
     page-title:
       suffix: dia lagel rof ylppA
     property_results:

--- a/config/locales/en/shared.yml
+++ b/config/locales/en/shared.yml
@@ -626,16 +626,9 @@ en:
             borderline: You cannot predict the outcome.
             not_known: Work still needs to be done to determine the likelihood of success.
       types_of_income_form:
-        citizens:
-          none_of_these: I receive none of these payments
         providers:
           none_of_these: My client receives none of these payments
         hints:
-          citizens:
-            friends_or_family: "Select if a friend or relative regularly gives you money to help with living costs. Do not include one-off payments."
-            benefits: For example, Child Benefit or tax credits.
-            maintenance_in: This includes child maintenance.
-            pension: Include State, workplace and personal pensions.
           providers:
             friends_or_family: For example, money from a family member for rent or bills.
             benefits: For example, Child Benefit or tax credits.
@@ -647,19 +640,12 @@ en:
             Your solicitor will look at your bank statements and put your transactions into the categories you select.
             We need this information to check if you qualify financially for legal aid.
       types_of_outgoings_form:
-        citizens:
-          none_of_these: I make none of these payments
         providers:
           none_of_these: My client makes none of these payments
         hints:
           rent_or_mortgage: For example, rent, mortgage or board and lodging.
           child_care: For example, to a childminder, nanny or nursery.
           maintenance_out: This includes child maintenance.
-        expanded_explanation:
-          heading: Why am I being asked this?
-          list: |
-            Your solicitor will look at your bank statements and put your transactions into the categories you select.
-            We need this information to check if you qualify financially for legal aid.
     page-title:
       suffix: Apply for legal aid  - GOV.UK
     property_results:


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3642)

Use GOV.UK components library to render all instances of the details component
Also removed some code in the types_of_income and types_of_outgoings forms which was no longer used as the citizen is not asked questions about payment types anymore

***I rebased on @agoldstone93 's  AP-3991 summary list component branch so that's why there are so many changes showing at the moment***

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
