### PR TITLE
AP-4468: Update feature step susceptible to false positives

### DIFF
--- a/features/providers/check_your_answers.feature
+++ b/features/providers/check_your_answers.feature
@@ -54,7 +54,7 @@ Feature: Checking answers backwards and forwards
     And the answer for 'Outstanding mortgage' should be '£100,000'
     And the answer for 'Shared ownership' should be "No"
     And the answer for 'Restrictions' should be 'Yes'
-    And the answer for 'Restrictions' should be 'Restrictions include:'
+    And the answer for 'Restrictions Details' should be 'Restrictions include:'
 
   @javascript
   Scenario: I am able to go back and not change property owned and come straight back to check passported answers

--- a/features/providers/check_your_answers.feature
+++ b/features/providers/check_your_answers.feature
@@ -169,8 +169,15 @@ Feature: Checking answers backwards and forwards
     And I select 'Vaccine Damage Payments Scheme'
     Then I click 'Save and continue'
     Then I am on the check your answers page for policy disregards
-    And the answer for 'policy disregards' should be 'England Infected Blood Support Scheme'
-    And the answer for 'policy disregards' should be 'Vaccine Damage Payments Scheme'
+    And the "policy disregards items" list's questions and answers should match:
+      | question | answer |
+      | England Infected Blood Support Scheme | Yes |
+      | Vaccine Damage Payments Scheme | Yes |
+      | Variant Creutzfeldt-Jakob disease (vCJD) Trust | No |
+      | Criminal Injuries Compensation Scheme | No |
+      | National Emergencies Trust (NET) | No |
+      | We Love Manchester Emergency Fund | No |
+      | The London Emergencies Trust | No |
 
     @javascript
     Scenario: I want to change property value via the capital check your answers page

--- a/features/providers/check_your_answers.feature
+++ b/features/providers/check_your_answers.feature
@@ -234,7 +234,7 @@ Feature: Checking answers backwards and forwards
       Then I click 'Save and continue'
       Then I should be on a page showing 'Check your answers'
       And the answer for 'Restrictions' should be 'Yes'
-      And the answer for 'Restrictions' should be 'Restraint or freezing order'
+      And the answer for 'Restrictions details' should be 'Restraint or freezing order'
       And I click Check Your Answers Change link for 'Restrictions'
       Then I should be on a page showing 'Is there anything else you need to tell us about your client’s assets?'
       Then I choose 'No'

--- a/features/providers/passported_journey.feature
+++ b/features/providers/passported_journey.feature
@@ -90,8 +90,8 @@ Feature: passported_journey completes application
     Then I enter the application merits task statement of case statement field 'This is some test data for the statement of case'
     Then I click 'Save and continue'
     Then I should be on a page showing "Check your answers"
-    Then I should be on a page showing "hello_world.pdf (15.7 KB)"
-    And the answer for 'Statement of case' should be 'This is some test data for the statement of case'
+    And the answer for 'Statement of case' should be 'hello_world.pdf (15.7 KB)'
+    And I should be on a page showing "This is some test data for the statement of case"
     Then I click 'Save and continue'
     And I should be on a page showing "Confirm the following"
     Then I check "I confirm the above is correct and that I'll get a signed declaration from my client"

--- a/features/step_definitions/check_your_answers_steps.rb
+++ b/features/step_definitions/check_your_answers_steps.rb
@@ -82,6 +82,13 @@ Then("the {string} section's questions and answers should match:") do |section, 
   expect_matching_questions_and_answers(actual_selector: "[data-check-your-answers-section=\"#{section}\"]", expected_table: table)
 end
 
+Then("the {string} list's questions and answers should match:") do |section, table|
+  section.downcase!
+  section.gsub!(/\s+/, "_")
+  section = "#app-check-your-answers__#{section}"
+  expect_matching_questions_and_answers(actual_selector: section, expected_table: table)
+end
+
 Then("the radio button response for {string} should be {string}") do |question, answer|
   question.downcase!
   question.gsub!(/\s+/, "-")

--- a/features/step_definitions/civil_journey_steps.rb
+++ b/features/step_definitions/civil_journey_steps.rb
@@ -948,11 +948,14 @@ Then("I click on the add payments link for outgoing type {string}") do |outgoing
 end
 
 Then("the answer for {string} should be {string}") do |field_name, answer|
-  # TODO: Deprecate or refactor this so it actually works as expected AP-4468 raised to address
   field_name.downcase!
   field_name.gsub!(/\s+/, "_")
-  expect(page).to have_css("#app-check-your-answers__#{field_name}")
-  expect(page).to have_content(answer)
+  selector = "#app-check-your-answers__#{field_name}"
+
+  expect(page).to have_css(selector)
+  within(selector) do
+    expect(page).to have_content(answer)
+  end
 end
 
 Then("the {string} answer for vehicle {int} should be {string}") do |field_name, vehicle, answer|


### PR DESCRIPTION



## What
Amend step susceptible to false positives and use, correct or replace in features

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4468)

- Amend offending step to use within so as to prevent false positives
- Correct newly failing feature step call by correct the section name used
- Correct use of step for statement of case where expected text is not actually
  connected to the DOM row, wrongly or rightly?!
- Add new step to allow CYA list items to exhausively check row questions and answers

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
