### PR TITLE
Bump hmpps-clamav to latest commit shah

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     volumes:
     - pgdata:/var/lib/postgresql/data
   clamav:
-    image: ghcr.io/ministryofjustice/hmpps-clamav:sha-0ae98e9
+    image: ghcr.io/ministryofjustice/hmpps-clamav:sha-ae9a953
     ports:
     - "3310:3310"
   web:

--- a/helm_deploy/apply-for-legal-aid/templates/deployment_web.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/deployment_web.yaml
@@ -27,7 +27,7 @@ spec:
       containers:
         # https://github.com/ministryofjustice/hmpps-utility-container-images
         - name: clamav
-          image: ghcr.io/ministryofjustice/hmpps-clamav:sha-0ae98e9
+          image: ghcr.io/ministryofjustice/hmpps-clamav:sha-ae9a953
           imagePullPolicy: IfNotPresent
           ports:
             - name: clamav


### PR DESCRIPTION
## What
Bump anti virus softare, [hmpps-clamav](https://github.com/ministryofjustice/hmpps-utility-container-images/pkgs/container/hmpps-clamav), to latest version

From sha-0ae98e9 to sha-ae9a953

## Test
I have UAT'd an upload of malware with successful blocking.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
