### PR TITLE
AP-4574: Partner error messages on shared pages

### DIFF
--- a/app/controllers/providers/means/add_other_vehicles_controller.rb
+++ b/app/controllers/providers/means/add_other_vehicles_controller.rb
@@ -24,6 +24,7 @@ module Providers
           journey: :provider,
           radio_buttons_input_name: :add_another_vehicle,
           form_params:,
+          error: error_message,
         )
       end
 
@@ -31,6 +32,11 @@ module Providers
         return {} unless params[:binary_choice_form]
 
         params.require(:binary_choice_form).permit(:add_another_vehicle)
+      end
+
+      def error_message
+        key_name = legal_aid_application&.applicant&.has_partner_with_no_contrary_interest? ? "error_with_partner" : "error"
+        I18n.t("providers.add_another_vehicles.show.#{key_name}")
       end
     end
   end

--- a/app/controllers/providers/means/restrictions_controller.rb
+++ b/app/controllers/providers/means/restrictions_controller.rb
@@ -13,7 +13,7 @@ module Providers
     private
 
       def form_params
-        merge_with_model(legal_aid_application, journey: :providers) do
+        merge_with_model(legal_aid_application) do
           return {} unless params[:legal_aid_application]
 
           params.require(:legal_aid_application).permit(:has_restrictions, :restrictions_details)

--- a/app/controllers/providers/means/vehicles_controller.rb
+++ b/app/controllers/providers/means/vehicles_controller.rb
@@ -14,7 +14,7 @@ module Providers
     private
 
       def form_params
-        merge_with_model(legal_aid_application, journey: :providers) do
+        merge_with_model(legal_aid_application) do
           next {} unless params[:legal_aid_application]
 
           params.require(:legal_aid_application).permit(:own_vehicle)

--- a/app/forms/base_form.rb
+++ b/app/forms/base_form.rb
@@ -90,6 +90,10 @@ class BaseForm
     @draft
   end
 
+  def has_partner_with_no_contrary_interest?
+    model.applicant&.has_partner_with_no_contrary_interest?
+  end
+
 private
 
   def clean_attributes(hash)
@@ -127,5 +131,11 @@ private
       model_value = model_attributes[method]
       instance_variable_set(:"@#{method}", model_value) if !model_value.nil? && attributes[method].nil?
     end
+  end
+
+  def error_key(key_name)
+    return "#{key_name}_with_partner" if has_partner_with_no_contrary_interest?
+
+    key_name
   end
 end

--- a/app/forms/legal_aid_applications/own_home_form.rb
+++ b/app/forms/legal_aid_applications/own_home_form.rb
@@ -4,7 +4,7 @@ module LegalAidApplications
 
     attr_accessor :own_home
 
-    validates :own_home, presence: { unless: :draft? }
+    validates :own_home, presence_partner_optional: { partner_labels: :has_partner_with_no_contrary_interest? }, unless: :draft?
 
     delegate :own_home_no?, :own_home_mortgage?, :own_home_owned_outright?, to: :model
   end

--- a/app/forms/legal_aid_applications/own_vehicle_form.rb
+++ b/app/forms/legal_aid_applications/own_vehicle_form.rb
@@ -2,18 +2,14 @@ module LegalAidApplications
   class OwnVehicleForm < BaseForm
     form_for LegalAidApplication
 
-    attr_accessor :own_vehicle, :journey
+    attr_accessor :own_vehicle
 
     validate :own_vehicle_presence
 
     def own_vehicle_presence
       return if draft? || own_vehicle.present?
 
-      errors.add(:own_vehicle, I18n.t("activemodel.errors.models.legal_aid_application.attributes.own_vehicle.#{journey}.blank"))
-    end
-
-    def exclude_from_model
-      [:journey]
+      errors.add(:own_vehicle, I18n.t("activemodel.errors.models.legal_aid_application.attributes.own_vehicle.#{error_key('blank')}"))
     end
   end
 end

--- a/app/forms/legal_aid_applications/property_details_form.rb
+++ b/app/forms/legal_aid_applications/property_details_form.rb
@@ -11,16 +11,16 @@ module LegalAidApplications
 
     attr_accessor(*ATTRIBUTES)
 
-    validates :property_value, presence: { unless: :draft? }
-    validates :property_value, allow_blank: true, currency: { greater_than_or_equal_to: 0.0 }
+    validates :property_value, presence_partner_optional: { partner_labels: :has_partner_with_no_contrary_interest? }, unless: :draft?
+    validates :property_value, allow_blank: true, currency: { greater_than_or_equal_to: 0.0, partner_labels: :has_partner_with_no_contrary_interest? }
 
     validates :outstanding_mortgage_amount, presence: { unless: :outstanding_mortgage_amount_presence }
     validates :outstanding_mortgage_amount, allow_blank: true, currency: { greater_than_or_equal_to: 0.0 }
 
-    validates :shared_ownership, presence: { unless: :draft? }
+    validates :shared_ownership, presence_partner_optional: { partner_labels: :has_partner_with_no_contrary_interest? }, unless: :draft?
 
-    validates :percentage_home, presence: {  unless: :draft? }
-    validates :percentage_home, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 100 }, allow_blank: true
+    validates :percentage_home, presence_partner_optional: { partner_labels: :has_partner_with_no_contrary_interest? }, unless: :draft?
+    validates :percentage_home, allow_blank: true, numericality_partner_optional: { greater_than_or_equal_to: 0, less_than_or_equal_to: 100, partner_labels: :has_partner_with_no_contrary_interest? }
 
     def attributes_to_clean
       %i[property_value outstanding_mortgage_amount]

--- a/app/forms/legal_aid_applications/restrictions_form.rb
+++ b/app/forms/legal_aid_applications/restrictions_form.rb
@@ -2,34 +2,14 @@ module LegalAidApplications
   class RestrictionsForm < BaseForm
     form_for LegalAidApplication
 
-    attr_accessor :has_restrictions, :restrictions_details, :journey
+    attr_accessor :has_restrictions, :restrictions_details
 
     before_validation :clear_restrictions_details
 
-    validate :restrictions_presence
-    validate :restrictions_details_presence
+    validates :has_restrictions, presence_partner_optional: { partner_labels: :has_partner_with_no_contrary_interest? }, unless: :draft?
+    validates :restrictions_details, presence_partner_optional: { partner_labels: :has_partner_with_no_contrary_interest? }, unless: proc { has_restrictions.to_s != "true" }
 
   private
-
-    def restrictions_presence
-      return if draft? || has_restrictions.present?
-
-      add_blank_error_for :has_restrictions
-    end
-
-    def restrictions_details_presence
-      return if draft? || has_restrictions.to_s != "true"
-
-      add_blank_error_for :restrictions_details if restrictions_details.blank?
-    end
-
-    def add_blank_error_for(attribute)
-      errors.add(attribute, I18n.t("activemodel.errors.models.legal_aid_application.attributes.#{attribute}.#{journey}.blank"))
-    end
-
-    def exclude_from_model
-      [:journey]
-    end
 
     def clear_restrictions_details
       restrictions_details&.clear if has_restrictions.to_s == "false"

--- a/app/forms/providers/policy_disregards_form.rb
+++ b/app/forms/providers/policy_disregards_form.rb
@@ -22,6 +22,10 @@ module Providers
       CHECK_BOXES_ATTRIBUTES.map { |attribute| __send__(attribute) }.any?(&:present?)
     end
 
+    def has_partner_with_no_contrary_interest?
+      model.legal_aid_application.applicant&.has_partner_with_no_contrary_interest?
+    end
+
   private
 
     def any_checkbox_checked_or_draft
