### PR TITLE
AP-4285: Set cash transaction ownership

### DIFF
--- a/app/controllers/providers/means/cash_incomes_controller.rb
+++ b/app/controllers/providers/means/cash_incomes_controller.rb
@@ -26,6 +26,8 @@ module Providers
           .except(:cash_income)
           .merge({
             legal_aid_application_id: legal_aid_application[:id],
+            owner_type: "Applicant",
+            owner_id: legal_aid_application.applicant.id,
             none_selected: params[:aggregated_cash_income][:none_selected],
           })
       end

--- a/app/controllers/providers/means/cash_outgoings_controller.rb
+++ b/app/controllers/providers/means/cash_outgoings_controller.rb
@@ -25,6 +25,8 @@ module Providers
           .require(:aggregated_cash_outgoings)
           .except(:cash_outgoings)
           .merge({ legal_aid_application_id: legal_aid_application[:id],
+                   owner_type: "Applicant",
+                   owner_id: legal_aid_application.applicant.id,
                    none_selected: params[:aggregated_cash_outgoings][:none_selected] })
       end
 

--- a/app/models/base_aggregated_cash_transaction.rb
+++ b/app/models/base_aggregated_cash_transaction.rb
@@ -14,7 +14,7 @@ class BaseAggregatedCashTransaction
   validate :validate_at_least_one_selected
   validate :checkbox_integrity
 
-  attr_accessor :month1, :month2, :month3
+  attr_accessor :month1, :month2, :month3, :owner_id, :owner_type
 
   def initialize(legal_aid_application_id:)
     super
@@ -110,6 +110,8 @@ private
 
       CashTransaction.create!(
         legal_aid_application_id:,
+        owner_type:,
+        owner_id:,
         transaction_type_id: transaction_type_id(category),
         transaction_date: date,
         amount:,

--- a/app/models/cash_transaction.rb
+++ b/app/models/cash_transaction.rb
@@ -5,6 +5,7 @@ class CashTransaction < ApplicationRecord
 
   belongs_to :legal_aid_application
   belongs_to :transaction_type
+  belongs_to :owner, polymorphic: true
 
   validates :month_number, inclusion: { in: [1, 2, 3] }
 

--- a/db/migrate/20230821070336_add_owner_to_cash_transaction.rb
+++ b/db/migrate/20230821070336_add_owner_to_cash_transaction.rb
@@ -1,0 +1,9 @@
+class AddOwnerToCashTransaction < ActiveRecord::Migration[7.0]
+  def change
+    safety_assured do
+      change_table :cash_transactions, bulk: true do |t|
+        t.belongs_to :owner, polymorphic: true, type: :uuid
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_15_155824) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_21_070336) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -264,7 +264,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_15_155824) do
     t.datetime "updated_at", null: false
     t.integer "month_number"
     t.uuid "transaction_type_id"
+    t.string "owner_type"
+    t.uuid "owner_id"
     t.index ["legal_aid_application_id", "transaction_type_id", "month_number"], name: "cash_transactions_unique", unique: true
+    t.index ["owner_type", "owner_id"], name: "index_cash_transactions_on_owner"
   end
 
   create_table "ccms_opponent_ids", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/lib/tasks/migrate_cash_transaction_ownership.rake
+++ b/lib/tasks/migrate_cash_transaction_ownership.rake
@@ -1,0 +1,31 @@
+namespace :migrate do
+  desc "AP-4285: Migrate the ownership of cash transactions to applicant"
+  # This will allow future employments to be assigned to partner
+  task cash_transaction_ownership: :environment do
+    records = CashTransaction.all
+    Rails.logger.info "Migrating cash_transaction => Applicant"
+    Rails.logger.info "----------------------------------------"
+    Rails.logger.info "cash_transactions.count: #{records.count}"
+    Rails.logger.info "cash_transactions with owner: #{records.where.not(owner_id: nil).count}"
+    Rails.logger.info "cash_transactions without owner: #{records.where(owner_id: nil).count}"
+    Rails.logger.info "-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-="
+    Benchmark.benchmark do |bm|
+      bm.report("Migrate:") do
+        ActiveRecord::Base.transaction do
+          records.where(owner_id: nil).each do |record|
+            applicant = record.legal_aid_application.applicant
+            record.update!(
+              owner_id: applicant.id,
+              owner_type: applicant.class,
+            )
+          end
+          raise StandardError, "Not all cash_transactions updated" if records.where(owner_id: nil).count.positive?
+        end
+      end
+    end
+    Rails.logger.info "-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-="
+    Rails.logger.info "cash_transactions with owner: #{records.where.not(owner_id: nil).count}"
+    Rails.logger.info "cash_transactions without owner: #{records.where(owner_id: nil).count}"
+    Rails.logger.info "----------------------------------------"
+  end
+end

--- a/spec/factories/legal_aid_applications.rb
+++ b/spec/factories/legal_aid_applications.rb
@@ -879,6 +879,8 @@ FactoryBot.define do
                  transaction_type: benefits,
                  transaction_date: count.days.ago.to_date,
                  amount: 111,
