### PR TITLE
Fix: @individual parameter missing from partial

### DIFF
--- a/app/views/providers/means_reports/_with_bank_statement_uploads.html.erb
+++ b/app/views/providers/means_reports/_with_bank_statement_uploads.html.erb
@@ -41,7 +41,7 @@
 
   <section class="print-no-break">
     <% if @legal_aid_application.full_employment_details? %>
-      <%= render "shared/check_answers/full_employment_details", read_only: true, partner: false %>
+      <%= render "shared/check_answers/full_employment_details", individual: "Your client", read_only: true, partner: false %>
     <% end %>
   </section>
 

--- a/app/views/providers/means_reports/_with_cfe_result_details.html.erb
+++ b/app/views/providers/means_reports/_with_cfe_result_details.html.erb
@@ -32,7 +32,7 @@
 
   <section class="print-no-break">
     <% if @legal_aid_application.full_employment_details? %>
-      <%= render "shared/check_answers/full_employment_details", read_only: true, partner: false %>
+      <%= render "shared/check_answers/full_employment_details", individual: "Your client", read_only: true, partner: false %>
     <% end %>
   </section>
 


### PR DESCRIPTION



## What

There were two places where the call to the full_employment_details was not being passed the `individual` parameter.  This caused the means report generation to fail when there was a call to the employment block


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
