### PR TITLE
Fix: Gemfile.lock order

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -547,10 +547,10 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    redis (5.0.8)
-      redis-client (>= 0.17.0)
     rdoc (6.5.0)
       psych (>= 4.0.0)
+    redis (5.0.8)
+      redis-client (>= 0.17.0)
     redis-client (0.18.0)
       connection_pool
     regexp_parser (2.8.2)


### PR DESCRIPTION
## What

While rebasing the rails 7 PR, there was a conflict that I manually resolved and got the gems in the wrong, alphabetical, sequence.

This works fine on the servers but this PR should prevent other users seeing confusing update after running bundle install

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
