### PR TITLE
AP-4452: Remove organisation feature flag

### DIFF
--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -23,7 +23,6 @@ module Admin
                                       :allow_welsh_translation,
                                       :enable_ccms_submission,
                                       :partner_means_assessment,
-                                      :opponent_organisations,
                                       :linked_applications)
     end
 

--- a/app/forms/settings/setting_form.rb
+++ b/app/forms/settings/setting_form.rb
@@ -7,7 +7,6 @@ module Settings
                   :allow_welsh_translation,
                   :enable_ccms_submission,
                   :partner_means_assessment,
-                  :opponent_organisations,
                   :linked_applications
 
     validates :mock_true_layer_data,
@@ -15,7 +14,6 @@ module Settings
               :allow_welsh_translation,
               :enable_ccms_submission,
               :partner_means_assessment,
-              :opponent_organisations,
               :linked_applications,
               presence: true
   end

--- a/app/helpers/task_list_helper.rb
+++ b/app/helpers/task_list_helper.rb
@@ -31,10 +31,6 @@ private
     legal_aid_application.involved_children.empty?
   end
 
-  def application_has_no_opponents?(legal_aid_application)
-    legal_aid_application.opponents.empty?
-  end
-
   def proceeding_task_url(name, application, ccms_code)
     url = "providers_merits_task_list_#{url_fragment(name)}_path".to_sym
 
@@ -48,7 +44,7 @@ private
   def new_url_fragment(name, status, application)
     name = "has_other_involved_children" if name.eql?(:children_application) && (status.eql?(:complete) || application.involved_children.any?)
     name = "has_other_opponent" if name.eql?(:opponent_name) && (status.eql?(:complete) || application.opponents.any?)
-    name = "opponent_type" if name.eql?(:opponent_name) && Setting.opponent_organisations?
+    name = "opponent_type" if name.eql?(:opponent_name)
     I18n.t("providers.merits_task_lists.task_list_item.urls.#{name}")
   end
 
@@ -60,20 +56,6 @@ private
   end
 
   def display_new_page?(legal_aid_application, task_name)
-    return false if Setting.opponent_organisations? && task_name.eql?(:opponent_name)
-    return false unless %i[children_application opponent_name].include?(task_name)
-
-    [
-      starting_children_application_for_first_time?(legal_aid_application, task_name),
-      starting_opponents_name_for_first_time?(legal_aid_application, task_name),
-    ].any?(true)
-  end
-
-  def starting_children_application_for_first_time?(legal_aid_application, task_name)
     task_name.eql?(:children_application) && application_has_no_involved_children?(legal_aid_application)
-  end
-
-  def starting_opponents_name_for_first_time?(legal_aid_application, task_name)
-    task_name.eql?(:opponent_name) && application_has_no_opponents?(legal_aid_application)
   end
 end

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -27,10 +27,6 @@ class Setting < ApplicationRecord
     setting.partner_means_assessment
   end
 
-  def self.opponent_organisations?
-    setting.opponent_organisations
-  end
-
   def self.linked_applications?
     setting.linked_applications
   end

--- a/app/services/flow/flows/provider_merits.rb
+++ b/app/services/flow/flows/provider_merits.rb
@@ -80,7 +80,7 @@ module Flow
             if application.opponents.any?
               urls.providers_legal_aid_application_has_other_opponent_path(application)
             else
-              Setting.opponent_organisations? ? urls.providers_legal_aid_application_opponent_type_path(application) : urls.new_providers_legal_aid_application_opponent_individual_path(application)
+              urls.providers_legal_aid_application_opponent_type_path(application)
             end
           end,
         },
