### PR TITLE
Rubocop: services/CCMS fixes

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -137,7 +137,7 @@ RSpec/LetSetup:
     - 'spec/workers/bank_holiday_update_worker_spec.rb'
     - 'spec/workers/true_layer_banks_update_worker_spec.rb'
 
-# Offense count: 988
+# Offense count: 905
 # Configuration parameters: EnforcedStyle, IgnoreSharedExamples.
 # SupportedStyles: always, named_only
 RSpec/NamedSubject:
@@ -236,16 +236,6 @@ RSpec/NamedSubject:
     - 'spec/services/banking/bank_transaction_balance_calculator_spec.rb'
     - 'spec/services/banking/bank_transactions_trimmer_spec.rb'
     - 'spec/services/banking/state_benefit_analyser_service_spec.rb'
-    - 'spec/services/ccms/attribute_configuration_spec.rb'
-    - 'spec/services/ccms/manual_review_determiner_spec.rb'
-    - 'spec/services/ccms/parsers/applicant_add_response_parser_spec.rb'
-    - 'spec/services/ccms/restart_submissions_spec.rb'
-    - 'spec/services/ccms/submitters/add_applicant_service_spec.rb'
-    - 'spec/services/ccms/submitters/add_case_service_spec.rb'
-    - 'spec/services/ccms/submitters/check_applicant_status_service_spec.rb'
-    - 'spec/services/ccms/submitters/obtain_applicant_reference_service_spec.rb'
-    - 'spec/services/ccms/submitters/obtain_document_id_service_spec.rb'
-    - 'spec/services/ccms/submitters/upload_documents_service_spec.rb'
     - 'spec/services/dashboard_event_handler_spec.rb'
     - 'spec/services/delegated_functions_date_service_spec.rb'
     - 'spec/services/flow/base_flow_service_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -51,7 +51,7 @@ RSpec/ExpectActual:
   Exclude:
     - 'spec/services/reports/means_report_creator_spec.rb'
 
-# Offense count: 50
+# Offense count: 12
 RSpec/ExpectInHook:
   Exclude:
     - 'spec/models/application_merits_task/involved_child_spec.rb'
@@ -59,21 +59,6 @@ RSpec/ExpectInHook:
     - 'spec/models/legal_aid_application_spec.rb'
     - 'spec/requests/citizens/gather_transactions_spec.rb'
     - 'spec/services/bank_holiday_retriever_service_spec.rb'
-    - 'spec/services/ccms/requestors/applicant_add_requestor_spec.rb'
-    - 'spec/services/ccms/requestors/applicant_add_status_requestor_spec.rb'
-    - 'spec/services/ccms/requestors/applicant_search_requestor_spec.rb'
-    - 'spec/services/ccms/requestors/case_add_requestor_xml_blocks/passported_attributes_spec.rb'
-    - 'spec/services/ccms/requestors/case_add_status_requestor_spec.rb'
-    - 'spec/services/ccms/requestors/document_id_requestor_spec.rb'
-    - 'spec/services/ccms/requestors/document_upload_requestor_spec.rb'
-    - 'spec/services/ccms/requestors/reference_data_requestor_spec.rb'
-    - 'spec/services/ccms/submitters/add_applicant_service_spec.rb'
-    - 'spec/services/ccms/submitters/add_case_service_spec.rb'
-    - 'spec/services/ccms/submitters/check_applicant_status_service_spec.rb'
-    - 'spec/services/ccms/submitters/obtain_applicant_reference_service_spec.rb'
-    - 'spec/services/ccms/submitters/obtain_case_reference_service_spec.rb'
-    - 'spec/services/ccms/submitters/obtain_document_id_service_spec.rb'
-    - 'spec/services/ccms/submitters/upload_documents_service_spec.rb'
     - 'spec/services/provider_after_login_service_spec.rb'
     - 'spec/services/reports/mis/application_details_report_spec.rb'
     - 'spec/services/true_layer/api_client_mock_spec.rb'

--- a/spec/services/ccms/attribute_configuration_spec.rb
+++ b/spec/services/ccms/attribute_configuration_spec.rb
@@ -34,7 +34,7 @@ module CCMS
 
       context "when one key's value is replaced in an existing attribute block" do
         it "replaces the one key's value that has been specified in the merged file and contains all the other originals" do
-          modified_attr_block = subject[:bank_acct][:BALANCE]
+          modified_attr_block = config[:bank_acct][:BALANCE]
           expect(modified_attr_block.keys).to eq %i[value br100_meaning response_type user_defined]
           expect(modified_attr_block[:value]).to eq "#new_bank_balance_method"
           expect(modified_attr_block[:br100_meaning]).to eq "Bank accounts: Current Balance"

--- a/spec/services/ccms/manual_review_determiner_spec.rb
+++ b/spec/services/ccms/manual_review_determiner_spec.rb
@@ -8,11 +8,11 @@ module CCMS
     let(:legal_aid_application) { create(:legal_aid_application) }
 
     describe "#manual_review_required?" do
-      subject { determiner.manual_review_required? }
+      subject(:manual_review_required) { determiner.manual_review_required? }
 
       context "when an assessment is not yet carried out on legal aid application" do
         it "raises an error" do
-          expect { subject }.to raise_error RuntimeError, "Unable to determine whether Manual review is required before means assessment"
+          expect { manual_review_required }.to raise_error RuntimeError, "Unable to determine whether Manual review is required before means assessment"
         end
       end
 
