### PR TITLE
Fix: Benefit breakdown view

### DIFF
--- a/app/views/shared/check_answers/_benefits_breakdown.html.erb
+++ b/app/views/shared/check_answers/_benefits_breakdown.html.erb
@@ -4,7 +4,7 @@
 <%= govuk_summary_list(actions: false) do |summary_list| %>
   <% @legal_aid_application.applicant.state_benefits.each do |benefit| %>
     <% summary_list.with_row do |row|
-         row.with_key { benefit.description }
+         row.with_key { benefit.description || "" }
          row.with_value { "#{gds_number_to_currency(benefit.amount)} #{t("transaction_types.frequencies.#{benefit.frequency}").downcase}" }
        end %>
   <% end %>

--- a/spec/cassettes/CFECivil_SubmissionBuilder/_call/when_HostEnv_is_not_set/still_generates_the_expected_JSON_but_uses_missing_in_the_header.yml
+++ b/spec/cassettes/CFECivil_SubmissionBuilder/_call/when_HostEnv_is_not_set/still_generates_the_expected_JSON_but_uses_missing_in_the_header.yml
@@ -2,26 +2,24 @@
 http_interactions:
 - request:
     method: post
-    uri: https://main-cfe-civil-uat.cloud-platform.service.justice.gov.uk/v6/assessments
+    uri: https://cfe-civil-staging.cloud-platform.service.justice.gov.uk/v6/assessments
     body:
       encoding: UTF-8
-      string: '{"assessment":{"client_reference_id":"L-8B9-UJN","submission_date":"2023-05-30"},"proceeding_types":[{"ccms_code":"DA001","client_involvement_type":"A"}],"applicant":{"date_of_birth":"1993-03-19","employed":false,"involvement_type":"applicant","has_partner_opponent":false,"receives_qualifying_benefit":true},"capitals":{"bank_accounts":[{"description":"Current
-        accounts","value":"558790.72"},{"description":"Savings accounts","value":"121335.0"},{"description":"Money
-        not in a bank account","value":"686453.86"},{"description":"Access to another
-        person''s bank account","value":"445715.67"},{"description":"ISAs, National
-        Savings Certificates and Premium Bonds","value":"403362.79"},{"description":"Shares
-        in a public limited company","value":"296596.92"},{"description":"PEPs, unit
-        trusts, capital bonds and government stocks","value":"430573.98"},{"description":"Life
-        assurance and endowment policies not linked to a mortgage","value":"773735.08"}],"non_liquid_capital":[]},"vehicles":[{"value":5000.0,"loan_amount_outstanding":250.0,"date_of_purchase":"2023-01-10","in_regular_use":true}],"properties":{"main_home":{"value":841157.03,"outstanding_mortgage":963023.55,"percentage_owned":38.47,"shared_with_housing_assoc":false},"additional_properties":[{"value":0.0,"outstanding_mortgage":0.0,"percentage_owned":0.0,"shared_with_housing_assoc":false}]},"explicit_remarks":[{"category":"policy_disregards","details":[]}]}'
+      string: '{"assessment":{"client_reference_id":"L-HMW-4CY","submission_date":"2023-06-19","level_of_help":"certificated"},"proceeding_types":[{"ccms_code":"DA001","client_involvement_type":"A"}],"applicant":{"date_of_birth":"1969-07-07","employed":false,"involvement_type":"applicant","has_partner_opponent":false,"receives_qualifying_benefit":true},"capitals":{"bank_accounts":[{"description":"Current
+        accounts","value":"-132265.07"},{"description":"Savings accounts","value":"111431.56"},{"description":"Money
+        not in a bank account","value":"46816.69"},{"description":"Access to another
+        person''s bank account","value":"730820.69"},{"description":"ISAs, National
+        Savings Certificates and Premium Bonds","value":"320242.39"},{"description":"Shares
+        in a public limited company","value":"12550.94"},{"description":"PEPs, unit
+        trusts, capital bonds and government stocks","value":"877518.48"},{"description":"Life
+        assurance and endowment policies not linked to a mortgage","value":"367783.82"}],"non_liquid_capital":[]},"vehicles":[{"value":5000.0,"loan_amount_outstanding":250.0,"date_of_purchase":"2023-01-10","in_regular_use":true}],"properties":{"main_home":{"value":841157.03,"outstanding_mortgage":963023.55,"percentage_owned":38.47,"shared_with_housing_assoc":false},"additional_properties":[{"value":0.0,"outstanding_mortgage":0.0,"percentage_owned":0.0,"shared_with_housing_assoc":false}]},"explicit_remarks":[{"category":"policy_disregards","details":[]}]}'
     headers:
       Content-Type:
       - application/json
       Accept:
       - application/json;version=6
-      Useragent:
-      - CivilApply/1.0
       User-Agent:
-      - Faraday v2.7.5
+      - CivilApply/1.0
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -30,11 +28,11 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 30 May 2023 09:22:00 GMT
+      - Mon, 19 Jun 2023 14:05:30 GMT
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '4889'
+      - '4838'
       Connection:
       - keep-alive
       X-Frame-Options:
@@ -52,24 +50,24 @@ http_interactions:
       Vary:
       - Accept
       Etag:
-      - W/"8175ee986663bd3186f200bdd4e1385b"
+      - W/"8f8dd1505bdac60801d373b32abe74d2"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - d6d701cabff7ba07044d90b98780144d
+      - 0107bb5439ecd8f8377677c0c4c09bf6
       X-Runtime:
-      - '0.732062'
+      - '0.327914'
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
-      string: '{"version":"6","timestamp":"2023-05-30T09:22:00.100Z","success":true,"result_summary":{"overall_result":{"result":"contribution_required","capital_contribution":3713564.02,"income_contribution":0.0,"proceeding_types":[{"ccms_code":"DA001","client_involvement_type":"A","upper_threshold":0.0,"lower_threshold":0.0,"result":"contribution_required"}]},"gross_income":{"total_gross_income":0.0,"proceeding_types":[{"ccms_code":"DA001","client_involvement_type":"A","upper_threshold":999999999999.0,"lower_threshold":0.0,"result":"pending"}],"combined_total_gross_income":0.0},"disposable_income":{"dependant_allowance_under_16":0,"dependant_allowance_over_16":0,"dependant_allowance":0,"gross_housing_costs":0.0,"housing_benefit":0.0,"net_housing_costs":0.0,"maintenance_allowance":0.0,"total_outgoings_and_allowances":0.0,"total_disposable_income":0.0,"employment_income":{"gross_income":0.0,"benefits_in_kind":0.0,"tax":0.0,"national_insurance":0.0,"fixed_employment_deduction":0.0,"net_employment_income":0.0},"income_contribution":0.0,"proceeding_types":[{"ccms_code":"DA001","client_involvement_type":"A","upper_threshold":999999999999.0,"lower_threshold":315.0,"result":"pending"}],"combined_total_disposable_income":0.0,"combined_total_outgoings_and_allowances":0.0,"partner_allowance":0},"capital":{"pensioner_disregard_applied":0.0,"total_liquid":3716564.02,"total_non_liquid":0.0,"total_vehicle":0.0,"total_property":0.0,"total_mortgage_allowance":999999999999.0,"total_capital":3716564.02,"subject_matter_of_dispute_disregard":0.0,"assessed_capital":3716564.02,"total_capital_with_smod":3716564.02,"disputed_non_property_disregard":0,"proceeding_types":[{"ccms_code":"DA001","client_involvement_type":"A","upper_threshold":999999999999.0,"lower_threshold":3000.0,"result":"contribution_required"}],"combined_disputed_capital":0.0,"combined_non_disputed_capital":3716564.02,"capital_contribution":3713564.02,"pensioner_capital_disregard":0.0,"combined_assessed_capital":3716564.02}},"assessment":{"id":"ef8a5aea-2a5f-47f8-acc5-08eb48a0cabf","client_reference_id":"L-8B9-UJN","submission_date":"2023-05-30","level_of_help":"certificated","applicant":{"date_of_birth":"1993-03-19","involvement_type":"applicant","employed":false,"has_partner_opponent":false,"receives_qualifying_benefit":true},"gross_income":{"employment_income":[],"irregular_income":{"monthly_equivalents":{"student_loan":0.0,"unspecified_source":0.0}},"state_benefits":{"monthly_equivalents":{"all_sources":0.0,"cash_transactions":0,"bank_transactions":[]}},"other_income":{"monthly_equivalents":{"all_sources":{"friends_or_family":0,"maintenance_in":0,"property_or_lodger":0,"pension":0},"bank_transactions":{"friends_or_family":0,"maintenance_in":0,"property_or_lodger":0,"pension":0},"cash_transactions":{"friends_or_family":0,"maintenance_in":0,"property_or_lodger":0,"pension":0}}}},"disposable_income":{"monthly_equivalents":{"all_sources":{"child_care":0.0,"rent_or_mortgage":0.0,"maintenance_out":0.0,"legal_aid":0.0},"bank_transactions":{"child_care":0.0,"rent_or_mortgage":0.0,"maintenance_out":0.0,"legal_aid":0.0},"cash_transactions":{"child_care":0.0,"rent_or_mortgage":0.0,"maintenance_out":0.0,"legal_aid":0.0}},"childcare_allowance":0.0,"deductions":{"dependants_allowance":0.0,"disregarded_state_benefits":0.0}},"capital":{"capital_items":{"liquid":[{"description":"Current
-        accounts","value":558790.72},{"description":"Savings accounts","value":121335.0},{"description":"Money
-        not in a bank account","value":686453.86},{"description":"Access to another
-        person''s bank account","value":445715.67},{"description":"ISAs, National
-        Savings Certificates and Premium Bonds","value":403362.79},{"description":"Shares
-        in a public limited company","value":296596.92},{"description":"PEPs, unit
-        trusts, capital bonds and government stocks","value":430573.98},{"description":"Life
-        assurance and endowment policies not linked to a mortgage","value":773735.08}],"non_liquid":[],"vehicles":[{"value":5000.0,"loan_amount_outstanding":250.0,"date_of_purchase":"2023-01-10","in_regular_use":true,"included_in_assessment":false,"disregards_and_deductions":4750.0,"assessed_value":0.0}],"properties":{"main_home":{"value":841157.03,"outstanding_mortgage":963023.55,"percentage_owned":38.47,"main_home":true,"shared_with_housing_assoc":false,"transaction_allowance":0.0,"allowable_outstanding_mortgage":963023.55,"net_value":-121866.52,"net_equity":-46882.05,"smod_allowance":0,"main_home_equity_disregard":-46882.05,"assessed_equity":0.0},"additional_properties":[{"value":0.0,"outstanding_mortgage":0.0,"percentage_owned":0.0,"main_home":false,"shared_with_housing_assoc":false,"transaction_allowance":0.0,"allowable_outstanding_mortgage":0.0,"net_value":0.0,"net_equity":0.0,"smod_allowance":0,"main_home_equity_disregard":0.0,"assessed_equity":0.0}]}}},"remarks":{"current_account_balance":{"residual_balance":[]}}}}'
-  recorded_at: Tue, 30 May 2023 09:22:00 GMT
+      string: '{"version":"6","timestamp":"2023-06-19T14:05:30.322Z","success":true,"result_summary":{"overall_result":{"result":"contribution_required","capital_contribution":2464164.57,"income_contribution":0.0,"proceeding_types":[{"ccms_code":"DA001","client_involvement_type":"A","upper_threshold":0.0,"lower_threshold":0.0,"result":"contribution_required"}]},"gross_income":{"total_gross_income":0.0,"proceeding_types":[{"ccms_code":"DA001","client_involvement_type":"A","upper_threshold":999999999999.0,"lower_threshold":0.0,"result":"pending"}],"combined_total_gross_income":0.0},"disposable_income":{"dependant_allowance_under_16":0,"dependant_allowance_over_16":0,"dependant_allowance":0,"gross_housing_costs":0.0,"housing_benefit":0.0,"net_housing_costs":0.0,"maintenance_allowance":0.0,"total_outgoings_and_allowances":0.0,"total_disposable_income":0.0,"employment_income":{"gross_income":0.0,"benefits_in_kind":0.0,"tax":0.0,"national_insurance":0.0,"fixed_employment_deduction":0.0,"net_employment_income":0.0},"income_contribution":0.0,"proceeding_types":[{"ccms_code":"DA001","client_involvement_type":"A","upper_threshold":999999999999.0,"lower_threshold":315.0,"result":"pending"}],"combined_total_disposable_income":0.0,"combined_total_outgoings_and_allowances":0.0,"partner_allowance":0},"capital":{"pensioner_disregard_applied":0.0,"total_liquid":2467164.57,"total_non_liquid":0.0,"total_vehicle":0.0,"total_property":0.0,"total_mortgage_allowance":999999999999.0,"total_capital":2467164.57,"subject_matter_of_dispute_disregard":0.0,"assessed_capital":2467164.57,"total_capital_with_smod":2467164.57,"disputed_non_property_disregard":0,"proceeding_types":[{"ccms_code":"DA001","client_involvement_type":"A","upper_threshold":999999999999.0,"lower_threshold":3000.0,"result":"contribution_required"}],"combined_disputed_capital":0,"combined_non_disputed_capital":2467164.57,"capital_contribution":2464164.57,"pensioner_capital_disregard":0.0,"combined_assessed_capital":2467164.57}},"assessment":{"id":"fa7d8680-d4d7-49f3-9eeb-69d61876a1b8","client_reference_id":"L-HMW-4CY","submission_date":"2023-06-19","level_of_help":"certificated","applicant":{"date_of_birth":"1969-07-07","involvement_type":"applicant","employed":false,"has_partner_opponent":false,"receives_qualifying_benefit":true},"gross_income":{"employment_income":[],"irregular_income":{"monthly_equivalents":{"student_loan":0.0,"unspecified_source":0.0}},"state_benefits":{"monthly_equivalents":{"all_sources":0.0,"cash_transactions":0,"bank_transactions":[]}},"other_income":{"monthly_equivalents":{"all_sources":{"friends_or_family":0,"maintenance_in":0,"property_or_lodger":0,"pension":0},"bank_transactions":{"friends_or_family":0,"maintenance_in":0,"property_or_lodger":0,"pension":0},"cash_transactions":{"friends_or_family":0,"maintenance_in":0,"property_or_lodger":0,"pension":0}}}},"disposable_income":{"monthly_equivalents":{"all_sources":{"child_care":0.0,"rent_or_mortgage":0.0,"maintenance_out":0.0,"legal_aid":0.0},"bank_transactions":{"child_care":0.0,"rent_or_mortgage":0.0,"maintenance_out":0.0,"legal_aid":0.0},"cash_transactions":{"child_care":0.0,"rent_or_mortgage":0.0,"maintenance_out":0.0,"legal_aid":0.0}},"childcare_allowance":0.0,"deductions":{"dependants_allowance":0.0,"disregarded_state_benefits":0.0}},"capital":{"capital_items":{"liquid":[{"description":"Current
+        accounts","value":-132265.07},{"description":"Savings accounts","value":111431.56},{"description":"Money
+        not in a bank account","value":46816.69},{"description":"Access to another
+        person''s bank account","value":730820.69},{"description":"ISAs, National
+        Savings Certificates and Premium Bonds","value":320242.39},{"description":"Shares
+        in a public limited company","value":12550.94},{"description":"PEPs, unit
+        trusts, capital bonds and government stocks","value":877518.48},{"description":"Life
+        assurance and endowment policies not linked to a mortgage","value":367783.82}],"non_liquid":[],"vehicles":[{"value":5000.0,"loan_amount_outstanding":250.0,"date_of_purchase":"2023-01-10","in_regular_use":true,"included_in_assessment":false,"disregards_and_deductions":4750.0,"assessed_value":0.0}],"properties":{"main_home":{"value":841157.03,"outstanding_mortgage":963023.55,"percentage_owned":38.47,"main_home":true,"shared_with_housing_assoc":false,"transaction_allowance":0.0,"allowable_outstanding_mortgage":963023.55,"net_value":-121866.52,"net_equity":-46882.05,"smod_allowance":0,"main_home_equity_disregard":-46882.05,"assessed_equity":0.0},"additional_properties":[{"value":0.0,"outstanding_mortgage":0.0,"percentage_owned":0.0,"main_home":false,"shared_with_housing_assoc":false,"transaction_allowance":0.0,"allowable_outstanding_mortgage":0.0,"net_value":0.0,"net_equity":0.0,"smod_allowance":0,"main_home_equity_disregard":0.0,"assessed_equity":0.0}]}}},"remarks":{}}}'
+  recorded_at: Mon, 19 Jun 2023 14:05:30 GMT
 recorded_with: VCR 6.1.0

--- a/spec/cassettes/CFECivil_SubmissionBuilder/_call/when_not_saving_the_result/does_not_create_a_submission_history_object.yml
+++ b/spec/cassettes/CFECivil_SubmissionBuilder/_call/when_not_saving_the_result/does_not_create_a_submission_history_object.yml
@@ -2,24 +2,24 @@
 http_interactions:
 - request:
     method: post
-    uri: https://main-cfe-civil-uat.cloud-platform.service.justice.gov.uk/v6/assessments
+    uri: https://cfe-civil-staging.cloud-platform.service.justice.gov.uk/v6/assessments
     body:
       encoding: UTF-8
-      string: '{"assessment":{"client_reference_id":"L-6MV-KK9","submission_date":"2023-04-19"},"proceeding_types":[{"ccms_code":"DA001","client_involvement_type":"A"}],"applicant":{"date_of_birth":"2002-09-10","employed":false,"involvement_type":"applicant","has_partner_opponent":false,"receives_qualifying_benefit":true},"capitals":{"bank_accounts":[{"description":"Current
-        accounts","value":"279647.36"},{"description":"Savings accounts","value":"-61951.21"},{"description":"Money
-        not in a bank account","value":"176788.15"},{"description":"Access to another
-        person''s bank account","value":"459213.06"},{"description":"ISAs, National
-        Savings Certificates and Premium Bonds","value":"85834.23"},{"description":"Shares
-        in a public limited company","value":"181289.67"},{"description":"PEPs, unit
-        trusts, capital bonds and government stocks","value":"798055.11"},{"description":"Life
-        assurance and endowment policies not linked to a mortgage","value":"356173.4"}],"non_liquid_capital":[]},"vehicles":[{"value":5000.0,"loan_amount_outstanding":250.0,"date_of_purchase":"2023-01-10","in_regular_use":true}],"properties":{"main_home":{"value":841157.03,"outstanding_mortgage":963023.55,"percentage_owned":38.47,"shared_with_housing_assoc":false},"additional_properties":[{"value":0.0,"outstanding_mortgage":0.0,"percentage_owned":0.0,"shared_with_housing_assoc":false}]},"explicit_remarks":[{"category":"policy_disregards","details":[]}]}'
+      string: '{"assessment":{"client_reference_id":"L-JY6-0N1","submission_date":"2023-06-19","level_of_help":"certificated"},"proceeding_types":[{"ccms_code":"DA001","client_involvement_type":"A"}],"applicant":{"date_of_birth":"1989-07-07","employed":false,"involvement_type":"applicant","has_partner_opponent":false,"receives_qualifying_benefit":true},"capitals":{"bank_accounts":[{"description":"Current
+        accounts","value":"490654.88"},{"description":"Savings accounts","value":"-97149.42"},{"description":"Money
+        not in a bank account","value":"322221.74"},{"description":"Access to another
+        person''s bank account","value":"537447.67"},{"description":"ISAs, National
+        Savings Certificates and Premium Bonds","value":"262452.67"},{"description":"Shares
+        in a public limited company","value":"756469.11"},{"description":"PEPs, unit
+        trusts, capital bonds and government stocks","value":"375622.97"},{"description":"Life
+        assurance and endowment policies not linked to a mortgage","value":"164902.29"}],"non_liquid_capital":[]},"vehicles":[{"value":5000.0,"loan_amount_outstanding":250.0,"date_of_purchase":"2023-01-10","in_regular_use":true}],"properties":{"main_home":{"value":841157.03,"outstanding_mortgage":963023.55,"percentage_owned":38.47,"shared_with_housing_assoc":false},"additional_properties":[{"value":0.0,"outstanding_mortgage":0.0,"percentage_owned":0.0,"shared_with_housing_assoc":false}]},"explicit_remarks":[{"category":"policy_disregards","details":[]}]}'
     headers:
       Content-Type:
       - application/json
       Accept:
       - application/json;version=6
       User-Agent:
-      - Faraday v2.7.4
+      - CivilApply/1.0 test
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -28,11 +28,11 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 19 Apr 2023 06:25:01 GMT
+      - Mon, 19 Jun 2023 14:05:27 GMT
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '4774'
+      - '4888'
       Connection:
       - keep-alive
       X-Frame-Options:
@@ -50,24 +50,24 @@ http_interactions:
       Vary:
       - Accept
       Etag:
-      - W/"65e5e0e6c377bd4e4dcb30826fcf748b"
+      - W/"3eaf482557171f31db663ff0f741926c"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 9cdba64e9f8f2f8cd12ed8f1c480ab8f
+      - 0671e1a60376212ad3963eb6954434dd
       X-Runtime:
-      - '0.310708'
+      - '0.278477'
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
-      string: '{"version":"6","timestamp":"2023-04-19T06:25:01.441Z","success":true,"result_summary":{"overall_result":{"result":"contribution_required","capital_contribution":2334000.98,"income_contribution":0.0,"proceeding_types":[{"ccms_code":"DA001","client_involvement_type":"A","upper_threshold":0.0,"lower_threshold":0.0,"result":"contribution_required"}]},"gross_income":{"total_gross_income":0.0,"proceeding_types":[{"ccms_code":"DA001","client_involvement_type":"A","upper_threshold":999999999999.0,"lower_threshold":0.0,"result":"pending"}],"combined_total_gross_income":0.0},"disposable_income":{"dependant_allowance":0.0,"gross_housing_costs":0.0,"housing_benefit":0.0,"net_housing_costs":0.0,"maintenance_allowance":0.0,"total_outgoings_and_allowances":0.0,"total_disposable_income":0.0,"employment_income":{"gross_income":0.0,"benefits_in_kind":0.0,"tax":0.0,"national_insurance":0.0,"fixed_employment_deduction":0.0,"net_employment_income":0.0},"income_contribution":0.0,"proceeding_types":[{"ccms_code":"DA001","client_involvement_type":"A","upper_threshold":999999999999.0,"lower_threshold":315.0,"result":"pending"}],"combined_total_disposable_income":0.0,"combined_total_outgoings_and_allowances":0.0,"partner_allowance":0},"capital":{"pensioner_disregard_applied":0.0,"total_liquid":2337000.98,"total_non_liquid":0.0,"total_vehicle":0.0,"total_property":0.0,"total_mortgage_allowance":999999999999.0,"total_capital":2337000.98,"subject_matter_of_dispute_disregard":0.0,"capital_contribution":2334000.98,"assessed_capital":2337000.98,"total_capital_with_smod":2337000.98,"disputed_non_property_disregard":0.0,"proceeding_types":[{"ccms_code":"DA001","client_involvement_type":"A","upper_threshold":999999999999.0,"lower_threshold":3000.0,"result":"contribution_required"}],"pensioner_capital_disregard":0.0,"combined_assessed_capital":2337000.98}},"assessment":{"id":"390632de-4333-4e89-b378-cf99b5a63e03","client_reference_id":"L-6MV-KK9","submission_date":"2023-04-19","level_of_help":"certificated","applicant":{"date_of_birth":"2002-09-10","involvement_type":"applicant","employed":false,"has_partner_opponent":false,"receives_qualifying_benefit":true,"self_employed":false},"gross_income":{"employment_income":[],"irregular_income":{"monthly_equivalents":{"student_loan":0.0,"unspecified_source":0.0}},"state_benefits":{"monthly_equivalents":{"all_sources":0.0,"cash_transactions":0,"bank_transactions":[]}},"other_income":{"monthly_equivalents":{"all_sources":{"friends_or_family":0,"maintenance_in":0,"property_or_lodger":0,"pension":0},"bank_transactions":{"friends_or_family":0,"maintenance_in":0,"property_or_lodger":0,"pension":0},"cash_transactions":{"friends_or_family":0,"maintenance_in":0,"property_or_lodger":0,"pension":0}}}},"disposable_income":{"monthly_equivalents":{"all_sources":{"child_care":0.0,"rent_or_mortgage":0.0,"maintenance_out":0.0,"legal_aid":0.0},"bank_transactions":{"child_care":0.0,"rent_or_mortgage":0.0,"maintenance_out":0.0,"legal_aid":0.0},"cash_transactions":{"child_care":0.0,"rent_or_mortgage":0.0,"maintenance_out":0.0,"legal_aid":0.0}},"childcare_allowance":0.0,"deductions":{"dependants_allowance":0.0,"disregarded_state_benefits":0.0}},"capital":{"capital_items":{"liquid":[{"description":"Life
-        assurance and endowment policies not linked to a mortgage","value":356173.4},{"description":"PEPs,
-        unit trusts, capital bonds and government stocks","value":798055.11},{"description":"Shares
-        in a public limited company","value":181289.67},{"description":"ISAs, National
-        Savings Certificates and Premium Bonds","value":85834.23},{"description":"Access
-        to another person''s bank account","value":459213.06},{"description":"Money
-        not in a bank account","value":176788.15},{"description":"Savings accounts","value":-61951.21},{"description":"Current
-        accounts","value":279647.36}],"non_liquid":[],"vehicles":[{"value":5000.0,"loan_amount_outstanding":250.0,"date_of_purchase":"2023-01-10","in_regular_use":true,"included_in_assessment":false,"disregards_and_deductions":4750.0,"assessed_value":0.0}],"properties":{"main_home":{"value":841157.03,"outstanding_mortgage":963023.55,"percentage_owned":38.47,"main_home":true,"shared_with_housing_assoc":false,"transaction_allowance":0.0,"allowable_outstanding_mortgage":963023.55,"net_value":-121866.52,"net_equity":-46882.05,"smod_allowance":0,"main_home_equity_disregard":-46882.05,"assessed_equity":0.0},"additional_properties":[{"value":0.0,"outstanding_mortgage":0.0,"percentage_owned":0.0,"main_home":false,"shared_with_housing_assoc":false,"transaction_allowance":0.0,"allowable_outstanding_mortgage":0.0,"net_value":0.0,"net_equity":0.0,"smod_allowance":0,"main_home_equity_disregard":0.0,"assessed_equity":0.0}]}}},"remarks":{"current_account_balance":{"residual_balance":[]}}}}'
-  recorded_at: Wed, 19 Apr 2023 06:24:59 GMT
+      string: '{"version":"6","timestamp":"2023-06-19T14:05:27.640Z","success":true,"result_summary":{"overall_result":{"result":"contribution_required","capital_contribution":2906771.33,"income_contribution":0.0,"proceeding_types":[{"ccms_code":"DA001","client_involvement_type":"A","upper_threshold":0.0,"lower_threshold":0.0,"result":"contribution_required"}]},"gross_income":{"total_gross_income":0.0,"proceeding_types":[{"ccms_code":"DA001","client_involvement_type":"A","upper_threshold":999999999999.0,"lower_threshold":0.0,"result":"pending"}],"combined_total_gross_income":0.0},"disposable_income":{"dependant_allowance_under_16":0,"dependant_allowance_over_16":0,"dependant_allowance":0,"gross_housing_costs":0.0,"housing_benefit":0.0,"net_housing_costs":0.0,"maintenance_allowance":0.0,"total_outgoings_and_allowances":0.0,"total_disposable_income":0.0,"employment_income":{"gross_income":0.0,"benefits_in_kind":0.0,"tax":0.0,"national_insurance":0.0,"fixed_employment_deduction":0.0,"net_employment_income":0.0},"income_contribution":0.0,"proceeding_types":[{"ccms_code":"DA001","client_involvement_type":"A","upper_threshold":999999999999.0,"lower_threshold":315.0,"result":"pending"}],"combined_total_disposable_income":0.0,"combined_total_outgoings_and_allowances":0.0,"partner_allowance":0},"capital":{"pensioner_disregard_applied":0.0,"total_liquid":2909771.33,"total_non_liquid":0.0,"total_vehicle":0.0,"total_property":0.0,"total_mortgage_allowance":999999999999.0,"total_capital":2909771.33,"subject_matter_of_dispute_disregard":0.0,"assessed_capital":2909771.33,"total_capital_with_smod":2909771.33,"disputed_non_property_disregard":0,"proceeding_types":[{"ccms_code":"DA001","client_involvement_type":"A","upper_threshold":999999999999.0,"lower_threshold":3000.0,"result":"contribution_required"}],"combined_disputed_capital":0,"combined_non_disputed_capital":2909771.33,"capital_contribution":2906771.33,"pensioner_capital_disregard":0.0,"combined_assessed_capital":2909771.33}},"assessment":{"id":"b29776af-61b3-4219-9f35-f339a2e564ae","client_reference_id":"L-JY6-0N1","submission_date":"2023-06-19","level_of_help":"certificated","applicant":{"date_of_birth":"1989-07-07","involvement_type":"applicant","employed":false,"has_partner_opponent":false,"receives_qualifying_benefit":true},"gross_income":{"employment_income":[],"irregular_income":{"monthly_equivalents":{"student_loan":0.0,"unspecified_source":0.0}},"state_benefits":{"monthly_equivalents":{"all_sources":0.0,"cash_transactions":0,"bank_transactions":[]}},"other_income":{"monthly_equivalents":{"all_sources":{"friends_or_family":0,"maintenance_in":0,"property_or_lodger":0,"pension":0},"bank_transactions":{"friends_or_family":0,"maintenance_in":0,"property_or_lodger":0,"pension":0},"cash_transactions":{"friends_or_family":0,"maintenance_in":0,"property_or_lodger":0,"pension":0}}}},"disposable_income":{"monthly_equivalents":{"all_sources":{"child_care":0.0,"rent_or_mortgage":0.0,"maintenance_out":0.0,"legal_aid":0.0},"bank_transactions":{"child_care":0.0,"rent_or_mortgage":0.0,"maintenance_out":0.0,"legal_aid":0.0},"cash_transactions":{"child_care":0.0,"rent_or_mortgage":0.0,"maintenance_out":0.0,"legal_aid":0.0}},"childcare_allowance":0.0,"deductions":{"dependants_allowance":0.0,"disregarded_state_benefits":0.0}},"capital":{"capital_items":{"liquid":[{"description":"Current
+        accounts","value":490654.88},{"description":"Savings accounts","value":-97149.42},{"description":"Money
+        not in a bank account","value":322221.74},{"description":"Access to another
+        person''s bank account","value":537447.67},{"description":"ISAs, National
+        Savings Certificates and Premium Bonds","value":262452.67},{"description":"Shares
+        in a public limited company","value":756469.11},{"description":"PEPs, unit
+        trusts, capital bonds and government stocks","value":375622.97},{"description":"Life
+        assurance and endowment policies not linked to a mortgage","value":164902.29}],"non_liquid":[],"vehicles":[{"value":5000.0,"loan_amount_outstanding":250.0,"date_of_purchase":"2023-01-10","in_regular_use":true,"included_in_assessment":false,"disregards_and_deductions":4750.0,"assessed_value":0.0}],"properties":{"main_home":{"value":841157.03,"outstanding_mortgage":963023.55,"percentage_owned":38.47,"main_home":true,"shared_with_housing_assoc":false,"transaction_allowance":0.0,"allowable_outstanding_mortgage":963023.55,"net_value":-121866.52,"net_equity":-46882.05,"smod_allowance":0,"main_home_equity_disregard":-46882.05,"assessed_equity":0.0},"additional_properties":[{"value":0.0,"outstanding_mortgage":0.0,"percentage_owned":0.0,"main_home":false,"shared_with_housing_assoc":false,"transaction_allowance":0.0,"allowable_outstanding_mortgage":0.0,"net_value":0.0,"net_equity":0.0,"smod_allowance":0,"main_home_equity_disregard":0.0,"assessed_equity":0.0}]}}},"remarks":{"current_account_balance":{"residual_balance":[]}}}}'
+  recorded_at: Mon, 19 Jun 2023 14:05:27 GMT
 recorded_with: VCR 6.1.0

--- a/spec/cassettes/CFECivil_SubmissionBuilder/_call/when_not_saving_the_result/does_not_save_a_submission_object.yml
+++ b/spec/cassettes/CFECivil_SubmissionBuilder/_call/when_not_saving_the_result/does_not_save_a_submission_object.yml
@@ -2,24 +2,24 @@
 http_interactions:
 - request:
     method: post
-    uri: https://main-cfe-civil-uat.cloud-platform.service.justice.gov.uk/v6/assessments
+    uri: https://cfe-civil-staging.cloud-platform.service.justice.gov.uk/v6/assessments
     body:
       encoding: UTF-8
-      string: '{"assessment":{"client_reference_id":"L-LH2-T2K","submission_date":"2023-04-19"},"proceeding_types":[{"ccms_code":"DA001","client_involvement_type":"A"}],"applicant":{"date_of_birth":"1976-01-27","employed":false,"involvement_type":"applicant","has_partner_opponent":false,"receives_qualifying_benefit":true},"capitals":{"bank_accounts":[{"description":"Current
-        accounts","value":"622120.1"},{"description":"Savings accounts","value":"-130632.33"},{"description":"Money
-        not in a bank account","value":"106202.99"},{"description":"Access to another
-        person''s bank account","value":"189244.97"},{"description":"ISAs, National
-        Savings Certificates and Premium Bonds","value":"815970.02"},{"description":"Shares
-        in a public limited company","value":"500709.77"},{"description":"PEPs, unit
-        trusts, capital bonds and government stocks","value":"74531.78"},{"description":"Life
-        assurance and endowment policies not linked to a mortgage","value":"985770.56"}],"non_liquid_capital":[]},"vehicles":[{"value":5000.0,"loan_amount_outstanding":250.0,"date_of_purchase":"2023-01-10","in_regular_use":true}],"properties":{"main_home":{"value":841157.03,"outstanding_mortgage":963023.55,"percentage_owned":38.47,"shared_with_housing_assoc":false},"additional_properties":[{"value":0.0,"outstanding_mortgage":0.0,"percentage_owned":0.0,"shared_with_housing_assoc":false}]},"explicit_remarks":[{"category":"policy_disregards","details":[]}]}'
+      string: '{"assessment":{"client_reference_id":"L-57W-PLH","submission_date":"2023-06-19","level_of_help":"certificated"},"proceeding_types":[{"ccms_code":"DA001","client_involvement_type":"A"}],"applicant":{"date_of_birth":"1973-04-22","employed":false,"involvement_type":"applicant","has_partner_opponent":false,"receives_qualifying_benefit":true},"capitals":{"bank_accounts":[{"description":"Current
+        accounts","value":"352394.35"},{"description":"Savings accounts","value":"-767656.34"},{"description":"Money
+        not in a bank account","value":"77830.7"},{"description":"Access to another
+        person''s bank account","value":"374080.92"},{"description":"ISAs, National
+        Savings Certificates and Premium Bonds","value":"24263.66"},{"description":"Shares
+        in a public limited company","value":"343216.74"},{"description":"PEPs, unit
+        trusts, capital bonds and government stocks","value":"19161.22"},{"description":"Life
+        assurance and endowment policies not linked to a mortgage","value":"573166.33"}],"non_liquid_capital":[]},"vehicles":[{"value":5000.0,"loan_amount_outstanding":250.0,"date_of_purchase":"2023-01-10","in_regular_use":true}],"properties":{"main_home":{"value":841157.03,"outstanding_mortgage":963023.55,"percentage_owned":38.47,"shared_with_housing_assoc":false},"additional_properties":[{"value":0.0,"outstanding_mortgage":0.0,"percentage_owned":0.0,"shared_with_housing_assoc":false}]},"explicit_remarks":[{"category":"policy_disregards","details":[]}]}'
     headers:
       Content-Type:
       - application/json
       Accept:
       - application/json;version=6
       User-Agent:
-      - Faraday v2.7.4
+      - CivilApply/1.0 test
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -28,11 +28,11 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 19 Apr 2023 06:25:02 GMT
+      - Mon, 19 Jun 2023 14:05:27 GMT
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '4775'
+      - '4885'
       Connection:
       - keep-alive
       X-Frame-Options:
@@ -50,24 +50,24 @@ http_interactions:
       Vary:
       - Accept
       Etag:
-      - W/"e0b71251d493da3227cc268cb95cec79"
+      - W/"743fe4bfcbe4af02820b341cb0ab6967"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 2598c0737905569bc7c00f115e850da5
+      - a6164585100e928ccc77de67c93ac0ab
       X-Runtime:
-      - '0.290014'
+      - '0.251932'
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
-      string: '{"version":"6","timestamp":"2023-04-19T06:25:02.499Z","success":true,"result_summary":{"overall_result":{"result":"contribution_required","capital_contribution":3291550.19,"income_contribution":0.0,"proceeding_types":[{"ccms_code":"DA001","client_involvement_type":"A","upper_threshold":0.0,"lower_threshold":0.0,"result":"contribution_required"}]},"gross_income":{"total_gross_income":0.0,"proceeding_types":[{"ccms_code":"DA001","client_involvement_type":"A","upper_threshold":999999999999.0,"lower_threshold":0.0,"result":"pending"}],"combined_total_gross_income":0.0},"disposable_income":{"dependant_allowance":0.0,"gross_housing_costs":0.0,"housing_benefit":0.0,"net_housing_costs":0.0,"maintenance_allowance":0.0,"total_outgoings_and_allowances":0.0,"total_disposable_income":0.0,"employment_income":{"gross_income":0.0,"benefits_in_kind":0.0,"tax":0.0,"national_insurance":0.0,"fixed_employment_deduction":0.0,"net_employment_income":0.0},"income_contribution":0.0,"proceeding_types":[{"ccms_code":"DA001","client_involvement_type":"A","upper_threshold":999999999999.0,"lower_threshold":315.0,"result":"pending"}],"combined_total_disposable_income":0.0,"combined_total_outgoings_and_allowances":0.0,"partner_allowance":0},"capital":{"pensioner_disregard_applied":0.0,"total_liquid":3294550.19,"total_non_liquid":0.0,"total_vehicle":0.0,"total_property":0.0,"total_mortgage_allowance":999999999999.0,"total_capital":3294550.19,"subject_matter_of_dispute_disregard":0.0,"capital_contribution":3291550.19,"assessed_capital":3294550.19,"total_capital_with_smod":3294550.19,"disputed_non_property_disregard":0.0,"proceeding_types":[{"ccms_code":"DA001","client_involvement_type":"A","upper_threshold":999999999999.0,"lower_threshold":3000.0,"result":"contribution_required"}],"pensioner_capital_disregard":0.0,"combined_assessed_capital":3294550.19}},"assessment":{"id":"8dd5033a-39cb-4f16-a0ea-ada999f8e883","client_reference_id":"L-LH2-T2K","submission_date":"2023-04-19","level_of_help":"certificated","applicant":{"date_of_birth":"1976-01-27","involvement_type":"applicant","employed":false,"has_partner_opponent":false,"receives_qualifying_benefit":true,"self_employed":false},"gross_income":{"employment_income":[],"irregular_income":{"monthly_equivalents":{"student_loan":0.0,"unspecified_source":0.0}},"state_benefits":{"monthly_equivalents":{"all_sources":0.0,"cash_transactions":0,"bank_transactions":[]}},"other_income":{"monthly_equivalents":{"all_sources":{"friends_or_family":0,"maintenance_in":0,"property_or_lodger":0,"pension":0},"bank_transactions":{"friends_or_family":0,"maintenance_in":0,"property_or_lodger":0,"pension":0},"cash_transactions":{"friends_or_family":0,"maintenance_in":0,"property_or_lodger":0,"pension":0}}}},"disposable_income":{"monthly_equivalents":{"all_sources":{"child_care":0.0,"rent_or_mortgage":0.0,"maintenance_out":0.0,"legal_aid":0.0},"bank_transactions":{"child_care":0.0,"rent_or_mortgage":0.0,"maintenance_out":0.0,"legal_aid":0.0},"cash_transactions":{"child_care":0.0,"rent_or_mortgage":0.0,"maintenance_out":0.0,"legal_aid":0.0}},"childcare_allowance":0.0,"deductions":{"dependants_allowance":0.0,"disregarded_state_benefits":0.0}},"capital":{"capital_items":{"liquid":[{"description":"Life
-        assurance and endowment policies not linked to a mortgage","value":985770.56},{"description":"PEPs,
-        unit trusts, capital bonds and government stocks","value":74531.78},{"description":"Shares
-        in a public limited company","value":500709.77},{"description":"ISAs, National
-        Savings Certificates and Premium Bonds","value":815970.02},{"description":"Access
-        to another person''s bank account","value":189244.97},{"description":"Money
-        not in a bank account","value":106202.99},{"description":"Savings accounts","value":-130632.33},{"description":"Current
-        accounts","value":622120.1}],"non_liquid":[],"vehicles":[{"value":5000.0,"loan_amount_outstanding":250.0,"date_of_purchase":"2023-01-10","in_regular_use":true,"included_in_assessment":false,"disregards_and_deductions":4750.0,"assessed_value":0.0}],"properties":{"main_home":{"value":841157.03,"outstanding_mortgage":963023.55,"percentage_owned":38.47,"main_home":true,"shared_with_housing_assoc":false,"transaction_allowance":0.0,"allowable_outstanding_mortgage":963023.55,"net_value":-121866.52,"net_equity":-46882.05,"smod_allowance":0,"main_home_equity_disregard":-46882.05,"assessed_equity":0.0},"additional_properties":[{"value":0.0,"outstanding_mortgage":0.0,"percentage_owned":0.0,"main_home":false,"shared_with_housing_assoc":false,"transaction_allowance":0.0,"allowable_outstanding_mortgage":0.0,"net_value":0.0,"net_equity":0.0,"smod_allowance":0,"main_home_equity_disregard":0.0,"assessed_equity":0.0}]}}},"remarks":{"current_account_balance":{"residual_balance":[]}}}}'
-  recorded_at: Wed, 19 Apr 2023 06:25:00 GMT
+      string: '{"version":"6","timestamp":"2023-06-19T14:05:27.121Z","success":true,"result_summary":{"overall_result":{"result":"contribution_required","capital_contribution":1761113.92,"income_contribution":0.0,"proceeding_types":[{"ccms_code":"DA001","client_involvement_type":"A","upper_threshold":0.0,"lower_threshold":0.0,"result":"contribution_required"}]},"gross_income":{"total_gross_income":0.0,"proceeding_types":[{"ccms_code":"DA001","client_involvement_type":"A","upper_threshold":999999999999.0,"lower_threshold":0.0,"result":"pending"}],"combined_total_gross_income":0.0},"disposable_income":{"dependant_allowance_under_16":0,"dependant_allowance_over_16":0,"dependant_allowance":0,"gross_housing_costs":0.0,"housing_benefit":0.0,"net_housing_costs":0.0,"maintenance_allowance":0.0,"total_outgoings_and_allowances":0.0,"total_disposable_income":0.0,"employment_income":{"gross_income":0.0,"benefits_in_kind":0.0,"tax":0.0,"national_insurance":0.0,"fixed_employment_deduction":0.0,"net_employment_income":0.0},"income_contribution":0.0,"proceeding_types":[{"ccms_code":"DA001","client_involvement_type":"A","upper_threshold":999999999999.0,"lower_threshold":315.0,"result":"pending"}],"combined_total_disposable_income":0.0,"combined_total_outgoings_and_allowances":0.0,"partner_allowance":0},"capital":{"pensioner_disregard_applied":0.0,"total_liquid":1764113.92,"total_non_liquid":0.0,"total_vehicle":0.0,"total_property":0.0,"total_mortgage_allowance":999999999999.0,"total_capital":1764113.92,"subject_matter_of_dispute_disregard":0.0,"assessed_capital":1764113.92,"total_capital_with_smod":1764113.92,"disputed_non_property_disregard":0,"proceeding_types":[{"ccms_code":"DA001","client_involvement_type":"A","upper_threshold":999999999999.0,"lower_threshold":3000.0,"result":"contribution_required"}],"combined_disputed_capital":0,"combined_non_disputed_capital":1764113.92,"capital_contribution":1761113.92,"pensioner_capital_disregard":0.0,"combined_assessed_capital":1764113.92}},"assessment":{"id":"17346b75-aa16-45a9-b062-8de213162d8d","client_reference_id":"L-57W-PLH","submission_date":"2023-06-19","level_of_help":"certificated","applicant":{"date_of_birth":"1973-04-22","involvement_type":"applicant","employed":false,"has_partner_opponent":false,"receives_qualifying_benefit":true},"gross_income":{"employment_income":[],"irregular_income":{"monthly_equivalents":{"student_loan":0.0,"unspecified_source":0.0}},"state_benefits":{"monthly_equivalents":{"all_sources":0.0,"cash_transactions":0,"bank_transactions":[]}},"other_income":{"monthly_equivalents":{"all_sources":{"friends_or_family":0,"maintenance_in":0,"property_or_lodger":0,"pension":0},"bank_transactions":{"friends_or_family":0,"maintenance_in":0,"property_or_lodger":0,"pension":0},"cash_transactions":{"friends_or_family":0,"maintenance_in":0,"property_or_lodger":0,"pension":0}}}},"disposable_income":{"monthly_equivalents":{"all_sources":{"child_care":0.0,"rent_or_mortgage":0.0,"maintenance_out":0.0,"legal_aid":0.0},"bank_transactions":{"child_care":0.0,"rent_or_mortgage":0.0,"maintenance_out":0.0,"legal_aid":0.0},"cash_transactions":{"child_care":0.0,"rent_or_mortgage":0.0,"maintenance_out":0.0,"legal_aid":0.0}},"childcare_allowance":0.0,"deductions":{"dependants_allowance":0.0,"disregarded_state_benefits":0.0}},"capital":{"capital_items":{"liquid":[{"description":"Current
+        accounts","value":352394.35},{"description":"Savings accounts","value":-767656.34},{"description":"Money
+        not in a bank account","value":77830.7},{"description":"Access to another
+        person''s bank account","value":374080.92},{"description":"ISAs, National
+        Savings Certificates and Premium Bonds","value":24263.66},{"description":"Shares
+        in a public limited company","value":343216.74},{"description":"PEPs, unit
+        trusts, capital bonds and government stocks","value":19161.22},{"description":"Life
+        assurance and endowment policies not linked to a mortgage","value":573166.33}],"non_liquid":[],"vehicles":[{"value":5000.0,"loan_amount_outstanding":250.0,"date_of_purchase":"2023-01-10","in_regular_use":true,"included_in_assessment":false,"disregards_and_deductions":4750.0,"assessed_value":0.0}],"properties":{"main_home":{"value":841157.03,"outstanding_mortgage":963023.55,"percentage_owned":38.47,"main_home":true,"shared_with_housing_assoc":false,"transaction_allowance":0.0,"allowable_outstanding_mortgage":963023.55,"net_value":-121866.52,"net_equity":-46882.05,"smod_allowance":0,"main_home_equity_disregard":-46882.05,"assessed_equity":0.0},"additional_properties":[{"value":0.0,"outstanding_mortgage":0.0,"percentage_owned":0.0,"main_home":false,"shared_with_housing_assoc":false,"transaction_allowance":0.0,"allowable_outstanding_mortgage":0.0,"net_value":0.0,"net_equity":0.0,"smod_allowance":0,"main_home_equity_disregard":0.0,"assessed_equity":0.0}]}}},"remarks":{"current_account_balance":{"residual_balance":[]}}}}'
+  recorded_at: Mon, 19 Jun 2023 14:05:27 GMT
 recorded_with: VCR 6.1.0

--- a/spec/cassettes/CFECivil_SubmissionBuilder/_call/when_not_saving_the_result/generates_the_expected_JSON.yml
+++ b/spec/cassettes/CFECivil_SubmissionBuilder/_call/when_not_saving_the_result/generates_the_expected_JSON.yml
@@ -2,24 +2,24 @@
 http_interactions:
 - request:
     method: post
-    uri: https://main-cfe-civil-uat.cloud-platform.service.justice.gov.uk/v6/assessments
+    uri: https://cfe-civil-staging.cloud-platform.service.justice.gov.uk/v6/assessments
     body:
       encoding: UTF-8
-      string: '{"assessment":{"client_reference_id":"L-DX5-HJX","submission_date":"2023-04-19"},"proceeding_types":[{"ccms_code":"DA001","client_involvement_type":"A"}],"applicant":{"date_of_birth":"2000-10-29","employed":false,"involvement_type":"applicant","has_partner_opponent":false,"receives_qualifying_benefit":true},"capitals":{"bank_accounts":[{"description":"Current
-        accounts","value":"-150954.15"},{"description":"Savings accounts","value":"-339940.2"},{"description":"Money
-        not in a bank account","value":"294288.04"},{"description":"Access to another
-        person''s bank account","value":"919707.29"},{"description":"ISAs, National
-        Savings Certificates and Premium Bonds","value":"711060.65"},{"description":"Shares
-        in a public limited company","value":"275469.78"},{"description":"PEPs, unit
-        trusts, capital bonds and government stocks","value":"226298.62"},{"description":"Life
-        assurance and endowment policies not linked to a mortgage","value":"437516.56"}],"non_liquid_capital":[]},"vehicles":[{"value":5000.0,"loan_amount_outstanding":250.0,"date_of_purchase":"2023-01-10","in_regular_use":true}],"properties":{"main_home":{"value":841157.03,"outstanding_mortgage":963023.55,"percentage_owned":38.47,"shared_with_housing_assoc":false},"additional_properties":[{"value":0.0,"outstanding_mortgage":0.0,"percentage_owned":0.0,"shared_with_housing_assoc":false}]},"explicit_remarks":[{"category":"policy_disregards","details":[]}]}'
+      string: '{"assessment":{"client_reference_id":"L-MDM-CKH","submission_date":"2023-06-19","level_of_help":"certificated"},"proceeding_types":[{"ccms_code":"DA001","client_involvement_type":"A"}],"applicant":{"date_of_birth":"1999-09-05","employed":false,"involvement_type":"applicant","has_partner_opponent":false,"receives_qualifying_benefit":true},"capitals":{"bank_accounts":[{"description":"Current
+        accounts","value":"237425.88"},{"description":"Savings accounts","value":"662807.56"},{"description":"Money
+        not in a bank account","value":"247381.13"},{"description":"Access to another
+        person''s bank account","value":"293037.11"},{"description":"ISAs, National
+        Savings Certificates and Premium Bonds","value":"483050.37"},{"description":"Shares
+        in a public limited company","value":"439812.03"},{"description":"PEPs, unit
+        trusts, capital bonds and government stocks","value":"870339.11"},{"description":"Life
+        assurance and endowment policies not linked to a mortgage","value":"845374.65"}],"non_liquid_capital":[]},"vehicles":[{"value":5000.0,"loan_amount_outstanding":250.0,"date_of_purchase":"2023-01-10","in_regular_use":true}],"properties":{"main_home":{"value":841157.03,"outstanding_mortgage":963023.55,"percentage_owned":38.47,"shared_with_housing_assoc":false},"additional_properties":[{"value":0.0,"outstanding_mortgage":0.0,"percentage_owned":0.0,"shared_with_housing_assoc":false}]},"explicit_remarks":[{"category":"policy_disregards","details":[]}]}'
     headers:
       Content-Type:
       - application/json
       Accept:
       - application/json;version=6
       User-Agent:
-      - Faraday v2.7.4
+      - CivilApply/1.0 test
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -28,11 +28,11 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 19 Apr 2023 06:25:01 GMT
+      - Mon, 19 Jun 2023 14:05:26 GMT
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '4728'
+      - '4888'
       Connection:
       - keep-alive
       X-Frame-Options:
@@ -50,24 +50,24 @@ http_interactions:
       Vary:
       - Accept
       Etag:
-      - W/"3dcc3ea48d2a5c3eeef31d26047f488f"
+      - W/"a8e137f85fac09fcb1bb40ae077ff9c6"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 6ee6cabe22763a859d06b5d13a68984d
+      - 2575af2e449c42030b943b0ad1a43676
       X-Runtime:
-      - '0.305881'
+      - '0.309630'
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
-      string: '{"version":"6","timestamp":"2023-04-19T06:25:01.946Z","success":true,"result_summary":{"overall_result":{"result":"contribution_required","capital_contribution":2861340.94,"income_contribution":0.0,"proceeding_types":[{"ccms_code":"DA001","client_involvement_type":"A","upper_threshold":0.0,"lower_threshold":0.0,"result":"contribution_required"}]},"gross_income":{"total_gross_income":0.0,"proceeding_types":[{"ccms_code":"DA001","client_involvement_type":"A","upper_threshold":999999999999.0,"lower_threshold":0.0,"result":"pending"}],"combined_total_gross_income":0.0},"disposable_income":{"dependant_allowance":0.0,"gross_housing_costs":0.0,"housing_benefit":0.0,"net_housing_costs":0.0,"maintenance_allowance":0.0,"total_outgoings_and_allowances":0.0,"total_disposable_income":0.0,"employment_income":{"gross_income":0.0,"benefits_in_kind":0.0,"tax":0.0,"national_insurance":0.0,"fixed_employment_deduction":0.0,"net_employment_income":0.0},"income_contribution":0.0,"proceeding_types":[{"ccms_code":"DA001","client_involvement_type":"A","upper_threshold":999999999999.0,"lower_threshold":315.0,"result":"pending"}],"combined_total_disposable_income":0.0,"combined_total_outgoings_and_allowances":0.0,"partner_allowance":0},"capital":{"pensioner_disregard_applied":0.0,"total_liquid":2864340.94,"total_non_liquid":0.0,"total_vehicle":0.0,"total_property":0.0,"total_mortgage_allowance":999999999999.0,"total_capital":2864340.94,"subject_matter_of_dispute_disregard":0.0,"capital_contribution":2861340.94,"assessed_capital":2864340.94,"total_capital_with_smod":2864340.94,"disputed_non_property_disregard":0.0,"proceeding_types":[{"ccms_code":"DA001","client_involvement_type":"A","upper_threshold":999999999999.0,"lower_threshold":3000.0,"result":"contribution_required"}],"pensioner_capital_disregard":0.0,"combined_assessed_capital":2864340.94}},"assessment":{"id":"2db57108-9681-4a4a-b315-78f9c81bad2c","client_reference_id":"L-DX5-HJX","submission_date":"2023-04-19","level_of_help":"certificated","applicant":{"date_of_birth":"2000-10-29","involvement_type":"applicant","employed":false,"has_partner_opponent":false,"receives_qualifying_benefit":true,"self_employed":false},"gross_income":{"employment_income":[],"irregular_income":{"monthly_equivalents":{"student_loan":0.0,"unspecified_source":0.0}},"state_benefits":{"monthly_equivalents":{"all_sources":0.0,"cash_transactions":0,"bank_transactions":[]}},"other_income":{"monthly_equivalents":{"all_sources":{"friends_or_family":0,"maintenance_in":0,"property_or_lodger":0,"pension":0},"bank_transactions":{"friends_or_family":0,"maintenance_in":0,"property_or_lodger":0,"pension":0},"cash_transactions":{"friends_or_family":0,"maintenance_in":0,"property_or_lodger":0,"pension":0}}}},"disposable_income":{"monthly_equivalents":{"all_sources":{"child_care":0.0,"rent_or_mortgage":0.0,"maintenance_out":0.0,"legal_aid":0.0},"bank_transactions":{"child_care":0.0,"rent_or_mortgage":0.0,"maintenance_out":0.0,"legal_aid":0.0},"cash_transactions":{"child_care":0.0,"rent_or_mortgage":0.0,"maintenance_out":0.0,"legal_aid":0.0}},"childcare_allowance":0.0,"deductions":{"dependants_allowance":0.0,"disregarded_state_benefits":0.0}},"capital":{"capital_items":{"liquid":[{"description":"Life
-        assurance and endowment policies not linked to a mortgage","value":437516.56},{"description":"PEPs,
-        unit trusts, capital bonds and government stocks","value":226298.62},{"description":"Shares
-        in a public limited company","value":275469.78},{"description":"ISAs, National
-        Savings Certificates and Premium Bonds","value":711060.65},{"description":"Access
-        to another person''s bank account","value":919707.29},{"description":"Money
-        not in a bank account","value":294288.04},{"description":"Savings accounts","value":-339940.2},{"description":"Current
-        accounts","value":-150954.15}],"non_liquid":[],"vehicles":[{"value":5000.0,"loan_amount_outstanding":250.0,"date_of_purchase":"2023-01-10","in_regular_use":true,"included_in_assessment":false,"disregards_and_deductions":4750.0,"assessed_value":0.0}],"properties":{"main_home":{"value":841157.03,"outstanding_mortgage":963023.55,"percentage_owned":38.47,"main_home":true,"shared_with_housing_assoc":false,"transaction_allowance":0.0,"allowable_outstanding_mortgage":963023.55,"net_value":-121866.52,"net_equity":-46882.05,"smod_allowance":0,"main_home_equity_disregard":-46882.05,"assessed_equity":0.0},"additional_properties":[{"value":0.0,"outstanding_mortgage":0.0,"percentage_owned":0.0,"main_home":false,"shared_with_housing_assoc":false,"transaction_allowance":0.0,"allowable_outstanding_mortgage":0.0,"net_value":0.0,"net_equity":0.0,"smod_allowance":0,"main_home_equity_disregard":0.0,"assessed_equity":0.0}]}}},"remarks":{}}}'
-  recorded_at: Wed, 19 Apr 2023 06:24:59 GMT
+      string: '{"version":"6","timestamp":"2023-06-19T14:05:26.643Z","success":true,"result_summary":{"overall_result":{"result":"contribution_required","capital_contribution":4076227.84,"income_contribution":0.0,"proceeding_types":[{"ccms_code":"DA001","client_involvement_type":"A","upper_threshold":0.0,"lower_threshold":0.0,"result":"contribution_required"}]},"gross_income":{"total_gross_income":0.0,"proceeding_types":[{"ccms_code":"DA001","client_involvement_type":"A","upper_threshold":999999999999.0,"lower_threshold":0.0,"result":"pending"}],"combined_total_gross_income":0.0},"disposable_income":{"dependant_allowance_under_16":0,"dependant_allowance_over_16":0,"dependant_allowance":0,"gross_housing_costs":0.0,"housing_benefit":0.0,"net_housing_costs":0.0,"maintenance_allowance":0.0,"total_outgoings_and_allowances":0.0,"total_disposable_income":0.0,"employment_income":{"gross_income":0.0,"benefits_in_kind":0.0,"tax":0.0,"national_insurance":0.0,"fixed_employment_deduction":0.0,"net_employment_income":0.0},"income_contribution":0.0,"proceeding_types":[{"ccms_code":"DA001","client_involvement_type":"A","upper_threshold":999999999999.0,"lower_threshold":315.0,"result":"pending"}],"combined_total_disposable_income":0.0,"combined_total_outgoings_and_allowances":0.0,"partner_allowance":0},"capital":{"pensioner_disregard_applied":0.0,"total_liquid":4079227.84,"total_non_liquid":0.0,"total_vehicle":0.0,"total_property":0.0,"total_mortgage_allowance":999999999999.0,"total_capital":4079227.84,"subject_matter_of_dispute_disregard":0.0,"assessed_capital":4079227.84,"total_capital_with_smod":4079227.84,"disputed_non_property_disregard":0,"proceeding_types":[{"ccms_code":"DA001","client_involvement_type":"A","upper_threshold":999999999999.0,"lower_threshold":3000.0,"result":"contribution_required"}],"combined_disputed_capital":0,"combined_non_disputed_capital":4079227.84,"capital_contribution":4076227.84,"pensioner_capital_disregard":0.0,"combined_assessed_capital":4079227.84}},"assessment":{"id":"de513ad0-4ea4-4bb3-876a-f16c4c1c3308","client_reference_id":"L-MDM-CKH","submission_date":"2023-06-19","level_of_help":"certificated","applicant":{"date_of_birth":"1999-09-05","involvement_type":"applicant","employed":false,"has_partner_opponent":false,"receives_qualifying_benefit":true},"gross_income":{"employment_income":[],"irregular_income":{"monthly_equivalents":{"student_loan":0.0,"unspecified_source":0.0}},"state_benefits":{"monthly_equivalents":{"all_sources":0.0,"cash_transactions":0,"bank_transactions":[]}},"other_income":{"monthly_equivalents":{"all_sources":{"friends_or_family":0,"maintenance_in":0,"property_or_lodger":0,"pension":0},"bank_transactions":{"friends_or_family":0,"maintenance_in":0,"property_or_lodger":0,"pension":0},"cash_transactions":{"friends_or_family":0,"maintenance_in":0,"property_or_lodger":0,"pension":0}}}},"disposable_income":{"monthly_equivalents":{"all_sources":{"child_care":0.0,"rent_or_mortgage":0.0,"maintenance_out":0.0,"legal_aid":0.0},"bank_transactions":{"child_care":0.0,"rent_or_mortgage":0.0,"maintenance_out":0.0,"legal_aid":0.0},"cash_transactions":{"child_care":0.0,"rent_or_mortgage":0.0,"maintenance_out":0.0,"legal_aid":0.0}},"childcare_allowance":0.0,"deductions":{"dependants_allowance":0.0,"disregarded_state_benefits":0.0}},"capital":{"capital_items":{"liquid":[{"description":"Current
+        accounts","value":237425.88},{"description":"Savings accounts","value":662807.56},{"description":"Money
+        not in a bank account","value":247381.13},{"description":"Access to another
+        person''s bank account","value":293037.11},{"description":"ISAs, National
+        Savings Certificates and Premium Bonds","value":483050.37},{"description":"Shares
+        in a public limited company","value":439812.03},{"description":"PEPs, unit
+        trusts, capital bonds and government stocks","value":870339.11},{"description":"Life
+        assurance and endowment policies not linked to a mortgage","value":845374.65}],"non_liquid":[],"vehicles":[{"value":5000.0,"loan_amount_outstanding":250.0,"date_of_purchase":"2023-01-10","in_regular_use":true,"included_in_assessment":false,"disregards_and_deductions":4750.0,"assessed_value":0.0}],"properties":{"main_home":{"value":841157.03,"outstanding_mortgage":963023.55,"percentage_owned":38.47,"main_home":true,"shared_with_housing_assoc":false,"transaction_allowance":0.0,"allowable_outstanding_mortgage":963023.55,"net_value":-121866.52,"net_equity":-46882.05,"smod_allowance":0,"main_home_equity_disregard":-46882.05,"assessed_equity":0.0},"additional_properties":[{"value":0.0,"outstanding_mortgage":0.0,"percentage_owned":0.0,"main_home":false,"shared_with_housing_assoc":false,"transaction_allowance":0.0,"allowable_outstanding_mortgage":0.0,"net_value":0.0,"net_equity":0.0,"smod_allowance":0,"main_home_equity_disregard":0.0,"assessed_equity":0.0}]}}},"remarks":{"current_account_balance":{"residual_balance":[]}}}}'
+  recorded_at: Mon, 19 Jun 2023 14:05:26 GMT
 recorded_with: VCR 6.1.0

--- a/spec/cassettes/CFECivil_SubmissionBuilder/_call/when_saving_the_result/does_not_create_a_submission_history_object.yml
+++ b/spec/cassettes/CFECivil_SubmissionBuilder/_call/when_saving_the_result/does_not_create_a_submission_history_object.yml
@@ -2,24 +2,24 @@
 http_interactions:
 - request:
     method: post
-    uri: https://main-cfe-civil-uat.cloud-platform.service.justice.gov.uk/v6/assessments
+    uri: https://cfe-civil-staging.cloud-platform.service.justice.gov.uk/v6/assessments
     body:
       encoding: UTF-8
-      string: '{"assessment":{"client_reference_id":"L-LNA-9P4","submission_date":"2023-04-19"},"proceeding_types":[{"ccms_code":"DA001","client_involvement_type":"A"}],"applicant":{"date_of_birth":"1989-05-09","employed":false,"involvement_type":"applicant","has_partner_opponent":false,"receives_qualifying_benefit":true},"capitals":{"bank_accounts":[{"description":"Current
-        accounts","value":"-455392.73"},{"description":"Savings accounts","value":"-791965.41"},{"description":"Money
-        not in a bank account","value":"513771.54"},{"description":"Access to another
-        person''s bank account","value":"429647.29"},{"description":"ISAs, National
-        Savings Certificates and Premium Bonds","value":"321552.37"},{"description":"Shares
-        in a public limited company","value":"957538.74"},{"description":"PEPs, unit
-        trusts, capital bonds and government stocks","value":"903928.59"},{"description":"Life
-        assurance and endowment policies not linked to a mortgage","value":"187267.46"}],"non_liquid_capital":[]},"vehicles":[{"value":5000.0,"loan_amount_outstanding":250.0,"date_of_purchase":"2023-01-10","in_regular_use":true}],"properties":{"main_home":{"value":841157.03,"outstanding_mortgage":963023.55,"percentage_owned":38.47,"shared_with_housing_assoc":false},"additional_properties":[{"value":0.0,"outstanding_mortgage":0.0,"percentage_owned":0.0,"shared_with_housing_assoc":false}]},"explicit_remarks":[{"category":"policy_disregards","details":[]}]}'
+      string: '{"assessment":{"client_reference_id":"L-JL3-MBJ","submission_date":"2023-06-19","level_of_help":"certificated"},"proceeding_types":[{"ccms_code":"DA001","client_involvement_type":"A"}],"applicant":{"date_of_birth":"1998-06-11","employed":false,"involvement_type":"applicant","has_partner_opponent":false,"receives_qualifying_benefit":true},"capitals":{"bank_accounts":[{"description":"Current
+        accounts","value":"525715.0"},{"description":"Savings accounts","value":"-733561.75"},{"description":"Money
+        not in a bank account","value":"905979.33"},{"description":"Access to another
+        person''s bank account","value":"889628.94"},{"description":"ISAs, National
+        Savings Certificates and Premium Bonds","value":"112506.67"},{"description":"Shares
+        in a public limited company","value":"521424.52"},{"description":"PEPs, unit
+        trusts, capital bonds and government stocks","value":"864279.54"},{"description":"Life
+        assurance and endowment policies not linked to a mortgage","value":"952507.18"}],"non_liquid_capital":[]},"vehicles":[{"value":5000.0,"loan_amount_outstanding":250.0,"date_of_purchase":"2023-01-10","in_regular_use":true}],"properties":{"main_home":{"value":841157.03,"outstanding_mortgage":963023.55,"percentage_owned":38.47,"shared_with_housing_assoc":false},"additional_properties":[{"value":0.0,"outstanding_mortgage":0.0,"percentage_owned":0.0,"shared_with_housing_assoc":false}]},"explicit_remarks":[{"category":"policy_disregards","details":[]}]}'
     headers:
       Content-Type:
       - application/json
       Accept:
       - application/json;version=6
       User-Agent:
-      - Faraday v2.7.4
+      - CivilApply/1.0 test
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -28,11 +28,11 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 19 Apr 2023 06:25:00 GMT
+      - Mon, 19 Jun 2023 14:05:29 GMT
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '4729'
+      - '4888'
       Connection:
       - keep-alive
       X-Frame-Options:
@@ -50,24 +50,24 @@ http_interactions:
       Vary:
       - Accept
       Etag:
-      - W/"5509a6637defeaafc407993d8eaaef72"
+      - W/"ca216a9974752be1b7269430f68c2de6"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 67ad17771108ab254b5f132bf826675e
+      - b3daff82b25fb7a0ecafcaba4e9bc537
       X-Runtime:
-      - '0.874162'
+      - '0.240885'
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
-      string: '{"version":"6","timestamp":"2023-04-19T06:25:00.205Z","success":true,"result_summary":{"overall_result":{"result":"contribution_required","capital_contribution":3310705.99,"income_contribution":0.0,"proceeding_types":[{"ccms_code":"DA001","client_involvement_type":"A","upper_threshold":0.0,"lower_threshold":0.0,"result":"contribution_required"}]},"gross_income":{"total_gross_income":0.0,"proceeding_types":[{"ccms_code":"DA001","client_involvement_type":"A","upper_threshold":999999999999.0,"lower_threshold":0.0,"result":"pending"}],"combined_total_gross_income":0.0},"disposable_income":{"dependant_allowance":0.0,"gross_housing_costs":0.0,"housing_benefit":0.0,"net_housing_costs":0.0,"maintenance_allowance":0.0,"total_outgoings_and_allowances":0.0,"total_disposable_income":0.0,"employment_income":{"gross_income":0.0,"benefits_in_kind":0.0,"tax":0.0,"national_insurance":0.0,"fixed_employment_deduction":0.0,"net_employment_income":0.0},"income_contribution":0.0,"proceeding_types":[{"ccms_code":"DA001","client_involvement_type":"A","upper_threshold":999999999999.0,"lower_threshold":315.0,"result":"pending"}],"combined_total_disposable_income":0.0,"combined_total_outgoings_and_allowances":0.0,"partner_allowance":0},"capital":{"pensioner_disregard_applied":0.0,"total_liquid":3313705.99,"total_non_liquid":0.0,"total_vehicle":0.0,"total_property":0.0,"total_mortgage_allowance":999999999999.0,"total_capital":3313705.99,"subject_matter_of_dispute_disregard":0.0,"capital_contribution":3310705.99,"assessed_capital":3313705.99,"total_capital_with_smod":3313705.99,"disputed_non_property_disregard":0.0,"proceeding_types":[{"ccms_code":"DA001","client_involvement_type":"A","upper_threshold":999999999999.0,"lower_threshold":3000.0,"result":"contribution_required"}],"pensioner_capital_disregard":0.0,"combined_assessed_capital":3313705.99}},"assessment":{"id":"e3126bf7-4914-417f-a053-faac5e519df0","client_reference_id":"L-LNA-9P4","submission_date":"2023-04-19","level_of_help":"certificated","applicant":{"date_of_birth":"1989-05-09","involvement_type":"applicant","employed":false,"has_partner_opponent":false,"receives_qualifying_benefit":true,"self_employed":false},"gross_income":{"employment_income":[],"irregular_income":{"monthly_equivalents":{"student_loan":0.0,"unspecified_source":0.0}},"state_benefits":{"monthly_equivalents":{"all_sources":0.0,"cash_transactions":0,"bank_transactions":[]}},"other_income":{"monthly_equivalents":{"all_sources":{"friends_or_family":0,"maintenance_in":0,"property_or_lodger":0,"pension":0},"bank_transactions":{"friends_or_family":0,"maintenance_in":0,"property_or_lodger":0,"pension":0},"cash_transactions":{"friends_or_family":0,"maintenance_in":0,"property_or_lodger":0,"pension":0}}}},"disposable_income":{"monthly_equivalents":{"all_sources":{"child_care":0.0,"rent_or_mortgage":0.0,"maintenance_out":0.0,"legal_aid":0.0},"bank_transactions":{"child_care":0.0,"rent_or_mortgage":0.0,"maintenance_out":0.0,"legal_aid":0.0},"cash_transactions":{"child_care":0.0,"rent_or_mortgage":0.0,"maintenance_out":0.0,"legal_aid":0.0}},"childcare_allowance":0.0,"deductions":{"dependants_allowance":0.0,"disregarded_state_benefits":0.0}},"capital":{"capital_items":{"liquid":[{"description":"Life
-        assurance and endowment policies not linked to a mortgage","value":187267.46},{"description":"PEPs,
-        unit trusts, capital bonds and government stocks","value":903928.59},{"description":"Shares
-        in a public limited company","value":957538.74},{"description":"ISAs, National
-        Savings Certificates and Premium Bonds","value":321552.37},{"description":"Access
-        to another person''s bank account","value":429647.29},{"description":"Money
-        not in a bank account","value":513771.54},{"description":"Savings accounts","value":-791965.41},{"description":"Current
-        accounts","value":-455392.73}],"non_liquid":[],"vehicles":[{"value":5000.0,"loan_amount_outstanding":250.0,"date_of_purchase":"2023-01-10","in_regular_use":true,"included_in_assessment":false,"disregards_and_deductions":4750.0,"assessed_value":0.0}],"properties":{"main_home":{"value":841157.03,"outstanding_mortgage":963023.55,"percentage_owned":38.47,"main_home":true,"shared_with_housing_assoc":false,"transaction_allowance":0.0,"allowable_outstanding_mortgage":963023.55,"net_value":-121866.52,"net_equity":-46882.05,"smod_allowance":0,"main_home_equity_disregard":-46882.05,"assessed_equity":0.0},"additional_properties":[{"value":0.0,"outstanding_mortgage":0.0,"percentage_owned":0.0,"main_home":false,"shared_with_housing_assoc":false,"transaction_allowance":0.0,"allowable_outstanding_mortgage":0.0,"net_value":0.0,"net_equity":0.0,"smod_allowance":0,"main_home_equity_disregard":0.0,"assessed_equity":0.0}]}}},"remarks":{}}}'
-  recorded_at: Wed, 19 Apr 2023 06:24:58 GMT
+      string: '{"version":"6","timestamp":"2023-06-19T14:05:29.742Z","success":true,"result_summary":{"overall_result":{"result":"contribution_required","capital_contribution":4769041.18,"income_contribution":0.0,"proceeding_types":[{"ccms_code":"DA001","client_involvement_type":"A","upper_threshold":0.0,"lower_threshold":0.0,"result":"contribution_required"}]},"gross_income":{"total_gross_income":0.0,"proceeding_types":[{"ccms_code":"DA001","client_involvement_type":"A","upper_threshold":999999999999.0,"lower_threshold":0.0,"result":"pending"}],"combined_total_gross_income":0.0},"disposable_income":{"dependant_allowance_under_16":0,"dependant_allowance_over_16":0,"dependant_allowance":0,"gross_housing_costs":0.0,"housing_benefit":0.0,"net_housing_costs":0.0,"maintenance_allowance":0.0,"total_outgoings_and_allowances":0.0,"total_disposable_income":0.0,"employment_income":{"gross_income":0.0,"benefits_in_kind":0.0,"tax":0.0,"national_insurance":0.0,"fixed_employment_deduction":0.0,"net_employment_income":0.0},"income_contribution":0.0,"proceeding_types":[{"ccms_code":"DA001","client_involvement_type":"A","upper_threshold":999999999999.0,"lower_threshold":315.0,"result":"pending"}],"combined_total_disposable_income":0.0,"combined_total_outgoings_and_allowances":0.0,"partner_allowance":0},"capital":{"pensioner_disregard_applied":0.0,"total_liquid":4772041.18,"total_non_liquid":0.0,"total_vehicle":0.0,"total_property":0.0,"total_mortgage_allowance":999999999999.0,"total_capital":4772041.18,"subject_matter_of_dispute_disregard":0.0,"assessed_capital":4772041.18,"total_capital_with_smod":4772041.18,"disputed_non_property_disregard":0,"proceeding_types":[{"ccms_code":"DA001","client_involvement_type":"A","upper_threshold":999999999999.0,"lower_threshold":3000.0,"result":"contribution_required"}],"combined_disputed_capital":0,"combined_non_disputed_capital":4772041.18,"capital_contribution":4769041.18,"pensioner_capital_disregard":0.0,"combined_assessed_capital":4772041.18}},"assessment":{"id":"a1f9416b-9537-441f-9369-e86bdf2225f8","client_reference_id":"L-JL3-MBJ","submission_date":"2023-06-19","level_of_help":"certificated","applicant":{"date_of_birth":"1998-06-11","involvement_type":"applicant","employed":false,"has_partner_opponent":false,"receives_qualifying_benefit":true},"gross_income":{"employment_income":[],"irregular_income":{"monthly_equivalents":{"student_loan":0.0,"unspecified_source":0.0}},"state_benefits":{"monthly_equivalents":{"all_sources":0.0,"cash_transactions":0,"bank_transactions":[]}},"other_income":{"monthly_equivalents":{"all_sources":{"friends_or_family":0,"maintenance_in":0,"property_or_lodger":0,"pension":0},"bank_transactions":{"friends_or_family":0,"maintenance_in":0,"property_or_lodger":0,"pension":0},"cash_transactions":{"friends_or_family":0,"maintenance_in":0,"property_or_lodger":0,"pension":0}}}},"disposable_income":{"monthly_equivalents":{"all_sources":{"child_care":0.0,"rent_or_mortgage":0.0,"maintenance_out":0.0,"legal_aid":0.0},"bank_transactions":{"child_care":0.0,"rent_or_mortgage":0.0,"maintenance_out":0.0,"legal_aid":0.0},"cash_transactions":{"child_care":0.0,"rent_or_mortgage":0.0,"maintenance_out":0.0,"legal_aid":0.0}},"childcare_allowance":0.0,"deductions":{"dependants_allowance":0.0,"disregarded_state_benefits":0.0}},"capital":{"capital_items":{"liquid":[{"description":"Current
+        accounts","value":525715.0},{"description":"Savings accounts","value":-733561.75},{"description":"Money
+        not in a bank account","value":905979.33},{"description":"Access to another
+        person''s bank account","value":889628.94},{"description":"ISAs, National
+        Savings Certificates and Premium Bonds","value":112506.67},{"description":"Shares
+        in a public limited company","value":521424.52},{"description":"PEPs, unit
+        trusts, capital bonds and government stocks","value":864279.54},{"description":"Life
+        assurance and endowment policies not linked to a mortgage","value":952507.18}],"non_liquid":[],"vehicles":[{"value":5000.0,"loan_amount_outstanding":250.0,"date_of_purchase":"2023-01-10","in_regular_use":true,"included_in_assessment":false,"disregards_and_deductions":4750.0,"assessed_value":0.0}],"properties":{"main_home":{"value":841157.03,"outstanding_mortgage":963023.55,"percentage_owned":38.47,"main_home":true,"shared_with_housing_assoc":false,"transaction_allowance":0.0,"allowable_outstanding_mortgage":963023.55,"net_value":-121866.52,"net_equity":-46882.05,"smod_allowance":0,"main_home_equity_disregard":-46882.05,"assessed_equity":0.0},"additional_properties":[{"value":0.0,"outstanding_mortgage":0.0,"percentage_owned":0.0,"main_home":false,"shared_with_housing_assoc":false,"transaction_allowance":0.0,"allowable_outstanding_mortgage":0.0,"net_value":0.0,"net_equity":0.0,"smod_allowance":0,"main_home_equity_disregard":0.0,"assessed_equity":0.0}]}}},"remarks":{"current_account_balance":{"residual_balance":[]}}}}'
+  recorded_at: Mon, 19 Jun 2023 14:05:29 GMT
 recorded_with: VCR 6.1.0

--- a/spec/cassettes/CFECivil_SubmissionBuilder/_call/when_saving_the_result/does_not_save_a_submission_object.yml
+++ b/spec/cassettes/CFECivil_SubmissionBuilder/_call/when_saving_the_result/does_not_save_a_submission_object.yml
@@ -2,24 +2,24 @@
 http_interactions:
 - request:
     method: post
-    uri: https://main-cfe-civil-uat.cloud-platform.service.justice.gov.uk/v6/assessments
+    uri: https://cfe-civil-staging.cloud-platform.service.justice.gov.uk/v6/assessments
     body:
       encoding: UTF-8
-      string: '{"assessment":{"client_reference_id":"L-YR7-5PR","submission_date":"2023-04-19"},"proceeding_types":[{"ccms_code":"DA001","client_involvement_type":"A"}],"applicant":{"date_of_birth":"2002-03-16","employed":false,"involvement_type":"applicant","has_partner_opponent":false,"receives_qualifying_benefit":true},"capitals":{"bank_accounts":[{"description":"Current
-        accounts","value":"-978265.18"},{"description":"Savings accounts","value":"599009.09"},{"description":"Money
-        not in a bank account","value":"347195.51"},{"description":"Access to another
-        person''s bank account","value":"635588.9"},{"description":"ISAs, National
-        Savings Certificates and Premium Bonds","value":"271071.16"},{"description":"Shares
-        in a public limited company","value":"811122.59"},{"description":"PEPs, unit
-        trusts, capital bonds and government stocks","value":"505209.68"},{"description":"Life
-        assurance and endowment policies not linked to a mortgage","value":"917865.54"}],"non_liquid_capital":[]},"vehicles":[{"value":5000.0,"loan_amount_outstanding":250.0,"date_of_purchase":"2023-01-10","in_regular_use":true}],"properties":{"main_home":{"value":841157.03,"outstanding_mortgage":963023.55,"percentage_owned":38.47,"shared_with_housing_assoc":false},"additional_properties":[{"value":0.0,"outstanding_mortgage":0.0,"percentage_owned":0.0,"shared_with_housing_assoc":false}]},"explicit_remarks":[{"category":"policy_disregards","details":[]}]}'
+      string: '{"assessment":{"client_reference_id":"L-815-M0V","submission_date":"2023-06-19","level_of_help":"certificated"},"proceeding_types":[{"ccms_code":"DA001","client_involvement_type":"A"}],"applicant":{"date_of_birth":"1962-11-19","employed":false,"involvement_type":"applicant","has_partner_opponent":false,"receives_qualifying_benefit":true},"capitals":{"bank_accounts":[{"description":"Current
+        accounts","value":"513402.15"},{"description":"Savings accounts","value":"392116.01"},{"description":"Money
+        not in a bank account","value":"485267.93"},{"description":"Access to another
+        person''s bank account","value":"592922.21"},{"description":"ISAs, National
+        Savings Certificates and Premium Bonds","value":"997424.36"},{"description":"Shares
+        in a public limited company","value":"825235.15"},{"description":"PEPs, unit
+        trusts, capital bonds and government stocks","value":"518776.95"},{"description":"Life
+        assurance and endowment policies not linked to a mortgage","value":"661928.48"}],"non_liquid_capital":[]},"vehicles":[{"value":5000.0,"loan_amount_outstanding":250.0,"date_of_purchase":"2023-01-10","in_regular_use":true}],"properties":{"main_home":{"value":841157.03,"outstanding_mortgage":963023.55,"percentage_owned":38.47,"shared_with_housing_assoc":false},"additional_properties":[{"value":0.0,"outstanding_mortgage":0.0,"percentage_owned":0.0,"shared_with_housing_assoc":false}]},"explicit_remarks":[{"category":"policy_disregards","details":[]}]}'
     headers:
       Content-Type:
       - application/json
       Accept:
       - application/json;version=6
       User-Agent:
-      - Faraday v2.7.4
+      - CivilApply/1.0 test
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -28,11 +28,11 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 19 Apr 2023 06:25:00 GMT
+      - Mon, 19 Jun 2023 14:05:28 GMT
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '4727'
+      - '4898'
       Connection:
       - keep-alive
       X-Frame-Options:
@@ -50,24 +50,24 @@ http_interactions:
       Vary:
       - Accept
       Etag:
-      - W/"34a86c527b6affb6a3bcc3e14cd81da3"
+      - W/"abb866ec9aa0340891496eb5e5d7be14"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 349f0a7673510593e61792826ff87119
+      - 07bcdc0d2a0a93a578455b3e5ca2b1f2
       X-Runtime:
-      - '0.309363'
+      - '0.557183'
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
-      string: '{"version":"6","timestamp":"2023-04-19T06:25:00.811Z","success":true,"result_summary":{"overall_result":{"result":"contribution_required","capital_contribution":4084062.47,"income_contribution":0.0,"proceeding_types":[{"ccms_code":"DA001","client_involvement_type":"A","upper_threshold":0.0,"lower_threshold":0.0,"result":"contribution_required"}]},"gross_income":{"total_gross_income":0.0,"proceeding_types":[{"ccms_code":"DA001","client_involvement_type":"A","upper_threshold":999999999999.0,"lower_threshold":0.0,"result":"pending"}],"combined_total_gross_income":0.0},"disposable_income":{"dependant_allowance":0.0,"gross_housing_costs":0.0,"housing_benefit":0.0,"net_housing_costs":0.0,"maintenance_allowance":0.0,"total_outgoings_and_allowances":0.0,"total_disposable_income":0.0,"employment_income":{"gross_income":0.0,"benefits_in_kind":0.0,"tax":0.0,"national_insurance":0.0,"fixed_employment_deduction":0.0,"net_employment_income":0.0},"income_contribution":0.0,"proceeding_types":[{"ccms_code":"DA001","client_involvement_type":"A","upper_threshold":999999999999.0,"lower_threshold":315.0,"result":"pending"}],"combined_total_disposable_income":0.0,"combined_total_outgoings_and_allowances":0.0,"partner_allowance":0},"capital":{"pensioner_disregard_applied":0.0,"total_liquid":4087062.47,"total_non_liquid":0.0,"total_vehicle":0.0,"total_property":0.0,"total_mortgage_allowance":999999999999.0,"total_capital":4087062.47,"subject_matter_of_dispute_disregard":0.0,"capital_contribution":4084062.47,"assessed_capital":4087062.47,"total_capital_with_smod":4087062.47,"disputed_non_property_disregard":0.0,"proceeding_types":[{"ccms_code":"DA001","client_involvement_type":"A","upper_threshold":999999999999.0,"lower_threshold":3000.0,"result":"contribution_required"}],"pensioner_capital_disregard":0.0,"combined_assessed_capital":4087062.47}},"assessment":{"id":"d9f3d8e7-67d8-4506-b44a-16488868bb8c","client_reference_id":"L-YR7-5PR","submission_date":"2023-04-19","level_of_help":"certificated","applicant":{"date_of_birth":"2002-03-16","involvement_type":"applicant","employed":false,"has_partner_opponent":false,"receives_qualifying_benefit":true,"self_employed":false},"gross_income":{"employment_income":[],"irregular_income":{"monthly_equivalents":{"student_loan":0.0,"unspecified_source":0.0}},"state_benefits":{"monthly_equivalents":{"all_sources":0.0,"cash_transactions":0,"bank_transactions":[]}},"other_income":{"monthly_equivalents":{"all_sources":{"friends_or_family":0,"maintenance_in":0,"property_or_lodger":0,"pension":0},"bank_transactions":{"friends_or_family":0,"maintenance_in":0,"property_or_lodger":0,"pension":0},"cash_transactions":{"friends_or_family":0,"maintenance_in":0,"property_or_lodger":0,"pension":0}}}},"disposable_income":{"monthly_equivalents":{"all_sources":{"child_care":0.0,"rent_or_mortgage":0.0,"maintenance_out":0.0,"legal_aid":0.0},"bank_transactions":{"child_care":0.0,"rent_or_mortgage":0.0,"maintenance_out":0.0,"legal_aid":0.0},"cash_transactions":{"child_care":0.0,"rent_or_mortgage":0.0,"maintenance_out":0.0,"legal_aid":0.0}},"childcare_allowance":0.0,"deductions":{"dependants_allowance":0.0,"disregarded_state_benefits":0.0}},"capital":{"capital_items":{"liquid":[{"description":"Life
-        assurance and endowment policies not linked to a mortgage","value":917865.54},{"description":"PEPs,
-        unit trusts, capital bonds and government stocks","value":505209.68},{"description":"Shares
-        in a public limited company","value":811122.59},{"description":"ISAs, National
-        Savings Certificates and Premium Bonds","value":271071.16},{"description":"Access
-        to another person''s bank account","value":635588.9},{"description":"Money
-        not in a bank account","value":347195.51},{"description":"Savings accounts","value":599009.09},{"description":"Current
-        accounts","value":-978265.18}],"non_liquid":[],"vehicles":[{"value":5000.0,"loan_amount_outstanding":250.0,"date_of_purchase":"2023-01-10","in_regular_use":true,"included_in_assessment":false,"disregards_and_deductions":4750.0,"assessed_value":0.0}],"properties":{"main_home":{"value":841157.03,"outstanding_mortgage":963023.55,"percentage_owned":38.47,"main_home":true,"shared_with_housing_assoc":false,"transaction_allowance":0.0,"allowable_outstanding_mortgage":963023.55,"net_value":-121866.52,"net_equity":-46882.05,"smod_allowance":0,"main_home_equity_disregard":-46882.05,"assessed_equity":0.0},"additional_properties":[{"value":0.0,"outstanding_mortgage":0.0,"percentage_owned":0.0,"main_home":false,"shared_with_housing_assoc":false,"transaction_allowance":0.0,"allowable_outstanding_mortgage":0.0,"net_value":0.0,"net_equity":0.0,"smod_allowance":0,"main_home_equity_disregard":0.0,"assessed_equity":0.0}]}}},"remarks":{}}}'
-  recorded_at: Wed, 19 Apr 2023 06:24:58 GMT
+      string: '{"version":"6","timestamp":"2023-06-19T14:05:28.388Z","success":true,"result_summary":{"overall_result":{"result":"contribution_required","capital_contribution":4884073.24,"income_contribution":0.0,"proceeding_types":[{"ccms_code":"DA001","client_involvement_type":"A","upper_threshold":0.0,"lower_threshold":0.0,"result":"contribution_required"}]},"gross_income":{"total_gross_income":0.0,"proceeding_types":[{"ccms_code":"DA001","client_involvement_type":"A","upper_threshold":999999999999.0,"lower_threshold":0.0,"result":"pending"}],"combined_total_gross_income":0.0},"disposable_income":{"dependant_allowance_under_16":0,"dependant_allowance_over_16":0,"dependant_allowance":0,"gross_housing_costs":0.0,"housing_benefit":0.0,"net_housing_costs":0.0,"maintenance_allowance":0.0,"total_outgoings_and_allowances":0.0,"total_disposable_income":0.0,"employment_income":{"gross_income":0.0,"benefits_in_kind":0.0,"tax":0.0,"national_insurance":0.0,"fixed_employment_deduction":0.0,"net_employment_income":0.0},"income_contribution":0.0,"proceeding_types":[{"ccms_code":"DA001","client_involvement_type":"A","upper_threshold":999999999999.0,"lower_threshold":315.0,"result":"pending"}],"combined_total_disposable_income":0.0,"combined_total_outgoings_and_allowances":0.0,"partner_allowance":0},"capital":{"pensioner_disregard_applied":100000.0,"total_liquid":4987073.24,"total_non_liquid":0.0,"total_vehicle":0.0,"total_property":0.0,"total_mortgage_allowance":999999999999.0,"total_capital":4987073.24,"subject_matter_of_dispute_disregard":0.0,"assessed_capital":4887073.24,"total_capital_with_smod":4987073.24,"disputed_non_property_disregard":0,"proceeding_types":[{"ccms_code":"DA001","client_involvement_type":"A","upper_threshold":999999999999.0,"lower_threshold":3000.0,"result":"contribution_required"}],"combined_disputed_capital":0,"combined_non_disputed_capital":4987073.24,"capital_contribution":4884073.24,"pensioner_capital_disregard":100000.0,"combined_assessed_capital":4887073.24}},"assessment":{"id":"20f36abd-8388-46f5-bdd9-17cd5822d69f","client_reference_id":"L-815-M0V","submission_date":"2023-06-19","level_of_help":"certificated","applicant":{"date_of_birth":"1962-11-19","involvement_type":"applicant","employed":false,"has_partner_opponent":false,"receives_qualifying_benefit":true},"gross_income":{"employment_income":[],"irregular_income":{"monthly_equivalents":{"student_loan":0.0,"unspecified_source":0.0}},"state_benefits":{"monthly_equivalents":{"all_sources":0.0,"cash_transactions":0,"bank_transactions":[]}},"other_income":{"monthly_equivalents":{"all_sources":{"friends_or_family":0,"maintenance_in":0,"property_or_lodger":0,"pension":0},"bank_transactions":{"friends_or_family":0,"maintenance_in":0,"property_or_lodger":0,"pension":0},"cash_transactions":{"friends_or_family":0,"maintenance_in":0,"property_or_lodger":0,"pension":0}}}},"disposable_income":{"monthly_equivalents":{"all_sources":{"child_care":0.0,"rent_or_mortgage":0.0,"maintenance_out":0.0,"legal_aid":0.0},"bank_transactions":{"child_care":0.0,"rent_or_mortgage":0.0,"maintenance_out":0.0,"legal_aid":0.0},"cash_transactions":{"child_care":0.0,"rent_or_mortgage":0.0,"maintenance_out":0.0,"legal_aid":0.0}},"childcare_allowance":0.0,"deductions":{"dependants_allowance":0.0,"disregarded_state_benefits":0.0}},"capital":{"capital_items":{"liquid":[{"description":"Current
+        accounts","value":513402.15},{"description":"Savings accounts","value":392116.01},{"description":"Money
+        not in a bank account","value":485267.93},{"description":"Access to another
+        person''s bank account","value":592922.21},{"description":"ISAs, National
+        Savings Certificates and Premium Bonds","value":997424.36},{"description":"Shares
+        in a public limited company","value":825235.15},{"description":"PEPs, unit
+        trusts, capital bonds and government stocks","value":518776.95},{"description":"Life
+        assurance and endowment policies not linked to a mortgage","value":661928.48}],"non_liquid":[],"vehicles":[{"value":5000.0,"loan_amount_outstanding":250.0,"date_of_purchase":"2023-01-10","in_regular_use":true,"included_in_assessment":false,"disregards_and_deductions":4750.0,"assessed_value":0.0}],"properties":{"main_home":{"value":841157.03,"outstanding_mortgage":963023.55,"percentage_owned":38.47,"main_home":true,"shared_with_housing_assoc":false,"transaction_allowance":0.0,"allowable_outstanding_mortgage":963023.55,"net_value":-121866.52,"net_equity":-46882.05,"smod_allowance":0,"main_home_equity_disregard":-46882.05,"assessed_equity":0.0},"additional_properties":[{"value":0.0,"outstanding_mortgage":0.0,"percentage_owned":0.0,"main_home":false,"shared_with_housing_assoc":false,"transaction_allowance":0.0,"allowable_outstanding_mortgage":0.0,"net_value":0.0,"net_equity":0.0,"smod_allowance":0,"main_home_equity_disregard":0.0,"assessed_equity":0.0}]}}},"remarks":{"current_account_balance":{"residual_balance":[]}}}}'
+  recorded_at: Mon, 19 Jun 2023 14:05:28 GMT
 recorded_with: VCR 6.1.0

--- a/spec/cassettes/CFECivil_SubmissionBuilder/_call/when_saving_the_result/generates_the_expected_JSON.yml
+++ b/spec/cassettes/CFECivil_SubmissionBuilder/_call/when_saving_the_result/generates_the_expected_JSON.yml
@@ -2,24 +2,24 @@
 http_interactions:
 - request:
     method: post
-    uri: https://main-cfe-civil-uat.cloud-platform.service.justice.gov.uk/v6/assessments
+    uri: https://cfe-civil-staging.cloud-platform.service.justice.gov.uk/v6/assessments
     body:
       encoding: UTF-8
-      string: '{"assessment":{"client_reference_id":"L-E8K-3T0","submission_date":"2023-04-19"},"proceeding_types":[{"ccms_code":"DA001","client_involvement_type":"A"}],"applicant":{"date_of_birth":"1975-05-25","employed":false,"involvement_type":"applicant","has_partner_opponent":false,"receives_qualifying_benefit":true},"capitals":{"bank_accounts":[{"description":"Current
-        accounts","value":"694935.42"},{"description":"Savings accounts","value":"-654916.34"},{"description":"Money
-        not in a bank account","value":"761883.13"},{"description":"Access to another
-        person''s bank account","value":"541552.8"},{"description":"ISAs, National
-        Savings Certificates and Premium Bonds","value":"929662.92"},{"description":"Shares
-        in a public limited company","value":"71559.81"},{"description":"PEPs, unit
-        trusts, capital bonds and government stocks","value":"612363.29"},{"description":"Life
-        assurance and endowment policies not linked to a mortgage","value":"187410.09"}],"non_liquid_capital":[]},"vehicles":[{"value":5000.0,"loan_amount_outstanding":250.0,"date_of_purchase":"2023-01-10","in_regular_use":true}],"properties":{"main_home":{"value":841157.03,"outstanding_mortgage":963023.55,"percentage_owned":38.47,"shared_with_housing_assoc":false},"additional_properties":[{"value":0.0,"outstanding_mortgage":0.0,"percentage_owned":0.0,"shared_with_housing_assoc":false}]},"explicit_remarks":[{"category":"policy_disregards","details":[]}]}'
+      string: '{"assessment":{"client_reference_id":"L-902-940","submission_date":"2023-06-19","level_of_help":"certificated"},"proceeding_types":[{"ccms_code":"DA001","client_involvement_type":"A"}],"applicant":{"date_of_birth":"1982-11-06","employed":false,"involvement_type":"applicant","has_partner_opponent":false,"receives_qualifying_benefit":true},"capitals":{"bank_accounts":[{"description":"Current
+        accounts","value":"813526.36"},{"description":"Savings accounts","value":"567666.62"},{"description":"Money
+        not in a bank account","value":"325274.4"},{"description":"Access to another
+        person''s bank account","value":"7555.93"},{"description":"ISAs, National
+        Savings Certificates and Premium Bonds","value":"714645.96"},{"description":"Shares
+        in a public limited company","value":"595470.41"},{"description":"PEPs, unit
+        trusts, capital bonds and government stocks","value":"157669.15"},{"description":"Life
+        assurance and endowment policies not linked to a mortgage","value":"112480.0"}],"non_liquid_capital":[]},"vehicles":[{"value":5000.0,"loan_amount_outstanding":250.0,"date_of_purchase":"2023-01-10","in_regular_use":true}],"properties":{"main_home":{"value":841157.03,"outstanding_mortgage":963023.55,"percentage_owned":38.47,"shared_with_housing_assoc":false},"additional_properties":[{"value":0.0,"outstanding_mortgage":0.0,"percentage_owned":0.0,"shared_with_housing_assoc":false}]},"explicit_remarks":[{"category":"policy_disregards","details":[]}]}'
     headers:
       Content-Type:
       - application/json
       Accept:
       - application/json;version=6
       User-Agent:
-      - Faraday v2.7.4
+      - CivilApply/1.0 test
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -28,11 +28,11 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 19 Apr 2023 06:24:59 GMT
+      - Mon, 19 Jun 2023 14:05:29 GMT
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '4775'
+      - '4884'
       Connection:
       - keep-alive
       X-Frame-Options:
@@ -50,24 +50,24 @@ http_interactions:
       Vary:
       - Accept
       Etag:
-      - W/"02fd3d9922e3d0a7d4d364da7fb23659"
+      - W/"e930e4038268cfdd031f4cf827d087d9"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - c58e578a274dcdd2c6dbb0d28b7541c9
+      - e02f6b3d8365e4654e23f8c5fd24b9f1
       X-Runtime:
-      - '0.462210'
+      - '0.421097'
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
-      string: '{"version":"6","timestamp":"2023-04-19T06:24:59.047Z","success":true,"result_summary":{"overall_result":{"result":"contribution_required","capital_contribution":3796367.46,"income_contribution":0.0,"proceeding_types":[{"ccms_code":"DA001","client_involvement_type":"A","upper_threshold":0.0,"lower_threshold":0.0,"result":"contribution_required"}]},"gross_income":{"total_gross_income":0.0,"proceeding_types":[{"ccms_code":"DA001","client_involvement_type":"A","upper_threshold":999999999999.0,"lower_threshold":0.0,"result":"pending"}],"combined_total_gross_income":0.0},"disposable_income":{"dependant_allowance":0.0,"gross_housing_costs":0.0,"housing_benefit":0.0,"net_housing_costs":0.0,"maintenance_allowance":0.0,"total_outgoings_and_allowances":0.0,"total_disposable_income":0.0,"employment_income":{"gross_income":0.0,"benefits_in_kind":0.0,"tax":0.0,"national_insurance":0.0,"fixed_employment_deduction":0.0,"net_employment_income":0.0},"income_contribution":0.0,"proceeding_types":[{"ccms_code":"DA001","client_involvement_type":"A","upper_threshold":999999999999.0,"lower_threshold":315.0,"result":"pending"}],"combined_total_disposable_income":0.0,"combined_total_outgoings_and_allowances":0.0,"partner_allowance":0},"capital":{"pensioner_disregard_applied":0.0,"total_liquid":3799367.46,"total_non_liquid":0.0,"total_vehicle":0.0,"total_property":0.0,"total_mortgage_allowance":999999999999.0,"total_capital":3799367.46,"subject_matter_of_dispute_disregard":0.0,"capital_contribution":3796367.46,"assessed_capital":3799367.46,"total_capital_with_smod":3799367.46,"disputed_non_property_disregard":0.0,"proceeding_types":[{"ccms_code":"DA001","client_involvement_type":"A","upper_threshold":999999999999.0,"lower_threshold":3000.0,"result":"contribution_required"}],"pensioner_capital_disregard":0.0,"combined_assessed_capital":3799367.46}},"assessment":{"id":"f83c6345-62f1-4bd3-8a1d-9255036bc854","client_reference_id":"L-E8K-3T0","submission_date":"2023-04-19","level_of_help":"certificated","applicant":{"date_of_birth":"1975-05-25","involvement_type":"applicant","employed":false,"has_partner_opponent":false,"receives_qualifying_benefit":true,"self_employed":false},"gross_income":{"employment_income":[],"irregular_income":{"monthly_equivalents":{"student_loan":0.0,"unspecified_source":0.0}},"state_benefits":{"monthly_equivalents":{"all_sources":0.0,"cash_transactions":0,"bank_transactions":[]}},"other_income":{"monthly_equivalents":{"all_sources":{"friends_or_family":0,"maintenance_in":0,"property_or_lodger":0,"pension":0},"bank_transactions":{"friends_or_family":0,"maintenance_in":0,"property_or_lodger":0,"pension":0},"cash_transactions":{"friends_or_family":0,"maintenance_in":0,"property_or_lodger":0,"pension":0}}}},"disposable_income":{"monthly_equivalents":{"all_sources":{"child_care":0.0,"rent_or_mortgage":0.0,"maintenance_out":0.0,"legal_aid":0.0},"bank_transactions":{"child_care":0.0,"rent_or_mortgage":0.0,"maintenance_out":0.0,"legal_aid":0.0},"cash_transactions":{"child_care":0.0,"rent_or_mortgage":0.0,"maintenance_out":0.0,"legal_aid":0.0}},"childcare_allowance":0.0,"deductions":{"dependants_allowance":0.0,"disregarded_state_benefits":0.0}},"capital":{"capital_items":{"liquid":[{"description":"Life
-        assurance and endowment policies not linked to a mortgage","value":187410.09},{"description":"PEPs,
-        unit trusts, capital bonds and government stocks","value":612363.29},{"description":"Shares
-        in a public limited company","value":71559.81},{"description":"ISAs, National
-        Savings Certificates and Premium Bonds","value":929662.92},{"description":"Access
-        to another person''s bank account","value":541552.8},{"description":"Money
-        not in a bank account","value":761883.13},{"description":"Savings accounts","value":-654916.34},{"description":"Current
-        accounts","value":694935.42}],"non_liquid":[],"vehicles":[{"value":5000.0,"loan_amount_outstanding":250.0,"date_of_purchase":"2023-01-10","in_regular_use":true,"included_in_assessment":false,"disregards_and_deductions":4750.0,"assessed_value":0.0}],"properties":{"main_home":{"value":841157.03,"outstanding_mortgage":963023.55,"percentage_owned":38.47,"main_home":true,"shared_with_housing_assoc":false,"transaction_allowance":0.0,"allowable_outstanding_mortgage":963023.55,"net_value":-121866.52,"net_equity":-46882.05,"smod_allowance":0,"main_home_equity_disregard":-46882.05,"assessed_equity":0.0},"additional_properties":[{"value":0.0,"outstanding_mortgage":0.0,"percentage_owned":0.0,"main_home":false,"shared_with_housing_assoc":false,"transaction_allowance":0.0,"allowable_outstanding_mortgage":0.0,"net_value":0.0,"net_equity":0.0,"smod_allowance":0,"main_home_equity_disregard":0.0,"assessed_equity":0.0}]}}},"remarks":{"current_account_balance":{"residual_balance":[]}}}}'
-  recorded_at: Wed, 19 Apr 2023 06:24:56 GMT
+      string: '{"version":"6","timestamp":"2023-06-19T14:05:29.138Z","success":true,"result_summary":{"overall_result":{"result":"contribution_required","capital_contribution":3291288.83,"income_contribution":0.0,"proceeding_types":[{"ccms_code":"DA001","client_involvement_type":"A","upper_threshold":0.0,"lower_threshold":0.0,"result":"contribution_required"}]},"gross_income":{"total_gross_income":0.0,"proceeding_types":[{"ccms_code":"DA001","client_involvement_type":"A","upper_threshold":999999999999.0,"lower_threshold":0.0,"result":"pending"}],"combined_total_gross_income":0.0},"disposable_income":{"dependant_allowance_under_16":0,"dependant_allowance_over_16":0,"dependant_allowance":0,"gross_housing_costs":0.0,"housing_benefit":0.0,"net_housing_costs":0.0,"maintenance_allowance":0.0,"total_outgoings_and_allowances":0.0,"total_disposable_income":0.0,"employment_income":{"gross_income":0.0,"benefits_in_kind":0.0,"tax":0.0,"national_insurance":0.0,"fixed_employment_deduction":0.0,"net_employment_income":0.0},"income_contribution":0.0,"proceeding_types":[{"ccms_code":"DA001","client_involvement_type":"A","upper_threshold":999999999999.0,"lower_threshold":315.0,"result":"pending"}],"combined_total_disposable_income":0.0,"combined_total_outgoings_and_allowances":0.0,"partner_allowance":0},"capital":{"pensioner_disregard_applied":0.0,"total_liquid":3294288.83,"total_non_liquid":0.0,"total_vehicle":0.0,"total_property":0.0,"total_mortgage_allowance":999999999999.0,"total_capital":3294288.83,"subject_matter_of_dispute_disregard":0.0,"assessed_capital":3294288.83,"total_capital_with_smod":3294288.83,"disputed_non_property_disregard":0,"proceeding_types":[{"ccms_code":"DA001","client_involvement_type":"A","upper_threshold":999999999999.0,"lower_threshold":3000.0,"result":"contribution_required"}],"combined_disputed_capital":0,"combined_non_disputed_capital":3294288.83,"capital_contribution":3291288.83,"pensioner_capital_disregard":0.0,"combined_assessed_capital":3294288.83}},"assessment":{"id":"5eb77b72-66db-42ed-8e41-c37bb304ecac","client_reference_id":"L-902-940","submission_date":"2023-06-19","level_of_help":"certificated","applicant":{"date_of_birth":"1982-11-06","involvement_type":"applicant","employed":false,"has_partner_opponent":false,"receives_qualifying_benefit":true},"gross_income":{"employment_income":[],"irregular_income":{"monthly_equivalents":{"student_loan":0.0,"unspecified_source":0.0}},"state_benefits":{"monthly_equivalents":{"all_sources":0.0,"cash_transactions":0,"bank_transactions":[]}},"other_income":{"monthly_equivalents":{"all_sources":{"friends_or_family":0,"maintenance_in":0,"property_or_lodger":0,"pension":0},"bank_transactions":{"friends_or_family":0,"maintenance_in":0,"property_or_lodger":0,"pension":0},"cash_transactions":{"friends_or_family":0,"maintenance_in":0,"property_or_lodger":0,"pension":0}}}},"disposable_income":{"monthly_equivalents":{"all_sources":{"child_care":0.0,"rent_or_mortgage":0.0,"maintenance_out":0.0,"legal_aid":0.0},"bank_transactions":{"child_care":0.0,"rent_or_mortgage":0.0,"maintenance_out":0.0,"legal_aid":0.0},"cash_transactions":{"child_care":0.0,"rent_or_mortgage":0.0,"maintenance_out":0.0,"legal_aid":0.0}},"childcare_allowance":0.0,"deductions":{"dependants_allowance":0.0,"disregarded_state_benefits":0.0}},"capital":{"capital_items":{"liquid":[{"description":"Current
+        accounts","value":813526.36},{"description":"Savings accounts","value":567666.62},{"description":"Money
+        not in a bank account","value":325274.4},{"description":"Access to another
+        person''s bank account","value":7555.93},{"description":"ISAs, National Savings
+        Certificates and Premium Bonds","value":714645.96},{"description":"Shares
+        in a public limited company","value":595470.41},{"description":"PEPs, unit
+        trusts, capital bonds and government stocks","value":157669.15},{"description":"Life
+        assurance and endowment policies not linked to a mortgage","value":112480.0}],"non_liquid":[],"vehicles":[{"value":5000.0,"loan_amount_outstanding":250.0,"date_of_purchase":"2023-01-10","in_regular_use":true,"included_in_assessment":false,"disregards_and_deductions":4750.0,"assessed_value":0.0}],"properties":{"main_home":{"value":841157.03,"outstanding_mortgage":963023.55,"percentage_owned":38.47,"main_home":true,"shared_with_housing_assoc":false,"transaction_allowance":0.0,"allowable_outstanding_mortgage":963023.55,"net_value":-121866.52,"net_equity":-46882.05,"smod_allowance":0,"main_home_equity_disregard":-46882.05,"assessed_equity":0.0},"additional_properties":[{"value":0.0,"outstanding_mortgage":0.0,"percentage_owned":0.0,"main_home":false,"shared_with_housing_assoc":false,"transaction_allowance":0.0,"allowable_outstanding_mortgage":0.0,"net_value":0.0,"net_equity":0.0,"smod_allowance":0,"main_home_equity_disregard":0.0,"assessed_equity":0.0}]}}},"remarks":{"current_account_balance":{"residual_balance":[]}}}}'
+  recorded_at: Mon, 19 Jun 2023 14:05:29 GMT
 recorded_with: VCR 6.1.0

--- a/spec/services/cfe_civil/submission_builder_spec.rb
+++ b/spec/services/cfe_civil/submission_builder_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe CFECivil::SubmissionBuilder, :vcr do
                             used_regularly: true),
              other_assets_declaration: build(:other_assets_declaration, :all_nil))
     end
-    let(:staging_host) { "https://main-cfe-civil-uat.cloud-platform.service.justice.gov.uk/" }
+    let(:staging_host) { "https://cfe-civil-staging.cloud-platform.service.justice.gov.uk/" }
     let(:save_result) { true } # this is for once we switch to using CFECivil permanently
 
     before do
@@ -110,7 +110,7 @@ RSpec.describe CFECivil::SubmissionBuilder, :vcr do
                             used_regularly: true),
              other_assets_declaration: build(:other_assets_declaration, :all_nil))
     end
-    let(:staging_host) { "https://main-cfe-civil-uat.cloud-platform.service.justice.gov.uk/" }
+    let(:staging_host) { "https://cfe-civil-staging.cloud-platform.service.justice.gov.uk/" }
     let(:save_result) { true } # this is for once we switch to using CFECivil permanently
 
     context "when sending data to CFE fails with an unexpected error" do


### PR DESCRIPTION
## What

The benefit changes were intended to roll out as a single hit, but some providers pause before submitting.  
We have seen, so far, at least one application that has a state benefit without a description.

This fix will allow that application to complete, generate a means report, and be submitted to CCMS.  it should allow applications in a similar state to proceed as well

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
