### PR TITLE
Anonymise success prospect details

### DIFF
--- a/db/anonymise/rules.rb
+++ b/db/anonymise/rules.rb
@@ -91,7 +91,11 @@ NINO_REGEXP = /^[A-CEGHJ-PR-TW-Z]{1}[A-CEGHJ-NPR-TW-Z]{1}[0-9]{6}[A-DFM]{1}$/
   cfe_submissions: {
     cfe_result: nil,
   },
-  chances_of_successes: {},
+  chances_of_successes: {
+    success_prospect_details: lambda do |original_value, row_context|
+      row_context[:field_1_val] = Faker::Lorem.paragraph(sentence_count: 2) unless original_value.eql?('\N')
+    end,
+  },
   citizen_access_tokens: {},
   debugs: {},
   dependants: {

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -1,6 +1,11 @@
 def build_postgres_url
-  "postgres://#{ENV.fetch('POSTGRES_USER', '')}:#{ENV.fetch('POSTGRES_PASSWORD', '')}" \
-    "@#{ENV.fetch('POSTGRES_HOST', '')}:5432/#{ENV.fetch('POSTGRES_DATABASE', '')}"
+  config = Rails.configuration.database_configuration
+  host     = config[Rails.env]["host"]
+  database = config[Rails.env]["database"]
+  username = config[Rails.env]["username"]
+  password = config[Rails.env]["password"]
+
+  "postgres://#{username}:#{password}@#{host}:5432/#{database}"
 end
 
 namespace :db do


### PR DESCRIPTION

## What
Anonymise `chances_of_successes#success_prospect_details` during dump

Because this field may contain sensitive information

Also, amend the connect details mechanism for anonymised database dumping

## Testing

I have tested this by performing a database dump both locally with rails `db:export` and via the script
on the branch and both work. The `chances_of_successes#success_prospect_details` is anonymised only
when it is not null.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
