### PR TITLE
Fix: CCMS Queue errors

### DIFF
--- a/app/controllers/admin/ccms_queues_controller.rb
+++ b/app/controllers/admin/ccms_queues_controller.rb
@@ -1,7 +1,5 @@
 module Admin
   class CCMSQueuesController < AdminBaseController
-    before_action :authenticate_admin_user!
-
     def index
       @in_progress = CCMS::Submission.where.not(aasm_state: %w[completed abandoned]).order(created_at: :desc)
     end


### PR DESCRIPTION
## What

A 500 error is being recorded everytime an admin visits the ccms_queue/show page

There is no error in the logs, but a 500 response is shown on kibana

I cannot trace any reason for this, but the `authenticate_admin_user!` method is being called twice, once explicitly in this controller and again in the inherited AdminBaseController

That seems a bit superfluous, so I am removing this one to see if it is causing the issue

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
