### PR TITLE
AP-2509: Improve error handling when case_ccms_reference is ERROR

### DIFF
--- a/app/services/ccms/parsers/reference_data_response_parser.rb
+++ b/app/services/ccms/parsers/reference_data_response_parser.rb
@@ -6,6 +6,7 @@ module CCMS
 
       def reference_id
         @reference_id ||= parse(:extracted_reference_id)
+        check_case_ccms_reference
       end
 
       def response_type
@@ -20,6 +21,12 @@ module CCMS
 
       def extracted_reference_id
         text_from(RESULTS_PATH)
+      end
+
+      def check_case_ccms_reference
+        return @reference_id if @reference_id != "ERROR"
+
+        raise CCMSError, "case_ccms_reference returned as ERROR"
       end
     end
   end

--- a/spec/data/ccms/reference_data_response_error.xml
+++ b/spec/data/ccms/reference_data_response_error.xml
@@ -1,0 +1,34 @@
+<env:Envelope xmlns:env="http://schemas.xmlsoap.org/soap/envelope/" xmlns:wsa="http://www.w3.org/2005/08/addressing">
+  <env:Header>
+    <wsa:MessageID>urn:9591BC1056B811ECBFEBBD66E45C90AB</wsa:MessageID>
+    <wsa:ReplyTo>
+      <wsa:Address>http://www.w3.org/2005/08/addressing/anonymous</wsa:Address>
+      <wsa:ReferenceParameters>
+        <instra:tracking.compositeInstanceCreatedTime xmlns:instra="http://xmlns.oracle.com/sca/tracking/1.0">2021-12-06T17:18:52.326Z</instra:tracking.compositeInstanceCreatedTime>
+      </wsa:ReferenceParameters>
+    </wsa:ReplyTo>
+    <wsa:FaultTo>
+      <wsa:Address>http://www.w3.org/2005/08/addressing/anonymous</wsa:Address>
+      <wsa:ReferenceParameters>
+        <instra:tracking.compositeInstanceCreatedTime xmlns:instra="http://xmlns.oracle.com/sca/tracking/1.0">2021-12-06T17:18:52.326Z</instra:tracking.compositeInstanceCreatedTime>
+      </wsa:ReferenceParameters>
+    </wsa:FaultTo>
+  </env:Header>
+  <env:Body>
+    <ReferenceDataInqRS xmlns="http://legalservices.gov.uk/CCMS/Common/ReferenceData/1.0/ReferenceDataBIM" xmlns:msg="http://legalservices.gov.uk/CCMS/Common/ReferenceData/1.0/ReferenceDataBIM">
+      <header:HeaderRS xmlns:header="http://legalservices.gov.uk/Enterprise/Common/1.0/Header">
+        <header:TransactionID>20190301030405123456</header:TransactionID>
+        <header:RequestDetails>
+          <header:TransactionRequestID>20190301030405123456</header:TransactionRequestID>
+          <header:Language>ENG</header:Language>
+          <header:UserRole>EXTERNAL</header:UserRole>
+        </header:RequestDetails>
+        <header:Status>
+          <header:Status>Error</header:Status>
+          <header:StatusFreeText>Check Log Id 202112061718522440982985733 for details</header:StatusFreeText>
+        </header:Status>
+      </header:HeaderRS>
+      <msg:Results>ERROR</msg:Results>
+    </ReferenceDataInqRS>
+  </env:Body>
+</env:Envelope>

--- a/spec/services/ccms/parsers/reference_data_response_parser_spec.rb
+++ b/spec/services/ccms/parsers/reference_data_response_parser_spec.rb
@@ -99,6 +99,17 @@ module CCMS
           end
         end
       end
+
+      context "when the response fails and the case_ccms_reference is ERROR" do
+        let(:response_xml) { ccms_data_from_file "reference_data_response_error.xml" }
+
+        it "returns false" do
+          expect {
+            parser = described_class.new(expected_tx_id, response_xml)
+            parser.reference_id
+          }.to raise_error CCMS::CCMSError, "case_ccms_reference returned as ERROR"
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2509)

Ensure an error is raised if CCMS returns the case_ccms_reference as `ERROR`

Add a new xml response block replicating a live response that failed so we can test the situation

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