@@ -29,7 +33,7 @@ module Providers
     end
 
     def error_message_for_none_selected
-      I18n.t("activemodel.errors.models.policy_disregards.attributes.base.none_selected")
+      I18n.t("activemodel.errors.models.policy_disregards.attributes.base.#{error_key('none_selected')}")
     end
   end
 end

--- a/app/forms/savings_amounts/offline_accounts_form.rb
+++ b/app/forms/savings_amounts/offline_accounts_form.rb
@@ -66,8 +66,12 @@ module SavingsAmounts
       errors.add :check_box_offline_current_accounts, error_message_for_no_account_selected unless any_checkbox_checked? || draft?
     end
 
+    def has_partner_with_no_contrary_interest?
+      model.legal_aid_application&.applicant&.has_partner_with_no_contrary_interest?
+    end
+
     def error_message_for_no_account_selected
-      I18n.t("activemodel.errors.models.savings_amount.attributes.base.providers.no_account_selected")
+      I18n.t("activemodel.errors.models.savings_amount.attributes.base.providers.#{error_key('no_account_selected')}")
     end
   end
 end

--- a/app/validators/currency_validator.rb
+++ b/app/validators/currency_validator.rb
@@ -3,13 +3,39 @@ class CurrencyValidator < ActiveModel::Validations::NumericalityValidator
 
   def validate_each(record, attr_name, value)
     clean_value = clean_numeric_value(value)
-    super(record, attr_name, clean_value)
-    return if record.errors[attr_name].any?
+    super(record, attr_name, clean_value) # this requires the actual attribute symbol, e.g. :cash
 
-    record.errors.add(attr_name, :too_many_decimals) unless ONLY_2_DECIMALS_PATTERN.match?(clean_value)
+    replace_error_with_partner(record, attr_name) if any_errors_for?(record, attr_name) && use_partner_labels?(record)
+    return if any_errors_for?(record, attr_name)
+
+    record.errors.add(attr_name, decimal_error(record)) unless ONLY_2_DECIMALS_PATTERN.match?(clean_value)
   end
 
   def clean_numeric_value(value)
     CurrencyCleaner.new(value).call
+  end
+
+private
+
+  def any_errors_for?(record, attr_name)
+    record.errors[attr_name].any?
+  end
+
+  def use_partner_labels?(record)
+    return false if options[:partner_labels].blank?
+
+    record.send(options[:partner_labels])
+  end
+
+  def replace_error_with_partner(record, attr_name)
+    original_error_type = record.errors.where(attr_name).first.type
+    partner_error_type = "#{original_error_type}_with_partner".to_sym
+
+    record.errors.delete(attr_name) # delete original
+    record.errors.add(attr_name, partner_error_type) # replace with partner version
+  end
+
+  def decimal_error(record)
+    use_partner_labels?(record) ? :too_many_decimals_with_partner : :too_many_decimals
   end
 end

--- a/app/validators/numericality_partner_optional_validator.rb
+++ b/app/validators/numericality_partner_optional_validator.rb
@@ -1,0 +1,32 @@
+class NumericalityPartnerOptionalValidator < ActiveModel::Validations::NumericalityValidator
+  def validate_each(record, attr_name, value)
+    clean_value = clean_numeric_value(value)
+    super(record, attr_name, clean_value) # this requires the actual attribute symbol, e.g. :cash
+
+    replace_error_with_partner(record, attr_name) if any_errors_for?(record, attr_name) && use_partner_labels?(record)
+  end
+
+  def clean_numeric_value(value)
+    CurrencyCleaner.new(value).call
+  end
+
+private
+
+  def any_errors_for?(record, attr_name)
+    record.errors[attr_name].any?
+  end
+
+  def use_partner_labels?(record)
+    return false if options[:partner_labels].blank?
+
+    record.send(options[:partner_labels])
+  end
+
+  def replace_error_with_partner(record, attr_name)
+    original_error_type = record.errors.where(attr_name).first.type
+    partner_error_type = "#{original_error_type}_with_partner".to_sym
+
+    record.errors.delete(attr_name) # delete original
+    record.errors.add(attr_name, partner_error_type) # replace with partner version
+  end
+end

--- a/app/validators/presence_partner_optional_validator.rb
+++ b/app/validators/presence_partner_optional_validator.rb
@@ -1,0 +1,6 @@
+class PresencePartnerOptionalValidator < ActiveModel::Validations::PresenceValidator
+  def validate_each(record, attr_name, value)
+    key_name = record.send(options[:partner_labels]) ? :blank_with_partner : :blank
+    record.errors.add(attr_name, key_name, **options) if value.blank?
+  end
+end

--- a/app/views/providers/means/other_assets/show.html.erb
+++ b/app/views/providers/means/other_assets/show.html.erb
@@ -7,7 +7,12 @@
 
     <%= form.govuk_check_boxes_fieldset :other_assets,
                                         legend: { text: page_title, size: "xl", tag: "h1" },
-                                        hint: { text: t(".fieldset_hint") } do %>
+                                        hint: { text: t(".fieldset_hint") },
+                                        form_group: { class: @form.errors[:check_box_valuable_items_value].any? ? "govuk-form-group--error" : "" } do %>
+      <% if @form.errors[:check_box_valuable_items_value].any? %>
+        <p class="govuk-error-message" id="savings-amount-cash-error">
+          <span class="govuk-visually-hidden">Error: </span><%= @form.errors[:check_box_valuable_items_value].first %></p>
+      <% end %>
       <div class="govuk-checkboxes" data-module="govuk-checkboxes">
         <div class="deselect-group" data-deselect-ctrl="#other-assets-declaration-none-selected-true-field">
           <%= form.govuk_check_box :check_box_valuable_items_value,

--- a/app/views/providers/means/savings_and_investments/show.html.erb
+++ b/app/views/providers/means/savings_and_investments/show.html.erb
@@ -7,18 +7,22 @@
 
   <%= form.govuk_check_boxes_fieldset :savings_amount,
                                       legend: { text: page_title, size: "xl", tag: "h1" },
-                                      hint: { text: t("generic.select_all_that_apply") } do %>
+                                      hint: { text: t("generic.select_all_that_apply") },
+                                      form_group: { class: @form.errors[:check_box_cash].any? ? "govuk-form-group--error" : "" } do %>
+    <% if @form.errors[:check_box_cash].any? %>
+      <p class="govuk-error-message" id="savings-amount-cash-error">
+        <span class="govuk-visually-hidden">Error: </span><%= @form.errors[:check_box_cash].first %></p>
+    <% end %>
     <div class="govuk-checkboxes" data-module="govuk-checkboxes">
       <div class="deselect-group" data-deselect-ctrl="#savings-amount-none-selected-true-field">
         <% attributes.each_with_index do |attribute, idx| %>
-          <% link_errors = idx.zero? %>
           <% check_box_attribute = "check_box_#{attribute}" %>
           <% value = @form.send(attribute) %>
           <% @form.__send__("#{check_box_attribute}=", @form.send(check_box_attribute).present? || value.present?) %>
           <%= form.govuk_check_box check_box_attribute,
                                    true,
                                    multiple: false,
-                                   link_errors:,
+                                   link_errors: idx.zero?,
                                    label: { text: t(".#{check_box_attribute}") },
                                    hint: { text: t(".hint.#{individual}.#{check_box_attribute}", default: "") } do %>
             <%= form.govuk_text_field attribute,

