### PR TITLE
Sonarcloud: exclude cassettes from analysis

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,2 +1,3 @@
 sonar.sources=app, lib
 sonar.tests=features, spec
+sonar.test.exclusions=features/cassettes/**/*, spec/cassettes/**/*


### PR DESCRIPTION
## What
Exclude cassettes from analysis

There is a 400 character limit on directory/file name lengths
in sonarcloud. Cassettes do not need to be analysed and because
cassette names and dirs are automatically generated by VCR based
on spec file names and example/scenario descriptions these names can
up up being very long.

[Came out of story](https://dsdmoj.atlassian.net/browse/AP-4399)


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
