### PR TITLE
AP-3805 Part 2 add owner to employments

### DIFF
--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -17,6 +17,7 @@ class Applicant < ApplicationRecord
   has_many :bank_transactions, through: :bank_accounts
   has_many :regular_transactions, as: :owner
   has_many :hmrc_responses, class_name: "HMRC::Response", as: :owner
+  has_many :employments, as: :owner
 
   encrypts :encrypted_true_layer_token
 

--- a/app/models/employment.rb
+++ b/app/models/employment.rb
@@ -1,4 +1,5 @@
 class Employment < ApplicationRecord
   belongs_to :legal_aid_application
+  belongs_to :owner, polymorphic: true
   has_many :employment_payments, dependent: :destroy
 end

--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -1,6 +1,7 @@
 class Partner < ApplicationRecord
   belongs_to :legal_aid_application, dependent: :destroy
   has_many :hmrc_responses, class_name: "HMRC::Response", as: :owner
+  has_many :employments, as: :owner
 
   def pretty_postcode
     pretty_postcode? ? postcode : postcode.insert(-4, " ")

--- a/app/services/hmrc/parsed_response/persistor.rb
+++ b/app/services/hmrc/parsed_response/persistor.rb
@@ -43,8 +43,9 @@ module HMRC
       end
 
       def create_employments
+        applicant = @application.applicant
         employments_array.each_with_index do |_emp, i|
-          @application.employments << ::Employment.new(name: "Job #{i + 1}")
+          @application.employments << ::Employment.new(name: "Job #{i + 1}", owner_id: applicant.id, owner_type: applicant.class)
         end
       end
 

--- a/db/migrate/20230703102937_add_owner_to_employment.rb
+++ b/db/migrate/20230703102937_add_owner_to_employment.rb
@@ -1,0 +1,9 @@
+class AddOwnerToEmployment < ActiveRecord::Migration[7.0]
+  def change
+    safety_assured do
+      change_table :employments, bulk: true do |t|
+        t.belongs_to :owner, polymorphic: true, type: :uuid
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
-ActiveRecord::Schema[7.0].define(version: 2023_06_28_085216) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_03_102937) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -441,7 +440,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_28_085216) do
     t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "owner_type"
+    t.uuid "owner_id"
     t.index ["legal_aid_application_id"], name: "index_employments_on_legal_aid_application_id"
+    t.index ["owner_type", "owner_id"], name: "index_employments_on_owner"
   end
 
   create_table "feedbacks", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/features/step_definitions/bank_statement_upload_steps.rb
+++ b/features/step_definitions/bank_statement_upload_steps.rb
@@ -3,11 +3,12 @@ Given "I have completed a non-passported employed application with bank statemen
     :legal_aid_application,
     :with_proceedings,
     :with_employed_applicant,
-    :with_single_employment,
     :with_extra_employment_information,
     :with_non_passported_state_machine,
     :provider_confirming_applicant_eligibility,
   )
+
+  create :employment, legal_aid_application: @legal_aid_application, owner_id: @legal_aid_application.applicant.id, owner_type: "Applicant"
 
   login_as @legal_aid_application.provider
 
@@ -33,7 +34,6 @@ Given "I have completed a non-passported employed application with bank statemen
     :legal_aid_application,
     :with_proceedings,
     :with_employed_applicant,
-    :with_single_employment,
     :with_extra_employment_information,
     :with_rent_or_mortgage_regular_transaction,
     :with_housing_benefit_regular_transaction,
@@ -43,6 +43,8 @@ Given "I have completed a non-passported employed application with bank statemen
   )
 
   create :attachment, :bank_statement, legal_aid_application: @legal_aid_application
+
+  create :employment, legal_aid_application: @legal_aid_application, owner_id: @legal_aid_application.applicant.id, owner_type: "Applicant"
 
   login_as @legal_aid_application.provider
 

