### PR TITLE
Fix: Flickering test

### DIFF
--- a/spec/requests/providers/means/remove_dependant_controller_spec.rb
+++ b/spec/requests/providers/means/remove_dependant_controller_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe Providers::Means::RemoveDependantsController do
       let(:remove_dependant) { "not sure" }
 
       it "show errors" do
-        expect(response.body).to include(I18n.t("providers.means.remove_dependants.show.error", name: dependant.name))
+        expect(response.body).to include(I18n.t("providers.means.remove_dependants.show.error", name: html_compare(dependant.name)))
       end
     end
 
@@ -82,7 +82,7 @@ RSpec.describe Providers::Means::RemoveDependantsController do
       let(:params) { nil }
 
       it "show errors" do
-        expect(response.body).to include(I18n.t("providers.means.remove_dependants.show.error", name: dependant.name))
+        expect(response.body).to include(I18n.t("providers.means.remove_dependants.show.error", name: html_compare(dependant.name)))
       end
     end
   end


### PR DESCRIPTION




## What

This test failed locally when a name with an apostrophe was generated by faker.  Using the html_compare helper removes the chance of it happening again

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