--- a/app/views/providers/means/savings_and_investments/show.html.erb
+++ b/app/views/providers/means/savings_and_investments/show.html.erb
@@ -19,7 +19,7 @@
           <% check_box_attribute = "check_box_#{attribute}" %>
           <% value = @form.send(attribute) %>
           <% @form.__send__("#{check_box_attribute}=", @form.send(check_box_attribute).present? || value.present?) %>
-          <%= form.govuk_check_box check_box_attribute,
+          <%= form.govuk_check_box check_box_attribute.to_sym,
                                    true,
                                    multiple: false,
                                    link_errors: idx.zero?,

--- a/config/locales/cy/activemodel.yml
+++ b/config/locales/cy/activemodel.yml
@@ -269,10 +269,7 @@ cy:
             own_home:
               blank: ni evil yeht taht emoh eht snwo tneilc ruoy fi sey tceleS
             own_vehicle:
-              citizens:
-                blank: elcihev a nwo uoy fi sey tceleS
-              providers:
-                blank: elcihev a snwo tneilc ruoy fi sey tceleS
+              blank: elcihev a snwo tneilc ruoy fi sey tceleS
             property_value:
               blank: emoh s'tneilc ruoy rof eulav detamitse na retnE
               greater_than_or_equal_to: erom ro 0 eb tsum eulav detamitsE

--- a/config/locales/cy/activemodel.yml
+++ b/config/locales/cy/activemodel.yml
@@ -254,12 +254,8 @@ cy:
             has_dependants:
               blank: stnadneped yna sah tneilc ruoy fi sey tceleS
             has_restrictions:
-              citizens:
-                blank: stessa ruoy tsniaga gniworrob ro gnilles morf uoy tneverp taht
+              blank: stessa ruoy tsniaga gniworrob ro gnilles morf uoy tneverp taht
                   snoitcirtser era ereht fi sey tceleS
-              providers:
-                blank: stessa rieht tsniaga gniworrob ro gnilles morf tneilc ruoy
-                  tneverp taht snoitcirtser era ereht fi sey tceleS
             open_banking_consents:
               providers:
                 blank: eerga uoy fi sey tceleS
@@ -293,10 +289,7 @@ cy:
             shared_ownership:
               blank: esle enoyna htiw emoh rieht snwo tneilc ruoy fi sey tceleS
             restrictions_details:
-              citizens:
-                blank: yhw dna ,tsniaga worrob ro lles tonnac uoy stessa eht retnE
-              providers:
-                blank: yhw dna ,tsniaga worrob ro lles tonnac tneilc ruoy stessa eht
+              blank: yhw dna ,tsniaga worrob ro lles tonnac tneilc ruoy stessa eht
                   retnE
             substantive_application:
               blank: won noitacilppa evitnatsbus a ekam ot tnaw uoy fi sey tceleS

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -458,7 +458,8 @@ en:
             full_employment_details:
               blank: Enter your client's employment details
             own_home:
-              blank: Select yes if they own the home that they live in
+              blank: Select whether your client owns the home they live in
+              blank_with_partner: Select whether your client or their partner own the home your client lives in
             own_vehicle:
               blank: Select yes if your client owns a vehicle
               blank_with_partner: Select whether your client or their partner own a vehicle

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -810,32 +810,32 @@ en:
               blank: Enter the total amount in your client's current accounts
               greater_than_or_equal_to: Total in client's current accounts must be 0 or more
               not_a_number: "Total in client's current accounts must be an amount of money, like 60,000"
-              too_many_decimals: Estimated total in client's current accounts must not include more than 2 decimal numbers
+              too_many_decimals: Total in client's current accounts must not include more than 2 decimal numbers
             offline_savings_accounts:
               blank: Enter the total amount in your client's savings accounts
               greater_than_or_equal_to: Total in client's savings accounts must be 0 or more
               not_a_number: Total in client's savings accounts must be an amount of money, like 60,000
-              too_many_decimals: Estimated total in client's savings accounts must not include more than 2 decimal numbers
+              too_many_decimals: Total in client's savings accounts must not include more than 2 decimal numbers
             partner_offline_current_accounts:
-              blank: Enter the estimated total in the partners' current accounts
+              blank: Enter the total amount in the partner's current accounts
               greater_than_or_equal_to: Total in partners' current accounts must be 0 or more
               not_a_number: Total in partners' current accounts must be an amount of money, like 60,000
-              too_many_decimals: Estimated total in partners' current accounts must not include more than 2 decimal numbers
+              too_many_decimals: Total in partners' current accounts must not include more than 2 decimal numbers
             partner_offline_savings_accounts:
-              blank: Enter the estimated total in the partners' savings accounts
+              blank: Enter the total amount in the partner's savings accounts
               greater_than_or_equal_to: Total in partners' savings accounts must be 0 or more
               not_a_number: Total in partners' savings accounts must be an amount of money, like 60,000
-              too_many_decimals: Estimated total in partners' savings accounts must not include more than 2 decimal numbers
+              too_many_decimals: Total in partners' savings accounts must not include more than 2 decimal numbers
             joint_offline_current_accounts:
-              blank: Enter the estimated total in all joint current accounts
+              blank: Enter the total amount in your client and their partner's joint current accounts
               greater_than_or_equal_to: Total in joint current accounts must be 0 or more
               not_a_number: Total in joint current accounts must be an amount of money, like 60,000
-              too_many_decimals: Estimated total in joint current accounts must not include more than 2 decimal numbers
+              too_many_decimals: Total in joint current accounts must not include more than 2 decimal numbers
             joint_offline_savings_accounts:
-              blank: Enter the estimated total in all joint savings accounts
+              blank: Enter the total amount in your client and their partner's joint savings accounts
               greater_than_or_equal_to: Total in joint savings accounts must be 0 or more
               not_a_number: Total in joint savings accounts must be an amount of money, like 60,000
-              too_many_decimals: Estimated total in joint savings accounts must not include more than 2 decimal numbers
+              too_many_decimals: Total in joint savings accounts must not include more than 2 decimal numbers
             life_assurance_endowment_policy:
               blank: Enter the total value of life assurance policies
               greater_than_or_equal_to: Total of life assurance policies must be 0 or more

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -850,16 +850,16 @@ en:
               greater_than_or_equal_to: Total of certificates and bonds must be 0 or more
               not_a_number: Total of certificates and bonds must be an amount of money, like 60,000
               too_many_decimals: Estimated trust value must not include more than 2 decimal numbers
-              blank_with_partner: P+++ Enter the value of ISAs, National Savings Certificates and Premium Bonds for both your client and their partner
-              greater_than_or_equal_to_with_partner: P+++ Total of certificates and bonds must be 0 or more
-              not_a_number_with_partner: P+++ Total of certificates and bonds must be an amount of money, like 60,000
-              too_many_decimals_with_partner: P+++ Estimated trust value must not include more than 2 decimal numbers
+              blank_with_partner: Enter the value of ISAs, National Savings Certificates and Premium Bonds for both your client and their partner
+              greater_than_or_equal_to_with_partner: Total of certificates and bonds must be 0 or more
+              not_a_number_with_partner: Total of certificates and bonds must be an amount of money, like 60,000
+              too_many_decimals_with_partner: Estimated trust value must not include more than 2 decimal numbers
             other_person_account:
               blank: Enter the estimated total in other people's accounts
               greater_than_or_equal_to: Total in other people's accounts must be 0 or more
               not_a_number: Total in other people's accounts must be an amount of money, like 60,000
               too_many_decimals: Estimated other people's accounts value must not include more than 2 decimal numbers