@@ -93,20 +93,12 @@ module Flow
         has_other_opponents: {
           path: ->(application) { urls.providers_legal_aid_application_has_other_opponent_path(application) },
           forward: lambda { |application, has_other_opponent|
-            if has_other_opponent
-              Setting.opponent_organisations? ? :opponent_types : :opponent_individuals
-            else
-              Flow::MeritsLoop.forward_flow(application, :application)
-            end
+            has_other_opponent ? :opponent_types : Flow::MeritsLoop.forward_flow(application, :application)
           },
         },
         remove_opponent: {
           forward: lambda { |application|
-            if application.opponents.count.positive?
-              :has_other_opponents
-            else
-              Setting.opponent_organisations? ? :opponent_types : :opponent_individuals
-            end
+            application.opponents.count.positive? ? :has_other_opponents : :opponent_types
           },
         },
         opponents_mental_capacities: {

--- a/app/views/admin/settings/show.html.erb
+++ b/app/views/admin/settings/show.html.erb
@@ -57,16 +57,6 @@
         ) %>
 
     <%= form.govuk_collection_radio_buttons(
-          :opponent_organisations,
-          yes_no_options,
-          :value,
-          :label,
-          inline: true,
-          hint: { text: t(".hints.opponent_organisations") },
-          legend: { text: t(".labels.opponent_organisations") },
-        ) %>
-
-    <%= form.govuk_collection_radio_buttons(
           :linked_applications,
           yes_no_options,
           :value,

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -73,7 +73,6 @@ en:
           enable_ccms_submission: Allow CCMS submissions
           enable_evidence_upload: Enable the new evidence upload feature
           partner_means_assessment: Enable Partner Means Assessment
-          opponent_organisations: Enable Opponent Organisations
           linked_applications: Enable linked applications
         hints:
           mock_true_layer_data: Select Yes and TrueLayer data will be replaced by mock data from %{bank_transaction_filename}
@@ -84,7 +83,6 @@ en:
           enable_ccms_submission: Yes by default, only set to No if CCMS is being taken offline
           enable_evidence_upload: Select Yes to enable the new evidence upload feature for solicitors
           partner_means_assessment: Select Yes to allow Providers to complete the Partner Means Assessment
-          opponent_organisations: Select Yes to enable the opponent organisations feature for solicitors
           linked_applications: Select Yes to enable the linked applications feature for solicitors
       update:
         notice: Settings have been updated

--- a/db/migrate/20231004144844_remove_opponent_organisations_flag_from_settings.rb
+++ b/db/migrate/20231004144844_remove_opponent_organisations_flag_from_settings.rb
@@ -1,0 +1,7 @@
+class RemoveOpponentOrganisationsFlagFromSettings < ActiveRecord::Migration[7.0]
+  def change
+    safety_assured do
+      remove_column :settings, :opponent_organisations, :boolean, null: false, default: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -926,7 +926,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_06_091714) do
     t.datetime "digest_extracted_at", precision: nil, default: "1970-01-01 00:00:01"
     t.boolean "partner_means_assessment", default: false, null: false
     t.datetime "cfe_compare_run_at"
-    t.boolean "opponent_organisations", default: false, null: false
     t.boolean "linked_applications", default: false, null: false
   end
 

--- a/features/providers/check_ccms_autogrant.feature
+++ b/features/providers/check_ccms_autogrant.feature
@@ -36,11 +36,15 @@ Feature: Checking ccms means does NOT auto grant
     Then I fill "application_merits_task_incident_occurred_on_2i" with "4"
     Then I fill "application_merits_task_incident_occurred_on_1i" with "20"
     Then I click 'Save and continue'
-    Then I should be on a page showing "Opponent"
-    When I fill "First Name" with "John"
-    And I fill "Last Name" with "Doe"
+    Then  I should be on a page with title "Is the opponent an individual or an organisation?"
+    And I choose a 'An individual' radio button
     When I click 'Save and continue'
-    Then I should be on a page showing "You have added 1 opponent"
+    Then I should be on a page with title "Opponent"
+    When I fill "First Name" with "John"
+    Then I fill "Last Name" with "Doe"
+    When I click 'Save and continue'
+    Then I should be on a page with title "You have added 1 opponent"
+    And I should be on a page showing "Do you need to add another opponent?"
     When I choose "No"
     And I click 'Save and continue'
     Then I should be on a page showing "Do all parties have the mental capacity to understand the terms of a court order?"
@@ -105,11 +109,15 @@ Feature: Checking ccms means does NOT auto grant
     Then I fill "application_merits_task_incident_occurred_on_2i" with "4"
     Then I fill "application_merits_task_incident_occurred_on_1i" with "20"
     Then I click 'Save and continue'
-    Then I should be on a page showing "Opponent"
-    When I fill "First Name" with "John"
-    And I fill "Last Name" with "Doe"
+    Then  I should be on a page with title "Is the opponent an individual or an organisation?"
+    And I choose a 'An individual' radio button
     When I click 'Save and continue'
