### PR TITLE
AP-4359: Add cfe_civil partner submission

### DIFF
--- a/app/services/cfe_civil/component_list.rb
+++ b/app/services/cfe_civil/component_list.rb
@@ -10,6 +10,7 @@ module CFECivil
       Components::Vehicles,
       Components::Properties,
       Components::ExplicitRemarks,
+      Components::Partner,
     ].freeze
 
     NON_PASSPORTED_WITH_BANK_TRANSACTIONS_SERVICES = [
@@ -27,6 +28,7 @@ module CFECivil
       Components::IrregularIncomes,
       Components::Employments,
       Components::CashTransactions,
+      Components::Partner,
     ].freeze
 
     NON_PASSPORTED_WITH_REGULAR_TRANSACTIONS_SERVICES = [
@@ -42,6 +44,7 @@ module CFECivil
       Components::Employments,
       Components::RegularTransactions,
       Components::CashTransactions,
+      Components::Partner,
     ].freeze
 
     def self.call(object)

--- a/app/services/cfe_civil/components/base_data_block.rb
+++ b/app/services/cfe_civil/components/base_data_block.rb
@@ -1,14 +1,15 @@
 module CFECivil
   module Components
     class BaseDataBlock
-      attr_reader :legal_aid_application
+      attr_reader :legal_aid_application, :owner_type
 
-      def self.call(legal_aid_application)
-        new(legal_aid_application).call
+      def self.call(legal_aid_application, owner_type = "Applicant")
+        new(legal_aid_application, owner_type).call
       end
 
-      def initialize(legal_aid_application)
+      def initialize(legal_aid_application, owner_type = "Applicant")
         @legal_aid_application = legal_aid_application
+        @owner_type = owner_type
       end
     end
   end

--- a/app/services/cfe_civil/components/capitals.rb
+++ b/app/services/cfe_civil/components/capitals.rb
@@ -21,6 +21,13 @@ module CFECivil
         life_assurance_endowment_policy: "Life assurance and endowment policies not linked to a mortgage",
       }.freeze
 
