### PR TITLE
CFE: Update Spreadsheet Comparison

### DIFF
--- a/app/services/cfe/store_compare_result.rb
+++ b/app/services/cfe/store_compare_result.rb
@@ -38,6 +38,9 @@ module CFE
 
     def worksheet_reload
       @spreadsheet = @sheet_service.get_spreadsheet(spreadsheet_key)
+      requests = [{ clear_basic_filter: { sheet_id: @spreadsheet.sheets[0].properties.sheet_id } }]
+      update_request = Google::Apis::SheetsV4::BatchUpdateSpreadsheetRequest.new(requests:)
+      @sheet_service.batch_update_spreadsheet(spreadsheet_key, update_request)
     end
 
     def spreadsheet_key

--- a/spec/services/cfe/store_compare_result_spec.rb
+++ b/spec/services/cfe/store_compare_result_spec.rb
@@ -6,7 +6,9 @@ module CFE
 
     let(:service_creds) { instance_double(Google::Auth::ServiceAccountCredentials, fetch_access_token!: {}) }
     let(:sheet_service) { instance_double(Google::Apis::SheetsV4::SheetsService) }
-    let(:spreadsheet) { instance_double(Google::Apis::SheetsV4::Spreadsheet) }
+    let(:spreadsheet) { instance_spy(Google::Apis::SheetsV4::Spreadsheet) }
+    let(:sheet) { instance_spy(Google::Apis::SheetsV4::Spreadsheet) }
+    let(:sheet_properties) { instance_spy(Google::Apis::SheetsV4::SheetProperties) }
     let(:sheet_id) { "123456789" }
     let(:data_submitted) { ["Fake", "data", true] }
     let(:append_value_response) { instance_double(Google::Apis::SheetsV4::AppendValuesResponse) }
@@ -15,6 +17,9 @@ module CFE
 
     before do
       allow(sheet_service).to receive(:append_spreadsheet_value).and_return(append_value_response)
+      allow(spreadsheet).to receive(:sheets).and_return([sheet])
+      allow(sheet).to receive(:properties).and_return(sheet_properties)
+      allow(sheet_properties).to receive(:sheet_id).and_return(sheet_id)
       allow(append_value_response).to receive(:updates).and_return(update_value_response)
       allow(update_value_response).to receive(:updated_range).and_return(output_response)
     end
@@ -26,6 +31,7 @@ module CFE
       expect(sheet_service).to receive(:authorization=).once
       expect(sheet_service).to receive(:get_spreadsheet).and_return(spreadsheet).once
       expect(sheet_service).to receive(:append_spreadsheet_value).once
+      expect(sheet_service).to receive(:batch_update_spreadsheet).once
 
       call_submit_data
     end


### PR DESCRIPTION
## What

Previously, if the data sheet was left filtered the tool would find the last "complete" row and then add 1 to the number and export. If the sheet had 4000 rows and the last filtered row was 3001, the tool would export to 3002 onwards, overwriting previous records

This PR ensures that any filters on the data sheet are cleared before exporting further data

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
