### PR TITLE
AP-3805: HRMC request for partner

### DIFF
--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -2,4 +2,13 @@ class Partner < ApplicationRecord
   belongs_to :legal_aid_application, dependent: :destroy
   has_many :hmrc_responses, class_name: "HMRC::Response", as: :owner
   has_many :employments, as: :owner
+
+  def json_for_hmrc
+    {
+      first_name:,
+      last_name:,
+      dob: date_of_birth,
+      nino: national_insurance_number,
+    }
+  end
 end

--- a/app/services/hmrc/create_responses_service.rb
+++ b/app/services/hmrc/create_responses_service.rb
@@ -12,18 +12,18 @@ module HMRC
     end
 
     def call
-      # return unless @legal_aid_application.hmrc_responses.empty?
+      return unless @legal_aid_application.hmrc_responses.empty?
 
       individuals = []
       individuals << @legal_aid_application.applicant
-      if @legal_aid_application.applicant.has_partner?
+      if @legal_aid_application.applicant.has_partner? && @legal_aid_application.partner.has_national_insurance_number?
         # not sure if we do need to check whether they have NI or not but have left it in for now
-        individuals << @legal_aid_application.partner if @legal_aid_application.partner.has_national_insurance_number?
+        individuals << @legal_aid_application.partner
       end
 
       USE_CASES.each do |use_case|
         individuals.each do |person|
-          hmrc_response = @legal_aid_application.hmrc_responses.create(use_case:, owner_id: person.id, owner_type: person.class)
+          hmrc_response = person.hmrc_responses.create(use_case:, legal_aid_application: @legal_aid_application)
           if use_mock?
             MockInterfaceResponseService.call(hmrc_response)
           else

--- a/app/services/hmrc/create_responses_service.rb
+++ b/app/services/hmrc/create_responses_service.rb
@@ -14,12 +14,8 @@ module HMRC
     def call
       return unless @legal_aid_application.hmrc_responses.empty?
 
-      individuals = []
-      individuals << @legal_aid_application.applicant
-      if @legal_aid_application.applicant.has_partner? && @legal_aid_application.partner.has_national_insurance_number?
-        # not sure if we do need to check whether they have NI or not but have left it in for now
-        individuals << @legal_aid_application.partner
-      end
+      individuals = [@legal_aid_application.applicant]
+      individuals << @legal_aid_application.partner if check_partner?
 
       USE_CASES.each do |use_case|
         individuals.each do |person|
@@ -41,6 +37,10 @@ module HMRC
 
     def not_production_environment?
       !HostEnv.production?
+    end
+
+    def check_partner?
+      @legal_aid_application.applicant.has_partner? && @legal_aid_application.partner.has_national_insurance_number?
     end
   end
 end

--- a/app/services/hmrc/interface/submission_service.rb
+++ b/app/services/hmrc/interface/submission_service.rb
@@ -17,7 +17,7 @@ module HMRC
       end
 
       def request_body
-        @request_body ||= { filter: applicant_values.merge(date_values) }.to_json
+        @request_body ||= { filter: owner_values.merge(date_values) }.to_json
       end
 
     private
@@ -30,8 +30,8 @@ module HMRC
         @use_case ||= @hmrc_response.use_case
       end
 
-      def applicant_values
-        @applicant_values ||= @hmrc_response.owner.json_for_hmrc
+      def owner_values
+        @owner_values ||= @hmrc_response.owner.json_for_hmrc
       end
 
       def date_values

--- a/app/services/hmrc/interface/submission_service.rb
+++ b/app/services/hmrc/interface/submission_service.rb
@@ -31,7 +31,7 @@ module HMRC
       end
 
       def applicant_values
-        @applicant_values ||= application.applicant.json_for_hmrc
+        @applicant_values ||= @hmrc_response.owner.json_for_hmrc
       end
 
       def date_values

--- a/app/services/hmrc/mock_interface_response_service.rb
+++ b/app/services/hmrc/mock_interface_response_service.rb
@@ -22,14 +22,15 @@ module HMRC
       new(*args).call
     end
 
-    attr_reader :application
+    attr_reader :application, :owner
 
     delegate :applicant, to: :application, allow_nil: true
-    delegate :first_name, :last_name, :national_insurance_number, :date_of_birth, to: :applicant, allow_nil: true
+    delegate :first_name, :last_name, :national_insurance_number, :date_of_birth, to: :owner, allow_nil: true
 
     def initialize(hmrc_response)
       @hmrc_response = hmrc_response
       @application = @hmrc_response.legal_aid_application
