### PR TITLE
AP-4575[ext]: handle clearup of copy case data for negative and reverse flows 

### DIFF
--- a/app/forms/copy_case/confirmation_form.rb
+++ b/app/forms/copy_case/confirmation_form.rb
@@ -5,10 +5,17 @@ module CopyCase
     attr_accessor :copy_case_id, :copy_case_confirmation
 
     validates :copy_case_id, presence: true, unless: :draft?
-    validates :copy_case_confirmation, presence: true, unless: proc { draft? || copy_case_confirmation.present? }
+    validates :copy_case_confirmation, presence: true, unless: :draft?
 
     def save
-      return if invalid? || draft? || !copy_case_confirmed?
+      return if invalid? || draft?
+
+      unless copy_case_confirmed?
+        model.copy_case = nil
+        model.copy_case_id = nil
+        model.save!(validate: false)
+        return
+      end
 
       cloner = CopyCase::ClonerService.new(legal_aid_application, legal_aid_application_to_copy)
       cloner.call

--- a/app/forms/copy_case/invitation_form.rb
+++ b/app/forms/copy_case/invitation_form.rb
@@ -4,6 +4,8 @@ module CopyCase
 
     attr_accessor :copy_case
 
-    validates :copy_case, presence: true, unless: proc { draft? || copy_case.present? }
+    validates :copy_case, presence: true, unless: :draft?
+
+    after_validation { model.copy_case_id = nil }
   end
 end

--- a/spec/forms/copy_case/confirmation_form_spec.rb
+++ b/spec/forms/copy_case/confirmation_form_spec.rb
@@ -34,10 +34,32 @@ RSpec.describe CopyCase::ConfirmationForm, type: :form do
     context "with yes chosen" do
       let(:copy_case_confirmation) { "true" }
 
+      it "does not change copy_case" do
+        expect { call_save }.not_to change { legal_aid_application.reload.copy_case }
+      end
+
+      it "does not change copy_case_id" do
+        expect { call_save }.not_to change { legal_aid_application.reload.copy_case_id }
+      end
+
       it "calls the cloner service" do
         call_save
         expect(cloner_klass).to have_received(:new).with(legal_aid_application, source_application)
         expect(cloner).to have_received(:call)
+      end
+
+      context "when copy_case and copy_case_id already set" do
+        before do
+          legal_aid_application.update!(copy_case: true, copy_case_id: source_application.id)
+        end
+
+        it "does not update copy_case" do
+          expect { call_save }.not_to change { legal_aid_application.reload.copy_case }.from(true)
+        end
+
+        it "does not update copy_case_id" do
+          expect { call_save }.not_to change { legal_aid_application.reload.copy_case_id }.from(source_application.id)
+        end
       end
     end
 
@@ -47,6 +69,20 @@ RSpec.describe CopyCase::ConfirmationForm, type: :form do
       it "does not call the cloner service" do
         call_save
         expect(cloner).not_to have_received(:call)
+      end
+
+      context "when copy_case and copy_case_id already set" do
+        before do
+          legal_aid_application.update!(copy_case: true, copy_case_id: source_application.id)
+        end
+
+        it "nullifies copy_case" do
+          expect { call_save }.to change { legal_aid_application.reload.copy_case }.from(true).to(nil)
+        end
+
+        it "nullifies copy_case_id" do
+          expect { call_save }.to change { legal_aid_application.reload.copy_case_id }.from(source_application.id).to(nil)
+        end
       end
     end
 
@@ -63,6 +99,20 @@ RSpec.describe CopyCase::ConfirmationForm, type: :form do
         expect(instance.errors.messages.values.flatten)
           .to include("Select yes if you want to copy the application")
       end
+
+      context "when copy_case and copy_case_id already set" do
+        before do
+          legal_aid_application.update!(copy_case: true, copy_case_id: source_application.id)
+        end
+
+        it "does not update copy_case" do
+          expect { call_save }.not_to change { legal_aid_application.reload.copy_case }.from(true)
+        end
+
+        it "does not update copy_case_id" do
+          expect { call_save }.not_to change { legal_aid_application.reload.copy_case_id }.from(source_application.id)
+        end
+      end
     end
   end
 
@@ -76,6 +126,20 @@ RSpec.describe CopyCase::ConfirmationForm, type: :form do
         save_as_draft
         expect(cloner).not_to have_received(:call)
       end
+
+      context "when copy_case and copy_case_id already set" do
+        before do
+          legal_aid_application.update!(copy_case: true, copy_case_id: source_application.id)
+        end
+
+        it "does not update copy_case" do
+          expect { save_as_draft }.not_to change { legal_aid_application.reload.copy_case }.from(true)
+        end
+
+        it "does not update copy_case_id" do
+          expect { save_as_draft }.not_to change { legal_aid_application.reload.copy_case_id }.from(source_application.id)
+        end
+      end
     end
 
     context "with no chosen" do
@@ -85,6 +149,20 @@ RSpec.describe CopyCase::ConfirmationForm, type: :form do
         save_as_draft
         expect(cloner).not_to have_received(:call)
       end
+
+      context "when copy_case and copy_case_id already set" do
+        before do
+          legal_aid_application.update!(copy_case: true, copy_case_id: source_application.id)
+        end
+
+        it "does not update copy_case" do
+          expect { save_as_draft }.not_to change { legal_aid_application.reload.copy_case }.from(true)
+        end
+
+        it "does not update copy_case_id" do
+          expect { save_as_draft }.not_to change { legal_aid_application.reload.copy_case_id }.from(source_application.id)
+        end
+      end
     end
 
     context "with no answer chosen" do
