### PR TITLE
CFE: Comparison sheet filter update

### DIFF
--- a/app/services/cfe/compare_results.rb
+++ b/app/services/cfe/compare_results.rb
@@ -7,6 +7,7 @@ module CFE
     end
 
     def call
+      ResetGoogleSheetFilter.call
       legal_aid_applications.each do |legal_aid_application|
         compare_values_for legal_aid_application
       end

--- a/app/services/cfe/reset_google_sheet_filter.rb
+++ b/app/services/cfe/reset_google_sheet_filter.rb
@@ -1,0 +1,35 @@
+module CFE
+  class ResetGoogleSheetFilter
+    include SharedGoogleSheet
+    # NOTE: This is intended as a temporary class while we switch from CFE-Legacy to CFE-Civil
+    # Once that change over is complete, the aim is that this can be removed, along with
+
+    def self.call
+      new.call
+    end
+
+    def initialize
+      log_message "Initializing"
+      secret_file = StringIO.new(google_secret.to_json)
+      authorizer = Google::Auth::ServiceAccountCredentials.make_creds(json_key_io: secret_file, scope: SCOPE)
+      authorizer.fetch_access_token!
+
+      @sheet_service = Google::Apis::SheetsV4::SheetsService.new
+      @sheet_service.authorization = authorizer
+    end
+
+    def call
+      reset_worksheet_filter
+      log_message "Filter reset"
+    end
+
+  private
+
+    def reset_worksheet_filter
+      @spreadsheet = @sheet_service.get_spreadsheet(spreadsheet_key)
+      requests = [{ clear_basic_filter: { sheet_id: @spreadsheet.sheets[0].properties.sheet_id } }]
+      update_request = Google::Apis::SheetsV4::BatchUpdateSpreadsheetRequest.new(requests:)
+      @sheet_service.batch_update_spreadsheet(spreadsheet_key, update_request)
+    end
+  end
+end

--- a/app/services/cfe/shared_google_sheet.rb
+++ b/app/services/cfe/shared_google_sheet.rb
@@ -1,0 +1,30 @@
+module CFE
+  module SharedGoogleSheet
+    SCOPE = Google::Apis::SheetsV4::AUTH_SPREADSHEETS
+
+    def spreadsheet_key
+      @spreadsheet_key ||= ENV.fetch("CFE_COMPARISON_SHEET_ID", nil)
+    end
+
+    def log_message(message)
+      message = "#{self.class} :: #{message}"
+      message = Time.current.strftime("%F %T.%L ") + message if Rails.env.development?
+      Rails.logger.info message
+    end
+
+    def google_secret
+      {
+        type: "service_account",
+        project_id: "laa-apply-for-legal-aid",
+        private_key_id: ENV.fetch("GOOGLE_SHEETS_PRIVATE_KEY_ID", nil),
+        private_key: ENV.fetch("GOOGLE_SHEETS_PRIVATE_KEY_VALUE", nil),
+        client_email: ENV.fetch("GOOGLE_SHEETS_CLIENT_EMAIL", nil),
+        client_id: ENV.fetch("GOOGLE_SHEETS_CLIENT_ID", nil),
+        auth_uri: "https://accounts.google.com/o/oauth2/auth",
+        token_uri: "https://oauth2.googleapis.com/token",
+        auth_provider_x509_cert_url: "https://www.googleapis.com/oauth2/v1/certs",
+        client_x509_cert_url: "https://www.googleapis.com/robot/v1/metadata/x509/laa-apply-service%40laa-apply-for-legal-aid.iam.gserviceaccount.com",
+      }
+    end
+  end
+end

--- a/app/services/cfe/store_compare_result.rb
+++ b/app/services/cfe/store_compare_result.rb
@@ -1,8 +1,8 @@
 module CFE
   class StoreCompareResult
+    include SharedGoogleSheet
     # NOTE: This is intended as a temporary class while we switch from CFE-Legacy to CFE-Civil
     # Once that change over is complete, the aim is that this can be removed, along with
-    SCOPE = Google::Apis::SheetsV4::AUTH_SPREADSHEETS
 
     def self.call(value_array)
       new.call(value_array)
@@ -41,31 +41,6 @@ module CFE
       requests = [{ clear_basic_filter: { sheet_id: @spreadsheet.sheets[0].properties.sheet_id } }]
       update_request = Google::Apis::SheetsV4::BatchUpdateSpreadsheetRequest.new(requests:)
       @sheet_service.batch_update_spreadsheet(spreadsheet_key, update_request)
-    end
-
-    def spreadsheet_key
-      @spreadsheet_key ||= ENV.fetch("CFE_COMPARISON_SHEET_ID", nil)
-    end
-
-    def log_message(message)
-      message = "#{self.class} :: #{message}"
-      message = Time.current.strftime("%F %T.%L ") + message if Rails.env.development?
-      Rails.logger.info message
-    end
-
-    def google_secret
-      {
-        type: "service_account",
-        project_id: "laa-apply-for-legal-aid",
-        private_key_id: ENV.fetch("GOOGLE_SHEETS_PRIVATE_KEY_ID", nil),
-        private_key: ENV.fetch("GOOGLE_SHEETS_PRIVATE_KEY_VALUE", nil),
-        client_email: ENV.fetch("GOOGLE_SHEETS_CLIENT_EMAIL", nil),
-        client_id: ENV.fetch("GOOGLE_SHEETS_CLIENT_ID", nil),
-        auth_uri: "https://accounts.google.com/o/oauth2/auth",
-        token_uri: "https://oauth2.googleapis.com/token",
-        auth_provider_x509_cert_url: "https://www.googleapis.com/oauth2/v1/certs",
-        client_x509_cert_url: "https://www.googleapis.com/robot/v1/metadata/x509/laa-apply-service%40laa-apply-for-legal-aid.iam.gserviceaccount.com",
-      }
     end
   end
 end

