### PR TITLE
Fix: uri gem CVE warning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ gem "sentry-ruby"
 gem "sentry-sidekiq"
 gem "simple_command"
 gem "tzinfo-data"
+gem "uri", ">= 0.12.2"
 gem "webdack-uuid_migration", "~> 1.4.0"
 
 # Reduces boot times through caching; required in config/boot.rb

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -680,6 +680,7 @@ GEM
       tzinfo (>= 1.0.0)
     uber (0.1.0)
     unicode-display_width (2.4.2)
+    uri (0.12.2)
     vcr (6.2.0)
     version_gem (1.1.3)
     view_component (3.3.0)
@@ -807,6 +808,7 @@ DEPENDENCIES
   strong_migrations
   super_diff
   tzinfo-data
+  uri (>= 0.12.2)
   vcr
   view_component
   webdack-uuid_migration (~> 1.4.0)


### PR DESCRIPTION

## What

This has been documented on the [ruby-lang](https://www.ruby-lang.org/en/news/2023/06/29/redos-in-uri-CVE-2023-36617/) website and was picked up by a docker scout scan

Presumably this will be fixed in a future ruby patch release and, at that point, this explicit requirement can be removed from the Gemfile

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
