### PR TITLE
Fix: Speed up CircleCI integration test steps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -231,8 +231,6 @@ jobs:
     executor: test-executor
     steps:
     - checkout
-    - browser-tools/install-chrome
-    - browser-tools/install-chromedriver
     - *decrypt_secrets
     - *restore_gems_cache
     - *install_gems
@@ -242,6 +240,8 @@ jobs:
     - *install_js_packages
     - *save_js_packages_cache
     - run: bundle exec rails assets:precompile
+    - browser-tools/install-chrome
+    - browser-tools/install-chromedriver
     - run:
         name: Run integration tests
         command: |


### PR DESCRIPTION
## What

The `rails assets:precompile` in unit tests takes <10s but in integration tests it was taking 2m+

This PR resequences the integration test steps - precompile now runs before installing chromedrivers, etc

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
