### PR TITLE
Update: CFE Comparison

### DIFF
--- a/app/services/cfe/compare_submission.rb
+++ b/app/services/cfe/compare_submission.rb
@@ -86,6 +86,7 @@ module CFE
       [
         /assessment-capital-capital_items-vehicles-\d-date_of_purchase/,
         /assessment-capital-capital_items-properties-main_home-main_home_equity_disregard/,
+        /result_summary-capital-assessed_capital/,
       ].any? { |pattern| pattern.match?(key.join("-")) }
     end
 


### PR DESCRIPTION
## What

We saw a disparity in the return values for result_summary/capital/assessed_capital 

After analysing the return values it was determined that it does not affect the Apply service as the value is applied correctly in the calculations and we do not explicitly display that field.  

After extending the scenarios it was assessed that the correct value is shown when a pensioner_capital_disregard is generated but when it was not applicable Legacy returned a minus figure of the full amount and civil returns 0 (the amount applied).  

Therefore we are ignoring this field for the comparisons going forward

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