+      PARTNER_SAVINGS_AMOUNT_FIELDS = {
+        partner_offline_current_accounts: "Partner current accounts",
+        partner_offline_savings_accounts: "Partner savings accounts",
+        joint_offline_current_accounts: "Joint current accounts",
+        joint_offline_savings_accounts: "Joint savings accounts",
+      }.freeze
+
       def call
         {
           capitals: {
@@ -37,6 +44,8 @@ module CFECivil
       end
 
       def itemised_other_assets
+        return [] if owner_type == "Partner"
+
         array_of_hashes_for(other_assets_declaration, OTHER_ASSET_FIELDS)
       end
 
@@ -45,6 +54,8 @@ module CFECivil
       end
 
       def bank_accounts
+        return [] if owner_type == "Partner"
+
         [current_account_balance, savings_account_balance].compact
       end
 
@@ -67,7 +78,8 @@ module CFECivil
       end
 
       def savings_amounts
-        array_of_hashes_for(savings_amount, SAVINGS_AMOUNT_FIELDS)
+        fields = owner_type == "Partner" ? PARTNER_SAVINGS_AMOUNT_FIELDS : SAVINGS_AMOUNT_FIELDS
+        array_of_hashes_for(savings_amount, fields)
       end
 
       def array_of_hashes_for(model, field_names_and_descriptions)

--- a/app/services/cfe_civil/components/cash_transactions.rb
+++ b/app/services/cfe_civil/components/cash_transactions.rb
@@ -15,7 +15,8 @@ module CFECivil
     private
 
       def cash_transactions_for(operation)
-        cash_transactions.joins(:transaction_type).where(transaction_type: { operation: })
+        cash_transactions.joins(:transaction_type)
+                         .where(transaction_type: { operation: }).where(owner_type:)
                          .order("transaction_type.name", :transaction_date)
                          .group_by(&:transaction_type_id)
       end

--- a/app/services/cfe_civil/components/employments.rb
+++ b/app/services/cfe_civil/components/employments.rb
@@ -1,11 +1,13 @@
 module CFECivil
   module Components
     class Employments < BaseDataBlock
-      delegate :employments, to: :legal_aid_application
-
       def call
         if employment_and_payments?
-          { employment_income: employment_income_payload }.to_json
+          if owner_type.eql?("Partner")
+            { employments: employment_income_payload }.to_json
+          else
+            { employment_income: employment_income_payload }.to_json
+          end
         else
           {}.to_json
         end
@@ -13,8 +15,16 @@ module CFECivil
 
     private
 
+      def party
+        @party ||= legal_aid_application.send(owner_type.downcase)
+      end
+
       def employment_and_payments?
-        legal_aid_application.hmrc_employment_income? && legal_aid_application.employment_payments.present?
+        party.hmrc_employment_income? && party.employment_payments.present?
+      end
+
+      def employments
+        party.employments
       end
 
       def employment_income_payload

--- a/app/services/cfe_civil/components/irregular_incomes.rb
+++ b/app/services/cfe_civil/components/irregular_incomes.rb
@@ -2,35 +2,57 @@ module CFECivil
   module Components
     class IrregularIncomes < BaseDataBlock
       def call
-        {
-          irregular_incomes: {
-            payments: payment_data,
-          },
-        }.to_json
+        payment_data.to_json
       end
 
     private
 
       def payment_data
-        if student_finance_data?
-          [
-            {
-              income_type: "student_loan",
-              frequency: "annual",
-              amount: student_finance_amount.to_f,
+        if student_finance_data? && owner_type.eql?("Partner")
+          {
+            irregular_incomes: [
+              {
+                income_type: "student_loan",
+                frequency: "annual",
+                amount: student_finance_amount.to_f,
+              },
+            ],
+          }
+        elsif student_finance_data?
+          {
+            irregular_incomes: {
+              payments: [
+                {
+                  income_type: "student_loan",
+                  frequency: "annual",
+                  amount: student_finance_amount.to_f,
+                },
+              ],
             },
-          ]
+          }
+        elsif owner_type.eql?("Partner")
+          {
+            irregular_incomes: [],
+          }
         else
-          []
+          {
+            irregular_incomes: {
+              payments: [],
+            },
+          }
         end
       end
 
+      def party
+        @party ||= legal_aid_application.send(owner_type.downcase)
+      end
+
       def student_finance_data?
-        legal_aid_application.applicant.student_finance? && student_finance_amount.positive?
+        party.student_finance? && student_finance_amount.positive?
       end
 
       def student_finance_amount
-        legal_aid_application.applicant.student_finance_amount
+        party.student_finance_amount
       end
     end
   end

--- a/app/services/cfe_civil/components/partner.rb
+++ b/app/services/cfe_civil/components/partner.rb
@@ -7,14 +7,15 @@ module CFECivil
         return {}.to_json if partner.blank?
 
         result = base_partner
-        result.merge! JSON.parse(Components::CashTransactions.new(@legal_aid_application, "Partner").call) # so far... all other models are stored as Applicant/Partner
-        result.merge! JSON.parse(Components::IrregularIncomes.new(@legal_aid_application, "Partner").call) # so far... all other models are stored as Applicant/Partner
-        result.merge! JSON.parse(Components::Vehicles.new(@legal_aid_application, "partner").call) # this is stored as client/partner
-        result.merge! JSON.parse(Components::Employments.new(@legal_aid_application, "Partner").call) # this is stored as Applicant/Partner
-        result.merge! JSON.parse(Components::RegularTransactions.new(@legal_aid_application, "Partner").call) # this is stored as Applicant/Partner
-        result.merge! JSON.parse(Components::Capitals.new(@legal_aid_application, "Partner").call) # this is stored as Applicant/Partner
-        # employment_details # skipping this is a ccq datatype, we don't use it
-        # self_employment_details # skipping this is a ccq datatype, we don't use it
+        # Most records are stored with an Owner field that is tied to Applicant or Partner models, using their IDs
+        # Vehicles are stored with the, optional, output of a radio button as client or partner (lower cased)
+        # For this reason the call to Components::Vehicles.new is slightly different from the rest of the generators
+        result.merge! JSON.parse(Components::CashTransactions.new(@legal_aid_application, "Partner").call)
+        result.merge! JSON.parse(Components::IrregularIncomes.new(@legal_aid_application, "Partner").call)
+        result.merge! JSON.parse(Components::Vehicles.new(@legal_aid_application, "partner").call)
+        result.merge! JSON.parse(Components::Employments.new(@legal_aid_application, "Partner").call)
+        result.merge! JSON.parse(Components::RegularTransactions.new(@legal_aid_application, "Partner").call)
+        result.merge! JSON.parse(Components::Capitals.new(@legal_aid_application, "Partner").call)
         # Outgoings # skipped, these are generated from Truelayer and that is not currently supported by the partner flow
         # state_benefits # skipped, these are generated from Truelayer and that is not currently supported by the partner flow
         # other_incomes # skipped, these are generated from Truelayer and that is not currently supported by the partner flow

--- a/app/services/cfe_civil/components/partner.rb
+++ b/app/services/cfe_civil/components/partner.rb
@@ -1,0 +1,40 @@
+module CFECivil
+  module Components
+    class Partner < BaseDataBlock
+      delegate :partner, to: :legal_aid_application
+
+      def call
+        return {}.to_json if partner.blank?
+
+        result = base_partner
+        result.merge! JSON.parse(Components::CashTransactions.new(@legal_aid_application, "Partner").call) # so far... all other models are stored as Applicant/Partner
+        result.merge! JSON.parse(Components::IrregularIncomes.new(@legal_aid_application, "Partner").call) # so far... all other models are stored as Applicant/Partner
+        result.merge! JSON.parse(Components::Vehicles.new(@legal_aid_application, "partner").call) # this is stored as client/partner
+        result.merge! JSON.parse(Components::Employments.new(@legal_aid_application, "Partner").call) # this is stored as Applicant/Partner
+        result.merge! JSON.parse(Components::RegularTransactions.new(@legal_aid_application, "Partner").call) # this is stored as Applicant/Partner
+        result.merge! JSON.parse(Components::Capitals.new(@legal_aid_application, "Partner").call) # this is stored as Applicant/Partner
+        # employment_details # skipping this is a ccq datatype, we don't use it
+        # self_employment_details # skipping this is a ccq datatype, we don't use it
+        # Outgoings # skipped, these are generated from Truelayer and that is not currently supported by the partner flow
+        # state_benefits # skipped, these are generated from Truelayer and that is not currently supported by the partner flow
+        # other_incomes # skipped, these are generated from Truelayer and that is not currently supported by the partner flow
+        # capitals # skipped, these are generated from Truelayer and that is not currently supported by the partner flow
+        # additional_properties # skipping as this is submitted via client
+        # dependants # skipping as this is submitted via client
+        {
+          partner: result,
+        }.to_json
+      end
+
+    private
+
+      def base_partner
+        {
+          partner: {
+            date_of_birth: partner.date_of_birth.strftime("%Y-%m-%d"),
+          },
+        }
+      end
+    end
+  end
+end

--- a/app/services/cfe_civil/components/regular_transactions.rb
+++ b/app/services/cfe_civil/components/regular_transactions.rb
@@ -1,8 +1,6 @@
 module CFECivil
   module Components
     class RegularTransactions < BaseDataBlock
-      delegate :regular_transactions, to: :legal_aid_application
-
       def call
         {
           regular_transactions: build_regular_transactions,
@@ -11,8 +9,12 @@ module CFECivil
 
     private
 
+      def party
+        @party ||= legal_aid_application.send(owner_type.downcase)
+      end
+
       def build_regular_transactions
-        regular_transactions.each_with_object([]) do |regular_transaction, payload|
+        party.regular_transactions.each_with_object([]) do |regular_transaction, payload|
           payload << {
             category: regular_transaction.transaction_type.name,
             operation: regular_transaction.transaction_type.operation,

--- a/spec/factories/employments.rb
+++ b/spec/factories/employments.rb
@@ -49,6 +49,52 @@ FactoryBot.define do
                net_employment_income: 1902.3)
       end
     end
+    trait :example2_usecase1 do
+      id { "87654321-1234-1234-1234-123456789abc" }
+      name { "Job 877" }
+
+      after(:create) do |employment|
+        create(:employment_payment,
+               id: "20231024-0000-0000-0000-123456789abc",
+               employment:,
+               date: Date.new(2021, 11, 28),
+               gross: 1868.98,
+               benefits_in_kind: 0.0,
+               tax: -161.8,
+               national_insurance: -128.64,
+               net_employment_income: 1578.54)
+
+        create(:employment_payment,
+               id: "20230924-0000-0000-0000-123456789abc",
+               employment:,
+               date: Date.new(2021, 10, 28),
+               gross: 1868.98,
+               benefits_in_kind: 0.0,
+               tax: -111,
+               national_insurance: -128.64,
+               net_employment_income: 1629.34)
+
+        create(:employment_payment,
+               id: "20230824-0000-0000-0000-123456789abc",
+               employment:,
+               date: Date.new(2021, 9, 28),
+               gross: 2492.61,
+               benefits_in_kind: 0.0,
+               tax: -286.6,
+               national_insurance: -203.47,
+               net_employment_income: 2002.54)
+
+        create(:employment_payment,
+               id: "20230724-0000-0000-0000-123456789abc",
+               employment:,
+               date: Date.new(2021, 8, 28),
+               gross: 2345.29,
+               benefits_in_kind: 0.0,
+               tax: -257.2,
+               national_insurance: -185.79,
+               net_employment_income: 1902.3)
+      end
+    end
 
     trait :with_irregularities do
       after(:create) do |employment|

--- a/spec/factories/regular_transactions.rb
+++ b/spec/factories/regular_transactions.rb
@@ -24,5 +24,9 @@ FactoryBot.define do
     trait :rent_or_mortgage do
       transaction_type { TransactionType.find_by(name: "rent_or_mortgage") || create(:transaction_type, :rent_or_mortgage) }
     end
+
+    trait :friends_or_family do
+      transaction_type { TransactionType.find_by(name: "friends_or_family") || create(:transaction_type, :friends_or_family) }
+    end
   end
 end

--- a/spec/services/cfe_civil/component_list_spec.rb
+++ b/spec/services/cfe_civil/component_list_spec.rb
@@ -17,6 +17,7 @@ module CFECivil
             Components::Vehicles,
             Components::Properties,
             Components::ExplicitRemarks,
+            Components::Partner,
           ])
         end
       end
@@ -40,6 +41,7 @@ module CFECivil
             Components::IrregularIncomes,
             Components::Employments,
             Components::CashTransactions,
+            Components::Partner,
           ])
         end
       end