-              blank_with_partner: Enter the value that can be accessed from other people's bank account for both your client and their partner
+              blank_with_partner: Enter the value that can be accessed from another person's bank account for both your client and their partner
               greater_than_or_equal_to_with_partner: Total in other people's accounts must be 0 or more
               not_a_number_with_partner: Total in other people's accounts must be an amount of money, like 60,000
               too_many_decimals_with_partner: Estimated other people's accounts value must not include more than 2 decimal numbers

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -465,21 +465,30 @@ en:
               blank_with_partner: Select whether your client or their partner own a vehicle
             property_value:
               blank: Enter how much the home your client lives in is worth
+              blank_with_partner: Enter how much the home your client and their partner lives in is worth
               greater_than_or_equal_to: How much the home your client lives in in must be 0 or more
+              greater_than_or_equal_to_with_partner: How much the home your client and their partner lives in must be 0 or more
               not_a_number: How much the home your client lives in must be an amount of money, like 60,000
-              too_many_decimals: How much the home your client lives in cannot include more than 2 decimal numbers
+              not_a_number_with_partner: The value of the home your client and their partner live in must be a number, like 60,000
+              too_many_decimals: The value of the home your client lives in cannot include more than 2 decimal places
+              too_many_decimals_with_partner: The value of the home your client and their partner live in cannot include more than 2 decimal places
             outstanding_mortgage_amount:
               blank: Enter how much is left to pay on the mortgage
-              greater_than_or_equal_to: How much is left to pay on the mortgage must be 0 or more
-              not_a_number: How much is left to pay on the mortgage must be an amount of money, like 60,000
-              too_many_decimals: How much is left to pay on the mortgage cannot include more than 2 decimal numbers
+              greater_than_or_equal_to: The amount left to pay on the mortgage must be 0 or more
+              not_a_number: The amount left to pay on the mortgage must be a number, like 60,000
+              too_many_decimals: The amount left to pay on the mortgage cannot include more than 2 decimal places
             shared_ownership:
               blank: Select yes if your client owns the home with anyone else
+              blank_with_partner: Select whether your client or their partner own the home with anyone else
             percentage_home:
               blank: Enter what percentage of the house your client legally owns
-              greater_than_or_equal_to: The percentage of the house your client legally owns must be 100 or less, like 60
-              less_than_or_equal_to: The percentage of the house your client legally owns must be 100 or less, like 60
-              not_a_number: The percentage of the house your client legally owns must be 100 or less, like 60
+              blank_with_partner: Enter what percentage of the house your client and their partner legally own
+              greater_than_or_equal_to: &value-1-100 The percentage of the house your client legally owns must be between 0 and 100, like 60
+              greater_than_or_equal_to_with_partner: &value-1-100-partner The percentage of the house your client and their partner legally own must be between 0 and 100, like 60
+              less_than_or_equal_to: *value-1-100
+              less_than_or_equal_to_with_partner: *value-1-100-partner
+              not_a_number: *value-1-100
+              not_a_number_with_partner: *value-1-100-partner
             restrictions_details:
               citizens:
                 blank: Enter the assets you cannot sell or borrow against, and why

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -460,10 +460,8 @@ en:
             own_home:
               blank: Select yes if they own the home that they live in
             own_vehicle:
-              citizens:
-                blank: Select yes if you own a vehicle
-              providers:
-                blank: Select yes if your client owns a vehicle
+              blank: Select yes if your client owns a vehicle
+              blank_with_partner: Select whether your client or their partner own a vehicle
             property_value:
               blank: Enter how much the home your client lives in is worth
               greater_than_or_equal_to: How much the home your client lives in in must be 0 or more

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -427,10 +427,8 @@ en:
               blank: Select yes if you want to add another proceeding
               must_add_domestic_abuse: You must add at least one domestic abuse proceeding
             has_restrictions:
-              citizens:
-                blank: Select yes if there are restrictions that prevent you from selling or borrowing against your assets
-              providers:
-                blank: Select yes if your client is prohibited from selling or borrowing against their assets
+              blank: Select yes if your client is prohibited from selling or borrowing against their assets
+              blank_with_partner: Select if your client or their partner is banned from selling or borrowing against their assets
             open_banking_consents:
               providers:
                 blank: Select yes if your client uses online banking
@@ -490,10 +488,8 @@ en:
               not_a_number: *value-1-100
               not_a_number_with_partner: *value-1-100-partner
             restrictions_details:
-              citizens:
-                blank: Enter the assets you cannot sell or borrow against, and why
-              providers:
-                blank: Enter the assets your client cannot sell or borrow against, and why
+              blank: Enter the assets your client cannot sell or borrow against, and why
+              blank_with_partner: Enter which assets your client or their partner cannot sell or borrow against, and why
             substantive_application:
               blank: Select yes if you want to make a substantive application now
             uncategorised_bank_transactions:

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -514,51 +514,88 @@ en:
               greater_than_or_equal_to: Estimated value must be £500 or more
               not_a_number: Estimated valuable items value must be an amount of money, like 60,000
               too_many_decimals: Estimated valuable items value must not include more than 2 decimal numbers
+              blank_with_partner: Enter the value of any valuable items worth £500 or more for both your client and their partner
+              greater_than_or_equal_to_with_partner: Estimated value must be £500 or more
+              not_a_number_with_partner: Estimated valuable items value must be an amount of money, like 60,000
+              too_many_decimals_with_partner: Estimated valuable items value must not include more than 2 decimal numbers
             land_value:
               blank: Enter the estimated land value
               greater_than_or_equal_to: Estimated land value must be 0 or more
               not_a_number: Estimated land value must be an amount of money, like 60,000
               too_many_decimals: Estimated land value must not include more than 2 decimal numbers
+              blank_with_partner: Enter the value of land for both your client and their partner
+              greater_than_or_equal_to_with_partner: Estimated land value must be 0 or more
+              not_a_number_with_partner: Estimated land value must be an amount of money, like 60,000
+              too_many_decimals_with_partner: Estimated land value must not include more than 2 decimal numbers
             inherited_assets_value:
               blank: Enter the estimated value of estate
               greater_than_or_equal_to: Estimated money assets value must be 0 or more
               not_a_number: Estimated estate value must be an amount of money, like 60,000
               too_many_decimals: Estimated money assets value must not include more than 2 decimal numbers
+              blank_with_partner: Enter the value of money or assets from the estate of a person who has died for both your client and their partner
+              greater_than_or_equal_to_with_partner: Estimated money assets value must be 0 or more
+              not_a_number_with_partner: Estimated estate value must be an amount of money, like 60,000
+              too_many_decimals_with_partner: Estimated money assets value must not include more than 2 decimal numbers
             money_owed_value:
               blank: Enter the estimated value of money owed
               greater_than_or_equal_to: Estimated money owed value must be 0 or more
               not_a_number: Estimated money owed must be an amount of money, like 60,000
               too_many_decimals: Estimated money owed value must not include more than 2 decimal numbers
+              blank_with_partner: Enter the amount owed for both your client and their partner
+              greater_than_or_equal_to_with_partner: Estimated money owed value must be 0 or more
+              not_a_number_with_partner: Estimated money owed must be an amount of money, like 60,000
+              too_many_decimals_with_partner: Estimated money owed value must not include more than 2 decimal numbers
             second_home_mortgage:
               blank: Enter outstanding mortgage amount
               greater_than_or_equal_to: Estimated second home mortgage must be 0 or more
               not_a_number: Outstanding mortgage amount must be an amount of money, like 60,000
               too_many_decimals: Estimated second home mortgage must not include more than 2 decimal numbers
