### PR TITLE
Rubocop: Address RSpec/ContextWording exclusions in CCMS tests

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -47,37 +47,15 @@ RSpec/AnyInstance:
     - 'spec/services/reports/merits_report_creator_spec.rb'
     - 'spec/services/reports/mis/application_details_report_spec.rb'
 
-# Offense count: 465
+# Offense count: 333
 # Configuration parameters: Prefixes, AllowedPatterns.
 # Prefixes: when, with, without
 RSpec/ContextWording:
   Exclude:
-    - 'spec/services/ccms/attribute_configuration_spec.rb'
-    - 'spec/services/ccms/attribute_value_generator_spec.rb'
-    - 'spec/services/ccms/manual_review_determiner_spec.rb'
-    - 'spec/services/ccms/parsers/applicant_add_response_parser_spec.rb'
-    - 'spec/services/ccms/parsers/applicant_search_response_parser_spec.rb'
-    - 'spec/services/ccms/parsers/case_add_response_parser_spec.rb'
-    - 'spec/services/ccms/parsers/case_add_status_response_parser_spec.rb'
-    - 'spec/services/ccms/parsers/document_id_response_parser_spec.rb'
-    - 'spec/services/ccms/parsers/reference_data_response_parser_spec.rb'
-    - 'spec/services/ccms/payload_generators/entity_attributes_generator_spec.rb'
-    - 'spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_additional_property_attributes_spec.rb'
     - 'spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_attributes_spec.rb'
-    - 'spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_benefits_attrs_spec.rb'
-    - 'spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_dependant_child_attributes_spec.rb'
     - 'spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_entities_spec.rb'
     - 'spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_variable_attributes_spec.rb'
     - 'spec/services/ccms/requestors/case_add_requestor_xml_blocks/passported_attributes_spec.rb'
-    - 'spec/services/ccms/submitters/add_applicant_service_spec.rb'
-    - 'spec/services/ccms/submitters/add_case_service_spec.rb'
-    - 'spec/services/ccms/submitters/check_applicant_status_service_spec.rb'
-    - 'spec/services/ccms/submitters/check_case_status_service_spec.rb'
-    - 'spec/services/ccms/submitters/obtain_applicant_reference_service_spec.rb'
-    - 'spec/services/ccms/submitters/obtain_case_reference_service_spec.rb'
-    - 'spec/services/ccms/submitters/obtain_document_id_service_spec.rb'
-    - 'spec/services/ccms/submitters/upload_documents_service_spec.rb'
-
 
 # Offense count: 1
 # This cop supports safe autocorrection (--autocorrect).

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -312,7 +312,6 @@ RSpec/NamedSubject:
     - 'spec/services/ccms/submitters/check_applicant_status_service_spec.rb'
     - 'spec/services/ccms/submitters/check_case_status_service_spec.rb'
     - 'spec/services/ccms/submitters/obtain_applicant_reference_service_spec.rb'
-    - 'spec/services/ccms/submitters/obtain_case_reference_service_spec.rb'
     - 'spec/services/ccms/submitters/obtain_document_id_service_spec.rb'
     - 'spec/services/ccms/submitters/upload_documents_service_spec.rb'
     - 'spec/services/dashboard_event_handler_spec.rb'

--- a/spec/services/ccms/attribute_configuration_spec.rb
+++ b/spec/services/ccms/attribute_configuration_spec.rb
@@ -113,7 +113,7 @@ module CCMS
       end
     end
 
-    context "invalid application type" do
+    context "when an invalid application type is provided" do
       subject(:config) { described_class.new(application_type: :unknown_type).config }
 
       it "raises" do

--- a/spec/services/ccms/attribute_value_generator_spec.rb
+++ b/spec/services/ccms/attribute_value_generator_spec.rb
@@ -6,8 +6,8 @@ module CCMS
     let(:value_generator) { described_class.new(submission) }
 
     describe "#method_missing" do
-      context "standardly_named_method" do
-        context "bank account" do
+      context "with a standardly_named_method" do
+        describe "bank account" do
           let(:my_account) { double BankAccount }
           let(:options) { { bank_acct: my_account } }
           let(:bank_account_name) { "MY ACCOUNT" }
@@ -19,7 +19,7 @@ module CCMS
           end
         end
 
-        context "vehicle" do
+        describe "vehicle" do
           let(:my_vehicle) { double "Vehicle" }
           let(:options) { { vehicle: my_vehicle } }
           let(:my_regno) { "AB12CDE" }
@@ -31,7 +31,7 @@ module CCMS
           end
         end
 
-        context "wage_slip" do
+        describe "wage_slip" do
           let(:my_wage_slip) { double "WageSlip" }
           let(:options) { { wage_slip: my_wage_slip } }
           let(:my_ni_contribution) { 34.78 }
@@ -43,7 +43,7 @@ module CCMS
           end
         end
 
-        context "proceeding" do
+        describe "proceeding" do
           let(:my_proceeding) { double Proceeding }
           let(:options) { { proceeding: my_proceeding } }
           let(:my_name) { "Non-mol" }
@@ -56,7 +56,7 @@ module CCMS
         end
       end
 