+                 owner_type: "Applicant",
+                 owner_id: application.applicant.id,
                  month_number: count / 30)
 
           application.transaction_types << benefits
@@ -931,6 +933,8 @@ FactoryBot.define do
                  transaction_type: rent_or_mortgage,
                  transaction_date: count.days.ago.to_date,
                  amount: 222,
+                 owner_type: "Applicant",
+                 owner_id: application.applicant.id,
                  month_number: count / 30)
 
           application.transaction_types << rent_or_mortgage

--- a/spec/forms/providers/means/regular_income_form_spec.rb
+++ b/spec/forms/providers/means/regular_income_form_spec.rb
@@ -218,7 +218,7 @@ RSpec.describe Providers::Means::RegularIncomeForm do
 
       it "does not update an application's cash transactions" do
         legal_aid_application = create(:legal_aid_application, :with_applicant)
-        cash_transaction = create(:cash_transaction, legal_aid_application:)
+        cash_transaction = create(:cash_transaction, legal_aid_application:, owner_type: "Applicant", owner_id: legal_aid_application.applicant.id)
         form = described_class.new(legal_aid_application:)
 
         form.save
@@ -357,11 +357,15 @@ RSpec.describe Providers::Means::RegularIncomeForm do
         _income_cash_transaction = create(
           :cash_transaction,
           legal_aid_application:,
+          owner_type: "Applicant",
+          owner_id: legal_aid_application.applicant.id,
           transaction_type: pension,
         )
         outgoing_cash_transaction = create(
           :cash_transaction,
           legal_aid_application:,
+          owner_type: "Applicant",
+          owner_id: legal_aid_application.applicant.id,
           transaction_type: child_care,
         )
 