@@ -61,6 +63,7 @@ module CFECivil
             Components::Employments,
             Components::RegularTransactions,
             Components::CashTransactions,
+            Components::Partner,
           ])
         end
       end

--- a/spec/services/cfe_civil/components/capitals_spec.rb
+++ b/spec/services/cfe_civil/components/capitals_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe CFECivil::Components::Capitals do
       subject(:call) { described_class.call(legal_aid_application, "Partner") }
 
       it "returns json in the expected format with the partner and joint bank values merged" do
-        expect(call).to match_json_expression({
+        expect(call).to eq({
           capitals: {
             bank_accounts: [
               { description: "Partner current accounts", value: offline_partner_current_balance.to_s },
@@ -71,7 +71,7 @@ RSpec.describe CFECivil::Components::Capitals do
             ],
             non_liquid_capital: [],
           },
-        })
+        }.to_json)
       end
     end
   end

--- a/spec/services/cfe_civil/components/capitals_spec.rb
+++ b/spec/services/cfe_civil/components/capitals_spec.rb
@@ -5,8 +5,14 @@ RSpec.describe CFECivil::Components::Capitals do
 
   let(:legal_aid_application) { create(:legal_aid_application, :with_applicant, with_bank_accounts: 6) }
   let(:submission) { create(:cfe_submission, aasm_state: "applicant_created", legal_aid_application:) }
-  let(:current_balance) { Faker::Number.decimal(l_digits: 3, r_digits: 2) }
-  let(:savings_balance) { Faker::Number.decimal(l_digits: 3, r_digits: 2) }
+  let(:online_current_balance) { Faker::Number.decimal(l_digits: 3, r_digits: 2) }
+  let(:online_savings_balance) { Faker::Number.decimal(l_digits: 3, r_digits: 2) }
+  let(:offline_current_balance) { Faker::Number.decimal(l_digits: 3, r_digits: 2) }
+  let(:offline_savings_balance) { Faker::Number.decimal(l_digits: 3, r_digits: 2) }
+  let(:offline_partner_current_balance) { Faker::Number.decimal(l_digits: 3, r_digits: 2) }
+  let(:offline_partner_savings_balance) { Faker::Number.decimal(l_digits: 3, r_digits: 2) }
+  let(:offline_joint_current_balance) { Faker::Number.decimal(l_digits: 3, r_digits: 2) }
+  let(:offline_joint_savings_balance) { Faker::Number.decimal(l_digits: 3, r_digits: 2) }
 
   before do
     create(:other_assets_declaration,
@@ -17,26 +23,56 @@ RSpec.describe CFECivil::Components::Capitals do
            legal_aid_application:,
            inherited_assets_value: nil,
            money_owed_value: 0.0)
-    allow(legal_aid_application).to receive(:online_savings_accounts_balance).and_return(savings_balance)
-    allow(legal_aid_application).to receive(:online_current_accounts_balance).and_return(current_balance)
+    allow(legal_aid_application).to receive(:online_savings_accounts_balance).and_return(online_savings_balance)
+    allow(legal_aid_application).to receive(:online_current_accounts_balance).and_return(online_current_balance)
+    create(:savings_amount,
+           legal_aid_application:,
+           offline_current_accounts: offline_current_balance,
+           offline_savings_accounts: offline_savings_balance,
+           partner_offline_current_accounts: offline_partner_current_balance,
+           partner_offline_savings_accounts: offline_partner_savings_balance,
+           joint_offline_current_accounts: offline_joint_current_balance,
+           joint_offline_savings_accounts: offline_joint_savings_balance)
   end
 
   describe ".call" do