-    Then I should be on a page showing "You have added 1 opponent"
+    Then I should be on a page with title "Opponent"
+    When I fill "First Name" with "John"
+    Then I fill "Last Name" with "Doe"
+    When I click 'Save and continue'
+    Then I should be on a page with title "You have added 1 opponent"
+    And I should be on a page showing "Do you need to add another opponent?"
     When I choose "No"
     And I click 'Save and continue'
     Then I should be on a page showing "Do all parties have the mental capacity to understand the terms of a court order?"

--- a/features/providers/check_nonpassport_autogrant.feature
+++ b/features/providers/check_nonpassport_autogrant.feature
@@ -85,12 +85,16 @@ Feature: Checking ccms means does NOT auto grant for non passported applications
     Then I fill "application_merits_task_incident_occurred_on_3i" with "4"
     Then I fill "application_merits_task_incident_occurred_on_2i" with "4"
     Then I fill "application_merits_task_incident_occurred_on_1i" with "20"
-    Then I click 'Save and continue'
-    Then I should be on a page showing "Opponent"
-    When I fill "First Name" with "John"
-    And I fill "Last Name" with "Doe"
     When I click 'Save and continue'
-    Then I should be on a page showing "You have added 1 opponent"
+    Then  I should be on a page with title "Is the opponent an individual or an organisation?"
+    And I choose a 'An individual' radio button
+    When I click 'Save and continue'
+    Then I should be on a page with title "Opponent"
+    When I fill "First Name" with "John"
+    Then I fill "Last Name" with "Doe"
+    When I click 'Save and continue'
+    Then I should be on a page with title "You have added 1 opponent"
+    And I should be on a page showing "Do you need to add another opponent?"
     When I choose "No"
     And I click 'Save and continue'
     Then I should be on a page showing "Do all parties have the mental capacity to understand the terms of a court order?"
@@ -213,12 +217,16 @@ Feature: Checking ccms means does NOT auto grant for non passported applications
     Then I fill "application_merits_task_incident_occurred_on_3i" with "4"
     Then I fill "application_merits_task_incident_occurred_on_2i" with "4"
     Then I fill "application_merits_task_incident_occurred_on_1i" with "20"
-    Then I click 'Save and continue'
-    Then I should be on a page showing "Opponent"
-    When I fill "First Name" with "John"
-    And I fill "Last Name" with "Doe"
     When I click 'Save and continue'
-    Then I should be on a page showing "You have added 1 opponent"
+    Then  I should be on a page with title "Is the opponent an individual or an organisation?"
+    And I choose a 'An individual' radio button
+    When I click 'Save and continue'
+    Then I should be on a page with title "Opponent"
+    When I fill "First Name" with "John"
+    Then I fill "Last Name" with "Doe"
+    When I click 'Save and continue'
+    Then I should be on a page with title "You have added 1 opponent"
+    And I should be on a page showing "Do you need to add another opponent?"
     When I choose "No"
     And I click 'Save and continue'
     Then I should be on a page showing "Do all parties have the mental capacity to understand the terms of a court order?"

--- a/features/providers/merits_task_list.feature
+++ b/features/providers/merits_task_list.feature
@@ -12,11 +12,15 @@ Feature: Merits task list
     When I enter the 'told' date of 2 days ago
     And I enter the 'occurred' date of 2 days ago
     When I click 'Save and continue'
-    Then I should be on a page showing "Opponent"
-    When I fill "First Name" with "John"
-    And I fill "Last Name" with "Doe"
+    Then  I should be on a page with title "Is the opponent an individual or an organisation?"
+    And I choose a 'An individual' radio button
     When I click 'Save and continue'
-    Then I should be on a page showing "You have added 1 opponent"
+    Then I should be on a page with title "Opponent"
+    When I fill "First Name" with "John"
+    Then I fill "Last Name" with "Doe"
+    When I click 'Save and continue'
+    Then I should be on a page with title "You have added 1 opponent"
+    And I should be on a page showing "Do you need to add another opponent?"
     When I choose "No"
     And I click 'Save and continue'
     Then I should be on a page showing "Do all parties have the mental capacity to understand the terms of a court order?"
@@ -84,16 +88,26 @@ Feature: Merits task list
     When I enter the 'told' date of 2 days ago
     And I enter the 'occurred' date of 2 days ago
     When I click 'Save and continue'
