### PR TITLE
Rubocop: reduce RSpec/ContextWording infractions

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -47,41 +47,11 @@ RSpec/AnyInstance:
     - 'spec/services/reports/merits_report_creator_spec.rb'
     - 'spec/services/reports/mis/application_details_report_spec.rb'
 
-# Offense count: 867
+# Offense count: 680
 # Configuration parameters: Prefixes, AllowedPatterns.
 # Prefixes: when, with, without
 RSpec/ContextWording:
   Exclude:
-    - 'spec/requests/providers/check_merits_answers_spec.rb'
-    - 'spec/requests/providers/check_passported_answers_spec.rb'
-    - 'spec/requests/providers/check_provider_answers_spec.rb'
-    - 'spec/requests/providers/client_completed_means_spec.rb'
-    - 'spec/requests/providers/concerns/draftable_spec.rb'
-    - 'spec/requests/providers/confirm_dwp_non_passported_applications_spec.rb'
-    - 'spec/requests/providers/confirm_offices_spec.rb'
-    - 'spec/requests/providers/email_addresses_spec.rb'
-    - 'spec/requests/providers/end_of_applications_spec.rb'
-    - 'spec/requests/providers/gateway_evidence_spec.rb'
-    - 'spec/requests/providers/has_evidence_of_benefits_spec.rb'
-    - 'spec/requests/providers/has_other_proceedings_controller_spec.rb'
-    - 'spec/requests/providers/income_summary_spec.rb'
-    - 'spec/requests/providers/invalid_logins_spec.rb'
-    - 'spec/requests/providers/legal_aid_applications_spec.rb'
-    - 'spec/requests/providers/means/dependants_controller_spec.rb'
-    - 'spec/requests/providers/means/has_dependants_controller_spec.rb'
-    - 'spec/requests/providers/means/remove_dependant_controller_spec.rb'
-    - 'spec/requests/providers/means/restrictions_spec.rb'
-    - 'spec/requests/providers/means/savings_and_investments_spec.rb'
-    - 'spec/requests/providers/means/shared_ownerships_spec.rb'
-    - 'spec/requests/providers/means/vehicles_spec.rb'
-    - 'spec/requests/providers/merits_task_lists_controller_spec.rb'
-    - 'spec/requests/providers/received_benefit_confirmations_spec.rb'
-    - 'spec/requests/providers/select_offices_spec.rb'
-    - 'spec/requests/providers/transactions_spec.rb'
-    - 'spec/requests/providers/uploaded_evidence_collection_spec.rb'
-    - 'spec/requests/providers/vehicles/ages_spec.rb'
-    - 'spec/requests/providers/vehicles/estimated_values_spec.rb'
-    - 'spec/requests/providers/vehicles/regular_uses_spec.rb'
     - 'spec/requests/saml_idp_spec.rb'
     - 'spec/requests/saml_sessions_spec.rb'
     - 'spec/requests/status_spec.rb'

--- a/spec/requests/providers/check_merits_answers_spec.rb
+++ b/spec/requests/providers/check_merits_answers_spec.rb
@@ -21,13 +21,13 @@ RSpec.describe "check merits answers requests" do
 
     before { allow(LegalFramework::MeritsTasksService).to receive(:call).with(application).and_return(smtl) }
 
-    context "unauthenticated" do
+    context "when the provider is unauthenticated" do
       before { subject }
 
       it_behaves_like "a provider not authenticated"
     end
 
-    context "logged in as an authenticated provider" do
+    context "when logged in as an authenticated provider" do
       before do
         login_as application.provider
         subject
@@ -135,12 +135,12 @@ RSpec.describe "check merits answers requests" do
 
     before { allow(LegalFramework::MeritsTasksService).to receive(:call).with(application).and_return(smtl) }
 
-    context "logged in as an authenticated provider" do
+    context "when logged in as an authenticated provider" do
       before do
         login_as application.provider
       end
 
-      context "Continue button pressed" do
+      context "when the continue button is pressed" do
         let(:submit_button) { { continue_button: "Continue" } }
 
         it "redirects to next page" do
@@ -150,7 +150,7 @@ RSpec.describe "check merits answers requests" do
       end
     end
 
-    context "unauthenticated" do
+    context "when the provider is unauthenticated" do
       before { subject }
 
       it_behaves_like "a provider not authenticated"
@@ -173,13 +173,13 @@ RSpec.describe "check merits answers requests" do
       create(:chances_of_success, :with_optional_text, proceeding: da001)
     end
 
-    context "unauthenticated" do
+    context "when the provider is unauthenticated" do
       before { subject }
 
       it_behaves_like "a provider not authenticated"
     end
 
-    context "logged in as an authenticated provider" do
+    context "when logged in as an authenticated provider" do
       before do
         allow(LegalFramework::MeritsTasksService).to receive(:call).with(application).and_return(smtl)
         login_as application.provider

--- a/spec/requests/providers/check_passported_answers_spec.rb
+++ b/spec/requests/providers/check_passported_answers_spec.rb
@@ -18,13 +18,13 @@ RSpec.describe "check passported answers requests" do
              own_vehicle:)
     end
 
-    context "unauthenticated" do
+    context "when the provider is unauthenticated" do
       before { subject }
 
       it_behaves_like "a provider not authenticated"
     end
 
-    context "logged in as an authenticated provider" do
+    context "when logged in as an authenticated provider" do
       before do
         login_as application.provider
         application.reload
@@ -68,7 +68,7 @@ RSpec.describe "check passported answers requests" do
         expect(node.text).not_to include(I18n.t(".generic.yes"))
       end
 
