### PR TITLE
Fix: Reduce 502 errors on pods

### DIFF
--- a/helm_deploy/apply-for-legal-aid/templates/cronjob-admin-report.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/cronjob-admin-report.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: {{ .Release.Name | trunc 26 }}-daily-admin-report
   labels:
-    app: {{ template "apply-for-legal-aid.name" . }}
+    app: {{ template "apply-for-legal-aid.name" . }}-cron-admin-report
     chart: {{ template "apply-for-legal-aid.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}

--- a/helm_deploy/apply-for-legal-aid/templates/cronjob-db-backup-cleanup.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/cronjob-db-backup-cleanup.yaml
@@ -4,7 +4,7 @@ kind: CronJob
 metadata:
   name: {{ .Release.Name | trunc 26 }}-clean-db-backups
   labels:
-    app: {{ template "apply-for-legal-aid.name" . }}
+    app: {{ template "apply-for-legal-aid.name" . }}-cron-db-backup-cleanup
     chart: {{ template "apply-for-legal-aid.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}

--- a/helm_deploy/apply-for-legal-aid/templates/cronjob-deliver-scheduled-mail.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/cronjob-deliver-scheduled-mail.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: {{ .Release.Name | trunc 26 }}-scheduled-mailings
   labels:
-    app: {{ template "apply-for-legal-aid.name" . }}
+    app: {{ template "apply-for-legal-aid.name" . }}-cron-scheduled-mail
     chart: {{ template "apply-for-legal-aid.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}

--- a/helm_deploy/apply-for-legal-aid/templates/cronjob-destroy-purgeable.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/cronjob-destroy-purgeable.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: {{ .Release.Name | trunc 26 }}-destroy-purgeable
   labels:
-    app: {{ template "apply-for-legal-aid.name" . }}
+    app: {{ template "apply-for-legal-aid.name" . }}-cron-destroy-purgeable
     chart: {{ template "apply-for-legal-aid.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}

--- a/helm_deploy/apply-for-legal-aid/templates/cronjob-export-digest.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/cronjob-export-digest.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: {{ .Release.Name | trunc 26 }}-export-digest
   labels:
-    app: {{ template "apply-for-legal-aid.name" . }}
+    app: {{ template "apply-for-legal-aid.name" . }}-cron-export-digest
     chart: {{ template "apply-for-legal-aid.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}

--- a/helm_deploy/apply-for-legal-aid/templates/cronjob-extract-digest.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/cronjob-extract-digest.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: {{ .Release.Name | trunc 26 }}-extract-digest
   labels:
-    app: {{ template "apply-for-legal-aid.name" . }}
+    app: {{ template "apply-for-legal-aid.name" . }}-cron-extract-digest
     chart: {{ template "apply-for-legal-aid.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}

--- a/helm_deploy/apply-for-legal-aid/templates/cronjob-hourly-db-backup.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/cronjob-hourly-db-backup.yaml
@@ -4,7 +4,7 @@ kind: CronJob
 metadata:
   name: {{ .Release.Name | trunc 26 }}-hourly-db-backup
   labels:
-    app: {{ template "apply-for-legal-aid.name" . }}
+    app: {{ template "apply-for-legal-aid.name" . }}-cron-db-backup
     chart: {{ template "apply-for-legal-aid.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}

--- a/helm_deploy/apply-for-legal-aid/templates/cronjob-mark-purgeable.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/cronjob-mark-purgeable.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: {{ .Release.Name | trunc 26 }}-mark-purgeable
   labels:
-    app: {{ template "apply-for-legal-aid.name" . }}
+    app: {{ template "apply-for-legal-aid.name" . }}-cron-mark-purgeable
     chart: {{ template "apply-for-legal-aid.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}

--- a/helm_deploy/apply-for-legal-aid/templates/cronjob-metrics.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/cronjob-metrics.yaml
@@ -4,7 +4,7 @@ kind: CronJob
 metadata:
   name: {{ .Release.Name }}-metrics
   labels:
-    app: {{ template "apply-for-legal-aid.name" . }}
+    app: {{ template "apply-for-legal-aid.name" . }}-cron-metrics
     chart: {{ template "apply-for-legal-aid.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}

--- a/helm_deploy/apply-for-legal-aid/templates/cronjob-reset-dashboard-overnight.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/cronjob-reset-dashboard-overnight.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: {{ .Release.Name | trunc 26 }}-reset-counter
   labels:
-    app: {{ template "apply-for-legal-aid.name" . }}
+    app: {{ template "apply-for-legal-aid.name" . }}-cron-reset-dashboard
     chart: {{ template "apply-for-legal-aid.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}

--- a/helm_deploy/apply-for-legal-aid/templates/deployment_metrics.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/deployment_metrics.yaml
@@ -20,7 +20,7 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "apply-for-legal-aid.name" . }}
+        app: {{ template "apply-for-legal-aid.name" . }}-metrics
         release: {{ .Release.Name }}
         service: {{ template "apply-for-legal-aid.fullname" . }}-metrics
     spec:


### PR DESCRIPTION

## What

Following the work Abdi presented at Dev COP and previous attempt at updating pod idenifiers to reduce 502 errors.

We previously added identifiers to the worker pods, but we still see a number of 502 errors during the day, matching the exact pattern shown on their slides, two IP addresses.

This adds explicit cron tags to all the cron jobs in case they run at a time where a user is trying to use the service, e.g. db backups, scheduled mails, etc.

This will probably cause issues when merging and deploying and with in-progress branches, shoult and I will help you merge and rebase as needed :+1:


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
