### PR TITLE
AP-4138: Update partner vehicle questions

### DIFF
--- a/app/controllers/providers/check_capital_answers_controller.rb
+++ b/app/controllers/providers/check_capital_answers_controller.rb
@@ -2,6 +2,7 @@ module Providers
   class CheckCapitalAnswersController < ProviderBaseController
     def show
       legal_aid_application.check_non_passported_means! unless legal_aid_application.checking_non_passported_means?
+      @vehicle_owner = vehicle_owner
     end
 
     def update
@@ -27,6 +28,12 @@ module Providers
 
     def check_financial_eligibility
       CFECivil::SubmissionBuilder.call(@legal_aid_application)
+    end
+
+    def vehicle_owner
+      return if legal_aid_application.vehicle.blank?
+
+      t(".options.#{legal_aid_application.vehicle.owner}")
     end
   end
 end

--- a/app/controllers/providers/means/vehicle_details_controller.rb
+++ b/app/controllers/providers/means/vehicle_details_controller.rb
@@ -3,6 +3,10 @@ module Providers
     class VehicleDetailsController < ProviderBaseController
       def show
         @form = ::Vehicles::DetailsForm.new(model: vehicle)
+        unless legal_aid_application.applicant.has_partner_with_no_contrary_interest?
+          legal_aid_application.vehicle.owner = "client"
+          legal_aid_application.vehicle.save!
+        end
       end
 
       def update
@@ -20,7 +24,8 @@ module Providers
         return { model: vehicle } if params[:vehicle].nil?
 
         merge_with_model(vehicle) do
