### PR TITLE
Rubocop: Final removal of NamedSubject exclusions

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -110,32 +110,6 @@ RSpec/LetSetup:
     - 'spec/workers/bank_holiday_update_worker_spec.rb'
     - 'spec/workers/true_layer_banks_update_worker_spec.rb'
 
-# Offense count: 90
-# Configuration parameters: EnforcedStyle, IgnoreSharedExamples.
-# SupportedStyles: always, named_only
-RSpec/NamedSubject:
-  Exclude:
-    - 'spec/services/page_history_service_spec.rb'
-    - 'spec/services/pdf_converter_spec.rb'
-    - 'spec/services/populators/transaction_type_populator_spec.rb'
-    - 'spec/services/provider_after_login_service_spec.rb'
-    - 'spec/services/provider_details_retriever_spec.rb'
-    - 'spec/services/provider_email_service_spec.rb'
-    - 'spec/services/reports/bank_transactions/bank_transaction_report_creator_spec.rb'
-    - 'spec/services/reports/merits_report_creator_spec.rb'
-    - 'spec/services/reports/mis/non_passported_application_csv_line_spec.rb'
-    - 'spec/services/reports/reports_creator_spec.rb'
-    - 'spec/services/required_document_category_analyser_spec.rb'
-    - 'spec/services/submit_application_reminder_service_spec.rb'
-    - 'spec/services/submit_provider_reminder_service_spec.rb'
-    - 'spec/services/substantive_application_deadline_calculator_spec.rb'
-    - 'spec/services/true_layer/api_client_mock_spec.rb'
-    - 'spec/services/true_layer/banks_retriever_spec.rb'
-    - 'spec/services/true_layer/importers/import_account_balance_service_spec.rb'
-    - 'spec/services/true_layer/importers/import_account_holders_service_spec.rb'
-    - 'spec/services/true_layer/importers/import_accounts_service_spec.rb'
-    - 'spec/services/true_layer_error_decoder_spec.rb'
-
 # Offense count: 16
 RSpec/RepeatedDescription:
   Exclude:
@@ -153,7 +127,6 @@ RSpec/RepeatedExample:
     - 'spec/requests/providers/means/savings_and_investments_spec.rb'
     - 'spec/requests/providers/offline_accounts_spec.rb'
     - 'spec/services/ccms/requestors/case_add_requestor_xml_blocks/passported_attributes_spec.rb'
-    - 'spec/services/provider_after_login_service_spec.rb'
 
 # Offense count: 20
 RSpec/RepeatedExampleGroupDescription:
@@ -198,7 +171,6 @@ RSpec/StubbedMock:
     - 'spec/services/digest_exporter_spec.rb'
     - 'spec/services/govuk_emails/delivery_man_spec.rb'
     - 'spec/services/metrics/send_metrics_spec.rb'
-    - 'spec/services/provider_after_login_service_spec.rb'
     - 'spec/services/reports/mis/application_details_report_spec.rb'
     - 'spec/services/true_layer/api_client_mock_spec.rb'
 

--- a/spec/services/page_history_service_spec.rb
+++ b/spec/services/page_history_service_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe PageHistoryService do
-  subject { described_class.new(page_history_id:) }
+  subject(:page_history_service) { described_class.new(page_history_id:) }
 
   let!(:redis) { Redis.new(url: Rails.configuration.x.redis.page_history_url) }
   let(:page_history_id) { SecureRandom.uuid }
@@ -13,7 +13,7 @@ RSpec.describe PageHistoryService do
   after { redis.quit }
 
   describe "#write" do
-    before { subject.write(page_history) }
+    before { page_history_service.write(page_history) }
 
     it "creates a history record with the correct key" do
       expect(redis.keys).to eq [key]
@@ -28,7 +28,7 @@ RSpec.describe PageHistoryService do
     before { redis.set(key, page_history) }
 
     it "returns the correct history record" do
-      expect(JSON.parse(subject.read)).to eq page_history
+      expect(JSON.parse(page_history_service.read)).to eq page_history
     end
   end
 end

--- a/spec/services/pdf_converter_spec.rb
+++ b/spec/services/pdf_converter_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 FileStruct = Struct.new(:name, :content_type)
 
 RSpec.describe PdfConverter do
-  subject do
+  subject(:call) do
     described_class.call(attachment.id)
   end
 
@@ -24,11 +24,11 @@ RSpec.describe PdfConverter do
       context "when original file is already a pdf" do
         it "does not convert the file" do
           expect(Libreconv).not_to receive(:convert)
-          subject
+          call
         end
 
         it "creates an attachment record for the pdf" do
-          expect { subject }.to change(Attachment, :count).by 1
+          expect { call }.to change(Attachment, :count).by 1
         end
       end
 
@@ -37,13 +37,13 @@ RSpec.describe PdfConverter do
 
         it "converts the file to pdf" do
           expect(Libreconv).to receive(:convert)
-          expect { subject }.to change(ActiveStorage::Attachment, :count).by(1)
+          expect { call }.to change(ActiveStorage::Attachment, :count).by(1)
           pdf_attachment = statement_of_case.pdf_attachments.first
           expect(pdf_attachment.attachment_name).to eq "statement_of_case.pdf"
         end
 
         it "relates the pdf record to the original file" do
-          subject
+          call
           pdf_attachment = statement_of_case.pdf_attachments.first
           attachment = statement_of_case.original_attachments.first
           expect(attachment.pdf_attachment_id).to eq pdf_attachment.id
