### PR TITLE
Change anti-virus script and tests

### DIFF
--- a/bin/install_clamav_on_mac
+++ b/bin/install_clamav_on_mac
@@ -5,6 +5,7 @@
 
 CONFIG_FOLDER=$(brew --prefix)/etc/clamav
 CLAMD_CONFIG_FILE=$CONFIG_FOLDER/clamd.conf
+CLAMD_TCP_SOCKET=3310
 FRESHCLAM_CONFIG_FILE=$CONFIG_FOLDER/freshclam.conf
 DB_FOLDER=$(brew --prefix)/var/lib/clamav
 TMP_FOLDER=$DB_FOLDER/tmp
@@ -17,6 +18,7 @@ FRESHCLAM_LOG_FILE=$LOG_FOLDER/freshclam.log
 FRESHCLAM_ERROR_LOG_FILE=$LOG_FOLDER/freshclam.error.log
 BREW_SYMLINK_FOLDER=$(brew --prefix)/sbin
 
+
 if [ ! -d "$BREW_SYMLINK_FOLDER" ]; then
   sudo mkdir -p "$BREW_SYMLINK_FOLDER"
   sudo chown -R `whoami`:admin $(brew --prefix)/sbin
@@ -24,34 +26,50 @@ fi
 
 ( brew list --versions clamav > /dev/null ) || brew install clamav || exit
 
+# create clamd config from sample if not exists
 [ -e "$CLAMD_CONFIG_FILE" ] || (
   sudo cp "${CLAMD_CONFIG_FILE}.sample" "$CLAMD_CONFIG_FILE"
+)
+
+# amend clamd config from sample
+if test -f "$CLAMD_CONFIG_FILE"; then
   sudo sed -e "s/# Example config file/# Config file/" \
            -e "s/^Example$/# Example/" \
            -e "s/^#LogFile .*/LogFile ${CLAMD_LOG_FILE//\//\\/}/" \
            -e "s/^#PidFile .*/PidFile ${RUN_FOLDER//\//\\/}\/clamd.pid/" \
            -e "s/^#DatabaseDirectory .*/DatabaseDirectory ${DB_FOLDER//\//\\/}/" \
-           -e "s/^#LocalSocket .*/LocalSocket ${RUN_FOLDER//\//\\/}\/clamd.socket/" \
+           -e "s/^.*LocalSocket .*/#LocalSocket ${RUN_FOLDER//\//\\/}\/clamd.socket/" \
+           -e "s/^.*TCPSocket .*/TCPSocket $CLAMD_TCP_SOCKET/" \
+           -e "s/^.*TCPAddr .*/TCPAddr localhost/" \
            -i -n "$CLAMD_CONFIG_FILE"
-)
+fi
+
+# create freshclam config from sample if not exists
 [ -e "$FRESHCLAM_CONFIG_FILE" ] || (
   sudo cp "${FRESHCLAM_CONFIG_FILE}.sample" "$FRESHCLAM_CONFIG_FILE"
-  sudo sed -e "s/# Example config file/# Config file/" \
-           -e "s/^Example$/# Example/" \
-           -e "s/^#DatabaseDirectory .*/DatabaseDirectory ${DB_FOLDER//\//\\/}/" \
-           -e "s/^#UpdateLogFile .*/UpdateLogFile ${FRESHCLAM_LOG_FILE//\//\\/}/" \
-           -e "s/^#PidFile .*/PidFile ${RUN_FOLDER//\//\\/}\/freshclam.pid/" \
-           -e "s/^#NotifyClamd .*/NotifyClamd ${CLAMD_CONFIG_FILE//\//\\/}/" \
-           -i -n "$FRESHCLAM_CONFIG_FILE"
 )
+
+# amend freshclam config from sample
+if test -f "$FRESHCLAM_CONFIG_FILE"; then
+  sudo sed -e "s/# Example config file/# Config file/" \
+         -e "s/^Example$/# Example/" \
+         -e "s/^#DatabaseDirectory .*/DatabaseDirectory ${DB_FOLDER//\//\\/}/" \
+         -e "s/^#UpdateLogFile .*/UpdateLogFile ${FRESHCLAM_LOG_FILE//\//\\/}/" \
+         -e "s/^#PidFile .*/PidFile ${RUN_FOLDER//\//\\/}\/freshclam.pid/" \
+         -e "s/^#NotifyClamd .*/NotifyClamd ${CLAMD_CONFIG_FILE//\//\\/}/" \
+         -i -n "$FRESHCLAM_CONFIG_FILE"
+fi
+
 sudo mkdir -p "$DB_FOLDER"
 sudo mkdir -p "$TMP_FOLDER"
 sudo mkdir -p "$RUN_FOLDER"
