### PR TITLE
Fix: Update CFE Comparison

### DIFF
--- a/app/services/cfe/compare_submission.rb
+++ b/app/services/cfe/compare_submission.rb
@@ -106,6 +106,7 @@ module CFE
     def override_message(key)
       overrides = {
         "assessment/capital/capital_items/vehicles" => "override_vehicle",
+        "assessment/remarks/employment/multiple_employments" => "override_employment_remarks",
       }
       override = overrides[key.join("/")]
       return unless override
@@ -118,6 +119,14 @@ module CFE
       v6_value = @v6_result.dig(*key)
       if v6_value.empty? && v5_value.present?
         @results["assessment/capital/capital_items/vehicles"] = "CFE-Civil did not return a vehicle"
+      end
+    end
+
+    def override_employment_remarks(key)
+      v5_value = @v5_result.dig(*key)
+      v6_value = @v6_result.dig(*key)
+      if v6_value.nil? && v5_value.present?
+        @results[key] = "We did not send employments to CFE_Civil so no remarks"
       end
     end
 

--- a/spec/fixtures/files/cfe_civil_comparison/v5/employment_mismatch.json
+++ b/spec/fixtures/files/cfe_civil_comparison/v5/employment_mismatch.json
@@ -1,0 +1,256 @@
+{
+  "version": "5",
+  "timestamp": "2023-06-21T11:44:10.321Z",
+  "success": true,
+  "result_summary":
+  {
+    "overall_result":
+    {
+      "result": "eligible",
+      "capital_contribution": 0.0,
+      "income_contribution": 0.0,
+      "proceeding_types":
+      [
+        {
+          "ccms_code": "DA004",
+          "client_involvement_type": "A",
+          "upper_threshold": 0.0,
+          "lower_threshold": 0.0,
+          "result": "eligible"
+        }
+      ]
+    },
+    "gross_income":
+    {
+      "total_gross_income": 168.95,
+      "proceeding_types":
+      [
+        {
+          "ccms_code": "DA004",
+          "client_involvement_type": "A",
+          "upper_threshold": 999999999999.0,
+          "lower_threshold": 0.0,
+          "result": "eligible"
+        }
+      ]
+    },
+    "disposable_income":
+    {
+      "dependant_allowance": 677.8,
+      "gross_housing_costs": 0.0,
+      "housing_benefit": 0.0,
+      "net_housing_costs": 0.0,
+      "maintenance_allowance": 0.0,
+      "total_outgoings_and_allowances": 722.8,
+      "total_disposable_income": -553.85,
+      "employment_income":
+      {
+        "gross_income": 0.0,
+        "benefits_in_kind": 0.0,
+        "tax": 0.0,
+        "national_insurance": 0.0,
+        "fixed_employment_deduction": -45.0,
+        "net_employment_income": -45.0
+      },
+      "income_contribution": 0.0,
+      "proceeding_types":
+      [
+        {
+          "ccms_code": "DA004",
+          "client_involvement_type": "A",
+          "upper_threshold": 999999999999.0,
+          "lower_threshold": 315.0,
+          "result": "eligible"
+        }
+      ]
+    },
+    "capital":
+    {
+      "total_liquid": 0.0,
+      "total_non_liquid": 0.0,
+      "total_vehicle": 0.0,
+      "total_property": 0.0,
+      "total_mortgage_allowance": 999999999999.0,
+      "total_capital": 0.0,
+      "pensioner_capital_disregard": 0.0,
+      "subject_matter_of_dispute_disregard": 0.0,
+      "capital_contribution": 0.0,
+      "assessed_capital": 0.0,
+      "proceeding_types":
+      [
+        {
+          "ccms_code": "DA004",
+          "client_involvement_type": "A",
+          "upper_threshold": 999999999999.0,
+          "lower_threshold": 3000.0,
+          "result": "eligible"
+        }
+      ]
+    }
+  },
+  "assessment":
+  {
+    "id": "d4605e8e-bf91-4d29-84b7-52ada9834916",
+    "client_reference_id": "L-PLR-MNW",
+    "submission_date": "2023-06-21",
+    "applicant":
+    {
+      "date_of_birth": "1993-07-22",
+      "involvement_type": "applicant",
+      "employed": false,
+      "has_partner_opponent": false,
+      "receives_qualifying_benefit": false,
+      "self_employed": false
+    },
+    "gross_income":
+    {
+      "employment_income":
+      [
+        {
+          "name": "Job 1",
+          "payments":
+          []
+        },
+        {
+          "name": "Job 2",
+          "payments":
+          []
+        }
+      ],
+      "irregular_income":
+      {
+        "monthly_equivalents":
+        {
+          "student_loan": 0.0,
+          "unspecified_source": 0.0
+        }
+      },
+      "state_benefits":
+      {
+        "monthly_equivalents":
+        {
+          "all_sources": 168.95,
+          "cash_transactions": 0.0,
+          "bank_transactions":
+          []
+        }
+      },
+      "other_income":
+      {
+        "monthly_equivalents":
+        {
+          "all_sources":
+          {
+            "friends_or_family": 0.0,
+            "maintenance_in": 0.0,
+            "property_or_lodger": 0.0,
+            "pension": 0.0
+          },
+          "bank_transactions":
+          {
+            "friends_or_family": 0.0,
+            "maintenance_in": 0.0,
+            "property_or_lodger": 0.0,
+            "pension": 0.0
+          },
+          "cash_transactions":
+          {
+            "friends_or_family": 0.0,
+            "maintenance_in": 0.0,
+            "property_or_lodger": 0.0,
+            "pension": 0.0
+          }
+        }
+      }
+    },
+    "disposable_income":
+    {
+      "monthly_equivalents":
+      {
+        "all_sources":
+        {
+          "child_care": 0.0,
+          "rent_or_mortgage": 0.0,
+          "maintenance_out": 0.0,
+          "legal_aid": 0.0
+        },
+        "bank_transactions":
+        {
+          "child_care": 0.0,
+          "rent_or_mortgage": 0.0,
+          "maintenance_out": 0.0,
+          "legal_aid": 0.0
+        },
+        "cash_transactions":
+        {
+          "child_care": 0.0,
+          "rent_or_mortgage": 0.0,
+          "maintenance_out": 0.0,
+          "legal_aid": 0.0
+        }
+      },
+      "childcare_allowance": 0.0,
+      "deductions":
+      {
+        "dependants_allowance": 677.8,
+        "disregarded_state_benefits": 0.0
+      }
+    },
+    "capital":
+    {
+      "capital_items":
+      {
+        "liquid":
+        [],
+        "non_liquid":
+        [],
+        "vehicles":
+        [],
+        "properties":
+        {
+          "main_home":
+          {
+            "value": "0.0",
+            "outstanding_mortgage": "0.0",
+            "percentage_owned": "0.0",
+            "main_home": true,
+            "shared_with_housing_assoc": false,
+            "transaction_allowance": "0.0",
+            "allowable_outstanding_mortgage": "0.0",
+            "net_value": "0.0",
+            "net_equity": "0.0",
+            "main_home_equity_disregard": "100000.0",
+            "assessed_equity": "0.0"
+          },
+          "additional_properties":
+          [
+            {
+              "value": "0.0",
+              "outstanding_mortgage": "0.0",
+              "percentage_owned": "0.0",
+              "main_home": false,
+              "shared_with_housing_assoc": false,
+              "transaction_allowance": "0.0",
+              "allowable_outstanding_mortgage": "0.0",
+              "net_value": "0.0",
+              "net_equity": "0.0",
+              "main_home_equity_disregard": "0.0",
+              "assessed_equity": "0.0"
+            }
+          ]
+        }
+      }
+    },
+    "remarks":
+    {
+      "employment":
+      {
+        "multiple_employments":
+        [
+          "30b02f6a-3125-4b1d-b0af-7b50664e2107",
+          "439fa4ec-2b3d-431e-a3c4-43a3dcf0f3bc"
+        ]
+      }
+    }
+  }
+}

