### PR TITLE
Remove linebreak from opponents#last_name rule

### DIFF
--- a/db/anonymise/rules.rb
+++ b/db/anonymise/rules.rb
@@ -149,7 +149,7 @@ NINO_REGEXP = /^[A-CEGHJ-PR-TW-Z]{1}[A-CEGHJ-NPR-TW-Z]{1}[0-9]{6}[A-DFM]{1}$/
   offices_providers: {},
   opponents: {
     first_name: -> { Faker::Name.first_name },
-    last_name: -> { "#{Faker::Name.last_name}\n" },
+    last_name: -> { Faker::Name.last_name },
   },
   opponents_applications: {
     reason_for_applying: -> { Faker::Lorem.sentence },


### PR DESCRIPTION

## What
Remove linebreak from opponents#last_name rule

Breaks dump file's opponents COPY command by forcing
a linebreak mid record

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
