### PR TITLE
AP-4284: Add db structure for polymorphic opponent individuals

### DIFF
--- a/db/anonymise/rules.rb
+++ b/db/anonymise/rules.rb
@@ -115,6 +115,10 @@ NINO_REGEXP = /^[A-CEGHJ-PR-TW-Z]{1}[A-CEGHJ-NPR-TW-Z]{1}[0-9]{6}[A-DFM]{1}$/
   incidents: {
     details: -> { Faker::Lorem.sentence },
   },
+  individuals: {
+    first_name: -> { Faker::Name.first_name },
+    last_name: -> { Faker::Name.last_name },
+  },
   involved_children: {
     full_name: -> { Faker::Name.name },
   },

--- a/db/migrate/20230720124309_create_individuals.rb
+++ b/db/migrate/20230720124309_create_individuals.rb
@@ -1,0 +1,9 @@
+class CreateIndividuals < ActiveRecord::Migration[7.0]
+  def change
+    create_table :individuals, id: :uuid do |t|
+      t.string "first_name"
+      t.string "last_name"
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230720125540_add_opposable_to_opponents.rb
+++ b/db/migrate/20230720125540_add_opposable_to_opponents.rb
@@ -1,0 +1,7 @@
+class AddOpposableToOpponents < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :opponents, :opposable, polymorphic: true, index: { unique: true, algorithm: :concurrently }, type: :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_13_083234) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_20_124309) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -513,6 +513,13 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_13_083234) do
     t.datetime "updated_at", precision: nil, null: false
     t.date "told_on"
     t.index ["legal_aid_application_id"], name: "index_incidents_on_legal_aid_application_id"
+  end
+
+  create_table "individuals", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "first_name"
+    t.string "last_name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "involved_children", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_20_124309) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_20_125540) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -682,7 +682,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_20_124309) do
     t.integer "ccms_opponent_id"
     t.string "first_name"
     t.string "last_name"
+    t.string "opposable_type"
+    t.uuid "opposable_id"
     t.index ["legal_aid_application_id"], name: "index_opponents_on_legal_aid_application_id"
+    t.index ["opposable_type", "opposable_id"], name: "index_opponents_on_opposable", unique: true
   end
 
   create_table "opponents_applications", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|


### PR DESCRIPTION

## What
Add database structures necessary to migrate opponents to polymorphic individual opponents

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4284)

-  Create individuals table
-  Add opposable to opponents table, but null values allowed

First part of database changes required to migrate opponents to being a polymorphic
relationship, so that we can extend opponents to include organisations

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
