### PR TITLE
AP-4481: Fix opponent individual CCMS injection payload

### DIFF
--- a/app/models/application_merits_task/individual.rb
+++ b/app/models/application_merits_task/individual.rb
@@ -13,7 +13,7 @@ module ApplicationMeritsTask
     end
 
     def ccms_relationship_to_client
-      "UNKNOWN"
+      "NONE"
     end
 
     def ccms_child?

--- a/app/services/ccms/payload_generators/other_party_attribute_generator.rb
+++ b/app/services/ccms/payload_generators/other_party_attribute_generator.rb
@@ -31,7 +31,7 @@ module CCMS
           xml.__send__(:"casebio:OtherPartyDetail") do
             xml.__send__(:"casebio:Person") do
               xml.__send__(:"casebio:Name") do
-                xml.__send__(:"common:Title", "")
+                xml.__send__(:"common:Title", "MR.")
                 xml.__send__(:"common:Surname", other_party.last_name)
                 xml.__send__(:"common:FirstName", other_party.first_name)
               end

--- a/spec/data/ccms/case_add_request.xml
+++ b/spec/data/ccms/case_add_request.xml
@@ -237,7 +237,7 @@
                           <common:Attribute>
                             <common:Attribute>RELATIONSHIP_TO_CLIENT</common:Attribute>
                             <common:ResponseType>text</common:ResponseType>
-                            <common:ResponseValue>UNKNOWN</common:ResponseValue>
+                            <common:ResponseValue>NONE</common:ResponseValue>
                             <common:UserDefinedInd>true</common:UserDefinedInd>
                           </common:Attribute>
                         </common:Attributes>
@@ -2656,13 +2656,13 @@
                           <common:Attribute>
                             <common:Attribute>OPP_RELATIONSHIP_TO_CLIENT</common:Attribute>
                             <common:ResponseType>text</common:ResponseType>
-                            <common:ResponseValue>Unknown</common:ResponseValue>
+                            <common:ResponseValue>None</common:ResponseValue>
                             <common:UserDefinedInd>false</common:UserDefinedInd>
                           </common:Attribute>
                           <common:Attribute>
                             <common:Attribute>RELATIONSHIP_TO_CLIENT</common:Attribute>
                             <common:ResponseType>text</common:ResponseType>
-                            <common:ResponseValue>UNKNOWN</common:ResponseValue>
+                            <common:ResponseValue>NONE</common:ResponseValue>
                             <common:UserDefinedInd>true</common:UserDefinedInd>
                           </common:Attribute>
                           <common:Attribute>

--- a/spec/data/ccms/case_add_request.xml
+++ b/spec/data/ccms/case_add_request.xml
@@ -45,7 +45,7 @@
                 <casebio:OtherPartyDetail>
                   <casebio:Person>
                     <casebio:Name>
-                      <common:Title/>
+                      <common:Title>MR.</common:Title>
                       <common:Surname>Test-Opponent</common:Surname>
                       <common:FirstName>Joffrey</common:FirstName>
                     </casebio:Name>

--- a/spec/data/ccms/df_case_add_request.xml
+++ b/spec/data/ccms/df_case_add_request.xml
@@ -45,7 +45,7 @@
                 <casebio:OtherPartyDetail>
                   <casebio:Person>
                     <casebio:Name>
-                      <common:Title/>
+                      <common:Title>MR.</common:Title>
                       <common:Surname>Test-Opponent</common:Surname>
                       <common:FirstName>Joffrey</common:FirstName>
                     </casebio:Name>

--- a/spec/data/ccms/df_case_add_request.xml
+++ b/spec/data/ccms/df_case_add_request.xml
@@ -243,7 +243,7 @@
                           <common:Attribute>
                             <common:Attribute>RELATIONSHIP_TO_CLIENT</common:Attribute>
                             <common:ResponseType>text</common:ResponseType>
-                            <common:ResponseValue>UNKNOWN</common:ResponseValue>
+                            <common:ResponseValue>NONE</common:ResponseValue>
                             <common:UserDefinedInd>true</common:UserDefinedInd>
                           </common:Attribute>
                         </common:Attributes>
@@ -2692,13 +2692,13 @@
                           <common:Attribute>
                             <common:Attribute>OPP_RELATIONSHIP_TO_CLIENT</common:Attribute>
                             <common:ResponseType>text</common:ResponseType>
-                            <common:ResponseValue>Unknown</common:ResponseValue>
+                            <common:ResponseValue>None</common:ResponseValue>
                             <common:UserDefinedInd>false</common:UserDefinedInd>
                           </common:Attribute>
                           <common:Attribute>
                             <common:Attribute>RELATIONSHIP_TO_CLIENT</common:Attribute>
                             <common:ResponseType>text</common:ResponseType>