+      @owner = @hmrc_response.owner
       @submission_id = SecureRandom.uuid
       @reference_date = @application.calculation_date || Time.zone.today
       @use_case_name = "use_case_#{@hmrc_response.use_case}"

--- a/app/services/hmrc/parsed_response/validator.rb
+++ b/app/services/hmrc/parsed_response/validator.rb
@@ -5,14 +5,15 @@ module HMRC
 
       Error = Struct.new(:attribute, :message)
 
-      def self.call(hmrc_response, applicant:)
-        new(hmrc_response, applicant:).call
+      # person can be Applicant or Partner
+      def self.call(hmrc_response, person:)
+        new(hmrc_response, person:).call
       end
 
-      def initialize(hmrc_response, applicant:)
+      def initialize(hmrc_response, person:)
         @hmrc_response = hmrc_response
         @response = hmrc_response.response
-        @applicant = applicant
+        @person = person
         @errors = []
       end
 
@@ -30,7 +31,7 @@ module HMRC
 
     private
 
-      attr_reader :hmrc_response, :response, :applicant
+      attr_reader :hmrc_response, :response, :person
 
       def validate_use_case
         errors << error(:use_case, "use_case must be \"one\", but was \"#{hmrc_response.use_case}\"") if hmrc_response.use_case != "one"
@@ -59,10 +60,10 @@ module HMRC
       end
 
       def validate_response_individual
-        errors << error(:individual, "individual must match applicant") unless individual &&
-          applicant &&
-          applicant.national_insurance_number.casecmp?(individual["nino"]) &&
-          applicant.date_of_birth.iso8601 == individual["dateOfBirth"]
+        errors << error(:individual, "individual must match person") unless individual &&
+          person &&
+          person.national_insurance_number.casecmp?(individual["nino"]) &&
+          person.date_of_birth.iso8601 == individual["dateOfBirth"]
       end
 
       def validate_response_employments

--- a/app/views/admin/legal_aid_applications/submissions/show.html.erb
+++ b/app/views/admin/legal_aid_applications/submissions/show.html.erb
@@ -21,9 +21,9 @@
       <% @legal_aid_application.hmrc_responses.each do |hmrc_response| %>
         <details>
           <summary class="govuk-heading-m govuk-details__summary"
-                   title="HMRC use case <%= hmrc_response.use_case %>"
-                   aria-label="HMRC use case <%= hmrc_response.use_case %> result">
-            HMRC use case <%= hmrc_response.use_case %>
+                   title="HMRC use case <%= hmrc_response.use_case %> <%= hmrc_response.owner_type %>"
+                   aria-label="HMRC use case <%= hmrc_response.use_case %> <%= hmrc_response.owner_type %> result">
+            HMRC response - use case <%= hmrc_response.use_case %> for the <%= hmrc_response.owner_type.downcase %>
           </summary>
           <section>
             <% if hmrc_response.response.present? %>

