### PR TITLE
Amend example for RedisScanner utility class

### DIFF
--- a/lib/utilities/redis_scanner.rb
+++ b/lib/utilities/redis_scanner.rb
@@ -9,13 +9,11 @@ require "redis"
 # scanner.results
 #
 # Example usage:
-# redis = Sidekiq.redis { |r| r }
 #
 # require_relative 'lib/utilities/redis_scanner'
 #
+# redis  = Redis.new(url: Rails.configuration.x.redis.base_url)
 # scanner = Utilities::RedisScanner.new(redis)
-# OR
-# scanner = Utilities::RedisScanner.new(redis.redis) # if redis is instance of Redis::Namespace
 #
 # search for all keys that do not start with "stat"
 # scanner.call(/^((?!stat:).)*$/)


### PR DESCRIPTION

## What

Amend example for RedisScanner utility class

The scanner requires an instance of the Redis gem's Redis client
rather than the Redis connection return by Sidekiq.redis.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
