### PR TITLE
Fix: update context nesting so test passes every time

### DIFF
--- a/spec/services/banking/state_benefit_analyser_service_spec.rb
+++ b/spec/services/banking/state_benefit_analyser_service_spec.rb
@@ -70,22 +70,22 @@ RSpec.describe Banking::StateBenefitAnalyserService do
           expect(legal_aid_application.transaction_types).to include(included_benefit_transaction_type)
           expect(legal_aid_application.transaction_types).to include(excluded_benefit_transaction_type)
         end
+      end
 
-        context "and it's with child benefit under a new code HMRC CHILD BENEFIT" do
-          before do
-            create_list(:bank_transaction, 1, :credit, description: "HMRC CHILD BENEFIT", bank_account: bank_account1)
-            call
-          end
+      context "and it's with child benefit under a new code HMRC CHILD BENEFIT" do
+        before do
+          create_list(:bank_transaction, 1, :credit, description: "HMRC CHILD BENEFIT", bank_account: bank_account1)
+          call
+        end
 
-          it "marks the transaction as a state benefit" do
-            tx = legal_aid_application.reload.bank_transactions.first
-            expect(tx.transaction_type_id).to eq included_benefit_transaction_type.id
-          end
+        it "marks the transaction as a state benefit" do
+          tx = legal_aid_application.reload.bank_transactions.first
+          expect(tx.transaction_type_id).to eq included_benefit_transaction_type.id
+        end
 
-          it "updates the meta data with the label of the state benefit" do
-            tx = legal_aid_application.reload.bank_transactions.first
-            expect(tx.meta_data).to eq({ code: "HMRC CHILD BENEFIT", label: "hmrc_child_benefit", name: "Child Benefit", selected_by: "System" })
-          end
+        it "updates the meta data with the label of the state benefit" do
+          tx = legal_aid_application.reload.bank_transactions.first
+          expect(tx.meta_data).to eq({ code: "HMRC CHILD BENEFIT", label: "hmrc_child_benefit", name: "Child Benefit", selected_by: "System" })
         end
       end
 


### PR DESCRIPTION
## What

There is a flickering test caused by adding two bank transactions, and asserting what the first of these will look like. Due to race conditions, the order of the two is not consistent. This PR changes nesting of the context within a spec so only one bank transaction is added, giving a more consistent result

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