@@ -25,7 +25,7 @@ module CCMS
             let!(:cfe_result) { create(:cfe_v3_result, submission: cfe_submission) }
 
             it "returns false" do
-              expect(subject).to be false
+              expect(manual_review_required).to be false
             end
           end
 
@@ -34,7 +34,7 @@ module CCMS
             let!(:cfe_result) { create(:cfe_v3_result, submission: cfe_submission) }
 
             it "returns true" do
-              expect(subject).to be true
+              expect(manual_review_required).to be true
             end
           end
         end
@@ -47,7 +47,7 @@ module CCMS
             let!(:cfe_result) { create(:cfe_v3_result, submission: cfe_submission) }
 
             it "returns true" do
-              expect(subject).to be true
+              expect(manual_review_required).to be true
             end
           end
 
@@ -56,7 +56,7 @@ module CCMS
             let!(:cfe_result) { create(:cfe_v3_result, submission: cfe_submission) }
 
             it "returns true" do
-              expect(subject).to be true
+              expect(manual_review_required).to be true
             end
           end
         end
@@ -73,7 +73,7 @@ module CCMS
               let!(:cfe_result) { create(:cfe_v3_result, :with_capital_contribution_required, submission: cfe_submission) }
 
               it "returns true" do
-                expect(subject).to be true
+                expect(manual_review_required).to be true
               end
             end
 
@@ -82,7 +82,7 @@ module CCMS
 
               context "and there are restrictions" do # TODO: check this - description does not match expectation
                 it "returns false" do
-                  expect(subject).to be true
+                  expect(manual_review_required).to be true
                 end
               end
 
@@ -90,7 +90,7 @@ module CCMS
                 before { legal_aid_application.update! has_restrictions: false }
 
                 it "returns false" do
-                  expect(subject).to be false
+                  expect(manual_review_required).to be false
                 end
               end
             end
@@ -103,7 +103,7 @@ module CCMS
               let!(:cfe_result) { create(:cfe_v3_result, :with_capital_contribution_required, submission: cfe_submission) }
 
               it "returns true" do
-                expect(subject).to be true
+                expect(manual_review_required).to be true
               end
             end
 
@@ -112,7 +112,7 @@ module CCMS
 
               context "but with restrictions" do
                 it "returns false" do
-                  expect(subject).to be true
+                  expect(manual_review_required).to be true
                 end
               end
 
@@ -120,7 +120,7 @@ module CCMS
                 before { legal_aid_application.update! has_restrictions: false }
 
                 it "returns false" do
-                  expect(subject).to be false
+                  expect(manual_review_required).to be false
                 end
               end
             end
@@ -137,7 +137,7 @@ module CCMS
               let!(:cfe_result) { create(:cfe_v3_result, :with_capital_contribution_required, submission: cfe_submission) }
 
               it "returns true" do
-                expect(subject).to be true
+                expect(manual_review_required).to be true
               end
             end
 
@@ -146,7 +146,7 @@ module CCMS
 
               context "and there are restrictions" do # TODO: check this - description does not match expectation
                 it "returns false" do
-                  expect(subject).to be true
+                  expect(manual_review_required).to be true
                 end
               end
 
@@ -154,7 +154,7 @@ module CCMS
                 before { legal_aid_application.update! has_restrictions: false }
 
                 it "returns true" do
-                  expect(subject).to be true
+                  expect(manual_review_required).to be true
                 end
               end
             end
@@ -167,7 +167,7 @@ module CCMS
               let!(:cfe_result) { create(:cfe_v3_result, :with_capital_contribution_required, submission: cfe_submission) }
 
               it "returns true" do
-                expect(subject).to be true
+                expect(manual_review_required).to be true
               end
             end
 
@@ -176,7 +176,7 @@ module CCMS
 
               context "and there are restrictions" do # TODO: check this - description does not match expectation
                 it "returns false" do
-                  expect(subject).to be true
+                  expect(manual_review_required).to be true
                 end
               end
 
@@ -185,7 +185,7 @@ module CCMS
 
                 it "returns true" do
                   legal_aid_application.reload
-                  expect(subject).to be true
+                  expect(manual_review_required).to be true
                 end
               end
             end
@@ -198,7 +198,7 @@ module CCMS
           let!(:cfe_result) { create(:cfe_v4_result, submission: cfe_submission) }
 
           it "returns true" do
-            expect(subject).to be true
+            expect(manual_review_required).to be true
           end
         end
 
@@ -208,7 +208,7 @@ module CCMS
           let!(:cfe_result) { create(:cfe_v4_result, submission: cfe_submission) }
 
           it "returns false" do
-            expect(subject).to be false
+            expect(manual_review_required).to be false
           end
         end
 
@@ -217,7 +217,7 @@ module CCMS
           let!(:cfe_result) { create(:cfe_v4_result, submission: cfe_submission) }
 
           it "returns true" do
-            expect(subject).to be true
+            expect(manual_review_required).to be true
           end
         end
 
@@ -226,7 +226,7 @@ module CCMS
           let!(:cfe_result) { create(:cfe_v4_result, submission: cfe_submission) }
 
           it "returns false" do
-            expect(subject).to be false
+            expect(manual_review_required).to be false
           end
         end
 
@@ -237,14 +237,14 @@ module CCMS
           let!(:cfe_result) { create(:cfe_v5_result, submission: cfe_submission) }
 
           it "returns true" do
-            expect(subject).to be true
+            expect(manual_review_required).to be true
           end
         end
       end
     end
 
     describe "#review_reasons" do
