### PR TITLE
Rubocop: Address RSpec/NamedSubjects in services

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -110,28 +110,11 @@ RSpec/LetSetup:
     - 'spec/workers/bank_holiday_update_worker_spec.rb'
     - 'spec/workers/true_layer_banks_update_worker_spec.rb'
 
-# Offense count: 189
+# Offense count: 90
 # Configuration parameters: EnforcedStyle, IgnoreSharedExamples.
 # SupportedStyles: always, named_only
 RSpec/NamedSubject:
   Exclude:
-    - 'spec/services/admin/provider_details_service_spec.rb'
-    - 'spec/services/bank_holiday_retriever_service_spec.rb'
-    - 'spec/services/banking/bank_transaction_balance_calculator_spec.rb'
-    - 'spec/services/banking/bank_transactions_trimmer_spec.rb'
-    - 'spec/services/banking/state_benefit_analyser_service_spec.rb'
-    - 'spec/services/dashboard_event_handler_spec.rb'
-    - 'spec/services/delegated_functions_date_service_spec.rb'
-    - 'spec/services/flow/base_flow_service_spec.rb'
-    - 'spec/services/flow/key_point_spec.rb'
-    - 'spec/services/govuk_emails/delivery_man_spec.rb'
-    - 'spec/services/job_queue_spec.rb'
-    - 'spec/services/legal_framework/add_proceeding_service_spec.rb'
-    - 'spec/services/legal_framework/lead_proceeding_assignment_service_spec.rb'
-    - 'spec/services/malware_scanner_spec.rb'
-    - 'spec/services/metrics/send_metrics_spec.rb'
-    - 'spec/services/metrics/sidekiq_queue_sizes_spec.rb'
-    - 'spec/services/mock_benefit_check_service_spec.rb'
     - 'spec/services/page_history_service_spec.rb'
     - 'spec/services/pdf_converter_spec.rb'
     - 'spec/services/populators/transaction_type_populator_spec.rb'

--- a/spec/services/admin/provider_details_service_spec.rb
+++ b/spec/services/admin/provider_details_service_spec.rb
@@ -76,7 +76,7 @@ module Admin
 
     describe "#check" do
       context "when there are errors" do
-        subject { service.check }
+        subject(:check) { service.check }
 
         it_behaves_like "service handling error conditions"
       end
@@ -84,18 +84,18 @@ module Admin
       context "when the user adds non-ascii characters to their name" do
         # we suspect that this comes from a cut and paste from MS into
         # the login box when parsed it returns BRAND%20NEW\u2011USER
-        subject { service.check }
+        subject(:check) { service.check }
 
         let(:username) { "brand new‑user" }
         let(:response_body) { sarah_smith_response.to_json }
         let(:http_status) { 200 }
 
         it "responds with :error" do
-          expect(subject).to eq :error
+          expect(check).to eq :error
         end
 
         it "displays an appropriate message" do
-          subject
+          check
           expect(service.message).to eq "'brand new‑user' contains unicode characters, please re-type if cut and pasted"
         end
       end
@@ -120,13 +120,13 @@ module Admin
 
     describe "#create" do
       context "when there are errors" do
-        subject { service.create }
+        subject(:create) { service.create }
 
         it_behaves_like "service handling error conditions"
       end
 
       context "when the response is success" do
-        subject { service.create }
+        subject(:create) { service.create }
 
         let(:http_status) { 200 }
 
@@ -134,19 +134,19 @@ module Admin
           let(:response_body) { sarah_smith_response.to_json }
 
           it "creates the provider" do
-            expect { subject }.to change(Provider, :count).by(1)
+            expect { create }.to change(Provider, :count).by(1)
             expect(Provider.exists?(username:)).to be true
           end
 
           it "creates the firm linked to the provider" do
-            expect { subject }.to change(Firm, :count).by(1)
+            expect { create }.to change(Firm, :count).by(1)
             provider = Provider.find_by(username:)
             firm = provider.firm
             expect(firm.ccms_id).to eq "24493"
           end
 
           it "creates the offices linked to the firm" do
-            expect { subject }.to change(Office, :count).by(2)
+            expect { create }.to change(Office, :count).by(2)
             firm = Firm.find_by(name: "LOCAL LAW & CO LTD")
             offices = firm.offices.order(:code)
             expect(offices.size).to eq 2
@@ -167,18 +167,18 @@ module Admin
           let(:response_body) { sarah_smith_response.to_json }
 
           it "creates the provider" do
-            expect { subject }.to change(Provider, :count).by(1)
+            expect { create }.to change(Provider, :count).by(1)
             expect(Provider.exists?(username:)).to be true
           end
 
           it "links the provider to the firm" do
