### PR TITLE
AP-4350: Drop first_name, last_name from opponents

### DIFF
--- a/db/migrate/20230815072458_remove_first_name_last_name_from_opponents.rb
+++ b/db/migrate/20230815072458_remove_first_name_last_name_from_opponents.rb
@@ -1,0 +1,5 @@
+class RemoveFirstNameLastNameFromOpponents < ActiveRecord::Migration[7.0]
+  def change
+    safety_assured { remove_columns :opponents, :first_name, :last_name }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_07_135356) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_15_072458) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -673,8 +673,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_07_135356) do
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.integer "ccms_opponent_id"
-    t.string "first_name"
-    t.string "last_name"
     t.string "opposable_type"
     t.uuid "opposable_id"
     t.index ["legal_aid_application_id"], name: "index_opponents_on_legal_aid_application_id"


### PR DESCRIPTION
## What
Drop the first_name and last_name attributes from opponents

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4350)

Second part of removal of unneeded attributes following
move to using individuals as a polymorphic relation - [first PR](https://github.com/ministryofjustice/laa-apply-for-legal-aid/pull/5617).

A third PR will remove the ignore_columns from opponents model, following [strong_migrations removing column style](https://github.com/ankane/strong_migrations#removing-a-column).

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
