### PR TITLE
Fix: DB Export clear production flag on restore

### DIFF
--- a/scripts/db_export.sh
+++ b/scripts/db_export.sh
@@ -37,5 +37,5 @@ Do you care about the current state of your dev DB? read on, otherwise skip to s
    PGOPTIONS='--client-min-messages=warning' psql -q -d apply_for_legal_aid_dev -c "drop schema public cascade" -c "create schema public"
 
 3. Restore the database
-   psql -q -P pager=off -d apply_for_legal_aid_dev -f ./tmp/$environment.anon.sql
+   psql -q -P pager=off -d apply_for_legal_aid_dev -f ./tmp/$environment.anon.sql && rails db:environment:set RAILS_ENV=development
 INSTRUCTIONS


### PR DESCRIPTION



## What

The suggested script shown to the user restores the file to the local DB but the internal metadata leaves the DB flagged as production.  This can cause issues if the user wants to reset or rebuild their local DB.

This PR adds the `&& rails db:environment:set RAILS_ENV=development` command to the psql restore line.  This ensures rails is set to be in development mode when the database is successfully restored


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