-            expect { subject }.not_to change(Firm, :count)
+            expect { create }.not_to change(Firm, :count)
             provider = Provider.find_by(username:)
             expect(provider.firm).to eq firm
           end
 
           it "does not add any offices" do
-            expect { subject }.not_to change(Office, :count)
+            expect { create }.not_to change(Office, :count)
           end
         end
 
@@ -191,18 +191,18 @@ module Admin
           let(:response_body) { sarah_smith_response.to_json }
 
           it "creates the provider" do
-            expect { subject }.to change(Provider, :count).by(1)
+            expect { create }.to change(Provider, :count).by(1)
             expect(Provider.exists?(username:)).to be true
           end
 
           it "links the provider to the firm" do
-            expect { subject }.not_to change(Firm, :count)
+            expect { create }.not_to change(Firm, :count)
             provider = Provider.find_by(username:)
             expect(provider.firm).to eq firm
           end
 
           it "creates the additional offices" do
-            expect { subject }.to change(Office, :count).by(1)
+            expect { create }.to change(Office, :count).by(1)
             expect(firm.reload.offices.map(&:code)).to match_array(%w[8M609S 8B869F])
           end
         end

--- a/spec/services/bank_holiday_retriever_service_spec.rb
+++ b/spec/services/bank_holiday_retriever_service_spec.rb
@@ -1,13 +1,13 @@
 require "rails_helper"
 
 RSpec.describe BankHolidayRetriever, vcr: { cassette_name: "gov_uk_bank_holiday_api", allow_playback_repeats: true } do
-  subject { described_class.new }
+  subject(:bank_holiday_retriever) { described_class.new }
 
   let(:group) { "england-and-wales" }
 
   describe ".dates" do
     it "returns same as instance dates for group" do
-      expect(described_class.dates).to eq(subject.dates(group))
+      expect(described_class.dates).to eq(bank_holiday_retriever.dates(group))
     end
 
     context "when the call fails" do
