### PR TITLE
AP-3805 Update HMRC Responses to have owner 

### DIFF
--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -16,6 +16,7 @@ class Applicant < ApplicationRecord
   has_many :bank_accounts, through: :bank_providers
   has_many :bank_transactions, through: :bank_accounts
   has_many :regular_transactions, as: :owner
+  has_many :hmrc_responses, class_name: "HMRC::Response", as: :owner
 
   encrypts :encrypted_true_layer_token
 

--- a/app/models/hmrc/response.rb
+++ b/app/models/hmrc/response.rb
@@ -6,6 +6,7 @@ module HMRC
 
     USE_CASES = %w[one two].freeze
     belongs_to :legal_aid_application, inverse_of: :hmrc_responses
+    belongs_to :owner, polymorphic: true
     validates :use_case, presence: true, inclusion: { in: USE_CASES }
 
     def self.use_case_one_for(laa_id)

--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -1,5 +1,6 @@
 class Partner < ApplicationRecord
   belongs_to :legal_aid_application, dependent: :destroy
+  has_many :hmrc_responses, class_name: "HMRC::Response", as: :owner
 
   def pretty_postcode
     pretty_postcode? ? postcode : postcode.insert(-4, " ")

--- a/app/services/hmrc/create_responses_service.rb
+++ b/app/services/hmrc/create_responses_service.rb
@@ -14,8 +14,10 @@ module HMRC
     def call
       return unless @legal_aid_application.hmrc_responses.empty?
 
+      applicant = @legal_aid_application.applicant
+
       USE_CASES.each do |use_case|
-        hmrc_response = @legal_aid_application.hmrc_responses.create(use_case:)
+        hmrc_response = @legal_aid_application.hmrc_responses.create(use_case:, owner_id: applicant.id, owner_type: applicant.class)
         if use_mock?
           MockInterfaceResponseService.call(hmrc_response)
         else

--- a/db/migrate/20230628085216_add_owner_to_hmrc_responses.rb
+++ b/db/migrate/20230628085216_add_owner_to_hmrc_responses.rb
@@ -1,0 +1,9 @@
+class AddOwnerToHMRCResponses < ActiveRecord::Migration[7.0]
+  def change
+    safety_assured do
+      change_table :hmrc_responses, bulk: true do |t|
+        t.belongs_to :owner, polymorphic: true, type: :uuid
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_19_152614) do
+
+ActiveRecord::Schema[7.0].define(version: 2023_06_28_085216) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -495,7 +496,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_19_152614) do
     t.datetime "updated_at", null: false
     t.uuid "legal_aid_application_id"
     t.string "url"
+    t.string "owner_type"
+    t.uuid "owner_id"
     t.index ["legal_aid_application_id"], name: "index_hmrc_responses_on_legal_aid_application_id"
+    t.index ["owner_type", "owner_id"], name: "index_hmrc_responses_on_owner"
   end
 
   create_table "incidents", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/lib/tasks/migrate_hmrc_responses.rake
+++ b/lib/tasks/migrate_hmrc_responses.rake
@@ -1,0 +1,31 @@
+namespace :migrate do
+  desc "AP-3805: Migrate the ownership of HMRC responses to applicant"
+  # This will allow future HMRC responses to be assigned to partner
+  task hmrc_responses: :environment do
+    responses = HMRC::Response.all
+    Rails.logger.info "Migrating HMRC responses => Applicant"
+    Rails.logger.info "----------------------------------------"
+    Rails.logger.info "HMRCResponse.count: #{responses.count}"
+    Rails.logger.info "HMRCResponse with owner: #{responses.where.not(owner_id: nil).count}"
+    Rails.logger.info "HMRCResponse without owner: #{responses.where(owner_id: nil).count}"
+    Rails.logger.info "-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-="
+    Benchmark.benchmark do |bm|
+      bm.report("Migrate:") do
+        ActiveRecord::Base.transaction do
+          responses.where(owner_id: nil).each do |response|
+            applicant = response.legal_aid_application.applicant
+            response.update!(
+              owner_id: applicant.id,
+              owner_type: applicant.class,
+            )
+          end
+        end
+      end
+      raise StandardError, "Not all responses updated" if responses.where(owner_id: nil).count.positive?
+    end
+    Rails.logger.info "-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-="
+    Rails.logger.info "HMRCResponse with owner: #{responses.where.not(owner_id: nil).count}"
+    Rails.logger.info "HMRCResponse without owner: #{responses.where(owner_id: nil).count}"
+    Rails.logger.info "----------------------------------------"
+  end
+end

