### PR TITLE
Fix: Update flaky RemoveInvolvedChildController test

### DIFF
--- a/spec/requests/providers/application_merits_task/remove_involved_child_spec.rb
+++ b/spec/requests/providers/application_merits_task/remove_involved_child_spec.rb
@@ -72,7 +72,7 @@ module Providers
 
           it "shows the correct error message" do
             subject
-            expect(response.body).to include(I18n.t("providers.application_merits_task.remove_involved_child.show.error", name: child.full_name))
+            expect(unescaped_response_body).to include(I18n.t("providers.application_merits_task.remove_involved_child.show.error", name: child.full_name))
           end
 
           it "does not delete a record" do


### PR DESCRIPTION




## What

When checking the passing of a name to the translation helper we should use unescaped_response_body so that, when faker generates a name with an apostrophe, the html is unescaped

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