@@ -515,16 +519,22 @@ RSpec.describe Providers::Means::RegularIncomeForm do
         _old_income_cash_transaction = create(
           :cash_transaction,
           legal_aid_application:,
+          owner_type: "Applicant",
+          owner_id: legal_aid_application.applicant.id,
           transaction_type: maintenance_in,
         )
         existing_income_cash_transaction = create(
           :cash_transaction,
           legal_aid_application:,
+          owner_type: "Applicant",
+          owner_id: legal_aid_application.applicant.id,
           transaction_type: benefits,
         )
         outgoing_cash_transaction = create(
           :cash_transaction,
           legal_aid_application:,
+          owner_type: "Applicant",
+          owner_id: legal_aid_application.applicant.id,
           transaction_type: child_care,
         )
         params = {

--- a/spec/forms/providers/means/regular_outgoings_form_spec.rb
+++ b/spec/forms/providers/means/regular_outgoings_form_spec.rb
@@ -220,7 +220,7 @@ RSpec.describe Providers::Means::RegularOutgoingsForm do
 
       it "does not update an application's cash transactions" do
         legal_aid_application = create(:legal_aid_application, :with_applicant)
-        cash_transaction = create(:cash_transaction, legal_aid_application:)
+        cash_transaction = create(:cash_transaction, legal_aid_application:, owner_type: "Applicant", owner_id: legal_aid_application.applicant.id)
         form = described_class.new(legal_aid_application:)
 
         form.save

--- a/spec/models/aggregated_cash_income_spec.rb
+++ b/spec/models/aggregated_cash_income_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe AggregatedCashIncome do
   let(:aci) { described_class.new(legal_aid_application_id: application.id) }
-  let(:application) { create(:legal_aid_application, :with_proceedings) }
+  let(:application) { create(:legal_aid_application, :with_applicant, :with_proceedings) }
   let(:categories) { %i[benefits maintenance_in] }
   let!(:benefits) { create(:transaction_type, :benefits) }
   let!(:maintenance_in) { create(:transaction_type, :maintenance_in) }
@@ -85,12 +85,12 @@ RSpec.describe AggregatedCashIncome do
     end
 
     context "when cash income transaction records exist" do
-      let!(:pension_first_month) { create(:cash_transaction, :credit_month1, legal_aid_application: application, transaction_type: pension) }
-      let!(:pension_second_month) { create(:cash_transaction, :credit_month2, legal_aid_application: application, transaction_type: pension) }
-      let!(:pension_third_month) { create(:cash_transaction, :credit_month3, legal_aid_application: application, transaction_type: pension) }
-      let!(:maintenance_in_first_month) { create(:cash_transaction, :credit_month1, legal_aid_application: application, transaction_type: maintenance_in) }
-      let!(:maintenance_in_second_month) { create(:cash_transaction, :credit_month2, legal_aid_application: application, transaction_type: maintenance_in) }
-      let!(:maintenance_in_third_month) { create(:cash_transaction, :credit_month3, legal_aid_application: application, transaction_type: maintenance_in) }
+      let!(:pension_first_month) { create(:cash_transaction, :credit_month1, legal_aid_application: application, owner_type: "Applicant", owner_id: application.applicant.id, transaction_type: pension) }
+      let!(:pension_second_month) { create(:cash_transaction, :credit_month2, legal_aid_application: application, owner_type: "Applicant", owner_id: application.applicant.id, transaction_type: pension) }
+      let!(:pension_third_month) { create(:cash_transaction, :credit_month3, legal_aid_application: application, owner_type: "Applicant", owner_id: application.applicant.id, transaction_type: pension) }
+      let!(:maintenance_in_first_month) { create(:cash_transaction, :credit_month1, legal_aid_application: application, owner_type: "Applicant", owner_id: application.applicant.id, transaction_type: maintenance_in) }
+      let!(:maintenance_in_second_month) { create(:cash_transaction, :credit_month2, legal_aid_application: application, owner_type: "Applicant", owner_id: application.applicant.id, transaction_type: maintenance_in) }
+      let!(:maintenance_in_third_month) { create(:cash_transaction, :credit_month3, legal_aid_application: application, owner_type: "Applicant", owner_id: application.applicant.id, transaction_type: maintenance_in) }
       let(:month_1_date) { Date.new(2020, 12, 1) }
       let(:month_2_date) { Date.new(2020, 11, 1) }
       let(:month_3_date) { Date.new(2020, 10, 1) }
@@ -450,12 +450,12 @@ RSpec.describe AggregatedCashIncome do
       travel_back
     end
 
-    let!(:pension_first_month) { create(:cash_transaction, :credit_month1, legal_aid_application: application, transaction_type: pension) }
-    let!(:pension_second_month) { create(:cash_transaction, :credit_month2, legal_aid_application: application, transaction_type: pension) }
-    let!(:pension_third_month) { create(:cash_transaction, :credit_month3, legal_aid_application: application, transaction_type: pension) }
-    let!(:maintenance_in_first_month) { create(:cash_transaction, :credit_month1, legal_aid_application: application, transaction_type: maintenance_in) }
-    let!(:maintenance_in_second_month) { create(:cash_transaction, :credit_month2, legal_aid_application: application, transaction_type: maintenance_in) }
-    let!(:maintenance_in_third_month) { create(:cash_transaction, :credit_month3, legal_aid_application: application, transaction_type: maintenance_in) }
+    let!(:pension_first_month) { create(:cash_transaction, :credit_month1, legal_aid_application: application, owner_type: "Applicant", owner_id: application.applicant.id, transaction_type: pension) }
+    let!(:pension_second_month) { create(:cash_transaction, :credit_month2, legal_aid_application: application, owner_type: "Applicant", owner_id: application.applicant.id, transaction_type: pension) }
+    let!(:pension_third_month) { create(:cash_transaction, :credit_month3, legal_aid_application: application, owner_type: "Applicant", owner_id: application.applicant.id, transaction_type: pension) }
+    let!(:maintenance_in_first_month) { create(:cash_transaction, :credit_month1, legal_aid_application: application, owner_type: "Applicant", owner_id: application.applicant.id, transaction_type: maintenance_in) }
+    let!(:maintenance_in_second_month) { create(:cash_transaction, :credit_month2, legal_aid_application: application, owner_type: "Applicant", owner_id: application.applicant.id, transaction_type: maintenance_in) }
+    let!(:maintenance_in_third_month) { create(:cash_transaction, :credit_month3, legal_aid_application: application, owner_type: "Applicant", owner_id: application.applicant.id, transaction_type: maintenance_in) }
     let(:aci) { described_class.find_by(legal_aid_application_id: application.id) }
 
     describe "#period" do
@@ -514,6 +514,8 @@ RSpec.describe AggregatedCashIncome do
       maintenance_in2: "5",
       maintenance_in3: "6",
       legal_aid_application_id: application.id,
+      owner_type: "Applicant",
+      owner_id: application.applicant.id,
       none_selected: "",
     }
   end

--- a/spec/models/aggregated_cash_outgoings_spec.rb
+++ b/spec/models/aggregated_cash_outgoings_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe AggregatedCashOutgoings do
   let(:aco) { described_class.new(legal_aid_application_id: application.id) }
-  let(:application) { create(:legal_aid_application) }
+  let(:application) { create(:legal_aid_application, :with_applicant) }
   let(:categories) { %i[rent_or_mortgage maintenance_out] }
   let!(:rent_or_mortgage) { create(:transaction_type, :rent_or_mortgage) }
   let!(:maintenance_out) { create(:transaction_type, :maintenance_out) }
@@ -46,9 +46,9 @@ RSpec.describe AggregatedCashOutgoings do
     end
 
     context "when cash income transaction records exist" do
-      let!(:maintenance_out_first_month) { create(:cash_transaction, :credit_month1, legal_aid_application: application, transaction_type: maintenance_out) }
-      let!(:maintenance_out_second_month) { create(:cash_transaction, :credit_month2, legal_aid_application: application, transaction_type: maintenance_out) }
-      let!(:maintenance_out_third_month) { create(:cash_transaction, :credit_month3, legal_aid_application: application, transaction_type: maintenance_out) }
+      let!(:maintenance_out_first_month) { create(:cash_transaction, :credit_month1, legal_aid_application: application, owner_type: "Applicant", owner_id: application.applicant.id, transaction_type: maintenance_out) }
+      let!(:maintenance_out_second_month) { create(:cash_transaction, :credit_month2, legal_aid_application: application, owner_type: "Applicant", owner_id: application.applicant.id, transaction_type: maintenance_out) }
+      let!(:maintenance_out_third_month) { create(:cash_transaction, :credit_month3, legal_aid_application: application, owner_type: "Applicant", owner_id: application.applicant.id, transaction_type: maintenance_out) }
       let(:month_1_date) { Date.new(2020, 12, 1) }
       let(:month_2_date) { Date.new(2020, 11, 1) }
       let(:month_3_date) { Date.new(2020, 10, 1) }