-    it "returns json in the expected format" do
-      expect(call).to eq({
-        capitals: {
-          bank_accounts: [
-            { description: "Online current accounts", value: current_balance },
-            { description: "Online savings accounts", value: savings_balance },
-          ],
-          non_liquid_capital: [
-            { description: "Timeshare property", value: "555.55" },
-            { description: "Land", value: "777.77" },
-            { description: "Any valuable items worth more than £500", value: "888.88" },
-            { description: "Interest in a trust", value: "999.0" },
-          ],
-        },
-      }.to_json)
+    context "when invoked with no owner" do
+      it "returns json in the expected format with only the applicant bank values" do
+        expect(call).to eq({
+          capitals: {
+            bank_accounts: [
+              { description: "Current accounts", value: offline_current_balance.to_s },
+              { description: "Savings accounts", value: offline_savings_balance.to_s },
+              { description: "Online current accounts", value: online_current_balance },
+              { description: "Online savings accounts", value: online_savings_balance },
+            ],
+            non_liquid_capital: [
+              { description: "Timeshare property", value: "555.55" },
+              { description: "Land", value: "777.77" },
+              { description: "Any valuable items worth more than £500", value: "888.88" },
+              { description: "Interest in a trust", value: "999.0" },
+            ],
+          },
+        }.to_json)
+      end
+    end
+
+    context "when invoked with partner as owner" do
+      subject(:call) { described_class.call(legal_aid_application, "Partner") }
+
+      it "returns json in the expected format with the partner and joint bank values merged" do
+        expect(call).to match_json_expression({
+          capitals: {
+            bank_accounts: [
+              { description: "Partner current accounts", value: offline_partner_current_balance.to_s },
+              { description: "Partner savings accounts", value: offline_partner_savings_balance.to_s },
+              { description: "Joint current accounts", value: offline_joint_current_balance.to_s },
+              { description: "Joint savings accounts", value: offline_joint_savings_balance.to_s },
+            ],
+            non_liquid_capital: [],
+          },
+        })
+      end
     end
   end
 end

--- a/spec/services/cfe_civil/components/cash_transactions_spec.rb
+++ b/spec/services/cfe_civil/components/cash_transactions_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe CFECivil::Components::CashTransactions do
   subject(:call) { described_class.call(legal_aid_application) }
 
-  let(:legal_aid_application) { create(:legal_aid_application, :with_applicant) }
+  let(:legal_aid_application) { create(:legal_aid_application, :with_applicant_and_partner) }
 
   context "when there are no cash_transactions" do
     it "returns expected JSON structure" do
@@ -16,7 +16,7 @@ RSpec.describe CFECivil::Components::CashTransactions do
     end
   end
 
-  context "when cash transactions exist" do
+  context "when applicant cash transactions exist" do
     let(:benefits) { create(:transaction_type, :benefits) }
     let!(:first_benefits_month) { create(:cash_transaction, :credit_month1, legal_aid_application:, owner_type: "Applicant", owner_id: legal_aid_application.applicant.id, amount: 123.0, transaction_type: benefits) }
     let!(:second_benefits_month) { create(:cash_transaction, :credit_month2, legal_aid_application:, owner_type: "Applicant", owner_id: legal_aid_application.applicant.id, amount: 234.0, transaction_type: benefits) }
@@ -26,31 +26,66 @@ RSpec.describe CFECivil::Components::CashTransactions do
     let!(:second_maintenance_month) { create(:cash_transaction, :credit_month2, legal_aid_application:, owner_type: "Applicant", owner_id: legal_aid_application.applicant.id, amount: 234.0, transaction_type: maintenance_out) }
     let!(:third_maintenance_month) { create(:cash_transaction, :credit_month3, legal_aid_application:, owner_type: "Applicant", owner_id: legal_aid_application.applicant.id, amount: 345.0, transaction_type: maintenance_out) }
 