--- a/features/step_definitions/check_your_answers_steps.rb
+++ b/features/step_definitions/check_your_answers_steps.rb
@@ -5,7 +5,6 @@ Given("I have completed the income section of a non-passported application with 
     :legal_aid_application,
     :with_proceedings,
     :with_employed_applicant,
-    :with_single_employment,
     :with_extra_employment_information,
     :with_non_passported_state_machine,
     :with_fixed_offline_savings_accounts,
@@ -25,6 +24,8 @@ Given("I have completed the income section of a non-passported application with 
     set_lead_proceeding: :da002,
   )
 
+  create :employment, legal_aid_application: @legal_aid_application, owner_id: @legal_aid_application.applicant.id, owner_type: "Applicant"
+
   login_as @legal_aid_application.provider
 end
 
@@ -33,7 +34,6 @@ Given("I have completed the income and capital sections of a non-passported appl
     :legal_aid_application,
     :with_proceedings,
     :with_employed_applicant,
-    :with_single_employment,
     :with_extra_employment_information,
     :with_non_passported_state_machine,
     :with_fixed_offline_savings_accounts,
@@ -59,6 +59,7 @@ Given("I have completed the income and capital sections of a non-passported appl
     explicit_proceedings: %i[da002 da006],
     set_lead_proceeding: :da002,
   )
+  create :employment, legal_aid_application: @legal_aid_application, owner_id: @legal_aid_application.applicant.id, owner_type: "Applicant"
 
   login_as @legal_aid_application.provider
 end

--- a/features/step_definitions/civil_journey_steps.rb
+++ b/features/step_definitions/civil_journey_steps.rb
@@ -366,11 +366,12 @@ Given("I start the means review journey with employment income for a single job 
   @legal_aid_application = create(
     :application,
     :with_employed_applicant,
-    :with_single_employment,
     :with_proceedings,
     :with_non_passported_state_machine,
     :provider_assessing_means,
   )
+
+  create :employment, legal_aid_application: @legal_aid_application, owner_id: @legal_aid_application.applicant.id, owner_type: "Applicant"
 
   login_as @legal_aid_application.provider
   visit Flow::KeyPoint.path_for(
@@ -401,11 +402,13 @@ Given("I start the means review journey with employment income for multiple jobs
   @legal_aid_application = create(
     :application,
     :with_employed_applicant,
-    :with_multiple_employments,
     :with_proceedings,
     :with_non_passported_state_machine,
     :provider_assessing_means,
   )
+
+  create :employment, legal_aid_application: @legal_aid_application, owner_id: @legal_aid_application.applicant.id, owner_type: "Applicant"
+  create :employment, :example1_usecase1, legal_aid_application: @legal_aid_application, owner_id: @legal_aid_application.applicant.id, owner_type: "Applicant"
 
   login_as @legal_aid_application.provider
   visit Flow::KeyPoint.path_for(

--- a/lib/tasks/migrate_employments.rake
+++ b/lib/tasks/migrate_employments.rake
@@ -1,0 +1,31 @@
+namespace :migrate do
+  desc "AP-3805: Migrate the ownership of employments to applicant"
+  # This will allow future employments to be assigned to partner
+  task employments: :environment do
+    records = Employment.all
+    Rails.logger.info "Migrating employments => Applicant"
+    Rails.logger.info "----------------------------------------"
+    Rails.logger.info "HMRCResponse.count: #{records.count}"
+    Rails.logger.info "HMRCResponse with owner: #{records.where.not(owner_id: nil).count}"
+    Rails.logger.info "HMRCResponse without owner: #{records.where(owner_id: nil).count}"
+    Rails.logger.info "-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-="
+    Benchmark.benchmark do |bm|
+      bm.report("Migrate:") do
+        ActiveRecord::Base.transaction do
+          records.where(owner_id: nil).each do |record|
+            applicant = record.legal_aid_application.applicant
+            record.update!(
+              owner_id: applicant.id,
+              owner_type: applicant.class,
+            )
+          end
+        end
+      end
+      raise StandardError, "Not all employments updated" if records.where(owner_id: nil).count.positive?
+    end
+    Rails.logger.info "-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-="
+    Rails.logger.info "Employments with owner: #{records.where.not(owner_id: nil).count}"
+    Rails.logger.info "Employments without owner: #{records.where(owner_id: nil).count}"
+    Rails.logger.info "----------------------------------------"
+  end
+end

--- a/spec/factories/legal_aid_applications.rb
+++ b/spec/factories/legal_aid_applications.rb
@@ -27,11 +27,13 @@ FactoryBot.define do
     end
 
     trait :with_single_employment do
-      employments { [association(:employment)] }
+      applicant { build(:applicant, employed: true) }
+      employments { [association(:employment, owner_id: applicant.id, owner_type: applicant.class)] }
     end
 
     trait :with_multiple_employments do
-      employments { build_list(:employment, 3) }
+      applicant { build(:applicant, employed: true) }
+      employments { build_list(:employment, 3, owner_id: applicant.id, owner_type: applicant.class) }
     end
 
     trait :with_full_employment_information do

--- a/spec/models/hmrc/response_spec.rb
+++ b/spec/models/hmrc/response_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe HMRC::Response do
 
   describe ".after_update" do
     let(:persistor_class) { HMRC::ParsedResponse::Persistor }
-    let(:hmrc_response) { create(:hmrc_response, :use_case_one, owner_id: applicant.id, owner_type: applicant.class) }
+    let(:hmrc_response) { create(:hmrc_response, :use_case_one, legal_aid_application:, owner_id: applicant.id, owner_type: applicant.class) }
     let(:trigger_update) { hmrc_response.update!(url: "my_url") }
 
     before do

--- a/spec/models/legal_aid_application_spec.rb
+++ b/spec/models/legal_aid_application_spec.rb
@@ -1574,10 +1574,12 @@ RSpec.describe LegalAidApplication do
     end
 
     context "when there are Employment records" do
-      let(:laa) { create(:legal_aid_application, :with_multiple_employments) }
+      let(:laa) { create(:legal_aid_application, :with_applicant) }
+      let(:applicant) { laa.applicant }
+      let!(:employment) { create(:employment, legal_aid_application: laa, owner_id: applicant.id, owner_type: applicant.class) }
 
       it "returns true" do
-        expect(laa.hmrc_employment_income?).to be true
+        expect(laa.reload.hmrc_employment_income?).to be true
       end
     end
   end
@@ -1650,11 +1652,12 @@ RSpec.describe LegalAidApplication do
   end
 
   describe "#eligible_employment_payments" do
-    let(:laa) { create(:legal_aid_application, :with_transaction_period) }
+    let(:laa) { create(:legal_aid_application, :with_applicant, :with_transaction_period) }
+    let(:applicant) { laa.applicant }
 
     context "with one employment with employment payments" do
       before do
-        emp = create(:employment, legal_aid_application: laa)
+        emp = create(:employment, legal_aid_application: laa, owner_id: applicant.id, owner_type: applicant.class)
         create(:employment_payment, employment: emp, date: 1.month.ago)
         create(:employment_payment, employment: emp, date: 2.months.ago)
       end
@@ -1667,7 +1670,7 @@ RSpec.describe LegalAidApplication do
     end
 
     context "with one employment with no employment payments" do
-      before { create(:employment, legal_aid_application: laa) }
+      before { create(:employment, legal_aid_application: laa, owner_id: applicant.id, owner_type: applicant.class) }
 
       it "returns an empty collections" do
         expect(laa.eligible_employment_payments).to be_empty
@@ -1682,10 +1685,10 @@ RSpec.describe LegalAidApplication do
 
     context "with multiple employments" do
       before do
-        emp1 = create(:employment, legal_aid_application: laa)
+        emp1 = create(:employment, legal_aid_application: laa, owner_id: applicant.id, owner_type: applicant.class)
         create(:employment_payment, employment: emp1, date: 1.month.ago)
         create(:employment_payment, employment: emp1, date: 2.months.ago)
-        emp2 = create(:employment, legal_aid_application: laa)
+        emp2 = create(:employment, legal_aid_application: laa, owner_id: applicant.id, owner_type: applicant.class)
         create(:employment_payment, employment: emp2, date: 1.month.ago)
       end
 
@@ -1696,10 +1699,10 @@ RSpec.describe LegalAidApplication do
 
     context "with all payments before start of transaction period" do
       before do
-        emp1 = create(:employment, legal_aid_application: laa)
+        emp1 = create(:employment, legal_aid_application: laa, owner_id: applicant.id, owner_type: applicant.class)
         create(:employment_payment, employment: emp1, date: laa.transaction_period_start_on - 3.days)
         create(:employment_payment, employment: emp1, date: laa.transaction_period_start_on - 10.days)
-        emp2 = create(:employment, legal_aid_application: laa)
+        emp2 = create(:employment, legal_aid_application: laa, owner_id: applicant.id, owner_type: applicant.class)
         create(:employment_payment, employment: emp2, date: laa.transaction_period_start_on - 1.month)
       end
 
@@ -1710,7 +1713,7 @@ RSpec.describe LegalAidApplication do
 
     context "with one payment in transaction period, others before" do
       before do
-        emp1 = create(:employment, legal_aid_application: laa)
+        emp1 = create(:employment, legal_aid_application: laa, owner_id: applicant.id, owner_type: applicant.class)
         create(:employment_payment, employment: emp1, date: laa.transaction_period_start_on - 3.days)
         create(:employment_payment, employment: emp1, date: laa.transaction_period_start_on + 2.days)
         create(:employment_payment, employment: emp1, date: laa.transaction_period_start_on - 10.days)

--- a/spec/requests/providers/means/employed_incomes_spec.rb
+++ b/spec/requests/providers/means/employed_incomes_spec.rb
@@ -1,8 +1,9 @@
 require "rails_helper"
 
 RSpec.describe "employed incomes request" do
-  let(:application) { create(:legal_aid_application, :with_non_passported_state_machine, :with_transaction_period, :with_single_employment, applicant:) }
+  let(:application) { create(:legal_aid_application, :with_non_passported_state_machine, :with_transaction_period, applicant:) }
   let(:applicant) { create(:applicant, :employed) }
+  let(:employment) { create(:employment, legal_aid_application: application, owner_id: applicant.id, owner_type: applicant.class) }
   let(:provider) { application.provider }
   let(:setup_tasks) { {} }
 

--- a/spec/requests/providers/means/full_employment_details_controller_spec.rb
+++ b/spec/requests/providers/means/full_employment_details_controller_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe Providers::Means::FullEmploymentDetailsController do
       context "when the applicant has multiple jobs" do
         let(:before_actions) do
           create(:hmrc_response, :multiple_employments_usecase1, legal_aid_application_id: application.id, owner_id: applicant.id, owner_type: applicant.class)
-          create_list(:employment, 2, legal_aid_application: application)
+          create_list(:employment, 2, legal_aid_application: application, owner_id: applicant.id, owner_type: applicant.class)
         end
 
         it "returns http success" do

--- a/spec/requests/providers/means/unexpected_employed_incomes_spec.rb
+++ b/spec/requests/providers/means/unexpected_employed_incomes_spec.rb
@@ -1,8 +1,9 @@
 require "rails_helper"
 
 RSpec.describe "employed incomes request" do
-  let(:application) { create(:legal_aid_application, :with_non_passported_state_machine, :with_transaction_period, :with_single_employment, applicant:) }
+  let(:application) { create(:legal_aid_application, :with_non_passported_state_machine, :with_transaction_period, applicant:) }
   let(:applicant) { create(:applicant, :not_employed) }
+  let(:employment) { create(:employment, legal_aid_application: application, owner_id: applicant.id, owner_type: applicant.class) }
   let(:provider) { application.provider }
   let(:setup_tasks) { {} }
 

--- a/spec/requests/providers/means/unexpected_employed_incomes_spec.rb
+++ b/spec/requests/providers/means/unexpected_employed_incomes_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "employed incomes request" do
 
       context "when applicant is not employed but has employment payment records" do
         let(:setup_tasks) do
-          create(:employment, :with_payments_in_transaction_period, legal_aid_application: application)
+          create(:employment, :with_payments_in_transaction_period, legal_aid_application: application, owner_id: applicant.id, owner_type: applicant.class)
         end
 
         it "displays correct text when applicant is not_employed" do

--- a/spec/services/cfe/create_employments_service_spec.rb
+++ b/spec/services/cfe/create_employments_service_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe CFE::CreateEmploymentsService do
 
     context "applicant employed" do
       let(:applicant) { create(:applicant, :employed) }
-      let!(:employment) { create(:employment, :example1_usecase1, legal_aid_application: laa) }
+      let!(:employment) { create(:employment, :example1_usecase1, legal_aid_application: laa, owner_id: applicant.id, owner_type: applicant.class) }
 
       it "returns full payload" do
         expect(service.request_body).to eq full_payload.to_json
@@ -40,7 +40,7 @@ RSpec.describe CFE::CreateEmploymentsService do
 
     let(:applicant) { create(:applicant, :employed) }
     let(:expected_payload) { full_payload }
-    let!(:employment) { create(:employment, :example1_usecase1, legal_aid_application: laa) }
+    let!(:employment) { create(:employment, :example1_usecase1, legal_aid_application: laa, owner_id: applicant.id, owner_type: applicant.class) }
 
     it "updates the state on the submission record from irregular_income_created to employments_created" do
       expect(submission.aasm_state).to eq "irregular_income_created"

--- a/spec/services/cfe_civil/components/employments_spec.rb
+++ b/spec/services/cfe_civil/components/employments_spec.rb
@@ -14,9 +14,10 @@ RSpec.describe CFECivil::Components::Employments do
   end
 
   context "when the applicant is employed but has no PAYE data" do
+    let(:applicant) { create(:applicant, :employed) }
+
     before do
-      create(:applicant, :employed)
-      create(:employment, legal_aid_application:)
+      create(:employment, legal_aid_application:, owner_id: applicant.id, owner_type: "Applicant")
     end
 
     it "renders the expected, empty hash" do
@@ -25,9 +26,10 @@ RSpec.describe CFECivil::Components::Employments do
   end
 
   context "when the applicant is employed" do
+    let(:applicant) { create(:applicant, :employed) }
+
     before do
-      create(:applicant, :employed)
-      create(:employment, :example1_usecase1, legal_aid_application:)
+      create(:employment, :example1_usecase1, legal_aid_application:, owner_id: applicant.id, owner_type: "Applicant")
     end
 
     it "renders the expected JSON" do

--- a/spec/services/hmrc/parsed_response/persistor_spec.rb
+++ b/spec/services/hmrc/parsed_response/persistor_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe HMRC::ParsedResponse::Persistor do
 
       context "when employment and employment payment records already exist for this application" do
         let(:hmrc_response) { create(:hmrc_response, :example1_usecase1, legal_aid_application: application, owner_id: applicant.id, owner_type: applicant.class) }
-        let(:employment) { create(:employment, legal_aid_application: application) }
+        let(:employment) { create(:employment, legal_aid_application: application, owner_id: applicant.id, owner_type: applicant.class) }
 
         let(:employment_payment1) { create(:employment_payment, employment:) }
         let(:employment_payment2) { create(:employment_payment, employment:) }

--- a/spec/services/hmrc/status_analyzer_spec.rb
+++ b/spec/services/hmrc/status_analyzer_spec.rb
@@ -8,6 +8,7 @@ module HMRC
 
       let(:feature_flag) { true }
       let(:laa) { create(:legal_aid_application, :with_applicant, :with_transaction_period) }
+      let(:applicant) { laa.applicant }
       let(:applicant_employed) { true }
 
       context "and applicant not employed and no eligible payments" do
@@ -21,7 +22,7 @@ module HMRC
       context "with applicant not employed but eligible employment payments exist" do
         let(:applicant_employed) { false }
 
-        before { create(:employment, :with_payments_in_transaction_period, legal_aid_application: laa) }
+        before { create(:employment, :with_payments_in_transaction_period, legal_aid_application: laa, owner_id: applicant.id, owner_type: applicant.class) }
 
         it "returns :unexpected_employment_data" do
           expect(service_call).to eq :unexpected_employment_data
@@ -31,7 +32,7 @@ module HMRC
       context "with applicant not employed and non-eligible employment payments exist" do
         let(:applicant_employed) { false }
 
-        before { create(:employment, :with_payments_before_transaction_period, legal_aid_application: laa) }
+        before { create(:employment, :with_payments_before_transaction_period, legal_aid_application: laa, owner_id: applicant.id, owner_type: applicant.class) }
 
         it "returns :unexpected_employment_data" do
           expect(service_call).to eq :applicant_not_employed
@@ -39,7 +40,7 @@ module HMRC
       end
 
       context "and applicant has multiple employments" do
-        before { create_list(:employment, 2, legal_aid_application: laa) }
+        before { create_list(:employment, 2, legal_aid_application: laa, owner_id: applicant.id, owner_type: applicant.class) }
 
         it "returns hmrc_multiple_employments" do
           expect(service_call).to eq :hmrc_multiple_employments
@@ -47,7 +48,7 @@ module HMRC
       end
 
       context "and applicant has single employment" do
-        before { create(:employment, legal_aid_application: laa) }
+        before { create(:employment, legal_aid_application: laa, owner_id: applicant.id, owner_type: applicant.class) }
 
         it "returns hmrc_single_employment" do
           expect(service_call).to eq :hmrc_single_employment


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3805)

Update Employment model and DB table to have owner as a polymorphic column. 
The owner will be either the applicant or partner. At the moment the owner is just the applicant.
Added rake task to set owner of all existing employments to the applicant.
Updated rspecs and feature tests to create the employment object with an owner

NB: At the moment all employments have to be explicitly created in each setup step for rspec/features by passing the owner (in all cases the applicant right now). There is probably a more efficient way of doing this but I couldn't figure it out. It would be ideal if in the employment factory the owner could be created/added there, but the three-way dependency between LegalAidApplication, Employment, and Applicant/Partner makes it kind of awkward and circular

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
