### PR TITLE
AP-3718: Error summary does not appear on the 'select office' page 

### DIFF
--- a/app/views/providers/select_offices/show.html.erb
+++ b/app/views/providers/select_offices/show.html.erb
@@ -1,6 +1,8 @@
 <%= page_template page_title: t(".h1-heading", firm: firm.name), template: :basic do %>
   <%= form_with(model: @form, url: providers_select_office_path, method: :patch, local: true) do |form| %>
 
+    <%= form.govuk_error_summary %>
+
     <%= form.govuk_collection_radio_buttons(:selected_office_id,
                                             @form.model.offices,
                                             :id,


### PR DESCRIPTION

## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3718)

Add missing govuk_error_summary

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
