### PR TITLE
AP-3231: Uploading multiple files on the statement of case page with JS disabled

### DIFF
--- a/app/views/providers/application_merits_task/statement_of_cases/show.html.erb
+++ b/app/views/providers/application_merits_task/statement_of_cases/show.html.erb
@@ -75,16 +75,6 @@
               ) %>
 
         </div>
-
-        <h2 class="govuk-heading-m"><%= t(".h2-heading") %></h2>
-        <div id="uploaded-files-table-container">
-          <%= render partial: "uploaded_files", locals: { attachments: @form.model.original_attachments } %>
-          <% if @form.model.original_attachments.empty? %>
-            <p class="govuk-body">
-              <%= t(".no_files") %>
-            </p>
-          <% end %>
-        </div>
       </div>
 
       <div aria-live="assertive" class="govuk-visually-hidden" id="file-upload-status-message"></div>
@@ -98,6 +88,16 @@
 
     <% end %>
   <% end %>
+
+  <h2 class="govuk-heading-m"><%= t(".h2-heading") %></h2>
+  <div id="uploaded-files-table-container">
+    <%= render partial: "uploaded_files", locals: { attachments: @form.model.original_attachments } %>
+    <% if @form.model.original_attachments.empty? %>
+      <p class="govuk-body">
+        <%= t(".no_files") %>
+      </p>
+    <% end %>
+  </div>
 
   <%= form_with(
         model: @form,


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3231)

Moved `uploaded_files` partial outside form to fix bug

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
