### PR TITLE
Fix: Update MatchLabel with worker Suffix for sidekiq pods

### DIFF
--- a/helm_deploy/apply-for-legal-aid/templates/deployment_worker.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/deployment_worker.yaml
@@ -16,12 +16,12 @@ spec:
       maxSurge: 100%
   selector:
     matchLabels:
-      app: {{ template "apply-for-legal-aid.name" . }}
+      app: {{ template "apply-for-legal-aid.name" . }}-worker
       release: {{ .Release.Name }}
   template:
     metadata:
       labels:
-        app: {{ template "apply-for-legal-aid.name" . }}
+        app: {{ template "apply-for-legal-aid.name" . }}-worker
         release: {{ .Release.Name }}
     spec:
       containers:


### PR DESCRIPTION
## What

This came out of a conversation with @Obsiye around issues seen on CCCD

There is a chance that, as the deployment_worker pods share a label with the deployment_web pods,it causes routing issues that raise 502 errors on production.

This is because kubernetes sees the two types of pod as the same and tries to route web queries to a sidekiq pod that cannot respond to a Rails-based web request.

This PR adds a specific suffix to the worker pods so that kubernetes can route the requests correctly.

This has been tested on UAT and email requests were successfully sent, this means that the worker pods are still linked, and running, successfully.

The only way of testing _full_ success is to deploy to production and see if the number of 502 errors reduces.
I will set up a google sheet to track the number of 502 issues per day and update to track.

Headsup - there may be issues deploying as the labels on the running pods will not match the new labels.  There is a confluence document that explains what and why and the worker deployments will be deleted as needed for each environment

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
