### PR TITLE
Update CFE comparison

### DIFF
--- a/app/services/cfe/compare_submission.rb
+++ b/app/services/cfe/compare_submission.rb
@@ -87,6 +87,9 @@ module CFE
         /assessment-capital-capital_items-vehicles-\d-date_of_purchase/,
         /assessment-capital-capital_items-properties-main_home-main_home_equity_disregard/,
         /result_summary-capital-assessed_capital/,
+        /assessment-capital-capital_items-properties-main_home-transaction_allowance/,
+        /assessment-capital-capital_items-properties-main_home-net_value/,
+        /assessment-capital-capital_items-properties-main_home-net_equity/,
       ].any? { |pattern| pattern.match?(key.join("-")) }
     end
 


### PR DESCRIPTION
## What

We have seen some mismatches around the main_home values

After analysing the issues we have discovered that:
* it only occurs when the mortgage value exceeds the house value e.g. provider misses a zero from the house value
* It is another area where Legacy returns the calculated value regardless of whether it is negative or not, whereas Civil returns zero when the value is below zero

Because of this, we have agreed that we can ignore these fields as when the values are all positive they correctly align

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
