### PR TITLE
AP-4586: Update PrometheusExporter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,7 +76,7 @@ gem "libreconv"
 gem "business"
 
 # Monitoring
-gem "prometheus_exporter", "=0.4.17"
+gem "prometheus_exporter"
 gem "webrick"
 
 # Generating Fake applications for tests and admin user

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -452,7 +452,8 @@ GEM
       optimist (~> 3.0)
     pg (1.5.4)
     pg_dump_anonymize (0.1.2)
-    prometheus_exporter (0.4.17)
+    prometheus_exporter (2.0.8)
+      webrick
     propshaft (0.8.0)
       actionpack (>= 7.0.0)
       activesupport (>= 7.0.0)
@@ -776,7 +777,7 @@ DEPENDENCIES
   pagy
   pg
   pg_dump_anonymize
-  prometheus_exporter (= 0.4.17)
+  prometheus_exporter
   propshaft
   pry-byebug
   pry-rescue

--- a/helm_deploy/apply-for-legal-aid/templates/deployment_metrics.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/deployment_metrics.yaml
@@ -29,7 +29,7 @@ spec:
         - name: metrics
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: IfNotPresent
-          command: ['sh', '-c', 'bundle exec prometheus_exporter -a app/lib/prometheus_collectors/collectors.rb']
+          command: ['sh', '-c', 'bundle exec prometheus_exporter -b 0.0.0.0 -a app/lib/prometheus_collectors/collectors.rb']
           ports:
           - containerPort: 9394
           livenessProbe:


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4586)

The redis update was blocked by the locked version of this gem.  
This updates the code to remove the lock and add the changes required to make the newer versions work

The following steps were undertaken and then merged into a single commit- at each stage I monitored the prometheus website to ensure that metrics were being received
- [x] Update from v0.4.17 => v0.5.0
- [x] Add bind to 0.0.0.0 to the startup command, gem changes mean it will only accept connections to localhost without this binding
- [x] Update from v0.5.0 => v1.0.1
- [x] Update from v1.0.1 => v2.0.8

Once this is merged, we will need to update the promethus checks in CPE to update some of the check names, e.g. 
`ruby_http_duration_seconds` has changed to `ruby_http_request_duration_seconds`

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