@@ -404,6 +404,8 @@ RSpec.describe AggregatedCashOutgoings do
       maintenance_out2: "5",
       maintenance_out3: "6",
       legal_aid_application_id: application.id,
+      owner_type: "Applicant",
+      owner_id: application.applicant.id,
       none_selected: "",
     }
   end
@@ -455,6 +457,8 @@ RSpec.describe AggregatedCashOutgoings do
       maintenance_out2: "",
       maintenance_out3: "",
       legal_aid_application_id: application.id,
+      owner_type: "Applicant",
+      owner_id: application.applicant.id,
       none_selected: "true",
     }
   end

--- a/spec/models/cash_transaction_spec.rb
+++ b/spec/models/cash_transaction_spec.rb
@@ -1,8 +1,8 @@
 require "rails_helper"
 
 RSpec.describe CashTransaction do
-  let(:application1) { create(:legal_aid_application) }
-  let(:application2) { create(:legal_aid_application) }
+  let(:application1) { create(:legal_aid_application, :with_applicant) }
+  let(:application2) { create(:legal_aid_application, :with_applicant) }
   let(:benefits) { create(:transaction_type, :benefits) }
   let(:pension) { create(:transaction_type, :pension) }
   let(:benefit_transaction_array) { [] }
@@ -15,10 +15,22 @@ RSpec.describe CashTransaction do
 
   def cash_transactions_for(application, multiplier)
     (1..3).each do |number|
-      benefits_transaction = create(:cash_transaction, transaction_type: benefits, legal_aid_application: application, transaction_date: number.month.ago,
-                                                       amount: 100 * multiplier, month_number: number)
-      pension_transaction = create(:cash_transaction, transaction_type: pension, legal_aid_application: application, transaction_date: number.month.ago,
-                                                      amount: 200 * multiplier, month_number: number)
+      benefits_transaction = create(:cash_transaction,
+                                    transaction_type: benefits,
+                                    legal_aid_application: application,
+                                    owner_type: "Applicant",
+                                    owner_id: application.applicant.id,
+                                    transaction_date: number.month.ago,
+                                    amount: 100 * multiplier,
+                                    month_number: number)
+      pension_transaction = create(:cash_transaction,
+                                   transaction_type: pension,
+                                   legal_aid_application: application,
+                                   owner_type: "Applicant",
+                                   owner_id: application.applicant.id,
+                                   transaction_date: number.month.ago,
+                                   amount: 200 * multiplier,
+                                   month_number: number)
       benefit_transaction_array << benefits_transaction
       pension_transaction_array << pension_transaction
     end
@@ -40,7 +52,13 @@ RSpec.describe CashTransaction do
   end
 
   context "with date formatting" do
-    let(:ctx) { create(:cash_transaction, transaction_date: Date.new(2021, 2, 2), month_number: 1) }
+    let(:ctx) do
+      create(:cash_transaction,
+             legal_aid_application: application1,
+             owner_type: "Applicant",
+             owner_id: application1.applicant.id,
+             transaction_date: Date.new(2021, 2, 2), month_number: 1)
+    end
 
     describe ".period_start" do
       it "displays 1st day and month of transaction date" do

--- a/spec/models/legal_aid_application_transaction_type_spec.rb
+++ b/spec/models/legal_aid_application_transaction_type_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe LegalAidApplicationTransactionType do
-  let(:legal_aid_application) { create(:legal_aid_application) }
+  let(:legal_aid_application) { create(:legal_aid_application, :with_applicant) }
   let(:credit_transaction_type) { create(:transaction_type, :credit_with_standard_name) }
   let(:debit_transaction_type) { create(:transaction_type, :debit_with_standard_name) }
 
@@ -65,8 +65,8 @@ RSpec.describe LegalAidApplicationTransactionType do
              legal_aid_application:,
              transaction_type: debit_transaction_type)
 
-      legal_aid_application.cash_transactions.create!(transaction_type_id: credit_transaction_type.id, amount: 101, month_number: 1, transaction_date: Time.zone.now.to_date)
-      legal_aid_application.cash_transactions.create!(transaction_type_id: debit_transaction_type.id, amount: 103, month_number: 3, transaction_date: 2.months.ago)
+      legal_aid_application.cash_transactions.create!(owner_type: "Applicant", owner_id: legal_aid_application.applicant.id, transaction_type_id: credit_transaction_type.id, amount: 101, month_number: 1, transaction_date: Time.zone.now.to_date)
+      legal_aid_application.cash_transactions.create!(owner_type: "Applicant", owner_id: legal_aid_application.applicant.id, transaction_type_id: debit_transaction_type.id, amount: 103, month_number: 3, transaction_date: 2.months.ago)
     end
 
     context "when destroying object instance" do

