### PR TITLE
Fix: Allow a CCMS Submission when the flag is off

### DIFF
--- a/app/models/concerns/base_state_machine.rb
+++ b/app/models/concerns/base_state_machine.rb
@@ -5,7 +5,7 @@ class BaseStateMachine < ApplicationRecord
   delegate :non_means_tested?, to: :legal_aid_application
 
   def allow_ccms_submission?
-    EnableCCMSSubmission.call
+    EnableCCMSSubmission.call || ENV.fetch("LOCAL_CCMS_OVERRIDE", "false") == "true"
   end
 
   VALID_CCMS_REASONS = %i[


### PR DESCRIPTION
When we have turned off CCMS Submission there is usually a small number of queued submissions to restart.  After a significant outage we may want to try submitting one or two applications first before opening the floodgates.

This allows a developer to open a terminal window and start a rails console session that will allow some applications to be processed individually

Open a rails console with
```shell
LOCAL_CCMS_OVERRIDE=true rails c
```

Then you can find an application and
```ruby
@applications = LegalAidApplication.joins(:state_machine).
                                    where(state_machine_proxies: { aasm_state: "submission_paused" }).
                                    order(:created_at)
laa.first.restart_submission!
```



## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-XXX)

Describe what you did and why.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