-      subject { determiner.review_reasons }
+      subject(:review_reasons_result) { determiner.review_reasons }
 
       let(:cfe_result) { double "CFE Result", remarks: cfe_remarks, ineligible?: false }
       let(:cfe_remarks) { double "CFE Remarks", review_reasons: }
@@ -257,7 +257,7 @@ module CCMS
 
       context "without DWP Override" do
         it "just takes the review reasons from the CFE result" do
-          expect(subject).to eq review_reasons
+          expect(review_reasons_result).to eq review_reasons
         end
       end
 
@@ -265,7 +265,7 @@ module CCMS
         before { create(:dwp_override, legal_aid_application:) }
 
         it "adds the dwp review to the cfe result reasons" do
-          expect(subject).to eq override_reasons
+          expect(review_reasons_result).to eq override_reasons
         end
       end
 
@@ -273,7 +273,7 @@ module CCMS
         let(:legal_aid_application) { create(:legal_aid_application, extra_employment_information: true) }
 
         it "adds further_employment_details to the review reasons" do
-          expect(subject).to eq further_employment_details_reasons
+          expect(review_reasons_result).to eq further_employment_details_reasons
         end
       end
 
@@ -281,7 +281,7 @@ module CCMS
         let(:legal_aid_application) { create(:legal_aid_application, has_restrictions: true) }
 
         it "adds restrictions to the review reasons" do
-          expect(subject).to eq restrictions_reasons
+          expect(review_reasons_result).to eq restrictions_reasons
         end
       end
 
@@ -293,7 +293,7 @@ module CCMS
         end
 
         it "adds uploaded_bank_statements to the review reasons" do
-          expect(subject).to include(:uploaded_bank_statements)
+          expect(review_reasons_result).to include(:uploaded_bank_statements)
         end
       end
 
@@ -301,7 +301,7 @@ module CCMS
         let(:cfe_result) { double "CFE Result", remarks: cfe_remarks, ineligible?: true }
 
         it "adds ineligible to the review reasons" do
-          expect(subject).to include(:ineligible)
+          expect(review_reasons_result).to include(:ineligible)
         end
       end
     end

--- a/spec/services/ccms/parsers/applicant_add_response_parser_spec.rb
+++ b/spec/services/ccms/parsers/applicant_add_response_parser_spec.rb
@@ -40,27 +40,27 @@ module CCMS
       end
 
       context "when the response is unsuccessful" do
-        subject { described_class.new(expected_tx_id, response_xml) }
+        subject(:response_parser) { described_class.new(expected_tx_id, response_xml) }
 
         let(:response_xml) { ccms_data_from_file "applicant_add_response_failure.xml" }
 
         describe "#success?" do
           it "is false" do
-            expect(subject.success?).to be false
+            expect(response_parser.success?).to be false
           end
         end
 
         describe "#success" do
           it "is false" do
-            subject.success?
-            expect(subject.success).to be false
+            response_parser.success?
+            expect(response_parser.success).to be false
           end
         end
 
         describe "#message" do
           it "returns status concatenated with any free text" do
-            subject.success?
-            expect(subject.message).to eq "Failed: "
+            response_parser.success?
+            expect(response_parser.message).to eq "Failed: "
           end
         end
       end

--- a/spec/services/ccms/requestors/applicant_add_requestor_spec.rb
+++ b/spec/services/ccms/requestors/applicant_add_requestor_spec.rb
@@ -60,7 +60,7 @@ module CCMS
         let(:expected_xml) { requestor.__send__(:request_xml) }
 
         before do
-          expect(requestor).to receive(:soap_client).and_return(soap_client_double)
+          allow(requestor).to receive(:soap_client).and_return(soap_client_double)
         end
 
         it "calls the savon soap client" do

--- a/spec/services/ccms/requestors/applicant_add_status_requestor_spec.rb
+++ b/spec/services/ccms/requestors/applicant_add_status_requestor_spec.rb
@@ -36,7 +36,7 @@ module CCMS
         let(:expected_xml) { requestor.__send__(:request_xml) }
 
         before do
-          expect(requestor).to receive(:soap_client).and_return(soap_client_double)
+          allow(requestor).to receive(:soap_client).and_return(soap_client_double)
         end
 
         it "calls the savon soap client" do

--- a/spec/services/ccms/requestors/applicant_search_requestor_spec.rb
+++ b/spec/services/ccms/requestors/applicant_search_requestor_spec.rb
@@ -44,7 +44,7 @@ module CCMS
         let(:expected_xml) { requestor.__send__(:request_xml) }
 
         before do
-          expect(requestor).to receive(:soap_client).and_return(soap_client_double)
+          allow(requestor).to receive(:soap_client).and_return(soap_client_double)
         end
 
         it "calls the savon soap client" do

--- a/spec/services/ccms/requestors/case_add_requestor_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_spec.rb
@@ -75,7 +75,7 @@ module CCMS
 
         it "calls the savon soap client" do
           expect(soap_client_double).to receive(:call).with(expected_soap_operation, xml: expected_xml)
-          expect(requestor).to receive(:soap_client).and_return(soap_client_double)
+          allow(requestor).to receive(:soap_client).and_return(soap_client_double)
           requestor.call
         end
 

--- a/spec/services/ccms/requestors/case_add_requestor_xml_blocks/passported_attributes_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_xml_blocks/passported_attributes_spec.rb
@@ -553,7 +553,7 @@ module CCMS
 
         describe "GB_INPUT_B_3WP2_1A - applicant has financial interest in his main home" do
           context "when the applicant has no financial interest" do