@@ -93,6 +171,20 @@ RSpec.describe CopyCase::ConfirmationForm, type: :form do
       it "is valid" do
         save_as_draft
         expect(instance).to be_valid
+      end
+
+      context "when copy_case and copy_case_id already set" do
+        before do
+          legal_aid_application.update!(copy_case: true, copy_case_id: source_application.id)
+        end
+
+        it "does not update copy_case" do
+          expect { save_as_draft }.not_to change { legal_aid_application.reload.copy_case }.from(true)
+        end
+
+        it "does not update copy_case_id" do
+          expect { save_as_draft }.not_to change { legal_aid_application.reload.copy_case_id }.from(source_application.id)
+        end
       end
     end
   end

--- a/spec/forms/copy_case/invitation_form_spec.rb
+++ b/spec/forms/copy_case/invitation_form_spec.rb
@@ -5,6 +5,12 @@ RSpec.describe CopyCase::InvitationForm, type: :form do
 
   let(:legal_aid_application) { create(:legal_aid_application) }
 
+  let(:source_application) do
+    create(:legal_aid_application,
+           application_ref: "L-TVH-U0T",
+           provider: legal_aid_application.provider)
+  end
+
   let(:params) do
     {
       model: legal_aid_application,
@@ -24,11 +30,25 @@ RSpec.describe CopyCase::InvitationForm, type: :form do
           .to(true)
       end
 
+      it "maintains copy_case_id as nil" do
+        expect { call_save }.not_to change { legal_aid_application.reload.copy_case_id }.from(nil)
+      end
+
       context "when no previously chosen" do
         before { legal_aid_application.update!(copy_case: false) }
 
         it "updates copy_case to true" do
           expect { call_save }.to change(legal_aid_application, :copy_case).from(false).to(true)
+        end
+      end
+
+      context "when copy_case_id already set" do
+        before do
+          legal_aid_application.update!(copy_case_id: source_application.id)
+        end
+
+        it "nullifies copy_case_id" do
+          expect { call_save }.to change { legal_aid_application.reload.copy_case_id }.from(source_application.id).to(nil)
         end
       end
     end
@@ -49,6 +69,16 @@ RSpec.describe CopyCase::InvitationForm, type: :form do
           expect { call_save }.to change(legal_aid_application, :copy_case).from(true).to(false)
         end
       end
+
+      context "when copy_case_id already set" do
+        before do
+          legal_aid_application.update!(copy_case_id: source_application.id)
+        end
+
+        it "nullifies copy_case_id" do
+          expect { call_save }.to change { legal_aid_application.reload.copy_case_id }.from(source_application.id).to(nil)
+        end
+      end
     end
 
     context "with no answer chosen" do
@@ -64,6 +94,16 @@ RSpec.describe CopyCase::InvitationForm, type: :form do
         error_messages = instance.errors.messages.values.flatten
         expect(error_messages).to include("Select yes if you want to copy an application")
       end
+
+      context "when copy_case_id already set" do
+        before do
+          legal_aid_application.update!(copy_case_id: source_application.id)
+        end
+
+        it "does not update copy_case_id" do
+          expect { call_save }.not_to change { legal_aid_application.reload.copy_case_id }.from(source_application.id)
+        end
+      end
     end
   end
 
@@ -78,6 +118,16 @@ RSpec.describe CopyCase::InvitationForm, type: :form do
           .from(nil)
           .to(true)
       end
+
+      context "when copy_case_id already set" do
+        before do
+          legal_aid_application.update!(copy_case_id: source_application.id)
+        end
+
+        it "nullifies copy_case_id" do
+          expect { save_as_draft }.to change { legal_aid_application.reload.copy_case_id }.from(source_application.id).to(nil)
+        end
+      end
     end
 
     context "with no chosen" do
@@ -87,6 +137,16 @@ RSpec.describe CopyCase::InvitationForm, type: :form do
         expect { save_as_draft }.to change(legal_aid_application, :copy_case)
           .from(nil)
           .to(false)
+      end
+
+      context "when copy_case_id already set" do
+        before do
+          legal_aid_application.update!(copy_case_id: source_application.id)
+        end
+
+        it "nullifies copy_case_id" do
+          expect { save_as_draft }.to change { legal_aid_application.reload.copy_case_id }.from(source_application.id).to(nil)
+        end
       end
     end
 
@@ -100,6 +160,16 @@ RSpec.describe CopyCase::InvitationForm, type: :form do
 
       it "does not update copy_case" do
         expect { save_as_draft }.not_to change(legal_aid_application, :copy_case).from(nil)
+      end
+
+      context "when copy_case_id already set" do
+        before do
+          legal_aid_application.update!(copy_case_id: source_application.id)
+        end
+
+        it "does not update copy_case_id" do
+          expect { save_as_draft }.not_to change { legal_aid_application.reload.copy_case_id }.from(source_application.id)
+        end
       end
     end
   end


### PR DESCRIPTION
## What
Cleanup copy case related data during negative or reverse flows

[Link to original story](https://dsdmoj.atlassian.net/browse/AP-4575)
<details>
<summary>Add cleanup to copy case invitation form</summary>
When traversing backward though the flow the copy_case_id could
already have been added and even its details copied. If this page is
reached we need to remove the copy_case_id to start the process again.
</details>

<details>
<summary>Add cleanup to copy case confirmation form</summary>
When No is selected on the confirmation page we should nullify 
the copy_case boolean flag to indicate this as
false/unset and remove the id that was search for. this
leaves the application in a state equivalent to not
having copied anything. Flows can then allow the user
to restart the process.
</details>

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
