### PR TITLE
Rubocop: Address let! usage in tests

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -44,25 +44,6 @@ RSpec/AnyInstance:
     - 'spec/services/reports/merits_report_creator_spec.rb'
     - 'spec/services/reports/mis/application_details_report_spec.rb'
 
-# Offense count: 46
-RSpec/LetSetup:
-  Exclude:
-    - 'spec/forms/applicants/employed_form_spec.rb'
-    - 'spec/jobs/email_monitor_job_spec.rb'
-    - 'spec/jobs/scheduled_mailings_delivery_job_spec.rb'
-    - 'spec/presenters/applicant_account_presenter_spec.rb'
-    - 'spec/services/ccms/requestors/case_add_requestor_spec.rb'
-    - 'spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_additional_property_attributes_spec.rb'
-    - 'spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_attributes_spec.rb'
-    - 'spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_benefits_attrs_spec.rb'
-    - 'spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_dependant_child_attributes_spec.rb'
-    - 'spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_entities_spec.rb'
-    - 'spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_variable_attributes_spec.rb'
-    - 'spec/services/ccms/requestors/case_add_requestor_xml_blocks/passported_attributes_spec.rb'
-    - 'spec/services/reports/merits_report_creator_spec.rb'
-    - 'spec/workers/bank_holiday_update_worker_spec.rb'
-    - 'spec/workers/true_layer_banks_update_worker_spec.rb'
-
 # Offense count: 25
 RSpec/StubbedMock:
   Exclude:

--- a/spec/forms/applicants/employed_form_spec.rb
+++ b/spec/forms/applicants/employed_form_spec.rb
@@ -3,9 +3,7 @@ require "rails_helper"
 RSpec.describe Applicants::EmployedForm, type: :form do
   subject(:described_form) { described_class.new(form_params) }
 
-  let!(:application) { create(:legal_aid_application, applicant:) }
   let(:applicant) { create(:applicant, employed: nil) }
-
   let(:params) { { employed: true } }
   let(:form_params) { params.merge(model: applicant) }
 

--- a/spec/jobs/email_monitor_job_spec.rb
+++ b/spec/jobs/email_monitor_job_spec.rb
@@ -2,10 +2,11 @@ require "rails_helper"
 
 RSpec.describe EmailMonitorJob do
   describe "perform" do
-    let!(:waiting) { create(:scheduled_mailing, :due) }
-    let!(:created) { create(:scheduled_mailing, :created) }
-    let!(:processing) { create(:scheduled_mailing, :processing) }
-    let!(:sending) { create(:scheduled_mailing, :sending) }
+    before { create(:scheduled_mailing, :due) }
+
+    let(:created) { create(:scheduled_mailing, :created) }
+    let(:processing) { create(:scheduled_mailing, :processing) }
+    let(:sending) { create(:scheduled_mailing, :sending) }
 
     it "calls GovukEmails::Monitor for every scheduled mail record with a monitored status" do
       expect(GovukEmails::Monitor).to receive(:call).with(created.id)

--- a/spec/jobs/scheduled_mailings_delivery_job_spec.rb
+++ b/spec/jobs/scheduled_mailings_delivery_job_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe ScheduledMailingsDeliveryJob do
 
   describe "ScheduledMailingsDeliveryJob" do
     let(:application) { create(:application, :with_everything) }
-    let!(:mailing_one) { create(:scheduled_mailing, :due, legal_aid_application_id: application.id) }
-    let!(:mailing_two) { create(:scheduled_mailing, :due_later) }
+    let(:mailing_one) { create(:scheduled_mailing, :due, legal_aid_application_id: application.id) }
+    let(:mailing_two) { create(:scheduled_mailing, :due_later) }
 
     describe "perform" do
       context "when calling DeliveryMan" do

--- a/spec/presenters/applicant_account_presenter_spec.rb
+++ b/spec/presenters/applicant_account_presenter_spec.rb
@@ -3,20 +3,19 @@ require "rails_helper"
 RSpec.describe ApplicantAccountPresenter do
   subject(:applicant_account_presenter) { described_class.new(applicant.bank_providers.first) }
 
