### PR TITLE
AP-4575 [EXT]: Display copy case search ref if exists

### DIFF
--- a/app/controllers/providers/copy_case/searches_controller.rb
+++ b/app/controllers/providers/copy_case/searches_controller.rb
@@ -3,6 +3,8 @@ module Providers
     class SearchesController < ProviderBaseController
       prefix_step_with :copy_case
 
+      before_action :set_search_ref, only: :show
+
       def show
         @form = ::CopyCase::SearchForm.new(model: legal_aid_application)
       end
@@ -14,6 +16,14 @@ module Providers
       end
 
     private
+
+      def set_search_ref
+        @search_ref = searched_for_case&.application_ref
+      end
+
+      def searched_for_case
+        @searched_for_case ||= LegalAidApplication.find_by(id: legal_aid_application&.copy_case_id)
+      end
 
       def form_params
         merge_with_model(legal_aid_application) do

--- a/app/forms/copy_case/invitation_form.rb
+++ b/app/forms/copy_case/invitation_form.rb
@@ -5,7 +5,5 @@ module CopyCase
     attr_accessor :copy_case
 
     validates :copy_case, presence: true, unless: :draft?
-
-    after_validation { model.copy_case_id = nil }
   end
 end

--- a/app/views/providers/copy_case/searches/show.html.erb
+++ b/app/views/providers/copy_case/searches/show.html.erb
@@ -7,7 +7,7 @@
                                 label: { text: t(".search_ref.label"), size: "xl", tag: "h1" },
                                 hint: { text: t(".search_ref.hint") },
                                 width: "three-quarters",