-      context "non-standardly-named method" do
+      context "with a non-standardly-named method" do
         it "raises NoMethodError error" do
           expect {
             value_generator.no_such_method
@@ -66,25 +66,25 @@ module CCMS
     end
 
     describe "#respond_to?" do
-      context "standardly_named methods" do
+      context "with a standardly_named methods" do
         let(:my_account) { double BankAccount, name: "MY ACCOUNT" }
         let(:options) { { bank_acct: my_account } }
 
-        context "valid method on delegated object" do
+        context "and a valid method on delegated object" do
           it "returns true" do
             expect(value_generator.respond_to?(:bank_account_name)).to be true
           end
         end
       end
 
-      context "non-standardly-named methods" do
-        context "other existing method" do
+      context "with non-standardly-named methods" do
+        describe "other existing method" do
           it "returns true" do
             expect(value_generator.respond_to?(:bank_account_holders)).to be true
           end
         end
 
-        context "non-existing method" do
+        describe "non-existing method" do
           it "returns false" do
             expect(value_generator.respond_to?(:non_existent_method)).to be false
           end

--- a/spec/services/ccms/attribute_value_generator_spec.rb
+++ b/spec/services/ccms/attribute_value_generator_spec.rb
@@ -66,7 +66,7 @@ module CCMS
     end
 
     describe "#respond_to?" do
-      context "with a standardly_named methods" do
+      context "with standardly_named methods" do
         let(:my_account) { double BankAccount, name: "MY ACCOUNT" }
         let(:options) { { bank_acct: my_account } }
 

--- a/spec/services/ccms/manual_review_determiner_spec.rb
+++ b/spec/services/ccms/manual_review_determiner_spec.rb
@@ -10,17 +10,17 @@ module CCMS
     describe "#manual_review_required?" do
       subject { determiner.manual_review_required? }
 
-      context "assessment not yet carried out on legal aid application" do
+      context "when an assessment is not yet carried out on legal aid application" do
         it "raises an error" do
           expect { subject }.to raise_error RuntimeError, "Unable to determine whether Manual review is required before means assessment"
         end
       end
 
-      context "manual review setting true" do
+      context "when the manual review setting is true" do
         before { setting.update! manually_review_all_cases: true }
 
-        context "no DWP override" do
-          context "passported, no contrib, no_restrictions" do
+        context "and there is no DWP override" do
+          context "when passported, no contrib, no_restrictions" do
             let(:legal_aid_application) { create(:legal_aid_application, :with_positive_benefit_check_result) }
             let!(:cfe_result) { create(:cfe_v3_result, submission: cfe_submission) }
 
@@ -29,7 +29,7 @@ module CCMS
             end
           end
 
-          context "non-passported, no contrib" do
+          context "when non-passported, no contrib" do
             let(:legal_aid_application) { create(:legal_aid_application, :with_negative_benefit_check_result) }
             let!(:cfe_result) { create(:cfe_v3_result, submission: cfe_submission) }
 
@@ -42,7 +42,7 @@ module CCMS
         context "with DWP override" do
           before { create(:dwp_override, legal_aid_application:) }
 
-          context "passported, no contrib, no_restrictions" do
+          context "when passported, no contrib, no_restrictions" do
             let(:legal_aid_application) { create(:legal_aid_application, :with_positive_benefit_check_result) }
             let!(:cfe_result) { create(:cfe_v3_result, submission: cfe_submission) }
 
@@ -51,7 +51,7 @@ module CCMS
             end
           end
 
-          context "non-passported, no contrib" do
+          context "when non-passported, no contrib" do
             let(:legal_aid_application) { create(:legal_aid_application, :with_negative_benefit_check_result) }
             let!(:cfe_result) { create(:cfe_v3_result, submission: cfe_submission) }
 
@@ -62,14 +62,14 @@ module CCMS
         end
       end
 
-      context "manual review setting false" do
+      context "and manual review is set to false" do
         before { setting.update! manually_review_all_cases: false }
 
-        context "no DWP override" do
-          context "passported" do
+        context "without DWP override" do
+          context "and the application is passported" do
             let(:legal_aid_application) { create(:legal_aid_application, :with_positive_benefit_check_result, has_restrictions: true) }
 
-            context "contribution" do
+            context "and a contribution is required" do
               let!(:cfe_result) { create(:cfe_v3_result, :with_capital_contribution_required, submission: cfe_submission) }
 
               it "returns true" do
@@ -77,16 +77,16 @@ module CCMS
               end
             end
 
-            context "no contribution" do
+            context "and there is no contribution" do
               let!(:cfe_result) { create(:cfe_v3_result, submission: cfe_submission) }
 
-              context "restrictions" do
+              context "and there are restrictions" do # TODO: check this - description does not match expectation
                 it "returns false" do
                   expect(subject).to be true
                 end
               end
 
-              context "no restrictions" do
+              context "and no restrictions" do
                 before { legal_aid_application.update! has_restrictions: false }
 
                 it "returns false" do
@@ -96,10 +96,10 @@ module CCMS
             end
           end
 
-          context "non-passported" do
+          context "and the application is non-passported" do
             let(:legal_aid_application) { create(:legal_aid_application, :with_negative_benefit_check_result, has_restrictions: true) }
 
-            context "contribution" do
+            context "when there is a contribution" do
               let!(:cfe_result) { create(:cfe_v3_result, :with_capital_contribution_required, submission: cfe_submission) }
 
               it "returns true" do
@@ -107,16 +107,16 @@ module CCMS
               end
             end
 
-            context "no contribution" do
+            context "when there is no contribution" do
               let!(:cfe_result) { create(:cfe_v3_result, submission: cfe_submission) }
 
-              context "restrictions" do
+              context "but with restrictions" do
                 it "returns false" do
                   expect(subject).to be true
                 end
               end
 
-              context "no restrictions" do
+              context "and no restrictions" do
                 before { legal_aid_application.update! has_restrictions: false }
 
                 it "returns false" do
@@ -130,10 +130,10 @@ module CCMS
         context "with DWP override" do
           before { create(:dwp_override, legal_aid_application:) }
 
-          context "passported" do
+          context "and the application is passported" do
             let(:legal_aid_application) { create(:legal_aid_application, :with_positive_benefit_check_result, has_restrictions: true) }
 
-            context "contribution" do
+            context "when there is a contribution" do
               let!(:cfe_result) { create(:cfe_v3_result, :with_capital_contribution_required, submission: cfe_submission) }
 
               it "returns true" do
@@ -141,16 +141,16 @@ module CCMS
               end
             end
 
-            context "no contribution" do
+            context "when there is no contribution" do
               let!(:cfe_result) { create(:cfe_v3_result, submission: cfe_submission) }
 
-              context "restrictions" do
+              context "and there are restrictions" do # TODO: check this - description does not match expectation
                 it "returns false" do
                   expect(subject).to be true
                 end
               end
 
-              context "no restrictions" do
+              context "and there are no restrictions" do
                 before { legal_aid_application.update! has_restrictions: false }
 
                 it "returns true" do
@@ -160,10 +160,10 @@ module CCMS
             end
           end
 
-          context "non-passported" do
+          context "when the application is non-passported" do
             let(:legal_aid_application) { create(:legal_aid_application, :with_negative_benefit_check_result, has_restrictions: true) }
 
-            context "contribution" do
+            context "and a contribution is required" do
               let!(:cfe_result) { create(:cfe_v3_result, :with_capital_contribution_required, submission: cfe_submission) }
 
               it "returns true" do
@@ -171,16 +171,16 @@ module CCMS
               end
             end
 
-            context "no contribution" do
+            context "and there is no contribution" do
               let!(:cfe_result) { create(:cfe_v3_result, submission: cfe_submission) }
 
-              context "restrictions" do
+              context "and there are restrictions" do # TODO: check this - description does not match expectation
                 it "returns false" do
                   expect(subject).to be true
                 end
               end
 
-              context "no restrictions" do
+              context "and there are no restrictions" do
                 before { legal_aid_application.update! has_restrictions: false }
 
                 it "returns true" do
@@ -255,13 +255,13 @@ module CCMS
 
       before { allow_any_instance_of(cfe_submission.class).to receive(:result).and_return(cfe_result) }
 
-      context "No DWP Override" do
+      context "without DWP Override" do
         it "just takes the review reasons from the CFE result" do
           expect(subject).to eq review_reasons
         end
       end
 
-      context "With DWP override" do
+      context "with DWP override" do
         before { create(:dwp_override, legal_aid_application:) }
 
         it "adds the dwp review to the cfe result reasons" do

--- a/spec/services/ccms/parsers/applicant_add_response_parser_spec.rb
+++ b/spec/services/ccms/parsers/applicant_add_response_parser_spec.rb
@@ -5,7 +5,7 @@ module CCMS
     RSpec.describe ApplicantAddResponseParser, :ccms do
       let(:expected_tx_id) { "20190301030405123456" }
 
-      context "successful response" do
+      context "when the response is successful" do
         describe "#success?" do
           let(:response_xml) { ccms_data_from_file "applicant_add_response_success.xml" }
 
@@ -39,7 +39,7 @@ module CCMS
         end
       end
 
-      context "unsuccessful response" do
+      context "when the response is unsuccessful" do
         subject { described_class.new(expected_tx_id, response_xml) }
 
         let(:response_xml) { ccms_data_from_file "applicant_add_response_failure.xml" }
@@ -65,7 +65,7 @@ module CCMS
         end
       end
 
-      context "response with no status or exception" do
+      context "when the response has no status or exception" do
         let(:response_xml) { ccms_data_from_file "applicant_add_response_no_status.xml" }
 
         describe "#success?" do
@@ -76,7 +76,7 @@ module CCMS
         end
       end
 
-      context "wrong transaction id" do
+      context "when the transaction id is not matched" do
         let(:expected_tx_id) { "88880301030405123456" }
         let(:response_xml) { ccms_data_from_file "applicant_add_response_success.xml" }
 

--- a/spec/services/ccms/parsers/applicant_search_response_parser_spec.rb
+++ b/spec/services/ccms/parsers/applicant_search_response_parser_spec.rb
@@ -17,7 +17,7 @@ module CCMS
           }.to raise_error CCMS::CCMSError, "Invalid transaction request id #{expected_tx_id}"
         end
 