-  let!(:applicant) { create(:applicant) }
+  let(:applicant) { create(:applicant) }
   let(:addresses) do
     [{ address: Faker::Address.building_number,
        city: Faker::Address.city,
        zip: Faker::Address.zip }]
   end
-  let!(:applicant_bank_provider) { create(:bank_provider, applicant_id: applicant.id) }
+  let(:applicant_bank_provider) { create(:bank_provider, applicant_id: applicant.id) }
 
   let!(:applicant_bank_account_holder) do
-    create(:bank_account_holder, bank_provider_id: applicant_bank_provider.id,
-                                 addresses:)
+    create(:bank_account_holder, bank_provider_id: applicant_bank_provider.id, addresses:)
   end
 
-  let!(:applicant_bank_account) do
+  let(:applicant_bank_account) do
     create(:bank_account, bank_provider_id: applicant_bank_provider.id, currency: "GBP")
   end
 

--- a/spec/services/ccms/requestors/case_add_requestor_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_spec.rb
@@ -33,10 +33,7 @@ module CCMS
         end
 
         let(:proceeding) { legal_aid_application.proceedings.detect { |p| p.ccms_code == "DA001" } }
-
-        let!(:chances_of_success) do
-          create(:chances_of_success, :with_optional_text, proceeding:)
-        end
+        let(:chances_of_success) { proceeding.chances_of_success }
         let(:vehicles) { create_list(:vehicle, 1, estimated_value: 3030, payment_remaining: 881, purchased_on: Date.new(2008, 8, 22), used_regularly: true) }
         let(:domestic_abuse_summary) { create(:domestic_abuse_summary, :police_notified_true) }
 
@@ -57,18 +54,22 @@ module CCMS
         let(:opponents) { create_list(:opponent, 1, first_name: "Joffrey", last_name: "Test-Opponent") }
         let(:submission) { create(:submission, :case_ref_obtained, case_ccms_reference: "300000000001", legal_aid_application:) }
         let(:cfe_submission) { create(:cfe_submission, legal_aid_application:) }
-        let!(:cfe_result) { create(:cfe_v3_result, submission: cfe_submission) }
+        let(:cfe_result) { cfe_submission.cfe_result }
         let(:office) { create(:office, ccms_id: "4727432767") }
         let(:savings_amount) { create(:savings_amount, :all_nil) }
         let(:requestor) { described_class.new(submission, {}) }
-        let!(:involved_child1) { create(:involved_child, full_name: "First TestChild", date_of_birth: Date.parse("2019-01-20"), legal_aid_application:) }
-        let!(:involved_child2) { create(:involved_child, full_name: "Second TestChild", date_of_birth: Date.parse("2020-02-15"), legal_aid_application:) }
+        let(:involved_child1) { legal_aid_application.reload.involved_children.find_by(first_name: "First", last_name: "TestChild") }
+        let(:involved_child2) { legal_aid_application.reload.involved_children.find_by(first_name: "Second", last_name: "TestChild") }
 
         let(:request_xml) { requestor.__send__(:request_xml) }
         let(:expected_request_xml) { ccms_data_from_file("case_add_request.xml") }
         let(:request_created_at) { Time.zone.parse("2020-11-24T11:54:29.000") }
 
         before do
+          create(:cfe_v3_result, submission: cfe_submission)
+          create(:chances_of_success, :with_optional_text, proceeding:)
+          create(:involved_child, full_name: "First TestChild", date_of_birth: Date.parse("2019-01-20"), legal_aid_application:)
+          create(:involved_child, full_name: "Second TestChild", date_of_birth: Date.parse("2020-02-15"), legal_aid_application:)
           legal_aid_application.reload
           legal_aid_application.update!(opponents:)
           allow(Rails.configuration.x.ccms_soa).to receive(:client_username).and_return("FakeUser")

--- a/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_additional_property_attributes_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_additional_property_attributes_spec.rb
@@ -29,16 +29,16 @@ module CCMS
         end
 
         let(:proceeding) { legal_aid_application.proceedings.detect { |p| p.ccms_code == "DA001" } }