--- a/spec/requests/providers/means/cash_incomes_controller_spec.rb
+++ b/spec/requests/providers/means/cash_incomes_controller_spec.rb
@@ -73,6 +73,16 @@ RSpec.describe Providers::Means::CashIncomesController do
       it "updates the model attribute for no cash income to false" do
         expect { request }.to change { legal_aid_application.reload.no_cash_income }.from(nil).to(false)
       end
+
+      it "sets the applicant as owner" do
+        request
+        expect(legal_aid_application.cash_transactions.first).to have_attributes(
+          {
+            owner_type: "Applicant",
+            owner_id: legal_aid_application.applicant.id,
+          },
+        )
+      end
     end
 
     context "with nothing selected" do

--- a/spec/requests/providers/means/cash_incomes_controller_spec.rb
+++ b/spec/requests/providers/means/cash_incomes_controller_spec.rb
@@ -138,6 +138,7 @@ RSpec.describe Providers::Means::CashIncomesController do
     context "when checking answers" do
       let(:legal_aid_application) do
         create(:legal_aid_application,
+               :with_applicant,
                :with_non_passported_state_machine,
                :checking_means_income)
       end

--- a/spec/requests/providers/means/cash_outgoings_controller_spec.rb
+++ b/spec/requests/providers/means/cash_outgoings_controller_spec.rb
@@ -85,6 +85,16 @@ RSpec.describe Providers::Means::CashOutgoingsController do
             request
             expect(response).to redirect_to(providers_legal_aid_application_income_summary_index_path(legal_aid_application))
           end
+
+          it "sets the applicant as owner" do
+            request
+            expect(legal_aid_application.cash_transactions.first).to have_attributes(
+              {
+                owner_type: "Applicant",
+                owner_id: legal_aid_application.applicant.id,
+              },
+            )
+          end
         end
 
         context "with outgoings categories but no income categories" do

--- a/spec/requests/providers/means/cash_outgoings_controller_spec.rb
+++ b/spec/requests/providers/means/cash_outgoings_controller_spec.rb
@@ -215,6 +215,7 @@ RSpec.describe Providers::Means::CashOutgoingsController do
     context "when checking answers" do
       let(:legal_aid_application) do
         create(:legal_aid_application,
+               :with_applicant,
                :with_non_passported_state_machine,
                :checking_means_income)
       end

