### PR TITLE
Fix: Partner review application page

### DIFF
--- a/app/views/shared/check_answers/_partner_details.html.erb
+++ b/app/views/shared/check_answers/_partner_details.html.erb
@@ -8,13 +8,13 @@
   <% if :contrary_interest.in?(attributes) %>
     <% summary_list.with_row do |row| %>
       <% row.with_key { t(".contrary_interest") } %>
-      <% row.with_value { yes_no(@applicant.partner_has_contrary_interest?) } %>
+      <% row.with_value { yes_no(@legal_aid_application.applicant.partner_has_contrary_interest?) } %>
       <% row.with_action(text: t("generic.change"), visually_hidden_text: t(".partner_contrary_interest"),
                          href: providers_legal_aid_application_contrary_interest_path(@legal_aid_application)) %>
     <% end %>
   <% end %>
 
-  <% unless @applicant.partner_has_contrary_interest? %>
+  <% unless @legal_aid_application.applicant.partner_has_contrary_interest? %>
     <% if :first_name.in?(attributes) %>
       <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__partner_first_name" }) do |row| %>
         <%= row.with_key(text: t(".first_name"), classes: "govuk-!-width-one-half") %>


### PR DESCRIPTION

## What

The partner_details partial was calling `partner_has_contrary_interest?` on a non-existant @applicant object.  
Changing it to invoke the full path, `@legal_aid_application.applicant.partner_has_contrary_interest?` ensures the pages renders correctly

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
