### PR TITLE
Fix: remove unused copy_case_confirmation route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -165,7 +165,6 @@ Rails.application.routes.draw do
         resource :search, only: %i[show update]
         resource :confirmation, only: %i[show update]
       end
-      resource :copy_case_confirmation, only: %i[show update]
       resource :delete, controller: :delete, only: %i[show destroy]
       resources :proceedings_types, only: %i[index create]
       resource :has_other_proceedings, only: %i[show update destroy]


### PR DESCRIPTION


## What
Remove unused copy_case_confirmation route

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4575)

Leftover from an earlier unnamespaced controller iteration that was,
indevertently, not removed.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