-            before { expect(legal_aid_application).to receive(:own_home?).and_return(false) }
+            before { allow(legal_aid_application).to receive(:own_home?).and_return(false) }
 
             it "inserts false into the attribute block" do
               block = XmlExtractor.call(xml, :global_means, "GB_INPUT_B_3WP2_1A")
@@ -562,7 +562,7 @@ module CCMS
           end
 
           context "when there is a shared financial interest" do
-            before { expect(legal_aid_application).to receive(:own_home?).and_return(true) }
+            before { allow(legal_aid_application).to receive(:own_home?).and_return(true) }
 
             it "inserts true into the attribute block" do
               block = XmlExtractor.call(xml, :global_means, "GB_INPUT_B_3WP2_1A")
@@ -659,7 +659,7 @@ module CCMS
 
         describe "GB_INPUT_B_3WP2_1A - Applicant has a financial interest in main home?" do
           context "when the applicant has no financial interest in the main home" do
-            before { expect(legal_aid_application).to receive(:own_home).and_return(false) }
+            before { allow(legal_aid_application).to receive(:own_home).and_return(false) }
 
             it "inserts false into the attribute block" do
               block = XmlExtractor.call(xml, :global_means, "GB_INPUT_B_3WP2_1A")
@@ -668,7 +668,7 @@ module CCMS
           end
 
           context "when the applicant has a financial interest in the main home" do
-            before { expect(legal_aid_application).to receive(:own_home).and_return(true) }
+            before { allow(legal_aid_application).to receive(:own_home).and_return(true) }
 
             it "inserts true into the attribute block" do
               block = XmlExtractor.call(xml, :global_means, "GB_INPUT_B_3WP2_1A")
@@ -1110,7 +1110,7 @@ module CCMS
           end
 
           context "when the applicant DOES NOT own additional property" do
-            before { expect(legal_aid_application.other_assets_declaration).to receive(:second_home_value).and_return(nil) }
+            before { allow(legal_aid_application.other_assets_declaration).to receive(:second_home_value).and_return(nil) }
 
             it "returns false when client does NOT own additiaonl property" do
               block = XmlExtractor.call(xml, :global_means, "GB_INPUT_B_4WP2_1A")

--- a/spec/services/ccms/requestors/case_add_status_requestor_spec.rb
+++ b/spec/services/ccms/requestors/case_add_status_requestor_spec.rb
@@ -33,7 +33,7 @@ module CCMS
         let(:expected_xml) { requestor.__send__(:request_xml) }
 
         before do
-          expect(requestor).to receive(:soap_client).and_return(soap_client_double)
+          allow(requestor).to receive(:soap_client).and_return(soap_client_double)
         end
 
         it "calls the savon soap client" do

--- a/spec/services/ccms/requestors/document_id_requestor_spec.rb
+++ b/spec/services/ccms/requestors/document_id_requestor_spec.rb
@@ -97,7 +97,7 @@ module CCMS
         let(:expected_xml) { requestor.__send__(:request_xml) }
 
         before do
-          expect(requestor).to receive(:soap_client).and_return(soap_client_double)
+          allow(requestor).to receive(:soap_client).and_return(soap_client_double)
         end
 
         it "calls the savon soap client" do

--- a/spec/services/ccms/requestors/document_upload_requestor_spec.rb
+++ b/spec/services/ccms/requestors/document_upload_requestor_spec.rb
@@ -96,7 +96,7 @@ module CCMS
         let(:expected_xml) { requestor.__send__(:request_xml) }
 
         before do
-          expect(requestor).to receive(:soap_client).and_return(soap_client_double)
+          allow(requestor).to receive(:soap_client).and_return(soap_client_double)
         end
 
         it "calls the savon soap client" do

--- a/spec/services/ccms/requestors/reference_data_requestor_spec.rb
+++ b/spec/services/ccms/requestors/reference_data_requestor_spec.rb
@@ -37,7 +37,7 @@ module CCMS
 
         before do
           freeze_time
-          expect(requestor).to receive(:soap_client).and_return(soap_client_double)
+          allow(requestor).to receive(:soap_client).and_return(soap_client_double)
         end
 
         it "calls the savon soap client" do

--- a/spec/services/ccms/restart_submissions_spec.rb
+++ b/spec/services/ccms/restart_submissions_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe CCMS::RestartSubmissions do
     it { is_expected.to eql "2 CCMS submissions restarted" }
 
     it "changes the states to submitting_assessment" do
-      subject
+      restart_submissions
       expect(LegalAidApplication.first.reload.state).to eql "generating_reports"
       expect(LegalAidApplication.last.reload.state).to eql "generating_reports"
     end

--- a/spec/services/ccms/submitters/add_applicant_service_spec.rb
+++ b/spec/services/ccms/submitters/add_applicant_service_spec.rb
@@ -72,18 +72,22 @@ module CCMS
       context "when the operation is in error" do
         context "and it errors when adding an applicant" do
           let(:error) { [CCMS::CCMSError, Savon::Error, StandardError] }
+          let(:sample_error) { error.sample }
+          # let(:stubbed_applicant_requestor) { instance_double(CCMS::Requestors::ApplicantAddRequestor, call: false) }
 
           before do
