### PR TITLE
AP-4033 make child error messages and headings consistent

### DIFF
--- a/app/controllers/providers/application_merits_task/remove_involved_child_controller.rb
+++ b/app/controllers/providers/application_merits_task/remove_involved_child_controller.rb
@@ -2,17 +2,18 @@ module Providers
   module ApplicationMeritsTask
     class RemoveInvolvedChildController < ProviderBaseController
       def show
-        form
         involved_child
+        form
       end
 
       def update
+        involved_child
+
         if form.valid?
           involved_child&.destroy! if form.remove_involved_child?
           return go_forward
         end
 
-        involved_child
         render :show
       end
 
@@ -23,7 +24,12 @@ module Providers
           journey: :provider,
           radio_buttons_input_name: :remove_involved_child,
           form_params:,
+          error: error_message,
         )
+      end
+
+      def error_message
+        I18n.t("providers.application_merits_task.remove_involved_child.show.error", name: @involved_child.full_name)
       end
 
       def involved_child

--- a/app/controllers/providers/application_merits_task/remove_opponent_controller.rb
+++ b/app/controllers/providers/application_merits_task/remove_opponent_controller.rb
@@ -2,17 +2,18 @@ module Providers
   module ApplicationMeritsTask
     class RemoveOpponentController < ProviderBaseController
       def show
-        form
         opponent
+        form
       end
 
       def update
+        opponent
+
         if form.valid?
           opponent&.destroy! if form.remove_opponent?
           return go_forward
         end
 
-        opponent
         render :show
       end
 
@@ -23,6 +24,7 @@ module Providers
           journey: :provider,
           radio_buttons_input_name: :remove_opponent,
           form_params:,
+          error: error_message,
         )
       end
 
@@ -34,6 +36,10 @@ module Providers
         return {} unless params[:binary_choice_form]
 
         params.require(:binary_choice_form).permit(:remove_opponent)
+      end
+
+      def error_message
+        I18n.t("providers.application_merits_task.remove_opponent.show.error", name: @opponent.full_name)
       end
     end
   end

--- a/app/controllers/providers/means/remove_dependants_controller.rb
+++ b/app/controllers/providers/means/remove_dependants_controller.rb
@@ -2,11 +2,13 @@ module Providers
   module Means
     class RemoveDependantsController < ProviderBaseController
       def show
-        form
         dependant
+        form
       end
 
       def update
+        dependant
+
         if form.valid?
           dependant&.destroy! if form.remove_dependant?
           if legal_aid_application.dependants.count.zero?
@@ -16,7 +18,6 @@ module Providers
           return go_forward
         end
 
-        dependant
         render :show
       end
 
@@ -27,6 +28,7 @@ module Providers
           journey: :provider,
           radio_buttons_input_name: :remove_dependant,
           form_params:,
+          error: error_message,
         )
       end
 
@@ -38,6 +40,10 @@ module Providers
         return {} unless params[:binary_choice_form]
 
         params.require(:binary_choice_form).permit(:remove_dependant)
+      end
+
+      def error_message
+        I18n.t("providers.means.remove_dependants.show.error", name: dependant.name)
       end
     end
   end

--- a/app/models/concerns/binary_choice_form.rb
+++ b/app/models/concerns/binary_choice_form.rb
@@ -23,7 +23,7 @@ class BinaryChoiceForm
     @journey = journey
     @input_name = radio_buttons_input_name
     @action = action
-    @error = error || "error"
+    @error = error
   end
 
 private
@@ -41,6 +41,6 @@ private
   end
 
   def error_message
-    I18n.t("#{@journey.to_s.pluralize}.#{@input_name.to_s.pluralize}.#{@action}.#{@error}")
+    @error.nil? ? I18n.t("#{@journey.to_s.pluralize}.#{@input_name.to_s.pluralize}.#{@action}.error") : @error
   end
 end

--- a/app/views/providers/application_merits_task/remove_involved_child/show.html.erb
+++ b/app/views/providers/application_merits_task/remove_involved_child/show.html.erb
@@ -1,11 +1,11 @@
-<%= page_template page_title: t(".page_title", name: @involved_child.full_name), template: :basic do %>
+<%= form_with(
+      url: providers_legal_aid_application_remove_involved_child_path,
+      model: @form,
+      method: :patch,
+      local: true,
+    ) do |form| %>
 
