### PR TITLE
AP-4350: Ignore unneeded opponent model attributes

### DIFF
--- a/app/models/application_merits_task/opponent.rb
+++ b/app/models/application_merits_task/opponent.rb
@@ -2,6 +2,8 @@ module ApplicationMeritsTask
   class Opponent < ApplicationRecord
     include CCMSOpponentIdGenerator
 
+    self.ignored_columns += %w[first_name last_name]
+
     belongs_to :opposable, polymorphic: true, dependent: :destroy
     belongs_to :legal_aid_application
 

--- a/app/models/application_merits_task/opponent.rb
+++ b/app/models/application_merits_task/opponent.rb
@@ -7,15 +7,6 @@ module ApplicationMeritsTask
     belongs_to :opposable, polymorphic: true, dependent: :destroy
     belongs_to :legal_aid_application
 
-    # TODO: remove this when we remove the first and last name attributes from opponent - review from 31/07/2023
-    # NOTE: This is purely to continue to fill data on the opponent in case we need to rollback
-    before_save do
-      if opposable.is_a?(Individual)
-        self.first_name = opposable.first_name
-        self.last_name = opposable.last_name
-      end
-    end
-
     delegate :first_name,
              :last_name,
              :full_name,

--- a/spec/models/application_merits_task/opponent_spec.rb
+++ b/spec/models/application_merits_task/opponent_spec.rb
@@ -73,36 +73,5 @@ module ApplicationMeritsTask
         end
       end
     end
-
-    # TODO: remove this when we remove the first and last name attributes from opponent - review from 31/07/2023
-    # NOTE: This is purely to continue to fill data on the opponent in case we need to rollback
-    describe "#before_save" do
-      let(:opponent) { described_class.new(legal_aid_application: create(:legal_aid_application)) }
-
-      context "with opposable object" do
-        let(:individual) { ApplicationMeritsTask::Individual.new(first_name: "Billy", last_name: "Bob") }
-
-        before do
-          opponent.opposable = individual
-        end
-
-        it "saves the first and last name on the opponent to match opposable object" do
-          expect { opponent.save! }
-            .to change(opponent, :attributes)
-              .from(hash_including("first_name" => nil, "last_name" => nil))
-              .to(hash_including("first_name" => "Billy", "last_name" => "Bob"))
-        end
-
-        it "updates the first and last name on the opponent to match opposable object" do
-          opponent.save!
-          opponent.opposable.update!(first_name: "John", last_name: "Boy")
-
-          expect { opponent.save! }
-          .to change(opponent, :attributes)
-            .from(hash_including("first_name" => "Billy", "last_name" => "Bob"))
-            .to(hash_including("first_name" => "John", "last_name" => "Boy"))
-        end
-      end
-    end
   end
 end


### PR DESCRIPTION
## What
Ignore unneeded `opponents` model attributes as prelude to dropping

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4350)

Following migration to using opponent individuals and
organisations via a polymorphic relation these attributes
are no longer needed.

- [x] ignore the attributes
- [x] update dependant code - should just be the before_save hook 

There will be a follow up PR to remove/drop the opponents.first_name and opponents.last_name columns in a migration. This follows the [strong_migrations style for removing columns](https://github.com/ankane/strong_migrations#removing-a-column)


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
