### PR TITLE
Prevent sidekiq info log output during test run

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -9,6 +9,7 @@ redis_url = Rails.configuration.x.redis.base_url
 
 Sidekiq.configure_client do |config|
   config.redis = { url: redis_url }
+  config.logger.level = Logger::WARN if Rails.env.test?
 
   # accepts :expiration (optional)
   Sidekiq::Status.configure_client_middleware config, expiration: 30.minutes.to_i


### PR DESCRIPTION
## What
Prevent sidekiq info log output during test run

Dont't want to clutter up rspec and other test output
with information log entries as below.

```sh
......2023-10-24T11:22:09.788Z pid=43543 tid=rhf INFO: Sidekiq 7.1.6 connecting to Redis with options {:size=>10, :pool_name=>"internal", :url=>"redis://localhost:6379"}
```

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