-                            <common:ResponseValue>UNKNOWN</common:ResponseValue>
+                            <common:ResponseValue>NONE</common:ResponseValue>
                             <common:UserDefinedInd>true</common:UserDefinedInd>
                           </common:Attribute>
                           <common:Attribute>

--- a/spec/data/ccms/non_default_client_involvement_type.xml
+++ b/spec/data/ccms/non_default_client_involvement_type.xml
@@ -237,7 +237,7 @@
                           <common:Attribute>
                             <common:Attribute>RELATIONSHIP_TO_CLIENT</common:Attribute>
                             <common:ResponseType>text</common:ResponseType>
-                            <common:ResponseValue>UNKNOWN</common:ResponseValue>
+                            <common:ResponseValue>NONE</common:ResponseValue>
                             <common:UserDefinedInd>true</common:UserDefinedInd>
                           </common:Attribute>
                         </common:Attributes>
@@ -2656,13 +2656,13 @@
                           <common:Attribute>
                             <common:Attribute>OPP_RELATIONSHIP_TO_CLIENT</common:Attribute>
                             <common:ResponseType>text</common:ResponseType>
-                            <common:ResponseValue>Unknown</common:ResponseValue>
+                            <common:ResponseValue>None</common:ResponseValue>
                             <common:UserDefinedInd>false</common:UserDefinedInd>
                           </common:Attribute>
                           <common:Attribute>
                             <common:Attribute>RELATIONSHIP_TO_CLIENT</common:Attribute>
                             <common:ResponseType>text</common:ResponseType>
-                            <common:ResponseValue>UNKNOWN</common:ResponseValue>
+                            <common:ResponseValue>NONE</common:ResponseValue>
                             <common:UserDefinedInd>true</common:UserDefinedInd>
                           </common:Attribute>
                           <common:Attribute>

--- a/spec/data/ccms/non_default_client_involvement_type.xml
+++ b/spec/data/ccms/non_default_client_involvement_type.xml
@@ -45,7 +45,7 @@
                 <casebio:OtherPartyDetail>
                   <casebio:Person>
                     <casebio:Name>
-                      <common:Title/>
+                      <common:Title>MR.</common:Title>
                       <common:Surname>Test-Opponent</common:Surname>
                       <common:FirstName>Joffrey</common:FirstName>
                     </casebio:Name>

--- a/spec/models/application_merits_task/individual_spec.rb
+++ b/spec/models/application_merits_task/individual_spec.rb
@@ -6,7 +6,7 @@ module ApplicationMeritsTask
 
     it { expect(individual.ccms_other_party_type).to eq "PERSON" }
     it { expect(individual.ccms_relationship_to_case).to eq "OPP" }
-    it { expect(individual.ccms_relationship_to_client).to eq "UNKNOWN" }
+    it { expect(individual.ccms_relationship_to_client).to eq "NONE" }
     it { expect(individual.ccms_child?).to be false }
     it { expect(individual.ccms_opponent_relationship_to_case).to eq "Opponent" }
     it { expect(individual).to respond_to(:first_name, :last_name, :full_name) }

--- a/spec/services/ccms/payload_generators/other_party_attribute_generator_spec.rb
+++ b/spec/services/ccms/payload_generators/other_party_attribute_generator_spec.rb
@@ -30,7 +30,7 @@ module CCMS
             expect(call)
               .to have_xml("#{other_party_xpath}/casebio:OtherPartyID", "OPPONENT_99123456")
               .and have_xml("#{other_party_xpath}/casebio:SharedInd", "false")
-              .and have_xml("#{person_xpath}/casebio:Name/common:Title", "")
+              .and have_xml("#{person_xpath}/casebio:Name/common:Title", "MR.")
               .and have_xml("#{person_xpath}/casebio:Name/common:FirstName", "Joffrey")
               .and have_xml("#{person_xpath}/casebio:Name/common:Surname", "Baratheon")
               .and have_xml("#{person_xpath}/casebio:RelationToClient", "NONE")

--- a/spec/services/ccms/requestors/case_add_requestor_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_spec.rb
@@ -248,7 +248,7 @@ module CCMS
               .and have_xml("#{person_xpath}/casebio:Name/common:Title", "")
               .and have_xml("#{person_xpath}/casebio:Name/common:FirstName", "Joffrey")
               .and have_xml("#{person_xpath}/casebio:Name/common:Surname", "Baratheon")
-              .and have_xml("#{person_xpath}/casebio:RelationToClient", "UNKNOWN")
+              .and have_xml("#{person_xpath}/casebio:RelationToClient", "NONE")
               .and have_xml("#{person_xpath}/casebio:RelationToCase", "OPP")
 
             expect(request_xml)
@@ -257,7 +257,7 @@ module CCMS
               .and have_xml("#{person_xpath}/casebio:Name/common:Title", "")
               .and have_xml("#{person_xpath}/casebio:Name/common:FirstName", "Sansa")
               .and have_xml("#{person_xpath}/casebio:Name/common:Surname", "Stark")
