### PR TITLE
chore: snyk ignore (temporarily) golang.org CWE-226

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,10 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.25.0
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  SNYK-GOLANG-GOLANGORGXSYSUNIX-3310442:
+    - '*':
+        reason: esbuild's go dependency fixed to v0.0.0
+        expires: 2024-03-07T08:00:00.000Z
+        created: 2023-09-08T08:00:00.000Z
+patch: {}


### PR DESCRIPTION
## What

We are currently getting [CWE-226](https://security.snyk.io/vuln/SNYK-GOLANG-GOLANGORGXSYSUNIX-3310442) alerts while using esbuild in our container

This is due to the esbuild maintainers fixing the golang version to v0.0.0
see:
https://github.com/evanw/esbuild/commit/fd13718c6195afb9e63682476a774fa6d4483be0
https://github.com/evanw/esbuild/pull/3254
https://github.com/evanw/esbuild/pull/3248

As we cannot resolve this ourselves, we will ignore it for the next 6 months

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
