### PR TITLE
Rename copy case to copied case

### DIFF
--- a/app/controllers/providers/copy_case/confirmations_controller.rb
+++ b/app/controllers/providers/copy_case/confirmations_controller.rb
@@ -5,12 +5,12 @@ module Providers
 
       def show
         @form = ::CopyCase::ConfirmationForm.new(model: legal_aid_application)
-        @copiable_case = LegalAidApplication.find(legal_aid_application.copy_case_id)
+        @copiable_case = LegalAidApplication.find(legal_aid_application.copied_case_id)
       end
 
       def update
         @form = ::CopyCase::ConfirmationForm.new(form_params)
-        @copiable_case = LegalAidApplication.find(form_params[:copy_case_id])
+        @copiable_case = LegalAidApplication.find(form_params[:copied_case_id])
 
         render :show unless save_continue_or_draft(@form, copy_case_confirmed: @form.copy_case_confirmed?)
       end
@@ -21,7 +21,7 @@ module Providers
         merge_with_model(legal_aid_application) do
           next {} unless params[:legal_aid_application]
 
-          params.require(:legal_aid_application).permit(:copy_case_id, :copy_case_confirmation)
+          params.require(:legal_aid_application).permit(:copied_case_id, :copy_case_confirmation)
         end
       end
     end

--- a/app/controllers/providers/copy_case/invitations_controller.rb
+++ b/app/controllers/providers/copy_case/invitations_controller.rb
@@ -19,7 +19,7 @@ module Providers
         merge_with_model(legal_aid_application) do
           next {} unless params[:legal_aid_application]
 
-          params.require(:legal_aid_application).permit(:copy_case)
+          params.require(:legal_aid_application).permit(:copied_case)
         end
       end
     end

--- a/app/forms/copy_case/confirmation_form.rb
+++ b/app/forms/copy_case/confirmation_form.rb
@@ -2,9 +2,9 @@ module CopyCase
   class ConfirmationForm < BaseForm
     form_for LegalAidApplication
 
-    attr_accessor :copy_case_id, :copy_case_confirmation
+    attr_accessor :copied_case_id, :copy_case_confirmation
 
-    validates :copy_case_id, presence: true, unless: :draft?
+    validates :copied_case_id, presence: true, unless: :draft?
     validates :copy_case_confirmation, presence: true, unless: proc { draft? || copy_case_confirmation.present? }
 
     def save
@@ -16,7 +16,7 @@ module CopyCase
     alias_method :save!, :save
 
     def legal_aid_application_to_copy
-      @legal_aid_application_to_copy ||= LegalAidApplication.find(copy_case_id)
+      @legal_aid_application_to_copy ||= LegalAidApplication.find(copied_case_id)
     end
 
     def legal_aid_application

--- a/app/forms/copy_case/confirmation_form.rb
+++ b/app/forms/copy_case/confirmation_form.rb
@@ -7,6 +7,11 @@ module CopyCase
     validates :copied_case_id, presence: true, unless: :draft?
     validates :copy_case_confirmation, presence: true, unless: proc { draft? || copy_case_confirmation.present? }
 
+    after_validation do
+      model.copied_case = false unless copy_case_confirmed?
+      model.copied_case_id = nil unless copy_case_confirmed?
+    end
+
     def save
       return if invalid? || draft? || !copy_case_confirmed?
 

--- a/app/forms/copy_case/invitation_form.rb
+++ b/app/forms/copy_case/invitation_form.rb
@@ -5,5 +5,9 @@ module CopyCase
     attr_accessor :copied_case
 
     validates :copied_case, presence: true, unless: proc { draft? || copied_case.present? }
+
+    after_validation do
+      model.copied_case_id = nil
+    end
   end
 end

--- a/app/forms/copy_case/invitation_form.rb
+++ b/app/forms/copy_case/invitation_form.rb
@@ -2,8 +2,8 @@ module CopyCase
   class InvitationForm < BaseForm
     form_for LegalAidApplication
 