-              .and have_xml("#{person_xpath}/casebio:RelationToClient", "UNKNOWN")
+              .and have_xml("#{person_xpath}/casebio:RelationToClient", "NONE")
               .and have_xml("#{person_xpath}/casebio:RelationToCase", "OPP")
           end
         end

--- a/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_means_tested_attributes_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_means_tested_attributes_spec.rb
@@ -1099,7 +1099,7 @@ module CCMS
 
             it "hard-codes RELATIONSHIP_TO_CLIENT" do
               block = XmlExtractor.call(xml, entity, "RELATIONSHIP_TO_CLIENT")
-              expect(block).to have_text_response "UNKNOWN"
+              expect(block).to have_text_response "NONE"
             end
           end
 
@@ -1113,7 +1113,7 @@ module CCMS
 
             it "hard-codes OPP_RELATIONSHIP_TO_CLIENT" do
               block = XmlExtractor.call(xml, entity, "OPP_RELATIONSHIP_TO_CLIENT")
-              expect(block).to have_text_response "Unknown"
+              expect(block).to have_text_response "None"
             end
 
             it "generates OTHER_PARTY_ID" do
@@ -1153,7 +1153,7 @@ module CCMS
 
             it "hard-codes RELATIONSHIP_TO_CLIENT" do
               block = XmlExtractor.call(xml, entity, "RELATIONSHIP_TO_CLIENT")
-              expect(block).to have_text_response "UNKNOWN"
+              expect(block).to have_text_response "NONE"
             end
           end
         end
@@ -1189,7 +1189,7 @@ module CCMS
 
             it "hard-codes RELATIONSHIP_TO_CLIENT" do
               block = XmlExtractor.call(xml, entity, "RELATIONSHIP_TO_CLIENT")
-              expect(block).to have_text_response %w[UNKNOWN UNKNOWN]
+              expect(block).to have_text_response %w[NONE NONE]
             end
           end
 
@@ -1203,7 +1203,7 @@ module CCMS
 
             it "hard-codes OPP_RELATIONSHIP_TO_CLIENT" do
               block = XmlExtractor.call(xml, entity, "OPP_RELATIONSHIP_TO_CLIENT")
-              expect(block).to have_text_response %w[Unknown Unknown]
+              expect(block).to have_text_response %w[None None]
             end
 
             it "generates OTHER_PARTY_ID" do
@@ -1243,7 +1243,7 @@ module CCMS
 
             it "hard-codes RELATIONSHIP_TO_CLIENT" do
               block = XmlExtractor.call(xml, entity, "RELATIONSHIP_TO_CLIENT")
-              expect(block).to have_text_response %w[UNKNOWN UNKNOWN]
+              expect(block).to have_text_response %w[NONE NONE]
             end
           end
         end

--- a/spec/services/ccms/requestors/case_add_requestor_xml_blocks/passported_attributes_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_xml_blocks/passported_attributes_spec.rb
@@ -1509,7 +1509,7 @@ module CCMS
                     OTHER_PARTY_NAME: "Billy Bob",
                     OTHER_PARTY_TYPE: "PERSON",
                     RELATIONSHIP_TO_CASE: "OPP",
-                    RELATIONSHIP_TO_CLIENT: "UNKNOWN",
+                    RELATIONSHIP_TO_CLIENT: "NONE",
                   )
               end
             end
@@ -1588,10 +1588,10 @@ module CCMS
                     OTHER_PARTY_ORG: "false",
                     OTHER_PARTY_PERSON: "true",
                     RELATIONSHIP_TO_CASE: "OPP",
-                    RELATIONSHIP_TO_CLIENT: "UNKNOWN",
+                    RELATIONSHIP_TO_CLIENT: "NONE",
                     RELATIONSHIP_CASE_OPPONENT: "true",
                     OPP_RELATIONSHIP_TO_CASE: "Opponent",
-                    OPP_RELATIONSHIP_TO_CLIENT: "Unknown",
+                    OPP_RELATIONSHIP_TO_CLIENT: "None",
                     PARTY_IS_A_CHILD: "false",
                     RELATIONSHIP_CHILD: "false",
                     RELATIONSHIP_CASE_CHILD: "false",


### PR DESCRIPTION





## What
Amend opponent individual payload to fix CCMS/PUI amendment bug

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4481)


- Switch to using NONE/none instead of UNKNOWN/Unknown, then test
- Add a dummy title, then test

It was discovered that Individual Opponents injected by the Apply service were not being displayed on the Amend case screen in PUI. As the link states ‘Edit Opponents and other parties’ we believe Individual should appear on the Amend case (this is the screenshot with the ‘Edit opponents and other parties’ link) but only organisations are displayed as expected.

<img width="1068" alt="image-20230927-091223" src="https://github.com/ministryofjustice/laa-apply-for-legal-aid/assets/7016425/c0c6eb21-f280-481e-900b-7d94daf26732">



## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