-        let!(:chances_of_success) do
-          create(:chances_of_success, :with_optional_text, proceeding:)
-        end
-
         let(:ccms_reference) { "300000054005" }
         let(:submission) { create(:submission, :case_ref_obtained, legal_aid_application:, case_ccms_reference: ccms_reference) }
         let(:cfe_submission) { create(:cfe_submission, legal_aid_application:) }
-        let!(:cfe_result) { create(:cfe_v3_result, submission: cfe_submission) }
         let(:requestor) { described_class.new(submission, {}) }
         let(:xml) { requestor.formatted_xml }
+
+        before do
+          create(:chances_of_success, :with_optional_text, proceeding:)
+          create(:cfe_v3_result, submission: cfe_submission)
+        end
 
         it "generates the expected block for each of the hard coded attrs" do
           hard_coded_attrs.each do |attr|

--- a/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_attributes_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_attributes_spec.rb
@@ -31,20 +31,21 @@ module CCMS
         end
 
         let!(:proceeding) { legal_aid_application.proceedings.detect { |p| p.ccms_code == "DA001" } }
-        let!(:chances_of_success) do
-          create(:chances_of_success, :with_optional_text, proceeding:)
-        end
         let(:opponent) { legal_aid_application.opponent }
         let(:ccms_reference) { "300000054005" }
         let(:submission) { create(:submission, :case_ref_obtained, legal_aid_application:, case_ccms_reference: ccms_reference) }
         let(:cfe_submission) { create(:cfe_submission, legal_aid_application:) }
-        let!(:cfe_result) { create(:cfe_v3_result, submission: cfe_submission) }
         let(:requestor) { described_class.new(submission, {}) }
         let(:xml) { requestor.formatted_xml }
         let(:success_prospect) { :likely }
         let(:timestamp) { Time.current.strftime("%Y-%m-%d_%H.%M") }
         let(:applicant) { legal_aid_application.applicant }
         let(:default_cost) { legal_aid_application.lead_proceeding.substantive_cost_limitation }
+
+        before do
+          create(:chances_of_success, :with_optional_text, proceeding:)
+          create(:cfe_v3_result, submission: cfe_submission)
+        end
 
         # uncomment this example to create a file of the payload for manual inspection
         # it 'create example payload file' do

--- a/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_benefits_attrs_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_benefits_attrs_spec.rb
@@ -29,16 +29,17 @@ module CCMS
                  office:)
         end
         let!(:proceeding) { legal_aid_application.proceedings.detect { |p| p.ccms_code == "DA001" } }
-        let!(:chances_of_success) do
-          create(:chances_of_success, :with_optional_text, proceeding:)
-        end
         let(:ccms_reference) { "300000054005" }
         let(:submission) { create(:submission, :case_ref_obtained, legal_aid_application:, case_ccms_reference: ccms_reference) }
         let(:cfe_submission) { create(:cfe_submission, legal_aid_application:) }
-        let!(:cfe_result) { create(:cfe_v3_result, submission: cfe_submission) }
         let(:requestor) { described_class.new(submission, {}) }
         let(:xml) { requestor.formatted_xml }
         let(:applicant) { legal_aid_application.applicant }
+
+        before do
+          create(:chances_of_success, :with_optional_text, proceeding:)
+          create(:cfe_v3_result, submission: cfe_submission)
+        end
 
         describe "boolean attributes" do
           # these are all currently coded as FALSE until such time as we can determine which benefits are received

--- a/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_dependant_child_attributes_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_dependant_child_attributes_spec.rb
@@ -20,10 +20,14 @@ module CCMS
         let(:ccms_reference) { "300000054005" }
         let(:submission) { create(:submission, :case_ref_obtained, legal_aid_application:, case_ccms_reference: ccms_reference) }
         let(:cfe_submission) { create(:cfe_submission, legal_aid_application:) }
-        let!(:cfe_result) { create(:cfe_v3_result, submission: cfe_submission) }
         let(:requestor) { described_class.new(submission, {}) }
         let(:xml) { requestor.formatted_xml }
         let(:dependants) { legal_aid_application.dependants.all }
