### PR TITLE
Rubocop: Address RSpec/OverwritingSetup infractions

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -254,16 +254,6 @@ RSpec/NamedSubject:
     - 'spec/services/true_layer/importers/import_accounts_service_spec.rb'
     - 'spec/services/true_layer_error_decoder_spec.rb'
 
-# Offense count: 6
-RSpec/OverwritingSetup:
-  Exclude:
-    - 'spec/models/legal_aid_application_spec.rb'
-    - 'spec/requests/feedbacks_spec.rb'
-    - 'spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_variable_attributes_spec.rb'
-    - 'spec/services/reports/mis/application_detail_csv_line_spec.rb'
-    - 'spec/services/required_document_category_analyser_spec.rb'
-    - 'spec/services/true_layer/importers/import_accounts_service_spec.rb'
-
 # Offense count: 16
 RSpec/RepeatedDescription:
   Exclude:

--- a/spec/models/legal_aid_application_spec.rb
+++ b/spec/models/legal_aid_application_spec.rb
@@ -226,12 +226,6 @@ RSpec.describe LegalAidApplication do
       end
       let(:da001) { legal_aid_application.proceedings.find_by(ccms_code: "DA001") }
       let(:se014) { legal_aid_application.proceedings.find_by(ccms_code: "SE014") }
-      let!(:chances_of_success) do
-        create(:chances_of_success, :with_optional_text, proceeding: da004)
-      end
-      let!(:chances_of_success) do
-        create(:chances_of_success, :with_optional_text, proceeding: se014)
-      end
 
       it "returns the lead proceeding" do
         expect(legal_aid_application.lead_proceeding).to eq da001

--- a/spec/requests/feedbacks_spec.rb
+++ b/spec/requests/feedbacks_spec.rb
@@ -18,7 +18,6 @@ RSpec.describe "FeedbacksController" do
     let(:address_lookup_page) { "http://localhost:3000/providers/applications/#{application.id}/address_lookup" }
     let(:additional_accounts_page) { "http://localhost:3000/citizens/additional_accounts" }
     let(:originating_page) { "page_outside_apply_service" }
-    let(:provider) { create(:provider) }
     let(:application) { create(:application, provider:) }
     let(:page_history_id) { SecureRandom.uuid }
     let(:page_history) { [address_lookup_page, "/feedback"] }

--- a/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_variable_attributes_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_variable_attributes_spec.rb
@@ -476,7 +476,6 @@ module CCMS
           let(:benefits) { create(:transaction_type, :credit, name: "benefits") }
           let(:bank_account) { create(:bank_account, bank_provider:) }
           let(:bank_provider) { create(:bank_provider, applicant:) }
-          let(:bank_account) { create(:bank_account, bank_provider:) }
           let!(:benefits_bank_transaction) { create(:bank_transaction, :credit, transaction_type: benefits, bank_account:) }
           let(:applicant) { create(:applicant, :with_address) }
           let(:legal_aid_application) do

--- a/spec/services/reports/mis/application_detail_csv_line_spec.rb
+++ b/spec/services/reports/mis/application_detail_csv_line_spec.rb
@@ -196,7 +196,6 @@ module Reports
       let(:inherited_assets_value) { 300 }
       let(:money_owed_value) { 25 }
       let(:trust_value) { 99 }
-      let(:none_selected) { nil }
 
       let(:understands_terms_of_court_order) { true }
       let(:understands_terms_of_court_order_details) { "Understood" }

--- a/spec/services/required_document_category_analyser_spec.rb
+++ b/spec/services/required_document_category_analyser_spec.rb
@@ -44,7 +44,6 @@ RSpec.describe RequiredDocumentCategoryAnalyser do
 
     context "when the application has dwp result overriden and section 8 proceedings" do
       let(:dwp_override) { create(:dwp_override, :with_evidence) }
-      let(:application) { create(:legal_aid_application, dwp_override:) }
       let(:application) { create(:legal_aid_application, :with_multiple_proceedings_inc_section8, dwp_override:) }
 
       it "updates the required_document_categories with gateway_evidence" do

--- a/spec/services/true_layer/importers/import_accounts_service_spec.rb
+++ b/spec/services/true_layer/importers/import_accounts_service_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe TrueLayer::Importers::ImportAccountsService do
     let(:mock_account2) { TrueLayerHelpers::MOCK_DATA[:accounts][1] }
     let(:bank_account1) { bank_provider.bank_accounts.find_by(true_layer_id: mock_account1[:account_id]) }
     let(:bank_account2) { bank_provider.bank_accounts.find_by(true_layer_id: mock_account2[:account_id]) }
-    let!(:existing_bank_account) { create(:bank_account_holder, bank_provider:) }
     let!(:existing_bank_account) { create(:bank_account, bank_provider:) }
     let!(:existing_bank_account_transaction) { create(:bank_transaction, bank_account: existing_bank_account) }
 


### PR DESCRIPTION
## What

These occur when a spec is configured as

```ruby
let(:something) { create(:something) }
let(:something) { create(:something, :with_trait) }
```

and usually occur in long complex test files.

This PR removes the occurrences of duplicated `let`s and ensured the tests passed before committing

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
