### PR TITLE
Update CFE::CompareSubmission

### DIFF
--- a/app/services/cfe/compare_submission.rb
+++ b/app/services/cfe/compare_submission.rb
@@ -66,7 +66,14 @@ module CFE
           test_value.each do |values|
             case values
             when Hash
-              compare_array(key, values, @v6_result.dig(*key).find { |group| group[values.keys.first] == values[values.keys.first] })
+              v6_values = @v6_result.dig(*key).find do |group|
+                group[values.keys.first] == values[values.keys.first] && group[values.keys.second].to_s == values[values.keys.second].to_s
+              end
+              if v6_values.nil?
+                @results[key.join("/")] = "CFE-Legacy=#{values.keys.first}, could not find matching array in CFE-Civil"
+              else
+                compare_array(key, values, v6_values)
+              end
             when String
               # this should be an array of strings so test the above level
               result = test_value - @v6_result.dig(*key)

--- a/spec/fixtures/files/cfe_civil_comparison/v5/mismatch_array.json
+++ b/spec/fixtures/files/cfe_civil_comparison/v5/mismatch_array.json
@@ -197,7 +197,8 @@
           },
           {
             "description": "Current accounts",
-            "value": "300.0"
+            "value": "300.0",
+            "test": "error"
           }
         ],
         "non_liquid":