+
+        before do
+          create(:chances_of_success, :with_optional_text, proceeding:)
+          create(:cfe_v3_result, submission: cfe_submission)
+        end
 
         describe "non-passported" do
           let(:legal_aid_application) do
@@ -37,10 +41,7 @@ module CCMS
                    provider:,
                    office:)
           end
-          let!(:proceeding) { legal_aid_application.proceedings.detect { |p| p.ccms_code == "DA001" } }
-          let!(:chances_of_success) do
-            create(:chances_of_success, :with_optional_text, proceeding:)
-          end
+          let(:proceeding) { legal_aid_application.proceedings.detect { |p| p.ccms_code == "DA001" } }
 
           context "with dependant children" do
             let!(:younger_child) { create(:dependant, :under15, legal_aid_application:, number: 1, has_income: false, assets_value: 1_000) }

--- a/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_entities_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_entities_spec.rb
@@ -30,18 +30,16 @@ module CCMS
         end
 
         let!(:proceeding) { legal_aid_application.proceedings.detect { |p| p.ccms_code == "DA001" } }
-        let!(:chances_of_success) do
-          create(:chances_of_success, :with_optional_text, proceeding:)
-        end
         let(:ccms_reference) { "300000054005" }
         let(:submission) { create(:submission, :case_ref_obtained, legal_aid_application:, case_ccms_reference: ccms_reference) }
         let(:cfe_submission) { create(:cfe_submission, legal_aid_application:) }
-        let!(:cfe_result) { create(:cfe_v3_result, submission: cfe_submission) }
         let(:requestor) { described_class.new(submission, {}) }
         let(:xml) { requestor.formatted_xml }
         let(:success_prospect) { :likely }
 
         before do
+          create(:chances_of_success, :with_optional_text, proceeding:)
+          create(:cfe_v3_result, submission: cfe_submission)
           legal_aid_application.reload
         end
 
@@ -193,7 +191,8 @@ module CCMS
             let(:applicant) { legal_aid_application.applicant }
             let(:bank_provider) { create(:bank_provider, applicant:) }
             let(:bank_account) { create(:bank_account, bank_provider:) }
-            let!(:bank_transactions) { create_list(:bank_transaction, 2, :friends_or_family, bank_account:) }
+
+            before { create_list(:bank_transaction, 2, :friends_or_family, bank_account:) }
 
             it "generate the entity" do
               expect(xml).to have_means_entity "CLIENT_FINANCIAL_SUPPORT"

--- a/spec/services/reports/merits_report_creator_spec.rb
+++ b/spec/services/reports/merits_report_creator_spec.rb
@@ -18,13 +18,13 @@ RSpec.describe Reports::MeritsReportCreator do
            ccms_submission:)
   end
   let(:da001) { legal_aid_application.proceedings.find_by(ccms_code: "DA001") }
-  let!(:chances_of_success) do
-    create(:chances_of_success, :with_optional_text, proceeding: da001)
-  end
   let(:ccms_submission) { create(:ccms_submission, :case_ref_obtained) }
   let(:smtl) { create(:legal_framework_merits_task_list, :da001, legal_aid_application:) }
 
-  before { allow(LegalFramework::MeritsTasksService).to receive(:call).with(legal_aid_application).and_return(smtl) }
+  before do
+    create(:chances_of_success, :with_optional_text, proceeding: da001)
+    allow(LegalFramework::MeritsTasksService).to receive(:call).with(legal_aid_application).and_return(smtl)
+  end
 
   describe ".call" do
     it "attaches merits_report.pdf to the application" do
@@ -76,13 +76,10 @@ RSpec.describe Reports::MeritsReportCreator do
       end
 
       let(:da001) { legal_aid_application.proceedings.find_by(ccms_code: "DA001") }
-      let!(:chances_of_success) do
-        create(:chances_of_success, :with_optional_text, proceeding: da001)
-      end
-
       let(:ccms_submission) { create(:ccms_submission) }
 
       before do
+        create(:chances_of_success, :with_optional_text, proceeding: da001)
         allow_any_instance_of(CCMS::Submission).to receive(:process!).with(any_args).and_return(true)
       end
 
