### PR TITLE
AP-4441: Fix the overnight purge job

### DIFF
--- a/db/migrate/20230911120457_update_legal_framework_merits_task_list_foreign_key.rb
+++ b/db/migrate/20230911120457_update_legal_framework_merits_task_list_foreign_key.rb
@@ -1,0 +1,6 @@
+class UpdateLegalFrameworkMeritsTaskListForeignKey < ActiveRecord::Migration[7.0]
+  def change
+    remove_foreign_key :legal_framework_merits_task_lists, :legal_aid_applications
+    add_foreign_key :legal_framework_merits_task_lists, :legal_aid_applications, on_delete: :cascade, validate: false
+  end
+end

--- a/db/migrate/20230912082919_validate_legal_framework_merits_task_list_fk.rb
+++ b/db/migrate/20230912082919_validate_legal_framework_merits_task_list_fk.rb
@@ -1,0 +1,5 @@
+class ValidateLegalFrameworkMeritsTaskListFk < ActiveRecord::Migration[7.0]
+  def change
+    validate_foreign_key :legal_framework_merits_task_lists, :legal_aid_applications
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_11_120457) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_12_082919) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_05_133536) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_11_120457) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -1047,7 +1047,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_05_133536) do
   add_foreign_key "legal_aid_applications", "applicants"
   add_foreign_key "legal_aid_applications", "offices"
   add_foreign_key "legal_aid_applications", "providers"
-  add_foreign_key "legal_framework_merits_task_lists", "legal_aid_applications"
+  add_foreign_key "legal_framework_merits_task_lists", "legal_aid_applications", on_delete: :cascade
   add_foreign_key "legal_framework_submissions", "legal_aid_applications"
   add_foreign_key "matter_oppositions", "legal_aid_applications", on_delete: :cascade
   add_foreign_key "offices", "firms"


### PR DESCRIPTION


## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-XXX)

The overnight purge job had been failing because the LegalFrameworkMeritsTaskList was not being cascade deleted.  This PR updates the foreign key link between the two models and has been tested with an anonymised DB backup.

Before the fix, the job failed with the same error seen in production. After the fix it successfully completed

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