+
 [ -e "$CLAMD_LOG_FILE" ] || sudo touch "$CLAMD_LOG_FILE"
 [ -e "$CLAMD_ERROR_LOG_FILE" ] || sudo touch "$CLAMD_ERROR_LOG_FILE"
 [ -e "$FRESHCLAM_LOG_FILE" ] || sudo touch "$FRESHCLAM_LOG_FILE"
 [ -e "$FRESHCLAM_ERROR_LOG_FILE" ] || sudo touch "$FRESHCLAM_ERROR_LOG_FILE"
 [ -e "$CLAMD_SOCKET_FILE" ] || sudo touch "$CLAMD_SOCKET_FILE"
+
 sudo chown -R root:wheel "$CONFIG_FOLDER"
 sudo chown -R clamav:clamav "$DB_FOLDER"
 sudo chown -R clamav:clamav "$TMP_FOLDER"
@@ -65,6 +83,7 @@ CLAMD_DAEMON_NAME=clamav.clamd
 CLAMD_DAEMON_FILE=$DAEMON_FOLDER/$CLAMD_DAEMON_NAME.plist
 FRESHCLAM_DAEMON_NAME=clamav.freshclam
 FRESHCLAM_DAEMON_FILE=$DAEMON_FOLDER/$FRESHCLAM_DAEMON_NAME.plist
+
 sudo tee "$CLAMD_DAEMON_FILE" << EOF > /dev/null
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -84,6 +103,7 @@ sudo tee "$CLAMD_DAEMON_FILE" << EOF > /dev/null
 </dict>
 </plist>
 EOF
+
 sudo tee "$FRESHCLAM_DAEMON_FILE" << EOF > /dev/null
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -104,6 +124,25 @@ sudo tee "$FRESHCLAM_DAEMON_FILE" << EOF > /dev/null
 </dict>
 </plist>
 EOF
+
 sudo chown root:wheel "$CLAMD_DAEMON_FILE" "$FRESHCLAM_DAEMON_FILE"
 sudo chmod 0644 "$CLAMD_DAEMON_FILE" "$FRESHCLAM_DAEMON_FILE"
+
+# restart (changes may have been made)
+sudo launchctl unload "$CLAMD_DAEMON_FILE" "$FRESHCLAM_DAEMON_FILE"
 sudo launchctl load "$CLAMD_DAEMON_FILE" "$FRESHCLAM_DAEMON_FILE"
+
+# wait til port being listened too
+start=$(date +%s)
+printf "Restarting clamav, waiting for clamd to listen on port $CLAMD_TCP_SOCKET"
+while ! sudo lsof -PiTCP -sTCP:LISTEN | grep ".*clamd.*$CLAMD_TCP_SOCKET" > /dev/null; do
+  printf "."
+
+  if (( $(date +%s)-start > 60 ))
+  then
+    printf "timed out!\n"
+    break;
+  fi
+
+  sleep 5;
+done;

--- a/spec/services/malware_scanner_spec.rb
+++ b/spec/services/malware_scanner_spec.rb
@@ -37,17 +37,25 @@ RSpec.describe MalwareScanner, clamav: true do
       expect(subject.id).to eq(malware_scan_result.id)
     end
 
-    context "file is safe" do
-      it "sets virus_found to false" do
+    context "with file with no virus" do
+      it "#virus_found? returns true" do
         expect(subject.virus_found?).to be(false)
+      end
+
+      it "#scan_result is file: OK" do
+        expect(subject.scan_result).to match(/.*\/hello_world.pdf: OK/)
       end
     end
 
-    context "virus is found" do
-      let(:file_path) { Rails.root.join("spec/fixtures/files/malware.doc") }
+    context "with file with a virus" do
+      let(:file_path) { file_fixture("malware.doc") }
 
-      it "sets virus_found to true" do
+      it "MalwareScanResult#virus_found? returns true" do
         expect(subject.virus_found?).to be(true)
+      end
+
+      it "MalwareScanResult#scan_result is file: Trojan FOUND" do
+        expect(subject.scan_result).to match(/.*\/malware.doc: .*Trojan.* FOUND/)
       end
     end
 