--- a/spec/factory_specs/hmrc_response/use_case_one_helper_spec.rb
+++ b/spec/factory_specs/hmrc_response/use_case_one_helper_spec.rb
@@ -4,6 +4,8 @@ module FactoryHelpers
   module HMRCResponse
     RSpec.describe UseCaseOne do
       let(:correlation_id) { SecureRandom.uuid }
+      let(:legal_aid_application) { create(:legal_aid_application, :with_applicant) }
+      let(:applicant) { legal_aid_application.applicant }
 
       it "returns a hash with expected keys" do
         response = described_class.new(correlation_id).response
@@ -13,7 +15,7 @@ module FactoryHelpers
       end
 
       it "can be used inside a factory" do
-        rec = create(:hmrc_response, :use_case_one)
+        rec = create(:hmrc_response, :use_case_one, owner_id: applicant.id, owner_type: applicant.class)
         expect(rec.response["status"]).to eq "completed"
         expect(rec.response["data"].size).to eq 19
       end

--- a/spec/models/legal_aid_application_spec.rb
+++ b/spec/models/legal_aid_application_spec.rb
@@ -1639,9 +1639,10 @@ RSpec.describe LegalAidApplication do
   end
 
   describe "#hmrc_response_use_case_one" do
-    let(:laa) { create(:legal_aid_application) }
-    let!(:use_case_one) { create(:hmrc_response, :use_case_one, legal_aid_application: laa) }
-    let!(:use_case_two) { create(:hmrc_response, :use_case_two, legal_aid_application: laa) }
+    let(:laa) { create(:legal_aid_application, :with_applicant) }
+    let(:applicant) { laa.applicant }
+    let!(:use_case_one) { create(:hmrc_response, :use_case_one, legal_aid_application: laa, owner_id: applicant.id, owner_type: applicant.class) }
+    let!(:use_case_two) { create(:hmrc_response, :use_case_two, legal_aid_application: laa, owner_id: applicant.id, owner_type: applicant.class) }
 
     it "returns the use case one record" do
       expect(laa.hmrc_response_use_case_one).to eq use_case_one

--- a/spec/requests/providers/means/full_employment_details_controller_spec.rb
+++ b/spec/requests/providers/means/full_employment_details_controller_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 RSpec.describe Providers::Means::FullEmploymentDetailsController do
   let(:application) { create(:legal_aid_application, :with_applicant, :with_non_passported_state_machine) }
+  let(:applicant) { application.applicant }
   let(:provider) { application.provider }
   let(:before_actions) { {} }
 
@@ -22,7 +23,7 @@ RSpec.describe Providers::Means::FullEmploymentDetailsController do
       end
 
       context "when the no job data is returned" do
-        let(:before_actions) { create(:hmrc_response, :nil_response, legal_aid_application_id: application.id) }
+        let(:before_actions) { create(:hmrc_response, :nil_response, legal_aid_application_id: application.id, owner_id: applicant.id, owner_type: applicant.class) }
 
         it "returns http success" do
           expect(response).to have_http_status(:ok)
@@ -34,7 +35,7 @@ RSpec.describe Providers::Means::FullEmploymentDetailsController do
       end
 
       context "when the HMRC response is pending" do