--- a/spec/fixtures/files/cfe_civil_comparison/v5/payment_sequence_mismatch_array.json
+++ b/spec/fixtures/files/cfe_civil_comparison/v5/payment_sequence_mismatch_array.json
@@ -1,0 +1,283 @@
+{
+  "version": "5",
+  "timestamp": "2023-02-13T15:27:19.827Z",
+  "success": true,
+  "result_summary": {
+    "overall_result": {
+      "result": "contribution_required",
+      "capital_contribution": 0.0,
+      "income_contribution": 347.28,
+      "proceeding_types": [
+        {
+          "ccms_code": "DA004",
+          "client_involvement_type": "A",
+          "upper_threshold": 0.0,
+          "lower_threshold": 0.0,
+          "result": "contribution_required"
+        }
+      ]
+    },
+    "gross_income": {
+      "total_gross_income": 1084.53,
+      "proceeding_types": [
+        {
+          "ccms_code": "DA004",
+          "client_involvement_type": "A",
+          "upper_threshold": 999999999999.0,
+          "lower_threshold": 0.0,
+          "result": "eligible"
+        }
+      ]
+    },
+    "disposable_income": {
+      "dependant_allowance": 0.0,
+      "gross_housing_costs": 0.0,
+      "housing_benefit": 0.0,
+      "net_housing_costs": 0.0,
+      "maintenance_allowance": 0.0,
+      "total_outgoings_and_allowances": 146.49,
+      "total_disposable_income": 938.04,
+      "employment_income": {
+        "gross_income": 1084.53,
+        "benefits_in_kind": 0.0,
+        "tax": -49.2,
+        "national_insurance": -52.29,
+        "fixed_employment_deduction": -45.0,
+        "net_employment_income": 938.04
+      },
+      "income_contribution": 347.28,
+      "proceeding_types": [
+        {
+          "ccms_code": "DA004",
+          "client_involvement_type": "A",
+          "upper_threshold": 999999999999.0,
+          "lower_threshold": 315.0,
+          "result": "contribution_required"
+        }
+      ]
+    },
+    "capital": {
+      "total_liquid": 0.0,
+      "total_non_liquid": 0.0,
+      "total_vehicle": 0.0,
+      "total_property": 0.0,
+      "total_mortgage_allowance": 999999999999.0,
+      "total_capital": 0.0,
+      "pensioner_capital_disregard": 0.0,
+      "subject_matter_of_dispute_disregard": 0.0,
+      "capital_contribution": 0.0,
+      "assessed_capital": 0.0,
+      "proceeding_types": [
+        {
+          "ccms_code": "DA004",
+          "client_involvement_type": "A",
+          "upper_threshold": 999999999999.0,
+          "lower_threshold": 3000.0,
+          "result": "eligible"
+        }
+      ]
+    }
+  },
+  "assessment": {
+    "id": "17d69cb9-2469-426c-af1d-0cc9604c3634",
+    "client_reference_id": "L-Y8K-LHK",
+    "submission_date": "2023-02-13",
+    "applicant": {
+      "date_of_birth": "1970-03-12",
+      "involvement_type": "applicant",
+      "employed": true,
+      "has_partner_opponent": false,
+      "receives_qualifying_benefit": false,
+      "self_employed": false
+    },
+    "gross_income": {
+      "employment_income": [
+        {
+          "name": "Job 1",
+          "payments": [
+            {
+              "date": "2023-01-31",
+              "gross": 513.43,
+              "benefits_in_kind": 0.0,
+              "tax": 0.0,
+              "national_insurance": 0.0,
+              "net_employment_income": 513.43
+            },
+            {
+              "date": "2022-12-31",
+              "gross": 1987.31,
+              "benefits_in_kind": 0.0,
+              "tax": -187.8,
+              "national_insurance": -112.72,
+              "net_employment_income": 1686.79
+            },
+            {
+              "date": "2022-12-31",
+              "gross": -1245.01,
+              "benefits_in_kind": 0.0,
+              "tax": 0.0,
+              "national_insurance": 0.0,
+              "net_employment_income": -1245.01
+            },
+            {
+              "date": "2022-11-30",
+              "gross": 2083.47,
+              "benefits_in_kind": 0.0,
+              "tax": -207.0,
+              "national_insurance": -124.26,
+              "net_employment_income": 1752.21
+            },
+            {
+              "date": "2022-10-31",
+              "gross": 2083.47,
+              "benefits_in_kind": 0.0,
+              "tax": -207.2,
+              "national_insurance": -137.2,
+              "net_employment_income": 1739.07
+            }
+          ]
+        }
+      ],
+      "irregular_income": {
+        "monthly_equivalents": {
+          "student_loan": 0.0,
+          "unspecified_source": 0.0
+        }
+      },
+      "state_benefits": {
+        "monthly_equivalents": {
+          "all_sources": 0.0,
+          "cash_transactions": 0.0,
+          "bank_transactions": [
+
+          ]
+        }
+      },
+      "other_income": {
+        "monthly_equivalents": {
+          "all_sources": {
+            "friends_or_family": 0.0,
+            "maintenance_in": 0.0,
+            "property_or_lodger": 0.0,
+            "pension": 0.0
+          },
+          "bank_transactions": {
+            "friends_or_family": 0.0,
+            "maintenance_in": 0.0,
+            "property_or_lodger": 0.0,
+            "pension": 0.0
+          },
+          "cash_transactions": {
+            "friends_or_family": 0.0,
+            "maintenance_in": 0.0,
+            "property_or_lodger": 0.0,
+            "pension": 0.0
+          }
+        }
+      }
+    },
+    "disposable_income": {
+      "monthly_equivalents": {
+        "all_sources": {
+          "child_care": 0.0,
+          "rent_or_mortgage": 0.0,
+          "maintenance_out": 0.0,
+          "legal_aid": 0.0
+        },
+        "bank_transactions": {
+          "child_care": 0.0,
+          "rent_or_mortgage": 0.0,
+          "maintenance_out": 0.0,
+          "legal_aid": 0.0
+        },
+        "cash_transactions": {
+          "child_care": 0.0,
+          "rent_or_mortgage": 0.0,
+          "maintenance_out": 0.0,
+          "legal_aid": 0.0
+        }
+      },
+      "childcare_allowance": 0.0,
+      "deductions": {
+        "dependants_allowance": 0.0,
+        "disregarded_state_benefits": 0.0
+      }
+    },
+    "capital": {
+      "capital_items": {
+        "liquid": [
+          {
+            "description": "Online current accounts",
+            "value": "-1004.96"
+          }
+        ],
+        "non_liquid": [
+
+        ],
+        "vehicles": [
+          {
+            "value": 8000.0,
+            "loan_amount_outstanding": 0.0,
+            "date_of_purchase": "2021-02-13",
+            "in_regular_use": true,
+            "included_in_assessment": false,
+            "assessed_value": 0.0
+          }
+        ],
+        "properties": {
+          "main_home": {
+            "value": "0.0",
+            "outstanding_mortgage": "0.0",
+            "percentage_owned": "0.0",
+            "main_home": true,
+            "shared_with_housing_assoc": false,
+            "transaction_allowance": "0.0",
+            "allowable_outstanding_mortgage": "0.0",
+            "net_value": "0.0",
+            "net_equity": "0.0",
+            "main_home_equity_disregard": "100000.0",
+            "assessed_equity": "0.0"
+          },
+          "additional_properties": [
+            {
+              "value": "0.0",
+              "outstanding_mortgage": "0.0",
+              "percentage_owned": "0.0",
+              "main_home": false,
+              "shared_with_housing_assoc": false,
+              "transaction_allowance": "0.0",
+              "allowable_outstanding_mortgage": "0.0",
+              "net_value": "0.0",
+              "net_equity": "0.0",
+              "main_home_equity_disregard": "0.0",
+              "assessed_equity": "0.0"
+            }
+          ]
+        }
+      }
+    },
+    "remarks": {
+      "employment_tax": {
+        "refunds": [
+          "0214f3ca-f0f8-416a-a836-142b31618f6e",
+          "281c10e0-091c-43c7-815d-2eb1f78b2956"
+        ]
+      },
+      "employment_nic": {
+        "refunds": [
+          "0214f3ca-f0f8-416a-a836-142b31618f6e",
+          "281c10e0-091c-43c7-815d-2eb1f78b2956"
+        ]
+      },
+      "employment_payment": {
+        "unknown_frequency": [
+          "0214f3ca-f0f8-416a-a836-142b31618f6e",
+          "281c10e0-091c-43c7-815d-2eb1f78b2956",
+          "8df954a7-396a-479e-a39c-08493de5869c",
+          "a45d2cc5-9e2b-4d96-adbf-68a469fdd2f9",
+          "79ccc320-d22f-45d1-9b9b-033f5a4ff14d"
+        ]
+      }
+    }
+  }
+}

