### PR TITLE
AP-4321: Replace references to unused/maintained clamav images

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,18 +2,18 @@ version: '3'
 
 services:
   postgres:
-    image: postgres:10.5
+    image: postgres:11.6
     volumes:
     - pgdata:/var/lib/postgresql/data
   clamav:
-    image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/laa-apply-for-legal-aid/clamav:1.0.2
+    image: ghcr.io/ministryofjustice/hmpps-clamav:sha-0ae98e9
     ports:
     - "3310:3310"
-  api:
+  web:
     environment:
     - DB_HOST=postgres
     build: .
-    command: bin/run
+    command: docker/run
     ports:
     - "3002:3002"
     depends_on:


### PR DESCRIPTION

## What
Replace laa-apply-for-legal-aid/clamav with ministryofjustice/hmpps-clamav for docker-compose

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4321)

Remove reference to old, archived and unused clamav image.

The old clamav is archived and not used any longer, plus its ECR repo is to be deleted. This
updates to use the same exact image and commit as production.

I also:

1. updated postgres to production version
2. changed to use the docker/run script as bin/run no longer exists

see cloud-platform-environments PR to [remove clamav ECR repo](https://github.com/ministryofjustice/cloud-platform-environments/pull/14563)



## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
