### PR TITLE
Fix: Partner routing after income summary

### DIFF
--- a/app/services/flow/flows/provider_income.rb
+++ b/app/services/flow/flows/provider_income.rb
@@ -71,7 +71,13 @@ module Flow
         income_summary: {
           path: ->(application) { urls.providers_legal_aid_application_income_summary_index_path(application) },
           forward: lambda do |application|
-            application.outgoing_types? ? :outgoings_summary : :has_dependants
+            if application.outgoing_types?
+              :outgoings_summary
+            elsif application.applicant.has_partner_with_no_contrary_interest?
+              :partner_about_financial_means
+            else
+              :has_dependants
+            end
           end,
           check_answers: :check_income_answers,
         },

--- a/spec/requests/providers/income_summary_controller_spec.rb
+++ b/spec/requests/providers/income_summary_controller_spec.rb
@@ -103,6 +103,21 @@ RSpec.describe Providers::IncomeSummaryController do
         request
         expect(response).to redirect_to(providers_legal_aid_application_means_has_dependants_path(legal_aid_application))
       end
+
+      context "and there is a partner with no contrary interest" do
+        let(:legal_aid_application) do
+          create(:legal_aid_application,
+                 :with_applicant_and_partner,
+                 :with_non_passported_state_machine,
+                 :applicant_entering_means,
+                 transaction_types: [])
+        end
+
+        it "redirects to the partner financial means start page page" do
+          request
+          expect(response).to redirect_to(providers_legal_aid_application_partners_about_financial_means_path(legal_aid_application))
+        end
+      end
     end
 
     context "when outgoings categories are shown" do


### PR DESCRIPTION
## What

If an application is created where they have a partner but have not set any outgoing payments, the flow skips straight to dependants when it should move to the partner start income page.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