--- a/spec/services/malware_scanner_spec.rb
+++ b/spec/services/malware_scanner_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe MalwareScanner, clamav: true do
+RSpec.describe MalwareScanner do
   subject do
     described_class.call(
       file_path:,
@@ -11,6 +11,7 @@ RSpec.describe MalwareScanner, clamav: true do
 
   let(:provider) { create(:provider) }
   let(:file_path) { Rails.root.join("spec/fixtures/files/documents/hello_world.pdf") }
+
   let(:file_details) do
     {
       name: Faker::File.file_name,
@@ -37,8 +38,8 @@ RSpec.describe MalwareScanner, clamav: true do
       expect(subject.id).to eq(malware_scan_result.id)
     end
 
-    context "with file with no virus" do
-      it "#virus_found? returns true" do
+    context "with file with no virus", clamav: true do
+      it "#virus_found? returns false" do
         expect(subject.virus_found?).to be(false)
       end
 
@@ -47,7 +48,7 @@ RSpec.describe MalwareScanner, clamav: true do
       end
     end
 
-    context "with file with a virus" do
+    context "with file with a virus", clamav: true do
       let(:file_path) { file_fixture("malware.doc") }
 
       it "MalwareScanResult#virus_found? returns true" do
@@ -55,11 +56,12 @@ RSpec.describe MalwareScanner, clamav: true do
       end
 
       it "MalwareScanResult#scan_result is file: Trojan FOUND" do
+        puts subject.scan_result
         expect(subject.scan_result).to match(/.*\/malware.doc: .*Trojan.* FOUND/)
       end
     end
 
-    context "scanner down" do
+    context "when scanner is down" do
       let(:scan_result) { ["failed: No such file or directory. ERROR\n", "", double("process_status", exitstatus: 2, success?: false)] }
 
       before { allow(Open3).to receive(:capture3).and_return(scan_result) }
@@ -74,19 +76,22 @@ RSpec.describe MalwareScanner, clamav: true do
       end
     end
 
-    context "scan_result" do
-      let(:stub_stdout) { Faker::Lorem.sentence }
-      let(:scan_result) { [stub_stdout, "", double("process_status", success?: true, exitstatus: 0)] }
-
+    context "with any scan_result" do
       before { allow(Open3).to receive(:capture3).and_return(scan_result) }
 
+      let(:scan_result) do
+        ["whatever scan result",
+         "",
+         instance_double(Process::Status, success?: true, exitstatus: 0)]
+      end
+
       it "returns and records the result of the scan" do
-        expect(subject.scan_result).to eq(stub_stdout.strip)
-        expect(malware_scan_result.scan_result).to eq(stub_stdout.strip)
+        expect(subject.scan_result).to eq("whatever scan result")
+        expect(malware_scan_result.scan_result).to eq("whatever scan result")
       end
     end
 
-    context "not saving result" do
+    context "when not saving result" do
       subject { described_class.call(file_path:, save_result: false) }
 
       it "does not create a MalwareScanResult record" do


### PR DESCRIPTION
## What
Proposition to change the clamav install script, plus tests

- Change clamav install script to use TCP instead of LocalSocket configuration
- Add  more specific test for virus definition

This comes out of work on laa-assure-hmrc-data that identified false positive tests resulting from
failure to communicate with local clamav resulting in virsu_found? returning true, not because there
was a virus but because the scan returned an error.

The fix for assure was, firstly to ensure the tests fail for the right reason (a virus was found or not) and
secondly to amend the clamav install script to configure clamav to function as it does in a production like
environment - namely the App's clamav "client" communicates with the clamav "server" over TCP on localhost:3310.

**Pros IMO:**
1. it functions locally in a production like manner
2. the clamav config itself states that it binds to INADDR_ANY by default and that this is not wise
```
# TCP address.
# By default we bind to INADDR_ANY, probably not wise.
# Enable the following to provide some degree of protection
# from the outside world. This option can be specified multiple
# times if you want to listen on multiple IPs. IPv6 is now supported.
# Default: no
```
3. Use of LocalSocket seems to fail "sometimes"

**Cons**
 I am not sure whether using TCP, even on `localhost:3310` only, is less secure than using `LocalSocket` for our machines?


## Testing (locally)
- run the test, it may succeed or fail depending on your current clamav installation
```shell
rspec -fd spec/services/malware_scanner_spec.rb
```
- [optional] try disabling LocalSocket in config and run tests again, it should fail
```shell
# check your TCPSocket is closed
cat $(brew --prefix)/etc/clamav/clamd.conf | grep TCP
=>
# TCP port address.
#TCPSocket 3310
# TCP address.
#TCPAddr localhost

# open config in editor,
vim  $(brew --prefix)/etc/clamav/clamd.conf
# comment out this line 
...
LocalSocket /usr/local/var/run/clamav/clamd.socket
...

# restart (stop and start)
sudo launchctl unload /Library/LaunchDaemons/clamav.clamd.plist
sudo launchctl load /Library/LaunchDaemons/clamav.clamd.plist
```
- run the script
```shell
bin/install_clamav_on_mac
```
- run tests again and they should pass


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
