### PR TITLE
AP-4411: Fix incorrectly displaying warning letter sent info

### DIFF
--- a/app/forms/providers/application_merits_task/domestic_abuse_summary_form.rb
+++ b/app/forms/providers/application_merits_task/domestic_abuse_summary_form.rb
@@ -66,7 +66,7 @@ module Providers
       end
 
       def clear_warning_details
-        warning_letter_sent&.clear if warning_letter_sent_details.to_s == "true"
+        warning_letter_sent_details&.clear if warning_letter_sent.to_s == "true"
       end
 
       def clear_bail_details

--- a/app/views/shared/check_answers/_opponent_details.html.erb
+++ b/app/views/shared/check_answers/_opponent_details.html.erb
@@ -37,7 +37,7 @@
             html_attributes: { id: "app-check-your-answers__opponent_warning_letter_sent" },
           ) do |row| %>
         <%= row.with_key(text: t(".warning_letter_sent"), classes: "govuk-!-width-one-half") %>
-        <%= row.with_value(text: yes_no(parties_mental_capacity.understands_terms_of_court_order)) %>
+        <%= row.with_value(text: yes_no(domestic_abuse_summary.warning_letter_sent)) %>
         <%= row.with_action(
               text: t("generic.change"),
               href: providers_legal_aid_application_domestic_abuse_summary_path(@legal_aid_application),


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4411)

Update code to correctly show warning_letter_sent rather than understand_terms_of_court_order. Fix issue whereby warning_letter_sent_details were not clearing correctly

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