-        context "there are no applicants returned" do
+        context "when there are no applicants returned" do
           let(:parser) { described_class.new(expected_tx_id, no_results_response_xml) }
 
           it "extracts the number of records fetched" do
@@ -43,7 +43,7 @@ module CCMS
           end
         end
 
-        context "there is one applicant returned" do
+        context "when there is one applicant returned" do
           let(:parser) { described_class.new(expected_tx_id, one_result_response_xml) }
 
           it "extracts the number of records fetched" do
@@ -69,7 +69,7 @@ module CCMS
           end
         end
 
-        context "there are multiple applicants returned" do
+        context "when there are multiple applicants returned" do
           let(:parser) { described_class.new(expected_tx_id, multiple_results_response_xml) }
 
           it "extracts the number of records fetched" do
@@ -95,7 +95,7 @@ module CCMS
           end
         end
 
-        context "Number not matched" do
+        context "when the transaction id is not matched" do
           let(:expected_tx_id) { "202206241623547511370989944" }
           let(:parser) { described_class.new(expected_tx_id, number_not_matched_response_xml) }
 

--- a/spec/services/ccms/parsers/case_add_response_parser_spec.rb
+++ b/spec/services/ccms/parsers/case_add_response_parser_spec.rb
@@ -5,7 +5,7 @@ module CCMS
     RSpec.describe CaseAddResponseParser, :ccms do
       let(:expected_tx_id) { "20190301030405123456" }
 
