### PR TITLE
AP-4427: Add alert and area-live=assertive for screen readers and reformat sign in page

### DIFF
--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -1,4 +1,6 @@
 class SamlIdpController < SamlIdp::IdpController
+  layout "application"
+
   def create
     if params[:email].present?
       provider = idp_authenticate(params[:email], params[:password])

--- a/app/views/saml_idp/idp/new.html.erb
+++ b/app/views/saml_idp/idp/new.html.erb
@@ -1,0 +1,39 @@
+<%= page_template page_title: "Sign in", back_link: :none do %>
+
+  <% if @saml_idp_fail_msg %>
+    <div class="govuk-error-summary" data-module="govuk-error-summary">
+      <div role="alert" aria-live="assertive">
+        <h2 class="govuk-error-summary__title">
+          There is a problem
+        </h2>
+        <div id="saml_idp_fail_msg" class="govuk-error-summary__body">
+          <ul class="govuk-list govuk-error-summary__list">
+            <li>
+              <a data-turbo="false" href="#email">
+                <%= @saml_idp_fail_msg %>
+              </a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  <% end %>
+
+  <%= form_tag do %>
+    <%= hidden_field_tag("SAMLRequest", params[:SAMLRequest]) %>
+
+    <div class="govuk-form-group">
+      <%= label_tag :email, nil, class: "govuk-label" %>
+      <%= email_field_tag :email, params[:email], autocapitalize: "off", autocorrect: "off", spellcheck: "false", size: 30, autocomplete: "off", class: "govuk-input" %>
+    </div>
+
+    <div class="govuk-form-group">
+      <%= label_tag :password, nil, class: "govuk-label" %>
+      <%= password_field_tag :password, params[:password], autocapitalize: "off", autocorrect: "off", spellcheck: "false", size: 30, autocomplete: "off", class: "govuk-input" %>
+    </div>
+
+    <%= submit_tag "Sign in", class: "govuk-button" %>
+
+  <% end %>
+
+<% end %>


### PR DESCRIPTION
## What

[Announce error message via screen reader ](https://dsdmoj.atlassian.net/browse/AP-4427)

Added role="alert" aria-live="assertive" to sign in page so that error message will be announced via screen readers.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
