### PR TITLE
ap-4304: amend opponent_details cya

### DIFF
--- a/app/helpers/opponent_helper.rb
+++ b/app/helpers/opponent_helper.rb
@@ -1,4 +1,4 @@
-module OpponentUrlHelper
+module OpponentHelper
   def opponent_url(type, *)
     url = case type
           when "Individual"
@@ -9,5 +9,9 @@ module OpponentUrlHelper
             raise "type #{type} not supported"
           end
     Rails.application.routes.url_helpers.send(url, *)
+  end
+
+  def opponent_type_description(opponent)
+    opponent.type == "Individual" ? opponent.type : opponent.description
   end
 end

--- a/app/views/providers/application_merits_task/has_other_opponents/show.html.erb
+++ b/app/views/providers/application_merits_task/has_other_opponents/show.html.erb
@@ -23,7 +23,7 @@
         <% @legal_aid_application.opponents.order(:created_at).each do |opponent| %>
           <tr class="govuk-table__row">
             <td class="govuk-table__cell" id="opponent<%= opponent.id %>"><%= opponent.full_name %></td>
-            <td class="govuk-table__cell"><%= opponent.type == "Individual" ? opponent.type : opponent.description %></td>
+            <td class="govuk-table__cell"><%= opponent_type_description(opponent) %></td>
             <td class="govuk-table__cell">
               <%= link_to_accessible(
                     t("generic.change"),

--- a/app/views/shared/check_answers/_opponent_details.html.erb
+++ b/app/views/shared/check_answers/_opponent_details.html.erb
@@ -9,7 +9,7 @@
     <% opponents.order(:created_at).each_with_index do |opponent, i| %>
       <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__opponent_#{i + 1}" }) do |row| %>
         <%= row.with_key(text: "#{t('.opponent')} #{i + 1}", classes: "govuk-!-width-one-half") %>
-        <%= row.with_value(text: opponent.full_name) %>
+        <%= row.with_value { sanitize("#{opponent.full_name},<br>#{opponent_type_description(opponent)}") } %>
       <% end %>
     <% end %>
 

--- a/spec/helpers/opponent_helper_spec.rb
+++ b/spec/helpers/opponent_helper_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe OpponentHelper do
   let(:legal_aid_application) { create(:legal_aid_application) }
   let(:individual_opponent) { create(:opponent, :for_individual, legal_aid_application:) }
-  let(:organisation_opponent) { create(:opponent, :for_organisation, legal_aid_application:) }
+  let(:organisation_opponent) { create(:opponent, :for_organisation, legal_aid_application:, organisation_name: "Mid Beds Council", organisation_ccms_code: "LA", organisation_description: "Local Authority") }
 
   describe ".opponent_url" do
     context "when opponent has type Individual" do
@@ -23,6 +23,22 @@ RSpec.describe OpponentHelper do
     context "when called with unexpected values" do
       it "raises an error" do
         expect { opponent_url("Fake") }.to raise_error "type Fake not supported"
+      end
+    end
+  end
+
+  describe ".opponent_type_description" do
+    context "when opponent has type Individual" do
+      it "returns the opponent type" do
+        type_description = opponent_type_description(individual_opponent)
+        expect(type_description).to eq "Individual"
+      end
+    end
+
+    context "when opponent has type Organisation" do
+      it "returns the organisation description" do
+        type_description = opponent_type_description(organisation_opponent)
+        expect(type_description).to eq "Local Authority"
       end
     end
   end

--- a/spec/helpers/opponent_helper_spec.rb
+++ b/spec/helpers/opponent_helper_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe OpponentUrlHelper do
+RSpec.describe OpponentHelper do
   let(:legal_aid_application) { create(:legal_aid_application) }
   let(:individual_opponent) { create(:opponent, :for_individual, legal_aid_application:) }
   let(:organisation_opponent) { create(:opponent, :for_organisation, legal_aid_application:) }


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4304)

Amended opponent details on CYA page to match sigma designs

- Renamed opponent_url_helper -> opponent_helper in order to use it as a helper for opponent views more generally.
- Added opponent_type_description function to opponent_helper
- Used opponent_type_description to display opponents as required in ticket on Check your answers page (I believe this has also automatically updated the merits report to display opponent organisations correctly as they share the same view)

Describe what you did and why.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