+              blank_with_partner: Enter the outstanding mortgage amount for the second property or holiday home for both your client and their partner
+              greater_than_or_equal_to_with_partner: Estimated second home mortgage must be 0 or more
+              not_a_number_with_partner: Outstanding mortgage amount must be an amount of money, like 60,000
+              too_many_decimals_with_partner: Estimated second home mortgage must not include more than 2 decimal numbers
             second_home_percentage:
               blank: Enter property percentage share
               greater_than_or_equal_to: Estimated second home percentage value must be 0 or more
               not_a_number: Ownership share must be percentage, like 33.33
               too_many_decimals: Estimated second home percentage must not include more than 2 decimal numbers
+              blank_with_partner: Enter the share that your client and their partner owns in the second property or holiday home
+              greater_than_or_equal_to_with_partner: Estimated second home percentage value must be 0 or more
+              not_a_number_with_partner: Ownership share must be percentage, like 33.33
+              too_many_decimals_with_partner: Estimated second home percentage must not include more than 2 decimal numbers
             second_home_value:
               blank: Enter the estimated property value
               greater_than_or_equal_to: Estimated second home value must be 0 or more
               not_a_number: Estimated value must be an amount of money, like 60,000
               too_many_decimals: Estimated second home value must not include more than 2 decimal numbers
+              blank_with_partner: Enter the value of the second property or holiday home for both your client and their partner
+              greater_than_or_equal_to_with_partner: Estimated second home value must be 0 or more
+              not_a_number_with_partner: Estimated value must be an amount of money, like 60,000
+              too_many_decimals_with_partner: Estimated second home value must not include more than 2 decimal numbers
             timeshare_property_value:
               blank: Enter the estimated timeshare property value
               greater_than_or_equal_to: Estimated timeshare value must be 0 or more
               not_a_number: Estimated timeshare property value must be an amount of money, like 60,000
               too_many_decimals: Estimated timeshare value must not include more than 2 decimal numbers
+              blank_with_partner: Enter the value of the timeshare property, minus any loan and sale costs for both your client and their partner
+              greater_than_or_equal_to_with_partner: Estimated timeshare value must be 0 or more
+              not_a_number_with_partner: Estimated timeshare property value must be an amount of money, like 60,000
+              too_many_decimals_with_partner: Estimated timeshare value must not include more than 2 decimal numbers
             trust_value:
               blank: Enter the estimated value of trust
               greater_than_or_equal_to: Estimated trust value must be 0 or more
               not_a_number: Estimated trust value must be an amount of money, like 60,000
               too_many_decimals: Estimated trust value must not include more than 2 decimal numbers
+              blank_with_partner: Enter the value of interest in a trust for both your client and their partner
+              greater_than_or_equal_to_with_partner: Estimated trust value must be 0 or more
+              not_a_number_with_partner: Estimated trust value must be an amount of money, like 60,000
+              too_many_decimals_with_partner: Estimated trust value must not include more than 2 decimal numbers
             base:
               citizens:
                 none_selected: Select if you have any of these types of assets
               providers:
                 none_selected: Select if your client has any of these types of assets
+                none_selected_with_partner: Select the assets your client and their partner have, or select 'None of these assets'
         policy_disregards:
           attributes:
             base:

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -596,6 +596,7 @@ en:
           attributes:
             base:
               none_selected: Select if your client has received any of these payments
+              none_selected_with_partner: Select which schemes or trusts have paid either your client or their partner, or select 'None of these payments'
         proceeding:
           attributes:
             client_involvement_type_ccms_code:

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -748,25 +748,31 @@ en:
                 none_selected: Select if you have any of these savings or investments
               providers:
                 none_selected: Select if your client has any of these savings or investments
-                no_account_selected: Select if your client has current or savings accounts
+                none_selected_with_partner: Select the savings or investments your client and their partner have, or select 'None of these savings or investments'
+                no_account_selected: Select the bank accounts your client has, or select 'None of these'
+                no_account_selected_with_partner: Select the bank accounts your client and their partner have, or select 'None of these'
                 no_partner_account_selected: Select if the partner has current or savings accounts
             check_box_partner_offline_current_accounts:
               blank: Select if the partner has current or savings accounts
             cash:
-              blank: Enter the total amount of cash savings
-              greater_than_or_equal_to: Total cash savings must be 0 or more
-              not_a_number: Total cash savings must be an amount of money, like 60,000
-              too_many_decimals: Estimated cash value must not include more than 2 decimal numbers
+              blank: Enter the value of money that's not in a bank account for your client
+              greater_than_or_equal_to: The value of money that's not in a bank account must be 0 or more
+              not_a_number: The value of money that's not in a bank account must be an amount of money, like 60,000
+              too_many_decimals: The value of money that's not in a bank account must not include more than 2 decimal numbers
+              blank_with_partner: Enter the value of money that's not in a bank account for both your client and their partner
+              greater_than_or_equal_to_with_partner: The value of money that's not in a bank account must be 0 or more
+              not_a_number_with_partner: The value of money that's not in a bank account must be an amount of money, like 60,000
+              too_many_decimals_with_partner: The value of money that's not in a bank account must not include more than 2 decimal numbers
             offline_current_accounts:
-              blank: Enter the estimated total in all current accounts
-              greater_than_or_equal_to: Total in current accounts must be 0 or more
-              not_a_number: Total in current accounts must be an amount of money, like 60,000
-              too_many_decimals: Estimated total in current accounts must not include more than 2 decimal numbers
+              blank: Enter the total amount in your client's current accounts
+              greater_than_or_equal_to: Total in client's current accounts must be 0 or more
+              not_a_number: "Total in client's current accounts must be an amount of money, like 60,000"
+              too_many_decimals: Estimated total in client's current accounts must not include more than 2 decimal numbers
             offline_savings_accounts:
-              blank: Enter the estimated total in all savings accounts
-              greater_than_or_equal_to: Total in savings accounts must be 0 or more
-              not_a_number: Total in savings accounts must be an amount of money, like 60,000
-              too_many_decimals: Estimated total in savings accounts must not include more than 2 decimal numbers
+              blank: Enter the total amount in your client's savings accounts
+              greater_than_or_equal_to: Total in client's savings accounts must be 0 or more
+              not_a_number: Total in client's savings accounts must be an amount of money, like 60,000
+              too_many_decimals: Estimated total in client's savings accounts must not include more than 2 decimal numbers
             partner_offline_current_accounts:
               blank: Enter the estimated total in the partners' current accounts
               greater_than_or_equal_to: Total in partners' current accounts must be 0 or more
@@ -792,26 +798,46 @@ en:
               greater_than_or_equal_to: Total of life assurance policies must be 0 or more
               not_a_number: Total of life assurance policies must be an amount of money, like 60,000
               too_many_decimals: Estimated life assurance policies value must not include more than 2 decimal numbers
+              blank_with_partner: Enter the value of life assurance or endowment policies not linked to a mortgage for both your client and their partner
+              greater_than_or_equal_to_with_partner: Total of life assurance policies must be 0 or more
+              not_a_number_with_partner: Total of life assurance policies must be an amount of money, like 60,000
+              too_many_decimals_with_partner: Estimated life assurance policies value must not include more than 2 decimal numbers
             national_savings:
               blank: Enter the total value of certificates and bonds
               greater_than_or_equal_to: Total of certificates and bonds must be 0 or more
               not_a_number: Total of certificates and bonds must be an amount of money, like 60,000
               too_many_decimals: Estimated trust value must not include more than 2 decimal numbers
+              blank_with_partner: P+++ Enter the value of ISAs, National Savings Certificates and Premium Bonds for both your client and their partner
+              greater_than_or_equal_to_with_partner: P+++ Total of certificates and bonds must be 0 or more
+              not_a_number_with_partner: P+++ Total of certificates and bonds must be an amount of money, like 60,000
+              too_many_decimals_with_partner: P+++ Estimated trust value must not include more than 2 decimal numbers
             other_person_account:
