### PR TITLE
Update README.md to replace LastPass with 1Password

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ brew bundle
 
 Git-crypt is used for encryption. It uses either your personal public key or a symmetric key.
 
-1. To obtain the symmetric key you will need to get access to LastPass. Liase with a team member for this. Once you have the the key you can unlock:
+1. To obtain the symmetric key you will need to get access to 1Password. Liase with a team member for this. Once you have the the key you can unlock:
 
 ```sh
 git-crypt unlock path-to-symmetric-key
@@ -380,7 +380,7 @@ To enable full logs in the test environment, `ENV['RAILS_ENABLE_TEST_LOG']` must
 
 ### Staging and Production
 
-Staging and production databases are RDS instances on the MOJ Cloud Platform. Connection details are held in LastPass.
+Staging and production databases are RDS instances on the MOJ Cloud Platform. Connection details are held in 1Password.
 
 These databases are within the AWS VPC and are not publicly available. In order to connect
 to an RDS database from a local client, first run:

--- a/helm_deploy/apply-for-legal-aid/README.md
+++ b/helm_deploy/apply-for-legal-aid/README.md
@@ -3,7 +3,7 @@
 This describes the setup for helm and what is required to be in place to perform deploys.
 
 ## CI configuration
-The values are now stored in environment variables and contexts in circle ci - a full set of key value pairs can be found in lastpass
+The values are now stored in environment variables and contexts in circle ci - a full set of key value pairs can be found in 1Password.
 
 For more information on how to correctly configure CircleCI to be able to deploy to the K8S environment, click [here](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/using-circleci-for-continuous-deployment.html#add-variables-to-circleci).
 


### PR DESCRIPTION

## What

Updated the README.md with details of 1Password instead of LastPass since we are no longer using LastPass.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