-    Then I should be on a page showing "Opponent"
-    When I fill "First Name" with "John"
-    And I fill "Last Name" with "Doe"
+    Then  I should be on a page with title "Is the opponent an individual or an organisation?"
+    And I choose a 'An individual' radio button
     When I click 'Save and continue'
-    Then I should be on a page showing "You have added 1 opponent"
+    Then I should be on a page with title "Opponent"
+    When I fill "First Name" with "John"
+    Then I fill "Last Name" with "Doe"
+    When I click 'Save and continue'
+    Then I should be on a page with title "You have added 1 opponent"
+    And I should be on a page showing "Do you need to add another opponent?"
     When I choose "Yes"
     And I click 'Save and continue'
-    Then I should be on a page showing "Opponent"
+    Then  I should be on a page with title "Is the opponent an individual or an organisation?"
+    And I choose a 'An individual' radio button
+    When I click 'Save and continue'
+    Then I should be on a page with title "Opponent"
     When I fill "First Name" with "Jane"
-    And I fill "Last Name" with "Doe"
+    Then I fill "Last Name" with "Doe"
+    When I click 'Save and continue'
+    Then I should be on a page with title "You have added 2 opponents"
+    And I should be on a page showing "Do you need to add another opponent?"
     When I click 'Save and continue'
     Then I should be on a page showing "You have added 2 opponents"
     When I choose "No"
@@ -131,11 +145,15 @@ Feature: Merits task list
     When I enter the 'told' date of 2 days ago
     And I enter the 'occurred' date of 2 days ago
     When I click 'Save and continue'
-    Then I should be on a page showing "Opponent"
-    When I fill "First Name" with "John"
-    And I fill "Last Name" with "Doe"
+    Then  I should be on a page with title "Is the opponent an individual or an organisation?"
+    And I choose a 'An individual' radio button
     When I click 'Save and continue'
-    Then I should be on a page showing "You have added 1 opponent"
+    Then I should be on a page with title "Opponent"
+    When I fill "First Name" with "John"
+    Then I fill "Last Name" with "Doe"
+    When I click 'Save and continue'
+    Then I should be on a page with title "You have added 1 opponent"
+    And I should be on a page showing "Do you need to add another opponent?"
     When I choose "No"
     And I click 'Save and continue'
     Then I should be on a page showing "Do all parties have the mental capacity to understand the terms of a court order?"
@@ -182,11 +200,15 @@ Feature: Merits task list
     Then I enter the 'told' date of 2 days ago
     Then I enter the 'occurred' date of 2 days ago
     Then I click 'Save and continue'
-    Then I should be on a page showing "Opponent"
-    When I fill "First Name" with "John"
-    And I fill "Last Name" with "Doe"
+    Then  I should be on a page with title "Is the opponent an individual or an organisation?"
+    And I choose a 'An individual' radio button
     When I click 'Save and continue'
-    Then I should be on a page showing "You have added 1 opponent"
+    Then I should be on a page with title "Opponent"
+    When I fill "First Name" with "John"
+    Then I fill "Last Name" with "Doe"
+    When I click 'Save and continue'
+    Then I should be on a page with title "You have added 1 opponent"
+    And I should be on a page showing "Do you need to add another opponent?"
     When I choose "No"
     And I click 'Save and continue'
     Then I should be on a page showing "Do all parties have the mental capacity to understand the terms of a court order?"

--- a/features/providers/merits_task_list_opponent.feature
+++ b/features/providers/merits_task_list_opponent.feature
@@ -1,8 +1,7 @@
 Feature: Merits task list opponent
 
   Background:
-    Given the feature flag for opponent_organisations is enabled
-    When I have completed a non-passported application and reached the merits task_list
+    Given I have completed a non-passported application and reached the merits task_list
     Then I should be on the 'merits_task_list' page showing 'Opponents\nNOT STARTED'
     When I click link 'Opponents'
     Then I should be on a page showing "Is the opponent an individual or an organisation?"

--- a/features/providers/non_means_tested_journey/without_delegated_functions.feature
+++ b/features/providers/non_means_tested_journey/without_delegated_functions.feature
@@ -69,15 +69,20 @@ Feature: Non-means-tested applicant journey without use of delegation functions
     And I enter the 'occurred' date of 2 days ago
 
     When I click 'Save and continue'