--- a/spec/requests/providers/means/identify_types_of_incomes_controller_spec.rb
+++ b/spec/requests/providers/means/identify_types_of_incomes_controller_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Providers::Means::IdentifyTypesOfIncomesController do
-  let(:legal_aid_application) { create(:legal_aid_application) }
+  let(:legal_aid_application) { create(:legal_aid_application, :with_applicant) }
 
   let!(:outgoing_types) do
     [
@@ -156,12 +156,13 @@ RSpec.describe Providers::Means::IdentifyTypesOfIncomesController do
 
         let(:legal_aid_application) do
           laa = create(:legal_aid_application, :with_applicant, :with_non_passported_state_machine, transaction_types: [benefits_credit, rent_or_mortgage_debit])
-          laa.cash_transactions.create!(transaction_type_id: benefits_credit.id, amount: 101, month_number: 1, transaction_date: Time.zone.now.to_date)
-          laa.cash_transactions.create!(transaction_type_id: benefits_credit.id, amount: 102, month_number: 2, transaction_date: 1.month.ago)
-          laa.cash_transactions.create!(transaction_type_id: benefits_credit.id, amount: 103, month_number: 3, transaction_date: 2.months.ago)
-          laa.cash_transactions.create!(transaction_type_id: rent_or_mortgage_debit.id, amount: 301, month_number: 1, transaction_date: Time.zone.now.to_date)
-          laa.cash_transactions.create!(transaction_type_id: rent_or_mortgage_debit.id, amount: 302, month_number: 2, transaction_date: 1.month.ago)
-          laa.cash_transactions.create!(transaction_type_id: rent_or_mortgage_debit.id, amount: 303, month_number: 3, transaction_date: 2.months.ago)
+          applicant_id = laa.applicant.id
+          laa.cash_transactions.create!(owner_type: "Applicant", owner_id: applicant_id, transaction_type_id: benefits_credit.id, amount: 101, month_number: 1, transaction_date: Time.zone.now.to_date)
+          laa.cash_transactions.create!(owner_type: "Applicant", owner_id: applicant_id, transaction_type_id: benefits_credit.id, amount: 102, month_number: 2, transaction_date: 1.month.ago)
+          laa.cash_transactions.create!(owner_type: "Applicant", owner_id: applicant_id, transaction_type_id: benefits_credit.id, amount: 103, month_number: 3, transaction_date: 2.months.ago)
+          laa.cash_transactions.create!(owner_type: "Applicant", owner_id: applicant_id, transaction_type_id: rent_or_mortgage_debit.id, amount: 301, month_number: 1, transaction_date: Time.zone.now.to_date)
+          laa.cash_transactions.create!(owner_type: "Applicant", owner_id: applicant_id, transaction_type_id: rent_or_mortgage_debit.id, amount: 302, month_number: 2, transaction_date: 1.month.ago)
+          laa.cash_transactions.create!(owner_type: "Applicant", owner_id: applicant_id, transaction_type_id: rent_or_mortgage_debit.id, amount: 303, month_number: 3, transaction_date: 2.months.ago)
           laa
         end
 
@@ -184,15 +185,16 @@ RSpec.describe Providers::Means::IdentifyTypesOfIncomesController do
 
       let(:legal_aid_application) do
         laa = create(:legal_aid_application, :with_applicant, :with_non_passported_state_machine, transaction_types: [benefits_credit, friends_or_family_credit, rent_or_mortgage_debit])
-        laa.cash_transactions.create!(transaction_type_id: benefits_credit.id, amount: 101, month_number: 1, transaction_date: Time.zone.now.to_date)
-        laa.cash_transactions.create!(transaction_type_id: benefits_credit.id, amount: 102, month_number: 2, transaction_date: 1.month.ago)
-        laa.cash_transactions.create!(transaction_type_id: benefits_credit.id, amount: 103, month_number: 3, transaction_date: 2.months.ago)
-        laa.cash_transactions.create!(transaction_type_id: friends_or_family_credit.id, amount: 201, month_number: 1, transaction_date: Time.zone.now.to_date)
-        laa.cash_transactions.create!(transaction_type_id: friends_or_family_credit.id, amount: 202, month_number: 2, transaction_date: 1.month.ago)
-        laa.cash_transactions.create!(transaction_type_id: friends_or_family_credit.id, amount: 203, month_number: 3, transaction_date: 2.months.ago)
-        laa.cash_transactions.create!(transaction_type_id: rent_or_mortgage_debit.id, amount: 301, month_number: 1, transaction_date: Time.zone.now.to_date)
-        laa.cash_transactions.create!(transaction_type_id: rent_or_mortgage_debit.id, amount: 302, month_number: 2, transaction_date: 1.month.ago)
-        laa.cash_transactions.create!(transaction_type_id: rent_or_mortgage_debit.id, amount: 303, month_number: 3, transaction_date: 2.months.ago)
+        applicant_id = laa.applicant.id
+        laa.cash_transactions.create!(owner_type: "Applicant", owner_id: applicant_id, transaction_type_id: benefits_credit.id, amount: 101, month_number: 1, transaction_date: Time.zone.now.to_date)
+        laa.cash_transactions.create!(owner_type: "Applicant", owner_id: applicant_id, transaction_type_id: benefits_credit.id, amount: 102, month_number: 2, transaction_date: 1.month.ago)
+        laa.cash_transactions.create!(owner_type: "Applicant", owner_id: applicant_id, transaction_type_id: benefits_credit.id, amount: 103, month_number: 3, transaction_date: 2.months.ago)
+        laa.cash_transactions.create!(owner_type: "Applicant", owner_id: applicant_id, transaction_type_id: friends_or_family_credit.id, amount: 201, month_number: 1, transaction_date: Time.zone.now.to_date)
+        laa.cash_transactions.create!(owner_type: "Applicant", owner_id: applicant_id, transaction_type_id: friends_or_family_credit.id, amount: 202, month_number: 2, transaction_date: 1.month.ago)
+        laa.cash_transactions.create!(owner_type: "Applicant", owner_id: applicant_id, transaction_type_id: friends_or_family_credit.id, amount: 203, month_number: 3, transaction_date: 2.months.ago)
+        laa.cash_transactions.create!(owner_type: "Applicant", owner_id: applicant_id, transaction_type_id: rent_or_mortgage_debit.id, amount: 301, month_number: 1, transaction_date: Time.zone.now.to_date)
+        laa.cash_transactions.create!(owner_type: "Applicant", owner_id: applicant_id, transaction_type_id: rent_or_mortgage_debit.id, amount: 302, month_number: 2, transaction_date: 1.month.ago)
+        laa.cash_transactions.create!(owner_type: "Applicant", owner_id: applicant_id, transaction_type_id: rent_or_mortgage_debit.id, amount: 303, month_number: 3, transaction_date: 2.months.ago)
         laa
       end
 
@@ -336,12 +338,13 @@ RSpec.describe Providers::Means::IdentifyTypesOfIncomesController do
 
         let(:legal_aid_application) do
           laa = create(:legal_aid_application, :with_applicant, :with_non_passported_state_machine, transaction_types: [benefits_credit, rent_or_mortgage_debit])
-          laa.cash_transactions.create!(transaction_type_id: benefits_credit.id, amount: 101, month_number: 1, transaction_date: Time.zone.now.to_date)
-          laa.cash_transactions.create!(transaction_type_id: benefits_credit.id, amount: 102, month_number: 2, transaction_date: 1.month.ago)
-          laa.cash_transactions.create!(transaction_type_id: benefits_credit.id, amount: 103, month_number: 3, transaction_date: 2.months.ago)
-          laa.cash_transactions.create!(transaction_type_id: rent_or_mortgage_debit.id, amount: 301, month_number: 1, transaction_date: Time.zone.now.to_date)
-          laa.cash_transactions.create!(transaction_type_id: rent_or_mortgage_debit.id, amount: 302, month_number: 2, transaction_date: 1.month.ago)
-          laa.cash_transactions.create!(transaction_type_id: rent_or_mortgage_debit.id, amount: 303, month_number: 3, transaction_date: 2.months.ago)
+          applicant_id = laa.applicant.id
+          laa.cash_transactions.create!(owner_type: "Applicant", owner_id: applicant_id, transaction_type_id: benefits_credit.id, amount: 101, month_number: 1, transaction_date: Time.zone.now.to_date)
+          laa.cash_transactions.create!(owner_type: "Applicant", owner_id: applicant_id, transaction_type_id: benefits_credit.id, amount: 102, month_number: 2, transaction_date: 1.month.ago)
+          laa.cash_transactions.create!(owner_type: "Applicant", owner_id: applicant_id, transaction_type_id: benefits_credit.id, amount: 103, month_number: 3, transaction_date: 2.months.ago)
+          laa.cash_transactions.create!(owner_type: "Applicant", owner_id: applicant_id, transaction_type_id: rent_or_mortgage_debit.id, amount: 301, month_number: 1, transaction_date: Time.zone.now.to_date)
+          laa.cash_transactions.create!(owner_type: "Applicant", owner_id: applicant_id, transaction_type_id: rent_or_mortgage_debit.id, amount: 302, month_number: 2, transaction_date: 1.month.ago)
+          laa.cash_transactions.create!(owner_type: "Applicant", owner_id: applicant_id, transaction_type_id: rent_or_mortgage_debit.id, amount: 303, month_number: 3, transaction_date: 2.months.ago)
           laa
         end
 

--- a/spec/requests/providers/means/identify_types_of_outgoings_controller_spec.rb
+++ b/spec/requests/providers/means/identify_types_of_outgoings_controller_spec.rb
@@ -144,12 +144,13 @@ RSpec.describe Providers::Means::IdentifyTypesOfOutgoingsController do
 
         let(:legal_aid_application) do
           laa = create(:legal_aid_application, :with_applicant, :with_non_passported_state_machine, transaction_types: [benefits_credit, rent_or_mortgage_debit])
-          laa.cash_transactions.create!(transaction_type_id: benefits_credit.id, amount: 101, month_number: 1, transaction_date: Time.zone.now.to_date)
-          laa.cash_transactions.create!(transaction_type_id: benefits_credit.id, amount: 102, month_number: 2, transaction_date: 1.month.ago)
-          laa.cash_transactions.create!(transaction_type_id: benefits_credit.id, amount: 103, month_number: 3, transaction_date: 2.months.ago)
-          laa.cash_transactions.create!(transaction_type_id: rent_or_mortgage_debit.id, amount: 301, month_number: 1, transaction_date: Time.zone.now.to_date)
-          laa.cash_transactions.create!(transaction_type_id: rent_or_mortgage_debit.id, amount: 302, month_number: 2, transaction_date: 1.month.ago)
-          laa.cash_transactions.create!(transaction_type_id: rent_or_mortgage_debit.id, amount: 303, month_number: 3, transaction_date: 2.months.ago)
+          applicant_id = laa.applicant.id
+          laa.cash_transactions.create!(owner_type: "Applicant", owner_id: applicant_id, transaction_type_id: benefits_credit.id, amount: 101, month_number: 1, transaction_date: Time.zone.now.to_date)
+          laa.cash_transactions.create!(owner_type: "Applicant", owner_id: applicant_id, transaction_type_id: benefits_credit.id, amount: 102, month_number: 2, transaction_date: 1.month.ago)
+          laa.cash_transactions.create!(owner_type: "Applicant", owner_id: applicant_id, transaction_type_id: benefits_credit.id, amount: 103, month_number: 3, transaction_date: 2.months.ago)
+          laa.cash_transactions.create!(owner_type: "Applicant", owner_id: applicant_id, transaction_type_id: rent_or_mortgage_debit.id, amount: 301, month_number: 1, transaction_date: Time.zone.now.to_date)
+          laa.cash_transactions.create!(owner_type: "Applicant", owner_id: applicant_id, transaction_type_id: rent_or_mortgage_debit.id, amount: 302, month_number: 2, transaction_date: 1.month.ago)
+          laa.cash_transactions.create!(owner_type: "Applicant", owner_id: applicant_id, transaction_type_id: rent_or_mortgage_debit.id, amount: 303, month_number: 3, transaction_date: 2.months.ago)
           laa
         end
 
@@ -309,12 +310,13 @@ RSpec.describe Providers::Means::IdentifyTypesOfOutgoingsController do
 
         let(:legal_aid_application) do
           laa = create(:legal_aid_application, :with_applicant, :with_non_passported_state_machine, transaction_types: [benefits_credit, rent_or_mortgage_debit])
-          laa.cash_transactions.create!(transaction_type_id: benefits_credit.id, amount: 101, month_number: 1, transaction_date: Time.zone.now.to_date)
-          laa.cash_transactions.create!(transaction_type_id: benefits_credit.id, amount: 102, month_number: 2, transaction_date: 1.month.ago)
-          laa.cash_transactions.create!(transaction_type_id: benefits_credit.id, amount: 103, month_number: 3, transaction_date: 2.months.ago)
-          laa.cash_transactions.create!(transaction_type_id: rent_or_mortgage_debit.id, amount: 301, month_number: 1, transaction_date: Time.zone.now.to_date)
-          laa.cash_transactions.create!(transaction_type_id: rent_or_mortgage_debit.id, amount: 302, month_number: 2, transaction_date: 1.month.ago)
-          laa.cash_transactions.create!(transaction_type_id: rent_or_mortgage_debit.id, amount: 303, month_number: 3, transaction_date: 2.months.ago)
+          applicant_id = laa.applicant.id
+          laa.cash_transactions.create!(owner_type: "Applicant", owner_id: applicant_id, transaction_type_id: benefits_credit.id, amount: 101, month_number: 1, transaction_date: Time.zone.now.to_date)
+          laa.cash_transactions.create!(owner_type: "Applicant", owner_id: applicant_id, transaction_type_id: benefits_credit.id, amount: 102, month_number: 2, transaction_date: 1.month.ago)
+          laa.cash_transactions.create!(owner_type: "Applicant", owner_id: applicant_id, transaction_type_id: benefits_credit.id, amount: 103, month_number: 3, transaction_date: 2.months.ago)
+          laa.cash_transactions.create!(owner_type: "Applicant", owner_id: applicant_id, transaction_type_id: rent_or_mortgage_debit.id, amount: 301, month_number: 1, transaction_date: Time.zone.now.to_date)
+          laa.cash_transactions.create!(owner_type: "Applicant", owner_id: applicant_id, transaction_type_id: rent_or_mortgage_debit.id, amount: 302, month_number: 2, transaction_date: 1.month.ago)
+          laa.cash_transactions.create!(owner_type: "Applicant", owner_id: applicant_id, transaction_type_id: rent_or_mortgage_debit.id, amount: 303, month_number: 3, transaction_date: 2.months.ago)
           laa
         end
 

--- a/spec/services/cfe_civil/components/cash_transactions_spec.rb
+++ b/spec/services/cfe_civil/components/cash_transactions_spec.rb
@@ -18,13 +18,13 @@ RSpec.describe CFECivil::Components::CashTransactions do
 
   context "when cash transactions exist" do
     let(:benefits) { create(:transaction_type, :benefits) }
-    let!(:first_benefits_month) { create(:cash_transaction, :credit_month1, legal_aid_application:, amount: 123.0, transaction_type: benefits) }
-    let!(:second_benefits_month) { create(:cash_transaction, :credit_month2, legal_aid_application:, amount: 234.0, transaction_type: benefits) }
-    let!(:third_benefits_month) { create(:cash_transaction, :credit_month3, legal_aid_application:, amount: 345.0, transaction_type: benefits) }
+    let!(:first_benefits_month) { create(:cash_transaction, :credit_month1, legal_aid_application:, owner_type: "Applicant", owner_id: legal_aid_application.applicant.id, amount: 123.0, transaction_type: benefits) }
+    let!(:second_benefits_month) { create(:cash_transaction, :credit_month2, legal_aid_application:, owner_type: "Applicant", owner_id: legal_aid_application.applicant.id, amount: 234.0, transaction_type: benefits) }
+    let!(:third_benefits_month) { create(:cash_transaction, :credit_month3, legal_aid_application:, owner_type: "Applicant", owner_id: legal_aid_application.applicant.id, amount: 345.0, transaction_type: benefits) }
     let(:maintenance_out) { create(:transaction_type, :maintenance_out) }
-    let!(:first_maintenance_month) { create(:cash_transaction, :credit_month1, legal_aid_application:, amount: 123.0, transaction_type: maintenance_out) }
-    let!(:second_maintenance_month) { create(:cash_transaction, :credit_month2, legal_aid_application:, amount: 234.0, transaction_type: maintenance_out) }
-    let!(:third_maintenance_month) { create(:cash_transaction, :credit_month3, legal_aid_application:, amount: 345.0, transaction_type: maintenance_out) }
+    let!(:first_maintenance_month) { create(:cash_transaction, :credit_month1, legal_aid_application:, owner_type: "Applicant", owner_id: legal_aid_application.applicant.id, amount: 123.0, transaction_type: maintenance_out) }
+    let!(:second_maintenance_month) { create(:cash_transaction, :credit_month2, legal_aid_application:, owner_type: "Applicant", owner_id: legal_aid_application.applicant.id, amount: 234.0, transaction_type: maintenance_out) }
+    let!(:third_maintenance_month) { create(:cash_transaction, :credit_month3, legal_aid_application:, owner_type: "Applicant", owner_id: legal_aid_application.applicant.id, amount: 345.0, transaction_type: maintenance_out) }
 
     it "returns expected JSON structure" do
       expect(call).to eq({


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4285)

Set ownership of the cash transactions, this will ease work on AP-4106 too
Ensure that all controller, forms and tests set the Applicant as the owner of existing Cash Transactions, this will allow us to extend it to Partner in 4285 and 4106

Add a migration rake task to update existing records

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