@@ -54,14 +54,14 @@ RSpec.describe PdfConverter do
 
           it "converts the file to pdf" do
             expect(Libreconv).to receive(:convert)
-            expect { subject }.to change(ActiveStorage::Attachment, :count).by(1)
+            expect { call }.to change(ActiveStorage::Attachment, :count).by(1)
             pdf_attachment = statement_of_case.pdf_attachments.first
             expect(pdf_attachment.attachment_name).to eq "statement_of_case_2.pdf"
             expect(pdf_attachment.attachment_type).to eq "statement_of_case_pdf"
           end
 
           it "relates the pdf record to the original file" do
-            subject
+            call
             pdf_attachment = statement_of_case.pdf_attachments.first
             attachment = statement_of_case.original_attachments.first
             expect(attachment.pdf_attachment_id).to eq pdf_attachment.id
@@ -86,11 +86,11 @@ RSpec.describe PdfConverter do
       context "and original file is already a pdf" do
         it "does not convert the file" do
           expect(Libreconv).not_to receive(:convert)
-          subject
+          call
         end
 
         it "creates an attachment record for the pdf" do
-          expect { subject }.to change(Attachment, :count).by 1
+          expect { call }.to change(Attachment, :count).by 1
         end
       end
 
@@ -99,13 +99,13 @@ RSpec.describe PdfConverter do
 
         it "converts the file to pdf" do
           expect(Libreconv).to receive(:convert)
-          expect { subject }.to change(ActiveStorage::Attachment, :count).by(1)
+          expect { call }.to change(ActiveStorage::Attachment, :count).by(1)
           pdf_attachment = uploaded_evidence_collection.legal_aid_application.attachments.where(attachment_type: "gateway_evidence_pdf").first
           expect(pdf_attachment.attachment_name).to eq "gateway_evidence.pdf"
         end
 
         it "relates the pdf record to the original file" do
-          subject
+          call
           pdf_attachment = uploaded_evidence_collection.legal_aid_application.attachments.where(attachment_type: "gateway_evidence_pdf").first
           attachment = uploaded_evidence_collection.legal_aid_application.attachments.where(attachment_type: "gateway_evidence").first
           expect(attachment.pdf_attachment_id).to eq pdf_attachment.id
@@ -116,14 +116,14 @@ RSpec.describe PdfConverter do
 
           it "converts the file to pdf" do
             expect(Libreconv).to receive(:convert)
-            expect { subject }.to change(ActiveStorage::Attachment, :count).by(1)
+            expect { call }.to change(ActiveStorage::Attachment, :count).by(1)
             pdf_attachment = uploaded_evidence_collection.legal_aid_application.attachments.where(attachment_type: "gateway_evidence_pdf").first
             expect(pdf_attachment.attachment_name).to eq "gateway_evidence_2.pdf"
             expect(pdf_attachment.attachment_type).to eq "gateway_evidence_pdf"
           end
 
           it "relates the pdf record to the original file" do
-            subject
+            call
             pdf_attachment = uploaded_evidence_collection.legal_aid_application.attachments.where(attachment_type: "gateway_evidence_pdf").first
             attachment = uploaded_evidence_collection.legal_aid_application.attachments.where(attachment_type: "gateway_evidence").first
             expect(attachment.pdf_attachment_id).to eq pdf_attachment.id

--- a/spec/services/populators/transaction_type_populator_spec.rb
+++ b/spec/services/populators/transaction_type_populator_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 module Populators
   RSpec.describe TransactionTypePopulator do
     describe ".call" do
-      subject { described_class.call }
+      subject(:call) { described_class.call }
 
       let(:names) { TransactionType::NAMES }
       let(:credit_names) { names[:credit] }
@@ -12,11 +12,11 @@ module Populators
       let(:archived_credit_names) { %i[student_loan] }
 
       it "creates instances from names" do
-        expect { subject }.to change(TransactionType, :count).by(total)
+        expect { call }.to change(TransactionType, :count).by(total)
       end
 
       it "assigns the names to the correct operation" do
-        subject
+        call
         expect(TransactionType.debits.count).to eq(debit_names.length)
         expect(TransactionType.credits.count).to eq(credit_names.length - archived_credit_names.length)
         expect(debit_names.map(&:to_s)).to include(TransactionType.debits.first.name)
@@ -28,15 +28,15 @@ module Populators
         let!(:debit_transaction_type) { create(:transaction_type, :debit_with_standard_name) }
 
         it "creates one less transaction type" do
-          expect { subject }.to change(TransactionType, :count).by(total - 2)
+          expect { call }.to change(TransactionType, :count).by(total - 2)
         end
       end
 
       context "when run twice" do
         it "creates the same total number of instancees" do
           expect {
-            subject
-            subject
+            call
+            call
           }.to change(TransactionType, :count).by(total)
         end
       end
@@ -45,12 +45,12 @@ module Populators
         let!(:old_transaction_type) { create(:transaction_type, name: :council_tax) }
 
         it "sets the archived_at date in the database" do
-          subject
+          call
           expect(TransactionType.find_by(name: "council_tax").archived_at).not_to be_nil
         end
 
         it "does not set the archived_at date in the database for active transaction types" do
-          subject
+          call
           active_names = names.values.flatten - archived_credit_names
           active_names.each do |transaction_name|
             expect(TransactionType.find_by(name: transaction_name).archived_at).to be_nil
