### PR TITLE
Update CFECivil handling of outgoings

### DIFF
--- a/app/services/cfe_civil/components/outgoings.rb
+++ b/app/services/cfe_civil/components/outgoings.rb
@@ -12,18 +12,20 @@ module CFECivil
       def build_transactions
         bank_transactions.each_with_object([]) do |(transaction_type_id, array), result|
           name = TransactionType.find(transaction_type_id).name
-          type_hash = { name:, payments: transactions(array) }
+          type_hash = { name:, payments: transactions(name, array) }
           result << type_hash
         end
       end
 
-      def transactions(array)
+      def transactions(name, array)
         array.each_with_object([]) do |transaction, result|
-          result << {
+          data_block = {
             payment_date: transaction.happened_at.strftime("%Y-%m-%d"),
             amount: transaction.amount.abs.to_f,
             client_id: transaction.id,
           }
+          data_block[:housing_cost_type] = legal_aid_application.own_home? ? "mortgage" : "rent" if name == "rent_or_mortgage"
+          result << data_block
         end
       end
 

--- a/spec/services/cfe_civil/components/outgoings_spec.rb
+++ b/spec/services/cfe_civil/components/outgoings_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe CFECivil::Components::Outgoings do
     end
   end
 
-  context "when there outgoings have been created" do
+  context "when there outgoings have been created and the applicant does not have a mortgage" do
     let(:bank_provider) { create(:bank_provider, applicant: legal_aid_application.applicant) }
     let(:bank_account) { create(:bank_account, bank_provider:) }
     let!(:transaction1) { create(:bank_transaction, :rent_or_mortgage, bank_account:, happened_at: 10.days.ago, amount: 1150.0) }
@@ -34,8 +34,39 @@ RSpec.describe CFECivil::Components::Outgoings do
           {
             name: "rent_or_mortgage",
             payments: [
-              { payment_date: 40.days.ago.strftime("%F"), amount: 1150.0, client_id: transaction2.id },
-              { payment_date: 10.days.ago.strftime("%F"), amount: 1150.0, client_id: transaction1.id },
+              { payment_date: 40.days.ago.strftime("%F"), amount: 1150.0, client_id: transaction2.id, housing_cost_type: "rent" },
+              { payment_date: 10.days.ago.strftime("%F"), amount: 1150.0, client_id: transaction1.id, housing_cost_type: "rent" },
+            ],
+          },
+        ],
+      }.to_json)
+    end
+  end
+
+  context "when there outgoings have been created and the applicant has a mortgage" do
+    let(:legal_aid_application) { create(:legal_aid_application, :with_applicant, :with_own_home_mortgaged) }
+    let(:bank_provider) { create(:bank_provider, applicant: legal_aid_application.applicant) }
+    let(:bank_account) { create(:bank_account, bank_provider:) }
+    let!(:transaction1) { create(:bank_transaction, :rent_or_mortgage, bank_account:, happened_at: 10.days.ago, amount: 1150.0) }
+    let!(:transaction2) { create(:bank_transaction, :rent_or_mortgage, bank_account:, happened_at: 40.days.ago, amount: 1150.0) }
+    let!(:transaction3) { create(:bank_transaction, :child_care, bank_account:, happened_at: 15.days.ago, amount: 234.56) }
+    let!(:transaction4) { create(:bank_transaction, :child_care, bank_account:, happened_at: 45.days.ago, amount: 266.0) }
+
+    it "returns the expected JSON block" do
+      expect(call).to eq({
+        outgoings: [
+          {
+            name: "child_care",
+            payments: [
+              { payment_date: 45.days.ago.strftime("%F"), amount: 266.0, client_id: transaction4.id },
+              { payment_date: 15.days.ago.strftime("%F"), amount: 234.56, client_id: transaction3.id },
+            ],
+          },
+          {
+            name: "rent_or_mortgage",
+            payments: [
+              { payment_date: 40.days.ago.strftime("%F"), amount: 1150.0, client_id: transaction2.id, housing_cost_type: "mortgage" },
+              { payment_date: 10.days.ago.strftime("%F"), amount: 1150.0, client_id: transaction1.id, housing_cost_type: "mortgage" },
             ],
           },
         ],


### PR DESCRIPTION
## What

CFE-Civil requires a valid housing_cost_type when submitting transactions flagged as rent_or_mortgage, this feeds into a calculation for board and lodging that was never implemented into Apply and has been ignored by CFE Legacy.

This implements the correct logic and can be expanded if the correct board and lodging handling is implemented in the future

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