-        let(:before_actions) { create(:hmrc_response, :processing, legal_aid_application_id: application.id) }
+        let(:before_actions) { create(:hmrc_response, :processing, legal_aid_application_id: application.id, owner_id: applicant.id, owner_type: applicant.class) }
 
         it "returns http success" do
           expect(response).to have_http_status(:ok)
@@ -46,7 +47,7 @@ RSpec.describe Providers::Means::FullEmploymentDetailsController do
 
         describe "Sending a message to Sentry" do
           let(:before_actions) do
-            create(:hmrc_response, :processing, legal_aid_application_id: application.id)
+            create(:hmrc_response, :processing, legal_aid_application_id: application.id, owner_id: applicant.id, owner_type: applicant.class)
             expect(Sentry).to receive(:capture_message).with(/HMRC response still pending/)
           end
 
@@ -58,7 +59,7 @@ RSpec.describe Providers::Means::FullEmploymentDetailsController do
 
       context "when the applicant has multiple jobs" do
         let(:before_actions) do
-          create(:hmrc_response, :multiple_employments_usecase1, legal_aid_application_id: application.id)
+          create(:hmrc_response, :multiple_employments_usecase1, legal_aid_application_id: application.id, owner_id: applicant.id, owner_type: applicant.class)
           create_list(:employment, 2, legal_aid_application: application)
         end
 

--- a/spec/services/cfe/create_employments_service_spec.rb
+++ b/spec/services/cfe/create_employments_service_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe CFE::CreateEmploymentsService do
       let(:expected_payload_hash) { full_payload }
 
       before do
-        create(:hmrc_response, :example1_usecase1, legal_aid_application: laa)
+        create(:hmrc_response, :example1_usecase1, legal_aid_application: laa, owner_id: applicant.id, owner_type: applicant.class)
       end
 
       it_behaves_like "a failed call to CFE"

--- a/spec/services/hmrc/interface/result_service_spec.rb
+++ b/spec/services/hmrc/interface/result_service_spec.rb
@@ -3,7 +3,9 @@ require "rails_helper"
 RSpec.describe HMRC::Interface::ResultService do
   subject(:submission_result) { described_class.new(hmrc_response) }
 