-    Then I should be on a page showing "Opponent"
+    Then  I should be on a page with title "Is the opponent an individual or an organisation?"
+    And I choose a 'An individual' radio button
+
+    When I click 'Save and continue'
+    Then I should be on a page with title "Opponent"
     And I fill "First Name" with "John"
     And I fill "Last Name" with "Doe"
 
     When I click 'Save and continue'
-    Then I should be on a page showing "You have added 1 opponent"
-    When I choose "No"
-    And I click 'Save and continue'
+    Then I should be on a page with title "You have added 1 opponent"
+    And I should be on a page showing "Do you need to add another opponent?"
+    And I choose "No"
 
+    When I click 'Save and continue'
     Then I should be on a page showing "Do all parties have the mental capacity to understand the terms of a court order?"
     And I choose "Yes"
 

--- a/features/providers/passported_journey.feature
+++ b/features/providers/passported_journey.feature
@@ -49,11 +49,15 @@ Feature: passported_journey completes application
     Then I enter the 'told' date of 2 days ago
     Then I enter the 'occurred' date of 2 days ago
     Then I click 'Save and continue'
-    Then I should be on a page showing "Opponent"
-    When I fill "First Name" with "John"
-    And I fill "Last Name" with "Doe"
+    Then  I should be on a page with title "Is the opponent an individual or an organisation?"
+    And I choose a 'An individual' radio button
     When I click 'Save and continue'
-    Then I should be on a page showing "You have added 1 opponent"
+    Then I should be on a page with title "Opponent"
+    When I fill "First Name" with "John"
+    Then I fill "Last Name" with "Doe"
+    When I click 'Save and continue'
+    Then I should be on a page with title "You have added 1 opponent"
+    And I should be on a page showing "Do you need to add another opponent?"
     When I choose "No"
     And I click 'Save and continue'
     Then I should be on a page showing "Do all parties have the mental capacity to understand the terms of a court order?"

--- a/features/providers/search_opponent_organisations.feature
+++ b/features/providers/search_opponent_organisations.feature
@@ -2,8 +2,7 @@
 Feature: Search existing opponent organisations
 
 Background: User is on existing opponent organisation search page
-  Given the feature flag for opponent_organisations is enabled
-  And I insert cassette "lfa_organisations_all"
+  Given I insert cassette "lfa_organisations_all"
   When I have completed a non-passported application and reached the merits task_list
   Then I should be on the 'merits_task_list' page showing 'Opponents\nNOT STARTED'
   When I click link 'Opponents'

--- a/spec/helpers/task_list_helper_spec.rb
+++ b/spec/helpers/task_list_helper_spec.rb
@@ -1,80 +1,82 @@
 require "rails_helper"
 
 RSpec.describe TaskListHelper do
-  context "when passed an application with section 8 proceeding_types" do
-    let(:legal_aid_application) { create(:legal_aid_application, :with_multiple_proceedings_inc_section8) }
+  describe "#task_list_item" do
+    context "when passed an application with section 8 proceeding_types" do
+      let(:legal_aid_application) { create(:legal_aid_application, :with_multiple_proceedings_inc_section8) }
 
-    context "with a child already added" do
-      before { create(:involved_child, legal_aid_application:) }
+      context "with involded children task list item" do
+        context "when an involved child already added" do
+          before { create(:involved_child, legal_aid_application:) }
 
-      let(:expected) do
-        <<~RESULT
-          <li class="app-task-list__item">
-            <span class="app-task-list__task-name">
-                <a aria_describedby="children_application-status" aria-label="Children involved in this application" class="govuk-link" href="/providers/applications/#{legal_aid_application.id}/has_other_involved_children?locale=en">Children involved in this application</a>
-            </span>
-            <strong class="govuk-tag app-task-list__tag" id="children_application__status">Completed</strong>
-          </li>
-        RESULT
-      end
+          let(:expected) do
+            <<~RESULT
+              <li class="app-task-list__item">
+                <span class="app-task-list__task-name">
+                    <a aria_describedby="children_application-status" aria-label="Children involved in this application" class="govuk-link" href="/providers/applications/#{legal_aid_application.id}/has_other_involved_children?locale=en">Children involved in this application</a>
+                </span>
+                <strong class="govuk-tag app-task-list__tag" id="children_application__status">Completed</strong>
+              </li>
+            RESULT
+          end
 