--- a/spec/fixtures/files/cfe_civil_comparison/v6/employment_mismatch.json
+++ b/spec/fixtures/files/cfe_civil_comparison/v6/employment_mismatch.json
@@ -1,0 +1,250 @@
+{
+  "version": "6",
+  "timestamp": "2023-06-22T06:36:44.640Z",
+  "success": true,
+  "result_summary":
+  {
+    "overall_result":
+    {
+      "result": "eligible",
+      "capital_contribution": 0.0,
+      "income_contribution": 0.0,
+      "proceeding_types":
+      [
+        {
+          "ccms_code": "DA004",
+          "client_involvement_type": "A",
+          "upper_threshold": 0.0,
+          "lower_threshold": 0.0,
+          "result": "eligible"
+        }
+      ]
+    },
+    "gross_income":
+    {
+      "total_gross_income": 168.95,
+      "proceeding_types":
+      [
+        {
+          "ccms_code": "DA004",
+          "client_involvement_type": "A",
+          "upper_threshold": 999999999999.0,
+          "lower_threshold": 0.0,
+          "result": "eligible"
+        }
+      ],
+      "combined_total_gross_income": 168.95
+    },
+    "disposable_income":
+    {
+      "dependant_allowance_under_16": 677.8,
+      "dependant_allowance_over_16": 0,
+      "dependant_allowance": 677.8,
+      "gross_housing_costs": 0.0,
+      "housing_benefit": 0.0,
+      "net_housing_costs": 0.0,
+      "maintenance_allowance": 0.0,
+      "total_outgoings_and_allowances": 677.8,
+      "total_disposable_income": -508.85,
+      "employment_income":
+      {
+        "gross_income": 0.0,
+        "benefits_in_kind": 0.0,
+        "tax": 0.0,
+        "national_insurance": 0.0,
+        "fixed_employment_deduction": 0.0,
+        "net_employment_income": 0.0
+      },
+      "income_contribution": 0.0,
+      "proceeding_types":
+      [
+        {
+          "ccms_code": "DA004",
+          "client_involvement_type": "A",
+          "upper_threshold": 999999999999.0,
+          "lower_threshold": 315.0,
+          "result": "eligible"
+        }
+      ],
+      "combined_total_disposable_income": -508.85,
+      "combined_total_outgoings_and_allowances": 677.8,
+      "partner_allowance": 0
+    },
+    "capital":
+    {
+      "pensioner_disregard_applied": 0.0,
+      "total_liquid": 0.0,
+      "total_non_liquid": 0.0,
+      "total_vehicle": 0.0,
+      "total_property": 0.0,
+      "total_mortgage_allowance": 999999999999.0,
+      "total_capital": 0.0,
+      "subject_matter_of_dispute_disregard": 0.0,
+      "assessed_capital": 0.0,
+      "total_capital_with_smod": 0.0,
+      "disputed_non_property_disregard": 0,
+      "proceeding_types":
+      [
+        {
+          "ccms_code": "DA004",
+          "client_involvement_type": "A",
+          "upper_threshold": 999999999999.0,
+          "lower_threshold": 3000.0,
+          "result": "eligible"
+        }
+      ],
+      "combined_disputed_capital": 0,
+      "combined_non_disputed_capital": 0.0,
+      "capital_contribution": 0.0,
+      "pensioner_capital_disregard": 0.0,
+      "combined_assessed_capital": 0.0
+    }
+  },
+  "assessment":
+  {
+    "id": "25d0201c-743e-49e8-962e-5e3dc4509d06",
+    "client_reference_id": "L-PLR-MNW",
+    "submission_date": "2023-06-21",
+    "level_of_help": "certificated",
+    "applicant":
+    {
+      "date_of_birth": "1993-07-22",
+      "involvement_type": "applicant",
+      "employed": false,
+      "has_partner_opponent": false,
+      "receives_qualifying_benefit": false
+    },
+    "gross_income":
+    {
+      "employment_income":
+      [],
+      "irregular_income":
+      {
+        "monthly_equivalents":
+        {
+          "student_loan": 0.0,
+          "unspecified_source": 0.0
+        }
+      },
+      "state_benefits":
+      {
+        "monthly_equivalents":
+        {
+          "all_sources": 168.95,
+          "cash_transactions": 0.0,
+          "bank_transactions":
+          []
+        }
+      },
+      "other_income":
+      {
+        "monthly_equivalents":
+        {
+          "all_sources":
+          {
+            "friends_or_family": 0.0,
+            "maintenance_in": 0.0,
+            "property_or_lodger": 0.0,
+            "pension": 0.0
+          },
+          "bank_transactions":
+          {
+            "friends_or_family": 0.0,
+            "maintenance_in": 0.0,
+            "property_or_lodger": 0.0,
+            "pension": 0.0
+          },
+          "cash_transactions":
+          {
+            "friends_or_family": 0.0,
+            "maintenance_in": 0.0,
+            "property_or_lodger": 0.0,
+            "pension": 0.0
+          }
+        }
+      }
+    },
+    "disposable_income":
+    {
+      "monthly_equivalents":
+      {
+        "all_sources":
+        {
+          "child_care": 0.0,
+          "rent_or_mortgage": 0.0,
+          "maintenance_out": 0.0,
+          "legal_aid": 0.0
+        },
+        "bank_transactions":
+        {
+          "child_care": 0.0,
+          "rent_or_mortgage": 0.0,
+          "maintenance_out": 0.0,
+          "legal_aid": 0.0
+        },
+        "cash_transactions":
+        {
+          "child_care": 0.0,
+          "rent_or_mortgage": 0.0,
+          "maintenance_out": 0.0,
+          "legal_aid": 0.0
+        }
+      },
+      "childcare_allowance": 0.0,
+      "deductions":
+      {
+        "dependants_allowance": 677.8,
+        "disregarded_state_benefits": 0.0
+      }
+    },
+    "capital":
+    {
+      "capital_items":
+      {
+        "liquid":
+        [],
+        "non_liquid":
+        [],
+        "vehicles":
+        [],
+        "properties":
+        {
+          "main_home":
+          {
+            "value": 0.0,
+            "outstanding_mortgage": 0.0,
+            "percentage_owned": 0.0,
+            "main_home": true,
+            "shared_with_housing_assoc": false,
+            "transaction_allowance": 0.0,
+            "allowable_outstanding_mortgage": 0.0,
+            "net_value": 0.0,
+            "net_equity": 0.0,
+            "smod_allowance": 0,
+            "main_home_equity_disregard": 0.0,
+            "assessed_equity": 0.0
+          },
+          "additional_properties":
+          [
+            {
+              "value": 0.0,
+              "outstanding_mortgage": 0.0,
+              "percentage_owned": 0.0,
+              "main_home": false,
+              "shared_with_housing_assoc": false,
+              "transaction_allowance": 0.0,
+              "allowable_outstanding_mortgage": 0.0,
+              "net_value": 0.0,
+              "net_equity": 0.0,
+              "smod_allowance": 0,
+              "main_home_equity_disregard": 0.0,
+              "assessed_equity": 0.0
+            }
+          ]
+        }
+      }
+    },
+    "remarks":
+    {}
+  }
+}

