### PR TITLE
Fix: css table styling

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -26,6 +26,7 @@ $govuk-assets-path: "/";
 @import "print-styles";
 @import "submissions";
 @import "table-sort";
+@import "tables";
 @import "task-list";
 @import "width-style-correction";
 @import "citizens/spinner";


### PR DESCRIPTION


## What

This got removed in a refactor and left the tables on the blue-box page looking a bit lop-sided

### Current screen shot

![image](https://github.com/ministryofjustice/laa-apply-for-legal-aid/assets/6757677/f24ca2fc-e805-413d-aa74-7c0a5c12a362)

### with fix deployed
![image](https://github.com/ministryofjustice/laa-apply-for-legal-aid/assets/6757677/70401c44-4643-4d4a-a0e8-9654e91b7f0c)


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