--- a/spec/fixtures/files/cfe_civil_comparison/v6/mismatch_array.json
+++ b/spec/fixtures/files/cfe_civil_comparison/v6/mismatch_array.json
@@ -206,7 +206,8 @@
         [
           {
             "description": "Current accounts",
-            "value": 300.0
+            "value": 300.0,
+            "test": "no error"
           },
           {
             "description": "Savings accounts",

--- a/spec/fixtures/files/cfe_civil_comparison/v6/payment_sequence_mismatch_array.json
+++ b/spec/fixtures/files/cfe_civil_comparison/v6/payment_sequence_mismatch_array.json
@@ -1,0 +1,298 @@
+{
+  "version": "6",
+  "timestamp": "2023-05-19T08:06:04.328Z",
+  "success": true,
+  "result_summary": {
+    "overall_result": {
+      "result": "contribution_required",
+      "capital_contribution": 0.0,
+      "income_contribution": 347.28,
+      "proceeding_types": [
+        {
+          "ccms_code": "DA004",
+          "client_involvement_type": "A",
+          "upper_threshold": 0.0,
+          "lower_threshold": 0.0,
+          "result": "contribution_required"
+        }
+      ]
+    },
+    "gross_income": {
+      "total_gross_income": 1084.53,
+      "proceeding_types": [
+        {
+          "ccms_code": "DA004",
+          "client_involvement_type": "A",
+          "upper_threshold": 999999999999.0,
+          "lower_threshold": 0.0,
+          "result": "eligible"
+        }
+      ],
+      "combined_total_gross_income": 1084.53
+    },
+    "disposable_income": {
+      "dependant_allowance_under_16": 0,
+      "dependant_allowance_over_16": 0,
+      "dependant_allowance": 0,
+      "gross_housing_costs": 0.0,
+      "housing_benefit": 0.0,
+      "net_housing_costs": 0.0,
+      "maintenance_allowance": 0.0,
+      "total_outgoings_and_allowances": 146.49,
+      "total_disposable_income": 938.04,
+      "employment_income": {
+        "gross_income": 1084.53,
+        "benefits_in_kind": 0.0,
+        "tax": -49.2,
+        "national_insurance": -52.29,
+        "fixed_employment_deduction": -45.0,
+        "net_employment_income": 938.04
+      },
+      "income_contribution": 347.28,
+      "proceeding_types": [
+        {
+          "ccms_code": "DA004",
+          "client_involvement_type": "A",
+          "upper_threshold": 999999999999.0,
+          "lower_threshold": 315.0,
+          "result": "contribution_required"
+        }
+      ],
+      "combined_total_disposable_income": 938.04,
+      "combined_total_outgoings_and_allowances": 146.49,
+      "partner_allowance": 0
+    },
+    "capital": {
+      "pensioner_disregard_applied": 0.0,
+      "total_liquid": 0.0,
+      "total_non_liquid": 0.0,
+      "total_vehicle": 0.0,
+      "total_property": 0.0,
+      "total_mortgage_allowance": 999999999999.0,
+      "total_capital": 0.0,
+      "subject_matter_of_dispute_disregard": 0.0,
+      "assessed_capital": 0.0,
+      "total_capital_with_smod": 0.0,
+      "disputed_non_property_disregard": 0,
+      "proceeding_types": [
+        {
+          "ccms_code": "DA004",
+          "client_involvement_type": "A",
+          "upper_threshold": 999999999999.0,
+          "lower_threshold": 3000.0,
+          "result": "eligible"
+        }
+      ],
+      "combined_disputed_capital": 0.0,
+      "combined_non_disputed_capital": 0.0,
+      "capital_contribution": 0.0,
+      "pensioner_capital_disregard": 0.0,
+      "combined_assessed_capital": 0.0
+    }
+  },
+  "assessment": {
+    "id": "19e86200-ab4a-47de-8d89-ef0e0507091b",
+    "client_reference_id": "L-Y8K-LHK",
+    "submission_date": "2023-02-13",
+    "level_of_help": "certificated",
+    "applicant": {
+      "date_of_birth": "1970-03-12",
+      "involvement_type": "applicant",
+      "employed": true,
+      "has_partner_opponent": false,
+      "receives_qualifying_benefit": false
+    },
+    "gross_income": {
+      "employment_income": [
+        {
+          "name": "Job 1",
+          "payments": [
+            {
+              "date": "2023-01-31",
+              "gross": 513.43,
+              "benefits_in_kind": 0.0,
+              "tax": 0.0,
+              "national_insurance": 0.0,
+              "net_employment_income": 513.43
+            },
+            {
+              "date": "2022-12-31",
+              "gross": -1245.01,
+              "benefits_in_kind": 0.0,
+              "tax": 0.0,
+              "national_insurance": 0.0,
+              "net_employment_income": -1245.01
+            },
+            {
+              "date": "2022-12-31",
+              "gross": 1987.31,
+              "benefits_in_kind": 0.0,
+              "tax": -187.8,
+              "national_insurance": -112.72,
+              "net_employment_income": 1686.79
+            },
+            {
+              "date": "2022-11-30",
+              "gross": 2083.47,
+              "benefits_in_kind": 0.0,
+              "tax": -207.0,
+              "national_insurance": -124.26,
+              "net_employment_income": 1752.21
+            },
+            {
+              "date": "2022-10-31",
+              "gross": 2083.47,
+              "benefits_in_kind": 0.0,
+              "tax": -207.2,
+              "national_insurance": -137.2,
+              "net_employment_income": 1739.07
+            }
+          ]
+        }
+      ],
+      "irregular_income": {
+        "monthly_equivalents": {
+          "student_loan": 0.0,
+          "unspecified_source": 0.0
+        }
+      },
+      "state_benefits": {
+        "monthly_equivalents": {
+          "all_sources": 0.0,
+          "cash_transactions": 0.0,
+          "bank_transactions": [
+
+          ]
+        }
+      },
+      "other_income": {
+        "monthly_equivalents": {
+          "all_sources": {
+            "friends_or_family": 0.0,
+            "maintenance_in": 0.0,
+            "property_or_lodger": 0.0,
+            "pension": 0.0
+          },
+          "bank_transactions": {
+            "friends_or_family": 0.0,
+            "maintenance_in": 0.0,
+            "property_or_lodger": 0.0,
+            "pension": 0.0
+          },
+          "cash_transactions": {
+            "friends_or_family": 0.0,
+            "maintenance_in": 0.0,
+            "property_or_lodger": 0.0,
+            "pension": 0.0
+          }
+        }
+      }
+    },
+    "disposable_income": {
+      "monthly_equivalents": {
+        "all_sources": {
+          "child_care": 0.0,
+          "rent_or_mortgage": 0.0,
+          "maintenance_out": 0.0,
+          "legal_aid": 0.0
+        },
+        "bank_transactions": {
+          "child_care": 0.0,
+          "rent_or_mortgage": 0.0,
+          "maintenance_out": 0.0,
+          "legal_aid": 0.0
+        },
+        "cash_transactions": {
+          "child_care": 0.0,
+          "rent_or_mortgage": 0.0,
+          "maintenance_out": 0.0,
+          "legal_aid": 0.0
+        }
+      },
+      "childcare_allowance": 0.0,
+      "deductions": {
+        "dependants_allowance": 0.0,
+        "disregarded_state_benefits": 0.0
+      }
+    },
+    "capital": {
+      "capital_items": {
+        "liquid": [
+          {
+            "description": "Online current accounts",
+            "value": -1004.96
+          }
+        ],
+        "non_liquid": [
+
+        ],
+        "vehicles": [
+          {
+            "value": 8000.0,
+            "loan_amount_outstanding": 0.0,
+            "date_of_purchase": "2021-05-19",
+            "in_regular_use": true,
+            "included_in_assessment": false,
+            "disregards_and_deductions": 8000.0,
+            "assessed_value": 0.0
+          }
+        ],
+        "properties": {
+          "main_home": {
+            "value": 0.0,
+            "outstanding_mortgage": 0.0,
+            "percentage_owned": 0.0,
+            "main_home": true,
+            "shared_with_housing_assoc": false,
+            "transaction_allowance": 0.0,
+            "allowable_outstanding_mortgage": 0.0,
+            "net_value": 0.0,
+            "net_equity": 0.0,
+            "smod_allowance": 0,
+            "main_home_equity_disregard": 0.0,
+            "assessed_equity": 0.0
+          },
+          "additional_properties": [
+            {
+              "value": 0.0,
+              "outstanding_mortgage": 0.0,
+              "percentage_owned": 0.0,
+              "main_home": false,
+              "shared_with_housing_assoc": false,
+              "transaction_allowance": 0.0,
+              "allowable_outstanding_mortgage": 0.0,
+              "net_value": 0.0,
+              "net_equity": 0.0,
+              "smod_allowance": 0,
+              "main_home_equity_disregard": 0.0,
+              "assessed_equity": 0.0
+            }
+          ]
+        }
+      }
+    },
+    "remarks": {
+      "employment_tax": {
+        "refunds": [
+          "0214f3ca-f0f8-416a-a836-142b31618f6e",
+          "281c10e0-091c-43c7-815d-2eb1f78b2956"
+        ]
+      },
+      "employment_nic": {
+        "refunds": [
+          "0214f3ca-f0f8-416a-a836-142b31618f6e",
+          "281c10e0-091c-43c7-815d-2eb1f78b2956"
+        ]
+      },
+      "employment_payment": {
+        "unknown_frequency": [
+          "0214f3ca-f0f8-416a-a836-142b31618f6e",
+          "281c10e0-091c-43c7-815d-2eb1f78b2956",
+          "8df954a7-396a-479e-a39c-08493de5869c",
+          "a45d2cc5-9e2b-4d96-adbf-68a469fdd2f9",
+          "79ccc320-d22f-45d1-9b9b-033f5a4ff14d"
+        ]
+      }
+    }
+  }
+}

--- a/spec/services/cfe/compare_submission_spec.rb
+++ b/spec/services/cfe/compare_submission_spec.rb
@@ -120,5 +120,18 @@ RSpec.describe CFE::CompareSubmission do
 
       it { expect(call).to be true }
     end
+
+    context "when the assessment/gross_income/employment_income/0/payments sequence does not match" do
+      let(:cfe_legacy_result) { file_fixture("cfe_civil_comparison/v5/payment_sequence_mismatch_array.json").read }
+      let(:cfe_civil_result) { file_fixture("cfe_civil_comparison/v6/payment_sequence_mismatch_array.json").read }
+
+      before do
+        allow(cfe_result).to receive(:result).and_return(cfe_legacy_result)
+        allow(submission_builder).to receive(:cfe_result).and_return(cfe_civil_result)
+        allow(submission_builder).to receive(:request_body).and_return({ "fake" => "return" })
+      end
+
+      it { expect(call).to be true }
+    end
   end
 end


### PR DESCRIPTION
## What

Some of the arrays of hashes were getting returned in a different order When there are multiple payments in a month there is no way of guaranteeing the sequence.  This checks for multiple values in a hash and searches for a string match on both...

It is hacky and nasty but hopefully shortlived until we switch over when this, and all the fixtures, can be deleted

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