-  <%= form_with(
-        url: providers_legal_aid_application_remove_involved_child_path,
-        model: @form,
-        method: :patch,
-        local: true,
-      ) do |form| %>
+  <%= page_template page_title: t(".page_title", name: @involved_child.full_name), form:, template: :basic do %>
 
     <%= form.govuk_collection_radio_buttons :remove_involved_child,
                                             yes_no_options,

--- a/app/views/providers/application_merits_task/remove_opponent/show.html.erb
+++ b/app/views/providers/application_merits_task/remove_opponent/show.html.erb
@@ -1,17 +1,17 @@
-<%= page_template page_title: t(".page_title", name: @opponent.full_name), template: :basic do %>
+<%= form_with(
+      url: providers_legal_aid_application_remove_opponent_path,
+      model: @form,
+      method: :patch,
+      local: true,
+    ) do |form| %>
 
-  <%= form_with(
-        url: providers_legal_aid_application_remove_opponent_path,
-        model: @form,
-        method: :patch,
-        local: true,
-      ) do |form| %>
+    <%= page_template page_title: t(".page_title", name: @opponent.full_name), form:, template: :basic do %>
 
-    <%= form.govuk_collection_radio_buttons :remove_opponent,
-                                            yes_no_options,
-                                            :value,
-                                            :label,
-                                            legend: { text: content_for(:page_title), tag: "h1", size: "xl" } %>
+      <%= form.govuk_collection_radio_buttons :remove_opponent,
+                                              yes_no_options,
+                                              :value,
+                                              :label,
+                                              legend: { text: content_for(:page_title), tag: "h1", size: "xl" } %>
 
     <%= next_action_buttons(form:) %>
   <% end %>

--- a/app/views/providers/capital_introductions/show.html.erb
+++ b/app/views/providers/capital_introductions/show.html.erb
@@ -8,12 +8,12 @@
     </div>
 
     <h2 class="govuk-heading-m app-counter"><%= t(".merits_list_heading") %></h2>
-    <div class="govuk-!-padding-left-4">
+    <div class="govuk-!-padding-left-4 govuk-!-margin-bottom-6">
       <p class="govuk-body"><%= t(".merits_text") %></p>
       <%= list_from_translation_path ".capital_introductions.show.merits_items" %>
 
       <% if @legal_aid_application.section_8_proceedings? %>
-        <%= list_from_translation_path ".capital_introductions.show.section_8_items" %>
+          <%= list_from_translation_path ".capital_introductions.show.section_8_items" %>
       <% end %>
     </div>
   </div>

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -965,9 +965,7 @@ en:
           warning:
             delete: Are you sure you want to delete this dependant?
       remove_dependants:
-        show:
-          page_title: "Are you sure you want to remove %{name} from the application?"
-          error: "Select yes if you want to remove %{name} from the application"
+        show: *remove_show
       check_income_answers:
         show:
           h1-heading: Check your answers

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -431,7 +431,8 @@ en:
           add_another: Do you need to add another child?
       remove_involved_child:
         show: &remove_show
-          page_title: Do you want to remove %{name} from the application?
+          page_title: Are you sure you want to remove %{name} from the application?
+          error: Select yes if you want to remove %{name} from the application.
       remove_opponent:
         show: *remove_show
       date_client_told_incidents:
@@ -579,9 +580,6 @@ en:
     has_other_opponents:
       show:
         error: Select yes if you need to add another opponent
-    remove_dependants:
-      show:
-        error: Select yes if you wish to delete the dependant
     declarations:
       show:
         h1-heading: Declaration
@@ -968,7 +966,8 @@ en:
             delete: Are you sure you want to delete this dependant?
       remove_dependants:
         show:
-          page_title: "Are you sure you want to remove %{name}?"
+          page_title: "Are you sure you want to remove %{name} from the application?"
+          error: "Select yes if you want to remove %{name} from the application"
       check_income_answers:
         show:
           h1-heading: Check your answers

