### PR TITLE
AP-4442: Ensure dependant pages show save as draft button

### DIFF
--- a/app/controllers/providers/means/has_dependants_controller.rb
+++ b/app/controllers/providers/means/has_dependants_controller.rb
@@ -6,8 +6,10 @@ module Providers
       end
 
       def update
-        @form = LegalAidApplications::HasDependantsForm.new(form_params)
+        @form = LegalAidApplications::HasDependantsForm.new(form_params.merge(draft: params[:draft_button].present?))
         if @form.save
+          return continue_or_draft if draft_selected?
+
           remove_dependants unless legal_aid_application.has_dependants?
           go_forward
         else

--- a/app/controllers/providers/means/has_other_dependants_controller.rb
+++ b/app/controllers/providers/means/has_other_dependants_controller.rb
@@ -6,6 +6,7 @@ module Providers
       end
 
       def update
+        return continue_or_draft if draft_selected?
         return go_forward(form.has_other_dependant?) if form.valid?
 
         render :show

--- a/app/forms/legal_aid_applications/has_dependants_form.rb
+++ b/app/forms/legal_aid_applications/has_dependants_form.rb
@@ -2,8 +2,8 @@ module LegalAidApplications
   class HasDependantsForm < BaseForm
     form_for LegalAidApplication
 
-    attr_accessor :has_dependants
+    attr_accessor :has_dependants, :draft
 
-    validates :has_dependants, presence: true
+    validates :has_dependants, presence: true, unless: :draft?
   end
 end

--- a/app/views/providers/means/has_dependants/show.html.erb
+++ b/app/views/providers/means/has_dependants/show.html.erb
@@ -42,9 +42,6 @@
 
     <% end %>
 
-    <%= next_action_buttons(
-          show_draft: local_assigns.key?(:show_draft) ? show_draft : false,
-          form:,
-        ) %>
+    <%= next_action_buttons(show_draft: true, form:) %>
   <% end %>
 <% end %>

--- a/app/views/providers/means/has_other_dependants/show.html.erb
+++ b/app/views/providers/means/has_other_dependants/show.html.erb
@@ -39,7 +39,7 @@
                                               :label,
                                               legend: { text: content_for(:page_title), size: "m", tag: "h2" } %>
 
-      <%= next_action_buttons(form:) %>
+      <%= next_action_buttons(show_draft: true, form:) %>
     <% end %>
   <% end %>
 <% end %>


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4442)

One did not have it at all, the other was conditional reverting to false.  It was agreed that these should _always_ be present, so this PR sets the value to always be true on both pages

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
