### PR TITLE
Rubocop: Address remaining request RSpec/NamedSubject exclusions

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -110,27 +110,11 @@ RSpec/LetSetup:
     - 'spec/workers/bank_holiday_update_worker_spec.rb'
     - 'spec/workers/true_layer_banks_update_worker_spec.rb'
 
-# Offense count: 302
+# Offense count: 189
 # Configuration parameters: EnforcedStyle, IgnoreSharedExamples.
 # SupportedStyles: always, named_only
 RSpec/NamedSubject:
   Exclude:
-    - 'spec/requests/providers/select_offices_spec.rb'
-    - 'spec/requests/providers/start_spec.rb'
-    - 'spec/requests/providers/submitted_applications_controller_spec.rb'
-    - 'spec/requests/providers/substantive_applications_controller_spec.rb'
-    - 'spec/requests/providers/transactions_controller_spec.rb'
-    - 'spec/requests/providers/uploaded_evidence_collection_spec.rb'
-    - 'spec/requests/providers/use_ccms_controller_spec.rb'
-    - 'spec/requests/providers/vehicles/ages_controller_spec.rb'
-    - 'spec/requests/providers/vehicles/estimated_values_controller_spec.rb'
-    - 'spec/requests/providers/vehicles/regular_uses_controller_spec.rb'
-    - 'spec/requests/providers/vehicles/remaining_payments_controller_spec.rb'
-    - 'spec/requests/saml_sessions_spec.rb'
-    - 'spec/requests/v1/legal_aid_applications_spec.rb'
-    - 'spec/requests/v1/statement_of_cases_spec.rb'
-    - 'spec/requests/v1/uploaded_evidence_collections_spec.rb'
-    - 'spec/requests/v1/workers_spec.rb'
     - 'spec/services/admin/provider_details_service_spec.rb'
     - 'spec/services/bank_holiday_retriever_service_spec.rb'
     - 'spec/services/banking/bank_transaction_balance_calculator_spec.rb'

--- a/spec/requests/providers/select_offices_spec.rb
+++ b/spec/requests/providers/select_offices_spec.rb
@@ -9,10 +9,10 @@ RSpec.describe "provider selects office" do
   let(:provider) { create(:provider, firm:, offices: [first_office, second_office]) }
 
   describe "GET providers/select_office" do
-    subject { get providers_select_office_path }
+    subject(:get_request) { get providers_select_office_path }
 
     context "when the provider is not authenticated" do
-      before { subject }
+      before { get_request }
 
       it_behaves_like "a provider not authenticated"
     end
@@ -20,7 +20,7 @@ RSpec.describe "provider selects office" do
     context "when the provider is authenticated" do
       before do
         login_as provider
-        subject
+        get_request
       end
 
       it "returns http success" do
@@ -39,7 +39,7 @@ RSpec.describe "provider selects office" do
   end
 
   describe "PATCH providers/select_office" do
-    subject { patch providers_select_office_path, params: }
+    subject(:patch_request) { patch providers_select_office_path, params: }
 
     let(:params) do
       {
@@ -50,7 +50,7 @@ RSpec.describe "provider selects office" do
     context "when the provider is authenticated" do
       before do
         login_as provider
-        subject
+        patch_request
       end
 
       it "updates the record" do

--- a/spec/requests/providers/start_spec.rb
+++ b/spec/requests/providers/start_spec.rb
@@ -2,10 +2,8 @@ require "rails_helper"
 
 RSpec.describe "provider start of journey test" do
   describe "GET /providers" do
-    subject { get providers_root_path }
-
     before do
-      subject
+      get providers_root_path
     end
 
     it "returns http success" do

--- a/spec/requests/providers/submitted_applications_controller_spec.rb
+++ b/spec/requests/providers/submitted_applications_controller_spec.rb
@@ -28,14 +28,14 @@ RSpec.describe Providers::SubmittedApplicationsController do
   before { allow(LegalFramework::MeritsTasksService).to receive(:call).with(legal_aid_application).and_return(smtl) }
 
   describe "GET /providers/applications/:legal_aid_application_id/submitted_application" do
-    subject do
+    subject(:get_request) do
       get providers_legal_aid_application_submitted_application_path(legal_aid_application)
     end
 
     before do
       legal_aid_application.reload
       login
-      subject
+      get_request
     end
 
     it "renders successfully" do
@@ -57,7 +57,7 @@ RSpec.describe Providers::SubmittedApplicationsController do
     end
 
     it "includes the name of the firm" do
-      subject
+      get_request
       expect(unescaped_response_body).to include(firm.name)
     end
 
@@ -91,7 +91,7 @@ RSpec.describe Providers::SubmittedApplicationsController do
   end
 
   describe "employment income table" do
-    subject do
+    subject(:get_request) do
       login
       get providers_legal_aid_application_submitted_application_path(legal_aid_application)
     end
@@ -112,7 +112,7 @@ RSpec.describe Providers::SubmittedApplicationsController do
     let(:translation_path) { "shared.employment_income_table" }
 
     shared_examples "employment data is not present" do
-      before { subject }
+      before { get_request }
 
       it "does not display the employment income table" do
         expect(unescaped_response_body).not_to include I18n.t("#{translation_path}.benefits_in_kind")
@@ -128,7 +128,7 @@ RSpec.describe Providers::SubmittedApplicationsController do
 
     context "when employment data is present" do
       it "displays the employment income table" do
-        subject
+        get_request
         expect(unescaped_response_body).to include I18n.t("#{translation_path}.heading")
         expect(unescaped_response_body).to include I18n.t("#{translation_path}.benefits_in_kind")
         expect(unescaped_response_body).to include I18n.t("#{translation_path}.monthly_income_before_tax")
@@ -137,7 +137,7 @@ RSpec.describe Providers::SubmittedApplicationsController do
       end
 
       it "populates the employment income table with the correct data" do
-        subject
+        get_request
         expect(unescaped_response_body).to include gds_number_to_currency(cfe_result.employment_income_benefits_in_kind)
         expect(unescaped_response_body).to include gds_number_to_currency(cfe_result.employment_income_gross_income)
         expect(unescaped_response_body).to include gds_number_to_currency(cfe_result.employment_income_national_insurance)
@@ -145,19 +145,19 @@ RSpec.describe Providers::SubmittedApplicationsController do
       end
 
       it "displays the Other income header" do
-        subject
+        get_request
         expect(unescaped_response_body).to include I18n.t("shared.review_application.income_payments_and_assets.other_income")
       end
 
       it "does not display the extra employment information details" do
-        subject
+        get_request
         expect(unescaped_response_body).not_to include I18n.t("#{translation_path}.employment_details")
       end
 
       context "when employment details have been entered by the solicitor" do
         before do
           legal_aid_application.update!(extra_employment_information: true, extra_employment_information_details: "test details")
-          subject
+          get_request
         end
 
         it "displays the extra employment information details" do

--- a/spec/requests/providers/uploaded_evidence_collection_spec.rb
+++ b/spec/requests/providers/uploaded_evidence_collection_spec.rb
@@ -8,10 +8,10 @@ module Providers
     let(:i18n_error_path) { "activemodel.errors.models.uploaded_evidence_collection.attributes.original_file" }
 
     describe "GET /providers/applications/:legal_aid_application_id/uploaded_evidence_collection" do
-      subject { get providers_legal_aid_application_uploaded_evidence_collection_path(legal_aid_application) }
+      subject(:get_request) { get providers_legal_aid_application_uploaded_evidence_collection_path(legal_aid_application) }
 
       context "when the provider is not authenticated" do
-        before { subject }
+        before { get_request }
 
         it_behaves_like "a provider not authenticated"
       end
@@ -20,7 +20,7 @@ module Providers
         before do
           legal_aid_application.uploaded_evidence_collection = nil
           login_as provider
-          subject
+          get_request
         end
 
         it "returns http success" do
@@ -34,10 +34,10 @@ module Providers
     end
 
     describe "GET /providers/applications/:legal_aid_application_id/uploaded_evidence_collection/list" do
-      subject { get list_providers_legal_aid_application_uploaded_evidence_collection_path(legal_aid_application) }
+      subject(:get_request) { get list_providers_legal_aid_application_uploaded_evidence_collection_path(legal_aid_application) }
 
       context "when the provider is not authenticated" do
-        before { subject }
+        before { get_request }
 
         it_behaves_like "a provider not authenticated"
       end
@@ -46,7 +46,7 @@ module Providers
         before do
           legal_aid_application.uploaded_evidence_collection = nil
           login_as provider
-          subject
+          get_request
         end
 
         it "returns http success" do
@@ -56,7 +56,7 @@ module Providers
     end
 
     describe "PATCH /providers/applications/:legal_aid_application_id/uploaded_evidence_collection" do
-      subject { patch providers_legal_aid_application_uploaded_evidence_collection_path(legal_aid_application), params: }
+      subject(:patch_request) { patch providers_legal_aid_application_uploaded_evidence_collection_path(legal_aid_application), params: }
 
       let(:original_file) { uploaded_file("spec/fixtures/files/documents/hello_world.pdf", "application/pdf") }
       let(:uploaded_evidence_collection) { legal_aid_application.uploaded_evidence_collection }
@@ -83,20 +83,20 @@ module Providers
         let(:button_clicked) { upload_button }
 
         it "updates the record" do
-          subject
+          patch_request
           legal_aid_application.reload
           expect(uploaded_evidence_collection.original_attachments.count).to eq(1)
         end
 
         it "stores the original filename" do
-          subject
+          patch_request
           legal_aid_application.reload
           attachment = uploaded_evidence_collection.original_attachments.first
           expect(attachment.original_filename).to eq "hello_world.pdf"
         end
 
         it "returns http success" do
-          subject
+          patch_request
           expect(response).to have_http_status(:ok)
         end
 
@@ -104,7 +104,7 @@ module Providers
           let(:original_file) { uploaded_file("spec/fixtures/files/documents/hello_world.docx", "application/vnd.openxmlformats-officedocument.wordprocessingml.document") }
 
           it "updates the record" do
-            subject
+            patch_request
             expect(uploaded_evidence_collection.original_attachments.first).to be_present
           end
 
@@ -112,25 +112,25 @@ module Providers
             let!(:uploaded_evidence_collection) { create(:uploaded_evidence_collection, :with_multiple_files_attached, legal_aid_application:) }
 
             it "updates the record" do
-              subject
+              patch_request
               expect(uploaded_evidence_collection.original_attachments.count).to eq 4
             end
 
             it "increments the attachment filename" do
-              subject
+              patch_request
               attachment_names = uploaded_evidence_collection.original_attachments.map(&:attachment_name)
               expect(attachment_names).to include("uploaded_evidence_collection_4")
             end
           end
 
           it "has the relevant content type" do
-            subject
+            patch_request
             document = uploaded_evidence_collection.original_attachments.first.document
             expect(document.content_type).to eq "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
           end
 
           it "returns http success" do
-            subject
+            patch_request
             expect(response).to have_http_status(:ok)
           end
         end
@@ -140,12 +140,12 @@ module Providers
 
           it "does not update the record" do
             uploaded_evidence_collection
-            subject
+            patch_request
             expect(uploaded_evidence_collection).to be_nil
           end
 
           it "returns error message" do
-            subject
+            patch_request
             error = I18n.t("#{i18n_error_path}.content_type_invalid")
             expect(unescaped_response_body).to include(error)
           end
@@ -160,7 +160,7 @@ module Providers
 
           it "does not save the object and raises an error" do
             uploaded_evidence_collection
-            subject
+            patch_request
             error = I18n.t("#{i18n_error_path}.content_type_invalid", file_name: original_file.original_filename)
             expect(unescaped_response_body).to include(error)
             expect(uploaded_evidence_collection).to be_nil
@@ -175,7 +175,7 @@ module Providers
           end
 
           it "updates the record" do
-            subject
+            patch_request
             expect(uploaded_evidence_collection.original_attachments.first).to be_present
           end
         end
@@ -185,7 +185,7 @@ module Providers
 
           it "does not save the object and raises an error" do
             uploaded_evidence_collection
-            subject
+            patch_request
             error = I18n.t("#{i18n_error_path}.file_too_big", size: 7, file_name: original_file.original_filename)
             expect(unescaped_response_body).to include(error)
             expect(uploaded_evidence_collection).to be_nil
@@ -197,7 +197,7 @@ module Providers
 
           it "does not save the object and raises an error" do
             uploaded_evidence_collection
-            subject
+            patch_request
             error = I18n.t("#{i18n_error_path}.file_virus", file_name: original_file.original_filename)
             expect(unescaped_response_body).to include(error)
             expect(uploaded_evidence_collection).to be_nil
@@ -209,7 +209,7 @@ module Providers
 
           it "does not save the object and raises an error" do
             uploaded_evidence_collection
-            subject
+            patch_request
             error = I18n.t("#{i18n_error_path}.file_empty", file_name: original_file.original_filename)
             expect(unescaped_response_body).to include(error)
             expect(uploaded_evidence_collection).to be_nil
@@ -221,12 +221,12 @@ module Providers
 
           it "does not update the record" do
             uploaded_evidence_collection
-            subject
+            patch_request
             expect(uploaded_evidence_collection).to be_nil
           end
 
           it "return error message" do
-            subject
+            patch_request
             error = I18n.t("#{i18n_error_path}.no_file_chosen")
             expect(unescaped_response_body).to include(error)
           end
@@ -238,7 +238,7 @@ module Providers
           end
 
           it "returns error message" do
-            subject
+            patch_request
             error = I18n.t("#{i18n_error_path}.system_down")
             expect(unescaped_response_body).to include(error)
           end
@@ -253,13 +253,13 @@ module Providers
             let(:params_uploaded_evidence_collection) { {} }
 
             it "does not add a record" do
-              subject
+              patch_request
               expect(legal_aid_application.uploaded_evidence_collection).to be_nil
             end
 
             context "when no mandatory evidence is required" do
               it "redirects to the next page" do
-                subject
+                patch_request
                 expect(response).to redirect_to providers_legal_aid_application_check_merits_answers_path(legal_aid_application)
               end
             end
@@ -280,7 +280,7 @@ module Providers
                 let(:missing_categories) { %w[benefit_evidence] }
 
                 it "raises an error" do
-                  subject
+                  patch_request
                   error = I18n.t("#{i18n_error_path}.benefit_evidence_missing", benefit: "Universal Credit")
                   expect(unescaped_response_body).to include(error)
                 end
@@ -290,7 +290,7 @@ module Providers
                 let(:missing_categories) { %w[employment_evidence] }
 
                 it "raises an error" do
-                  subject
+                  patch_request
                   error = I18n.t("#{i18n_error_path}.employment_evidence_missing")
                   expect(unescaped_response_body).to include(error)
                 end
@@ -309,14 +309,14 @@ module Providers
               before { allow(DocumentCategory).to receive(:displayable_document_category_names).and_return(%w[gateway_evidence]) }
 
               it "redirects to the next page" do
-                subject
+                patch_request
                 expect(response).to redirect_to providers_legal_aid_application_check_merits_answers_path(legal_aid_application)
               end
             end
 
             context "when the file is uncategorised" do
               it "raises an error" do
-                subject
+                patch_request
                 error = I18n.t("#{i18n_error_path}.uncategorised_evidence")
                 expect(unescaped_response_body).to include(error)
               end
@@ -338,7 +338,7 @@ module Providers
                 let(:missing_categories) { %w[benefit_evidence] }
 
                 it "raises an error" do
-                  subject
+                  patch_request
                   error = I18n.t("#{i18n_error_path}.benefit_evidence_missing", benefit: "Universal Credit")
                   expect(unescaped_response_body).to include(error)
                 end
@@ -348,7 +348,7 @@ module Providers
                 let(:missing_categories) { %w[employment_evidence] }
 
                 it "raises an error" do
-                  subject
+                  patch_request
                   error = I18n.t("#{i18n_error_path}.employment_evidence_missing")
                   expect(unescaped_response_body).to include(error)
                 end
@@ -359,7 +359,7 @@ module Providers
                 let(:missing_categories) { %w[benefit_evidence] }
 
                 it "raises two errors" do
-                  subject
+                  patch_request
                   benefit_error = I18n.t("#{i18n_error_path}.benefit_evidence_missing", benefit: "Universal Credit")
                   uncategorised_error = I18n.t("#{i18n_error_path}.uncategorised_evidence")
                   expect(unescaped_response_body).to include(benefit_error)
@@ -381,14 +381,14 @@ module Providers
               before { allow(DocumentCategory).to receive(:displayable_document_category_names).and_return(%w[gateway_evidence]) }
 
               it "redirects to the next page" do
-                subject
+                patch_request
                 expect(response).to redirect_to providers_legal_aid_application_check_merits_answers_path(legal_aid_application)
               end
             end
 
             context "when a file is uncategorised" do
               it "raises an error" do
-                subject
+                patch_request
                 error = I18n.t("#{i18n_error_path}.uncategorised_evidence")
                 expect(unescaped_response_body).to include(error)
               end
@@ -414,7 +414,7 @@ module Providers
                 end
 
                 it "raises an error" do
-                  subject
+                  patch_request
                   error = I18n.t("#{i18n_error_path}.benefit_evidence_missing", benefit: "Universal Credit")
                   expect(unescaped_response_body).to include(error)
                 end
@@ -429,7 +429,7 @@ module Providers
                 end
 
                 it "raises an error" do
-                  subject
+                  patch_request
                   error = I18n.t("#{i18n_error_path}.employment_evidence_missing")
                   expect(unescaped_response_body).to include(error)
                 end
@@ -439,7 +439,7 @@ module Providers
                 let(:missing_categories) { %w[benefit_evidence employment_evidence] }
 
                 it "raises two errors" do
-                  subject
+                  patch_request
                   benefit_error = I18n.t("#{i18n_error_path}.benefit_evidence_missing", benefit: "Universal Credit")
                   employment_error = I18n.t("#{i18n_error_path}.employment_evidence_missing")
                   uncategorised_error = I18n.t("#{i18n_error_path}.uncategorised_evidence")
@@ -458,13 +458,13 @@ module Providers
 
         context "when no files have been uploaded" do
           it "updates the record" do
-            subject
+            patch_request
             expect(uploaded_evidence_collection).to be_present
           end
         end
 
         it "redirects to provider draft endpoint" do
-          subject
+          patch_request
           expect(response).to redirect_to provider_draft_endpoint
         end
 
@@ -472,14 +472,14 @@ module Providers
           let(:original_file) { nil }
 
           it "redirects to provider draft endpoint" do
-            subject
+            patch_request
             expect(response).to redirect_to provider_draft_endpoint
           end
         end
       end
 
       context "when submitted with Delete" do
-        subject { patch providers_legal_aid_application_uploaded_evidence_collection_path(legal_aid_application), params: delete_params }
+        subject(:patch_request) { patch providers_legal_aid_application_uploaded_evidence_collection_path(legal_aid_application), params: delete_params }
 
         let(:button_clicked) { delete_button }
         let(:uploaded_evidence_collection) { create(:uploaded_evidence_collection, :with_original_file_attached) }
@@ -502,14 +502,14 @@ module Providers
         end
 
         it "returns http success" do
-          subject
+          patch_request
           expect(response).to have_http_status(:ok)
         end
 
         context "when only original file exists" do
           it "deletes the file" do
             attachment_id = original_file.id
-            expect { subject }.to change(Attachment, :count).by(-1)
+            expect { patch_request }.to change(Attachment, :count).by(-1)
             expect(Attachment.exists?(attachment_id)).to be(false)
           end
         end
@@ -518,7 +518,7 @@ module Providers
           let(:uploaded_evidence_collection) { create(:uploaded_evidence_collection, :with_original_and_pdf_files_attached) }
 
           it "deletes both attachments" do
-            expect { subject }.to change(Attachment, :count).by(-2)
+            expect { patch_request }.to change(Attachment, :count).by(-2)
           end
         end
 
@@ -535,7 +535,7 @@ module Providers
           end
 
           it "returns http success" do
-            subject
+            patch_request
             expect(response).to have_http_status(:ok)
           end
         end

--- a/spec/requests/providers/use_ccms_controller_spec.rb
+++ b/spec/requests/providers/use_ccms_controller_spec.rb
@@ -5,10 +5,10 @@ RSpec.describe Providers::UseCCMSController do
   let(:provider) { legal_aid_application.provider }
 
   describe "GET /providers/applications/:id/use_ccms" do
-    subject { get providers_legal_aid_application_use_ccms_path(legal_aid_application) }
+    subject(:get_request) { get providers_legal_aid_application_use_ccms_path(legal_aid_application) }
 
     context "when the provider is not authenticated" do
-      before { subject }
+      before { get_request }
 
       it_behaves_like "a provider not authenticated"
     end
@@ -19,19 +19,19 @@ RSpec.describe Providers::UseCCMSController do
       end
 
       context "when state is not already use_ccms" do
-        before { subject }
+        before { get_request }
 
         it "returns http success" do
           expect(response).to have_http_status(:ok)
         end
 
         it "shows text to use CCMS" do
-          subject
+          get_request
           expect(response.body).to include(I18n.t("shared.use_ccms.title_html"))
         end
 
         it "sets the state to use_ccms" do
-          subject
+          get_request
           expect(legal_aid_application.reload.state).to eq "use_ccms"
         end
       end
@@ -40,18 +40,18 @@ RSpec.describe Providers::UseCCMSController do
         before { legal_aid_application.use_ccms!(:applicant_self_employed) }
 
         it "returns http success" do
-          subject
+          get_request
           expect(response).to have_http_status(:ok)
         end
 
         it "does not call :use_ccms!" do
           expect(legal_aid_application).not_to receive(:use_ccms!)
-          subject
+          get_request
         end
 
         it "leaves the ccms reason as :applicant_self_employed" do
           allow_any_instance_of(ActionDispatch::Request).to receive(:referer).and_return("http://www.example.com/providers")
-          subject
+          get_request
           expect(legal_aid_application.reload.ccms_reason).to eq "applicant_self_employed"
         end
       end

--- a/spec/requests/v1/legal_aid_applications_spec.rb
+++ b/spec/requests/v1/legal_aid_applications_spec.rb
@@ -5,16 +5,16 @@ RSpec.describe "GET /v1/legal_aid_applications" do
   let(:id) { legal_aid_application.id }
 
   describe "GET /v1/legal_aid_applications/:id" do
-    subject { delete v1_legal_aid_application_path(id:) }
+    subject(:get_request) { delete v1_legal_aid_application_path(id:) }
 
     context "when the application exists" do
       it "returns http success" do
-        subject
+        get_request
         expect(response).to have_http_status(:success)
       end
 
       it "sets the application to discarded" do
-        expect { subject }.to change { legal_aid_application.reload.discarded_at }
+        expect { get_request }.to change { legal_aid_application.reload.discarded_at }
       end
     end
 
@@ -22,7 +22,7 @@ RSpec.describe "GET /v1/legal_aid_applications" do
       let(:id) { SecureRandom.hex }
 
       it "returns http not found" do
-        subject
+        get_request
         expect(response).to have_http_status(:not_found)
       end
     end
@@ -31,7 +31,7 @@ RSpec.describe "GET /v1/legal_aid_applications" do
       let!(:scheduled_mailing) { create(:scheduled_mailing, legal_aid_application:) }
 
       it "clears any scheduled mailings" do
-        expect { subject }.to change { legal_aid_application.scheduled_mailings.first.cancelled_at }
+        expect { get_request }.to change { legal_aid_application.scheduled_mailings.first.cancelled_at }
       end
     end
   end

--- a/spec/requests/v1/statement_of_cases_spec.rb
+++ b/spec/requests/v1/statement_of_cases_spec.rb
@@ -7,23 +7,23 @@ RSpec.describe "POST /v1/statement_of_case" do
   let(:params) { { legal_aid_application_id: id, file: } }
 
   describe "POST /v1/statement_of_cases" do
-    subject(:request) { post v1_statement_of_cases_path, params: }
+    subject(:post_request) { post v1_statement_of_cases_path, params: }
 
     context "when the application exists" do
       it "returns http success" do
-        subject
+        post_request
         expect(response).to have_http_status(:success)
       end
 
       it "adds the statement of case to the legal aid application" do
-        expect { subject }.to change { legal_aid_application.reload.attachments.length }.by 1
+        expect { post_request }.to change { legal_aid_application.reload.attachments.length }.by 1
       end
 
       context "when the application has no statement of case" do
         let(:legal_aid_application) { create(:legal_aid_application, attachments: []) }
 
         it "does not increment the attachment name" do
-          subject
+          post_request
           expect(legal_aid_application.reload.attachments.length).to match(1)
           expect(legal_aid_application.reload.attachments.last.attachment_name).to match("statement_of_case")
         end
@@ -34,7 +34,7 @@ RSpec.describe "POST /v1/statement_of_case" do
         let(:legal_aid_application) { create(:legal_aid_application, attachments: [statement_of_case]) }
 
         it "increments the attachment name" do
-          subject
+          post_request
           expect(legal_aid_application.reload.attachments.length).to match(2)
           expect(legal_aid_application.reload.attachments.order(:attachment_name).last.attachment_name).to match("statement_of_case_1")
         end
@@ -46,7 +46,7 @@ RSpec.describe "POST /v1/statement_of_case" do
         let(:legal_aid_application) { create(:legal_aid_application, attachments: [soc1, soc2]) }
 
         it "increments the attachment name" do
-          subject
+          post_request
           expect(legal_aid_application.reload.attachments.length).to match(3)
           expect(legal_aid_application.reload.attachments.order(:attachment_name).last.attachment_name).to match("statement_of_case_2")
         end
@@ -57,7 +57,7 @@ RSpec.describe "POST /v1/statement_of_case" do
         let(:i18n_error_message) { I18n.t("activemodel.errors.models.application_merits_task/statement_of_case.attributes.original_file.file_virus", file_name: "malware.doc") }
 
         it "does not save the object and raises a 500 error with text" do
-          subject
+          post_request
           expect(legal_aid_application.reload.attachments.length).to match(0)
           expect(response).to have_http_status(:bad_request)
           expect(response.body).to include(i18n_error_message)
@@ -70,7 +70,7 @@ RSpec.describe "POST /v1/statement_of_case" do
         let(:i18n_error_path) { "activemodel.errors.models.application_merits_task/statement_of_case.attributes.original_file" }
 
         it "does not save the object and raises a 500 error with text" do
-          subject
+          post_request
           expect(legal_aid_application.reload.attachments.length).to match(0)
           expect(response).to have_http_status(:bad_request)
           expect(response.body).to include(I18n.t("#{i18n_error_path}.system_down"))
@@ -82,7 +82,7 @@ RSpec.describe "POST /v1/statement_of_case" do
       let(:id) { SecureRandom.hex }
 
       it "returns http not found" do
-        subject
+        post_request
         expect(response).to have_http_status(:not_found)
       end
     end

--- a/spec/requests/v1/uploaded_evidence_collections_spec.rb
+++ b/spec/requests/v1/uploaded_evidence_collections_spec.rb
@@ -9,23 +9,23 @@ RSpec.describe "POST /v1/uploaded_evidence_collections" do
   let(:i18n_error_path) { "activemodel.errors.models.uploaded_evidence_collection.attributes.original_file" }
 
   describe "POST /v1/uploaded_evidence_collections" do
-    subject { post v1_uploaded_evidence_collections_path, params: }
+    subject(:post_request) { post v1_uploaded_evidence_collections_path, params: }
 
     context "when the application exists" do
       it "returns http success" do
-        subject
+        post_request
         expect(response).to have_http_status(:success)
       end
 
       it "adds the attachment to the legal aid application" do
-        expect { subject }.to change { legal_aid_application.reload.attachments.length }.by 1
+        expect { post_request }.to change { legal_aid_application.reload.attachments.length }.by 1
       end
 
       context "when the application has no attachments" do
         let(:legal_aid_application) { create(:legal_aid_application, attachments: []) }
 
         it "does not increment the attachment name" do
-          subject
+          post_request
           expect(legal_aid_application.reload.attachments.length).to match(1)
           expect(legal_aid_application.reload.attachments.last.attachment_name).to match("uploaded_evidence_collection")
         end
@@ -36,7 +36,7 @@ RSpec.describe "POST /v1/uploaded_evidence_collections" do
         let(:legal_aid_application) { create(:legal_aid_application, attachments: [attachment]) }
 
         it "increments the attachment name" do
-          subject
+          post_request
           expect(legal_aid_application.reload.attachments.length).to match(2)
           expect(legal_aid_application.reload.attachments.order(:attachment_name).last.attachment_name).to match("uploaded_evidence_collection_1")
         end
@@ -48,7 +48,7 @@ RSpec.describe "POST /v1/uploaded_evidence_collections" do
         let(:legal_aid_application) { create(:legal_aid_application, attachments: [uec1, uec2]) }
 
         it "increments the attachment name" do
-          subject
+          post_request
           expect(legal_aid_application.reload.attachments.length).to match(3)
           expect(legal_aid_application.reload.attachments.order(:attachment_name).last.attachment_name).to match("uploaded_evidence_collection_2")
         end
@@ -58,7 +58,7 @@ RSpec.describe "POST /v1/uploaded_evidence_collections" do
         let(:file) { uploaded_file("spec/fixtures/files/malware.doc") }
 
         it "does not save the object and raises an error" do
-          subject
+          post_request
           error = I18n.t("#{i18n_error_path}.file_virus", file_name: file.original_filename)
           expect(response.body).to include(error)
           expect(uploaded_evidence_collection).to be_nil
@@ -71,7 +71,7 @@ RSpec.describe "POST /v1/uploaded_evidence_collections" do
         let(:i18n_error_path) { "activemodel.errors.models.application_merits_task/statement_of_case.attributes.original_file" }
 
         it "does not save the object and raises a 500 error with text" do
-          subject
+          post_request
           expect(legal_aid_application.reload.attachments.length).to match(0)
           expect(response).to have_http_status(:bad_request)
           expect(response.body).to include(I18n.t("#{i18n_error_path}.system_down"))
@@ -83,7 +83,7 @@ RSpec.describe "POST /v1/uploaded_evidence_collections" do
       let(:id) { SecureRandom.hex }
 
       it "returns http not found" do
-        subject
+        post_request
         expect(response).to have_http_status(:not_found)
       end
     end

--- a/spec/requests/v1/workers_spec.rb
+++ b/spec/requests/v1/workers_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe "GET /v1/workers" do
   describe "GET /v1/workers/:worker_id" do
-    subject { get v1_worker_path(id: worker_id) }
+    subject(:get_request) { get v1_worker_path(id: worker_id) }
 
     let(:worker_id) { SecureRandom.hex }
     let(:worker_status) do
@@ -19,7 +19,7 @@ RSpec.describe "GET /v1/workers" do
     end
 
     it "returns a successful response with the status and errors of the worker" do
-      subject
+      get_request
       expected_json = worker_status.slice("status", "errors")
 
       expect(response).to have_http_status(:ok)


### PR DESCRIPTION
## What

This addresses the final batch of request specs without named subjects, only leaving the service infractions

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