--- a/features/step_definitions/partner_means_check.rb
+++ b/features/step_definitions/partner_means_check.rb
@@ -19,6 +19,7 @@ Given(/^an applicant named (\S+) (\S+) with a partner has completed their true l
                                              :provider_assessing_means,
                                              :with_proceedings,
                                              applicant: @applicant,
+                                             partner: create(:partner),
                                              provider_step: "client_completed_means",
                                              provider: @registered_provider
   bank_account = @applicant.bank_accounts.first

--- a/spec/services/cfe_civil/components/employments_spec.rb
+++ b/spec/services/cfe_civil/components/employments_spec.rb
@@ -14,10 +14,9 @@ RSpec.describe CFECivil::Components::Employments do
   end
 
   context "when the applicant is employed but has no PAYE data" do
-    let(:applicant) { create(:applicant, :employed) }
-
     before do
-      create(:employment, legal_aid_application:, owner_id: applicant.id, owner_type: "Applicant")
+      applicant = create(:applicant, :employed)
+      create(:employment, legal_aid_application:, owner_id: applicant.id, owner_type: applicant.class)
     end
 
     it "renders the expected, empty hash" do
@@ -29,7 +28,8 @@ RSpec.describe CFECivil::Components::Employments do
     let(:applicant) { create(:applicant, :employed) }
 
     before do
-      create(:employment, :example1_usecase1, legal_aid_application:, owner_id: applicant.id, owner_type: "Applicant")
+      create(:applicant, :employed)
+      create(:employment, :example1_usecase1, legal_aid_application:, owner_id: applicant.id, owner_type: applicant.class)
     end
 
     it "renders the expected JSON" do

--- a/spec/services/hmrc/create_responses_service_spec.rb
+++ b/spec/services/hmrc/create_responses_service_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe HMRC::CreateResponsesService do
         expect { call }.to change { legal_aid_application.hmrc_responses.count }.by(2)
       end
 
-      it "adds te applicant as owner to each response record created" do
+      it "adds the applicant as owner to each response record created" do
         legal_aid_application.reload.hmrc_responses.each do |response|
           expect(response.owner_id).to eq(legal_aid_application.applicant.id)
           expect(response.owner_type).to eq(legal_aid_application.applicant.class)
@@ -65,6 +65,30 @@ RSpec.describe HMRC::CreateResponsesService do
               expect(HMRC::MockInterfaceResponseService).to have_received(:call).twice
             end
           end
+        end
+      end
+    end
+
+    context "when successful and applicant has a partner with an NI number" do
+      let(:legal_aid_application) { create(:legal_aid_application, :with_applicant_and_partner, :with_transaction_period) }
+
+      it "creates four hmrc_response records, one for each use case for each individual" do
+        expect { call }.to change { legal_aid_application.hmrc_responses.count }.by(4)
+        expect(legal_aid_application.applicant.hmrc_responses.count).to eq 2
+        expect(legal_aid_application.partner.hmrc_responses.count).to eq 2
+      end
+
+      it "adds the applicant as owner to each response record created" do
+        legal_aid_application.applicant.reload.hmrc_responses.each do |response|
+          expect(response.owner_id).to eq(legal_aid_application.applicant.id)
+          expect(response.owner_type).to eq(legal_aid_application.applicant.class)
+        end
+      end
+
+      it "adds the partner as owner to each response record created" do
+        legal_aid_application.partner.reload.hmrc_responses.each do |response|
+          expect(response.owner_id).to eq(legal_aid_application.partner.id)
+          expect(response.owner_type).to eq(legal_aid_application.partner.class)
         end
       end
     end

--- a/spec/services/hmrc/interface/submission_service_spec.rb
+++ b/spec/services/hmrc/interface/submission_service_spec.rb
@@ -96,38 +96,25 @@ RSpec.describe HMRC::Interface::SubmissionService do
   describe ".request_body" do
     subject(:request_body) { interface.request_body }
 
-    context "when the owner is an applicant" do
-      let(:expected_data) do
-        {
-          filter: {
-            first_name: owner.first_name,
-            last_name: owner.last_name,
-            dob: owner.date_of_birth,
-            nino: owner.national_insurance_number,
-            start_date: Time.zone.today - 3.months,
-            end_date: Time.zone.today,
-          },
-        }.to_json
-      end
+    let(:expected_data) do
+      {
+        filter: {
+          first_name: owner.first_name,
+          last_name: owner.last_name,
+          dob: owner.date_of_birth,
+          nino: owner.national_insurance_number,
+          start_date: Time.zone.today - 3.months,
+          end_date: Time.zone.today,
+        },
+      }.to_json
+    end
 
+    context "when the owner is an applicant" do
       it { expect(request_body).to eq(expected_data) }
     end
 
     context "when the owner is a partner" do
       let(:owner) { application.partner }
-
-      let(:expected_data) do
-        {
-          filter: {
-            first_name: owner.first_name,
-            last_name: owner.last_name,
-            dob: owner.date_of_birth,
-            nino: owner.national_insurance_number,
-            start_date: Time.zone.today - 3.months,
-            end_date: Time.zone.today,
-          },
-        }.to_json
-      end
 
       it { expect(request_body).to eq(expected_data) }
     end

--- a/spec/services/hmrc/mock_interface_response_service_spec.rb
+++ b/spec/services/hmrc/mock_interface_response_service_spec.rb
@@ -5,7 +5,8 @@ RSpec.describe HMRC::MockInterfaceResponseService do
 
   let(:applicant) { create(:applicant) }
   let(:application) { create(:legal_aid_application, applicant:) }
-  let(:hmrc_response) { create(:hmrc_response, :use_case_one, legal_aid_application: application, submission_id: guid, owner_id: applicant.id, owner_type: applicant.class) }
+  let(:owner) { applicant }
+  let(:hmrc_response) { create(:hmrc_response, :use_case_one, legal_aid_application: application, submission_id: guid, owner_id: owner.id, owner_type: owner.class) }
   let(:guid) { SecureRandom.uuid }
   let(:hmrc_data) { hmrc_response.response["data"] }
   let(:not_found_response) do
@@ -374,6 +375,17 @@ RSpec.describe HMRC::MockInterfaceResponseService do
         expect(hmrc_data[1]["individuals/matching/individual"]["firstName"]).to eq "Oakley"
         expect(hmrc_data[17]["benefits_and_credits/working_tax_credit/applications"][0]["awards"][0]["totalEntitlement"]).not_to be_nil
       end
+    end
+  end
+
+  context "when the mock response owner is set to a partner that is available to the mock response service" do
+    let(:applicant) { create(:applicant, first_name: "Langley", last_name: "Yorke", national_insurance_number: "MN212451D", date_of_birth: "1992-07-22") }
+    let(:partner) { create(:partner, first_name: "Ida", last_name: "Paisley", national_insurance_number: "OE726113A", date_of_birth: "1987-11-24") }
+    let(:application) { create(:legal_aid_application, applicant:, partner:) }
+    let(:owner) { partner }
+
+    it "returns data for the partner, _not_ the applicant" do
+      expect(hmrc_data[1]["individuals/matching/individual"]["firstName"]).to eq "Ida"
     end
   end
 end

--- a/spec/services/hmrc/parsed_response/validator_spec.rb
+++ b/spec/services/hmrc/parsed_response/validator_spec.rb
@@ -2,9 +2,9 @@ require "rails_helper"
 
 RSpec.describe HMRC::ParsedResponse::Validator do
   describe ".call" do
-    subject(:call) { described_class.call(hmrc_response, applicant:) }
+    subject(:call) { described_class.call(hmrc_response, person: applicant) }
 
-    let(:instance) { described_class.new(hmrc_response, applicant:) }
+    let(:instance) { described_class.new(hmrc_response, person: applicant) }
     let(:applicant) { create(:legal_aid_application, :with_applicant).applicant }
 
     let(:valid_individual_response) do
@@ -33,7 +33,7 @@ RSpec.describe HMRC::ParsedResponse::Validator do
     end
 
     context "when HRMC response use_case is \"two\"" do
-      let(:instance) { described_class.new(hmrc_response, applicant:) }
+      let(:instance) { described_class.new(hmrc_response, person: applicant) }
       let(:hmrc_response) { create(:hmrc_response, use_case: "two", response: valid_response_hash, owner_id: applicant.id, owner_type: applicant.class) }
 
       it { expect(instance.call).to be_falsey }
@@ -44,15 +44,15 @@ RSpec.describe HMRC::ParsedResponse::Validator do
       }
     end
 
