### PR TITLE
Update: CFE Civil comparison

### DIFF
--- a/app/services/cfe/compare_submission.rb
+++ b/app/services/cfe/compare_submission.rb
@@ -99,7 +99,7 @@ module CFE
 
     def compare_values(v5_value, v6_value)
       if v6_value.is_a?(Numeric) || v5_value.is_a?(Numeric)
-        v6_value.to_d == v5_value.to_d
+        sprintf("%.2f", v6_value) == sprintf("%.2f", v5_value)
       else
         v6_value == v5_value
       end

--- a/spec/fixtures/files/cfe_civil_comparison/v5/rounding.json
+++ b/spec/fixtures/files/cfe_civil_comparison/v5/rounding.json
@@ -1,0 +1,255 @@
+{
+  "version": "5",
+  "timestamp": "2023-05-04T15:46:26.818Z",
+  "success": true,
+  "result_summary": {
+    "overall_result": {
+      "result": "contribution_required",
+      "capital_contribution": 707.06,
+      "income_contribution": 114.41,
+      "proceeding_types": [
+        {
+          "ccms_code": "DA004",
+          "client_involvement_type": "A",
+          "upper_threshold": 0.0,
+          "lower_threshold": 0.0,
+          "result": "contribution_required"
+        },
+        {
+          "ccms_code": "DA005",
+          "client_involvement_type": "A",
+          "upper_threshold": 0.0,
+          "lower_threshold": 0.0,
+          "result": "contribution_required"
+        }
+      ]
+    },
+    "gross_income": {
+      "total_gross_income": 1662.73,
+      "proceeding_types": [
+        {
+          "ccms_code": "DA004",
+          "client_involvement_type": "A",
+          "upper_threshold": 999999999999.0,
+          "lower_threshold": 0.0,
+          "result": "eligible"
+        },
+        {
+          "ccms_code": "DA005",
+          "client_involvement_type": "A",
+          "upper_threshold": 999999999999.0,
+          "lower_threshold": 0.0,
+          "result": "eligible"
+        }
+      ]
+    },
+    "disposable_income": {
+      "dependant_allowance": 1016.7,
+      "gross_housing_costs": 0.0,
+      "housing_benefit": 0.0,
+      "net_housing_costs": 0.0,
+      "maintenance_allowance": 0.0,
+      "total_outgoings_and_allowances": 1063.27,
+      "total_disposable_income": 599.46,
+      "employment_income": {
+        "gross_income": 0.0,
+        "benefits_in_kind": 0.0,
+        "tax": 0.0,
+        "national_insurance": 0.0,
+        "fixed_employment_deduction": 0.0,
+        "net_employment_income": 0.0
+      },
+      "income_contribution": 114.41,
+      "proceeding_types": [
+        {
+          "ccms_code": "DA004",
+          "client_involvement_type": "A",
+          "upper_threshold": 999999999999.0,
+          "lower_threshold": 315.0,
+          "result": "contribution_required"
+        },
+        {
+          "ccms_code": "DA005",
+          "client_involvement_type": "A",
+          "upper_threshold": 999999999999.0,
+          "lower_threshold": 315.0,
+          "result": "contribution_required"
+        }
+      ]
+    },
+    "capital": {
+      "total_liquid": 3707.06,
+      "total_non_liquid": 0.0,
+      "total_vehicle": 0.0,
+      "total_property": 0.0,
+      "total_mortgage_allowance": 999999999999.0,
+      "total_capital": 3707.06,
+      "pensioner_capital_disregard": 0.0,
+      "subject_matter_of_dispute_disregard": 0.0,
+      "capital_contribution": 707.06,
+      "assessed_capital": 3707.06,
+      "proceeding_types": [
+        {
+          "ccms_code": "DA004",
+          "client_involvement_type": "A",
+          "upper_threshold": 999999999999.0,
+          "lower_threshold": 3000.0,
+          "result": "contribution_required"
+        },
+        {
+          "ccms_code": "DA005",
+          "client_involvement_type": "A",
+          "upper_threshold": 999999999999.0,
+          "lower_threshold": 3000.0,
+          "result": "contribution_required"
+        }
+      ]
+    }
+  },
+  "assessment": {
+    "id": "ef103bf3-1315-47f4-8126-00c415aedfa0",
+    "client_reference_id": "L-2M3-R9P",
+    "submission_date": "2023-05-04",
+    "applicant": {
+      "date_of_birth": "1983-09-18",
+      "involvement_type": "applicant",
+      "employed": false,
+      "has_partner_opponent": false,
+      "receives_qualifying_benefit": false,
+      "self_employed": false
+    },
+    "gross_income": {
+      "employment_income": [
+
+      ],
+      "irregular_income": {
+        "monthly_equivalents": {
+          "student_loan": 1437.5,
+          "unspecified_source": 0.0
+        }
+      },
+      "state_benefits": {
+        "monthly_equivalents": {
+          "all_sources": 225.23,
+          "cash_transactions": 0.0,
+          "bank_transactions": [
+            {
+              "name": "Child Benefit",
+              "monthly_value": "225.23",
+              "excluded_from_income_assessment": false
+            }
+          ]
+        }
+      },
+      "other_income": {
+        "monthly_equivalents": {
+          "all_sources": {
+            "friends_or_family": 0.0,
+            "maintenance_in": 0.0,
+            "property_or_lodger": 0.0,
+            "pension": 0.0
+          },
+          "bank_transactions": {
+            "friends_or_family": 0.0,
+            "maintenance_in": 0.0,
+            "property_or_lodger": 0.0,
+            "pension": 0.0
+          },
+          "cash_transactions": {
+            "friends_or_family": 0.0,
+            "maintenance_in": 0.0,
+            "property_or_lodger": 0.0,
+            "pension": 0.0
+          }
+        }
+      }
+    },
+    "disposable_income": {
+      "monthly_equivalents": {
+        "all_sources": {
+          "child_care": 46.57,
+          "rent_or_mortgage": 0.0,
+          "maintenance_out": 0.0,
+          "legal_aid": 0.0
+        },
+        "bank_transactions": {
+          "child_care": 46.57,
+          "rent_or_mortgage": 0.0,
+          "maintenance_out": 0.0,
+          "legal_aid": 0.0
+        },
+        "cash_transactions": {
+          "child_care": 0.0,
+          "rent_or_mortgage": 0.0,
+          "maintenance_out": 0.0,
+          "legal_aid": 0.0
+        }
+      },
+      "childcare_allowance": 46.57,
+      "deductions": {
+        "dependants_allowance": 1016.7,
+        "disregarded_state_benefits": 0.0
+      }
+    },
+    "capital": {
+      "capital_items": {
+        "liquid": [
+          {
+            "description": "Online current accounts",
+            "value": "3707.06"
+          }
+        ],
+        "non_liquid": [
+
+        ],
+        "vehicles": [
+
+        ],
+        "properties": {
+          "main_home": {
+            "value": "300000.0",
+            "outstanding_mortgage": "150000.0",
+            "percentage_owned": "50.0",
+            "main_home": true,
+            "shared_with_housing_assoc": false,
+            "transaction_allowance": "9000.0",
+            "allowable_outstanding_mortgage": "150000.0",
+            "net_value": "141000.0",
+            "net_equity": "70500.0",
+            "main_home_equity_disregard": "100000.0",
+            "assessed_equity": "0.0"
+          },
+          "additional_properties": [
+            {
+              "value": "0.0",
+              "outstanding_mortgage": "0.0",
+              "percentage_owned": "0.0",
+              "main_home": false,
+              "shared_with_housing_assoc": false,
+              "transaction_allowance": "0.0",
+              "allowable_outstanding_mortgage": "0.0",
+              "net_value": "0.0",
+              "net_equity": "0.0",
+              "main_home_equity_disregard": "0.0",
+              "assessed_equity": "0.0"
+            }
+          ]
+        }
+      }
+    },
+    "remarks": {
+      "state_benefit_payment": {
+        "amount_variation": [
+          "7c4a1816-181c-4777-8c8f-7414b27b8c42",
+          "bf2c5c14-961e-4df5-9e19-7d542a807dd0",
+          "5c5c22d8-6e15-4ad0-b873-b964dfbd0cd6"
+        ]
+      },
+      "outgoings_childcare": {
+        "unknown_frequency": [
+          "2da0b53b-2e2c-4ea4-8920-e4e14dbb59e7"
+        ]
+      }
+    }
+  }
+}