--- a/spec/services/cfe/compare_submission_spec.rb
+++ b/spec/services/cfe/compare_submission_spec.rb
@@ -146,5 +146,18 @@ RSpec.describe CFE::CompareSubmission do
 
       it { expect(call).to be false }
     end
+
+    context "when the /assessment/gross_income/employment_income value is empty in v6" do
+      let(:cfe_legacy_result) { file_fixture("cfe_civil_comparison/v5/employment_mismatch.json").read }
+      let(:cfe_civil_result) { file_fixture("cfe_civil_comparison/v6/employment_mismatch.json").read }
+
+      before do
+        allow(cfe_result).to receive(:result).and_return(cfe_legacy_result)
+        allow(submission_builder).to receive(:cfe_result).and_return(cfe_civil_result)
+        allow(submission_builder).to receive(:request_body).and_return({ "fake" => "return" })
+      end
+
+      it { expect(call).to be false }
+    end
   end
 end


### PR DESCRIPTION
## What

The handling of employment has changed in CFE Civil this has been accepted and we no longer send empty employment blocks to the new version unless actual pay is included.

In this instance, there were two empty employment
blocks so Legacy adds multiple employment remarks
but Civil has no employments and adds no remarks

This adds an override handler so it will add an
observation to the comparison spreadsheet for
review and, ultimately, to be ignored

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
