### PR TITLE
AP-4597:Update required evidence text,add line break,and add accessib…

### DIFF
--- a/app/views/providers/uploaded_evidence_collections/_upload_evidence.html.erb
+++ b/app/views/providers/uploaded_evidence_collections/_upload_evidence.html.erb
@@ -7,7 +7,7 @@
       local: true,
     ) do |form| %>
 
-  <%#= form.govuk_error_summary %>
+  <% if @uploaded_evidence_collection.errors.any? %>
     <div class="govuk-error-summary" data-module="govuk-error-summary">
       <div role="alert">
         <h2 class="govuk-error-summary__title">
@@ -15,16 +15,16 @@
         </h2>
         <div class="govuk-error-summary__body">
           <ul class="govuk-list govuk-error-summary__list">
-            <% if @mandatory_evidence_errors %>
-                <% @mandatory_evidence_errors.each do |error| %>
-                    <span class="govuk-visually-hidden">Error:</span>
-                    <%= error.message %><br>
-                <% end %>
+            <% @uploaded_evidence_collection.errors.each do |error| %>
+              <li>
+                <%= govuk_link_to error.type, "##{error.attribute}" %>
+              </li>
             <% end %>
           </ul>
         </div>
       </div>
     </div>
+  <% end %>
 
   <%= render partial: "shared/forms/error_summary_hidden", locals: { field_id: "uploaded-evidence-collection-original-file-field" } %>
 
@@ -60,8 +60,8 @@
         <% if @mandatory_evidence_errors %>
             <p id="dropzone-mandatory-error" class='govuk-error-message dropzone-error govuk-!-margin-bottom-1'>
               <% @mandatory_evidence_errors.each do |error| %>
-                  <span class="govuk-visually-hidden">Error:</span>
-                  <%= error.message %><br>
+                <span class="govuk-visually-hidden">Error:</span>
+                <%= error.message %><br>
               <% end %>
             </p>
         <% end %>

--- a/app/views/providers/uploaded_evidence_collections/_upload_evidence.html.erb
+++ b/app/views/providers/uploaded_evidence_collections/_upload_evidence.html.erb
@@ -43,8 +43,8 @@
         <% if @mandatory_evidence_errors %>
             <p id="dropzone-mandatory-error" class='govuk-error-message dropzone-error govuk-!-margin-bottom-1'>
               <% @mandatory_evidence_errors.each do |error| %>
-                <span class="govuk-visually-hidden">Error:</span>
-                <%= error.message %>
+                  <span class="govuk-visually-hidden">Error:</span>
+                  <%= error.message %><br>
               <% end %>
             </p>
         <% end %>

--- a/app/views/providers/uploaded_evidence_collections/_upload_evidence.html.erb
+++ b/app/views/providers/uploaded_evidence_collections/_upload_evidence.html.erb
@@ -42,7 +42,7 @@
         <div class="govuk-hint"><%= t(".size_hint") %></div>
         <% if @mandatory_evidence_errors %>
             <p id="dropzone-mandatory-error" class='govuk-error-message dropzone-error govuk-!-margin-bottom-1'>
-              <% @mandatory_evidence_errors.first do |error| %>
+              <% @mandatory_evidence_errors.each do |error| %>
                   <span class="govuk-visually-hidden">Error:</span>
                   <%= error.message %><br>
               <% end %>

--- a/app/views/providers/uploaded_evidence_collections/_upload_evidence.html.erb
+++ b/app/views/providers/uploaded_evidence_collections/_upload_evidence.html.erb
@@ -42,7 +42,7 @@
         <div class="govuk-hint"><%= t(".size_hint") %></div>
         <% if @mandatory_evidence_errors %>
             <p id="dropzone-mandatory-error" class='govuk-error-message dropzone-error govuk-!-margin-bottom-1'>
-              <% @mandatory_evidence_errors.each do |error| %>
+              <% @mandatory_evidence_errors.first do |error| %>
                   <span class="govuk-visually-hidden">Error:</span>
                   <%= error.message %><br>
               <% end %>

--- a/app/views/providers/uploaded_evidence_collections/_upload_evidence.html.erb
+++ b/app/views/providers/uploaded_evidence_collections/_upload_evidence.html.erb
@@ -7,7 +7,24 @@
       local: true,
     ) do |form| %>
 
-  <%= form.govuk_error_summary %>
+  <%#= form.govuk_error_summary %>
+    <div class="govuk-error-summary" data-module="govuk-error-summary">
+      <div role="alert">
+        <h2 class="govuk-error-summary__title">
+          <%= t("generic.errors.problem_text") %>
+        </h2>
+        <div class="govuk-error-summary__body">
+          <ul class="govuk-list govuk-error-summary__list">
+            <% if @mandatory_evidence_errors %>
+                <% @mandatory_evidence_errors.each do |error| %>
+                    <span class="govuk-visually-hidden">Error:</span>
+                    <%= error.message %><br>
+                <% end %>
+            <% end %>
+          </ul>
+        </div>
+      </div>
+    </div>
 
   <%= render partial: "shared/forms/error_summary_hidden", locals: { field_id: "uploaded-evidence-collection-original-file-field" } %>
 

--- a/app/views/providers/uploaded_evidence_collections/_uploaded_files.html.erb
+++ b/app/views/providers/uploaded_evidence_collections/_uploaded_files.html.erb
@@ -41,13 +41,12 @@
                 end
                 row.with_cell do
                   govuk_button_to(
-                    t(".delete"),
+                    t(".delete_html", filename: attachment.document.filename),
                     providers_legal_aid_application_uploaded_evidence_collection_path(@legal_aid_application),
                     method: :patch,
                     name: "delete_button",
                     class: "button-as-link",
                     params: { attachment_id: attachment.id },
-                    "aria-label": attachment.document.filename,
                   )
                 end
               end

--- a/app/views/providers/uploaded_evidence_collections/_uploaded_files.html.erb
+++ b/app/views/providers/uploaded_evidence_collections/_uploaded_files.html.erb
@@ -47,7 +47,7 @@
                     name: "delete_button",
                     class: "button-as-link",
                     params: { attachment_id: attachment.id },
-                    suffix: attachment.document.filename,
+                    "aria-label": attachment.document.filename,
                   )
                 end
               end

--- a/app/views/providers/uploaded_evidence_collections/show.html.erb
+++ b/app/views/providers/uploaded_evidence_collections/show.html.erb
@@ -11,7 +11,6 @@
       page_title: t(".h1-heading"),
       head_title: new_head_title,
       template: :basic,
-      show_errors_for: @submission_form&.model,
       back_link: { path: providers_legal_aid_application_merits_task_list_path(@legal_aid_application) },
     ) do %>
 

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -799,6 +799,7 @@ en:
         status: Status
         uploaded: Uploaded
         delete: Delete
+        delete_html: Delete <span class="govuk-visually-hidden">%{filename}</span>
         select_a_category: Select a category
         select_a_category_label: "Select a category for %{filename}"
         update: Update

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -769,9 +769,9 @@ en:
         h1-heading: Upload your client's bank statements
     uploaded_evidence_collections:
       upload_evidence:
-        single_item: "Use this page to provide evidence of %{evidence_type}."
-        section_8_evidence: Use this page to provide optional gateway evidence.
-        single_non_specific_item: "Use this page to provide %{item}."
+        single_item: "Use this page to upload %{evidence_type}."
+        section_8_evidence: Use this page to upload gateway evidence. This is optional.
+        single_non_specific_item: "Use this page to upload %{item}."
         list_text: 'Use this page to upload:'
         benefit_evidence: evidence that your client receives %{benefit}
         client_employment_evidence: evidence of your client's employment
@@ -780,7 +780,7 @@ en:
         court_application: the application to court for Section 8 proceedings (optional)
         court_order: the court order for Section 8 proceedings
         court_application_or_order: the application to court or court order for Section 8 proceedings
-        expert_report: expert reports, for example a CAFCASS report (optional)
+        expert_report: expert reports - for example, a CAFCASS report (optional)
         size_hint: The maximum file size is 7MB. Files must be a DOC, DOCX, RTF, ODT, JPG, BMP, PNG, TIF or PDF.
         dropzone_message: Drag and drop files here or
         choose_files_btn: Choose files

--- a/features/providers/check_single_employment.feature
+++ b/features/providers/check_single_employment.feature
@@ -138,7 +138,7 @@ Feature: Check single employment
 
     When I click 'Save and continue'
     Then I should be on a page showing "Upload supporting evidence"
-    And I should see "Use this page to provide evidence of your client's employment."
+    And I should see "Use this page to upload evidence of your client's employment."
 
     When I upload an evidence file named 'hello_world.pdf'
     And I sleep for 2 seconds

--- a/features/providers/partner_means_assessment/upload_partner_employment_evidence.feature
+++ b/features/providers/partner_means_assessment/upload_partner_employment_evidence.feature
@@ -31,4 +31,4 @@ Feature: Check partner employment evidence upload
     And I have completed an application where client and partner are both employed and "partner" has additional information
     And I visit "uploaded evidence collection"
 
-    Then I should see "Use this page to provide evidence of the partner's employment"
+    Then I should see "Use this page to upload evidence of the partner's employment"


### PR DESCRIPTION
…ilty for delete button



## What

[Fix error and accessibility messages on upload evidence page](https://dsdmoj.atlassian.net/browse/AP-4597)

Fix error and accessibility messages on upload evidence page so that:

- The error message at the top of the page lists out _every_ document that is missing which needs to be uploaded. Due to this design requirement, customised code was needed instead of the GOVUK Form Builder component. 
- In situations when the client has failed to upload more than one of the required documents, in the “Uploaded files” drop zone each required document is listed on a separate line rather than as a run-on sentence. 
- When using screen readers, such as VoicOver, the delete link reads out "Delete filename.doc" instead of just “delete.”

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