-          params.require(:vehicle).permit(:estimated_value,
+          params.require(:vehicle).permit(:owner,
+                                          :estimated_value,
                                           :more_than_three_years_old,
                                           :payment_remaining,
                                           :payments_remain,

--- a/app/views/providers/means/vehicle_details/show.html.erb
+++ b/app/views/providers/means/vehicle_details/show.html.erb
@@ -9,8 +9,8 @@
     <%= form.govuk_fieldset legend: { size: "xl", tag: "h1", text: page_title }  do %>
       <% if @legal_aid_application.applicant.has_partner_with_no_contrary_interest? %>
         <%= form.govuk_radio_buttons_fieldset(:owner, legend: { size: "m", text: t(".owner.question") }) do %>
-          <% Vehicles::DetailsForm.radio_options.each do |f| %>
-            <%= form.govuk_radio_button :owner, f.value, label: { text: f.label }, link_errors: true %>
+          <% Vehicles::DetailsForm.radio_options.each_with_index do |f, index| %>
+            <%= form.govuk_radio_button :owner, f.value, label: { text: f.label }, link_errors: index.zero? %>
           <% end %>
         <% end %>
       <% end %>

--- a/app/views/providers/means/vehicle_details/show.html.erb
+++ b/app/views/providers/means/vehicle_details/show.html.erb
@@ -7,6 +7,14 @@
   <%= page_template page_title: t(".heading"), template: :basic, form: do %>
 
     <%= form.govuk_fieldset legend: { size: "xl", tag: "h1", text: page_title }  do %>
+      <% if @legal_aid_application.applicant.has_partner_with_no_contrary_interest? %>
+        <%= form.govuk_radio_buttons_fieldset(:owner, legend: { size: "m", text: t(".owner.question") }) do %>
+          <% Vehicles::DetailsForm.radio_options.each do |f| %>
+            <%= form.govuk_radio_button :owner, f.value, label: { text: f.label }, link_errors: true %>
+          <% end %>
+        <% end %>
+      <% end %>
+
       <%= form.govuk_text_field :estimated_value,
                                 label: { text: t(".estimated_value.question"), tag: "h2", size: "m" },
                                 hint: { text: t(".estimated_value.use_car_valuation_sites") },

--- a/app/views/shared/check_answers/_assets.html.erb
+++ b/app/views/shared/check_answers/_assets.html.erb
@@ -1,13 +1,18 @@
 <% read_only = false unless local_assigns.key?(:read_only) %>
 <% online_savings_accounts = @legal_aid_application.online_savings_accounts_balance %>
 <% online_current_accounts = @legal_aid_application.online_current_accounts_balance %>
+<% individual = if @legal_aid_application.applicant.has_partner_with_no_contrary_interest?
+                  "your client or their partner"
+                else
+                  "your client"
+                end %>
 
 <section class="print-no-break">
   <%= render "shared/check_answers/property", read_only: %>
 </section>
 
 <section class="print-no-break">
-  <%= render "shared/check_answers/vehicles", read_only: %>
+  <%= render "shared/check_answers/vehicles", read_only:, individual: %>
 
   <% if @legal_aid_application.non_passported? && !@legal_aid_application.uploading_bank_statements? %>
     <!-- non-passported truelayer only -->

--- a/app/views/shared/check_answers/_vehicles.html.erb
+++ b/app/views/shared/check_answers/_vehicles.html.erb
@@ -3,13 +3,15 @@
   <%= t(".#{journey_type}.heading") %>
 </h3>
 
+<% partner = @legal_aid_application.applicant.has_partner_with_no_contrary_interest? %>
+
 <%= govuk_summary_list(
       actions: !read_only,
       classes: "govuk-!-margin-bottom-9",
       html_attributes: { id: "vehicles-questions" },
     ) do |summary_list| %>
   <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__vehicles" }) do |row| %>
-    <%= row.with_key(text: t(".#{journey_type}.own"), classes: "govuk-!-width-one-half") %>
+    <%= row.with_key(text: t(".#{journey_type}.own", individual:), classes: "govuk-!-width-one-half") %>
     <%= row.with_value { yes_no(@legal_aid_application.own_vehicle?) } %>
     <%= row.with_action(
           text: t("generic.change"),
@@ -19,6 +21,18 @@
   <% end %>
 
   <% if @legal_aid_application.own_vehicle? %>
+    <% if @legal_aid_application.applicant.has_partner_with_no_contrary_interest? %>
+      <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__vehicles_owner" }) do |row| %>
+        <%= row.with_key(text: t(".#{journey_type}.owner"), classes: "govuk-!-width-one-half") %>
+        <%= row.with_value { @vehicle_owner } %>
+        <%= row.with_action(
+              text: t("generic.change"),
+              href: check_answer_url_for(journey_type, :vehicle_details, @legal_aid_application),
+              visually_hidden_text: t(".#{journey_type}.owner"),
+            ) %>
+      <% end %>
+    <% end %>
+
     <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__vehicles_estimated_values" }) do |row| %>
       <%= row.with_key(text: t(".#{journey_type}.estimated_value"), classes: "govuk-!-width-one-half") %>
       <%= row.with_value { gds_number_to_currency(@legal_aid_application.vehicle.estimated_value) } %>

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -800,6 +800,8 @@ en:
               uncategorised_evidence: Select a category for each uploaded file
         vehicle:
           attributes:
+            owner:
+              blank: Select who owns the vehicle
             estimated_value:
               blank: Enter the estimated value of the vehicle
               not_a_number: Estimated value must be an amount of money, like 5,000

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -1051,6 +1051,10 @@ en:
         what_happens_next:
           heading: What happens next
           text: We'll use your answers to check your client's financial eligibility for legal aid.
+        options:
+          client: My client
+          partner: The partner
+          client_and_partner: My client and their partner
     merits_task_lists:
       show:
         page_heading: Provide details of the case

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -975,6 +975,12 @@ en:
       vehicle_details:
         show:
           heading: Vehicle details
+          owner:
+            question: Who owns the vehicle?
+            options:
+              client: My client
+              partner: The partner
+              client_and_partner: My client and their partner
           estimated_value:
             question: How much is the vehicle worth?
             use_car_valuation_sites: You can use car valuation websites to find this out.

--- a/config/locales/en/shared.yml
+++ b/config/locales/en/shared.yml
@@ -457,7 +457,8 @@ en:
       vehicles:
         providers:
           heading: Vehicles
-          own: Does your client own a vehicle?
+          own: Does %{individual} own a vehicle?
+          owner: Who owns the vehicle?
           estimated_value: What is the estimated value of the vehicle?
           payment_remaining: Are there any payments left on the vehicle?
           more_than_three_years_old: The vehicle was bought more than three years ago?

--- a/db/migrate/20230918144429_add_owner_to_vehicles.rb
+++ b/db/migrate/20230918144429_add_owner_to_vehicles.rb
@@ -1,0 +1,5 @@
+class AddOwnerToVehicles < ActiveRecord::Migration[7.0]
+  def change
+    add_column :vehicles, :owner, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_18_142519) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_18_144429) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -1016,6 +1016,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_18_142519) do
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.boolean "more_than_three_years_old"
+    t.string "owner"
     t.index ["legal_aid_application_id"], name: "index_vehicles_on_legal_aid_application_id"
   end
 

