### PR TITLE
Rubocop: address RSpec/RepeatedDescription exclusions

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -110,16 +110,6 @@ RSpec/LetSetup:
     - 'spec/workers/bank_holiday_update_worker_spec.rb'
     - 'spec/workers/true_layer_banks_update_worker_spec.rb'
 
-# Offense count: 16
-RSpec/RepeatedDescription:
-  Exclude:
-    - 'spec/forms/legal_aid_applications/substantive_application_form_spec.rb'
-    - 'spec/models/cfe/v2/result_spec.rb'
-    - 'spec/models/cfe/v3/result_spec.rb'
-    - 'spec/models/dependant_spec.rb'
-    - 'spec/services/ccms/requestors/case_add_requestor_xml_blocks/passported_attributes_spec.rb'
-    - 'spec/services/ccms/submitters/upload_documents_service_spec.rb'
-
 # Offense count: 10
 RSpec/RepeatedExample:
   Exclude:

--- a/spec/forms/legal_aid_applications/substantive_application_form_spec.rb
+++ b/spec/forms/legal_aid_applications/substantive_application_form_spec.rb
@@ -23,9 +23,11 @@ RSpec.describe LegalAidApplications::SubstantiveApplicationForm, type: :form do
         .to(substantive_application)
     end
 
-    it "updates application" do
-      expect(described_form.save).to be true
-      expect(application).not_to be_substantive_application
+    context "when setting the value to false" do
+      it "does not set the substantive_application state of the application" do
+        expect(described_form.save).to be true
+        expect(application).not_to be_substantive_application
+      end
     end
 
     context "when completing substantive application now selected" do

--- a/spec/models/cfe/v2/result_spec.rb
+++ b/spec/models/cfe/v2/result_spec.rb
@@ -317,12 +317,12 @@ module CFE
 
       describe "vehicles?" do
         context "when vehicle(s) exist" do
-          it "returns a boolean response" do
+          it "returns true" do
             expect(eligible_result.vehicles?).to be true
           end
 
           context "when vehicles do not exist"
-          it "returns a boolean response" do
+          it "returns false" do
             expect(no_vehicles.vehicles?).to be false
           end
         end

--- a/spec/models/cfe/v3/result_spec.rb
+++ b/spec/models/cfe/v3/result_spec.rb
@@ -280,12 +280,12 @@ module CFE
 
       describe "vehicles?" do
         context "when vehicle(s) exist" do
-          it "returns a boolean response if vehicles exist" do
+          it "returns true" do
             expect(eligible_result.vehicles?).to be true
           end
 
           context "when vehicles do not exist"
-          it "returns a boolean response if vehicles exist" do
+          it "returns false" do
             expect(no_vehicles.vehicles?).to be false
           end
         end

--- a/spec/models/dependant_spec.rb
+++ b/spec/models/dependant_spec.rb
@@ -69,26 +69,26 @@ RSpec.describe Dependant do
   end
 
   describe "#over_fifteen?" do
-    context "when less than 15 years old" do
+    context "when 10 years old" do
       let(:date_of_birth) { 10.years.ago }
 
-      it "returns false" do
+      it "over_fifteen? returns false" do
         expect(dependant.over_fifteen?).to be(false)
       end
 
-      it "returns false" do
+      it "sixteen_or_over? returns false" do
         expect(dependant.sixteen_or_over?).to be(false)
       end
     end
 
-    context "when more than 15 years old" do
+    context "when more than 20 years old" do
       let(:date_of_birth) { 20.years.ago }
 
-      it "returns true" do
+      it "over_fifteen? returns true" do
         expect(dependant.over_fifteen?).to be(true)
       end
 
-      it "returns true" do
+      it "sixteen_or_over? returns true" do
         expect(dependant.sixteen_or_over?).to be(true)
       end
     end
@@ -96,11 +96,11 @@ RSpec.describe Dependant do
     context "when 15 and a half years old" do
       let(:date_of_birth) { 15.years.ago + 6.months }
 
-      it "returns false" do
+      it "over_fifteen? returns false" do
         expect(dependant.over_fifteen?).to be(false)
       end
 
-      it "returns false" do
+      it "sixteen_or_over? returns false" do
         expect(dependant.sixteen_or_over?).to be(false)
       end
     end

--- a/spec/services/ccms/requestors/case_add_requestor_xml_blocks/passported_attributes_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_xml_blocks/passported_attributes_spec.rb
@@ -1259,11 +1259,6 @@ module CCMS
             end
           end
 
-          it "CASES_FEES_DISTRIBUTED should be hard coded to 1" do
-            block = XmlExtractor.call(xml, :global_merits, "CASES_FEES_DISTRIBUTED")
-            expect(block).to have_number_response 1
-          end
-
           it "NEW_APPL_OR_AMENDMENT should be hard coded to APPLICATION" do
             %i[global_means global_merits].each do |entity|
               block = XmlExtractor.call(xml, entity, "NEW_APPL_OR_AMENDMENT")

--- a/spec/services/ccms/submitters/upload_documents_service_spec.rb
+++ b/spec/services/ccms/submitters/upload_documents_service_spec.rb
@@ -124,14 +124,6 @@ RSpec.describe CCMS::Submitters::UploadDocumentsService, :ccms do
         expect(first_history.success).to be false
         expect(first_history.details).to match(/#{error}/)
         expect(first_history.details).to match(/this document submission has failed/)
-      end
-
-      it "writes a history record on completion that updates the state" do
-        expect { instance.call }.to raise_error(CCMS::CCMSError, /The following documents failed to upload:/)
-        expect(history.from_state).to eq "case_created"
-        expect(history.to_state).to eq "failed"
-        expect(history.success).to be false
-        expect(history.details).to match(/#{error}/)
         expect(history.details).to match(/failed to upload/)
       end
     end


### PR DESCRIPTION


## What

Remove the todo entry for RSpec/RepeatedDescription and update the repeated descriptions in the tests.  Most of the times this invloved clarifying the text to be more specific.  In one instance I deleted a completely duplicated test and in another I merged the expectations as the initial lines were identical but the check for the error message had a slight change


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
