### PR TITLE
AP-3194: Update error handling in line with DAC review

### DIFF
--- a/app/views/providers/means/identify_types_of_incomes/show.html.erb
+++ b/app/views/providers/means/identify_types_of_incomes/show.html.erb
@@ -13,11 +13,11 @@
                                         classes: ["govuk-!-margin-bottom-5"],
                                         hint: { text: t("generic.select_all_that_apply") }) do %>
       <div class="deselect-group govuk-!-padding-bottom-1" data-deselect-ctrl="#legal-aid-application-none-selected-true-field">
-        <% TransactionType.credits.not_children.each do |transaction_type| %>
+        <% TransactionType.credits.not_children.each_with_index do |transaction_type, index| %>
           <%= form.govuk_check_box(
                 :transaction_type_ids,
                 transaction_type.id,
-                link_errors: true,
+                link_errors: index.zero?,
                 label: { text: t("transaction_types.names.providers.#{transaction_type.name}") },
                 hint: { text: t(".hints.#{transaction_type.name}", default: "") },
               ) %>

--- a/app/views/providers/means/identify_types_of_outgoings/show.html.erb
+++ b/app/views/providers/means/identify_types_of_outgoings/show.html.erb
@@ -12,11 +12,11 @@
                                         caption: { text: t("generic.client_means_caption"), size: "l" },
                                         hint: { text: t("generic.select_all_that_apply") } do %>
       <div class="deselect-group govuk-!-padding-bottom-1" data-deselect-ctrl="#legal-aid-application-none-selected-true-field">
-        <% TransactionType.debits.each do |transaction_type| %>
+        <% TransactionType.debits.each_with_index do |transaction_type, index| %>
           <%= form.govuk_check_box(
                 :transaction_type_ids,
                 transaction_type.id,
-                link_errors: true,
+                link_errors: index.zero?,
                 label: { text: t("transaction_types.names.providers.#{transaction_type.name}") },
                 hint: { text: t(".hints.#{transaction_type.name}", default: "") },
               ) %>


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3194)

This was applying the same error tag to _all_ transactions this applies the same pattern seen on the regular_* pages

Set the first input to be marked as an error so the standard error block at the top of the page has a target to link to while still allowing the listing of checkboxes for accessibility users

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