-    it "returns expected JSON structure" do
-      expect(call).to eq({
-        cash_transactions: {
-          income: [
-            {
-              category: "benefits",
-              payments: [
-                { date: Date.current.at_beginning_of_month - 3.months, amount: 345.0, client_id: third_benefits_month.id },
-                { date: Date.current.at_beginning_of_month - 2.months, amount: 234.0, client_id: second_benefits_month.id },
-                { date: Date.current.at_beginning_of_month - 1.month, amount: 123.0, client_id: first_benefits_month.id },
-              ],
-            },
-          ],
-          outgoings: [
-            {
-              category: "maintenance_out",
-              payments: [
-                { date: Date.current.at_beginning_of_month - 3.months, amount: 345.0, client_id: third_maintenance_month.id },
-                { date: Date.current.at_beginning_of_month - 2.months, amount: 234.0, client_id: second_maintenance_month.id },
-                { date: Date.current.at_beginning_of_month - 1.month, amount: 123.0, client_id: first_maintenance_month.id },
-              ],
-            },
-          ],
-        },
-      }.to_json)
+    before do
+      create(:cash_transaction, :credit_month1, legal_aid_application:, owner_type: "Partner", owner_id: legal_aid_application.partner.id, amount: 456.0, transaction_type: benefits)
+      create(:cash_transaction, :credit_month2, legal_aid_application:, owner_type: "Partner", owner_id: legal_aid_application.partner.id, amount: 789.0, transaction_type: benefits)
+      create(:cash_transaction, :credit_month3, legal_aid_application:, owner_type: "Partner", owner_id: legal_aid_application.partner.id, amount: 890.0, transaction_type: benefits)
+    end
+
+    context "when no owner_type is specified" do
+      it "returns expected JSON structure" do
+        expect(call).to eq({
+          cash_transactions: {
+            income: [
+              {
+                category: "benefits",
+                payments: [
+                  { date: Date.current.at_beginning_of_month - 3.months, amount: 345.0, client_id: third_benefits_month.id },
+                  { date: Date.current.at_beginning_of_month - 2.months, amount: 234.0, client_id: second_benefits_month.id },
+                  { date: Date.current.at_beginning_of_month - 1.month, amount: 123.0, client_id: first_benefits_month.id },
+                ],
+              },
+            ],
+            outgoings: [
+              {
+                category: "maintenance_out",
+                payments: [
+                  { date: Date.current.at_beginning_of_month - 3.months, amount: 345.0, client_id: third_maintenance_month.id },
+                  { date: Date.current.at_beginning_of_month - 2.months, amount: 234.0, client_id: second_maintenance_month.id },
+                  { date: Date.current.at_beginning_of_month - 1.month, amount: 123.0, client_id: first_maintenance_month.id },
+                ],
+              },
+            ],
+          },
+        }.to_json)
+      end
+    end
+
+    context "when partner is specified as owner" do
+      subject(:call) { described_class.call(legal_aid_application, "Partner") }
+
+      let(:partner_transactions) { legal_aid_application.cash_transactions.where(owner_type: "Partner") }
+      let(:month_three) { partner_transactions.find_by(transaction_date: Date.current.at_beginning_of_month - 3.months) }
+      let(:month_two) { partner_transactions.find_by(transaction_date: Date.current.at_beginning_of_month - 2.months) }
+      let(:month_one) { partner_transactions.find_by(transaction_date: Date.current.at_beginning_of_month - 1.month) }
+
+      it "returns expected JSON structure" do
+        expect(call).to eq({
+          cash_transactions: {
+            income: [
+              {
+                category: "benefits",
+                payments: [
+                  { date: month_three.transaction_date, amount: 890.0, client_id: month_three.id },
+                  { date: month_two.transaction_date, amount: 789.0, client_id: month_two.id },
+                  { date: month_one.transaction_date, amount: 456.0, client_id: month_one.id },
+                ],
+              },
+            ],
+            outgoings: [],
+          },
+        }.to_json)
+      end
     end
   end
 end

--- a/spec/services/cfe_civil/components/employments_spec.rb
+++ b/spec/services/cfe_civil/components/employments_spec.rb
@@ -3,10 +3,10 @@ require "rails_helper"
 RSpec.describe CFECivil::Components::Employments do
   subject(:call) { described_class.call(legal_aid_application) }
 
-  let(:legal_aid_application) { create(:legal_aid_application, :with_applicant) }
+  let(:legal_aid_application) { create(:legal_aid_application) }
 
   context "when the applicant is not employed" do
-    before { create(:applicant, :not_employed) }
+    before { create(:applicant, :not_employed, legal_aid_application:) }
 
     it "renders the expected, empty hash" do
       expect(call).to eq({}.to_json)
@@ -15,7 +15,7 @@ RSpec.describe CFECivil::Components::Employments do
 
   context "when the applicant is employed but has no PAYE data" do
     before do
-      applicant = create(:applicant, :employed)
+      applicant = create(:applicant, :employed, legal_aid_application:)
       create(:employment, legal_aid_application:, owner_id: applicant.id, owner_type: applicant.class)
     end
 
@@ -24,61 +24,116 @@ RSpec.describe CFECivil::Components::Employments do
     end
   end
 
-  context "when the applicant is employed" do
-    let(:applicant) { create(:applicant, :employed) }
-
+  context "when the applicant and partner are employed" do
     before do
-      create(:applicant, :employed)
+      applicant = create(:applicant, :employed, legal_aid_application:)
+      partner = create(:partner, :employed, legal_aid_application:)
       create(:employment, :example1_usecase1, legal_aid_application:, owner_id: applicant.id, owner_type: applicant.class)
+      create(:employment, :example2_usecase1, legal_aid_application:, owner_id: partner.id, owner_type: partner.class)
     end
 
