### PR TITLE
Fix: Opponent bug in anonymizer

### DIFF
--- a/db/anonymise/rules.rb
+++ b/db/anonymise/rules.rb
@@ -1,5 +1,11 @@
 require "faker"
 
+# If you see a "extra data after last expected column" when attempting to restore
+# it means that the final column in the table has been anonymized and it removes
+# the newline.  If this occurs on a new table, change the final column in the
+# table, check the output, and add a new line character after your new, anonymized,
+# data, e.g. ```last_name: -> { "#{Faker::Name.last_name}\n" },```
+
 NINO_REGEXP = /^[A-CEGHJ-PR-TW-Z]{1}[A-CEGHJ-NPR-TW-Z]{1}[0-9]{6}[A-DFM]{1}$/
 
 @rules = {
@@ -35,7 +41,7 @@ NINO_REGEXP = /^[A-CEGHJ-PR-TW-Z]{1}[A-CEGHJ-NPR-TW-Z]{1}[0-9]{6}[A-DFM]{1}$/
   },
   application_digests: {},
   attachments: {
-    original_filename: -> { "#{Faker::Bank.name}.pdf" },
+    original_filename: -> { "#{Faker::Bank.name}.pdf\n" },
   },
   attempts_to_settles: {
     attempts_made: -> { Faker::Lorem.sentence },
@@ -143,7 +149,7 @@ NINO_REGEXP = /^[A-CEGHJ-PR-TW-Z]{1}[A-CEGHJ-NPR-TW-Z]{1}[0-9]{6}[A-DFM]{1}$/
   offices_providers: {},
   opponents: {
     first_name: -> { Faker::Name.first_name },
-    last_name: -> { Faker::Name.last_name },
+    last_name: -> { "#{Faker::Name.last_name}\n" },
   },
   opponents_applications: {
     reason_for_applying: -> { Faker::Lorem.sentence },


### PR DESCRIPTION



## What

This occurred a few times when it was set up and I had not noticed the recurrence, or needed to use the affected tables

This adds an explanation to the anonymizer ruleset and updates the two affected tables

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
