### PR TITLE
AP-4399: Rename organisation columns part 2

### DIFF
--- a/app/models/application_merits_task/opponent.rb
+++ b/app/models/application_merits_task/opponent.rb
@@ -12,9 +12,7 @@ module ApplicationMeritsTask
              :ccms_child?,
              :ccms_opponent_relationship_to_case,
              :name,
-             :ccms_code,
              :ccms_type_code,
-             :description,
              :ccms_type_text,
              :type,
              to: :opposable

--- a/app/models/application_merits_task/organisation.rb
+++ b/app/models/application_merits_task/organisation.rb
@@ -4,9 +4,6 @@ module ApplicationMeritsTask
 
     delegate :generate_ccms_opponent_id, :ccms_opponent_id, to: :opponent
 
-    alias_attribute :ccms_type_code, :ccms_code
-    alias_attribute :ccms_type_text, :description
-
     def ccms_relationship_to_case
       "OPP"
     end

--- a/db/migrate/20230905133536_rename_organisations_columns.rb
+++ b/db/migrate/20230905133536_rename_organisations_columns.rb
@@ -1,0 +1,8 @@
+class RenameOrganisationsColumns < ActiveRecord::Migration[7.0]
+  def change
+    safety_assured do
+      rename_column :organisations, :ccms_code, :ccms_type_code
+      rename_column :organisations, :description, :ccms_type_text
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_24_132946) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_05_133536) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -696,8 +696,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_24_132946) do
 
   create_table "organisations", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "name", null: false
-    t.string "ccms_code", null: false
-    t.string "description", null: false
+    t.string "ccms_type_code", null: false
+    t.string "ccms_type_text", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/spec/forms/opponents/organisation_form_spec.rb
+++ b/spec/forms/opponents/organisation_form_spec.rb
@@ -64,8 +64,6 @@ RSpec.describe Opponents::OrganisationForm, :vcr, type: :form do
 
         expect(organisation_form.model).to have_attributes(
           name: "Central Beds Council",
-          ccms_code: "LA",
-          description: "Local Authority",
           ccms_type_code: "LA",
           ccms_type_text: "Local Authority",
         )

--- a/spec/models/application_merits_task/organisation_spec.rb
+++ b/spec/models/application_merits_task/organisation_spec.rb
@@ -7,7 +7,7 @@ module ApplicationMeritsTask
     it { expect(organisation.ccms_relationship_to_case).to eq "OPP" }
     it { expect(organisation.ccms_child?).to be false }
     it { expect(organisation.ccms_opponent_relationship_to_case).to eq "Opponent" }
-    it { expect(organisation).to respond_to(:name, :ccms_code, :description, :ccms_type_code, :ccms_type_text) }
+    it { expect(organisation).to respond_to(:name, :ccms_type_code, :ccms_type_text) }
     it { expect(organisation.type).to eq "Organisation" }
 
     context "with an opponent" do


### PR DESCRIPTION
## What
Rename organisations#ccms_code and organisations#description

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4399)

These names are clearer descriptions of their data content and
purpose as well as what is currently returned from LFA's
organisation endpoints.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
