### PR TITLE
chore: group npm dependencies in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,4 +36,6 @@ updates:
     npm-jest:
       # Define patterns to include dependencies in the group (based on # dependency name)
       patterns:
+        - "babel*"
         - "jest*"  # A wildcard string that matches multiple dependency names syt
+        - "stylelint*"


### PR DESCRIPTION
## What

Group Babel and Stylelint dependencies together, thereby creating a single PR for related dependencies instead of many

[Dependabot grouping feature in public beta](https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/)

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