-    it "renders the expected JSON" do
-      expect(call).to eq({
-        employment_income: [
-          {
-            name: "Job 788",
-            client_id: "12345678-1234-1234-1234-123456789abc",
-            payments: [
-              {
-                client_id: "20211128-0000-0000-0000-123456789abc",
-                date: "2021-11-28",
-                gross: 1868.98,
-                benefits_in_kind: 0.0,
-                tax: -161.8,
-                national_insurance: -128.64,
-                net_employment_income: 1578.54,
-              },
-              {
-                client_id: "20211028-0000-0000-0000-123456789abc",
-                date: "2021-10-28",
-                gross: 1868.98,
-                benefits_in_kind: 0.0,
-                tax: -111.0,
-                national_insurance: -128.64,
-                net_employment_income: 1629.34,
-              },
-              {
-                client_id: "20210928-0000-0000-0000-123456789abc",
-                date: "2021-09-28",
-                gross: 2492.61,
-                benefits_in_kind: 0.0,
-                tax: -286.6,
-                national_insurance: -203.47,
-                net_employment_income: 2002.54,
-              },
-              {
-                client_id: "20210828-0000-0000-0000-123456789abc",
-                date: "2021-08-28",
-                gross: 2345.29,
-                benefits_in_kind: 0.0,
-                tax: -257.2,
-                national_insurance: -185.79,
-                net_employment_income: 1902.3,
-              },
-            ],
-          },
-        ],
-      }.to_json)
+    context "and no owner type is specified" do
+      it "renders the expected JSON for just the client" do
+        expect(call).to eq({
+          employment_income: [
+            {
+              name: "Job 788",
+              client_id: "12345678-1234-1234-1234-123456789abc",
+              payments: [
+                {
+                  client_id: "20211128-0000-0000-0000-123456789abc",
+                  date: "2021-11-28",
+                  gross: 1868.98,
+                  benefits_in_kind: 0.0,
+                  tax: -161.8,
+                  national_insurance: -128.64,
+                  net_employment_income: 1578.54,
+                },
+                {
+                  client_id: "20211028-0000-0000-0000-123456789abc",
+                  date: "2021-10-28",
+                  gross: 1868.98,
+                  benefits_in_kind: 0.0,
+                  tax: -111.0,
+                  national_insurance: -128.64,
+                  net_employment_income: 1629.34,
+                },
+                {
+                  client_id: "20210928-0000-0000-0000-123456789abc",
+                  date: "2021-09-28",
+                  gross: 2492.61,
+                  benefits_in_kind: 0.0,
+                  tax: -286.6,
+                  national_insurance: -203.47,
+                  net_employment_income: 2002.54,
+                },
+                {
+                  client_id: "20210828-0000-0000-0000-123456789abc",
+                  date: "2021-08-28",
+                  gross: 2345.29,
+                  benefits_in_kind: 0.0,
+                  tax: -257.2,
+                  national_insurance: -185.79,
+                  net_employment_income: 1902.3,
+                },
+              ],
+            },
+          ],
+        }.to_json)
+      end
+    end
+
+    context "and partner is specified as owner type" do
+      subject(:call) { described_class.call(legal_aid_application, "Partner") }
+
+      it "renders the expected JSON for just the partner" do
+        expect(call).to eq({
+          employments: [
+            {
+              name: "Job 877",
+              client_id: "87654321-1234-1234-1234-123456789abc",
+              payments: [
+                {
+                  client_id: "20231024-0000-0000-0000-123456789abc",
+                  date: "2021-11-28",
+                  gross: 1868.98,
+                  benefits_in_kind: 0.0,
+                  tax: -161.8,
+                  national_insurance: -128.64,
+                  net_employment_income: 1578.54,
+                },
+                {
+                  client_id: "20230924-0000-0000-0000-123456789abc",
+                  date: "2021-10-28",
+                  gross: 1868.98,
+                  benefits_in_kind: 0.0,
+                  tax: -111.0,
+                  national_insurance: -128.64,
+                  net_employment_income: 1629.34,
+                },
+                {
+                  client_id: "20230824-0000-0000-0000-123456789abc",
+                  date: "2021-09-28",
+                  gross: 2492.61,
+                  benefits_in_kind: 0.0,
+                  tax: -286.6,
+                  national_insurance: -203.47,
+                  net_employment_income: 2002.54,
+                },
+                {
+                  client_id: "20230724-0000-0000-0000-123456789abc",
+                  date: "2021-08-28",
+                  gross: 2345.29,
+                  benefits_in_kind: 0.0,
+                  tax: -257.2,
+                  national_insurance: -185.79,
+                  net_employment_income: 1902.3,
+                },
+              ],
+            },
+          ],
+        }.to_json)
+      end
     end
   end
 end

--- a/spec/services/cfe_civil/components/irregular_incomes_spec.rb
+++ b/spec/services/cfe_civil/components/irregular_incomes_spec.rb
@@ -21,10 +21,6 @@ RSpec.describe CFECivil::Components::IrregularIncomes do
   context "when both applicant and partner record student finance" do
     let(:applicant) { create(:applicant, student_finance: true, student_finance_amount: 3628.07) }
     let(:partner) { create(:partner, student_finance: true, student_finance_amount: 1234.56) }
-    # before do
-    #   create(:applicant, student_finance: true, student_finance_amount: 3628.07)
-    #   create(:partner, student_finance: true, student_finance_amount: 1234.56)
-    # end
 
     context "when no owner type is specified" do
       it "returns the expected JSON block with only the applicant data" do

--- a/spec/services/cfe_civil/components/irregular_incomes_spec.rb
+++ b/spec/services/cfe_civil/components/irregular_incomes_spec.rb
@@ -3,10 +3,11 @@ require "rails_helper"
 RSpec.describe CFECivil::Components::IrregularIncomes do
   subject(:call) { described_class.call(legal_aid_application) }
 
-  let(:legal_aid_application) { create(:legal_aid_application, applicant:) }
+  let(:legal_aid_application) { create(:legal_aid_application, applicant:, partner:) }
 
   context "when there are no irregular payments" do
     let(:applicant) { create(:applicant, student_finance: false) }
+    let(:partner) { nil }
 
     it "returns the expected, empty, JSON block" do
       expect(call).to eq({
@@ -17,21 +18,44 @@ RSpec.describe CFECivil::Components::IrregularIncomes do
     end
   end
 
-  context "when payments are recorded" do
+  context "when both applicant and partner record student finance" do
     let(:applicant) { create(:applicant, student_finance: true, student_finance_amount: 3628.07) }
+    let(:partner) { create(:partner, student_finance: true, student_finance_amount: 1234.56) }
+    # before do
+    #   create(:applicant, student_finance: true, student_finance_amount: 3628.07)
+    #   create(:partner, student_finance: true, student_finance_amount: 1234.56)
+    # end
 
-    it "returns the expected JSON block" do
-      expect(call).to eq({
-        irregular_incomes: {
-          payments: [
+    context "when no owner type is specified" do
+      it "returns the expected JSON block with only the applicant data" do
+        expect(call).to eq({
+          irregular_incomes: {
+            payments: [
+              {
+                income_type: "student_loan",
+                frequency: "annual",
+                amount: 3628.07,
+              },
+            ],
+          },
+        }.to_json)
+      end
+    end
+
+    context "when partner is specified as owner type" do
+      subject(:call) { described_class.call(legal_aid_application, "Partner") }
+
+      it "returns the expected JSON block with only the partner data" do
+        expect(call).to eq({
+          irregular_incomes: [
             {
               income_type: "student_loan",
               frequency: "annual",
-              amount: 3628.07,
+              amount: 1234.56,
             },
           ],
-        },
-      }.to_json)
+        }.to_json)
+      end
     end
   end
 end

--- a/spec/services/cfe_civil/components/partner_spec.rb
+++ b/spec/services/cfe_civil/components/partner_spec.rb
@@ -1,0 +1,236 @@
+require "rails_helper"
+
+RSpec.describe CFECivil::Components::Partner do
+  subject(:call) { described_class.call(legal_aid_application) }
+
+  let(:legal_aid_application) do
+    create(:legal_aid_application,
+           :with_applicant_and_partner,
+           :with_positive_benefit_check_result,
+           transaction_period_finish_on: Time.zone.today)
+  end
+
+  describe ".call" do
+    context "when there is no partner" do
+      let(:legal_aid_application) do
+        create(:legal_aid_application,
+               :with_positive_benefit_check_result,
+               transaction_period_finish_on: Time.zone.today)
+      end
+
+      it "returns an empty json hash" do
+        expect(call).to eq({}.to_json)
+      end
+    end
+
+    it "returns json in the expected format" do
+      expect(call).to eq({
+        partner: {
+          partner: {
+            date_of_birth: legal_aid_application.partner.date_of_birth.strftime("%Y-%m-%d"),
+          },
+          cash_transactions: {
+            income: [],
+            outgoings: [],
+          },
+          irregular_incomes: [],
+          vehicles: [],
+          regular_transactions: [],
+          capitals: {
+            bank_accounts: [],
+            non_liquid_capital: [],
+          },
+        },
+      }.to_json)
+    end
+
+    context "when the partner has a vehicle" do
+      before do
+        create(:vehicle,
+               legal_aid_application:,
+               estimated_value: 2345.0,
+               payment_remaining: 321.0,
+               purchased_on: Date.new(2020, 5, 18),
+               used_regularly: true,
+               owner: "partner")
+      end
+
+      it "returns json in the expected format" do
+        expect(call).to eq({
+          partner: {
+            partner: {
+              date_of_birth: legal_aid_application.partner.date_of_birth.strftime("%Y-%m-%d"),
+            },
+            cash_transactions: {
+              income: [],
+              outgoings: [],
+            },
+            irregular_incomes: [],
+            vehicles: [
+              value: 2345.0,
+              loan_amount_outstanding: 321.0,
+              date_of_purchase: "2020-05-18",
+              in_regular_use: true,
+            ],
+            regular_transactions: [],
+            capitals: {
+              bank_accounts: [],
+              non_liquid_capital: [],
+            },
+          },
+        }.to_json)
+      end
+    end
+
+    context "when the partner has a regular friends and family income" do
+      before do
+        create(:regular_transaction,
+               :friends_or_family,
+               legal_aid_application:,
+               amount: 501.00,
+               frequency: "monthly",
+               owner_type: legal_aid_application.partner.class,
+               owner_id: legal_aid_application.partner.id)
+      end
+
+      it "returns json in the expected format" do
+        expect(call).to eq({
+          partner: {
+            partner: {
+              date_of_birth: legal_aid_application.partner.date_of_birth.strftime("%Y-%m-%d"),
+            },
+            cash_transactions: {
+              income: [],
+              outgoings: [],
+            },
+            irregular_incomes: [],
+            vehicles: [],
+            regular_transactions: [
+              {
+                category: "friends_or_family",
+                operation: "credit",
+                amount: 501.00,
+                frequency: "monthly",
+              },
+            ],
+            capitals: {
+              bank_accounts: [],
+              non_liquid_capital: [],
+            },
+          },
+        }.to_json)
+      end
+    end
+
+    context "when there are partner and joint bank accounts" do
+      before do
+        create(:savings_amount,
+               legal_aid_application:,
+               offline_current_accounts: 111,
+               offline_savings_accounts: 222,
+               partner_offline_current_accounts: 333,
+               partner_offline_savings_accounts: 444,
+               joint_offline_current_accounts: 555,
+               joint_offline_savings_accounts: 666)
+      end
+
+      it "returns json in the expected format" do
+        expect(call).to eq({
+          partner: {
+            partner: {
+              date_of_birth: legal_aid_application.partner.date_of_birth.strftime("%Y-%m-%d"),
+            },
+            cash_transactions: {
+              income: [],
+              outgoings: [],
+            },
+            irregular_incomes: [],
+            vehicles: [],
+            regular_transactions: [],
+            capitals: {
+              bank_accounts: [
+                { description: "Partner current accounts", value: "333.0" },
+                { description: "Partner savings accounts", value: "444.0" },
+                { description: "Joint current accounts", value: "555.0" },
+                { description: "Joint savings accounts", value: "666.0" },
+              ],
+              non_liquid_capital: [],
+            },
+          },
+        }.to_json)
+      end
+    end
+
+    context "when the partner is employed" do
+      before do
+        partner = legal_aid_application.partner
+        create(:employment, :example2_usecase1, legal_aid_application:, owner_id: partner.id, owner_type: partner.class)
+      end
+
+      it "returns json in the expected format" do
+        expect(call).to eq({
+          partner: {
+            partner: {
+              date_of_birth: legal_aid_application.partner.date_of_birth.strftime("%Y-%m-%d"),
+            },
+            cash_transactions: {
+              income: [],
+              outgoings: [],
+            },
+            irregular_incomes: [],
+            vehicles: [],
+            employments: [
+              {
+                name: "Job 877",
+                client_id: "87654321-1234-1234-1234-123456789abc",
+                payments: [
+                  {
+                    client_id: "20231024-0000-0000-0000-123456789abc",
+                    date: "2021-11-28",
+                    gross: 1868.98,
+                    benefits_in_kind: 0.0,
+                    tax: -161.8,
+                    national_insurance: -128.64,
+                    net_employment_income: 1578.54,
+                  },
+                  {
+                    client_id: "20230924-0000-0000-0000-123456789abc",
+                    date: "2021-10-28",
+                    gross: 1868.98,
+                    benefits_in_kind: 0.0,
+                    tax: -111.0,
+                    national_insurance: -128.64,
+                    net_employment_income: 1629.34,
+                  },
+                  {
+                    client_id: "20230824-0000-0000-0000-123456789abc",
+                    date: "2021-09-28",
+                    gross: 2492.61,
+                    benefits_in_kind: 0.0,
+                    tax: -286.6,
+                    national_insurance: -203.47,
+                    net_employment_income: 2002.54,
+                  },
+                  {
+                    client_id: "20230724-0000-0000-0000-123456789abc",
+                    date: "2021-08-28",
+                    gross: 2345.29,
+                    benefits_in_kind: 0.0,
+                    tax: -257.2,
+                    national_insurance: -185.79,
+                    net_employment_income: 1902.3,
+                  },
+                ],
+              },
+            ],
+            regular_transactions: [],
+            capitals: {
+              bank_accounts: [],
+              non_liquid_capital: [],
+            },
+          },
+        }.to_json)
+      end
+    end
+  end
+end

--- a/spec/services/cfe_civil/components/regular_transactions_spec.rb
+++ b/spec/services/cfe_civil/components/regular_transactions_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe CFECivil::Components::RegularTransactions do
   subject(:call) { described_class.call(legal_aid_application) }
 
-  let(:legal_aid_application) { create(:legal_aid_application, :with_applicant) }
+  let(:legal_aid_application) { create(:legal_aid_application, :with_applicant_and_partner) }
 
   context "when there are no regular transactions" do
     it "returns the expected, empty, JSON block" do
@@ -13,37 +13,69 @@ RSpec.describe CFECivil::Components::RegularTransactions do
     end
   end
 
-  context "when there are regular transactions" do
+  context "when there are regular transactions for both Applicant and Partner" do
     before do
+      applicant = legal_aid_application.applicant
+      partner = legal_aid_application.partner
       create(:regular_transaction,
              :maintenance_out,
              legal_aid_application:,
              amount: 222.22,
-             frequency: "monthly")
+             frequency: "monthly",
+             owner_type: applicant.class,
+             owner_id: applicant.id)
       create(:regular_transaction,
              :maintenance_in,
              legal_aid_application:,
              amount: 111.11,
-             frequency: "monthly")
+             frequency: "monthly",
+             owner_type: applicant.class,
+             owner_id: applicant.id)
+      create(:regular_transaction,
+             :friends_or_family,
+             legal_aid_application:,
+             amount: 501.00,
+             frequency: "monthly",
+             owner_type: partner.class,
+             owner_id: partner.id)
     end
 
-    it "returns the expected JSON block" do
-      expect(JSON.parse(call)).to match_json_expression({
-        regular_transactions: [
-          {
-            category: "maintenance_in",
-            operation: "credit",
-            amount: 111.11,
-            frequency: "monthly",
-          },
-          {
-            category: "maintenance_out",
-            operation: "debit",
-            amount: 222.22,
-            frequency: "monthly",
-          },
-        ],
-      })
+    context "and no owner is specified" do
+      it "returns the expected JSON block" do
+        expect(JSON.parse(call)).to match_json_expression({
+          regular_transactions: [
+            {
+              category: "maintenance_in",
+              operation: "credit",
+              amount: 111.11,
+              frequency: "monthly",
+            },
+            {
+              category: "maintenance_out",
+              operation: "debit",
+              amount: 222.22,
+              frequency: "monthly",
+            },
+          ],
+        })
+      end
+    end
+
+    context "and partner is specified as owner type" do
+      subject(:call) { described_class.call(legal_aid_application, "Partner") }
+
+      it "returns the expected JSON block just for the partner" do
+        expect(JSON.parse(call)).to match_json_expression({
+          regular_transactions: [
+            {
+              category: "friends_or_family",
+              operation: "credit",
+              amount: 501.00,
+              frequency: "monthly",
+            },
+          ],
+        })
+      end
     end
   end
 end

--- a/spec/services/cfe_civil/components/vehicles_spec.rb
+++ b/spec/services/cfe_civil/components/vehicles_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe CFECivil::Components::Vehicles do
   subject(:call) { described_class.call(legal_aid_application) }
 
-  let(:legal_aid_application) { create(:legal_aid_application, :with_applicant) }
+  let(:legal_aid_application) { create(:legal_aid_application, :with_applicant_and_partner) }
 
   context "when there are no vehicles" do
     it "returns the expected JSON block" do
@@ -13,25 +13,50 @@ RSpec.describe CFECivil::Components::Vehicles do
     end
   end
 
-  context "when a vehicle has been added" do
+  context "when vehicles have been added for both client and partner" do
     before do
       create(:vehicle,
              legal_aid_application:,
              estimated_value: 2345.0,
              payment_remaining: 321.0,
              purchased_on: Date.new(2020, 5, 18),
-             used_regularly: true)
+             used_regularly: true,
+             owner: "client")
+      create(:vehicle,
+             legal_aid_application:,
+             estimated_value: 3254.0,
+             payment_remaining: 123.0,
+             purchased_on: Date.new(2022, 6, 15),
+             used_regularly: true,
+             owner: "partner")
     end
 
-    it "returns the expected JSON block" do
-      expect(call).to eq({
-        vehicles: [
-          value: 2345.0,
-          loan_amount_outstanding: 321.0,
-          date_of_purchase: "2020-05-18",
-          in_regular_use: true,
-        ],
-      }.to_json)
+    context "and no owner is specified" do
+      it "returns the expected JSON block with only the applicant vehicle" do
+        expect(call).to eq({
+          vehicles: [
+            value: 2345.0,
+            loan_amount_outstanding: 321.0,
+            date_of_purchase: "2020-05-18",
+            in_regular_use: true,
+          ],
+        }.to_json)
+      end
+    end
+
+    context "and the partner is set as owner" do
+      subject(:call) { described_class.call(legal_aid_application, "partner") }
+
+      it "returns the expected JSON block with only the partner vehicle" do
+        expect(call).to eq({
+          vehicles: [
+            value: 3254.0,
+            loan_amount_outstanding: 123.0,
+            date_of_purchase: "2022-06-15",
+            in_regular_use: true,
+          ],
+        }.to_json)
+      end
     end
   end
 end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4359)

Update the CFE submission builder to add a partner object, if needed.

Update the, current supported, individual components to build an applicant or partner data set if an owner tpe of partner is submitted.

Some of the components are not needed, and some will need updating in the future when the truelayer flow is implemented for the partners

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