-                                value: params["search_ref"] || "" %>
+                                value: @search_ref || "" %>
 
       <%= next_action_buttons(
             form:,

--- a/spec/forms/copy_case/invitation_form_spec.rb
+++ b/spec/forms/copy_case/invitation_form_spec.rb
@@ -41,16 +41,6 @@ RSpec.describe CopyCase::InvitationForm, type: :form do
           expect { call_save }.to change(legal_aid_application, :copy_case).from(false).to(true)
         end
       end
-
-      context "when copy_case_id already set" do
-        before do
-          legal_aid_application.update!(copy_case_id: source_application.id)
-        end
-
-        it "nullifies copy_case_id" do
-          expect { call_save }.to change { legal_aid_application.reload.copy_case_id }.from(source_application.id).to(nil)
-        end
-      end
     end
 
     context "with no chosen" do
@@ -67,16 +57,6 @@ RSpec.describe CopyCase::InvitationForm, type: :form do
 
         it "updates copy_case to false" do
           expect { call_save }.to change(legal_aid_application, :copy_case).from(true).to(false)
-        end
-      end
-
-      context "when copy_case_id already set" do
-        before do
-          legal_aid_application.update!(copy_case_id: source_application.id)
-        end
-
-        it "nullifies copy_case_id" do
-          expect { call_save }.to change { legal_aid_application.reload.copy_case_id }.from(source_application.id).to(nil)
         end
       end
     end
@@ -118,16 +98,6 @@ RSpec.describe CopyCase::InvitationForm, type: :form do
           .from(nil)
           .to(true)
       end
-
-      context "when copy_case_id already set" do
-        before do
-          legal_aid_application.update!(copy_case_id: source_application.id)
-        end
-
-        it "nullifies copy_case_id" do
-          expect { save_as_draft }.to change { legal_aid_application.reload.copy_case_id }.from(source_application.id).to(nil)
-        end
-      end
     end
 
     context "with no chosen" do
@@ -137,16 +107,6 @@ RSpec.describe CopyCase::InvitationForm, type: :form do
         expect { save_as_draft }.to change(legal_aid_application, :copy_case)
           .from(nil)
           .to(false)
-      end
-
-      context "when copy_case_id already set" do
-        before do
-          legal_aid_application.update!(copy_case_id: source_application.id)
-        end
-
-        it "nullifies copy_case_id" do
-          expect { save_as_draft }.to change { legal_aid_application.reload.copy_case_id }.from(source_application.id).to(nil)
-        end
       end
     end
 

--- a/spec/requests/providers/copy_case/searches_controller_spec.rb
+++ b/spec/requests/providers/copy_case/searches_controller_spec.rb
@@ -22,10 +22,18 @@ RSpec.describe Providers::CopyCase::SearchesController do
 
     it "renders page with expected heading" do
       expect(response).to have_http_status(:ok)
-      expect(page).to have_css(
-        "h1",
-        text: "What is the LAA reference of the application you want to copy?",
-      )
+      expect(page)
+        .to have_css("h1", text: "What is the LAA reference of the application you want to copy?")
+        .and have_field("What is the LAA reference of the application you want to copy?")
+    end
+
+    context "when copy_case_id already set on the application" do
+      let(:legal_aid_application) { create(:legal_aid_application, copy_case_id: source_application.id) }
+      let(:source_application) { create(:legal_aid_application, application_ref: "L-TVH-U0T") }
+
+      it "renders page with prefilled search value" do
+        expect(page).to have_field("What is the LAA reference of the application you want to copy?", with: "L-TVH-U0T")
+      end
     end
   end
 
@@ -41,7 +49,7 @@ RSpec.describe Providers::CopyCase::SearchesController do
       it_behaves_like "a provider not authenticated"
     end
 
-    context "when Search" do
+    context "when searching" do
       context "with a valid application reference" do
         let(:params) { { legal_aid_application: { search_ref: source_application.application_ref } } }
         let(:source_application) { create(:legal_aid_application, application_ref: "L-TVH-U0T", provider: legal_aid_application.provider) }
@@ -65,7 +73,9 @@ RSpec.describe Providers::CopyCase::SearchesController do
         it "stays on the page and displays validation error" do
           patch_request
           expect(response).to have_http_status(:ok)
-          expect(page).to have_error_message("The application reference entered cannot be found")
+          expect(page)
+            .to have_error_message("The application reference entered cannot be found")
+            .and have_field("What is the LAA reference of the application you want to copy?", with: "L-TVH-U0T")
         end
 
         it "does not store the source application's id" do
@@ -79,7 +89,9 @@ RSpec.describe Providers::CopyCase::SearchesController do
         it "stays on the page and displays validation error" do
           patch_request
           expect(response).to have_http_status(:ok)
-          expect(page).to have_error_message("Enter a valid application reference to search for")
+          expect(page)
+            .to have_error_message("Enter a valid application reference to search for")
+            .and have_field("What is the LAA reference of the application you want to copy?", with: "INVALID-APP-REF")
         end
 
         it "does not store the source application's id" do
@@ -93,7 +105,9 @@ RSpec.describe Providers::CopyCase::SearchesController do
         it "stays on the page and displays validation error" do
           patch_request
           expect(response).to have_http_status(:ok)
-          expect(page).to have_error_message("The application reference entered cannot be found")
+          expect(page)
+            .to have_error_message("The application reference entered cannot be found")
+            .and have_field("What is the LAA reference of the application you want to copy?", with: "L-FFF-FFF")
         end
 
         it "does not store the source application's id" do
@@ -107,7 +121,9 @@ RSpec.describe Providers::CopyCase::SearchesController do
         it "stays on the page and displays validation error" do
           patch_request
           expect(response).to have_http_status(:ok)
-          expect(page).to have_error_message("Enter an application reference to search for")
+          expect(page)
+            .to have_error_message("Enter an application reference to search for")
+            .and have_field("What is the LAA reference of the application you want to copy?", with: "")
         end
 
         it "does not store the source application's id" do


### PR DESCRIPTION

## What
"Remember" already searched for copy case reference during back paging

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4575)

when backpaging we can display the existing
application reference of a previous search
and copy flow. This means the user does not have to
go and retrieve it again if they went back inadvertently
or are attempting to get further back to amend details.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