@@ -61,10 +61,10 @@ module Populators
 
     describe ".call(:without_income)" do
       # this is called from an old migration
-      subject { described_class.call(:without_income) }
+      subject(:call) { described_class.call(:without_income) }
 
       it "does not attempt to update other_income fields" do
-        subject
+        call
         expect(TransactionType.where(other_income: true).count).to eq 0
       end
     end

--- a/spec/services/provider_after_login_service_spec.rb
+++ b/spec/services/provider_after_login_service_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe ProviderAfterLoginService do
-  subject { service.call }
+  subject(:call) { service.call }
 
   let(:service) { described_class.new(provider) }
 
@@ -12,7 +12,7 @@ RSpec.describe ProviderAfterLoginService do
       before { allow(Rails.configuration.x.laa_portal).to receive(:mock_saml).and_return(false) }
 
       it "updates the provider invalid login details" do
-        subject
+        call
         expect(provider.invalid_login_details).to eq "role"
       end
     end
@@ -24,7 +24,7 @@ RSpec.describe ProviderAfterLoginService do
         before { allow(ProviderDetailsCreator).to receive(:call).and_raise(ProviderDetailsRetriever::ApiRecordNotFoundError) }
 
         it "updates the provider invalid login details" do
-          subject
+          call
           expect(provider.invalid_login_details).to eq "api_details_user_not_found"
         end
       end
@@ -33,12 +33,7 @@ RSpec.describe ProviderAfterLoginService do
         before { allow(ProviderDetailsCreator).to receive(:call).with(provider) }
 
         it "does not update invalid login details" do
-          subject
-          expect(provider.invalid_login_details).to be_nil
-        end
-
-        it "clears the invalid_login_details_field" do
-          subject
+          call
           expect(provider.invalid_login_details).to be_nil
         end
       end
@@ -47,7 +42,7 @@ RSpec.describe ProviderAfterLoginService do
         before { allow(ProviderDetailsCreator).to receive(:call).and_raise(ProviderDetailsRetriever::ApiError) }
 
         it "updates the provider invalid login details" do
-          subject
+          call
           expect(provider.invalid_login_details).to eq "provider_details_api_error"
         end
       end

--- a/spec/services/provider_details_retriever_spec.rb
+++ b/spec/services/provider_details_retriever_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 DummyResponseStruct = Struct.new(:message, :code, :body)
 
 RSpec.describe ProviderDetailsRetriever do
-  subject { described_class.call(username) }
+  subject(:call) { described_class.call(username) }
 
   let(:api_url) { "https://ccms-pda.stg.legalservices.gov.uk/api/providerDetails" }
   let(:provider) { create(:provider) }
@@ -16,10 +16,10 @@ RSpec.describe ProviderDetailsRetriever do
     shared_examples_for "get response from API" do
       it "returns the expected data structure" do
         expected_keys = %i[providerFirmId contactUserId contacts providerOffices feeEarners]
-        expect(subject.keys).to match_array(expected_keys)
+        expect(call.keys).to match_array(expected_keys)
 
         expected_office_keys = %i[id name]
-        expect(subject[:providerOffices][0].keys).to match_array(expected_office_keys)
+        expect(call[:providerOffices][0].keys).to match_array(expected_office_keys)
       end
     end
 
@@ -27,7 +27,7 @@ RSpec.describe ProviderDetailsRetriever do
       it "raises ApiError" do
         allow(Net::HTTP).to receive(:get_response).and_raise(RuntimeError, "Something went wrong")
         expect {
-          subject
+          call
         }.to raise_error(ProviderDetailsRetriever::ApiError, "Provider details error: RuntimeError :: Something went wrong")
       end
     end
