### PR TITLE
AP-4039: Fix non-js application delete

### DIFF
--- a/app/controllers/providers/delete_controller.rb
+++ b/app/controllers/providers/delete_controller.rb
@@ -1,0 +1,14 @@
+module Providers
+  class DeleteController < ProviderBaseController
+    def show
+      redirect_to providers_legal_aid_applications_path if @legal_aid_application.discarded?
+    end
+
+    def destroy
+      @legal_aid_application.discard
+      @legal_aid_application.scheduled_mailings.map(&:cancel!)
+
+      redirect_to providers_legal_aid_applications_path
+    end
+  end
+end

--- a/spec/requests/providers/delete_controller_spec.rb
+++ b/spec/requests/providers/delete_controller_spec.rb
@@ -1,0 +1,60 @@
+require "rails_helper"
+
+RSpec.describe Providers::DeleteController do
+  let(:legal_aid_application) { create(:legal_aid_application, :with_everything, substantive_application_deadline_on: 1.day.ago) }
+  let(:provider) { legal_aid_application.provider }
+
+  describe "GET /providers/applications/:id/delete" do
+    subject(:show_delete_view) { get providers_legal_aid_application_delete_path(legal_aid_application) }
+
+    context "when the provider is not authenticated" do
+      before { show_delete_view }
+
+      it_behaves_like "a provider not authenticated"
+    end
+
+    context "when the provider is authenticated" do
+      before do
+        login_as provider
+        show_delete_view
+      end
+
+      it "returns http success" do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "displays the correct page" do
+        expect(unescaped_response_body).to include("Are you sure you want to delete this application?")
+      end
+
+      it "displays the application data" do
+        expect(unescaped_response_body).to include(legal_aid_application.application_ref)
+      end
+    end
+  end
+
+  describe "DELETE /admin/legal_aid_applications/:legal_aid_application_id/destroy" do
+    subject(:submit_delete_request) { delete providers_legal_aid_application_delete_path(legal_aid_application) }
+
+    before { login_as provider }
+
+    context "when the application has no pre-existing scheduled mails" do
+      it "sets the application to discarded" do
+        expect { submit_delete_request }.to change { legal_aid_application.reload.discarded_at }
+      end
+
+      it "returns http found" do
+        submit_delete_request
+        expect(response).to have_http_status(:found)
+      end
+    end
+
+    context "when the application has a pre-existing scheduled mail" do
+      before { create(:scheduled_mailing, legal_aid_application:) }
+
+      it "clears any scheduled mailings" do
+        expect { submit_delete_request }.to change { legal_aid_application.scheduled_mailings.first.cancelled_at }
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4039)

The non-js delete controller was mistakenly deleted as part of the JS modal delete implementation.  
This PR simply restores the files deleted as part of #3165 and updates them inline with recent rubocop changes

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
