### PR TITLE
AP-4323: Add short lived credentials service account name to all cronjobs

### DIFF
--- a/helm_deploy/apply-for-legal-aid/templates/cronjob-admin-report.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/cronjob-admin-report.yaml
@@ -20,6 +20,7 @@ spec:
           labels:
             reportuploader: cronjob
         spec:
+          serviceAccountName: "{{ .Values.service_account.name }}"
           containers:
           - name: daily-admin-report
             image: '{{ .Values.image.repository }}:{{ .Values.image.tag }}'

--- a/helm_deploy/apply-for-legal-aid/templates/cronjob-deliver-scheduled-mail.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/cronjob-deliver-scheduled-mail.yaml
@@ -17,6 +17,7 @@ spec:
       backoffLimit: 1
       template:
         spec:
+          serviceAccountName: "{{ .Values.service_account.name }}"
           containers:
           - name: rake-task
             image: '{{ .Values.image.repository }}:{{ .Values.image.tag }}'

--- a/helm_deploy/apply-for-legal-aid/templates/cronjob-destroy-purgeable.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/cronjob-destroy-purgeable.yaml
@@ -20,6 +20,7 @@ spec:
           labels:
             reportuploader: cronjob
         spec:
+          serviceAccountName: "{{ .Values.service_account.name }}"
           containers:
           - name: destroy-purgeable
             image: '{{ .Values.image.repository }}:{{ .Values.image.tag }}'

--- a/helm_deploy/apply-for-legal-aid/templates/cronjob-export-digest.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/cronjob-export-digest.yaml
@@ -20,6 +20,7 @@ spec:
           labels:
             reportuploader: cronjob
         spec:
+          serviceAccountName: "{{ .Values.service_account.name }}"
           containers:
           - name: export-digest
             image: '{{ .Values.image.repository }}:{{ .Values.image.tag }}'

--- a/helm_deploy/apply-for-legal-aid/templates/cronjob-extract-digest.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/cronjob-extract-digest.yaml
@@ -20,6 +20,7 @@ spec:
           labels:
             reportuploader: cronjob
         spec:
+          serviceAccountName: "{{ .Values.service_account.name }}"
           containers:
           - name: extract-digest
             image: '{{ .Values.image.repository }}:{{ .Values.image.tag }}'

--- a/helm_deploy/apply-for-legal-aid/templates/cronjob-mark-purgeable.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/cronjob-mark-purgeable.yaml
@@ -20,6 +20,7 @@ spec:
           labels:
             reportuploader: cronjob
         spec:
+          serviceAccountName: "{{ .Values.service_account.name }}"
           containers:
           - name: mark-purgeable
             image: '{{ .Values.image.repository }}:{{ .Values.image.tag }}'

--- a/helm_deploy/apply-for-legal-aid/templates/cronjob-metrics.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/cronjob-metrics.yaml
@@ -18,6 +18,7 @@ spec:
       backoffLimit: 1
       template:
         spec:
+          serviceAccountName: "{{ .Values.service_account.name }}"
           containers:
           - name: rake-task
             image: '{{ .Values.image.repository }}:{{ .Values.image.tag }}'

--- a/helm_deploy/apply-for-legal-aid/templates/cronjob-reset-dashboard-overnight.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/cronjob-reset-dashboard-overnight.yaml
@@ -17,6 +17,7 @@ spec:
       backoffLimit: 1
       template:
         spec:
+          serviceAccountName: "{{ .Values.service_account.name }}"
           containers:
           - name: reset-dashboard
             image: '{{ .Values.image.repository }}:{{ .Values.image.tag }}'


### PR DESCRIPTION
## What
Add short lived credentials service account name to all cronjobs

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4323)

If jobs need access to AWS resources, such as S3, they will
require the IRSA credentials.

Adding to all cronjobs is just a precaution that matches
previous long lived credential provision via secrets.

## Test

I tested this on UAT and it fixes the daily admin report

**job completion**
<img width="1508" alt="Screenshot 2023-07-14 at 10 05 51" src="https://github.com/ministryofjustice/laa-apply-for-legal-aid/assets/7016425/5bb46529-a84f-4bbd-96a6-c9035f10c7d6">

**file uploaded**
<img width="2315" alt="Screenshot 2023-07-14 at 10 04 30" src="https://github.com/ministryofjustice/laa-apply-for-legal-aid/assets/7016425/5f17669e-30d3-4ea5-9a98-0967128a5364">


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