-      context "applicant does not have any savings" do
+      context "when the applicant does not have any savings" do
         let(:application) do
           create(:legal_aid_application,
                  :with_everything,
@@ -85,7 +85,7 @@ RSpec.describe "check passported answers requests" do
         end
       end
 
-      context "applicant does not have any other assets" do
+      context "when the applicant does not have any other assets" do
         let(:application) do
           create(:legal_aid_application,
                  :with_everything,
@@ -102,7 +102,7 @@ RSpec.describe "check passported answers requests" do
         end
       end
 
-      context "applicant does not have any capital restrictions" do
+      context "when the applicant does not have any capital restrictions" do
         let(:application) do
           create(:legal_aid_application,
                  :with_everything,
@@ -119,7 +119,7 @@ RSpec.describe "check passported answers requests" do
         end
       end
 
-      context "applicant does not have any capital" do
+      context "when the applicant does not have any capital" do
         let(:application) do
           create(:legal_aid_application,
                  :with_applicant,
@@ -166,7 +166,7 @@ RSpec.describe "check passported answers requests" do
         expect(application.reload).to be_checking_passported_answers
       end
 
-      context "applicant does not own home" do
+      context "when the applicant does not own home" do
         let(:application) do
           create(:legal_aid_application,
                  :with_everything,
@@ -187,7 +187,7 @@ RSpec.describe "check passported answers requests" do
         end
       end
 
-      context "applicant owns home without mortgage" do
+      context "when the applicant owns home without mortgage" do
         let(:application) do
           create(:legal_aid_application,
                  :with_everything,
@@ -203,7 +203,7 @@ RSpec.describe "check passported answers requests" do
         end
       end
 
-      context "applicant received england infected blood scheme" do
+      context "when the applicant received england infected blood scheme payments" do
         let!(:application) do
           create(:legal_aid_application,
                  :with_everything,
@@ -220,7 +220,7 @@ RSpec.describe "check passported answers requests" do
         end
       end
 
-      context "applicant is sole owner of home" do
+      context "when the applicant is sole owner of home" do
         let(:application) do
           create(:legal_aid_application,
                  :with_everything,
@@ -237,7 +237,7 @@ RSpec.describe "check passported answers requests" do
         end
       end
 
-      context "applicant does not have vehicle" do
+      context "when the applicant does not have vehicle" do
         let(:vehicle) { nil }
         let(:own_vehicle) { false }
 
@@ -271,12 +271,12 @@ RSpec.describe "check passported answers requests" do
     end
     let(:params) { {} }
 
-    context "logged in as an authenticated provider" do
+    context "when logged in as an authenticated provider" do
       before do
         login_as application.provider
       end
 
-      context "call to Check Financial Eligibility Service is successful" do
+      context "when the call to Check Financial Eligibility Service is successful" do
         before do
           allow(CFECivil::SubmissionBuilder).to receive(:call).with(application).and_return(true)
           subject
@@ -290,7 +290,7 @@ RSpec.describe "check passported answers requests" do
           expect(application.reload.provider_entering_merits?).to be true
         end
 
-        context "Form submitted using Save as draft button" do
+        context "when the Form is submitted using Save as draft button" do
           let(:params) { { draft_button: "Save as draft" } }
 
           it "redirects provider to provider's applications page" do
@@ -304,7 +304,7 @@ RSpec.describe "check passported answers requests" do
         end
       end
 
-      context "call to Check Financial Eligibility Service is unsuccessful" do
+      context "when the call to Check Financial Eligibility Service is unsuccessful" do
         before do
           allow(CFECivil::SubmissionBuilder).to receive(:call).with(application).and_return(false)
           subject
@@ -316,7 +316,7 @@ RSpec.describe "check passported answers requests" do
       end
     end
 
-    context "unauthenticated" do
+    context "when the provider is unauthenticated" do
       before { subject }
 
       it_behaves_like "a provider not authenticated"
@@ -334,13 +334,13 @@ RSpec.describe "check passported answers requests" do
              :with_proceedings)
     end
 
-    context "unauthenticated" do
+    context "when the provider is unauthenticated" do
       before { subject }
 
       it_behaves_like "a provider not authenticated"
     end
 
-    context "logged in as an authenticated provider" do
+    context "when logged in as an authenticated provider" do
       let(:application) do
         create(:legal_aid_application,
                :with_everything,

--- a/spec/requests/providers/check_provider_answers_spec.rb
+++ b/spec/requests/providers/check_provider_answers_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Providers::CheckProviderAnswersController do
         expect(unescaped_response_body).to include("Check your answers")
       end
 
-      context "delegated functions not used" do
+      context "when delegated functions were not used" do
         let(:application) do
           create(
             :legal_aid_application,
@@ -62,7 +62,7 @@ RSpec.describe Providers::CheckProviderAnswersController do
         end
       end
 
-      context "provider has used delegated functions" do
+      context "when the provider has used delegated functions" do
         let(:application) do
           create(
             :legal_aid_application,
@@ -424,7 +424,7 @@ RSpec.describe Providers::CheckProviderAnswersController do
       end
     end
 
-    context "When Save as draft clicked" do
+    context "when Save as draft clicked" do
       subject(:request) { patch "/providers/applications/#{application_id}/check_provider_answers/continue", params: }
 
       let(:params) do

--- a/spec/requests/providers/client_completed_means_spec.rb
+++ b/spec/requests/providers/client_completed_means_spec.rb
@@ -96,10 +96,10 @@ RSpec.describe Providers::ClientCompletedMeansController do
         login_as provider
       end
 
-      context "Continue button pressed" do
+      context "when the continue button is pressed" do
         let(:submit_button) { { continue_button: "Continue" } }
 
-        context "employment income data was received from HMRC" do
+        context "and employment income data was received from HMRC" do
           before do
             allow_any_instance_of(Applicant).to receive(:hmrc_employment_income?).and_return(true)
             allow_any_instance_of(Applicant).to receive(:has_multiple_employments?).and_return(false)
@@ -111,7 +111,7 @@ RSpec.describe Providers::ClientCompletedMeansController do
           end
         end
 
-        context "unknown result obtained from HMRC::StatusAnalyzer" do
+        context "and an unknown result was obtained from HMRC::StatusAnalyzer" do
           before do
             allow(HMRC::StatusAnalyzer).to receive(:call).with(legal_aid_application).and_return(:xxx)
           end
@@ -121,7 +121,7 @@ RSpec.describe Providers::ClientCompletedMeansController do
           end
         end
 
-        context "no employment income data was received from HMRC" do
+        context "and no employment income data was received from HMRC" do
           before { allow_any_instance_of(LegalAidApplication).to receive(:hmrc_employment_income?).and_return(false) }
 
           it "redirects to the no employed income page" do
@@ -130,7 +130,7 @@ RSpec.describe Providers::ClientCompletedMeansController do
           end
         end
 
-        context "employment income data for multiple jobs was received from HMRC" do
+        context "and employment income data for multiple jobs was received from HMRC" do
           before do
             allow_any_instance_of(LegalAidApplication).to receive(:hmrc_employment_income?).and_return(true)
             allow_any_instance_of(LegalAidApplication).to receive(:has_multiple_employments?).and_return(true)
@@ -142,7 +142,7 @@ RSpec.describe Providers::ClientCompletedMeansController do
           end
         end
 
-        context "transactions exist, and applicant is not employed" do
+        context "and transactions exist, and applicant is not employed" do
           let(:submit_button) { { continue_button: "Continue" } }
           let(:transaction_type) { create(:transaction_type, :pension) }
           let(:applicant) { create(:applicant, :not_employed) }
@@ -164,7 +164,7 @@ RSpec.describe Providers::ClientCompletedMeansController do
         end
       end
 
-      context "Save as draft button pressed" do
+      context "when the Save as draft is button pressed" do
         let(:submit_button) { { draft_button: "Save as draft" } }
 
         it "redirects provider to provider's applications page" do

--- a/spec/requests/providers/concerns/draftable_spec.rb
+++ b/spec/requests/providers/concerns/draftable_spec.rb
@@ -25,10 +25,10 @@ RSpec.describe Providers::Draftable do
       login_as provider
     end
 
-    context "Form submitted using Continue button" do
+    context "when the Form is submitted using Continue button" do
       let(:submit_button) { { anything: "That is not draft_button" } }
 
-      context "when the application is in draft" do
+      context "and the application is in draft" do
         let(:application) { create(:legal_aid_application, :draft) }
 
         it "redirects provider to next step of the submission" do
@@ -42,7 +42,7 @@ RSpec.describe Providers::Draftable do
       end
     end
 
-    context "Form submitted using Save as draft button" do
+    context "when the Form is submitted using Save as draft button" do
       let(:submit_button) do
         { draft_button: "Save as draft" }
       end
@@ -86,7 +86,7 @@ RSpec.describe Providers::Draftable do
         end
       end
 
-      context "with partial valid input" do
+      context "when the there is partially valid input" do
         let(:params) do
           {
             applicant: {

--- a/spec/requests/providers/confirm_dwp_non_passported_applications_spec.rb
+++ b/spec/requests/providers/confirm_dwp_non_passported_applications_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe Providers::ConfirmDWPNonPassportedApplicationsController do
   end
 
   describe "PATCH /providers/applications/:legal_aid_application_id/confirm_dwp_non_passported_applications" do
-    context "submitting with Continue button" do
+    context "when submitting with the Continue button" do
       subject { patch "/providers/applications/#{application_id}/confirm_dwp_non_passported_applications", params: }
 
       let(:params) do
@@ -88,7 +88,7 @@ RSpec.describe Providers::ConfirmDWPNonPassportedApplicationsController do
         allow(HMRC::CreateResponsesService).to receive(:call).with(application).and_return(double(HMRC::CreateResponsesService, call: %w[one two]))
       end
 
-      context "the results are correct" do
+      context "and the results are correct" do
         let(:params) do
           {
             continue_button: "Continue",
@@ -124,7 +124,7 @@ RSpec.describe Providers::ConfirmDWPNonPassportedApplicationsController do
         end
       end
 
-      context "the solicitor wants to override the results with a non joint benefit" do
+      context "and the solicitor wants to override the results with a non joint benefit" do
         before { allow(Setting).to receive(:partner_means_assessment?).and_return(true) }
 
         let(:application) { create(:legal_aid_application, :with_applicant_and_partner, :with_proceedings, :at_checking_applicant_details) }
@@ -165,7 +165,7 @@ RSpec.describe Providers::ConfirmDWPNonPassportedApplicationsController do
         end
       end
 
-      context "the solicitor wants to override the results with a partner" do
+      context "and the solicitor wants to override the results with a partner" do
         before { allow(Setting).to receive(:partner_means_assessment?).and_return(true) }
 
         let(:application) { create(:legal_aid_application, :with_proceedings, :at_checking_applicant_details, :with_applicant_and_partner) }
@@ -206,7 +206,7 @@ RSpec.describe Providers::ConfirmDWPNonPassportedApplicationsController do
         end
       end
 
-      context "the solicitor does not select a radio button" do
+      context "and the solicitor does not select a radio button" do
         it "displays an error" do
           subject
           expect(response.body).to include(I18n.t("providers.confirm_dwp_non_passported_applications.show.error"))
@@ -214,7 +214,7 @@ RSpec.describe Providers::ConfirmDWPNonPassportedApplicationsController do
       end
     end
 
-    context "submitting with Save As Draft button" do
+    context "when submitting with the Save As Draft button" do
       subject { patch "/providers/applications/#{application_id}/confirm_dwp_non_passported_applications", params: }
 
       let(:params) do

--- a/spec/requests/providers/confirm_offices_spec.rb
+++ b/spec/requests/providers/confirm_offices_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "provider confirm office" do
       it_behaves_like "a provider not authenticated"
     end
 
-    context "invalid login" do
+    context "when the provider uses an invalid login" do
       let(:provider) { create(:provider, invalid_login_details: "role") }
 
       before do
@@ -46,7 +46,7 @@ RSpec.describe "provider confirm office" do
         expect(session["page_history_id"]).not_to be_nil
       end
 
-      context "firm has only one office" do
+      context "when the firm has only one office" do
         let!(:office) { nil }
 
         it "assigns office 2 to the provider" do
@@ -58,7 +58,7 @@ RSpec.describe "provider confirm office" do
         end
       end
 
-      context "provider has not selected office" do
+      context "when the provider has not selected an office" do
         let(:provider) { create(:provider, firm:, selected_office: nil) }
 
         it "redirects to the select office page" do
@@ -83,7 +83,7 @@ RSpec.describe "provider confirm office" do
         expect(response).to redirect_to providers_legal_aid_applications_path
       end
 
-      context "invalid params - nothing specified" do
+      context "when the params are invalid - nothing specified" do
         let(:params) { {} }
 
         it "returns http_success" do
@@ -95,7 +95,7 @@ RSpec.describe "provider confirm office" do
         end
       end
 
-      context "no is selected" do
+      context "when no is selected" do
         let(:params) { { binary_choice_form: { confirm_office: "false" } } }
 
         it "redirects to the office select page" do

--- a/spec/requests/providers/email_addresses_spec.rb
+++ b/spec/requests/providers/email_addresses_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe "update client email address before application confirmation" do
         login_as provider
       end
 
-      context "Continue button pressed" do
+      context "and the Continue button is pressed" do
         let(:submit_button) { { continue_button: "Continue" } }
 
         it "redirects to next page" do

--- a/spec/requests/providers/end_of_applications_spec.rb
+++ b/spec/requests/providers/end_of_applications_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe Providers::EndOfApplicationsController do
       expect(response).to redirect_to(flow_forward_path)
     end
 
-    context "Submitted using draft button" do
+    context "when Submitted using the draft button" do
       let(:params) { { draft_button: "Save as draft" } }
 
       it "redirects provider to provider's applications page" do

--- a/spec/requests/providers/gateway_evidence_spec.rb
+++ b/spec/requests/providers/gateway_evidence_spec.rb
@@ -66,7 +66,7 @@ module Providers
         expect(response).to redirect_to providers_legal_aid_application_check_merits_answers_path(legal_aid_application)
       end
 
-      context "upload button pressed" do
+      context "when the upload button is pressed" do
         let(:params_gateway_evidence) do
           {
             original_file:,
@@ -84,7 +84,7 @@ module Providers
           expect(response).to have_http_status(:ok)
         end
 
-        context "word document" do
+        context "and a word document is uploaded" do
           let(:original_file) { uploaded_file("spec/fixtures/files/documents/hello_world.docx", "application/vnd.openxmlformats-officedocument.wordprocessingml.document") }
 
           it "updates the record" do
@@ -147,7 +147,7 @@ module Providers
           end
         end
 
-        context "no file chosen" do
+        context "and no file is chosen" do
           let(:original_file) { nil }
 
           it "does not update the record" do
@@ -162,7 +162,7 @@ module Providers
           end
         end
 
-        context "virus scanner is down" do
+        context "when the virus scanner is down" do
           before do
             allow_any_instance_of(MalwareScanResult).to receive(:scanner_working).with(any_args).and_return(false)
           end
@@ -175,9 +175,9 @@ module Providers
         end
       end
 
-      context "Continue button pressed" do
-        context "model has no files attached previously" do
-          context "file is invalid content type" do
+      context "when the Continue button is pressed" do
+        context "and model has no files attached previously" do
+          context "and file is invalid content type" do
             let(:original_file) { uploaded_file("spec/fixtures/files/zip.zip", "application/zip") }
 
             it "does not save the object and raise an error" do
@@ -188,7 +188,7 @@ module Providers
             end
           end
 
-          context "no files chosen" do
+          context "and no files are chosen" do
             let(:original_file) { nil }
 
             it "does not add a record" do
@@ -202,7 +202,7 @@ module Providers
             end
           end
 
-          context "file is invalid mime type but has valid content_type" do
+          context "and the file has an invalid mime type but has valid content_type" do
             let(:original_file) { uploaded_file("spec/fixtures/files/zip.zip", "application/zip") }
 
             before do
@@ -217,7 +217,7 @@ module Providers
             end
           end
 
-          context "file is too big" do
+          context "when the file is too big" do
             before { allow(File).to receive(:size).and_return(9_437_184) }
 
             it "does not save the object and raise an error" do
@@ -228,7 +228,7 @@ module Providers
             end
           end
 
-          context "file is empty" do
+          context "when the file is empty" do
             let(:original_file) { uploaded_file("spec/fixtures/files/empty_file.pdf", "application/pdf") }
 
             it "does not save the object and raise an error" do
@@ -239,7 +239,7 @@ module Providers
             end
           end
 
-          context "file contains a malware", clamav: true do
+          context "when the file contains malware", clamav: true do
             let(:original_file) { uploaded_file("spec/fixtures/files/malware.doc") }
 
             it "does not save the object and raise an error" do
@@ -251,19 +251,17 @@ module Providers
           end
         end
 
-        context "model already has files attached" do
+        context "when the model already has files attached" do
           before { create(:gateway_evidence, :with_original_file_attached, legal_aid_application:) }
 
-          context "additional file uploaded" do
-            it "attaches the file" do
-              subject
-              expect(gateway_evidence.original_attachments.count).to eq 2
-            end
+          it "attaches the additional file" do
+            subject
+            expect(gateway_evidence.original_attachments.count).to eq 2
           end
         end
       end
 
-      context "Save as draft" do
+      context "when the Save as draft button is clicked" do
         let(:button_clicked) { draft_button }
 
         it "updates the record" do
@@ -276,7 +274,7 @@ module Providers
           expect(response).to redirect_to provider_draft_endpoint
         end
 
-        context "nothing specified" do
+        context "and no file is specified" do
           let(:original_file) { nil }
 
           it "redirects to provider draft endpoint" do

--- a/spec/requests/providers/has_evidence_of_benefits_spec.rb
+++ b/spec/requests/providers/has_evidence_of_benefits_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Providers::HasEvidenceOfBenefitsController do
       it_behaves_like "a provider not authenticated"
     end
 
-    context "evidence upload" do
+    context "when evidence has been uploaded" do
       it "does not mention the caseworker in the main hint" do
         expect(response.body).to include I18n.t("providers.has_evidence_of_benefits.show.evidence_hint")
       end
@@ -78,7 +78,7 @@ RSpec.describe Providers::HasEvidenceOfBenefitsController do
       expect(legal_aid_application.reload.state).to eq "applicant_details_checked"
     end
 
-    context "application state is already applicant_details_checked" do
+    context "when the application state is already applicant_details_checked" do
       let(:legal_aid_application) { create(:legal_aid_application, :with_dwp_override, :applicant_details_checked) }
 
       it "does not update the state" do
@@ -95,7 +95,7 @@ RSpec.describe Providers::HasEvidenceOfBenefitsController do
       expect(response).to redirect_to(providers_legal_aid_application_substantive_application_path(legal_aid_application))
     end
 
-    context "does not use delegated functions" do
+    context "when the provider has not used delegated functions" do
       let(:legal_aid_application) { create(:legal_aid_application, :with_dwp_override, :applicant_details_checked) }
 
       it "redirects to the upload capital introductions page" do
@@ -107,7 +107,7 @@ RSpec.describe Providers::HasEvidenceOfBenefitsController do
       expect(legal_aid_application.reload.state_machine).to be_a PassportedStateMachine
     end
 
-    context "choose no" do
+    context "when the provider chose no" do
       let(:has_evidence_of_benefit) { "false" }
 
       it "updates the dwp_override model" do
@@ -124,7 +124,7 @@ RSpec.describe Providers::HasEvidenceOfBenefitsController do
       end
     end
 
-    context "choose nothing" do
+    context "when the provider has chosen nothing" do
       let(:has_evidence_of_benefit) { nil }
 
       it "show errors" do
@@ -139,7 +139,7 @@ RSpec.describe Providers::HasEvidenceOfBenefitsController do
       end
     end
 
-    context "Form submitted with Save as draft button" do
+    context "when the form is submitted with the Save as draft button" do
       let(:params) { { draft_button: "Save as draft" } }
 
       it "redirects to the list of applications" do

--- a/spec/requests/providers/has_other_proceedings_controller_spec.rb
+++ b/spec/requests/providers/has_other_proceedings_controller_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Providers::HasOtherProceedingsController do
   describe "PATCH /providers/:application_id/has_other_proceedings" do
     subject! { patch providers_legal_aid_application_has_other_proceedings_path(legal_aid_application), params: }
 
-    context "Form submitted with Save as draft button" do
+    context "when the Form is submitted with the Save as draft button" do
       let(:params) { { legal_aid_application: { has_other_proceeding: "" }, draft_button: "Save and come back later" } }
 
       it "redirects to the list of applications" do
@@ -49,7 +49,7 @@ RSpec.describe Providers::HasOtherProceedingsController do
       end
     end
 
-    context "choose yes" do
+    context "when the provider chose yes" do
       let(:params) { { legal_aid_application: { has_other_proceeding: "true" } } }
 
       it "redirects to the page to add another proceeding type" do
@@ -57,7 +57,7 @@ RSpec.describe Providers::HasOtherProceedingsController do
       end
     end
 
-    context "choose no" do
+    context "when the provider chose no" do
       let(:params) { { legal_aid_application: { has_other_proceeding: "false" } } }
 
       it "redirects to the delegated functions page" do
@@ -95,7 +95,7 @@ RSpec.describe Providers::HasOtherProceedingsController do
       end
     end
 
-    context "choose nothing" do
+    context "when the provider chose nothing" do
       let(:params) { { legal_aid_application: { has_other_proceeding: "" }, continue_button: "Save and continue" } }
 
       it "stays on the page if there is a validation error" do
@@ -104,8 +104,8 @@ RSpec.describe Providers::HasOtherProceedingsController do
       end
     end
 
-    context "with only Section 8 proceedings selected" do
-      context "choose no" do
+    context "when only Section 8 proceedings selected" do
+      context "and the provider chose no" do
         let(:legal_aid_application) { create(:legal_aid_application, :with_proceedings, assign_lead_proceeding: false, explicit_proceedings: [:se013]) }
         let(:params) { { legal_aid_application: { has_other_proceeding: "false" } } }
 
@@ -115,7 +115,7 @@ RSpec.describe Providers::HasOtherProceedingsController do
         end
       end
 
-      context "choose yes" do
+      context "and the provider chose yes" do
         let(:params) { { legal_aid_application: { has_other_proceeding: "true" } } }
 
         it "redirects to the page to add another proceeding type" do
@@ -124,7 +124,7 @@ RSpec.describe Providers::HasOtherProceedingsController do
       end
     end
 
-    context "with at least one domestic abuse and at least one section 8 proceeding" do
+    context "when at least one domestic abuse and at least one section 8 proceeding" do
       let(:legal_aid_application) do
         create(:legal_aid_application,
                :with_proceedings,
@@ -156,7 +156,7 @@ RSpec.describe Providers::HasOtherProceedingsController do
       }
     end
 
-    context "remove proceeding" do
+    context "when a proceeding is removed" do
       it "removes one proceeding" do
         expect { subject }.to change { legal_aid_application.proceedings.count }.by(-1)
       end
@@ -171,7 +171,7 @@ RSpec.describe Providers::HasOtherProceedingsController do
         expect(response.body).to include("You have added 1 proceeding")
       end
 
-      context "delete lead proceeding" do
+      context "and it's the lead proceeding" do
         subject { delete providers_legal_aid_application_has_other_proceedings_path(legal_aid_application), params: }
 
         let(:params) do
@@ -185,7 +185,7 @@ RSpec.describe Providers::HasOtherProceedingsController do
       end
     end
 
-    context "remove all proceedings" do
+    context "when all proceedings are removed" do
       let(:other_params) do
         { ccms_code: legal_aid_application.proceedings.first.ccms_code }
       end

--- a/spec/requests/providers/income_summary_spec.rb
+++ b/spec/requests/providers/income_summary_spec.rb
@@ -43,14 +43,14 @@ RSpec.describe Providers::IncomeSummaryController do
       it_behaves_like "a provider not authenticated"
     end
 
-    context "not all transaction types selected" do
+    context "when not all transaction types selected" do
       it "displays an Add additional income types section" do
         subject
         expect(response.body).to include(I18n.t("providers.income_summary.add_other_income.add_other_income"))
       end
     end
 
-    context "all transaction types selected" do
+    context "when all transaction types selected" do
       before do
         legal_aid_application.transaction_types << maintenance
         legal_aid_application.transaction_types << pension
@@ -62,7 +62,7 @@ RSpec.describe Providers::IncomeSummaryController do
       end
     end
 
-    context "with assigned (by type) transactions" do
+    context "when assigned (by type) transactions" do
       let(:applicant) { create(:applicant) }
       let(:bank_provider) { create(:bank_provider, applicant:) }
       let(:bank_account) { create(:bank_account, bank_provider:) }
@@ -90,7 +90,7 @@ RSpec.describe Providers::IncomeSummaryController do
 
     before { subject }
 
-    context "with no outgoings categories previously selected" do
+    context "when no outgoings categories previously selected" do
       let(:legal_aid_application) do
         create(:legal_aid_application,
                :with_applicant,
@@ -105,7 +105,7 @@ RSpec.describe Providers::IncomeSummaryController do
       end
     end
 
-    context "with outgoings categories" do
+    context "when outgoings categories are shown" do
       let!(:maintenance_out) { create(:transaction_type, :debit, name: "maintenance_out") }
       let(:legal_aid_application) do
         create(:legal_aid_application,
@@ -126,7 +126,7 @@ RSpec.describe Providers::IncomeSummaryController do
       it_behaves_like "a provider not authenticated"
     end
 
-    context "Form submitted with Save as draft button" do
+    context "when the Form is submitted with the Save as draft button" do
       let(:submit_button) { { draft_button: "Save as draft" } }
 
       it "redirects to the list of applications" do
@@ -134,7 +134,7 @@ RSpec.describe Providers::IncomeSummaryController do
       end
     end
 
-    context "The transaction type category has no bank transactions" do
+    context "when the transaction type category has no bank transactions" do
       subject { post providers_legal_aid_application_income_summary_index_path(legal_aid_application), params: submit_button }
 
       let(:applicant) { create(:applicant) }
@@ -156,7 +156,7 @@ RSpec.describe Providers::IncomeSummaryController do
       end
     end
 
-    context "no disregarded benefits are categorised" do
+    context "when no disregarded benefits are categorised" do
       let(:excluded_benefits) { create(:transaction_type, :credit, name: "excluded_benefits") }
       let(:legal_aid_application) { create(:legal_aid_application, :with_non_passported_state_machine, applicant:, transaction_types: [excluded_benefits]) }
 

--- a/spec/requests/providers/invalid_logins_spec.rb
+++ b/spec/requests/providers/invalid_logins_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "provider confirm office" do
       get providers_invalid_login_path
     end
 
-    context "no CCMS_Apply role" do
+    context "when there is no CCMS_Apply role" do
       let(:detail) { "role" }
 
       it "has the no permissions title" do
@@ -22,7 +22,7 @@ RSpec.describe "provider confirm office" do
       end
     end
 
-    context "no user on CCMS Provider details API" do
+    context "when there is no user on CCMS Provider details API" do
       let(:detail) { "api_details_user_not_found" }
 
       it "has the no permissions title" do
@@ -34,7 +34,7 @@ RSpec.describe "provider confirm office" do
       end
     end
 
-    context "API error" do
+    context "when the provider details API returns an error" do
       let(:detail) { "provider_details_api_error" }
 
       it "has the no error title" do

--- a/spec/requests/providers/legal_aid_applications_spec.rb
+++ b/spec/requests/providers/legal_aid_applications_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "providers legal aid application requests" do
         expect(response).to have_http_status(:ok)
       end
 
-      context "provider is not a portal_enabled user" do
+      context "when the provider is not a portal_enabled user" do
         let(:provider) { create(:provider, :without_portal_enabled) }
 
         it "redirects to error page" do

--- a/spec/requests/providers/means/dependants_controller_spec.rb
+++ b/spec/requests/providers/means/dependants_controller_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe Providers::Means::DependantsController do
       end
     end
 
-    context "while provider checking answers of citizen" do
+    context "when provider is checking answers of citizen" do
       let(:legal_aid_application) { create(:legal_aid_application, :with_applicant, :with_non_passported_state_machine, :checking_means_income) }
 
       it "redirects to the has other dependants page" do

--- a/spec/requests/providers/means/has_dependants_controller_spec.rb
+++ b/spec/requests/providers/means/has_dependants_controller_spec.rb
@@ -57,8 +57,8 @@ RSpec.describe Providers::Means::HasDependantsController do
       end
     end
 
-    context "valid params" do
-      context "when provider answers yes" do
+    context "when there are valid params" do
+      context "and the provider answers yes" do
         let(:params) { { legal_aid_application: { has_dependants: "true" } } }
 
         it "sets has_dependants to true" do
@@ -71,7 +71,7 @@ RSpec.describe Providers::Means::HasDependantsController do
         end
       end
 
-      context "when provider answers no" do
+      context "and the provider answers no" do
         let(:params) { { legal_aid_application: { has_dependants: "false" } } }
 
         it "sets has_dependants to false" do
@@ -124,7 +124,7 @@ RSpec.describe Providers::Means::HasDependantsController do
       end
     end
 
-    context "invalid params - nothing specified" do
+    context "when the params are invalid - nothing specified" do
       let(:params) { {} }
 
       it "returns http_success" do

--- a/spec/requests/providers/means/remove_dependant_controller_spec.rb
+++ b/spec/requests/providers/means/remove_dependant_controller_spec.rb
@@ -37,10 +37,10 @@ RSpec.describe Providers::Means::RemoveDependantsController do
       }
     end
 
-    context "choose yes" do
+    context "when the provider chose yes" do
       let(:remove_dependant) { "true" }
 
-      context "when no dependants remain after deletion" do
+      context "and no dependants remain after deletion" do
         it "redirects to the has_dependants page" do
           expect(response).to redirect_to(providers_legal_aid_application_means_has_dependants_path(legal_aid_application))
         end
@@ -53,7 +53,7 @@ RSpec.describe Providers::Means::RemoveDependantsController do
         end
       end
 
-      context "when dependants remain after the deletion" do
+      context "and dependants remain after the deletion" do
         let(:extra_dependant_count) { 1 }
 
         it "redirects to the has_other_dependants page" do
@@ -62,7 +62,7 @@ RSpec.describe Providers::Means::RemoveDependantsController do
       end
     end
 
-    context "choose no" do
+    context "when the provider chose no" do
       let(:remove_dependant) { "false" }
 
       it "redirects to the has other dependants page" do
@@ -70,15 +70,15 @@ RSpec.describe Providers::Means::RemoveDependantsController do
       end
     end
 
-    context "try a hack to submit something else" do
+    context "when someone tries a hack to submit something else" do
       let(:remove_dependant) { "not sure" }
 
-      it "show errors" do
+      it "shows errors" do
         expect(response.body).to include(I18n.t("providers.means.remove_dependants.show.error", name: html_compare(dependant.name)))
       end
     end
 
-    context "choose nothing" do
+    context "when the provider choose nothing" do
       let(:params) { nil }
 
       it "show errors" do

--- a/spec/requests/providers/means/restrictions_spec.rb
+++ b/spec/requests/providers/means/restrictions_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe "provider restrictions request" do
         subject
       end
 
-      context "Form submitted with continue button" do
+      context "and the Form is submitted with continue button" do
         let(:submit_button) do
           {
             continue_button: "Continue",
@@ -95,7 +95,7 @@ RSpec.describe "provider restrictions request" do
           end
         end
 
-        context "provider checking answers on passported route" do
+        context "when provider is checking answers on passported route" do
           let(:application) { create(:legal_aid_application, :with_applicant, :passported, :with_passported_state_machine, :checking_passported_answers) }
 
           it "redirects to check passported answers" do
@@ -103,14 +103,14 @@ RSpec.describe "provider restrictions request" do
           end
         end
 
-        context "invalid params" do
+        context "when submitted with invalid params" do
           let(:restrictions_details) { "" }
 
           it "displays error" do
             expect(response.body).to include(translation_for(:restrictions_details, "blank"))
           end
 
-          context "no params" do
+          context "and there are no params" do
             let(:has_restrictions) { "" }
 
             it "displays error" do
@@ -119,7 +119,7 @@ RSpec.describe "provider restrictions request" do
           end
         end
 
-        context "provider checking answers on nonpassported route" do
+        context "when the provider is checking answers on nonpassported route" do
           let(:application) { create(:legal_aid_application, :with_applicant, :with_non_passported_state_machine, :checking_non_passported_means) }
 
           it "redirects to the check capital answers page" do
@@ -129,14 +129,14 @@ RSpec.describe "provider restrictions request" do
         end
       end
 
-      context "Form submitted with Save as draft button" do
+      context "when the Form is submitted with Save as draft button" do
         let(:submit_button) do
           {
             draft_button: "Save as draft",
           }
         end
 
-        context "after success" do
+        describe "after success" do
           before do
             login_as provider
             subject

--- a/spec/requests/providers/means/savings_and_investments_spec.rb
+++ b/spec/requests/providers/means/savings_and_investments_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "providers savings and investments" do
       end
 
       describe "back link" do
-        context "applicant does not own home" do
+        context "when the applicant does not own home" do
           before { get providers_legal_aid_application_means_own_home_path(application) }
 
           it "points to the own home page" do
@@ -38,7 +38,7 @@ RSpec.describe "providers savings and investments" do
           end
         end
 
-        context "applicant owns home with shared ownership" do
+        context "when the applicant owns home with shared ownership" do
           before { get providers_legal_aid_application_means_percentage_home_path(application) }
 
           it "points to percentage owned page" do
@@ -47,7 +47,7 @@ RSpec.describe "providers savings and investments" do
           end
         end
 
-        context "applicant owns home sole ownership" do
+        context "when the applicant owns home sole ownership" do
           before { get providers_legal_aid_application_means_shared_ownership_path(application) }
 
           it "points to the shared ownership page" do
@@ -78,14 +78,14 @@ RSpec.describe "providers savings and investments" do
         login_as application.provider
       end
 
-      context "Submitted with Continue button" do
+      context "and Submitted with Continue button" do
         let(:submit_button) do
           {
             continue_button: "Continue",
           }
         end
 
-        context "not in checking passported answers state" do
+        context "when not in checking passported answers state" do
           it "updates the cash amount" do
             expect { subject }.to change { savings_amount.reload.cash.to_s }.to(cash)
           end
@@ -101,7 +101,7 @@ RSpec.describe "providers savings and investments" do
             expect(response).to redirect_to(providers_legal_aid_application_means_other_assets_path(application))
           end
 
-          context "none of these checkbox is selected" do
+          context "when none of these checkbox is selected" do
             let(:params) { { savings_amount: { none_selected: "true" } } }
 
             it "sets none_selected to true" do
@@ -110,7 +110,7 @@ RSpec.describe "providers savings and investments" do
             end
           end
 
-          context "with invalid input" do
+          context "when submitted with invalid input" do
             let(:cash) { "fifty" }
 
             it "renders successfully" do
@@ -126,7 +126,7 @@ RSpec.describe "providers savings and investments" do
             end
           end
 
-          context "checkbox checked with no value entered" do
+          context "when checkbox checked and no value entered" do
             let(:params) do
               {
                 savings_amount: {
@@ -157,7 +157,7 @@ RSpec.describe "providers savings and investments" do
             expect(response).to redirect_to(providers_legal_aid_application_means_restrictions_path(application))
           end
 
-          context "no savings" do
+          context "and no savings" do
             let(:offline_current_accounts) { 0 }
             let(:offline_savings_accounts) { 0 }
 
@@ -167,7 +167,7 @@ RSpec.describe "providers savings and investments" do
           end
         end
 
-        context "provider checking citizen's answers" do
+        context "when checking citizen's answers" do
           let(:application) { create(:legal_aid_application, :with_applicant, :with_savings_amount, :with_non_passported_state_machine, :checking_non_passported_means) }
           let(:submit_button) do
             {
@@ -183,7 +183,7 @@ RSpec.describe "providers savings and investments" do
         end
       end
 
-      context "Submitted with Save as draft button" do
+      context "when Submitted with Save as draft button" do
         let(:submit_button) do
           {
             draft_button: "Save as draft",
@@ -210,7 +210,7 @@ RSpec.describe "providers savings and investments" do
           expect(response).to redirect_to providers_legal_aid_applications_path
         end
 
-        context "with invalid input" do
+        context "when submitted with invalid input" do
           let(:cash) { "fifty" }
 
           it "renders successfully" do

--- a/spec/requests/providers/means/shared_ownerships_spec.rb
+++ b/spec/requests/providers/means/shared_ownerships_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "providers shared ownership request test" do
       end
 
       describe "back link" do
-        context "applicant owns with mortgage" do
+        context "when the applicant owns with mortgage" do
           before { get providers_legal_aid_application_means_outstanding_mortgage_path(legal_aid_application) }
 
           it "points to oustanding mortgage page" do
@@ -39,7 +39,7 @@ RSpec.describe "providers shared ownership request test" do
           end
         end
 
-        context "applicant owns home outright" do
+        context "when the applicant owns home outright" do
           before { get providers_legal_aid_application_means_property_value_path(legal_aid_application) }
 
           it "points to the property value page" do
@@ -69,14 +69,14 @@ RSpec.describe "providers shared ownership request test" do
         login_as legal_aid_application.provider
       end
 
-      context "Submitted with Continue button" do
+      context "and has Submitted with Continue button" do
         let(:submit_button) do
           {
             continue_button: "Continue",
           }
         end
 
-        context "Yes path" do
+        describe "Yes path" do
           let!(:shared_ownership) { LegalAidApplication::SHARED_OWNERSHIP_YES_REASONS.first }
 
           it "does NOT create an new application record" do
@@ -94,7 +94,7 @@ RSpec.describe "providers shared ownership request test" do
             expect(legal_aid_application.reload.shared_ownership).to eq shared_ownership
           end
 
-          context "while checking answers" do
+          context "when checking answers" do
             let(:legal_aid_application) { create(:legal_aid_application, :with_applicant, :checking_passported_answers) }
 
             it "redirects to the next step in flow" do
@@ -104,7 +104,7 @@ RSpec.describe "providers shared ownership request test" do
           end
         end
 
-        context "No path" do
+        describe "No path" do
           let!(:shared_ownership) { LegalAidApplication::SHARED_OWNERSHIP_NO_REASONS.first }
 
           it "does NOT create an new application record" do
@@ -123,7 +123,7 @@ RSpec.describe "providers shared ownership request test" do
             expect(legal_aid_application.percentage_home).to eq 100.0
           end
 
-          context "while checking answers" do
+          context "when checking answers" do
             let(:legal_aid_application) { create(:legal_aid_application, :with_applicant, :with_passported_state_machine, :checking_passported_answers) }
 
             it "redirects to check answers page" do
@@ -133,7 +133,7 @@ RSpec.describe "providers shared ownership request test" do
           end
         end
 
-        context "with an invalid param" do
+        describe "with an invalid param" do
           let(:params) { { legal_aid_application: { shared_ownership: "" } } }
 
           it "re-renders the form with the validation errors" do
@@ -145,14 +145,14 @@ RSpec.describe "providers shared ownership request test" do
         end
       end
 
-      context "submitted with a Save as Draft button" do
+      context "when submitted with a Save as Draft button" do
         let(:submit_button) do
           {
             draft_button: "Save as draft",
           }
         end
 
-        context "Yes path" do
+        describe "Yes path" do
           let!(:shared_ownership) { LegalAidApplication::SHARED_OWNERSHIP_YES_REASONS.first }
 
           it "does NOT create an new application record" do
@@ -170,7 +170,7 @@ RSpec.describe "providers shared ownership request test" do
             expect(legal_aid_application.reload.shared_ownership).to eq shared_ownership
           end
 
-          context "while checking answers" do
+          context "when checking answers" do
             let(:legal_aid_application) { create(:legal_aid_application, :with_applicant, :checking_passported_answers) }
 
             it "redirects to the applications list page" do
@@ -180,7 +180,7 @@ RSpec.describe "providers shared ownership request test" do
           end
         end
 
-        context "No path" do
+        describe "No path" do
           let!(:shared_ownership) { LegalAidApplication::SHARED_OWNERSHIP_NO_REASONS.first }
 
           it "does NOT create an new application record" do
@@ -198,7 +198,7 @@ RSpec.describe "providers shared ownership request test" do
             expect(legal_aid_application.reload.shared_ownership).to eq shared_ownership
           end
 
-          context "while checking answers" do
+          context "when checking answers" do
             let(:legal_aid_application) { create(:legal_aid_application, :with_applicant, :checking_passported_answers) }
 
             it "redirects to the applications list page" do

--- a/spec/requests/providers/means/vehicles_spec.rb
+++ b/spec/requests/providers/means/vehicles_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe Providers::Means::VehiclesController do
         end
       end
 
-      context "while checking answers" do
+      context "when checking answers" do
         let(:legal_aid_application) { create(:legal_aid_application, :with_passported_state_machine, :checking_passported_answers) }
 
         it "redirects to next page" do
@@ -97,7 +97,7 @@ RSpec.describe Providers::Means::VehiclesController do
       end
     end
 
-    context 'with option "false"' do
+    context 'when submitted with option "false"' do
       let(:own_vehicle) { "false" }
       let(:target_url) do
         providers_legal_aid_application_applicant_bank_account_path(legal_aid_application)
@@ -129,7 +129,7 @@ RSpec.describe Providers::Means::VehiclesController do
         end
       end
 
-      context "while checking answers" do
+      context "when checking answers" do
         let(:legal_aid_application) { create(:legal_aid_application, :with_non_passported_state_machine, :checking_non_passported_means) }
 
         it "redirects to check capital answers page" do
@@ -138,7 +138,7 @@ RSpec.describe Providers::Means::VehiclesController do
         end
       end
 
-      context "while checking passported answers" do
+      context "when checking passported answers" do
         let(:legal_aid_application) { create(:legal_aid_application, :with_passported_state_machine, :checking_passported_answers) }
 
         it "redirects to passported check answers page" do

--- a/spec/requests/providers/merits_task_lists_controller_spec.rb
+++ b/spec/requests/providers/merits_task_lists_controller_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Providers::MeritsTaskListsController do
   describe "GET /providers/merits_task_list" do
     subject { get providers_legal_aid_application_merits_task_list_path(legal_aid_application) }
 
-    context "the record does not exist" do
+    context "when the record does not exist" do
       let(:task_list) { build(:legal_framework_serializable_merits_task_list) }
 
       it "returns http success" do
@@ -36,7 +36,7 @@ RSpec.describe Providers::MeritsTaskListsController do
       end
     end
 
-    context "the record already exists" do
+    context "when the record already exists" do
       before do
         login_provider
         create(:legal_framework_merits_task_list, legal_aid_application:)
@@ -57,7 +57,7 @@ RSpec.describe Providers::MeritsTaskListsController do
       end
     end
 
-    context "the task list was started before the opponent split was implemented" do
+    context "when the task list was started before the opponent split was implemented" do
       let(:task_list) { create(:legal_framework_merits_task_list, :broken_opponent, legal_aid_application:) }
 
       before do
@@ -92,8 +92,8 @@ RSpec.describe Providers::MeritsTaskListsController do
         patch providers_legal_aid_application_merits_task_list_path(legal_aid_application)
       end
 
-      context "evidence upload" do
-        context "when at least one evidence type is required" do
+      describe "evidence upload" do
+        context "and at least one evidence type is required" do
           it "redirects to the new upload evidence page" do
             expect(response).to redirect_to(providers_legal_aid_application_uploaded_evidence_collection_path(legal_aid_application))
           end

--- a/spec/requests/providers/received_benefit_confirmations_spec.rb
+++ b/spec/requests/providers/received_benefit_confirmations_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Providers::ReceivedBenefitConfirmationsController do
       login_as application.provider
     end
 
-    context "validation error" do
+    context "when there is a validation error" do
       it "displays error if nothing selected" do
         subject
         expect(response).to have_http_status(:ok)
@@ -61,10 +61,10 @@ RSpec.describe Providers::ReceivedBenefitConfirmationsController do
       end
     end
 
-    context "benefit selected" do
+    context "when benefit selected" do
       let(:params) { { dwp_override: { passporting_benefit: :universal_credit } } }
 
-      context "add new record" do
+      context "and provider adds a new record" do
         it "adds a dwp override record" do
           expect { subject }.to change(DWPOverride, :count).by(1)
         end
@@ -75,7 +75,7 @@ RSpec.describe Providers::ReceivedBenefitConfirmationsController do
         end
       end
 
-      context "remove record when changed to none selected" do
+      context "when changed to none selected" do
         before do
           params = { dwp_override: { passporting_benefit: :universal_credit } }
           patch "/providers/applications/#{application_id}/received_benefit_confirmation", params:
@@ -94,7 +94,7 @@ RSpec.describe Providers::ReceivedBenefitConfirmationsController do
       end
     end
 
-    context "none of these selected" do
+    context "when none of these selected" do
       let(:params) { { dwp_override: { passporting_benefit: :none_selected } } }
 
       it "does not add a dwp override record" do

--- a/spec/requests/providers/select_offices_spec.rb
+++ b/spec/requests/providers/select_offices_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe "provider selects office" do
         expect(response).to redirect_to providers_legal_aid_applications_path
       end
 
-      context "invalid params - nothing specified" do
+      context "when the params are invalid - nothing specified" do
         let(:params) { {} }
 
         it "returns http_success" do
@@ -73,7 +73,7 @@ RSpec.describe "provider selects office" do
         end
       end
 
-      context "invalid params - selects office from different provider" do
+      context "when the params are invalid - nothing specified - selects office from different provider" do
         let(:params) do
           {
             provider: { selected_office_id: third_office.id },

--- a/spec/requests/providers/transactions_spec.rb
+++ b/spec/requests/providers/transactions_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Providers::TransactionsController do
       expect(unescaped_response_body).to include(I18n.t("transaction_types.page_titles.#{transaction_type.name}"))
     end
 
-    context "When there are transactions" do
+    context "when there are transactions" do
       let(:not_matching_operation) { (TransactionType::NAMES.keys.map(&:to_s) - [transaction_type.operation.to_s]).first }
       let(:other_transaction_type) { create(:transaction_type, :pension) }
       let!(:bank_transaction_matching) { create(:bank_transaction, bank_account:, operation: transaction_type.operation) }
@@ -82,11 +82,11 @@ RSpec.describe Providers::TransactionsController do
     context "when the call to Check Financial Eligibility Service for excluded benefits" do
       let(:transaction_type) { create(:transaction_type, :excluded_benefits) }
 
-      context "is successful" do
+      context "and the call is successful" do
         it_behaves_like "GET #providers/transactions"
       end
 
-      context "is un-successful" do
+      context "and the call is un-successful" do
         before { allow(CFECivil::ObtainStateBenefitTypesService).to receive(:call).and_raise(StandardError) }
 
         it "redirects to the problem path as it cannot show the list of excluded benefits" do

--- a/spec/requests/providers/uploaded_evidence_collection_spec.rb
+++ b/spec/requests/providers/uploaded_evidence_collection_spec.rb
@@ -74,7 +74,7 @@ module Providers
 
       before { login_as provider }
 
-      context "upload button pressed" do
+      context "when the upload button is pressed" do
         let(:params_uploaded_evidence_collection) do
           {
             original_file:,
@@ -100,7 +100,7 @@ module Providers
           expect(response).to have_http_status(:ok)
         end
 
-        context "word document" do
+        context "when a word document is selected" do
           let(:original_file) { uploaded_file("spec/fixtures/files/documents/hello_world.docx", "application/vnd.openxmlformats-officedocument.wordprocessingml.document") }
 
           it "updates the record" do
@@ -135,7 +135,7 @@ module Providers
           end
         end
 
-        context "with an invalid file type" do
+        context "when an invalid file type is uploaded" do
           let(:original_file) { uploaded_file("spec/fixtures/files/zip.zip", "application/zip") }
 
           it "does not update the record" do
@@ -151,7 +151,7 @@ module Providers
           end
         end
 
-        context "with an invalid mime type but valid content_type" do
+        context "when an invalid mime type but valid content_type is uploaded" do
           let(:original_file) { uploaded_file("spec/fixtures/files/zip.zip", "application/zip") }
 
           before do
@@ -167,7 +167,7 @@ module Providers
           end
         end
 
-        context "with invalid uploaded file header" do
+        context "when a file with an invalid file header is uploaded" do
           let(:original_file) { uploaded_file("spec/fixtures/files/documents/hello_world.docx", "application/vnd.openxmlformats-officedocument.wordprocessingml.document") }
 
           before do
@@ -180,7 +180,7 @@ module Providers
           end
         end
 
-        context "with a file that is too big" do
+        context "when a file that is too big is uploaded" do
           before { allow(File).to receive(:size).and_return(9_437_184) }
 
           it "does not save the object and raises an error" do
@@ -192,7 +192,7 @@ module Providers
           end
         end
 
-        context "with a file that contains malware", clamav: true do
+        context "when a file that contains malware is uploaded", clamav: true do
           let(:original_file) { uploaded_file("spec/fixtures/files/malware.doc") }
 
           it "does not save the object and raises an error" do
@@ -204,7 +204,7 @@ module Providers
           end
         end
 
-        context "with a file that is empty" do
+        context "when a file that is empty is uploaded" do
           let(:original_file) { uploaded_file("spec/fixtures/files/empty_file.pdf", "application/pdf") }
 
           it "does not save the object and raises an error" do
@@ -216,7 +216,7 @@ module Providers
           end
         end
 
-        context "no file chosen" do
+        context "when no file chosen" do
           let(:original_file) { nil }
 
           it "does not update the record" do
@@ -232,7 +232,7 @@ module Providers
           end
         end
 
-        context "virus scanner is down" do
+        context "when virus scanner is down" do
           before do
             allow_any_instance_of(MalwareScanResult).to receive(:scanner_working).with(any_args).and_return(false)
           end
@@ -245,11 +245,11 @@ module Providers
         end
       end
 
-      context "Continue button pressed" do
+      context "when Continue button pressed" do
         let(:button_clicked) { continue_button }
 
-        context "model has no files attached previously" do
-          context "no files uploaded" do
+        context "and model has no files attached previously" do
+          context "and no files uploaded" do
             let(:params_uploaded_evidence_collection) { {} }
 
             it "does not add a record" do
@@ -298,7 +298,7 @@ module Providers
             end
           end
 
-          context "with a file uploaded" do
+          context "when a file is uploaded" do
             let(:attachment_type) { "uncategorised" }
             let(:attachment) { create(:attachment, attachment_name: "test_file.pdf", attachment_type:, legal_aid_application:) }
             let(:params_uploaded_evidence_collection) { { attachment.id.to_s => attachment.attachment_type.to_s } }
@@ -451,7 +451,7 @@ module Providers
         end
       end
 
-      context "Save as draft" do
+      context "when submitted with Save as draft" do
         let(:button_clicked) { draft_button }
 
         context "when no files have been uploaded" do
@@ -466,7 +466,7 @@ module Providers
           expect(response).to redirect_to provider_draft_endpoint
         end
 
-        context "nothing specified" do
+        context "when nothing specified" do
           let(:original_file) { nil }
 
           it "redirects to provider draft endpoint" do
@@ -476,7 +476,7 @@ module Providers
         end
       end
 
-      context "Delete" do
+      context "when submitted with Delete" do
         subject { patch providers_legal_aid_application_uploaded_evidence_collection_path(legal_aid_application), params: delete_params }
 
         let(:button_clicked) { delete_button }

--- a/spec/requests/providers/vehicles/ages_spec.rb
+++ b/spec/requests/providers/vehicles/ages_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe Providers::Vehicles::AgesController do
       end
     end
 
-    context "Form submitted using Save as draft button" do
+    context "when the Form is submitted using Save as draft button" do
       let(:submit_button) { { draft_button: "Save as draft" } }
 
       it "redirects provider to provider's applications page" do

--- a/spec/requests/providers/vehicles/estimated_values_spec.rb
+++ b/spec/requests/providers/vehicles/estimated_values_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe Providers::Vehicles::EstimatedValuesController do
       end
     end
 
-    context "Form submitted using Save as draft button" do
+    context "when the Form is submitted using Save as draft button" do
       let(:submit_button) { { draft_button: "Save as draft" } }
 
       it "redirects provider to provider's applications page" do

--- a/spec/requests/providers/vehicles/regular_uses_spec.rb
+++ b/spec/requests/providers/vehicles/regular_uses_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Providers::Vehicles::RegularUsesController do
       expect(response).to redirect_to(next_url)
     end
 
-    context "with false" do
+    context "when submitted with false" do
       let(:used_regularly) { false }
 
       it "updates vehicle" do
@@ -67,7 +67,7 @@ RSpec.describe Providers::Vehicles::RegularUsesController do
       end
     end
 
-    context "with false on a passported journey" do
+    context "when false on a passported journey" do
       let(:legal_aid_application) { create(:legal_aid_application, :with_vehicle, :passported) }
       let(:used_regularly) { false }
 
@@ -82,7 +82,7 @@ RSpec.describe Providers::Vehicles::RegularUsesController do
       end
     end
 
-    context "without value" do
+    context "when submitted without a value" do
       let(:params) { {} }
 
       it "renders successfully" do
@@ -101,7 +101,7 @@ RSpec.describe Providers::Vehicles::RegularUsesController do
       end
     end
 
-    context "Form submitted using Save as draft button" do
+    context "when the Form is submitted using Save as draft button" do
       let(:submit_button) { { draft_button: "Save as draft" } }
 
       it "redirects provider to provider's applications page" do
@@ -144,7 +144,7 @@ RSpec.describe Providers::Vehicles::RegularUsesController do
       it_behaves_like "a provider not authenticated"
     end
 
-    context "while checking answers" do
+    context "when checking answers" do
       let(:legal_aid_application) { create(:legal_aid_application, :with_non_passported_state_machine, :checking_non_passported_means) }
 
       it "redirects to check capital answers page" do
@@ -153,7 +153,7 @@ RSpec.describe Providers::Vehicles::RegularUsesController do
       end
     end
 
-    context "while checking passported answers" do
+    context "when checking passported answers" do
       let(:legal_aid_application) { create(:legal_aid_application, :with_passported_state_machine, :checking_passported_answers) }
 
       it "redirects to passported check answers page" do


### PR DESCRIPTION

## What

Remove files from the todo list and manually update the
tests to use accepted verbs while still making sense

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
