### PR TITLE
AP-4428 Enable accessible modal buttons when using NVDA

### DIFF
--- a/app/assets/stylesheets/modal-dialogue.scss
+++ b/app/assets/stylesheets/modal-dialogue.scss
@@ -1,38 +1,9 @@
-// modal (background overlay)
-.modal {
-  display: block;
-  visibility: hidden;
-  position: fixed;
-  z-index: 1000;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  overflow: auto;
-  background-color: rgb(0, 0, 0);
-  background-color: rgba(0, 0, 0, .4);
-}
-
-// modal content
-.modal-content {
+dialog {
   width: 40%;
-  margin: 15% auto;
-  padding: 20px;
-  border: 1px solid #888888;
-  background-color: #fefefe;
-}
+  border: none;
 
-// close button
-.close {
-  float: right;
-  color: #575757;
-  font-size: 28px;
-  font-weight: bold;
-}
-
-.close:hover,
-.close:focus {
-  color: govuk-colour("black");
-  text-decoration: none;
-  cursor: pointer;
+  &::backdrop {
+    background-color: rgb(0, 0, 0);
+    background-color: rgba(0, 0, 0, .4);
+  }
 }

--- a/app/javascript/src/modal-dialogue.js
+++ b/app/javascript/src/modal-dialogue.js
@@ -1,82 +1,5 @@
 import axios from 'axios'
 
-const MODAL_OPEN_MESSAGE = 'A new window has opened inside the current window'
-
-function announceModal () {
-  const messagesDiv = document.querySelector('#screen-reader-messages')
-  messagesDiv.innerText = MODAL_OPEN_MESSAGE
-}
-
-function openModal (modal) {
-  modal.style.visibility = 'visible'
-}
-
-function closeModal (modal) {
-  modal.style.visibility = 'hidden'
-}
-
-// set the tab index to -1 for all elements on the underlying page
-function makeModalTabbable (modal, nonModalElems) {
-  const dialogElements = modal.querySelectorAll('.modal-dialog')
-  dialogElements.forEach((elem) => {
-    elem.setAttribute('tabindex', 0)
-  })
-  nonModalElems.forEach((elem) => {
-    elem.setAttribute('data-previous-tabindex', elem.getAttribute('tabindex'))
-    elem.setAttribute('tabindex', -1)
-  })
-}
-
-// restore the tab index for all elements on the underlying page and set to -1 for all modal dialog elements
-function updateTabIndex (modal, nonModalElems) {
-  const dialogElements = modal.querySelectorAll('.modal-dialog')
-  dialogElements.forEach((elem) => {
-    elem.setAttribute('tabindex', -1)
-  })
-  nonModalElems.forEach((elem) => {
-    elem.setAttribute('tabindex', elem.getAttribute('data-previous-tabindex'))
-  })
-}
-
-// while open, prevent tabbing to outside the dialogue
-// and listen for ESC key to close the dialogue
-function handleKeyEvents (modal, previouslyFocusedElement, nonModalElems) {
-  modal.focus()
-  const modalContent = modal.querySelector('.modal-content')
-  modalContent.addEventListener('keydown', (event) => {
-    const KEY_TAB = 9
-    const KEY_ESC = 27
-
-    // to keep tab keypresses within the modal and not the (hidden) document underneath
-    const firstFocusableElement = modalContent.firstElementChild
-    const lastFocusableElement = modalContent.lastElementChild
-
-    switch (event.keyCode) {
-      case KEY_TAB:
-        if (event.shiftKey) {
-          if (document.activeElement === firstFocusableElement) {
-            event.preventDefault()
-            lastFocusableElement.focus()
-          }
-        } else {
-          if (document.activeElement === lastFocusableElement) {
-            event.preventDefault()
-            firstFocusableElement.focus()
-          }
-        }
-
-        break
-      case KEY_ESC:
-        closeModal(modal)
-        updateTabIndex(modal, nonModalElems)
-        previouslyFocusedElement.focus()
-        break
-      default:
-        break
-    }
-  })
-}
-
 async function deleteApplication (applicationId) {
   const url = `/v1/legal_aid_applications/${applicationId}`
   const response = await axios({
@@ -86,74 +9,68 @@ async function deleteApplication (applicationId) {
   return response.status
 }
 
-function startModal (modal, previouslyFocusedElement, nonModalElems) {
-  // display the modal
-  openModal(modal)
-  handleKeyEvents(modal, previouslyFocusedElement, nonModalElems)
-  announceModal()
-
-  // Get the button and span elements that close the modal
-  const closeButtons = modal.querySelectorAll('.close-modal')
-  closeButtons.forEach((btn) => {
-    btn.addEventListener('click', (event) => {
-      event.preventDefault()
-      closeModal(modal)
-      updateTabIndex(modal, nonModalElems)
-      previouslyFocusedElement.focus()
-    })
-    btn.addEventListener('keydown', (event) => {
-      const KEY_ENTER = 13
-      if (event.keyCode === KEY_ENTER) {
-        event.preventDefault()
-        closeModal(modal)
-        updateTabIndex(modal, nonModalElems)
-        previouslyFocusedElement.focus()
-      }
-    })
-  })
-
-  // close modal and refresh page when an application is deleted
-  const confirmDeleteBtn = modal.querySelector('.confirm-delete-btn')
-  confirmDeleteBtn.addEventListener('click', (event) => {
-    const applicationRef = modal.id.replace('-modal', '')
-    const applicationId = document.getElementById(`${applicationRef}-id`).textContent.trim()
-    deleteApplication(applicationId).then(() => {
-      closeModal(modal)
-      window.location.reload()
-      previouslyFocusedElement.focus()
-    }).catch((error) => {
-      console.error(error.message)
-    })
-  })
-
-  // When the user clicks anywhere outside of the modal, close it
-  window.onclick = function (event) {
-    if (event.target === modal) {
-      closeModal(modal)
-      updateTabIndex(modal, nonModalElems)
-      previouslyFocusedElement.focus()
-    }
-  }
+function initModalDialog () {
+  openModal()
+  deleteAppCloseModal()
+  closeModal()
 }
 
-function initiateModals () {
-  const deleteButtons = document.querySelectorAll('[data-toggle="modal"]')
-  const nonModalElements = document.querySelectorAll('body *:not(.modal-dialog):not([tabindex="-1"])') // all tabbable non-modal elements
+function openModal () {
+  const openModals = document.querySelectorAll('[data-modal-open-target]')
 
-  if (deleteButtons) {
-    // When the user clicks on the button, open the modal
-    deleteButtons.forEach((deleteBtn) => {
-      deleteBtn.addEventListener('click', () => {
-        // find the corresponding modal for that button
-        const modalId = deleteBtn.id.replace('-btn', '')
-        const modal = document.getElementById(modalId)
-        startModal(modal, deleteBtn, nonModalElements)
-        makeModalTabbable(modal, nonModalElements)
-      })
+  openModals.forEach((openModal) => {
+    openModal.addEventListener('click', () => {
+      const modalId = openModal.getAttribute('data-modal-open-target')
+      const modal = document.getElementById(modalId)
+
+      modal.showModal()
     })
-  }
+  })
+}
+
+function deleteAppCloseModal () {
+  const deleteCloseModals = document.querySelectorAll('[data-modal-delete-close-target]')
+
+  deleteCloseModals.forEach((deleteCloseModal) => {
+    deleteCloseModal.addEventListener('click', () => {
+      const modalId = deleteCloseModal.getAttribute('data-modal-delete-close-target')
+      const modal = document.getElementById(modalId)
+      const applicationId = modalId.replace('modal-', '')
+
+      deleteApplication(applicationId).then(() => {
+        modal.close()
+        window.location.reload()
+      }).catch((error) => {
+        console.error(error.message)
+      })
+
+      modal.close()
+    })
+  })
+}
+
+function closeModal () {
+  const closeModals = document.querySelectorAll('[data-modal-close-target]')
+
+  closeModals.forEach((closeModal) => {
+    closeModal.addEventListener('click', () => {
+      const modalId = closeModal.getAttribute('data-modal-close-target')
+      const modal = document.getElementById(modalId)
+
+      modal.close()
+    })
+  })
 }
 
 document.addEventListener('DOMContentLoaded', (e) => {
-  initiateModals()
+  const dialog = document.querySelector('dialog')
+  if (dialog) initModalDialog()
 })
+
+export {
+  deleteApplication,
+  initModalDialog,
+  openModal,
+  deleteAppCloseModal,
+  closeModal
+}

--- a/app/views/providers/legal_aid_applications/_legal_aid_applications.html.erb
+++ b/app/views/providers/legal_aid_applications/_legal_aid_applications.html.erb
@@ -82,10 +82,9 @@
                     )
 
                     concat tag.button(
-                      class: "govuk-button govuk-button--secondary govuk-!-margin-1 script hidden",
+                      class: "govuk-button govuk-button--secondary govuk-!-margin-0 script hidden",
                       id: "#{application.application_ref}-modal-btn",
-                      "data-toggle": "modal",
-                      "data-target": "#{application.application_ref}_modal",
+                      "data-modal-open-target": "modal-#{application.id}",
                     ) {
                              t(".delete_html", reference: application.application_ref, applicant_name: application.applicant.full_name)
                            }

--- a/app/views/shared/partials/_modal_dialogue.html.erb
+++ b/app/views/shared/partials/_modal_dialogue.html.erb
@@ -1,24 +1,24 @@
-<div class="modal modal-dialog" id="<%= application.application_ref %>-modal" tabindex="0">
-  <div class="modal-content" aria-modal="true" aria-hidden="true" role="dialog" aria-label="Confirm delete application">
-    <span class="close close-modal" aria-label="Close modal">&times;</span>
-    <h1 class="govuk-heading-l modal-dialog" id="modal-title-<%= index %>"><%= t(".page_title") %></h1>
-    <div class="govuk-panel__body">
-      <ul class="govuk-list govuk-!-margin-bottom-4">
-        <li>
-          <strong><%= t(".applicant") %>: </strong>
-          <%= application.applicant_full_name %>
-        </li>
-        <li>
-          <strong><%= t(".reference") %>: </strong>
-          <%= application.application_ref %>
-        </li>
-      </ul>
-    </div>
+<dialog class="app-modal" id="modal-<%= application.id %>">
+  <div class="modal-content">
+    <h1 class="govuk-heading-l"><%= t(".page_title") %></h1>
+
+    <%= govuk_summary_list(actions: false, classes: "govuk-!-display-inline govuk-summary-list--no-border") do |summary_list|
+          summary_list.with_row do |row|
+            row.with_key { t(".applicant") }
+            row.with_value { application.applicant_full_name }
+          end
+          summary_list.with_row do |row|
+            row.with_key { t(".reference") }
+            row.with_value { application.application_ref }
+          end
+        end %>
 
     <%= govuk_warning_text(text: t(".warning")) %>
-
-    <span class="hidden" aria-hidden="true" id="<%= application.application_ref %>-id"><%= application.id %></span>
-    <button class="govuk-button govuk-button--warning confirm-delete-btn modal-dialog"><%= t(".yes_button") %></button>
-    <button class="govuk-button govuk-!-margin-left-3 close-modal modal-dialog"><%= t(".no_button") %></button>
   </div>
-</div>
+
+  <div class='govuk-button-group'>
+    <button class="govuk-button govuk-button--warning" data-modal-delete-close-target="modal-<%= application.id %>"><%= t(".yes_button") %></button>
+    <button class="govuk-button app-modal-close" data-modal-close-target="modal-<%= application.id %>"><%= t(".no_button") %></button>
+  </div>
+
+</dialog>

--- a/features/step_definitions/civil_journey_steps.rb
+++ b/features/step_definitions/civil_journey_steps.rb
@@ -979,15 +979,15 @@ Then("the answer for all {string} categories should be {string}") do |field_name
 end
 
 Then("the delete modal should open") do
-  expect(page).to have_css(".modal-dialog")
+  expect(page).to have_css(".app-modal")
 end
 
 Then("I click the close button for the modal") do
-  find(".close").click
+  find(".app-modal-close").click
 end
 
 Then("the delete modal should not be visible") do
-  expect(page).not_to have_css("modal-dialog")
+  expect(page).not_to have_css(".app-modal")
 end
 
 Then("I select a proceeding type and continue") do


### PR DESCRIPTION
## What

[Modal delete buttons inaccessible when NVDA is running](https://dsdmoj.atlassian.net/browse/AP-4428)

Update modal to use `<dialog>` html element as it represents a modal or non-modal dialog box or other interactive component, such as a dismissible alert, inspector, or sub-window, plus this will be semantically correct and therefore assistive technology tools should clearly describe its meaning to users.

The auditors recommended we test the site using different assistive technology to ensure that the screen reader output is consistent across multiple platforms and devices.

To be checked using the following matrix:

| Browser | NVDA      | VoiceOver |
| :------ | :------:  | ----:     |
| Chrome  |  ok   | ok    |
| Edge    |  ok   | ok    |
| Firefox |  ok   | ok    |
| Safari |  -  | ok    |

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
