### PR TITLE
chore: use `--no-install-recommends` flag to `apt` in dockerfile

### DIFF
--- a/docker/apply_ci.dockerfile
+++ b/docker/apply_ci.dockerfile
@@ -3,7 +3,8 @@ MAINTAINER apply for legal aid team
 
 RUN wget https://mirrors.kernel.org/ubuntu/pool/main/libf/libffi/libffi6_3.2.1-8_amd64.deb -O /tmp/libffi6_3.2.1-8_amd64.deb
 RUN sudo apt-get update
-RUN sudo apt install /tmp/libffi6_3.2.1-8_amd64.deb
-RUN sudo apt-get install -y postgresql-client \
-                            clamav-daemon \
-                            git-crypt
+RUN sudo apt install --no-install-recommends /tmp/libffi6_3.2.1-8_amd64.deb
+RUN sudo apt-get install -y --no-install-recommends \
+	                            postgresql-client \
+                              clamav-daemon \
+                              git-crypt


### PR DESCRIPTION
## What

Add `--no-install-recommends` flag to `apt` in dockerfile to prevent unnecessary packages from being installed, thereby reducing possible attack vectors and reducing bloatware in Docker.

See [We reduced our Docker images by 60% with –no-install-recommends](https://ubuntu.com/blog/we-reduced-our-docker-images-by-60-with-no-install-recommends)

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