-      context "successful response" do
+      context "when the response is successful" do
         let(:response_xml) { ccms_data_from_file "case_add_response.xml" }
 
         describe "#success?" do
@@ -39,7 +39,7 @@ module CCMS
         end
       end
 
-      context "unsuccessful response" do
+      context "when the response is sunsuccessful" do
         let(:response_xml) { ccms_data_from_file "case_add_response_failure.xml" }
 
         describe "#success?" do

--- a/spec/services/ccms/parsers/case_add_response_parser_spec.rb
+++ b/spec/services/ccms/parsers/case_add_response_parser_spec.rb
@@ -39,7 +39,7 @@ module CCMS
         end
       end
 
-      context "when the response is sunsuccessful" do
+      context "when the response is unsuccessful" do
         let(:response_xml) { ccms_data_from_file "case_add_response_failure.xml" }
 
         describe "#success?" do

--- a/spec/services/ccms/parsers/case_add_status_response_parser_spec.rb
+++ b/spec/services/ccms/parsers/case_add_status_response_parser_spec.rb
@@ -3,11 +3,11 @@ require "rails_helper"
 module CCMS
   module Parsers
     RSpec.describe CaseAddStatusResponseParser, :ccms do
-      context "successful response" do
+      context "when the response is successful" do
         describe "#success?" do
           let(:expected_tx_id) { "20190301030405123456" }
 
-          context "normal success response" do
+          describe "normal success response" do
             let(:response_xml) { ccms_data_from_file "case_add_status_response.xml" }
 
             it "extracts the status" do
@@ -39,7 +39,7 @@ module CCMS
             end
           end
 
-          context "case already submitted response" do
+          context "when a case already submitted response is received" do
             let(:response_xml) { ccms_data_from_file "case_add_status_response_already_submitted.xml" }
 
             describe "#success" do
@@ -53,7 +53,7 @@ module CCMS
         end
       end
 
-      context "response where case not yet ready" do
+      context "when the case not yet ready response is received" do
         let(:response_xml) { ccms_data_from_file "case_add_status_response_user_authenticated.xml" }
         let(:expected_tx_id) { "20190301030405123456" }
 

--- a/spec/services/ccms/parsers/document_id_response_parser_spec.rb
+++ b/spec/services/ccms/parsers/document_id_response_parser_spec.rb
@@ -7,7 +7,7 @@ module CCMS
       let(:expected_tx_id) { "20190301030405123456" }
       let(:expected_document_id) { "4420073" }
 
-      context "success" do
+      context "when the response is successful" do
         let(:response_xml) { ccms_data_from_file "document_id_response.xml" }
         let(:parser) { described_class.new(expected_tx_id, response_xml) }
 
@@ -27,7 +27,7 @@ module CCMS
         end
       end
 
-      context "error" do
+      context "when the response is an error" do
         let(:response_xml) { ccms_data_from_file "document_id_response_failure.xml" }
 
         describe "#success" do

--- a/spec/services/ccms/parsers/reference_data_response_parser_spec.rb
+++ b/spec/services/ccms/parsers/reference_data_response_parser_spec.rb
@@ -6,7 +6,7 @@ module CCMS
       let(:expected_tx_id) { "20190301030405123456" }
       let(:expected_reference_number) { "300000135140" }
 
-      context "successful response" do
+      context "when the successful is response" do
         let(:response_xml) { ccms_data_from_file "reference_data_response.xml" }
 
         describe "#reference_id" do
@@ -40,7 +40,7 @@ module CCMS
         end
       end
 
-      context "failed response with message" do
+      context "when the response fails with message" do
         let(:response_xml) { ccms_data_from_file "reference_data_response_failure.xml" }
 
         describe "#success" do
@@ -60,7 +60,7 @@ module CCMS
         end
       end
 
-      context "failed response without message" do
+      context "when the response fails without message" do
         let(:response_xml) { ccms_data_from_file "reference_data_response_without_status_free_text.xml" }
 
         describe "#success" do
@@ -80,7 +80,7 @@ module CCMS
         end
       end
 
-      context "failed response - server side exception" do
+      context "when the response fails with a server side exception" do
         let(:response_xml) { ccms_data_from_file "reference_data_response_exception.xml" }
 
         describe "#success" do

--- a/spec/services/ccms/parsers/reference_data_response_parser_spec.rb
+++ b/spec/services/ccms/parsers/reference_data_response_parser_spec.rb
@@ -6,7 +6,7 @@ module CCMS
       let(:expected_tx_id) { "20190301030405123456" }
       let(:expected_reference_number) { "300000135140" }
 
-      context "when the successful is response" do
+      context "when the response is successful" do
         let(:response_xml) { ccms_data_from_file "reference_data_response.xml" }
 
         describe "#reference_id" do

--- a/spec/services/ccms/payload_generators/entity_attributes_generator_spec.rb
+++ b/spec/services/ccms/payload_generators/entity_attributes_generator_spec.rb
@@ -12,9 +12,9 @@ module CCMS
       let(:xml) { double Nokogiri::XML::Builder }
       let(:options) { {} }
 
-      context "private methods" do
+      describe "private methods" do
         describe "#extract_response_value" do
-          context "response_type is text, number, boolean" do
+          context "when the response_type is text, number, boolean" do
             it "returns config value" do
               config = {
                 value: 10,
@@ -38,7 +38,7 @@ module CCMS
             }.to raise_error CCMS::CCMSError, "Submission #{submission.id} - Unknown response type in attributes config yaml file: numeric"
           end
 