--- a/features/providers/partner_means_assessment/end_to_end_capital_assessment.feature
+++ b/features/providers/partner_means_assessment/end_to_end_capital_assessment.feature
@@ -1,0 +1,13 @@
+Feature: partner_means_assessment full journey
+  @javascript
+  Scenario: I am able to complete a minimal (answering no to everything) partner capital assessment to check your answers
+    Given csrf is enabled
+    And the feature flag for partner_means_assessment is enabled
+    And I complete the partner journey as far as capital introductions
+    
+    When I click 'Continue'
+    Then I should be on a page with title "Does your client or their partner own the home your client lives in?"
+
+    When I choose "No"
+    And I click "Save and continue"
+    Then I should be on a page with title "Does your client or their partner own a vehicle?"

--- a/features/step_definitions/partner_means_check.rb
+++ b/features/step_definitions/partner_means_check.rb
@@ -29,6 +29,17 @@ Given("I complete the partner journey as far as {string}") do |step|
   visit(path)
 end
 
+Given("I complete the partner journey as far as capital introductions") do
+  @legal_aid_application = create(
+    :legal_aid_application,
+    :with_applicant_and_partner,
+  )
+
+  login_as @legal_aid_application.provider
+
+  visit(providers_legal_aid_application_capital_introduction_path(@legal_aid_application))
+end
+
 Given(/^an applicant named (\S+) (\S+) with a partner has completed their true layer interactions$/) do |first_name, last_name|
   @applicant = FactoryBot.create :applicant,
                                  :employed,

--- a/lib/tasks/add_vehicle_ownership.rake
+++ b/lib/tasks/add_vehicle_ownership.rake
@@ -1,0 +1,27 @@
+namespace :migrate do
+  desc "AP-4138: Add the owner of vehicles to exiting applications"
+
+  task vehicle_ownership: :environment do
+    records = Vehicle.all
+    Rails.logger.info "Add vehicle ownership => Applicant"
+    Rails.logger.info "----------------------------------------"
+    Rails.logger.info "vehicle.count: #{records.count}"
+    Rails.logger.info "vehicle with owner: #{records.where.not(owner: nil).count}"
+    Rails.logger.info "vehicle without owner: #{records.where(owner: nil).count}"
+    Rails.logger.info "-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-="
+    Benchmark.benchmark do |bm|
+      bm.report("Migrate:") do
+        ActiveRecord::Base.transaction do
+          records.where(owner: nil).each do |record|
+            record.update!(owner: "client")
+          end
+          raise StandardError, "Not all vehicles updated" if records.where(owner: nil).count.positive?
+        end
+      end
+    end
+    Rails.logger.info "-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-="
+    Rails.logger.info "vehicle with owner: #{records.where.not(owner: nil).count}"
+    Rails.logger.info "vehicle without owner: #{records.where(owner: nil).count}"
+    Rails.logger.info "----------------------------------------"
+  end
+end

--- a/spec/factories/vehicles.rb
+++ b/spec/factories/vehicles.rb
@@ -10,6 +10,14 @@ FactoryBot.define do
       used_regularly { Faker::Boolean.boolean }
     end
 
+    trait :owned_by_partner do
+      estimated_value { Faker::Commerce.price(range: 2000..10_000) }
+      owner { "partner" }
+      payment_remaining { Faker::Commerce.price(range: 100..1_000) }
+      purchased_on { Faker::Date.between(from: 20.years.ago, to: 2.days.ago) }
+      used_regularly { Faker::Boolean.boolean }
+    end
+
     trait :with_applicant_and_partner do
       legal_aid_application { association(:legal_aid_application, :with_applicant_and_partner) }
     end

--- a/spec/factories/vehicles.rb
+++ b/spec/factories/vehicles.rb
@@ -4,9 +4,14 @@ FactoryBot.define do
 
     trait :populated do
       estimated_value { Faker::Commerce.price(range: 2000..10_000) }
+      owner { "client" }
       payment_remaining { Faker::Commerce.price(range: 100..1_000) }
       purchased_on { Faker::Date.between(from: 20.years.ago, to: 2.days.ago) }
       used_regularly { Faker::Boolean.boolean }