-    attr_accessor :copy_case
+    attr_accessor :copied_case
 
-    validates :copy_case, presence: true, unless: proc { draft? || copy_case.present? }
+    validates :copied_case, presence: true, unless: proc { draft? || copied_case.present? }
   end
 end

--- a/app/forms/copy_case/search_form.rb
+++ b/app/forms/copy_case/search_form.rb
@@ -16,7 +16,7 @@ module CopyCase
     def save
       return false unless valid?
 
-      model.update!(copy_case_id: copiable_case.id) unless draft?
+      model.update!(copied_case_id: copiable_case.id) unless draft?
 
       true
     end

--- a/app/services/flow/flows/provider_start.rb
+++ b/app/services/flow/flows/provider_start.rb
@@ -51,7 +51,7 @@ module Flow
         copy_case_invitations: {
           path: ->(application) { urls.providers_legal_aid_application_copy_case_invitation_path(application) },
           forward: lambda do |application|
-            if application.copy_case?
+            if application.copied_case?
               :copy_case_searches
             else
               application.proceedings.any? ? :has_other_proceedings : :proceedings_types

--- a/app/views/providers/copy_case/confirmations/show.html.erb
+++ b/app/views/providers/copy_case/confirmations/show.html.erb
@@ -18,7 +18,7 @@
           end
         end %>
 
-    <%= form.hidden_field :copy_case_id, value: @copiable_case.id %>
+    <%= form.hidden_field :copied_case_id, value: @copiable_case.id %>
 
     <%= form.govuk_collection_radio_buttons(
           :copy_case_confirmation,

--- a/app/views/providers/copy_case/invitations/show.html.erb
+++ b/app/views/providers/copy_case/invitations/show.html.erb
@@ -5,7 +5,7 @@
   <%= page_template page_title: t(".heading"), template: :basic, form: do %>
 
     <%= form.govuk_collection_radio_buttons(
-          :copy_case,
+          :copied_case,
           yes_no_options,
           :value,
           :label,

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -411,7 +411,7 @@ en:
               blank: Enter details of the incident
         legal_aid_application:
           attributes:
-            copy_case:
+            copied_case:
               blank: Select yes if you want to copy an application
             copy_case_confirmation:
               blank: Select yes if you want to copy the application

--- a/db/migrate/20231020085303_add_copy_case_to_legal_aid_application.rb
+++ b/db/migrate/20231020085303_add_copy_case_to_legal_aid_application.rb
@@ -1,6 +1,6 @@
 class AddCopyCaseToLegalAidApplication < ActiveRecord::Migration[7.0]
   def change
     add_column :legal_aid_applications, :copy_case, :boolean
-    add_column :legal_aid_applications, :copy_case_id, :uuid
+    add_column :legal_aid_applications, :copied_case_id, :uuid
   end
 end

--- a/db/migrate/20231116133937_rename_copy_case.rb
+++ b/db/migrate/20231116133937_rename_copy_case.rb
@@ -1,0 +1,8 @@
+class RenameCopyCase < ActiveRecord::Migration[7.1]
+  def change
+    safety_assured do
+      rename_column :legal_aid_applications, :copy_case, :copied_case
+      rename_column :legal_aid_applications, :copy_case_id, :copied_case_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_10_20_085303) do
+ActiveRecord::Schema[7.1].define(version: 2023_11_16_133937) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -602,8 +602,8 @@ ActiveRecord::Schema[7.1].define(version: 2023_10_20_085303) do
     t.decimal "substantive_cost_requested"
     t.string "substantive_cost_reasons"
     t.boolean "applicant_in_receipt_of_housing_benefit"
-    t.boolean "copy_case"
-    t.uuid "copy_case_id"
+    t.boolean "copied_case"
+    t.uuid "copied_case_id"
     t.index ["applicant_id"], name: "index_legal_aid_applications_on_applicant_id"
     t.index ["application_ref"], name: "index_legal_aid_applications_on_application_ref", unique: true
     t.index ["discarded_at"], name: "index_legal_aid_applications_on_discarded_at"

--- a/spec/forms/copy_case/confirmation_form_spec.rb
+++ b/spec/forms/copy_case/confirmation_form_spec.rb
@@ -6,13 +6,13 @@ RSpec.describe CopyCase::ConfirmationForm, type: :form do
   let(:params) do
     {
       model: legal_aid_application,
-      copy_case_id:,
+      copied_case_id:,
       copy_case_confirmation:,
     }
   end
 
   let(:legal_aid_application) { create(:legal_aid_application) }
-  let(:copy_case_id) { source_application.id }
+  let(:copied_case_id) { source_application.id }
 
   let(:source_application) do
     create(:legal_aid_application,

--- a/spec/forms/copy_case/invitation_form_spec.rb
+++ b/spec/forms/copy_case/invitation_form_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe CopyCase::InvitationForm, type: :form do
   let(:params) do
     {
       model: legal_aid_application,
-      copy_case:,
+      copied_case:,
     }
   end
 
@@ -16,43 +16,43 @@ RSpec.describe CopyCase::InvitationForm, type: :form do
     subject(:call_save) { instance.save }
 
     context "with yes chosen" do
-      let(:copy_case) { "true" }
+      let(:copied_case) { "true" }
 
-      it "updates copy_case" do
-        expect { call_save }.to change { legal_aid_application.reload.copy_case }
+      it "updates copied_case" do
+        expect { call_save }.to change { legal_aid_application.reload.copied_case }
           .from(nil)
           .to(true)
       end
 
       context "when no previously chosen" do
-        before { legal_aid_application.update!(copy_case: false) }
+        before { legal_aid_application.update!(copied_case: false) }
 
-        it "updates copy_case to true" do
-          expect { call_save }.to change(legal_aid_application, :copy_case).from(false).to(true)
+        it "updates copied_case to true" do
+          expect { call_save }.to change(legal_aid_application, :copied_case).from(false).to(true)
         end
       end
     end
 
     context "with no chosen" do
-      let(:copy_case) { "false" }
+      let(:copied_case) { "false" }
 
-      it "updates copy_case" do
-        expect { call_save }.to change { legal_aid_application.reload.copy_case }
+      it "updates copied_case" do
+        expect { call_save }.to change { legal_aid_application.reload.copied_case }
           .from(nil)
           .to(false)
       end
 
       context "when yes previously chosen" do
-        before { legal_aid_application.update!(copy_case: true) }
+        before { legal_aid_application.update!(copied_case: true) }
 
-        it "updates copy_case to false" do
-          expect { call_save }.to change(legal_aid_application, :copy_case).from(true).to(false)
+        it "updates copied_case to false" do
+          expect { call_save }.to change(legal_aid_application, :copied_case).from(true).to(false)
         end
       end
     end
 
     context "with no answer chosen" do
-      let(:copy_case) { "" }
+      let(:copied_case) { "" }
 
       it "is invalid" do
         call_save
@@ -71,35 +71,35 @@ RSpec.describe CopyCase::InvitationForm, type: :form do
     subject(:save_as_draft) { instance.save_as_draft }
 
     context "with yes chosen" do
-      let(:copy_case) { "true" }
+      let(:copied_case) { "true" }
 
-      it "updates copy_case" do
-        expect { save_as_draft }.to change(legal_aid_application, :copy_case)
+      it "updates copied_case" do
+        expect { save_as_draft }.to change(legal_aid_application, :copied_case)
           .from(nil)
           .to(true)
       end
     end
 
     context "with no chosen" do
-      let(:copy_case) { "false" }
+      let(:copied_case) { "false" }
 
-      it "updates copy_case" do
-        expect { save_as_draft }.to change(legal_aid_application, :copy_case)
+      it "updates copied_case" do
+        expect { save_as_draft }.to change(legal_aid_application, :copied_case)
           .from(nil)
           .to(false)
       end
     end
 
     context "with no answer chosen" do
-      let(:copy_case) { "" }
+      let(:copied_case) { "" }
 
       it "is valid" do
         save_as_draft
         expect(instance).to be_valid
       end
 
-      it "does not update copy_case" do
-        expect { save_as_draft }.not_to change(legal_aid_application, :copy_case).from(nil)
+      it "does not update copied_case" do
+        expect { save_as_draft }.not_to change(legal_aid_application, :copied_case).from(nil)
       end
     end
   end

--- a/spec/forms/copy_case/search_form_spec.rb
+++ b/spec/forms/copy_case/search_form_spec.rb
@@ -35,8 +35,8 @@ RSpec.describe CopyCase::SearchForm, type: :form do
             .to(source_application)
         end
 
-        it "stores the copy_case_id" do
-          expect { call_save }.to change { legal_aid_application.reload.copy_case_id }
+        it "stores the copied_case_id" do
+          expect { call_save }.to change { legal_aid_application.reload.copied_case_id }
             .from(nil)
             .to(source_application.id)
         end
@@ -56,8 +56,8 @@ RSpec.describe CopyCase::SearchForm, type: :form do
             .from(nil)
         end
 
-        it "does not store the copy_case_id" do
-          expect { call_save }.not_to change { legal_aid_application.reload.copy_case_id }.from(nil)
+        it "does not store the copied_case_id" do
+          expect { call_save }.not_to change { legal_aid_application.reload.copied_case_id }.from(nil)
         end
 
         it "adds the appropriate error message" do
@@ -77,8 +77,8 @@ RSpec.describe CopyCase::SearchForm, type: :form do
         expect(instance.errors.messages.values.flatten).to include("The application reference entered cannot be found")
       end
 
-      it "does not store the copy_case_id" do
-        expect { call_save }.not_to change { legal_aid_application.reload.copy_case_id }.from(nil)
+      it "does not store the copied_case_id" do
+        expect { call_save }.not_to change { legal_aid_application.reload.copied_case_id }.from(nil)
       end
     end
 
@@ -92,8 +92,8 @@ RSpec.describe CopyCase::SearchForm, type: :form do
         expect(instance.errors.messages.values.flatten).to include("Enter an application reference to search for")
       end
 
-      it "does not store the copy_case_id" do
-        expect { call_save }.not_to change { legal_aid_application.reload.copy_case_id }.from(nil)
+      it "does not store the copied_case_id" do
+        expect { call_save }.not_to change { legal_aid_application.reload.copied_case_id }.from(nil)
       end
     end
   end
@@ -111,8 +111,8 @@ RSpec.describe CopyCase::SearchForm, type: :form do
         expect(instance).to be_valid
       end
 
-      it "does not store the copy_case_id" do
-        expect { save_as_draft }.not_to change { legal_aid_application.reload.copy_case_id }.from(nil)
+      it "does not store the copied_case_id" do
+        expect { save_as_draft }.not_to change { legal_aid_application.reload.copied_case_id }.from(nil)
       end
     end
 
@@ -126,8 +126,8 @@ RSpec.describe CopyCase::SearchForm, type: :form do
         expect(instance).to be_valid
       end
 
-      it "does not store the copy_case_id" do
-        expect { save_as_draft }.not_to change { legal_aid_application.reload.copy_case_id }.from(nil)
+      it "does not store the copied_case_id" do
+        expect { save_as_draft }.not_to change { legal_aid_application.reload.copied_case_id }.from(nil)
       end
     end
 
@@ -141,8 +141,8 @@ RSpec.describe CopyCase::SearchForm, type: :form do
         expect(instance).to be_valid
       end
 
-      it "does not store the copy_case_id" do
-        expect { save_as_draft }.not_to change { legal_aid_application.reload.copy_case_id }.from(nil)
+      it "does not store the copied_case_id" do
+        expect { save_as_draft }.not_to change { legal_aid_application.reload.copied_case_id }.from(nil)
       end
     end
   end

--- a/spec/requests/providers/copy_case/confirmations_controller_spec.rb
+++ b/spec/requests/providers/copy_case/confirmations_controller_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Providers::CopyCase::ConfirmationsController do
 
     context "when the provider is authenticated" do
       before do
-        legal_aid_application.update!(copy_case_id: source_application.id)
+        legal_aid_application.update!(copied_case_id: source_application.id)
       end
 
       it "renders page with expected headings" do
@@ -49,7 +49,7 @@ RSpec.describe Providers::CopyCase::ConfirmationsController do
     end
 
     context "when yes chosen" do
-      let(:params) { { legal_aid_application: { copy_case_id: source_application.id, copy_case_confirmation: "true" } } }
+      let(:params) { { legal_aid_application: { copied_case_id: source_application.id, copy_case_confirmation: "true" } } }
 
       it "redirects to the has national insurance number page" do
         patch_request
@@ -62,7 +62,7 @@ RSpec.describe Providers::CopyCase::ConfirmationsController do
     end
 
     context "when no chosen" do
-      let(:params) { { legal_aid_application: { copy_case_id: source_application.id, copy_case_confirmation: "false" } } }
+      let(:params) { { legal_aid_application: { copied_case_id: source_application.id, copy_case_confirmation: "false" } } }
 
       it "redirects to the copy case invitation page" do
         patch_request
@@ -75,7 +75,7 @@ RSpec.describe Providers::CopyCase::ConfirmationsController do
     end
 
     context "when no answer chosen" do
-      let(:params) { { legal_aid_application: { copy_case_id: source_application.id } } }
+      let(:params) { { legal_aid_application: { copied_case_id: source_application.id } } }
 
       it "stays on the page and displays validation error" do
         patch_request
@@ -85,7 +85,7 @@ RSpec.describe Providers::CopyCase::ConfirmationsController do
     end
 
     context "when form submitted using Save as draft button" do
-      let(:params) { { legal_aid_application: { copy_case_id: source_application.id }, draft_button: "irrelevant" } }
+      let(:params) { { legal_aid_application: { copied_case_id: source_application.id }, draft_button: "irrelevant" } }
 
       it "redirects provider to provider's applications page" do
         patch_request

--- a/spec/requests/providers/copy_case/invitations_controller_spec.rb
+++ b/spec/requests/providers/copy_case/invitations_controller_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Providers::CopyCase::InvitationsController do
     end
 
     context "when yes chosen" do
-      let(:params) { { legal_aid_application: { copy_case: "true" } } }
+      let(:params) { { legal_aid_application: { copied_case: "true" } } }
 
       it "redirects to the copy case searches page" do
         patch_request
@@ -57,12 +57,12 @@ RSpec.describe Providers::CopyCase::InvitationsController do
       end
 
       it "records the answer" do
-        expect { patch_request }.to change { legal_aid_application.reload.copy_case }.from(nil).to(true)
+        expect { patch_request }.to change { legal_aid_application.reload.copied_case }.from(nil).to(true)
       end
     end
 
     context "when no chosen" do
-      let(:params) { { legal_aid_application: { copy_case: "false" } } }
+      let(:params) { { legal_aid_application: { copied_case: "false" } } }
 
       context "without proceedings" do
         before { legal_aid_application.proceedings.destroy_all }
@@ -73,7 +73,7 @@ RSpec.describe Providers::CopyCase::InvitationsController do
         end
 
         it "records the answer" do
-          expect { patch_request }.to change { legal_aid_application.reload.copy_case }.from(nil).to(false)
+          expect { patch_request }.to change { legal_aid_application.reload.copied_case }.from(nil).to(false)
         end
       end
 
@@ -86,13 +86,13 @@ RSpec.describe Providers::CopyCase::InvitationsController do
         end
 
         it "records the answer" do
-          expect { patch_request }.to change { legal_aid_application.reload.copy_case }.from(nil).to(false)
+          expect { patch_request }.to change { legal_aid_application.reload.copied_case }.from(nil).to(false)
         end
       end
     end
 
     context "when no answer chosen" do
-      let(:params) { { legal_aid_application: { copy_case: "" }, continue_button: "Save and continue" } }
+      let(:params) { { legal_aid_application: { copied_case: "" }, continue_button: "irrelevant" } }
 
       it "stays on the page and displays validation error" do
         patch_request
@@ -102,7 +102,7 @@ RSpec.describe Providers::CopyCase::InvitationsController do
     end
 
     context "when form submitted using Save as draft button" do
-      let(:params) { { legal_aid_application: { copy_case: "" }, draft_button: "irrelevant" } }
+      let(:params) { { legal_aid_application: { copied_case: "" }, draft_button: "irrelevant" } }
 
       it "redirects provider to provider's applications page" do
         patch_request
@@ -114,7 +114,7 @@ RSpec.describe Providers::CopyCase::InvitationsController do
       end
 
       it "does not record the answer" do
-        expect { patch_request }.not_to change { legal_aid_application.reload.copy_case }.from(nil)
+        expect { patch_request }.not_to change { legal_aid_application.reload.copied_case }.from(nil)
       end
     end
   end

--- a/spec/requests/providers/copy_case/searches_controller_spec.rb
+++ b/spec/requests/providers/copy_case/searches_controller_spec.rb
@@ -46,8 +46,8 @@ RSpec.describe Providers::CopyCase::SearchesController do
         let(:params) { { legal_aid_application: { search_ref: source_application.application_ref } } }
         let(:source_application) { create(:legal_aid_application, application_ref: "L-TVH-U0T", provider: legal_aid_application.provider) }
 
-        it "stores the copy_case_id" do
-          expect { patch_request }.to change { legal_aid_application.reload.copy_case_id }
+        it "stores the copied_case_id" do
+          expect { patch_request }.to change { legal_aid_application.reload.copied_case_id }
             .from(nil)
             .to(source_application.id)
         end
@@ -69,7 +69,7 @@ RSpec.describe Providers::CopyCase::SearchesController do
         end
 
         it "does not store the source application's id" do
-          expect { patch_request }.not_to change { legal_aid_application.reload.copy_case_id }.from(nil)
+          expect { patch_request }.not_to change { legal_aid_application.reload.copied_case_id }.from(nil)
         end
       end
 
@@ -83,7 +83,7 @@ RSpec.describe Providers::CopyCase::SearchesController do
         end
 
         it "does not store the source application's id" do
-          expect { patch_request }.not_to change { legal_aid_application.reload.copy_case_id }.from(nil)
+          expect { patch_request }.not_to change { legal_aid_application.reload.copied_case_id }.from(nil)
         end
       end
 
@@ -97,7 +97,7 @@ RSpec.describe Providers::CopyCase::SearchesController do
         end
 
         it "does not store the source application's id" do
-          expect { patch_request }.not_to change { legal_aid_application.reload.copy_case_id }.from(nil)
+          expect { patch_request }.not_to change { legal_aid_application.reload.copied_case_id }.from(nil)
         end
       end
 
@@ -111,7 +111,7 @@ RSpec.describe Providers::CopyCase::SearchesController do
         end
 
         it "does not store the source application's id" do
-          expect { patch_request }.not_to change { legal_aid_application.reload.copy_case_id }.from(nil)
+          expect { patch_request }.not_to change { legal_aid_application.reload.copied_case_id }.from(nil)
         end
       end
     end
@@ -129,7 +129,7 @@ RSpec.describe Providers::CopyCase::SearchesController do
       end
 
       it "does not store the source application's id" do
-        expect { patch_request }.not_to change { legal_aid_application.reload.copy_case_id }.from(nil)
+        expect { patch_request }.not_to change { legal_aid_application.reload.copied_case_id }.from(nil)
       end
     end
   end


### PR DESCRIPTION

## What
Rename copy_case and copy_case_id columns

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4575)

rename to copied_xxx as this makes for a more pleasant qualifier
(e.g. legal_aid_application.copied_case?, legal_aid_application.copied_case_id)
and is more grepable given the `copy_case` namespacing.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