-    context "when applicant is nil" do
-      let(:instance) { described_class.new(hmrc_response, applicant: nil) }
+    context "when person is nil" do
+      let(:instance) { described_class.new(hmrc_response, person: nil) }
       let(:hmrc_response) { create(:hmrc_response, use_case: "one", response: valid_response_hash, owner_id: applicant.id, owner_type: applicant.class) }
 
       it { expect(instance.call).to be_falsey }
 
       it {
         instance.call
-        expect(instance.errors.collect(&:message)).to include("individual must match applicant")
+        expect(instance.errors.collect(&:message)).to include("individual must match person")
       }
     end
 
@@ -237,7 +237,7 @@ RSpec.describe HMRC::ParsedResponse::Validator do
 
       it {
         instance.call
-        expect(instance.errors.collect(&:message)).to include("individual must match applicant")
+        expect(instance.errors.collect(&:message)).to include("individual must match person")
       }
     end
 
@@ -257,7 +257,7 @@ RSpec.describe HMRC::ParsedResponse::Validator do
 
       it {
         instance.call
-        expect(instance.errors.collect(&:message)).to include("individual must match applicant")
+        expect(instance.errors.collect(&:message)).to include("individual must match person")
       }
     end
 
@@ -283,7 +283,7 @@ RSpec.describe HMRC::ParsedResponse::Validator do
 
       it {
         instance.call
-        expect(instance.errors.collect(&:message)).to include("individual must match applicant")
+        expect(instance.errors.collect(&:message)).to include("individual must match person")
       }
     end
 
@@ -311,7 +311,7 @@ RSpec.describe HMRC::ParsedResponse::Validator do
 
       it {
         instance.call
-        expect(instance.errors.collect(&:message)).to include("individual must match applicant")
+        expect(instance.errors.collect(&:message)).to include("individual must match person")
       }
     end
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3805)

Part 3 of the ticket to allow HMRC requests for partners

This switches `HMRC::CreateResponsesService` and `HMRC::MockInterfaceResponseService` to parse the owner of the `HMRC::Response` object, whether it is an Applicant or Partner.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
