### PR TITLE
AP-4293: Use new ECR repo with IRSA for push

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -338,7 +338,7 @@ jobs:
                         --install --wait \
                         --namespace=${K8S_NAMESPACE} \
                         --values ./helm_deploy/apply-for-legal-aid/values-staging.yaml \
-                        --set image.repository="${ECR_REGISTRY}/${GITHUB_TEAM_NAME_SLUG}/${REPO_NAME}" \
+                        --set image.repository="${ECR_REGISTRY}/${ECR_REPOSITORY}" \
                         --set image.tag="${CIRCLE_SHA1}"
 
   deploy_production:
@@ -355,7 +355,7 @@ jobs:
                         --install --wait \
                         --namespace=${K8S_NAMESPACE} \
                         --values ./helm_deploy/apply-for-legal-aid/values-production.yaml \
-                        --set image.repository="${ECR_REGISTRY}/${GITHUB_TEAM_NAME_SLUG}/${REPO_NAME}" \
+                        --set image.repository="${ECR_REGISTRY}/${ECR_REPOSITORY}" \
                         --set image.tag="${CIRCLE_SHA1}"
 
   clean_up_ecr:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,8 +9,6 @@ executors:
   basic-executor:
     docker:
       - image: cimg/base:2020.01
-        environment:
-          GITHUB_TEAM_NAME_SLUG: laa-apply-for-legal-aid
   linting-executor:
     docker:
       - image: cimg/ruby:3.2.2-browsers
@@ -22,7 +20,6 @@ executors:
     docker:
       - image: ministryofjustice/cloud-platform-tools:2.3.0
         environment:
-          GITHUB_TEAM_NAME_SLUG: laa-apply-for-legal-aid
           TZ: Europe/London
   notification-executor:
     docker:
@@ -35,7 +32,6 @@ executors:
       - image: ministryofjustice/apply-ci:latest-3.2.2
         environment:
           RAILS_ENV: test
-          GITHUB_TEAM_NAME_SLUG: laa-apply-for-legal-aid
           CACHE_VERSION: v1
           NODE_OPTIONS: --openssl-legacy-provider
       - image: cimg/postgres:11.16

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,7 @@
 version: 2.1
 
 orbs:
+  aws-cli: circleci/aws-cli@4.0.0
   browser-tools: circleci/browser-tools@1.2.3
   slack: circleci/slack@4.5.2
 
@@ -41,6 +42,33 @@ executors:
       - image: cimg/redis:6.2
       - image: ghcr.io/ministryofjustice/hmpps-clamav:latest
 
+commands:
+  build-and-push-to-ecr:
+    description: Build and push image to ECR repository
+    steps:
+      - run:
+          name: Build docker image
+          command: |
+            docker build \
+            --build-arg BUILD_DATE=$(date +%Y-%m-%dT%H:%M:%S%z) \
+            --build-arg BUILD_TAG="app-${CIRCLE_SHA1}" \
+            --build-arg APP_BRANCH=${CIRCLE_BRANCH} \
+            -t app . | while read line ; do echo "$(date +"%T") > $line" ; done ;
+      - aws-cli/setup:
+          role_arn: $ECR_ROLE_TO_ASSUME
+          region: $ECR_REGION
+      - run:
+          name: Push image to ECR repository
+          command: |
+            aws ecr get-login-password --region ${ECR_REGION} | docker login --username AWS --password-stdin ${ECR_REGISTRY}
+            docker tag app "${ECR_REGISTRY}/${ECR_REPOSITORY}:${CIRCLE_SHA1}"
+            docker push "${ECR_REGISTRY}/${ECR_REPOSITORY}:${CIRCLE_SHA1}"
+
+            if [ "${CIRCLE_BRANCH}" == "main" ]; then
+              docker tag app "${ECR_REGISTRY}/${ECR_REPOSITORY}:latest"
+              docker push "${ECR_REGISTRY}/${ECR_REPOSITORY}:latest"
+            fi
+
 references:
   decrypt_secrets: &decrypt_secrets
     run:
@@ -48,6 +76,7 @@ references:
       command: |
         echo "${GIT_CRYPT_KEY}" | base64 -d > git-crypt.key
         git-crypt unlock git-crypt.key
+
   authenticate_k8s_live: &authenticate_k8s_live
     run:
       name: Authenticate with cluster
@@ -57,6 +86,7 @@ references:
         kubectl config set-credentials circleci --token=${K8S_TOKEN_LIVE}
         kubectl config set-context ${K8S_CLUSTER_NAME_LIVE} --cluster=${K8S_CLUSTER_NAME_LIVE} --user=circleci --namespace=${K8S_NAMESPACE}
         kubectl config use-context ${K8S_CLUSTER_NAME_LIVE}
+
   install_gems: &install_gems
     run:
       name: Install ruby gems