@@ -103,11 +100,9 @@ RSpec.describe Reports::MeritsReportCreator do
         let(:ccms_submission) { create(:ccms_submission) }
 
         let(:da001) { legal_aid_application.proceedings.find_by(ccms_code: "DA001") }
-        let!(:chances_of_success) do
-          create(:chances_of_success, :with_optional_text, proceeding: da001)
-        end
 
         before do
+          create(:chances_of_success, :with_optional_text, proceeding: da001)
           allow(legal_aid_application).to receive(:case_ccms_reference).and_return(nil)
           allow(legal_aid_application).to receive(:create_ccms_submission).and_return(ccms_submission)
         end

--- a/spec/workers/bank_holiday_update_worker_spec.rb
+++ b/spec/workers/bank_holiday_update_worker_spec.rb
@@ -5,22 +5,25 @@ RSpec.describe BankHolidayUpdateWorker, vcr: { cassette_name: "gov_uk_bank_holid
 
   let(:bank_holiday_update_worker) { described_class.new }
   let(:stale_date) { Time.current.utc - described_class::UPDATE_INTERVAL - 2.hours }
-  let!(:bank_holiday) { create(:bank_holiday) }
 
-  it "returns true" do
-    expect(update_worker).to be true
-  end
+  context "when it is current" do
+    before { create(:bank_holiday) }
 
-  it "does not change the bank holiday" do
-    expect { update_worker }.not_to change(bank_holiday, :reload)
-  end
+    it "returns true" do
+      expect(update_worker).to be true
+    end
 
-  it "does not create a new bank holiday" do
-    expect { update_worker }.not_to change(BankHoliday, :count)
+    it "does not change the bank holiday" do
+      expect { update_worker }.not_to change(BankHoliday.first, :reload)
+    end
+
+    it "does not create a new bank holiday" do
+      expect { update_worker }.not_to change(BankHoliday, :count)
+    end
   end
 
   context "when outdated" do
-    let!(:bank_holiday) { create(:bank_holiday, updated_at: stale_date) }
+    before { create(:bank_holiday, updated_at: stale_date) }
 
     it "creates a new bank holiday instance" do
       expect { update_worker }.to change(BankHoliday, :count).by(1)
@@ -41,7 +44,7 @@ RSpec.describe BankHolidayUpdateWorker, vcr: { cassette_name: "gov_uk_bank_holid
   end
 
   context "when data retrieval fails" do
-    let!(:bank_holiday) { create(:bank_holiday, updated_at: stale_date) }
+    before { create(:bank_holiday, updated_at: stale_date) }
 
     it "raises error" do
       allow(BankHolidayRetriever).to receive(:dates).and_raise(BankHolidayRetriever::UnsuccessfulRetrievalError)

--- a/spec/workers/true_layer_banks_update_worker_spec.rb
+++ b/spec/workers/true_layer_banks_update_worker_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe TrueLayerBanksUpdateWorker, vcr: { cassette_name: "true_layer_ban
   end
 
   context "when outdated" do
-    let!(:true_layer_bank) { create(:true_layer_bank, updated_at: stale_date) }
+    let(:true_layer_bank) { create(:true_layer_bank, updated_at: stale_date) }
 
     it "creates a new bank holiday instance" do
       expect { update_worker }.to change(TrueLayerBank, :count).by(1)
@@ -41,7 +41,7 @@ RSpec.describe TrueLayerBanksUpdateWorker, vcr: { cassette_name: "true_layer_ban
   end
 
   context "when data retrieval fails" do
-    let!(:true_layer_bank) { create(:true_layer_bank, updated_at: stale_date) }
+    let(:true_layer_bank) { create(:true_layer_bank, updated_at: stale_date) }
 
     it "raises error" do
       allow(TrueLayer::BanksRetriever).to receive(:banks).and_raise(TrueLayer::BanksRetriever::UnsuccessfulRetrievalError)


### PR DESCRIPTION
## What

Remove RSpec/LetSetup from rubocop_todo
Remove all superfluous let! invocations from the RSpec code

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