-            sample_error = error.sample
-            expect_any_instance_of(CCMS::Requestors::ApplicantAddRequestor).to receive(:call).and_raise(sample_error, "oops")
-            expect { instance.call }.to raise_error(sample_error)
+            # allow(stubbed_applicant_requestor).to receive(:call).and_raise(sample_error, "oops")
+            # allow(CCMS::Requestors::ApplicantAddRequestor).to receive(:new).and_return(stubbed_applicant_requestor)
+            allow_any_instance_of(CCMS::Requestors::ApplicantAddRequestor).to receive(:call).and_raise(sample_error, "oops")
           end
 
           it "does not change submission state" do
+            expect { instance.call }.to raise_error(sample_error)
             expect(submission.reload.aasm_state).to eq "case_ref_obtained"
           end
 
           it "records the error in the submission history" do
+            expect { instance.call }.to raise_error(sample_error)
             submission_history = submission.submission_history
             expect(submission_history.count).to eq 1
             expect(history.from_state).to eq "case_ref_obtained"
@@ -109,15 +113,13 @@ module CCMS
         context "when the response is unsuccessful from CCMS adding an applicant" do
           let(:response_body) { ccms_data_from_file "applicant_add_response_failure.xml" }
 
-          before do
-            expect { instance.call }.to raise_error(CCMS::CCMSUnsuccessfulResponseError, "AddApplicantService failed with unsuccessful response for submission: #{submission.id}")
-          end
-
           it "does not change state" do
+            expect { instance.call }.to raise_error(CCMS::CCMSUnsuccessfulResponseError, "AddApplicantService failed with unsuccessful response for submission: #{submission.id}")
             expect(submission.aasm_state).to eq "case_ref_obtained"
           end
 
           it "records the error in the submission history" do
+            expect { instance.call }.to raise_error(CCMS::CCMSUnsuccessfulResponseError, "AddApplicantService failed with unsuccessful response for submission: #{submission.id}")
             submission_history = submission.reload.submission_history
             expect(submission_history.count).to eq 1
             expect(history.from_state).to eq "case_ref_obtained"
@@ -126,6 +128,7 @@ module CCMS
           end
 
           it "stores the reqeust body in the submission history record" do
