### PR TITLE
Ap 3655 use link helpers part 1

### DIFF
--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -6,7 +6,7 @@ module AdminHelper
                             [path, nil]
                           end
 
-    link = link_to_accessible name, link_path, class: "govuk-link govuk-link--no-visited-state"
+    link = govuk_link_to name, link_path, class: "govuk-link govuk-link--no-visited-state"
     content_tag :li, link, class: li_class
   end
 end

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -6,7 +6,7 @@ module AdminHelper
                             [path, nil]
                           end
 
-    link = govuk_link_to name, link_path, class: "govuk-link govuk-link--no-visited-state"
+    link = govuk_link_to name, link_path, { no_visited_state: true }
     content_tag :li, link, class: li_class
   end
 end

--- a/app/helpers/flow_helper.rb
+++ b/app/helpers/flow_helper.rb
@@ -41,6 +41,6 @@ module FlowHelper
 
   def next_action_link(continue_id: :continue, continue_text: t("generic.save_and_continue"), html_class: nil)
     klasses = ["govuk-button", html_class].compact.join(" ")
-    link_to_accessible(continue_text, forward_path, id: continue_id, class: klasses)
+    govuk_link_to(continue_text, forward_path, id: continue_id, class: klasses)
   end
 end

--- a/app/helpers/language_switcher_helper.rb
+++ b/app/helpers/language_switcher_helper.rb
@@ -3,7 +3,7 @@ module LanguageSwitcherHelper
     links = ""
 
     I18n.available_locales.each do |locale|
-      link = I18n.locale == locale ? t("generic.#{locale}") : link_to_accessible(t("generic.#{locale}"), url_for(locale:))
+      link = I18n.locale == locale ? t("generic.#{locale}") : govuk_link_to(t("generic.#{locale}"), url_for(locale:))
       links << "#{link} | "
     end
     links.delete_suffix! " | "

--- a/app/helpers/providers_helper.rb
+++ b/app/helpers/providers_helper.rb
@@ -1,6 +1,6 @@
 module ProvidersHelper
   def link_to_application(text, legal_aid_application)
-    link_to_accessible text, url_for_application(legal_aid_application)
+    govuk_link_to(text, url_for_application(legal_aid_application))
   end
 
   def url_for_application(legal_aid_application)

--- a/app/views/accessibility_statement/index.html.erb
+++ b/app/views/accessibility_statement/index.html.erb
@@ -11,7 +11,7 @@
     <% end %>
   </ul>
 
-  <p class="govuk-body"><%= link_to_accessible t(".ability_net.prefix"), "https://mcmw.abilitynet.org.uk/" %><%= t(".ability_net.suffix") %></p>
+  <p class="govuk-body"><%= govuk_link_to t(".ability_net.prefix"), "https://mcmw.abilitynet.org.uk/" %><%= t(".ability_net.suffix") %></p>
 
   <h2 class="govuk-heading-m"><%= t(".no_access") %></h2>
 
@@ -23,7 +23,7 @@
 
   <h2 class="govuk-heading-m"><%= t(".enforcement") %></h2>
 
-  <p class="govuk-body"><%= t(".ehrc.heading") %><%= link_to_accessible t(".ehrc.link_text"), "https://www.equalityadvisoryservice.com/" %></p>
+  <p class="govuk-body"><%= t(".ehrc.heading") %><%= govuk_link_to t(".ehrc.link_text"), "https://www.equalityadvisoryservice.com/" %></p>
 
   <h2 class="govuk-heading-m"><%= t(".accessibility.info_1") %></h2>
 
@@ -31,7 +31,7 @@
 
   <h2 class="govuk-heading-m"><%= t(".accessibility.compliance.status") %></h2>
 
-  <p class="govuk-body"><%= t(".accessibility.compliance.info_prefix") %><%= link_to_accessible t(".accessibility.compliance.link_text"), "https://www.w3.org/TR/WCAG21/" %><%= t(".accessibility.compliance.info_suffix") %></p>
+  <p class="govuk-body"><%= t(".accessibility.compliance.info_prefix") %><%= govuk_link_to t(".accessibility.compliance.link_text"), "https://www.w3.org/TR/WCAG21/" %><%= t(".accessibility.compliance.info_suffix") %></p>
 
   <h2 class="govuk-heading-m"><%= t(".burden.heading") %></h2>
 

--- a/app/views/admin/ccms_queues/show.html.erb
+++ b/app/views/admin/ccms_queues/show.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-breadcrumbs">
   <ol class="govuk-breadcrumbs__list">
     <li class="govuk-breadcrumbs__list-item">
-      <%= link_to_accessible("CCMS Queue", admin_ccms_queues_path, class: "govuk-breadcrumbs__link") %>
+      <%= govuk_link_to("CCMS Queue", admin_ccms_queues_path, class: "govuk-breadcrumbs__link") %>
     </li>
     <li class="govuk-breadcrumbs__list-item">
       <%= @legal_aid_application.application_ref %>
@@ -47,11 +47,11 @@
   <% else %>
     <%= govuk_details(summary_text: t(".restart")) do %>
       <p><%= t(".restart_details") %></p>
-      <p><%= link_to_accessible t(".restart"), restart_current_submission_admin_ccms_queue_path(@submission.id), class: "govuk-button govuk-!-margin-bottom-0" %></p>
+      <p><%= govuk_link_to t(".restart"), restart_current_submission_admin_ccms_queue_path(@submission.id), class: "govuk-button govuk-!-margin-bottom-0" %></p>
     <% end %>
     <%= govuk_details(summary_text: t(".reset")) do %>
       <p><%= t(".reset_details") %></p>
-      <p><%= link_to_accessible t(".reset"), reset_and_restart_admin_ccms_queue_path(@submission.id), class: "govuk-button govuk-!-margin-bottom-0" %></p>
+      <p><%= govuk_link_to t(".reset"), reset_and_restart_admin_ccms_queue_path(@submission.id), class: "govuk-button govuk-!-margin-bottom-0" %></p>
     <% end %>
   <% end %>
 </div>

--- a/app/views/admin/firms/index.html.erb
+++ b/app/views/admin/firms/index.html.erb
@@ -31,7 +31,7 @@
                   end
                 end
                 row.with_cell do
-                  link_to_accessible(
+                  govuk_link_to(
                     t(".view_users_html", provider: firm.name),
                     admin_firm_providers_path(firm),
                     id: "firm-#{firm.id}",

--- a/app/views/admin/legal_aid_applications/submissions/show.html.erb
+++ b/app/views/admin/legal_aid_applications/submissions/show.html.erb
@@ -11,11 +11,11 @@
   <dl class="govuk-body kvp">
     <% if @legal_aid_application&.means_report&.document.present? %>
       <dt>Means report</dt>
-      <dd><%= link_to_accessible("Download means report", download_means_report_admin_legal_aid_applications_submission_path(@legal_aid_application)) %></dd>
+      <dd><%= govuk_link_to("Download means report", download_means_report_admin_legal_aid_applications_submission_path(@legal_aid_application)) %></dd>
     <% end %>
     <% if @legal_aid_application&.merits_report&.document.present? %>
       <dt>Merits report</dt>
-      <dd><%= link_to_accessible("Download merits report", download_merits_report_admin_legal_aid_applications_submission_path(@legal_aid_application)) %>
+      <dd><%= govuk_link_to("Download merits report", download_merits_report_admin_legal_aid_applications_submission_path(@legal_aid_application)) %>
     <% end %>
     <% if @legal_aid_application&.hmrc_responses.any? %>
       <% @legal_aid_application.hmrc_responses.each do |hmrc_response| %>
@@ -97,11 +97,11 @@
             <dt class="govuk-!-margin-bottom-5"></dt>
             <dd>
               <% if submission_history.request.present? %>
-                <%= link_to_accessible "Download XML Request", download_xml_request_admin_legal_aid_applications_submission_path(submission_history) %>
+                <%= govuk_link_to "Download XML Request", download_xml_request_admin_legal_aid_applications_submission_path(submission_history) %>
               <% end %>
               <br>
               <% if submission_history.response.present? %>
-                <%= link_to_accessible "Download XML Response", download_xml_response_admin_legal_aid_applications_submission_path(submission_history) %>
+                <%= govuk_link_to "Download XML Response", download_xml_response_admin_legal_aid_applications_submission_path(submission_history) %>
               <% end %>
             </dd>
         <% end %>

--- a/app/views/admin/reports/index.html.erb
+++ b/app/views/admin/reports/index.html.erb
@@ -22,7 +22,7 @@
               body.with_row do |row|
                 row.with_cell(text: report[:report_title])
                 row.with_cell do
-                  link_to_accessible(report[:path_text], __send__(report[:path], format: :csv))
+                  govuk_link_to(report[:path_text], __send__(report[:path], format: :csv))
                 end
               end
             end

--- a/app/views/admin/user_dashboard/index.html.erb
+++ b/app/views/admin/user_dashboard/index.html.erb
@@ -6,5 +6,5 @@
 
 <br>
 
-<%= link_to_accessible t(".firm_permissions"), admin_roles_path, class: "govuk-heading-m", id: "firm_permissions", method: :get %>
-<%= link_to_accessible t(".firms"), admin_firms_path, class: "govuk-heading-m", id: "firm_permissions", method: :get %>
+<%= govuk_link_to t(".firm_permissions"), admin_roles_path, class: "govuk-heading-m", id: "firm_permissions", method: :get %>
+<%= govuk_link_to t(".firms"), admin_firms_path, class: "govuk-heading-m", id: "firm_permissions", method: :get %>

--- a/app/views/citizens/accounts/index.html.erb
+++ b/app/views/citizens/accounts/index.html.erb
@@ -41,7 +41,7 @@
 
     <% end %>
 
-    <p><%= link_to_accessible t(".link_other_account"), citizens_banks_path, class: "govuk-link" %></p>
+    <p><%= govuk_link_to t(".link_other_account"), citizens_banks_path, class: "govuk-link" %></p>
 
     <div class="govuk-!-padding-top-3">
       <%= next_action_link(continue_text: t("generic.continue")) %>

--- a/app/views/citizens/accounts/index.html.erb
+++ b/app/views/citizens/accounts/index.html.erb
@@ -41,7 +41,7 @@
 
     <% end %>
 
-    <p><%= govuk_link_to t(".link_other_account"), citizens_banks_path, class: "govuk-link" %></p>
+    <p><%= govuk_link_to t(".link_other_account"), citizens_banks_path %></p>
 
     <div class="govuk-!-padding-top-3">
       <%= next_action_link(continue_text: t("generic.continue")) %>

--- a/app/views/citizens/check_answers/_bank_accounts.html.erb
+++ b/app/views/citizens/check_answers/_bank_accounts.html.erb
@@ -24,5 +24,5 @@
 <% end %>
 
 <div class="govuk-body govuk-!-padding-bottom-4">
-  <%= govuk_link_to t("citizens.check_answers.index.link_other_account"), citizens_banks_path, class: "govuk-link" %>
+  <%= govuk_link_to t("citizens.check_answers.index.link_other_account"), citizens_banks_path %>
 </div>

--- a/app/views/citizens/check_answers/_bank_accounts.html.erb
+++ b/app/views/citizens/check_answers/_bank_accounts.html.erb
@@ -24,5 +24,5 @@
 <% end %>
 
 <div class="govuk-body govuk-!-padding-bottom-4">
-  <%= link_to_accessible t("citizens.check_answers.index.link_other_account"), citizens_banks_path, class: "govuk-link" %>
+  <%= govuk_link_to t("citizens.check_answers.index.link_other_account"), citizens_banks_path, class: "govuk-link" %>
 </div>

--- a/app/views/citizens/gather_transactions/display_error.html.erb
+++ b/app/views/citizens/gather_transactions/display_error.html.erb
@@ -6,7 +6,7 @@
 
   <% if @error_decoder.show_link? %>
     <p class="govuk-body">
-      <%= link_to_accessible(
+      <%= govuk_link_to(
             t(".bank_selection_link"),
             citizens_banks_path,
           ) %>

--- a/app/views/citizens/means_test_results/show.html.erb
+++ b/app/views/citizens/means_test_results/show.html.erb
@@ -28,5 +28,5 @@
 <% end %>
 
 <%= govuk_inset_text do %>
-  <p class="govuk-body govuk-!-padding-bottom-2"><%= link_to_accessible t(".feedback_prefix"), new_feedback_path %><%= t(".feedback_suffix") %></p>
+  <p class="govuk-body govuk-!-padding-bottom-2"><%= govuk_link_to t(".feedback_prefix"), new_feedback_path %><%= t(".feedback_suffix") %></p>
 <% end %>

--- a/app/views/citizens/resend_link_requests/show.html.erb
+++ b/app/views/citizens/resend_link_requests/show.html.erb
@@ -1,6 +1,6 @@
 <%= page_template page_title: t(".page_title"), back_link: :none do %>
   <p class="govuk-body">
-    <%= link_to_accessible(
+    <%= govuk_link_to(
           t(".new_link_request"),
           citizens_resend_link_request_path(params[:id]),
           method: :patch,

--- a/app/views/feedback/show.html.erb
+++ b/app/views/feedback/show.html.erb
@@ -3,7 +3,7 @@
     <p><%= t(".close_tab") %></p>
   <% else %>
     <p class="govuk-body">
-      <%= link_to_accessible t(".link"), back_path, class: "govuk-link govuk-link--no-visited-state" %>
+      <%= govuk_link_to t(".link"), back_path, { no_visited_state: true } %>
     </p>
   <% end %>
 <% end %>

--- a/app/views/problem/index.html.erb
+++ b/app/views/problem/index.html.erb
@@ -3,6 +3,6 @@
   <p><%= t(".answers_saved") %></p>
 
   <p class="govuk-body">
-    <%= link_to_accessible t("generic.back_to_your_applications"), providers_legal_aid_applications_path %>
+    <%= govuk_link_to t("generic.back_to_your_applications"), providers_legal_aid_applications_path %>
   </p>
 <% end %>


### PR DESCRIPTION

## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3655)

Replaced all instances of `link_to_accessible` with the `govuk_link_to` component in the helper, admin, citizens, feedback and problem files. 

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
