### PR TITLE
Fix: Ensure truelayer transactions set ownership too

### DIFF
--- a/app/controllers/providers/means/identify_types_of_incomes_controller.rb
+++ b/app/controllers/providers/means/identify_types_of_incomes_controller.rb
@@ -54,12 +54,14 @@ module Providers
           add_transaction_type(form_tt) if existing_credit_transaction_type_ids.exclude?(form_tt.id)
           arr.append(form_tt.id)
         end
-
         destroy_all_credit_transaction_types(except: keep)
       end
 
       def add_transaction_type(transaction_type)
-        legal_aid_application.transaction_types << transaction_type
+        LegalAidApplicationTransactionType.create(legal_aid_application:,
+                                                  transaction_type:,
+                                                  owner_type: "Applicant",
+                                                  owner_id: legal_aid_application.applicant.id)
       end
 
       def destroy_all_credit_transaction_types(except:)

--- a/app/controllers/providers/means/identify_types_of_outgoings_controller.rb
+++ b/app/controllers/providers/means/identify_types_of_outgoings_controller.rb
@@ -54,7 +54,10 @@ module Providers
       end
 
       def add_transaction_type(transaction_type)
-        legal_aid_application.transaction_types << transaction_type
+        LegalAidApplicationTransactionType.create(legal_aid_application:,
+                                                  transaction_type:,
+                                                  owner_type: "Applicant",
+                                                  owner_id: legal_aid_application.applicant.id)
       end
 
       def destroy_all_debit_transaction_types(except:)

--- a/spec/requests/providers/means/identify_types_of_incomes_controller_spec.rb
+++ b/spec/requests/providers/means/identify_types_of_incomes_controller_spec.rb
@@ -108,6 +108,11 @@ RSpec.describe Providers::Means::IdentifyTypesOfIncomesController do
         request
         expect(response).to redirect_to(providers_legal_aid_application_means_cash_income_path)
       end
+
+      it "creates a legal_aid_application_transaction_types record with ownership" do
+        expect { request }.to change(legal_aid_application.legal_aid_application_transaction_types, :count).by(3)
+        expect(legal_aid_application.legal_aid_application_transaction_types.first.owner_type).to eq "Applicant"
+      end
     end
 
     context "when application has transaction types of other kind" do
@@ -248,7 +253,8 @@ RSpec.describe Providers::Means::IdentifyTypesOfIncomesController do
       let(:legal_aid_application) do
         create(:legal_aid_application,
                :with_non_passported_state_machine,
-               :checking_means_income)
+               :checking_means_income,
+               :with_applicant)
       end
 
       let(:params) { { legal_aid_application: { none_selected: "true" } } }

--- a/spec/requests/providers/means/identify_types_of_outgoings_controller_spec.rb
+++ b/spec/requests/providers/means/identify_types_of_outgoings_controller_spec.rb
@@ -90,6 +90,11 @@ RSpec.describe Providers::Means::IdentifyTypesOfOutgoingsController do
         expect(response).to redirect_to(providers_legal_aid_application_means_cash_outgoing_path(legal_aid_application))
       end
 
+      it "creates a legal_aid_application_transaction_types record with ownership" do
+        expect { request }.to change(legal_aid_application.legal_aid_application_transaction_types, :count).by(3)
+        expect(legal_aid_application.legal_aid_application_transaction_types.first.owner_type).to eq "Applicant"
+      end
+
       context "with bank statement upload flow" do
         before do
           legal_aid_application.provider.permissions << Permission.find_or_create_by(role: "application.non_passported.bank_statement_upload.*")
@@ -226,7 +231,8 @@ RSpec.describe Providers::Means::IdentifyTypesOfOutgoingsController do
       let(:legal_aid_application) do
         create(:legal_aid_application,
                :with_non_passported_state_machine,
-               :checking_means_income)
+               :checking_means_income,
+               :with_applicant)
       end
 
       let(:params) { { legal_aid_application: { none_selected: "true" } } }


### PR DESCRIPTION
## What

While working on AP-4285, I found another pattern for creating LegalAidApplicationTransactionType records in the DB

This fix ensures that the truelayer client controllers are creating the record with ownership so that tests will pass and Client records will not 'drift' onto the pages of Partners

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