--- a/features/providers/merits_task_list.feature
+++ b/features/providers/merits_task_list.feature
@@ -114,7 +114,7 @@ Feature: Merits task list
     When I click 'Save and continue'
     Then I should be on the 'has_other_involved_children' page showing 'You have added 1 child'
     When I click link 'Remove'
-    Then I should be on a page showing 'Do you want to remove John Doe Jr from the application?'
+    Then I should be on a page showing 'Are you sure you want to remove John Doe Jr from the application?'
     When I choose 'Yes'
     And I click 'Save and continue'
     Then I should be on the 'involved_children/new' page showing 'Enter details of the children involved in this application'

--- a/features/providers/non_passported_journey/with_dependants.feature
+++ b/features/providers/non_passported_journey/with_dependants.feature
@@ -108,7 +108,7 @@ Feature: non_passported_journey with dependants
     Then I should be on the 'has_other_dependants' page showing "Does your client have any other dependants?"
     And I should see 'Pugsley Addams'
     When I click has other dependants remove link for dependant '2'
-    Then I should be on a page showing 'Are you sure you want to remove Pugsley Addams'
+    Then I should be on a page showing 'Are you sure you want to remove Pugsley Addams from the application'
     When I choose "Yes"
     And I click 'Save and continue'
     Then I should be on the 'has_other_dependants' page showing "Does your client have any other dependants?"

--- a/spec/requests/providers/application_merits_task/remove_involved_child_spec.rb
+++ b/spec/requests/providers/application_merits_task/remove_involved_child_spec.rb
@@ -2,24 +2,24 @@ require "rails_helper"
 
 module Providers
   module ApplicationMeritsTask
-    RSpec.describe HasOtherInvolvedChildrenController do
+    RSpec.describe RemoveInvolvedChildController do
       let(:application) { create(:legal_aid_application) }
       let(:provider) { application.provider }
-      let!(:child2) { create(:involved_child, legal_aid_application: application) }
+      let!(:child) { create(:involved_child, legal_aid_application: application) }
 
       before { login_as provider }
 
       describe "show GET /providers/applications/:legal_aid_application_id/remove_involved_child/:id" do
-        subject { get providers_legal_aid_application_remove_involved_child_path(application, child2) }
+        subject { get providers_legal_aid_application_remove_involved_child_path(application, child) }
 
         it "displays the childs details" do
           subject
-          expect(response.body).to include(html_compare(child2.full_name))
+          expect(response.body).to include(html_compare(child.full_name))
         end
       end
 
       describe "update PATCH /providers/applications/:legal_aid_application_id/remove_involved_child/:id" do
-        subject { patch providers_legal_aid_application_remove_involved_child_path(application, child2), params: }
+        subject { patch providers_legal_aid_application_remove_involved_child_path(application, child), params: }
 
         let(:params) do
           {
@@ -69,6 +69,11 @@ module Providers
 
         context "with neither yes nor no specified" do
           let(:radio_button) { "" }
+
+          it "shows the correct error message" do
+            subject
+            expect(response.body).to include(I18n.t("providers.application_merits_task.remove_involved_child.show.error", name: child.full_name))
+          end
 
           it "does not delete a record" do
             expect { subject }.not_to change { application.involved_children.count }

--- a/spec/requests/providers/means/remove_dependant_controller_spec.rb
+++ b/spec/requests/providers/means/remove_dependant_controller_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe Providers::Means::RemoveDependantsController do
       let(:remove_dependant) { "not sure" }
 
       it "show errors" do
-        expect(response.body).to include(I18n.t("providers.remove_dependants.show.error"))
+        expect(response.body).to include(I18n.t("providers.means.remove_dependants.show.error", name: dependant.name))
       end
     end
 
@@ -82,7 +82,7 @@ RSpec.describe Providers::Means::RemoveDependantsController do
       let(:params) { nil }
 
       it "show errors" do
-        expect(response.body).to include(I18n.t("providers.remove_dependants.show.error"))
+        expect(response.body).to include(I18n.t("providers.means.remove_dependants.show.error", name: dependant.name))
       end
     end
   end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4033)

Update headings and error messages on remove_dependant and remove_involved_child pages to make them consistent and to include the name of the person to be removed
Both these pages use the BinaryChoiceForm so it requires changing this slightly to accept an error message, so the name could be passed into the form

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