+    end
+
+    trait :with_applicant_and_partner do
+      legal_aid_application { association(:legal_aid_application, :with_applicant_and_partner) }
     end
   end
 end

--- a/spec/forms/vehicles/details_form_spec.rb
+++ b/spec/forms/vehicles/details_form_spec.rb
@@ -3,17 +3,19 @@ require "rails_helper"
 RSpec.describe Vehicles::DetailsForm, :vcr, type: :form do
   subject(:vehicle_details_form) { described_class.new(form_params) }
 
-  let(:model) { create(:vehicle) }
+  let(:model) { create(:vehicle, :with_applicant_and_partner) }
   let(:params) do
     {
       estimated_value:,
       more_than_three_years_old:,
+      owner:,
       payment_remaining:,
       payments_remain:,
       used_regularly:,
     }
   end
   let(:estimated_value) { "" }
+  let(:owner) { "" }
   let(:more_than_three_years_old) { "" }
   let(:payment_remaining) { "" }
   let(:payments_remain) { "" }
@@ -26,6 +28,7 @@ RSpec.describe Vehicles::DetailsForm, :vcr, type: :form do
       it "raises an error" do
         expect(vehicle_details_form.valid?).to be false
         expect(vehicle_details_form.errors.messages).to match_array(
+          owner: ["Select who owns the vehicle"],
           estimated_value: ["Enter the estimated value of the vehicle"],
           more_than_three_years_old: ["Select yes if the vehicle was bought over 3 years ago"],
           payments_remain: ["Select yes if there are any payments left on the vehicle"],
@@ -37,6 +40,7 @@ RSpec.describe Vehicles::DetailsForm, :vcr, type: :form do
     context "when values are provided" do
       let(:estimated_value) { "5000.00" }
       let(:more_than_three_years_old) { "false" }
+      let(:owner) { "client" }
       let(:payments_remain) { "true" }
       let(:payment_remaining) { "1000" }
       let(:used_regularly) { "true" }
@@ -53,6 +57,7 @@ RSpec.describe Vehicles::DetailsForm, :vcr, type: :form do
 
     let(:estimated_value) { "£5000.00" }
     let(:more_than_three_years_old) { "false" }
+    let(:owner) { "client" }
     let(:payments_remain) { "true" }
     let(:payment_remaining) { 1000 }
     let(:used_regularly) { "true" }
@@ -64,6 +69,7 @@ RSpec.describe Vehicles::DetailsForm, :vcr, type: :form do
         expect(model.reload).to have_attributes(
           estimated_value: 5000,
           more_than_three_years_old: false,
+          owner: "client",
           payment_remaining: 1000,
           used_regularly: true,
         )
@@ -79,6 +85,7 @@ RSpec.describe Vehicles::DetailsForm, :vcr, type: :form do
         expect(model.reload).to have_attributes(
           estimated_value: 5000,
           more_than_three_years_old: false,
+          owner: "client",
           payment_remaining: 0,
           used_regularly: true,
         )

--- a/spec/requests/providers/check_capital_answers_controller_spec.rb
+++ b/spec/requests/providers/check_capital_answers_controller_spec.rb
@@ -73,6 +73,16 @@ RSpec.describe Providers::CheckCapitalAnswersController do
         expect(response.body).not_to include(I18n.t("shared.check_answers_vehicles.providers.used_regularly"))
       end
     end
+
+    context "when applicant has partner who owns vehicle" do
+      let(:own_vehicle) { true }
+      let(:vehicle) { create(:vehicle, :owned_by_partner) }
+      let(:applicant) { create(:applicant, has_partner: true, partner_has_contrary_interest: false) }
+
+      it "shows 'The partner' as the owner" do
+        expect(response.body).to have_css("#app-check-your-answers__vehicles_owner", text: "The partner")
+      end
+    end
   end
 
   describe "PATCH /providers/applications/:legal_aid_application_id/check_capital_answers" do


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4138)

Add owner question which is only displayed when applicant has a partner. When applicant has no partner, `owner` is set to 'client'. Add a rake task to update existing vehicles to have an owner set to 'client'

As vehicles can be owned by the applicant, the partner or both, the `owner` is a string value

<img width="556" alt="image" src="https://github.com/ministryofjustice/laa-apply-for-legal-aid/assets/13471320/2e10855f-5122-4d98-9255-e3490ae19017">

To do:
- [x] Add rake task to add ownership to existing applications

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