-          context "raises exception" do
+          context "when an exception is raised" do
             before do
               allow_any_instance_of(described_class).to receive(:extract_raw_value).and_raise(TypeError, "type error")
             end

--- a/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_additional_property_attributes_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_additional_property_attributes_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 module CCMS
   module Requestors
     RSpec.describe NonPassportedCaseAddRequestor, :ccms do
-      context "XML request" do
+      describe "XML request" do
         let(:expected_tx_id) { "201904011604570390059770666" }
         let(:firm) { create(:firm, name: "Firm1") }
         let(:office) { create(:office, firm:) }

--- a/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_benefits_attrs_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_benefits_attrs_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 module CCMS
   module Requestors
     RSpec.describe NonPassportedCaseAddRequestor, :ccms do
-      context "XML request" do
+      describe "XML request" do
         let(:expected_tx_id) { "201904011604570390059770666" }
         let(:proceeding_type) { legal_aid_application.application_proceeding_types.first.proceeding_type }
         let(:firm) { create(:firm, name: "Firm1") }
@@ -40,7 +40,7 @@ module CCMS
         let(:xml) { requestor.formatted_xml }
         let(:applicant) { legal_aid_application.applicant }
 
-        context "boolean attributes" do
+        describe "boolean attributes" do
           # these are all currently coded as FALSE until such time as we can determine which benefits are received
           it "generates the attribute blocks as false" do
             boolean_benefit_attrs.each do |attr_name|
@@ -51,7 +51,7 @@ module CCMS
           end
         end
 
-        context "value_attributes" do
+        describe "value_attributes" do
           # These are all omitted until such time sa we can determine which benefits are received
 
           it "omits all attributes" do

--- a/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_dependant_child_attributes_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_dependant_child_attributes_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 module CCMS
   module Requestors
     RSpec.describe NonPassportedCaseAddRequestor, :ccms do
-      context "XML request" do
+      describe "XML request" do
         let(:expected_tx_id) { "201904011604570390059770666" }
         let(:firm) { create(:firm, name: "Firm1") }
         let(:office) { create(:office, firm:) }
@@ -25,7 +25,7 @@ module CCMS
         let(:xml) { requestor.formatted_xml }
         let(:dependants) { legal_aid_application.dependants.all }
 
