### PR TITLE
Remove use of LOCAL_CLAMAV

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -39,8 +39,6 @@ ADMIN_ALLOW_RESET=<true or false>
 ADMIN_PASSWORD=<password>
 ADMIN_SHOW_FORM=<true or false>
 
-LOCAL_CLAMAV=true
-
 # Connection to CCMS SOA
 CCMS_SOA_AWS_GATEWAY_API_KEY=<aws-gateway-api-key-for-environment>
 CCMS_SOA_CLIENT_USERNAME=<username>

--- a/README.md
+++ b/README.md
@@ -192,7 +192,6 @@ Ensure you have an `.env.test` file. This can be the same as your .env.developme
 
 Set `BC_USE_DEV_MOCK=true` to mock the call to the benefits checker.
 Set `LAA_PORTAL_MOCK_SAML=true` to mock any calls to portal SAML auth.
-Set `LOCAL_CLAMAV=true`
 Set `LEGAL_FRAMEWORK_API_HOST=<staging api>`
 Set `CHECK_FINANCIAL_ELIGIBILITY_HOST=<staging api>`
 Set `HMRC_API_HOST=<staging api>`

--- a/app/services/malware_scanner.rb
+++ b/app/services/malware_scanner.rb
@@ -5,9 +5,6 @@ class MalwareScanner
     new(**args).call
   end
 
-  LOCAL_COMMAND     = %w[clamdscan --fdpass --no-summary].freeze
-  CONTAINER_COMMAND = %w[clamdscan -c config/clamd.container.conf --stream --no-summary].freeze
-
   def initialize(file_path:, uploader: nil, file_details: nil, save_result: true)
     @file_path    = file_path
     @uploader     = uploader
@@ -54,6 +51,6 @@ private
   end
 
   def command
-    Rails.configuration.x.local_clamav == "true" ? LOCAL_COMMAND : CONTAINER_COMMAND
+    %w[clamdscan -c config/clamd.container.conf --stream --no-summary].freeze
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -96,7 +96,6 @@ module LaaApplyForLegalAid
 
     config.x.geckoboard.api_key = ENV.fetch("GECKOBOARD_API_KEY", nil)
 
-    config.x.local_clamav = ENV.fetch("LOCAL_CLAMAV", nil)
     config.x.bc_use_dev_mock = ENV.fetch("BC_USE_DEV_MOCK", nil)
     config.x.ordnance_survey_api_key = ENV.fetch("ORDNANCE_SURVEY_API_KEY", nil)
 

--- a/spec/services/malware_scanner_spec.rb
+++ b/spec/services/malware_scanner_spec.rb
@@ -56,7 +56,6 @@ RSpec.describe MalwareScanner do
       end
 
       it "MalwareScanResult#scan_result is file: Trojan FOUND" do
-        puts subject.scan_result
         expect(subject.scan_result).to match(/.*\/malware.doc: .*Trojan.* FOUND/)
       end
     end


### PR DESCRIPTION
## What
Remove use of LOCAL_CLAMAV

The bin/install_clamav_on_mac was altered to install and
configure local claim to use TCP instead of Local[unix]Socket
This means local clamav server and client should work in the same way
as the production clamav server client - namely itwill use the
`clamd.container.conf` settings for TCP.

Therefore we do not need, and should no longer use, the LOCAL_CLAMAV var
and its assoicated command which uses `--fdpass` (for improved speed?!).

```
--fdpass
Pass the file descriptor permissions to clamd. This is useful if clamd is
running as a different user as it is faster than streaming the file to clamd.
Only available if connected to clamd via local(unix) socket.
```

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
