### PR TITLE
Fix: Remove FFI from Circle CI lint executor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,13 +90,6 @@ references:
         gem update --system
         bundle install --path=vendor/bundle --jobs=4 && bundle clean
 
-  install_lib_ffi: &install_lib_ffi
-    run:
-      name: Install libffi6
-      command: |
-        wget http://mirrors.kernel.org/ubuntu/pool/main/libf/libffi/libffi6_3.2.1-8_amd64.deb
-        sudo apt install ./libffi6_3.2.1-8_amd64.deb
-
   install_js_packages: &install_js_packages
     run:
       name: Install Yarn packages
@@ -138,7 +131,6 @@ jobs:
     - *update_packages
     - run: sudo apt-get install -y git-crypt
     - *decrypt_secrets
-    - *install_lib_ffi
     - *restore_gems_cache
     - *install_gems
     - *save_gems_cache


### PR DESCRIPTION
## What

This was added a while ago because of a change to Ubuntu, circle jobs started failing one day because the `ffi` package wasn't installed any more... that was two years ago

Try removing it to see if it is still required as a stand-alone step

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
