### PR TITLE
Rubocop: Remove RSpec/ExpectInHook exclusions

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -51,18 +51,6 @@ RSpec/ExpectActual:
   Exclude:
     - 'spec/services/reports/means_report_creator_spec.rb'
 
-# Offense count: 12
-RSpec/ExpectInHook:
-  Exclude:
-    - 'spec/models/application_merits_task/involved_child_spec.rb'
-    - 'spec/models/dashboard/widget_spec.rb'
-    - 'spec/models/legal_aid_application_spec.rb'
-    - 'spec/requests/citizens/gather_transactions_spec.rb'
-    - 'spec/services/bank_holiday_retriever_service_spec.rb'
-    - 'spec/services/provider_after_login_service_spec.rb'
-    - 'spec/services/reports/mis/application_details_report_spec.rb'
-    - 'spec/services/true_layer/api_client_mock_spec.rb'
-
 # Offense count: 192
 RSpec/LetSetup:
   Exclude:

--- a/spec/models/application_merits_task/involved_child_spec.rb
+++ b/spec/models/application_merits_task/involved_child_spec.rb
@@ -68,7 +68,7 @@ module ApplicationMeritsTask
       let(:expected_id) { Faker::Number.number(digits: 8) }
 
       context "when ccms_opponent_id is nil" do
-        before { expect(CCMS::OpponentId).to receive(:next_serial_id).and_return(expected_id) }
+        before { allow(CCMS::OpponentId).to receive(:next_serial_id).and_return(expected_id) }
 
         let(:involved_child) { create(:involved_child, full_name: "John Doe", ccms_opponent_id: nil) }
 
@@ -83,15 +83,15 @@ module ApplicationMeritsTask
       end
 
       context "when ccms_opponent_id is already populated" do
-        before { expect(CCMS::OpponentId).not_to receive(:next_serial_id) }
-
         let(:involved_child) { create(:involved_child, full_name: "John Doe", ccms_opponent_id: 4553) }
 
         it "returns the value" do
+          expect(CCMS::OpponentId).not_to receive(:next_serial_id)
           expect(involved_child.generate_ccms_opponent_id).to eq 4553
         end
 
         it "does not update the record with a different value" do
+          expect(CCMS::OpponentId).not_to receive(:next_serial_id)
           involved_child.generate_ccms_opponent_id
           expect(involved_child.reload.ccms_opponent_id).to eq 4553
         end

--- a/spec/models/dashboard/widget_spec.rb
+++ b/spec/models/dashboard/widget_spec.rb
@@ -61,7 +61,7 @@ module Dashboard
 
     describe "run" do
       before do
-        expect(datasets_client).to receive(:find_or_create).and_return(dataset)
+        allow(datasets_client).to receive(:find_or_create).and_return(dataset)
       end
 
       it "sends expected data" do

--- a/spec/models/legal_aid_application_spec.rb
+++ b/spec/models/legal_aid_application_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe LegalAidApplication do
     subject(:capture_policy_disregards) { legal_aid_application.capture_policy_disregards? }
 
     context "when calculation date is nil" do
-      before { expect(legal_aid_application).to receive(:calculation_date).and_return(nil) }
+      before { allow(legal_aid_application).to receive(:calculation_date).and_return(nil) }
 
       context "with today's date before start of policy disregards" do
         it "returns false" do
@@ -131,7 +131,7 @@ RSpec.describe LegalAidApplication do
     end
 
     context "with calculation date set" do
-      before { expect(legal_aid_application).to receive(:calculation_date).and_return(calculation_date) }
+      before { allow(legal_aid_application).to receive(:calculation_date).and_return(calculation_date) }
 
       context "with today's date before start of policy disregards" do
         let(:calculation_date) { Date.new(2021, 1, 7) }

--- a/spec/requests/citizens/gather_transactions_spec.rb
+++ b/spec/requests/citizens/gather_transactions_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe "citizen accounts request" do
     let(:worker) { {} }
 
     before do
-      expect(ImportBankDataWorker).to receive(:perform_async).with(legal_aid_application.id).and_return(worker_id)
+      allow(ImportBankDataWorker).to receive(:perform_async).with(legal_aid_application.id).and_return(worker_id)
       allow(Sidekiq::Status).to receive(:get_all).and_return(worker)
       sign_in_citizen_for_application(legal_aid_application)
       get_request

--- a/spec/services/bank_holiday_retriever_service_spec.rb
+++ b/spec/services/bank_holiday_retriever_service_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe BankHolidayRetriever, vcr: { cassette_name: "gov_uk_bank_holiday_
       let(:uri) { URI.parse(described_class::API_URL) }
 
       before do
-        expect(Net::HTTP).to receive(:get_response).with(uri).and_return(DummyErrorReturnObj.new)
+        allow(Net::HTTP).to receive(:get_response).with(uri).and_return(DummyErrorReturnObj.new)
       end
 
       it "raises error" do

--- a/spec/services/provider_after_login_service_spec.rb
+++ b/spec/services/provider_after_login_service_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe ProviderAfterLoginService do
       let(:provider) { create(:provider, :created_by_devise, :with_ccms_apply_role, invalid_login_details: "provider_details_api_error") }
 
       context "and the provider cannot be found on Provider Details API" do
-        before { expect(ProviderDetailsCreator).to receive(:call).and_raise(ProviderDetailsRetriever::ApiRecordNotFoundError) }
+        before { allow(ProviderDetailsCreator).to receive(:call).and_raise(ProviderDetailsRetriever::ApiRecordNotFoundError) }
 
         it "updates the provider invalid login details" do
           subject
@@ -30,7 +30,7 @@ RSpec.describe ProviderAfterLoginService do
       end
 
       context "and the provider found on Provider Details API" do
-        before { expect(ProviderDetailsCreator).to receive(:call).with(provider) }
+        before { allow(ProviderDetailsCreator).to receive(:call).with(provider) }
 
         it "does not update invalid login details" do
           subject
@@ -44,7 +44,7 @@ RSpec.describe ProviderAfterLoginService do
       end
 
       context "and the provider details API not available" do
-        before { expect(ProviderDetailsCreator).to receive(:call).and_raise(ProviderDetailsRetriever::ApiError) }
+        before { allow(ProviderDetailsCreator).to receive(:call).and_raise(ProviderDetailsRetriever::ApiError) }
 
         it "updates the provider invalid login details" do
           subject

--- a/spec/services/reports/mis/application_details_report_spec.rb
+++ b/spec/services/reports/mis/application_details_report_spec.rb
@@ -53,7 +53,7 @@ module Reports
         end
 
         context "when there is an exception" do
-          before { expect(report).to receive(:generate_temp_file).and_raise(RuntimeError) }
+          before { allow(report).to receive(:generate_temp_file).and_raise(RuntimeError) }
 
           it "notifies sentry" do
             expect(Sentry).to receive(:capture_message)

--- a/spec/services/true_layer/api_client_mock_spec.rb
+++ b/spec/services/true_layer/api_client_mock_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe TrueLayer::ApiClientMock do
       end
 
       before do
-        expect(Setting).to receive(:bank_transaction_filename).and_return(csv_file)
+        allow(Setting).to receive(:bank_transaction_filename).and_return(csv_file)
       end
 
       it "returns the sample data" do


### PR DESCRIPTION
## What

In a before hook, we should only use `allow` to set an required response. If we actually "expect" something, it should be in an `it` test block

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