-      it "returns a link" do
-        expect(helper.task_list_item(name: :children_application,
-                                     status: :complete,
-                                     legal_aid_application:,
-                                     ccms_code: nil)).to eq expected
-      end
-    end
-
-    context "with no child added" do
-      let(:expected) do
-        <<~RESULT
-          <li class="app-task-list__item">
-            <span class="app-task-list__task-name">
-                <a aria_describedby="children_application-status" aria-label="Children involved in this application" class="govuk-link" href="/providers/applications/#{legal_aid_application.id}/involved_children/new?locale=en">Children involved in this application</a>
-            </span>
-            <strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="children_application__status">Not started</strong>
-          </li>
-        RESULT
-      end
-
-      it "returns a link" do
-        expect(helper.task_list_item(name: :children_application,
-                                     status: :not_started,
-                                     legal_aid_application:,
-                                     ccms_code: nil)).to eq expected
-      end
-    end
-
-    context "with chances of success" do
-      let(:proceeding) { legal_aid_application.proceedings.find_by(ccms_code: "DA001") }
-
-      let(:expected) do
-        <<~RESULT
-          <li class="app-task-list__item">
-            <span class="app-task-list__task-name">
-                <a aria_describedby="chances_of_success-status" aria-label="Chances of success" class="govuk-link" href="/providers/merits_task_list/#{proceeding.id}/chances_of_success?locale=en">Chances of success</a>
-            </span>
-            <strong class="govuk-tag app-task-list__tag" id="chances_of_success_DA001_status">Completed</strong>
-          </li>
-        RESULT
-      end
-
-      it "returns a link" do
-        expect(helper.task_list_item(name: :chances_of_success,
-                                     status: :complete,
-                                     legal_aid_application:,
-                                     ccms_code: :DA001)).to eq expected
-      end
-    end
-
-    context "with opponent" do
-      context "when opponent_organisations flag is set to true" do
-        before do
-          allow(Setting).to receive(:opponent_organisations?).and_return(true)
+          it "returns expected html" do
+            expect(helper.task_list_item(name: :children_application,
+                                         status: :complete,
+                                         legal_aid_application:,
+                                         ccms_code: nil)).to eq expected
+          end
         end
 
-        context "with no opponents added" do
+        context "when no involved child added" do
+          let(:expected) do
+            <<~RESULT
+              <li class="app-task-list__item">
+                <span class="app-task-list__task-name">
+                    <a aria_describedby="children_application-status" aria-label="Children involved in this application" class="govuk-link" href="/providers/applications/#{legal_aid_application.id}/involved_children/new?locale=en">Children involved in this application</a>
+                </span>
+                <strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="children_application__status">Not started</strong>
+              </li>
+            RESULT
+          end
+
+          it "returns expected html" do
+            expect(helper.task_list_item(name: :children_application,
+                                         status: :not_started,
+                                         legal_aid_application:,
+                                         ccms_code: nil)).to eq expected
+          end
+        end
+      end
+
+      context "with chances of success list item" do
+        let(:proceeding) { legal_aid_application.proceedings.find_by(ccms_code: "DA001") }
+
+        context "when chance of success already added" do
+          let(:expected) do
+            <<~RESULT
+              <li class="app-task-list__item">
+                <span class="app-task-list__task-name">
+                    <a aria_describedby="chances_of_success-status" aria-label="Chances of success" class="govuk-link" href="/providers/merits_task_list/#{proceeding.id}/chances_of_success?locale=en">Chances of success</a>
+                </span>
+                <strong class="govuk-tag app-task-list__tag" id="chances_of_success_DA001_status">Completed</strong>
+              </li>
+            RESULT
+          end
+
+          it "returns expected html" do
+            expect(helper.task_list_item(name: :chances_of_success,
+                                         status: :complete,
+                                         legal_aid_application:,
+                                         ccms_code: :DA001)).to eq expected
+          end
+        end
+      end
+
+      context "with opponent task list item" do
+        context "when no opponents added" do
+          before { legal_aid_application.opponents.destroy_all }
+
           let(:expected) do
             <<~RESULT
               <li class="app-task-list__item">