@@ -25,16 +25,16 @@ RSpec.describe BankHolidayRetriever, vcr: { cassette_name: "gov_uk_bank_holiday_
 
   describe "#data" do
     it "is a hash" do
-      expect(subject.data).to be_a(Hash)
+      expect(bank_holiday_retriever.data).to be_a(Hash)
     end
 
     it "has the expected basic structure" do
-      expect(subject.data.keys).to include(group)
+      expect(bank_holiday_retriever.data.keys).to include(group)
     end
   end
 
   describe "#dates" do
-    let(:dates) { subject.dates(group) }
+    let(:dates) { bank_holiday_retriever.dates(group) }
 
     it "is an array" do
       expect(dates).to be_a(Array)

--- a/spec/services/banking/bank_transaction_balance_calculator_spec.rb
+++ b/spec/services/banking/bank_transaction_balance_calculator_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 module Banking
   RSpec.describe BankTransactionBalanceCalculator do
-    subject { described_class.call(application) }
+    subject(:bank_transaction_balance_calculator) { described_class.call(application) }
 
     let(:application) { create(:legal_aid_application, :with_applicant) }
     let(:applicant) { application.applicant }
@@ -12,7 +12,7 @@ module Banking
 
     before do
       populate_all_transactions
-      subject
+      bank_transaction_balance_calculator
     end
 
     describe ".call" do

--- a/spec/services/banking/bank_transactions_trimmer_spec.rb
+++ b/spec/services/banking/bank_transactions_trimmer_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe Banking::BankTransactionsTrimmer do
   describe ".call" do
-    subject { described_class.call(application) }
+    subject(:bank_transaction_trimmer) { described_class.call(application) }
 
     let(:application) { create(:legal_aid_application, :with_applicant) }
     let(:applicant) { application.applicant }
@@ -21,7 +21,7 @@ RSpec.describe Banking::BankTransactionsTrimmer do
       let(:period_end) { Date.parse("2021-01-07").beginning_of_day }
 
       it "does not delete any transactions" do
-        expect { subject }.not_to change(BankTransaction, :count)
+        expect { bank_transaction_trimmer }.not_to change(BankTransaction, :count)
       end
     end
 
@@ -30,7 +30,7 @@ RSpec.describe Banking::BankTransactionsTrimmer do
       let(:period_end) { Date.parse("2021-01-04").beginning_of_day }
 
       it "has deleted records happened on after 4/1/2021" do
-        expect { subject }.to change(BankTransaction, :count).by(-4)
+        expect { bank_transaction_trimmer }.to change(BankTransaction, :count).by(-4)
         expect(application.bank_transactions.pluck(:happened_at)).not_to include("2021-01-05T01:00:00")
         expect(application.bank_transactions.pluck(:happened_at)).not_to include("2021-01-06T01:00:00")
       end

--- a/spec/services/banking/state_benefit_analyser_service_spec.rb
+++ b/spec/services/banking/state_benefit_analyser_service_spec.rb
@@ -20,12 +20,12 @@ RSpec.describe Banking::StateBenefitAnalyserService do
       let!(:transactions) { create_mix_of_non_benefit_transactions }
 
       it "does not change any bank transactions" do
-        subject
+        call
         expect(legal_aid_application.reload.bank_transactions.order(:id)).to eq transactions
       end
 
       it "does not add any transaction types to the legal aid application" do
-        expect { subject }.not_to change { legal_aid_application.transaction_types.count }
+        expect { call }.not_to change { legal_aid_application.transaction_types.count }
       end
     end
 
@@ -51,20 +51,20 @@ RSpec.describe Banking::StateBenefitAnalyserService do
         let!(:transactions) { create_list(:bank_transaction, 1, :credit, description: "010101010101-CHB", bank_account: bank_account1) }
 
         it "marks the transaction as a state benefit" do
-          subject
+          call
           tx = legal_aid_application.reload.bank_transactions.first
           expect(tx.transaction_type_id).to eq included_benefit_transaction_type.id
         end
 
         it "updates the meta data with the label of the state benefit" do
-          subject
+          call
           tx = legal_aid_application.reload.bank_transactions.first
           expect(tx.meta_data).to eq({ code: "CHB", label: "child_benefit", name: "Child Benefit", selected_by: "System" })
         end
 
         it "adds both included and excluded transaction types to the legal aid application" do
           expect(legal_aid_application.transaction_types.count).to be_zero
-          subject
+          call
           expect(legal_aid_application.transaction_types).to include(included_benefit_transaction_type)
           expect(legal_aid_application.transaction_types).to include(excluded_benefit_transaction_type)
         end
@@ -73,13 +73,13 @@ RSpec.describe Banking::StateBenefitAnalyserService do
           let!(:transactions) { create_list(:bank_transaction, 1, :credit, description: "HMRC CHILD BENEFIT", bank_account: bank_account1) }
 
           it "marks the transaction as a state benefit" do
-            subject
+            call
             tx = legal_aid_application.reload.bank_transactions.first
             expect(tx.transaction_type_id).to eq included_benefit_transaction_type.id
           end
 
           it "updates the meta data with the label of the state benefit" do
-            subject
+            call
             tx = legal_aid_application.reload.bank_transactions.first
             expect(tx.meta_data).to eq({ code: "HMRC CHILD BENEFIT", label: "hmrc_child_benefit", name: "Child Benefit", selected_by: "System" })
           end
@@ -90,20 +90,20 @@ RSpec.describe Banking::StateBenefitAnalyserService do
         let!(:transactions) { create_list(:bank_transaction, 1, :credit, description: "DWP #{nino} DLA", bank_account: bank_account1) }
 
         it "marks the transaction as a state benefit" do
-          subject
+          call
           tx = legal_aid_application.reload.bank_transactions.first
           expect(tx.transaction_type_id).to eq excluded_benefit_transaction_type.id
         end
 
         it "updates the meta data with the label of the state benefit" do
-          subject
+          call
           tx = legal_aid_application.reload.bank_transactions.first
           expect(tx.meta_data).to eq({ code: "DLA", label: "disability_living_allowance", name: "Disability Living Allowance", selected_by: "System" })
         end
 
         it "adds both included and excluded transaction types to the legal aid application" do
           expect(legal_aid_application.transaction_types.count).to be_zero
-          subject
+          call
           expect(legal_aid_application.transaction_types).to include(included_benefit_transaction_type)
           expect(legal_aid_application.transaction_types).to include(excluded_benefit_transaction_type)
         end

--- a/spec/services/dashboard_event_handler_spec.rb
+++ b/spec/services/dashboard_event_handler_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe DashboardEventHandler do
   end
 
   context "when a ccms_submission is saved" do
-    subject { create(:ccms_submission, aasm_state: state) }
+    subject(:create_ccms_submission) { create(:ccms_submission, aasm_state: state) }
 
     before { ActiveJob::Base.queue_adapter = :test }
 
@@ -63,11 +63,11 @@ RSpec.describe DashboardEventHandler do
 
       it "does not fire additional Application jobs" do
         # one is fired from creating the LegalAidApplication required by the ccms_submission factory
-        expect { subject }.to have_enqueued_job(Dashboard::UpdaterJob).with("Applications").at_most(1).times
+        expect { create_ccms_submission }.to have_enqueued_job(Dashboard::UpdaterJob).with("Applications").at_most(1).times
       end
 
       it "fires PendingCCMSSubmissions job" do
-        expect { subject }.to have_enqueued_job(Dashboard::UpdaterJob).with("PendingCCMSSubmissions").once
+        expect { create_ccms_submission }.to have_enqueued_job(Dashboard::UpdaterJob).with("PendingCCMSSubmissions").once
       end
     end
 
@@ -75,11 +75,11 @@ RSpec.describe DashboardEventHandler do
       let(:state) { "failed" }
 
       it "fires the Applications job" do
-        expect { subject }.to have_enqueued_job(Dashboard::UpdaterJob).with("Applications").at_least(1).times
+        expect { create_ccms_submission }.to have_enqueued_job(Dashboard::UpdaterJob).with("Applications").at_least(1).times
       end
 
       it "fires PendingCCMSSubmissions job" do
-        expect { subject }.to have_enqueued_job(Dashboard::UpdaterJob).with("PendingCCMSSubmissions").once
+        expect { create_ccms_submission }.to have_enqueued_job(Dashboard::UpdaterJob).with("PendingCCMSSubmissions").once
       end
     end
 
@@ -87,11 +87,11 @@ RSpec.describe DashboardEventHandler do
       let(:state) { "completed" }
 
       it "fires the Applications job" do
-        expect { subject }.to have_enqueued_job(Dashboard::UpdaterJob).with("Applications").at_least(1).times
+        expect { create_ccms_submission }.to have_enqueued_job(Dashboard::UpdaterJob).with("Applications").at_least(1).times
       end
 
       it "fires the PendingCCMSSubmissions job" do
-        expect { subject }.to have_enqueued_job(Dashboard::UpdaterJob).with("PendingCCMSSubmissions").once
+        expect { create_ccms_submission }.to have_enqueued_job(Dashboard::UpdaterJob).with("PendingCCMSSubmissions").once
       end
     end
 
@@ -100,11 +100,11 @@ RSpec.describe DashboardEventHandler do
 
       it "does not fire additional Application jobs" do
         # one is fired from creating the LegalAidApplication required by the ccms_submission factory
-        expect { subject }.to have_enqueued_job(Dashboard::UpdaterJob).with("Applications").at_most(1).times
+        expect { create_ccms_submission }.to have_enqueued_job(Dashboard::UpdaterJob).with("Applications").at_most(1).times
       end
 
       it "fires the PendingCCMSSubmissions job" do
-        expect { subject }.to have_enqueued_job(Dashboard::UpdaterJob).with("PendingCCMSSubmissions").once
+        expect { create_ccms_submission }.to have_enqueued_job(Dashboard::UpdaterJob).with("PendingCCMSSubmissions").once
       end
     end
 
@@ -113,11 +113,11 @@ RSpec.describe DashboardEventHandler do
 
       it "does not fire additional Application jobs" do
         # one is fired from creating the LegalAidApplication required by the ccms_submission factory
-        expect { subject }.to have_enqueued_job(Dashboard::UpdaterJob).with("Applications").at_most(1).times
+        expect { create_ccms_submission }.to have_enqueued_job(Dashboard::UpdaterJob).with("Applications").at_most(1).times
       end
 
       it "does not fire a PendingCCMSSubmissions job" do
-        expect { subject }.not_to have_enqueued_job(Dashboard::UpdaterJob).with("PendingCCMSSubmissions")
+        expect { create_ccms_submission }.not_to have_enqueued_job(Dashboard::UpdaterJob).with("PendingCCMSSubmissions")
       end
     end
   end

--- a/spec/services/delegated_functions_date_service_spec.rb
+++ b/spec/services/delegated_functions_date_service_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 
 RSpec.describe DelegatedFunctionsDateService do
   describe "sets date on proceeding records", :vcr do
-    subject { described_class.call(laa) }
+    subject(:call) { described_class.call(laa) }
 
     let(:laa) { create(:legal_aid_application) }
     let!(:proceeding1) do
@@ -25,7 +25,7 @@ RSpec.describe DelegatedFunctionsDateService do
     end
 
     it "returns true" do
-      expect(subject).to be true
+      expect(call).to be true
     end
 
     describe "sets the substantive_application_deadline_on date" do
@@ -35,7 +35,7 @@ RSpec.describe DelegatedFunctionsDateService do
         let(:expected_deadline) { Date.new(2021, 6, 8) }
 
         it "sets the substantive_application_deadline_on date" do
-          subject
+          call
           expect(laa.reload.substantive_application_deadline_on).to eq expected_deadline
         end
       end
@@ -46,7 +46,7 @@ RSpec.describe DelegatedFunctionsDateService do
         let(:reported_date) { nil }
 
         it "sets the substantive application_deadline_on to nil" do
-          subject
+          call
           expect(laa.reload.substantive_application_deadline_on).to be_nil
         end
       end
@@ -68,7 +68,7 @@ RSpec.describe DelegatedFunctionsDateService do
           end
 
           it "deletes the scheduled mails" do
-            subject
+            call
             expect(ScheduledMailing.where(mailer_klass: "SubmitApplicationReminderMailer", legal_aid_application_id: laa.id)).to be_empty
           end
         end
@@ -85,7 +85,7 @@ RSpec.describe DelegatedFunctionsDateService do
           end
 
           it "replaces existing email with one with new date" do
-            subject
+            call
             new_scheduled_mailings = ScheduledMailing.where(mailer_klass: "SubmitApplicationReminderMailer", legal_aid_application_id: laa.id)
             expect(new_scheduled_mailings.size).to eq 2
             expect(new_scheduled_mailings.map(&:scheduled_at)).to contain_exactly(expected_date1, expected_date2)
@@ -94,7 +94,7 @@ RSpec.describe DelegatedFunctionsDateService do
 
         context "when no scheduled mail already exists" do
           it "creates a new scheduled mail" do
-            expect { subject }.to change(ScheduledMailing, :count).by(2)
+            expect { call }.to change(ScheduledMailing, :count).by(2)
             new_scheduled_mailings = ScheduledMailing.where(mailer_klass: "SubmitApplicationReminderMailer", legal_aid_application_id: laa.id)
             expect(new_scheduled_mailings.size).to eq 2
             expect(new_scheduled_mailings.map(&:scheduled_at)).to contain_exactly(expected_date1, expected_date2)

--- a/spec/services/flow/base_flow_service_spec.rb
+++ b/spec/services/flow/base_flow_service_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 class TestFlowService < Flow::BaseFlowService; end
 
 RSpec.describe Flow::BaseFlowService do
-  subject do
+  subject(:base_flow_service) do
     flow_service_class.new(
       legal_aid_application:,
       current_step:,
@@ -29,7 +29,7 @@ RSpec.describe Flow::BaseFlowService do
 
     context "when on the default locale" do
       it "returns forward url with en locale" do
-        expect(subject.forward_path).to eq("/citizens/additional_accounts?locale=en")
+        expect(base_flow_service.forward_path).to eq("/citizens/additional_accounts?locale=en")
       end
     end
 
@@ -39,7 +39,7 @@ RSpec.describe Flow::BaseFlowService do
       end
 
       it "returns forward url with cy locale" do
-        expect(subject.forward_path).to eq("/citizens/additional_accounts?locale=cy")
+        expect(base_flow_service.forward_path).to eq("/citizens/additional_accounts?locale=cy")
       end
     end
 
@@ -47,7 +47,7 @@ RSpec.describe Flow::BaseFlowService do
       let(:current_step) { :consents }
 
       it "returns forward url" do
-        expect(subject.forward_path).to eq("/citizens/contact_provider?locale=en")
+        expect(base_flow_service.forward_path).to eq("/citizens/contact_provider?locale=en")
       end
     end
 
@@ -55,7 +55,7 @@ RSpec.describe Flow::BaseFlowService do
       let(:current_step) { :foo_bar }
 
       it "raises an error" do
-        expect { subject.forward_path }.to raise_error(/not defined/)
+        expect { base_flow_service.forward_path }.to raise_error(/not defined/)
       end
     end
 
@@ -63,7 +63,7 @@ RSpec.describe Flow::BaseFlowService do
       let(:steps) { { foo: :bar } }
 
       it "raises an error" do
-        expect { subject.forward_path }.to raise_error(/not defined/)
+        expect { base_flow_service.forward_path }.to raise_error(/not defined/)
       end
     end
   end
@@ -92,14 +92,14 @@ RSpec.describe Flow::BaseFlowService do
 
     describe "#current_path" do
       it "returns path" do
-        expect(subject.current_path).to eq(path)
+        expect(base_flow_service.current_path).to eq(path)
       end
 
       context "when path is a proc" do
         let(:path) { ->(passed_in) { passed_in } }
 
         it "passes in the legal aid application" do
-          expect(subject.current_path).to eq(legal_aid_application)
+          expect(base_flow_service.current_path).to eq(legal_aid_application)
         end
 
         context "and params exist" do
@@ -107,7 +107,7 @@ RSpec.describe Flow::BaseFlowService do
           let(:path) { ->(passed_in, params) { [passed_in, params] } }
 
           it "passes in the legal aid application and the params" do
-            expect(subject.current_path).to eq([legal_aid_application, params])
+            expect(base_flow_service.current_path).to eq([legal_aid_application, params])
           end
         end
       end
@@ -116,14 +116,14 @@ RSpec.describe Flow::BaseFlowService do
         let(:path) { nil }
 
         it "raises an error" do
-          expect { subject.current_path }.to raise_error(/not defined/)
+          expect { base_flow_service.current_path }.to raise_error(/not defined/)
         end
       end
     end
 
     describe "#forward_path" do
       it "returns forward url" do
-        expect(subject.forward_path).to eq(forward_url)
+        expect(base_flow_service.forward_path).to eq(forward_url)
       end
     end
   end

--- a/spec/services/flow/key_point_spec.rb
+++ b/spec/services/flow/key_point_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Flow::KeyPoint do
-  subject { described_class.new(journey, key_point) }
+  subject(:flow_key_point) { described_class.new(journey, key_point) }
 
   let(:journey) { :providers }
   let(:key_point) { :start_after_applicant_completes_means }
@@ -17,13 +17,13 @@ RSpec.describe Flow::KeyPoint do
 
   describe "#step" do
     it "returns the matching step" do
-      expect(subject.step).to eq(step)
+      expect(flow_key_point.step).to eq(step)
     end
   end
 
   describe "#path" do
     it "returns the matching path from flow" do
-      expect(subject.path(legal_aid_application)).to eq(flow.current_path)
+      expect(flow_key_point.path(legal_aid_application)).to eq(flow.current_path)
     end
   end
 

--- a/spec/services/job_queue_spec.rb
+++ b/spec/services/job_queue_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe JobQueue do
   let(:other_job) { MockQueuedJob.new(ScheduledMailingsDeliveryJob, short_delay.from_now) }
 
   describe ".enqueued?" do
-    subject { described_class.enqueued?(EmailMonitorJob) }
+    subject(:enqueued?) { described_class.enqueued?(EmailMonitorJob) }
 
     before { allow(Sidekiq::ScheduledSet).to receive(:new).and_return(job_queue) }
 
@@ -17,7 +17,7 @@ RSpec.describe JobQueue do
       let(:job_queue) { [] }
 
       it "returns false" do
-        expect(subject).to be false
+        expect(enqueued?).to be false
       end
     end
 
@@ -25,7 +25,7 @@ RSpec.describe JobQueue do
       let(:job_queue) { [late_job] }
 
       it "returns false" do
-        expect(subject).to be false
+        expect(enqueued?).to be false
       end
     end
 
@@ -33,7 +33,7 @@ RSpec.describe JobQueue do
       let(:job_queue) { [early_job] }
 
       it "returns true" do
-        expect(subject).to be true
+        expect(enqueued?).to be true
       end
     end
 
@@ -41,7 +41,7 @@ RSpec.describe JobQueue do
       let(:job_queue) { [early_job, late_job] }
 
       it "returns true" do
-        expect(subject).to be true
+        expect(enqueued?).to be true
       end
     end
 
@@ -49,7 +49,7 @@ RSpec.describe JobQueue do
       let(:job_queue) { [other_job] }
 
       it "returns false" do
-        expect(subject).to be false
+        expect(enqueued?).to be false
       end
     end
   end

--- a/spec/services/legal_framework/add_proceeding_service_spec.rb
+++ b/spec/services/legal_framework/add_proceeding_service_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 module LegalFramework
   RSpec.describe AddProceedingService, :vcr do
-    subject { described_class.new(legal_aid_application) }
+    subject(:add_proceeding_service) { described_class.new(legal_aid_application) }
 
     let(:legal_aid_application) { create(:legal_aid_application, :with_applicant) }
     let(:ccms_code) { "DA004" }
@@ -16,26 +16,26 @@ module LegalFramework
         end
 
         it "adds a proceeding" do
-          expect { subject.call(**params) }.to change { legal_aid_application.proceedings.count }.by(1)
+          expect { add_proceeding_service.call(**params) }.to change { legal_aid_application.proceedings.count }.by(1)
         end
 
         context "and the proceedings already exist" do
           let(:legal_aid_application) { create(:legal_aid_application, :with_applicant, :with_proceedings) }
 
           it "adds another proceeding type" do
-            subject.call(**params)
+            add_proceeding_service.call(**params)
             expect(legal_aid_application.proceedings.count).to eq 2
           end
         end
 
         it "calls LeadProceedingAssignmentService" do
           expect(LeadProceedingAssignmentService).to receive(:call).with(legal_aid_application)
-          subject.call(**params)
+          add_proceeding_service.call(**params)
         end
 
         context "when a proceeding is created" do
           before do
-            subject.call(**params)
+            add_proceeding_service.call(**params)
           end
 
           let(:proceeding) { legal_aid_application.proceedings.first }
@@ -63,12 +63,12 @@ module LegalFramework
         end
 
         it "returns false" do
-          expect(subject.call(**params)).to be false
+          expect(add_proceeding_service.call(**params)).to be false
         end
 
         it "does not call LeadProceedingAssignmentService" do
           expect(LeadProceedingAssignmentService).not_to receive(:call).with(legal_aid_application)
-          subject.call(**params)
+          add_proceeding_service.call(**params)
         end
       end
     end

--- a/spec/services/legal_framework/lead_proceeding_assignment_service_spec.rb
+++ b/spec/services/legal_framework/lead_proceeding_assignment_service_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 module LegalFramework
   RSpec.describe LeadProceedingAssignmentService do
-    subject { described_class.call(laa) }
+    subject(:lead_proceeding_assignment) { described_class.call(laa) }
 
     let(:p_da1) { laa.proceedings.where(ccms_code: "DA001").first }
     let(:p_da2) { laa.proceedings.where(ccms_code: "DA004").first }
@@ -16,7 +16,7 @@ module LegalFramework
       before { make_lead!(p_da2) }
 
       it "changes nothing" do
-        subject
+        lead_proceeding_assignment
         expect(p_s81.lead_proceeding?).to be false
         expect(p_s82.lead_proceeding?).to be false
         expect(p_da1.lead_proceeding?).to be false
@@ -29,7 +29,7 @@ module LegalFramework
       let(:first_proceeding) { laa.proceedings.in_order_of_addition.first }
 
       it "sets the proceeding added first as the lead proceeding" do
-        subject
+        lead_proceeding_assignment
         expect(first_proceeding.lead_proceeding?).to be true
         laa.proceedings.in_order_of_addition[1..].each do |proceeding|
           expect(proceeding.lead_proceeding?).to be false
@@ -41,7 +41,7 @@ module LegalFramework
       let(:explicit_proceedings) { %i[se013 se014] }
 
       it "sets the proceeding added first as the lead proceeding" do
-        subject
+        lead_proceeding_assignment
         expect(p_s81.lead_proceeding?).to be true
         expect(p_s82.lead_proceeding?).to be false
       end

--- a/spec/services/malware_scanner_spec.rb
+++ b/spec/services/malware_scanner_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe MalwareScanner do
-  subject do
+  subject(:malware_scanner) do
     described_class.call(
       file_path:,
       uploader: provider,
@@ -24,27 +24,27 @@ RSpec.describe MalwareScanner do
 
   describe "#call" do
     it "creates a MalwareScanResult record" do
-      expect { subject }.to change(MalwareScanResult, :count).by(1)
+      expect { malware_scanner }.to change(MalwareScanResult, :count).by(1)
     end
 
     it "records uploader and details of file" do
-      subject
+      malware_scanner
       expect(malware_scan_result.uploader).to eq(provider)
       expect(malware_scan_result.file_details).to eq(file_details)
     end
 
     it "returns created MalwareScanResult record" do
-      expect(subject).to be_a(MalwareScanResult)
-      expect(subject.id).to eq(malware_scan_result.id)
+      expect(malware_scanner).to be_a(MalwareScanResult)
+      expect(malware_scanner.id).to eq(malware_scan_result.id)
     end
 
     context "with file with no virus", clamav: true do
       it "#virus_found? returns false" do
-        expect(subject.virus_found?).to be(false)
+        expect(malware_scanner.virus_found?).to be(false)
       end
 
       it "#scan_result is file: OK" do
-        expect(subject.scan_result).to match(/.*\/hello_world.pdf: OK/)
+        expect(malware_scanner.scan_result).to match(/.*\/hello_world.pdf: OK/)
       end
     end
 
@@ -52,11 +52,11 @@ RSpec.describe MalwareScanner do
       let(:file_path) { file_fixture("malware.doc") }
 
       it "MalwareScanResult#virus_found? returns true" do
-        expect(subject.virus_found?).to be(true)
+        expect(malware_scanner.virus_found?).to be(true)
       end
 
       it "MalwareScanResult#scan_result is file: Trojan FOUND" do
-        expect(subject.scan_result).to match(/.*\/malware.doc: .*Trojan.* FOUND/)
+        expect(malware_scanner.scan_result).to match(/.*\/malware.doc: .*Trojan.* FOUND/)
       end
     end
 
@@ -66,12 +66,12 @@ RSpec.describe MalwareScanner do
       before { allow(Open3).to receive(:capture3).and_return(scan_result) }
 
       it "returns false" do
-        expect(subject.scanner_working).to be false
+        expect(malware_scanner.scanner_working).to be false
       end
 
       it "notifies sentry" do
         expect(AlertManager).to receive(:capture_message).with(/ClamdscanError, failed: No such file or directory. ERROR/)
-        subject
+        malware_scanner
       end
     end
 
@@ -85,20 +85,20 @@ RSpec.describe MalwareScanner do
       end
 
       it "returns and records the result of the scan" do
-        expect(subject.scan_result).to eq("whatever scan result")
+        expect(malware_scanner.scan_result).to eq("whatever scan result")
         expect(malware_scan_result.scan_result).to eq("whatever scan result")
       end
     end
 
     context "when not saving result" do
-      subject { described_class.call(file_path:, save_result: false) }
+      subject(:malware_scanner) { described_class.call(file_path:, save_result: false) }
 
       it "does not create a MalwareScanResult record" do
-        expect { subject }.not_to change(MalwareScanResult, :count)
+        expect { malware_scanner }.not_to change(MalwareScanResult, :count)
       end
 
       it "returns a MalwareScanResult object" do
-        expect(subject).to be_a(MalwareScanResult)
+        expect(malware_scanner).to be_a(MalwareScanResult)
       end
     end
   end

--- a/spec/services/metrics/send_metrics_spec.rb
+++ b/spec/services/metrics/send_metrics_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe Metrics::SendMetrics do
   describe "#call" do
-    subject { described_class.call }
+    subject(:call_send_metrics) { described_class.call }
 
     let(:metrics_service_host) { Faker::Internet.domain_word }
     let(:prometheus_client) { spy(PrometheusExporter::Client) }
@@ -19,12 +19,12 @@ RSpec.describe Metrics::SendMetrics do
         .to receive(:new)
         .with(host: metrics_service_host, thread_sleep: prometheus_thread_sleep)
         .and_return(prometheus_client)
-      subject
+      call_send_metrics
     end
 
     it "sleeps for twice the time of a prometheus loop" do
       expect_any_instance_of(Object).to receive(:sleep).with(prometheus_thread_sleep * 2)
-      subject
+      call_send_metrics
     end
 
     it "sends to prometheus the size of sidekiq queues" do
@@ -35,7 +35,7 @@ RSpec.describe Metrics::SendMetrics do
           queue: "mailers",
         ),
       )
-      subject
+      call_send_metrics
     end
   end
 end

--- a/spec/services/metrics/sidekiq_queue_sizes_spec.rb
+++ b/spec/services/metrics/sidekiq_queue_sizes_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe Metrics::SidekiqQueueSizes do
   describe "#call" do
-    subject { described_class.call(prometheus_client) }
+    subject(:call_queue_sizes) { described_class.call(prometheus_client) }
 
     let(:queues) { %w[default mailers active_storage_analysis active_storage_purge] }
     let(:prometheus_client) { spy(PrometheusExporter::Client) }
@@ -14,7 +14,7 @@ RSpec.describe Metrics::SidekiqQueueSizes do
           type: collector_type, queue:, size: Sidekiq::Queue.new(queue).size,
         )
       end