-              blank: Enter the estimated total in other people’s accounts
-              greater_than_or_equal_to: Total in other people’s accounts must be 0 or more
-              not_a_number: Total in other people’s accounts must be an amount of money, like 60,000
-              too_many_decimals: Estimated other people’s accounts value must not include more than 2 decimal numbers
+              blank: Enter the estimated total in other people's accounts
+              greater_than_or_equal_to: Total in other people's accounts must be 0 or more
+              not_a_number: Total in other people's accounts must be an amount of money, like 60,000
+              too_many_decimals: Estimated other people's accounts value must not include more than 2 decimal numbers
+              blank_with_partner: Enter the value that can be accessed from other people's bank account for both your client and their partner
+              greater_than_or_equal_to_with_partner: Total in other people's accounts must be 0 or more
+              not_a_number_with_partner: Total in other people's accounts must be an amount of money, like 60,000
+              too_many_decimals_with_partner: Estimated other people's accounts value must not include more than 2 decimal numbers
             peps_unit_trusts_capital_bonds_gov_stocks:
               blank: Enter the total value of other investments
               greater_than_or_equal_to: Total of other investments must be 0 or more
               not_a_number: Total of other investments must be an amount of money, like 60,000
               too_many_decimals: Estimated other investments value must not include more than 2 decimal numbers
+              blank_with_partner: Enter the total value of other investments for both your client and their partner
+              greater_than_or_equal_to_with_partner: Total of other investments must be 0 or more
+              not_a_number_with_partner: Total of other investments must be an amount of money, like 60,000
+              too_many_decimals_with_partner: Estimated other investments value must not include more than 2 decimal numbers
             plc_shares:
               blank: Enter the total value of shares
               greater_than_or_equal_to: Total of shares must be 0 or more
               not_a_number: Total of shares must be an amount of money, like 60,000
               too_many_decimals: Estimated shares value must not include more than 2 decimal numbers
+              blank_with_partner: Enter the value of shares in a PLC for both your client and their partner
+              greater_than_or_equal_to_with_partner: Total of shares must be 0 or more
+              not_a_number_with_partner: Total of shares must be an amount of money, like 60,000
+              too_many_decimals_with_partner: Estimated shares value must not include more than 2 decimal numbers
         setting:
           attributes:
             mock_true_layer_data:

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -786,6 +786,7 @@ en:
     add_another_vehicles:
       show:
         error: Select yes if they have other vehicles
+        error_with_partner: Select whether your client or their partner has any other vehicles
     add_another_state_benefits:
       show:
         error: Select yes if they have received other benefits

--- a/spec/forms/legal_aid_applications/property_details_form_spec.rb
+++ b/spec/forms/legal_aid_applications/property_details_form_spec.rb
@@ -1,0 +1,90 @@
+require "rails_helper"
+
+RSpec.describe LegalAidApplications::PropertyDetailsForm, type: :form do
+  subject(:described_form) { described_class.new(params.merge(model: legal_aid_application)) }
+
+  let(:legal_aid_application) { create(:legal_aid_application, :with_applicant_and_address) }
+
+  let(:params) do
+    {
+      property_value:,
+      outstanding_mortgage_amount: "20",
+      shared_ownership: "friend_family_member_or_other_individual",
+      percentage_home:,
+    }
+  end
+  let(:property_value) { "10,000" }
+  let(:percentage_home) { "85" }
+
+  describe "#validate" do
+    context "when no params are specified" do
+      let(:params) { {} }
+
+      it "raises an error" do
+        expect(described_form.save).to be false
+        expect(described_form.errors[:property_value]).to eq ["Enter how much the home your client lives in is worth"]
+        expect(described_form.errors[:outstanding_mortgage_amount]).to eq ["Enter how much is left to pay on the mortgage"]
+        expect(described_form.errors[:shared_ownership]).to eq ["Select yes if your client owns the home with anyone else"]
+        expect(described_form.errors[:percentage_home]).to eq ["Enter what percentage of the house your client legally owns"]
+      end
+    end
+
+    describe "property_value" do
+      before { described_form.valid? }
+
+      context "when the value is non numeric" do
+        let(:property_value) { "BOB" }
+
+        it { expect(described_form.errors[:property_value]).to eq ["How much the home your client lives in must be an amount of money, like 60,000"] }
+      end
+
+      context "when the value is below zero" do
+        let(:property_value) { "-50,000" }
+
+        it { expect(described_form.errors[:property_value]).to eq ["How much the home your client lives in in must be 0 or more"] }
+      end
+
+      context "when the value has too many decimals" do
+        let(:property_value) { "10,000.050" }
+
+        it { expect(described_form.errors[:property_value]).to eq ["The value of the home your client lives in cannot include more than 2 decimal places"] }
+      end
+    end
+
+    describe "percentage_home" do
+      before { described_form.valid? }
+
+      context "when the value is non numeric" do
+        let(:percentage_home) { "BOB" }
+
+        it { expect(described_form.errors[:percentage_home]).to eq ["The percentage of the house your client legally owns must be between 0 and 100, like 60"] }
+      end
+
+      context "when the value is below zero" do
+        let(:percentage_home) { "-50" }
+
+        it { expect(described_form.errors[:percentage_home]).to eq ["The percentage of the house your client legally owns must be between 0 and 100, like 60"] }
+      end
+
+      context "when the value is above 100" do
+        let(:percentage_home) { "110" }
+
+        it { expect(described_form.errors[:percentage_home]).to eq ["The percentage of the house your client legally owns must be between 0 and 100, like 60"] }
+      end
+    end
+  end
+
+  describe "#save" do
+    it "updates the legal aid application property attributes" do
+      expect(legal_aid_application.property_value).to be_nil
+      expect(legal_aid_application.outstanding_mortgage_amount).to be_nil
+      expect(legal_aid_application.shared_ownership).to be_nil
+      expect(legal_aid_application.percentage_home).to be_nil
+      described_form.save!
+      expect(legal_aid_application.property_value).to eq 10_000
+      expect(legal_aid_application.outstanding_mortgage_amount).to eq 20
+      expect(legal_aid_application.shared_ownership).to eq "friend_family_member_or_other_individual"
+      expect(legal_aid_application.percentage_home).to eq 85
+    end
+  end
+end

--- a/spec/forms/legal_aid_applications/restrictions_form_spec.rb
+++ b/spec/forms/legal_aid_applications/restrictions_form_spec.rb
@@ -4,14 +4,12 @@ RSpec.describe LegalAidApplications::RestrictionsForm, type: :form do
   subject(:described_form) { described_class.new(form_params) }
 
   let(:application) { create(:legal_aid_application, :with_applicant) }
-  let(:journey) { %i[providers citizens].sample }
   let(:restrictions_details) { Faker::Lorem.paragraph }
   let(:has_restrictions) { "true" }
   let(:params) do
     {
       has_restrictions:,
       restrictions_details:,
-      journey:,
     }
   end
   let(:form_params) { params.merge(model: application) }
@@ -52,7 +50,7 @@ RSpec.describe LegalAidApplications::RestrictionsForm, type: :form do
       end
 
       it "generates the expected error message" do
-        expect(described_form.errors[:restrictions_details]).to include I18n.t("activemodel.errors.models.legal_aid_application.attributes.restrictions_details.#{journey}.blank")
+        expect(described_form.errors[:restrictions_details]).to include "Enter the assets your client cannot sell or borrow against, and why"
       end
 
       context "with no restrictions present" do
