### PR TITLE
[AP-3648] Use start button helper

### DIFF
--- a/app/assets/stylesheets/govuk-mods.scss
+++ b/app/assets/stylesheets/govuk-mods.scss
@@ -29,9 +29,4 @@ dl.govuk-list.inline-list {
   }
 }
 
-// Start button IE11 fix - adding a width of 15.5px to the SVG (AP-933)
-.govuk-button__start-icon {
-  width: 15.5px;
-}
-
 // stylelint-enable selector-no-qualifying-type

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -73,17 +73,6 @@ module ApplicationHelper
     content_tag :button, text, class: "govuk-button govuk-button--secondary no-print print-button", type: "button"
   end
 
-  def start_button_label(button_text)
-    "#{t("generic.#{button_text}")} ".html_safe << content_tag(:svg,
-                                                               content_tag(:path, "", fill: "currentColor", d: "M0 0h13l20 20-20 20H0l20-20z"),
-                                                               class: "govuk-button__start-icon",
-                                                               xmlns: "http://www.w3.org/2000/svg",
-                                                               height: "19",
-                                                               viewBox: "0 0 33 40",
-                                                               role: "presentation",
-                                                               focusable: "false")
-  end
-
   def linked_children_names(proceeding)
     proceeding.involved_children.map(&:full_name).join("</br>").html_safe
   end

--- a/app/views/citizens/legal_aid_applications/index.html.erb
+++ b/app/views/citizens/legal_aid_applications/index.html.erb
@@ -23,10 +23,6 @@
 
   <p class="govuk-body"><%= t(".online_banking_details") %></p>
 
-  <%= link_to_accessible start_button_label(:start_now),
-                         forward_path,
-                         class: "govuk-button govuk-button--start govuk-!-margin-top-2",
-                         role: "button",
-                         id: "start" %>
+  <%= govuk_start_button(text: t("generic.start_now"), href: forward_path, html_attributes: { id: "start" }) %>
 
 <% end %>

--- a/app/views/providers/legal_aid_applications/index.html.erb
+++ b/app/views/providers/legal_aid_applications/index.html.erb
@@ -1,11 +1,6 @@
 <%= page_template(page_title: t(".heading_1"), back_link: :none) do %>
 
-  <%= link_to_accessible(start_button_label(:new_app),
-                         providers_declaration_path,
-                         class: "govuk-button govuk-button--start",
-                         role: "button",
-                         id: "start",
-                         method: :get) %>
+  <%= govuk_start_button(text: t("generic.new_app"), href: providers_declaration_path, html_attributes: { id: "start" }) %>
 
 <% end %>
 

--- a/app/views/providers/start/index.html.erb
+++ b/app/views/providers/start/index.html.erb
@@ -17,10 +17,6 @@
 
     <p class="govuk-body"><%= t(".use_ccms_para_html") %></p>
 
-    <%= link_to_accessible start_button_label(:start_now),
-                           providers_legal_aid_applications_path,
-                           role: "button",
-                           class: "govuk-button govuk-button--start",
-                           id: "start" %>
+    <%= govuk_start_button(text: t("generic.start_now"), href: providers_legal_aid_applications_path, html_attributes: { id: "start" }) %>
   </div>
 </div>


### PR DESCRIPTION

## What

[Use start button helper](https://dsdmoj.atlassian.net/browse/AP-3648)

Update views to use the start button helper from the govuk-components gem
Identify and remove redundant code related to the start button component

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