@@ -80,6 +110,7 @@ references:
     run:
       name: Kubectl deployment setup UAT
       command: |
+        # TOOD: do we ned to login to ecr here? I don't think so
         aws ecr get-login-password --region eu-west-2 | docker login --username AWS --password-stdin ${ECR_ENDPOINT}
         echo -n ${K8S_CLUSTER_CERT_LIVE} | base64 -d > ./ca.crt
         kubectl config set-cluster ${K8S_CLUSTER_NAME_LIVE} --certificate-authority=./ca.crt --server=https://${K8S_CLUSTER_NAME_LIVE}
@@ -276,26 +307,7 @@ jobs:
     - setup_remote_docker:
         version: 20.10.7
     - *decrypt_secrets
-    - run:
-        name: Build docker images
-        command: |
-          docker build \
-          --build-arg BUILD_DATE=$(date +%Y-%m-%dT%H:%M:%S%z) \
-          --build-arg BUILD_TAG="app-${CIRCLE_SHA1}" \
-          --build-arg APP_BRANCH=${CIRCLE_BRANCH} \
-          -t app . | while read line ; do echo "$(date +"%T") > $line" ; done ;
-    - run:
-        name: Push docker image to ECR repo
-        command: |
-          aws ecr get-login-password --region eu-west-2 | docker login --username AWS --password-stdin ${ECR_ENDPOINT}
-          docker tag app "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${REPO_NAME}:${CIRCLE_SHA1}"
-          docker push "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${REPO_NAME}:${CIRCLE_SHA1}"
-
-          case "${CIRCLE_BRANCH}" in
-            main)
-              docker tag app "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${REPO_NAME}:latest"
-              docker push "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${REPO_NAME}:latest"
-          esac
+    - build-and-push-to-ecr
 
   deploy_uat: &deploy_uat
     executor: cloud-platform-executor
@@ -308,6 +320,7 @@ jobs:
         name: Helm deployment to UAT
         command: |
           ./bin/uat_deploy
+
   deploy_main_uat:
     <<: *deploy_uat
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,8 +106,6 @@ references:
     run:
       name: Kubectl deployment setup UAT
       command: |
-        # TOOD: do we ned to login to ecr here? I don't think so
-        aws ecr get-login-password --region eu-west-2 | docker login --username AWS --password-stdin ${ECR_REGISTRY}
         echo -n ${K8S_CLUSTER_CERT_LIVE} | base64 -d > ./ca.crt
         kubectl config set-cluster ${K8S_CLUSTER_NAME_LIVE} --certificate-authority=./ca.crt --server=https://${K8S_CLUSTER_NAME_LIVE}
         kubectl config set-credentials circleci --token=${K8S_TOKEN_LIVE}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,7 +111,7 @@ references:
       name: Kubectl deployment setup UAT
       command: |
         # TOOD: do we ned to login to ecr here? I don't think so
-        aws ecr get-login-password --region eu-west-2 | docker login --username AWS --password-stdin ${ECR_ENDPOINT}
+        aws ecr get-login-password --region eu-west-2 | docker login --username AWS --password-stdin ${ECR_REGISTRY}
         echo -n ${K8S_CLUSTER_CERT_LIVE} | base64 -d > ./ca.crt
         kubectl config set-cluster ${K8S_CLUSTER_NAME_LIVE} --certificate-authority=./ca.crt --server=https://${K8S_CLUSTER_NAME_LIVE}
         kubectl config set-credentials circleci --token=${K8S_TOKEN_LIVE}
@@ -338,7 +338,7 @@ jobs:
                         --install --wait \
                         --namespace=${K8S_NAMESPACE} \
                         --values ./helm_deploy/apply-for-legal-aid/values-staging.yaml \
-                        --set image.repository="${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${REPO_NAME}" \
+                        --set image.repository="${ECR_REGISTRY}/${GITHUB_TEAM_NAME_SLUG}/${REPO_NAME}" \
                         --set image.tag="${CIRCLE_SHA1}"
 
   deploy_production:
@@ -355,7 +355,7 @@ jobs:
                         --install --wait \
                         --namespace=${K8S_NAMESPACE} \
                         --values ./helm_deploy/apply-for-legal-aid/values-production.yaml \
-                        --set image.repository="${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${REPO_NAME}" \
+                        --set image.repository="${ECR_REGISTRY}/${GITHUB_TEAM_NAME_SLUG}/${REPO_NAME}" \
                         --set image.tag="${CIRCLE_SHA1}"
 
   clean_up_ecr:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,16 +102,6 @@ references:
       name: Install Yarn packages
       command: yarn --frozen-lockfile
 
-  setup_uat_kubectl: &setup_uat_kubectl
-    run:
-      name: Kubectl deployment setup UAT
-      command: |
-        echo -n ${K8S_CLUSTER_CERT_LIVE} | base64 -d > ./ca.crt
-        kubectl config set-cluster ${K8S_CLUSTER_NAME_LIVE} --certificate-authority=./ca.crt --server=https://${K8S_CLUSTER_NAME_LIVE}
-        kubectl config set-credentials circleci --token=${K8S_TOKEN_LIVE}
-        kubectl config set-context ${K8S_CLUSTER_NAME_LIVE} --cluster=${K8S_CLUSTER_NAME_LIVE} --user=circleci --namespace=${K8S_UAT_NAMESPACE}
-        kubectl config use-context ${K8S_CLUSTER_NAME_LIVE}
-
   update_packages: &update_packages
     run:
       name: Update packages
@@ -308,7 +298,7 @@ jobs:
     steps:
     - checkout
     - setup_remote_docker
-    - *setup_uat_kubectl
+    - *authenticate_k8s_live
     - *decrypt_secrets
     - deploy:
         name: Helm deployment to UAT
@@ -367,7 +357,7 @@ jobs:
     steps:
     - checkout
     - setup_remote_docker
-    - *setup_uat_kubectl
+    - *authenticate_k8s_live
     - run:
         name: Delete dependabot deployment
         command: |

--- a/bin/uat_deploy
+++ b/bin/uat_deploy
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 deploy() {
-  IMG_REPO="$ECR_ENDPOINT/$GITHUB_TEAM_NAME_SLUG/$REPO_NAME"
+  IMG_REPO="$ECR_REGISTRY/$GITHUB_TEAM_NAME_SLUG/$REPO_NAME"
   RELEASE_BRANCH=$(echo $CIRCLE_BRANCH | tr '[:upper:]' '[:lower:]' | sed 's:^\w*\/::' | tr -s ' _/[]().' '-' | cut -c1-30 | sed 's/-$//')
   RELEASE_NAME="apply-$RELEASE_BRANCH"
   RELEASE_HOST="$RELEASE_BRANCH-applyforlegalaid-uat.cloud-platform.service.justice.gov.uk"

--- a/bin/uat_deploy
+++ b/bin/uat_deploy
@@ -1,7 +1,6 @@
 #!/bin/sh
 
 deploy() {
-  IMG_REPO="$ECR_REGISTRY/$GITHUB_TEAM_NAME_SLUG/$REPO_NAME"
   RELEASE_BRANCH=$(echo $CIRCLE_BRANCH | tr '[:upper:]' '[:lower:]' | sed 's:^\w*\/::' | tr -s ' _/[]().' '-' | cut -c1-30 | sed 's/-$//')
   RELEASE_NAME="apply-$RELEASE_BRANCH"
   RELEASE_HOST="$RELEASE_BRANCH-applyforlegalaid-uat.cloud-platform.service.justice.gov.uk"
@@ -15,7 +14,7 @@ deploy() {
                 --namespace=${K8S_NAMESPACE} \
                 --values ./helm_deploy/apply-for-legal-aid/values-uat.yaml \
                 --set deploy.host="$RELEASE_HOST" \
-                --set image.repository="$IMG_REPO" \
+                --set image.repository="${ECR_REGISTRY}/${ECR_REPOSITORY}" \
                 --set image.tag="${CIRCLE_SHA1}" \
                 --set ingress.hosts="{$RELEASE_HOST}" \
                 --set ingress.annotations."external-dns\.alpha\.kubernetes\.io/set-identifier"="$IDENTIFIER"


### PR DESCRIPTION
## What
Amend config to push to new ECR repo which uses IRSA and lifecycle policy

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4293)

- Add command to build and push to new ECR repo using IRSA
- Replace ECR_ENDPOINT with ECR_REGISTRY
- Amend ECR repo to pull from
- Remove GITHUB_TEAM_NAME_SLUG envvar
- Remove unneeded ECR login
- Remove almost duplicate step for UAT

See this [cloud platform environments PR](https://github.com/ministryofjustice/cloud-platform-environments/pull/14533) that creates the new ECR repo with IRSA for circleci and adds a lifecycle policy relating to [AP-4294](https://dsdmoj.atlassian.net/browse/AP-4294)

Once merged then [AP-4294](https://github.com/ministryofjustice/laa-apply-for-legal-aid/pull/5472) can be too and the following vars can be removed from circleci environment variables:

AWS_ACCESS_KEY_ID
AWS_SECRET_ACCESS_KEY
AWS_DEFAULT_REGION
ECR_ENDPOINT
REPO_NAME

AFTER use of new repo for a couple of days we can delete the old - see [AP-4319](https://dsdmoj.atlassian.net/browse/AP-4319)

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.


[AP-4294]: https://dsdmoj.atlassian.net/browse/AP-4294?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[AP-4319]: https://dsdmoj.atlassian.net/browse/AP-4319?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