-        context "non-passported" do
+        describe "non-passported" do
           let(:legal_aid_application) do
             create(:legal_aid_application,
                    :with_everything,
@@ -46,8 +46,8 @@ module CCMS
             let!(:younger_child) { create(:dependant, :under15, legal_aid_application:, number: 1, has_income: false, assets_value: 1_000) }
             let!(:older_child) { create(:dependant, :child16_to18, legal_aid_application:, number: 2, has_income: true, assets_value: 0) }
 
-            context "variable attributes" do
-              context "attribute CLI_RES_PER_INPUT_T_12WP3_1A - Person residing: name" do
+            context "and variable attributes" do
+              describe "attribute CLI_RES_PER_INPUT_T_12WP3_1A - Person residing: name" do
                 let(:blocks) { XmlExtractor.call(xml, :client_residing_person, "CLI_RES_PER_INPUT_T_12WP3_1A") }
                 let(:sorted_blocks) { blocks.sort { |a, b| a.css("ResponseValue").text <=> b.css("ResponseValue").text } }
 
@@ -63,7 +63,7 @@ module CCMS
                 end
               end
 
-              context "attribute CLI_RES_PER_INPUT_B_12WP3_30A - Person residing: Employed?" do
+              describe "attribute CLI_RES_PER_INPUT_B_12WP3_30A - Person residing: Employed?" do
                 let(:blocks) { XmlExtractor.call(xml, :client_residing_person, "CLI_RES_PER_INPUT_B_12WP3_30A") }
 
                 it "only generates a block for the adult_dependants" do
@@ -75,7 +75,7 @@ module CCMS
                 end
               end
 
-              context "attribute CLI_RES_PER_INPUT_B_12WP3_31A - Dependant: receive their own income?" do
+              describe "attribute CLI_RES_PER_INPUT_B_12WP3_31A - Dependant: receive their own income?" do
                 let(:blocks) { XmlExtractor.call(xml, :client_residing_person, "CLI_RES_PER_INPUT_B_12WP3_31A") }
 
                 it "generates a block only for adult dependants" do
@@ -87,14 +87,14 @@ module CCMS
                 end
               end
 
-              context "attribute CLI_RES_PER_INPUT_T_12WP3_17A - Person residing: relationship to client" do
+              describe "attribute CLI_RES_PER_INPUT_T_12WP3_17A - Person residing: relationship to client" do
                 before do
                   legal_aid_application.dependants.map(&:destroy!)
                   create(:dependant, legal_aid_application:, date_of_birth: dob, relationship:)
                   legal_aid_application.reload
                 end
 
-                context "adult_relative" do
+                context "when adult_relative" do
                   let(:relationship) { "adult_relative" }
                   let(:dob) { 22.years.ago }
                   let(:blocks) { XmlExtractor.call(xml, :client_residing_person, "CLI_RES_PER_INPUT_T_12WP3_17A") }
@@ -108,7 +108,7 @@ module CCMS
                   end
                 end
 
-                context "child 15 or less" do
+                context "when child 15 or less" do
                   let(:relationship) { "child_relative" }
                   let(:dob) { 14.years.ago }
                   let(:blocks) { XmlExtractor.call(xml, :client_residing_person, "CLI_RES_PER_INPUT_T_12WP3_17A") }
@@ -118,7 +118,7 @@ module CCMS
                   end
                 end
 
-                context "child 16 or more" do
+                context "when child 16 or more" do
                   let(:relationship) { "child_relative" }
                   let(:dob) { 17.years.ago }
                   let(:blocks) { XmlExtractor.call(xml, :client_residing_person, "CLI_RES_PER_INPUT_T_12WP3_17A") }
@@ -129,7 +129,7 @@ module CCMS
                 end
               end
 
-              context "attribute CLI_RES_PER_INPUT_B_12WP3_35A - Person residing: entitled to claim benefits?" do
+              describe "attribute CLI_RES_PER_INPUT_B_12WP3_35A - Person residing: entitled to claim benefits?" do
                 let(:blocks) { XmlExtractor.call(xml, :client_residing_person, "CLI_RES_PER_INPUT_B_12WP3_35A") }
 
                 it "only produces a block for adult relatives" do
@@ -142,12 +142,12 @@ module CCMS
                 end
               end
 
-              context "attribute CLI_RES_PER_INPUT_B_12WP3_19A - Person residing: Capital over £8000?" do
+              describe "attribute CLI_RES_PER_INPUT_B_12WP3_19A - Person residing: Capital over £8000?" do
                 before { dependants.each { |dep| dep.update!(assets_value: value) } }
 
                 let(:blocks) { XmlExtractor.call(xml, :client_residing_person, "CLI_RES_PER_INPUT_B_12WP3_19A") }
 
-                context "all dependants have over £8,000 of assets" do
+                context "when all dependants have over £8,000 of assets" do
                   let(:value) { 8_000.01 }
 
                   it "codes all blocks to true" do
@@ -155,7 +155,7 @@ module CCMS
                   end
                 end
 
-                context "all dependants have less than £8,000 in assets" do
+                context "when all dependants have less than £8,000 in assets" do
                   let(:value) { 7_999.99 }
 
                   it "codes all blocks to false" do
@@ -164,7 +164,7 @@ module CCMS
                 end
               end
 
-              context "attribute CLI_RES_PER_INPUT_B_12WP3_21A - Dependant: Relationship is child aged 15 and under" do
+              describe "attribute CLI_RES_PER_INPUT_B_12WP3_21A - Dependant: Relationship is child aged 15 and under" do
                 let(:blocks) { XmlExtractor.call(xml, :client_residing_person, "CLI_RES_PER_INPUT_B_12WP3_21A") }
 
                 it "is true for the younger child" do
@@ -178,7 +178,7 @@ module CCMS
                 end
               end
 
-              context "attribute CLI_RES_PER_INPUT_B_12WP3_23A - Person Residing: The child receives their own income?" do
+              describe "attribute CLI_RES_PER_INPUT_B_12WP3_23A - Person Residing: The child receives their own income?" do
                 let(:blocks) { XmlExtractor.call(xml, :client_residing_person, "CLI_RES_PER_INPUT_B_12WP3_23A") }
 
                 it "is false for the younger child without income" do
@@ -192,7 +192,7 @@ module CCMS
                 end
               end
 
-              context "attribute CLI_RES_PER_INPUT_B_12WP3_24A - Dependant: Relationship is child aged 16 and over" do
+              describe "attribute CLI_RES_PER_INPUT_B_12WP3_24A - Dependant: Relationship is child aged 16 and over" do
                 let(:blocks) { XmlExtractor.call(xml, :client_residing_person, "CLI_RES_PER_INPUT_B_12WP3_24A") }
 
                 it "is false for the younger child" do
@@ -206,12 +206,12 @@ module CCMS
                 end
               end
 
-              context "attribute CLI_RES_PER_INPUT_B_12WP3_28A - Dependant: Relationship is adult" do
+              describe "attribute CLI_RES_PER_INPUT_B_12WP3_28A - Dependant: Relationship is adult" do
                 let(:blocks) { XmlExtractor.call(xml, :client_residing_person, "CLI_RES_PER_INPUT_B_12WP3_28A") }
 
                 before { dependants.each { |dep| dep.update!(relationship:) } }
 
-                context "all dependants are children" do
+                context "when all dependants are children" do
                   let(:relationship) { "child_relative" }
 
                   it "returns false for all blocks" do
@@ -219,7 +219,7 @@ module CCMS
                   end
                 end
 
-                context "all dependants are adults" do
+                context "when all dependants are adults" do
                   let(:relationship) { "adult_relative" }
 
                   it "returns true for all blocks" do
@@ -228,7 +228,7 @@ module CCMS
                 end
               end
 
-              context "attribute CLI_RES_PER_INPUT_D_12WP3_3A - Person residing: DOB" do
+              describe "attribute CLI_RES_PER_INPUT_D_12WP3_3A - Person residing: DOB" do
                 let(:blocks) { XmlExtractor.call(xml, :client_residing_person, "CLI_RES_PER_INPUT_D_12WP3_3A") }
 
                 before do
@@ -247,7 +247,7 @@ module CCMS
               end
             end
 
-            context "hard coded attributes" do
+            describe "hard coded attributes" do
               let(:hard_coded_attrs) do
                 [
                   # key for XmlExtractor xpath, attribute name, response type, user_defined?, expected_value

--- a/spec/services/ccms/submitters/add_applicant_service_spec.rb
+++ b/spec/services/ccms/submitters/add_applicant_service_spec.rb
@@ -27,8 +27,8 @@ module CCMS
         allow_any_instance_of(CCMS::Requestors::ApplicantAddRequestor).to receive(:transaction_request_id).and_return("20190301030405123456")
       end
 
-      context "operation successful" do
-        context "no applicant exists on the CCMS system" do
+      context "when the operation is successful" do
+        context "and no applicant exists on the CCMS system" do
           it "sets state to applicant_submitted" do
             subject.call
             expect(submission.aasm_state).to eq "applicant_submitted"
@@ -69,8 +69,8 @@ module CCMS
         end
       end
 
-      context "operation in error" do
-        context "error when adding an applicant" do
+      context "when the operation is in error" do
+        context "and it errors when adding an applicant" do
           let(:error) { [CCMS::CCMSError, Savon::Error, StandardError] }
 
           before do
@@ -106,7 +106,7 @@ module CCMS
           end
         end
 
-        context "unsuccessful response from CCMS adding an applicant" do
+        context "when the response is unsuccessful from CCMS adding an applicant" do
           let(:response_body) { ccms_data_from_file "applicant_add_response_failure.xml" }
 
           before do

--- a/spec/services/ccms/submitters/add_case_service_spec.rb
+++ b/spec/services/ccms/submitters/add_case_service_spec.rb
@@ -44,7 +44,7 @@ module CCMS
         allow_any_instance_of(CCMS::Requestors::CaseAddRequestor).to receive(:transaction_request_id).and_return("20190301030405123456")
       end
 
-      context "operation successful" do
+      context "when the operation is successful" do
         it "sets state to case_submitted" do
           subject.call
           expect(submission.aasm_state).to eq "case_submitted"
@@ -55,7 +55,7 @@ module CCMS
           expect(submission.case_add_transaction_id).to eq "20190301030405123456"
         end
 
-        context "there are documents to upload" do
+        context "and there are documents to upload" do
           let(:submission) { create(:submission, :document_ids_obtained, legal_aid_application:) }
 
           it "writes a history record" do
@@ -84,7 +84,7 @@ module CCMS
           end
         end
 
-        context "there are no documents to upload" do
+        context "and there are no documents to upload" do
           it "writes a history record" do
             expect { subject.call }.to change(SubmissionHistory, :count).by(1)
             expect(history.from_state).to eq "applicant_ref_obtained"
@@ -111,8 +111,8 @@ module CCMS
         end
       end
 
-      context "operation in error" do
-        context "error when adding a case" do
+      context "when the operation is unsuccessful" do
+        context "and an error is raised when adding a case" do
           let(:error) { [CCMS::CCMSError, Savon::Error, StandardError] }
 
           before do
@@ -143,7 +143,7 @@ module CCMS
           end
         end
 
-        context "unsuccessful response from CCMS adding a case" do
+        context "when there is an unsuccessful response from CCMS adding a case" do
           let(:response_body) { ccms_data_from_file "case_add_response_failure.xml" }
 
           before do

--- a/spec/services/ccms/submitters/check_applicant_status_service_spec.rb
+++ b/spec/services/ccms/submitters/check_applicant_status_service_spec.rb
@@ -24,12 +24,12 @@ module CCMS
         allow_any_instance_of(CCMS::Requestors::ApplicantAddStatusRequestor).to receive(:transaction_request_id).and_return("20190301030405123456")
       end
 
-      context "applicant_submitted state" do
-        context "operation successful" do
-          context "applicant not yet created" do
+      describe "applicant_submitted state" do
+        context "when the operation is successful" do
+          context "and the applicant is not yet created" do
             let(:response_body) { ccms_data_from_file "applicant_add_status_response_no_such_party.xml" }
 
-            context "poll count remains below limit" do
+            context "and poll count remains below limit" do
               it "increments the poll count" do
                 expect { subject.call }.to change(submission, :applicant_poll_count).by 1
               end
@@ -61,7 +61,7 @@ module CCMS
               end
             end
 
-            context "poll count reaches limit" do
+            context "and poll count reaches limit" do
               before do
                 submission.applicant_poll_count = Submission::POLL_LIMIT - 1
               end
@@ -92,7 +92,7 @@ module CCMS
             end
           end
 
-          context "applicant is created" do
+          context "and the applicant is created" do
             let(:expected_applicant_ccms_reference) { Faker::Number.number.to_s }
 
             before do
@@ -125,7 +125,7 @@ module CCMS
           end
         end
 
-        context "operation unsuccessful" do
+        context "when the operation is unsuccessful" do
           let(:error) { [CCMS::CCMSError, Savon::Error, StandardError] }
 
           before do

--- a/spec/services/ccms/submitters/check_case_status_service_spec.rb
+++ b/spec/services/ccms/submitters/check_case_status_service_spec.rb
@@ -13,11 +13,11 @@ RSpec.describe CCMS::Submitters::CheckCaseStatusService, :ccms do
     allow(subject).to receive(:case_add_status_requestor).and_return(case_add_status_requestor)
   end
 
-  context "applicant_submitted state" do
-    context "operation successful" do
+  describe "applicant_submitted state" do
+    context "when the operation is successful" do
       let(:transaction_request_id_in_example_response) { "20190301030405123456" }
 
-      context "case not yet created" do
+      context "and the case is not yet created" do
         before do
           allow(case_add_status_requestor).to receive(:formatted_xml).and_return(case_add_status_request)
           expect(case_add_status_requestor).to receive(:call).and_return(case_add_status_response)
@@ -25,7 +25,7 @@ RSpec.describe CCMS::Submitters::CheckCaseStatusService, :ccms do
           allow_any_instance_of(CCMS::Parsers::CaseAddStatusResponseParser).to receive(:success?).and_return(false)
         end
 
-        context "poll count remains below limit" do
+        context "and poll count remains below limit" do
           it "increments the poll count" do
             expect { subject.call }.to change(submission, :case_poll_count).by 1
           end
@@ -56,7 +56,7 @@ RSpec.describe CCMS::Submitters::CheckCaseStatusService, :ccms do
           end
         end
 
-        context "poll count reaches limit" do
+        context "and poll count reaches limit" do
           before do
             submission.case_poll_count = CCMS::Submission::POLL_LIMIT - 1
           end
@@ -92,7 +92,7 @@ RSpec.describe CCMS::Submitters::CheckCaseStatusService, :ccms do
         end
       end
 
-      context "case is created" do
+      context "when the case is created" do
         before do
           allow(case_add_status_requestor).to receive(:formatted_xml).and_return(case_add_status_request)
           expect(case_add_status_requestor).to receive(:call).and_return(case_add_status_response)
@@ -129,7 +129,7 @@ RSpec.describe CCMS::Submitters::CheckCaseStatusService, :ccms do
       end
     end
 
-    context "operation unsuccessful" do
+    context "when the operation is unsuccessful" do
       let(:transaction_request_id_in_example_response) { "20190301030405123456" }
       let(:error) { [CCMS::CCMSError, Savon::Error, StandardError] }
 

--- a/spec/services/ccms/submitters/obtain_applicant_reference_service_spec.rb
+++ b/spec/services/ccms/submitters/obtain_applicant_reference_service_spec.rb
@@ -28,8 +28,8 @@ module CCMS
         allow_any_instance_of(CCMS::Requestors::ApplicantSearchRequestor).to receive(:transaction_request_id).and_return("20190301030405123456")
       end
 
-      context "operation successful" do
-        context "applicant exists on the CCMS system" do
+      context "when the operation is successful" do
+        context "and the applicant exists on the CCMS system" do
           before do
             stub_request(:post, endpoint).with(body: /ClientInqRQ/).to_return(body: response_body, status: 200)
           end
@@ -116,15 +116,15 @@ module CCMS
           end
         end
 
-        context "applicant exists on CCMS but applicant details are not returned" do
+        context "and applicant exists on CCMS but applicant details are not returned" do
           before { stub_request(:post, endpoint).with(body: /ClientInqRQ/).to_return(body: no_applicant_details_response_body, status: 200) }
 
           it_behaves_like "applicant does not exist on CCMS"
         end
       end
 
-      context "operation in error" do
-        context "error when searching for applicant" do
+      context "when the operation is unsuccessful" do
+        context "and an error is raised when searching for applicant" do
           let(:error) { [CCMS::CCMSError, Savon::Error, StandardError] }
 
           before do

--- a/spec/services/ccms/submitters/obtain_document_id_service_spec.rb
+++ b/spec/services/ccms/submitters/obtain_document_id_service_spec.rb
@@ -28,7 +28,7 @@ module CCMS
         VCR.turn_on!
       end
 
-      context "operation successful" do
+      context "when the operation is successful" do
         before do
           # stub a post request - any body, any headers
           stub_request(:post, endpoint).to_return(body: response_body, status: 200)
@@ -37,14 +37,14 @@ module CCMS
           allow_any_instance_of(CCMS::Requestors::DocumentIdRequestor).to receive(:transaction_request_id).and_return("20190301030405123456")
         end
 
-        context "the application has no documents" do
+        context "and the application has no documents" do
           it "does not create any document objects" do
             subject.call
             expect(submission.submission_documents.count).to eq 0
           end
         end
 
-        context "the application has documents to upload" do
+        context "and the application has documents to upload" do
           before do
             create(:attachment, :merits_report, legal_aid_application:)
             create(:attachment, :means_report, legal_aid_application:)
@@ -145,7 +145,7 @@ module CCMS
         end
       end
 
-      context "operation unsuccessful" do
+      context "when the operation is unsuccessful" do
         let(:history) { SubmissionHistory.where(submission_id: submission.id, request: nil, response: nil).last }
         # There should only be one record in this state, so if it fails it's a legitimate error,
         # previously a race condition would occur where both records where created to

--- a/spec/services/ccms/submitters/upload_documents_service_spec.rb
+++ b/spec/services/ccms/submitters/upload_documents_service_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe CCMS::Submitters::UploadDocumentsService, :ccms do
     allow(document_upload_requestor).to receive(:formatted_xml).and_return(expected_response)
   end
 
-  context "operation successful" do
+  context "when the operation is successful" do
     let(:history) { histories.where(to_state: "completed").last }
 
     before do
@@ -95,10 +95,10 @@ RSpec.describe CCMS::Submitters::UploadDocumentsService, :ccms do
     end
   end
 
-  context "operation unsuccessful" do
+  context "when the operation is unsuccessful" do
     let(:history) { histories.where(request: nil, response: nil, to_state: "failed").last }
 
-    context "operation fails due to a CCMS::CCMSError exception" do
+    context "and the operation fails due to a CCMS::CCMSError exception" do
       let(:error) { [CCMS::CCMSError, Savon::Error, StandardError] }
 
       before do
@@ -133,7 +133,7 @@ RSpec.describe CCMS::Submitters::UploadDocumentsService, :ccms do
       end
     end
 
-    context "operation fails due to an error response from ccms" do
+    context "and the operation fails due to an error response from ccms" do
       before do
         allow_any_instance_of(CCMS::Parsers::DocumentUploadResponseParser).to receive(:success?).and_return(false)
         allow(document_upload_requestor).to receive(:call).and_return(document_upload_response)


### PR DESCRIPTION
## What

Start addressing the context exclusions in the CCMS namespace, remove another 106 infractions

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