@@ -85,9 +87,8 @@ RSpec.describe TaskListHelper do
               </li>
             RESULT
           end
-          let(:opponent) { create(:opponent, :for_organisation, legal_aid_application:) }
 
-          it "returns a link" do
+          it "returns expected html" do
             expect(helper.task_list_item(name: :opponent_name,
                                          status: :not_started,
                                          legal_aid_application:,
@@ -95,7 +96,9 @@ RSpec.describe TaskListHelper do
           end
         end
 
-        context "with an opponent already added" do
+        context "when an opponent already added" do
+          before { create(:opponent, :for_individual, legal_aid_application:) }
+
           let(:expected) do
             <<~RESULT
               <li class="app-task-list__item">
@@ -107,8 +110,7 @@ RSpec.describe TaskListHelper do
             RESULT
           end
 
-          it "returns a link" do
-            create(:opponent, :for_organisation, legal_aid_application:)
+          it "returns expected html" do
             expect(helper.task_list_item(name: :opponent_name,
                                          status: :complete,
                                          legal_aid_application:,
@@ -116,54 +118,29 @@ RSpec.describe TaskListHelper do
           end
         end
       end
+    end
+  end
 
-      context "when opponent_organisations flag is set to false" do
-        before do
-          allow(Setting).to receive(:opponent_organisations?).and_return(false)
-        end
+  describe "#task_list_includes?" do
+    subject(:task_list_includes?) { helper.task_list_includes?(legal_aid_application, task_name) }
 
-        context "with no opponents added" do
-          let(:expected) do
-            <<~RESULT
-              <li class="app-task-list__item">
-                <span class="app-task-list__task-name">
-                    <a aria_describedby="opponent_name-status" aria-label="Opponents" class="govuk-link" href="/providers/applications/#{legal_aid_application.id}/opponent_individuals/new?locale=en">Opponents</a>
-                </span>
-                <strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="opponent_name__status">Not started</strong>
-              </li>
-            RESULT
-          end
-          let(:opponent) { create(:opponent, :for_organisation, legal_aid_application:) }
+    let(:legal_aid_application) { create(:legal_aid_application, :with_multiple_proceedings_inc_section8) }
+    let(:task_name) { :opponent_name }
 
-          it "returns a link" do
-            expect(helper.task_list_item(name: :opponent_name,
-                                         status: :not_started,
-                                         legal_aid_application:,
-                                         ccms_code: nil)).to eq expected
-          end
-        end
+    before do
+      create(:legal_framework_merits_task_list, :da001, legal_aid_application:)
+    end
 
-        context "with an opponent already added" do
-          let(:expected) do
-            <<~RESULT
-              <li class="app-task-list__item">
-                <span class="app-task-list__task-name">
-                    <a aria_describedby="opponent_name-status" aria-label="Opponents" class="govuk-link" href="/providers/applications/#{legal_aid_application.id}/has_other_opponent?locale=en">Opponents</a>
-                </span>
-                <strong class="govuk-tag app-task-list__tag" id="opponent_name__status">Completed</strong>
-              </li>
-            RESULT
-          end
+    context "when task name is included in list of required tasks from LFA" do
+      let(:task_name) { :opponent_name }
 
-          it "returns a link" do
-            create(:opponent, :for_individual, legal_aid_application:)
-            expect(helper.task_list_item(name: :opponent_name,
-                                         status: :complete,
-                                         legal_aid_application:,
-                                         ccms_code: nil)).to eq expected
-          end
-        end
-      end
+      it { is_expected.to be_truthy }
+    end
+
+    context "when task name is NOT included in list of required tasks from LFA" do
+      let(:task_name) { :why_matter_opposed }
+
+      it { is_expected.to be_falsey }
     end
   end
 end

--- a/spec/models/setting_spec.rb
+++ b/spec/models/setting_spec.rb
@@ -13,7 +13,6 @@ RSpec.describe Setting do
         expect(rec.bank_transaction_filename).to eq "db/sample_data/bank_transactions.csv"
         expect(rec.alert_via_sentry?).to be true
         expect(rec.partner_means_assessment?).to be false
-        expect(rec.opponent_organisations?).to be false
         expect(rec.linked_applications?).to be false
       end
     end
@@ -28,7 +27,6 @@ RSpec.describe Setting do
           bank_transaction_filename: "my_special_file.csv",
           alert_via_sentry: true,
           partner_means_assessment: true,
-          opponent_organisations: true,
           linked_applications: true,
         )
       end
@@ -42,7 +40,6 @@ RSpec.describe Setting do
         expect(rec.bank_transaction_filename).to eq "my_special_file.csv"
         expect(rec.alert_via_sentry?).to be true
         expect(rec.partner_means_assessment?).to be true
-        expect(rec.opponent_organisations?).to be true
         expect(rec.linked_applications?).to be true
       end
     end
@@ -59,7 +56,6 @@ RSpec.describe Setting do
       expect(described_class.bank_transaction_filename).to eq "db/sample_data/bank_transactions.csv"
       expect(described_class.alert_via_sentry?).to be true
       expect(described_class.partner_means_assessment?).to be false
-      expect(described_class.opponent_organisations?).to be false
       expect(described_class.linked_applications?).to be false
     end
   end

--- a/spec/requests/admin/settings_controller_spec.rb
+++ b/spec/requests/admin/settings_controller_spec.rb
@@ -41,7 +41,6 @@ RSpec.describe Admin::SettingsController do
           allow_welsh_translation: "true",
           enable_ccms_submission: "true",
           partner_means_assessment: "true",
-          opponent_organisations: "true",
           linked_applications: "true",
         },
       }
@@ -57,7 +56,6 @@ RSpec.describe Admin::SettingsController do
       expect(setting.mock_true_layer_data?).to be(true)
       expect(setting.allow_welsh_translation?).to be(true)
       expect(setting.partner_means_assessment?).to be(true)
-      expect(setting.opponent_organisations?).to be(true)
       expect(setting.linked_applications?).to be(true)
     end
 

--- a/spec/requests/providers/application_merits_task/domestic_abuse_summaries_controller_spec.rb
+++ b/spec/requests/providers/application_merits_task/domestic_abuse_summaries_controller_spec.rb
@@ -98,9 +98,9 @@ module Providers
         context "when the first task is complete" do
           before { legal_aid_application.legal_framework_merits_task_list.mark_as_complete!(:application, :latest_incident_details) }
 
-          it "redirects to the next incomplete question" do
+          it "redirects to the next incomplete question, opponent types" do
             patch_das
-            expect(response).to redirect_to(new_providers_legal_aid_application_opponent_individual_path(legal_aid_application))
+            expect(response).to redirect_to(providers_legal_aid_application_opponent_type_path(legal_aid_application))
           end
         end
 

--- a/spec/requests/providers/application_merits_task/remove_opponent_controller_spec.rb
+++ b/spec/requests/providers/application_merits_task/remove_opponent_controller_spec.rb
@@ -38,29 +38,16 @@ module Providers
           end
 
           context "and it is the only opponent on the application" do
-            context "with opponent organisations flag enabled" do
-              before { allow(Setting).to receive(:opponent_organisations?).and_return(true) }
-
-              it "redirects to the choose opponent type page" do
-                submit_remove
-                expect(response).to redirect_to(providers_legal_aid_application_opponent_type_path(application))
-              end
-            end
-
-            context "with opponent organisations flag disabled" do
-              before { allow(Setting).to receive(:opponent_organisations?).and_return(false) }
-
-              it "redirects to the add new opponent individual page" do
-                submit_remove
-                expect(response).to redirect_to(new_providers_legal_aid_application_opponent_individual_path(application))
-              end
+            it "redirects to the choose opponent type page" do
+              submit_remove
+              expect(response).to redirect_to(providers_legal_aid_application_opponent_type_path(application))
             end
           end
 
           context "and another opponent exists" do
             before { create(:opponent, legal_aid_application: application) }
 
-            it "redirects back to the has_other_involved_children page" do
+            it "redirects to the has_other_opponent page" do
               submit_remove
               expect(response).to redirect_to(providers_legal_aid_application_has_other_opponent_path(application))
             end


### PR DESCRIPTION

## What
Remove opponent organisations feature flag

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4452)

The feature has been live since 04/10/2023 so we can get rid 
of the feature flag.

- [X] Remove opponent organisations feature flag
- [X] Remove flag from flows and amend controller specs inline
- [X] Remove flag from task list helper and refactor
- [x] Remove flag feature tests and amend scenarios inline with new flows

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