+            expect { instance.call }.to raise_error(CCMS::CCMSUnsuccessfulResponseError, "AddApplicantService failed with unsuccessful response for submission: #{submission.id}")
             expect(history.request).to be_soap_envelope_with(
               command: "clientbim:ClientAddRQ",
               transaction_id: "20190301030405123456",
@@ -140,6 +143,7 @@ module CCMS
           end
 
           it "stores the response body in the submission history record" do
+            expect { instance.call }.to raise_error(CCMS::CCMSUnsuccessfulResponseError, "AddApplicantService failed with unsuccessful response for submission: #{submission.id}")
             expect(history.response).to eq response_body
           end
         end

--- a/spec/services/ccms/submitters/add_applicant_service_spec.rb
+++ b/spec/services/ccms/submitters/add_applicant_service_spec.rb
@@ -73,11 +73,8 @@ module CCMS
         context "and it errors when adding an applicant" do
           let(:error) { [CCMS::CCMSError, Savon::Error, StandardError] }
           let(:sample_error) { error.sample }
-          # let(:stubbed_applicant_requestor) { instance_double(CCMS::Requestors::ApplicantAddRequestor, call: false) }
 
           before do
-            # allow(stubbed_applicant_requestor).to receive(:call).and_raise(sample_error, "oops")
-            # allow(CCMS::Requestors::ApplicantAddRequestor).to receive(:new).and_return(stubbed_applicant_requestor)
             allow_any_instance_of(CCMS::Requestors::ApplicantAddRequestor).to receive(:call).and_raise(sample_error, "oops")
           end
 

--- a/spec/services/ccms/submitters/add_applicant_service_spec.rb
+++ b/spec/services/ccms/submitters/add_applicant_service_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 module CCMS
   module Submitters
     RSpec.describe AddApplicantService, :ccms do
-      subject { described_class.new(submission) }
+      subject(:instance) { described_class.new(submission) }
 
       let(:legal_aid_application) { create(:legal_aid_application, :with_applicant_and_address) }
       let(:applicant) { legal_aid_application.applicant }
@@ -30,17 +30,17 @@ module CCMS
       context "when the operation is successful" do
         context "and no applicant exists on the CCMS system" do
           it "sets state to applicant_submitted" do
-            subject.call
+            instance.call
             expect(submission.aasm_state).to eq "applicant_submitted"
           end
 
           it "records the transaction id of the request" do
-            subject.call
+            instance.call
             expect(submission.applicant_add_transaction_id).to eq "20190301030405123456"
           end
 
           it "writes a history record" do
-            expect { subject.call }.to change(CCMS::SubmissionHistory, :count).by(1)
+            expect { instance.call }.to change(CCMS::SubmissionHistory, :count).by(1)
             expect(history.from_state).to eq "case_ref_obtained"
             expect(history.to_state).to eq "applicant_submitted"
             expect(history.success).to be true
@@ -48,7 +48,7 @@ module CCMS
           end
 
           it "stores the reqeust body in the submission history record" do
-            subject.call
+            instance.call
             expect(history.request).to be_soap_envelope_with(
               command: "clientbim:ClientAddRQ",
               transaction_id: "20190301030405123456",
@@ -63,7 +63,7 @@ module CCMS
           end
 
           it "stores the response body in the submission history record" do
-            subject.call
+            instance.call
             expect(history.response).to eq response_body
           end
         end
@@ -76,7 +76,7 @@ module CCMS
           before do
             sample_error = error.sample
             expect_any_instance_of(CCMS::Requestors::ApplicantAddRequestor).to receive(:call).and_raise(sample_error, "oops")
-            expect { subject.call }.to raise_error(sample_error)
+            expect { instance.call }.to raise_error(sample_error)
           end
 
           it "does not change submission state" do
@@ -110,7 +110,7 @@ module CCMS
           let(:response_body) { ccms_data_from_file "applicant_add_response_failure.xml" }
 
           before do
-            expect { subject.call }.to raise_error(CCMS::CCMSUnsuccessfulResponseError, "AddApplicantService failed with unsuccessful response for submission: #{submission.id}")
+            expect { instance.call }.to raise_error(CCMS::CCMSUnsuccessfulResponseError, "AddApplicantService failed with unsuccessful response for submission: #{submission.id}")
           end
 
           it "does not change state" do

--- a/spec/services/ccms/submitters/add_case_service_spec.rb
+++ b/spec/services/ccms/submitters/add_case_service_spec.rb
@@ -161,18 +161,19 @@ module CCMS
       context "when operation encounters error" do
         context "with error while adding a case" do
           let(:error) { [CCMS::CCMSError, Savon::Error, StandardError] }
+          let(:fake_error) { error.sample }
 
           before do
-            fake_error = error.sample
-            expect_any_instance_of(CCMS::Requestors::CaseAddRequestor).to receive(:call).and_raise(fake_error, "oops")
-            expect { instance.call }.to raise_error(fake_error, "oops")
+            allow_any_instance_of(CCMS::Requestors::CaseAddRequestor).to receive(:call).and_raise(fake_error, "oops")
           end
 
           it "does not change the state" do
+            expect { instance.call }.to raise_error(fake_error, "oops")
             expect(submission.aasm_state).to eq "applicant_ref_obtained"
           end
 
           it "records the error in the submission history" do
+            expect { instance.call }.to raise_error(fake_error, "oops")
             expect(SubmissionHistory.count).to eq 1
             expect(history.from_state).to eq "applicant_ref_obtained"
             expect(history.to_state).to eq "failed"
@@ -193,15 +194,13 @@ module CCMS
         context "when an unsuccessful response is received from CCMS" do
           let(:response_body) { ccms_data_from_file "case_add_response_failure.xml" }
 
-          before do
-            expect { instance.call }.to raise_error(CCMS::CCMSUnsuccessfulResponseError, "AddCaseService failed with unsuccessful response for submission: #{submission.id}")
-          end
-
           it "does not change state" do
+            expect { instance.call }.to raise_error(CCMS::CCMSUnsuccessfulResponseError, "AddCaseService failed with unsuccessful response for submission: #{submission.id}")
             expect(submission.aasm_state).to eq "applicant_ref_obtained"
           end
 
           it "records the error in the submission history" do
+            expect { instance.call }.to raise_error(CCMS::CCMSUnsuccessfulResponseError, "AddCaseService failed with unsuccessful response for submission: #{submission.id}")
             expect(SubmissionHistory.count).to eq 1
             expect(history.from_state).to eq "applicant_ref_obtained"
             expect(history.to_state).to eq "failed"
@@ -209,6 +208,7 @@ module CCMS
           end
 
           it "stores the reqeust body in the submission history record" do
+            expect { instance.call }.to raise_error(CCMS::CCMSUnsuccessfulResponseError, "AddCaseService failed with unsuccessful response for submission: #{submission.id}")
             expect(history.request).to be_soap_envelope_with(
               command: "casebim:CaseAddRQ",
               transaction_id: "20190301030405123456",
@@ -219,6 +219,7 @@ module CCMS
           end
 
           it "stores the response body in the submission history record" do
+            expect { instance.call }.to raise_error(CCMS::CCMSUnsuccessfulResponseError, "AddCaseService failed with unsuccessful response for submission: #{submission.id}")
             expect(history.response).to eq response_body
           end
         end

--- a/spec/services/ccms/submitters/check_applicant_status_service_spec.rb
+++ b/spec/services/ccms/submitters/check_applicant_status_service_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 module CCMS
   module Submitters
     RSpec.describe CheckApplicantStatusService, :ccms do
-      subject { described_class.new(submission) }
+      subject(:instance) { described_class.new(submission) }
 
       let(:submission) { create(:submission, :applicant_submitted) }
       let(:history) { SubmissionHistory.find_by(submission_id: submission.id) }
@@ -31,15 +31,15 @@ module CCMS
 
             context "and poll count remains below limit" do
               it "increments the poll count" do
-                expect { subject.call }.to change(submission, :applicant_poll_count).by 1
+                expect { instance.call }.to change(submission, :applicant_poll_count).by 1
               end
 
               it "does not change the state" do
-                expect { subject.call }.not_to change(submission, :aasm_state)
+                expect { instance.call }.not_to change(submission, :aasm_state)
               end
 
               it "writes a history record" do
-                expect { subject.call }.to change(SubmissionHistory, :count).by(1)
+                expect { instance.call }.to change(SubmissionHistory, :count).by(1)
                 expect(history.from_state).to eq "applicant_submitted"
                 expect(history.to_state).to eq "applicant_submitted"
                 expect(history.success).to be true
@@ -48,7 +48,7 @@ module CCMS
               end
 
               it "stores the reqeust body in the submission history record" do
-                subject.call
+                instance.call
                 expect(history.request).to be_soap_envelope_with(
                   command: "clientbim:ClientAddUpdtStatusRQ",
                   transaction_id: "20190301030405123456",
@@ -56,7 +56,7 @@ module CCMS
               end
 
               it "stores the response body in the submission history record" do
-                subject.call
+                instance.call
                 expect(history.response).to eq response_body
               end
             end
@@ -67,15 +67,15 @@ module CCMS
               end
 
               it "increments the poll count" do
-                expect { subject.call }.to change(submission, :applicant_poll_count).by 1
+                expect { instance.call }.to change(submission, :applicant_poll_count).by 1
               end
 
               it "does not change the state" do
-                expect { subject.call }.not_to change(submission, :aasm_state)
+                expect { instance.call }.not_to change(submission, :aasm_state)
               end
 
               it "writes a history record" do
-                expect { subject.call }.to change(SubmissionHistory, :count).by(1)
+                expect { instance.call }.to change(SubmissionHistory, :count).by(1)
                 expect(history.from_state).to eq "applicant_submitted"
                 expect(history.to_state).to eq "failed"
                 expect(history.success).to be false
@@ -83,7 +83,7 @@ module CCMS
               end
 
               it "stores the reqeust body in the submission history record" do
-                subject.call
+                instance.call
                 expect(history.request).to be_soap_envelope_with(
                   command: "clientbim:ClientAddUpdtStatusRQ",
                   transaction_id: "20190301030405123456",
@@ -100,15 +100,15 @@ module CCMS
             end
 
             it "changes the state to applicant_ref_obtained" do
-              expect { subject.call }.to change(submission, :aasm_state).to "applicant_ref_obtained"
+              expect { instance.call }.to change(submission, :aasm_state).to "applicant_ref_obtained"
             end
 
             it "updates the applicant_ccms_reference" do
-              expect { subject.call }.to change(submission, :applicant_ccms_reference).to expected_applicant_ccms_reference
+              expect { instance.call }.to change(submission, :applicant_ccms_reference).to expected_applicant_ccms_reference
             end
 
             it "writes a history record" do
-              expect { subject.call }.to change(SubmissionHistory, :count).by(1)
+              expect { instance.call }.to change(SubmissionHistory, :count).by(1)
               expect(history.from_state).to eq "applicant_submitted"
               expect(history.to_state).to eq "applicant_ref_obtained"
               expect(history.success).to be true
@@ -116,7 +116,7 @@ module CCMS
             end
 
             it "stores the reqeust body in the submission history record" do
-              subject.call
+              instance.call
               expect(history.request).to be_soap_envelope_with(
                 command: "clientbim:ClientAddUpdtStatusRQ",
                 transaction_id: "20190301030405123456",
@@ -131,7 +131,7 @@ module CCMS
           before do
             fake_error = error.sample
             expect_any_instance_of(CCMS::Requestors::ApplicantAddStatusRequestor).to receive(:call).and_raise(fake_error, "oops")
-            expect { subject.call }.to raise_error(fake_error, "oops")
+            expect { instance.call }.to raise_error(fake_error, "oops")
           end
 
           it "increments the poll count" do

--- a/spec/services/ccms/submitters/check_applicant_status_service_spec.rb
+++ b/spec/services/ccms/submitters/check_applicant_status_service_spec.rb
@@ -127,22 +127,24 @@ module CCMS
 
         context "when the operation is unsuccessful" do
           let(:error) { [CCMS::CCMSError, Savon::Error, StandardError] }
+          let(:fake_error) { error.sample }
 
           before do
-            fake_error = error.sample
-            expect_any_instance_of(CCMS::Requestors::ApplicantAddStatusRequestor).to receive(:call).and_raise(fake_error, "oops")
-            expect { instance.call }.to raise_error(fake_error, "oops")
+            allow_any_instance_of(CCMS::Requestors::ApplicantAddStatusRequestor).to receive(:call).and_raise(fake_error, "oops")
           end
 
           it "increments the poll count" do
+            expect { instance.call }.to raise_error(fake_error, "oops")
             expect(submission.applicant_poll_count).to eq 1
           end
 
           it "does not change state" do
+            expect { instance.call }.to raise_error(fake_error, "oops")
             expect(submission.aasm_state).to eq "applicant_submitted"
           end
 
           it "records the error in the submission history" do
+            expect { instance.call }.to raise_error(fake_error, "oops")
             expect(SubmissionHistory.count).to eq 1
             expect(history.from_state).to eq "applicant_submitted"
             expect(history.to_state).to eq "failed"

--- a/spec/services/ccms/submitters/obtain_case_reference_service_spec.rb
+++ b/spec/services/ccms/submitters/obtain_case_reference_service_spec.rb
@@ -63,7 +63,7 @@ module CCMS
         let(:fake_error) { error.sample } # TODO: avoid this pattern
 
         before do
-          expect_any_instance_of(CCMS::Requestors::ReferenceDataRequestor).to receive(:call).and_raise(fake_error, "oops")
+          allow_any_instance_of(CCMS::Requestors::ReferenceDataRequestor).to receive(:call).and_raise(fake_error, "oops")
         end
 
         it "does not change the state" do

--- a/spec/services/ccms/submitters/obtain_document_id_service_spec.rb
+++ b/spec/services/ccms/submitters/obtain_document_id_service_spec.rb
@@ -154,19 +154,20 @@ module CCMS
         context "when populating documents" do
           let!(:statement_of_case) { create(:statement_of_case, :with_original_and_pdf_files_attached, legal_aid_application:) }
           let(:error) { [CCMS::CCMSError, Savon::Error, StandardError] }
+          let(:fake_error) { error.sample }
 
           before do
-            fake_error = error.sample
             allow_any_instance_of(CCMS::Requestors::DocumentIdRequestor).to receive(:transaction_request_id).and_return("20190301030405123456")
-            expect_any_instance_of(CCMS::Requestors::DocumentIdRequestor).to receive(:call).and_raise(fake_error, "Failed to obtain document ids for")
-            expect { instance.call }.to raise_error(fake_error, "Failed to obtain document ids for")
+            allow_any_instance_of(CCMS::Requestors::DocumentIdRequestor).to receive(:call).and_raise(fake_error, "Failed to obtain document ids for")
           end
 
           it "does not change the state" do
+            expect { instance.call }.to raise_error(fake_error, "Failed to obtain document ids for")
             expect(submission.aasm_state).to eq "applicant_ref_obtained"
           end
 
           it "writes a history record" do
+            expect { instance.call }.to raise_error(fake_error, "Failed to obtain document ids for")
             expect(SubmissionHistory.count).to eq 2
             expect(history.from_state).to eq "applicant_ref_obtained" # this is failing gets case_submitted
             expect(history.to_state).to eq "failed"
@@ -180,21 +181,23 @@ module CCMS
 
         context "when requesting document_ids" do
           before do
-            expect_any_instance_of(CCMS::Requestors::DocumentIdRequestor).to receive(:call).and_raise(CCMSError, "failure populating document hash")
-            expect { instance.call }.to raise_error(CCMSError, "failure populating document hash")
+            allow_any_instance_of(CCMS::Requestors::DocumentIdRequestor).to receive(:call).and_raise(CCMSError, "failure populating document hash")
           end
 
           let(:statement_of_case) { create(:statement_of_case, :with_original_and_pdf_files_attached, legal_aid_application:) }
 
           it "does not change the state" do
+            expect { instance.call }.to raise_error(CCMSError, "failure populating document hash")
             expect(submission.aasm_state).to eq "applicant_ref_obtained"
           end
 
           it "changes the document state to failed" do
+            expect { instance.call }.to raise_error(CCMSError, "failure populating document hash")
             expect(submission.submission_documents.first.status).to eq "failed"
           end
 
           it "writes a history record" do
+            expect { instance.call }.to raise_error(CCMSError, "failure populating document hash")
             expect(SubmissionHistory.count).to eq 2
             expect(history.from_state).to eq "applicant_ref_obtained"
             expect(history.to_state).to eq "failed"

--- a/spec/services/ccms/submitters/upload_documents_service_spec.rb
+++ b/spec/services/ccms/submitters/upload_documents_service_spec.rb
@@ -100,23 +100,25 @@ RSpec.describe CCMS::Submitters::UploadDocumentsService, :ccms do
 
     context "and the operation fails due to a CCMS::CCMSError exception" do
       let(:error) { [CCMS::CCMSError, Savon::Error, StandardError] }
+      let(:fake_error) { error.sample }
 
       before do
-        fake_error = error.sample
         allow(document_upload_requestor).to receive(:call).and_raise(fake_error, "this document submission has failed")
-        expect { instance.call }.to raise_error(CCMS::CCMSError, /The following documents failed to upload:/)
       end
 
       it "does not change the submission state" do
+        expect { instance.call }.to raise_error(CCMS::CCMSError, /The following documents failed to upload:/)
         expect(submission.reload.aasm_state).to eq "case_created"
       end
 
       it "writes a history record for each document and on completion" do
+        expect { instance.call }.to raise_error(CCMS::CCMSError, /The following documents failed to upload:/)
         submission_history = submission.submission_history
         expect(submission_history.count).to eq 5
       end
 
       it "writes a history record on completion that updates the state" do
+        expect { instance.call }.to raise_error(CCMS::CCMSError, /The following documents failed to upload:/)
         expect(first_history.from_state).to eq "case_created"
         expect(first_history.to_state).to eq "failed"
         expect(first_history.success).to be false
@@ -125,6 +127,7 @@ RSpec.describe CCMS::Submitters::UploadDocumentsService, :ccms do
       end
 
       it "writes a history record on completion that updates the state" do
+        expect { instance.call }.to raise_error(CCMS::CCMSError, /The following documents failed to upload:/)
         expect(history.from_state).to eq "case_created"
         expect(history.to_state).to eq "failed"
         expect(history.success).to be false
@@ -137,15 +140,16 @@ RSpec.describe CCMS::Submitters::UploadDocumentsService, :ccms do
       before do
         allow_any_instance_of(CCMS::Parsers::DocumentUploadResponseParser).to receive(:success?).and_return(false)
         allow(document_upload_requestor).to receive(:call).and_return(document_upload_response)
-        expect { instance.call }.to raise_error(CCMS::CCMSError)
       end
 
       it "writes a history record for each document and on completion" do
+        expect { instance.call }.to raise_error(CCMS::CCMSError)
         submission_history = submission.submission_history
         expect(submission_history.count).to eq 5
       end
 
       it "writes a history record on completion that updates the state" do
+        expect { instance.call }.to raise_error(CCMS::CCMSError)
         expect(history.from_state).to eq "case_created"
         expect(history.to_state).to eq "failed"
         expect(history.success).to be false


### PR DESCRIPTION

## What

As we are about to ramp up work in the CCMS namespace I wanted to try and remove some of the rubocop infractions we've been ignoring!

This addresses the issues with:
* RSpec/NamedSubject
* RSpec/ExpectInHook

If this gets approved while I'm away, please merge.
Also, please bear in mind the number of offences we currently ignore in the services/CCMS area when extending or duplicating tests! 

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