@@ -63,7 +61,7 @@ RSpec.describe LegalAidApplications::RestrictionsForm, type: :form do
         end
 
         it "generates the expected error message" do
-          expect(described_form.errors[:has_restrictions]).to include I18n.t("activemodel.errors.models.legal_aid_application.attributes.has_restrictions.#{journey}.blank")
+          expect(described_form.errors[:has_restrictions]).to include "Select yes if your client is prohibited from selling or borrowing against their assets"
         end
       end
     end

--- a/spec/forms/savings_amounts/savings_amounts_form_spec.rb
+++ b/spec/forms/savings_amounts/savings_amounts_form_spec.rb
@@ -41,12 +41,12 @@ RSpec.describe SavingsAmounts::SavingsAmountsForm, type: :form do
       shared_examples_for "it has an error" do
         let(:attribute_map) do
           {
-            cash: /total.*cash savings/i,
-            other_person_account: /other people’s accounts/,
-            national_savings: /certificates and bonds/,
+            cash: /value of money that's/i,
+            other_person_account: /other people's.*account/,
+            national_savings: /certificates and.*bonds/i,
             plc_shares: /shares/,
-            peps_unit_trusts_capital_bonds_gov_stocks: /total.*of other investments/i,
-            life_assurance_endowment_policy: /total.*of life assurance policies/i,
+            peps_unit_trusts_capital_bonds_gov_stocks: /total.* of other investments/i,
+            life_assurance_endowment_policy: /(total|value).*of life assurance.*policies/i,
           }
         end
         it "returns false" do
@@ -69,7 +69,7 @@ RSpec.describe SavingsAmounts::SavingsAmountsForm, type: :form do
 
       context "when the amounts are empty" do
         let(:amount_params) { attributes.index_with { |_attr| "" } }
-        let(:expected_error) { /enter the( estimated)? total/i }
+        let(:expected_error) { /^Enter the/i }
 
         it_behaves_like "it has an error"
       end
@@ -85,12 +85,12 @@ RSpec.describe SavingsAmounts::SavingsAmountsForm, type: :form do
         context "and are not bank account attributes" do
           let(:attribute_map) do
             {
-              cash: /total.*cash savings/i,
-              other_person_account: /other people’s accounts/,
-              national_savings: /certificates and bonds/,
+              cash: /value of money that's/i,
+              other_person_account: /other people's accounts/,
+              national_savings: /certificates and.*bonds/i,
               plc_shares: /shares/,
-              peps_unit_trusts_capital_bonds_gov_stocks: /total.*of other investments/i,
-              life_assurance_endowment_policy: /total.*of life assurance policies/i,
+              peps_unit_trusts_capital_bonds_gov_stocks: /total.* of other investments/i,
+              life_assurance_endowment_policy: /(total|value).*of life assurance.*policies/i,
             }
           end
           let(:amount_params) { attributes.index_with { |_attr| Faker::Number.negative.to_s } }

--- a/spec/requests/providers/means/restrictions_spec.rb
+++ b/spec/requests/providers/means/restrictions_spec.rb
@@ -157,6 +157,6 @@ RSpec.describe "provider restrictions request" do
   end
 
   def translation_for(attr, error)
-    I18n.t("activemodel.errors.models.legal_aid_application.attributes.#{attr}.providers.#{error}")
+    I18n.t("activemodel.errors.models.legal_aid_application.attributes.#{attr}.#{error}")
   end
 end

--- a/spec/requests/providers/means/savings_and_investments_controller_spec.rb
+++ b/spec/requests/providers/means/savings_and_investments_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "providers savings and investments" do
+RSpec.describe Providers::Means::SavingsAndInvestmentsController do
   let(:application) { create(:legal_aid_application, :with_applicant, :with_savings_amount) }
   let(:savings_amount) { application.savings_amount }
 
@@ -111,7 +111,7 @@ RSpec.describe "providers savings and investments" do
 
             it "displays an error" do
               patch_request
-              expect(response.body).to match(I18n.t("activemodel.errors.models.savings_amount.attributes.cash.not_a_number"))
+              expect(response.body).to match(html_compare("The value of money that's not in a bank account must be an amount of money, like 60,000"))
               expect(response.body).to match("govuk-error-message")
               expect(response.body).to match("govuk-form-group--error")
             end
@@ -129,7 +129,7 @@ RSpec.describe "providers savings and investments" do
 
             it "displays error for field" do
               patch_request
-              expect(response.body).to match(I18n.t("activemodel.errors.models.savings_amount.attributes.cash.blank"))
+              expect(response.body).to match(html_compare(I18n.t("activemodel.errors.models.savings_amount.attributes.cash.blank")))
             end
           end
         end
@@ -206,7 +206,7 @@ RSpec.describe "providers savings and investments" do
 
           it "displays an error" do
             patch_request
-            expect(response.body).to match(I18n.t("activemodel.errors.models.savings_amount.attributes.cash.not_a_number"))
+            expect(response.body).to match(html_compare(I18n.t("activemodel.errors.models.savings_amount.attributes.cash.not_a_number")))
             expect(response.body).to match("govuk-error-message")
             expect(response.body).to match("govuk-form-group--error")
           end

--- a/spec/requests/providers/offline_accounts_spec.rb
+++ b/spec/requests/providers/offline_accounts_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe "providers offine accounts" do
 
             it "displays an error" do
               patch_request
-              expect(response.body).to match(I18n.t("activemodel.errors.models.savings_amount.attributes.offline_current_accounts.not_a_number"))
+              expect(response.body).to have_content("Total in client's current accounts must be an amount of money, like 60,000")
               expect(response.body).to match("govuk-error-message")
               expect(response.body).to match("govuk-form-group--error")
             end
@@ -184,7 +184,7 @@ RSpec.describe "providers offine accounts" do
 
           it "displays an error" do
             patch_request
-            expect(response.body).to match(I18n.t("activemodel.errors.models.savings_amount.attributes.offline_current_accounts.not_a_number"))
+            expect(response.body).to have_content("Total in client's current accounts must be an amount of money, like 60,000")
             expect(response.body).to match("govuk-error-message")
             expect(response.body).to match("govuk-form-group--error")
           end

--- a/spec/validators/currency_validator_spec.rb
+++ b/spec/validators/currency_validator_spec.rb
@@ -1,18 +1,33 @@
 require "rails_helper"
 
-class DummyClass
+class DummyCurrencyClass
   include ActiveModel::Model
   include ActiveModel::Validations
 
-  attr_accessor :val1, :val2, :val3
+  attr_accessor :val1, :val2, :val3, :val4, :val5
 
   validates :val1, :val2, currency: { greater_than_or_equal_to: 0 }, allow_blank: true
   validates :val3, currency: { greater_than_or_equal_to: 0 }
+  validates :val4, currency: { greater_than_or_equal_to: 0, partner_labels: :always_include_partner? }
+  validates :val5, currency: { greater_than_or_equal_to: 0, partner_labels: :always_exclude_partner? }
+
+  def always_include_partner?
+    true
+  end
+
+  def always_exclude_partner?
+    false
+  end
 end
 
 RSpec.describe CurrencyValidator do
   describe "numericality validation" do
-    let(:dummy) { DummyClass.new }
+    before do
+      en = { activemodel: { errors: { models: { dummy_currency_class: { attributes: { val4: { not_a_number_with_partner: "fake error" }, val5: { not_a_number_with_partner: "fake not a number partner error" } } } } } } }
+      I18n.backend.store_translations(:en, en)
+    end
+
+    let(:dummy) { DummyCurrencyClass.new }
 
     it "raises not numeric errors on each invalid field" do
       dummy.val1 = "abc"
