### PR TITLE
Chore: Amend babel dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,6 +37,6 @@ updates:
     npm-dependencies:
       # Define patterns to include dependencies in the group (based on # dependency name)
       patterns:
-        - "babel*"
+        - "*babel*"
         - "jest*"  # A wildcard string that matches multiple dependency names syt
         - "stylelint*"


### PR DESCRIPTION
## What

Slight amendment to the current babel group name, but today
16/Nov/23 we had two `@babel` dependabots opened that the
existing babel group did not trigger, adding the * prefix
should allow it to group wether it has the @ prefix or not

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