--- a/spec/fixtures/files/cfe_civil_comparison/v6/rounding.json
+++ b/spec/fixtures/files/cfe_civil_comparison/v6/rounding.json
@@ -1,0 +1,270 @@
+{
+  "version": "6",
+  "timestamp": "2023-05-11T08:10:49.075Z",
+  "success": true,
+  "result_summary": {
+    "overall_result": {
+      "result": "contribution_required",
+      "capital_contribution": 707.06,
+      "income_contribution": 114.41,
+      "proceeding_types": [
+        {
+          "ccms_code": "DA004",
+          "client_involvement_type": "A",
+          "upper_threshold": 0.0,
+          "lower_threshold": 0.0,
+          "result": "contribution_required"
+        },
+        {
+          "ccms_code": "DA005",
+          "client_involvement_type": "A",
+          "upper_threshold": 0.0,
+          "lower_threshold": 0.0,
+          "result": "contribution_required"
+        }
+      ]
+    },
+    "gross_income": {
+      "total_gross_income": 1662.73,
+      "proceeding_types": [
+        {
+          "ccms_code": "DA004",
+          "client_involvement_type": "A",
+          "upper_threshold": 999999999999.0,
+          "lower_threshold": 0.0,
+          "result": "eligible"
+        },
+        {
+          "ccms_code": "DA005",
+          "client_involvement_type": "A",
+          "upper_threshold": 999999999999.0,
+          "lower_threshold": 0.0,
+          "result": "eligible"
+        }
+      ],
+      "combined_total_gross_income": 1662.73
+    },
+    "disposable_income": {
+      "dependant_allowance_under_16": 1016.6999999999999,
+      "dependant_allowance_over_16": 0,
+      "dependant_allowance": 1016.6999999999999,
+      "gross_housing_costs": 0.0,
+      "housing_benefit": 0.0,
+      "net_housing_costs": 0.0,
+      "maintenance_allowance": 0.0,
+      "total_outgoings_and_allowances": 1063.269999999999,
+      "total_disposable_income": 599.460000000001,
+      "employment_income": {
+        "gross_income": 0.0,
+        "benefits_in_kind": 0.0,
+        "tax": 0.0,
+        "national_insurance": 0.0,
+        "fixed_employment_deduction": 0.0,
+        "net_employment_income": 0.0
+      },
+      "income_contribution": 114.41,
+      "proceeding_types": [
+        {
+          "ccms_code": "DA004",
+          "client_involvement_type": "A",
+          "upper_threshold": 999999999999.0,
+          "lower_threshold": 315.0,
+          "result": "contribution_required"
+        },
+        {
+          "ccms_code": "DA005",
+          "client_involvement_type": "A",
+          "upper_threshold": 999999999999.0,
+          "lower_threshold": 315.0,
+          "result": "contribution_required"
+        }
+      ],
+      "combined_total_disposable_income": 599.460000000001,
+      "combined_total_outgoings_and_allowances": 1063.269999999999,
+      "partner_allowance": 0
+    },
+    "capital": {
+      "pensioner_disregard_applied": 0.0,
+      "total_liquid": 3707.06,
+      "total_non_liquid": 0.0,
+      "total_vehicle": 0.0,
+      "total_property": 0.0,
+      "total_mortgage_allowance": 999999999999.0,
+      "total_capital": 3707.06,
+      "subject_matter_of_dispute_disregard": 0.0,
+      "assessed_capital": 3707.06,
+      "total_capital_with_smod": 3707.06,
+      "disputed_non_property_disregard": 0,
+      "proceeding_types": [
+        {
+          "ccms_code": "DA004",
+          "client_involvement_type": "A",
+          "upper_threshold": 999999999999.0,
+          "lower_threshold": 3000.0,
+          "result": "contribution_required"
+        },
+        {
+          "ccms_code": "DA005",
+          "client_involvement_type": "A",
+          "upper_threshold": 999999999999.0,
+          "lower_threshold": 3000.0,
+          "result": "contribution_required"
+        }
+      ],
+      "combined_disputed_capital": 0.0,
+      "combined_non_disputed_capital": 3707.06,
+      "capital_contribution": 707.06,
+      "pensioner_capital_disregard": 0.0,
+      "combined_assessed_capital": 3707.06
+    }
+  },
+  "assessment": {
+    "id": "0a4ef3b3-f669-4d7b-8e8a-4ae65ec975ad",
+    "client_reference_id": "L-2M3-R9P",
+    "submission_date": "2023-05-04",
+    "level_of_help": "certificated",
+    "applicant": {
+      "date_of_birth": "1983-09-18",
+      "involvement_type": "applicant",
+      "employed": false,
+      "has_partner_opponent": false,
+      "receives_qualifying_benefit": false,
+      "self_employed": false
+    },
+    "gross_income": {
+      "employment_income": [
+
+      ],
+      "irregular_income": {
+        "monthly_equivalents": {
+          "student_loan": 1437.5,
+          "unspecified_source": 0.0
+        }
+      },
+      "state_benefits": {
+        "monthly_equivalents": {
+          "all_sources": 225.23,
+          "cash_transactions": 0.0,
+          "bank_transactions": [
+            {
+              "name": "Child Benefit",
+              "monthly_value": 225.23,
+              "excluded_from_income_assessment": false
+            }
+          ]
+        }
+      },
+      "other_income": {
+        "monthly_equivalents": {
+          "all_sources": {
+            "friends_or_family": 0.0,
+            "maintenance_in": 0.0,
+            "property_or_lodger": 0.0,
+            "pension": 0.0
+          },
+          "bank_transactions": {
+            "friends_or_family": 0.0,
+            "maintenance_in": 0.0,
+            "property_or_lodger": 0.0,
+            "pension": 0.0
+          },
+          "cash_transactions": {
+            "friends_or_family": 0.0,
+            "maintenance_in": 0.0,
+            "property_or_lodger": 0.0,
+            "pension": 0.0
+          }
+        }
+      }
+    },
+    "disposable_income": {
+      "monthly_equivalents": {
+        "all_sources": {
+          "child_care": 46.57,
+          "rent_or_mortgage": 0.0,
+          "maintenance_out": 0.0,
+          "legal_aid": 0.0
+        },
+        "bank_transactions": {
+          "child_care": 46.57,
+          "rent_or_mortgage": 0.0,
+          "maintenance_out": 0.0,
+          "legal_aid": 0.0
+        },
+        "cash_transactions": {
+          "child_care": 0.0,
+          "rent_or_mortgage": 0.0,
+          "maintenance_out": 0.0,
+          "legal_aid": 0.0
+        }
+      },
+      "childcare_allowance": 46.57,
+      "deductions": {
+        "dependants_allowance": 1016.6999999999999,
+        "disregarded_state_benefits": 0.0
+      }
+    },
+    "capital": {
+      "capital_items": {
+        "liquid": [
+          {
+            "description": "Online current accounts",
+            "value": 3707.06
+          }
+        ],
+        "non_liquid": [
+
+        ],
+        "vehicles": [
+
+        ],
+        "properties": {
+          "main_home": {
+            "value": 300000.0,
+            "outstanding_mortgage": 150000.0,
+            "percentage_owned": 50.0,
+            "main_home": true,
+            "shared_with_housing_assoc": false,
+            "transaction_allowance": 9000.0,
+            "allowable_outstanding_mortgage": 150000.0,
+            "net_value": 141000.0,
+            "net_equity": 70500.0,
+            "smod_allowance": 0,
+            "main_home_equity_disregard": 70500.0,
+            "assessed_equity": 0.0
+          },
+          "additional_properties": [
+            {
+              "value": 0.0,
+              "outstanding_mortgage": 0.0,
+              "percentage_owned": 0.0,
+              "main_home": false,
+              "shared_with_housing_assoc": false,
+              "transaction_allowance": 0.0,
+              "allowable_outstanding_mortgage": 0.0,
+              "net_value": 0.0,
+              "net_equity": 0.0,
+              "smod_allowance": 0,
+              "main_home_equity_disregard": 0.0,
+              "assessed_equity": 0.0
+            }
+          ]
+        }
+      }
+    },
+    "remarks": {
+      "state_benefit_payment": {
+        "amount_variation": [
+          "5c5c22d8-6e15-4ad0-b873-b964dfbd0cd6",
+          "bf2c5c14-961e-4df5-9e19-7d542a807dd0",
+          "7c4a1816-181c-4777-8c8f-7414b27b8c42"
+        ]
+      },
+      "outgoings_childcare": {
+        "unknown_frequency": [
+          "2da0b53b-2e2c-4ea4-8920-e4e14dbb59e7"
+        ]
+      }
+    }
+  }
+}

--- a/spec/services/cfe/compare_submission_spec.rb
+++ b/spec/services/cfe/compare_submission_spec.rb
@@ -107,5 +107,18 @@ RSpec.describe CFE::CompareSubmission do
 
       it { expect(call).to be false }
     end
+
+    context "when there is are results with rounding issues" do
+      let(:cfe_legacy_result) { file_fixture("cfe_civil_comparison/v5/rounding.json").read }
+      let(:cfe_civil_result) { file_fixture("cfe_civil_comparison/v6/rounding.json").read }
+
+      before do
+        allow(cfe_result).to receive(:result).and_return(cfe_legacy_result)
+        allow(submission_builder).to receive(:cfe_result).and_return(cfe_civil_result)
+        allow(submission_builder).to receive(:request_body).and_return({ "fake" => "return" })
+      end
+
+      it { expect(call).to be true }
+    end
   end
 end


### PR DESCRIPTION
## What

CFE-Civil returns floats and sometimes these have recurring fractions Whereas CFE-Legacy returns string values rounded to 2 digits

This allows 1234.23456789 to equal 1234.23 to pass the comparison

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
