### PR TITLE
build(deps): bump govuk-frontend from 4.6.0 to 4.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "core-js": "^3.33.2",
     "dropzone": "^6.0.0-beta.2",
     "esbuild": "^0.19.5",
-    "govuk-frontend": "^4.6.0",
+    "govuk-frontend": "^4.7.0",
     "jest": "^29.7.0",
     "jquery": "^3.7.1",
     "js-search": "^2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3329,7 +3329,7 @@ gopd@^1.0.1:
   dependencies:
     get-intrinsic "^1.1.3"
 
-govuk-frontend@^4.6.0:
+govuk-frontend@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-4.7.0.tgz#69950b6c2e69f435ffe9aa60d8dee232dac977de"
   integrity sha512-0OsdCusF5qvLWwKziU8zqxiC0nq6WP0ZQuw51ymZ/1V0tO71oIKMlSLN2S9bm8RcEGSoidPt2A34gKxePrLjvg==


### PR DESCRIPTION

## What

Manually bump govuk-frontend from 4.6.0 to 4.7.0

It's been over 3 months since v4.7.0 was released, manually bumping it as our bot has not done it.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
