### PR TITLE
Test: Group Jest dependencies together in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,10 @@ updates:
     interval: daily
     time: "21:00"
     timezone: Europe/London
+  groups:
+    grouped-dependencies:
+      patterns:
+        - "aws-*"
   open-pull-requests-limit: 10
   ignore:
   - dependency-name: prometheus_exporter

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,3 +27,9 @@ updates:
   - "ministryofjustice/laa-apply-for-legal-aid"
   ignore:
     - dependency-name: "puppeteer"
+  groups:
+    # Specify a name for the group, which will be used in pull request titles and branch names
+    grouped-dependencies:
+      # Define patterns to include dependencies in the group (based on # dependency name)
+      patterns:
+        - "jest*"  # A wildcard string that matches multiple dependency names syt


### PR DESCRIPTION
## What

Rather than have two npm dependabot PRs for jest and jest-environment-jsdom try and get them grouped together to reduce circle runs when the first is merged and the second has to be rebased

Also, late addition, try grouping the aws-* PRs for the same reason

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