@@ -22,6 +37,8 @@ RSpec.describe CurrencyValidator do
       expect(dummy.errors[:val1]).to eq ["is not a number"]
       expect(dummy.errors[:val2]).to be_empty
       expect(dummy.errors[:val3]).to eq ["is not a number"]
+      expect(dummy.errors.details[:val4].first[:error]).to eq :not_a_number_with_partner
+      expect(dummy.errors[:val4]).to eq ["fake error"]
     end
 
     it "errors if given negative number" do
@@ -66,6 +83,17 @@ RSpec.describe CurrencyValidator do
       expect(dummy.errors.details[:val2].first[:error]).to eq :not_a_number
       expect(dummy.val1).to eq "1,23.00"
       expect(dummy.val2).to eq "-£1,23"
+    end
+
+    it "returns _with_partner suffixed labels when prompted" do
+      # this requires keys to be present in the activemodel errors locale
+      # as they use non standard key names
+      dummy.val4 = "1,234.123"
+      dummy.val5 = ""
+      expect(dummy).to be_invalid
+      expect(dummy.errors.details[:val4].first[:error]).to eq :too_many_decimals_with_partner
+      expect(dummy.errors.details[:val5].first[:error]).to eq :not_a_number
+      expect(dummy.val4).to eq "1,234.123"
     end
   end
 end

--- a/spec/validators/numericality_partner_optional_validator_spec.rb
+++ b/spec/validators/numericality_partner_optional_validator_spec.rb
@@ -1,0 +1,81 @@
+require "rails_helper"
+
+class DummyNumericalityClass
+  include ActiveModel::Model
+  include ActiveModel::Validations
+
+  attr_accessor :val1, :val2, :val3, :val4, :val5
+
+  validates :val1, :val2, numericality_partner_optional: { greater_than_or_equal_to: 0 }, allow_blank: true
+  validates :val3, numericality_partner_optional: { greater_than_or_equal_to: 0 }
+  validates :val4, numericality_partner_optional: { greater_than_or_equal_to: 0, partner_labels: :always_include_partner? }
+  validates :val5, numericality_partner_optional: { greater_than_or_equal_to: 0, partner_labels: :always_exclude_partner? }
+
+  def always_include_partner?
+    true
+  end
+
+  def always_exclude_partner?
+    false
+  end
+end
+
+RSpec.describe NumericalityPartnerOptionalValidator do
+  describe "numericality validation" do
+    before do
+      en = { activemodel: { errors: { models: { dummy_numericality_class: { attributes: { val4: { not_a_number_with_partner: "fake error" }, val5: { not_a_number_with_partner: "fake not a number partner error" } } } } } } }
+      I18n.backend.store_translations(:en, en)
+    end
+
+    let(:dummy) { DummyNumericalityClass.new }
+
+    it "raises not numeric errors on each invalid field" do
+      dummy.val1 = "abc"
+      dummy.val2 = ""
+      dummy.val3 = nil
+      expect(dummy).to be_invalid
+      expect(dummy.errors[:val1]).to eq ["is not a number"]
+      expect(dummy.errors[:val2]).to be_empty
+      expect(dummy.errors[:val3]).to eq ["is not a number"]
+      expect(dummy.errors.details[:val4].first[:error]).to eq :not_a_number_with_partner
+      expect(dummy.errors[:val4]).to eq ["fake error"]
+    end
+
+    it "errors if given negative number" do
+      dummy.val1 = Faker::Number.between(from: -9999, to: -1).to_s
+      dummy.val2 = Faker::Number.number.to_s
+      expect(dummy).to be_invalid
+      expect(dummy.errors[:val1]).to eq ["must be greater than or equal to 0"]
+      expect(dummy.errors[:val2]).to be_empty
+    end
+
+    it "does not clean the number if invalid" do
+      dummy.val1 = "-1,234"
+      dummy.val2 = "-£1,234.88"
+      expect(dummy).to be_invalid
+      expect(dummy.val1).to eq "-1,234"
+      expect(dummy.val2).to eq "-£1,234.88"
+    end
+
+    it "fails if comma is followed by less than 3 digits" do
+      dummy.val1 = "1,23.00"
+      dummy.val2 = "-£1,23"
+      expect(dummy).to be_invalid
+      expect(dummy.errors.details[:val1].first[:error]).to eq :not_a_number
+      expect(dummy.errors.details[:val2].first[:error]).to eq :not_a_number
+      expect(dummy.val1).to eq "1,23.00"
+      expect(dummy.val2).to eq "-£1,23"
+    end
+
+    it "returns _with_partner suffixed labels when prompted" do
+      # this requires keys to be present in the activemodel errors locale
+      # as they use non standard key names
+      dummy.val4 = "bob"
+      dummy.val5 = "jim"
+      expect(dummy).to be_invalid
+      expect(dummy.errors.details[:val4].first[:error]).to eq :not_a_number_with_partner
+      expect(dummy.errors.details[:val5].first[:error]).to eq :not_a_number
+      expect(dummy.val4).to eq "bob"
+    end
+  end
+end

--- a/spec/validators/presence_partner_optional_validator_spec.rb
+++ b/spec/validators/presence_partner_optional_validator_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+
+class DummyPartnerPresenceClass
+  include ActiveModel::Model
+  include ActiveModel::Validations
+
+  attr_accessor :val1, :val2, :val3
+
+  validates :val1, presence: true
+  validates :val2, presence_partner_optional: { partner_labels: :partner_check_true? }
+  validates :val3, presence_partner_optional: { partner_labels: :partner_check_false? }
+  # validates :val4, presence_partner_optional: true
+
+  def partner_check_true?
+    true
+  end
+
+  def partner_check_false?
+    false
+  end
+end
+
+RSpec.describe PresencePartnerOptionalValidator do
+  describe "presence validation" do
+    before do
+      en = { activemodel: { errors: { models: { dummy_partner_presence_class: { attributes: { val2: { blank: "fake error", blank_with_partner: "fake partner error" } } } } } } }
+      I18n.backend.store_translations(:en, en)
+    end
+
+    let(:dummy) { DummyPartnerPresenceClass.new }
+
+    it "raises blank or blank_with_partner errors on each invalid field" do
+      dummy.val1 = ""
+      dummy.val2 = ""
+      dummy.val3 = ""
+      expect(dummy).to be_invalid
+      expect(dummy.errors.details[:val1].first[:error]).to eq :blank
+      expect(dummy.errors.details[:val2].first[:error]).to eq :blank_with_partner
+      expect(dummy.errors.details[:val3].first[:error]).to eq :blank
+    end
+
+    it "returns _with_partner suffixed labels when prompted" do
+      # this requires keys to be present in the activemodel errors locale
+      # as they use non standard key names
+      dummy.val2 = ""
+      expect(dummy).to be_invalid
+      expect(dummy.errors[:val2]).to eq ["fake partner error"]
+    end
+  end
+end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4574)

This PR implements error messages on pages where we sometimes ask about client and sometimes about client _and_partner.

It updates the `currency_validator` and adds two new `*_partner_optional` validators to replace the error messages with a `_with_partner` suffixed version if `:partner_labels` is set to true

`partner_labels` should be passed a method of the form that will return true or false, this has been added to the base_from class using a method named `has_partner_with_no_contrary_interest?` that scans the connected model for an applicant with a parter with no contrary interest and sets the value accordingly.

If the form's model is non-standard, the `has_partner_with_no_contrary_interest?` method can be overridden in the form to check for the correct path.

This then adds all the new error messages from design

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
