### PR TITLE
Fix: CFE vehicle submission

### DIFF
--- a/app/services/cfe_civil/components/vehicles.rb
+++ b/app/services/cfe_civil/components/vehicles.rb
@@ -5,6 +5,10 @@ module CFECivil
         new(legal_aid_application, owner_type).call
       end
 
+      def initialize(legal_aid_application, owner_type = :client)
+        super
+      end
+
       def call
         {
           vehicles: vehicles_request_body,


### PR DESCRIPTION
## What

This was being called from the submissionbuilder in a way that used the inherited .new method that set the default owner_type to applicant, when the data is stored with owner "client"

This overrides the initializer to call with owner_type client

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