-  let(:hmrc_response) { create(:hmrc_response, :in_progress) }
+  let(:legal_aid_application) { create(:legal_aid_application, :with_applicant) }
+  let(:applicant) { legal_aid_application.applicant }
+  let(:hmrc_response) { create(:hmrc_response, :in_progress, owner_id: applicant.id, owner_type: applicant.class) }
   let(:expected_body) do
     {
       submission: hmrc_response.submission_id,

--- a/spec/services/hmrc/interface/submission_service_spec.rb
+++ b/spec/services/hmrc/interface/submission_service_spec.rb
@@ -20,8 +20,9 @@ RSpec.describe HMRC::Interface::SubmissionService do
   end
 
   let(:application) { create(:legal_aid_application, :with_applicant, :with_transaction_period) }
+  let(:applicant) { application.applicant }
   let(:use_case) { "one" }
-  let(:hmrc_response) { create(:hmrc_response, :use_case_one, legal_aid_application: application) }
+  let(:hmrc_response) { create(:hmrc_response, :use_case_one, legal_aid_application: application, owner_id: applicant.id, owner_type: applicant.class) }
 
   describe ".call" do
     subject(:call) { interface.call }

--- a/spec/services/hmrc/mock_interface_response_service_spec.rb
+++ b/spec/services/hmrc/mock_interface_response_service_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe HMRC::MockInterfaceResponseService do
 
   let(:applicant) { create(:applicant) }
   let(:application) { create(:legal_aid_application, applicant:) }
-  let(:hmrc_response) { create(:hmrc_response, :use_case_one, legal_aid_application: application, submission_id: guid) }
+  let(:hmrc_response) { create(:hmrc_response, :use_case_one, legal_aid_application: application, submission_id: guid, owner_id: applicant.id, owner_type: applicant.class) }
   let(:guid) { SecureRandom.uuid }
   let(:hmrc_data) { hmrc_response.response["data"] }
   let(:not_found_response) do

--- a/spec/services/hmrc/parsed_response/validator_spec.rb
+++ b/spec/services/hmrc/parsed_response/validator_spec.rb
@@ -27,14 +27,14 @@ RSpec.describe HMRC::ParsedResponse::Validator do
     end
 
     context "when response has persistable employment details" do
-      let(:hmrc_response) { create(:hmrc_response, use_case: "one", response: valid_response_hash) }
+      let(:hmrc_response) { create(:hmrc_response, use_case: "one", response: valid_response_hash, owner_id: applicant.id, owner_type: applicant.class) }
 
       it { expect(call).to be_truthy }
     end
 
     context "when HRMC response use_case is \"two\"" do
       let(:instance) { described_class.new(hmrc_response, applicant:) }
-      let(:hmrc_response) { create(:hmrc_response, use_case: "two", response: valid_response_hash) }
+      let(:hmrc_response) { create(:hmrc_response, use_case: "two", response: valid_response_hash, owner_id: applicant.id, owner_type: applicant.class) }
 
       it { expect(instance.call).to be_falsey }
 
@@ -46,7 +46,7 @@ RSpec.describe HMRC::ParsedResponse::Validator do
 
     context "when applicant is nil" do
       let(:instance) { described_class.new(hmrc_response, applicant: nil) }
-      let(:hmrc_response) { create(:hmrc_response, use_case: "one", response: valid_response_hash) }
+      let(:hmrc_response) { create(:hmrc_response, use_case: "one", response: valid_response_hash, owner_id: applicant.id, owner_type: applicant.class) }
 
       it { expect(instance.call).to be_falsey }
 
@@ -57,7 +57,7 @@ RSpec.describe HMRC::ParsedResponse::Validator do
     end
 
     context "when response is nil" do
-      let(:hmrc_response) { create(:hmrc_response, response: response_hash) }
+      let(:hmrc_response) { create(:hmrc_response, response: response_hash, owner_id: applicant.id, owner_type: applicant.class) }
       let(:response_hash) { nil }
 
       it { expect(call).to be_falsey }
@@ -69,7 +69,7 @@ RSpec.describe HMRC::ParsedResponse::Validator do
     end
 
     context "when response is empty hash" do
-      let(:hmrc_response) { create(:hmrc_response, response: response_hash) }
+      let(:hmrc_response) { create(:hmrc_response, response: response_hash, owner_id: applicant.id, owner_type: applicant.class) }
       let(:response_hash) { {} }
 
       it { expect(instance.call).to be_falsey }
@@ -81,7 +81,7 @@ RSpec.describe HMRC::ParsedResponse::Validator do
     end
 
     context "when response status is not \"completed\"" do
-      let(:hmrc_response) { create(:hmrc_response, response: response_hash) }
+      let(:hmrc_response) { create(:hmrc_response, response: response_hash, owner_id: applicant.id, owner_type: applicant.class) }
 
       let(:response_hash) do
         { "submission" => "must-be-present",
@@ -98,7 +98,7 @@ RSpec.describe HMRC::ParsedResponse::Validator do
     end
 
     context "when response submission is nil" do
-      let(:hmrc_response) { create(:hmrc_response, response: response_hash) }
+      let(:hmrc_response) { create(:hmrc_response, response: response_hash, owner_id: applicant.id, owner_type: applicant.class) }
 
       let(:response_hash) do
         { "submission" => nil,
@@ -115,7 +115,7 @@ RSpec.describe HMRC::ParsedResponse::Validator do
     end
 
     context "when response submission is blank" do
-      let(:hmrc_response) { create(:hmrc_response, response: response_hash) }
+      let(:hmrc_response) { create(:hmrc_response, response: response_hash, owner_id: applicant.id, owner_type: applicant.class) }
 
       let(:response_hash) do
         { "submission" => "",
@@ -132,7 +132,7 @@ RSpec.describe HMRC::ParsedResponse::Validator do
     end
 
     context "when response submission is missing" do
-      let(:hmrc_response) { create(:hmrc_response, response: response_hash) }
+      let(:hmrc_response) { create(:hmrc_response, response: response_hash, owner_id: applicant.id, owner_type: applicant.class) }
 
       let(:response_hash) do
         { "status" => "completed",
@@ -148,7 +148,7 @@ RSpec.describe HMRC::ParsedResponse::Validator do
     end
 
     context "when response data is a hash" do
-      let(:hmrc_response) { create(:hmrc_response, response: response_hash) }
+      let(:hmrc_response) { create(:hmrc_response, response: response_hash, owner_id: applicant.id, owner_type: applicant.class) }
 
       let(:response_hash) do
         { "submission" => "must-be-present",
@@ -165,7 +165,7 @@ RSpec.describe HMRC::ParsedResponse::Validator do
     end
 
     context "when response data is nil" do
-      let(:hmrc_response) { create(:hmrc_response, response: response_hash) }
+      let(:hmrc_response) { create(:hmrc_response, response: response_hash, owner_id: applicant.id, owner_type: applicant.class) }
 
       let(:response_hash) do
         { "submission" => "must-be-present",
@@ -182,7 +182,7 @@ RSpec.describe HMRC::ParsedResponse::Validator do
     end
 
     context "when response data has \"individuals/matching/individual\" details matching request" do
-      let(:hmrc_response) { create(:hmrc_response, legal_aid_application:, response: response_hash) }
+      let(:hmrc_response) { create(:hmrc_response, response: response_hash, owner_id: applicant.id, owner_type: applicant.class, legal_aid_application:) }
       let(:legal_aid_application) { create(:legal_aid_application, :with_applicant) }
 
       let(:response_hash) do
@@ -199,7 +199,7 @@ RSpec.describe HMRC::ParsedResponse::Validator do
     end
 
     context "when response data has \"individuals/matching/individual\" details matching but different name" do
-      let(:hmrc_response) { create(:hmrc_response, legal_aid_application:, response: response_hash) }
+      let(:hmrc_response) { create(:hmrc_response, response: response_hash, owner_id: applicant.id, owner_type: applicant.class, legal_aid_application:) }
       let(:legal_aid_application) { create(:legal_aid_application, :with_applicant) }
 
       let(:valid_individual_response) do
@@ -223,7 +223,7 @@ RSpec.describe HMRC::ParsedResponse::Validator do
     end
 
     context "when response data \"individuals/matching/individual\" details are missing" do
-      let(:hmrc_response) { create(:hmrc_response, response: response_hash) }
+      let(:hmrc_response) { create(:hmrc_response, response: response_hash, owner_id: applicant.id, owner_type: applicant.class) }
 
       let(:response_hash) do
         { "submission" => "must-be-present",
@@ -242,7 +242,7 @@ RSpec.describe HMRC::ParsedResponse::Validator do
     end
 
     context "when response data \"individuals/matching/individual\" details are empty" do
-      let(:hmrc_response) { create(:hmrc_response, response: response_hash) }
+      let(:hmrc_response) { create(:hmrc_response, response: response_hash, owner_id: applicant.id, owner_type: applicant.class) }
 
       let(:response_hash) do
         { "submission" => "must-be-present",
@@ -262,7 +262,7 @@ RSpec.describe HMRC::ParsedResponse::Validator do
     end
 
     context "when response data \"individuals/matching/individual\" details has invalid dateOfBirth date" do
-      let(:hmrc_response) { create(:hmrc_response, legal_aid_application:, response: response_hash) }
+      let(:hmrc_response) { create(:hmrc_response, response: response_hash, owner_id: applicant.id, owner_type: applicant.class, legal_aid_application:) }
       let(:legal_aid_application) { create(:legal_aid_application, :with_applicant) }
 
       let(:response_hash) do
@@ -288,7 +288,7 @@ RSpec.describe HMRC::ParsedResponse::Validator do
     end
 
     context "when response data \"individuals/matching/individual\" details do not match applicant" do
-      let(:hmrc_response) { create(:hmrc_response, legal_aid_application:, response: response_hash) }
+      let(:hmrc_response) { create(:hmrc_response, response: response_hash, owner_id: applicant.id, owner_type: applicant.class, legal_aid_application:) }
       let(:legal_aid_application) { create(:legal_aid_application, :with_applicant) }
 
       let(:response_hash) do
@@ -316,7 +316,7 @@ RSpec.describe HMRC::ParsedResponse::Validator do
     end
 
     context "when response data \"income/paye/paye\" \"income\" is nil" do
-      let(:hmrc_response) { create(:hmrc_response, response: response_hash) }
+      let(:hmrc_response) { create(:hmrc_response, response: response_hash, owner_id: applicant.id, owner_type: applicant.class) }
 
       let(:response_hash) do
         { "submission" => "must-be-present",
@@ -333,7 +333,7 @@ RSpec.describe HMRC::ParsedResponse::Validator do
     end
 
     context "when response data \"income/paye/paye\" \"income\" is hash" do
-      let(:hmrc_response) { create(:hmrc_response, response: response_hash) }
+      let(:hmrc_response) { create(:hmrc_response, response: response_hash, owner_id: applicant.id, owner_type: applicant.class) }
 
       let(:response_hash) do
         { "submission" => "must-be-present",
@@ -350,7 +350,7 @@ RSpec.describe HMRC::ParsedResponse::Validator do
     end
 
     context "when response data \"income/paye/paye\" \"income\" contains invalid inPayPeriod1 string" do
-      let(:hmrc_response) { create(:hmrc_response, response: response_hash) }
+      let(:hmrc_response) { create(:hmrc_response, response: response_hash, owner_id: applicant.id, owner_type: applicant.class) }
 
       let(:response_hash) do
         {
@@ -381,7 +381,7 @@ RSpec.describe HMRC::ParsedResponse::Validator do
     end
 
     context "when response data \"income/paye/paye\" \"income\" contains valid inPayPeriod1 float" do
-      let(:hmrc_response) { create(:hmrc_response, response: response_hash) }
+      let(:hmrc_response) { create(:hmrc_response, response: response_hash, owner_id: applicant.id, owner_type: applicant.class) }
 
       let(:response_hash) do
         {
@@ -410,7 +410,7 @@ RSpec.describe HMRC::ParsedResponse::Validator do
     end
 
     context "when response data \"income/paye/paye\" \"income\" contains valid inPayPeriod1 integer" do
-      let(:hmrc_response) { create(:hmrc_response, response: response_hash) }
+      let(:hmrc_response) { create(:hmrc_response, response: response_hash, owner_id: applicant.id, owner_type: applicant.class) }
 
       let(:response_hash) do
         {
@@ -439,7 +439,7 @@ RSpec.describe HMRC::ParsedResponse::Validator do
     end
 
     context "when response data \"income/paye/paye\" \"income\" contains multiple inPayPeriod1 including one invalid string" do
-      let(:hmrc_response) { create(:hmrc_response, response: response_hash) }
+      let(:hmrc_response) { create(:hmrc_response, response: response_hash, owner_id: applicant.id, owner_type: applicant.class) }
 
       let(:response_hash) do
         {
@@ -477,7 +477,7 @@ RSpec.describe HMRC::ParsedResponse::Validator do
     end
 
     context "when response data \"income/paye/paye\" \"income\" contains valid format of paymentDate" do
-      let(:hmrc_response) { create(:hmrc_response, response: response_hash) }
+      let(:hmrc_response) { create(:hmrc_response, response: response_hash, owner_id: applicant.id, owner_type: applicant.class) }
 
       let(:response_hash) do
         {
@@ -506,7 +506,7 @@ RSpec.describe HMRC::ParsedResponse::Validator do
     end
 
     context "when response data \"income/paye/paye\" \"income\" contains invalid date for paymentDate" do
-      let(:hmrc_response) { create(:hmrc_response, response: response_hash) }
+      let(:hmrc_response) { create(:hmrc_response, response: response_hash, owner_id: applicant.id, owner_type: applicant.class) }
 
       let(:response_hash) do
         {
@@ -538,7 +538,7 @@ RSpec.describe HMRC::ParsedResponse::Validator do
     end
 
     context "when response data \"income/paye/paye\" \"income\" contains non-iso8601 format of paymentDate" do
-      let(:hmrc_response) { create(:hmrc_response, response: response_hash) }
+      let(:hmrc_response) { create(:hmrc_response, response: response_hash, owner_id: applicant.id, owner_type: applicant.class) }
 
       let(:response_hash) do
         {
@@ -570,7 +570,7 @@ RSpec.describe HMRC::ParsedResponse::Validator do
     end
 
     context "when response data \"income/paye/paye\" \"income\" contains multiple paymentDates including one invalid" do
-      let(:hmrc_response) { create(:hmrc_response, response: response_hash) }
+      let(:hmrc_response) { create(:hmrc_response, response: response_hash, owner_id: applicant.id, owner_type: applicant.class) }
 
       let(:response_hash) do
         {
@@ -609,7 +609,7 @@ RSpec.describe HMRC::ParsedResponse::Validator do
     end
 
     context "when response data \"employments/paye/employments\" is valid" do
-      let(:hmrc_response) { create(:hmrc_response, legal_aid_application:, response: response_hash) }
+      let(:hmrc_response) { create(:hmrc_response, response: response_hash, owner_id: applicant.id, owner_type: applicant.class, legal_aid_application:) }
       let(:legal_aid_application) { create(:legal_aid_application, :with_applicant) }
 
       let(:response_hash) do
@@ -626,7 +626,7 @@ RSpec.describe HMRC::ParsedResponse::Validator do
     end
 
     context "when response data \"employments/paye/employments\" is missing" do
-      let(:hmrc_response) { create(:hmrc_response, response: response_hash) }
+      let(:hmrc_response) { create(:hmrc_response, response: response_hash, owner_id: applicant.id, owner_type: applicant.class) }
 
       let(:response_hash) do
         { "submission" => "must-be-present",
@@ -643,7 +643,7 @@ RSpec.describe HMRC::ParsedResponse::Validator do
     end
 
     context "when response data \"employments/paye/employments\" is nil" do
-      let(:hmrc_response) { create(:hmrc_response, response: response_hash) }
+      let(:hmrc_response) { create(:hmrc_response, response: response_hash, owner_id: applicant.id, owner_type: applicant.class) }
 
       let(:response_hash) do
         { "submission" => "must-be-present",
@@ -660,7 +660,7 @@ RSpec.describe HMRC::ParsedResponse::Validator do
     end
 
     context "when response data \"employments/paye/employments\" is empty" do
-      let(:hmrc_response) { create(:hmrc_response, response: response_hash) }
+      let(:hmrc_response) { create(:hmrc_response, response: response_hash, owner_id: applicant.id, owner_type: applicant.class) }
 
       let(:response_hash) do
         { "submission" => "must-be-present",
@@ -688,7 +688,7 @@ RSpec.describe HMRC::ParsedResponse::Validator do
       end
 
       context "with use_case \"one\"" do
-        let(:hmrc_response) { create(:hmrc_response, use_case: "one", response: response_hash) }
+        let(:hmrc_response) { create(:hmrc_response, response: response_hash, use_case: "one", owner_id: applicant.id, owner_type: applicant.class) }
 
         before do
           allow(AlertManager).to receive(:capture_message)
@@ -702,7 +702,7 @@ RSpec.describe HMRC::ParsedResponse::Validator do
       end
 
       context "with use_case \"two\"" do
-        let(:hmrc_response) { create(:hmrc_response, use_case: "two", response: response_hash) }
+        let(:hmrc_response) { create(:hmrc_response, response: response_hash, use_case: "two", owner_id: applicant.id, owner_type: applicant.class) }
 
         before do
           allow(AlertManager).to receive(:capture_message)
@@ -716,8 +716,8 @@ RSpec.describe HMRC::ParsedResponse::Validator do
     end
 
     context "when client details are not found by HMRC" do
-      let(:hmrc_response) { create(:hmrc_response, use_case: "one", response: response_hash) }
-      let(:response_hash) do
+      let(:hmrc_response) { create(:hmrc_response, response: response_hash, owner_id: applicant.id, owner_type: applicant.class) }
+      let!(:response_hash) do
         { "submission" => "must-be-present",
           "status" => "failed",
           "data" => [{ "error" => "submitted client details could not be found in HMRC service" }] }
@@ -736,7 +736,7 @@ RSpec.describe HMRC::ParsedResponse::Validator do
     end
 
     context "when client has no employments recorded by HMRC" do
-      let(:hmrc_response) { create(:hmrc_response, use_case: "one", response: response_hash) }
+      let(:hmrc_response) { create(:hmrc_response, response: response_hash, owner_id: applicant.id, owner_type: applicant.class) }
       let(:response_hash) do
         { "submission" => "must-be-present",
           "status" => "completed",

--- a/spec/workers/hmrc/result_worker_spec.rb
+++ b/spec/workers/hmrc/result_worker_spec.rb
@@ -4,7 +4,11 @@ RSpec.describe HMRC::ResultWorker do
   subject(:worker) { described_class.new }
 
   let(:application) { create(:legal_aid_application, :with_applicant, :with_transaction_period) }
-  let(:hmrc_response) { create(:hmrc_response, :use_case_one, :in_progress, legal_aid_application: application, response: nil) }
+  let(:applicant) { application.applicant }
+  let(:hmrc_response) do
+    create(:hmrc_response, :use_case_one, :in_progress, legal_aid_application: application,
+                                                        response: nil, owner_id: applicant.id, owner_type: applicant.class)
+  end
 
   describe ".perform" do
     subject(:perform) { worker.perform(hmrc_response.id) }

--- a/spec/workers/hmrc/submission_worker_spec.rb
+++ b/spec/workers/hmrc/submission_worker_spec.rb
@@ -4,7 +4,8 @@ RSpec.describe HMRC::SubmissionWorker do
   subject(:worker) { described_class.new }
 
   let(:application) { create(:legal_aid_application, :with_applicant, :with_transaction_period) }
-  let(:hmrc_response) { create(:hmrc_response, :use_case_two, legal_aid_application: application) }
+  let(:applicant) { application.applicant }
+  let(:hmrc_response) { create(:hmrc_response, :use_case_two, legal_aid_application: application, owner_id: applicant.id, owner_type: applicant.class) }
 
   it { is_expected.to be_a described_class }
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3805)

Altered the HMRC responses table and model so a HMRC response can now belong to _either_ an applicant object or a partner object. At the moment all responses will belong to an applicant and the partner HMRC response functionality will be added in a future PR.

The existing relation to a legal_aid_application is left as is

 - Added a polymorphic column 'owner' to the hmrc_responses table
 - Added ActiveRecord has_many hmrc_responses associations to Applicant and Partner 
 - Added a rake task to update existing hmrc_responses and set the owner to the applicant
 - Updated the HMRC create_responses_service to add the applicant as owner when a new response is created

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