-      subject
+      call_queue_sizes
     end
 
     context "with known sizes" do
@@ -35,7 +35,7 @@ RSpec.describe Metrics::SidekiqQueueSizes do
             type: collector_type, queue:, size: expected_sizes[queue],
           )
         end
-        subject
+        call_queue_sizes
       end
     end
   end

--- a/spec/services/mock_benefit_check_service_spec.rb
+++ b/spec/services/mock_benefit_check_service_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe MockBenefitCheckService do
-  subject { described_class.call(application) }
+  subject(:mock_benefit_check) { described_class.call(application) }
 
   let(:last_name) { "Smith" }
   let(:date_of_birth) { "1999/01/11".to_date }
@@ -11,22 +11,22 @@ RSpec.describe MockBenefitCheckService do
 
   describe ".call" do
     it "returns confirmation_ref" do
-      expect(subject[:confirmation_ref]).to eq("mocked:#{described_class}")
+      expect(mock_benefit_check[:confirmation_ref]).to eq("mocked:#{described_class}")
     end
 
     it "returns 'Yes' as in known data" do
-      expect(subject[:benefit_checker_status]).to eq("Yes")
+      expect(mock_benefit_check[:benefit_checker_status]).to eq("Yes")
     end
 
     context "with incorrect date" do
       let(:date_of_birth) { "2012/01/10".to_date }
 
       it "returns no" do
-        expect(subject[:benefit_checker_status]).to eq("No")
+        expect(mock_benefit_check[:benefit_checker_status]).to eq("No")
       end
 
       it "returns confirmation_ref" do
-        expect(subject[:confirmation_ref]).to eq("mocked:#{described_class}")
+        expect(mock_benefit_check[:confirmation_ref]).to eq("mocked:#{described_class}")
       end
     end
 
@@ -34,7 +34,7 @@ RSpec.describe MockBenefitCheckService do
       let(:last_name) { "Unknown" }
 
       it "returns no" do
-        expect(subject[:benefit_checker_status]).to eq("No")
+        expect(mock_benefit_check[:benefit_checker_status]).to eq("No")
       end
     end
   end


### PR DESCRIPTION
## What

First of two PRs addressing RSpec/NamedSubject exclusions in the services folder

This addresses those in services where the folder or class starts with `a` to `m`

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