--- a/app/services/cfe/store_compare_result.rb
+++ b/app/services/cfe/store_compare_result.rb
@@ -38,9 +38,6 @@ module CFE
 
     def worksheet_reload
       @spreadsheet = @sheet_service.get_spreadsheet(spreadsheet_key)
-      requests = [{ clear_basic_filter: { sheet_id: @spreadsheet.sheets[0].properties.sheet_id } }]
-      update_request = Google::Apis::SheetsV4::BatchUpdateSpreadsheetRequest.new(requests:)
-      @sheet_service.batch_update_spreadsheet(spreadsheet_key, update_request)
     end
   end
 end

--- a/spec/services/cfe/compare_results_spec.rb
+++ b/spec/services/cfe/compare_results_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe CFE::CompareResults do
       allow(sub_builder).to receive(:request_body).and_return({})
       allow(CFECivil::SubmissionBuilder).to receive(:new).and_return(sub_builder)
       allow(CFE::StoreCompareResult).to receive(:new).and_return(store_compare_result)
+      allow(CFE::ResetGoogleSheetFilter).to receive(:call).and_return(true)
     end
 
     let(:fake_v6_result) { file_fixture("cfe_civil_comparison/v6/compare_result.json").read }

--- a/spec/services/cfe/reset_google_sheet_filter_spec.rb
+++ b/spec/services/cfe/reset_google_sheet_filter_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+module CFE
+  RSpec.describe ResetGoogleSheetFilter do
+    subject(:call_reset) { described_class.call }
+
+    let(:service_creds) { instance_double(Google::Auth::ServiceAccountCredentials, fetch_access_token!: {}) }
+    let(:sheet_service) { instance_double(Google::Apis::SheetsV4::SheetsService) }
+    let(:spreadsheet) { instance_spy(Google::Apis::SheetsV4::Spreadsheet) }
+    let(:sheet) { instance_spy(Google::Apis::SheetsV4::Spreadsheet) }
+    let(:sheet_properties) { instance_spy(Google::Apis::SheetsV4::SheetProperties) }
+    let(:sheet_id) { "123456789" }
+
+    before do
+      allow(spreadsheet).to receive(:sheets).and_return([sheet])
+      allow(sheet).to receive(:properties).and_return(sheet_properties)
+      allow(sheet_properties).to receive(:sheet_id).and_return(sheet_id)
+    end
+
+    it "submits data to the spreadsheet" do
+      expect(Google::Auth::ServiceAccountCredentials).to receive(:make_creds).and_return(service_creds).once
+      expect(service_creds).to receive(:fetch_access_token!).once
+      expect(Google::Apis::SheetsV4::SheetsService).to receive(:new).and_return(sheet_service).once
+      expect(sheet_service).to receive(:authorization=).once
+      expect(sheet_service).to receive(:get_spreadsheet).and_return(spreadsheet).once
+      expect(sheet_service).to receive(:batch_update_spreadsheet).once
+
+      call_reset
+    end
+  end
+end

--- a/spec/services/cfe/store_compare_result_spec.rb
+++ b/spec/services/cfe/store_compare_result_spec.rb
@@ -7,9 +7,6 @@ module CFE
     let(:service_creds) { instance_double(Google::Auth::ServiceAccountCredentials, fetch_access_token!: {}) }
     let(:sheet_service) { instance_double(Google::Apis::SheetsV4::SheetsService) }
     let(:spreadsheet) { instance_spy(Google::Apis::SheetsV4::Spreadsheet) }
-    let(:sheet) { instance_spy(Google::Apis::SheetsV4::Spreadsheet) }
-    let(:sheet_properties) { instance_spy(Google::Apis::SheetsV4::SheetProperties) }
-    let(:sheet_id) { "123456789" }
     let(:data_submitted) { ["Fake", "data", true] }
     let(:append_value_response) { instance_double(Google::Apis::SheetsV4::AppendValuesResponse) }
     let(:update_value_response) { instance_double(Google::Apis::SheetsV4::UpdateValuesResponse) }
@@ -17,9 +14,6 @@ module CFE
 
     before do
       allow(sheet_service).to receive(:append_spreadsheet_value).and_return(append_value_response)
-      allow(spreadsheet).to receive(:sheets).and_return([sheet])
-      allow(sheet).to receive(:properties).and_return(sheet_properties)
-      allow(sheet_properties).to receive(:sheet_id).and_return(sheet_id)
       allow(append_value_response).to receive(:updates).and_return(update_value_response)
       allow(update_value_response).to receive(:updated_range).and_return(output_response)
     end
@@ -31,7 +25,6 @@ module CFE
       expect(sheet_service).to receive(:authorization=).once
       expect(sheet_service).to receive(:get_spreadsheet).and_return(spreadsheet).once
       expect(sheet_service).to receive(:append_spreadsheet_value).once
-      expect(sheet_service).to receive(:batch_update_spreadsheet).once
 
       call_submit_data
     end


### PR DESCRIPTION
## What

The overnight comparison tool has been erroring and looping because of the number of API calls to google sheets 

I added a method of clearing the filter but it was being called on each line addition, in retrospect it should only be called once, at the start of the run, and this PR implements that.

This code is still quite inefficient, but should only be running for another two weeks until we cut over permanently

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