@@ -40,7 +40,7 @@ RSpec.describe ProviderDetailsRetriever do
 
       it "encode properly the username" do
         expect(URI).to receive(:parse).at_least(:once).with(/#{escaped_username}/).and_call_original
-        subject
+        call
       end
 
       context "and the username has a space", vcr: { cassette_name: "encoded_provider_details_api" } do
@@ -49,7 +49,7 @@ RSpec.describe ProviderDetailsRetriever do
 
         it "encodes with a %20 in place of a space" do
           expect(URI).to receive(:parse).at_least(:once).with(/#{escaped_username}/).and_call_original
-          subject
+          call
         end
       end
 
@@ -59,7 +59,7 @@ RSpec.describe ProviderDetailsRetriever do
         end
 
         it "raises error" do
-          expect { subject }.to raise_error(described_class::ApiError)
+          expect { call }.to raise_error(described_class::ApiError)
         end
       end
     end

--- a/spec/services/provider_email_service_spec.rb
+++ b/spec/services/provider_email_service_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 require "sidekiq/testing"
 
 RSpec.describe ProviderEmailService do
-  subject { described_class.new(application) }
+  subject(:provider_email_service) { described_class.new(application) }
 
   let(:applicant) { create(:applicant, first_name: "John", last_name: "Doe") }
   let(:provider) { create(:provider, email: "test@example.com") }
@@ -20,7 +20,7 @@ RSpec.describe ProviderEmailService do
     end
 
     it "schedules a mail for immediate delivery" do
-      expect { subject.send_email }.to change(ScheduledMailing, :count).by(1)
+      expect { provider_email_service.send_email }.to change(ScheduledMailing, :count).by(1)
 
       rec = ScheduledMailing.first
       expect(rec.legal_aid_application_id).to eq application.id

--- a/spec/services/reports/bank_transactions/bank_transaction_report_creator_spec.rb
+++ b/spec/services/reports/bank_transactions/bank_transaction_report_creator_spec.rb
@@ -26,10 +26,10 @@ module Reports
 
       describe ".call" do
         context "when there is no local_csv param" do
-          subject { described_class.call(legal_aid_application) }
+          subject(:call) { described_class.call(legal_aid_application) }
 
           it "attaches bank_transaction_report.csv to the application" do
-            subject
+            call
             legal_aid_application.reload
             expect(legal_aid_application.bank_transaction_report.document.content_type).to eq("text/csv")
             expect(legal_aid_application.bank_transaction_report.document.filename).to eq("bank_transaction_report.csv")
@@ -38,20 +38,20 @@ module Reports
           context "and the report already exists" do
             it "does not attach a report" do
               create(:attachment, :bank_transaction_report, legal_aid_application:)
-              expect { subject }.not_to change(Attachment, :count)
+              expect { call }.not_to change(Attachment, :count)
             end
           end
         end
 
         context "when there is a local_csv param" do
-          subject { creator.call(local_csv: true) }
+          subject(:call) { creator.call(local_csv: true) }
 
           let(:creator) { described_class.new(legal_aid_application) }
           let(:tempfile) { Rails.root.join("tmp/bank_transactions.csv") }
 
           it "creates a local file" do
             FileUtils.rm_rf(tempfile)
-            subject
+            call
             expect(File.exist?(tempfile)).to be true
           end
         end

--- a/spec/services/reports/merits_report_creator_spec.rb
+++ b/spec/services/reports/merits_report_creator_spec.rb
@@ -1,8 +1,8 @@
 require "rails_helper"
 
 RSpec.describe Reports::MeritsReportCreator do
-  subject do
-    # dont' match on path - webpacker keeps changing the second part of the path
+  subject(:call) do
+    # don't match on path - webpacker keeps changing the second part of the path
     VCR.use_cassette("stylesheets2", match_requests_on: %i[method host headers]) do
       described_class.call(legal_aid_application)
     end
@@ -29,7 +29,7 @@ RSpec.describe Reports::MeritsReportCreator do
   describe ".call" do
     it "attaches merits_report.pdf to the application" do
       expect(Providers::MeritsReportsController.renderer).to receive(:render).and_call_original
-      subject
+      call
       legal_aid_application.reload
       expect(legal_aid_application.merits_report.document.content_type).to eq("application/pdf")
       expect(legal_aid_application.merits_report.document.filename).to eq("merits_report.pdf")
@@ -42,7 +42,7 @@ RSpec.describe Reports::MeritsReportCreator do
       before { allow(Rails.logger).to receive(:info) }
 
       it "does not attach a report if one already exists" do
-        expect { subject }.not_to change(Attachment, :count)
+        expect { call }.not_to change(Attachment, :count)
         expect(Rails.logger).to have_received(:info).with(expected_log).once
       end
 
@@ -56,7 +56,7 @@ RSpec.describe Reports::MeritsReportCreator do
 
         it "creates a new report if the existing one is not downloadable" do
           # the count won';'t change as we delete one and create one
-          expect { subject }.not_to change(Attachment, :count)
+          expect { call }.not_to change(Attachment, :count)
           # check the original one has been deleted
           expect { attachment.reload }.to raise_error(ActiveRecord::RecordNotFound)
           expect(Rails.logger).to have_received(:info).with(expected_log)
@@ -88,7 +88,7 @@ RSpec.describe Reports::MeritsReportCreator do
 
       it "processes the existing ccms submission" do
         expect(legal_aid_application.reload.ccms_submission).to receive(:process!)
-        subject
+        call
       end
 
       context "and the ccms submission does not exist" do
@@ -115,7 +115,7 @@ RSpec.describe Reports::MeritsReportCreator do
         it "creates a ccms submission" do
           expect(legal_aid_application.reload).to receive(:create_ccms_submission)
           expect_any_instance_of(described_class).to receive(:process_ccms_submission)
-          subject
+          call
         end
       end
     end

--- a/spec/services/reports/mis/non_passported_application_csv_line_spec.rb
+++ b/spec/services/reports/mis/non_passported_application_csv_line_spec.rb
@@ -25,7 +25,7 @@ module Reports
       end
 
       describe ".call" do
-        subject { described_class.call(application) }
+        subject(:call) { described_class.call(application) }
 
         let(:application) { create(:legal_aid_application, :with_applicant, :at_assessment_submitted) }
         let(:provider) { application.provider }
@@ -33,13 +33,13 @@ module Reports
         let(:time) { Time.zone.local(2020, 9, 20, 2, 3, 44) }
 
         it "returns an array of nine fields" do
-          expect(subject.size).to eq 8
+          expect(call.size).to eq 8
         end
 
         context "when it's an undiscarded application" do
           it "returns an array with the expected values" do
             travel_to(time) do
-              fields = subject
+              fields = call
               expect(fields[0]).to eq application.state
               expect(fields[1]).to eq application.ccms_reason
               expect(fields[2]).to eq provider.username
@@ -57,7 +57,7 @@ module Reports
 
           it "returns an array with the expected values" do
             travel_to(time) do
-              fields = subject
+              fields = call
               expect(fields[0]).to eq application.state
               expect(fields[1]).to eq application.ccms_reason
               expect(fields[2]).to eq provider.username
@@ -74,7 +74,7 @@ module Reports
           before { provider.email = "=malicious_code" }
 
           it "returns the escaped text" do
-            expect(subject[3]).to eq "'=malicious_code"
+            expect(call[3]).to eq "'=malicious_code"
           end
         end
       end

--- a/spec/services/reports/reports_creator_spec.rb
+++ b/spec/services/reports/reports_creator_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Reports::ReportsCreator do
-  subject { described_class.call(legal_aid_application) }
+  subject(:call) { described_class.call(legal_aid_application) }
 
   let(:legal_aid_application) do
     create(:legal_aid_application,
@@ -17,7 +17,7 @@ RSpec.describe Reports::ReportsCreator do
       expect(Reports::MeritsReportCreator).to receive(:call).with(legal_aid_application)
       expect(Reports::MeansReportCreator).to receive(:call).with(legal_aid_application)
       expect(Reports::BankTransactions::BankTransactionReportCreator).not_to receive(:call).with(legal_aid_application)
-      subject
+      call
       legal_aid_application.reload
       expect(legal_aid_application.state).to eq("submitting_assessment")
     end
@@ -37,7 +37,7 @@ RSpec.describe Reports::ReportsCreator do
         expect(Reports::MeritsReportCreator).to receive(:call).with(legal_aid_application)
         expect(Reports::MeansReportCreator).to receive(:call).with(legal_aid_application)
         expect(Reports::BankTransactions::BankTransactionReportCreator).to receive(:call).with(legal_aid_application)
-        subject
+        call
         legal_aid_application.reload
         expect(legal_aid_application.state).to eq("submitting_assessment")
       end

--- a/spec/services/required_document_category_analyser_spec.rb
+++ b/spec/services/required_document_category_analyser_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe RequiredDocumentCategoryAnalyser do
   before { DocumentCategoryPopulator.call }
 
   describe "#call" do
-    subject { described_class.call(application) }
+    subject(:call) { described_class.call(application) }
 
     context "when the application has dwp result overriden" do
       let(:dwp_override) { create(:dwp_override, :with_evidence) }
@@ -12,13 +12,13 @@ RSpec.describe RequiredDocumentCategoryAnalyser do
 
       context "when the provider has evidence of benefits" do
         it "updates the required_document_categories with benefit_evidence" do
-          subject
+          call
           expect(application.required_document_categories).to eq %w[benefit_evidence]
         end
 
         it "overwrites any existing required_document_categories" do
           application.update!(required_document_categories: %w[gateway_evidence])
-          subject
+          call
           expect(application.required_document_categories).to eq %w[benefit_evidence]
         end
       end
@@ -27,7 +27,7 @@ RSpec.describe RequiredDocumentCategoryAnalyser do
         let(:dwp_override) { create(:dwp_override, :with_no_evidence) }
 
         it "does not update the required_document_categories with benefit_evidence" do
-          subject
+          call
           expect(application.required_document_categories).to be_empty
         end
       end
@@ -37,7 +37,7 @@ RSpec.describe RequiredDocumentCategoryAnalyser do
       let(:application) { create(:legal_aid_application, :with_multiple_proceedings_inc_section8) }
 
       it "updates the required_document_categories with gateway_evidence" do
-        subject
+        call
         expect(application.required_document_categories).to eq %w[gateway_evidence]
       end
     end
@@ -47,7 +47,7 @@ RSpec.describe RequiredDocumentCategoryAnalyser do
       let(:application) { create(:legal_aid_application, :with_multiple_proceedings_inc_section8, dwp_override:) }
 
       it "updates the required_document_categories with gateway_evidence" do
-        subject
+        call
         expect(application.required_document_categories).to eq %w[benefit_evidence gateway_evidence]
       end
     end
@@ -56,7 +56,7 @@ RSpec.describe RequiredDocumentCategoryAnalyser do
       let(:application) { create(:legal_aid_application) }
 
       it "updates the required_document_categories with an empty array" do
-        subject
+        call
         expect(application.required_document_categories).to eq []
       end
     end
@@ -65,7 +65,7 @@ RSpec.describe RequiredDocumentCategoryAnalyser do
       let(:application) { create(:legal_aid_application, extra_employment_information_details: "test details") }
 
       it "updates the required_document_categories with employment_evidence" do
-        subject
+        call
         expect(application.required_document_categories).to eq %w[employment_evidence]
       end
     end
@@ -74,7 +74,7 @@ RSpec.describe RequiredDocumentCategoryAnalyser do
       let(:application) { create(:legal_aid_application, :with_opponents_application_proceeding) }
 
       it "updates the required_document_categories with court_application_or_order" do
-        subject
+        call
         expect(application.required_document_categories).to eq %w[court_application_or_order]
       end
     end
@@ -83,7 +83,7 @@ RSpec.describe RequiredDocumentCategoryAnalyser do
       let(:application) { create(:legal_aid_application, :with_final_hearing_proceeding) }
 
       it "updates the required_document_categories with court_order and expert_report" do
-        subject
+        call
         expect(application.required_document_categories).to match_array %w[court_order expert_report]
       end
     end
@@ -92,7 +92,7 @@ RSpec.describe RequiredDocumentCategoryAnalyser do
       let(:application) { create(:legal_aid_application, :with_opponents_application_proceeding, :with_final_hearing_proceeding) }
 
       it "updates the required_document_categories with court_order and expert_report" do
-        subject
+        call
         expect(application.required_document_categories).to match_array %w[court_application court_order expert_report]
       end
     end

--- a/spec/services/submit_application_reminder_service_spec.rb
+++ b/spec/services/submit_application_reminder_service_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 require "sidekiq/testing"
 
 RSpec.describe SubmitApplicationReminderService, :vcr do
-  subject { described_class.new(application) }
+  subject(:submit_application_reminder_service) { described_class.new(application) }
 
   let(:provider) { create(:provider, email: "test@example.com") }
   let(:application) do
@@ -19,7 +19,7 @@ RSpec.describe SubmitApplicationReminderService, :vcr do
 
   describe "#send_email" do
     it "creates two scheduled mailing records" do
-      expect { subject.send_email }.to change(ScheduledMailing, :count).by(2)
+      expect { submit_application_reminder_service.send_email }.to change(ScheduledMailing, :count).by(2)
     end
 
     describe "sending the email" do
@@ -38,16 +38,16 @@ RSpec.describe SubmitApplicationReminderService, :vcr do
     end
 
     context "when SubmitApplicationReminderMailer already exists" do
-      before { subject.send_email }
+      before { submit_application_reminder_service.send_email }
 
       it "adds two new mailer jobs" do
-        expect { subject.send_email }.to change(ScheduledMailing, :count).by(2)
+        expect { submit_application_reminder_service.send_email }.to change(ScheduledMailing, :count).by(2)
       end
 
       it "cancels pre-existing jobs" do
         expect(ScheduledMailing.where(cancelled_at: nil).count).to eq(2)
         expect(ScheduledMailing.count).to eq(2)
-        subject.send_email
+        submit_application_reminder_service.send_email
         expect(ScheduledMailing.where.not(cancelled_at: nil).count).to eq(2)
         expect(ScheduledMailing.count).to eq(4)
       end

--- a/spec/services/submit_provider_reminder_service_spec.rb
+++ b/spec/services/submit_provider_reminder_service_spec.rb
@@ -2,15 +2,13 @@ require "rails_helper"
 require "sidekiq/testing"
 
 RSpec.describe SubmitProviderReminderService, :vcr do
-  subject { described_class.new(application) }
-
   let(:provider) { create(:provider, email: "test@example.com") }
   let(:application) { create(:application, :with_applicant, provider:) }
   let(:application_url) { "http://test.com" }
 
   describe "#send_email" do
     it "creates two scheduled mailing records" do
-      expect { subject.send_email }.to change(ScheduledMailing, :count).by(1)
+      expect { described_class.new(application).send_email }.to change(ScheduledMailing, :count).by(1)
     end
 
     describe "sending the email" do

--- a/spec/services/substantive_application_deadline_calculator_spec.rb
+++ b/spec/services/substantive_application_deadline_calculator_spec.rb
@@ -3,13 +3,13 @@ require "rails_helper"
 
 RSpec.describe SubstantiveApplicationDeadlineCalculator, :vcr do
   describe ".call" do
-    subject { described_class.call(df_date) }
+    subject(:call) { described_class.call(df_date) }
 
     context "when passed the regular 4 weeks" do
       let(:df_date) { Date.new(2021, 2, 26) }
 
       it "returns a date 20 working days after" do
-        expect(subject).to eq Date.new(2021, 3, 26)
+        expect(call).to eq Date.new(2021, 3, 26)
       end
     end
 
@@ -17,7 +17,7 @@ RSpec.describe SubstantiveApplicationDeadlineCalculator, :vcr do
       let(:df_date) { Date.new(2020, 12, 15) }
 
       it "returns a date taking bank holidays into account" do
-        expect(subject).to eq Date.new(2021, 1, 15)
+        expect(call).to eq Date.new(2021, 1, 15)
       end
     end
   end

--- a/spec/services/true_layer/api_client_mock_spec.rb
+++ b/spec/services/true_layer/api_client_mock_spec.rb
@@ -1,28 +1,28 @@
 require "rails_helper"
 
 RSpec.describe TrueLayer::ApiClientMock do
-  subject { described_class.new(SecureRandom.hex) }
+  subject(:api_client_mock) { described_class.new(SecureRandom.hex) }
 
   describe "#provider" do
     it "returns sample data" do
-      expect(subject.provider.value).to eq(TrueLayer::SampleData::PROVIDERS)
+      expect(api_client_mock.provider.value).to eq(TrueLayer::SampleData::PROVIDERS)
     end
   end
 
   describe "#account_holders" do
     it "returns sample data" do
-      expect(subject.account_holders.value).to eq(TrueLayer::SampleData::ACCOUNT_HOLDERS)
+      expect(api_client_mock.account_holders.value).to eq(TrueLayer::SampleData::ACCOUNT_HOLDERS)
     end
   end
 
   describe "#accounts" do
     it "returns sample data" do
-      expect(subject.accounts.value).to eq(TrueLayer::SampleData::ACCOUNTS)
+      expect(api_client_mock.accounts.value).to eq(TrueLayer::SampleData::ACCOUNTS)
     end
   end
 
   describe "#transactions" do
-    let(:result) { subject.transactions.value }
+    let(:result) { api_client_mock.transactions.value }
 
     it "returns sample data" do
       expect(result).not_to be_empty
@@ -35,7 +35,7 @@ RSpec.describe TrueLayer::ApiClientMock do
     end
 
     it "always returns the same data" do
-      second_result = subject.transactions.value
+      second_result = api_client_mock.transactions.value
       expect(result).to eq(second_result)
     end
 
@@ -90,7 +90,7 @@ RSpec.describe TrueLayer::ApiClientMock do
 
   describe "#account_balance" do
     it "returns sample data" do
-      expect(subject.account_balance.value).to eq(TrueLayer::SampleData::BALANCES)
+      expect(api_client_mock.account_balance.value).to eq(TrueLayer::SampleData::BALANCES)
     end
   end
 end

--- a/spec/services/true_layer/banks_retriever_spec.rb
+++ b/spec/services/true_layer/banks_retriever_spec.rb
@@ -1,11 +1,11 @@
 require "rails_helper"
 
 RSpec.describe TrueLayer::BanksRetriever, vcr: { cassette_name: "true_layer_banks_api", allow_playback_repeats: true } do
-  subject { described_class.new }
+  subject(:banks_retriever) { described_class.new }
 
   describe ".banks" do
     it "returns same as instance banks" do
-      expect(described_class.banks).to eq(subject.banks)
+      expect(described_class.banks).to eq(banks_retriever.banks)
     end
 
     context "when there is a failure" do
@@ -22,7 +22,7 @@ RSpec.describe TrueLayer::BanksRetriever, vcr: { cassette_name: "true_layer_bank
   end
 
   describe "#banks" do
-    let(:banks) { subject.banks }
+    let(:banks) { banks_retriever.banks }
 
     it "is an array" do
       expect(banks).to be_a(Array)

--- a/spec/services/true_layer/importers/import_account_balance_service_spec.rb
+++ b/spec/services/true_layer/importers/import_account_balance_service_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe TrueLayer::Importers::ImportAccountBalanceService do
   let(:api_client) { TrueLayer::ApiClient.new(SecureRandom.hex) }
 
   describe "#call" do
-    subject { described_class.call(api_client, bank_account) }
+    subject(:call) { described_class.call(api_client, bank_account) }
 
     context "when a request is successful" do
       before do
@@ -15,11 +15,11 @@ RSpec.describe TrueLayer::Importers::ImportAccountBalanceService do
       end
 
       it "updates the balance of the account" do
-        expect { subject }.to change { bank_account.balance.to_s }.to(mock_result[:current].to_s)
+        expect { call }.to change { bank_account.balance.to_s }.to(mock_result[:current].to_s)
       end
 
       it "is successful" do
-        expect(subject.success?).to be(true)
+        expect(call.success?).to be(true)
       end
     end
 
@@ -29,11 +29,11 @@ RSpec.describe TrueLayer::Importers::ImportAccountBalanceService do
       end
 
       it "does not change the balance of the account" do
-        expect { subject }.not_to change(bank_account, :balance)
+        expect { call }.not_to change(bank_account, :balance)
       end
 
       it "returns an error" do
-        expect(JSON.parse(subject.errors.to_json).deep_symbolize_keys.keys.first).to eq(:import_account_balance)
+        expect(JSON.parse(call.errors.to_json).deep_symbolize_keys.keys.first).to eq(:import_account_balance)
       end
     end
   end

--- a/spec/services/true_layer/importers/import_account_holders_service_spec.rb
+++ b/spec/services/true_layer/importers/import_account_holders_service_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe TrueLayer::Importers::ImportAccountHoldersService do
   let(:api_client) { TrueLayer::ApiClient.new(SecureRandom.hex) }
 
   describe "#call" do
-    subject { described_class.call(api_client, bank_provider) }
+    subject(:call) { described_class.call(api_client, bank_provider) }
 
     let(:mock_account_holder1) { TrueLayerHelpers::MOCK_DATA[:account_holders][0] }
     let(:mock_account_holder2) { TrueLayerHelpers::MOCK_DATA[:account_holders][1] }
@@ -19,7 +19,7 @@ RSpec.describe TrueLayer::Importers::ImportAccountHoldersService do
       end
 
       it "adds the bank account holders to the bank_provider" do
-        subject
+        call
         expect(bank_account_holder1.full_name).to eq(mock_account_holder1[:full_name])
         expect(bank_account_holder1.true_layer_response).to eq(mock_account_holder1.deep_stringify_keys)
         expect(bank_account_holder1.addresses).to eq(mock_account_holder1[:addresses].map(&:deep_stringify_keys))
@@ -28,12 +28,12 @@ RSpec.describe TrueLayer::Importers::ImportAccountHoldersService do
       end
 
       it "removes existing bank account holders" do
-        subject
+        call
         expect { existing_bank_account_holder.reload }.to raise_error ActiveRecord::RecordNotFound
       end
 
       it "is successful" do
-        expect(subject.success?).to be(true)
+        expect(call.success?).to be(true)
       end
     end
 
@@ -43,11 +43,11 @@ RSpec.describe TrueLayer::Importers::ImportAccountHoldersService do
       end
 
       it "does not change anything" do
-        expect { subject }.not_to change { bank_provider.bank_account_holders.count }
+        expect { call }.not_to change { bank_provider.bank_account_holders.count }
       end
 
       it "returns an error" do
-        expect(JSON.parse(subject.errors.to_json).deep_symbolize_keys.keys.first).to eq(:import_account_holders)
+        expect(JSON.parse(call.errors.to_json).deep_symbolize_keys.keys.first).to eq(:import_account_holders)
       end
     end
   end

--- a/spec/services/true_layer/importers/import_accounts_service_spec.rb
+++ b/spec/services/true_layer/importers/import_accounts_service_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe TrueLayer::Importers::ImportAccountsService do
   let(:api_client) { TrueLayer::ApiClient.new(SecureRandom.hex) }
 
   describe "#call" do
-    subject { described_class.call(api_client, bank_provider) }
+    subject(:call) { described_class.call(api_client, bank_provider) }
 
     let(:mock_account1) { TrueLayerHelpers::MOCK_DATA[:accounts][0] }
     let(:mock_account2) { TrueLayerHelpers::MOCK_DATA[:accounts][1] }
@@ -20,7 +20,7 @@ RSpec.describe TrueLayer::Importers::ImportAccountsService do
       end
 
       it "adds the bank accounts to the bank_provider" do
-        subject
+        call
         expect(bank_account1.true_layer_response).to eq(mock_account1.deep_stringify_keys)
         expect(bank_account1.true_layer_id).to eq(mock_account1[:account_id])
         expect(bank_account1.name).to eq(mock_account1[:display_name])
@@ -33,13 +33,13 @@ RSpec.describe TrueLayer::Importers::ImportAccountsService do
       end
 
       it "removes existing bank account and transactions" do
-        subject
+        call
         expect { existing_bank_account.reload }.to raise_error ActiveRecord::RecordNotFound
         expect { existing_bank_account_transaction.reload }.to raise_error ActiveRecord::RecordNotFound
       end
 
       it "is successful" do
-        expect(subject.success?).to be(true)
+        expect(call.success?).to be(true)
       end
     end
 
@@ -49,11 +49,11 @@ RSpec.describe TrueLayer::Importers::ImportAccountsService do
       end
 
       it "does not change anything" do
-        expect { subject }.not_to change { bank_provider.bank_accounts.count }
+        expect { call }.not_to change { bank_provider.bank_accounts.count }
       end
 
       it "returns an error" do
-        expect(JSON.parse(subject.errors.to_json).deep_symbolize_keys.keys.first).to eq(:import_accounts)
+        expect(JSON.parse(call.errors.to_json).deep_symbolize_keys.keys.first).to eq(:import_accounts)
       end
     end
   end

--- a/spec/services/true_layer_error_decoder_spec.rb
+++ b/spec/services/true_layer_error_decoder_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe TrueLayerErrorDecoder do
-  subject { described_class.new(error_details) }
+  subject(:true_layer_error_decoder) { described_class.new(error_details) }
 
   let(:error_details) { true_layer_error_details_array }
   let(:error_description) { "TrueLayer's detailed explanation of the error" }
@@ -11,7 +11,7 @@ RSpec.describe TrueLayerErrorDecoder do
       let(:error_code) { "account_temporarily_locked" }
 
       it "returns the correct translation" do
-        expect(subject.error_heading).to eq I18n.t("true_layer_errors.headings.account_temporarily_locked")
+        expect(true_layer_error_decoder.error_heading).to eq I18n.t("true_layer_errors.headings.account_temporarily_locked")
       end
     end
 
@@ -20,12 +20,12 @@ RSpec.describe TrueLayerErrorDecoder do
       let(:error_description) { "The flux capacitor is not working" }
 
       it "returns the generic unknown error message" do
-        expect(subject.error_heading).to eq I18n.t("true_layer_errors.headings.unknown")
+        expect(true_layer_error_decoder.error_heading).to eq I18n.t("true_layer_errors.headings.unknown")
       end
 
       it "sends the details to sentry" do
         expect(AlertManager).to receive(:capture_message).with("Unknown error code received from TrueLayer: flux_capacitor_outage :: The flux capacitor is not working")
-        subject.error_heading
+        true_layer_error_decoder.error_heading
       end
     end
   end
@@ -35,7 +35,7 @@ RSpec.describe TrueLayerErrorDecoder do
       let(:error_code) { "internal_server_error" }
 
       it "returns the correct translation" do
-        expect(subject.error_detail).to eq I18n.t("true_layer_errors.detail.internal_server_error")
+        expect(true_layer_error_decoder.error_detail).to eq I18n.t("true_layer_errors.detail.internal_server_error")
       end
     end
 
@@ -44,7 +44,7 @@ RSpec.describe TrueLayerErrorDecoder do
       let(:error_description) { "The flux capacitor is not working" }
 
       it "returns the generic unknown error message" do
-        expect(subject.error_detail).to eq I18n.t("true_layer_errors.detail.unknown")
+        expect(true_layer_error_decoder.error_detail).to eq I18n.t("true_layer_errors.detail.unknown")
       end
     end
   end
@@ -54,7 +54,7 @@ RSpec.describe TrueLayerErrorDecoder do
       let(:error_code) { "wrong_credentials" }
 
       it "returns true" do
-        expect(subject.show_link?).to be true
+        expect(true_layer_error_decoder.show_link?).to be true
       end
     end
 
@@ -62,7 +62,7 @@ RSpec.describe TrueLayerErrorDecoder do
       let(:error_code) { "account_permanently_locked" }
 
       it "returns true" do
-        expect(subject.show_link?).to be false
+        expect(true_layer_error_decoder.show_link?).to be false
       end
     end
   end


### PR DESCRIPTION
This is the final PR addressing RSpec/NamedSubject exclusions.

It addresses those in services where the folder or class starts with n to x

It switches to using `subject(:call)` for brevity

## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-XXX)

Describe what you did and why.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
