### PR TITLE
Fix: GatewayEvidence count in admin report

### DIFF
--- a/app/services/reports/mis/application_detail_csv_line.rb
+++ b/app/services/reports/mis/application_detail_csv_line.rb
@@ -423,7 +423,7 @@ module Reports
       end
 
       def gateway_evidence_count
-        gateway_evidence.present? ? gateway_evidence.pdf_attachments.count : ""
+        gateway_evidence.present? ? laa.attachments.gateway_evidence_pdf.count : ""
       end
 
       def proceedings_df_used


### PR DESCRIPTION
## What

A while ago #5630 removed some code around gateway evidence because we believed it was obsolete.  The admin report generator still had a reference to a deleted method.  This replaces the CSV generator with the internal structure of the deleted method

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
