### PR TITLE
Fix: Update CFE::BaseResult ownership

### DIFF
--- a/app/models/cfe/submission.rb
+++ b/app/models/cfe/submission.rb
@@ -4,7 +4,7 @@ module CFE
 
     belongs_to :legal_aid_application
     has_many :submission_histories, -> { order(created_at: :asc) }, inverse_of: :submission
-    has_one :result, class_name: "BaseResult"
+    has_one :result, class_name: "BaseResult", dependent: :destroy
 
     delegate :passported?, :non_passported?, :uploading_bank_statements?, to: :legal_aid_application
 


### PR DESCRIPTION
## What

These are not being deleted when the owning cfe_submission is deleted by its owner, the legal_aid_application.

This has been tested on a local instance and ensures that deleting a legal_aid_appliation now destroys the linked cfe_result

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
