### PR TITLE
[AP-3641] Use cookie banner helper

### DIFF
--- a/app/javascript/src/cookie_banner.js
+++ b/app/javascript/src/cookie_banner.js
@@ -14,14 +14,16 @@ async function updateCookiePreferences (providerId, action) {
 function initCookieBanner (cookieBanner) {
   const buttons = cookieBanner.querySelectorAll('.govuk-button')
   buttons.forEach((btn) => {
-    if (btn.value === 'hide') {
+    if (btn.getAttribute('data-value') === 'hide') {
       btn.addEventListener('click', (e) => {
+        e.preventDefault()
         hide(cookieBanner)
       })
     } else {
       btn.addEventListener('click', (e) => {
+        e.preventDefault()
         const providerId = document.getElementById('provider-id').textContent.trim()
-        const btnValue = e.target.value
+        const btnValue = e.target.getAttribute('data-value')
         updateCookiePreferences(providerId, btnValue).then(() => {
           const mainContent = cookieBanner.querySelector('#main-cookie-content')
           const newContent = cookieBanner.querySelector(`#${btnValue}-content`)
@@ -36,7 +38,7 @@ function initCookieBanner (cookieBanner) {
 }
 
 document.addEventListener('DOMContentLoaded', (e) => {
-  const cookieBanner = document.querySelector('#cookie-banner')
+  const cookieBanner = document.querySelector('.govuk-cookie-banner')
   if (cookieBanner) {
     initCookieBanner(cookieBanner)
   }

--- a/app/views/shared/partials/_cookie_banner.html.erb
+++ b/app/views/shared/partials/_cookie_banner.html.erb
@@ -1,69 +1,23 @@
-<div class="govuk-cookie-banner" id="cookie-banner" data-nosnippet role="region" aria-label="Cookies on Apply for legal aid">
-  <div class="govuk-cookie-banner__message govuk-width-container" id="main-cookie-content">
+<%= govuk_cookie_banner(aria_label: t(".title")) do |cb| %>
+  <% cb.with_message(heading_text: t(".title"), html_attributes: { id: "main-cookie-content" }) do |m| %>
     <span class="hidden" aria-hidden="true" id="provider-id"><%= current_provider.id %></span>
+    <p class="govuk-body"><%= t(".we_use_some") %></p>
+    <p class="govuk-body"><%= t(".wed_also_like") %></p>
 
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-        <h2 class="govuk-cookie-banner__heading govuk-heading-m"><%= t(".title") %></h2>
+    <% m.with_action { govuk_button_link_to(t(".accept"), "#", { data: { value: "accept" } }) } %>
+    <% m.with_action { govuk_button_link_to(t(".reject"), "#", { data: { value: "reject" } }) } %>
+    <% m.with_action { govuk_link_to(t(".view"), providers_cooky_path(current_provider)) } %>
+  <% end %>
 
-        <div class="govuk-cookie-banner__content">
-          <p class="govuk-body"><%= t(".we_use_some") %></p>
-          <p class="govuk-body"><%= t(".wed_also_lie") %></p>
-        </div>
-      </div>
-    </div>
+  <% cb.with_message(role: "alert", html_attributes: { id: "accept-content", hidden: true }) do |m| %>
+    <p class="govuk-body"><%= t(".cookie_confirmation_msg_html", cookie_state: t(".accepted"), cookie_path: providers_cooky_path(current_provider)) %></p>
 
-    <div class="govuk-button-group">
-      <button value="accept" type="button" name="cookies" class="govuk-button" data-module="govuk-button">
-        <%= t(".accept") %>
-      </button>
-      <button value="reject" type="button" name="cookies" class="govuk-button" data-module="govuk-button">
-        <%= t(".reject") %>
-      </button>
-      <%= link_to_accessible t(".view"), providers_cooky_path(current_provider), class: "govuk-link" %>
-    </div>
-  </div>
+    <% m.with_action { govuk_button_link_to(t(".hide"), "#", { data: { value: "hide" } }) } %>
+  <% end %>
 
-  <div class="govuk-cookie-banner__message govuk-width-container" role="alert" id="accept-content" hidden>
+  <% cb.with_message(role: "alert", html_attributes: { id: "reject-content", hidden: true }) do |m| %>
+    <p class="govuk-body"><%= t(".cookie_confirmation_msg_html", cookie_state: t(".rejected"), cookie_path: providers_cooky_path(current_provider)) %></p>
 
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-
-        <div class="govuk-cookie-banner__content">
-          <p class="govuk-body">
-            <%= t(".accepted") %>
-            <%= link_to_accessible t(".link_text"), providers_cooky_path(current_provider), class: "govuk-link" %>
-            <%= t(".any_time") %>
-          </p>
-        </div>
-      </div>
-    </div>
-
-    <div class="govuk-button-group">
-      <button value="hide" class="govuk-button" data-module="govuk-button">
-        <%= t(".hide") %>
-      </button>
-    </div>
-  </div>
-
-  <div class="govuk-cookie-banner__message govuk-width-container" role="alert" id="reject-content" hidden>
-
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-
-        <div class="govuk-cookie-banner__content">
-          <p class="govuk-body">
-            <%= t(".rejected") %>
-            <%= link_to_accessible t(".link_text"), providers_cooky_path(current_provider), class: "govuk-link" %>
-            <%= t(".any_time") %>
-        </div>
-      </div>
-    </div>
-
-    <div class="govuk-button-group">
-      <button value="hide" class="govuk-button" data-module="govuk-button">
-        <%= t(".hide") %>
-      </button>
-    </div>
-  </div>
-</div>
+    <% m.with_action { govuk_button_link_to(t(".hide"), "#", { data: { value: "hide" } }) } %>
+  <% end %>
+<% end %>

--- a/config/locales/en/shared.yml
+++ b/config/locales/en/shared.yml
@@ -5,14 +5,14 @@ en:
       cookie_banner:
         title: Cookies on Apply for legal aid
         we_use_some: We use some essential cookies to make this service work.
-        wed_also_lie: "We'd also like to use analytics cookies so we can understand how you use the service and make improvements."
+        wed_also_like: "We'd also like to use analytics cookies so we can understand how you use the service and make improvements."
         accept: Accept analytics cookies
         reject: Reject analytics cookies
         view: View cookies
-        accepted: "You've accepted analytics cookies. You can "
-        rejected: "You've rejected analytics cookies. You can "
-        any_time: " at any time"
-        link_text: change your cookie settings
+        cookie_confirmation_msg_html: |
+          You've %{cookie_state} analytics cookies. You can <a class="govuk-link" href="%{cookie_path}">change your cookie settings</a> at any time
+        accepted: accepted
+        rejected: rejected
         hide: Hide this message
       modal_dialogue:
         page_title: Are you sure you want to delete this application?

--- a/features/providers/cookies.feature
+++ b/features/providers/cookies.feature
@@ -18,10 +18,10 @@ Feature: Cookies
   Scenario: I am able to update my cookie preferences via the cookies banner and Hide the notice
     Given I start the journey without cookie preferences
 
-    When I click 'Accept analytics cookies'
+    When I click link 'Accept analytics cookies'
     Then I should see "You've accepted analytics cookies."
 
-    When I click 'Hide'
+    When I click link 'Hide'
     Then I should not see "You've accepted analytics cookies."
 
   Scenario: I am able to view the cookies page from the cookies banner and save changes
@@ -37,7 +37,7 @@ Feature: Cookies
   Scenario: I am able to Accept analytics cookie and then change my cookie preferences via the cookies banner
     Given I start the journey without cookie preferences
 
-    When I click 'Accept analytics cookies'
+    When I click link 'Accept analytics cookies'
     Then I should see "You've accepted analytics cookies."
     And I should see "You can change your cookie settings at any time"
 
@@ -47,7 +47,7 @@ Feature: Cookies
   Scenario: I am able to Reject analytics cookie and then change my cookie preferences via the cookies banner
     Given I start the journey without cookie preferences
 
-    When I click 'Reject analytics cookies'
+    When I click link 'Reject analytics cookies'
     Then I should see "You've rejected analytics cookies."
     And I should see "You can change your cookie settings at any time"
 
@@ -59,7 +59,7 @@ Feature: Cookies
     Given I visit the application service
     And I click link "Start"
     And I click link "Make a new application"
-    And I click "Accept analytics cookies"
+    And I click link "Accept analytics cookies"
 
     # required for test to pass locally with chrome headless
     Then I temporarily resize browser window to width 1600 height 1000 and click "Apply for legal aid"


### PR DESCRIPTION
## What

[Use cookie banner helper](https://dsdmoj.atlassian.net/browse/AP-3641)

Update cookie banner view, `govuk_cookie_banner` accepts multiple message component, message component used for the accept/reject actions.
 
Update locales to reflect translation change

Cookie helper now uses links instead of buttons, JS module updated to reflect change

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
