### PR TITLE
Fix thread saftey connection pool issue

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -76,4 +76,8 @@ Rails.application.configure do
 
   # Switch to determine whether or not o collect HMRC data
   config.x.collect_hmrc_data = true
+
+  # This needs adding due to a rails 7.1.1 bug(?!) related to Unsafe threading and AR connection pool issues
+  # see https://github.com/rails/rails/issues/46797 for a good description
+  config.active_job.queue_adapter = :test
 end


### PR DESCRIPTION
Fix intermittent feature test failure

Intermittent cucumber test failure on CI for the
`features/providers/bank_statement_upload/uploading_files.feature`
with output such as:

```shell
message type 0x32 arrived from server while idle
message type 0x54 arrived from server while idle
message type 0x43 arrived from server while idle
message type 0x5a arrived from server while idle
```

From investigation it appears to be caused by a possible rails 7.1.1
bug(?!) related to Unsafe threading and AR connection pool issues
see https://github.com/rails/rails/issues/46797 for a good description.

you can test locally by looping over this particular test BUT it
is less reproducible locally than on CI.

```shell
for i in {1..10}; do; cucumber features/providers/bank_statement_upload/uploading_files.feature; done;
```

This also seems to have fixed the issue on assure see [commit](https://github.com/ministryofjustice/laa-assure-hmrc-data/pull/582/commits/2faeab6c3de37366520d89c0c22cfe65389c175c) 

## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-XXX)

Describe what you did and why.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
