### PR TITLE
Fix: vehicle_detail error handling

### DIFF
--- a/app/views/providers/means/vehicle_details/_form.html.erb
+++ b/app/views/providers/means/vehicle_details/_form.html.erb
@@ -43,7 +43,7 @@
         <% end %>
         <%= form.govuk_radio_button(:payments_remain, false,
                                     label: { text: t("generic.no") },
-                                    checked: @form.payment_remaining.present? && @form.payment_remaining.zero?) %>
+                                    checked: @form.payment_remaining.present? && @form.payment_remaining.eql?(0)) %>
       <% end %>
 
       <%= form.govuk_collection_radio_buttons(


### PR DESCRIPTION
## What

This seems to have been present for a while but only triggered today. I saw it on UAT and then shortly after on prod.

It occurs when a provider says `yes, payments remain` but then enter text, e.g. `n/a` into the field.  One of the handlers used `!= 0` and the other used `.zero?`.

`.zero?` fails when the value is a string but `.eql?(0)` works as expected

This PR updates both checks to use the same, working, style of check

`== 0` was tried but failed an erblint check suggesting `use .zero?` 🤔 

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
