### PR TITLE
AP-4324: Migrate opponents to polymorphism

### DIFF
--- a/db/anonymise/rules.rb
+++ b/db/anonymise/rules.rb
@@ -115,6 +115,10 @@ NINO_REGEXP = /^[A-CEGHJ-PR-TW-Z]{1}[A-CEGHJ-NPR-TW-Z]{1}[0-9]{6}[A-DFM]{1}$/
   incidents: {
     details: -> { Faker::Lorem.sentence },
   },
+  individual_opponents: {
+    first_name: -> { Faker::Name.first_name },
+    last_name: -> { Faker::Name.last_name },
+  },
   involved_children: {
     full_name: -> { Faker::Name.name },
   },

--- a/db/migrate/20230717114132_create_individual_opponents.rb
+++ b/db/migrate/20230717114132_create_individual_opponents.rb
@@ -1,0 +1,9 @@
+class CreateIndividualOpponents < ActiveRecord::Migration[7.0]
+  def change
+    create_table :individual_opponents, id: :uuid do |t|
+      t.string "first_name"
+      t.string "last_name"
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230717124415_add_opposable_to_opponent.rb
+++ b/db/migrate/20230717124415_add_opposable_to_opponent.rb
@@ -1,0 +1,12 @@
+class AddOpposableToOpponent < ActiveRecord::Migration[7.0]
+  def change
+    safety_assured do
+      change_table :opponents, bulk: true do |t|
+        t.string :opposable_type, true: false
+        t.uuid :opposable_id, null: true, type: :uuid
+
+        t.index [:opposable_id, :opposable_type], unique: true
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_17_114132) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_17_124415) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -682,7 +682,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_17_114132) do
     t.integer "ccms_opponent_id"
     t.string "first_name"
     t.string "last_name"
+    t.string "opposable_type"
+    t.uuid "opposable_id"
     t.index ["legal_aid_application_id"], name: "index_opponents_on_legal_aid_application_id"
+    t.index ["opposable_id", "opposable_type"], name: "index_opponents_on_opposable_id_and_opposable_type", unique: true
   end
 
   create_table "opponents_applications", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_11_081546) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_17_114132) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -513,6 +513,13 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_11_081546) do
     t.datetime "updated_at", precision: nil, null: false
     t.date "told_on"
     t.index ["legal_aid_application_id"], name: "index_incidents_on_legal_aid_application_id"
+  end
+
+  create_table "individual_opponents", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "first_name"
+    t.string "last_name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "involved_children", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|


### PR DESCRIPTION
## What
Create structures for migration to polymorphic opponents

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4324)

To allow for organisation opponents, one option is to use polymorphism.  This
will require changing existing data structures for "individual" opponents in one or
more PRs, and subsequent PRs to implement "organisation" opponents.

To prepare for polymorphic opponents we need to 
- [X] migration to create individual_opponents table with first_name and last_name
- [X] migration to add polymorphic association, opposable, to opponents table (opposable_type, oppossable_id) with `null: true` to allow normal functionality 

A second PR could
- [ ] data migration to copy all opponents table data to individual_opponents
- [ ] code changes to use polymorphic association for ApplicationMeritsTask::Opponent::Individual

A third PR could then cleanup
- [ ] migration to enforce opposable to make opponents_type and opponents_id null: false
- [ ] migration to remove opponents first_name and last_name columns from opponents table

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
