### PR TITLE
AP-4567: Add non-passported to list of reasons on means report

### DIFF
--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -515,7 +515,7 @@ class LegalAidApplication < ApplicationRecord
   end
 
   def manual_client_employment_information?
-    applicant.extra_employment_information? || full_employment_details.present?
+    applicant&.extra_employment_information? || full_employment_details.present?
   end
 
   def manual_partner_employment_information?

--- a/app/services/ccms/manual_review_determiner.rb
+++ b/app/services/ccms/manual_review_determiner.rb
@@ -60,6 +60,7 @@ module CCMS
       application_review_reasons << :dwp_override if dwp_override
       application_review_reasons << :restrictions if has_restrictions?
       application_review_reasons << :policy_disregards if policy_disregards?
+      application_review_reasons << :non_passported if non_passported?
       application_review_reasons << :further_employment_details if manually_entered_employment_information?
       application_review_reasons << :uploaded_bank_statements if uploading_bank_statements?
       application_review_reasons << :ineligible if cfe_result.ineligible?

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -1298,6 +1298,7 @@ en:
           refunds: Tax or NI refunds
           uploaded_bank_statements: Bank statements uploaded
           ineligible: Applicant is ineligible
+          non_passported: Non-Passported application
       show:
         client_details_heading: Client details
         evidence_upload_heading: Supporting evidence

--- a/features/providers/means_report.feature
+++ b/features/providers/means_report.feature
@@ -103,6 +103,7 @@ Feature: Means report
       | question | answer |
       | Caseworker review required? | Yes |
       | Review reasons | Bank statements uploaded |
+      | Review reasons | Non-Passported application |
 
     And the Capital result questions should exist:
       | question |
@@ -271,6 +272,11 @@ Feature: Means report
       | question |
       | Caseworker review required? |
       | Review reasons |
+
+    And the Caseworker review section should contain:
+      | question | answer |
+      | Caseworker review required? | Yes |
+      | Review reasons | Non-Passported application |
 
     And the Capital result questions should exist:
       | question |

--- a/spec/services/ccms/manual_review_determiner_spec.rb
+++ b/spec/services/ccms/manual_review_determiner_spec.rb
@@ -257,10 +257,10 @@ module CCMS
 
       let(:cfe_result) { double "CFE Result", remarks: cfe_remarks, ineligible?: false }
       let(:cfe_remarks) { double "CFE Remarks", review_reasons: }
-      let(:review_reasons) { %i[unknown_frequency multi_benefit] }
-      let(:override_reasons) { %i[unknown_frequency multi_benefit dwp_override] }
-      let(:further_employment_details_reasons) { %i[unknown_frequency multi_benefit further_employment_details] }
-      let(:restrictions_reasons) { %i[unknown_frequency multi_benefit restrictions] }
+      let(:review_reasons) { %i[unknown_frequency multi_benefit non_passported] }
+      let(:override_reasons) { %i[unknown_frequency multi_benefit non_passported dwp_override] }
+      let(:further_employment_details_reasons) { %i[unknown_frequency multi_benefit non_passported further_employment_details] }
+      let(:restrictions_reasons) { %i[unknown_frequency multi_benefit non_passported restrictions] }
 
       before { allow_any_instance_of(cfe_submission.class).to receive(:result).and_return(cfe_result) }
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4567)

Add "Non-Passported application" to list of review reasons on means report if the application is non-passported. This is to avoid a situation whereby caseworkers are flagged to review an application but the list of review reasons is empty

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
