### PR TITLE
Fix chromedriver at v114

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -249,6 +249,7 @@ jobs:
     - run: bundle exec rails assets:precompile
     - browser-tools/install-chrome:
         chrome-version: 114.0.5735.90
+        replace-existing: true
     - browser-tools/install-chromedriver
     - run:
         name: Run integration tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   aws-cli: circleci/aws-cli@4.0.0
-  browser-tools: circleci/browser-tools@1.2.3
+  browser-tools: circleci/browser-tools@1.4.3
   slack: circleci/slack@4.5.2
 
 executors:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -247,9 +247,7 @@ jobs:
     - *install_js_packages
     - *save_js_packages_cache
     - run: bundle exec rails assets:precompile
-    - browser-tools/install-chrome:
-        chrome-version: 114.0.5735.90
-        replace-existing: true
+    - browser-tools/install-chrome
     - browser-tools/install-chromedriver
     - run:
         name: Run integration tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -247,7 +247,8 @@ jobs:
     - *install_js_packages
     - *save_js_packages_cache
     - run: bundle exec rails assets:precompile
-    - browser-tools/install-chrome
+    - browser-tools/install-chrome:
+        chrome-version: 114.0.5735.90
     - browser-tools/install-chromedriver
     - run:
         name: Run integration tests

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -41,11 +41,7 @@ allowed_sites = [
 
 WebMock.disable_net_connect!(allow: allowed_sites, net_http_connect_on_start: true)
 
-if Rails.env.test?
-  Webdrivers::Chromedriver.required_version = "114.0.5735.90"
-elsif ENV["CIRCLECI"]
-  Webdrivers::Chromedriver.required_version = "112.0.5615.49"
-end
+Webdrivers::Chromedriver.required_version = ENV["CIRCLECI"] ? "112.0.5615.49" : "114.0.5735.90"
 
 Webdrivers::Chromedriver.update
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -41,6 +41,7 @@ allowed_sites = [
 
 WebMock.disable_net_connect!(allow: allowed_sites, net_http_connect_on_start: true)
 
+Webdrivers::Chromedriver.required_version = "114.0.5735.90"
 Webdrivers::Chromedriver.update
 
 Capybara.register_driver :headless_chrome do |app|

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -41,7 +41,12 @@ allowed_sites = [
 
 WebMock.disable_net_connect!(allow: allowed_sites, net_http_connect_on_start: true)
 
-Webdrivers::Chromedriver.required_version = "114.0.5735.90"
+if Rails.env.test?
+  Webdrivers::Chromedriver.required_version = "114.0.5735.90"
+elsif ENV["CIRCLECI"]
+  Webdrivers::Chromedriver.required_version = "112.0.5615.49"
+end
+
 Webdrivers::Chromedriver.update
 
 Capybara.register_driver :headless_chrome do |app|


### PR DESCRIPTION
## What

- Temporarily fix chromedriver at v114 when running locally to allow cucumber feature tests to run without failing, due to this issue: https://github.com/titusfortner/webdrivers/issues/247
- Fix chromedriver at v112 in CircleCI as this is the only version that seems to be working at the moment. I tried fixing the version to v114 in circle in the CircleCI `config.yml` [using this guidance](https://circleci.com/developer/orbs/orb/circleci/browser-tools#commands-install-chrome) but it didn't work

There is a ticket in the backlog to come up with a more long term fix: https://dsdmoj.atlassian.net/browse/AP-4345

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
