### PR TITLE
Share the have_error_message helper

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -80,6 +80,7 @@ RSpec.configure do |config|
   config.include Devise::Test::ControllerHelpers, type: :controller
   config.include Devise::Test::IntegrationHelpers, type: :request
   config.include Capybara::RSpecMatchers, type: :request
+  config.include Capybara::RequestHelpers, type: :request
 end
 
 Shoulda::Matchers.configure do |config|

--- a/spec/requests/providers/application_merits_task/matter_opposed_reasons_controller_spec.rb
+++ b/spec/requests/providers/application_merits_task/matter_opposed_reasons_controller_spec.rb
@@ -168,8 +168,4 @@ RSpec.describe Providers::ApplicationMeritsTask::MatterOpposedReasonsController 
     application_tasks = merits_task_list.reload.task_list.tasks[:application]
     application_tasks.detect { |task| task.name == :why_matter_opposed }
   end
-
-  def have_error_message(text)
-    have_css(".govuk-error-summary__list > li", text:)
-  end
 end

--- a/spec/requests/providers/confirm_client_declarations_controller_spec.rb
+++ b/spec/requests/providers/confirm_client_declarations_controller_spec.rb
@@ -81,8 +81,4 @@ RSpec.describe Providers::ConfirmClientDeclarationsController do
       it_behaves_like "a provider not authenticated"
     end
   end
-
-  def have_error_message(text)
-    have_css(".govuk-error-summary__list > li", text:)
-  end
 end

--- a/spec/requests/providers/has_national_insurance_numbers_controller_spec.rb
+++ b/spec/requests/providers/has_national_insurance_numbers_controller_spec.rb
@@ -88,9 +88,5 @@ RSpec.describe Providers::HasNationalInsuranceNumbersController do
         expect(page).to have_error_message("Select yes if the client has a National Insurance number")
       end
     end
-
-    def have_error_message(text)
-      have_css(".govuk-error-summary__list > li", text:)
-    end
   end
 end

--- a/spec/requests/providers/has_other_proceedings_controller_spec.rb
+++ b/spec/requests/providers/has_other_proceedings_controller_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe Providers::HasOtherProceedingsController do
 
       it "stays on the page if there is a validation error" do
         expect(response).to have_http_status(:ok)
-        expect(page).to have_error_message("has_other_proceeding.blank")
+        expect(page).to have_error_message("Select yes if you want to add another proceeding")
       end
     end
 
@@ -137,13 +137,6 @@ RSpec.describe Providers::HasOtherProceedingsController do
         proceeding_id = Query::IncompleteProceedings.call(legal_aid_application).in_order_of_addition.first.id
         expect(response).to redirect_to(providers_legal_aid_application_client_involvement_type_path(legal_aid_application.id, proceeding_id))
       end
-    end
-
-    def have_error_message(key)
-      have_css(
-        ".govuk-error-summary__list > li",
-        text: I18n.t(key, scope: "activemodel.errors.models.legal_aid_application.attributes"),
-      )
     end
   end
 

--- a/spec/requests/providers/means/student_finances_controller_spec.rb
+++ b/spec/requests/providers/means/student_finances_controller_spec.rb
@@ -159,8 +159,4 @@ RSpec.describe Providers::Means::StudentFinancesController do
       it_behaves_like "an authenticated provider from a different firm"
     end
   end
-
-  def have_error_message(message)
-    have_css(".govuk-error-summary__list > li", text: message)
-  end
 end

--- a/spec/requests/providers/partners/client_has_partners_controller_spec.rb
+++ b/spec/requests/providers/partners/client_has_partners_controller_spec.rb
@@ -57,9 +57,5 @@ RSpec.describe Providers::Partners::ClientHasPartnersController do
         expect(page).to have_error_message("Select yes if the client has a partner")
       end
     end
-
-    def have_error_message(text)
-      have_css(".govuk-error-summary__list > li", text:)
-    end
   end
 end

--- a/spec/requests/providers/partners/contrary_interests_controller_spec.rb
+++ b/spec/requests/providers/partners/contrary_interests_controller_spec.rb
@@ -84,9 +84,5 @@ RSpec.describe Providers::Partners::ContraryInterestsController do
         end
       end
     end
-
-    def have_error_message(text)
-      have_css(".govuk-error-summary__list > li", text:)
-    end
   end
 end

--- a/spec/requests/providers/partners/student_finances_controller_spec.rb
+++ b/spec/requests/providers/partners/student_finances_controller_spec.rb
@@ -158,8 +158,4 @@ RSpec.describe Providers::Partners::StudentFinancesController do
       it_behaves_like "an authenticated provider from a different firm"
     end
   end
-
-  def have_error_message(message)
-    have_css(".govuk-error-summary__list > li", text: message)
-  end
 end

--- a/spec/support/capybara/request_helpers.rb
+++ b/spec/support/capybara/request_helpers.rb
@@ -1,0 +1,14 @@
+module Capybara
+  module RequestHelpers
+    def self.included(base)
+      super
+      base.include(ContentHelpers)
+    end
+
+    module ContentHelpers
+      def have_error_message(text)
+        have_css(".govuk-error-summary__list > li", text:)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What
Mixin the have_error_message helper to all request specs

[Came out of story](https://dsdmoj.atlassian.net/browse/AP-4575)

use an extensible mixin for request spec capybara based helpers. Currently
there is only the have_error_message helper but there could be others in
the future or already existing that could be shared via this mechanims.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
